### PR TITLE
Improve JWT secret auto-generation log

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/JwtAuthenticationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/JwtAuthenticationTests.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.IO;
+using System.Linq;
+using Nethermind.Core.Authentication;
+using Nethermind.Core.Test.IO;
+using Nethermind.Logging;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test;
+
+public class JwtAuthenticationTests
+{
+    [Test]
+    public void FromFile_logs_when_secret_is_automatically_created()
+    {
+        using TempPath tempDirectory = TempPath.GetTempDirectory();
+        string secretPath = Path.Combine(tempDirectory.Path, "jwt.hex");
+        TestLogger testLogger = new();
+
+        JwtAuthentication.FromFile(secretPath, Timestamper.Default, new ILogger(testLogger));
+
+        string secret = File.ReadAllText(secretPath);
+        bool hasCreatedLog = testLogger.LogList.Any(log =>
+            log.Contains(secretPath) && log.Contains("automatically created"));
+
+        Assert.That(secret, Has.Length.EqualTo(64));
+        Assert.That(secret, Does.Match("^[0-9a-fA-F]{64}$"));
+        Assert.That(hasCreatedLog, Is.True);
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Authentication/JwtAuthentication.cs
+++ b/src/Nethermind/Nethermind.Core/Authentication/JwtAuthentication.cs
@@ -111,7 +111,7 @@ public sealed partial class JwtAuthentication : IRpcAuthentication
                 throw;
             }
 
-            if (logger.IsWarn) logger.Warn($"The authentication secret hasn't been found in '{fileInfo.FullName}'so it has been automatically created.");
+            if (logger.IsWarn) logger.Warn($"The authentication secret file '{fileInfo.FullName}' was not found or was empty, so it has been automatically created.");
 
             return new(secret, timestamper, logger);
         }


### PR DESCRIPTION
This PR improves the log emitted when Nethermind automatically creates a JWT authentication secret file.


Fixes #7747.


## Changes

The existing message did not clearly describe the generated file state. The new message includes the full JWT secret file path and clarifies that the file was either missing or empty before Nethermind created it.


## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
