### PR TITLE
remove total difficulty from eth_getBlockByNumber/Hash

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Eth/BlockForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/BlockForRpc.cs
@@ -70,11 +70,6 @@ public class BlockForRpc
                 SlotNumber = block.SlotNumber;
             }
 
-            // Intentional divergence from Geth: non-merge chains still emit totalDifficulty when it's loaded.
-            if (specProvider.MergeBlockNumber is null)
-            {
-                TotalDifficulty = block.TotalDifficulty;
-            }
         }
 
         Number = block.Number;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1428,6 +1428,19 @@ public partial class EthRpcModuleTests
         }
     }
 
+    [TestCase(true, TestName = "ByHash")]
+    [TestCase(false, TestName = "ByNumber")]
+    public async Task EthGetBlockByX_OmitsTotalDifficulty(bool byHash)
+    {
+        using Context ctx = await Context.Create();
+        string method = byHash ? "eth_getBlockByHash" : "eth_getBlockByNumber";
+        string param = byHash ? ctx.Test.BlockTree.Genesis!.Hash!.ToString() : "latest";
+        string serialized = await ctx.Test.TestEthRpc(method, param, "false");
+        JObject result = (JObject)JToken.Parse(serialized)["result"]!;
+
+        Assert.That(result.ContainsKey("totalDifficulty"), Is.False);
+    }
+
     [TestCase("eth_getHeaderByHash", "0x0000000000000000000000000000000000000000000000000000000000000000", TestName = "UnknownHash")]
     [TestCase("eth_getHeaderByNumber", "0x9999999", TestName = "UnknownNumber")]
     [TestCase("eth_getHeaderByNumber", "finalized", TestName = "FinalizedAbsent")]


### PR DESCRIPTION
Fixes #12007

## Changes

- Remove `totalDifficulty` from `eth_getBlockByNumber` and `eth_getBlockByHash` responses to match Geth behaviour
- Add regression tests asserting `totalDifficulty` is absent from block RPC responses

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added `EthGetBlockByX_OmitsTotalDifficulty` parameterised over both `eth_getBlockByHash` and `eth_getBlockByNumber`.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] Yes

`totalDifficulty` is no longer included in `eth_getBlockByNumber` and `eth_getBlockByHash` responses, matching Geth behaviour. Clients relying on this field should derive total difficulty from other sources.

## Remarks

Previously `BlockForRpc` set `TotalDifficulty` for non-merge chains (`specProvider.MergeBlockNumber is null`). The field is now unconditionally omitted.
