### PR TITLE
Gate DB load and sync-pivot resolution before MultiSyncModeSelector starts

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/StartingSyncPivotUpdaterTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/StartingSyncPivotUpdaterTests.cs
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using NSubstitute;
 using Nethermind.Blockchain;
@@ -26,9 +29,9 @@ namespace Nethermind.Merge.Plugin.Test.Synchronization
     public class StartingSyncPivotUpdaterTests
     {
         private IBlockTree? _blockTree;
-        private ISyncModeSelector? _syncModeSelector;
         private ISyncPeerPool? _syncPeerPool;
         private ISyncConfig? _syncConfig;
+        private ISyncProgressResolver? _syncProgressResolver;
         private IBlockCacheService? _blockCacheService;
         private IBeaconSyncStrategy? _beaconSyncStrategy;
         private IDb? _metadataDb;
@@ -64,34 +67,34 @@ namespace Nethermind.Merge.Plugin.Test.Synchronization
             _blockTree = Build.A.BlockTree()
                 .WithMetadataDb(_metadataDb)
                 .TestObject;
-            _syncModeSelector = Substitute.For<ISyncModeSelector>();
             _syncConfig = new SyncConfig()
             {
-                MaxAttemptsToUpdatePivot = 1
+                FastSync = true,
+                MaxAttemptsToUpdatePivot = 1,
+                MultiSyncModeSelectorLoopTimerMs = 1
             };
+            // Eligibility inputs that MultiSyncModeSelector used to gate UpdatingPivot on are now checked by the updater itself.
+            _syncProgressResolver = Substitute.For<ISyncProgressResolver>();
+            _syncProgressResolver.FindBestFullState().Returns(0);
             _blockCacheService = new BlockCacheService();
             _beaconSyncStrategy = Substitute.For<IBeaconSyncStrategy>();
+            _beaconSyncStrategy.MergeTransitionFinished.Returns(true);
         }
 
-        [Test]
-        public void TrySetFreshPivot_saves_FinalizedHash_in_db()
-        {
-            _ = new StartingSyncPivotUpdater(
-                _blockTree!,
-                _syncModeSelector!,
-                _syncPeerPool!,
-                _syncConfig!,
-                _blockCacheService!,
-                _beaconSyncStrategy!,
-                LimboLogs.Instance
-            );
+        private StartingSyncPivotUpdater CreateUpdater() =>
+            new(_blockTree!, _syncPeerPool!, _syncConfig!, _syncProgressResolver!, _blockCacheService!, _beaconSyncStrategy!, LimboLogs.Instance);
 
-            SyncModeChangedEventArgs args = new(SyncMode.FastSync, SyncMode.UpdatingPivot);
+        private UnsafeStartingSyncPivotUpdater CreateUnsafeUpdater() =>
+            new(_blockTree!, _syncPeerPool!, _syncConfig!, _syncProgressResolver!, _blockCacheService!, _beaconSyncStrategy!, LimboLogs.Instance);
+
+        [Test]
+        public async Task TrySetFreshPivot_saves_FinalizedHash_in_db()
+        {
             Hash256 expectedFinalizedHash = _externalPeerBlockTree!.HeadHash;
             long expectedPivotBlockNumber = _externalPeerBlockTree!.Head!.Number;
             _beaconSyncStrategy!.GetFinalizedHash().Returns(expectedFinalizedHash);
 
-            _syncModeSelector!.Changed += Raise.EventWith(args);
+            await CreateUpdater().EnsureSyncPivot(default);
 
             byte[] storedData = _metadataDb!.Get(MetadataDbKeys.UpdatedPivotData)!;
             Rlp.ValueDecoderContext ctx = new(storedData!);
@@ -104,51 +107,32 @@ namespace Nethermind.Merge.Plugin.Test.Synchronization
 
         [TestCase(2, 0, TestName = "Finite_attempts_fall_back_to_static_pivot_after_exhaustion")]
         [TestCase(ISyncConfig.InfiniteAttempts, ISyncConfig.InfiniteAttempts, TestName = "Infinite_attempts_never_fall_back_to_static_pivot")]
-        public void TrySetFreshPivot_fallback_respects_MaxAttemptsToUpdatePivot(int maxAttempts, int expectedFinalConfigValue)
+        public async Task TrySetFreshPivot_fallback_respects_MaxAttemptsToUpdatePivot(int maxAttempts, int expectedFinalConfigValue)
         {
             _syncConfig!.MaxAttemptsToUpdatePivot = maxAttempts;
             // Finalized hash unset → TrySetFreshPivot returns null → counts as a failed attempt.
             _beaconSyncStrategy!.GetFinalizedHash().Returns((Hash256?)null);
 
-            _ = new StartingSyncPivotUpdater(
-                _blockTree!,
-                _syncModeSelector!,
-                _syncPeerPool!,
-                _syncConfig!,
-                _blockCacheService!,
-                _beaconSyncStrategy!,
-                LimboLogs.Instance
-            );
+            using CancellationTokenSource cts = new();
+            Task task = CreateUpdater().EnsureSyncPivot(cts.Token);
 
-            SyncModeChangedEventArgs args = new(SyncMode.FastSync, SyncMode.UpdatingPivot);
-            for (int i = 0; i < 100; i++)
-            {
-                _syncModeSelector!.Changed += Raise.EventWith(args);
-            }
+            // Finite attempts: the loop gives up on its own. Infinite attempts: it never completes, so cancel it.
+            await Task.WhenAny(task, Task.Delay(500));
+            cts.Cancel();
+            try { await task; } catch (OperationCanceledException) { }
 
             Assert.That(_syncConfig.MaxAttemptsToUpdatePivot, Is.EqualTo(expectedFinalConfigValue));
         }
 
         [Test]
-        public void TrySetFreshPivot_for_unsafe_updater_saves_pivot_64_blocks_behind_HeadBlockHash_in_db()
+        public async Task TrySetFreshPivot_for_unsafe_updater_saves_pivot_64_blocks_behind_HeadBlockHash_in_db()
         {
-            _ = new UnsafeStartingSyncPivotUpdater(
-                _blockTree!,
-                _syncModeSelector!,
-                _syncPeerPool!,
-                _syncConfig!,
-                _blockCacheService!,
-                _beaconSyncStrategy!,
-                LimboLogs.Instance
-            );
-
-            SyncModeChangedEventArgs args = new(SyncMode.FastSync, SyncMode.UpdatingPivot);
             Hash256 expectedHeadBlockHash = _externalPeerBlockTree!.HeadHash;
             long expectedPivotBlockNumber = _externalPeerBlockTree!.Head!.Number - 64;
             Hash256 expectedPivotBlockHash = _externalPeerBlockTree!.FindLevel(expectedPivotBlockNumber)!.BlockInfos[0].BlockHash;
             _beaconSyncStrategy!.GetHeadBlockHash().Returns(expectedHeadBlockHash);
 
-            _syncModeSelector!.Changed += Raise.EventWith(args);
+            await CreateUnsafeUpdater().EnsureSyncPivot(default);
 
             byte[] storedData = _metadataDb!.Get(MetadataDbKeys.UpdatedPivotData)!;
             Rlp.ValueDecoderContext ctx = new(storedData!);
@@ -160,26 +144,16 @@ namespace Nethermind.Merge.Plugin.Test.Synchronization
         }
 
         [Test]
-        public void TrySetFreshPivot_for_unsafe_updater_ignores_peer_header_with_mismatched_number()
+        public async Task TrySetFreshPivot_for_unsafe_updater_ignores_peer_header_with_mismatched_number()
         {
             long requestedPivotNumber = _externalPeerBlockTree!.Head!.Number - 64;
             Hash256 wrongNumberHash = _externalPeerBlockTree!.FindLevel(requestedPivotNumber + 5)!.BlockInfos[0].BlockHash;
             _syncPeer!.GetBlockHeaders(requestedPivotNumber, 1, 0, default)
                 .ReturnsForAnyArgs(_ => _externalPeerBlockTree!.FindHeaders(wrongNumberHash, 1, 0, default));
 
-            _ = new UnsafeStartingSyncPivotUpdater(
-                _blockTree!,
-                _syncModeSelector!,
-                _syncPeerPool!,
-                _syncConfig!,
-                _blockCacheService!,
-                _beaconSyncStrategy!,
-                LimboLogs.Instance
-            );
-
             _beaconSyncStrategy!.GetHeadBlockHash().Returns(_externalPeerBlockTree!.HeadHash);
 
-            _syncModeSelector!.Changed += Raise.EventWith(new SyncModeChangedEventArgs(SyncMode.FastSync, SyncMode.UpdatingPivot));
+            await CreateUnsafeUpdater().EnsureSyncPivot(default);
 
             Assert.That(_metadataDb!.Get(MetadataDbKeys.UpdatedPivotData), Is.Null,
                 "a peer header at a number other than the requested one must not set the pivot");

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -40,7 +40,6 @@ using Nethermind.Serialization.Json;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.State;
 using Nethermind.Synchronization;
-using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Trie.Pruning;
 using Nethermind.TxPool;
 
@@ -287,7 +286,7 @@ public class BaseMergePluginModule : Module
             .ResolveOnServiceActivation<IPeerRefresher, ISynchronizer>()
 
             .AddSingleton<StartingSyncPivotUpdater>()
-            .ResolveOnServiceActivation<StartingSyncPivotUpdater, ISyncModeSelector>()
+            .Bind<ISyncPivotResolver, StartingSyncPivotUpdater>()
 
             // Invalid chain tracker wrapper should be after other validator.
             .AddDecorator<IHeaderValidator, InvalidHeaderInterceptor>()

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
@@ -19,86 +19,66 @@ using Nethermind.Synchronization.Peers;
 
 namespace Nethermind.Merge.Plugin.Synchronization;
 
-public class StartingSyncPivotUpdater : IDisposable
+public class StartingSyncPivotUpdater(
+    IBlockTree blockTree,
+    ISyncPeerPool syncPeerPool,
+    ISyncConfig syncConfig,
+    ISyncProgressResolver syncProgressResolver,
+    IBlockCacheService blockCacheService,
+    IBeaconSyncStrategy beaconSyncStrategy,
+    ILogManager logManager) : ISyncPivotResolver, IDisposable
 {
     private const string Pivot = "pivot";
 
-    private readonly IBlockTree _blockTree;
-    private readonly ISyncModeSelector _syncModeSelector;
-    private readonly ISyncPeerPool _syncPeerPool;
-    private readonly ISyncConfig _syncConfig;
-    protected readonly IBlockCacheService _blockCacheService;
-    protected readonly IBeaconSyncStrategy _beaconSyncStrategy;
-    protected readonly ILogger _logger;
+    private readonly IBlockTree _blockTree = blockTree;
+    private readonly ISyncPeerPool _syncPeerPool = syncPeerPool;
+    private readonly ISyncConfig _syncConfig = syncConfig;
+    private readonly ISyncProgressResolver _syncProgressResolver = syncProgressResolver;
+    protected readonly IBlockCacheService _blockCacheService = blockCacheService;
+    protected readonly IBeaconSyncStrategy _beaconSyncStrategy = beaconSyncStrategy;
+    protected readonly ILogger _logger = logManager.GetClassLogger<StartingSyncPivotUpdater>();
 
     private CancellationTokenSource? _cancellation = new();
 
-    private int _maxAttempts;
-    private int _attemptsLeft;
-    private int _updateInProgress;
+    // Note: Blocktree would have set MaxAttemptsToUpdatePivot to 0 if sync pivot is in DB
+    private int _maxAttempts = syncConfig.MaxAttemptsToUpdatePivot;
+    private int _attemptsLeft = syncConfig.MaxAttemptsToUpdatePivot;
     private Hash256 _alreadyAnnouncedNewPivotHash = Keccak.Zero;
 
-    public StartingSyncPivotUpdater(IBlockTree blockTree,
-        ISyncModeSelector syncModeSelector,
-        ISyncPeerPool syncPeerPool,
-        ISyncConfig syncConfig,
-        IBlockCacheService blockCacheService,
-        IBeaconSyncStrategy beaconSyncStrategy,
-        ILogManager logManager)
-    {
-        _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
-        _syncModeSelector = syncModeSelector ?? throw new ArgumentNullException(nameof(syncModeSelector));
-        _syncPeerPool = syncPeerPool ?? throw new ArgumentNullException(nameof(syncPeerPool));
-        _syncConfig = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
-        _blockCacheService = blockCacheService ?? throw new ArgumentNullException(nameof(blockCacheService));
-        _beaconSyncStrategy = beaconSyncStrategy ?? throw new ArgumentNullException(nameof(beaconSyncStrategy));
-        _logger = logManager?.GetClassLogger<StartingSyncPivotUpdater>() ?? throw new ArgumentNullException(nameof(logManager));
-
-        _maxAttempts = syncConfig.MaxAttemptsToUpdatePivot; // Note: Blocktree would have set this to 0 if sync pivot is in DB
-        _attemptsLeft = syncConfig.MaxAttemptsToUpdatePivot;
-
-        if (_maxAttempts != 0 && !syncConfig.StaticSnapPivot)
-        {
-            _syncModeSelector.Changed += OnSyncModeChanged;
-        }
-    }
-
-    private async void OnSyncModeChanged(object? sender, SyncModeChangedEventArgs syncMode)
+    public async Task EnsureSyncPivot(CancellationToken cancellationToken)
     {
         CancellationTokenSource? cancellation = _cancellation;
-        if (cancellation is null)
-        {
-            return;
-        }
+        if (cancellation is null) return;
+
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cancellation.Token);
+        CancellationToken token = linkedCts.Token;
+        TimeSpan retryDelay = TimeSpan.FromMilliseconds(_syncConfig.MultiSyncModeSelectorLoopTimerMs);
 
         try
         {
-            CancellationToken token = cancellation.Token;
-
-            if ((syncMode.Current & SyncMode.UpdatingPivot) != 0 && Interlocked.CompareExchange(ref _updateInProgress, 1, 0) == 0)
+            while (!token.IsCancellationRequested)
             {
+                if (!ShouldUpdatePivot())
+                {
+                    if (_logger.IsInfo) _logger.Info("Skipping pivot update");
+                    return;
+                }
+
                 if (await TrySetFreshPivot(token))
                 {
-                    _syncModeSelector.Changed -= OnSyncModeChanged;
+                    return;
                 }
-                else if (_attemptsLeft-- > 0 || _maxAttempts == ISyncConfig.InfiniteAttempts)
+
+                // Mirrors the previous per-tick fallback: keep retrying while attempts remain (or forever
+                // when infinite), otherwise give up and fall back to the pivot from the config file.
+                if (!(_attemptsLeft-- > 0 || _maxAttempts == ISyncConfig.InfiniteAttempts))
                 {
-                    Interlocked.CompareExchange(ref _updateInProgress, 0, 1);
-                }
-                else
-                {
-                    _syncModeSelector.Changed -= OnSyncModeChanged;
                     _syncConfig.MaxAttemptsToUpdatePivot = 0;
                     if (_logger.IsInfo) _logger.Info("Failed to update pivot block, skipping it and using pivot from config file.");
+                    return;
                 }
-            }
 
-            // if sync mode is different than UpdatePivot, it means it will never be in UpdatePivot
-            if ((syncMode.Current & SyncMode.UpdatingPivot) == 0)
-            {
-                _syncModeSelector.Changed -= OnSyncModeChanged;
-                _syncConfig.MaxAttemptsToUpdatePivot = 0;
-                if (_logger.IsInfo) _logger.Info("Skipping pivot update");
+                await Task.Delay(retryDelay, token);
             }
         }
         catch (Exception e) when (e is OperationCanceledException or ObjectDisposedException)
@@ -107,9 +87,16 @@ public class StartingSyncPivotUpdater : IDisposable
         catch (Exception e)
         {
             if (_logger.IsError) _logger.Error("Unexpected error while updating the starting sync pivot.", e);
-            Interlocked.CompareExchange(ref _updateInProgress, 0, 1);
         }
     }
+
+    // The negation of the former MultiSyncModeSelector.ShouldBeInUpdatingPivot check.
+    private bool ShouldUpdatePivot() =>
+        !_syncConfig.StaticSnapPivot &&
+        _syncConfig.MaxAttemptsToUpdatePivot != 0 &&
+        _syncConfig.FastSync &&
+        _beaconSyncStrategy.MergeTransitionFinished &&
+        _syncProgressResolver.FindBestFullState() == 0; // only resolve a fresh pivot when no state has been downloaded yet
 
     private async Task<bool> TrySetFreshPivot(CancellationToken cancellationToken)
     {
@@ -256,9 +243,5 @@ public class StartingSyncPivotUpdater : IDisposable
         }
     }
 
-    public void Dispose()
-    {
-        _syncModeSelector.Changed -= OnSyncModeChanged;
-        CancellationTokenExtensions.CancelDisposeAndClear(ref _cancellation);
-    }
+    public void Dispose() => CancellationTokenExtensions.CancelDisposeAndClear(ref _cancellation);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/UnsafeStartingSyncPivotUpdater.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/UnsafeStartingSyncPivotUpdater.cs
@@ -21,13 +21,13 @@ namespace Nethermind.Merge.Plugin.Synchronization;
 
 public class UnsafeStartingSyncPivotUpdater(
     IBlockTree blockTree,
-    ISyncModeSelector syncModeSelector,
     ISyncPeerPool syncPeerPool,
     ISyncConfig syncConfig,
+    ISyncProgressResolver syncProgressResolver,
     IBlockCacheService blockCacheService,
     IBeaconSyncStrategy beaconSyncStrategy,
     ILogManager logManager)
-    : StartingSyncPivotUpdater(blockTree, syncModeSelector, syncPeerPool, syncConfig,
+    : StartingSyncPivotUpdater(blockTree, syncPeerPool, syncConfig, syncProgressResolver,
         blockCacheService, beaconSyncStrategy, logManager)
 {
     protected override async Task<(Hash256 Hash, long Number)?> TryGetPivotData(CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -773,6 +773,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         IPayloadPreparationService payloadPreparationService,
         IBlockCacheService blockCacheService,
         IMergeSyncController mergeSyncController,
+        ISyncConfig syncConfig,
         ITestEnv preMergeTestEnv
     ) : ITestEnv
     {
@@ -816,7 +817,16 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             blockCacheService.TryAddBlock(headBlock);
             blockCacheService.FinalizedHash = finalizedBlock.Hash!;
 
-            await preMergeTestEnv.WaitForSyncMode(mode => mode != SyncMode.UpdatingPivot, cancellationToken);
+            // In fast sync the starting pivot is resolved from the finalized block (before the sync mode
+            // selector starts); wait for that before kicking off beacon header sync. Full sync keeps the
+            // config pivot and never resolves a fresh one, so there is nothing to wait for.
+            if (syncConfig.FastSync)
+            {
+                while (blockTree.SyncPivot.BlockHash != finalizedBlock.Hash)
+                {
+                    await Task.Delay(50, cancellationToken);
+                }
+            }
             mergeSyncController.InitBeaconHeaderSync(headBlock.Header);
 
             await preMergeTestEnv.SyncUntilFinished(server, cancellationToken, finalizedDistanceFromHead);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorBeaconTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorBeaconTests.cs
@@ -116,15 +116,6 @@ public class MultiSyncModeSelectorBeaconTests(bool needToWaitForHeaders, MultiSy
             .TheSyncModeShouldBe(SyncMode.Disconnected);
 
     [Test]
-    public void Load_from_db() => Scenario.GoesLikeThis(_needToWaitForHeaders)
-            .WhenInBeaconSyncMode(_mode)
-            .WhateverTheSyncProgressIs()
-            .WhateverThePeerPoolLooks()
-            .WhenThisNodeIsLoadingBlocksFromDb()
-            .ThenInAnySyncConfiguration()
-            .TheSyncModeShouldBe(SyncMode.DbLoad);
-
-    [Test]
     public void Simple_archive() => Scenario.GoesLikeThis(_needToWaitForHeaders)
             .WhenInBeaconSyncMode(_mode)
             .IfThisNodeHasNeverSyncedBefore()

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorFastSyncTests.cs
@@ -43,22 +43,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                 .TheSyncModeShouldBe(SyncMode.Disconnected);
 
         [Test]
-        public void Load_from_db() => Scenario.GoesLikeThis(_needToWaitForHeaders)
-                .WhateverTheSyncProgressIs()
-                .WhateverThePeerPoolLooks()
-                .WhenThisNodeIsLoadingBlocksFromDb()
-                .ThenInAnySyncConfiguration()
-                .TheSyncModeShouldBe(SyncMode.DbLoad);
-
-        [Test]
-        public void Load_from_without_merge_sync_pivot_resolved() => Scenario.GoesLikeThis(_needToWaitForHeaders)
-                .WhenMergeSyncPivotNotResolvedYet()
-                .WhateverThePeerPoolLooks()
-                .WhenThisNodeIsLoadingBlocksFromDb()
-                .ThenInAnyFastSyncConfiguration()
-                .TheSyncModeShouldBe(SyncMode.DbLoad | SyncMode.UpdatingPivot);
-
-        [Test]
         public void Simple_archive() => Scenario.GoesLikeThis(_needToWaitForHeaders)
                 .IfThisNodeHasNeverSyncedBefore()
                 .AndGoodPeersAreKnown()

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTestsBase.Scenario.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorTestsBase.Scenario.cs
@@ -166,7 +166,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     SyncProgressResolver.FindBestHeader().Returns(0);
                     SyncProgressResolver.FindBestFullBlock().Returns(0);
                     SyncProgressResolver.FindBestFullState().Returns(0);
-                    SyncProgressResolver.IsLoadingBlocksFromDb().Returns(false);
                     SyncProgressResolver.IsFastBlocksFinished().Returns(FastBlocksState.None);
                     SyncProgressResolver.SyncPivot.Returns((Pivot.Number, Keccak.Zero));
 
@@ -666,12 +665,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     return this;
                 }
 
-                public ScenarioBuilder WhenThisNodeIsLoadingBlocksFromDb()
-                {
-                    _overwrites.Add(() => SyncProgressResolver.IsLoadingBlocksFromDb().Returns(true));
-                    return this;
-                }
-
                 public ScenarioBuilder WhenStateAndBestHeaderCanBeBeDifferent(int maxBlockDiff)
                 {
                     _overwrites.Add(() => SyncConfig.HeaderStateDistance = maxBlockDiff);
@@ -845,20 +838,6 @@ namespace Nethermind.Synchronization.Test.ParallelSync
                     return this;
                 }
 
-                public ScenarioBuilder WhenMergeSyncPivotNotResolvedYet()
-                {
-                    _syncProgressSetups.Add(
-                        () =>
-                        {
-                            SyncConfig.MaxAttemptsToUpdatePivot = 3;
-                            BeaconSyncStrategy = Substitute.For<IBeaconSyncStrategy>();
-                            BeaconSyncStrategy.MergeTransitionFinished.Returns(true);
-                            return "merge sync pivot not resolved yet";
-                        }
-                    );
-
-                    return this;
-                }
             }
 
             public static ScenarioBuilder GoesLikeThis(bool needToWaitForHeaders) =>

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -88,6 +88,7 @@ public class SyncedTxGossipPolicyTests
         public event EventHandler<SyncModeChangedEventArgs> Changing { add { } remove { } }
         public event EventHandler<SyncModeChangedEventArgs>? Changed;
         public Task StopAsync() => Task.CompletedTask;
+        public Task StartAsync() => Task.CompletedTask;
         public void Update() { }
         public void Dispose() { }
     }

--- a/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
+++ b/src/Nethermind/Nethermind.Synchronization/IBeaconSyncStrategy.cs
@@ -1,16 +1,20 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Synchronization
 {
-    public class No : IBeaconSyncStrategy
+    public class No : IBeaconSyncStrategy, ISyncPivotResolver
     {
         private No() { }
 
         public static No BeaconSync { get; } = new();
+
+        public static No SyncPivot => BeaconSync;
 
         public bool ShouldBeInBeaconHeaders() => false;
 
@@ -21,6 +25,8 @@ namespace Nethermind.Synchronization
         public long? GetTargetBlockHeight() => null;
         public Hash256? GetFinalizedHash() => null;
         public Hash256? GetHeadBlockHash() => null;
+
+        public Task EnsureSyncPivot(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 
     public interface IBeaconSyncStrategy
@@ -34,5 +40,19 @@ namespace Nethermind.Synchronization
         public long? GetTargetBlockHeight();
         public Hash256? GetFinalizedHash();
         public Hash256? GetHeadBlockHash();
+    }
+
+    /// <summary>
+    /// Resolves the starting sync pivot before mode selection begins. Awaited once, before
+    /// <see cref="ParallelSync.ISyncModeSelector.Start"/>, so that sync feeds never run against a stale pivot.
+    /// </summary>
+    /// <remarks>The default (non-merge) implementation is a no-op that completes immediately.</remarks>
+    public interface ISyncPivotResolver
+    {
+        /// <summary>
+        /// Completes once the sync pivot is resolved from the Consensus Layer, attempts are exhausted
+        /// (falling back to the config pivot), or pivot resolution is not applicable to this node.
+        /// </summary>
+        Task EnsureSyncPivot(CancellationToken cancellationToken);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncModeSelector.cs
@@ -19,6 +19,8 @@ namespace Nethermind.Synchronization.ParallelSync
 
         event EventHandler<SyncModeChangedEventArgs> Changed;
 
+        Task StartAsync();
+
         void Update();
 
         async Task WaitUntilMode(Func<SyncMode, bool> predicate, CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncProgressResolver.cs
@@ -22,8 +22,6 @@ namespace Nethermind.Synchronization.ParallelSync
 
         bool IsFastBlockAccessListsFinished();
 
-        bool IsLoadingBlocksFromDb();
-
         long FindBestProcessedBlock();
 
         UInt256 ChainDifficulty { get; }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -34,20 +34,26 @@ namespace Nethermind.Synchronization.ParallelSync
     ///     - Beacon modes are allied directly.
     ///     - If no Beacon mode is applied and we have good peers on the network we apply <see cref="SyncMode.Full"/>,.
     /// </remarks>
-    public class MultiSyncModeSelector : ISyncModeSelector
+    public class MultiSyncModeSelector(
+        ISyncProgressResolver syncProgressResolver,
+        ISyncPeerPool syncPeerPool,
+        ISyncConfig syncConfig,
+        IBeaconSyncStrategy beaconSyncStrategy,
+        IBetterPeerStrategy betterPeerStrategy,
+        ILogManager logManager) : ISyncModeSelector
     {
         /// <summary>
         /// How many blocks can fast sync stay behind while state nodes is still syncing
         /// </summary>
         private const int StickyStateNodesDelta = 32;
 
-        private readonly ISyncProgressResolver _syncProgressResolver;
-        private readonly ISyncPeerPool _syncPeerPool;
-        private readonly ISyncConfig _syncConfig;
-        private readonly IBeaconSyncStrategy _beaconSyncStrategy;
-        private readonly IBetterPeerStrategy _betterPeerStrategy;
-        private readonly bool _needToWaitForHeaders;
-        private readonly ILogger _logger;
+        private readonly ISyncProgressResolver _syncProgressResolver = syncProgressResolver;
+        private readonly ISyncPeerPool _syncPeerPool = syncPeerPool;
+        private readonly ISyncConfig _syncConfig = syncConfig;
+        private readonly IBeaconSyncStrategy _beaconSyncStrategy = beaconSyncStrategy;
+        private readonly IBetterPeerStrategy _betterPeerStrategy = betterPeerStrategy;
+        private readonly bool _needToWaitForHeaders = syncConfig.NeedToWaitForHeader;
+        private readonly ILogger _logger = logManager.GetClassLogger<MultiSyncModeSelector>();
 
         private bool FastSyncEnabled => _syncConfig.FastSync;
         private bool FastBodiesEnabled => FastSyncEnabled && _syncConfig.DownloadBodiesInFastSync;
@@ -68,27 +74,9 @@ namespace Nethermind.Synchronization.ParallelSync
 
         public SyncMode Current { get; private set; } = SyncMode.Disconnected;
 
-        public MultiSyncModeSelector(
-            ISyncProgressResolver syncProgressResolver,
-            ISyncPeerPool syncPeerPool,
-            ISyncConfig syncConfig,
-            IBeaconSyncStrategy beaconSyncStrategy,
-            IBetterPeerStrategy betterPeerStrategy,
-            ILogManager logManager)
+        public async Task StartAsync()
         {
-            _logger = logManager?.GetClassLogger<MultiSyncModeSelector>() ?? throw new ArgumentNullException(nameof(logManager));
-            _syncConfig = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
-            _beaconSyncStrategy = beaconSyncStrategy ?? throw new ArgumentNullException(nameof(beaconSyncStrategy));
-            _syncPeerPool = syncPeerPool ?? throw new ArgumentNullException(nameof(syncPeerPool));
-            _betterPeerStrategy = betterPeerStrategy ?? throw new ArgumentNullException(nameof(betterPeerStrategy));
-            _syncProgressResolver = syncProgressResolver ?? throw new ArgumentNullException(nameof(syncProgressResolver));
-            _needToWaitForHeaders = syncConfig.NeedToWaitForHeader;
-
-            _ = StartAsync(_cancellation?.Token ?? CancellationToken.None);
-        }
-
-        private async Task StartAsync(CancellationToken cancellationToken)
-        {
+            CancellationToken cancellationToken = _cancellation?.Token ?? CancellationToken.None;
             using PeriodicTimer timer = new(TimeSpan.FromMilliseconds(_syncConfig.MultiSyncModeSelectorLoopTimerMs));
             try
             {
@@ -116,19 +104,9 @@ namespace Nethermind.Synchronization.ParallelSync
 
         public void Update()
         {
-            bool shouldBeInUpdatingPivot = ShouldBeInUpdatingPivot();
-
             SyncMode newModes;
             string reason = string.Empty;
-            if (_syncProgressResolver.IsLoadingBlocksFromDb())
-            {
-                newModes = SyncMode.DbLoad;
-                if (shouldBeInUpdatingPivot)
-                {
-                    newModes |= SyncMode.UpdatingPivot;
-                }
-            }
-            else if (!_syncConfig.SynchronizationEnabled)
+            if (!_syncConfig.SynchronizationEnabled)
             {
                 newModes = SyncMode.Disconnected;
                 reason = "Synchronization Disabled";
@@ -140,14 +118,14 @@ namespace Nethermind.Synchronization.ParallelSync
                 // if there are no peers that we could use then we cannot sync
                 if (peerBlock is null or 0)
                 {
-                    newModes = shouldBeInUpdatingPivot ? SyncMode.UpdatingPivot : inBeaconControl ? SyncMode.WaitingForBlock : SyncMode.Disconnected;
+                    newModes = inBeaconControl ? SyncMode.WaitingForBlock : SyncMode.Disconnected;
                     reason = "No Useful Peers";
                 }
                 // to avoid expensive checks we make this simple check at the beginning
                 else
                 {
                     Snapshot best = EnsureSnapshot(peerDifficulty, peerBlock.Value, inBeaconControl);
-                    best.IsInBeaconHeaders = ShouldBeInBeaconHeaders(shouldBeInUpdatingPivot);
+                    best.IsInBeaconHeaders = ShouldBeInBeaconHeaders();
 
                     if (!FastSyncEnabled)
                     {
@@ -178,7 +156,6 @@ namespace Nethermind.Synchronization.ParallelSync
                     {
                         try
                         {
-                            best.IsInUpdatingPivot = shouldBeInUpdatingPivot;
                             best.IsInFastSync = ShouldBeInFastSyncMode(best);
                             best.IsInStateSync = ShouldBeInStateSyncMode(best);
                             best.IsInStateNodes = ShouldBeInStateNodesMode(best);
@@ -192,7 +169,6 @@ namespace Nethermind.Synchronization.ParallelSync
                             if (_logger.IsTrace) _logger.Trace($"Snapshot: {BuildStateStringDebug(best)}");
 
                             newModes = SyncMode.None;
-                            CheckAddFlag(best.IsInUpdatingPivot, SyncMode.UpdatingPivot, ref newModes);
                             CheckAddFlag(best.IsInBeaconHeaders, SyncMode.BeaconHeaders, ref newModes);
                             CheckAddFlag(best.IsInFastHeaders, SyncMode.FastHeaders, ref newModes);
                             CheckAddFlag(best.IsInFastBodies, SyncMode.FastBodies, ref newModes);
@@ -301,47 +277,17 @@ namespace Nethermind.Synchronization.ParallelSync
             return result;
         }
 
-        private bool ShouldBeInBeaconHeaders(bool shouldBeInUpdatingPivot)
+        private bool ShouldBeInBeaconHeaders()
         {
             bool shouldBeInBeaconHeaders = _beaconSyncStrategy.ShouldBeInBeaconHeaders();
-            bool shouldBeNotInUpdatingPivot = !shouldBeInUpdatingPivot;
-
-            bool result = shouldBeInBeaconHeaders &&
-                          shouldBeNotInUpdatingPivot;
 
             if (_logger.IsTrace)
             {
                 LogDetailedSyncModeChecks("BEACON HEADERS",
-                    (nameof(shouldBeInBeaconHeaders), shouldBeInBeaconHeaders),
-                    (nameof(shouldBeNotInUpdatingPivot), shouldBeNotInUpdatingPivot));
+                    (nameof(shouldBeInBeaconHeaders), shouldBeInBeaconHeaders));
             }
 
-            return result;
-        }
-
-        private bool ShouldBeInUpdatingPivot()
-        {
-            if (_syncConfig.StaticSnapPivot) return false;
-
-            bool updateRequestedAndNotFinished = _syncConfig.MaxAttemptsToUpdatePivot is > 0 or ISyncConfig.InfiniteAttempts;
-            bool isPostMerge = _beaconSyncStrategy.MergeTransitionFinished;
-            bool stateSyncNotFinished = _syncProgressResolver.FindBestFullState() == 0;
-
-            bool result = updateRequestedAndNotFinished &&
-                          FastSyncEnabled &&
-                          isPostMerge &&
-                          stateSyncNotFinished;
-
-            if (_logger.IsTrace)
-            {
-                LogDetailedSyncModeChecks("UPDATING PIVOT",
-                    (nameof(updateRequestedAndNotFinished), updateRequestedAndNotFinished),
-                    (nameof(FastSyncEnabled), FastSyncEnabled),
-                    (nameof(isPostMerge), isPostMerge),
-                    (nameof(stateSyncNotFinished), stateSyncNotFinished));
-            }
-
-            return result;
+            return shouldBeInBeaconHeaders;
         }
 
         private bool ShouldBeInFastSyncMode(Snapshot best)
@@ -357,8 +303,6 @@ namespace Nethermind.Synchronization.ParallelSync
                 // we are fine to start from zero if we do not use fast blocks
                 return false;
             }
-
-            bool notInUpdatingPivot = !best.IsInUpdatingPivot;
 
             // Shared with fast sync
             bool notInBeaconModes = !best.IsInAnyBeaconMode;
@@ -376,8 +320,7 @@ namespace Nethermind.Synchronization.ParallelSync
             bool stateNotDownloadedYet = !best.StateDownloaded;
             bool notNeedToWaitForHeaders = NotNeedToWaitForHeaders;
 
-            bool result = notInUpdatingPivot &&
-                          notInBeaconModes &&
+            bool result = notInBeaconModes &&
                           postPivotPeerAvailable &&
                           notReachedFullSyncTransition &&
                           stateNotDownloadedYet &&
@@ -386,7 +329,6 @@ namespace Nethermind.Synchronization.ParallelSync
             if (_logger.IsTrace)
             {
                 LogDetailedSyncModeChecks("FAST",
-                    (nameof(notInUpdatingPivot), notInUpdatingPivot),
                     (nameof(notInBeaconModes), notInBeaconModes),
                     (nameof(postPivotPeerAvailable), postPivotPeerAvailable),
                     (nameof(notReachedFullSyncTransition), notReachedFullSyncTransition),
@@ -399,8 +341,6 @@ namespace Nethermind.Synchronization.ParallelSync
 
         private bool ShouldBeInFullSyncMode(Snapshot best)
         {
-            bool notInUpdatingPivot = !best.IsInUpdatingPivot;
-
             // Shared with fast sync
             bool notInBeaconModes = !best.IsInAnyBeaconMode;
             bool postPivotPeerAvailable = best.AnyPostPivotPeerKnown;
@@ -414,8 +354,7 @@ namespace Nethermind.Synchronization.ParallelSync
             bool notInStateSync = !best.IsInStateSync;
             bool notNeedToWaitForHeaders = NotNeedToWaitForHeaders;
 
-            bool result = notInUpdatingPivot &&
-                          notInBeaconModes &&
+            bool result = notInBeaconModes &&
                           desiredPeerKnown &&
                           postPivotPeerAvailable &&
                           hasFastSyncBeenActive &&
@@ -426,7 +365,6 @@ namespace Nethermind.Synchronization.ParallelSync
             if (_logger.IsTrace)
             {
                 LogDetailedSyncModeChecks("FULL",
-                    (nameof(notInUpdatingPivot), notInUpdatingPivot),
                     (nameof(notInBeaconModes), notInBeaconModes),
                     (nameof(desiredPeerKnown), desiredPeerKnown),
                     (nameof(postPivotPeerAvailable), postPivotPeerAvailable),
@@ -441,19 +379,15 @@ namespace Nethermind.Synchronization.ParallelSync
 
         private bool ShouldBeInFullSyncModeInArchiveMode(Snapshot best)
         {
-            bool notInUpdatingPivot = !best.IsInUpdatingPivot;
-
             bool notInBeaconModes = !best.IsInAnyBeaconMode;
             bool desiredPeerKnown = AnyDesiredPeerKnown(best);
 
-            bool result = notInUpdatingPivot &&
-                          notInBeaconModes &&
+            bool result = notInBeaconModes &&
                           desiredPeerKnown;
 
             if (_logger.IsTrace)
             {
                 LogDetailedSyncModeChecks("FULL",
-                    (nameof(notInUpdatingPivot), notInUpdatingPivot),
                     (nameof(notInBeaconModes), notInBeaconModes),
                     (nameof(desiredPeerKnown), desiredPeerKnown));
             }
@@ -464,21 +398,17 @@ namespace Nethermind.Synchronization.ParallelSync
         // ReSharper disable once UnusedParameter.Local
         private bool ShouldBeInFastHeadersMode(Snapshot best)
         {
-            bool notInUpdatingPivot = !best.IsInUpdatingPivot;
-
             bool fastBlocksHeadersNotFinished = !FastBlocksHeadersFinished;
 
             if (_logger.IsTrace)
             {
                 LogDetailedSyncModeChecks("HEADERS",
-                    (nameof(notInUpdatingPivot), notInUpdatingPivot),
                     (nameof(fastBlocksHeadersNotFinished), fastBlocksHeadersNotFinished));
             }
 
             // this is really the only condition - fast blocks headers can always run if there are peers until it is done
             // also fast blocks headers can run in parallel with all other sync modes
-            return notInUpdatingPivot &&
-                   fastBlocksHeadersNotFinished;
+            return fastBlocksHeadersNotFinished;
         }
 
         private bool ShouldBeInFastBodiesMode(Snapshot best)
@@ -552,7 +482,7 @@ namespace Nethermind.Synchronization.ParallelSync
             return result;
         }
 
-        private static bool ShouldBeInDisconnectedMode(Snapshot best) => !best.IsInUpdatingPivot &&
+        private static bool ShouldBeInDisconnectedMode(Snapshot best) =>
                 !best.IsInFastBodies &&
                 !best.IsInFastHeaders &&
                 !best.IsInFastReceipts &&
@@ -567,7 +497,6 @@ namespace Nethermind.Synchronization.ParallelSync
         private bool ShouldBeInStateSyncMode(Snapshot best)
         {
             bool fastSyncEnabled = FastSyncEnabled;
-            bool notInUpdatingPivot = !best.IsInUpdatingPivot;
             bool notInBeaconModes = !best.IsInAnyBeaconMode;
             bool hasFastSyncBeenActive = best.Header >= best.PivotNumber;
             bool hasAnyPostPivotPeer = best.AnyPostPivotPeerKnown || (_syncConfig.StaticSnapPivot && best.Peer.Block >= best.PivotNumber);
@@ -578,7 +507,6 @@ namespace Nethermind.Synchronization.ParallelSync
             bool stateNotDownloadedYet = !best.StateDownloaded;
 
             bool result = fastSyncEnabled &&
-                          notInUpdatingPivot &&
                           notInBeaconModes &&
                           hasFastSyncBeenActive &&
                           hasAnyPostPivotPeer &&
@@ -590,7 +518,6 @@ namespace Nethermind.Synchronization.ParallelSync
             {
                 LogDetailedSyncModeChecks("STATE",
                     (nameof(fastSyncEnabled), fastSyncEnabled),
-                    (nameof(notInUpdatingPivot), notInUpdatingPivot),
                     (nameof(hasFastSyncBeenActive), hasFastSyncBeenActive),
                     (nameof(hasAnyPostPivotPeer), hasAnyPostPivotPeer),
                     ($"{nameof(notInFastSync)} || {nameof(stickyStateNodes)}", notInFastSync || stickyStateNodes),
@@ -746,10 +673,9 @@ namespace Nethermind.Synchronization.ParallelSync
                 PivotNumber = pivotNumber;
 
                 IsInWaitingForBlock = IsInDisconnected = IsInFastReceipts = IsInFastBlockAccessLists = IsInFastBodies = IsInFastHeaders
-                    = IsInFastSync = IsInFullSync = IsInStateSync = IsInStateNodes = IsInBeaconHeaders = IsInUpdatingPivot = false;
+                    = IsInFastSync = IsInFullSync = IsInStateSync = IsInStateNodes = IsInBeaconHeaders = false;
             }
 
-            public bool IsInUpdatingPivot { get; set; }
             public bool IsInFastHeaders { get; set; }
             public bool IsInFastBodies { get; set; }
             public bool IsInFastReceipts { get; set; }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/StaticSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/StaticSelector.cs
@@ -35,6 +35,7 @@ namespace Nethermind.Synchronization.ParallelSync
         }
 
         public Task StopAsync() => Task.CompletedTask;
+        public Task StartAsync() => Task.CompletedTask;
         public void Update() { }
 
         public event EventHandler<SyncModeChangedEventArgs> Changing

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -29,7 +29,6 @@ namespace Nethermind.Synchronization.ParallelSync
         public long FindBestFullState() => _fullStateFinder.FindBestFullState();
         public long FindBestHeader() => _blockTree.BestSuggestedHeader?.Number ?? 0;
         public long FindBestFullBlock() => Math.Min(FindBestHeader(), _blockTree.BestSuggestedBody?.Number ?? 0); // avoiding any potential concurrency issue
-        public bool IsLoadingBlocksFromDb() => !_blockTree.CanAcceptNewBlocks;
         public long FindBestProcessedBlock() => _blockTree.Head?.Number ?? -1;
         public UInt256 ChainDifficulty => _blockTree.BestSuggestedBody?.TotalDifficulty ?? UInt256.Zero;
 

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using Autofac.Features.AttributeFilters;
+using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Consensus;
@@ -32,6 +33,8 @@ namespace Nethermind.Synchronization
         ISyncModeSelector syncModeSelector,
         ISyncReport syncReport,
         ISyncConfig syncConfig,
+        IBlockTree blockTree,
+        ISyncPivotResolver syncPivotResolver,
         ILogManager logManager,
         INodeStatsManager nodeStatsManager,
         [KeyFilter(nameof(FullSyncFeed))] SyncFeedComponent<BlocksRequest> fullSyncComponent,
@@ -91,8 +94,29 @@ namespace Nethermind.Synchronization
                 SyncModeSelector.Changed += GCOnFeedFinished;
             }
 
-            // Make unit test faster.
-            SyncModeSelector.Update();
+            // Mode selection only begins once startup prerequisites are met: the DB block load has finished
+            // and the starting sync pivot has been resolved. Until then the feeds wired above stay dormant.
+            _ = StartModeSelectorAfterGates(_syncCancellation!.Token);
+        }
+
+        private async Task StartModeSelectorAfterGates(CancellationToken cancellationToken)
+        {
+            try
+            {
+                // Gate 1: the block tree cannot accept new blocks while a bulk DB load holds it, so wait for
+                // that to finish (the old DbLoad sync mode polled the same flag every selector tick).
+                while (!blockTree.CanAcceptNewBlocks)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(syncConfig.MultiSyncModeSelectorLoopTimerMs), cancellationToken);
+                }
+                await syncPivotResolver.EnsureSyncPivot(cancellationToken);
+                await SyncModeSelector.StartAsync();
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception e)
+            {
+                if (_logger.IsError) _logger.Error("Failed to start sync mode selector", e);
+            }
         }
 
         private void GCOnFeedFinished(object? sender, SyncModeChangedEventArgs e)
@@ -306,6 +330,7 @@ public class SynchronizerModule(ISyncConfig syncConfig) : Module
             .AddSingleton<MallocTrimmer>()
             .AddSingleton<ISyncPointers, SyncPointers>()
             .AddSingleton<IBeaconSyncStrategy>(No.BeaconSync)
+            .AddSingleton<ISyncPivotResolver>(No.SyncPivot)
             .AddSingleton<IPivot, Pivot>() // Used by sync report
             .AddSingleton<IBetterPeerStrategy, TotalDifficultyBetterPeerStrategy>()
             .AddSingleton<IPoSSwitcher>(NoPoS.Instance)

--- a/src/Nethermind/Nethermind.Taiko/TaikoSyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoSyncProgressResolver.cs
@@ -51,7 +51,6 @@ public sealed class TaikoSyncProgressResolver(
     public bool IsFastBlocksBodiesFinished() => inner.IsFastBlocksBodiesFinished();
     public bool IsFastBlocksReceiptsFinished() => inner.IsFastBlocksReceiptsFinished();
     public bool IsFastBlockAccessListsFinished() => inner.IsFastBlockAccessListsFinished();
-    public bool IsLoadingBlocksFromDb() => inner.IsLoadingBlocksFromDb();
     public long FindBestProcessedBlock() => inner.FindBestProcessedBlock();
     public UInt256 ChainDifficulty => inner.ChainDifficulty;
     // On Taiko TotalDifficulty is always 0; the default resolver does


### PR DESCRIPTION
## Changes

`MultiSyncModeSelector` (MSMS) is meant to project sync state into `SyncMode` flags each tick, but two of its modes were one-shot startup prerequisites wired into the per-tick logic:

- **`DbLoad`** was a short-circuit at the top of `Update()` derived from the block-tree lock.
- **`UpdatingPivot`** was a *driver*: MSMS emitting the flag triggered `StartingSyncPivotUpdater` via an `async void` `Changed` handler with an `Interlocked` reentrancy guard, and the flag was threaded as a `!IsInUpdatingPivot` precondition through ~10 `ShouldBeIn*` predicates.

This moves both out into gates the synchronizer runs **before** mode selection starts:

- The synchronizer waits for the initial DB block load to finish by polling the existing `IBlockTree.CanAcceptNewBlocks` (the same flag the old `DbLoad` mode checked every tick). `ISyncProgressResolver.IsLoadingBlocksFromDb()` is removed.
- New `ISyncPivotResolver.EnsureSyncPivot(ct)` (no-op `No.SyncPivot` default, bound to `StartingSyncPivotUpdater` in the merge module). The updater becomes an owned retry loop that self-checks eligibility (the negation of the former `ShouldBeInUpdatingPivot`) and drops its `ISyncModeSelector` dependency — removing the `async void` handler and reentrancy guard.
- `MultiSyncModeSelector` no longer auto-starts in its constructor; it exposes `StartAsync()`, which `Synchronizer.Start` invokes only after both gates clear. The `DbLoad` short-circuit, `ShouldBeInUpdatingPivot`, the `IsInUpdatingPivot` snapshot flag, and all `notInUpdatingPivot` terms are gone (~100 fewer lines in MSMS).

`SyncMode.UpdatingPivot` / `DbLoad` enum members are kept (MSMS just never emits them) so external consumers (tx gossip policy, sync report, `HaveNotSynced*` helpers) are untouched.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`StartingSyncPivotUpdaterTests` now drives `EnsureSyncPivot` directly instead of raising selector events; the obsolete `DbLoad`/`UpdatingPivot` MSMS scenario tests were removed and the `E2ESyncTests` pivot-wait adjusted. Full `Nethermind.Synchronization.Test` (2043 passed / 393 skipped) and `Nethermind.Merge.Plugin.Test` (1523 passed; 1 pre-existing block-production timing flake, passes in isolation) are green; the integration sync tests and `FullSync` E2E confirm the gated `StartAsync` path.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
