### PR TITLE
SLOAD Improvements

### DIFF
--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -175,7 +175,10 @@ namespace Nethermind.State
         /// <returns>True if value has been set</returns>
         protected bool TryGetCachedValue(in StorageCell storageCell, out byte[]? bytes)
         {
-            if (_intraBlockCache.TryGetValue(storageCell, out StackList<int> stack))
+            // The intra-block cache only holds journaled WRITES; on read-mostly executions
+            // (eth_call) it is empty, and the count check skips hashing the 52-byte cell on
+            // every SLOAD.
+            if (_intraBlockCache.Count != 0 && _intraBlockCache.TryGetValue(storageCell, out StackList<int> stack))
             {
                 int lastChangeIndex = stack.Peek();
                 {

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -175,9 +175,8 @@ namespace Nethermind.State
         /// <returns>True if value has been set</returns>
         protected bool TryGetCachedValue(in StorageCell storageCell, out byte[]? bytes)
         {
-            // The intra-block cache only holds journaled WRITES; on read-mostly executions
-            // (eth_call) it is empty, and the count check skips hashing the 52-byte cell on
-            // every SLOAD.
+            // If the cache is completely empty (no writes or reads yet this transaction),
+            // skip hashing the 52-byte cell — TryGetValue would miss anyway.
             if (_intraBlockCache.Count != 0 && _intraBlockCache.TryGetValue(storageCell, out StackList<int> stack))
             {
                 int lastChangeIndex = stack.Peek();

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -51,8 +51,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         if (resetBlockChanges)
         {
             _storages.ResetAndClear();
-            _lastStorageAddress = null;
-            _lastStorage = null;
+            InvalidateStorageMemo();
             _toUpdateRoots.Clear();
         }
     }
@@ -265,15 +264,17 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     public void ClearStorageMap()
     {
         _storages.Clear();
+        InvalidateStorageMemo();
+    }
+
+    private Address? _lastStorageAddress;
+    private PerContractState? _lastStorage;
+
+    private void InvalidateStorageMemo()
+    {
         _lastStorageAddress = null;
         _lastStorage = null;
     }
-
-    // Consecutive SLOADs overwhelmingly hit the same contract; the one-entry memo removes a
-    // dictionary lookup from the per-SLOAD hot path. Cleared wherever _storages is cleared
-    // (the pooled PerContractState is returned there and must not be reachable).
-    private Address? _lastStorageAddress;
-    private PerContractState? _lastStorage;
 
     private PerContractState GetOrCreateStorage(Address address)
     {

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -51,6 +51,8 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         if (resetBlockChanges)
         {
             _storages.ResetAndClear();
+            _lastStorageAddress = null;
+            _lastStorage = null;
             _toUpdateRoots.Clear();
         }
     }
@@ -260,19 +262,39 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             Db.Metrics.IncrementStorageTreeWrites(writes);
     }
 
-    public void ClearStorageMap() => _storages.Clear();
+    public void ClearStorageMap()
+    {
+        _storages.Clear();
+        _lastStorageAddress = null;
+        _lastStorage = null;
+    }
+
+    // Consecutive SLOADs overwhelmingly hit the same contract; the one-entry memo removes a
+    // dictionary lookup from the per-SLOAD hot path. Cleared wherever _storages is cleared
+    // (the pooled PerContractState is returned there and must not be reachable).
+    private Address? _lastStorageAddress;
+    private PerContractState? _lastStorage;
 
     private PerContractState GetOrCreateStorage(Address address)
     {
+        if (_lastStorageAddress == address)
+        {
+            return _lastStorage!;
+        }
+
         ref PerContractState? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_storages, address, out bool exists);
         if (!exists) value = PerContractState.Rent(address, this);
+        _lastStorageAddress = address;
+        _lastStorage = value;
         return value;
     }
 
     public void WarmUp(in StorageCell storageCell, bool isEmpty)
     {
         if (!isEmpty)
+        {
             LoadFromTree(in storageCell);
+        }
     }
 
     private ReadOnlySpan<byte> LoadFromTree(in StorageCell storageCell) =>


### PR DESCRIPTION
## Changes

### Per-contract storage memo 

(`PersistentStorageProvider`).** Consecutive SLOADs overwhelmingly hit the same contract; a one-entry memo (`_lastStorageAddress` → `_lastStorage`) removes the `_storages` dictionary lookup from the per-SLOAD path. Invalidated wherever `_storages` is cleared, so the pooled per-contract state is never reachable after return.
  
### Skip cell hashing on read-mostly executions 

** The intra-block cache only holds journaled *writes*. On read-mostly executions (e.g. `eth_call`) it is empty, so a `_intraBlockCache.Count != 0` guard skips hashing the 52-byte storage cell on every SLOAD before the lookup that would miss anyway.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No