### PR TITLE
RPC admin_* - pause & resume block processing

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessingPauseGateTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessingPauseGateTests.cs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Consensus.Processing;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test;
+
+[Parallelizable(ParallelScope.All)]
+public class BlockProcessingPauseGateTests
+{
+    [Test]
+    public void Pause_whenRunning_transitionsToPausedAndIsIdempotent()
+    {
+        BlockProcessingPauseGate gate = new();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(gate.IsPaused, Is.False, "a fresh gate starts running");
+            Assert.That(gate.Pause(), Is.True, "the first pause transitions from running to paused");
+            Assert.That(gate.Pause(), Is.False, "pausing an already-paused gate reports no transition");
+            Assert.That(gate.IsPaused, Is.True, "the gate remains paused");
+        }
+    }
+
+    [Test]
+    public void Resume_whenPaused_transitionsToRunningAndIsIdempotent()
+    {
+        BlockProcessingPauseGate gate = new();
+        gate.Pause();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(gate.Resume(), Is.True, "resuming a paused gate transitions to running");
+            Assert.That(gate.Resume(), Is.False, "resuming an already-running gate reports no transition");
+            Assert.That(gate.IsPaused, Is.False, "the gate remains running");
+        }
+    }
+
+    [Test]
+    public void WaitWhilePausedAsync_whenRunning_completesSynchronously()
+    {
+        BlockProcessingPauseGate gate = new();
+
+        ValueTask wait = gate.WaitWhilePausedAsync(CancellationToken.None);
+
+        Assert.That(wait.IsCompleted, Is.True, "the loop must not park when the gate is running");
+    }
+
+    [Test]
+    public async Task WaitWhilePausedAsync_whenPaused_parksUntilResumed()
+    {
+        BlockProcessingPauseGate gate = new();
+        gate.Pause();
+
+        ValueTask parked = gate.WaitWhilePausedAsync(CancellationToken.None);
+        Assert.That(parked.IsCompleted, Is.False, "the loop must park while the gate is paused");
+
+        gate.Resume();
+
+        await parked; // completes deterministically once resumed; no timing window
+        Assert.That(gate.IsPaused, Is.False, "the gate is running after resume");
+    }
+
+    [Test]
+    public void WaitWhilePausedAsync_whenCancelledWhilePaused_throwsOperationCanceled()
+    {
+        BlockProcessingPauseGate gate = new();
+        gate.Pause();
+        using CancellationTokenSource cts = new();
+
+        ValueTask parked = gate.WaitWhilePausedAsync(cts.Token);
+        cts.Cancel();
+
+        Assert.That(async () => await parked, Throws.InstanceOf<OperationCanceledException>());
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessingPauseGateTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessingPauseGateTests.cs
@@ -12,21 +12,21 @@ namespace Nethermind.Blockchain.Test;
 [Parallelizable(ParallelScope.All)]
 public class BlockProcessingPauseGateTests
 {
-    [TestCase(false, true, true, true, TestName = "Pause from running transitions to paused")]
-    [TestCase(true, true, false, true, TestName = "Pause while already paused is a no-op")]
-    [TestCase(true, false, true, false, TestName = "Resume from paused transitions to running")]
-    [TestCase(false, false, false, false, TestName = "Resume while already running is a no-op")]
-    public void Transition_reportsWhetherStateChanged(bool startPaused, bool pause, bool expectedTransitioned, bool expectedPausedAfter)
+    [TestCase(Operation.Pause, false, true, TestName = "Pause from running transitions to paused")]
+    [TestCase(Operation.Pause, true, false, TestName = "Pause while already paused is a no-op")]
+    [TestCase(Operation.Resume, true, true, TestName = "Resume from paused transitions to running")]
+    [TestCase(Operation.Resume, false, false, TestName = "Resume while already running is a no-op")]
+    public void Transition_reportsWhetherStateChanged(Operation operation, bool startPaused, bool expectedTransitioned)
     {
         BlockProcessingPauseGate gate = new();
         if (startPaused) gate.Pause();
 
-        bool transitioned = pause ? gate.Pause() : gate.Resume();
+        bool transitioned = operation == Operation.Pause ? gate.Pause() : gate.Resume();
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(transitioned, Is.EqualTo(expectedTransitioned), "the call reports whether it changed the state");
-            Assert.That(gate.IsPaused, Is.EqualTo(expectedPausedAfter), "the resulting paused state");
+            Assert.That(gate.IsPaused, Is.EqualTo(operation == Operation.Pause), "Pause ends paused; Resume ends running");
         }
     }
 
@@ -65,5 +65,11 @@ public class BlockProcessingPauseGateTests
         cts.Cancel();
 
         Assert.That(async () => await parked, Throws.InstanceOf<OperationCanceledException>());
+    }
+
+    public enum Operation
+    {
+        Pause,
+        Resume
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessingPauseGateTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessingPauseGateTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Processing;
@@ -50,8 +51,7 @@ public class BlockProcessingPauseGateTests
 
         gate.Resume();
 
-        await parked; // completes deterministically once resumed; no timing window
-        Assert.That(gate.IsPaused, Is.False, "the gate is running after resume");
+        await parked;
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessingPauseGateTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessingPauseGateTests.cs
@@ -11,31 +11,21 @@ namespace Nethermind.Blockchain.Test;
 [Parallelizable(ParallelScope.All)]
 public class BlockProcessingPauseGateTests
 {
-    [Test]
-    public void Pause_whenRunning_transitionsToPausedAndIsIdempotent()
+    [TestCase(false, true, true, true, TestName = "Pause from running transitions to paused")]
+    [TestCase(true, true, false, true, TestName = "Pause while already paused is a no-op")]
+    [TestCase(true, false, true, false, TestName = "Resume from paused transitions to running")]
+    [TestCase(false, false, false, false, TestName = "Resume while already running is a no-op")]
+    public void Transition_reportsWhetherStateChanged(bool startPaused, bool pause, bool expectedTransitioned, bool expectedPausedAfter)
     {
         BlockProcessingPauseGate gate = new();
+        if (startPaused) gate.Pause();
+
+        bool transitioned = pause ? gate.Pause() : gate.Resume();
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(gate.IsPaused, Is.False, "a fresh gate starts running");
-            Assert.That(gate.Pause(), Is.True, "the first pause transitions from running to paused");
-            Assert.That(gate.Pause(), Is.False, "pausing an already-paused gate reports no transition");
-            Assert.That(gate.IsPaused, Is.True, "the gate remains paused");
-        }
-    }
-
-    [Test]
-    public void Resume_whenPaused_transitionsToRunningAndIsIdempotent()
-    {
-        BlockProcessingPauseGate gate = new();
-        gate.Pause();
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(gate.Resume(), Is.True, "resuming a paused gate transitions to running");
-            Assert.That(gate.Resume(), Is.False, "resuming an already-running gate reports no transition");
-            Assert.That(gate.IsPaused, Is.False, "the gate remains running");
+            Assert.That(transitioned, Is.EqualTo(expectedTransitioned), "the call reports whether it changed the state");
+            Assert.That(gate.IsPaused, Is.EqualTo(expectedPausedAfter), "the resulting paused state");
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessingPauseGateTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessingPauseGateTests.cs
@@ -12,21 +12,22 @@ namespace Nethermind.Blockchain.Test;
 [Parallelizable(ParallelScope.All)]
 public class BlockProcessingPauseGateTests
 {
-    [TestCase(Operation.Pause, false, true, TestName = "Pause from running transitions to paused")]
-    [TestCase(Operation.Pause, true, false, TestName = "Pause while already paused is a no-op")]
-    [TestCase(Operation.Resume, true, true, TestName = "Resume from paused transitions to running")]
-    [TestCase(Operation.Resume, false, false, TestName = "Resume while already running is a no-op")]
-    public void Transition_reportsWhetherStateChanged(Operation operation, bool startPaused, bool expectedTransitioned)
+    [TestCase(Operation.Pause, false, TestName = "Pause from running transitions to paused")]
+    [TestCase(Operation.Pause, true, TestName = "Pause while already paused is a no-op")]
+    [TestCase(Operation.Resume, true, TestName = "Resume from paused transitions to running")]
+    [TestCase(Operation.Resume, false, TestName = "Resume while already running is a no-op")]
+    public void Transition_reportsWhetherStateChanged(Operation operation, bool startPaused)
     {
         BlockProcessingPauseGate gate = new();
         if (startPaused) gate.Pause();
 
-        bool transitioned = operation == Operation.Pause ? gate.Pause() : gate.Resume();
+        bool pausing = operation == Operation.Pause;
+        bool transitioned = pausing ? gate.Pause() : gate.Resume();
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(transitioned, Is.EqualTo(expectedTransitioned), "the call reports whether it changed the state");
-            Assert.That(gate.IsPaused, Is.EqualTo(operation == Operation.Pause), "Pause ends paused; Resume ends running");
+            Assert.That(gate.IsPaused, Is.EqualTo(pausing), "Pause ends paused; Resume ends running");
+            Assert.That(transitioned, Is.EqualTo(startPaused != pausing), "a transition happens only when the resulting state differs from the start");
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessingPauseGate.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessingPauseGate.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Consensus.Processing;
+
+/// <summary>
+/// A reusable async gate for a single-consumer loop: the loop parks while paused and proceeds once
+/// resumed. <see cref="Pause"/> and <see cref="Resume"/> may be called from any thread.
+/// </summary>
+internal sealed class BlockProcessingPauseGate
+{
+    private readonly Lock _lock = new();
+
+    // Non-null exactly while paused; the task completes when processing is resumed.
+    private volatile TaskCompletionSource? _resumeSignal;
+
+    public bool IsPaused => _resumeSignal is not null;
+
+    /// <returns><c>true</c> if this call transitioned from running to paused.</returns>
+    public bool Pause()
+    {
+        lock (_lock)
+        {
+            if (_resumeSignal is not null) return false;
+            _resumeSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            return true;
+        }
+    }
+
+    /// <returns><c>true</c> if this call transitioned from paused to running.</returns>
+    public bool Resume()
+    {
+        TaskCompletionSource? signal;
+        lock (_lock)
+        {
+            signal = _resumeSignal;
+            _resumeSignal = null;
+        }
+
+        signal?.TrySetResult();
+        return signal is not null;
+    }
+
+    /// <summary>Completes synchronously when not paused; otherwise awaits <see cref="Resume"/> or cancellation.</summary>
+    public async ValueTask WaitWhilePausedAsync(CancellationToken cancellationToken)
+    {
+        while (_resumeSignal is { } resume)
+        {
+            await resume.Task.WaitAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessingPauseGate.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessingPauseGate.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,7 +37,11 @@ internal sealed class BlockProcessingPauseGate
         return signal is not null;
     }
 
-    public async ValueTask WaitWhilePausedAsync(CancellationToken cancellationToken)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask WaitWhilePausedAsync(CancellationToken cancellationToken) =>
+        _resumeSignal is null ? ValueTask.CompletedTask : WaitWhilePausedSlowAsync(cancellationToken);
+
+    private async ValueTask WaitWhilePausedSlowAsync(CancellationToken cancellationToken)
     {
         while (_resumeSignal is { } resume)
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessingPauseGate.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessingPauseGate.cs
@@ -6,20 +6,13 @@ using System.Threading.Tasks;
 
 namespace Nethermind.Consensus.Processing;
 
-/// <summary>
-/// A reusable async gate for a single-consumer loop: the loop parks while paused and proceeds once
-/// resumed. <see cref="Pause"/> and <see cref="Resume"/> may be called from any thread.
-/// </summary>
 internal sealed class BlockProcessingPauseGate
 {
     private readonly Lock _lock = new();
-
-    // Non-null exactly while paused; the task completes when processing is resumed.
     private volatile TaskCompletionSource? _resumeSignal;
 
     public bool IsPaused => _resumeSignal is not null;
 
-    /// <returns><c>true</c> if this call transitioned from running to paused.</returns>
     public bool Pause()
     {
         lock (_lock)
@@ -30,7 +23,6 @@ internal sealed class BlockProcessingPauseGate
         }
     }
 
-    /// <returns><c>true</c> if this call transitioned from paused to running.</returns>
     public bool Resume()
     {
         TaskCompletionSource? signal;
@@ -44,7 +36,6 @@ internal sealed class BlockProcessingPauseGate
         return signal is not null;
     }
 
-    /// <summary>Completes synchronously when not paused; otherwise awaits <see cref="Resume"/> or cancellation.</summary>
     public async ValueTask WaitWhilePausedAsync(CancellationToken cancellationToken)
     {
         while (_resumeSignal is { } resume)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -30,7 +30,7 @@ using static Nethermind.Core.Threading.ProcessingThread;
 
 namespace Nethermind.Consensus.Processing;
 
-public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessingQueue
+public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessingQueue, IBlockProcessingPauseControl
 {
     public int SoftMaxRecoveryQueueSizeInTx = 10000; // adjust based on tx or gas
     public const int MaxProcessingQueueSize = 2048; // adjust based on tx or gas
@@ -79,6 +79,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
     private const int MaxBranchSize = 8192;
     private readonly CompositeBlockTracer _compositeBlockTracer = new();
     private readonly Stopwatch _stopwatch = new();
+    private readonly BlockProcessingPauseGate _pauseGate = new();
 
     public event EventHandler<IBlockchainProcessor.InvalidBlockEventArgs>? InvalidBlock;
     public event EventHandler<BlockStatistics>? NewProcessingStatistics;
@@ -203,10 +204,25 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         static void ThrowAlreadyStarted() => throw new InvalidOperationException($"{nameof(BlockchainProcessor)} already started");
     }
 
+    public bool IsPaused => _pauseGate.IsPaused;
+
+    public void Pause()
+    {
+        if (_pauseGate.Pause() && _logger.IsInfo) _logger.Info("Block processing paused.");
+    }
+
+    public void Resume()
+    {
+        if (_pauseGate.Resume() && _logger.IsInfo) _logger.Info("Block processing resumed.");
+    }
+
     public async Task StopAsync(bool processRemainingBlocks = false)
     {
         if (_disposed) return;
         _disposed = true;
+
+        // Unblock the loop in case it is parked on a pause, so shutdown cannot deadlock.
+        _pauseGate.Resume();
 
         bool isStarted = _processorTask is not null;
         if (isStarted)
@@ -325,6 +341,9 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         GCScheduler.Instance.SwitchOnBackgroundGC(0);
         while (await _blockQueue.Reader.WaitToReadAsync(CancellationToken))
         {
+            // Park here while paused; enqueued blocks accumulate in the queue until resumed.
+            await _pauseGate.WaitWhilePausedAsync(CancellationToken);
+
             using ThreadExtensions.Disposable handle = Thread.CurrentThread.SetHighestPriority();
             // Have block, switch off background GC timer
             GCScheduler.Instance.SwitchOffBackgroundGC(_blockQueue.Reader.Count);
@@ -356,7 +375,8 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
     private void ProcessBlocks()
     {
         bool isTrace = _logger.IsTrace;
-        while (_blockQueue.Reader.TryRead(out BlockRef blockRef))
+        // Re-check the pause before each dequeue so a mid-drain pause takes effect at the next block boundary.
+        while (!_pauseGate.IsPaused && _blockQueue.Reader.TryRead(out BlockRef blockRef))
         {
             try
             {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -540,8 +540,9 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
 
     public bool IsProcessingBlocks(ulong? maxProcessingInterval) =>
         _processorTask?.IsCompleted == false && _recoveryTask?.IsCompleted == false &&
-        // user does not setup interval and we cannot set interval time based on chainspec
-        (maxProcessingInterval is null || _lastProcessedBlock.AddSeconds(maxProcessingInterval.Value) > DateTime.UtcNow);
+        // A deliberate pause is not a stall: while paused the processor stops advancing on purpose,
+        // so the staleness check is bypassed to avoid tripping liveness/health probes.
+        (_pauseGate.IsPaused || maxProcessingInterval is null || _lastProcessedBlock.AddSeconds(maxProcessingInterval.Value) > DateTime.UtcNow);
 
     private void TraceFailingBranch(in ProcessingBranch processingBranch, ProcessingOptions options, IBlockTracer blockTracer, DumpOptions dumpType)
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -221,8 +221,6 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         if (_disposed) return;
         _disposed = true;
 
-        _pauseGate.Resume();
-
         bool isStarted = _processorTask is not null;
         if (isStarted)
         {
@@ -233,6 +231,7 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         _recoveryComplete = true;
         if (processRemainingBlocks)
         {
+            _pauseGate.Resume();
             _recoveryQueue.Writer.TryComplete();
             await (_recoveryTask ?? Task.CompletedTask);
             _blockQueue.Writer.TryComplete();

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockchainProcessor.cs
@@ -221,7 +221,6 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         if (_disposed) return;
         _disposed = true;
 
-        // Unblock the loop in case it is parked on a pause, so shutdown cannot deadlock.
         _pauseGate.Resume();
 
         bool isStarted = _processorTask is not null;
@@ -341,7 +340,6 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
         GCScheduler.Instance.SwitchOnBackgroundGC(0);
         while (await _blockQueue.Reader.WaitToReadAsync(CancellationToken))
         {
-            // Park here while paused; enqueued blocks accumulate in the queue until resumed.
             await _pauseGate.WaitWhilePausedAsync(CancellationToken);
 
             using ThreadExtensions.Disposable handle = Thread.CurrentThread.SetHighestPriority();
@@ -375,7 +373,6 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
     private void ProcessBlocks()
     {
         bool isTrace = _logger.IsTrace;
-        // Re-check the pause before each dequeue so a mid-drain pause takes effect at the next block boundary.
         while (!_pauseGate.IsPaused && _blockQueue.Reader.TryRead(out BlockRef blockRef))
         {
             try
@@ -540,8 +537,6 @@ public sealed class BlockchainProcessor : IBlockchainProcessor, IBlockProcessing
 
     public bool IsProcessingBlocks(ulong? maxProcessingInterval) =>
         _processorTask?.IsCompleted == false && _recoveryTask?.IsCompleted == false &&
-        // A deliberate pause is not a stall: while paused the processor stops advancing on purpose,
-        // so the staleness check is bypassed to avoid tripping liveness/health probes.
         (_pauseGate.IsPaused || maxProcessingInterval is null || _lastProcessedBlock.AddSeconds(maxProcessingInterval.Value) > DateTime.UtcNow);
 
     private void TraceFailingBranch(in ProcessingBranch processingBranch, ProcessingOptions options, IBlockTracer blockTracer, DumpOptions dumpType)

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessingPauseControl.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessingPauseControl.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Consensus.Processing;
+
+/// <summary>
+/// Controls pausing and resuming of the block processing loop. Kept separate from
+/// <see cref="IBlockProcessingQueue"/> because pausing is a diagnostic/testing concern that the
+/// vast majority of queue consumers neither need nor can support.
+/// </summary>
+public interface IBlockProcessingPauseControl
+{
+    /// <summary>
+    /// Pauses dequeuing of blocks. A block already being processed finishes; the loop then parks
+    /// before the next block. Blocks can still be enqueued and accumulate until <see cref="Resume"/>
+    /// is called. Idempotent.
+    /// </summary>
+    void Pause();
+
+    /// <summary>Resumes processing previously paused via <see cref="Pause"/>. No-op when not paused.</summary>
+    void Resume();
+
+    /// <summary>Whether block processing is currently paused.</summary>
+    bool IsPaused { get; }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessingPauseControl.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockProcessingPauseControl.cs
@@ -3,23 +3,11 @@
 
 namespace Nethermind.Consensus.Processing;
 
-/// <summary>
-/// Controls pausing and resuming of the block processing loop. Kept separate from
-/// <see cref="IBlockProcessingQueue"/> because pausing is a diagnostic/testing concern that the
-/// vast majority of queue consumers neither need nor can support.
-/// </summary>
 public interface IBlockProcessingPauseControl
 {
-    /// <summary>
-    /// Pauses dequeuing of blocks. A block already being processed finishes; the loop then parks
-    /// before the next block. Blocks can still be enqueued and accumulate until <see cref="Resume"/>
-    /// is called. Idempotent.
-    /// </summary>
     void Pause();
 
-    /// <summary>Resumes processing previously paused via <see cref="Pause"/>. No-op when not paused.</summary>
     void Resume();
 
-    /// <summary>Whether block processing is currently paused.</summary>
     bool IsPaused { get; }
 }

--- a/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
@@ -80,6 +80,7 @@ public class BlockProcessingModule(IInitConfig initConfig, IBlocksConfig blocksC
             .AddSingleton<IMainProcessingContext, MainProcessingContext>()
             // Then component that has no ambiguity is extracted back out.
             .Map<IBlockProcessingQueue, MainProcessingContext>(ctx => (IBlockProcessingQueue)ctx.BlockchainProcessor)
+            .Map<IBlockProcessingPauseControl, MainProcessingContext>(ctx => (IBlockProcessingPauseControl)ctx.BlockchainProcessor)
             .Bind<IMainProcessingContext, MainProcessingContext>()
 
             // Some configuration that applies to validation and rpc but not to block producer. Plugins can add

--- a/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
@@ -7,6 +7,7 @@ using Nethermind.Api;
 using Nethermind.Blockchain;
 using Nethermind.Facade.Filters;
 using Nethermind.Config;
+using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Stateless;
 using Nethermind.Consensus.Tracing;
 using Nethermind.Core;
@@ -120,5 +121,6 @@ public class RpcModules(IJsonRpcConfig jsonRpcConfig) : Module
             ctx.Resolve<ChainSpec>().Parameters,
             ctx.Resolve<ITrustedNodesManager>(),
             ctx.Resolve<ISubscriptionManager>(),
-            ctx.Resolve<IJsonRpcConfig>());
+            ctx.Resolve<IJsonRpcConfig>(),
+            ctx.Resolve<IBlockProcessingPauseControl>());
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -612,12 +612,13 @@ public class AdminModuleTests
         Assert.That(peerInfo.Id.Bytes.AsSpan(32, 32).ToArray(), Is.EqualTo(expectedHashBytes), "the hash bytes from the JSON must occupy the last 32 bytes of the public key payload");
     }
 
-    [TestCase(true, TestName = "pause delegates to Pause and reports the paused state")]
-    [TestCase(false, TestName = "resume delegates to Resume and reports the running state")]
-    public void Admin_blockProcessingVerb_delegatesToControlAndReportsState(bool pause)
+    [TestCase(true, TestName = "pause delegates to Pause")]
+    [TestCase(false, TestName = "resume delegates to Resume")]
+    public void Admin_blockProcessingVerb_delegatesToControlAndReportsAccepted(bool pause)
     {
         IBlockProcessingPauseControl control = Substitute.For<IBlockProcessingPauseControl>();
         IAdminRpcModule module = BuildAdminRpcModuleWith(blockProcessingPauseControl: control);
+        // Simulate the control reaching the requested state after the call.
         control.IsPaused.Returns(pause);
 
         ResultWrapper<bool> result = pause
@@ -637,7 +638,7 @@ public class AdminModuleTests
                 control.DidNotReceive().Pause();
             }
 
-            Assert.That(result.Data, Is.EqualTo(pause), "the verb returns the resulting paused state");
+            Assert.That(result.Data, Is.True, "the verb returns true once the processor reached the requested state");
         }
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Config;
+using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -100,7 +101,8 @@ public class AdminModuleTests
             new ChainSpec { Parameters = new ChainParameters() }.Parameters,
             Substitute.For<ITrustedNodesManager>(),
             _subscriptionManager,
-            new JsonRpcConfig());
+            new JsonRpcConfig(),
+            Substitute.For<IBlockProcessingPauseControl>());
         _adminRpcModule.Context = new JsonRpcContext(RpcEndpoint.Ws, _jsonRpcDuplexClient);
 
         _serializer = new EthereumJsonSerializer();
@@ -610,10 +612,32 @@ public class AdminModuleTests
         Assert.That(peerInfo.Id.Bytes.AsSpan(32, 32).ToArray(), Is.EqualTo(expectedHashBytes), "the hash bytes from the JSON must occupy the last 32 bytes of the public key payload");
     }
 
+    [Test]
+    public void Admin_blockProcessing_pauseAndResume_delegatesToControlAndReportsState()
+    {
+        IBlockProcessingPauseControl pauseControl = Substitute.For<IBlockProcessingPauseControl>();
+        IAdminRpcModule module = BuildAdminRpcModuleWith(blockProcessingPauseControl: pauseControl);
+
+        pauseControl.IsPaused.Returns(true);
+        ResultWrapper<bool> paused = module.admin_pauseBlockProcessing();
+        pauseControl.Received(1).Pause();
+        Assert.That(paused.Data, Is.True, "pause must report the processor as paused after the call");
+
+        ResultWrapper<bool> queried = module.admin_isBlockProcessingPaused();
+        pauseControl.DidNotReceive().Resume();
+        Assert.That(queried.Data, Is.True, "the query must reflect the paused state without mutating it");
+
+        pauseControl.IsPaused.Returns(false);
+        ResultWrapper<bool> resumed = module.admin_resumeBlockProcessing();
+        pauseControl.Received(1).Resume();
+        Assert.That(resumed.Data, Is.False, "resume must report the processor as running after the call");
+    }
+
     private IAdminRpcModule BuildAdminRpcModuleWith(
         IStaticNodesManager? staticNodesManager = null,
         ITrustedNodesManager? trustedNodesManager = null,
-        IPeerPool? peerPool = null)
+        IPeerPool? peerPool = null,
+        IBlockProcessingPauseControl? blockProcessingPauseControl = null)
     {
         ChainSpec chainSpec = new() { Parameters = new ChainParameters() };
         return new AdminRpcModule(
@@ -627,7 +651,8 @@ public class AdminModuleTests
             chainSpec.Parameters,
             trustedNodesManager ?? Substitute.For<ITrustedNodesManager>(),
             _subscriptionManager,
-            new JsonRpcConfig());
+            new JsonRpcConfig(),
+            blockProcessingPauseControl ?? Substitute.For<IBlockProcessingPauseControl>());
     }
 
     private JsonRpcResult RaisePeerEventAndCapture(Action raiseEvent, out string subscriptionId, bool disposeSubscription = false, bool shouldReceive = true)
@@ -689,7 +714,8 @@ public class AdminModuleTests
             new ChainParameters(),
             Substitute.For<ITrustedNodesManager>(),
             subscriptionManager,
-            new JsonRpcConfig());
+            new JsonRpcConfig(),
+            Substitute.For<IBlockProcessingPauseControl>());
     }
 
     private static IPeerPool CreatePeerPool(Peer peer)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -618,7 +618,6 @@ public class AdminModuleTests
     {
         IBlockProcessingPauseControl control = Substitute.For<IBlockProcessingPauseControl>();
         IAdminRpcModule module = BuildAdminRpcModuleWith(blockProcessingPauseControl: control);
-        // Simulate the control reaching the requested state after the call.
         control.IsPaused.Returns(pause);
 
         ResultWrapper<bool> result = pause

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -612,25 +612,50 @@ public class AdminModuleTests
         Assert.That(peerInfo.Id.Bytes.AsSpan(32, 32).ToArray(), Is.EqualTo(expectedHashBytes), "the hash bytes from the JSON must occupy the last 32 bytes of the public key payload");
     }
 
-    [Test]
-    public void Admin_blockProcessing_pauseAndResume_delegatesToControlAndReportsState()
+    [TestCase(true, TestName = "pause delegates to Pause and reports the paused state")]
+    [TestCase(false, TestName = "resume delegates to Resume and reports the running state")]
+    public void Admin_blockProcessingVerb_delegatesToControlAndReportsState(bool pause)
     {
-        IBlockProcessingPauseControl pauseControl = Substitute.For<IBlockProcessingPauseControl>();
-        IAdminRpcModule module = BuildAdminRpcModuleWith(blockProcessingPauseControl: pauseControl);
+        IBlockProcessingPauseControl control = Substitute.For<IBlockProcessingPauseControl>();
+        IAdminRpcModule module = BuildAdminRpcModuleWith(blockProcessingPauseControl: control);
+        control.IsPaused.Returns(pause);
 
-        pauseControl.IsPaused.Returns(true);
-        ResultWrapper<bool> paused = module.admin_pauseBlockProcessing();
-        pauseControl.Received(1).Pause();
-        Assert.That(paused.Data, Is.True, "pause must report the processor as paused after the call");
+        ResultWrapper<bool> result = pause
+            ? module.admin_pauseBlockProcessing()
+            : module.admin_resumeBlockProcessing();
 
-        ResultWrapper<bool> queried = module.admin_isBlockProcessingPaused();
-        pauseControl.DidNotReceive().Resume();
-        Assert.That(queried.Data, Is.True, "the query must reflect the paused state without mutating it");
+        using (Assert.EnterMultipleScope())
+        {
+            if (pause)
+            {
+                control.Received(1).Pause();
+                control.DidNotReceive().Resume();
+            }
+            else
+            {
+                control.Received(1).Resume();
+                control.DidNotReceive().Pause();
+            }
 
-        pauseControl.IsPaused.Returns(false);
-        ResultWrapper<bool> resumed = module.admin_resumeBlockProcessing();
-        pauseControl.Received(1).Resume();
-        Assert.That(resumed.Data, Is.False, "resume must report the processor as running after the call");
+            Assert.That(result.Data, Is.EqualTo(pause), "the verb returns the resulting paused state");
+        }
+    }
+
+    [Test]
+    public void Admin_isBlockProcessingPaused_returnsStateWithoutMutating()
+    {
+        IBlockProcessingPauseControl control = Substitute.For<IBlockProcessingPauseControl>();
+        IAdminRpcModule module = BuildAdminRpcModuleWith(blockProcessingPauseControl: control);
+        control.IsPaused.Returns(true);
+
+        ResultWrapper<bool> result = module.admin_isBlockProcessingPaused();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Data, Is.True, "the query reflects the paused state");
+            control.DidNotReceive().Pause();
+            control.DidNotReceive().Resume();
+        }
     }
 
     private IAdminRpcModule BuildAdminRpcModuleWith(

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
 using Nethermind.Config;
+using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Network;
@@ -37,6 +38,7 @@ public class AdminRpcModule : IAdminRpcModule
     private readonly ITrustedNodesManager _trustedNodesManager;
     private readonly ISubscriptionManager _subscriptionManager;
     private readonly IJsonRpcConfig _jsonRpcConfig;
+    private readonly IBlockProcessingPauseControl _blockProcessingPauseControl;
 
     public AdminRpcModule(
         IBlockTree blockTree,
@@ -49,7 +51,8 @@ public class AdminRpcModule : IAdminRpcModule
         ChainParameters parameters,
         ITrustedNodesManager trustedNodesManager,
         ISubscriptionManager subscriptionManager,
-        IJsonRpcConfig jsonRpcConfig)
+        IJsonRpcConfig jsonRpcConfig,
+        IBlockProcessingPauseControl blockProcessingPauseControl)
     {
         _enode = enode ?? throw new ArgumentNullException(nameof(enode));
         _dataDir = dataDir ?? throw new ArgumentNullException(nameof(dataDir));
@@ -62,9 +65,25 @@ public class AdminRpcModule : IAdminRpcModule
         _trustedNodesManager = trustedNodesManager ?? throw new ArgumentNullException(nameof(trustedNodesManager));
         _subscriptionManager = subscriptionManager ?? throw new ArgumentNullException(nameof(subscriptionManager));
         _jsonRpcConfig = jsonRpcConfig ?? throw new ArgumentNullException(nameof(jsonRpcConfig));
+        _blockProcessingPauseControl = blockProcessingPauseControl ?? throw new ArgumentNullException(nameof(blockProcessingPauseControl));
 
         BuildNodeInfo();
     }
+
+    public ResultWrapper<bool> admin_pauseBlockProcessing()
+    {
+        _blockProcessingPauseControl.Pause();
+        return ResultWrapper<bool>.Success(_blockProcessingPauseControl.IsPaused);
+    }
+
+    public ResultWrapper<bool> admin_resumeBlockProcessing()
+    {
+        _blockProcessingPauseControl.Resume();
+        return ResultWrapper<bool>.Success(_blockProcessingPauseControl.IsPaused);
+    }
+
+    public ResultWrapper<bool> admin_isBlockProcessingPaused() =>
+        ResultWrapper<bool>.Success(_blockProcessingPauseControl.IsPaused);
 
     public async Task<ResultWrapper<bool>> admin_addPeer(string enode, bool persistent = false)
     {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -79,7 +79,7 @@ public class AdminRpcModule : IAdminRpcModule
     public ResultWrapper<bool> admin_resumeBlockProcessing()
     {
         _blockProcessingPauseControl.Resume();
-        return ResultWrapper<bool>.Success(_blockProcessingPauseControl.IsPaused);
+        return ResultWrapper<bool>.Success(!_blockProcessingPauseControl.IsPaused);
     }
 
     public ResultWrapper<bool> admin_isBlockProcessingPaused() =>

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
@@ -9,6 +9,27 @@ namespace Nethermind.JsonRpc.Modules.Admin;
 [RpcModule(ModuleType.Admin)]
 public interface IAdminRpcModule : IContextAwareRpcModule
 {
+    [JsonRpcMethod(Description = "Pauses local block processing. Blocks received from the network or consensus client are still queued but not processed; call `admin_resumeBlockProcessing` to process the accumulated backlog. Intended for testing and diagnostics.",
+        EdgeCaseHint = "Idempotent: pausing an already-paused processor is a no-op.",
+        ResponseDescription = "`true`, reflecting that block processing is paused after the call.",
+        ExampleResponse = "true",
+        IsImplemented = true)]
+    ResultWrapper<bool> admin_pauseBlockProcessing();
+
+    [JsonRpcMethod(Description = "Resumes local block processing previously paused via `admin_pauseBlockProcessing`, processing any blocks accumulated in the queue. Intended for testing and diagnostics.",
+        EdgeCaseHint = "Idempotent: resuming a processor that is not paused is a no-op.",
+        ResponseDescription = "`false`, reflecting that block processing is running after the call.",
+        ExampleResponse = "false",
+        IsImplemented = true)]
+    ResultWrapper<bool> admin_resumeBlockProcessing();
+
+    [JsonRpcMethod(Description = "Returns whether local block processing is currently paused.",
+        EdgeCaseHint = "",
+        ResponseDescription = "`true` if block processing is paused, `false` if running.",
+        ExampleResponse = "false",
+        IsImplemented = true)]
+    ResultWrapper<bool> admin_isBlockProcessingPaused();
+
     [JsonRpcMethod(Description = "Adds the given node as a static peer. The connection is maintained for the lifetime of the process. Set `persistent` to also write the peer to static-nodes.json so it is restored on restart.",
         EdgeCaseHint = "Returns `true` even if the peer was already in the static set.",
         ResponseDescription = "`true` if the peer is in the static set after the call.",

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
@@ -9,22 +9,21 @@ namespace Nethermind.JsonRpc.Modules.Admin;
 [RpcModule(ModuleType.Admin)]
 public interface IAdminRpcModule : IContextAwareRpcModule
 {
-    [JsonRpcMethod(Description = "Pauses local block processing. Blocks received from the network or consensus client are still queued but not processed; call `admin_resumeBlockProcessing` to process the accumulated backlog. Intended for testing and diagnostics.",
-        EdgeCaseHint = "Idempotent: pausing an already-paused processor is a no-op.",
-        ResponseDescription = "`true`, reflecting that block processing is paused after the call.",
+    [JsonRpcMethod(Description = "Pauses local block processing. Blocks received from the network or consensus client are still queued but not processed; call `admin_resumeBlockProcessing` to process the accumulated backlog. Use `admin_isBlockProcessingPaused` to query the state. Intended for testing and diagnostics.",
+        EdgeCaseHint = "Idempotent: pausing an already-paused processor is a no-op. While paused the node is reported as healthy (a deliberate pause is not treated as a processing stall).",
+        ResponseDescription = "`true` if block processing is paused after the call (the request succeeded); `false` if it did not take effect.",
         ExampleResponse = "true",
         IsImplemented = true)]
     ResultWrapper<bool> admin_pauseBlockProcessing();
 
     [JsonRpcMethod(Description = "Resumes local block processing previously paused via `admin_pauseBlockProcessing`, processing any blocks accumulated in the queue. Intended for testing and diagnostics.",
         EdgeCaseHint = "Idempotent: resuming a processor that is not paused is a no-op.",
-        ResponseDescription = "`false`, reflecting that block processing is running after the call.",
-        ExampleResponse = "false",
+        ResponseDescription = "`true` when the resume request was accepted.",
+        ExampleResponse = "true",
         IsImplemented = true)]
     ResultWrapper<bool> admin_resumeBlockProcessing();
 
     [JsonRpcMethod(Description = "Returns whether local block processing is currently paused.",
-        EdgeCaseHint = "",
         ResponseDescription = "`true` if block processing is paused, `false` if running.",
         ExampleResponse = "false",
         IsImplemented = true)]


### PR DESCRIPTION
Fixes Closes Resolves #9914

## RPC methods (admin namespace)

| Method | Description | Returns |
|---|---|---|
| `admin_pauseBlockProcessing` | Pause processing; blocks keep queuing | `true` if paused after the call |
| `admin_resumeBlockProcessing` | Resume and process the backlog | `true` if running after the call |
| `admin_isBlockProcessingPaused` | Query current state (no side effects) | `true` if paused |

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
