### PR TITLE
perf(processing): reduce empty/near-empty block overhead

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
@@ -170,7 +170,11 @@ public class BranchProcessor(
                 // Calculate the transaction hashes in the background and release tx sequence memory
                 // Hashes will be required for PersistentReceiptStorage in ForkchoiceUpdatedHandler
                 // Though we still want to release the memory even if syncing rather than processing live
-                TxHashCalculator.CalculateInBackground(suggestedBlock);
+                // Empty blocks have nothing to hash, so skip the ThreadPool dispatch entirely.
+                if (suggestedBlock.Transactions.Length > 0)
+                {
+                    TxHashCalculator.CalculateInBackground(suggestedBlock);
+                }
             }
 
             return processedBlocks;
@@ -224,7 +228,15 @@ public class BranchProcessor(
         }
         else if (preWarmer is not null)
         {
-            _clearTask = Task.Run(preWarmer.ClearCaches);
+            // Reached only when prewarming was skipped for this block (preWarmTask is null), so no
+            // warmer was ever queued for it; and the previous block's prewarm task — which only
+            // completes after its AddressWarmer finishes — is awaited every iteration before the
+            // next block runs. Nothing can be concurrently touching the prewarmer caches here, so
+            // clearing inline is race-free and avoids the per-block ThreadPool dispatch (and Task
+            // allocation) that otherwise dominates the cost of near-empty blocks during early
+            // archive sync. The clear is an O(1) epoch bump on already-empty caches.
+            preWarmer.ClearCaches();
+            _clearTask = Task.CompletedTask;
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BranchProcessor.cs
@@ -228,13 +228,6 @@ public class BranchProcessor(
         }
         else if (preWarmer is not null)
         {
-            // Reached only when prewarming was skipped for this block (preWarmTask is null), so no
-            // warmer was ever queued for it; and the previous block's prewarm task — which only
-            // completes after its AddressWarmer finishes — is awaited every iteration before the
-            // next block runs. Nothing can be concurrently touching the prewarmer caches here, so
-            // clearing inline is race-free and avoids the per-block ThreadPool dispatch (and Task
-            // allocation) that otherwise dominates the cost of near-empty blocks during early
-            // archive sync. The clear is an O(1) epoch bump on already-empty caches.
             preWarmer.ClearCaches();
             _clearTask = Task.CompletedTask;
         }


### PR DESCRIPTION
## Changes

Reduce per-block fixed overhead for blocks that skip prewarming (fewer than 3 transactions — most notably empty blocks, which are extremely common during early archive sync where the EVM does no work and this fixed overhead dominates).

- **Skip the `TxHashCalculator` background dispatch for zero-tx blocks.** An empty block has no transaction hashes to compute and no tx-sequence memory to release, so the `ThreadPool.UnsafeQueueUserWorkItem` (and its work-item allocation) is pure overhead.
- **Clear the prewarmer caches inline instead of via `Task.Run` when no prewarm task ran.** On this path `preWarmTask` is `null`, so no warmer was ever queued for the block, and the previous block's prewarm task — which only completes after its `AddressWarmer` finishes — is already awaited (`WaitAndClear`) before the next block runs. Nothing can be concurrently touching the prewarmer caches, so clearing inline is race-free and avoids a per-block `Task` allocation plus a `ThreadPool` dispatch. The clear itself is an O(1) epoch bump on already-empty caches.

### Benchmark

Measured with `Nethermind.Evm.Benchmark.BlockProcessingBenchmark` (full `BranchProcessor` pipeline incl. prewarmer). Because the test machine has a noticeable per-process timing offset, all variants were measured **within a single BenchmarkDotNet process window** for a fair comparison:

| `EmptyBlock` | median | vs baseline |
|---|---|---|
| baseline | 25.0 µs | — |
| inline clear only | 21.7 µs | −13% |
| both changes | 20.4 µs | **−18%** |

`SingleTransfer` improves ~5%. Larger blocks (≥3 tx) are unaffected — they take the unchanged `preWarmTask` continuation path.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes

#### Notes on testing

Covered by existing `BlockProcessorTests` + `BlockchainProcessorTests` (63 passed, 0 failed) and the existing `BlockProcessingBenchmark`. The changes are timing/scheduling-only and output-equivalent: transaction hashes are never read during block processing (only for post-processing receipt indexing / memory release), and the prewarmer caches are speculative read-side caches that never affect computed `StateRoot`/`ReceiptsRoot`/block hash.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
