### PR TITLE
feat(engine): align SSZ-REST wire format with execution-apis#793 update

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Benchmark/GetPayloadV3SerializationBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Benchmark/GetPayloadV3SerializationBenchmarks.cs
@@ -244,7 +244,7 @@ public class GetPayloadV3SerializationBenchmarks : IDisposable
     {
         ISszEndpointHandler[] handlers =
         [
-            new GetPayloadSszHandler<GetPayloadDescriptorV1, ExecutionPayload>(engine),
+            new GetPayloadSszHandler<GetPayloadDescriptorV1, GetPayloadV2Result>(engine),
             new GetPayloadSszHandler<GetPayloadDescriptorV2, GetPayloadV2Result>(engine),
             new GetPayloadSszHandler<GetPayloadDescriptorV3, GetPayloadV3Result>(engine),
             new GetPayloadSszHandler<GetPayloadDescriptorV4, GetPayloadV4Result>(engine),

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
@@ -238,8 +238,8 @@ public class SszCodecTests
     private static IEnumerable<TestCaseData> NonEmptyEncodings()
     {
         yield return new TestCaseData((Action<IBufferWriter<byte>>)(w =>
-            SszCodec.EncodeGetPayloadV1Response(MakeV2Result(SszTestData.MakeMinimalPayload(), UInt256.One), w)))
-            .SetName(nameof(Encoded_buffer_is_non_empty) + "_GetPayloadV1");
+            SszCodec.EncodeBuiltPayloadParis(MakeV2Result(SszTestData.MakeMinimalPayload(), UInt256.One), w)))
+            .SetName(nameof(Encoded_buffer_is_non_empty) + "_BuiltPayloadParis");
 
         yield return new TestCaseData((Action<IBufferWriter<byte>>)(w =>
         {
@@ -349,8 +349,8 @@ public class SszCodecTests
             .SetName(nameof(Encoded_buffer_length_is_consistent) + "_PayloadStatus");
 
         yield return new TestCaseData((Action<IBufferWriter<byte>>)(w =>
-            SszCodec.EncodeGetPayloadV1Response(MakeV2Result(SszTestData.MakeMinimalPayload(), UInt256.One), w)))
-            .SetName(nameof(Encoded_buffer_length_is_consistent) + "_GetPayloadV1");
+            SszCodec.EncodeBuiltPayloadParis(MakeV2Result(SszTestData.MakeMinimalPayload(), UInt256.One), w)))
+            .SetName(nameof(Encoded_buffer_length_is_consistent) + "_BuiltPayloadParis");
     }
 
     [TestCaseSource(nameof(BufferConsistentEncodings))]
@@ -362,14 +362,14 @@ public class SszCodecTests
     }
 
     [Test]
-    public void EncodeGetPayloadV1Response_fields_land_at_spec_defined_offsets()
+    public void EncodeBuiltPayloadParis_fields_land_at_spec_defined_offsets()
     {
         ExecutionPayload ep = SszTestData.MakeMinimalPayload();
         ep.BaseFeePerGas = new UInt256(0xABCDEF);
         UInt256 blockValue = new(0xCAFEBABEu);
 
         ArrayBufferWriter<byte> w = new();
-        SszCodec.EncodeGetPayloadV1Response(MakeV2Result(ep, blockValue), w);
+        SszCodec.EncodeBuiltPayloadParis(MakeV2Result(ep, blockValue), w);
         ReadOnlySpan<byte> buffer = w.WrittenSpan;
 
         uint epOffset = BitConverter.ToUInt32(buffer.Slice(0, 4));
@@ -388,7 +388,7 @@ public class SszCodecTests
     }
 
     [Test]
-    public void EncodeGetPayloadV1Response_all_static_fields_land_at_spec_defined_offsets()
+    public void EncodeBuiltPayloadParis_all_static_fields_land_at_spec_defined_offsets()
     {
         ExecutionPayload ep = new()
         {
@@ -410,7 +410,7 @@ public class SszCodecTests
         UInt256 blockValue = new(0xCAFEBABEu);
 
         ArrayBufferWriter<byte> w = new();
-        SszCodec.EncodeGetPayloadV1Response(MakeV2Result(ep, blockValue), w);
+        SszCodec.EncodeBuiltPayloadParis(MakeV2Result(ep, blockValue), w);
         ReadOnlySpan<byte> outer = w.WrittenSpan;
 
         uint epOffset = BitConverter.ToUInt32(outer.Slice(0, 4));

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
@@ -667,13 +667,50 @@ public class SszCodecTests
         ArrayBufferWriter<byte> w = new();
         SszCodec.EncodeGetPayloadV4Response(
             new GetPayloadV4Result(block, blockValue, new BlobsBundleV1(block), shouldOverrideBuilder: false, executionRequests: []), w);
-        ReadOnlySpan<byte> buf = w.WrittenSpan;
 
+        AssertPragueBuiltPayloadOffsets(w.WrittenSpan, blockValue, expectedShouldOverrideBuilder: 0, version: "V4");
+    }
+
+    [Test]
+    public void EncodeGetPayloadV5Response_all_static_fields_land_at_spec_defined_offsets()
+    {
+        UInt256 blockValue = new(0xC0FFEEu);
+        ExecutionPayloadV3 ep = SszTestData.MakeV3Payload();
+        Block block = (Block)ep.TryGetBlock();
+
+        ArrayBufferWriter<byte> w = new();
+        SszCodec.EncodeGetPayloadV5Response(
+            new GetPayloadV5Result(block, blockValue, new BlobsBundleV2(block), executionRequests: [], shouldOverrideBuilder: true), w);
+
+        AssertPragueBuiltPayloadOffsets(w.WrittenSpan, blockValue, expectedShouldOverrideBuilder: 1, version: "V5");
+    }
+
+    [Test]
+    public void EncodeGetPayloadV6Response_all_static_fields_land_at_spec_defined_offsets()
+    {
+        UInt256 blockValue = new(0xFEEDFACEu);
+        // 0xc0 is the RLP encoding of an empty list — minimum valid BAL payload for TryGetBlock.
+        ExecutionPayloadV4 ep = SszTestData.MakeV4Payload(blockAccessList: [0xc0], slotNumber: 42UL);
+        Block block = (Block)ep.TryGetBlock();
+
+        ArrayBufferWriter<byte> w = new();
+        SszCodec.EncodeGetPayloadV6Response(
+            new GetPayloadV6Result(block, blockValue, new BlobsBundleV2(block), executionRequests: [], shouldOverrideBuilder: false), w);
+
+        AssertPragueBuiltPayloadOffsets(w.WrittenSpan, blockValue, expectedShouldOverrideBuilder: 0, version: "V6");
+    }
+
+    // Shared assertion for the Prague+ BuiltPayload fixed section: identical for V4/V5/V6 since
+    // BlobsBundleV{1,2} and ExecutionPayloadV{3,4} are all variable-size (4-byte offsets).
+    private static void AssertPragueBuiltPayloadOffsets(
+        ReadOnlySpan<byte> buf, UInt256 blockValue, byte expectedShouldOverrideBuilder, string version)
+    {
         AssertGetPayloadResponseHeaderOffsets(buf, fixedSectionSize: 45, blockValue,
-            shouldOverrideBuilderOffset: 44, expectedShouldOverrideBuilder: 0, version: "V4");
+            shouldOverrideBuilderOffset: 44, expectedShouldOverrideBuilder, version);
 
         uint erOffset = BitConverter.ToUInt32(buf.Slice(40, 4));
-        Assert.That(erOffset, Is.GreaterThanOrEqualTo(45u), "execution_requests offset @ 40 must point past the 45-byte fixed section");
+        Assert.That(erOffset, Is.GreaterThanOrEqualTo(45u),
+            $"{version}: execution_requests offset @ 40 must point past the 45-byte fixed section");
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
@@ -229,10 +229,16 @@ public class SszCodecTests
         }
     }
 
+    // Container { payload(var) + block_value(32) }: 4-byte offset + 32-byte block_value.
+    private const int BuiltPayloadParisFixedSize = 36;
+
+    private static GetPayloadV2Result MakeV2Result(ExecutionPayload ep, UInt256 blockValue) =>
+        new((Block)ep.TryGetBlock(), blockValue);
+
     private static IEnumerable<TestCaseData> NonEmptyEncodings()
     {
         yield return new TestCaseData((Action<IBufferWriter<byte>>)(w =>
-            SszCodec.EncodeGetPayloadV1Response(SszTestData.MakeMinimalPayload(), w)))
+            SszCodec.EncodeGetPayloadV1Response(MakeV2Result(SszTestData.MakeMinimalPayload(), UInt256.One), w)))
             .SetName(nameof(Encoded_buffer_is_non_empty) + "_GetPayloadV1");
 
         yield return new TestCaseData((Action<IBufferWriter<byte>>)(w =>
@@ -343,7 +349,7 @@ public class SszCodecTests
             .SetName(nameof(Encoded_buffer_length_is_consistent) + "_PayloadStatus");
 
         yield return new TestCaseData((Action<IBufferWriter<byte>>)(w =>
-            SszCodec.EncodeGetPayloadV1Response(SszTestData.MakeMinimalPayload(), w)))
+            SszCodec.EncodeGetPayloadV1Response(MakeV2Result(SszTestData.MakeMinimalPayload(), UInt256.One), w)))
             .SetName(nameof(Encoded_buffer_length_is_consistent) + "_GetPayloadV1");
     }
 
@@ -360,19 +366,25 @@ public class SszCodecTests
     {
         ExecutionPayload ep = SszTestData.MakeMinimalPayload();
         ep.BaseFeePerGas = new UInt256(0xABCDEF);
+        UInt256 blockValue = new(0xCAFEBABEu);
 
         ArrayBufferWriter<byte> w = new();
-        SszCodec.EncodeGetPayloadV1Response(ep, w);
+        SszCodec.EncodeGetPayloadV1Response(MakeV2Result(ep, blockValue), w);
         ReadOnlySpan<byte> buffer = w.WrittenSpan;
 
-        Assert.That(buffer.Length, Is.GreaterThan(440 + 32), "encoded payload must be large enough to contain baseFeePerGas");
+        uint epOffset = BitConverter.ToUInt32(buffer.Slice(0, 4));
+        Assert.That(epOffset, Is.EqualTo((uint)BuiltPayloadParisFixedSize), "payload variable-length offset @ 0 must point at the 36-byte fixed-section end");
+        Assert.That(new UInt256(buffer.Slice(4, 32), isBigEndian: false), Is.EqualTo(blockValue), "block_value @ offset 4 (32 bytes, little-endian)");
 
-        UInt256 decodedBaseFee = new(buffer.Slice(440, 32), isBigEndian: false);
-        Assert.That(decodedBaseFee, Is.EqualTo(ep.BaseFeePerGas), "baseFeePerGas must be encoded at byte offset 440 per the Ethereum consensus spec");
+        ReadOnlySpan<byte> payload = buffer[BuiltPayloadParisFixedSize..];
+        Assert.That(payload.Length, Is.GreaterThan(440 + 32), "encoded inner payload must be large enough to contain baseFeePerGas");
 
-        Assert.That(buffer.Slice(0, 32).ToArray(), Is.EqualTo(ep.ParentHash!.Bytes.ToArray()), "parent_hash must be the first 32 bytes of the encoded payload");
+        UInt256 decodedBaseFee = new(payload.Slice(440, 32), isBigEndian: false);
+        Assert.That(decodedBaseFee, Is.EqualTo(ep.BaseFeePerGas), "baseFeePerGas must be encoded at byte offset 440 of the inner payload per the Ethereum consensus spec");
 
-        Assert.That(buffer.Slice(472, 32).ToArray(), Is.EqualTo(ep.BlockHash!.Bytes.ToArray()), "block_hash must be encoded at byte offset 472 per the Ethereum consensus spec");
+        Assert.That(payload.Slice(0, 32).ToArray(), Is.EqualTo(ep.ParentHash!.Bytes.ToArray()), "parent_hash must be the first 32 bytes of the inner payload");
+
+        Assert.That(payload.Slice(472, 32).ToArray(), Is.EqualTo(ep.BlockHash!.Bytes.ToArray()), "block_hash must be encoded at byte offset 472 of the inner payload per the Ethereum consensus spec");
     }
 
     [Test]
@@ -395,10 +407,17 @@ public class SszCodecTests
             BlockHash = TestItem.KeccakE,
             Transactions = Array.Empty<byte[]>()
         };
+        UInt256 blockValue = new(0xCAFEBABEu);
 
         ArrayBufferWriter<byte> w = new();
-        SszCodec.EncodeGetPayloadV1Response(ep, w);
-        ReadOnlySpan<byte> buf = w.WrittenSpan;
+        SszCodec.EncodeGetPayloadV1Response(MakeV2Result(ep, blockValue), w);
+        ReadOnlySpan<byte> outer = w.WrittenSpan;
+
+        uint epOffset = BitConverter.ToUInt32(outer.Slice(0, 4));
+        Assert.That(epOffset, Is.EqualTo((uint)BuiltPayloadParisFixedSize), "payload offset @ 0 must equal the 36-byte fixed-section size");
+        Assert.That(new UInt256(outer.Slice(4, 32), isBigEndian: false), Is.EqualTo(blockValue), "block_value @ offset 4");
+
+        ReadOnlySpan<byte> buf = outer[BuiltPayloadParisFixedSize..];
 
         using (Assert.EnterMultipleScope())
         {
@@ -493,6 +512,7 @@ public class SszCodecTests
         ReadOnlySpan<byte> buf,
         int fixedSectionSize,
         UInt256 expectedBlockValue,
+        int shouldOverrideBuilderOffset,
         byte expectedShouldOverrideBuilder,
         string version)
     {
@@ -506,7 +526,7 @@ public class SszCodecTests
         uint bbOffset = BitConverter.ToUInt32(buf.Slice(36, 4));
         Assert.That(bbOffset, Is.GreaterThanOrEqualTo((uint)fixedSectionSize), $"blobs_bundle offset @ 36 must point past the {fixedSectionSize}-byte fixed section");
 
-        Assert.That(buf[40], Is.EqualTo(expectedShouldOverrideBuilder), $"should_override_builder must encode as 0x{expectedShouldOverrideBuilder:X2} at offset 40");
+        Assert.That(buf[shouldOverrideBuilderOffset], Is.EqualTo(expectedShouldOverrideBuilder), $"should_override_builder must encode as 0x{expectedShouldOverrideBuilder:X2} at offset {shouldOverrideBuilderOffset}");
     }
 
     [Test]
@@ -521,7 +541,7 @@ public class SszCodecTests
             new GetPayloadV3Result(block, blockValue, new BlobsBundleV1(block), shouldOverrideBuilder: true), w);
 
         AssertGetPayloadResponseHeaderOffsets(w.WrittenSpan, fixedSectionSize: 41, blockValue,
-            expectedShouldOverrideBuilder: 1, version: "V3");
+            shouldOverrideBuilderOffset: 40, expectedShouldOverrideBuilder: 1, version: "V3");
     }
 
     [Test]
@@ -650,10 +670,10 @@ public class SszCodecTests
         ReadOnlySpan<byte> buf = w.WrittenSpan;
 
         AssertGetPayloadResponseHeaderOffsets(buf, fixedSectionSize: 45, blockValue,
-            expectedShouldOverrideBuilder: 0, version: "V4");
+            shouldOverrideBuilderOffset: 44, expectedShouldOverrideBuilder: 0, version: "V4");
 
-        uint erOffset = BitConverter.ToUInt32(buf.Slice(41, 4));
-        Assert.That(erOffset, Is.GreaterThanOrEqualTo(45u), "execution_requests offset @ 41 must point past the 45-byte fixed section");
+        uint erOffset = BitConverter.ToUInt32(buf.Slice(40, 4));
+        Assert.That(erOffset, Is.GreaterThanOrEqualTo(45u), "execution_requests offset @ 40 must point past the 45-byte fixed section");
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -939,6 +939,19 @@ public class SszMiddlewareTests
     }
 
     [Test]
+    public async Task Trailing_slash_on_fork_scoped_path_with_id_does_not_leak_into_extra()
+    {
+        _engineModule.engine_getPayloadV2(Arg.Any<byte[]>())
+            .Returns(ResultWrapper<GetPayloadV2Result?>.Success(new GetPayloadV2Result(MakeMinimalBlock(), UInt256.One)));
+
+        DefaultHttpContext ctx = MakeGetContext($"/engine/v2/{ParisUrl}/payloads/0x0102030405060708/");
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+    }
+
+    [Test]
     public async Task Unknown_fork_in_path_returns_400_unsupported_fork()
     {
         DefaultHttpContext ctx = MakePostContext("/engine/v2/atlantis/payloads", []);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -896,8 +896,7 @@ public class SszMiddlewareTests
         Assert.That(ctx.Response.ContentType, Does.Contain("application/json"));
     }
 
-    // Unknown extra path segments still 404. execution-apis#793 dropped the trailing-slash rule,
-    // so /capabilities/ and /forkchoice/ resolve normally — covered separately below.
+    // Unknown extra path segments still 404; trailing slashes are accepted (covered below).
     private static readonly object[] MalformedPathCases =
     [
         new object[] { "GET", "/engine/v2/capabilities/foo", true },

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -92,7 +92,7 @@ public class SszMiddlewareTests
             new ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV3, ForkchoiceUpdatedV3RequestWire>(_engineModule, _specProvider),
             new ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV4, ForkchoiceUpdatedRequestWire>(_engineModule, _specProvider),
 
-            new GetPayloadSszHandler<GetPayloadDescriptorV1, ExecutionPayload>(_engineModule),
+            new GetPayloadSszHandler<GetPayloadDescriptorV1, GetPayloadV2Result>(_engineModule),
             new GetPayloadSszHandler<GetPayloadDescriptorV2, GetPayloadV2Result>(_engineModule),
             new GetPayloadSszHandler<GetPayloadDescriptorV3, GetPayloadV3Result>(_engineModule),
             new GetPayloadSszHandler<GetPayloadDescriptorV4, GetPayloadV4Result>(_engineModule),
@@ -194,8 +194,7 @@ public class SszMiddlewareTests
     [TestCaseSource(nameof(GetPayloadRoutingCases))]
     public async Task GetPayload_routes_to_correct_handler_with_no_store_header(int version, string path)
     {
-        _engineModule.engine_getPayloadV1(Arg.Any<byte[]>())
-            .Returns(ResultWrapper<ExecutionPayload?>.Success(SszTestData.MakeMinimalPayload()));
+        // BuiltPayloadParis needs block_value, sourced from engine_getPayloadV2.
         _engineModule.engine_getPayloadV2(Arg.Any<byte[]>())
             .Returns(ResultWrapper<GetPayloadV2Result?>.Success(new GetPayloadV2Result(MakeMinimalBlock(), UInt256.One)));
 
@@ -205,8 +204,8 @@ public class SszMiddlewareTests
 
         Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
         Assert.That(ctx.Response.Headers["Cache-Control"].ToString(), Does.Contain("no-store"));
-        await _engineModule.Received(version == 1 ? 1 : 0).engine_getPayloadV1(Arg.Any<byte[]>());
-        await _engineModule.Received(version == 2 ? 1 : 0).engine_getPayloadV2(Arg.Any<byte[]>());
+        await _engineModule.DidNotReceive().engine_getPayloadV1(Arg.Any<byte[]>());
+        await _engineModule.Received(1).engine_getPayloadV2(Arg.Any<byte[]>());
     }
 
     private static readonly object[] ForkchoiceRoutingCases =
@@ -897,14 +896,10 @@ public class SszMiddlewareTests
         Assert.That(ctx.Response.ContentType, Does.Contain("application/json"));
     }
 
-    // Trailing slashes and unknown extra path segments must both 404 — spec forbids trailing slashes
-    // and handlers without AcceptsPathExtra must reject stray segments. Unscoped endpoints
-    // (capabilities, identity) must reject any extra segment instead of mis-classifying
-    // the trailing segment as an unsupported fork.
+    // Unknown extra path segments still 404. execution-apis#793 dropped the trailing-slash rule,
+    // so /capabilities/ and /forkchoice/ resolve normally — covered separately below.
     private static readonly object[] MalformedPathCases =
     [
-        new object[] { "POST", $"/engine/v2/{CancunUrl}/forkchoice/", true },
-        new object[] { "GET", "/engine/v2/capabilities/", false },
         new object[] { "GET", "/engine/v2/capabilities/foo", true },
         new object[] { "GET", "/engine/v2/identity/foo", true },
         new object[] { "POST", $"/engine/v2/{CancunUrl}/forkchoice/whatever", false },
@@ -930,6 +925,18 @@ public class SszMiddlewareTests
             string body = System.Text.Encoding.UTF8.GetString(ResponseBytes(ctx));
             Assert.That(body, Does.Contain("method-not-found"));
         }
+    }
+
+    [Test]
+    public async Task Trailing_slash_on_capabilities_resolves_normally()
+    {
+        DefaultHttpContext ctx = MakeBaseContext("GET", "/engine/v2/capabilities/", AuthenticatedPort);
+        ctx.Request.Headers.Accept = "application/json";
+        ctx.Request.Body = Stream.Null;
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszVersionDescriptors.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszVersionDescriptors.cs
@@ -142,12 +142,14 @@ public readonly struct ForkchoiceUpdatedDescriptorV4 : IForkchoiceUpdatedVersion
         ForkchoiceUpdatedHelpers.FirstTimestamp(wire.PayloadAttributes);
 }
 
-public readonly struct GetPayloadDescriptorV1 : IGetPayloadVersion<ExecutionPayload>
+// Routes to engine_getPayloadV2 (not V1) so the response carries block_value, required by
+// the Paris BuiltPayload wrapper introduced in execution-apis#793.
+public readonly struct GetPayloadDescriptorV1 : IGetPayloadVersion<GetPayloadV2Result>
 {
     public static int VersionNumber => EngineApiVersions.GetPayload.V1;
-    public static Task<ResultWrapper<ExecutionPayload?>> Call(IEngineRpcModule engine, byte[] id)
-        => engine.engine_getPayloadV1(id);
-    public static int Encode(ExecutionPayload result, IBufferWriter<byte> writer)
+    public static Task<ResultWrapper<GetPayloadV2Result?>> Call(IEngineRpcModule engine, byte[] id)
+        => engine.engine_getPayloadV2(id);
+    public static int Encode(GetPayloadV2Result result, IBufferWriter<byte> writer)
         => SszCodec.EncodeGetPayloadV1Response(result, writer);
 }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszVersionDescriptors.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszVersionDescriptors.cs
@@ -142,15 +142,14 @@ public readonly struct ForkchoiceUpdatedDescriptorV4 : IForkchoiceUpdatedVersion
         ForkchoiceUpdatedHelpers.FirstTimestamp(wire.PayloadAttributes);
 }
 
-// Routes to engine_getPayloadV2 (not V1) so the response carries block_value, required by
-// the Paris BuiltPayload wrapper introduced in execution-apis#793.
+// Paris (V1 routing) needs block_value, which engine_getPayloadV1 doesn't return — call V2.
 public readonly struct GetPayloadDescriptorV1 : IGetPayloadVersion<GetPayloadV2Result>
 {
     public static int VersionNumber => EngineApiVersions.GetPayload.V1;
     public static Task<ResultWrapper<GetPayloadV2Result?>> Call(IEngineRpcModule engine, byte[] id)
         => engine.engine_getPayloadV2(id);
     public static int Encode(GetPayloadV2Result result, IBufferWriter<byte> writer)
-        => SszCodec.EncodeGetPayloadV1Response(result, writer);
+        => SszCodec.EncodeBuiltPayloadParis(result, writer);
 }
 
 public readonly struct GetPayloadDescriptorV2 : IGetPayloadVersion<GetPayloadV2Result>

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
@@ -61,8 +61,8 @@ public static class SszCodec
         safeBlockHash: w.SafeBlockHash);
 
 
-    public static int EncodeGetPayloadV1Response(GetPayloadV2Result? r, IBufferWriter<byte> writer)
-        => EncodeToWriter(new GetPayloadResponseV1Wire
+    public static int EncodeBuiltPayloadParis(GetPayloadV2Result? r, IBufferWriter<byte> writer)
+        => EncodeToWriter(new BuiltPayloadParisWire
         {
             ExecutionPayload = new SszExecutionPayloadV1(r!.ExecutionPayload),
             BlockValue = r.BlockValue
@@ -152,7 +152,7 @@ public static class SszCodec
         return EncodeToWriter(new GetBlobsV2ResponseWire { Entries = arr }, writer);
     }
 
-    // execution-apis#793 forbids a separate BlobV3 wire type — /v3 entry shape is V2 verbatim.
+    // V3 entry shape is byte-identical to V2; only response-level semantics differ.
     public static int EncodeGetBlobsV3Response(IReadOnlyList<BlobAndProofV2?> blobs, IBufferWriter<byte> writer)
         => EncodeGetBlobsV2Response(blobs, writer);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
@@ -61,8 +61,12 @@ public static class SszCodec
         safeBlockHash: w.SafeBlockHash);
 
 
-    public static int EncodeGetPayloadV1Response(ExecutionPayload ep, IBufferWriter<byte> writer)
-        => EncodeToWriter(new SszExecutionPayloadV1(ep), writer);
+    public static int EncodeGetPayloadV1Response(GetPayloadV2Result? r, IBufferWriter<byte> writer)
+        => EncodeToWriter(new GetPayloadResponseV1Wire
+        {
+            ExecutionPayload = new SszExecutionPayloadV1(r!.ExecutionPayload),
+            BlockValue = r.BlockValue
+        }, writer);
 
     public static int EncodeGetPayloadV2Response(GetPayloadV2Result? r, IBufferWriter<byte> writer)
         => EncodeToWriter(new GetPayloadResponseV2Wire
@@ -148,19 +152,9 @@ public static class SszCodec
         return EncodeToWriter(new GetBlobsV2ResponseWire { Entries = arr }, writer);
     }
 
+    // execution-apis#793 forbids a separate BlobV3 wire type — /v3 entry shape is V2 verbatim.
     public static int EncodeGetBlobsV3Response(IReadOnlyList<BlobAndProofV2?> blobs, IBufferWriter<byte> writer)
-    {
-        int count = blobs.Count;
-        BlobV3EntryWire[] arr = new BlobV3EntryWire[count];
-        for (int i = 0; i < count; i++)
-        {
-            BlobAndProofV2? b = blobs[i];
-            arr[i] = b is null
-                ? new BlobV3EntryWire { Available = false, Contents = default }
-                : new BlobV3EntryWire { Available = true, Contents = new() { Blob = b.Blob, Proofs = b.Proofs.ToKzgWire() } };
-        }
-        return EncodeToWriter(new GetBlobsV3ResponseWire { Entries = arr }, writer);
-    }
+        => EncodeGetBlobsV2Response(blobs, writer);
 
     public static (byte[][] hashes, System.Collections.BitArray indices) DecodeGetBlobsV4Request(ReadOnlySequence<byte> buf)
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
@@ -90,8 +90,8 @@ public static class SszCodec
             ExecutionPayload = new SszExecutionPayloadV3(r!.ExecutionPayload),
             BlockValue = r.BlockValue,
             BlobsBundle = r.BlobsBundle.ToWire(),
-            ShouldOverrideBuilder = r.ShouldOverrideBuilder,
-            ExecutionRequests = r.ExecutionRequests.ToExecutionRequestsWire()
+            ExecutionRequests = r.ExecutionRequests.ToExecutionRequestsWire(),
+            ShouldOverrideBuilder = r.ShouldOverrideBuilder
         }, writer);
 
     public static int EncodeGetPayloadV5Response(GetPayloadV5Result? r, IBufferWriter<byte> writer)
@@ -100,8 +100,8 @@ public static class SszCodec
             ExecutionPayload = new SszExecutionPayloadV3(r!.ExecutionPayload),
             BlockValue = r.BlockValue,
             BlobsBundle = r.BlobsBundle.ToWire(),
-            ShouldOverrideBuilder = r.ShouldOverrideBuilder,
-            ExecutionRequests = r.ExecutionRequests.ToExecutionRequestsWire()
+            ExecutionRequests = r.ExecutionRequests.ToExecutionRequestsWire(),
+            ShouldOverrideBuilder = r.ShouldOverrideBuilder
         }, writer);
 
     public static int EncodeGetPayloadV6Response(GetPayloadV6Result? r, IBufferWriter<byte> writer)
@@ -110,8 +110,8 @@ public static class SszCodec
             ExecutionPayload = new SszExecutionPayloadV4(r!.ExecutionPayload),
             BlockValue = r.BlockValue,
             BlobsBundle = r.BlobsBundle.ToWire(),
-            ShouldOverrideBuilder = r.ShouldOverrideBuilder,
-            ExecutionRequests = r.ExecutionRequests.ToExecutionRequestsWire()
+            ExecutionRequests = r.ExecutionRequests.ToExecutionRequestsWire(),
+            ShouldOverrideBuilder = r.ShouldOverrideBuilder
         }, writer);
 
     public static byte[][] DecodeGetBlobsRequest(ReadOnlySequence<byte> buf)

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -253,7 +253,7 @@ public sealed class SszMiddleware
         if (!span.StartsWith(EnginePrefix.AsSpan(), StringComparison.OrdinalIgnoreCase))
             return false;
 
-        // execution-apis#793 no longer forbids trailing slashes — collapse them so the route resolves.
+        // Collapse a trailing slash so `/foo` and `/foo/` route identically.
         if (span.Length > EnginePrefix.Length && span[^1] == '/')
             span = span[..^1];
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -253,8 +253,9 @@ public sealed class SszMiddleware
         if (!span.StartsWith(EnginePrefix.AsSpan(), StringComparison.OrdinalIgnoreCase))
             return false;
 
-        if (span.EndsWith("/"))
-            return false;
+        // execution-apis#793 no longer forbids trailing slashes — collapse them so the route resolves.
+        if (span.Length > EnginePrefix.Length && span[^1] == '/')
+            span = span[..^1];
 
         int offset = EnginePrefix.Length;
         span = span[offset..];

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -253,9 +253,14 @@ public sealed class SszMiddleware
         if (!span.StartsWith(EnginePrefix.AsSpan(), StringComparison.OrdinalIgnoreCase))
             return false;
 
-        // Collapse a trailing slash so `/foo` and `/foo/` route identically.
-        if (span.Length > EnginePrefix.Length && span[^1] == '/')
-            span = span[..^1];
+        // Collapse a trailing slash so `/foo` and `/foo/` route identically; `pathLen` then
+        // bounds every subsequent `path.AsMemory(...)` slice so the slash never reaches `extra`.
+        int pathLen = path.Length;
+        if (pathLen > EnginePrefix.Length && path[pathLen - 1] == '/')
+        {
+            pathLen--;
+            span = span[..pathLen];
+        }
 
         int offset = EnginePrefix.Length;
         span = span[offset..];
@@ -264,7 +269,7 @@ public sealed class SszMiddleware
         if (span.Equals("identity".AsSpan(), StringComparison.OrdinalIgnoreCase)
             || span.Equals("capabilities".AsSpan(), StringComparison.OrdinalIgnoreCase))
         {
-            pathSegment = path.AsMemory(offset);
+            pathSegment = path.AsMemory(offset, pathLen - offset);
             return true;
         }
         // Unscoped endpoints don't accept path extras — reject "/identity/foo" / "/capabilities/foo"
@@ -320,7 +325,7 @@ public sealed class SszMiddleware
         if (nextSlash < span.Length)
         {
             offset += nextSlash + 1;
-            pathSegment = path.AsMemory(offset);
+            pathSegment = path.AsMemory(offset, pathLen - offset);
         }
         else
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddlewareConfigurer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddlewareConfigurer.cs
@@ -56,7 +56,7 @@ public sealed class SszMiddlewareConfigurer(IComponentContext ctx) : IJsonRpcSer
         services.AddSingleton<ISszEndpointHandler, ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV3, ForkchoiceUpdatedV3RequestWire>>();
         services.AddSingleton<ISszEndpointHandler, ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV4, ForkchoiceUpdatedRequestWire>>();
 
-        services.AddSingleton<ISszEndpointHandler, GetPayloadSszHandler<GetPayloadDescriptorV1, ExecutionPayload>>();
+        services.AddSingleton<ISszEndpointHandler, GetPayloadSszHandler<GetPayloadDescriptorV1, GetPayloadV2Result>>();
         services.AddSingleton<ISszEndpointHandler, GetPayloadSszHandler<GetPayloadDescriptorV2, GetPayloadV2Result>>();
         services.AddSingleton<ISszEndpointHandler, GetPayloadSszHandler<GetPayloadDescriptorV3, GetPayloadV3Result>>();
         services.AddSingleton<ISszEndpointHandler, GetPayloadSszHandler<GetPayloadDescriptorV4, GetPayloadV4Result>>();

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
@@ -205,7 +205,7 @@ public partial struct BlobsBundleV2Wire
 }
 
 [SszContainer]
-public partial struct GetPayloadResponseV1Wire
+public partial struct BuiltPayloadParisWire
 {
     public SszExecutionPayloadV1 ExecutionPayload { get; set; }
     public UInt256 BlockValue { get; set; }
@@ -227,8 +227,7 @@ public partial struct GetPayloadResponseV3Wire
     public bool ShouldOverrideBuilder { get; set; }
 }
 
-// execution-apis#793: execution_requests precedes should_override_builder on the wire,
-// diverging from legacy JSON-RPC envelope order. Mirrored in V5/V6 below.
+// Field order: execution_requests precedes should_override_builder (diverges from JSON-RPC).
 [SszContainer]
 public partial struct GetPayloadResponseV4Wire
 {

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
@@ -205,6 +205,13 @@ public partial struct BlobsBundleV2Wire
 }
 
 [SszContainer]
+public partial struct GetPayloadResponseV1Wire
+{
+    public SszExecutionPayloadV1 ExecutionPayload { get; set; }
+    public UInt256 BlockValue { get; set; }
+}
+
+[SszContainer]
 public partial struct GetPayloadResponseV2Wire
 {
     public SszExecutionPayloadV2 ExecutionPayload { get; set; }
@@ -220,14 +227,16 @@ public partial struct GetPayloadResponseV3Wire
     public bool ShouldOverrideBuilder { get; set; }
 }
 
+// execution-apis#793: execution_requests precedes should_override_builder on the wire,
+// diverging from legacy JSON-RPC envelope order. Mirrored in V5/V6 below.
 [SszContainer]
 public partial struct GetPayloadResponseV4Wire
 {
     public SszExecutionPayloadV3 ExecutionPayload { get; set; }
     public UInt256 BlockValue { get; set; }
     public BlobsBundleV1Wire BlobsBundle { get; set; }
-    public bool ShouldOverrideBuilder { get; set; }
     [SszList(256)] public SszTransaction[]? ExecutionRequests { get; set; }
+    public bool ShouldOverrideBuilder { get; set; }
 }
 
 [SszContainer]
@@ -236,8 +245,8 @@ public partial struct GetPayloadResponseV5Wire
     public SszExecutionPayloadV3 ExecutionPayload { get; set; }
     public UInt256 BlockValue { get; set; }
     public BlobsBundleV2Wire BlobsBundle { get; set; }
-    public bool ShouldOverrideBuilder { get; set; }
     [SszList(256)] public SszTransaction[]? ExecutionRequests { get; set; }
+    public bool ShouldOverrideBuilder { get; set; }
 }
 
 [SszContainer]
@@ -246,8 +255,8 @@ public partial struct GetPayloadResponseV6Wire
     public SszExecutionPayloadV4 ExecutionPayload { get; set; }
     public UInt256 BlockValue { get; set; }
     public BlobsBundleV2Wire BlobsBundle { get; set; }
-    public bool ShouldOverrideBuilder { get; set; }
     [SszList(256)] public SszTransaction[]? ExecutionRequests { get; set; }
+    public bool ShouldOverrideBuilder { get; set; }
 }
 
 [SszContainer]
@@ -394,24 +403,6 @@ public partial struct BlobV2EntryWire
 public partial struct GetBlobsV2ResponseWire
 {
     [SszList(128)] public BlobV2EntryWire[]? Entries { get; set; }
-}
-
-/// <summary>
-/// <c>BlobV3Entry = BlobV2Entry { available: Boolean; contents: BlobAndProofV2 }</c> per spec.
-/// Unlike V2 (all-or-nothing), V3 supports partial responses: missing blobs have
-/// <c>Available = false</c>; only a full EL outage returns 204.
-/// </summary>
-[SszContainer]
-public partial struct BlobV3EntryWire
-{
-    public bool Available { get; set; }
-    public BlobAndProofV2Wire Contents { get; set; }
-}
-
-[SszContainer]
-public partial struct GetBlobsV3ResponseWire
-{
-    [SszList(128)] public BlobV3EntryWire[]? Entries { get; set; }
 }
 
 [SszContainer]


### PR DESCRIPTION
## Summary

Tracks the 2026-06-17 update to [ethereum/execution-apis#793](https://github.com/ethereum/execution-apis/pull/793) (commit [`e509f20f`](https://github.com/ethereum/execution-apis/pull/793/commits/e509f20f9e9107c262bc65a46ea71cb3c8d19a7d) — _advertise all forks_), which supersedes the 2026-06-14 commit [`83151eea`](https://github.com/ethereum/execution-apis/pull/793/commits/83151eead3f87a354718f5765063f7817bde1628) — _engine-api: resolve feedback from implementers_ this PR originally targeted. Follow-up to #11887.

The 2026-06-17 spec update is largely documentation — per-fork worked examples for every endpoint, an explicit normative statement that the `{fork}` URL segment spans Paris through Amsterdam, and a clarification that BPO forks do not introduce their own `{fork}` segment (they reuse the named fork they layer on). Two items affect implementations:

* **`BuiltPayloadShanghai` resolved as `{payload, block_value}`.** The spec author confirmed in 2026-06-17 that the Shanghai wrapper does NOT carry `should_override_builder` — the field was introduced in Cancun (`engine_getPayloadV3`), alongside `blobs_bundle`. Nethermind already shipped the Shanghai shape this way in the previous commit on this PR (V2 wire = `{payload, block_value}`, intentionally diverging from the as-written-but-flagged-as-typo 2026-06-14 text), so no further code change is needed.
* **`BlobsBundleV{1,2}` list caps renamed.** The spec now uses `MAX_BLOB_COMMITMENTS_PER_BLOCK` (4096) in place of `MAX_BLOBS_PER_PAYLOAD`. Both resolve to the same numeric cap (4096), so the wire format is unchanged — only the spec naming was clarified. Nethermind already encodes with the 4096 cap.

Everything else the 2026-06-17 commit codifies — fork-segment range, BPO routing to the parent named fork, the `400 /engine-api/errors/unsupported-fork` response — already matched the existing implementation. No wire or behavioral changes vs. the previous commit on this PR.

The earlier (2026-06-14) wire-incompatible changes this PR ships, unchanged from the previous commit:

* **Paris `BuiltPayload` is now wrapped.** `BuiltPayloadParis = { payload, block_value }` per spec — was a bare `ExecutionPayloadParis` before. Added `BuiltPayloadParisWire`; `GetPayloadDescriptorV1` routes to `engine_getPayloadV2` to source `block_value`. The JSON-RPC V1 surface is unchanged — only the SSZ-REST `/paris/payloads/{id}` response is now wrapped.

* **Prague+ field order swapped.** Per the spec's now-explicit normative ordering, `execution_requests` precedes `should_override_builder` on the wire — intentionally diverging from the legacy JSON-RPC `engine_getPayload` envelope order. Reordered `GetPayloadResponseV{4,5,6}Wire`.

* **`/v3` reuses `BlobV2Entry` verbatim.** The spec now explicitly forbids defining a separate `BlobV3Entry` wire type (_to avoid the two drifting apart_). Removed `BlobV3EntryWire` and `GetBlobsV3ResponseWire`; `EncodeGetBlobsV3Response` aliases the V2 encoder.

* **Trailing slashes no longer rejected.** The spec dropped the _Trailing slashes are forbidden_ sentence. `SszMiddleware.TryRoute` now strips a single trailing slash before routing, so `/engine/v2/capabilities` and `/engine/v2/capabilities/` resolve identically.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

The SSZ-REST wire format changes here are breaking against the surface introduced in #11887, but that surface is itself unreleased and the spec it targets is still draft. No JSON-RPC behaviour changes.

## Testing

- [x] Yes
- [ ] No

#### Notes on testing

* `SszCodecTests` — V1 GetPayload assertions updated for the new wrapper offsets (payload now lives at offset 36 inside the outer container; outer carries the 4-byte payload offset + 32-byte block_value). V4 assertions adjusted for the swapped `execution_requests` / `should_override_builder` order (should-override-builder moves from offset 40 to 44, execution-requests offset from 41 to 40).
* `SszMiddlewareTests` — Removed two trailing-slash 404 cases that are no longer applicable; added a positive `Trailing_slash_on_capabilities_resolves_normally` case. V1 routing test updated for the V2-source change.
* All 1521 `Nethermind.Merge.Plugin.Test` tests pass; 107 SSZ-specific tests pass.

Hive `engine` test suite run against `/engine/v2/...` endpoints still required.

## Documentation

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)