### PR TITLE
Blob fee check fix

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -448,7 +448,7 @@ public abstract class BlockchainTestBase
         ("TransactionException.INITCODE_SIZE_EXCEEDED", "max initcode size exceeded"),
         ("TransactionException.NONCE_MISMATCH_TOO_LOW", "nonce too low"),
         ("TransactionException.NONCE_MISMATCH_TOO_HIGH", "nonce too high"),
-        ("TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS", "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee"),
+        ("TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS", "max fee per blob gas less than block blob gas fee"),
         ("TransactionException.TYPE_1_TX_PRE_FORK", "InvalidTxType: Transaction type in"),
         ("TransactionException.TYPE_2_TX_PRE_FORK", "InvalidTxType: Transaction type in"),
         ("TransactionException.TYPE_3_TX_PRE_FORK", "InvalidTxType: Transaction type in"),

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -137,7 +137,7 @@ public abstract class TransactionTestBase
         ["TransactionException.TYPE_3_TX_ZERO_BLOBS"] = ["blob transaction must have at least 1 blob"],
         ["TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH"] = ["InvalidBlobVersionedHashVersion"],
         ["TransactionException.TYPE_3_TX_CONTRACT_CREATION"] = ["blob transaction of type create"],
-        ["TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS"] = ["InsufficientMaxFeePerBlobGas"],
+        ["TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS"] = ["max fee per blob gas less than block blob gas fee"],
     };
 }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/BlockValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/BlockValidatorTests.cs
@@ -205,7 +205,7 @@ public class BlockValidatorTests
                 .TestObject,
             parent,
             new CustomSpecProvider(((ForkActivation)0, Cancun.Instance)),
-            "InsufficientMaxFeePerBlobGas")
+            "max fee per blob gas less than block blob gas fee")
         { TestName = "InsufficientMaxFeePerBlobGas" };
 
         yield return new TestCaseData(

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -358,7 +358,7 @@ public class BlockValidator(
 
             if (transaction.MaxFeePerBlobGas < feePerBlobGas)
             {
-                error = BlockErrorMessages.InsufficientMaxFeePerBlobGas;
+                error = BlockErrorMessages.InsufficientMaxFeePerBlobGas(transaction.SenderAddress, transaction.MaxFeePerBlobGas, feePerBlobGas);
                 if (_logger.IsDebug) _logger.Debug($"{Invalid(block)} Transaction at index {txIndex} has insufficient {nameof(transaction.MaxFeePerBlobGas)} to cover current blob gas fee: {transaction.MaxFeePerBlobGas} < {feePerBlobGas}.");
                 return false;
             }

--- a/src/Nethermind/Nethermind.Core/Messages/BlockErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Core/Messages/BlockErrorMessages.cs
@@ -11,8 +11,8 @@ public static class BlockErrorMessages
     public static string ExceededUncleLimit(int maxUncleCount) =>
         $"ExceededUncleLimit: Cannot have more than {maxUncleCount}.";
 
-    public const string InsufficientMaxFeePerBlobGas =
-        "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee.";
+    public static string InsufficientMaxFeePerBlobGas(Address? address, UInt256? blobGasFeeCap, UInt256 blobBaseFee) =>
+        $"max fee per blob gas less than block blob gas fee: address {address}, blobGasFeeCap: {blobGasFeeCap}, blobBaseFee: {blobBaseFee}";
 
     public static string InvalidLogsBloom(Bloom expected, Bloom actual) =>
         $"InvalidLogsBloom: Logs bloom in header does not match. Expected {expected}, got {actual}";

--- a/src/Nethermind/Nethermind.Core/Messages/BlockErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Core/Messages/BlockErrorMessages.cs
@@ -12,7 +12,7 @@ public static class BlockErrorMessages
         $"ExceededUncleLimit: Cannot have more than {maxUncleCount}.";
 
     public static string InsufficientMaxFeePerBlobGas(Address? address, UInt256? blobGasFeeCap, UInt256 blobBaseFee) =>
-        $"max fee per blob gas less than block blob gas fee: address {address}, blobGasFeeCap: {blobGasFeeCap}, blobBaseFee: {blobBaseFee}";
+        $"max fee per blob gas less than block blob gas fee: address {address?.ToString(withEip55Checksum: true)}, blobGasFeeCap: {blobGasFeeCap}, blobBaseFee: {blobBaseFee}";
 
     public static string InvalidLogsBloom(Bloom expected, Bloom actual) =>
         $"InvalidLogsBloom: Logs bloom in header does not match. Expected {expected}, got {actual}";

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorEip4844Tests.cs
@@ -4,7 +4,6 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
-using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
@@ -117,7 +116,7 @@ internal class TransactionProcessorEip4844Tests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.TransactionExecuted, Is.False);
-            Assert.That(result.ErrorDescription, Does.Contain(BlockErrorMessages.InsufficientMaxFeePerBlobGas));
+            Assert.That(result.ErrorDescription, Does.Contain("max fee per blob gas less than block blob gas fee"));
             Assert.That(_stateProvider.GetBalance(TestItem.PrivateKeyA.Address), Is.EqualTo(balance));
             Assert.That(_stateProvider.GetNonce(TestItem.PrivateKeyA.Address), Is.EqualTo(UInt256.Zero));
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1064,10 +1064,10 @@ namespace Nethermind.Evm.TransactionProcessing
                     return RequiredBalanceExceeds256Bits(tx);
                 }
 
-                if (validate && tx.MaxFeePerBlobGas < feePerBlobGas)
+                if (tx.MaxFeePerBlobGas < feePerBlobGas)
                 {
                     TraceLogInvalidTx(tx, "INSUFFICIENT_MAX_FEE_PER_BLOB_GAS");
-                    return TransactionResult.WithDetail(TransactionResult.ErrorType.InsufficientSenderBalance, BlockErrorMessages.InsufficientMaxFeePerBlobGas);
+                    return TransactionResult.WithDetail(TransactionResult.ErrorType.InsufficientSenderBalance, BlockErrorMessages.InsufficientMaxFeePerBlobGas(tx.SenderAddress, tx.MaxFeePerBlobGas, feePerBlobGas));
                 }
 
                 if (UInt256.AddOverflow(senderReservedGasPayment, blobBaseFee, out senderReservedGasPayment))

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -790,7 +790,7 @@ public partial class EthRpcModuleTests
 
         Assert.That(
             JToken.Parse(serialized)["error"]!["message"]!.Value<string>(),
-            Does.Contain(BlockErrorMessages.InsufficientMaxFeePerBlobGas));
+            Does.Contain("max fee per blob gas less than block blob gas fee"));
     }
 
     [TestCase(

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -937,7 +937,7 @@ public partial class EthRpcModuleTests
         """{"blobBaseFee":"0xb","baseFeePerGas":"0x1"}""",
         null,
         "max fee per blob gas less than block blob gas fee",
-        TestName = "blob tx rejected when maxFeePerBlobGas below blobBaseFee override")]    
+        TestName = "blob tx rejected when maxFeePerBlobGas below blobBaseFee override")]
 
     public async Task Eth_call_blobBaseFeePerGas_override_test(
         string txJson, string stateOverrideJson, string blockOverrideJson,

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -931,6 +931,13 @@ public partial class EthRpcModuleTests
         null,
         "max fee per blob gas less than block blob gas fee",
         TestName = "blob tx rejected when maxFeePerBlobGas below blobBaseFee override")]
+    [TestCase(
+        """{"from":"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099","to":"0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358","maxFeePerBlobGas":"0xa","blobVersionedHashes":["0x0122000000000000000000000000000000000000000000000000000000000000"],"gas":"0x5208"}""",
+        """{"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099":{"balance":"0x56BC75E2D63100000"}}""",
+        """{"blobBaseFee":"0xb","baseFeePerGas":"0x1"}""",
+        null,
+        "max fee per blob gas less than block blob gas fee",
+        TestName = "blob tx rejected when maxFeePerBlobGas below blobBaseFee override")]    
 
     public async Task Eth_call_blobBaseFeePerGas_override_test(
         string txJson, string stateOverrideJson, string blockOverrideJson,

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -929,7 +929,7 @@ public partial class EthRpcModuleTests
         """{"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099":{"balance":"0x56BC75E2D63100000"}}""",
         """{"blobBaseFee":"0xb","baseFeePerGas":"0x1"}""",
         null,
-        BlockErrorMessages.InsufficientMaxFeePerBlobGas,
+        "max fee per blob gas less than block blob gas fee",
         TestName = "blob tx rejected when maxFeePerBlobGas below blobBaseFee override")]
 
     public async Task Eth_call_blobBaseFeePerGas_override_test(
@@ -985,7 +985,7 @@ public partial class EthRpcModuleTests
         string serialized = await test.TestEthRpc("eth_call", tx, "latest", stateOverride, null);
         Assert.That(
             JToken.Parse(serialized)["error"]!["message"]!.Value<string>(),
-            Does.Contain(BlockErrorMessages.InsufficientMaxFeePerBlobGas));
+            Does.Contain("max fee per blob gas less than block blob gas fee"));
     }
 
     [TestCase(


### PR DESCRIPTION
## Changes

- Changed `BlockErrorMessages.InsufficientMaxFeePerBlobGas` from a `const string` to error same as geth
- Removed the `validate ` guard on the blob gas fee check in `BuyGas` so the check always runs regardless of the value of MaxFeePerGas (it was getting skipped when MaxFeePerGas was zero)
- Updated all call sites and tests accordingly

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Existing tests updated to assert against the new Geth-compatible error message substring (`"max fee per blob gas less than block blob gas fee"`).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No