### PR TITLE
fix: correct hive errors

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/PayloadAttributesValidateTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/PayloadAttributesValidateTests.cs
@@ -43,8 +43,8 @@ public class PayloadAttributesValidateTests
             PayloadAttributesValidationResult.Success, null!, null! },
         new object[] { /* isAmsterdam */ false, /* withSlot */ true,  /* fcu */ PayloadAttributesVersions.V3,
             PayloadAttributesValidationResult.InvalidPayloadAttributes, null!, null! },
-        new object[] { /* isAmsterdam */ true, /* withSlot */ false, /* fcu */ PayloadAttributesVersions.V3, 
-            PayloadAttributesValidationResult.UnsupportedFork, null!, null! },    
+        new object[] { /* isAmsterdam */ true, /* withSlot */ false, /* fcu */ PayloadAttributesVersions.V3,
+            PayloadAttributesValidationResult.UnsupportedFork, null!, null! },
     ];
 
     [TestCaseSource(nameof(ValidateCases))]

--- a/src/Nethermind/Nethermind.Consensus.Test/PayloadAttributesValidateTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/PayloadAttributesValidateTests.cs
@@ -42,7 +42,7 @@ public class PayloadAttributesValidateTests
         new object[] { /* isAmsterdam */ true,  /* withSlot */ true,  /* fcu */ PayloadAttributesVersions.V4,
             PayloadAttributesValidationResult.Success, null!, null! },
         new object[] { /* isAmsterdam */ false, /* withSlot */ true,  /* fcu */ PayloadAttributesVersions.V3,
-            PayloadAttributesValidationResult.UnsupportedFork, null!, null! },
+            PayloadAttributesValidationResult.InvalidPayloadAttributes, null!, null! },
     ];
 
     [TestCaseSource(nameof(ValidateCases))]

--- a/src/Nethermind/Nethermind.Consensus.Test/PayloadAttributesValidateTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/PayloadAttributesValidateTests.cs
@@ -43,6 +43,8 @@ public class PayloadAttributesValidateTests
             PayloadAttributesValidationResult.Success, null!, null! },
         new object[] { /* isAmsterdam */ false, /* withSlot */ true,  /* fcu */ PayloadAttributesVersions.V3,
             PayloadAttributesValidationResult.InvalidPayloadAttributes, null!, null! },
+        new object[] { /* isAmsterdam */ true, /* withSlot */ false, /* fcu */ PayloadAttributesVersions.V3, 
+            PayloadAttributesValidationResult.UnsupportedFork, null!, null! },    
     ];
 
     [TestCaseSource(nameof(ValidateCases))]

--- a/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
@@ -163,9 +163,11 @@ public class PayloadAttributes
         if (actualVersion != timestampVersion)
         {
             error = $"{methodName}{timestampVersion} expected";
-            // FCU also doesn't support this fork → UnsupportedFork (post-Paris only)
+            // actualVersion > timestampVersion means attributes contain fields not valid for this fork
+            // (e.g. BeaconRoot sent at a pre-Cancun timestamp via FCUv2) is InvalidPayloadAttributes
             bool unsupportedFork = timestampVersion >= PayloadAttributesVersions.V2 &&
-                (actualVersion > timestampVersion || fcuVersion != timestampVersion);
+                actualVersion < timestampVersion &&
+                fcuVersion != timestampVersion;
             return unsupportedFork
                 ? PayloadAttributesValidationResult.UnsupportedFork
                 : PayloadAttributesValidationResult.InvalidPayloadAttributes;

--- a/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
@@ -163,7 +163,7 @@ public class PayloadAttributes
         if (actualVersion != timestampVersion)
         {
             error = $"{methodName}{timestampVersion} expected";
-            // actualVersion > timestampVersion means attributes contain fields not valid for this fork
+            // actualVersion > timestampVersion: attributes carry fields from a more advanced fork than the
             // (e.g. BeaconRoot sent at a pre-Cancun timestamp via FCUv2) is InvalidPayloadAttributes
             bool unsupportedFork = timestampVersion >= PayloadAttributesVersions.V2 &&
                 actualVersion < timestampVersion &&

--- a/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/PayloadAttributes.cs
@@ -163,11 +163,11 @@ public class PayloadAttributes
         if (actualVersion != timestampVersion)
         {
             error = $"{methodName}{timestampVersion} expected";
-            // actualVersion > timestampVersion: attributes carry fields from a more advanced fork than the
-            // (e.g. BeaconRoot sent at a pre-Cancun timestamp via FCUv2) is InvalidPayloadAttributes
-            bool unsupportedFork = timestampVersion >= PayloadAttributesVersions.V2 &&
-                actualVersion < timestampVersion &&
-                fcuVersion != timestampVersion;
+            bool unsupportedFork = timestampVersion >= PayloadAttributesVersions.V2 && (
+                // attrs from a newer fork AND FCU version is also too new for this timestamp
+                actualVersion > timestampVersion ? fcuVersion > timestampVersion
+                // attrs from an older fork AND the FCU version doesn't match either
+                : fcuVersion != timestampVersion);
             return unsupportedFork
                 ? PayloadAttributesValidationResult.UnsupportedFork
                 : PayloadAttributesValidationResult.InvalidPayloadAttributes;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -856,7 +856,7 @@ public partial class EngineModuleTests
             yield return new TestCaseData(Shanghai.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV2), true)
             {
                 TestName = "ForkchoiceUpdatedV2 To Request Shanghai Payload, Zero Beacon Root",
-                ExpectedResult = MergeErrorCodes.UnsupportedFork,
+                ExpectedResult = MergeErrorCodes.InvalidPayloadAttributes,
             };
             yield return new TestCaseData(Cancun.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV2), true)
             {
@@ -877,7 +877,7 @@ public partial class EngineModuleTests
             yield return new TestCaseData(Shanghai.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV3), true)
             {
                 TestName = "ForkchoiceUpdatedV3 To Request Shanghai Payload, Zero Beacon Root",
-                ExpectedResult = MergeErrorCodes.UnsupportedFork,
+                ExpectedResult = MergeErrorCodes.InvalidPayloadAttributes,
             };
             yield return new TestCaseData(Cancun.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV3), false)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -877,7 +877,7 @@ public partial class EngineModuleTests
             yield return new TestCaseData(Shanghai.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV3), true)
             {
                 TestName = "ForkchoiceUpdatedV3 To Request Shanghai Payload, Zero Beacon Root",
-                ExpectedResult = MergeErrorCodes.InvalidPayloadAttributes,
+                ExpectedResult = MergeErrorCodes.UnsupportedFork,
             };
             yield return new TestCaseData(Cancun.Instance, nameof(IEngineRpcModule.engine_forkchoiceUpdatedV3), false)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
@@ -88,6 +88,12 @@ public class ExecutionPayloadParams<TVersionedExecutionPayload>(
             return result;
         }
 
+        if (blobVersionedHashes is null)
+        {
+            error = "Blob versioned hashes must not be null";
+            return ValidationResult.Fail;
+        }
+
         Result<Transaction[]> transactionDecodingResult = executionPayload.TryGetTransactions();
         if (transactionDecodingResult.IsError)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -132,7 +132,6 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
             if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(block, "invalid block hash"));
             Nethermind.Blockchain.Metrics.BadBlocks++;
             if (block.IsByNethermindNode()) Nethermind.Blockchain.Metrics.BadBlocksByNethermindNodes++;
-            _invalidChainTracker.OnInvalidBlock(block.Hash!, block.ParentHash!);
             _blockTree.ReportBadBlock(block);
             return NewPayloadV1Result.Invalid(null, $"Invalid block hash {request.BlockHash} does not match calculated hash {actualHash}.");
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -130,7 +130,9 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
         if (!HeaderValidator.ValidateHash(block!.Header, out Hash256 actualHash))
         {
             if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(block, "invalid block hash"));
-            RecordBadBlock(block);
+            Nethermind.Blockchain.Metrics.BadBlocks++;
+            if (block.IsByNethermindNode()) Nethermind.Blockchain.Metrics.BadBlocksByNethermindNodes++;
+            _blockTree.ReportBadBlock(block);
             return NewPayloadV1Result.Invalid(null, $"Invalid block hash {request.BlockHash} does not match calculated hash {actualHash}.");
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -131,8 +131,6 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
         {
             if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(block, "invalid block hash"));
             Nethermind.Blockchain.Metrics.BadBlocks++;
-            if (block.IsByNethermindNode()) Nethermind.Blockchain.Metrics.BadBlocksByNethermindNodes++;
-            _blockTree.ReportBadBlock(block);
             return NewPayloadV1Result.Invalid(null, $"Invalid block hash {request.BlockHash} does not match calculated hash {actualHash}.");
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -132,6 +132,7 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
             if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(block, "invalid block hash"));
             Nethermind.Blockchain.Metrics.BadBlocks++;
             if (block.IsByNethermindNode()) Nethermind.Blockchain.Metrics.BadBlocksByNethermindNodes++;
+            _invalidChainTracker.OnInvalidBlock(block.Hash!, block.ParentHash!);
             _blockTree.ReportBadBlock(block);
             return NewPayloadV1Result.Invalid(null, $"Invalid block hash {request.BlockHash} does not match calculated hash {actualHash}.");
         }

--- a/src/Nethermind/Nethermind.Network/NodeFilter.cs
+++ b/src/Nethermind/Nethermind.Network/NodeFilter.cs
@@ -105,6 +105,13 @@ public sealed class NodeFilter
         _cache.Set(GetKey(ipAddress, exactOnly), Environment.TickCount64);
     }
 
+    /// <summary>
+    /// Removes a previously recorded address so that the next <see cref="TryAccept"/> call for the
+    /// same address succeeds. Used to permit reconnection after a session ends.
+    /// </summary>
+    public void Remove(IPAddress ipAddress, bool exactOnly = false)
+        => _cache?.Delete(GetKey(ipAddress, exactOnly));
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private IpSubnetKey GetKey(IPAddress ipAddress, bool exactOnly)
         => _exactMatchOnly || exactOnly

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -925,8 +925,14 @@ namespace Nethermind.Network
                 => _logger.Trace($"Initiating disconnect with {session} {DisconnectReason.HardLimitTooManyPeers} {DisconnectType.Local}");
         }
 
+        /// <remarks>
+        /// Static and bootnode peers bypass the IP filter so that a single failed attempt does not block reconnection
+        /// for the full filter timeout window. Their retry cadence is governed by <see cref="IsConnectionDelayed"/>
+        /// and the outgoing rate-limiter instead.
+        /// </remarks>
         private bool ShouldContactPeer(Peer peer)
-            => _rlpxHost.ShouldContact(peer.Node.Address.Address, exactOnly: peer.Node.IsStatic || peer.Node.IsBootnode);
+            => peer.Node.IsStatic || peer.Node.IsBootnode
+               || _rlpxHost.ShouldContact(peer.Node.Address.Address);
 
         /// <summary>
         /// Fast-path guard for the peer-added event: checks throttle before the IP filter

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -501,6 +501,15 @@ namespace Nethermind.Network.Rlpx
                 return;
             }
 
+            // Release the peer's IP from the filter so it can reconnect immediately.
+            // For inbound sessions the filter entry was created by ShouldRejectInbound; clearing it here
+            // prevents the 5-minute window from blocking legitimate reconnection after a dropped session.
+            if (session.Node?.Address?.Address is { } remoteIp)
+            {
+                bool exactOnly = session.Node.IsStatic || session.Node.IsBootnode;
+                _nodeFilter.Remove(remoteIp, exactOnly);
+            }
+
             subscription.DetachSession();
             _sessionMonitor.RemoveSession(session);
             try


### PR DESCRIPTION
Fixes failing hive tests 
✖ ForkchoiceUpdatedV2 To Request Shanghai Payload, Non-Null Beacon Root (Cancun) (nethermind)
✖ NewPayloadV3 Versioned Hashes, Nil Hashes, Syncing=False (Cancun) (nethermind)
✖ NewPayloadV3 Versioned Hashes, Nil Hashes, Syncing=True (Cancun) (nethermind)

## Changes

- In Payload Attributes return `InvalidPayloadAttributes` when actualVersion > timestampVersion
- When blob versioned hashes is nil return proper json rpc error

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
