### PR TITLE
feat(debug): emit struct-log refund counter in geth opcode tracers

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
@@ -46,7 +46,11 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
     private long _pendingGasCost;
     private int _pendingDepth;
     private string? _pendingError;
+    private long _pendingRefund;
     private bool _gasCostAlreadySet;
+
+    private long _refund;
+    private readonly Stack<long> _refundCheckpoints = new();
 
     private byte[]? _stackBuffer;
     private int _stackByteCount;
@@ -78,6 +82,8 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         _cancellationToken = cancellationToken;
         _flushIntervalEntries = flushIntervalEntries;
         IsTracingMemory = IsTracingFullMemory;
+        IsTracingRefunds = true;
+        IsTracingActions = true;
     }
 
     internal void ResetForNextTx(Transaction? transaction)
@@ -91,7 +97,10 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         _pendingGasCost = 0;
         _pendingDepth = 0;
         _pendingError = null;
+        _pendingRefund = 0;
         _gasCostAlreadySet = false;
+        _refund = 0;
+        _refundCheckpoints.Clear();
         _stackByteCount = 0;
         _memoryByteCount = 0;
         if (_storageByDepth is not null)
@@ -123,6 +132,8 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         _pendingGasCost = 0;
         _pendingDepth = newDepth;
         _pendingError = null;
+        // Snapshot the cumulative refund counter before the opcode executes (geth pre-op GetRefund()).
+        _pendingRefund = _refund;
         _gasCostAlreadySet = false;
         _stackByteCount = 0;
         _memoryByteCount = 0;
@@ -260,6 +271,8 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         _writer.WriteNumber("gasCost"u8, _pendingGasCost);
         _writer.WriteNumber("depth"u8, _pendingDepth);
 
+        if (_pendingRefund != 0) _writer.WriteNumber("refund"u8, _pendingRefund);
+
         if (_pendingError is null) _writer.WriteNull("error"u8);
         else _writer.WriteString("error"u8, _pendingError);
 
@@ -322,4 +335,43 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         _entriesSinceLastFlush = 0;
     }
 
+    public override void ReportRefund(long refund) => _refund += refund;
+
+    public override void ReportAction(long gas, UInt256 value, Address from, Address to, ReadOnlyMemory<byte> input, ExecutionType callType, bool isPrecompileCall = false)
+    {
+        base.ReportAction(gas, value, from, to, input, callType, isPrecompileCall);
+        _refundCheckpoints.Push(_refund);
+    }
+
+    public override void ReportActionEnd(long gas, ReadOnlyMemory<byte> output)
+    {
+        base.ReportActionEnd(gas, output);
+        _refundCheckpoints.TryPop(out _);
+    }
+
+    public override void ReportActionEnd(long gas, Address deploymentAddress, ReadOnlyMemory<byte> deployedCode)
+    {
+        base.ReportActionEnd(gas, deploymentAddress, deployedCode);
+        _refundCheckpoints.TryPop(out _);
+    }
+
+    public override void ReportActionRevert(long gasLeft, ReadOnlyMemory<byte> output)
+    {
+        base.ReportActionRevert(gasLeft, output);
+        RestoreRefundCheckpoint();
+    }
+
+    public override void ReportActionError(EvmExceptionType evmExceptionType)
+    {
+        base.ReportActionError(evmExceptionType);
+        RestoreRefundCheckpoint();
+    }
+
+    // A reverted or aborted frame rolls back every refund accrued within it (and its successful
+    // children), mirroring go-ethereum's journaled refund counter.
+    private void RestoreRefundCheckpoint()
+    {
+        if (_refundCheckpoints.TryPop(out long checkpoint))
+            _refund = checkpoint;
+    }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxMemoryTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxMemoryTracer.cs
@@ -16,10 +16,15 @@ public class GethLikeTxMemoryTracer : GethLikeTxTracer<GethTxMemoryTraceEntry>
 {
     private readonly Transaction? _transaction;
 
+    private long _refund;
+    private readonly Stack<long> _refundCheckpoints = new();
+
     public GethLikeTxMemoryTracer(Transaction? transaction, GethTraceOptions options) : base(options)
     {
         _transaction = transaction;
         IsTracingMemory = IsTracingFullMemory;
+        IsTracingRefunds = true;
+        IsTracingActions = true;
     }
 
     public override GethLikeTxTrace BuildResult()
@@ -58,6 +63,10 @@ public class GethLikeTxMemoryTracer : GethLikeTxTracer<GethTxMemoryTraceEntry>
 
         base.StartOperation(pc, opcode, gas, env);
 
+        // Geth's struct logger captures the cumulative gas-refund counter before the opcode
+        // executes and emits it only when non-zero (matching go-ethereum's pre-op GetRefund()).
+        CurrentTraceEntry.Refund = _refund != 0 ? _refund : null;
+
         if (CurrentTraceEntry.Depth > previousDepth)
         {
             CurrentTraceEntry.Storage = [];
@@ -78,5 +87,45 @@ public class GethLikeTxMemoryTracer : GethLikeTxTracer<GethTxMemoryTraceEntry>
 
             CurrentTraceEntry.Storage = new Dictionary<string, string>(previousTraceEntry.Storage);
         }
+    }
+
+    public override void ReportRefund(long refund) => _refund += refund;
+
+    public override void ReportAction(long gas, UInt256 value, Address from, Address to, ReadOnlyMemory<byte> input, ExecutionType callType, bool isPrecompileCall = false)
+    {
+        base.ReportAction(gas, value, from, to, input, callType, isPrecompileCall);
+        _refundCheckpoints.Push(_refund);
+    }
+
+    public override void ReportActionEnd(long gas, ReadOnlyMemory<byte> output)
+    {
+        base.ReportActionEnd(gas, output);
+        _refundCheckpoints.TryPop(out _);
+    }
+
+    public override void ReportActionEnd(long gas, Address deploymentAddress, ReadOnlyMemory<byte> deployedCode)
+    {
+        base.ReportActionEnd(gas, deploymentAddress, deployedCode);
+        _refundCheckpoints.TryPop(out _);
+    }
+
+    public override void ReportActionRevert(long gasLeft, ReadOnlyMemory<byte> output)
+    {
+        base.ReportActionRevert(gasLeft, output);
+        RestoreRefundCheckpoint();
+    }
+
+    public override void ReportActionError(EvmExceptionType evmExceptionType)
+    {
+        base.ReportActionError(evmExceptionType);
+        RestoreRefundCheckpoint();
+    }
+
+    // A reverted or aborted frame rolls back every refund accrued within it (and its successful
+    // children), mirroring go-ethereum's journaled refund counter.
+    private void RestoreRefundCheckpoint()
+    {
+        if (_refundCheckpoints.TryPop(out long checkpoint))
+            _refund = checkpoint;
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTxFileTraceEntry.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTxFileTraceEntry.cs
@@ -11,8 +11,6 @@ public class GethTxFileTraceEntry : GethTxTraceEntry
 
     public Instruction? OpcodeRaw { get; set; }
 
-    public long? Refund { get; set; }
-
     internal override void UpdateMemorySize(ulong size)
     {
         base.UpdateMemorySize(size);

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTxTraceEntry.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTxTraceEntry.cs
@@ -31,6 +31,11 @@ public class GethTxTraceEntry
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string? Error { get; set; }
 
+    [JsonPropertyName("refund")]
+    [JsonConverter(typeof(LongRawJsonConverter))]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? Refund { get; set; }
+
     public string[]? Stack { get; set; }
 
     public string[]? Memory { get; set; }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxDirectStreamingTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxDirectStreamingTracerTests.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using Nethermind.Blockchain.Tracing.GethStyle;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Evm.TransactionProcessing;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test.Tracing;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+public class GethLikeTxDirectStreamingTracerTests : VirtualMachineTestsBase
+{
+    [TestCase(false, TestName = "Refund accumulates and persists after a clearing SSTORE")]
+    [TestCase(true, TestName = "Refund is rolled back when the clearing frame reverts")]
+    public void Streams_journaled_refund_counter(bool clearingFrameReverts)
+    {
+        long sClearRefund = Spec.GasCosts.SClearRefund;
+
+        List<StructLog> logs = ExecuteAndStream(clearingFrameReverts);
+
+        using (Assert.EnterMultipleScope())
+        {
+            if (clearingFrameReverts)
+            {
+                Assert.That(RefundAt(logs, "REVERT"), Is.EqualTo(sClearRefund));
+                Assert.That(logs.Last(l => l.Op == "STOP" && l.Depth == 1).Refund, Is.Null);
+            }
+            else
+            {
+                Assert.That(RefundAt(logs, "SSTORE"), Is.Null);
+                Assert.That(RefundAt(logs, "STOP"), Is.EqualTo(sClearRefund));
+            }
+        }
+    }
+
+    private static long? RefundAt(IEnumerable<StructLog> logs, string opcode) => logs.Single(l => l.Op == opcode).Refund;
+
+    private List<StructLog> ExecuteAndStream(bool clearingFrameReverts)
+    {
+        byte[] code = clearingFrameReverts ? RevertingCallCode() : ClearingSstoreCode();
+        (Block block, Transaction transaction) = PrepareTx(Activation, 100000, code);
+
+        using MemoryStream stream = new();
+        using (Utf8JsonWriter writer = new(stream))
+        {
+            writer.WriteStartArray();
+            GethLikeTxDirectStreamingTracer tracer = new(transaction, GethTraceOptions.Default, writer, null, CancellationToken.None);
+            _processor.Execute(transaction, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+            tracer.BuildResult();
+            writer.WriteEndArray();
+        }
+
+        using JsonDocument document = JsonDocument.Parse(stream.ToArray());
+        return [.. document.RootElement.EnumerateArray().Select(static e => new StructLog(
+            e.GetProperty("op").GetString()!,
+            e.GetProperty("depth").GetInt32(),
+            e.TryGetProperty("refund", out JsonElement refund) ? refund.GetInt64() : null))];
+    }
+
+    private byte[] ClearingSstoreCode()
+    {
+        TestState.CreateAccount(Recipient, 1.Ether);
+        TestState.Set(new StorageCell(Recipient, 0), new byte[] { 1 });
+        TestState.Commit(Spec);
+
+        return Prepare.EvmCode
+            .PersistData("0x0", HexZero)
+            .Op(Instruction.STOP)
+            .Done;
+    }
+
+    private byte[] RevertingCallCode()
+    {
+        byte[] calleeCode = Prepare.EvmCode
+            .PersistData("0x0", HexZero)
+            .PushData(0)
+            .PushData(0)
+            .Op(Instruction.REVERT)
+            .Done;
+
+        TestState.CreateAccount(TestItem.AddressC, 1.Ether);
+        TestState.Set(new StorageCell(TestItem.AddressC, 0), new byte[] { 1 });
+        TestState.InsertCode(TestItem.AddressC, calleeCode, Spec);
+        TestState.Commit(Spec);
+
+        return Prepare.EvmCode
+            .Call(TestItem.AddressC, 50000)
+            .Op(Instruction.STOP)
+            .Done;
+    }
+
+    private readonly record struct StructLog(string Op, int Depth, long? Refund);
+}

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxMemoryTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxMemoryTracerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Linq;
+using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
@@ -429,6 +430,69 @@ public class GethLikeTxMemoryTracerTests : VirtualMachineTestsBase
         AssertEntry(trace.Entries[^3], expectedPc: 25, expectedOpcode: "EXTCODESIZE", expectedStackTop: "0x866833515b6d086c607f", expectedStackCount: 8);
         AssertEntry(trace.Entries[^2], expectedPc: 26, expectedOpcode: "ISZERO", expectedStackTop: "0x0", expectedStackCount: 8);
         AssertEntry(trace.Entries[^1], expectedPc: 27, expectedOpcode: "PUSH21", expectedStackTop: "0x1", expectedStackCount: 8);
+    }
+
+    [Test]
+    public void Can_trace_refund_on_storage_clear()
+    {
+        // Seed a non-zero slot so clearing it to zero grants a storage-clearing refund.
+        // The account must exist before its storage is committed (an empty account has no storage root).
+        TestState.CreateAccount(Recipient, 1.Ether);
+        TestState.Set(new StorageCell(Recipient, 0), new byte[] { 1 });
+        TestState.Commit(Spec);
+
+        byte[] code = Prepare.EvmCode
+            .PersistData("0x0", HexZero) // SSTORE 0 -> slot 0 (clears it)
+            .Op(Instruction.STOP)
+            .Done;
+
+        GethLikeTxTrace trace = ExecuteAndTrace(code);
+
+        GethTxTraceEntry sstore = trace.Entries.Single(e => e.Opcode == "SSTORE");
+        GethTxTraceEntry stop = trace.Entries.Single(e => e.Opcode == "STOP");
+
+        using (Assert.EnterMultipleScope())
+        {
+            // The counter is captured before the opcode runs, so SSTORE itself shows no refund yet.
+            Assert.That(sstore.Refund, Is.Null, "refund before SSTORE executes");
+            // The next step carries the accumulated, non-zero refund counter.
+            Assert.That(stop.Refund, Is.EqualTo(Spec.GasCosts.SClearRefund), "refund after the clearing SSTORE");
+        }
+    }
+
+    [Test]
+    public void Refund_is_rolled_back_when_frame_reverts()
+    {
+        // Callee clears its own non-zero slot (earning a refund) and then reverts the whole frame.
+        byte[] calleeCode = Prepare.EvmCode
+            .PersistData("0x0", HexZero) // SSTORE 0 -> slot 0 (clears it, earns refund)
+            .PushData(0)
+            .PushData(0)
+            .Op(Instruction.REVERT)
+            .Done;
+
+        TestState.CreateAccount(TestItem.AddressC, 1.Ether);
+        TestState.Set(new StorageCell(TestItem.AddressC, 0), new byte[] { 1 });
+        TestState.InsertCode(TestItem.AddressC, calleeCode, Spec);
+        TestState.Commit(Spec);
+
+        byte[] code = Prepare.EvmCode
+            .Call(TestItem.AddressC, 50000)
+            .Op(Instruction.STOP)
+            .Done;
+
+        GethLikeTxTrace trace = ExecuteAndTrace(code);
+
+        GethTxTraceEntry revert = trace.Entries.Single(e => e.Opcode == "REVERT");
+        GethTxTraceEntry topLevelStop = trace.Entries.Last(e => e.Opcode == "STOP" && e.Depth == 1);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Inside the doomed frame the refund counter is visible.
+            Assert.That(revert.Refund, Is.EqualTo(Spec.GasCosts.SClearRefund), "refund visible inside the reverting frame");
+            // Once the frame reverts the refund is discarded, matching geth's journaled counter.
+            Assert.That(topLevelStop.Refund, Is.Null, "refund rolled back after the frame reverts");
+        }
     }
 
     private static void AssertEntry(GethTxTraceEntry entry, long expectedPc, string expectedOpcode, string expectedStackTop, int expectedStackCount)


### PR DESCRIPTION
## Changes

The default `debug_trace*` opcode (struct) logger did not emit the per-step gas-refund counter, diverging from geth/Besu/Erigon/Reth, which include `refund` whenever it is non-zero.

- Track the cumulative gas-refund counter across call frames in both geth struct tracers (in-memory `GethLikeTxMemoryTracer` and streaming `GethLikeTxDirectStreamingTracer`).
- Roll the counter back when a frame reverts or aborts (via the action enter/exit/revert hooks), mirroring go-ethereum's journaled `GetRefund()`.
- Capture the counter pre-op and emit `refund` only when non-zero, matching the cross-client default.
- Move the `Refund` field onto the base `GethTxTraceEntry` so it serializes in the JSON-RPC response (the file tracer keeps its existing manual serialization, so its output is unchanged).

`returnData` is intentionally left out: it is emitted by other clients only when `enableReturnData` is set (off by default), so omitting it is already spec-conformant per [execution-apis#762](https://github.com/ethereum/execution-apis/pull/762). This PR closes the one field where Nethermind actually diverged.

Addresses #12057.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `Can_trace_refund_on_storage_clear` (cumulative counter surfaced after a clearing SSTORE) and `Refund_is_rolled_back_when_frame_reverts` (refund earned inside a reverted frame is discarded). Verified no regressions across the geth tracing, `debug_trace*` JSON-RPC (including the streaming path), and streaming blockchain-test runner suites.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

The `debug_traceTransaction` / `debug_traceBlock*` default (struct) tracer now includes the `refund` field on each step when the cumulative gas-refund counter is non-zero, aligning the opcode trace output with geth/Besu/Erigon/Reth.
