### PR TITLE
add error in debug_traceBlock* if block is genesis

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceBlock.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceBlock.cs
@@ -407,6 +407,28 @@ public partial class DebugRpcModuleTests
             $"Streamed JSON differs from serializer output for {traceCount} traces");
     }
 
+    [TestCase("debug_traceBlockByNumber")]
+    [TestCase("debug_traceBlockByHash")]
+    public async Task Debug_traceBlock_returns_error_for_genesis(string method)
+    {
+        using Context context = await Context.Create();
+
+        object? arg = method switch
+        {
+            "debug_traceBlockByNumber" => context.Blockchain.BlockTree.Genesis!.Number,
+            _ => context.Blockchain.BlockTree.Genesis!.Hash
+        };
+
+        string response = await RpcTest.TestSerializedRequest(context.DebugRpcModule, method, arg, new GethTraceOptions());
+
+        using JsonDocument doc = JsonDocument.Parse(response);
+        JsonElement root = doc.RootElement;
+
+        Assert.That(root.TryGetProperty("error", out JsonElement error), Is.True, "Missing 'error' field");
+        Assert.That(error.GetProperty("message").GetString(), Is.EqualTo("genesis is not traceable"));
+        Assert.That(error.GetProperty("code").GetInt32(), Is.EqualTo(-32000));
+    }
+
     [TestCase("debug_traceBlock")]
     [TestCase("debug_traceBlockByNumber")]
     [TestCase("debug_traceBlockByHash")]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -351,10 +351,15 @@ public class DebugRpcModule(
 
     public ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>> debug_traceBlockByNumber(BlockParameter blockNumber, GethTraceOptions options = null)
     {
-        TryGetHeaderAndCheckState(blockNumber, out ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>? headerError);
+        BlockHeader? header = TryGetHeaderAndCheckState(blockNumber, out ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>? headerError);
         if (headerError is not null)
         {
             return headerError;
+        }
+
+        if (header?.Number == 0)
+        {
+            return ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>.Fail("genesis is not traceable", ErrorCodes.InvalidInput);
         }
 
         if (CanStreamStructLogs(options))
@@ -393,10 +398,15 @@ public class DebugRpcModule(
 
     public ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>> debug_traceBlockByHash(Hash256 blockHash, GethTraceOptions options = null)
     {
-        TryGetHeaderAndCheckState<IReadOnlyCollection<GethLikeTxTrace>>(blockHash, out ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>? headerError);
+        BlockHeader? header = TryGetHeaderAndCheckState(blockHash, out ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>? headerError);
         if (headerError is not null)
         {
             return headerError;
+        }
+
+        if (header?.Number == 0)
+        {
+            return ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>.Fail("genesis is not traceable", ErrorCodes.InvalidInput);
         }
 
         if (CanStreamStructLogs(options))

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -357,7 +357,7 @@ public class DebugRpcModule(
             return headerError;
         }
 
-        if (header?.Number == 0)
+        if (header.Number == 0)
         {
             return ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>.Fail("genesis is not traceable", ErrorCodes.InvalidInput);
         }
@@ -404,7 +404,7 @@ public class DebugRpcModule(
             return headerError;
         }
 
-        if (header?.Number == 0)
+        if (header.Number == 0)
         {
             return ResultWrapper<IReadOnlyCollection<GethLikeTxTrace>>.Fail("genesis is not traceable", ErrorCodes.InvalidInput);
         }


### PR DESCRIPTION
Fixes #12038

## Changes

- `debug_traceBlockByHash` and `debug_traceBlockByNumber` now return `{"code":-32000,"message":"genesis is not traceable"}` when the requested block is genesis, matching Geth behaviour
- Added regression tests for both methods

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
