### PR TITLE
fix(merge): use computed hash when recording bad block on NewPayload hash mismatch

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -459,8 +459,8 @@ public partial class EngineModuleTests
         Hash256 genesisHash = chain.BlockTree.HeadHash;
         await ProduceBranchV1(rpc, chain, 1, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: true);
 
-        // Build block 2 on block 1 (BuildAndGetPayloadResult sees block1 as head), 
-        // then corrupt BlockHash to genesisHash 
+        // Build block 2 on block 1 (BuildAndGetPayloadResult sees block1 as head),
+        // then corrupt BlockHash to genesisHash
         ExecutionPayload block2 = await BuildAndGetPayloadResult(chain, rpc);
         Hash256 realBlock2Hash = block2.BlockHash!;
         block2.BlockHash = genesisHash;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -449,6 +449,34 @@ public partial class EngineModuleTests
     }
 
     [Test]
+    public async Task executePayloadV1_invalid_hash_does_not_poison_chain_tracker()
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain();
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+
+        // Submit two blocks so SetChildParent registers both hashes in the chain tracker.
+        ExecutionPayload block1 = CreateBlockRequest(chain, CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressA);
+        await rpc.engine_newPayloadV1(block1);
+
+        ExecutionPayload block2 = CreateBlockRequest(chain, block1, TestItem.AddressA);
+        await rpc.engine_newPayloadV1(block2);
+
+        // Build block 3 but claim BlockHash = block1's hash.
+        ExecutionPayload block3 = CreateBlockRequest(chain, block2, TestItem.AddressA);
+        Hash256 realBlock3Hash = block3.BlockHash!;
+        block3.BlockHash = block1.BlockHash;
+
+        ResultWrapper<PayloadStatusV1> invalidResult = await rpc.engine_newPayloadV1(block3);
+        Assert.That(invalidResult.Data.Status, Is.EqualTo(PayloadStatus.Invalid));
+
+        // Without the fix, OnInvalidBlock(block1Hash, block2Hash) would mark block1 invalid and
+        // propagate to block2, causing block3 to be rejected as "part of an invalid chain".
+        block3.BlockHash = realBlock3Hash;
+        ResultWrapper<PayloadStatusV1> validResult = await rpc.engine_newPayloadV1(block3);
+        Assert.That(validResult.Data.Status, Is.EqualTo(PayloadStatus.Valid));
+    }
+
+    [Test]
     public async Task executePayloadV1_invalid_orphan_records_bad_block()
     {
         using MergeTestBlockchain chain = await CreateBlockchain();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -433,19 +433,22 @@ public partial class EngineModuleTests
     }
 
     [Test]
-    public async Task executePayloadV1_invalid_hash_records_bad_block()
+    public async Task executePayloadV1_invalid_hash_returns_invalid_and_does_not_store_bad_block()
     {
         using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = chain.EngineRpcModule;
         ExecutionPayload payload = await BuildAndGetPayloadResult(chain, rpc);
-        long blockNumber = payload.BlockNumber;
         payload.BlockHash = TestItem.KeccakC;
 
         ResultWrapper<PayloadStatusV1> result = await rpc.engine_newPayloadV1(payload);
 
         Assert.That(result.Data.Status, Is.EqualTo(PayloadStatus.Invalid));
+        // Hash-mismatched payloads are not stored in debug_getBadBlocks: block.Hash is the
+        // caller-supplied (unverified) value, and ReportBadBlock would write it to _invalidBlocks,
+        // which would prevent the legitimate block from being inserted if the CL later sends
+        // the same content with the correct BlockHash.
         IBadBlockStore badBlockStore = chain.Container.Resolve<IBadBlockStore>();
-        Assert.That(badBlockStore.GetAll().Single().Number, Is.EqualTo(blockNumber));
+        Assert.That(badBlockStore.GetAll(), Is.Empty);
     }
 
     [Test]
@@ -453,26 +456,23 @@ public partial class EngineModuleTests
     {
         using MergeTestBlockchain chain = await CreateBlockchain();
         IEngineRpcModule rpc = chain.EngineRpcModule;
+        Hash256 genesisHash = chain.BlockTree.HeadHash;
+        await ProduceBranchV1(rpc, chain, 1, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: true);
 
-        // Submit two blocks so SetChildParent registers both hashes in the chain tracker.
-        ExecutionPayload block1 = CreateBlockRequest(chain, CreateParentBlockRequestOnHead(chain.BlockTree), TestItem.AddressA);
-        await rpc.engine_newPayloadV1(block1);
+        // Build block 2 on block 1 (BuildAndGetPayloadResult sees block1 as head), 
+        // then corrupt BlockHash to genesisHash 
+        ExecutionPayload block2 = await BuildAndGetPayloadResult(chain, rpc);
+        Hash256 realBlock2Hash = block2.BlockHash!;
+        block2.BlockHash = genesisHash;
 
-        ExecutionPayload block2 = CreateBlockRequest(chain, block1, TestItem.AddressA);
-        await rpc.engine_newPayloadV1(block2);
-
-        // Build block 3 but claim BlockHash = block1's hash.
-        ExecutionPayload block3 = CreateBlockRequest(chain, block2, TestItem.AddressA);
-        Hash256 realBlock3Hash = block3.BlockHash!;
-        block3.BlockHash = block1.BlockHash;
-
-        ResultWrapper<PayloadStatusV1> invalidResult = await rpc.engine_newPayloadV1(block3);
+        ResultWrapper<PayloadStatusV1> invalidResult = await rpc.engine_newPayloadV1(block2);
         Assert.That(invalidResult.Data.Status, Is.EqualTo(PayloadStatus.Invalid));
 
-        // Without the fix, OnInvalidBlock(block1Hash, block2Hash) would mark block1 invalid and
-        // propagate to block2, causing block3 to be rejected as "part of an invalid chain".
-        block3.BlockHash = realBlock3Hash;
-        ResultWrapper<PayloadStatusV1> validResult = await rpc.engine_newPayloadV1(block3);
+        // Without the fix, OnInvalidBlock(genesisHash, block1Hash) would mark genesis invalid and
+        // propagate to block1 (its registered child), causing block2 to be rejected as
+        // "part of an invalid chain" even with the correct hash restored.
+        block2.BlockHash = realBlock2Hash;
+        ResultWrapper<PayloadStatusV1> validResult = await rpc.engine_newPayloadV1(block2);
         Assert.That(validResult.Data.Status, Is.EqualTo(PayloadStatus.Valid));
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -446,7 +446,6 @@ public partial class EngineModuleTests
         // Hash-mismatched payloads are not stored in debug_getBadBlocks: block.Hash is the
         // caller-supplied (unverified) value, and ReportBadBlock would write it to _invalidBlocks,
         // which would prevent the legitimate block from being inserted if the CL later sends
-        // the same content with the correct BlockHash.
         IBadBlockStore badBlockStore = chain.Container.Resolve<IBadBlockStore>();
         Assert.That(badBlockStore.GetAll(), Is.Empty);
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -467,9 +467,6 @@ public partial class EngineModuleTests
         ResultWrapper<PayloadStatusV1> invalidResult = await rpc.engine_newPayloadV1(block2);
         Assert.That(invalidResult.Data.Status, Is.EqualTo(PayloadStatus.Invalid));
 
-        // Without the fix, OnInvalidBlock(genesisHash, block1Hash) would mark genesis invalid and
-        // propagate to block1 (its registered child), causing block2 to be rejected as
-        // "part of an invalid chain" even with the correct hash restored.
         block2.BlockHash = realBlock2Hash;
         ResultWrapper<PayloadStatusV1> validResult = await rpc.engine_newPayloadV1(block2);
         Assert.That(validResult.Data.Status, Is.EqualTo(PayloadStatus.Valid));

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -132,10 +132,8 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
             if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(block, "invalid block hash"));
             Nethermind.Blockchain.Metrics.BadBlocks++;
             if (block.IsByNethermindNode()) Nethermind.Blockchain.Metrics.BadBlocksByNethermindNodes++;
-            // RecordBadBlock() is not called here as OnInvalidBlock is intentionally skipped here —
-            // block.Hash is unverified at this point and must not be used to poison the chain tracker.
-            block.Header.Hash = actualHash;
-            _blockTree.ReportBadBlock(block);
+            // Skip recording bad blocks: unverified hashes can poison tracking, 
+            // while computed hashes could incorrectly blacklist a valid block.
             return NewPayloadV1Result.Invalid(null, $"Invalid block hash {request.BlockHash} does not match calculated hash {actualHash}.");
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -130,7 +130,12 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
         if (!HeaderValidator.ValidateHash(block!.Header, out Hash256 actualHash))
         {
             if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(block, "invalid block hash"));
-            RecordBadBlock(block);
+            Nethermind.Blockchain.Metrics.BadBlocks++;
+            if (block.IsByNethermindNode()) Nethermind.Blockchain.Metrics.BadBlocksByNethermindNodes++;
+            //RecordBadBlocks() is not called here as OnInvalidBlock is intentionally skipped here —
+            // block.Hash is unverified at this point and must not be used to poison the chain tracker.
+            block.Header.Hash = actualHash;
+            _blockTree.ReportBadBlock(block);
             return NewPayloadV1Result.Invalid(null, $"Invalid block hash {request.BlockHash} does not match calculated hash {actualHash}.");
         }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -132,7 +132,7 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
             if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(block, "invalid block hash"));
             Nethermind.Blockchain.Metrics.BadBlocks++;
             if (block.IsByNethermindNode()) Nethermind.Blockchain.Metrics.BadBlocksByNethermindNodes++;
-            // Skip recording bad blocks: unverified hashes can poison tracking, 
+            // Skip recording bad blocks: unverified hashes can poison tracking,
             // while computed hashes could incorrectly blacklist a valid block.
             return NewPayloadV1Result.Invalid(null, $"Invalid block hash {request.BlockHash} does not match calculated hash {actualHash}.");
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -270,8 +270,8 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
     /// when it catches an <c>InvalidBlockException</c>: bumps the bad-block metrics, marks the chain
     /// as invalid in <see cref="IInvalidChainTracker"/>, and forwards the block to the
     /// <c>BadBlockStore</c> so it surfaces in <c>debug_getBadBlocks</c>.
-    /// Pre-process rejection sites (hash mismatch, failed orphan validation, failed suggested-block
-    /// validation) previously skipped all three.
+    /// Pre-process rejection sites (failed orphan validation, failed suggested-block
+    /// validation) previously skipped these two.
     /// </remarks>
     private void RecordBadBlock(Block block)
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -132,7 +132,7 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
             if (_logger.IsWarn) _logger.Warn(InvalidBlockHelper.GetMessage(block, "invalid block hash"));
             Nethermind.Blockchain.Metrics.BadBlocks++;
             if (block.IsByNethermindNode()) Nethermind.Blockchain.Metrics.BadBlocksByNethermindNodes++;
-            //RecordBadBlocks() is not called here as OnInvalidBlock is intentionally skipped here —
+            // RecordBadBlock() is not called here as OnInvalidBlock is intentionally skipped here —
             // block.Hash is unverified at this point and must not be used to poison the chain tracker.
             block.Header.Hash = actualHash;
             _blockTree.ReportBadBlock(block);


### PR DESCRIPTION
Fixes hive engine API test `ParentHash equals BlockHash on NewPayload, Syncing=False`
(Paris and Cancun variants). 

## Changes

- In `NewPayloadHandler.HandleAsync`, the hash-mismatch path previously called `RecordBadBlock(block)` which internally calls `_invalidChainTracker.OnInvalidBlock` and `_blockTree.ReportBadBlock` using block.Hash -the attacker-supplied claimed hash from the payload, not the real computed hash. Both calls are now skipped entirely.
- Bad-block metrics (Metrics.BadBlocks, Metrics.BadBlocksByNethermindNodes) are preserved.
- Added regression test & updated existing test

## Explanation 

`ExecutionPayload.TryGetBlock()` sets `block.Header.Hash = request.BlockHash` , the
claimed hash from the payload, not the computed one. When `ValidateHash` detects a mismatch,
`block.Hash` is still the unverified claimed value.

The hive test `ParentHash equals BlockHash on NewPayload` sends a payload where
`BlockHash = ParentHash = H5` (the current chain head hash). `RecordBadBlock` then called: `OnInvalidBlock(H5, H5)`

This marks H5 as invalid in the tracker with `lastValidHash = H5` , the block pointing
to itself as its own last valid ancestor. When the next legitimate block H6 arrives with
`parentHash = H5`, `IsOnKnownInvalidChain` traverses H6 → parent H5 → H5 is marked
invalid → H6 is rejected as `block is a part of an invalid chain, last valid is H5`.

ReportBadBlock is also skipped: storing the block under the real computed hash
(actualHash) would write it to _invalidBlocks, permanently preventing the legitimate
block from being inserted if the CL later resends the same content with the correct BlockHash.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

There is hive tests for these 
