### PR TITLE
Handle incompatible discovery fork IDs

### DIFF
--- a/src/Nethermind/Nethermind.Init/Modules/DiscoveryModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DiscoveryModule.cs
@@ -44,10 +44,13 @@ public class DiscoveryModule(IInitConfig initConfig, INetworkConfig networkConfi
                 EnrRecordParser enrRecordParser = new(nodeRecordSigner);
                 return new EnrDiscovery(enrRecordParser, networkConfig, logManager); // initialize with a proper network
             })
+            .AddSingleton<EnrForkIdFilteringNodeSource, EnrDiscovery, IEnrForkIdFilter, ILogManager>((enrDiscovery, enrForkIdFilter, logManager) =>
+                new EnrForkIdFilteringNodeSource(enrDiscovery, enrForkIdFilter, logManager))
+            .AddSingleton<IEnrForkIdFilter, EnrForkIdFilter>()
 
             // Allow feeding discovery app bootnodes from enr. Need `Run` to be called.
             .AddSingleton<NodeSourceToDiscV4Feeder>()
-            .AddKeyedSingleton<INodeSource>(NodeSourceToDiscV4Feeder.SourceKey, ctx => ctx.Resolve<EnrDiscovery>())
+            .AddKeyedSingleton<INodeSource>(NodeSourceToDiscV4Feeder.SourceKey, ctx => ctx.Resolve<EnrForkIdFilteringNodeSource>())
 
             // Uses by RPC also.
             .AddSingleton<IStaticNodesManager, ILogManager>(logManager =>
@@ -128,7 +131,7 @@ public class DiscoveryModule(IInitConfig initConfig, INetworkConfig networkConfi
         {
             // These are INodeSource only if `OnlyStaticPeers` is false.
             builder.Bind<INodeSource, IDiscoveryApp>();
-            if (networkConfig.EnableEnrDiscovery) builder.Bind<INodeSource, EnrDiscovery>();
+            if (networkConfig.EnableEnrDiscovery) builder.Bind<INodeSource, EnrForkIdFilteringNodeSource>();
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryV5AppTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/DiscoveryV5AppTests.cs
@@ -68,6 +68,7 @@ public class DiscoveryV5AppTests
         builder.RegisterInstance(ecdsa).As<IEthereumEcdsa>().As<IEcdsa>();
         builder.RegisterInstance(blockTree).As<IBlockTree>();
         builder.RegisterInstance(forkInfo).As<IForkInfo>();
+        builder.RegisterInstance(new TestEnrForkIdFilter()).As<IEnrForkIdFilter>();
         builder.RegisterInstance(Timestamper.Default).As<ITimestamper>();
         builder.RegisterInstance(new CryptoRandom()).As<ICryptoRandom>();
         builder.RegisterInstance(new NetworkStorage(_discoveryDb, LimboLogs.Instance)).Keyed<INetworkStorage>(DbNames.DiscoveryV5Nodes);

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/DiscoveryPersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/DiscoveryPersistenceManagerTests.cs
@@ -67,6 +67,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             _discv4Adapter,
             _kademlia,
             _discoveryConfig,
+            new TestEnrForkIdFilter(),
             _logManager);
 
         private static Task PingReceived(IKademliaAdapter adapter, NetworkNode node, int times = 1) =>

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/Kademlia/KademliaAdapterTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/Kademlia/KademliaAdapterTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
 using Nethermind.Kademlia;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
@@ -48,6 +49,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
         private ILogManager _logManager = null!;
         private ITimestamper _timestamper = null!;
         private IMsgSender _msgSender = null!;
+        private INodeRecordProvider _nodeRecordProvider = null!;
         private INodeStatsManager _nodeStatsManager = null!;
         private Node _testNode = null!;
         private PublicKey _testPublicKey = null!;
@@ -111,12 +113,17 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
             builder.WithDiscovery(TestItem.PrivateKeyB);
             _receiverSerializationManager = builder.TestObject;
 
-            INodeRecordProvider nodeRecordProvider = Substitute.For<INodeRecordProvider>();
-            nodeRecordProvider.GetCurrentAsync(Arg.Any<CancellationToken>()).Returns(new ValueTask<NodeRecord>(_selfNodeRecord));
+            _nodeRecordProvider = Substitute.For<INodeRecordProvider>();
+            _nodeRecordProvider.GetCurrentAsync(Arg.Any<CancellationToken>()).Returns(new ValueTask<NodeRecord>(_selfNodeRecord));
             _nodeStatsManager = Substitute.For<INodeStatsManager>();
             _nodeStatsManager.GetOrAdd(Arg.Any<Node>()).Returns(Substitute.For<INodeStats>());
 
-            _adapter = new KademliaAdapter(
+            _adapter = CreateAdapter();
+        }
+
+        private IKademliaAdapter CreateAdapter(IEnrForkIdFilter? enrForkIdFilter = null)
+        {
+            IKademliaAdapter adapter = new KademliaAdapter(
                 new Lazy<IKademlia<PublicKey, Node>>(() => _kademliaMessageReceiver),
                 new Lazy<INodeHealthTracker<Node>>(() => _nodeHealthTracker),
                 new DiscoveryConfig
@@ -127,13 +134,29 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
                     BondWaitTime = 1,
                 },
                 _kademliaConfig,
-                nodeRecordProvider,
+                _nodeRecordProvider,
+                enrForkIdFilter ?? new TestEnrForkIdFilter(),
                 _nodeStatsManager,
                 _timestamper,
                 Substitute.For<IProcessExitSource>(),
                 _logManager
             );
-            _adapter.MsgSender = _msgSender;
+
+            adapter.MsgSender = _msgSender;
+            return adapter;
+        }
+
+        private static NodeRecord CreateNodeRecord(PrivateKey privateKey, IPAddress ipAddress, int tcpPort, int udpPort, ulong enrSequence)
+            => TestEnrBuilder.BuildSigned(privateKey, ipAddress, tcpPort, udpPort, enrSequence: enrSequence);
+
+        private static bool HasEnrSequence(Node node, ulong enrSequence)
+        {
+            if (node.Enr is not { } record)
+            {
+                return false;
+            }
+
+            return record.EnrSequence == enrSequence;
         }
 
         [Test]
@@ -469,6 +492,165 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
             await _msgSender.Received(1).SendMsg(Arg.Is<PongMsg>(m =>
                 m.FarAddress!.Equals(_receiver.Address) &&
                 m.PingMdc == expectedPingMdc));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task OnIncomingMsg_ping_with_newer_enr_sequence_should_request_and_apply_enr(CancellationToken token)
+        {
+            await BondReceiver(token);
+
+            NodeRecord remoteRecord = CreateNodeRecord(
+                TestItem.PrivateKeyB,
+                _receiver.Address.Address,
+                _receiver.Address.Port,
+                _receiver.Address.Port,
+                2);
+            TaskCompletionSource<Node> refreshedNodeTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            _nodeHealthTracker
+                .When(tracker => tracker.OnIncomingMessageFrom(Arg.Any<Node>()))
+                .Do(callInfo =>
+                {
+                    Node node = (Node)callInfo[0]!;
+                    if (node.Id.Equals(_receiver.Id) && HasEnrSequence(node, remoteRecord.EnrSequence))
+                    {
+                        refreshedNodeTask.TrySetResult(node);
+                    }
+                });
+            ValueHash256 requestHash = TestItem.KeccakA.ValueHash256;
+            _msgSender
+                .When(x => x.SendMsg(Arg.Any<EnrRequestMsg>()))
+                .Do(callInfo =>
+                {
+                    EnrRequestMsg sent = (EnrRequestMsg)callInfo[0]!;
+                    sent.Hash = requestHash;
+                    EnrResponseMsg response = AddReceiverFarAddress(new EnrResponseMsg(
+                        _receiver.Address,
+                        remoteRecord,
+                        new Hash256(requestHash)));
+                    Task.Run(() => _adapter.OnIncomingMsg(response));
+                });
+
+            PingMsg pingMsg = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 20, _kademliaConfig.CurrentNodeId.Address)
+            {
+                EnrSequence = remoteRecord.EnrSequence
+            };
+            pingMsg.FarAddress = _receiver.Address;
+            pingMsg = AddReceiverFarAddress(pingMsg);
+
+            await _adapter.OnIncomingMsg(pingMsg);
+
+            Node refreshedNode = await refreshedNodeTask.Task.WaitAsync(token);
+            Assert.That(refreshedNode.Id, Is.EqualTo(_receiver.Id));
+            await _msgSender.Received(1).SendMsg(Arg.Is<EnrRequestMsg>(m => m.FarAddress!.Equals(_receiver.Address)));
+            _nodeHealthTracker.Received().OnIncomingMessageFrom(Arg.Is<Node>(n =>
+                n.Id.Equals(_receiver.Id) &&
+                HasEnrSequence(n, remoteRecord.EnrSequence)));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task OnIncomingMsg_ping_with_newer_incompatible_enr_sequence_should_remove_node(CancellationToken token)
+        {
+            _adapter = CreateAdapter(new TestEnrForkIdFilter(accept: false));
+            TaskCompletionSource<Node> removedNodeTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            _kademliaMessageReceiver
+                .When(kademlia => kademlia.Remove(Arg.Any<Node>()))
+                .Do(callInfo => removedNodeTask.TrySetResult((Node)callInfo[0]!));
+
+            NodeRecord remoteRecord = CreateNodeRecord(
+                TestItem.PrivateKeyB,
+                _receiver.Address.Address,
+                _receiver.Address.Port,
+                _receiver.Address.Port,
+                2);
+            ValueHash256 requestHash = TestItem.KeccakA.ValueHash256;
+            _msgSender
+                .When(x => x.SendMsg(Arg.Any<EnrRequestMsg>()))
+                .Do(callInfo =>
+                {
+                    EnrRequestMsg sent = (EnrRequestMsg)callInfo[0]!;
+                    sent.Hash = requestHash;
+                    EnrResponseMsg response = AddReceiverFarAddress(new EnrResponseMsg(
+                        _receiver.Address,
+                        remoteRecord,
+                        new Hash256(requestHash)));
+                    Task.Run(() => _adapter.OnIncomingMsg(response));
+                });
+
+            PingMsg pingMsg = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 20, _kademliaConfig.CurrentNodeId.Address)
+            {
+                EnrSequence = remoteRecord.EnrSequence
+            };
+            pingMsg.FarAddress = _receiver.Address;
+            pingMsg = AddReceiverFarAddress(pingMsg);
+
+            await _adapter.OnIncomingMsg(pingMsg);
+
+            Node removedNode = await removedNodeTask.Task.WaitAsync(token);
+            Assert.That(removedNode.Id, Is.EqualTo(_receiver.Id));
+            await _msgSender.DidNotReceive().SendMsg(Arg.Is<PingMsg>(m => m.FarAddress!.Equals(_receiver.Address)));
+            _kademliaMessageReceiver.Received(1).Remove(Arg.Is<Node>(n => n.Id.Equals(_receiver.Id)));
+            _nodeHealthTracker.DidNotReceive().OnIncomingMessageFrom(Arg.Is<Node>(n => n.Id.Equals(_receiver.Id)));
+        }
+
+        [Test]
+        [CancelAfter(10000)]
+        public async Task OnIncomingMsg_ping_without_enr_sequence_should_not_admit_node_while_enr_refresh_is_pending(CancellationToken token)
+        {
+            TaskCompletionSource<EnrRequestMsg> enrRequestTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<Node> refreshedNodeTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            NodeRecord remoteRecord = CreateNodeRecord(
+                TestItem.PrivateKeyB,
+                _receiver.Address.Address,
+                _receiver.Address.Port,
+                _receiver.Address.Port,
+                2);
+            _msgSender
+                .When(x => x.SendMsg(Arg.Any<EnrRequestMsg>()))
+                .Do(callInfo =>
+                {
+                    EnrRequestMsg sent = (EnrRequestMsg)callInfo[0]!;
+                    sent.Hash = TestItem.KeccakA.ValueHash256;
+                    enrRequestTask.TrySetResult(sent);
+                });
+            _nodeHealthTracker
+                .When(tracker => tracker.OnIncomingMessageFrom(Arg.Any<Node>()))
+                .Do(callInfo =>
+                {
+                    Node node = (Node)callInfo[0]!;
+                    if (node.Id.Equals(_receiver.Id) && HasEnrSequence(node, remoteRecord.EnrSequence))
+                    {
+                        refreshedNodeTask.TrySetResult(node);
+                    }
+                });
+
+            PingMsg firstPing = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 20, _kademliaConfig.CurrentNodeId.Address)
+            {
+                EnrSequence = remoteRecord.EnrSequence
+            };
+            firstPing.FarAddress = _receiver.Address;
+            firstPing = AddReceiverFarAddress(firstPing);
+
+            Task firstPingTask = _adapter.OnIncomingMsg(firstPing);
+            EnrRequestMsg request = await enrRequestTask.Task.WaitAsync(token);
+
+            PingMsg secondPing = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 20, _kademliaConfig.CurrentNodeId.Address);
+            secondPing.FarAddress = _receiver.Address;
+            secondPing = AddReceiverFarAddress(secondPing);
+
+            await _adapter.OnIncomingMsg(secondPing);
+
+            await _msgSender.DidNotReceive().SendMsg(Arg.Is<PingMsg>(m => m.FarAddress!.Equals(_receiver.Address)));
+            _nodeHealthTracker.DidNotReceive().OnIncomingMessageFrom(Arg.Is<Node>(n => n.Id.Equals(_receiver.Id)));
+
+            EnrResponseMsg response = AddReceiverFarAddress(new EnrResponseMsg(
+                _receiver.Address,
+                remoteRecord,
+                new Hash256(request.Hash!.Value)));
+            await _adapter.OnIncomingMsg(response);
+            await firstPingTask.WaitAsync(token);
+            await refreshedNodeTask.Task.WaitAsync(token);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/Kademlia/NodeSourceTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/Kademlia/NodeSourceTests.cs
@@ -66,6 +66,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
                 _discv4Adapter,
                 _discoveryConfig,
                 _kademliaConfig,
+                new TestEnrForkIdFilter(),
                 LimboLogs.Instance);
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv5/NodeSourceTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv5/NodeSourceTests.cs
@@ -112,6 +112,7 @@ public class NodeSourceTests
             new DiscoveryConfig { ConcurrentDiscoveryJob = 1 },
             new KademliaConfig<Node> { CurrentNodeId = CreateNode(0) },
             ExecutionLayerDiscv5RecordFilter.Instance,
+            new TestEnrForkIdFilter(),
             LimboLogs.Instance);
 
         await using IAsyncEnumerator<Node> enumerator = source.DiscoverNodes(token).GetAsyncEnumerator(token);
@@ -136,6 +137,7 @@ public class NodeSourceTests
             new DiscoveryConfig { ConcurrentDiscoveryJob = 0 },
             new KademliaConfig<Node> { CurrentNodeId = CreateNode(0) },
             ExecutionLayerDiscv5RecordFilter.Instance,
+            new TestEnrForkIdFilter(),
             LimboLogs.Instance);
     }
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/E2EDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/E2EDiscoveryTests.cs
@@ -53,6 +53,7 @@ public class E2EDiscoveryTests(DiscoveryVersion discoveryVersion)
 
         IForkInfo forkInfo = Substitute.For<IForkInfo>();
         forkInfo.GetForkId(Arg.Any<ulong>(), Arg.Any<ulong>()).Returns(new ForkId(0, 0));
+        forkInfo.ValidateForkId(Arg.Any<ForkId>(), Arg.Any<BlockHeader>()).Returns(ValidationResult.Valid);
 
         ContainerBuilder builder = new();
         builder

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/EnrForkIdFilterTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/EnrForkIdFilterTests.cs
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Logging;
+using Nethermind.Network.Enr;
+using NSubstitute;
+using NUnit.Framework;
+using EnrForkId = Nethermind.Network.Enr.ForkId;
+using NetworkForkId = Nethermind.Network.ForkId;
+
+namespace Nethermind.Network.Discovery.Test;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+public class EnrForkIdFilterTests
+{
+    [Test]
+    public void IsAcceptable_ShouldRejectRecordWithoutEthEntry()
+    {
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        EnrForkIdFilter filter = CreateFilter(forkInfo);
+
+        bool result = filter.IsAcceptable(new NodeRecord());
+
+        Assert.That(result, Is.False);
+        forkInfo.DidNotReceive().ValidateForkId(Arg.Any<NetworkForkId>(), Arg.Any<BlockHeader>());
+    }
+
+    [Test]
+    public void IsAcceptable_ShouldValidateEthForkId()
+    {
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        forkInfo.ValidateForkId(
+            Arg.Is<NetworkForkId>(forkId =>
+                forkId.ForkHash == 0x01020304 &&
+                forkId.Next == 128),
+            Arg.Any<BlockHeader>())
+            .Returns(ValidationResult.Valid);
+        EnrForkIdFilter filter = CreateFilter(forkInfo);
+
+        bool result = filter.IsAcceptable(CreateRecord([1, 2, 3, 4], 128));
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsAcceptable_ShouldRejectIncompatibleEthForkId()
+    {
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        forkInfo.ValidateForkId(Arg.Any<NetworkForkId>(), Arg.Any<BlockHeader>())
+            .Returns(ValidationResult.IncompatibleOrStale);
+        EnrForkIdFilter filter = CreateFilter(forkInfo);
+
+        bool result = filter.IsAcceptable(CreateRecord([1, 2, 3, 4], 128));
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsAcceptable_ShouldValidateNextBlockAboveSignedLongRange()
+    {
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        forkInfo.ValidateForkId(
+            Arg.Is<NetworkForkId>(forkId =>
+                forkId.ForkHash == 0x01020304 &&
+                forkId.Next == (ulong)long.MaxValue + 1),
+            Arg.Any<BlockHeader>())
+            .Returns(ValidationResult.Valid);
+        EnrForkIdFilter filter = CreateFilter(forkInfo);
+
+        bool result = filter.IsAcceptable(CreateRecord([1, 2, 3, 4], (ulong)long.MaxValue + 1));
+
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsAcceptable_ShouldRejectInvalidEthForkHash()
+    {
+        IForkInfo forkInfo = Substitute.For<IForkInfo>();
+        EnrForkIdFilter filter = CreateFilter(forkInfo);
+
+        bool result = filter.IsAcceptable(CreateRecord([1, 2, 3], 128));
+
+        Assert.That(result, Is.False);
+        forkInfo.DidNotReceive().ValidateForkId(Arg.Any<NetworkForkId>(), Arg.Any<BlockHeader>());
+    }
+
+    private static EnrForkIdFilter CreateFilter(IForkInfo forkInfo)
+        => new(Substitute.For<IBlockTree>(), forkInfo, LimboLogs.Instance);
+
+    private static NodeRecord CreateRecord(byte[] forkHash, ulong nextBlock)
+    {
+        NodeRecord record = new();
+        record.SetEntry(forkHash.Length == EnrForkId.ForkHashLength
+            ? new EthEntry(forkHash, nextBlock)
+            : new InvalidEthEntry(new EnrForkId(forkHash, nextBlock)));
+        return record;
+    }
+
+    private sealed class InvalidEthEntry(EnrForkId value) : EnrContentEntry<EnrForkId>(value)
+    {
+        public override string Key => EnrContentKey.Eth;
+
+        protected override int GetRlpLengthOfValue() => throw new NotSupportedException();
+
+        protected override void EncodeValue<TWriter>(ref TWriter writer) => throw new NotSupportedException();
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/EnrForkIdFilteringNodeSourceTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/EnrForkIdFilteringNodeSourceTests.cs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Logging;
+using Nethermind.Network.Enr;
+using Nethermind.Stats.Model;
+using NUnit.Framework;
+
+namespace Nethermind.Network.Discovery.Test;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+public class EnrForkIdFilteringNodeSourceTests
+{
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_ShouldSkipRejectedEnrNode(CancellationToken cancellationToken)
+    {
+        Node node = CreateNodeWithEnr();
+        EnrForkIdFilteringNodeSource source = new(
+            new TestNodeSource([node]),
+            new TestEnrForkIdFilter(accept: false),
+            LimboLogs.Instance);
+
+        await using IAsyncEnumerator<Node> enumerator = source.DiscoverNodes(cancellationToken).GetAsyncEnumerator(cancellationToken);
+
+        Assert.That(await enumerator.MoveNextAsync().AsTask(), Is.False);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_ShouldKeepNodesWithoutEnr(CancellationToken cancellationToken)
+    {
+        Node node = new(TestItem.PublicKeyA, "8.8.8.8", 30303);
+        EnrForkIdFilteringNodeSource source = new(
+            new TestNodeSource([node]),
+            new TestEnrForkIdFilter(accept: false),
+            LimboLogs.Instance);
+
+        await using IAsyncEnumerator<Node> enumerator = source.DiscoverNodes(cancellationToken).GetAsyncEnumerator(cancellationToken);
+
+        Assert.That(await enumerator.MoveNextAsync().AsTask(), Is.True);
+        Assert.That(enumerator.Current, Is.EqualTo(node));
+    }
+
+    private static Node CreateNodeWithEnr()
+    {
+        NodeRecord record = new();
+        record.SetEntry(IdEntry.Instance);
+        record.SetEntry(new IpEntry(IPAddress.Parse("8.8.8.8")));
+        record.SetEntry(new TcpEntry(30303));
+        record.SetEntry(new SecP256k1Entry(TestItem.PrivateKeyA.CompressedPublicKey));
+        record.EnrSequence = 1;
+        new NodeRecordSigner(new EthereumEcdsa(0), TestItem.PrivateKeyA).Sign(record);
+
+        return new Node(TestItem.PublicKeyA, "8.8.8.8", 30303)
+        {
+            Enr = record
+        };
+    }
+
+    private sealed class TestNodeSource(IReadOnlyList<Node> nodes) : INodeSource
+    {
+        public async IAsyncEnumerable<Node> DiscoverNodes([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return nodes[i];
+            }
+        }
+
+        public event EventHandler<NodeEventArgs>? NodeRemoved { add { } remove { } }
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/TestEnrForkIdFilter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/TestEnrForkIdFilter.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Network.Enr;
+
+namespace Nethermind.Network.Discovery.Test;
+
+internal sealed class TestEnrForkIdFilter(bool accept = true) : IEnrForkIdFilter
+{
+    public bool IsAcceptable(NodeRecord record) => accept;
+}

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/DiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/DiscoveryApp.cs
@@ -22,6 +22,7 @@ public class DiscoveryApp : KademliaDiscoveryApp
     private readonly IKademliaAdapter _discv4Adapter;
     private readonly Func<IChannel, NettyDiscoveryHandler> _discoveryHandlerFactory;
     private readonly ILifetimeScope _discv4Services;
+    private readonly IEnrForkIdFilter? _enrForkIdFilter;
 
     private NettyDiscoveryHandler? _discoveryHandler;
 
@@ -36,6 +37,7 @@ public class DiscoveryApp : KademliaDiscoveryApp
         Action<ContainerBuilder>? configureDiscv4Services = null)
         : base("discv4", networkConfig, ipResolver, processExitSource, logManager.GetClassLogger<DiscoveryApp>())
     {
+        _enrForkIdFilter = rootScope.ResolveOptional<IEnrForkIdFilter>();
         List<Node> bootNodes = CreateBootNodes(networkConfig.Bootnodes, Logger);
 
         _discv4Services = rootScope.BeginLifetimeScope(
@@ -116,6 +118,27 @@ public class DiscoveryApp : KademliaDiscoveryApp
         NettyDiscoveryHandler discoveryHandler = _discoveryHandlerFactory(channel);
         _discv4Adapter.MsgSender = discoveryHandler;
         return discoveryHandler;
+    }
+
+    public override void AddNodeToDiscovery(Node node)
+    {
+        if (node.Enr is not { } record || _enrForkIdFilter is null)
+        {
+            base.AddNodeToDiscovery(node);
+            return;
+        }
+
+        try
+        {
+            if (_enrForkIdFilter.IsAcceptable(record))
+            {
+                base.AddNodeToDiscovery(node);
+            }
+        }
+        catch (Exception e)
+        {
+            if (Logger.IsTrace) Logger.Trace($"Unable to parse discv4 discovery ENR for {node}: {e}");
+        }
     }
 
     public override void InitializeChannel(IChannel channel)

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
@@ -23,6 +23,7 @@ public sealed class KademliaAdapter(
     IDiscoveryConfig discoveryConfig,
     KademliaConfig<Node> kademliaConfig,
     INodeRecordProvider nodeRecordProvider,
+    IEnrForkIdFilter enrForkIdFilter,
     INodeStatsManager nodeStatsManager,
     ITimestamper timestamper,
     IProcessExitSource processExitSource,
@@ -201,7 +202,7 @@ public sealed class KademliaAdapter(
         if (!response.HasResponse) return false;
 
         session.OnPongReceived(response.Value.FarAddress ?? receiver.Address);
-        await RefreshRemoteRecordIfNewer(receiver, response.Value.EnrSequence, token);
+        await RefreshRemoteRecordIfNewer(receiver, session, response.Value.EnrSequence, token);
         return true;
     }
 
@@ -218,10 +219,38 @@ public sealed class KademliaAdapter(
         return response.HasResponse ? response.Value : null;
     }
 
-    private Task RefreshRemoteRecordIfNewer(Node node, ulong? advertisedSequence, CancellationToken token)
-        => advertisedSequence is { } sequence
-            ? base.RefreshRemoteRecordIfNewer(node, sequence, token)
-            : Task.CompletedTask;
+    private async Task<bool> RefreshRemoteRecordIfNewer(Node node, NodeSession session, ulong? advertisedSequence, CancellationToken token)
+    {
+        Node recordNode = GetSessionEnrNode(node, session);
+        if (advertisedSequence is not { } sequence || sequence == 0)
+        {
+            return recordNode.RequestingEnrSequence == 0;
+        }
+
+        if (recordNode.Enr is { Signature: not null } currentRecord && currentRecord.EnrSequence >= sequence)
+        {
+            return true;
+        }
+
+        if (recordNode.RequestingEnrSequence != 0)
+        {
+            return false;
+        }
+
+        await base.RefreshRemoteRecordIfNewer(recordNode, sequence, token);
+        return false;
+    }
+
+    private static Node GetSessionEnrNode(Node node, NodeSession session)
+    {
+        if (session.EnrNode is { } enrNode)
+        {
+            return enrNode;
+        }
+
+        session.EnrNode = node;
+        return node;
+    }
 
     protected override async ValueTask<NodeRecord?> RequestRemoteRecord(Node node, ulong requestedSequence, CancellationToken token)
     {
@@ -230,10 +259,26 @@ public sealed class KademliaAdapter(
     }
 
     protected override bool IsEnrValidForNode(Node node, NodeRecord record)
-        => HasExpectedNodeId(record, node.Id);
+    {
+        if (!HasExpectedNodeId(record, node.Id))
+        {
+            return false;
+        }
+
+        if (enrForkIdFilter.IsAcceptable(record))
+        {
+            return true;
+        }
+
+        RemoveNodeWithIncompatibleForkId(node);
+        return false;
+    }
 
     protected override void AddOrRefreshRemoteNode(Node node)
-        => kademlia.Value.AddOrRefresh(node);
+    {
+        kademlia.Value.AddOrRefresh(node);
+        nodeHealthTracker.Value.OnIncomingMessageFrom(node);
+    }
 
     public async Task<EnrResponseMsg?> SendEnrRequest(Node receiver, CancellationToken token)
     {
@@ -291,26 +336,28 @@ public sealed class KademliaAdapter(
         return true;
     }
 
-    private async Task HandlePing(Node node, NodeSession session, PingMsg ping, CancellationToken token)
+    private async Task<bool> HandlePing(Node node, NodeSession session, PingMsg ping, CancellationToken token)
     {
         if (Logger.IsTrace) Logger.Trace($"Receive ping from {node}");
         if (ping.Mdc is not { } pingMdc)
         {
             if (Logger.IsDebug) Logger.Debug($"Rejecting ping without packet hash from {node}");
-            return;
+            return false;
         }
 
         PongMsg msg = new(ping.FarAddress!, CalculateExpirationTime(), pingMdc, (await nodeRecordProvider.GetCurrentAsync(token)).EnrSequence);
         session.OnPingReceived();
         await SendMessage(session, msg, token);
-        await RefreshRemoteRecordIfNewer(node, ping.EnrSequence, token);
+        bool shouldAdmitNode = await RefreshRemoteRecordIfNewer(node, session, ping.EnrSequence, token);
 
-        if (!session.HasReceivedPong)
+        if (!session.HasReceivedPong && shouldAdmitNode)
         {
             // If we have never received any pong, then this peer is not bonded and we should not respond to any auth request.
             // Send a ping to bond the peer.
             _ = await Ping(node, token);
         }
+
+        return shouldAdmitNode;
     }
 
     public async Task OnIncomingMsg(DiscoveryMsg msg)
@@ -327,7 +374,11 @@ public sealed class KademliaAdapter(
 
                 NodeSession responseSession = GetSession(node);
                 responseSession.RecordStatsForIncomingMsg(msg);
-                nodeHealthTracker.Value.OnIncomingMessageFrom(node);
+                if (msgType != MsgType.EnrResponse)
+                {
+                    nodeHealthTracker.Value.OnIncomingMessageFrom(node);
+                }
+
                 return;
             }
 
@@ -340,8 +391,10 @@ public sealed class KademliaAdapter(
                 case MsgType.Ping:
                     PingMsg ping = (PingMsg)msg;
                     if (!ValidatePingAddress(ping)) return;
-                    await HandlePing(node, session, ping, token);
-                    nodeHealthTracker.Value.OnIncomingMessageFrom(node);
+                    if (await HandlePing(node, session, ping, token))
+                    {
+                        nodeHealthTracker.Value.OnIncomingMessageFrom(node);
+                    }
                     break;
                 case MsgType.FindNode:
                     if (await HandleFindNode(node, session, (FindNodeMsg)msg, token))
@@ -401,6 +454,12 @@ public sealed class KademliaAdapter(
 
     private static bool HasExpectedNodeId(NodeRecord record, PublicKey expectedNodeId)
         => record.GetObj<CompressedPublicKey>(EnrContentKey.SecP256k1)?.Decompress().Equals(expectedNodeId) == true;
+
+    private void RemoveNodeWithIncompatibleForkId(Node node)
+    {
+        kademlia.Value.Remove(node);
+        if (Logger.IsTrace) Logger.Trace($"Removed discv4 node {node:s} after incompatible refreshed ENR fork ID.");
+    }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/NodeSource.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/NodeSource.cs
@@ -17,6 +17,7 @@ public sealed class NodeSource(
     IKademliaAdapter discv4Adapter,
     IDiscoveryConfig discoveryConfig,
     KademliaConfig<Node> kademliaConfig,
+    IEnrForkIdFilter enrForkIdFilter,
     ILogManager logManager)
     : IKademliaNodeSource
 {
@@ -81,7 +82,7 @@ public sealed class NodeSource(
 
         async Task WriteDiscoveredNode(Node node)
         {
-            if (IsExcluded(node))
+            if (IsExcluded(node) || !IsForkIdAcceptable(node))
             {
                 return;
             }
@@ -117,7 +118,7 @@ public sealed class NodeSource(
 
         void Handler(object? _, Node addedNode)
         {
-            if (IsExcluded(addedNode))
+            if (IsExcluded(addedNode) || !IsForkIdAcceptable(addedNode))
             {
                 return;
             }
@@ -137,4 +138,22 @@ public sealed class NodeSource(
     }
 
     private bool IsExcluded(Node node) => node.IdHash.Equals(_currentNodeHash);
+
+    private bool IsForkIdAcceptable(Node node)
+    {
+        if (node.Enr is not { } record)
+        {
+            return true;
+        }
+
+        try
+        {
+            return enrForkIdFilter.IsAcceptable(record);
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Unable to parse discv4 discovered ENR for {node}: {e}");
+            return false;
+        }
+    }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/NodeSession.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/NodeSession.cs
@@ -19,12 +19,19 @@ public sealed record NodeSession(INodeStats NodeStats, ITimestamper Timestamper)
     private long _lastPongReceivedTicks;
     private long _lastPingReceivedTicks;
     private long _lastPingSentTicks;
+    private Node? _enrNode;
     private IPEndPoint? _lastPongEndpoint;
 
     public bool HasReceivedPing => Volatile.Read(ref _lastPingReceivedTicks) + BondTimeout.Ticks > Timestamper.UtcNow.Ticks;
     public bool NotTooManyFailure => Volatile.Read(ref _authenticatedRequestFailureCount) <= AuthenticatedRequestFailureLimit;
     public bool HasReceivedPong => Volatile.Read(ref _lastPongReceivedTicks) + BondTimeout.Ticks > Timestamper.UtcNow.Ticks;
     public bool HasTriedPingRecently => Volatile.Read(ref _lastPingSentTicks) + PingRetryTimeout.Ticks > Timestamper.UtcNow.Ticks;
+    internal Node? EnrNode
+    {
+        get => Volatile.Read(ref _enrNode);
+        set => Volatile.Write(ref _enrNode, value);
+    }
+
     public bool HasEndpointProof(IPEndPoint endpoint) =>
         HasReceivedPong && Volatile.Read(ref _lastPongEndpoint) is { } lastPongEndpoint && lastPongEndpoint.Equals(endpoint);
 

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/Kademlia/NodeSource.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/Kademlia/NodeSource.cs
@@ -18,6 +18,7 @@ public sealed class NodeSource(
     IDiscoveryConfig discoveryConfig,
     KademliaConfig<Node> kademliaConfig,
     IDiscv5RecordFilter recordFilter,
+    IEnrForkIdFilter enrForkIdFilter,
     ILogManager logManager)
     : IKademliaNodeSource
 {
@@ -151,7 +152,7 @@ public sealed class NodeSource(
 
         try
         {
-            if (recordFilter.Excludes(record))
+            if (recordFilter.Excludes(record) || !enrForkIdFilter.IsAcceptable(record))
             {
                 return false;
             }

--- a/src/Nethermind/Nethermind.Network.Discovery/EnrForkIdFilter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/EnrForkIdFilter.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain;
+using Nethermind.Logging;
+using Nethermind.Network.Enr;
+using System.Buffers.Binary;
+using EnrForkId = Nethermind.Network.Enr.ForkId;
+using NetworkForkId = Nethermind.Network.ForkId;
+
+namespace Nethermind.Network.Discovery;
+
+public sealed class EnrForkIdFilter(IBlockTree blockTree, IForkInfo forkInfo, ILogManager logManager) : IEnrForkIdFilter
+{
+    private readonly ILogger _logger = logManager.GetClassLogger<EnrForkIdFilter>();
+
+    public bool IsAcceptable(NodeRecord record)
+    {
+        if (!record.HasEntry(EnrContentKey.Eth))
+        {
+            if (_logger.IsTrace) _logger.Trace("ENR declined, missing eth fork ID entry.");
+            return false;
+        }
+
+        if (!TryGetForkId(record, out NetworkForkId forkId))
+        {
+            return false;
+        }
+
+        ValidationResult result = forkInfo.ValidateForkId(forkId, blockTree.Head?.Header);
+        if (result == ValidationResult.Valid)
+        {
+            return true;
+        }
+
+        if (_logger.IsTrace) _logger.Trace($"ENR declined, incompatible fork ID: {forkId}, validation result: {result}.");
+        return false;
+    }
+
+    private bool TryGetForkId(NodeRecord record, out NetworkForkId forkId)
+    {
+        forkId = default;
+
+        try
+        {
+            EnrForkId? enrForkId = record.GetValue<EnrForkId>(EnrContentKey.Eth);
+            if (enrForkId is null ||
+                enrForkId.Value.ForkHash.Length != sizeof(uint))
+            {
+                if (_logger.IsTrace) _logger.Trace("ENR declined, invalid eth fork ID entry.");
+                return false;
+            }
+
+            uint forkHash = BinaryPrimitives.ReadUInt32BigEndian(enrForkId.Value.ForkHash);
+            forkId = new NetworkForkId(forkHash, enrForkId.Value.Next);
+            return true;
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsTrace) _logger.Trace($"ENR declined, unable to parse eth fork ID entry: {e}");
+            return false;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Discovery/EnrForkIdFilteringNodeSource.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/EnrForkIdFilteringNodeSource.cs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.CompilerServices;
+using Nethermind.Logging;
+using Nethermind.Stats.Model;
+
+namespace Nethermind.Network.Discovery;
+
+public sealed class EnrForkIdFilteringNodeSource(
+    INodeSource nodeSource,
+    IEnrForkIdFilter enrForkIdFilter,
+    ILogManager logManager) : INodeSource
+{
+    private readonly ILogger _logger = logManager.GetClassLogger<EnrForkIdFilteringNodeSource>();
+
+    public async IAsyncEnumerable<Node> DiscoverNodes([EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (Node node in nodeSource.DiscoverNodes(cancellationToken))
+        {
+            if (IsForkIdAcceptable(node))
+            {
+                yield return node;
+            }
+        }
+    }
+
+    public event EventHandler<NodeEventArgs>? NodeRemoved
+    {
+        add => nodeSource.NodeRemoved += value;
+        remove => nodeSource.NodeRemoved -= value;
+    }
+
+    private bool IsForkIdAcceptable(Node node)
+    {
+        if (node.Enr is not { } record)
+        {
+            return true;
+        }
+
+        try
+        {
+            return enrForkIdFilter.IsAcceptable(record);
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Unable to parse ENR for discovered node {node}: {e}");
+            return false;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Network.Discovery/IEnrForkIdFilter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/IEnrForkIdFilter.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Network.Enr;
+
+namespace Nethermind.Network.Discovery;
+
+public interface IEnrForkIdFilter
+{
+    /// <summary>
+    /// Returns whether the ENR advertises an execution fork ID compatible with the local chain.
+    /// </summary>
+    /// <remarks>
+    /// Records without the <c>eth</c> entry, malformed fork hashes, or incompatible fork IDs are rejected.
+    /// </remarks>
+    bool IsAcceptable(NodeRecord record);
+}

--- a/src/Nethermind/Nethermind.Network.Discovery/Kademlia/DiscoveryPersistenceManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Kademlia/DiscoveryPersistenceManager.cs
@@ -30,6 +30,7 @@ public sealed class DiscoveryPersistenceManager(
     IKademliaMessageSender<PublicKey, Node> messageSender,
     IKademlia<PublicKey, Node> kademlia,
     IDiscoveryConfig discoveryConfig,
+    IEnrForkIdFilter enrForkIdFilter,
     ILogManager logManager)
 {
     private readonly INetworkStorage _discoveryStorage = discoveryStorage;
@@ -55,6 +56,10 @@ public sealed class DiscoveryPersistenceManager(
             try
             {
                 node = new Node(networkNode);
+                if (!IsForkIdAcceptable(node))
+                {
+                    continue;
+                }
             }
             catch (Exception e)
             {
@@ -131,5 +136,15 @@ public sealed class DiscoveryPersistenceManager(
         }
 
         return new NetworkNode(node.Id, node.Host, node.Port, reputation);
+    }
+
+    private bool IsForkIdAcceptable(Node node)
+    {
+        if (node.Enr is not { } record)
+        {
+            return true;
+        }
+
+        return enrForkIdFilter.IsAcceptable(record);
     }
 }

--- a/src/Nethermind/Nethermind.Network.Dns/EnrDiscovery.cs
+++ b/src/Nethermind/Nethermind.Network.Dns/EnrDiscovery.cs
@@ -91,7 +91,7 @@ public class EnrDiscovery : INodeSource
         IPAddress? ipAddress = nodeRecord.GetObj<IPAddress>(EnrContentKey.Ip);
         int? port = nodeRecord.GetValue<int>(EnrContentKey.Tcp) ?? nodeRecord.GetValue<int>(EnrContentKey.Udp);
         return compressedPublicKey is not null && ipAddress is not null && port is not null
-            ? new(compressedPublicKey.Decompress(), ipAddress.ToString(), port.Value)
+            ? new Node(compressedPublicKey.Decompress(), ipAddress.ToString(), port.Value) { Enr = nodeRecord }
             : null;
     }
 


### PR DESCRIPTION
## Changes

- Defer discv4 peer admission while a refreshed ENR fork ID is required or already pending.
- Remove discv4 discovery nodes when a refreshed signed same-node ENR fails fork-id validation.
- Avoid publishing bare-node health updates from handled ENR responses before the refreshed ENR has been validated.
- Add regression coverage for incompatible refreshed ENRs and pending ENR refreshes followed by sequence-less pings.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Targeted discovery/fork-id regression coverage passed. The broader discovery project still has an unrelated E2E discovery failure on this branch.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

None.