### PR TITLE
perf: eliminate Evm/Db metrics false sharing; parallel-safe gas-price aggregation

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
@@ -16,6 +16,7 @@ using Nethermind.Logging;
 using Nethermind.State.Proofs;
 using Nethermind.TxPool;
 using Nethermind.TxPool.Comparison;
+using Metrics = Nethermind.Evm.Metrics;
 
 namespace Nethermind.Consensus.Processing
 {
@@ -48,6 +49,7 @@ namespace Nethermind.Consensus.Processing
             public virtual TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions,
                 BlockReceiptsTracer receiptsTracer, CancellationToken token = default)
             {
+                Metrics.ResetBlockStats();
                 balManager.NextTransaction();
 
                 // We start with high number as don't want to resize too much
@@ -87,6 +89,10 @@ namespace Nethermind.Consensus.Processing
                 {
                     blockToProduce.Transactions = includedTx.ToArray();
                 }
+
+                Metrics.SeedBlockGasPriceIfEmpty(block.Header.BaseFeePerGas);
+                Metrics.PublishBlockGasPriceGauges();
+
                 return receiptsTracer.TxReceipts.ToArray();
             }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
@@ -16,7 +16,6 @@ using Nethermind.Logging;
 using Nethermind.State.Proofs;
 using Nethermind.TxPool;
 using Nethermind.TxPool.Comparison;
-using Metrics = Nethermind.Evm.Metrics;
 
 namespace Nethermind.Consensus.Processing
 {
@@ -49,7 +48,6 @@ namespace Nethermind.Consensus.Processing
             public virtual TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions,
                 BlockReceiptsTracer receiptsTracer, CancellationToken token = default)
             {
-                Metrics.ResetBlockStats();
                 balManager.NextTransaction();
 
                 // We start with high number as don't want to resize too much
@@ -89,10 +87,6 @@ namespace Nethermind.Consensus.Processing
                 {
                     blockToProduce.Transactions = includedTx.ToArray();
                 }
-
-                Metrics.SeedBlockGasPriceIfEmpty(block.Header.BaseFeePerGas);
-                Metrics.PublishBlockGasPriceGauges();
-
                 return receiptsTracer.TxReceipts.ToArray();
             }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
@@ -54,6 +54,8 @@ public partial class BlockProcessor
                 }
             }
 
+            Metrics.SeedBlockGasPriceIfEmpty(block.Header.BaseFeePerGas);
+
             return [.. receiptsTracer.TxReceipts];
 
             [DebuggerHidden]

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
@@ -55,6 +55,7 @@ public partial class BlockProcessor
             }
 
             Metrics.SeedBlockGasPriceIfEmpty(block.Header.BaseFeePerGas);
+            Metrics.PublishBlockGasPriceGauges();
 
             return [.. receiptsTracer.TxReceipts];
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -58,8 +58,10 @@ public partial class BlockProcessor
                 ? ProcessTransactionsParallel(block, processingOptions, receiptsTracer, token)
                 : ProcessTransactionsSequential(block, processingOptions, receiptsTracer, token);
 
-            // Seed empty/system-only blocks with the base fee after workers join.
+            // Seed empty/system-only blocks with the base fee, then publish gauges once - after workers
+            // join - from the final aggregates so a stale worker view cannot overwrite them.
             Metrics.SeedBlockGasPriceIfEmpty(block.Header.BaseFeePerGas);
+            Metrics.PublishBlockGasPriceGauges();
 
             return receipts;
         }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -31,6 +31,11 @@ public partial class BlockProcessor
         BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler? transactionProcessedEventHandler = null)
         : IBlockProcessor.IBlockTransactionsExecutor
     {
+        // Whether the most recent block ran the parallel BAL path. Written here on the block-processing
+        // thread and snapshotted into BlockData by ProcessingStats (also on that thread) for the report
+        // line; volatile so any other reader sees the latest value without a torn/cached read.
+        public static volatile bool LastBlockUsedParallelExecution;
+
         private readonly ILogger _logger = logManager.GetClassLogger<ParallelBlockValidationTransactionsExecutor>();
         private readonly IncrementalValidationWorkItem _incrementalValidationWorkItem = new();
         private BlockReceiptsTracer[] _receiptsTracerPool = [];
@@ -48,13 +53,16 @@ public partial class BlockProcessor
         {
             if (!balManager.Enabled)
             {
+                LastBlockUsedParallelExecution = false;
                 return inner.ProcessTransactions(block, processingOptions, receiptsTracer, token);
             }
 
             Metrics.ResetBlockStats();
             inner.SetupTxTimingMetrics(block);
 
-            TxReceipt[] receipts = !block.IsGenesis && balManager.ParallelExecutionEnabled
+            bool parallel = !block.IsGenesis && balManager.ParallelExecutionEnabled;
+            LastBlockUsedParallelExecution = parallel;
+            TxReceipt[] receipts = parallel
                 ? ProcessTransactionsParallel(block, processingOptions, receiptsTracer, token)
                 : ProcessTransactionsSequential(block, processingOptions, receiptsTracer, token);
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -54,9 +54,14 @@ public partial class BlockProcessor
             Metrics.ResetBlockStats();
             inner.SetupTxTimingMetrics(block);
 
-            return !block.IsGenesis && balManager.ParallelExecutionEnabled
+            TxReceipt[] receipts = !block.IsGenesis && balManager.ParallelExecutionEnabled
                 ? ProcessTransactionsParallel(block, processingOptions, receiptsTracer, token)
                 : ProcessTransactionsSequential(block, processingOptions, receiptsTracer, token);
+
+            // After all (possibly parallel) workers have joined, seed empty/system-only blocks with the base fee.
+            Metrics.SeedBlockGasPriceIfEmpty(block.Header.BaseFeePerGas);
+
+            return receipts;
         }
 
         private TxReceipt[] ProcessTransactionsSequential(Block block, ProcessingOptions processingOptions, BlockReceiptsTracer receiptsTracer, CancellationToken token)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -31,11 +31,6 @@ public partial class BlockProcessor
         BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler? transactionProcessedEventHandler = null)
         : IBlockProcessor.IBlockTransactionsExecutor
     {
-        // Whether the most recent block ran the parallel BAL path. Written here on the block-processing
-        // thread and snapshotted into BlockData by ProcessingStats (also on that thread) for the report
-        // line; volatile so any other reader sees the latest value without a torn/cached read.
-        public static volatile bool LastBlockUsedParallelExecution;
-
         private readonly ILogger _logger = logManager.GetClassLogger<ParallelBlockValidationTransactionsExecutor>();
         private readonly IncrementalValidationWorkItem _incrementalValidationWorkItem = new();
         private BlockReceiptsTracer[] _receiptsTracerPool = [];
@@ -53,20 +48,17 @@ public partial class BlockProcessor
         {
             if (!balManager.Enabled)
             {
-                LastBlockUsedParallelExecution = false;
                 return inner.ProcessTransactions(block, processingOptions, receiptsTracer, token);
             }
 
             Metrics.ResetBlockStats();
             inner.SetupTxTimingMetrics(block);
 
-            bool parallel = !block.IsGenesis && balManager.ParallelExecutionEnabled;
-            LastBlockUsedParallelExecution = parallel;
-            TxReceipt[] receipts = parallel
+            TxReceipt[] receipts = !block.IsGenesis && balManager.ParallelExecutionEnabled
                 ? ProcessTransactionsParallel(block, processingOptions, receiptsTracer, token)
                 : ProcessTransactionsSequential(block, processingOptions, receiptsTracer, token);
 
-            // After all (possibly parallel) workers have joined, seed empty/system-only blocks with the base fee.
+            // Seed empty/system-only blocks with the base fee after workers join.
             Metrics.SeedBlockGasPriceIfEmpty(block.Header.BaseFeePerGas);
 
             return receipts;

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -479,12 +479,15 @@ namespace Nethermind.Consensus.Processing
             double chunkMs = (chunkMicroseconds == 0 ? -1 : chunkMicroseconds / 1000.0);
             double runMs = (data.RunMicroseconds == 0 ? -1 : data.RunMicroseconds / 1000.0);
             string blockGas = "";
-            if (Evm.Metrics.BlockMinGasPrice != float.MaxValue)
+            // Read the stable gauges (published once per block, never reset) rather than the transient
+            // per-block aggregates: GenerateReport runs on the ThreadPool and can fire after the next
+            // block's ResetBlockStats has already cleared the transient values.
+            if (Evm.Metrics.GasPriceMax != 0f)
             {
-                float minGas = Evm.Metrics.BlockMinGasPrice;
-                float medianGas = Math.Max(minGas, Evm.Metrics.BlockEstMedianGasPrice);
-                float aveGas = Evm.Metrics.BlockAveGasPrice;
-                float maxGas = Evm.Metrics.BlockMaxGasPrice;
+                float minGas = Evm.Metrics.GasPriceMin;
+                float medianGas = Math.Max(minGas, Evm.Metrics.GasPriceMedian);
+                float aveGas = Evm.Metrics.GasPriceAve;
+                float maxGas = Evm.Metrics.GasPriceMax;
                 // Step the unit down (gwei -> mwei -> kwei -> wei) so small gas prices stay visible at :N3
                 // instead of all rendering 0.000 on low-base-fee chains.
                 (string unit, float scale) = minGas switch
@@ -507,10 +510,10 @@ namespace Nethermind.Consensus.Processing
                 ProcessingMs = chunkMs,
                 SlotMs = runMs,
                 MGasPerSecond = mgasPerSecond,
-                MinGas = Evm.Metrics.BlockMinGasPrice,
-                MedianGas = Math.Max(Evm.Metrics.BlockMinGasPrice, Evm.Metrics.BlockEstMedianGasPrice),
-                AveGas = Evm.Metrics.BlockAveGasPrice,
-                MaxGas = Evm.Metrics.BlockMaxGasPrice,
+                MinGas = Evm.Metrics.GasPriceMin,
+                MedianGas = Math.Max(Evm.Metrics.GasPriceMin, Evm.Metrics.GasPriceMedian),
+                AveGas = Evm.Metrics.GasPriceAve,
+                MaxGas = Evm.Metrics.GasPriceMax,
                 GasLimit = block.GasLimit
             });
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -598,9 +598,8 @@ namespace Nethermind.Consensus.Processing
                     _ => $"       {bps,10:F2} Blk/s "
                 };
 
-                // Execution-mode indicator: chains for parallel BAL validation, link for sequential.
-                // BlockAccessList is null until BAL (Amsterdam) activates, so a parallel-configured node
-                // still shows sequential pre-fork, when the parallel path does not actually run.
+                // Exec-mode indicator: chains for parallel BAL, link for sequential. BlockAccessList is
+                // null pre-Amsterdam, so a parallel-configured node correctly shows sequential pre-fork.
                 string execMode = _parallelExecution && block.BlockAccessList is not null ? " ⛓️" : " 🔗";
 
                 if (recoveryQueue > 0 || processingQueue > 0)

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -293,6 +293,10 @@ namespace Nethermind.Consensus.Processing
                 blockData.PerTxTicks = PerTxTimingCollector.Snapshot();
             }
 
+            // Snapshot on the block-processing thread; GenerateReport runs on a ThreadPool thread where
+            // the flag's own value would not be visible.
+            blockData.UsedParallelExecution = BlockProcessor.ParallelBlockValidationTransactionsExecutor.LastBlockUsedParallelExecution;
+
             CaptureReportData(blockData);
         }
 
@@ -478,7 +482,24 @@ namespace Nethermind.Consensus.Processing
             double bps = chunkMicroseconds == 0 ? -1 : chunkBlocks / chunkMicroseconds * 1_000_000.0;
             double chunkMs = (chunkMicroseconds == 0 ? -1 : chunkMicroseconds / 1000.0);
             double runMs = (data.RunMicroseconds == 0 ? -1 : data.RunMicroseconds / 1000.0);
-            string blockGas = Evm.Metrics.BlockMinGasPrice != float.MaxValue ? $"⛽ Gas gwei: {Evm.Metrics.BlockMinGasPrice:N3} .. {whiteText}{Math.Max(Evm.Metrics.BlockMinGasPrice, Evm.Metrics.BlockEstMedianGasPrice):N3}{resetColor} ({Evm.Metrics.BlockAveGasPrice:N3}) .. {Evm.Metrics.BlockMaxGasPrice:N3}" : "";
+            string blockGas = "";
+            if (Evm.Metrics.BlockMinGasPrice != float.MaxValue)
+            {
+                float minGas = Evm.Metrics.BlockMinGasPrice;
+                float medianGas = Math.Max(minGas, Evm.Metrics.BlockEstMedianGasPrice);
+                float aveGas = Evm.Metrics.BlockAveGasPrice;
+                float maxGas = Evm.Metrics.BlockMaxGasPrice;
+                // Step the unit down (gwei -> mwei -> kwei -> wei) so small gas prices stay visible at :N3
+                // instead of all rendering 0.000 on low-base-fee chains.
+                (string unit, float scale) = minGas switch
+                {
+                    0f or >= 0.001f => ("gwei", 1f),
+                    >= 0.000_001f => ("mwei", 1_000f),
+                    >= 0.000_000_001f => ("kwei", 1_000_000f),
+                    _ => ("wei", 1_000_000_000f),
+                };
+                blockGas = $"⛽ Gas {unit}: {minGas * scale:N3} .. {whiteText}{medianGas * scale:N3}{resetColor} ({aveGas * scale:N3}) .. {maxGas * scale:N3}";
+            }
             string mgasColor = whiteText;
 
             NewProcessingStatistics?.Invoke(this, new BlockStatistics()
@@ -581,13 +602,16 @@ namespace Nethermind.Consensus.Processing
                     _ => $"       {bps,10:F2} Blk/s "
                 };
 
+                // Execution-mode indicator: chains for parallel BAL validation, link for sequential.
+                string execMode = data.UsedParallelExecution ? " ⛓️" : " 🔗";
+
                 if (recoveryQueue > 0 || processingQueue > 0)
                 {
-                    _logger.Info($" Block throughput {mgasPerSecondColor}{mgasPerSecond,11:F2}{resetColor} MGas/s{(mgasPerSecond > 1000 ? "🔥" : "  ")}| {txps,10:N1} tps |{blobsOrBlocksPerSec}| recover {recoveryQueue,5:N0} | process {processingQueue,5:N0} | ops {chunkOpCodes,11:N0}");
+                    _logger.Info($" Block throughput {mgasPerSecondColor}{mgasPerSecond,11:F2}{resetColor} MGas/s{(mgasPerSecond > 1000 ? "🔥" : "  ")}| {txps,10:N1} tps |{blobsOrBlocksPerSec}| recover {recoveryQueue,5:N0} | process {processingQueue,5:N0} | ops {chunkOpCodes,11:N0}{execMode}");
                 }
                 else
                 {
-                    _logger.Info($" Block throughput {mgasPerSecondColor}{mgasPerSecond,11:F2}{resetColor} MGas/s{(mgasPerSecond > 1000 ? "🔥" : "  ")}| {txps,10:N1} tps |{blobsOrBlocksPerSec}| exec code{resetColor} cache {cachedContractsUsed,7:N0} |{resetColor} new {contractsAnalysed,6:N0} | ops {chunkOpCodes,11:N0}");
+                    _logger.Info($" Block throughput {mgasPerSecondColor}{mgasPerSecond,11:F2}{resetColor} MGas/s{(mgasPerSecond > 1000 ? "🔥" : "  ")}| {txps,10:N1} tps |{blobsOrBlocksPerSec}| exec code{resetColor} cache {cachedContractsUsed,7:N0} |{resetColor} new {contractsAnalysed,6:N0} | ops {chunkOpCodes,11:N0}{execMode}");
                 }
             }
 
@@ -808,6 +832,7 @@ namespace Nethermind.Consensus.Processing
                 data.GasUsed = 0;
                 data.TransactionCount = 0;
                 data.BlobCount = 0;
+                data.UsedParallelExecution = false;
 
                 // Reset the slow-block Delta* fields too. They're only written when the threshold
                 // is enabled (UpdateStats line ~270), so if a pooled instance was returned without
@@ -851,6 +876,7 @@ namespace Nethermind.Consensus.Processing
             public long GasUsed;
             public long TransactionCount;
             public long BlobCount;
+            public bool UsedParallelExecution;
             public long CurrentOpCodes;
             public long CurrentSLoadOps;
             public long CurrentSStoreOps;

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -599,7 +599,9 @@ namespace Nethermind.Consensus.Processing
                 };
 
                 // Execution-mode indicator: chains for parallel BAL validation, link for sequential.
-                string execMode = _parallelExecution ? " ⛓️" : " 🔗";
+                // BlockAccessList is null until BAL (Amsterdam) activates, so a parallel-configured node
+                // still shows sequential pre-fork, when the parallel path does not actually run.
+                string execMode = _parallelExecution && block.BlockAccessList is not null ? " ⛓️" : " 🔗";
 
                 if (recoveryQueue > 0 || processingQueue > 0)
                 {

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -293,10 +293,6 @@ namespace Nethermind.Consensus.Processing
                 blockData.PerTxTicks = PerTxTimingCollector.Snapshot();
             }
 
-            // Snapshot on the block-processing thread; GenerateReport runs on a ThreadPool thread where
-            // the flag's own value would not be visible.
-            blockData.UsedParallelExecution = BlockProcessor.ParallelBlockValidationTransactionsExecutor.LastBlockUsedParallelExecution;
-
             CaptureReportData(blockData);
         }
 
@@ -603,7 +599,7 @@ namespace Nethermind.Consensus.Processing
                 };
 
                 // Execution-mode indicator: chains for parallel BAL validation, link for sequential.
-                string execMode = data.UsedParallelExecution ? " ⛓️" : " 🔗";
+                string execMode = _parallelExecution ? " ⛓️" : " 🔗";
 
                 if (recoveryQueue > 0 || processingQueue > 0)
                 {
@@ -832,7 +828,6 @@ namespace Nethermind.Consensus.Processing
                 data.GasUsed = 0;
                 data.TransactionCount = 0;
                 data.BlobCount = 0;
-                data.UsedParallelExecution = false;
 
                 // Reset the slow-block Delta* fields too. They're only written when the threshold
                 // is enabled (UpdateStats line ~270), so if a pooled instance was returned without
@@ -876,7 +871,6 @@ namespace Nethermind.Consensus.Processing
             public long GasUsed;
             public long TransactionCount;
             public long BlobCount;
-            public bool UsedParallelExecution;
             public long CurrentOpCodes;
             public long CurrentSLoadOps;
             public long CurrentSStoreOps;

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -30,40 +30,40 @@ namespace Nethermind.Db
 
         [CounterMetric]
         [Description("Number of State Trie cache hits.")]
-        public static long StateTreeCache => _mainStateTreeCacheHits + _otherStateTreeCacheHits;
-        private static long _mainStateTreeCacheHits;
-        private static long _otherStateTreeCacheHits;
+        public static long StateTreeCache => _mainStateTreeCacheHits.Value + _otherStateTreeCacheHits.Value;
+        private static CacheLinePaddedLong _mainStateTreeCacheHits;
+        private static CacheLinePaddedLong _otherStateTreeCacheHits;
         // Exposed so consumers (e.g. ProcessingStats) can compute block-level deltas that exclude
         // background prewarmer activity, which runs with IsBlockProcessingThread = false.
-        internal static long MainThreadStateTreeCache => _mainStateTreeCacheHits;
-        internal static void IncrementStateTreeCacheHits() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStateTreeCacheHits : ref _otherStateTreeCacheHits);
+        internal static long MainThreadStateTreeCache => _mainStateTreeCacheHits.Value;
+        internal static void IncrementStateTreeCacheHits() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStateTreeCacheHits.Value : ref _otherStateTreeCacheHits.Value);
 
         [CounterMetric]
         [Description("Number of State Trie reads.")]
-        public static long StateTreeReads => _mainStateTreeReads + _otherStateTreeReads;
-        private static long _mainStateTreeReads;
-        private static long _otherStateTreeReads;
-        internal static long MainThreadStateTreeReads => _mainStateTreeReads;
-        internal static void IncrementStateTreeReads() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStateTreeReads : ref _otherStateTreeReads);
+        public static long StateTreeReads => _mainStateTreeReads.Value + _otherStateTreeReads.Value;
+        private static CacheLinePaddedLong _mainStateTreeReads;
+        private static CacheLinePaddedLong _otherStateTreeReads;
+        internal static long MainThreadStateTreeReads => _mainStateTreeReads.Value;
+        internal static void IncrementStateTreeReads() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStateTreeReads.Value : ref _otherStateTreeReads.Value);
 
         [CounterMetric]
         [Description("Number of State Reader reads.")]
-        public static long StateReaderReads => _mainStateReaderReads + _otherStateReaderReads;
-        private static long _mainStateReaderReads;
-        private static long _otherStateReaderReads;
-        internal static void IncrementStateReaderReads() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStateReaderReads : ref _otherStateReaderReads);
+        public static long StateReaderReads => _mainStateReaderReads.Value + _otherStateReaderReads.Value;
+        private static CacheLinePaddedLong _mainStateReaderReads;
+        private static CacheLinePaddedLong _otherStateReaderReads;
+        internal static void IncrementStateReaderReads() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStateReaderReads.Value : ref _otherStateReaderReads.Value);
 
         [CounterMetric]
         [Description("Number of state trie writes.")]
-        public static long StateTreeWrites => _stateTreeWrites;
-        private static long _stateTreeWrites;
-        internal static void IncrementStateTreeWrites(long value) => Interlocked.Add(ref _stateTreeWrites, value);
+        public static long StateTreeWrites => _stateTreeWrites.Value;
+        private static CacheLinePaddedLong _stateTreeWrites;
+        internal static void IncrementStateTreeWrites(long value) => Interlocked.Add(ref _stateTreeWrites.Value, value);
 
         [CounterMetric]
         [Description("Number of state trie writes skipped in net.")]
-        public static long StateSkippedWrites => _stateSkippedWrites;
-        private static long _stateSkippedWrites;
-        internal static void IncrementStateSkippedWrites(long value) => Interlocked.Add(ref _stateSkippedWrites, value);
+        public static long StateSkippedWrites => _stateSkippedWrites.Value;
+        private static CacheLinePaddedLong _stateSkippedWrites;
+        internal static void IncrementStateSkippedWrites(long value) => Interlocked.Add(ref _stateSkippedWrites.Value, value);
 
         [CounterMetric]
         [Description("Number of State DB duplicate writes during full pruning.")]
@@ -71,19 +71,19 @@ namespace Nethermind.Db
 
         [CounterMetric]
         [Description("Number of storage trie cache hits.")]
-        public static long StorageTreeCache => _mainStorageTreeCache + _otherStorageTreeCache;
-        private static long _mainStorageTreeCache;
-        private static long _otherStorageTreeCache;
-        internal static long MainThreadStorageTreeCache => _mainStorageTreeCache;
-        internal static void IncrementStorageTreeCache() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageTreeCache : ref _otherStorageTreeCache);
+        public static long StorageTreeCache => _mainStorageTreeCache.Value + _otherStorageTreeCache.Value;
+        private static CacheLinePaddedLong _mainStorageTreeCache;
+        private static CacheLinePaddedLong _otherStorageTreeCache;
+        internal static long MainThreadStorageTreeCache => _mainStorageTreeCache.Value;
+        internal static void IncrementStorageTreeCache() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageTreeCache.Value : ref _otherStorageTreeCache.Value);
 
         [CounterMetric]
         [Description("Number of storage trie reads.")]
-        public static long StorageTreeReads => _mainStorageTreeReads + _otherStorageTreeReads;
-        private static long _mainStorageTreeReads;
-        private static long _otherStorageTreeReads;
-        internal static long MainThreadStorageTreeReads => _mainStorageTreeReads;
-        internal static void IncrementStorageTreeReads() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageTreeReads : ref _otherStorageTreeReads);
+        public static long StorageTreeReads => _mainStorageTreeReads.Value + _otherStorageTreeReads.Value;
+        private static CacheLinePaddedLong _mainStorageTreeReads;
+        private static CacheLinePaddedLong _otherStorageTreeReads;
+        internal static long MainThreadStorageTreeReads => _mainStorageTreeReads.Value;
+        internal static void IncrementStorageTreeReads() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageTreeReads.Value : ref _otherStorageTreeReads.Value);
 
         [CounterMetric]
         [Description("Number of storage reader reads.")]
@@ -91,15 +91,15 @@ namespace Nethermind.Db
 
         [CounterMetric]
         [Description("Number of storage trie writes.")]
-        public static long StorageTreeWrites => _storageTreeWrites;
-        private static long _storageTreeWrites;
-        internal static void IncrementStorageTreeWrites(long value) => Interlocked.Add(ref _storageTreeWrites, value);
+        public static long StorageTreeWrites => _storageTreeWrites.Value;
+        private static CacheLinePaddedLong _storageTreeWrites;
+        internal static void IncrementStorageTreeWrites(long value) => Interlocked.Add(ref _storageTreeWrites.Value, value);
 
         [CounterMetric]
         [Description("Number of storage trie writes skipped in net.")]
-        public static long StorageSkippedWrites => _storageSkippedWrites;
-        private static long _storageSkippedWrites;
-        internal static void IncrementStorageSkippedWrites(long value) => Interlocked.Add(ref _storageSkippedWrites, value);
+        public static long StorageSkippedWrites => _storageSkippedWrites.Value;
+        private static CacheLinePaddedLong _storageSkippedWrites;
+        internal static void IncrementStorageSkippedWrites(long value) => Interlocked.Add(ref _storageSkippedWrites.Value, value);
 
         [GaugeMetric]
         [Description("Indicator if StateDb is being pruned.")]

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -87,7 +87,9 @@ namespace Nethermind.Db
 
         [CounterMetric]
         [Description("Number of storage reader reads.")]
-        public static long StorageReaderReads { get; set; }
+        public static long StorageReaderReads => _storageReaderReads.Value;
+        private static CacheLinePaddedLong _storageReaderReads;
+        internal static void IncrementStorageReaderReads() => Interlocked.Increment(ref _storageReaderReads.Value);
 
         [CounterMetric]
         [Description("Number of storage trie writes.")]

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -36,7 +36,7 @@ namespace Nethermind.Db
         // Exposed so consumers (e.g. ProcessingStats) can compute block-level deltas that exclude
         // background prewarmer activity, which runs with IsBlockProcessingThread = false.
         internal static long MainThreadStateTreeCache => _mainStateTreeCacheHits.Value;
-        internal static void IncrementStateTreeCacheHits() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStateTreeCacheHits.Value : ref _otherStateTreeCacheHits.Value);
+        internal static void AddStateTreeCacheHits(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStateTreeCacheHits.Value : ref _otherStateTreeCacheHits.Value, count);
 
         [CounterMetric]
         [Description("Number of State Trie reads.")]
@@ -44,7 +44,7 @@ namespace Nethermind.Db
         private static CacheLinePaddedLong _mainStateTreeReads;
         private static CacheLinePaddedLong _otherStateTreeReads;
         internal static long MainThreadStateTreeReads => _mainStateTreeReads.Value;
-        internal static void IncrementStateTreeReads() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStateTreeReads.Value : ref _otherStateTreeReads.Value);
+        internal static void AddStateTreeReads(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStateTreeReads.Value : ref _otherStateTreeReads.Value, count);
 
         [CounterMetric]
         [Description("Number of State Reader reads.")]
@@ -75,7 +75,7 @@ namespace Nethermind.Db
         private static CacheLinePaddedLong _mainStorageTreeCache;
         private static CacheLinePaddedLong _otherStorageTreeCache;
         internal static long MainThreadStorageTreeCache => _mainStorageTreeCache.Value;
-        internal static void IncrementStorageTreeCache() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageTreeCache.Value : ref _otherStorageTreeCache.Value);
+        internal static void AddStorageTreeCache(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStorageTreeCache.Value : ref _otherStorageTreeCache.Value, count);
 
         [CounterMetric]
         [Description("Number of storage trie reads.")]
@@ -83,7 +83,7 @@ namespace Nethermind.Db
         private static CacheLinePaddedLong _mainStorageTreeReads;
         private static CacheLinePaddedLong _otherStorageTreeReads;
         internal static long MainThreadStorageTreeReads => _mainStorageTreeReads.Value;
-        internal static void IncrementStorageTreeReads() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageTreeReads.Value : ref _otherStorageTreeReads.Value);
+        internal static void AddStorageTreeReads(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStorageTreeReads.Value : ref _otherStorageTreeReads.Value, count);
 
         [CounterMetric]
         [Description("Number of storage reader reads.")]

--- a/src/Nethermind/Nethermind.Evm.Test/GasPriceMetricsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/GasPriceMetricsTests.cs
@@ -80,4 +80,18 @@ public class GasPriceMetricsTests
         Assert.That(Metrics.BlockTransactions, Is.EqualTo(0));
         Assert.That(Metrics.GetBlockGasPrices(), Is.Null);
     }
+
+    [Test]
+    public void Gauges_publish_final_aggregates_not_per_tx_worker_value()
+    {
+        Metrics.UpdateBlockGasPrice(Gwei(10));
+        Metrics.UpdateBlockGasPrice(Gwei(30));
+
+        // Per-tx updates do not touch the gauges; only the explicit publish does (once, after workers join).
+        Metrics.PublishBlockGasPriceGauges();
+
+        Assert.That(Metrics.GasPriceMin, Is.EqualTo(10.0f));
+        Assert.That(Metrics.GasPriceMax, Is.EqualTo(30.0f));
+        Assert.That(Metrics.GasPriceAve, Is.EqualTo(20.0f));
+    }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/GasPriceMetricsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/GasPriceMetricsTests.cs
@@ -39,25 +39,22 @@ public class GasPriceMetricsTests
         Assert.That(prices.Value.Ave, Is.InRange(1.0f, 100.0f));
     }
 
-    [Test]
-    public void Seed_uses_base_fee_when_no_transaction_contributed()
+    // A non-zero base fee seeds all four aggregates; a zero base fee stays blank (no "0.000").
+    [TestCase(2u, 2.0f)]
+    [TestCase(0u, null)]
+    public void Seed_uses_base_fee_only_when_non_zero(ulong gwei, float? expected)
     {
-        Metrics.SeedBlockGasPriceIfEmpty(Gwei(2));
+        Metrics.SeedBlockGasPriceIfEmpty(Gwei(gwei));
 
         (float Min, float EstMedian, float Ave, float Max)? prices = Metrics.GetBlockGasPrices();
+        if (expected is null)
+        {
+            Assert.That(prices, Is.Null);
+            return;
+        }
+
         Assert.That(prices, Is.Not.Null);
-        Assert.That(prices!.Value.Min, Is.EqualTo(2.0f));
-        Assert.That(prices.Value.Max, Is.EqualTo(2.0f));
-        Assert.That(prices.Value.Ave, Is.EqualTo(2.0f));
-        Assert.That(prices.Value.EstMedian, Is.EqualTo(2.0f));
-    }
-
-    [Test]
-    public void Seed_does_not_render_zero_base_fee()
-    {
-        Metrics.SeedBlockGasPriceIfEmpty(UInt256.Zero);
-
-        Assert.That(Metrics.GetBlockGasPrices(), Is.Null, "zero base fee stays blank rather than showing 0.000");
+        Assert.That(prices!.Value, Is.EqualTo((expected.Value, expected.Value, expected.Value, expected.Value)));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/GasPriceMetricsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/GasPriceMetricsTests.cs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Covers the parallel-safe block gas-price aggregation and base-fee seeding in <see cref="Metrics"/>.
+/// </summary>
+/// <remarks>
+/// The aggregates are static process-wide state, so these run non-parallel and reset in setup.
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public class GasPriceMetricsTests
+{
+    private static UInt256 Gwei(ulong gwei) => new(gwei * 1_000_000_000UL);
+
+    [SetUp]
+    public void SetUp() => Metrics.ResetBlockStats();
+
+    [Test]
+    public void Concurrent_updates_do_not_lose_transactions_and_track_min_max()
+    {
+        const int count = 10_000;
+
+        // Each "tx" contributes a gas price of (i % 100 + 1) gwei across many threads at once.
+        Parallel.For(0, count, i => Metrics.UpdateBlockGasPrice(Gwei((ulong)(i % 100) + 1)));
+
+        (float Min, float EstMedian, float Ave, float Max)? prices = Metrics.GetBlockGasPrices();
+
+        Assert.That(Metrics.BlockTransactions, Is.EqualTo(count), "no updates lost under contention");
+        Assert.That(prices, Is.Not.Null);
+        Assert.That(prices!.Value.Min, Is.EqualTo(1.0f), "exact min regardless of interleaving");
+        Assert.That(prices.Value.Max, Is.EqualTo(100.0f), "exact max regardless of interleaving");
+        Assert.That(prices.Value.Ave, Is.InRange(1.0f, 100.0f));
+    }
+
+    [Test]
+    public void Seed_uses_base_fee_when_no_transaction_contributed()
+    {
+        Metrics.SeedBlockGasPriceIfEmpty(Gwei(2));
+
+        (float Min, float EstMedian, float Ave, float Max)? prices = Metrics.GetBlockGasPrices();
+        Assert.That(prices, Is.Not.Null);
+        Assert.That(prices!.Value.Min, Is.EqualTo(2.0f));
+        Assert.That(prices.Value.Max, Is.EqualTo(2.0f));
+        Assert.That(prices.Value.Ave, Is.EqualTo(2.0f));
+        Assert.That(prices.Value.EstMedian, Is.EqualTo(2.0f));
+    }
+
+    [Test]
+    public void Seed_does_not_render_zero_base_fee()
+    {
+        Metrics.SeedBlockGasPriceIfEmpty(UInt256.Zero);
+
+        Assert.That(Metrics.GetBlockGasPrices(), Is.Null, "zero base fee stays blank rather than showing 0.000");
+    }
+
+    [Test]
+    public void Seed_does_not_override_a_contributing_transaction()
+    {
+        Metrics.UpdateBlockGasPrice(Gwei(50));
+        Metrics.SeedBlockGasPriceIfEmpty(Gwei(2));
+
+        (float Min, float EstMedian, float Ave, float Max)? prices = Metrics.GetBlockGasPrices();
+        Assert.That(prices, Is.Not.Null);
+        Assert.That(prices!.Value.Min, Is.EqualTo(50.0f), "real tx price wins over base-fee seed");
+    }
+
+    [Test]
+    public void Gas_price_at_or_above_ulong_max_is_skipped()
+    {
+        // > ulong.MaxValue wei/gas (~18.4 ETH) is not a meaningful gas price.
+        Metrics.UpdateBlockGasPrice(new UInt256(0, 0, 1, 0));
+
+        Assert.That(Metrics.BlockTransactions, Is.EqualTo(0));
+        Assert.That(Metrics.GetBlockGasPrices(), Is.Null);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -37,9 +37,6 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        // Increment the opcode metric for TLOAD.
-        Metrics.TloadOpcode++;
-
         // Deduct the fixed gas cost for TLOAD.
         TGasPolicy.Consume(ref gas, GasCostOf.TLoad);
 
@@ -86,9 +83,6 @@ public static partial class EvmInstructions
     public static EvmExceptionType InstructionTStore<TGasPolicy>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
-        // Increment the opcode metric for TSTORE.
-        Metrics.TstoreOpcode++;
-
         VmState<TGasPolicy> vmState = vm.VmState;
 
         // Disallow storage modification during static calls.
@@ -290,9 +284,6 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        // Increment the opcode metric for MCOPY.
-        Metrics.MCopyOpcode++;
-
         // Pop destination, source, and length values; if any are missing, signal a stack underflow.
         if (!stack.PopUInt256(out UInt256 a, out UInt256 b, out UInt256 c)) goto StackUnderflow;
 

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -51,60 +51,60 @@ public class Metrics
 
     [CounterMetric]
     [Description("Number of Code DB cache reads.")]
-    public static long CodeDbCache => _mainCodeDbCache + _otherCodeDbCache;
-    private static long _mainCodeDbCache;
-    private static long _otherCodeDbCache;
+    public static long CodeDbCache => _mainCodeDbCache.Value + _otherCodeDbCache.Value;
+    private static CacheLinePaddedLong _mainCodeDbCache;
+    private static CacheLinePaddedLong _otherCodeDbCache;
     [Description("Number of Code DB cache reads on main processing thread.")]
-    public static long MainThreadCodeDbCache => _mainCodeDbCache;
-    internal static void IncrementCodeDbCache() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainCodeDbCache : ref _otherCodeDbCache);
+    public static long MainThreadCodeDbCache => _mainCodeDbCache.Value;
+    internal static void IncrementCodeDbCache() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainCodeDbCache.Value : ref _otherCodeDbCache.Value);
     [CounterMetric]
     [Description("Number of EVM exceptions thrown by contracts.")]
     public static long EvmExceptions { get; set; }
 
     [CounterMetric]
     [Description("Number of opcodes executed.")]
-    public static long OpCodes => _mainOpCodes + _otherOpCodes;
-    private static long _mainOpCodes;
-    private static long _otherOpCodes;
+    public static long OpCodes => _mainOpCodes.Value + _otherOpCodes.Value;
+    private static CacheLinePaddedLong _mainOpCodes;
+    private static CacheLinePaddedLong _otherOpCodes;
     [Description("Number of opcodes executed on main processing thread.")]
-    public static long MainThreadOpCodes => _mainOpCodes;
-    public static void IncrementOpCodes(int count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainOpCodes : ref _otherOpCodes, count);
+    public static long MainThreadOpCodes => _mainOpCodes.Value;
+    public static void IncrementOpCodes(int count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainOpCodes.Value : ref _otherOpCodes.Value, count);
 
     [CounterMetric]
     [Description("Number of SELFDESTRUCT calls.")]
-    public static long SelfDestructs => _mainSelfDestructs + _otherSelfDestructs;
-    private static long _mainSelfDestructs;
-    private static long _otherSelfDestructs;
+    public static long SelfDestructs => _mainSelfDestructs.Value + _otherSelfDestructs.Value;
+    private static CacheLinePaddedLong _mainSelfDestructs;
+    private static CacheLinePaddedLong _otherSelfDestructs;
     [Description("Number of SELFDESTRUCT calls on main processing thread.")]
-    public static long MainThreadSelfDestructs => _mainSelfDestructs;
-    public static void IncrementSelfDestructs() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSelfDestructs : ref _otherSelfDestructs);
+    public static long MainThreadSelfDestructs => _mainSelfDestructs.Value;
+    public static void IncrementSelfDestructs() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSelfDestructs.Value : ref _otherSelfDestructs.Value);
 
     [CounterMetric]
     [Description("Number of calls to other contracts.")]
-    public static long Calls => _mainCalls + _otherCalls;
-    private static long _mainCalls;
-    private static long _otherCalls;
+    public static long Calls => _mainCalls.Value + _otherCalls.Value;
+    private static CacheLinePaddedLong _mainCalls;
+    private static CacheLinePaddedLong _otherCalls;
     [Description("Number of calls to other contracts on main processing thread.")]
-    public static long MainThreadCalls => _mainCalls;
-    public static void IncrementCalls() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainCalls : ref _otherCalls);
+    public static long MainThreadCalls => _mainCalls.Value;
+    public static void IncrementCalls() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainCalls.Value : ref _otherCalls.Value);
 
     [CounterMetric]
     [Description("Number of SLOAD opcodes executed.")]
-    public static long SloadOpcode => _mainSLoadOpcode + _otherSLoadOpcode;
-    private static long _mainSLoadOpcode;
-    private static long _otherSLoadOpcode;
+    public static long SloadOpcode => _mainSLoadOpcode.Value + _otherSLoadOpcode.Value;
+    private static CacheLinePaddedLong _mainSLoadOpcode;
+    private static CacheLinePaddedLong _otherSLoadOpcode;
     [Description("Number of SLOAD opcodes executed on main processing thread.")]
-    public static long MainThreadSLoadOpcode => _mainSLoadOpcode;
-    public static void IncrementSLoadOpcode() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSLoadOpcode : ref _otherSLoadOpcode);
+    public static long MainThreadSLoadOpcode => _mainSLoadOpcode.Value;
+    public static void IncrementSLoadOpcode() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSLoadOpcode.Value : ref _otherSLoadOpcode.Value);
 
     [CounterMetric]
     [Description("Number of SSTORE opcodes executed.")]
-    public static long SstoreOpcode => _mainSStoreOpcode + _otherSStoreOpcode;
-    private static long _mainSStoreOpcode;
-    private static long _otherSStoreOpcode;
+    public static long SstoreOpcode => _mainSStoreOpcode.Value + _otherSStoreOpcode.Value;
+    private static CacheLinePaddedLong _mainSStoreOpcode;
+    private static CacheLinePaddedLong _otherSStoreOpcode;
     [Description("Number of SSTORE opcodes executed on main processing thread.")]
-    public static long MainThreadSStoreOpcode => _mainSStoreOpcode;
-    public static void IncrementSStoreOpcode() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSStoreOpcode : ref _otherSStoreOpcode);
+    public static long MainThreadSStoreOpcode => _mainSStoreOpcode.Value;
+    public static void IncrementSStoreOpcode() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSStoreOpcode.Value : ref _otherSStoreOpcode.Value);
 
     [Description("Number of TLOAD opcodes executed.")]
     public static long TloadOpcode { get; set; }
@@ -120,157 +120,157 @@ public class Metrics
 
     [CounterMetric]
     [Description("Number of calls made to addresses without code.")]
-    public static long EmptyCalls => _mainEmptyCalls + _otherEmptyCalls;
-    private static long _mainEmptyCalls;
-    private static long _otherEmptyCalls;
+    public static long EmptyCalls => _mainEmptyCalls.Value + _otherEmptyCalls.Value;
+    private static CacheLinePaddedLong _mainEmptyCalls;
+    private static CacheLinePaddedLong _otherEmptyCalls;
     [Description("Number of calls made to addresses without code on main processing thread.")]
-    public static long MainThreadEmptyCalls => _mainEmptyCalls;
-    public static void IncrementEmptyCalls() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainEmptyCalls : ref _otherEmptyCalls);
+    public static long MainThreadEmptyCalls => _mainEmptyCalls.Value;
+    public static void IncrementEmptyCalls() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainEmptyCalls.Value : ref _otherEmptyCalls.Value);
 
     [CounterMetric]
     [Description("Number of contract create calls.")]
-    public static long Creates => _mainCreates + _otherCreates;
-    private static long _mainCreates;
-    private static long _otherCreates;
+    public static long Creates => _mainCreates.Value + _otherCreates.Value;
+    private static CacheLinePaddedLong _mainCreates;
+    private static CacheLinePaddedLong _otherCreates;
     [Description("Number of contract create calls on main processing thread.")]
-    public static long MainThreadCreates => _mainCreates;
-    public static void IncrementCreates() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainCreates : ref _otherCreates);
+    public static long MainThreadCreates => _mainCreates.Value;
+    public static void IncrementCreates() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainCreates.Value : ref _otherCreates.Value);
 
     [Description("Number of contracts' code analysed for jump destinations.")]
-    public static long ContractsAnalysed => _mainContractsAnalysed + _otherContractsAnalysed;
-    private static long _mainContractsAnalysed;
-    private static long _otherContractsAnalysed;
+    public static long ContractsAnalysed => _mainContractsAnalysed.Value + _otherContractsAnalysed.Value;
+    private static CacheLinePaddedLong _mainContractsAnalysed;
+    private static CacheLinePaddedLong _otherContractsAnalysed;
     [Description("Number of contracts' code analysed for jump destinations on main processing thread.")]
-    public static long MainThreadContractsAnalysed => _mainContractsAnalysed;
-    public static void IncrementContractsAnalysed() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainContractsAnalysed : ref _otherContractsAnalysed);
+    public static long MainThreadContractsAnalysed => _mainContractsAnalysed.Value;
+    public static void IncrementContractsAnalysed() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainContractsAnalysed.Value : ref _otherContractsAnalysed.Value);
 
     // Cross-client execution metrics gated by ExecutionMetricsFlag.
     // Each Increment* method short-circuits when ExecutionMetricsFlag.IsActive is false:
     // since IsActive is a static property folded to a constant by the JIT, flipping the flag to
     // false elides the Interlocked.Increment / Interlocked.Add when inlined.
 
-    private static long _mainCodeReads;
-    internal static long MainThreadCodeReads => _mainCodeReads;
+    private static CacheLinePaddedLong _mainCodeReads;
+    internal static long MainThreadCodeReads => _mainCodeReads.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementCodeReads()
     {
         if (!ExecutionMetricsFlag.IsActive) return;
         if (!IsBlockProcessingThread) return;
-        Interlocked.Increment(ref _mainCodeReads);
+        Interlocked.Increment(ref _mainCodeReads.Value);
     }
 
-    private static long _mainCodeBytesRead;
-    internal static long MainThreadCodeBytesRead => _mainCodeBytesRead;
+    private static CacheLinePaddedLong _mainCodeBytesRead;
+    internal static long MainThreadCodeBytesRead => _mainCodeBytesRead.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementCodeBytesRead(int bytes)
     {
         if (!ExecutionMetricsFlag.IsActive) return;
         if (!IsBlockProcessingThread) return;
-        Interlocked.Add(ref _mainCodeBytesRead, bytes);
+        Interlocked.Add(ref _mainCodeBytesRead.Value, bytes);
     }
 
     [CounterMetric]
     [Description("Number of account writes during execution.")]
-    public static long AccountWrites => _mainAccountWrites + _otherAccountWrites;
-    private static long _mainAccountWrites;
-    private static long _otherAccountWrites;
-    internal static long MainThreadAccountWrites => _mainAccountWrites;
+    public static long AccountWrites => _mainAccountWrites.Value + _otherAccountWrites.Value;
+    private static CacheLinePaddedLong _mainAccountWrites;
+    private static CacheLinePaddedLong _otherAccountWrites;
+    internal static long MainThreadAccountWrites => _mainAccountWrites.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementAccountWrites()
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainAccountWrites : ref _otherAccountWrites);
+        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainAccountWrites.Value : ref _otherAccountWrites.Value);
     }
 
     [CounterMetric]
     [Description("Number of accounts deleted during execution.")]
-    public static long AccountDeleted => _mainAccountDeleted + _otherAccountDeleted;
-    private static long _mainAccountDeleted;
-    private static long _otherAccountDeleted;
-    internal static long MainThreadAccountDeleted => _mainAccountDeleted;
+    public static long AccountDeleted => _mainAccountDeleted.Value + _otherAccountDeleted.Value;
+    private static CacheLinePaddedLong _mainAccountDeleted;
+    private static CacheLinePaddedLong _otherAccountDeleted;
+    internal static long MainThreadAccountDeleted => _mainAccountDeleted.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementAccountDeleted()
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainAccountDeleted : ref _otherAccountDeleted);
+        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainAccountDeleted.Value : ref _otherAccountDeleted.Value);
     }
 
     [CounterMetric]
     [Description("Number of storage slot writes during execution.")]
-    public static long StorageWrites => _mainStorageWrites + _otherStorageWrites;
-    private static long _mainStorageWrites;
-    private static long _otherStorageWrites;
-    internal static long MainThreadStorageWrites => _mainStorageWrites;
+    public static long StorageWrites => _mainStorageWrites.Value + _otherStorageWrites.Value;
+    private static CacheLinePaddedLong _mainStorageWrites;
+    private static CacheLinePaddedLong _otherStorageWrites;
+    internal static long MainThreadStorageWrites => _mainStorageWrites.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementStorageWrites()
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageWrites : ref _otherStorageWrites);
+        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageWrites.Value : ref _otherStorageWrites.Value);
     }
 
     [CounterMetric]
     [Description("Number of storage slots deleted during execution.")]
-    public static long StorageDeleted => _mainStorageDeleted + _otherStorageDeleted;
-    private static long _mainStorageDeleted;
-    private static long _otherStorageDeleted;
-    internal static long MainThreadStorageDeleted => _mainStorageDeleted;
+    public static long StorageDeleted => _mainStorageDeleted.Value + _otherStorageDeleted.Value;
+    private static CacheLinePaddedLong _mainStorageDeleted;
+    private static CacheLinePaddedLong _otherStorageDeleted;
+    internal static long MainThreadStorageDeleted => _mainStorageDeleted.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementStorageDeleted()
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageDeleted : ref _otherStorageDeleted);
+        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageDeleted.Value : ref _otherStorageDeleted.Value);
     }
 
     [CounterMetric]
     [Description("Number of code writes during execution.")]
-    public static long CodeWrites => _mainCodeWrites + _otherCodeWrites;
-    private static long _mainCodeWrites;
-    private static long _otherCodeWrites;
-    internal static long MainThreadCodeWrites => _mainCodeWrites;
+    public static long CodeWrites => _mainCodeWrites.Value + _otherCodeWrites.Value;
+    private static CacheLinePaddedLong _mainCodeWrites;
+    private static CacheLinePaddedLong _otherCodeWrites;
+    internal static long MainThreadCodeWrites => _mainCodeWrites.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementCodeWrites()
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainCodeWrites : ref _otherCodeWrites);
+        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainCodeWrites.Value : ref _otherCodeWrites.Value);
     }
 
     [CounterMetric]
     [Description("Total bytes of code written during execution.")]
-    public static long CodeBytesWritten => _mainCodeBytesWritten + _otherCodeBytesWritten;
-    private static long _mainCodeBytesWritten;
-    private static long _otherCodeBytesWritten;
-    internal static long MainThreadCodeBytesWritten => _mainCodeBytesWritten;
+    public static long CodeBytesWritten => _mainCodeBytesWritten.Value + _otherCodeBytesWritten.Value;
+    private static CacheLinePaddedLong _mainCodeBytesWritten;
+    private static CacheLinePaddedLong _otherCodeBytesWritten;
+    internal static long MainThreadCodeBytesWritten => _mainCodeBytesWritten.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementCodeBytesWritten(int bytes)
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainCodeBytesWritten : ref _otherCodeBytesWritten, bytes);
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainCodeBytesWritten.Value : ref _otherCodeBytesWritten.Value, bytes);
     }
 
     [CounterMetric]
     [Description("Number of EIP-7702 delegations set during execution.")]
-    public static long Eip7702DelegationsSet => _mainEip7702DelegationsSet + _otherEip7702DelegationsSet;
-    private static long _mainEip7702DelegationsSet;
-    private static long _otherEip7702DelegationsSet;
-    internal static long MainThreadEip7702DelegationsSet => _mainEip7702DelegationsSet;
+    public static long Eip7702DelegationsSet => _mainEip7702DelegationsSet.Value + _otherEip7702DelegationsSet.Value;
+    private static CacheLinePaddedLong _mainEip7702DelegationsSet;
+    private static CacheLinePaddedLong _otherEip7702DelegationsSet;
+    internal static long MainThreadEip7702DelegationsSet => _mainEip7702DelegationsSet.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementEip7702DelegationsSet()
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainEip7702DelegationsSet : ref _otherEip7702DelegationsSet);
+        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainEip7702DelegationsSet.Value : ref _otherEip7702DelegationsSet.Value);
     }
 
     [CounterMetric]
     [Description("Number of EIP-7702 delegations cleared during execution.")]
-    public static long Eip7702DelegationsCleared => _mainEip7702DelegationsCleared + _otherEip7702DelegationsCleared;
-    private static long _mainEip7702DelegationsCleared;
-    private static long _otherEip7702DelegationsCleared;
-    internal static long MainThreadEip7702DelegationsCleared => _mainEip7702DelegationsCleared;
+    public static long Eip7702DelegationsCleared => _mainEip7702DelegationsCleared.Value + _otherEip7702DelegationsCleared.Value;
+    private static CacheLinePaddedLong _mainEip7702DelegationsCleared;
+    private static CacheLinePaddedLong _otherEip7702DelegationsCleared;
+    internal static long MainThreadEip7702DelegationsCleared => _mainEip7702DelegationsCleared.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementEip7702DelegationsCleared()
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainEip7702DelegationsCleared : ref _otherEip7702DelegationsCleared);
+        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainEip7702DelegationsCleared.Value : ref _otherEip7702DelegationsCleared.Value);
     }
 
     // Timing counters below accumulate elapsed <see cref="TimeSpan"/> ticks (100 ns), as produced
@@ -279,98 +279,98 @@ public class Metrics
     // <see cref="TimeSpan.TicksPerMillisecond"/>.
 
     [Description("Time spent on state hashing/merkleization (TimeSpan ticks). Sum of storage merkle + state root.")]
-    public static long StateHashTime => _mainStateHashTime + _otherStateHashTime;
-    private static long _mainStateHashTime;
-    private static long _otherStateHashTime;
-    internal static long MainThreadStateHashTime => _mainStateHashTime;
+    public static long StateHashTime => _mainStateHashTime.Value + _otherStateHashTime.Value;
+    private static CacheLinePaddedLong _mainStateHashTime;
+    private static CacheLinePaddedLong _otherStateHashTime;
+    internal static long MainThreadStateHashTime => _mainStateHashTime.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementStateHashTime(long ticks)
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStateHashTime : ref _otherStateHashTime, ticks);
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStateHashTime.Value : ref _otherStateHashTime.Value, ticks);
     }
 
     [Description("Time spent committing state to storage (ticks).")]
-    public static long CommitTime => _mainCommitTime + _otherCommitTime;
-    private static long _mainCommitTime;
-    private static long _otherCommitTime;
-    internal static long MainThreadCommitTime => _mainCommitTime;
+    public static long CommitTime => _mainCommitTime.Value + _otherCommitTime.Value;
+    private static CacheLinePaddedLong _mainCommitTime;
+    private static CacheLinePaddedLong _otherCommitTime;
+    internal static long MainThreadCommitTime => _mainCommitTime.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementCommitTime(long ticks)
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainCommitTime : ref _otherCommitTime, ticks);
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainCommitTime.Value : ref _otherCommitTime.Value, ticks);
     }
 
     [Description("Time spent on storage trie merkleization — Commit(commitRoots: true) (ticks).")]
-    public static long StorageMerkleTime => _mainStorageMerkleTime + _otherStorageMerkleTime;
-    private static long _mainStorageMerkleTime;
-    private static long _otherStorageMerkleTime;
-    internal static long MainThreadStorageMerkleTime => _mainStorageMerkleTime;
+    public static long StorageMerkleTime => _mainStorageMerkleTime.Value + _otherStorageMerkleTime.Value;
+    private static CacheLinePaddedLong _mainStorageMerkleTime;
+    private static CacheLinePaddedLong _otherStorageMerkleTime;
+    internal static long MainThreadStorageMerkleTime => _mainStorageMerkleTime.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementStorageMerkleTime(long ticks)
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStorageMerkleTime : ref _otherStorageMerkleTime, ticks);
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStorageMerkleTime.Value : ref _otherStorageMerkleTime.Value, ticks);
     }
 
     [Description("Time spent on state root recalculation + commit tree (ticks).")]
-    public static long StateRootTime => _mainStateRootTime + _otherStateRootTime;
-    private static long _mainStateRootTime;
-    private static long _otherStateRootTime;
-    internal static long MainThreadStateRootTime => _mainStateRootTime;
+    public static long StateRootTime => _mainStateRootTime.Value + _otherStateRootTime.Value;
+    private static CacheLinePaddedLong _mainStateRootTime;
+    private static CacheLinePaddedLong _otherStateRootTime;
+    internal static long MainThreadStateRootTime => _mainStateRootTime.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementStateRootTime(long ticks)
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStateRootTime : ref _otherStateRootTime, ticks);
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStateRootTime.Value : ref _otherStateRootTime.Value, ticks);
     }
 
     [Description("Time spent calculating bloom filters (ticks).")]
-    public static long BloomsTime => _mainBloomsTime + _otherBloomsTime;
-    private static long _mainBloomsTime;
-    private static long _otherBloomsTime;
-    internal static long MainThreadBloomsTime => _mainBloomsTime;
+    public static long BloomsTime => _mainBloomsTime.Value + _otherBloomsTime.Value;
+    private static CacheLinePaddedLong _mainBloomsTime;
+    private static CacheLinePaddedLong _otherBloomsTime;
+    internal static long MainThreadBloomsTime => _mainBloomsTime.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementBloomsTime(long ticks)
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainBloomsTime : ref _otherBloomsTime, ticks);
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainBloomsTime.Value : ref _otherBloomsTime.Value, ticks);
     }
 
     [Description("Time spent calculating receipts root (ticks).")]
-    public static long ReceiptsRootTime => _mainReceiptsRootTime + _otherReceiptsRootTime;
-    private static long _mainReceiptsRootTime;
-    private static long _otherReceiptsRootTime;
-    internal static long MainThreadReceiptsRootTime => _mainReceiptsRootTime;
+    public static long ReceiptsRootTime => _mainReceiptsRootTime.Value + _otherReceiptsRootTime.Value;
+    private static CacheLinePaddedLong _mainReceiptsRootTime;
+    private static CacheLinePaddedLong _otherReceiptsRootTime;
+    internal static long MainThreadReceiptsRootTime => _mainReceiptsRootTime.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void IncrementReceiptsRootTime(long ticks)
     {
         if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainReceiptsRootTime : ref _otherReceiptsRootTime, ticks);
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainReceiptsRootTime.Value : ref _otherReceiptsRootTime.Value, ticks);
     }
 
     [GaugeMetric]
     [Description("The number of tasks currently scheduled in the background.")]
     public static long NumberOfBackgroundTasksScheduled { get; set; }
 
-    private static long _totalBackgroundTasksQueued;
+    private static CacheLinePaddedLong _totalBackgroundTasksQueued;
     [GaugeMetric]
     [Description("Total number of tasks queued for background execution.")]
-    public static long TotalBackgroundTasksQueued => _totalBackgroundTasksQueued;
-    public static void IncrementTotalBackgroundTasksQueued() => Interlocked.Increment(ref _totalBackgroundTasksQueued);
+    public static long TotalBackgroundTasksQueued => _totalBackgroundTasksQueued.Value;
+    public static void IncrementTotalBackgroundTasksQueued() => Interlocked.Increment(ref _totalBackgroundTasksQueued.Value);
 
-    private static long _totalBackgroundTasksDropped;
+    private static CacheLinePaddedLong _totalBackgroundTasksDropped;
     [GaugeMetric]
     [Description("Total number of background tasks dropped because queue was full.")]
-    public static long TotalBackgroundTasksDropped => _totalBackgroundTasksDropped;
-    public static void IncrementTotalBackgroundTasksDropped() => Interlocked.Increment(ref _totalBackgroundTasksDropped);
+    public static long TotalBackgroundTasksDropped => _totalBackgroundTasksDropped.Value;
+    public static void IncrementTotalBackgroundTasksDropped() => Interlocked.Increment(ref _totalBackgroundTasksDropped.Value);
 
-    private static long _totalBackgroundTasksExecuted;
+    private static CacheLinePaddedLong _totalBackgroundTasksExecuted;
     [GaugeMetric]
     [Description("Total number of background tasks executed.")]
-    public static long TotalBackgroundTasksExecuted => _totalBackgroundTasksExecuted;
-    public static void IncrementTotalBackgroundTasksExecuted() => Interlocked.Increment(ref _totalBackgroundTasksExecuted);
+    public static long TotalBackgroundTasksExecuted => _totalBackgroundTasksExecuted.Value;
+    public static void IncrementTotalBackgroundTasksExecuted() => Interlocked.Increment(ref _totalBackgroundTasksExecuted.Value);
 
     internal static long BlockTransactions { get; set; }
 

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -461,6 +461,8 @@ public class Metrics
         if (Interlocked.CompareExchange(ref _minMaxGasPriceBits, PackFloats(gasPrice, gasPrice), empty) != empty)
             return; // a transaction already contributed
 
+        // Only ever called after all tx workers have joined, so no concurrent UpdateBlockGasPrice can
+        // observe the gap between the CAS above and these non-atomic seed writes.
         Volatile.Write(ref _countAveGasPriceBits, PackCountAve(0, gasPrice));
         Volatile.Write(ref _blockEstMedianGasPrice, gasPrice);
     }

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -345,7 +345,12 @@ public class Metrics
     // Block gas-price aggregates are updated once per transaction and, under parallel BAL validation, by
     // many workers concurrently. They are kept lock-free by packing two interdependent values into one
     // long updated with a single CAS: _minMaxGasPriceBits holds (min, max); _countAveGasPriceBits holds
-    // (count, running average) - packing count+ave together keeps the running mean exact under contention.
+    // (count, running average) - packing count+ave together keeps the transaction count exact under
+    // contention (the float average still carries normal accumulation rounding).
+    // These three are intentionally NOT cache-line padded: every worker CASes all three once per tx, so
+    // they are true-shared (the per-location contention is inherent and padding cannot remove it); padding
+    // would only separate them from each other while tripling the lines each tx touches. The once-per-tx
+    // frequency makes this immaterial next to the per-access counters the padding above targets.
     private static long _minMaxGasPriceBits = PackFloats(float.MaxValue, 0f);
     private static long _countAveGasPriceBits;
     // Order-dependent streaming estimate (already non-deterministic under parallelism); its own CAS.

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Threading;
+using Nethermind.Int256;
 
 [assembly: InternalsVisibleTo("Nethermind.Consensus")]
 [assembly: InternalsVisibleTo("Nethermind.State")]
@@ -440,10 +442,66 @@ public class Metrics
 
     public static void ResetBlockStats()
     {
-        BlockTransactions = 0;
-        BlockAveGasPrice = 0.0f;
-        BlockMaxGasPrice = 0.0f;
-        BlockEstMedianGasPrice = 0.0f;
-        BlockMinGasPrice = float.MaxValue;
+        lock (_gasPriceLock)
+        {
+            BlockTransactions = 0;
+            BlockAveGasPrice = 0.0f;
+            BlockMaxGasPrice = 0.0f;
+            BlockEstMedianGasPrice = 0.0f;
+            BlockMinGasPrice = float.MaxValue;
+        }
+    }
+
+    // Serializes the per-tx block gas-price aggregate update so parallel BAL validation workers,
+    // which each call UpdateBlockGasPrice once per transaction, produce race-free min/max and a
+    // deterministic running average/median. Contention is negligible: one short critical section per
+    // transaction, not per opcode.
+    private static readonly Lock _gasPriceLock = new();
+
+    /// <summary>Folds a transaction's effective gas price into the per-block aggregates.</summary>
+    /// <remarks>
+    /// Gas prices at or above <see cref="ulong.MaxValue"/> wei/gas (~18.4 ETH) are not meaningful for
+    /// these metrics, so the rare wider value is skipped rather than paying the multi-limb
+    /// <see cref="UInt256"/> to <see cref="double"/> conversion on the hot path.
+    /// </remarks>
+    internal static void UpdateBlockGasPrice(in UInt256 effectiveGasPrice)
+    {
+        if (!effectiveGasPrice.IsUint64) return;
+
+        float gasPrice = (float)(effectiveGasPrice.u0 / 1_000_000_000.0);
+
+        lock (_gasPriceLock)
+        {
+            BlockMinGasPrice = Math.Min(gasPrice, BlockMinGasPrice);
+            BlockMaxGasPrice = Math.Max(gasPrice, BlockMaxGasPrice);
+            BlockAveGasPrice = (BlockAveGasPrice * BlockTransactions + gasPrice) / (BlockTransactions + 1);
+            BlockEstMedianGasPrice += BlockAveGasPrice * 0.01f * float.Sign(gasPrice - BlockEstMedianGasPrice);
+            BlockTransactions++;
+        }
+    }
+
+    /// <summary>
+    /// Seeds the block gas-price aggregates with the block base fee when no user transaction
+    /// contributed (empty or system-only block), so the report shows a meaningful value.
+    /// </summary>
+    /// <remarks>
+    /// Skips zero-base-fee chains (pre-EIP-1559, some rollups, genesis): rendering "0.000" there is
+    /// less informative than the prior blank output.
+    /// </remarks>
+    internal static void SeedBlockGasPriceIfEmpty(in UInt256 baseFee)
+    {
+        if (!baseFee.IsUint64 || baseFee.IsZero) return;
+
+        float gasPrice = (float)(baseFee.u0 / 1_000_000_000.0);
+
+        lock (_gasPriceLock)
+        {
+            if (BlockMinGasPrice != float.MaxValue) return; // a transaction already contributed
+
+            BlockMinGasPrice = gasPrice;
+            BlockMaxGasPrice = gasPrice;
+            BlockAveGasPrice = gasPrice;
+            BlockEstMedianGasPrice = gasPrice;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -108,15 +108,6 @@ public class Metrics
     public static long MainThreadSStoreOpcode => _mainSStoreOpcode.Value;
     public static void IncrementSStoreOpcode() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSStoreOpcode.Value : ref _otherSStoreOpcode.Value);
 
-    [Description("Number of TLOAD opcodes executed.")]
-    public static long TloadOpcode { get; set; }
-
-    [Description("Number of TSTORE opcodes executed.")]
-    public static long TstoreOpcode { get; set; }
-
-    [Description("Number of MCOPY opcodes executed.")]
-    public static long MCopyOpcode { get; set; }
-
     [Description("Number of EXP opcodes executed.")]
     public static long ExpOpcode { get; set; }
 

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -108,9 +108,6 @@ public class Metrics
     public static long MainThreadSStoreOpcode => _mainSStoreOpcode.Value;
     public static void IncrementSStoreOpcode() => Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSStoreOpcode.Value : ref _otherSStoreOpcode.Value);
 
-    [Description("Number of EXP opcodes executed.")]
-    public static long ExpOpcode { get; set; }
-
     [CounterMetric]
     [Description("Number of calls made to addresses without code.")]
     public static long EmptyCalls => _mainEmptyCalls.Value + _otherEmptyCalls.Value;

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -458,13 +458,8 @@ public class Metrics
             if (prev == median) break;
             median = prev;
         }
-
-        // Latest-block Prometheus gauges; last-writer-wins is fine for a gauge.
-        GasPriceMin = BlockMinGasPrice;
-        if (BlockMaxGasPrice != 0) GasPriceMax = BlockMaxGasPrice;
-        if (newAve != 0) GasPriceAve = newAve;
-        float curMedian = BlockEstMedianGasPrice;
-        if (curMedian != 0) GasPriceMedian = curMedian;
+        // Gauges are not published here: a slow parallel worker could overwrite them with a stale view.
+        // PublishBlockGasPriceGauges() publishes once from the final aggregates after workers join.
     }
 
     /// <summary>
@@ -487,9 +482,20 @@ public class Metrics
 
         Volatile.Write(ref _countAveGasPriceBits, PackCountAve(0, gasPrice));
         Volatile.Write(ref _blockEstMedianGasPrice, gasPrice);
-        GasPriceMin = gasPrice;
-        GasPriceMax = gasPrice;
-        GasPriceAve = gasPrice;
-        GasPriceMedian = gasPrice;
+    }
+
+    /// <summary>
+    /// Publishes the latest-block gas-price gauges from the final aggregates. Call once after all
+    /// (possibly parallel) transactions are processed, so a slow worker cannot leave a stale value.
+    /// </summary>
+    internal static void PublishBlockGasPriceGauges()
+    {
+        float min = BlockMinGasPrice;
+        if (min == float.MaxValue) return; // no data this block; keep previous gauge values
+
+        GasPriceMin = min;
+        GasPriceMax = BlockMaxGasPrice;
+        GasPriceAve = BlockAveGasPrice;
+        GasPriceMedian = BlockEstMedianGasPrice;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -354,63 +354,33 @@ public class Metrics
     public static long TotalBackgroundTasksExecuted => _totalBackgroundTasksExecuted.Value;
     public static void IncrementTotalBackgroundTasksExecuted() => Interlocked.Increment(ref _totalBackgroundTasksExecuted.Value);
 
-    internal static long BlockTransactions { get; set; }
-
-    private static float _blockAveGasPrice;
-    internal static float BlockAveGasPrice
-    {
-        get => _blockAveGasPrice;
-        set
-        {
-            _blockAveGasPrice = value;
-            if (value != 0)
-            {
-                GasPriceAve = value;
-            }
-        }
-    }
-
-    private static float _blockMinGasPrice = float.MaxValue;
-    internal static float BlockMinGasPrice
-    {
-        get => _blockMinGasPrice;
-        set
-        {
-            _blockMinGasPrice = value;
-            if (_blockMinGasPrice != float.MaxValue)
-            {
-                GasPriceMin = value;
-            }
-        }
-    }
-
-    private static float _blockMaxGasPrice;
-    internal static float BlockMaxGasPrice
-    {
-        get => _blockMaxGasPrice;
-        set
-        {
-            _blockMaxGasPrice = value;
-            if (value != 0)
-            {
-                GasPriceMax = value;
-            }
-        }
-    }
-
+    // Block gas-price aggregates are updated once per transaction and, under parallel BAL validation, by
+    // many workers concurrently. They are kept lock-free by packing two interdependent values into one
+    // long updated with a single CAS: _minMaxGasPriceBits holds (min, max); _countAveGasPriceBits holds
+    // (count, running average) - packing count+ave together keeps the running mean exact under contention.
+    private static long _minMaxGasPriceBits = PackFloats(float.MaxValue, 0f);
+    private static long _countAveGasPriceBits;
+    // Order-dependent streaming estimate (already non-deterministic under parallelism); its own CAS.
     private static float _blockEstMedianGasPrice;
-    internal static float BlockEstMedianGasPrice
-    {
-        get => _blockEstMedianGasPrice;
-        set
-        {
-            _blockEstMedianGasPrice = value;
-            if (value != 0)
-            {
-                GasPriceMedian = value;
-            }
-        }
-    }
+
+    internal static long BlockTransactions => LoInt(Volatile.Read(ref _countAveGasPriceBits));
+    internal static float BlockAveGasPrice => HiFloat(Volatile.Read(ref _countAveGasPriceBits));
+    internal static float BlockMinGasPrice => LoFloat(Volatile.Read(ref _minMaxGasPriceBits));
+    internal static float BlockMaxGasPrice => HiFloat(Volatile.Read(ref _minMaxGasPriceBits));
+    internal static float BlockEstMedianGasPrice => Volatile.Read(ref _blockEstMedianGasPrice);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static long PackFloats(float lo, float hi)
+        => (uint)BitConverter.SingleToInt32Bits(lo) | ((long)(uint)BitConverter.SingleToInt32Bits(hi) << 32);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static long PackCountAve(int count, float ave)
+        => (uint)count | ((long)(uint)BitConverter.SingleToInt32Bits(ave) << 32);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float LoFloat(long bits) => BitConverter.Int32BitsToSingle((int)bits);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float HiFloat(long bits) => BitConverter.Int32BitsToSingle((int)(bits >> 32));
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int LoInt(long bits) => (int)bits;
 
     /// <summary>
     /// Gets block gas price data for external access. Returns (min, estMedian, ave, max).
@@ -418,10 +388,8 @@ public class Metrics
     /// </summary>
     public static (float Min, float EstMedian, float Ave, float Max)? GetBlockGasPrices()
     {
-        if (_blockMinGasPrice == float.MaxValue)
-            return null;
-
-        return (_blockMinGasPrice, _blockEstMedianGasPrice, _blockAveGasPrice, _blockMaxGasPrice);
+        float min = BlockMinGasPrice;
+        return min == float.MaxValue ? null : (min, BlockEstMedianGasPrice, BlockAveGasPrice, BlockMaxGasPrice);
     }
 
     [GaugeMetric]
@@ -442,24 +410,17 @@ public class Metrics
 
     public static void ResetBlockStats()
     {
-        lock (_gasPriceLock)
-        {
-            BlockTransactions = 0;
-            BlockAveGasPrice = 0.0f;
-            BlockMaxGasPrice = 0.0f;
-            BlockEstMedianGasPrice = 0.0f;
-            BlockMinGasPrice = float.MaxValue;
-        }
+        Volatile.Write(ref _minMaxGasPriceBits, PackFloats(float.MaxValue, 0f));
+        Volatile.Write(ref _countAveGasPriceBits, 0L);
+        Volatile.Write(ref _blockEstMedianGasPrice, 0f);
     }
-
-    // Serializes the once-per-tx gas-price aggregate update so parallel BAL workers don't race on it.
-    private static readonly Lock _gasPriceLock = new();
 
     /// <summary>Folds a transaction's effective gas price into the per-block aggregates.</summary>
     /// <remarks>
-    /// Gas prices at or above <see cref="ulong.MaxValue"/> wei/gas (~18.4 ETH) are not meaningful for
-    /// these metrics, so the rare wider value is skipped rather than paying the multi-limb
-    /// <see cref="UInt256"/> to <see cref="double"/> conversion on the hot path.
+    /// Lock-free: parallel BAL workers each call this once per transaction. Gas prices at or above
+    /// <see cref="ulong.MaxValue"/> wei/gas (~18.4 ETH) are not meaningful for these metrics, so the rare
+    /// wider value is skipped rather than paying the multi-limb <see cref="UInt256"/> to
+    /// <see cref="double"/> conversion.
     /// </remarks>
     internal static void UpdateBlockGasPrice(in UInt256 effectiveGasPrice)
     {
@@ -467,14 +428,43 @@ public class Metrics
 
         float gasPrice = (float)(effectiveGasPrice.u0 / 1_000_000_000.0);
 
-        lock (_gasPriceLock)
+        long mm = Volatile.Read(ref _minMaxGasPriceBits);
+        while (true)
         {
-            BlockMinGasPrice = Math.Min(gasPrice, BlockMinGasPrice);
-            BlockMaxGasPrice = Math.Max(gasPrice, BlockMaxGasPrice);
-            BlockAveGasPrice = (BlockAveGasPrice * BlockTransactions + gasPrice) / (BlockTransactions + 1);
-            BlockEstMedianGasPrice += BlockAveGasPrice * 0.01f * float.Sign(gasPrice - BlockEstMedianGasPrice);
-            BlockTransactions++;
+            long updated = PackFloats(MathF.Min(LoFloat(mm), gasPrice), MathF.Max(HiFloat(mm), gasPrice));
+            if (updated == mm) break;
+            long prev = Interlocked.CompareExchange(ref _minMaxGasPriceBits, updated, mm);
+            if (prev == mm) break;
+            mm = prev;
         }
+
+        float newAve;
+        long ca = Volatile.Read(ref _countAveGasPriceBits);
+        while (true)
+        {
+            int count = LoInt(ca);
+            newAve = (HiFloat(ca) * count + gasPrice) / (count + 1);
+            long prev = Interlocked.CompareExchange(ref _countAveGasPriceBits, PackCountAve(count + 1, newAve), ca);
+            if (prev == ca) break;
+            ca = prev;
+        }
+
+        float median = Volatile.Read(ref _blockEstMedianGasPrice);
+        while (true)
+        {
+            float updated = median + newAve * 0.01f * float.Sign(gasPrice - median);
+            if (updated == median) break;
+            float prev = Interlocked.CompareExchange(ref _blockEstMedianGasPrice, updated, median);
+            if (prev == median) break;
+            median = prev;
+        }
+
+        // Latest-block Prometheus gauges; last-writer-wins is fine for a gauge.
+        GasPriceMin = BlockMinGasPrice;
+        if (BlockMaxGasPrice != 0) GasPriceMax = BlockMaxGasPrice;
+        if (newAve != 0) GasPriceAve = newAve;
+        float curMedian = BlockEstMedianGasPrice;
+        if (curMedian != 0) GasPriceMedian = curMedian;
     }
 
     /// <summary>
@@ -483,7 +473,7 @@ public class Metrics
     /// </summary>
     /// <remarks>
     /// Skips zero-base-fee chains (pre-EIP-1559, some rollups, genesis): rendering "0.000" there is
-    /// less informative than the prior blank output.
+    /// less informative than the prior blank output. Called after workers join, so the CAS is uncontended.
     /// </remarks>
     internal static void SeedBlockGasPriceIfEmpty(in UInt256 baseFee)
     {
@@ -491,14 +481,15 @@ public class Metrics
 
         float gasPrice = (float)(baseFee.u0 / 1_000_000_000.0);
 
-        lock (_gasPriceLock)
-        {
-            if (BlockMinGasPrice != float.MaxValue) return; // a transaction already contributed
+        long empty = PackFloats(float.MaxValue, 0f);
+        if (Interlocked.CompareExchange(ref _minMaxGasPriceBits, PackFloats(gasPrice, gasPrice), empty) != empty)
+            return; // a transaction already contributed
 
-            BlockMinGasPrice = gasPrice;
-            BlockMaxGasPrice = gasPrice;
-            BlockAveGasPrice = gasPrice;
-            BlockEstMedianGasPrice = gasPrice;
-        }
+        Volatile.Write(ref _countAveGasPriceBits, PackCountAve(0, gasPrice));
+        Volatile.Write(ref _blockEstMedianGasPrice, gasPrice);
+        GasPriceMin = gasPrice;
+        GasPriceMax = gasPrice;
+        GasPriceAve = gasPrice;
+        GasPriceMedian = gasPrice;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -452,10 +452,7 @@ public class Metrics
         }
     }
 
-    // Serializes the per-tx block gas-price aggregate update so parallel BAL validation workers,
-    // which each call UpdateBlockGasPrice once per transaction, produce race-free min/max and a
-    // deterministic running average/median. Contention is negligible: one short critical section per
-    // transaction, not per opcode.
+    // Serializes the once-per-tx gas-price aggregate update so parallel BAL workers don't race on it.
     private static readonly Lock _gasPriceLock = new();
 
     /// <summary>Folds a transaction's effective gas price into the per-block aggregates.</summary>

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -176,11 +176,7 @@ public class Metrics
     private static CacheLinePaddedLong _otherAccountWrites;
     internal static long MainThreadAccountWrites => _mainAccountWrites.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void IncrementAccountWrites()
-    {
-        if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainAccountWrites.Value : ref _otherAccountWrites.Value);
-    }
+    internal static void AddAccountWrites(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainAccountWrites.Value : ref _otherAccountWrites.Value, count);
 
     [CounterMetric]
     [Description("Number of accounts deleted during execution.")]
@@ -189,11 +185,7 @@ public class Metrics
     private static CacheLinePaddedLong _otherAccountDeleted;
     internal static long MainThreadAccountDeleted => _mainAccountDeleted.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void IncrementAccountDeleted()
-    {
-        if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainAccountDeleted.Value : ref _otherAccountDeleted.Value);
-    }
+    internal static void AddAccountDeleted(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainAccountDeleted.Value : ref _otherAccountDeleted.Value, count);
 
     [CounterMetric]
     [Description("Number of storage slot writes during execution.")]
@@ -202,11 +194,7 @@ public class Metrics
     private static CacheLinePaddedLong _otherStorageWrites;
     internal static long MainThreadStorageWrites => _mainStorageWrites.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void IncrementStorageWrites()
-    {
-        if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageWrites.Value : ref _otherStorageWrites.Value);
-    }
+    internal static void AddStorageWrites(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStorageWrites.Value : ref _otherStorageWrites.Value, count);
 
     [CounterMetric]
     [Description("Number of storage slots deleted during execution.")]
@@ -228,11 +216,7 @@ public class Metrics
     private static CacheLinePaddedLong _otherCodeWrites;
     internal static long MainThreadCodeWrites => _mainCodeWrites.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void IncrementCodeWrites()
-    {
-        if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainCodeWrites.Value : ref _otherCodeWrites.Value);
-    }
+    internal static void AddCodeWrites(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainCodeWrites.Value : ref _otherCodeWrites.Value, count);
 
     [CounterMetric]
     [Description("Total bytes of code written during execution.")]
@@ -241,11 +225,7 @@ public class Metrics
     private static CacheLinePaddedLong _otherCodeBytesWritten;
     internal static long MainThreadCodeBytesWritten => _mainCodeBytesWritten.Value;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void IncrementCodeBytesWritten(int bytes)
-    {
-        if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainCodeBytesWritten.Value : ref _otherCodeBytesWritten.Value, bytes);
-    }
+    internal static void AddCodeBytesWritten(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainCodeBytesWritten.Value : ref _otherCodeBytesWritten.Value, count);
 
     [CounterMetric]
     [Description("Number of EIP-7702 delegations set during execution.")]

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -342,15 +342,9 @@ public class Metrics
     public static long TotalBackgroundTasksExecuted => _totalBackgroundTasksExecuted.Value;
     public static void IncrementTotalBackgroundTasksExecuted() => Interlocked.Increment(ref _totalBackgroundTasksExecuted.Value);
 
-    // Block gas-price aggregates are updated once per transaction and, under parallel BAL validation, by
-    // many workers concurrently. They are kept lock-free by packing two interdependent values into one
-    // long updated with a single CAS: _minMaxGasPriceBits holds (min, max); _countAveGasPriceBits holds
-    // (count, running average) - packing count+ave together keeps the transaction count exact under
-    // contention (the float average still carries normal accumulation rounding).
-    // These three are intentionally NOT cache-line padded: every worker CASes all three once per tx, so
-    // they are true-shared (the per-location contention is inherent and padding cannot remove it); padding
-    // would only separate them from each other while tripling the lines each tx touches. The once-per-tx
-    // frequency makes this immaterial next to the per-access counters the padding above targets.
+    // Lock-free per-tx block gas-price aggregates: each packs two interdependent values into one long
+    // CAS'd atomically - (min, max) and (count, running average). Not cache-line padded: they are
+    // true-shared (every worker CASes all three per tx), so padding cannot reduce the inherent contention.
     private static long _minMaxGasPriceBits = PackFloats(float.MaxValue, 0f);
     private static long _countAveGasPriceBits;
     // Order-dependent streaming estimate (already non-deterministic under parallelism); its own CAS.
@@ -408,12 +402,10 @@ public class Metrics
         Volatile.Write(ref _blockEstMedianGasPrice, 0f);
     }
 
-    /// <summary>Folds a transaction's effective gas price into the per-block aggregates.</summary>
+    /// <summary>Folds a transaction's effective gas price into the per-block aggregates (lock-free).</summary>
     /// <remarks>
-    /// Lock-free: parallel BAL workers each call this once per transaction. Gas prices at or above
-    /// <see cref="ulong.MaxValue"/> wei/gas (~18.4 ETH) are not meaningful for these metrics, so the rare
-    /// wider value is skipped rather than paying the multi-limb <see cref="UInt256"/> to
-    /// <see cref="double"/> conversion.
+    /// Prices >= <see cref="ulong.MaxValue"/> wei/gas (~18.4 ETH) are not meaningful and are skipped,
+    /// avoiding the multi-limb <see cref="UInt256"/>-to-<see cref="double"/> conversion.
     /// </remarks>
     internal static void UpdateBlockGasPrice(in UInt256 effectiveGasPrice)
     {
@@ -451,18 +443,14 @@ public class Metrics
             if (prev == median) break;
             median = prev;
         }
-        // Gauges are not published here: a slow parallel worker could overwrite them with a stale view.
-        // PublishBlockGasPriceGauges() publishes once from the final aggregates after workers join.
+        // Gauges published once by PublishBlockGasPriceGauges after workers join, not here (a slow
+        // worker could otherwise leave a stale value).
     }
 
     /// <summary>
-    /// Seeds the block gas-price aggregates with the block base fee when no user transaction
-    /// contributed (empty or system-only block), so the report shows a meaningful value.
+    /// Seeds the gas-price aggregates with the block base fee when no transaction contributed (empty /
+    /// system-only block). Skips zero base fee (pre-EIP-1559, genesis) - "0.000" is less useful than blank.
     /// </summary>
-    /// <remarks>
-    /// Skips zero-base-fee chains (pre-EIP-1559, some rollups, genesis): rendering "0.000" there is
-    /// less informative than the prior blank output. Called after workers join, so the CAS is uncontended.
-    /// </remarks>
     internal static void SeedBlockGasPriceIfEmpty(in UInt256 baseFee)
     {
         if (!baseFee.IsUint64 || baseFee.IsZero) return;

--- a/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
@@ -19,10 +19,8 @@ public interface IWorldStateScopeProvider
     bool HasRoot(BlockHeader? baseBlock);
 
     /// <param name="metrics">
-    /// Per-scope counter accumulator owned by the calling world state. Scopes that record state/storage
-    /// access metrics (e.g. the prewarmer) increment it instead of the global counters to avoid
-    /// cross-thread contention; the world state folds it into the globals at commit/scope end. Scopes
-    /// that do not record these metrics ignore it.
+    /// Per-scope accumulator the world state folds into the global counters at commit/scope end. Scopes
+    /// that record state/storage access metrics (e.g. the prewarmer) increment it; others ignore it.
     /// </param>
     IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics);
 

--- a/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
@@ -17,7 +17,14 @@ namespace Nethermind.Evm.State;
 public interface IWorldStateScopeProvider
 {
     bool HasRoot(BlockHeader? baseBlock);
-    IScope BeginScope(BlockHeader? baseBlock);
+
+    /// <param name="metrics">
+    /// Per-scope counter accumulator owned by the calling world state. Scopes that record state/storage
+    /// access metrics (e.g. the prewarmer) increment it instead of the global counters to avoid
+    /// cross-thread contention; the world state folds it into the globals at commit/scope end. Scopes
+    /// that do not record these metrics ignore it.
+    /// </param>
+    IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics);
 
     public interface IScope : IDisposable
     {

--- a/src/Nethermind/Nethermind.Evm/State/LocalMetrics.cs
+++ b/src/Nethermind/Nethermind.Evm/State/LocalMetrics.cs
@@ -32,8 +32,9 @@ public sealed class LocalMetrics
     public long StateSkippedWrites;
     public long StorageTreeCache;
     public long StorageTreeReads;
-    public long StorageTreeWrites;
-    public long StorageSkippedWrites;
+    // Note: storage trie write/skipped counters are NOT here - they are reported from
+    // ParallelUnbalancedWork worker finalizers (PersistentStorageProvider.ReportMetrics) and so go
+    // straight to the atomic global Db.Metrics, which a non-atomic per-scope accumulator cannot.
 
     // Execution write counters — gated by ExecutionMetricsFlag, matching Metrics.Increment*.
     public long AccountWrites;
@@ -54,10 +55,6 @@ public sealed class LocalMetrics
     public void IncrementStorageTreeCache() => StorageTreeCache++;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void IncrementStorageTreeReads() => StorageTreeReads++;
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void IncrementStorageTreeWrites(long count) => StorageTreeWrites += count;
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void IncrementStorageSkippedWrites(long count) => StorageSkippedWrites += count;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void IncrementStorageWrites()
@@ -97,8 +94,6 @@ public sealed class LocalMetrics
         StateSkippedWrites = 0;
         StorageTreeCache = 0;
         StorageTreeReads = 0;
-        StorageTreeWrites = 0;
-        StorageSkippedWrites = 0;
         AccountWrites = 0;
         AccountDeleted = 0;
         StorageWrites = 0;

--- a/src/Nethermind/Nethermind.Evm/State/LocalMetrics.cs
+++ b/src/Nethermind/Nethermind.Evm/State/LocalMetrics.cs
@@ -6,37 +6,27 @@ using System.Runtime.CompilerServices;
 namespace Nethermind.Evm.State;
 
 /// <summary>
-/// Per-scope, single-threaded accumulator for execution metric counters incremented from the
-/// world-state layer (state/storage trie reads, cache hits, writes, and the execution write
-/// counters).
+/// Per-scope accumulator for world-state metric counters, flushed into the global <see cref="Metrics"/> /
+/// <c>Db.Metrics</c> by the owning <c>WorldState</c> at commit and scope end.
 /// </summary>
 /// <remarks>
-/// A world-state scope is only ever touched by one thread at a time, so increments here are plain
-/// non-atomic adds. This avoids the cross-thread <see cref="System.Threading.Interlocked"/>
-/// contention that arises when many prewarm / parallel-BAL workers update the same global counter
-/// line. The owning <c>WorldState</c> folds these into the global <see cref="Metrics"/> /
-/// <c>Db.Metrics</c> counters once per boundary (per-tx commit and scope end) via its flush, then
-/// calls <see cref="Reset"/>. The execution write counters mirror the
-/// <see cref="ExecutionMetricsFlag"/> gating of their <see cref="Metrics"/> counterparts so a
-/// <c>NETHERMIND_NO_EXECUTION_METRICS</c> build still elides them.
+/// A scope is only ever touched by one thread, so increments are plain non-atomic adds - avoiding the
+/// per-access cross-thread <see cref="System.Threading.Interlocked"/> contention during prewarm /
+/// parallel-BAL. Write counters mirror the <see cref="ExecutionMetricsFlag"/> gating of their globals.
 /// </remarks>
 public sealed class LocalMetrics
 {
-    // Field order mirrors the declaration order of the static Db.Metrics / Evm.Metrics counters so
-    // the flush adds across them in progressive memory order rather than jumping back and forth.
-
-    // Db state/storage trie counters — always recorded (not gated).
+    // Field order matches the global declaration order so the flush walks memory forward.
     public long StateTreeCacheHits;
     public long StateTreeReads;
     public long StateTreeWrites;
     public long StateSkippedWrites;
     public long StorageTreeCache;
     public long StorageTreeReads;
-    // Note: storage trie write/skipped counters are NOT here - they are reported from
-    // ParallelUnbalancedWork worker finalizers (PersistentStorageProvider.ReportMetrics) and so go
-    // straight to the atomic global Db.Metrics, which a non-atomic per-scope accumulator cannot.
+    // Storage write/skipped counters are deliberately absent: reported from parallel worker finalizers,
+    // so they go straight to the atomic global Db.Metrics (see PersistentStorageProvider.ReportMetrics).
 
-    // Execution write counters — gated by ExecutionMetricsFlag, matching Metrics.Increment*.
+    // Execution write counters - gated by ExecutionMetricsFlag, matching Metrics.Increment*.
     public long AccountWrites;
     public long AccountDeleted;
     public long StorageWrites;

--- a/src/Nethermind/Nethermind.Evm/State/LocalMetrics.cs
+++ b/src/Nethermind/Nethermind.Evm/State/LocalMetrics.cs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.CompilerServices;
+
+namespace Nethermind.Evm.State;
+
+/// <summary>
+/// Per-scope, single-threaded accumulator for execution metric counters incremented from the
+/// world-state layer (state/storage trie reads, cache hits, writes, and the execution write
+/// counters).
+/// </summary>
+/// <remarks>
+/// A world-state scope is only ever touched by one thread at a time, so increments here are plain
+/// non-atomic adds. This avoids the cross-thread <see cref="System.Threading.Interlocked"/>
+/// contention that arises when many prewarm / parallel-BAL workers update the same global counter
+/// line. The owning <c>WorldState</c> folds these into the global <see cref="Metrics"/> /
+/// <c>Db.Metrics</c> counters once per boundary (per-tx commit and scope end) via its flush, then
+/// calls <see cref="Reset"/>. The execution write counters mirror the
+/// <see cref="ExecutionMetricsFlag"/> gating of their <see cref="Metrics"/> counterparts so a
+/// <c>NETHERMIND_NO_EXECUTION_METRICS</c> build still elides them.
+/// </remarks>
+public sealed class LocalMetrics
+{
+    // Field order mirrors the declaration order of the static Db.Metrics / Evm.Metrics counters so
+    // the flush adds across them in progressive memory order rather than jumping back and forth.
+
+    // Db state/storage trie counters — always recorded (not gated).
+    public long StateTreeCacheHits;
+    public long StateTreeReads;
+    public long StateTreeWrites;
+    public long StateSkippedWrites;
+    public long StorageTreeCache;
+    public long StorageTreeReads;
+    public long StorageTreeWrites;
+    public long StorageSkippedWrites;
+
+    // Execution write counters — gated by ExecutionMetricsFlag, matching Metrics.Increment*.
+    public long AccountWrites;
+    public long AccountDeleted;
+    public long StorageWrites;
+    public long CodeWrites;
+    public long CodeBytesWritten;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementStateTreeReads() => StateTreeReads++;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementStateTreeCacheHits() => StateTreeCacheHits++;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementStateTreeWrites(long count) => StateTreeWrites += count;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementStateSkippedWrites(long count) => StateSkippedWrites += count;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementStorageTreeCache() => StorageTreeCache++;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementStorageTreeReads() => StorageTreeReads++;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementStorageTreeWrites(long count) => StorageTreeWrites += count;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementStorageSkippedWrites(long count) => StorageSkippedWrites += count;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementStorageWrites()
+    {
+        if (ExecutionMetricsFlag.IsActive) StorageWrites++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementAccountWrites()
+    {
+        if (ExecutionMetricsFlag.IsActive) AccountWrites++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementAccountDeleted()
+    {
+        if (ExecutionMetricsFlag.IsActive) AccountDeleted++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementCodeWrites()
+    {
+        if (ExecutionMetricsFlag.IsActive) CodeWrites++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementCodeBytesWritten(int bytes)
+    {
+        if (ExecutionMetricsFlag.IsActive) CodeBytesWritten += bytes;
+    }
+
+    public void Reset()
+    {
+        StateTreeCacheHits = 0;
+        StateTreeReads = 0;
+        StateTreeWrites = 0;
+        StateSkippedWrites = 0;
+        StorageTreeCache = 0;
+        StorageTreeReads = 0;
+        StorageTreeWrites = 0;
+        StorageSkippedWrites = 0;
+        AccountWrites = 0;
+        AccountDeleted = 0;
+        StorageWrites = 0;
+        CodeWrites = 0;
+        CodeBytesWritten = 0;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -778,16 +778,9 @@ namespace Nethermind.Evm.TransactionProcessing
 
         private static void UpdateMetrics(ExecutionOptions opts, UInt256 effectiveGasPrice)
         {
-            if (opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp && (effectiveGasPrice[2] | effectiveGasPrice[3]) == 0)
+            if (opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp)
             {
-                float gasPrice = (float)((double)effectiveGasPrice / 1_000_000_000.0);
-
-                Metrics.BlockMinGasPrice = Math.Min(gasPrice, Metrics.BlockMinGasPrice);
-                Metrics.BlockMaxGasPrice = Math.Max(gasPrice, Metrics.BlockMaxGasPrice);
-
-                Metrics.BlockAveGasPrice = (Metrics.BlockAveGasPrice * Metrics.BlockTransactions + gasPrice) / (Metrics.BlockTransactions + 1);
-                Metrics.BlockEstMedianGasPrice += Metrics.BlockAveGasPrice * 0.01f * float.Sign(gasPrice - Metrics.BlockEstMedianGasPrice);
-                Metrics.BlockTransactions++;
+                Metrics.UpdateBlockGasPrice(effectiveGasPrice);
             }
         }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -778,7 +778,9 @@ namespace Nethermind.Evm.TransactionProcessing
 
         private static void UpdateMetrics(ExecutionOptions opts, UInt256 effectiveGasPrice)
         {
-            if (opts is ExecutionOptions.Commit or ExecutionOptions.None or ExecutionOptions.BuildUp)
+            // Block production (BuildUp) is excluded: payload builds run concurrently with block import
+            // on the same process-wide gas aggregates, and the gauges describe imported blocks, not candidates.
+            if (opts is ExecutionOptions.Commit or ExecutionOptions.None)
             {
                 Metrics.UpdateBlockGasPrice(effectiveGasPrice);
             }

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatOverridableWorldScopeTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatOverridableWorldScopeTests.cs
@@ -22,6 +22,14 @@ using NUnit.Framework;
 
 namespace Nethermind.State.Flat.Test;
 
+internal static class ScopeProviderTestExtensions
+{
+    // Test convenience overload: begins a scope with a throwaway metrics accumulator for tests that
+    // call the scope provider directly and do not assert on the folded counters.
+    public static IWorldStateScopeProvider.IScope BeginScope(this IWorldStateScopeProvider provider, BlockHeader? baseBlock)
+        => provider.BeginScope(baseBlock, new LocalMetrics());
+}
+
 public class FlatOverridableWorldScopeTests
 {
     private class TestContext : IDisposable

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatOverridableWorldScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatOverridableWorldScope.cs
@@ -131,7 +131,7 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
     {
         public bool HasRoot(BlockHeader? baseBlock) => flatOverrideScope.HasStateForBlock(baseBlock);
 
-        public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock)
+        public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics)
         {
             StateId currentState = new(baseBlock);
             SnapshotBundle snapshotBundle = flatOverrideScope.GatherSnapshotBundle(baseBlock);

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatScopeProvider.cs
@@ -30,7 +30,7 @@ public class FlatScopeProvider(
 
     public bool HasRoot(BlockHeader? baseBlock) => flatDbManager.HasStateForBlock(new StateId(baseBlock));
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock)
+    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics)
     {
         StateId currentState = new(baseBlock);
         SnapshotBundle snapshotBundle = flatDbManager.GatherSnapshotBundle(currentState, usage: usage);

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -17,6 +17,14 @@ using NUnit.Framework;
 
 namespace Nethermind.Store.Test;
 
+internal static class ScopeProviderTestExtensions
+{
+    // Test convenience overload: begins a scope with a throwaway metrics accumulator for tests that
+    // call the scope provider directly and do not assert on the folded counters.
+    public static IWorldStateScopeProvider.IScope BeginScope(this IWorldStateScopeProvider provider, BlockHeader baseBlock)
+        => provider.BeginScope(baseBlock, new LocalMetrics());
+}
+
 [TestFixture(false)]
 [TestFixture(true)]
 [Parallelizable(ParallelScope.All)]

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -798,7 +798,7 @@ public class StorageProviderTests(bool useFlat)
 
         public bool HasRoot(BlockHeader baseBlock) => scopeProvider.HasRoot(baseBlock);
 
-        public IWorldStateScopeProvider.IScope BeginScope(BlockHeader baseBlock) => new ScopeDecorator(scopeProvider.BeginScope(baseBlock), writtenData);
+        public IWorldStateScopeProvider.IScope BeginScope(BlockHeader baseBlock, LocalMetrics metrics) => new ScopeDecorator(scopeProvider.BeginScope(baseBlock, metrics), writtenData);
 
         private class ScopeDecorator(IWorldStateScopeProvider.IScope baseScope, WrittenData writtenData) : IWorldStateScopeProvider.IScope
         {

--- a/src/Nethermind/Nethermind.State/LocalMetricsFlush.cs
+++ b/src/Nethermind/Nethermind.State/LocalMetricsFlush.cs
@@ -26,8 +26,6 @@ internal static class LocalMetricsFlush
         if (m.StateSkippedWrites != 0) DbMetrics.IncrementStateSkippedWrites(m.StateSkippedWrites);
         if (m.StorageTreeCache != 0) DbMetrics.AddStorageTreeCache(m.StorageTreeCache);
         if (m.StorageTreeReads != 0) DbMetrics.AddStorageTreeReads(m.StorageTreeReads);
-        if (m.StorageTreeWrites != 0) DbMetrics.IncrementStorageTreeWrites(m.StorageTreeWrites);
-        if (m.StorageSkippedWrites != 0) DbMetrics.IncrementStorageSkippedWrites(m.StorageSkippedWrites);
 
         if (m.AccountWrites != 0) EvmMetrics.AddAccountWrites(m.AccountWrites);
         if (m.AccountDeleted != 0) EvmMetrics.AddAccountDeleted(m.AccountDeleted);

--- a/src/Nethermind/Nethermind.State/LocalMetricsFlush.cs
+++ b/src/Nethermind/Nethermind.State/LocalMetricsFlush.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Evm.State;
+using DbMetrics = Nethermind.Db.Metrics;
+using EvmMetrics = Nethermind.Evm.Metrics;
+
+namespace Nethermind.State;
+
+/// <summary>
+/// Folds a world-state scope's <see cref="LocalMetrics"/> accumulator into the global
+/// <see cref="DbMetrics"/> / <see cref="EvmMetrics"/> counters and resets it.
+/// </summary>
+/// <remarks>
+/// Lives in <c>Nethermind.State</c> because it is the only assembly that references both
+/// <c>Nethermind.Db</c> and <c>Nethermind.Evm</c>. Called on the same thread that accumulated, so
+/// the global counters' main/other split (keyed off <c>IsBlockProcessingThread</c>) stays correct.
+/// </remarks>
+internal static class LocalMetricsFlush
+{
+    internal static void Flush(this LocalMetrics m)
+    {
+        if (m.StateTreeCacheHits != 0) DbMetrics.AddStateTreeCacheHits(m.StateTreeCacheHits);
+        if (m.StateTreeReads != 0) DbMetrics.AddStateTreeReads(m.StateTreeReads);
+        if (m.StateTreeWrites != 0) DbMetrics.IncrementStateTreeWrites(m.StateTreeWrites);
+        if (m.StateSkippedWrites != 0) DbMetrics.IncrementStateSkippedWrites(m.StateSkippedWrites);
+        if (m.StorageTreeCache != 0) DbMetrics.AddStorageTreeCache(m.StorageTreeCache);
+        if (m.StorageTreeReads != 0) DbMetrics.AddStorageTreeReads(m.StorageTreeReads);
+        if (m.StorageTreeWrites != 0) DbMetrics.IncrementStorageTreeWrites(m.StorageTreeWrites);
+        if (m.StorageSkippedWrites != 0) DbMetrics.IncrementStorageSkippedWrites(m.StorageSkippedWrites);
+
+        if (m.AccountWrites != 0) EvmMetrics.AddAccountWrites(m.AccountWrites);
+        if (m.AccountDeleted != 0) EvmMetrics.AddAccountDeleted(m.AccountDeleted);
+        if (m.StorageWrites != 0) EvmMetrics.AddStorageWrites(m.StorageWrites);
+        if (m.CodeWrites != 0) EvmMetrics.AddCodeWrites(m.CodeWrites);
+        if (m.CodeBytesWritten != 0) EvmMetrics.AddCodeBytesWritten(m.CodeBytesWritten);
+
+        m.Reset();
+    }
+}

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -252,13 +252,15 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
     }
 
-    private void ReportMetrics(int writes, int skipped)
+    // Static + atomic on purpose: called from ParallelUnbalancedWork worker finalizers
+    // (see PersistentStorageProvider.std.cs), so it must not touch the non-atomic per-scope LocalMetrics.
+    private static void ReportMetrics(int writes, int skipped)
     {
         if (skipped > 0)
-            _metrics.IncrementStorageSkippedWrites(skipped);
+            Db.Metrics.IncrementStorageSkippedWrites(skipped);
 
         if (writes > 0)
-            _metrics.IncrementStorageTreeWrites(writes);
+            Db.Metrics.IncrementStorageTreeWrites(writes);
     }
 
     public void ClearStorageMap()

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -17,7 +17,6 @@ using Nethermind.Core.Resettables;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing.State;
 using Nethermind.Int256;
-using EvmMetrics = Nethermind.Evm.Metrics;
 using Nethermind.Logging;
 
 namespace Nethermind.State;
@@ -26,11 +25,12 @@ namespace Nethermind.State;
 /// Manages persistent storage allowing for snapshotting and restoring
 /// Persists data to ITrieStore
 /// </summary>
-internal sealed partial class PersistentStorageProvider(StateProvider stateProvider, ILogManager logManager)
+internal sealed partial class PersistentStorageProvider(StateProvider stateProvider, ILogManager logManager, LocalMetrics metrics)
     : PartialStorageProviderBase(logManager)
 {
     private IWorldStateScopeProvider.IScope _currentScope;
     private readonly StateProvider _stateProvider = stateProvider;
+    private readonly LocalMetrics _metrics = metrics;
     private readonly Dictionary<AddressAsKey, PerContractState> _storages = new(4_096);
     private readonly Dictionary<AddressAsKey, bool> _toUpdateRoots = [];
 
@@ -60,7 +60,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
     public override void Set(in StorageCell storageCell, byte[] newValue)
     {
-        EvmMetrics.IncrementStorageWrites();
+        _metrics.IncrementStorageWrites();
         base.Set(in storageCell, newValue);
     }
 
@@ -252,13 +252,13 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
     }
 
-    private static void ReportMetrics(int writes, int skipped)
+    private void ReportMetrics(int writes, int skipped)
     {
         if (skipped > 0)
-            Db.Metrics.IncrementStorageSkippedWrites(skipped);
+            _metrics.IncrementStorageSkippedWrites(skipped);
 
         if (writes > 0)
-            Db.Metrics.IncrementStorageTreeWrites(writes);
+            _metrics.IncrementStorageTreeWrites(writes);
     }
 
     public void ClearStorageMap()
@@ -503,7 +503,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             }
             else
             {
-                Db.Metrics.IncrementStorageTreeCache();
+                _provider._metrics.IncrementStorageTreeCache();
             }
 
             if (!storageCell.IsHash) _provider.PushToRegistryOnly(storageCell, valueChange.After);
@@ -512,7 +512,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         private byte[] LoadFromTreeStorage(StorageCell storageCell)
         {
-            Db.Metrics.IncrementStorageTreeReads();
+            _provider._metrics.IncrementStorageTreeReads();
 
             EnsureStorageTree();
             return !storageCell.IsHash

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -49,17 +49,18 @@ public class PrewarmerScopeProvider(
 {
     public bool HasRoot(BlockHeader? baseBlock) => baseProvider.HasRoot(baseBlock);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new ScopeWrapper(baseProvider.BeginScope(baseBlock), preBlockCaches, logManager, isPrewarmer);
+    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics) => new ScopeWrapper(baseProvider.BeginScope(baseBlock, metrics), preBlockCaches, logManager, isPrewarmer, metrics);
 
     public PreBlockCaches? Caches => preBlockCaches;
     public bool IsWarmWorldState => !isPrewarmer;
 
-    private sealed class ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, ILogManager logManager, bool isPrewarmer) : IWorldStateScopeProvider.IScope
+    private sealed class ScopeWrapper(IWorldStateScopeProvider.IScope baseScope, PreBlockCaches preBlockCaches, ILogManager logManager, bool isPrewarmer, LocalMetrics metrics) : IWorldStateScopeProvider.IScope
     {
         private readonly IWorldStateScopeProvider.IScope baseScope = baseScope;
         private readonly SeqlockCache<AddressAsKey, Account> preBlockCache = preBlockCaches.StateCache;
         private readonly SeqlockCache<StorageCell, byte[]> storageCache = preBlockCaches.StorageCache;
         private readonly bool isPrewarmer = isPrewarmer;
+        private readonly LocalMetrics _metrics = metrics;
         private readonly IMetricObserver _metricObserver = Metrics.PrewarmerGetTime;
         private readonly bool _measureMetric = Metrics.DetailedMetricsEnabled;
         private readonly PrewarmerGetTimeLabels _labels = isPrewarmer ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
@@ -81,7 +82,8 @@ public class PrewarmerScopeProvider(
                 baseScope.CreateStorageTree(address),
                 storageCache,
                 address,
-                isPrewarmer);
+                isPrewarmer,
+                _metrics);
 
         public IWorldStateScopeProvider.IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum)
         {
@@ -136,7 +138,7 @@ public class PrewarmerScopeProvider(
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
                 // Consumers seed the scope-local cache on a hit for their later commit; populators don't.
                 if (!isPrewarmer) baseScope.HintGet(address, account);
-                Metrics.IncrementStateTreeCacheHits();
+                _metrics.IncrementStateTreeCacheHits();
             }
             else
             {
@@ -187,12 +189,14 @@ public class PrewarmerScopeProvider(
         IWorldStateScopeProvider.IStorageTree baseStorageTree,
         SeqlockCache<StorageCell, byte[]> preBlockCache,
         Address address,
-        bool isPrewarmer) : IWorldStateScopeProvider.IStorageTree
+        bool isPrewarmer,
+        LocalMetrics metrics) : IWorldStateScopeProvider.IStorageTree
     {
         private readonly IWorldStateScopeProvider.IStorageTree baseStorageTree = baseStorageTree;
         private readonly SeqlockCache<StorageCell, byte[]> preBlockCache = preBlockCache;
         private readonly Address address = address;
         private readonly bool isPrewarmer = isPrewarmer;
+        private readonly LocalMetrics _metrics = metrics;
         private readonly IMetricObserver _metricObserver = Db.Metrics.PrewarmerGetTime;
         private readonly bool _measureMetric = Db.Metrics.DetailedMetricsEnabled;
         private readonly PrewarmerGetTimeLabels _labels = isPrewarmer ? PrewarmerGetTimeLabels.Prewarmer : PrewarmerGetTimeLabels.NonPrewarmer;
@@ -206,7 +210,7 @@ public class PrewarmerScopeProvider(
             if (preBlockCache.TryGetValue(in storageCell, out byte[] value))
             {
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
-                Db.Metrics.IncrementStorageTreeCache();
+                _metrics.IncrementStorageTreeCache();
             }
             else
             {
@@ -222,7 +226,7 @@ public class PrewarmerScopeProvider(
 
         private byte[] LoadFromTreeStorage(in StorageCell storageCell)
         {
-            Db.Metrics.IncrementStorageTreeReads();
+            _metrics.IncrementStorageTreeReads();
 
             return !storageCell.IsHash
                 ? baseStorageTree.Get(storageCell.Index)

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -21,15 +21,15 @@ using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing.State;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Metrics = Nethermind.Db.Metrics;
-using EvmMetrics = Nethermind.Evm.Metrics;
 using static Nethermind.State.StateProvider;
 
 namespace Nethermind.State;
 
-internal class StateProvider(ILogManager logManager) : IJournal<int>
+internal class StateProvider(ILogManager logManager, LocalMetrics metrics) : IJournal<int>
 {
     private static readonly UInt256 _zero = UInt256.Zero;
+
+    private readonly LocalMetrics _metrics = metrics;
 
     private readonly Dictionary<AddressAsKey, StackList<int>> _intraTxCache = [];
     private readonly HashSet<AddressAsKey> _committedThisRound = [];
@@ -136,8 +136,8 @@ internal class StateProvider(ILogManager logManager) : IJournal<int>
             _blockCodeInsertFilter.Set(codeHash);
             inserted = true;
 
-            EvmMetrics.IncrementCodeWrites();
-            EvmMetrics.IncrementCodeBytesWritten(code.Length);
+            _metrics.IncrementCodeWrites();
+            _metrics.IncrementCodeBytesWritten(code.Length);
         }
 
         Account? account = GetThroughCache(address) ?? ThrowIfNull(address);
@@ -710,9 +710,9 @@ internal class StateProvider(ILogManager logManager) : IJournal<int>
         }
 
         if (writes > 0)
-            Metrics.IncrementStateTreeWrites(writes);
+            _metrics.IncrementStateTreeWrites(writes);
         if (skipped > 0)
-            Metrics.IncrementStateSkippedWrites(skipped);
+            _metrics.IncrementStateSkippedWrites(skipped);
     }
 
     public bool WarmUp(Address address)
@@ -724,24 +724,24 @@ internal class StateProvider(ILogManager logManager) : IJournal<int>
         ref ChangeTrace accountChanges = ref CollectionsMarshal.GetValueRefOrAddDefault(_blockChanges, addressAsKey, out bool exists);
         if (!exists)
         {
-            Metrics.IncrementStateTreeReads();
+            _metrics.IncrementStateTreeReads();
             Account? account = _tree.Get(address);
 
             accountChanges = new(account, account);
         }
         else
         {
-            Metrics.IncrementStateTreeCacheHits();
+            _metrics.IncrementStateTreeCacheHits();
         }
         return accountChanges.After;
     }
 
     internal void SetState(Address address, Account? account)
     {
-        EvmMetrics.IncrementAccountWrites();
+        _metrics.IncrementAccountWrites();
         if (account is null)
         {
-            EvmMetrics.IncrementAccountDeleted();
+            _metrics.IncrementAccountDeleted();
         }
 
         ref ChangeTrace accountChanges = ref CollectionsMarshal.GetValueRefOrAddDefault(_blockChanges, address, out _);

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -32,7 +32,7 @@ namespace Nethermind.State
                 return Bytes.ZeroByteSpan;
             }
 
-            Metrics.StorageReaderReads++;
+            Metrics.IncrementStorageReaderReads();
 
             StorageTree storage = new(_trieStore.GetTrieStore(address), Keccak.EmptyTreeHash, _logManager);
             return storage.Get(index, new Hash256(storageRoot));

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -45,7 +45,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
 
     public bool HasRoot(BlockHeader? baseBlock) => _trieStore.HasRoot(baseBlock?.StateRoot ?? Keccak.EmptyTreeHash);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock)
+    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics)
     {
         IDisposable trieStoreCloser = _trieStore.BeginScope(baseBlock);
         _backingStateTree ??= CreateStateTree();

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -33,9 +33,8 @@ namespace Nethermind.State
         internal readonly StateProvider _stateProvider;
         internal readonly PersistentStorageProvider _persistentStorageProvider;
         private readonly TransientStorageProvider _transientStorageProvider;
-        // Per-scope, single-threaded counter accumulator shared with the providers and the scope
-        // (see BeginScope), folded into the global Metrics in Commit/EndScope to avoid per-increment
-        // cross-thread Interlocked contention during prewarm / parallel-BAL execution.
+        // Per-scope counter accumulator shared with the providers and scope; folded into the global
+        // Metrics in Commit/EndScope to avoid per-increment cross-thread contention.
         private readonly LocalMetrics _localMetrics = new();
         private IWorldStateScopeProvider.IScope? _currentScope;
         private bool _isInScope;

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -33,6 +33,10 @@ namespace Nethermind.State
         internal readonly StateProvider _stateProvider;
         internal readonly PersistentStorageProvider _persistentStorageProvider;
         private readonly TransientStorageProvider _transientStorageProvider;
+        // Per-scope, single-threaded counter accumulator shared with the providers and the scope
+        // (see BeginScope), folded into the global Metrics in Commit/EndScope to avoid per-increment
+        // cross-thread Interlocked contention during prewarm / parallel-BAL execution.
+        private readonly LocalMetrics _localMetrics = new();
         private IWorldStateScopeProvider.IScope? _currentScope;
         private bool _isInScope;
         private readonly ILogger _logger;
@@ -51,8 +55,8 @@ namespace Nethermind.State
             ILogManager? logManager)
         {
             ScopeProvider = scopeProvider;
-            _stateProvider = new StateProvider(logManager);
-            _persistentStorageProvider = new PersistentStorageProvider(_stateProvider, logManager);
+            _stateProvider = new StateProvider(logManager, _localMetrics);
+            _persistentStorageProvider = new PersistentStorageProvider(_stateProvider, logManager, _localMetrics);
             _transientStorageProvider = new TransientStorageProvider(logManager);
             _logger = logManager.GetClassLogger<WorldState>();
         }
@@ -231,7 +235,7 @@ namespace Nethermind.State
 
             try
             {
-                _currentScope = ScopeProvider.BeginScope(baseBlock);
+                _currentScope = ScopeProvider.BeginScope(baseBlock, _localMetrics);
                 _stateProvider.SetScope(_currentScope);
                 _persistentStorageProvider.SetBackendScope(_currentScope);
             }
@@ -254,6 +258,8 @@ namespace Nethermind.State
             {
                 if (_currentScope is not null)
                 {
+                    // Fold any counters accumulated outside a Commit (e.g. prewarmer read warming) before the scope closes.
+                    _localMetrics.Flush();
                     Reset();
                     _stateProvider.SetScope(null);
                     _currentScope.Dispose();
@@ -342,6 +348,10 @@ namespace Nethermind.State
                 _persistentStorageProvider.FlushToTree(writeBatch);
                 _stateProvider.FlushToTree(writeBatch);
             }
+
+            // Fold this scope's accumulated counters into the global metrics. Runs per-tx commit and
+            // at block-end on the block-processing thread, keeping ProcessingStats' MainThread* deltas current.
+            _localMetrics.Flush();
         }
 
         public Snapshot TakeSnapshot(bool newTransactionStart = false)

--- a/src/Nethermind/Nethermind.State/WorldStateMetricsScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateMetricsScopeProvider.cs
@@ -18,7 +18,7 @@ public class WorldStateMetricsScopeProvider(IWorldStateScopeProvider baseProvide
     private double _stateMerkleizationTime;
 
     public bool HasRoot(BlockHeader? baseBlock) => _baseProvider.HasRoot(baseBlock);
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock) => new MetricsScope(_baseProvider.BeginScope(baseBlock), this);
+    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics) => new MetricsScope(_baseProvider.BeginScope(baseBlock, metrics), this);
 
     private sealed class MetricsScope(IWorldStateScopeProvider.IScope baseScope, WorldStateMetricsScopeProvider parent) : IWorldStateScopeProvider.IScope
     {

--- a/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
@@ -22,10 +22,10 @@ public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopePr
     public bool HasRoot(BlockHeader? baseBlock) =>
         baseScopeProvider.HasRoot(baseBlock);
 
-    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock)
+    public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics)
     {
         long scopeId = Interlocked.Increment(ref _currentScopeId);
-        return new ScopeWrapper(baseScopeProvider.BeginScope(baseBlock), scopeId, _logger);
+        return new ScopeWrapper(baseScopeProvider.BeginScope(baseBlock, metrics), scopeId, _logger);
     }
 
     private class ScopeWrapper(IWorldStateScopeProvider.IScope innerScope, long scopeId, ILogger logger) : IWorldStateScopeProvider.IScope

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1056,7 +1056,7 @@ namespace Nethermind.TxPool
                 }
                 else
                 {
-                    Db.Metrics.IncrementStateTreeCacheHits();
+                    Db.Metrics.AddStateTreeCacheHits(1);
                 }
 
                 return true;


### PR DESCRIPTION
## Changes

- Isolate contended Evm/Db metric counters on their own cache lines (`CacheLinePaddedLong`) to remove false sharing between the main block-processing thread and prewarm/parallel-BAL workers.
- Accumulate state/db counters in a per-world-state-scope `LocalMetrics` (plain non-atomic adds on a single-threaded scope), folded into the global counters at commit and scope end - removing per-access cross-thread `Interlocked` contention during prewarm / parallel BAL validation. Storage write/skipped counters that are reported from parallel worker finalizers stay on the atomic global.
- Make block gas-price aggregation parallel-safe and lock-free via packed-`long` CAS: `(min, max)` and `(count, running average)` each packed into one `long` updated by a single `Interlocked.CompareExchange`; publish the Prometheus gauges once from the final aggregates after workers join; seed empty / system-only blocks with the base fee; exclude block production (`BuildUp`) so speculative builds don't clobber the importing block's aggregates.
- `ProcessingStats`: auto-step the gas-price unit (gwei -> mwei -> kwei -> wei) so low base fees stay visible, and append a sequential/parallel execution-mode indicator gated on the block having a Block Access List.
- Make `StorageReaderReads` atomic; remove the unused `TLOAD`/`TSTORE`/`MCOPY`/`EXP` opcode metrics.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New `GasPriceMetricsTests` cover 10k-way concurrent aggregation (no lost updates, exact min/max), base-fee seeding (incl. the zero-base-fee blank case and tx-wins-over-seed), the wide-value skip, and once-only gauge publishing. Existing `MetricsIntegrationTests` and `BlockProcessorTests` (42/42) pass; solution builds clean. Reviewed with Codex and specialist passes; all findings addressed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Breaking: the `TLOAD`, `TSTORE`, `MCOPY` and `EXP` opcode metrics are removed, so their exported Prometheus metric names no longer exist (they were non-atomic and lightly used). Dashboards referencing them should be updated.
