### PR TITLE
fix: wrap `eth_simulate` with no eip3607 spec to skip sender is not eoa check

### DIFF
--- a/scripts/known-failing-hive-tests.txt
+++ b/scripts/known-failing-hive-tests.txt
@@ -3,10 +3,6 @@
 testing_buildBlockV1/build-block-empty-transactions (nethermind)
 testing_buildBlockV1/build-block-with-transactions (nethermind)
 
-# eth_simulateV1 — execution-apis spec ↔ test fixture mismatches. Tracked in
-# https://github.com/NethermindEth/nethermind/issues/11412
-eth_simulateV1/ethSimulate-simple-send-from-contract-with-validation (nethermind)
-
 # graphql
 
 01_eth_blockNumber (nethermind)

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.cs
@@ -73,5 +73,12 @@ public static class IReleaseSpecExtensions
         /// </summary>
         public IReleaseSpec WithoutEip158() =>
             spec.IsEip158Enabled ? new NoEip158Spec(spec) : spec;
+
+        /// <summary>
+        /// Returns a spec with EIP-3607 disabled, allowing contract addresses to act as transaction senders.
+        /// Used in <c>eth_simulateV1</c> where state-overridden contracts may be the <c>from</c> address.
+        /// </summary>
+        public IReleaseSpec WithoutEip3607() =>
+            spec.IsEip3607Enabled ? new NoEip3607Spec(spec) : spec;
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/NoEip3607Spec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/NoEip3607Spec.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core.Specs;
+
+/// <summary>
+/// Wraps a release spec and disables EIP-3607 so that contracts can act as transaction senders
+/// in simulated calls without being rejected by the sender-has-deployed-code check.
+/// </summary>
+internal sealed class NoEip3607Spec(IReleaseSpec spec) : ReleaseSpecDecorator(spec)
+{
+    public override bool IsEip3607Enabled => false;
+}

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
@@ -41,9 +41,7 @@ public class SimulateTransactionProcessorAdapter(ITransactionProcessor transacti
     public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
     {
         _currentTxIndex = 0;
-        BlockExecutionContext ctx = blockExecutionContext.Spec.IsEip3607Enabled
-            ? new BlockExecutionContext(blockExecutionContext.Header, blockExecutionContext.Spec.WithoutEip3607())
-            : blockExecutionContext;
+        BlockExecutionContext ctx = new(blockExecutionContext.Header, blockExecutionContext.Spec.WithoutEip3607());
         transactionProcessor.SetBlockExecutionContext(in ctx);
     }
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
@@ -40,6 +41,9 @@ public class SimulateTransactionProcessorAdapter(ITransactionProcessor transacti
     public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
     {
         _currentTxIndex = 0;
-        transactionProcessor.SetBlockExecutionContext(in blockExecutionContext);
+        BlockExecutionContext ctx = blockExecutionContext.Spec.IsEip3607Enabled
+            ? new BlockExecutionContext(blockExecutionContext.Header, blockExecutionContext.Spec.WithoutEip3607())
+            : blockExecutionContext;
+        transactionProcessor.SetBlockExecutionContext(in ctx);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -749,17 +749,18 @@ public class EthSimulateTestsBlocksAndTransactions
     }
 
     /// <summary>
-    /// Regression test: eth_simulateV1 with validation:true and a sender address that has deployed
-    /// code (EIP-3607) must return -38024 (SenderIsNotEoa).
+    /// Regression test for the Hive <c>ethSimulate-simple-send-from-contract-with-validation</c> case:
+    /// eth_simulateV1 must allow a state-overridden contract address as the <c>from</c> sender even
+    /// when <c>validation:true</c>. EIP-3607 must not be enforced inside simulate.
     /// </summary>
     [Test]
-    public async Task eth_simulateV1_sender_is_not_eoa_returns_spec_error_code()
+    public async Task eth_simulateV1_contract_sender_with_state_override_succeeds_when_validation_enabled()
     {
         OverridableReleaseSpec spec = new(London.Instance) { IsEip3607Enabled = true };
         TestSpecProvider specProvider = new(spec) { AllowTestChainOverride = false };
         TestRpcBlockchain chain = await TestRpcBlockchain.ForTest(new TestRpcBlockchain()).Build(specProvider);
 
-        // Override TestItem.AddressC with contract code — makes it a non-EOA sender.
+        // Override TestItem.AddressC with contract code and balance — the simulate call uses it as sender.
         SimulatePayload<TransactionForRpc> payload = new()
         {
             BlockStateCalls =
@@ -796,7 +797,9 @@ public class EthSimulateTestsBlocksAndTransactions
         ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
             chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
 
-        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.SenderIsNotEoa));
+        Assert.That(result.Result.ResultType, Is.EqualTo(Core.ResultType.Success));
+        Assert.That(result.Data, Is.Not.Null);
+        Assert.That(result.Data![0].Calls.First().Error, Is.Null);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #12053

As mentioned in RPC & Hive discrepancy i have made the changes following this comment 
https://github.com/NethermindEth/nethermind/issues/11412#issuecomment-4432910571

## Changes

- Add `WithoutEip3607()` as an extension method 
- Apply `WithoutEip3607()` in `SimulateTransactionProcessorAdapter.SetBlockExecutionContext` so the wrapped spec is used for all simulate calls
- Changed regression test

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Covers the failing Hive test `ethSimulate-simple-send-from-contract-with-validation`.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
