### PR TITLE
Bump pyspec fixtures to tests-bal@v7.3.2

### DIFF
--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
@@ -6,6 +6,6 @@ namespace Ethereum.Blockchain.Pyspec.Test;
 public class Constants
 {
     public const string ARCHIVE_URL_TEMPLATE = "https://github.com/ethereum/execution-specs/releases/download/{0}/{1}";
-    public const string DEFAULT_ARCHIVE_VERSION = "tests-bal@v7.3.1";
+    public const string DEFAULT_ARCHIVE_VERSION = "tests-bal@v7.3.2";
     public const string DEFAULT_ARCHIVE_NAME = "fixtures_bal.tar.gz";
 }


### PR DESCRIPTION
## Changes

- Update to BAL test release v7.3.2 restores the full per-fork fixture set (Frontier..Osaka plus the transitions) that v7.3.0/v7.3.1 had reduced to Amsterdam-only, bringing back multi-fork EEST coverage.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
