### PR TITLE
change message to return execution reverted in access list 

### DIFF
--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -365,6 +365,35 @@ public class BlockchainBridgeTests
         Assert.That(callOutput.AccessList!.Any(e => e.Address == PrecompiledAddresses.ECRecover), Is.True);
     }
 
+    [TestCase(null, null)]
+    [TestCase(null, "some plain error string")]
+    public void CreateAccessList_reverting_tx_returns_execution_reverted_error(byte[]? returnValue, string? tracerError)
+    {
+        BlockHeader header = Build.A.BlockHeader.TestObject;
+        Transaction tx = Build.A.Transaction
+            .WithSenderAddress(TestItem.AddressA)
+            .WithTo(TestItem.AddressB)
+            .TestObject;
+
+        _transactionProcessor.CallAndRestore(Arg.Any<Transaction>(), Arg.Any<ITxTracer>())
+            .Returns(callInfo =>
+            {
+                ITxTracer tracer = callInfo.ArgAt<ITxTracer>(1);
+                tracer.ReportAction(tx.GasLimit, UInt256.Zero, TestItem.AddressA, TestItem.AddressB, ReadOnlyMemory<byte>.Empty, ExecutionType.TRANSACTION);
+                tracer.ReportActionError(EvmExceptionType.Revert);
+                tracer.MarkAsFailed(TestItem.AddressB, new GasConsumed(21000, 0), returnValue ?? [], tracerError);
+                return TransactionResult.EvmException(EvmExceptionType.Revert);
+            });
+
+        CallOutput callOutput = _blockchainBridge.CreateAccessList(header, tx, null, false, null, default);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(callOutput.Error, Is.EqualTo("execution reverted"));
+            Assert.That(callOutput.ExecutionReverted, Is.True);
+        }
+    }
+
     private CallOutput InvokeCreateAccessListWithMockedAccess(
         bool optimize,
         Address[] accessedAddresses,

--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -366,6 +366,7 @@ public class BlockchainBridgeTests
     }
 
     [TestCase(null, null)]
+    [TestCase(null, "revert")]
     [TestCase(null, "some plain error string")]
     public void CreateAccessList_reverting_tx_returns_execution_reverted_error(byte[]? returnValue, string? tracerError)
     {

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -341,13 +341,21 @@ namespace Nethermind.Facade
                 previousAccessList = accessTracer.AccessList;
             } while (!stop);
 
+            bool executionReverted = result.EvmExceptionType == EvmExceptionType.Revert;
+            // Geth always surfaces plain "execution reverted" for eth_createAccessList,
+            // regardless of whether the revert payload carries a decoded reason.
+            string? error = executionReverted
+                ? "execution reverted"
+                : result.GetErrorMessage(outputTracer.Error);
+
             return new CallOutput
             {
-                Error = result.GetErrorMessage(outputTracer.Error),
+                Error = error,
                 GasSpent = outputTracer.GasSpent,
                 OperationGas = outputTracer.OperationGas,
                 OutputData = outputTracer.ReturnValue,
                 InputError = !result.TransactionExecuted,
+                ExecutionReverted = executionReverted,
                 AccessList = accessTracer.AccessList,
             };
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -2213,7 +2213,7 @@ public partial class EthRpcModuleTests
 
         (JToken result, long gasUsed) = await CallCreateAccessList(ctx, transaction, stateOverrideJson: null, optimize: true);
 
-        Assert.That(result["error"]!.Value<string>(), Is.EqualTo("revert"));
+        Assert.That(result["error"]!.Value<string>(), Is.EqualTo("execution reverted"));
         Assert.That(gasUsed, Is.EqualTo(77496));
         // AL must contain the newly created contract address with storage key 0x81.
         // Contract address is deterministic: keccak256(rlp([sender, nonce=0]))[12:]


### PR DESCRIPTION
Fixes #12012

## Changes

- `eth_createAccessList`: `ConvergeAccessList` now detects execution reverts via `EvmExceptionType.Revert` and always returns `"execution reverted"` in the error field, matching Geth (previously returned the raw tracer label `"revert"`)
- **Please note in access list geth ignores the Error message but we did not previously , should i add execution reverted with data instead as we do for other calls , but then it will be a mismatch with geth** 

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- Added `CreateAccessList_reverting_tx_returns_execution_reverted_error` in `BlockchainBridgeTests` — two `[TestCase]` variants (null payload + null error, null payload + plain error string) both assert `Error == "execution reverted"` and `ExecutionReverted == true`
- Updated `Eth_createAccessList_gas_calculation_reverting_sstore_returns_access_list_and_vm_error` in `EthRpcModuleTests` to expect `"execution reverted"` instead of `"revert"`

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
