### PR TITLE
style: enforce IDE0063 (use simple `using` statement)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -75,7 +75,7 @@ dotnet_style_namespace_match_folder = true:warning
 
 csharp_indent_labels = one_less_than_current
 csharp_using_directive_placement = outside_namespace:silent
-csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_simple_using_statement = true:warning
 csharp_prefer_braces = when_multiline:suggestion
 csharp_style_namespace_declarations = file_scoped:suggestion
 csharp_style_prefer_method_group_conversion = true:silent

--- a/src/Nethermind/Ethereum.Test.Base/TestLoader.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TestLoader.cs
@@ -65,16 +65,12 @@ public static class TestLoader
             DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
             NumberHandling = JsonNumberHandling.AllowReadingFromString
         };
-        using (Stream stream = assembly.GetManifestResourceStream(resourceName))
-        {
-            Assert.That(stream, Is.Not.Null);
-            using (StreamReader reader = new(stream))
-            {
-                string testJson = reader.ReadToEnd();
-                TContainer testSpecs =
-                    JsonSerializer.Deserialize<TContainer>(testJson, jsonOptions);
-                return testExtractor(testSpecs);
-            }
-        }
+        using Stream stream = assembly.GetManifestResourceStream(resourceName);
+        Assert.That(stream, Is.Not.Null);
+        using StreamReader reader = new(stream);
+        string testJson = reader.ReadToEnd();
+        TContainer testSpecs =
+            JsonSerializer.Deserialize<TContainer>(testJson, jsonOptions);
+        return testExtractor(testSpecs);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Data/FileLocalDataSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Data/FileLocalDataSourceTests.cs
@@ -21,41 +21,35 @@ public class FileLocalDataSourceTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void correctly_reads_existing_file()
     {
-        using (TempPath tempFile = TempPath.GetTempFile())
-        {
-            File.WriteAllText(tempFile.Path, GenerateStringJson("A", "B", "C"));
-            // var x = new EthereumJsonSerializer().Serialize(new string []{"A", "B", "C"});
-            using FileLocalDataSource<string[]> fileLocalDataSource = new(tempFile.Path, new EthereumJsonSerializer(), new RealFileSystem(), LimboLogs.Instance);
-            Assert.That(fileLocalDataSource.Data, Is.EqualTo(new[] { "A", "B", "C" }));
-        }
+        using TempPath tempFile = TempPath.GetTempFile();
+        File.WriteAllText(tempFile.Path, GenerateStringJson("A", "B", "C"));
+        // var x = new EthereumJsonSerializer().Serialize(new string []{"A", "B", "C"});
+        using FileLocalDataSource<string[]> fileLocalDataSource = new(tempFile.Path, new EthereumJsonSerializer(), new RealFileSystem(), LimboLogs.Instance);
+        Assert.That(fileLocalDataSource.Data, Is.EqualTo(new[] { "A", "B", "C" }));
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
     public async Task correctly_updates_from_existing_file()
     {
-        using (TempPath tempFile = TempPath.GetTempFile())
+        using TempPath tempFile = TempPath.GetTempFile();
+        await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("A"));
+        int interval = 30;
+        using FileLocalDataSource<string[]> fileLocalDataSource = new(tempFile.Path, new EthereumJsonSerializer(), new RealFileSystem(), LimboLogs.Instance, interval);
+        int changedRaised = 0;
+        SemaphoreSlim handle = new(0);
+        fileLocalDataSource.Changed += (sender, args) =>
         {
-            await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("A"));
-            int interval = 30;
-            using (FileLocalDataSource<string[]> fileLocalDataSource = new(tempFile.Path, new EthereumJsonSerializer(), new RealFileSystem(), LimboLogs.Instance, interval))
-            {
-                int changedRaised = 0;
-                SemaphoreSlim handle = new(0);
-                fileLocalDataSource.Changed += (sender, args) =>
-                {
-                    Interlocked.Increment(ref changedRaised);
-                    handle.Release();
-                };
-                await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("C", "B"));
-                await WaitForData(fileLocalDataSource, ["C", "B"], handle);
-                Assert.That(changedRaised, Is.GreaterThanOrEqualTo(1));
+            Interlocked.Increment(ref changedRaised);
+            handle.Release();
+        };
+        await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("C", "B"));
+        await WaitForData(fileLocalDataSource, ["C", "B"], handle);
+        Assert.That(changedRaised, Is.GreaterThanOrEqualTo(1));
 
-                int afterFirst = Volatile.Read(ref changedRaised);
-                await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("E", "F"));
-                await WaitForData(fileLocalDataSource, ["E", "F"], handle);
-                Assert.That(Volatile.Read(ref changedRaised), Is.GreaterThan(afterFirst));
-            }
-        }
+        int afterFirst = Volatile.Read(ref changedRaised);
+        await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("E", "F"));
+        await WaitForData(fileLocalDataSource, ["E", "F"], handle);
+        Assert.That(Volatile.Read(ref changedRaised), Is.GreaterThan(afterFirst));
     }
 
     private static async Task WaitForData(FileLocalDataSource<string[]> source, string[] expected, SemaphoreSlim handle)
@@ -80,20 +74,18 @@ public class FileLocalDataSourceTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public async Task correctly_updates_from_new_file()
     {
-        using (TempPath tempFile = TempPath.GetTempFile())
-        using (FileLocalDataSource<string[]> fileLocalDataSource = new(tempFile.Path, new EthereumJsonSerializer(), new RealFileSystem(), LimboLogs.Instance, 10))
+        using TempPath tempFile = TempPath.GetTempFile();
+        using FileLocalDataSource<string[]> fileLocalDataSource = new(tempFile.Path, new EthereumJsonSerializer(), new RealFileSystem(), LimboLogs.Instance, 10);
+        int changedRaised = 0;
+        SemaphoreSlim handle = new(0);
+        fileLocalDataSource.Changed += (sender, args) =>
         {
-            int changedRaised = 0;
-            SemaphoreSlim handle = new(0);
-            fileLocalDataSource.Changed += (sender, args) =>
-            {
-                Interlocked.Increment(ref changedRaised);
-                handle.Release();
-            };
-            await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("A", "B"));
-            await WaitForData(fileLocalDataSource, ["A", "B"], handle);
-            Assert.That(changedRaised, Is.GreaterThanOrEqualTo(1));
-        }
+            Interlocked.Increment(ref changedRaised);
+            handle.Release();
+        };
+        await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("A", "B"));
+        await WaitForData(fileLocalDataSource, ["A", "B"], handle);
+        Assert.That(changedRaised, Is.GreaterThanOrEqualTo(1));
     }
 
     private static string GenerateStringJson(params string[] items) => $"[{string.Join(", ", items.Select(static i => $"\"{i}\""))}]";
@@ -113,54 +105,48 @@ public class FileLocalDataSourceTests
     [Ignore("Causing repeated pains on GitHub actions.")]
     public async Task retries_loading_file()
     {
-        using (TempPath tempFile = TempPath.GetTempFile())
+        using TempPath tempFile = TempPath.GetTempFile();
+        await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("A", "B", "C"));
+        int interval = 30;
+        using FileLocalDataSource<string[]> fileLocalDataSource = new(tempFile.Path, new EthereumJsonSerializer(), new RealFileSystem(), LimboLogs.Instance, interval);
+        using (FileStream file = File.Open(tempFile.Path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
         {
-            await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("A", "B", "C"));
-            int interval = 30;
-            using FileLocalDataSource<string[]> fileLocalDataSource = new(tempFile.Path, new EthereumJsonSerializer(), new RealFileSystem(), LimboLogs.Instance, interval);
-            using (FileStream file = File.Open(tempFile.Path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+            using (StreamWriter writer = new(file, leaveOpen: true))
             {
-                using (StreamWriter writer = new(file, leaveOpen: true))
-                {
-                    await writer.WriteAsync(GenerateStringJson("A", "B", "C", "D"));
-                }
-
-                await Task.Delay(10 * interval);
-
-                Assert.That(fileLocalDataSource.Data, Is.EqualTo(new[] { "A", "B", "C" }));
+                await writer.WriteAsync(GenerateStringJson("A", "B", "C", "D"));
             }
 
             await Task.Delay(10 * interval);
 
-            Assert.That(fileLocalDataSource.Data, Is.EqualTo(new[] { "A", "B", "C", "D" }));
+            Assert.That(fileLocalDataSource.Data, Is.EqualTo(new[] { "A", "B", "C" }));
         }
+
+        await Task.Delay(10 * interval);
+
+        Assert.That(fileLocalDataSource.Data, Is.EqualTo(new[] { "A", "B", "C", "D" }));
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
     public async Task loads_default_when_deleted_file()
     {
-        using (TempPath tempFile = TempPath.GetTempFile())
+        using TempPath tempFile = TempPath.GetTempFile();
+        await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("A"));
+        using FileLocalDataSource<string[]> fileLocalDataSource = new(tempFile.Path, new EthereumJsonSerializer(), new RealFileSystem(), LimboLogs.Instance, 50);
+        int changedRaised = 0;
+        SemaphoreSlim handle = new(0);
+        fileLocalDataSource.Changed += (sender, args) =>
         {
-            await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("A"));
-            using (FileLocalDataSource<string[]> fileLocalDataSource = new(tempFile.Path, new EthereumJsonSerializer(), new RealFileSystem(), LimboLogs.Instance, 50))
-            {
-                int changedRaised = 0;
-                SemaphoreSlim handle = new(0);
-                fileLocalDataSource.Changed += (sender, args) =>
-                {
-                    Interlocked.Increment(ref changedRaised);
-                    handle.Release();
-                };
-                await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("C", "B"));
-                await WaitForData(fileLocalDataSource, ["C", "B"], handle);
-                Assert.That(changedRaised, Is.GreaterThanOrEqualTo(1));
+            Interlocked.Increment(ref changedRaised);
+            handle.Release();
+        };
+        await File.WriteAllTextAsync(tempFile.Path, GenerateStringJson("C", "B"));
+        await WaitForData(fileLocalDataSource, ["C", "B"], handle);
+        Assert.That(changedRaised, Is.GreaterThanOrEqualTo(1));
 
-                int afterFirst = Volatile.Read(ref changedRaised);
-                File.Delete(tempFile.Path);
-                await WaitForCondition(handle, () => fileLocalDataSource.Data is null);
-                Assert.That(fileLocalDataSource.Data, Is.Null);
-                Assert.That(Volatile.Read(ref changedRaised), Is.GreaterThan(afterFirst));
-            }
-        }
+        int afterFirst = Volatile.Read(ref changedRaised);
+        File.Delete(tempFile.Path);
+        await WaitForCondition(handle, () => fileLocalDataSource.Data is null);
+        Assert.That(fileLocalDataSource.Data, Is.Null);
+        Assert.That(Volatile.Read(ref changedRaised), Is.GreaterThan(afterFirst));
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
@@ -195,19 +195,17 @@ namespace Nethermind.Core.Test
 
             try
             {
-                using (MemoryStream ms = new())
-                {
-                    sw = new StreamWriter(ms);
-                    sr = new StreamReader(ms);
+                using MemoryStream ms = new();
+                sw = new StreamWriter(ms);
+                sr = new StreamReader(ms);
 
-                    bytes.StreamHex(sw);
-                    sw.Flush();
+                bytes.StreamHex(sw);
+                sw.Flush();
 
-                    ms.Position = 0;
+                ms.Position = 0;
 
-                    string result = sr.ReadToEnd();
-                    Assert.That(result, Is.EqualTo("0f10ff"));
-                }
+                string result = sr.ReadToEnd();
+                Assert.That(result, Is.EqualTo("0f10ff"));
             }
             finally
             {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/CompactReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/CompactReceiptDecoderTests.cs
@@ -206,11 +206,9 @@ namespace Nethermind.Core.Test.Encoding
 
             CompactReceiptStorageDecoder decoder = new();
             Rlp rlp = decoder.Encode(receipts);
-            using (NettyRlpStream nettyRlpStream = decoder.EncodeToNewNettyStream(receipts))
-            {
-                byte[] nettyBytes = nettyRlpStream.AsSpan().ToArray();
-                Assert.That(nettyBytes, Is.EqualTo(rlp.Bytes));
-            }
+            using NettyRlpStream nettyRlpStream = decoder.EncodeToNewNettyStream(receipts);
+            byte[] nettyBytes = nettyRlpStream.AsSpan().ToArray();
+            Assert.That(nettyBytes, Is.EqualTo(rlp.Bytes));
         }
 
         public static IEnumerable<(TxReceipt, string)> TestCaseSource()

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptDecoderTests.cs
@@ -228,11 +228,9 @@ namespace Nethermind.Core.Test.Encoding
 
             ReceiptStorageDecoder decoder = new();
             Rlp rlp = decoder.Encode(receipts);
-            using (NettyRlpStream nettyRlpStream = decoder.EncodeToNewNettyStream(receipts))
-            {
-                byte[] nettyBytes = nettyRlpStream.AsSpan().ToArray();
-                Assert.That(nettyBytes, Is.EqualTo(rlp.Bytes));
-            }
+            using NettyRlpStream nettyRlpStream = decoder.EncodeToNewNettyStream(receipts);
+            byte[] nettyBytes = nettyRlpStream.AsSpan().ToArray();
+            Assert.That(nettyBytes, Is.EqualTo(rlp.Bytes));
         }
 
         public static IEnumerable<(TxReceipt, string)> TestCaseSource()

--- a/src/Nethermind/Nethermind.Db.Test/LogIndex/LogIndexStorageIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/LogIndex/LogIndexStorageIntegrationTests.cs
@@ -237,8 +237,8 @@ namespace Nethermind.Db.Test.LogIndex
             }
 
             // Create new storage to force-load everything from DB
-            await using (ILogIndexStorage testStorage = CreateLogIndexStorage(compactionDistance))
-                VerifyReceipts(testStorage, testData);
+            await using ILogIndexStorage testStorage = CreateLogIndexStorage(compactionDistance);
+            VerifyReceipts(testStorage, testData);
         }
 
         [Combinatorial]

--- a/src/Nethermind/Nethermind.Evm.Test/VmStateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VmStateTests.cs
@@ -63,10 +63,8 @@ namespace Nethermind.Evm.Test
         public void Nothing_to_commit()
         {
             VmState<EthereumGasPolicy> parentVmState = CreateEvmState();
-            using (VmState<EthereumGasPolicy> vmState = CreateEvmState(parentVmState))
-            {
-                vmState.CommitToParent(parentVmState);
-            }
+            using VmState<EthereumGasPolicy> vmState = CreateEvmState(parentVmState);
+            vmState.CommitToParent(parentVmState);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -246,6 +246,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                 }
 
                 // For nested call frames, merge the results and restore the previous execution state.
+#pragma warning disable IDE0063 // Cannot simplify: the `goto Failure` above jumps past this scope, which a `using` declaration would forbid (CS8648)
                 using (VmState<TGasPolicy> previousState = _currentState)
                 {
                     // Restore the previous state from the stack and mark it as a continuation.
@@ -305,6 +306,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                         HandleRevert(previousState, callResult, ref previousCallOutput);
                     }
                 }
+#pragma warning restore IDE0063
             }
             // Handle specific EVM or overflow exceptions by routing to the failure handling block.
             catch (Exception ex) when (ex is EvmException or OverflowException)

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/RlpItemListTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/Messages/RlpItemListTests.cs
@@ -230,11 +230,9 @@ public class RlpItemListTests
             Assert.That(child0.ReadContent(1).ToArray(), Is.EqualTo(new byte[] { 0x02 }));
         }
 
-        using (IRlpItemList child1 = outer.GetNestedItemList(1))
-        {
-            Assert.That(child1.Count, Is.EqualTo(1));
-            Assert.That(child1.ReadContent(0).ToArray(), Is.EqualTo(new byte[] { 0x03 }));
-        }
+        using IRlpItemList child1 = outer.GetNestedItemList(1);
+        Assert.That(child1.Count, Is.EqualTo(1));
+        Assert.That(child1.ReadContent(0).ToArray(), Is.EqualTo(new byte[] { 0x03 }));
     }
 
     [TestCaseSource(nameof(TestCases))]
@@ -297,12 +295,10 @@ public class RlpItemListTests
         }
 
         // After disposing child0, the next GetNestedItemList should reuse the pooled child.
-        using (IRlpItemList child1 = outer.GetNestedItemList(1))
-        {
-            Assert.That(child1.Count, Is.EqualTo(2));
-            Assert.That(child1.ReadContent(0).ToArray(), Is.EqualTo(new byte[] { 0x33 }));
-            Assert.That(child1.ReadContent(1).ToArray(), Is.EqualTo(new byte[] { 0x44 }));
-        }
+        using IRlpItemList child1 = outer.GetNestedItemList(1);
+        Assert.That(child1.Count, Is.EqualTo(2));
+        Assert.That(child1.ReadContent(0).ToArray(), Is.EqualTo(new byte[] { 0x33 }));
+        Assert.That(child1.ReadContent(1).ToArray(), Is.EqualTo(new byte[] { 0x44 }));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatOverridableWorldScopeTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatOverridableWorldScopeTests.cs
@@ -121,11 +121,9 @@ public class FlatOverridableWorldScopeTests
             {
                 writeBatch.Set(testAddress, testAccount);
 
-                using (IWorldStateScopeProvider.IStorageWriteBatch storageBatch = writeBatch.CreateStorageWriteBatch(testAddress, 2))
-                {
-                    storageBatch.Set(storageIndex1, storageValue1);
-                    storageBatch.Set(storageIndex2, storageValue2);
-                }
+                using IWorldStateScopeProvider.IStorageWriteBatch storageBatch = writeBatch.CreateStorageWriteBatch(testAddress, 2);
+                storageBatch.Set(storageIndex1, storageValue1);
+                storageBatch.Set(storageIndex2, storageValue2);
             }
             scope.Commit(1);
             baseBlock = Build.A.BlockHeader.WithNumber(1).WithStateRoot(scope.RootHash).TestObject;

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -87,10 +87,8 @@ public class ScopeProviderTests(bool useFlat)
             {
                 writeBatch.Set(TestItem.AddressA, new Account(100, 100));
 
-                using (IWorldStateScopeProvider.IStorageWriteBatch storageSet = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1))
-                {
-                    storageSet.Set(1, [1, 2, 3]);
-                }
+                using IWorldStateScopeProvider.IStorageWriteBatch storageSet = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1);
+                storageSet.Set(1, [1, 2, 3]);
             }
 
             scope.Commit(1);
@@ -114,10 +112,8 @@ public class ScopeProviderTests(bool useFlat)
 
         using (IWorldStateScopeProvider.IScope scope = ctx.ScopeProvider.BeginScope(null))
         {
-            using (IWorldStateScopeProvider.ICodeSetter writer = scope.CodeDb.BeginCodeWrite())
-            {
-                writer.Set(TestItem.KeccakA, [1, 2, 3]);
-            }
+            using IWorldStateScopeProvider.ICodeSetter writer = scope.CodeDb.BeginCodeWrite();
+            writer.Set(TestItem.KeccakA, [1, 2, 3]);
         }
 
         if (!useFlat)
@@ -140,15 +136,13 @@ public class ScopeProviderTests(bool useFlat)
         // Simulates the EIP-161 scenario: storage is flushed for an account that was
         // then deleted (set to null) during state commit. The write batch Dispose should
         // skip the storage root update for the deleted account instead of throwing.
-        using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(1))
+        using IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(1);
+        using (IWorldStateScopeProvider.IStorageWriteBatch storageSet = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1))
         {
-            using (IWorldStateScopeProvider.IStorageWriteBatch storageSet = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1))
-            {
-                storageSet.Set(1, [1, 2, 3]);
-            }
-
-            writeBatch.Set(TestItem.AddressA, null);
+            storageSet.Set(1, [1, 2, 3]);
         }
+
+        writeBatch.Set(TestItem.AddressA, null);
     }
 
     [Test]
@@ -171,10 +165,8 @@ public class ScopeProviderTests(bool useFlat)
                     storageA.Set(2, [30, 40]);
                 }
 
-                using (IWorldStateScopeProvider.IStorageWriteBatch storageB = writeBatch.CreateStorageWriteBatch(TestItem.AddressB, 1))
-                {
-                    storageB.Set(5, [50, 60]);
-                }
+                using IWorldStateScopeProvider.IStorageWriteBatch storageB = writeBatch.CreateStorageWriteBatch(TestItem.AddressB, 1);
+                storageB.Set(5, [50, 60]);
             }
 
             scope.Commit(1);
@@ -283,10 +275,8 @@ public class ScopeProviderTests(bool useFlat)
                 writeBatch.Set(TestItem.AddressA, new Account(100, 100));
                 writeBatch.Set(TestItem.AddressB, new Account(200, 200));
 
-                using (IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1))
-                {
-                    storageA.Set(1, [10, 20]);
-                }
+                using IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1);
+                storageA.Set(1, [10, 20]);
             }
 
             scope.Commit(1);
@@ -317,10 +307,8 @@ public class ScopeProviderTests(bool useFlat)
             using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(1))
             {
                 writeBatch.Set(TestItem.AddressA, new Account(100, 100));
-                using (IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1))
-                {
-                    storageA.Set(1, [10, 20]);
-                }
+                using IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1);
+                storageA.Set(1, [10, 20]);
             }
 
             scope.Commit(1);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -640,11 +640,9 @@ public class SyncServerTests
         IScopedTrieStore scopedTrieStore = trieStore.GetTrieStore(null);
         using (IBlockCommitter _ = trieStore.BeginBlockCommit(1))
         {
-            using (ICommitter committer = scopedTrieStore.BeginCommit(node))
-            {
-                TreePath path = TreePath.Empty;
-                committer.CommitNode(ref path, node);
-            }
+            using ICommitter committer = scopedTrieStore.BeginCommit(node);
+            TreePath path = TreePath.Empty;
+            committer.CommitNode(ref path, node);
         }
 
         Assert.That(stateDb.KeyExists(nodeKey), Is.False);

--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -347,14 +347,12 @@ namespace Nethermind.Trie.Test.Pruning
             {
                 TrieNode fakeRoot = new(NodeType.Leaf, []); // 192B
                 fakeRoot.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath);
-                using (ICommitter committer = fullTrieStore.BeginStateBlockCommit(i, fakeRoot))
+                using ICommitter committer = fullTrieStore.BeginStateBlockCommit(i, fakeRoot);
+                for (int j = 0; j < 1 + i % 3; j++)
                 {
-                    for (int j = 0; j < 1 + i % 3; j++)
-                    {
-                        TrieNode trieNode = new(NodeType.Leaf, []); // 192B
-                        trieNode.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath);
-                        committer.CommitNode(ref emptyPath, trieNode);
-                    }
+                    TrieNode trieNode = new(NodeType.Leaf, []); // 192B
+                    trieNode.ResolveKey(NullTrieNodeResolver.Instance, ref emptyPath);
+                    committer.CommitNode(ref emptyPath, trieNode);
                 }
             }
 
@@ -658,8 +656,7 @@ namespace Nethermind.Trie.Test.Pruning
                     committer.CommitNode(ref emptyPath, storage1);
                 }
 
-                using (ICommitter _ = trieStore.BeginCommit(a)) { }
-
+                using ICommitter _ = trieStore.BeginCommit(a);
             }
 
             using (ICommitter _ = fullTrieStore.BeginStateBlockCommit(2, a)) { }
@@ -1232,10 +1229,8 @@ namespace Nethermind.Trie.Test.Pruning
             for (int i = 0; i < 2; i++)
             {
                 TrieNode node = new(NodeType.Leaf, TestItem.Keccaks[i % 4], new CappedArray<byte>(new byte[2]));
-                using (ICommitter committer = fullTrieStore.BeginStateBlockCommit(i + 1, node))
-                {
-                    committer.CommitNode(ref emptyPath, node);
-                }
+                using ICommitter committer = fullTrieStore.BeginStateBlockCommit(i + 1, node);
+                committer.CommitNode(ref emptyPath, node);
             }
 
             fullTrieStore.Dispose();
@@ -1742,7 +1737,7 @@ namespace Nethermind.Trie.Test.Pruning
             TrieNode trieNode = new(NodeType.Leaf, Keccak.Zero);
             Action commitBlock1 = () =>
             {
-                using (ICommitter _ = fullTrieStore.BeginStateBlockCommit(1, trieNode)) { }
+                using ICommitter _ = fullTrieStore.BeginStateBlockCommit(1, trieNode);
             };
 
             Assert.That(commitBlock1, Throws.Nothing);

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -931,11 +931,9 @@ public class TrieNodeTests
 
         using (IBlockCommitter _ = fullTrieStore.BeginBlockCommit(0))
         {
-            using (ICommitter? committer = trieStore.BeginCommit(leaf2))
-            {
-                committer.CommitNode(ref path, leaf1);
-                committer.CommitNode(ref path, leaf2);
-            }
+            using ICommitter? committer = trieStore.BeginCommit(leaf2);
+            committer.CommitNode(ref path, leaf1);
+            committer.CommitNode(ref path, leaf2);
         }
 
         TrieNode trieNode = new(NodeType.Branch);

--- a/tools/StatsAnalyzer/Nethermind.StatsAnalyzer.Plugin/Tracer/StatsAnalyzerFileTracer.cs
+++ b/tools/StatsAnalyzer/Nethermind.StatsAnalyzer.Plugin/Tracer/StatsAnalyzerFileTracer.cs
@@ -182,10 +182,8 @@ public abstract class StatsAnalyzerFileTracer<TxTrace, TxTracer>(
 
         ct.ThrowIfCancellationRequested();
 
-        using (Stream file = fileSystem.File.Open(fileName, FileMode.Create, FileAccess.Write))
-        using (Utf8JsonWriter jsonWriter = new(file))
-        {
-            JsonSerializer.Serialize(jsonWriter, trace, serializerOptions);
-        }
+        using Stream file = fileSystem.File.Open(fileName, FileMode.Create, FileAccess.Write);
+        using Utf8JsonWriter jsonWriter = new(file);
+        JsonSerializer.Serialize(jsonWriter, trace, serializerOptions);
     }
 }


### PR DESCRIPTION
## Changes

- Raise `csharp_prefer_simple_using_statement` from `suggestion` to `warning` in `.editorconfig`, so IDE0063 is now enforced at build time (`EnforceCodeStyleInBuild` is already enabled).
- Apply the IDE0063 fixer across `Nethermind.slnx` via `dotnet format`, converting braced `using (...) { }` blocks to simple `using` declarations in 12 files. The rule only fires where the disposed scope already extends to the end of the enclosing block, so every conversion is semantics-preserving (dispose timing is unchanged).
- `Nethermind.Evm/VirtualMachine.cs` keeps one braced `using` with an inline `#pragma warning disable IDE0063` + justification: a preceding `goto Failure` jumps past that scope, which a `using` declaration would forbid (CS8648), so IDE0063's own suggested fix does not compile there.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Mechanical, analyzer-driven change. Verified with a full `dotnet build -c release Nethermind.slnx`: build succeeds with zero errors and zero remaining IDE0063 warnings.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No