### PR TITLE
Move NonceManager and BackgroundTaskScheduler to DI

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
@@ -35,7 +35,7 @@ namespace Nethermind.Api
         IWorldStateManager? WorldStateManager { get; }
         IMainProcessingContext MainProcessingContext { get; }
         ITxSender? TxSender { get; set; }
-        INonceManager? NonceManager { get; set; }
+        INonceManager? NonceManager { get; }
         ITxPool? TxPool { get; set; }
 
         ITransactionComparerProvider? TransactionComparerProvider { get; set; }
@@ -49,7 +49,7 @@ namespace Nethermind.Api
         IBlockProducerEnvFactory BlockProducerEnvFactory { get; }
 
         IBlockProductionPolicy? BlockProductionPolicy { get; set; }
-        IBackgroundTaskScheduler BackgroundTaskScheduler { get; set; }
+        IBackgroundTaskScheduler BackgroundTaskScheduler { get; }
         ICensorshipDetector CensorshipDetector { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -107,14 +107,14 @@ namespace Nethermind.Api
         public ITimerFactory TimerFactory => Context.Resolve<ITimerFactory>();
         public IMainProcessingContext MainProcessingContext => Context.Resolve<IMainProcessingContext>();
         public ITxSender? TxSender { get; set; }
-        public INonceManager? NonceManager { get; set; }
+        public INonceManager? NonceManager => Context.Resolve<INonceManager>();
         public ITxPool? TxPool { get; set; }
         public TxValidator? TxValidator => Context.Resolve<TxValidator>();
         public ITxValidator? HeadTxValidator => Context.ResolveOptionalKeyed<ITxValidator>(ITxValidator.HeadTxValidatorKey);
 
         public IBlockProducerEnvFactory BlockProducerEnvFactory => Context.Resolve<IBlockProducerEnvFactory>();
         public IBlockProductionPolicy? BlockProductionPolicy { get; set; }
-        public IBackgroundTaskScheduler BackgroundTaskScheduler { get; set; } = null!;
+        public IBackgroundTaskScheduler BackgroundTaskScheduler => Context.Resolve<IBackgroundTaskScheduler>();
         public ICensorshipDetector CensorshipDetector { get; set; } = new NoopCensorshipDetector();
         public IWallet? Wallet { get; set; }
         public ITransactionComparerProvider? TransactionComparerProvider { get; set; }

--- a/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModule.cs
@@ -7,7 +7,6 @@ using Nethermind.Api;
 using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
-using Nethermind.Consensus.Scheduler;
 using Nethermind.Db;
 using Nethermind.Init.Modules;
 using Nethermind.JsonRpc;
@@ -45,12 +44,6 @@ public class PseudoNethermindModule(ChainSpec spec, IConfigProvider configProvid
             .AddModule(new TestBlockProcessingModule())
 
             // Environments
-            .AddSingleton<IBackgroundTaskScheduler, IMainProcessingContext, IChainHeadInfoProvider>((blockProcessingContext, chainHeadInfoProvider) => new BackgroundTaskScheduler(
-                blockProcessingContext.BranchProcessor,
-                chainHeadInfoProvider,
-                initConfig.BackgroundTaskConcurrency,
-                initConfig.BackgroundTaskMaxNumber,
-                logManager))
             .AddSingleton<IProcessExitSource>(new ProcessExitSource(default))
             .AddSingleton<IJsonSerializer, EthereumJsonSerializer>()
 

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestBlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestBlockProcessingModule.cs
@@ -24,7 +24,6 @@ public class TestBlockProcessingModule : Module
             .AddSingleton<IBlockPreprocessorStep, RecoverSignatures>()
 
             .AddSingleton<ITxPool, TxPool.TxPool>()
-            .AddSingleton<INonceManager, IChainHeadInfoProvider>((chainHeadInfoProvider) => new NonceManager(chainHeadInfoProvider.ReadOnlyStateProvider))
 
             // Seems to be only used by block producer.
             .AddScoped<IGasLimitCalculator, TargetAdjustedGasLimitCalculator>()

--- a/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
@@ -14,6 +14,7 @@ using Nethermind.Consensus.ExecutionRequests;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Rewards;
+using Nethermind.Consensus.Scheduler;
 using Nethermind.Consensus.Tracing;
 using Nethermind.Consensus.Validators;
 using Nethermind.Consensus.Withdrawals;
@@ -82,6 +83,14 @@ public class BlockProcessingModule(IInitConfig initConfig, IBlocksConfig blocksC
             .Map<IBlockProcessingQueue, MainProcessingContext>(ctx => (IBlockProcessingQueue)ctx.BlockchainProcessor)
             .Map<IBlockProcessingPauseControl, MainProcessingContext>(ctx => (IBlockProcessingPauseControl)ctx.BlockchainProcessor)
             .Bind<IMainProcessingContext, MainProcessingContext>()
+
+            .AddSingleton<INonceManager, IChainHeadInfoProvider>((chainHeadInfoProvider) => new NonceManager(chainHeadInfoProvider.ReadOnlyStateProvider))
+            .AddSingleton<IBackgroundTaskScheduler, IMainProcessingContext, IChainHeadInfoProvider, ILogManager>((mainProcessingContext, chainHeadInfoProvider, logManager) => new BackgroundTaskScheduler(
+                mainProcessingContext.BranchProcessor,
+                chainHeadInfoProvider,
+                initConfig.BackgroundTaskConcurrency,
+                initConfig.BackgroundTaskMaxNumber,
+                logManager))
 
             // Some configuration that applies to validation and rpc but not to block producer. Plugins can add
             // modules in case they have special case where it only apply to validation and rpc but not block producer.

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -14,7 +14,6 @@ using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Processing.CensorshipDetector;
 using Nethermind.Consensus.Producers;
-using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.TxPool;
@@ -41,7 +40,6 @@ namespace Nethermind.Init.Steps
             (IApiWithStores getApi, IApiWithBlockchain setApi) = _api.ForBlockchain;
             setApi.TransactionComparerProvider = new TransactionComparerProvider(getApi.SpecProvider!, getApi.BlockTree!.AsReadOnly());
 
-            IInitConfig initConfig = getApi.Config<IInitConfig>();
             IBlocksConfig blocksConfig = getApi.Config<IBlocksConfig>();
 
             ThisNodeInfo.AddInfo("Gaslimit     :", $"{blocksConfig.TargetBlockGasLimit:N0}");
@@ -58,21 +56,10 @@ namespace Nethermind.Init.Steps
             ITxSigner txSigner = new WalletTxSigner(getApi.Wallet, getApi.SpecProvider!.ChainId);
             TxSealer nonceReservingTxSealer =
                 new(txSigner, getApi.Timestamper);
-            INonceManager nonceManager = new NonceManager(chainHeadInfoProvider.ReadOnlyStateProvider);
-            setApi.NonceManager = nonceManager;
-            setApi.TxSender = new TxPoolSender(txPool, nonceReservingTxSealer, nonceManager, getApi.EthereumEcdsa!);
+            setApi.TxSender = new TxPoolSender(txPool, nonceReservingTxSealer, _api.NonceManager!, getApi.EthereumEcdsa!);
             setApi.BlockProductionPolicy = CreateBlockProductionPolicy();
 
             IBranchProcessor mainBranchProcessor = setApi.MainProcessingContext.BranchProcessor;
-
-            BackgroundTaskScheduler backgroundTaskScheduler = new(
-                mainBranchProcessor,
-                chainHeadInfoProvider,
-                initConfig.BackgroundTaskConcurrency,
-                initConfig.BackgroundTaskMaxNumber,
-                _api.LogManager);
-            setApi.BackgroundTaskScheduler = backgroundTaskScheduler;
-            _api.DisposeStack.Push(backgroundTaskScheduler);
 
             ICensorshipDetectorConfig censorshipDetectorConfig = _api.Config<ICensorshipDetectorConfig>();
             if (censorshipDetectorConfig.Enabled)

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -29,7 +29,6 @@ using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Test;
 using Nethermind.Specs.Test.ChainSpecStyle;
-using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -176,7 +175,6 @@ public class AuRaMergeEngineModuleTests(bool parallel) : EngineModuleTests(paral
                 .AddDecorator<AuRaNethermindApi>((_, api) =>
                 {
                     api.EngineSigner = NullSigner.Instance;
-                    api.NonceManager = Substitute.For<INonceManager>();
                     return api;
                 })
                 .AddModule(new AuRaMergeModule())

--- a/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
@@ -28,7 +28,6 @@ using Nethermind.Consensus.Clique;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Rewards;
-using Nethermind.Consensus.Scheduler;
 using Nethermind.Consensus.Tracing;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
@@ -212,8 +211,6 @@ public class EthereumRunnerTests
 
         api.NodeKey = new InsecureProtectedPrivateKey(TestItem.PrivateKeyA);
         api.BlockProducerRunner = Substitute.For<IBlockProducerRunner>();
-        api.BackgroundTaskScheduler = Substitute.For<IBackgroundTaskScheduler>();
-        api.NonceManager = Substitute.For<INonceManager>();
 
         if (api is AuRaNethermindApi auRaNethermindApi)
         {

--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcModuleTestOverrides.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcModuleTestOverrides.cs
@@ -52,6 +52,7 @@ public class XdcModuleTestOverrides(IConfigProvider configProvider, ILogManager 
             .AddSingleton<IPenaltyHandler, PenaltyHandler>()
 
             // Environments
+            .AddSingleton<INonceManager, IChainHeadInfoProvider>((chainHeadInfoProvider) => new NonceManager(chainHeadInfoProvider.ReadOnlyStateProvider))
             .AddSingleton<IBackgroundTaskScheduler, IMainProcessingContext, IChainHeadInfoProvider>((blockProcessingContext, chainHeadInfoProvider) => new BackgroundTaskScheduler(
                 blockProcessingContext.BranchProcessor,
                 chainHeadInfoProvider,


### PR DESCRIPTION
## Changes

Move `NonceManager` and `BackgroundTaskScheduler` out of manual construction in the `InitializeBlockchain` step and into Autofac DI.

- Register `INonceManager` and `IBackgroundTaskScheduler` as singletons in `BlockProcessingModule` (their dependencies — `IChainHeadInfoProvider`, `IMainProcessingContext`, `IInitConfig`, `ILogManager` — are already available there).
- Remove the manual `new NonceManager(...)` / `new BackgroundTaskScheduler(...)` and the `setApi.*` assignments from `InitializeBlockchain`. `TxPoolSender` now takes the DI instance via `_api.NonceManager`.
- The scheduler's `IAsyncDisposable` lifetime is now owned by Autofac, replacing the manual `_api.DisposeStack.Push(...)`.
- `NethermindApi.NonceManager` / `BackgroundTaskScheduler` become computed getters (`=> Context.Resolve<…>()`), matching the existing convention used by sibling properties (`MainProcessingContext`, `TxValidator`, …); the corresponding `IApiWithBlockchain` members become get-only.
- Dedupe the equivalent registrations in the test modules. The Xdc test path keeps self-providing both services because it does not load `BlockProcessingModule`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

No new tests added — this is a wiring relocation already exercised by the existing DI-based test paths. The pre-existing `NonceManagerTests` (`Nethermind.TxPool.Test`), `BackgroundTaskScheduler*` tests (`Nethermind.Consensus.Test`), protocol-handler tests (`Nethermind.Network.Test`), `TxPoolBridgeTests` (`Nethermind.Facade.Test`), and the Xdc suite all pass against the new registrations. Full solution builds in release.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
