### PR TITLE
EvmPooledMemory fix

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
@@ -78,6 +78,25 @@ public class EvmPooledMemoryTests : EvmMemoryTestsBase
         Assert.That(result, Is.EqualTo(0L));
     }
 
+    [TestCase(70 * 1024)]
+    [TestCase(2 * 1024 * 1024)]
+    public void Large_pooled_buffer_is_zeroed_on_reuse(int size)
+    {
+        EvmPooledMemory dirty = new();
+        UInt256 zero = UInt256.Zero;
+        Span<byte> pattern = new byte[size];
+        pattern.Fill(0xff);
+        Assert.That(dirty.TrySave(in zero, pattern), Is.True);
+        dirty.Dispose();
+
+        EvmPooledMemory clean = new();
+        UInt256 length = (UInt256)size;
+        Assert.That(clean.TryLoadSpan(in zero, in length, out Span<byte> data), Is.True);
+        Assert.That(data.Length, Is.EqualTo(size));
+        Assert.That(data.IndexOfAnyExcept((byte)0), Is.EqualTo(-1), "pooled buffer leaked stale data");
+        clean.Dispose();
+    }
+
     [Test]
     public void CalculateMemoryCost_LengthExceedsLongMax_ShouldReturnOutOfGas()
     {

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -7,9 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !ZK_EVM
-using System.Buffers;
-#endif
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Evm.Tracing;
@@ -430,14 +427,6 @@ public struct EvmPooledMemory
     [ThreadStatic] private static byte[]?[]? _cleanArrays;
     [ThreadStatic] private static int _cleanArrayCount;
 
-#if !ZK_EVM
-    private const int MaxSharedArrayLength = 1 << 20;
-    // Above this, buffers fall back to plain allocation (not pooled), as before this change.
-    private const int MaxLargePooledArrayLength = 1 << 22;
-    private static readonly ArrayPool<byte> _largeArrayPool =
-        ArrayPool<byte>.Create(maxArrayLength: MaxLargePooledArrayLength, maxArraysPerBucket: 16);
-#endif
-
     private static byte[] RentClean(int minLength)
     {
         byte[]?[]? cache = _cleanArrays;
@@ -485,6 +474,12 @@ public struct EvmPooledMemory
 
     private static void ReturnLarge(byte[] array) => SafeArrayPool<byte>.Shared.Return(array);
 #else
+    private const int MaxSharedArrayLength = 1 << 20;
+    // Above this, buffers fall back to plain allocation (not pooled), as before this change.
+    private const int MaxLargePooledArrayLength = 1 << 22;
+    private static readonly System.Buffers.ArrayPool<byte> _largeArrayPool =
+        System.Buffers.ArrayPool<byte>.Create(maxArrayLength: MaxLargePooledArrayLength, maxArraysPerBucket: 16);
+
     private static byte[] RentLarge(int minLength)
         => minLength > MaxSharedArrayLength
             ? _largeArrayPool.Rent(minLength)

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -431,8 +431,9 @@ public struct EvmPooledMemory
     [ThreadStatic] private static int _cleanArrayCount;
 
 #if !ZK_EVM
-    private const int MaxSharedArrayLength = 1 << 20;             // 1 MiB: ArrayPool<byte>.Shared ceiling
-    private const int MaxLargePooledArrayLength = 4 * 1024 * 1024; // 4 MiB ceiling for the bounded pool
+    private const int MaxSharedArrayLength = 1 << 20;
+    // Above this, buffers fall back to plain allocation (not pooled), as before this change.
+    private const int MaxLargePooledArrayLength = 1 << 22;
     private static readonly ArrayPool<byte> _largeArrayPool =
         ArrayPool<byte>.Create(maxArrayLength: MaxLargePooledArrayLength, maxArraysPerBucket: 16);
 #endif

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -7,7 +7,11 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#if !ZK_EVM
+using System.Buffers;
+#endif
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Evm.Tracing;
 using Nethermind.Int256;
 
@@ -426,6 +430,13 @@ public struct EvmPooledMemory
     [ThreadStatic] private static byte[]?[]? _cleanArrays;
     [ThreadStatic] private static int _cleanArrayCount;
 
+#if !ZK_EVM
+    private const int MaxSharedArrayLength = 1 << 20;             // 1 MiB: ArrayPool<byte>.Shared ceiling
+    private const int MaxLargePooledArrayLength = 4 * 1024 * 1024; // 4 MiB ceiling for the bounded pool
+    private static readonly ArrayPool<byte> _largeArrayPool =
+        ArrayPool<byte>.Create(maxArrayLength: MaxLargePooledArrayLength, maxArraysPerBucket: 16);
+#endif
+
     private static byte[] RentClean(int minLength)
     {
         byte[]?[]? cache = _cleanArrays;
@@ -442,13 +453,23 @@ public struct EvmPooledMemory
             }
         }
 
+        if (minLength > MaxCachedArrayLength)
+        {
+            byte[] pooled = RentLarge(minLength);
+            Array.Clear(pooled);
+            return pooled;
+        }
+
         return new byte[BitOperations.RoundUpToPowerOf2((uint)minLength)];
     }
 
     private static void ReturnClean(byte[] array, int dirtyLength)
     {
         if (array.Length > MaxCachedArrayLength)
+        {
+            ReturnLarge(array);
             return;
+        }
 
         byte[]?[] cache = _cleanArrays ??= new byte[CleanCacheSlots][];
         if (_cleanArrayCount < CleanCacheSlots)
@@ -457,6 +478,25 @@ public struct EvmPooledMemory
             cache[_cleanArrayCount++] = array;
         }
     }
+
+#if ZK_EVM
+    private static byte[] RentLarge(int minLength) => SafeArrayPool<byte>.Shared.Rent(minLength);
+
+    private static void ReturnLarge(byte[] array) => SafeArrayPool<byte>.Shared.Return(array);
+#else
+    private static byte[] RentLarge(int minLength)
+        => minLength > MaxSharedArrayLength
+            ? _largeArrayPool.Rent(minLength)
+            : SafeArrayPool<byte>.Shared.Rent(minLength);
+
+    private static void ReturnLarge(byte[] array)
+    {
+        if (array.Length > MaxSharedArrayLength)
+            _largeArrayPool.Return(array);
+        else
+            SafeArrayPool<byte>.Shared.Return(array);
+    }
+#endif
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void RentSlow()


### PR DESCRIPTION
Pool large EVM memory buffers (>64 KB, including the >1 MB tier) instead of fresh-allocating and dropping them to the LOH every frame, cutting the dominant `eth_call` allocation during burst of heavy `eth_calls` (`RentClean`, ~3.5 GB → ~0.6 GB and falling) and the Gen2 GC pauses that spike tail latency under load.

Before
<img width="1177" height="69" alt="Screenshot 2026-06-20 at 1 11 19 AM" src="https://github.com/user-attachments/assets/87c7d87a-a23c-4986-b056-b8f65ae173ce" />

After
<img width="1179" height="68" alt="Screenshot 2026-06-20 at 1 11 43 AM" src="https://github.com/user-attachments/assets/5f67c974-960c-41b0-b29e-4044e3c3847f" />

## Changes

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No