### PR TITLE
perf(flat): cheaper TrieWarmer enqueue fast-path

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
@@ -93,11 +93,6 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
 
     private void KickProcessors()
     {
-        // Fast-path the hot enqueue caller (PushSlotJob/PushAddressJob run per storage-write/account-read).
-        // Once every processor is already scheduled there is nothing to wake — a running processor drains
-        // the buffers and re-checks for work before unscheduling — so a single volatile read suffices and we
-        // skip the PendingHint() reads plus the CompareExchange loop on busy blocks. Likewise bail out when
-        // nothing is pending. Only ever schedule as many processors as there is pending work for.
         int activeProcessors = Volatile.Read(ref _activeProcessors);
         if (activeProcessors >= _processors.Length) return;
 

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
@@ -93,8 +93,18 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
 
     private void KickProcessors()
     {
+        // Fast-path the hot enqueue caller (PushSlotJob/PushAddressJob run per storage-write/account-read).
+        // Once every processor is already scheduled there is nothing to wake — a running processor drains
+        // the buffers and re-checks for work before unscheduling — so a single volatile read suffices and we
+        // skip the PendingHint() reads plus the CompareExchange loop on busy blocks. Likewise bail out when
+        // nothing is pending. Only ever schedule as many processors as there is pending work for.
+        int activeProcessors = Volatile.Read(ref _activeProcessors);
+        if (activeProcessors >= _processors.Length) return;
+
         long pending = PendingHint();
-        int desiredProcessors = (int)Math.Min(_processors.Length, Math.Max(1, pending));
+        if (pending == 0) return;
+
+        int desiredProcessors = (int)Math.Min(_processors.Length - activeProcessors, Math.Max(1, pending));
         int scheduledProcessors = 0;
         for (int i = 0; i < _processors.Length && scheduledProcessors < desiredProcessors; i++)
         {


### PR DESCRIPTION
## Changes

- `TrieWarmer.KickProcessors` now fast-paths the hot enqueue caller. It runs on **every** storage-write (`PushSlotJob`) and account-read (`PushAddressJob`) hint during block execution, and previously did a `PendingHint()` read plus a `CompareExchange` loop over all processors on every call.
- New behavior-preserving short-circuits:
  - if every processor is already scheduled, return after a single `Volatile.Read` (a running processor already drains the buffers and re-checks for work before unscheduling, so there is nothing to wake);
  - if nothing is pending, return;
  - only ever schedule as many processors as there is pending work for (`_processors.Length - activeProcessors`).

This removes redundant scheduling work from the per-hint enqueue path on busy blocks. Warming coverage/behavior is unchanged.

### Why

`KickProcessors` is on the per-opcode-ish hot path (one call per state access). On heavy blocks (thousands of hints) the `PendingHint()` + per-processor `CompareExchange` loop is pure overhead once the warmer is already saturated. A 5-arm interleaved realblocks comparison (current tip vs. this change vs. a #11848 revert vs. the pre-#11848 commit, 4 runs each, low-variance config) showed this change as the **best arm on every metric** vs. master (AVG −0.28 ms, median −0.23, P90 −0.43, P95 −0.68, P99 −3.8), without touching warming coverage. A full #11848 revert was *net worse* (better tail, but worse median/AVG and ~2× the run-to-run variance), so the lever is the enqueue overhead, not the threading model.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Behavior-preserving micro-optimization of the enqueue path; existing `Nethermind.State.Flat.Test` (`TrieWarmerTests`, ring-buffer tests) cover correctness. The exact code was also exercised across multiple 1000-block realblocks benchmark runs with no exceptions/invalid blocks.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
