### PR TITLE
Allow to omit TargetGasLimit

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
@@ -229,7 +229,6 @@ public class PayloadAttributes
             >= PayloadAttributesVersions.V2 when Withdrawals is null => $"{nameof(Withdrawals)} must be provided",
             >= PayloadAttributesVersions.V3 when ParentBeaconBlockRoot is null => $"{nameof(ParentBeaconBlockRoot)} must be provided",
             >= PayloadAttributesVersions.V4 when SlotNumber is null => $"{nameof(SlotNumber)} must be provided",
-            >= PayloadAttributesVersions.V4 when TargetGasLimit is null => $"{nameof(TargetGasLimit)} must be provided",
             _ => null
         };
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -2124,6 +2124,13 @@ public partial class EngineModuleTests
                     ExpectedResult = MergeErrorCodes.InvalidPayloadAttributes,
                 };
 
+            static TestCaseData ValidFieldCase(IReleaseSpec spec, string method, PayloadAttributes attrs, string testName) =>
+                new(spec, method, attrs)
+                {
+                    TestName = testName,
+                    ExpectedResult = ErrorCodes.None,
+                };
+
             yield return InvalidFieldCase(Paris.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV1), Attrs(mutate: a => a.Timestamp = 0), "FCUv1 Timestamp zero");
             yield return InvalidFieldCase(Paris.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV1), Attrs(mutate: a => a.PrevRandao = null), "FCUv1 PrevRandao null");
             yield return InvalidFieldCase(Paris.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV1), Attrs(mutate: a => a.SuggestedFeeRecipient = null), "FCUv1 SuggestedFeeRecipient null");
@@ -2132,7 +2139,7 @@ public partial class EngineModuleTests
             yield return InvalidFieldCase(Amsterdam.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV4), Attrs(parentBeaconBlockRoot: Keccak.Zero, slotNumber: 1, targetGasLimit: 30_000_000), "FCUv4 Withdrawals null");
             yield return InvalidFieldCase(Amsterdam.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV4), Attrs(withdrawals: [], slotNumber: 1, targetGasLimit: 30_000_000), "FCUv4 ParentBeaconBlockRoot null");
             yield return InvalidFieldCase(Amsterdam.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV4), Attrs(withdrawals: [], parentBeaconBlockRoot: Keccak.Zero, targetGasLimit: 30_000_000), "FCUv4 SlotNumber null");
-            yield return InvalidFieldCase(Amsterdam.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV4), Attrs(withdrawals: [], parentBeaconBlockRoot: Keccak.Zero, slotNumber: 1), "FCUv4 TargetGasLimit null");
+            yield return ValidFieldCase(Amsterdam.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV4), Attrs(withdrawals: [], parentBeaconBlockRoot: Keccak.Zero, slotNumber: 1), "FCUv4 TargetGasLimit null");
         }
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszCodecTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -521,10 +522,7 @@ public class SszCodecTests
 
         byte[] encoded = ForkchoiceUpdatedRequestWire.Encode(wire);
 
-        ForkchoiceUpdatedRequestWire.Decode(encoded, out ForkchoiceUpdatedRequestWire decoded);
-        ForkchoiceStateV1 state = SszCodec.ForkchoiceStateV1FromWire(decoded.ForkchoiceState);
-        PayloadAttributes? attrs = decoded.PayloadAttributes is { Length: > 0 } a
-            ? SszCodec.PayloadAttributesFromWire(a[0]) : null;
+        SszCodec.DecodeForkchoiceUpdatedV4Request(Seq(encoded), out ForkchoiceStateV1 state, out PayloadAttributes? attrs);
 
         Assert.That(state.HeadBlockHash, Is.EqualTo(TestItem.KeccakA));
         Assert.That(attrs, Is.Not.Null);
@@ -532,6 +530,78 @@ public class SszCodecTests
         Assert.That(attrs.SlotNumber, Is.EqualTo(expectedSlot), "slot_number must be decoded from the fixed uint64 that follows parent_beacon_block_root");
         Assert.That(attrs.TargetGasLimit, Is.EqualTo((long)expectedTargetGasLimit), "target_gas_limit must be decoded from the fixed uint64 that follows slot_number");
         Assert.That(attrs.SuggestedFeeRecipient, Is.EqualTo(TestItem.AddressB));
+    }
+
+    [Test]
+    public void DecodeFcuV4Request_without_target_gas_limit_preserves_null()
+    {
+        ulong expectedSlot = 0xAABBCCDD_11223344UL;
+
+        ForkchoiceUpdatedV4WithoutTargetGasLimitRequestWire wire = new()
+        {
+            ForkchoiceState = new ForkchoiceStateWire
+            {
+                HeadBlockHash = TestItem.KeccakA,
+                SafeBlockHash = TestItem.KeccakB,
+                FinalizedBlockHash = TestItem.KeccakC,
+            },
+            PayloadAttributes =
+            [
+                new PayloadAttributesV4WithoutTargetGasLimitWire
+                {
+                    Timestamp = 0x0102030405060708UL,
+                    PrevRandao = TestItem.KeccakD,
+                    SuggestedFeeRecipient = TestItem.AddressB,
+                    Withdrawals = [],
+                    ParentBeaconBlockRoot = TestItem.KeccakE,
+                    SlotNumber = expectedSlot,
+                }
+            ]
+        };
+
+        byte[] encoded = ForkchoiceUpdatedV4WithoutTargetGasLimitRequestWire.Encode(wire);
+
+        SszCodec.DecodeForkchoiceUpdatedV4Request(Seq(encoded), out ForkchoiceStateV1 state, out PayloadAttributes? attrs);
+
+        Assert.That(state.HeadBlockHash, Is.EqualTo(TestItem.KeccakA));
+        Assert.That(attrs, Is.Not.Null);
+        Assert.That(attrs!.ParentBeaconBlockRoot, Is.EqualTo(TestItem.KeccakE));
+        Assert.That(attrs.SlotNumber, Is.EqualTo(expectedSlot));
+        Assert.That(attrs.TargetGasLimit, Is.Null);
+        Assert.That(attrs.SuggestedFeeRecipient, Is.EqualTo(TestItem.AddressB));
+    }
+
+    [Test]
+    public void DecodeFcuV4Request_rejects_target_gas_limit_above_long_max_value()
+    {
+        ForkchoiceUpdatedRequestWire wire = new()
+        {
+            ForkchoiceState = new ForkchoiceStateWire
+            {
+                HeadBlockHash = TestItem.KeccakA,
+                SafeBlockHash = TestItem.KeccakB,
+                FinalizedBlockHash = TestItem.KeccakC,
+            },
+            PayloadAttributes =
+            [
+                new PayloadAttributesWire
+                {
+                    Timestamp = 1,
+                    PrevRandao = TestItem.KeccakD,
+                    SuggestedFeeRecipient = TestItem.AddressB,
+                    Withdrawals = [],
+                    ParentBeaconBlockRoot = TestItem.KeccakE,
+                    SlotNumber = 1,
+                    TargetGasLimit = (ulong)long.MaxValue + 1,
+                }
+            ]
+        };
+
+        byte[] encoded = ForkchoiceUpdatedRequestWire.Encode(wire);
+
+        Assert.That(
+            () => SszCodec.DecodeForkchoiceUpdatedV4Request(Seq(encoded), out _, out _),
+            Throws.TypeOf<InvalidDataException>());
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -76,7 +76,7 @@ public class SszMiddlewareTests
             new ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV1, ForkchoiceUpdatedV1RequestWire>(_engineModule),
             new ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV2, ForkchoiceUpdatedV2RequestWire>(_engineModule),
             new ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV3, ForkchoiceUpdatedV3RequestWire>(_engineModule),
-            new ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV4, ForkchoiceUpdatedRequestWire>(_engineModule),
+            new ForkchoiceUpdatedV4SszHandler(_engineModule),
 
             new GetPayloadSszHandler<GetPayloadDescriptorV1, ExecutionPayload>(_engineModule),
             new GetPayloadSszHandler<GetPayloadDescriptorV2, GetPayloadV2Result>(_engineModule),

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
@@ -5,6 +5,8 @@ using System;
 using System.Buffers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Nethermind.Consensus;
+using Nethermind.Consensus.Producers;
 using Nethermind.JsonRpc;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Serialization.Ssz;
@@ -28,6 +30,20 @@ public sealed class ForkchoiceUpdatedSszHandler<TVersion, TWire>(IEngineRpcModul
     {
         TWire.Decode(body, out TWire wire);
         ResultWrapper<ForkchoiceUpdatedV1Result> result = await TVersion.Call(engineModule, wire);
+        await WriteSszResultAsync(ctx, result, SszCodec.EncodeForkchoiceUpdatedResponse);
+    }
+}
+
+public sealed class ForkchoiceUpdatedV4SszHandler(IEngineRpcModule engineModule) : SszEndpointHandlerBase
+{
+    public override string HttpMethod => "POST";
+    public override string Resource => SszRestPaths.Forkchoice;
+    public override int? Version => EngineApiVersions.Fcu.V4;
+
+    public override async Task HandleAsync(HttpContext ctx, int version, ReadOnlyMemory<char> extra, ReadOnlySequence<byte> body)
+    {
+        SszCodec.DecodeForkchoiceUpdatedV4Request(body, out ForkchoiceStateV1 state, out PayloadAttributes? attrs);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await engineModule.engine_forkchoiceUpdatedV4(state, attrs);
         await WriteSszResultAsync(ctx, result, SszCodec.EncodeForkchoiceUpdatedResponse);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
@@ -34,6 +34,10 @@ public sealed class ForkchoiceUpdatedSszHandler<TVersion, TWire>(IEngineRpcModul
     }
 }
 
+/// <summary>
+/// Handles <c>POST /engine/v4/forkchoice</c> while accepting both V4
+/// payload-attributes layouts, with or without <c>targetGasLimit</c>.
+/// </summary>
 public sealed class ForkchoiceUpdatedV4SszHandler(IEngineRpcModule engineModule) : SszEndpointHandlerBase
 {
     public override string HttpMethod => "POST";

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszVersionDescriptors.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszVersionDescriptors.cs
@@ -111,17 +111,6 @@ public readonly struct ForkchoiceUpdatedDescriptorV3 : IForkchoiceUpdatedVersion
     }
 }
 
-public readonly struct ForkchoiceUpdatedDescriptorV4 : IForkchoiceUpdatedVersion<ForkchoiceUpdatedRequestWire>
-{
-    public static int VersionNumber => EngineApiVersions.Fcu.V4;
-    public static Task<ResultWrapper<ForkchoiceUpdatedV1Result>> Call(IEngineRpcModule engine, in ForkchoiceUpdatedRequestWire wire)
-    {
-        ForkchoiceStateV1 state = SszCodec.ForkchoiceStateV1FromWire(wire.ForkchoiceState);
-        PayloadAttributes? attrs = wire.PayloadAttributes is { Length: > 0 } a ? SszCodec.PayloadAttributesFromWire(a[0]) : null;
-        return engine.engine_forkchoiceUpdatedV4(state, attrs);
-    }
-}
-
 public readonly struct GetPayloadDescriptorV1 : IGetPayloadVersion<ExecutionPayload>
 {
     public static int VersionNumber => EngineApiVersions.GetPayload.V1;

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
@@ -323,7 +323,7 @@ public static class SszCodec
             ForkchoiceUpdatedRequestWire.Decode(body, out wire);
             return true;
         }
-        catch (Exception e) when (e is InvalidDataException or ArgumentException or IndexOutOfRangeException)
+        catch (Exception e) when (e is InvalidDataException or ArgumentException)
         {
             wire = default;
             return false;

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszCodec.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -290,7 +291,44 @@ public static class SszCodec
             withdrawals: pa.Withdrawals.ToDomain(),
             parentBeaconBlockRoot: pa.ParentBeaconBlockRoot,
             slotNumber: pa.SlotNumber,
-            targetGasLimit: (long)pa.TargetGasLimit);
+            targetGasLimit: SszNumericChecks.CheckedLong(pa.TargetGasLimit));
+
+    internal static PayloadAttributes PayloadAttributesFromWire(PayloadAttributesV4WithoutTargetGasLimitWire pa) =>
+        BuildPayloadAttributes(pa.Timestamp, pa.PrevRandao, pa.SuggestedFeeRecipient,
+            withdrawals: pa.Withdrawals.ToDomain(),
+            parentBeaconBlockRoot: pa.ParentBeaconBlockRoot,
+            slotNumber: pa.SlotNumber);
+
+    internal static void DecodeForkchoiceUpdatedV4Request(
+        ReadOnlySequence<byte> body,
+        out ForkchoiceStateV1 forkchoiceState,
+        out PayloadAttributes? payloadAttributes)
+    {
+        if (TryDecodeForkchoiceUpdatedV4Request(body, out ForkchoiceUpdatedRequestWire wire))
+        {
+            forkchoiceState = ForkchoiceStateV1FromWire(wire.ForkchoiceState);
+            payloadAttributes = wire.PayloadAttributes is { Length: > 0 } attrs ? PayloadAttributesFromWire(attrs[0]) : null;
+            return;
+        }
+
+        ForkchoiceUpdatedV4WithoutTargetGasLimitRequestWire.Decode(body, out ForkchoiceUpdatedV4WithoutTargetGasLimitRequestWire oldWire);
+        forkchoiceState = ForkchoiceStateV1FromWire(oldWire.ForkchoiceState);
+        payloadAttributes = oldWire.PayloadAttributes is { Length: > 0 } oldAttrs ? PayloadAttributesFromWire(oldAttrs[0]) : null;
+    }
+
+    private static bool TryDecodeForkchoiceUpdatedV4Request(ReadOnlySequence<byte> body, out ForkchoiceUpdatedRequestWire wire)
+    {
+        try
+        {
+            ForkchoiceUpdatedRequestWire.Decode(body, out wire);
+            return true;
+        }
+        catch (Exception e) when (e is InvalidDataException or ArgumentException or IndexOutOfRangeException)
+        {
+            wire = default;
+            return false;
+        }
+    }
 
     private static PayloadAttributes BuildPayloadAttributes(
         ulong timestamp,

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddlewareConfigurer.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddlewareConfigurer.cs
@@ -51,7 +51,7 @@ public sealed class SszMiddlewareConfigurer(IComponentContext ctx) : IJsonRpcSer
         services.AddSingleton<ISszEndpointHandler, ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV1, ForkchoiceUpdatedV1RequestWire>>();
         services.AddSingleton<ISszEndpointHandler, ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV2, ForkchoiceUpdatedV2RequestWire>>();
         services.AddSingleton<ISszEndpointHandler, ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV3, ForkchoiceUpdatedV3RequestWire>>();
-        services.AddSingleton<ISszEndpointHandler, ForkchoiceUpdatedSszHandler<ForkchoiceUpdatedDescriptorV4, ForkchoiceUpdatedRequestWire>>();
+        services.AddSingleton<ISszEndpointHandler, ForkchoiceUpdatedV4SszHandler>();
 
         services.AddSingleton<ISszEndpointHandler, GetPayloadSszHandler<GetPayloadDescriptorV1, ExecutionPayload>>();
         services.AddSingleton<ISszEndpointHandler, GetPayloadSszHandler<GetPayloadDescriptorV2, GetPayloadV2Result>>();

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
@@ -84,6 +84,17 @@ public partial struct PayloadAttributesWire
 }
 
 [SszContainer]
+public partial struct PayloadAttributesV4WithoutTargetGasLimitWire
+{
+    public ulong Timestamp { get; set; }
+    public Hash256 PrevRandao { get; set; }
+    public Address SuggestedFeeRecipient { get; set; }
+    [SszList(16)] public SszWithdrawal[]? Withdrawals { get; set; }
+    public Hash256 ParentBeaconBlockRoot { get; set; }
+    public ulong SlotNumber { get; set; }
+}
+
+[SszContainer]
 public partial struct ForkchoiceUpdatedV1RequestWire
 {
     public ForkchoiceStateWire ForkchoiceState { get; set; }
@@ -109,6 +120,13 @@ public partial struct ForkchoiceUpdatedRequestWire
 {
     public ForkchoiceStateWire ForkchoiceState { get; set; }
     [SszList(1)] public PayloadAttributesWire[]? PayloadAttributes { get; set; }
+}
+
+[SszContainer]
+public partial struct ForkchoiceUpdatedV4WithoutTargetGasLimitRequestWire
+{
+    public ForkchoiceStateWire ForkchoiceState { get; set; }
+    [SszList(1)] public PayloadAttributesV4WithoutTargetGasLimitWire[]? PayloadAttributes { get; set; }
 }
 
 [SszContainer]


### PR DESCRIPTION
## Changes

- Allows `PayloadAttributes.TargetGasLimit` to be omitted while keeping V4 `SlotNumber` validation required.
- Adds SSZ `/engine/v4/forkchoice` compatibility decoding for both payload-attributes shapes: with and without `targetGasLimit`.
- Keeps supplied SSZ `targetGasLimit` range-checked before conversion to `long`.
- Adds regression coverage for omitted, supplied, and oversized SSZ `targetGasLimit` values.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet test --project src\Nethermind\Nethermind.Merge.Plugin.Test\Nethermind.Merge.Plugin.Test.csproj -c release -p:SaveDiskSpace=true -- --filter FullyQualifiedName~ForkchoiceUpdated_should_validate_payload_attributes_fields`
- `dotnet test --project src\Nethermind\Nethermind.Merge.Plugin.Test\Nethermind.Merge.Plugin.Test.csproj -c release -p:SaveDiskSpace=true -- --filter FullyQualifiedName~DecodeFcuV4Request`
- `dotnet test --project src\Nethermind\Nethermind.Merge.Plugin.Test\Nethermind.Merge.Plugin.Test.csproj -c release -p:SaveDiskSpace=true -- --filter FullyQualifiedName~Forkchoice_calls_correct_engine_module_version`
- `dotnet test --project src\Nethermind\Nethermind.Merge.Plugin.Test\Nethermind.Merge.Plugin.Test.csproj -c release -p:SaveDiskSpace=true -- --filter "FullyQualifiedName~SszRest|FullyQualifiedName~ForkchoiceUpdated_should_validate_payload_attributes_fields"`
- `dotnet build src\Nethermind\Nethermind.slnx -p:EnforceCodeStyleInBuild=true -p:TreatWarningsAsErrors=false -p:GenerateDocumentationFile=true -p:NoWarn=CS0419%3BCS1570%3BCS1572%3BCS1573%3BCS1574%3BCS1584%3BCS1587%3BCS1591%3BCS1658%3BCS1711%3BCS1712%3BCS1723%3BCS1734%3BCS1735%3BNU1701%3BNUnit1032 -p:SaveDiskSpace=true`
- GitHub PR checks finished with 515 passing checks, 1 skipped check, and no failures.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This intentionally bridges older Engine API payload attributes that do not include `targetGasLimit` with the newer Amsterdam/Gloas shape where the field is supplied.