### PR TITLE
stop skipping hive tests which are fixed by commit #822 in execution-apis

### DIFF
--- a/scripts/known-failing-hive-tests.txt
+++ b/scripts/known-failing-hive-tests.txt
@@ -3,6 +3,9 @@
 testing_buildBlockV1/build-block-empty-transactions (nethermind)
 testing_buildBlockV1/build-block-with-transactions (nethermind)
 
+# eth_simulateV1 — execution-apis spec ↔ test fixture mismatches. Tracked in
+# https://github.com/NethermindEth/nethermind/issues/11412
+eth_simulateV1/ethSimulate-simple-send-from-contract-with-validation (nethermind)
 
 # graphql
 

--- a/scripts/known-failing-hive-tests.txt
+++ b/scripts/known-failing-hive-tests.txt
@@ -3,14 +3,6 @@
 testing_buildBlockV1/build-block-empty-transactions (nethermind)
 testing_buildBlockV1/build-block-with-transactions (nethermind)
 
-# eth_simulateV1 — execution-apis spec ↔ test fixture mismatches. Tracked in
-# https://github.com/NethermindEth/nethermind/issues/11412
-eth_simulateV1/ethSimulate-basefee-too-low-with-validation-38012 (nethermind)
-eth_simulateV1/ethSimulate-check-invalid-nonce (nethermind)
-eth_simulateV1/ethSimulate-gas-fees-and-value-error-38014-with-validation (nethermind)
-eth_simulateV1/ethSimulate-simple-no-funds-with-validation (nethermind)
-eth_simulateV1/ethSimulate-simple-no-funds-with-validation-without-nonces (nethermind)
-eth_simulateV1/ethSimulate-simple-send-from-contract-with-validation (nethermind)
 
 # graphql
 


### PR DESCRIPTION
As per #11412 hive tests changed correcting the error codes for cases 1-5 so adding them back 