### PR TITLE
fix(zkevm): Zero-init BLS MSM precompile output buffer

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Precompiles/zkevm/Bls12381G1MsmPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/zkevm/Bls12381G1MsmPrecompile.cs
@@ -24,7 +24,6 @@ public partial class Bls12381G1MsmPrecompile
         return pairCount == 1 ? Mul(inputData.Span) : Msm(inputData.Span, pairCount);
     }
 
-    [SkipLocalsInit]
     private static Result<byte[]> Msm(ReadOnlySpan<byte> input, int pairCount)
     {
         int decodedLen = pairCount * (Eip2537.LenG1Trimmed + Eip2537.LenFr);
@@ -63,7 +62,6 @@ public partial class Bls12381G1MsmPrecompile
         return HandleResult(output, status);
     }
 
-    [SkipLocalsInit]
     private static Result<byte[]> Mul(ReadOnlySpan<byte> input)
     {
         Span<byte> decoded = stackalloc byte[Eip2537.LenG1Trimmed + Eip2537.LenFr];

--- a/src/Nethermind/Nethermind.Evm.Precompiles/zkevm/Bls12381G2MsmPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/zkevm/Bls12381G2MsmPrecompile.cs
@@ -24,7 +24,6 @@ public partial class Bls12381G2MsmPrecompile
         return pairCount == 1 ? Mul(inputData.Span) : Msm(inputData.Span, pairCount);
     }
 
-    [SkipLocalsInit]
     private static Result<byte[]> Msm(ReadOnlySpan<byte> input, int pairCount)
     {
         int decodedLen = pairCount * (Eip2537.LenG2Trimmed + Eip2537.LenFr);
@@ -63,7 +62,6 @@ public partial class Bls12381G2MsmPrecompile
         return HandleResult(output, status);
     }
 
-    [SkipLocalsInit]
     private static Result<byte[]> Mul(ReadOnlySpan<byte> input)
     {
         Span<byte> decoded = stackalloc byte[Eip2537.LenG2Trimmed + Eip2537.LenFr];


### PR DESCRIPTION
## Changes

The `Bls12381G1MsmPrecompile` and `Bls12381G2MsmPrecompile` zkEVM variants marked their `Msm`/`Mul` helpers with `[SkipLocalsInit]` and passed a `stackalloc` output buffer to the zkVM accelerator. For a point-at-infinity result the accelerator leaves the output buffer untouched, relying on the caller's buffer already holding the all-zeros infinity encoding. The uninitialized buffer of garbage data flowed into the CALL return region and, via `MLOAD`, into LOG topics, corrupting the logs bloom and (consequently) the receipts root, surfacing as `InvalidLogsBloom`/`InvalidReceiptsRoot` in zkVM while the same input validated fine on x64/arm64.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

This bug is only reproducible under the zkVM. Tested manually.