### PR TITLE
fix(json): stop CountingStreamPipeWriter.Advance from flushing mid-write

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Json/CountingStreamPipeWriterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/CountingStreamPipeWriterTests.cs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Serialization.Json;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Json;
+
+[Parallelizable(ParallelScope.All)]
+public class CountingStreamPipeWriterTests
+{
+    // Mirrors the options EthereumJsonSerializer uses for its pipe writer.
+    private static StreamPipeWriterOptions Options =>
+        new(pool: MemoryPool<byte>.Shared, minimumBufferSize: 16 * 1024, leaveOpen: true);
+
+    [Test]
+    public void Advance_does_not_flush_and_invalidate_outstanding_buffer()
+    {
+        // Regression for #9198. Previously Advance flushed the buffered data (and reset _tailMemory)
+        // as soon as it crossed _minimumBufferSize. A consumer that obtained one buffer and advanced
+        // into it more than once — which Utf8JsonWriter effectively does across a pipe flush — then
+        // hit ArgumentOutOfRangeException on the next Advance because _tailMemory had been cleared.
+        // The BCL StreamPipeWriter never flushes inside Advance; neither should this one.
+        using MemoryStream stream = new();
+        CountingStreamPipeWriter writer = new(stream, Options);
+
+        const int first = 20_000;  // crosses the 16 KiB threshold on the first Advance
+        const int second = 5_000;
+
+        // Obtain a single buffer and advance into it twice without requesting it again in between.
+        Span<byte> buffer = writer.GetSpan(64 * 1024);
+        buffer.Slice(0, first).Fill(0xAB);
+        writer.Advance(first);
+
+        // The old in-Advance flush recycled this segment and cleared _tailMemory here, so the next
+        // Advance threw ArgumentOutOfRangeException. It must not.
+        buffer.Slice(first, second).Fill(0xCD);
+        Assert.DoesNotThrow(() => writer.Advance(second));
+
+        writer.Complete();
+
+        Assert.That(stream.Length, Is.EqualTo(first + second));
+        Assert.That(writer.WrittenCount, Is.EqualTo(first + second));
+        byte[] written = stream.ToArray();
+        Assert.That(written.AsSpan(0, first).ToArray(), Is.All.EqualTo((byte)0xAB));
+        Assert.That(written.AsSpan(first, second).ToArray(), Is.All.EqualTo((byte)0xCD));
+    }
+
+    [Test]
+    public async Task SerializeAsync_large_payload_round_trips()
+    {
+        // Exercises System.Text.Json's async PipeWriter path (Utf8JsonWriter.Dispose -> Flush ->
+        // CountingStreamPipeWriter.Advance), the exact frame that threw in #9198, with a payload
+        // large enough to span many buffer segments and pipe flushes.
+        string[] payload = Enumerable.Range(0, 100_000).Select(i => $"item-{i:D6}").ToArray();
+
+        EthereumJsonSerializer serializer = new();
+        await using MemoryStream stream = new();
+
+        long written = await serializer.SerializeAsync(stream, payload, CancellationToken.None);
+
+        Assert.That(written, Is.EqualTo(stream.Length));
+        stream.Position = 0;
+        Assert.That(serializer.Deserialize<string[]>(stream), Is.EqualTo(payload));
+    }
+
+    [Test]
+    public void Serialize_large_payload_round_trips()
+    {
+        // The synchronous path never calls FlushAsync mid-write, so the relocated threshold flush
+        // (now in the buffer hand-off path) is what keeps memory bounded. Verify it stays correct.
+        string[] payload = Enumerable.Range(0, 100_000).Select(i => $"item-{i:D6}").ToArray();
+
+        EthereumJsonSerializer serializer = new();
+        using MemoryStream stream = new();
+
+        long written = serializer.Serialize(stream, payload);
+
+        Assert.That(written, Is.EqualTo(stream.Length));
+        stream.Position = 0;
+        Assert.That(serializer.Deserialize<string[]>(stream), Is.EqualTo(payload));
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/Json/CountingStreamPipeWriterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/CountingStreamPipeWriterTests.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Serialization.Json;
@@ -17,31 +16,22 @@ namespace Nethermind.Core.Test.Json;
 [Parallelizable(ParallelScope.All)]
 public class CountingStreamPipeWriterTests
 {
-    // Mirrors the options EthereumJsonSerializer uses for its pipe writer.
     private static StreamPipeWriterOptions Options =>
         new(pool: MemoryPool<byte>.Shared, minimumBufferSize: 16 * 1024, leaveOpen: true);
 
     [Test]
     public void Advance_does_not_flush_and_invalidate_outstanding_buffer()
     {
-        // Regression for #9198. Previously Advance flushed the buffered data (and reset _tailMemory)
-        // as soon as it crossed _minimumBufferSize. A consumer that obtained one buffer and advanced
-        // into it more than once — which Utf8JsonWriter effectively does across a pipe flush — then
-        // hit ArgumentOutOfRangeException on the next Advance because _tailMemory had been cleared.
-        // The BCL StreamPipeWriter never flushes inside Advance; neither should this one.
         using MemoryStream stream = new();
         CountingStreamPipeWriter writer = new(stream, Options);
 
-        const int first = 20_000;  // crosses the 16 KiB threshold on the first Advance
+        const int first = 20_000;
         const int second = 5_000;
 
-        // Obtain a single buffer and advance into it twice without requesting it again in between.
         Span<byte> buffer = writer.GetSpan(64 * 1024);
         buffer.Slice(0, first).Fill(0xAB);
         writer.Advance(first);
 
-        // The old in-Advance flush recycled this segment and cleared _tailMemory here, so the next
-        // Advance threw ArgumentOutOfRangeException. It must not.
         buffer.Slice(first, second).Fill(0xCD);
         Assert.DoesNotThrow(() => writer.Advance(second));
 
@@ -54,35 +44,18 @@ public class CountingStreamPipeWriterTests
         Assert.That(written.AsSpan(first, second).ToArray(), Is.All.EqualTo((byte)0xCD));
     }
 
-    [Test]
-    public async Task SerializeAsync_large_payload_round_trips()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Large_payload_round_trips(bool useAsync)
     {
-        // Exercises System.Text.Json's async PipeWriter path (Utf8JsonWriter.Dispose -> Flush ->
-        // CountingStreamPipeWriter.Advance), the exact frame that threw in #9198, with a payload
-        // large enough to span many buffer segments and pipe flushes.
         string[] payload = Enumerable.Range(0, 100_000).Select(i => $"item-{i:D6}").ToArray();
 
         EthereumJsonSerializer serializer = new();
         await using MemoryStream stream = new();
 
-        long written = await serializer.SerializeAsync(stream, payload, CancellationToken.None);
-
-        Assert.That(written, Is.EqualTo(stream.Length));
-        stream.Position = 0;
-        Assert.That(serializer.Deserialize<string[]>(stream), Is.EqualTo(payload));
-    }
-
-    [Test]
-    public void Serialize_large_payload_round_trips()
-    {
-        // The synchronous path never calls FlushAsync mid-write, so the relocated threshold flush
-        // (now in the buffer hand-off path) is what keeps memory bounded. Verify it stays correct.
-        string[] payload = Enumerable.Range(0, 100_000).Select(i => $"item-{i:D6}").ToArray();
-
-        EthereumJsonSerializer serializer = new();
-        using MemoryStream stream = new();
-
-        long written = serializer.Serialize(stream, payload);
+        long written = useAsync
+            ? await serializer.SerializeAsync(stream, payload, CancellationToken.None)
+            : serializer.Serialize(stream, payload);
 
         Assert.That(written, Is.EqualTo(stream.Length));
         stream.Position = 0;

--- a/src/Nethermind/Nethermind.Core.Test/Json/CountingStreamPipeWriterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/CountingStreamPipeWriterTests.cs
@@ -44,9 +44,7 @@ public class CountingStreamPipeWriterTests
         Assert.That(written.AsSpan(first, second).ToArray(), Is.All.EqualTo((byte)0xCD));
     }
 
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task Large_payload_round_trips(bool useAsync)
+    public async Task Large_payload_round_trips([Values] bool useAsync)
     {
         string[] payload = Enumerable.Range(0, 100_000).Select(i => $"item-{i:D6}").ToArray();
 

--- a/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
@@ -193,12 +193,8 @@ public sealed class CountingStreamPipeWriter : CountingWriter
                     _tailBytesBuffered = 0;
                 }
 
-                // Bound the in-memory buffer by flushing completed segments to the inner stream once
-                // the buffered data crosses the threshold. This is done here, at buffer hand-off, and
-                // never in Advance: flushing recycles segments and clears _tailMemory, but a consumer
-                // such as Utf8JsonWriter may still hold a buffer it obtained earlier and continue to
-                // Advance against it across an async PipeWriter flush. Resetting that state inside
-                // Advance desynchronizes the consumer's view and trips the Advance range check (#9198).
+                // Threshold flush happens here, never in Advance: a consumer may still hold a buffer
+                // obtained earlier and Advance into it across the flush.
                 if (_bytesBuffered > _minimumBufferSize)
                 {
                     FlushInternal(writeToStream: true);
@@ -208,7 +204,6 @@ public sealed class CountingStreamPipeWriter : CountingWriter
 
                 if (_head is null)
                 {
-                    // FlushInternal recycled all segments; start a fresh chain.
                     _head = _tail = newSegment;
                 }
                 else
@@ -216,8 +211,6 @@ public sealed class CountingStreamPipeWriter : CountingWriter
                     _tail!.SetNext(newSegment);
                     _tail = newSegment;
                 }
-
-                _tailBytesBuffered = 0;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
@@ -130,11 +130,6 @@ public sealed class CountingStreamPipeWriter : CountingWriter
         _bytesBuffered += bytes;
         _tailMemory = _tailMemory[bytes..];
         WrittenCount += bytes;
-
-        if (_bytesBuffered > _minimumBufferSize)
-        {
-            FlushInternal(writeToStream: true);
-        }
     }
 
     /// <inheritdoc />
@@ -198,10 +193,31 @@ public sealed class CountingStreamPipeWriter : CountingWriter
                     _tailBytesBuffered = 0;
                 }
 
+                // Bound the in-memory buffer by flushing completed segments to the inner stream once
+                // the buffered data crosses the threshold. This is done here, at buffer hand-off, and
+                // never in Advance: flushing recycles segments and clears _tailMemory, but a consumer
+                // such as Utf8JsonWriter may still hold a buffer it obtained earlier and continue to
+                // Advance against it across an async PipeWriter flush. Resetting that state inside
+                // Advance desynchronizes the consumer's view and trips the Advance range check (#9198).
+                if (_bytesBuffered > _minimumBufferSize)
+                {
+                    FlushInternal(writeToStream: true);
+                }
+
                 BufferSegment newSegment = AllocateSegment(sizeHint);
 
-                _tail.SetNext(newSegment);
-                _tail = newSegment;
+                if (_head is null)
+                {
+                    // FlushInternal recycled all segments; start a fresh chain.
+                    _head = _tail = newSegment;
+                }
+                else
+                {
+                    _tail!.SetNext(newSegment);
+                    _tail = newSegment;
+                }
+
+                _tailBytesBuffered = 0;
             }
         }
     }


### PR DESCRIPTION
Fixes #9198

## Changes

- Removed the eager flush from `CountingStreamPipeWriter.Advance`. `Advance` now only commits bytes and slices `_tailMemory`, matching the BCL `StreamPipeWriter` it was forked from — it no longer performs I/O or resets buffer state (`_head`/`_tail`/`_tailMemory`) as a side effect.
- Moved the threshold-driven flush to the `GetMemory`/`GetSpan` buffer hand-off (`AllocateMemory`), so completed segments are still flushed once buffered data crosses `_minimumBufferSize`, keeping the synchronous serialization path memory-bounded.
- Added regression tests in `Nethermind.Core.Test`.

### Root cause

WebSocket/IPC JSON-RPC responses intermittently failed with `ArgumentOutOfRangeException ... (Parameter 'bytes')`:

at CountingStreamPipeWriter.Advance(Int32 bytes)
at System.Text.Json.Utf8JsonWriter.Flush()
at System.Text.Json.Utf8JsonWriter.Dispose()
at JsonTypeInfo`1.SerializeAsync(PipeWriter pipeWriter, …)
at EthereumJsonSerializer.SerializeAsync[T](Stream, …)

`CountingStreamPipeWriter` is a fork of `System.IO.Pipelines.StreamPipeWriter` with one deviation: it flushed synchronously inside `Advance` once `_bytesBuffered > _minimumBufferSize`, which recycled segments and set `_tailMemory = default`. System.Text.Json's async `PipeWriter` serialization writes into a buffer obtained earlier and commits the remaining bytes at `Utf8JsonWriter.Dispose() → Flush() → Advance()`. With the buffer state already torn down by the in-`Advance` flush, that final `Advance` failed `(uint)bytes > (uint)_tailMemory.Length` and threw. The upstream `StreamPipeWriter` never flushes inside `Advance`; this change restores that contract. 

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `CountingStreamPipeWriterTests`:
- `Advance_does_not_flush_and_invalidate_outstanding_buffer` — deterministic regression: obtains one buffer and advances into it twice across the threshold. Throws `ArgumentOutOfRangeException` on `master`, passes with the fix.
- `SerializeAsync_large_payload_round_trips` / `Serialize_large_payload_round_trips` — exercise the async (the exact frame from the issue) and sync serialization paths with a large payload and assert a clean round-trip.

All three pass; no other tests affected.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

