### PR TITLE
fix(rpc): unsafe `ValueTask` synchronous wait during streaming

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
@@ -11,6 +11,7 @@ using Collections.Pooled;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
@@ -317,7 +318,7 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         if (_pipeWriter is null) return;
         if (++_entriesSinceLastFlush < _flushIntervalEntries) return;
         _writer.Flush();
-        _pipeWriter.FlushAsync(_cancellationToken).GetAwaiter().GetResult();
+        _pipeWriter.FlushAsync(_cancellationToken).SafeWait();
         _entriesSinceLastFlush = 0;
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/StreamingParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/StreamingParityLikeTxTracer.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Extensions;
 using Nethermind.Evm;
 using Nethermind.Int256;
 using Nethermind.Serialization.Json;
@@ -644,7 +645,7 @@ public class StreamingParityLikeTxTracer : ParityLikeTxTracer
     {
         if (_pipeWriter is null || _entriesSinceLastFlush < _flushIntervalEntries) return;
         _writer.Flush();
-        _pipeWriter.FlushAsync(_cancellationToken).GetAwaiter().GetResult();
+        _pipeWriter.FlushAsync(_cancellationToken).SafeWait();
         _entriesSinceLastFlush = 0;
     }
 

--- a/src/Nethermind/Nethermind.Core.Test/IO/AsyncCompletingStream.cs
+++ b/src/Nethermind/Nethermind.Core.Test/IO/AsyncCompletingStream.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Nethermind.JsonRpc.Test;
+namespace Nethermind.Core.Test.IO;
 
 /// <inheritdoc />
 /// <summary>

--- a/src/Nethermind/Nethermind.Core/Extensions/ValueTaskWaitExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/ValueTaskWaitExtensions.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Core.Extensions;
+
+/// <summary>
+/// Synchronous, blocking consumers for <see cref="ValueTask"/> / <see cref="ValueTask{TResult}"/> that honor the
+/// single-consumption contract of <see cref="System.Threading.Tasks.Sources.IValueTaskSource"/>-backed value tasks.
+/// </summary>
+/// <remarks>
+/// Prevents <see cref="InvalidOperationException"/> when using <c>.GetAwaiter().GetResult()</c> on a non-completed value task,
+/// while removing allocation of <c>.AsTask().GetAwaiter().GetResult()</c> approach.
+/// </remarks>
+public static class ValueTaskWaitExtensions
+{
+    [ThreadStatic]
+    private static Gate? _gate;
+
+    /// <summary>Blocks the current thread until <paramref name="valueTask"/> completes.</summary>
+    /// <param name="valueTask">The value task to wait on. Must not have been consumed yet.</param>
+    public static void SafeWait(this ValueTask valueTask)
+    {
+        ValueTaskAwaiter awaiter = valueTask.GetAwaiter();
+        if (awaiter.IsCompleted)
+        {
+            awaiter.GetResult();
+            return;
+        }
+
+        Gate gate = RentResetGate();
+        awaiter.UnsafeOnCompleted(gate.Signal);
+        gate.Event.Wait();
+        awaiter.GetResult();
+    }
+
+    /// <summary>Blocks the current thread until <paramref name="valueTask"/> completes, discarding its result.</summary>
+    /// <param name="valueTask">The value task to wait on. Must not have been consumed yet.</param>
+    public static void SafeWait<TResult>(this ValueTask<TResult> valueTask) => valueTask.SafeGetResult();
+
+    /// <summary>Blocks the current thread until <paramref name="valueTask"/> completes, then returns its result.</summary>
+    /// <param name="valueTask">The value task to wait on. Must not have been consumed yet.</param>
+    public static TResult SafeGetResult<TResult>(this ValueTask<TResult> valueTask)
+    {
+        ValueTaskAwaiter<TResult> awaiter = valueTask.GetAwaiter();
+        if (awaiter.IsCompleted)
+            return awaiter.GetResult();
+
+        Gate gate = RentResetGate();
+        awaiter.UnsafeOnCompleted(gate.Signal);
+        gate.Event.Wait();
+        return awaiter.GetResult();
+    }
+
+    private static Gate RentResetGate()
+    {
+        Gate gate = _gate ??= new Gate();
+        gate.Event.Reset();
+        return gate;
+    }
+
+    private sealed class Gate
+    {
+        public readonly ManualResetEventSlim Event = new(initialState: false);
+        public readonly Action Signal;
+
+        public Gate() => Signal = Event.Set;
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Extensions/ValueTaskWaitExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/ValueTaskWaitExtensions.cs
@@ -1,73 +1,35 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
-using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nethermind.Core.Extensions;
 
-/// <summary>
-/// Synchronous, blocking consumers for <see cref="ValueTask"/> / <see cref="ValueTask{TResult}"/> that honor the
-/// single-consumption contract of <see cref="System.Threading.Tasks.Sources.IValueTaskSource"/>-backed value tasks.
-/// </summary>
-/// <remarks>
-/// Prevents <see cref="InvalidOperationException"/> when using <c>.GetAwaiter().GetResult()</c> on a non-completed value task,
-/// while removing allocation of <c>.AsTask().GetAwaiter().GetResult()</c> approach.
-/// </remarks>
 public static class ValueTaskWaitExtensions
 {
-    [ThreadStatic]
-    private static Gate? _gate;
-
     /// <summary>Blocks the current thread until <paramref name="valueTask"/> completes.</summary>
+    /// <remarks>Can allocate a new <see cref="Task"/> instance in some cases.</remarks>
     /// <param name="valueTask">The value task to wait on. Must not have been consumed yet.</param>
     public static void SafeWait(this ValueTask valueTask)
     {
-        ValueTaskAwaiter awaiter = valueTask.GetAwaiter();
-        if (awaiter.IsCompleted)
+        if (valueTask.IsCompleted)
         {
-            awaiter.GetResult();
+            valueTask.GetAwaiter().GetResult();
             return;
         }
 
-        Gate gate = RentResetGate();
-        awaiter.UnsafeOnCompleted(gate.Signal);
-        gate.Event.Wait();
-        awaiter.GetResult();
+        valueTask.AsTask().GetAwaiter().GetResult();
     }
 
     /// <summary>Blocks the current thread until <paramref name="valueTask"/> completes, discarding its result.</summary>
+    /// <remarks>Can allocate a new <see cref="Task"/> instance in some cases.</remarks>
     /// <param name="valueTask">The value task to wait on. Must not have been consumed yet.</param>
     public static void SafeWait<TResult>(this ValueTask<TResult> valueTask) => valueTask.SafeGetResult();
 
     /// <summary>Blocks the current thread until <paramref name="valueTask"/> completes, then returns its result.</summary>
+    /// <remarks>Can allocate a new <see cref="Task"/> instance in some cases.</remarks>
     /// <param name="valueTask">The value task to wait on. Must not have been consumed yet.</param>
-    public static TResult SafeGetResult<TResult>(this ValueTask<TResult> valueTask)
-    {
-        ValueTaskAwaiter<TResult> awaiter = valueTask.GetAwaiter();
-        if (awaiter.IsCompleted)
-            return awaiter.GetResult();
-
-        Gate gate = RentResetGate();
-        awaiter.UnsafeOnCompleted(gate.Signal);
-        gate.Event.Wait();
-        return awaiter.GetResult();
-    }
-
-    private static Gate RentResetGate()
-    {
-        Gate gate = _gate ??= new Gate();
-        gate.Event.Reset();
-        return gate;
-    }
-
-    private sealed class Gate
-    {
-        public readonly ManualResetEventSlim Event = new(initialState: false);
-        public readonly Action Signal;
-
-        public Gate() => Signal = Event.Set;
-    }
+    public static TResult SafeGetResult<TResult>(this ValueTask<TResult> valueTask) => valueTask.IsCompleted
+        ? valueTask.GetAwaiter().GetResult()
+        : valueTask.AsTask().GetAwaiter().GetResult();
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/AsyncCompletingStream.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/AsyncCompletingStream.cs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.JsonRpc.Test;
+
+/// <inheritdoc />
+/// <summary>
+/// A stream whose async writes and flushes never complete synchronously.
+/// </summary>
+public sealed class AsyncCompletingStream : MemoryStream
+{
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        await base.WriteAsync(buffer, cancellationToken);
+    }
+
+    public override async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        await Task.Yield();
+        await base.FlushAsync(cancellationToken);
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceCallMany.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceCallMany.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.IO.Pipelines;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Blockchain.Find;
@@ -147,6 +149,26 @@ public partial class DebugRpcModuleTests
         JArray result = await RunTraceCallManyAsJson(ctx, [bundle], options);
 
         Assert.That(result.Select(r => ((JArray)r).Count), Is.EqualTo([1]));
+    }
+
+    [Test]
+    public async Task Debug_traceCallMany_with_async_stream()
+    {
+        using Context ctx = await CreateContext();
+        ctx.Blockchain.Container.Resolve<IJsonRpcConfig>().EnableTracingStreamMode = true;
+
+        // Multiple bundles so FlushBetweenBundles runs more than once.
+        TransactionBundle[] bundles = [CreateBundle(CreateTransaction()), CreateBundle(CreateTransaction(to: TestItem.AddressD))];
+        ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>> result = ctx.DebugRpcModule.debug_traceCallMany(bundles, BlockParameter.Latest);
+        Assert.That(result.Data, Is.AssignableTo<IStreamableResult>());
+        IStreamableResult streaming = (IStreamableResult)result.Data;
+
+        await using AsyncCompletingStream stream = new();
+        PipeWriter writer = PipeWriter.Create(stream);
+
+        Assert.DoesNotThrowAsync(async () => await streaming.WriteToAsync(writer, CancellationToken.None));
+
+        await writer.CompleteAsync();
     }
 
     private static async Task<JArray> RunTraceCallManyAsJson(Context ctx, TransactionBundle[] bundles, GethTraceOptions? options = null)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceCallMany.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceCallMany.cs
@@ -11,6 +11,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.IO;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Evm;
 using Nethermind.Facade.Eth.RpcTransaction;
@@ -152,7 +153,7 @@ public partial class DebugRpcModuleTests
     }
 
     [Test]
-    public async Task Debug_traceCallMany_with_async_stream()
+    public async Task Debug_traceCallMany_to_async_stream()
     {
         using Context ctx = await CreateContext();
         ctx.Blockchain.Container.Resolve<IJsonRpcConfig>().EnableTracingStreamMode = true;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -19,6 +19,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Facade;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.IO;
 using Nethermind.Int256;
 using Nethermind.JsonRpc.Modules.Trace;
 using Nethermind.JsonRpc.Test.Modules.Eth;
@@ -1573,7 +1574,7 @@ public class TraceRpcModuleTests
     // regression test ensuring asynchronous streaming pipe doesn't crash tracing
     // was caused by synchronously waiting non-completed IValueTaskSource-backed ValueTask
     [Test]
-    public async Task trace_block_with_async_stream()
+    public async Task trace_block_to_async_stream()
     {
         Context context = new();
         await context.Build();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -1570,6 +1570,30 @@ public class TraceRpcModuleTests
         Assert.That(output, Is.EqualTo("0x" + new string('0', 64)));
     }
 
+    // regression test ensuring asynchronous streaming pipe doesn't crash tracing
+    // was caused by synchronously waiting non-completed IValueTaskSource-backed ValueTask
+    [Test]
+    public async Task trace_block_with_async_stream()
+    {
+        Context context = new();
+        await context.Build();
+        context.Blockchain.Container.Resolve<IJsonRpcConfig>().EnableTracingStreamMode = true;
+
+        Block block = context.Blockchain.BlockTree.Head!;
+        Assert.That(block.Transactions, Is.Not.Empty, "block must contain transactions so AddTrace is exercised");
+
+        ResultWrapper<IEnumerable<ParityTxTraceFromStore>> result = context.TraceRpcModule.trace_block(new BlockParameter(block.Number));
+        Assert.That(result.Data, Is.AssignableTo<IStreamableResult>());
+        IStreamableResult streaming = (IStreamableResult)result.Data;
+
+        await using AsyncCompletingStream stream = new();
+        System.IO.Pipelines.PipeWriter writer = System.IO.Pipelines.PipeWriter.Create(stream);
+
+        Assert.DoesNotThrowAsync(async () => await streaming.WriteToAsync(writer, CancellationToken.None));
+
+        await writer.CompleteAsync();
+    }
+
     private static void AssertBalanceChange(ParityAccountStateChange? stateChanges, UInt256 before, UInt256 after)
     {
         Assert.That(stateChanges?.Balance, Is.Not.Null);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TraceRpcModuleTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.IO.Pipelines;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -1588,7 +1589,7 @@ public class TraceRpcModuleTests
         IStreamableResult streaming = (IStreamableResult)result.Data;
 
         await using AsyncCompletingStream stream = new();
-        System.IO.Pipelines.PipeWriter writer = System.IO.Pipelines.PipeWriter.Create(stream);
+        PipeWriter writer = PipeWriter.Create(stream);
 
         Assert.DoesNotThrowAsync(async () => await streaming.WriteToAsync(writer, CancellationToken.None));
 

--- a/src/Nethermind/Nethermind.JsonRpc.TraceStore.Test/TraceStoreRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.TraceStore.Test/TraceStoreRpcModuleTests.cs
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.IO.Pipelines;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.IO;
 using Nethermind.Db;
 using Nethermind.Blockchain.Tracing.ParityStyle;
 using Nethermind.Facade.Eth.RpcTransaction;
@@ -114,6 +118,23 @@ public class TraceStoreRpcModuleTests
         Assert.That(JToken.Parse(Serializer.Serialize(test.Module.trace_filter(new TraceFilterForRpc { FromBlock = new BlockParameter(1), ToBlock = BlockParameter.Latest }))), Is.EqualTo(JToken.Parse(Serializer.Serialize(ResultWrapper<IEnumerable<ParityTxTraceFromStore>>.Success(test.NonDbTraces.SelectMany(ParityTxTraceFromStore.FromTxTrace))))).Using(JToken.EqualityComparer));
 
         test.InnerModule.Received().trace_filter(Arg.Any<TraceFilterForRpc>());
+    }
+
+    [Test]
+    public async Task trace_block_to_async_stream()
+    {
+        TestContext test = new();
+
+        ResultWrapper<IEnumerable<ParityTxTraceFromStore>> result = test.Module.trace_block(BlockParameter.Latest);
+        Assert.That(result.Data, Is.AssignableTo<IStreamableResult>());
+        IStreamableResult streaming = (IStreamableResult)result.Data;
+
+        await using AsyncCompletingStream stream = new();
+        PipeWriter writer = PipeWriter.Create(stream);
+
+        Assert.DoesNotThrowAsync(async () => await streaming.WriteToAsync(writer, CancellationToken.None));
+
+        await writer.CompleteAsync();
     }
 
     private class TestContext

--- a/src/Nethermind/Nethermind.JsonRpc.TraceStore/TraceStoreRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.TraceStore/TraceStoreRpcModule.cs
@@ -7,6 +7,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Evm;
 using Nethermind.Blockchain.Tracing.ParityStyle;
@@ -58,7 +59,7 @@ public class TraceStoreRpcModule(ITraceRpcModule traceModule,
     {
         if (pipeWriter is null) return;
         writer.Flush();
-        pipeWriter.FlushAsync(ct).GetAwaiter().GetResult();
+        pipeWriter.FlushAsync(ct).SafeWait();
     }
 
     private ResultWrapper<IEnumerable<T>> BuildStoreStreamingResult<T>(

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/GethLikeTxTraceStreamingBundleResult.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/GethLikeTxTraceStreamingBundleResult.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Facade.Eth.RpcTransaction;
 using Nethermind.Logging;
 
@@ -116,7 +117,7 @@ public sealed class GethLikeTxTraceStreamingBundleResult : JsonStreamingResultBa
     {
         if (pipeWriter is null) return;
         writer.Flush();
-        pipeWriter.FlushAsync(cancellationToken).GetAwaiter().GetResult();
+        pipeWriter.FlushAsync(cancellationToken).SafeWait();
     }
 }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/StreamingParityLikeBlockTracer.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Trace/StreamingParityLikeBlockTracer.cs
@@ -10,6 +10,7 @@ using Nethermind.Blockchain.Tracing.ParityStyle;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 using Nethermind.Serialization.Json;
 
@@ -218,6 +219,6 @@ public sealed class StreamingParityLikeBlockTracer : ParityLikeBlockTracer, IDis
     {
         if (_pipeWriter is null) return;
         _writer.Flush();
-        _pipeWriter.FlushAsync(_cancellationToken).GetAwaiter().GetResult();
+        _pipeWriter.FlushAsync(_cancellationToken).SafeWait();
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/StreamPipeWriter.cs
@@ -338,7 +338,6 @@ public sealed class CountingStreamPipeWriter : CountingWriter
 
     private void Cancel() => InternalTokenSource.Cancel();
 
-    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
     private async ValueTask<FlushResult> FlushAsyncInternal(bool writeToStream, ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
     {
         // Write all completed segments and whatever remains in the current segment


### PR DESCRIPTION
Fixes #12005

Fixes unsafe synchonous waiting of potentially non-completed `ValueTask`s (check number 3 [here](https://devblogs.microsoft.com/dotnet/understanding-the-whys-whats-and-whens-of-valuetask/#valid-consumption-patterns-for-valuetasks)).

## Changes

- Drop pooled value-task builder in `CountingStreamPipeWriter` flushing.
  - Now uses default one, creating new underlying `Task` instance if waiting is needed.
- `SafeWait` extension method safely waiting for `ValueTask` (via `AsTask` if not completed).
  - Won't allocate for `Task`-backed `ValueTask`s (as above).
- Replaced `.GetAwaiter().GetResult()` with `SafeWait` during flushing for the following streaming RPCs:
  - `debug_*` (Geth-style streaming tracer);
  - `trace_*` (Parity-style streaming tracer and TraceStore plugin when enabled).
- Tests exercising the fix.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Remarks

- Related benchmarks like one in https://github.com/NethermindEth/nethermind/pull/11755 may need to be rerun.
- Alternative approaches considered:
  - Making all parent calls `async` - questionable changes accross 20+ files.
  - Using `[ThreadLocal] ManualResetEventSlim` to avoid potential allocation on `AsTask`.
