### PR TITLE
Default RocksDB exit flush to WAL-only, add opt-in full flush

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/AdjustedRocksdbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/AdjustedRocksdbConfig.cs
@@ -39,7 +39,6 @@ public class AdjustedRocksdbConfig(
 
     public double CompressibilityHint => baseConfig.CompressibilityHint;
 
-    public bool FlushOnExit => baseConfig.FlushOnExit;
-    public bool FullFlushOnExit => baseConfig.FullFlushOnExit;
+    public FlushOnExitMode FlushOnExit => baseConfig.FlushOnExit;
     public IntPtr? BlockCache => blockCache ?? baseConfig.BlockCache;
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/AdjustedRocksdbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/AdjustedRocksdbConfig.cs
@@ -40,5 +40,6 @@ public class AdjustedRocksdbConfig(
     public double CompressibilityHint => baseConfig.CompressibilityHint;
 
     public bool FlushOnExit => baseConfig.FlushOnExit;
+    public bool FullFlushOnExit => baseConfig.FullFlushOnExit;
     public IntPtr? BlockCache => blockCache ?? baseConfig.BlockCache;
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -82,8 +82,7 @@ public class DbConfig : IDbConfig
     public bool? VerifyChecksum { get; set; } = true;
     public bool EnableFileWarmer { get; set; } = false;
     public double CompressibilityHint { get; set; } = 1.0;
-    public bool FlushOnExit { get; set; } = true;
-    public bool FullFlushOnExit { get; set; } = false;
+    public FlushOnExitMode FlushOnExit { get; set; } = FlushOnExitMode.WalOnly;
 
     public string BadBlocksDbRocksDbOptions { get; set; } = "";
     public string? BadBlocksDbAdditionalRocksDbOptions { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -83,6 +83,7 @@ public class DbConfig : IDbConfig
     public bool EnableFileWarmer { get; set; } = false;
     public double CompressibilityHint { get; set; } = 1.0;
     public bool FlushOnExit { get; set; } = true;
+    public bool FullFlushOnExit { get; set; } = false;
 
     public string BadBlocksDbRocksDbOptions { get; set; } = "";
     public string? BadBlocksDbAdditionalRocksDbOptions { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/FlushOnExitMode.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/FlushOnExitMode.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Db.Rocks.Config;
+
+/// <summary>Controls how a RocksDB instance is flushed when it is disposed on shutdown.</summary>
+public enum FlushOnExitMode
+{
+    /// <summary>Do not flush on exit.</summary>
+    None,
+
+    /// <summary>
+    /// Flush only the write-ahead log on exit. Fast shutdown; WAL-backed writes are recovered by
+    /// WAL replay on the next start.
+    /// </summary>
+    WalOnly,
+
+    /// <summary>Flush the write-ahead log and materialize all memtables into SST files on exit.</summary>
+    Full,
+}

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -34,6 +34,7 @@ public interface IDbConfig : IConfig
     bool EnableFileWarmer { get; set; }
     double CompressibilityHint { get; set; }
     bool FlushOnExit { get; set; }
+    bool FullFlushOnExit { get; set; }
 
     string BadBlocksDbRocksDbOptions { get; set; }
     string? BadBlocksDbAdditionalRocksDbOptions { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -33,8 +33,10 @@ public interface IDbConfig : IConfig
     bool? VerifyChecksum { get; set; }
     bool EnableFileWarmer { get; set; }
     double CompressibilityHint { get; set; }
-    bool FlushOnExit { get; set; }
-    bool FullFlushOnExit { get; set; }
+    [ConfigItem(
+        Description = "How RocksDB is flushed on shutdown. 'None' skips flushing; 'WalOnly' flushes only the write-ahead log (fast, recovered via WAL replay on restart); 'Full' also materializes memtables into SST files (slower).",
+        DefaultValue = "WalOnly")]
+    FlushOnExitMode FlushOnExit { get; set; }
 
     string BadBlocksDbRocksDbOptions { get; set; }
     string? BadBlocksDbAdditionalRocksDbOptions { get; set; }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IRocksDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IRocksDbConfig.cs
@@ -20,7 +20,6 @@ public interface IRocksDbConfig
     ulong? RowCacheSize { get; }
     bool EnableFileWarmer { get; }
     double CompressibilityHint { get; }
-    bool FlushOnExit { get; }
-    bool FullFlushOnExit { get; }
+    FlushOnExitMode FlushOnExit { get; }
     IntPtr? BlockCache { get; }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IRocksDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IRocksDbConfig.cs
@@ -21,5 +21,6 @@ public interface IRocksDbConfig
     bool EnableFileWarmer { get; }
     double CompressibilityHint { get; }
     bool FlushOnExit { get; }
+    bool FullFlushOnExit { get; }
     IntPtr? BlockCache { get; }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -63,8 +63,7 @@ public class PerTableDbConfig : IRocksDbConfig
     public ulong? RowCacheSize => ReadConfig<ulong?>(nameof(RowCacheSize));
     public bool EnableFileWarmer => ReadConfig<bool>(nameof(EnableFileWarmer));
     public double CompressibilityHint => ReadConfig<double>(nameof(CompressibilityHint));
-    public bool FlushOnExit => ReadConfig<bool?>(nameof(FlushOnExit)) ?? true;
-    public bool FullFlushOnExit => ReadConfig<bool?>(nameof(FullFlushOnExit)) ?? false;
+    public FlushOnExitMode FlushOnExit => ReadConfig<FlushOnExitMode?>(nameof(FlushOnExit)) ?? FlushOnExitMode.WalOnly;
     public IntPtr? BlockCache => null;
 
     private T? ReadConfig<T>(string propertyName) => ReadConfig<T>(_dbConfig, propertyName, _reversedPrefixes);

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/PerTableDbConfig.cs
@@ -64,6 +64,7 @@ public class PerTableDbConfig : IRocksDbConfig
     public bool EnableFileWarmer => ReadConfig<bool>(nameof(EnableFileWarmer));
     public double CompressibilityHint => ReadConfig<double>(nameof(CompressibilityHint));
     public bool FlushOnExit => ReadConfig<bool?>(nameof(FlushOnExit)) ?? true;
+    public bool FullFlushOnExit => ReadConfig<bool?>(nameof(FullFlushOnExit)) ?? false;
     public IntPtr? BlockCache => null;
 
     private T? ReadConfig<T>(string propertyName) => ReadConfig<T>(_dbConfig, propertyName, _reversedPrefixes);

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1500,7 +1500,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
         _reader.Dispose();
 
-        if (_perTableDbConfig.FlushOnExit) InnerFlush(false);
+        if (_perTableDbConfig.FlushOnExit) InnerFlush(onlyWal: !_perTableDbConfig.FullFlushOnExit);
         ReleaseUnmanagedResources();
 
         _dbsByPath.Remove(_fullPath!, out _);

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1500,7 +1500,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
         _reader.Dispose();
 
-        if (_perTableDbConfig.FlushOnExit) InnerFlush(onlyWal: !_perTableDbConfig.FullFlushOnExit);
+        if (_perTableDbConfig.FlushOnExit != FlushOnExitMode.None)
+            InnerFlush(onlyWal: _perTableDbConfig.FlushOnExit == FlushOnExitMode.WalOnly);
         ReleaseUnmanagedResources();
 
         _dbsByPath.Remove(_fullPath!, out _);

--- a/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
@@ -72,16 +72,16 @@ public class PerTableDbConfigTests
         Assert.That(config.MaxOpenFiles, Is.EqualTo(2));
     }
 
-    [TestCase(null, false, TestName = "FullFlushOnExit defaults to false")]
-    [TestCase(true, true)]
-    [TestCase(false, false)]
-    public void FullFlushOnExit_reads_general_config(bool? configured, bool expected)
+    [TestCase(null, FlushOnExitMode.WalOnly, TestName = "FlushOnExit defaults to WalOnly")]
+    [TestCase(FlushOnExitMode.None, FlushOnExitMode.None)]
+    [TestCase(FlushOnExitMode.Full, FlushOnExitMode.Full)]
+    public void FlushOnExit_reads_general_config(FlushOnExitMode? configured, FlushOnExitMode expected)
     {
         DbConfig dbConfig = new();
-        if (configured is not null) dbConfig.FullFlushOnExit = configured.Value;
+        if (configured is not null) dbConfig.FlushOnExit = configured.Value;
 
         PerTableDbConfig config = new(dbConfig, DbNames.Receipts);
-        Assert.That(config.FullFlushOnExit, Is.EqualTo(expected));
+        Assert.That(config.FlushOnExit, Is.EqualTo(expected));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
@@ -72,6 +72,18 @@ public class PerTableDbConfigTests
         Assert.That(config.MaxOpenFiles, Is.EqualTo(2));
     }
 
+    [TestCase(null, false, TestName = "FullFlushOnExit defaults to false")]
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public void FullFlushOnExit_reads_general_config(bool? configured, bool expected)
+    {
+        DbConfig dbConfig = new();
+        if (configured is not null) dbConfig.FullFlushOnExit = configured.Value;
+
+        PerTableDbConfig config = new(dbConfig, DbNames.Receipts);
+        Assert.That(config.FullFlushOnExit, Is.EqualTo(expected));
+    }
+
     [Test]
     public void AllDbConfigMemberMustBeDeclaredInIDbConfig()
     {

--- a/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
@@ -350,7 +350,7 @@ public class EthereumRunnerTests
             initConfig.BaseDbPath = tempPath.Path;
 
             IDbConfig dbConfig = configProvider.GetConfig<IDbConfig>();
-            dbConfig.FlushOnExit = false;
+            dbConfig.FlushOnExit = FlushOnExitMode.None;
 
             INetworkConfig networkConfig = configProvider.GetConfig<INetworkConfig>();
             int port = basePort + testIndex;


### PR DESCRIPTION
## Changes

On shutdown, `DbOnTheRocks.Dispose()` performed a **full** flush of each RocksDB instance — flushing the WAL **and** materializing the memtable into SST files. The memtable can be tens or hundreds of MB, so this flush can be slow enough that a container orchestrator's shutdown grace period SIGKILLs Nethermind mid-flush.

Flushing only the WAL is sufficient for durability: WAL-backed writes are fsynced and replayed on the next start, so the memtable does not need to be materialized into SST at exit time.

The exit-flush behavior is now controlled by a single `FlushOnExit` config option of type `FlushOnExitMode` (replacing the previous `FlushOnExit` bool):

| `FlushOnExit` | exit flush |
|---|---|
| `WalOnly` (**default**) | flush only the WAL — fast, durable shutdown; recovered via WAL replay on restart |
| `Full` | flush the WAL **and** materialize memtables into SST files (the old default) |
| `None` | no flush |

No native plumbing was needed — `InnerFlush(bool onlyWal)` already supported a WAL-only mode; only the `Dispose()` path's flush mode changed. The public `Flush(bool onlyWal = false)` API and all explicit callers are unchanged.

> Note: DisableWAL writes (snap sync, Era import, pruning) are out of scope here — their persistence is the responsibility of the respective logic via an explicit flush, not the dispose path.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
- [x] Optimization
- [x] Breaking change (a change that causes existing functionality not to work as expected)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added a parameterized regression test in `PerTableDbConfigTests` covering the `FlushOnExit` enum (default `WalOnly` and explicit overrides). The native flush behavior in `Dispose()` is not unit-testable without a real RocksDB instance and is left to manual/integration verification.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes

The default behavior on shutdown changed from a full flush to a WAL-only flush. The `FlushOnExit` config option changed from a `bool` to the `FlushOnExitMode` enum (`None` / `WalOnly` / `Full`); the old `FlushOnExit: false` becomes `FlushOnExit: None`, and the old full-flush-on-exit behavior is `FlushOnExit: Full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
