### PR TITLE
Centralize the local node identity in IEnode via EnodeProvider

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Processing;

--- a/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
@@ -25,8 +25,6 @@ namespace Nethermind.Api
         IBlockProducer? BlockProducer { get; set; }
         IBlockProducerRunner BlockProducerRunner { get; set; }
 
-        IEnode? Enode { get; set; }
-
         IManualBlockProductionTrigger ManualBlockProductionTrigger { get; }
         ISealer Sealer { get; }
         ISealEngine SealEngine { get; }

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -67,7 +67,6 @@ namespace Nethermind.Api
         public IDbProvider DbProvider => Context.Resolve<IDbProvider>();
         public ISigner? EngineSigner { get; set; }
         public ISignerStore? EngineSignerStore { get; set; }
-        public IEnode? Enode { get; set; }
         public IEthereumEcdsa EthereumEcdsa => Context.Resolve<IEthereumEcdsa>();
         public IFileSystem FileSystem => Context.Resolve<IFileSystem>();
         public IEngineRequestsTracker EngineRequestsTracker => Context.Resolve<IEngineRequestsTracker>();

--- a/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
@@ -45,6 +45,10 @@ public class NetworkModule(IConfigProvider configProvider) : Module
             .AddSingleton<ITxGossipPolicySource, TxGossipPolicySource>()
             .AddCompositeOrderedComponents<ITxGossipPolicy, CompositeTxGossipPolicy>(singleInstance: true)
             .AddSingleton<IIPResolver, IPResolver>()
+
+            .AddSingleton<EnodeProvider>()
+            .Map<IEnode, EnodeProvider>(provider => provider.Enode)
+
             .AddSingleton<IForkInfo, ForkInfo>()
 
             // Rlpxhost

--- a/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
@@ -7,7 +7,6 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Container;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
 using Nethermind.Network;
@@ -139,7 +138,6 @@ public class NetworkModule(IConfigProvider configProvider) : Module
             .AddMessageSerializer<V71.BlockAccessListsMessage, V71.BlockAccessListsMessageSerializer>()
 
             // P2P protocol handler factory (accepts any version; validation happens after Hello)
-            .Map<PublicKey, IRlpxHost>(rlpx => rlpx.LocalNodeId)
             .AddProtocolHandler<P2PProtocolHandler>(Protocol.P2P)
 
             .AddSingleton<State.SnapServer.ISnapServer, State.IWorldStateManager>(wsm => wsm.SnapServer)

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -9,6 +9,7 @@ using Nethermind.Api;
 using Nethermind.Api.Extensions;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Exceptions;
 using Nethermind.Db;
@@ -57,6 +58,7 @@ public class InitializeNetwork : IStep
     private readonly NodeSourceToDiscV4Feeder _enrDiscoveryAppFeeder;
     private readonly ISyncConfig _syncConfig;
     private readonly IInitConfig _initConfig;
+    private readonly IEnode _enode;
     protected readonly IProtocolHandlerFactory[] _protocolHandlerFactories;
 
     private readonly ILogger _logger;
@@ -75,10 +77,12 @@ public class InitializeNetwork : IStep
         INetworkConfig networkConfig,
         ISyncConfig syncConfig,
         IInitConfig initConfig,
+        IEnode enode,
         ILogManager logManager
     )
     {
         _api = api;
+        _enode = enode;
         NodeStatsManager = nodeStatsManager;
         _synchronizer = synchronizer;
         _syncPeerPool = syncPeerPool;
@@ -183,18 +187,13 @@ public class InitializeNetwork : IStep
             _logger.Error("Unable to start the peer manager.", e);
         }
 
-        if (_api.Enode is null)
-        {
-            throw new InvalidOperationException("Cannot initialize network without knowing own enode");
-        }
-
         ProductInfo.InitializePublicClientId(_networkConfig.PublicClientIdFormat);
 
-        ThisNodeInfo.AddInfo("Ethereum     :", $"tcp://{_api.Enode.HostIp}:{_api.Enode.Port} ");
+        ThisNodeInfo.AddInfo("Ethereum     :", $"tcp://{_enode.HostIp}:{_enode.Port} ");
         ThisNodeInfo.AddInfo("Client id    :", ProductInfo.ClientId);
         ThisNodeInfo.AddInfo("Public id    :", ProductInfo.PublicClientId);
-        ThisNodeInfo.AddInfo("This node    :", $"{_api.Enode.Info} ");
-        ThisNodeInfo.AddInfo("Node address :", $"{_api.Enode.Address} (do not use as an account)");
+        ThisNodeInfo.AddInfo("This node    :", $"{_enode.Info} ");
+        ThisNodeInfo.AddInfo("Node address :", $"{_enode.Address} (do not use as an account)");
     }
 
     private Task StartDiscovery()

--- a/src/Nethermind/Nethermind.Init/Steps/SetupKeyStore.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/SetupKeyStore.cs
@@ -1,12 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Steps;
-using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Crypto;
 using Nethermind.KeyStore;
@@ -62,11 +60,6 @@ namespace Nethermind.Init.Steps
             {
                 set.OriginalSignerKey = nodeKeyManager.LoadSignerKey();
             }
-
-            IPAddress ipAddress = networkConfig.ExternalIp is not null ? IPAddress.Parse(networkConfig.ExternalIp) : IPAddress.Loopback;
-            IEnode enode = set.Enode = new Enode(nodeKey.PublicKey, ipAddress, networkConfig.P2PPort);
-
-            get.LogManager.SetGlobalVariable("enode", enode.ToString());
 
             networkConfig.Bootnodes = [.. networkConfig.Bootnodes.Where(bn => bn.NodeId != nodeKey.PublicKey)];
 

--- a/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/DiscoveryApp.cs
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Autofac;
-using Autofac.Features.AttributeFilters;
 using DotNetty.Handlers.Logging;
 using DotNetty.Transport.Channels;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.ServiceStopper;
-using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Discovery.Discv4;
@@ -36,7 +34,7 @@ public class DiscoveryApp : IDiscoveryApp, IAsyncDisposable
 
     public DiscoveryApp(
         ILifetimeScope rootScope,
-        [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
+        IEnode enode,
         INetworkConfig networkConfig,
         IDiscoveryConfig discoveryConfig,
         IProcessExitSource processExitSource,
@@ -76,7 +74,7 @@ public class DiscoveryApp : IDiscoveryApp, IAsyncDisposable
             (builder) =>
             {
                 builder
-                .AddModule(new DiscV4KademliaModule(nodeKey.PublicKey, bootNodes))
+                .AddModule(new DiscV4KademliaModule(enode.PublicKey, bootNodes))
                 .AddSingleton<DiscV4Services>();
 
                 configureDiscv4Services?.Invoke(builder);

--- a/src/Nethermind/Nethermind.Network.Test/NodesLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodesLoaderTests.cs
@@ -5,10 +5,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Nethermind.Config;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Discovery;
-using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using NSubstitute;
@@ -32,8 +33,7 @@ public class NodesLoaderTests
         _discoveryConfig = new DiscoveryConfig();
         _statsManager = Substitute.For<INodeStatsManager>();
         _peerStorage = Substitute.For<INetworkStorage>();
-        IRlpxHost rlpxHost = Substitute.For<IRlpxHost>();
-        _loader = new NodesLoader(_networkConfig, _statsManager, _peerStorage, rlpxHost, LimboLogs.Instance);
+        _loader = new NodesLoader(_networkConfig, _statsManager, _peerStorage, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/NodesLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodesLoaderTests.cs
@@ -3,10 +3,10 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Nethermind.Config;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Modules;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Discovery;
@@ -33,7 +33,7 @@ public class NodesLoaderTests
         _discoveryConfig = new DiscoveryConfig();
         _statsManager = Substitute.For<INodeStatsManager>();
         _peerStorage = Substitute.For<INetworkStorage>();
-        _loader = new NodesLoader(_networkConfig, _statsManager, _peerStorage, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
+        _loader = new NodesLoader(_networkConfig, _statsManager, _peerStorage, new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 30303), LimboLogs.Instance);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -3,11 +3,12 @@
 
 using System.Linq;
 using System.Collections.Generic;
+using System.Net;
+using Nethermind.Config;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Modules;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
 using Nethermind.Network.Contract.P2P;
@@ -64,7 +65,7 @@ namespace Nethermind.Network.Test.P2P
 
             return new P2PProtocolHandler(
                 _session,
-                new InsecureProtectedPrivateKey(TestItem.PrivateKeyA),
+                new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 30303),
                 _nodeStatsManager,
                 _serializer,
                 Substitute.For<IBackgroundTaskScheduler>(),

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -7,6 +7,7 @@ using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
 using Nethermind.Network.Contract.P2P;
@@ -63,7 +64,7 @@ namespace Nethermind.Network.Test.P2P
 
             return new P2PProtocolHandler(
                 _session,
-                TestItem.PublicKeyA,
+                new InsecureProtectedPrivateKey(TestItem.PrivateKeyA),
                 _nodeStatsManager,
                 _serializer,
                 Substitute.For<IBackgroundTaskScheduler>(),

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -138,7 +138,8 @@ namespace Nethermind.Network.Test.P2P
         public void Sets_local_node_id_from_constructor()
         {
             P2PProtocolHandler p2PProtocolHandler = CreateSession();
-            Assert.That(TestItem.PublicKeyA, Is.EqualTo(p2PProtocolHandler.LocalNodeId));
+            p2PProtocolHandler.Init();
+            _session.Received(1).DeliverMessage(Arg.Is<HelloMessage>(m => m.NodeId == TestItem.PublicKeyA));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerFilteringIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerFilteringIntegrationTests.cs
@@ -12,7 +12,6 @@ using DotNetty.Transport.Channels;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Modules;
 using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Logging;
@@ -45,14 +44,14 @@ public class PeerManagerFilteringIntegrationTests
             MaxOutgoingConnectPerSec = 1000000
         };
 
-        NodesLoader nodesLoader = new(networkConfig, stats, storage, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
+        NodesLoader nodesLoader = new(networkConfig, stats, storage, new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 30303), LimboLogs.Instance);
         IStaticNodesManager staticNodesManager = Substitute.For<IStaticNodesManager>();
         staticNodesManager.DiscoverNodes(Arg.Any<CancellationToken>()).Returns(AsyncEnumerable.Empty<Node>());
         TestNodeSource testNodeSource = new();
         CompositeNodeSource nodeSources = new(nodesLoader, Substitute.For<IDiscoveryApp>(), staticNodesManager, testNodeSource);
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
         IPeerPool peerPool = new PeerPool(nodeSources, stats, storage, networkConfig, LimboLogs.Instance, trustedNodesManager);
-        PeerManager peerManager = new(trackingMock, peerPool, stats, networkConfig, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
+        PeerManager peerManager = new(trackingMock, peerPool, stats, networkConfig, new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 30303), LimboLogs.Instance);
 
         try
         {
@@ -154,14 +153,14 @@ public class PeerManagerFilteringIntegrationTests
                 MaxOutgoingConnectPerSec = 1000000
             };
 
-            NodesLoader nodesLoader = new(networkConfig, stats, storage, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
+            NodesLoader nodesLoader = new(networkConfig, stats, storage, new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 30303), LimboLogs.Instance);
             StaticNodesManager = Substitute.For<IStaticNodesManager>();
             StaticNodesManager.DiscoverNodes(Arg.Any<CancellationToken>()).Returns(AsyncEnumerable.Empty<Node>());
             TestNodeSource = new TestNodeSource();
             CompositeNodeSource nodeSources = new(nodesLoader, Substitute.For<IDiscoveryApp>(), StaticNodesManager, TestNodeSource);
             ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
             PeerPool = new PeerPool(nodeSources, stats, storage, networkConfig, LimboLogs.Instance, trustedNodesManager);
-            PeerManager = new PeerManager(RlpxMock, PeerPool, stats, networkConfig, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
+            PeerManager = new PeerManager(RlpxMock, PeerPool, stats, networkConfig, new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 30303), LimboLogs.Instance);
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerFilteringIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerFilteringIntegrationTests.cs
@@ -12,6 +12,7 @@ using DotNetty.Transport.Channels;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Logging;
@@ -44,14 +45,14 @@ public class PeerManagerFilteringIntegrationTests
             MaxOutgoingConnectPerSec = 1000000
         };
 
-        NodesLoader nodesLoader = new(networkConfig, stats, storage, trackingMock, LimboLogs.Instance);
+        NodesLoader nodesLoader = new(networkConfig, stats, storage, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
         IStaticNodesManager staticNodesManager = Substitute.For<IStaticNodesManager>();
         staticNodesManager.DiscoverNodes(Arg.Any<CancellationToken>()).Returns(AsyncEnumerable.Empty<Node>());
         TestNodeSource testNodeSource = new();
         CompositeNodeSource nodeSources = new(nodesLoader, Substitute.For<IDiscoveryApp>(), staticNodesManager, testNodeSource);
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
         IPeerPool peerPool = new PeerPool(nodeSources, stats, storage, networkConfig, LimboLogs.Instance, trustedNodesManager);
-        PeerManager peerManager = new(trackingMock, peerPool, stats, networkConfig, LimboLogs.Instance);
+        PeerManager peerManager = new(trackingMock, peerPool, stats, networkConfig, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
 
         try
         {
@@ -153,14 +154,14 @@ public class PeerManagerFilteringIntegrationTests
                 MaxOutgoingConnectPerSec = 1000000
             };
 
-            NodesLoader nodesLoader = new(networkConfig, stats, storage, RlpxMock, LimboLogs.Instance);
+            NodesLoader nodesLoader = new(networkConfig, stats, storage, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
             StaticNodesManager = Substitute.For<IStaticNodesManager>();
             StaticNodesManager.DiscoverNodes(Arg.Any<CancellationToken>()).Returns(AsyncEnumerable.Empty<Node>());
             TestNodeSource = new TestNodeSource();
             CompositeNodeSource nodeSources = new(nodesLoader, Substitute.For<IDiscoveryApp>(), StaticNodesManager, TestNodeSource);
             ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
             PeerPool = new PeerPool(nodeSources, stats, storage, networkConfig, LimboLogs.Instance, trustedNodesManager);
-            PeerManager = new PeerManager(RlpxMock, PeerPool, stats, networkConfig, LimboLogs.Instance);
+            PeerManager = new PeerManager(RlpxMock, PeerPool, stats, networkConfig, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
         }
 
         public async ValueTask DisposeAsync()
@@ -194,7 +195,6 @@ public class PeerManagerFilteringIntegrationTests
 
         public Task Init() => Task.CompletedTask;
         public Task Shutdown() => Task.CompletedTask;
-        public PublicKey LocalNodeId { get; } = TestItem.PublicKeyA;
         public int LocalPort => 30303;
         public event EventHandler<SessionEventArgs>? SessionCreated;
         public event SessionDisconnectedEventHandler? SessionDisconnected { add { } remove { } }
@@ -222,7 +222,6 @@ public class PeerManagerFilteringIntegrationTests
 
         public Task Init() => Task.CompletedTask;
         public Task Shutdown() => Task.CompletedTask;
-        public PublicKey LocalNodeId { get; } = TestItem.PublicKeyA;
         public int LocalPort => 30303;
         public event EventHandler<SessionEventArgs>? SessionCreated { add { } remove { } }
         public event SessionDisconnectedEventHandler? SessionDisconnected { add { } remove { } }

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -13,7 +13,6 @@ using Nethermind.Config;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Modules;
 using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Logging;
@@ -727,7 +726,7 @@ namespace Nethermind.Network.Test
                 ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
                 Stats = new NodeStatsManager(timerFactory, LimboLogs.Instance);
                 Storage = new InMemoryStorage();
-                NodesLoader = new NodesLoader(new NetworkConfig(), Stats, Storage, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
+                NodesLoader = new NodesLoader(new NetworkConfig(), Stats, Storage, new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 30303), LimboLogs.Instance);
                 NetworkConfig = new NetworkConfig();
                 NetworkConfig.MaxActivePeers = maxActivePeers;
                 NetworkConfig.PeersPersistenceInterval = 50;
@@ -742,7 +741,7 @@ namespace Nethermind.Network.Test
                 CreatePeerManager();
             }
 
-            public void CreatePeerManager() => PeerManager = new PeerManager(RlpxPeer, PeerPool, Stats, NetworkConfig, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
+            public void CreatePeerManager() => PeerManager = new PeerManager(RlpxPeer, PeerPool, Stats, NetworkConfig, new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 30303), LimboLogs.Instance);
 
             public void SetupPersistedPeers(int count) => Storage.UpdateNodes(CreateNodes(count));
 

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -13,6 +13,7 @@ using Nethermind.Config;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Logging;
@@ -726,7 +727,7 @@ namespace Nethermind.Network.Test
                 ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
                 Stats = new NodeStatsManager(timerFactory, LimboLogs.Instance);
                 Storage = new InMemoryStorage();
-                NodesLoader = new NodesLoader(new NetworkConfig(), Stats, Storage, RlpxPeer, LimboLogs.Instance);
+                NodesLoader = new NodesLoader(new NetworkConfig(), Stats, Storage, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
                 NetworkConfig = new NetworkConfig();
                 NetworkConfig.MaxActivePeers = maxActivePeers;
                 NetworkConfig.PeersPersistenceInterval = 50;
@@ -741,7 +742,7 @@ namespace Nethermind.Network.Test
                 CreatePeerManager();
             }
 
-            public void CreatePeerManager() => PeerManager = new PeerManager(RlpxPeer, PeerPool, Stats, NetworkConfig, LimboLogs.Instance);
+            public void CreatePeerManager() => PeerManager = new PeerManager(RlpxPeer, PeerPool, Stats, NetworkConfig, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), LimboLogs.Instance);
 
             public void SetupPersistedPeers(int count) => Storage.UpdateNodes(CreateNodes(count));
 
@@ -934,7 +935,6 @@ namespace Nethermind.Network.Test
 
             public Task Shutdown() => Task.CompletedTask;
 
-            public PublicKey LocalNodeId { get; } = TestItem.PublicKeyA;
             public int LocalPort => 0;
             public event EventHandler<SessionEventArgs> SessionCreated;
             public event SessionDisconnectedEventHandler SessionDisconnected;

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -136,7 +136,6 @@ public class ProtocolsManagerTests
 
             _rlpxHost = Substitute.For<IRlpxHost>();
             _rlpxHost.LocalPort.Returns(_localPort);
-            _rlpxHost.LocalNodeId.Returns(TestItem.PublicKeyA);
             ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
             _nodeStatsManager = new NodeStatsManager(timerFactory, LimboLogs.Instance);
             _blockTree = Substitute.For<IBlockTree>();

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
@@ -165,7 +166,7 @@ public class ProtocolsManagerTests
 
         private IProtocolHandlerFactory[] BuildProtocolHandlerFactories() => [
                 new ReusableProtocolHandlerFactory<P2PProtocolHandler>(
-                    session => new P2PProtocolHandler(session, _rlpxHost.LocalNodeId, _nodeStatsManager, _serializer, RunImmediatelyScheduler.Instance, LimboLogs.Instance),
+                    session => new P2PProtocolHandler(session, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), _nodeStatsManager, _serializer, RunImmediatelyScheduler.Instance, LimboLogs.Instance),
                     Protocol.P2P),
                 new ReusableProtocolHandlerFactory<Eth66ProtocolHandler>(
                     session => new Eth66ProtocolHandler(session, _serializer, _nodeStatsManager, _syncServer, RunImmediatelyScheduler.Instance, _txPool, _gossipPolicy, _forkInfo, LimboLogs.Instance),

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Net;
 using System.Numerics;
 using DotNetty.Transport.Channels;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -13,7 +15,6 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Modules;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
@@ -165,7 +166,7 @@ public class ProtocolsManagerTests
 
         private IProtocolHandlerFactory[] BuildProtocolHandlerFactories() => [
                 new ReusableProtocolHandlerFactory<P2PProtocolHandler>(
-                    session => new P2PProtocolHandler(session, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA), _nodeStatsManager, _serializer, RunImmediatelyScheduler.Instance, LimboLogs.Instance),
+                    session => new P2PProtocolHandler(session, new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 30303), _nodeStatsManager, _serializer, RunImmediatelyScheduler.Instance, LimboLogs.Instance),
                     Protocol.P2P),
                 new ReusableProtocolHandlerFactory<Eth66ProtocolHandler>(
                     session => new Eth66ProtocolHandler(session, _serializer, _nodeStatsManager, _syncServer, RunImmediatelyScheduler.Instance, _txPool, _gossipPolicy, _forkInfo, LimboLogs.Instance),

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/RlpxPeerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/RlpxPeerTests.cs
@@ -4,8 +4,6 @@
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Modules;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P.Analyzers;
@@ -25,7 +23,6 @@ namespace Nethermind.Network.Test.Rlpx
         {
             RlpxHost host = new(
                 Substitute.For<IMessageSerializationService>(),
-                new InsecureProtectedPrivateKey(TestItem.PrivateKeyA),
                 Substitute.For<IHandshakeService>(),
                 Substitute.For<ISessionMonitor>(),
                 NullDisconnectsAnalyzer.Instance,

--- a/src/Nethermind/Nethermind.Network.Test/RlpxHostIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/RlpxHostIntegrationTests.cs
@@ -4,7 +4,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Modules;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P;
@@ -86,7 +85,6 @@ public class RlpxHostIntegrationTests
 
         return new RlpxHost(
             Substitute.For<IMessageSerializationService>(),
-            new InsecureProtectedPrivateKey(TestItem.PrivateKeyA),
             Substitute.For<IHandshakeService>(),
             Substitute.For<ISessionMonitor>(),
             NullDisconnectsAnalyzer.Instance,

--- a/src/Nethermind/Nethermind.Network/EnodeProvider.cs
+++ b/src/Nethermind/Nethermind.Network/EnodeProvider.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Net;
+using Autofac.Features.AttributeFilters;
+using Nethermind.Config;
+using Nethermind.Crypto;
+using Nethermind.Logging;
+using Nethermind.Network.Config;
+
+namespace Nethermind.Network;
+
+public class EnodeProvider(
+    [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
+    INetworkConfig networkConfig,
+    ILogManager logManager)
+{
+    private IEnode? _enode;
+
+    public IEnode Enode => _enode ??= Build();
+
+    private IEnode Build()
+    {
+        IPAddress ipAddress = networkConfig.ExternalIp is not null
+            ? IPAddress.Parse(networkConfig.ExternalIp)
+            : IPAddress.Loopback;
+        Enode enode = new(nodeKey.PublicKey, ipAddress, networkConfig.P2PPort);
+        logManager.SetGlobalVariable("enode", enode.ToString());
+        return enode;
+    }
+}

--- a/src/Nethermind/Nethermind.Network/NodesLoader.cs
+++ b/src/Nethermind/Nethermind.Network/NodesLoader.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Config;
-using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
@@ -23,14 +22,14 @@ namespace Nethermind.Network
         INetworkConfig networkConfig,
         INodeStatsManager stats,
         [KeyFilter(DbNames.PeersDb)] INetworkStorage peerStorage,
-        [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
+        IEnode enode,
         ILogManager logManager) : INodeSource
     {
-        private readonly INetworkConfig _networkConfig = networkConfig ?? throw new ArgumentNullException(nameof(networkConfig));
-        private readonly INodeStatsManager _stats = stats ?? throw new ArgumentNullException(nameof(stats));
-        private readonly INetworkStorage _peerStorage = peerStorage ?? throw new ArgumentNullException(nameof(peerStorage));
-        private readonly IProtectedPrivateKey _nodeKey = nodeKey ?? throw new ArgumentNullException(nameof(nodeKey));
-        private readonly ILogger _logger = logManager?.GetClassLogger<NodesLoader>() ?? throw new ArgumentNullException(nameof(logManager));
+        private readonly INetworkConfig _networkConfig = networkConfig;
+        private readonly INodeStatsManager _stats = stats;
+        private readonly INetworkStorage _peerStorage = peerStorage;
+        private readonly IEnode _enode = enode;
+        private readonly ILogger _logger = logManager.GetClassLogger<NodesLoader>();
 
         public IAsyncEnumerable<Node> DiscoverNodes(CancellationToken cancellationToken)
         {
@@ -53,7 +52,7 @@ namespace Nethermind.Network
             });
 
             IEnumerable<Node> combined = allPeers
-                .Where(p => p.Id != _nodeKey.PublicKey)
+                .Where(p => p.Id != _enode.PublicKey)
                 .Where(p => !_networkConfig.OnlyStaticPeers || p.IsStatic);
 
             return combined.ToAsyncEnumerable();

--- a/src/Nethermind/Nethermind.Network/NodesLoader.cs
+++ b/src/Nethermind/Nethermind.Network/NodesLoader.cs
@@ -7,10 +7,10 @@ using System.Linq;
 using System.Threading;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Config;
+using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
-using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 
@@ -23,13 +23,13 @@ namespace Nethermind.Network
         INetworkConfig networkConfig,
         INodeStatsManager stats,
         [KeyFilter(DbNames.PeersDb)] INetworkStorage peerStorage,
-        IRlpxHost rlpxHost,
+        [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
         ILogManager logManager) : INodeSource
     {
         private readonly INetworkConfig _networkConfig = networkConfig ?? throw new ArgumentNullException(nameof(networkConfig));
         private readonly INodeStatsManager _stats = stats ?? throw new ArgumentNullException(nameof(stats));
         private readonly INetworkStorage _peerStorage = peerStorage ?? throw new ArgumentNullException(nameof(peerStorage));
-        private readonly IRlpxHost _rlpxHost = rlpxHost ?? throw new ArgumentNullException(nameof(rlpxHost));
+        private readonly IProtectedPrivateKey _nodeKey = nodeKey ?? throw new ArgumentNullException(nameof(nodeKey));
         private readonly ILogger _logger = logManager?.GetClassLogger<NodesLoader>() ?? throw new ArgumentNullException(nameof(logManager));
 
         public IAsyncEnumerable<Node> DiscoverNodes(CancellationToken cancellationToken)
@@ -53,7 +53,7 @@ namespace Nethermind.Network
             });
 
             IEnumerable<Node> combined = allPeers
-                .Where(p => p.Id != _rlpxHost.LocalNodeId)
+                .Where(p => p.Id != _nodeKey.PublicKey)
                 .Where(p => !_networkConfig.OnlyStaticPeers || p.IsStatic);
 
             return combined.ToAsyncEnumerable();

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -8,14 +8,13 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Autofac.Features.AttributeFilters;
 using FastEnumUtility;
+using Nethermind.Config;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Contract.P2P;
 using Nethermind.Network.P2P.EventArg;
@@ -28,7 +27,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers;
 
 public class P2PProtocolHandler(
     ISession session,
-    [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
+    IEnode enode,
     INodeStatsManager nodeStatsManager,
     IMessageSerializationService serializer,
     IBackgroundTaskScheduler backgroundTaskScheduler,
@@ -62,7 +61,7 @@ public class P2PProtocolHandler(
     private readonly List<Capability> _supportedCapabilities = [];
 
     public int ListenPort { get; } = session.LocalPort;
-    private readonly PublicKey _localNodeId = nodeKey.PublicKey;
+    private readonly PublicKey _localNodeId = enode.PublicKey;
     private string RemoteClientId { get; set; }
 
     public bool HasAvailableCapability(Capability capability) => _availableCapabilities.Contains(capability);

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -62,7 +62,7 @@ public class P2PProtocolHandler(
     private readonly List<Capability> _supportedCapabilities = [];
 
     public int ListenPort { get; } = session.LocalPort;
-    public PublicKey LocalNodeId { get; } = nodeKey.PublicKey;
+    private readonly PublicKey _localNodeId = nodeKey.PublicKey;
     private string RemoteClientId { get; set; }
 
     public bool HasAvailableCapability(Capability capability) => _availableCapabilities.Contains(capability);
@@ -432,7 +432,7 @@ public class P2PProtocolHandler(
         {
             Capabilities = _supportedCapabilities.ToPooledList(),
             ClientId = ProductInfo.PublicClientId,
-            NodeId = LocalNodeId,
+            NodeId = _localNodeId,
             ListenPort = ListenPort,
             P2PVersion = ProtocolVersion
         };

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -8,12 +8,14 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Autofac.Features.AttributeFilters;
 using FastEnumUtility;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Contract.P2P;
 using Nethermind.Network.P2P.EventArg;
@@ -26,7 +28,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers;
 
 public class P2PProtocolHandler(
     ISession session,
-    PublicKey localNodeId,
+    [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
     INodeStatsManager nodeStatsManager,
     IMessageSerializationService serializer,
     IBackgroundTaskScheduler backgroundTaskScheduler,
@@ -60,7 +62,7 @@ public class P2PProtocolHandler(
     private readonly List<Capability> _supportedCapabilities = [];
 
     public int ListenPort { get; } = session.LocalPort;
-    public PublicKey LocalNodeId { get; } = localNodeId;
+    public PublicKey LocalNodeId { get; } = nodeKey.PublicKey;
     private string RemoteClientId { get; set; }
 
     public bool HasAvailableCapability(Capability capability) => _availableCapabilities.Contains(capability);

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -13,14 +13,13 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using Autofac.Features.AttributeFilters;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.ServiceStopper;
-using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P;
@@ -39,7 +38,7 @@ namespace Nethermind.Network
         private readonly ILogger _logger;
         private readonly INetworkConfig _networkConfig;
         private readonly IRlpxHost _rlpxHost;
-        private readonly IProtectedPrivateKey _nodeKey;
+        private readonly IEnode _enode;
         private readonly INodeStatsManager _stats;
         private readonly SemaphoreSlim _peerUpdateRequested = new(0, 1);
         private Task? _peerUpdateLoopTask;
@@ -73,19 +72,12 @@ namespace Nethermind.Network
             IPeerPool peerPool,
             INodeStatsManager stats,
             INetworkConfig networkConfig,
-            [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
+            IEnode enode,
             ILogManager logManager)
         {
-            ArgumentNullException.ThrowIfNull(rlpxHost);
-            ArgumentNullException.ThrowIfNull(peerPool);
-            ArgumentNullException.ThrowIfNull(stats);
-            ArgumentNullException.ThrowIfNull(networkConfig);
-            ArgumentNullException.ThrowIfNull(nodeKey);
-            ArgumentNullException.ThrowIfNull(logManager);
-
             _logger = logManager.GetClassLogger<PeerManager>();
             _rlpxHost = rlpxHost;
-            _nodeKey = nodeKey;
+            _enode = enode;
             _stats = stats;
             _networkConfig = networkConfig;
             _onHandshakeComplete = OnHandshakeComplete;
@@ -1034,7 +1026,7 @@ namespace Nethermind.Network
         private ConnectionDirection ChooseDirectionToKeep(PublicKey remoteNode)
         {
             if (_logger.IsTrace) TraceChoosingDirection();
-            byte[] localKey = _nodeKey.PublicKey.Bytes;
+            byte[] localKey = _enode.PublicKey.Bytes;
             byte[] remoteKey = remoteNode.Bytes;
             for (int i = 0; i < remoteNode.Bytes.Length; i++)
             {

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -13,12 +13,14 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Autofac.Features.AttributeFilters;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.ServiceStopper;
+using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P;
@@ -37,6 +39,7 @@ namespace Nethermind.Network
         private readonly ILogger _logger;
         private readonly INetworkConfig _networkConfig;
         private readonly IRlpxHost _rlpxHost;
+        private readonly IProtectedPrivateKey _nodeKey;
         private readonly INodeStatsManager _stats;
         private readonly SemaphoreSlim _peerUpdateRequested = new(0, 1);
         private Task? _peerUpdateLoopTask;
@@ -70,16 +73,19 @@ namespace Nethermind.Network
             IPeerPool peerPool,
             INodeStatsManager stats,
             INetworkConfig networkConfig,
+            [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
             ILogManager logManager)
         {
             ArgumentNullException.ThrowIfNull(rlpxHost);
             ArgumentNullException.ThrowIfNull(peerPool);
             ArgumentNullException.ThrowIfNull(stats);
             ArgumentNullException.ThrowIfNull(networkConfig);
+            ArgumentNullException.ThrowIfNull(nodeKey);
             ArgumentNullException.ThrowIfNull(logManager);
 
             _logger = logManager.GetClassLogger<PeerManager>();
             _rlpxHost = rlpxHost;
+            _nodeKey = nodeKey;
             _stats = stats;
             _networkConfig = networkConfig;
             _onHandshakeComplete = OnHandshakeComplete;
@@ -1028,7 +1034,7 @@ namespace Nethermind.Network
         private ConnectionDirection ChooseDirectionToKeep(PublicKey remoteNode)
         {
             if (_logger.IsTrace) TraceChoosingDirection();
-            byte[] localKey = _rlpxHost.LocalNodeId.Bytes;
+            byte[] localKey = _nodeKey.PublicKey.Bytes;
             byte[] remoteKey = remoteNode.Bytes;
             for (int i = 0; i < remoteNode.Bytes.Length; i++)
             {

--- a/src/Nethermind/Nethermind.Network/Rlpx/IRlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/IRlpxHost.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using Nethermind.Core.Crypto;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.EventArg;
 using Nethermind.Stats.Model;
@@ -24,7 +23,6 @@ namespace Nethermind.Network.Rlpx
         Task Init();
         Task<bool> ConnectAsync(Node node);
         Task Shutdown();
-        PublicKey LocalNodeId { get; }
         int LocalPort { get; }
 
         /// <summary>

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -9,15 +9,12 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Autofac.Features.AttributeFilters;
 using DotNetty.Common.Concurrency;
 using DotNetty.Handlers.Logging;
 using DotNetty.Transport.Bootstrapping;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Sockets;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P;
@@ -37,7 +34,6 @@ namespace Nethermind.Network.Rlpx
         private IEventLoopGroup? _workerGroup;
 
         private bool _isInitialized;
-        public PublicKey LocalNodeId { get; }
         public int LocalPort { get; }
         private string? LocalIp { get; }
         private readonly IHandshakeService _handshakeService;
@@ -63,7 +59,6 @@ namespace Nethermind.Network.Rlpx
 
         public RlpxHost(
             IMessageSerializationService serializationService,
-            [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
             IHandshakeService handshakeService,
             ISessionMonitor sessionMonitor,
             IDisconnectsAnalyzer disconnectsAnalyzer,
@@ -72,7 +67,6 @@ namespace Nethermind.Network.Rlpx
             IChannelFactory? channelFactory = null)
         {
             ArgumentNullException.ThrowIfNull(serializationService);
-            ArgumentNullException.ThrowIfNull(nodeKey);
             ArgumentNullException.ThrowIfNull(handshakeService);
             ArgumentNullException.ThrowIfNull(sessionMonitor);
             ArgumentNullException.ThrowIfNull(disconnectsAnalyzer);
@@ -94,7 +88,6 @@ namespace Nethermind.Network.Rlpx
             _sessionMonitor = sessionMonitor;
             _disconnectsAnalyzer = disconnectsAnalyzer;
             _handshakeService = handshakeService;
-            LocalNodeId = nodeKey.PublicKey;
             LocalPort = networkConfig.P2PPort;
             LocalIp = networkConfig.LocalIp;
             _sendLatency = TimeSpan.FromMilliseconds(networkConfig.SimulateSendLatencyMs);

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Build.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Build.cs
@@ -89,7 +89,6 @@ namespace Nethermind.Runner.Test.Ethereum
 
         public static void MockOutNethermindApi(NethermindApi api)
         {
-            api.Enode = Substitute.For<IEnode>();
             api.TxPool = Substitute.For<ITxPool>();
             api.Wallet = Substitute.For<IWallet>();
             api.BlockProducer = Substitute.For<IBlockProducer>();

--- a/src/Nethermind/Nethermind.Runner.Test/Module/NetworkModuleTest.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/NetworkModuleTest.cs
@@ -258,6 +258,7 @@ public class NetworkModuleTest
                 networkConfig,
                 syncConfig,
                 Substitute.For<IInitConfig>(),
+                Substitute.For<IEnode>(),
                 logManager)
     {
         public Task RunInitPeer() => InitPeer();

--- a/src/Nethermind/Nethermind.Xdc/Discovery/XdcDiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Xdc/Discovery/XdcDiscoveryApp.cs
@@ -4,7 +4,6 @@
 using Autofac;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Config;
-using Nethermind.Crypto;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Discovery;
@@ -13,14 +12,14 @@ namespace Nethermind.Xdc.Discovery;
 
 public class XdcDiscoveryApp(
     ILifetimeScope rootScope,
-    [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey,
+    IEnode enode,
     IProcessExitSource processExitSource,
     INetworkConfig networkConfig,
     IDiscoveryConfig discoveryConfig,
     ILogManager logManager)
     : DiscoveryApp(
         rootScope,
-        nodeKey,
+        enode,
         networkConfig,
         discoveryConfig,
         processExitSource,


### PR DESCRIPTION
## Changes

The local node's identity (public key / enode) was re-derived in several places — mapped off `IRlpxHost`, exposed as redundant `LocalNodeId` properties, and held only on `INethermindApi.Enode` (not in DI). This PR makes **`IEnode` the single owner of the local node identity** and routes every consumer through it.

- **`EnodeProvider` (new)** lazily builds and owns the local `IEnode` from the node key + `INetworkConfig`, and `IEnode` is now registered in DI (`.Map<IEnode, EnodeProvider>`). `INethermindApi.Enode` is removed; enode construction (and the `enode` log global) moves out of `SetupKeyStore` into `EnodeProvider`, and `InitializeNetwork` injects `IEnode` for startup logging.
- **Removed the `PublicKey` DI component** that was mapped from `IRlpxHost.LocalNodeId` — resolving the node id no longer forces constructing the entire RLPx host.
- **Removed redundant `LocalNodeId` exposures:** `P2PProtocolHandler.LocalNodeId` (used only internally, not on `IP2PProtocolHandler`) and `IRlpxHost`/`RlpxHost.LocalNodeId`. `RlpxHost` no longer takes the node key at all.
- **Consumers that only needed the node's public key** — `P2PProtocolHandler`, `PeerManager`, `NodesLoader`, `DiscoveryApp`, `XdcDiscoveryApp` — now inject `IEnode` and read `.PublicKey` instead of injecting `IProtectedPrivateKey`.

No behavior change: the node id / enode string are identical; the identity is just owned in one place and sourced consistently.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Existing tests were adapted to the new constructor shapes. Verified locally: full `Nethermind.slnx` build clean (0 warnings/errors); `Nethermind.Network.Test` (1128 passing) and the `Nethermind.Runner.Test` `NetworkModule` DI-resolution tests pass; `E2ESyncTests` green — it exercises the production DI path where `IEnode` resolves from `EnodeProvider` in the full container and `P2PProtocolHandler`/`PeerManager`/`NodesLoader` complete the P2P `Hello` handshake and sync.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
