### PR TITLE
Refresh snap-sync account storage root via verified GetAccountRange

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -273,6 +273,40 @@ public class SnapServerTest
         }
     }
 
+    // A non-existent account is a terminal no-op only when its absence is *proven* by the verified range -
+    // the storage root must be left untouched and the refresh must not retry.
+    [Test]
+    public void TestRefreshAccount_VerifiedNotFound()
+    {
+        using ISnapServerContext context = CreateContext();
+        FillWithTestAccounts(context);
+
+        // A path immediately before an existing account: the account is absent, but the next account proves it.
+        ValueHash256 path = TestItem.Tree.AccountsWithPaths[1].Path.DecrementPath();
+        (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
+            context.Server.GetAccountRanges(context.RootHash, path, path.IncrementPath(), 4000, CancellationToken.None);
+        using AccountsAndProofs response = new() { PathAndAccounts = accounts, Proofs = proofs };
+
+        PathWithAccount stale = new(path, Build.An.Account.WithBalance(2).TestObject);
+        using AccountsToRefreshRequest request = new()
+        {
+            RootHash = context.RootHash,
+            Paths = new ArrayPoolList<AccountWithStorageStartingHash>(1)
+            {
+                new() { PathAndAccount = stale, StorageStartingHash = ValueKeccak.Zero, StorageHashLimit = Keccak.MaxValue }
+            }
+        };
+
+        AddRangeResult result = context.SnapProvider.RefreshAccounts(request, response);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(AddRangeResult.OK));
+            // Absent account: nothing adopted, storage root unchanged.
+            Assert.That(stale.Account.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash));
+        }
+    }
+
     [Test]
     public void TestGetTrieNode_Root()
     {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -192,6 +192,87 @@ public class SnapServerTest
         proofs.Dispose();
     }
 
+    // Refresh re-fetches a single account via GetAccountRange and verifies its storage root against the
+    // state root from the proof. A correct root must verify and propagate the real storage root; a wrong
+    // root must be rejected.
+    [TestCase(true, AddRangeResult.OK)]
+    [TestCase(false, AddRangeResult.DifferentRootHash)]
+    public void TestRefreshAccount(bool useCorrectRoot, AddRangeResult expectedResult)
+    {
+        using ISnapServerContext context = CreateContext();
+        FillWithTestAccounts(context);
+        Hash256 storageRoot = FillAccountWithDefaultStorage(context);
+
+        ValueHash256 path = TestItem.Tree.AccountsWithPaths[0].Path;
+        (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
+            context.Server.GetAccountRanges(context.RootHash, path, path.IncrementPath(), 4000, CancellationToken.None);
+        using AccountsAndProofs response = new() { PathAndAccounts = accounts, Proofs = proofs };
+
+        PathWithAccount stale = new(path, Build.An.Account.WithBalance(2).TestObject);
+        using AccountsToRefreshRequest request = new()
+        {
+            RootHash = useCorrectRoot ? context.RootHash : TestItem.KeccakA,
+            Paths = new ArrayPoolList<AccountWithStorageStartingHash>(1)
+            {
+                new() { PathAndAccount = stale, StorageStartingHash = ValueKeccak.Zero, StorageHashLimit = Keccak.MaxValue }
+            }
+        };
+
+        AddRangeResult result = context.SnapProvider.RefreshAccounts(request, response);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(expectedResult));
+            // On success the stale empty storage root must be replaced by the verified one.
+            Assert.That(stale.Account.StorageRoot, Is.EqualTo(useCorrectRoot ? storageRoot : Keccak.EmptyTreeHash));
+        }
+    }
+
+    // The range proof can omit the leaf node. Verification must still succeed by setting the account from the
+    // returned accounts (not by hashing a proof node), then checking the reconstructed root.
+    [Test]
+    public void TestRefreshAccount_LeafMissingFromProof()
+    {
+        using ISnapServerContext context = CreateContext();
+        FillWithTestAccounts(context);
+        Hash256 storageRoot = FillAccountWithDefaultStorage(context);
+
+        ValueHash256 path = TestItem.Tree.AccountsWithPaths[0].Path;
+        (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
+            context.Server.GetAccountRanges(context.RootHash, path, path.IncrementPath(), 4000, CancellationToken.None);
+
+        // Drop the leaf nodes from the proof; the leaves are still present in the returned accounts.
+        ArrayPoolList<byte[]> trimmedProofs = new(proofs.Count);
+        for (int i = 0; i < proofs.Count; i++)
+        {
+            byte[] proof = proofs[i].ToArray();
+            TrieNode node = new(NodeType.Unknown, proof);
+            node.ResolveNode(null!, TreePath.Empty);
+            if (!node.IsLeaf) trimmedProofs.Add(proof);
+        }
+        Assert.That(trimmedProofs.Count, Is.LessThan(proofs.Count), "test setup: expected at least one leaf in the proof");
+        proofs.Dispose();
+
+        using AccountsAndProofs response = new() { PathAndAccounts = accounts, Proofs = new ByteArrayListAdapter(trimmedProofs) };
+        PathWithAccount stale = new(path, Build.An.Account.WithBalance(2).TestObject);
+        using AccountsToRefreshRequest request = new()
+        {
+            RootHash = context.RootHash,
+            Paths = new ArrayPoolList<AccountWithStorageStartingHash>(1)
+            {
+                new() { PathAndAccount = stale, StorageStartingHash = ValueKeccak.Zero, StorageHashLimit = Keccak.MaxValue }
+            }
+        };
+
+        AddRangeResult result = context.SnapProvider.RefreshAccounts(request, response);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(AddRangeResult.OK));
+            Assert.That(stale.Account.StorageRoot, Is.EqualTo(storageRoot));
+        }
+    }
+
     [Test]
     public void TestGetTrieNode_Root()
     {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapProvider.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Synchronization.SnapSync
 
         void AddCodes(IReadOnlyList<ValueHash256> requestedHashes, IByteArrayList codes);
 
-        void RefreshAccounts(AccountsToRefreshRequest request, IByteArrayList response);
+        AddRangeResult RefreshAccounts(AccountsToRefreshRequest request, AccountsAndProofs response);
 
         void RetryRequest(SnapSyncBatch batch);
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -269,19 +269,17 @@ namespace Nethermind.Synchronization.SnapSync
             return new SnapSyncBatch { AccountRangeRequest = range };
         }
 
-        private SnapSyncBatch DequeAccountToRefresh(Hash256 rootHash)
+        private SnapSyncBatch? DequeAccountToRefresh(Hash256 rootHash)
         {
+            // One account per request: each refresh is served by a single GetAccountRange.
+            if (!AccountsToRefresh.TryDequeue(out AccountWithStorageStartingHash acc))
+                return null;
+
             Interlocked.Increment(ref _activeAccRefreshRequests);
 
             LogRequest($"AccountsToRefresh: {AccountsToRefresh.Count}");
 
-            int queueLength = AccountsToRefresh.Count;
-            ArrayPoolList<AccountWithStorageStartingHash> paths = new(queueLength);
-
-            for (int i = 0; i < queueLength && AccountsToRefresh.TryDequeue(out AccountWithStorageStartingHash acc); i++)
-            {
-                paths.Add(acc);
-            }
+            ArrayPoolList<AccountWithStorageStartingHash> paths = new(1) { acc };
 
             return new SnapSyncBatch { AccountsToRefreshRequest = new AccountsToRefreshRequest { RootHash = rootHash, Paths = paths } };
         }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -15,7 +15,6 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Logging;
-using Nethermind.Serialization.Rlp;
 using Nethermind.State.Snap;
 using Nethermind.Trie;
 
@@ -308,8 +307,10 @@ namespace Nethermind.Synchronization.SnapSync
         {
             account = null;
             IReadOnlyList<PathWithAccount> accounts = response.PathAndAccounts;
+            // An empty response carries no range to verify, so the account's absence cannot be proven here -
+            // retry rather than concluding (unproven) that it was deleted.
             if (accounts.Count == 0)
-                return response.Proofs.Count == 0 ? RefreshVerifyResult.Expired : RefreshVerifyResult.NotFound;
+                return RefreshVerifyResult.Expired;
 
             AddRangeResult result;
             try
@@ -319,15 +320,18 @@ namespace Nethermind.Synchronization.SnapSync
                 ISnapTrieFactory factory = new PatriciaSnapTrieFactory(new NodeStorage(new MemDb()), logManager);
                 result = SnapProviderHelper.VerifyAccountRange(factory, stateRoot, path, path.IncrementPath(), accounts, response.Proofs);
             }
-            catch (Exception e) when (e is TrieException or TrieNodeException or RlpException)
+            catch (Exception)
             {
+                // The proof is untrusted P2P data: any failure assembling or decoding it (trie, RLP, bounds, etc.)
+                // means the proof is invalid, never a crash of the sync task.
                 return RefreshVerifyResult.InvalidProof;
             }
 
             if (result != AddRangeResult.OK)
                 return RefreshVerifyResult.InvalidProof;
 
-            // Filter to the requested account; the response also carries at least one account past the limit.
+            // The verified range proves which accounts exist around [path, path + 1]; filter to the requested one.
+            // Its absence here is therefore a proven non-existence (deleted account), not an unverified guess.
             for (int i = 0; i < accounts.Count; i++)
             {
                 if (accounts[i].Path == path)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -15,7 +15,9 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
 using Nethermind.State.Snap;
+using Nethermind.Trie;
 
 namespace Nethermind.Synchronization.SnapSync
 {
@@ -243,50 +245,98 @@ namespace Nethermind.Synchronization.SnapSync
             }
         }
 
-        public void RefreshAccounts(AccountsToRefreshRequest request, IByteArrayList response)
+        public AddRangeResult RefreshAccounts(AccountsToRefreshRequest request, AccountsAndProofs response)
         {
-            int respLength = response.Count;
-            ReadOnlySpan<AccountWithStorageStartingHash> paths = request.Paths.AsSpan();
-            for (int reqIndex = 0; reqIndex < paths.Length; reqIndex++)
+            AccountWithStorageStartingHash requestedPath = request.Paths[0];
+            ValueHash256 path = requestedPath.PathAndAccount.Path;
+
+            AddRangeResult result;
+            switch (VerifyRefreshedAccount(response, request.RootHash, path, out Account? account))
             {
-                AccountWithStorageStartingHash requestedPath = paths[reqIndex];
-
-                if (reqIndex < respLength)
-                {
-                    ReadOnlySpan<byte> nodeData = response[reqIndex];
-
-                    if (nodeData.Length == 0)
-                    {
-                        RetryAccountRefresh(requestedPath);
-                        _logger.Trace($"SNAP - Empty Account Refresh: {requestedPath.PathAndAccount.Path}");
-                        continue;
-                    }
-
-                    requestedPath.PathAndAccount.Account = requestedPath.PathAndAccount.Account.WithChangedStorageRoot(Keccak.Compute(nodeData));
+                case RefreshVerifyResult.Verified:
+                    result = AddRangeResult.OK;
+                    requestedPath.PathAndAccount.Account = requestedPath.PathAndAccount.Account.WithChangedStorageRoot(account!.StorageRoot);
 
                     if (requestedPath.StorageStartingHash > ValueKeccak.Zero)
                     {
-                        StorageRange range = new()
+                        _progressTracker.EnqueueNextSlot(new StorageRange
                         {
                             Accounts = new ArrayPoolList<PathWithAccount>(1) { requestedPath.PathAndAccount },
                             StartingHash = requestedPath.StorageStartingHash,
                             LimitHash = requestedPath.StorageHashLimit
-                        };
-
-                        _progressTracker.EnqueueNextSlot(range);
+                        });
                     }
                     else
                     {
                         _progressTracker.EnqueueAccountStorage(requestedPath.PathAndAccount);
                     }
-                }
-                else
-                {
+                    break;
+
+                case RefreshVerifyResult.NotFound:
+                    // The account no longer exists at the pivot, so there is no storage to retrieve. It remains
+                    // tracked for healing. Terminal success - must not retry or the refresh would loop forever.
+                    result = AddRangeResult.OK;
+                    break;
+
+                case RefreshVerifyResult.Expired:
+                    // The peer does not have the state for this root (stale pivot).
+                    result = AddRangeResult.ExpiredRootHash;
                     RetryAccountRefresh(requestedPath);
-                }
+                    break;
+
+                default: // InvalidProof - the proof does not reconstruct the state root.
+                    result = AddRangeResult.DifferentRootHash;
+                    RetryAccountRefresh(requestedPath);
+                    break;
             }
 
+            Metrics.SnapRangeResult.Increment(new SnapRangeResult(isStorage: false, result: result));
+            // Must be the last statement, after any enqueue, so IsSnapGetRangesFinished cannot observe
+            // an empty queue with a zeroed active count while work is still being scheduled.
             _progressTracker.ReportAccountRefreshFinished();
+            return result;
+        }
+
+        private enum RefreshVerifyResult { Verified, NotFound, Expired, InvalidProof }
+
+        /// <summary>
+        /// Reconstructs the returned account range and verifies it against <paramref name="stateRoot"/> in an
+        /// isolated, empty-backed trie - the account leaf is set from the response, not assumed to be in the proof -
+        /// then extracts the verified account at <paramref name="path"/>. Nothing is written to the client state DB.
+        /// </summary>
+        private RefreshVerifyResult VerifyRefreshedAccount(AccountsAndProofs response, Hash256 stateRoot, in ValueHash256 path, out Account? account)
+        {
+            account = null;
+            IReadOnlyList<PathWithAccount> accounts = response.PathAndAccounts;
+            if (accounts.Count == 0)
+                return response.Proofs.Count == 0 ? RefreshVerifyResult.Expired : RefreshVerifyResult.NotFound;
+
+            AddRangeResult result;
+            try
+            {
+                // Empty-backed isolated factory: a proof node that cannot be resolved from the proof itself fails
+                // verification instead of being completed from (or racing) the live client state DB.
+                ISnapTrieFactory factory = new PatriciaSnapTrieFactory(new NodeStorage(new MemDb()), logManager);
+                result = SnapProviderHelper.VerifyAccountRange(factory, stateRoot, path, path.IncrementPath(), accounts, response.Proofs);
+            }
+            catch (Exception e) when (e is TrieException or TrieNodeException or RlpException)
+            {
+                return RefreshVerifyResult.InvalidProof;
+            }
+
+            if (result != AddRangeResult.OK)
+                return RefreshVerifyResult.InvalidProof;
+
+            // Filter to the requested account; the response also carries at least one account past the limit.
+            for (int i = 0; i < accounts.Count; i++)
+            {
+                if (accounts[i].Path == path)
+                {
+                    account = accounts[i].Account;
+                    return RefreshVerifyResult.Verified;
+                }
+            }
+            return RefreshVerifyResult.NotFound;
         }
 
         private void RetryAccountRefresh(AccountWithStorageStartingHash requestedPath) => _progressTracker.EnqueueAccountRefresh(requestedPath.PathAndAccount, requestedPath.StorageStartingHash, requestedPath.StorageHashLimit);

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -70,6 +70,25 @@ namespace Nethermind.Synchronization.SnapSync
             return (AddRangeResult.OK, moreChildrenToRight, tree.RootHash, isRootPersisted);
         }
 
+        /// <summary>
+        /// Verifies that <paramref name="accounts"/> and <paramref name="proofs"/> reconstruct
+        /// <paramref name="expectedRootHash"/> for the range starting at <paramref name="startingHash"/>, without
+        /// committing anything. Intended for single-account refresh against an isolated, empty-backed factory:
+        /// the boundary nodes and the returned accounts are assembled in memory only to recompute the root, so an
+        /// incomplete proof fails verification rather than being completed from (or racing) the live state DB.
+        /// </summary>
+        public static AddRangeResult VerifyAccountRange(
+            ISnapTrieFactory factory,
+            in ValueHash256 expectedRootHash,
+            in ValueHash256 startingHash,
+            in ValueHash256 limitHash,
+            IReadOnlyList<PathWithAccount> accounts,
+            IByteArrayList? proofs)
+        {
+            using ISnapTree<PathWithAccount> tree = factory.CreateStateTree();
+            return BuildAndVerifyRoot(tree, accounts, startingHash, limitHash, expectedRootHash, proofs).result;
+        }
+
         private static (AddRangeResult result, bool moreChildrenToRight, bool isRootPersisted) CommitRange<TEntry>(
             ISnapTree<TEntry> tree,
             IReadOnlyList<TEntry> entries,
@@ -78,23 +97,8 @@ namespace Nethermind.Synchronization.SnapSync
             in ValueHash256 expectedRootHash,
             IByteArrayList? proofs) where TEntry : ISnapEntry
         {
-            if (entries.Count == 0)
-                return (AddRangeResult.EmptyRange, true, false);
-
-            // Validate sorting order
-            for (int i = 1; i < entries.Count; i++)
-            {
-                if (entries[i - 1].Path.CompareTo(entries[i].Path) >= 0)
-                    return (AddRangeResult.InvalidOrder, true, false);
-            }
-
-            if (entries[0].Path < startingHash)
-                return (AddRangeResult.InvalidOrder, true, false);
-
-            ValueHash256 lastPath = entries[entries.Count - 1].Path;
-
-            (AddRangeResult result, List<(TrieNode, TreePath)> sortedBoundaryList, bool moreChildrenToRight) =
-                FillBoundaryTree(tree, startingHash, lastPath, limitHash, expectedRootHash, proofs);
+            (AddRangeResult result, List<(TrieNode, TreePath)>? sortedBoundaryList, bool moreChildrenToRight) =
+                BuildAndVerifyRoot(tree, entries, startingHash, limitHash, expectedRootHash, proofs);
 
             if (result != AddRangeResult.OK)
                 return (result, true, false);
@@ -102,6 +106,7 @@ namespace Nethermind.Synchronization.SnapSync
             // The upper bound is used to prevent proof nodes that covers next range from being persisted, except if
             // this is the last range. This prevent double node writes per path which break flat. It also prevent leaf o
             // that is after the range from being persisted, which prevent double write again.
+            ValueHash256 lastPath = entries[entries.Count - 1].Path;
             ValueHash256 upperBound = lastPath;
             if (upperBound > limitHash)
             {
@@ -112,17 +117,53 @@ namespace Nethermind.Synchronization.SnapSync
                 if (!moreChildrenToRight) upperBound = ValueKeccak.MaxValue;
             }
 
-            tree.BulkSetAndUpdateRootHash(entries);
-
-            if (tree.RootHash.ValueHash256 != expectedRootHash)
-                return (AddRangeResult.DifferentRootHash, true, false);
-
             StitchBoundaries(sortedBoundaryList, tree, startingHash);
 
             tree.Commit(upperBound);
 
             bool isRootPersisted = sortedBoundaryList is not { Count: > 0 } || sortedBoundaryList[0].Item1.IsPersisted;
             return (AddRangeResult.OK, moreChildrenToRight, isRootPersisted);
+        }
+
+        /// <summary>
+        /// Fills the boundary proof nodes and bulk-sets the range entries into <paramref name="tree"/> in memory,
+        /// then checks that the recomputed root equals <paramref name="expectedRootHash"/>. Nothing is committed.
+        /// </summary>
+        private static (AddRangeResult result, List<(TrieNode, TreePath)>? sortedBoundaryList, bool moreChildrenToRight) BuildAndVerifyRoot<TEntry>(
+            ISnapTree<TEntry> tree,
+            IReadOnlyList<TEntry> entries,
+            in ValueHash256 startingHash,
+            in ValueHash256 limitHash,
+            in ValueHash256 expectedRootHash,
+            IByteArrayList? proofs) where TEntry : ISnapEntry
+        {
+            if (entries.Count == 0)
+                return (AddRangeResult.EmptyRange, null, false);
+
+            // Validate sorting order
+            for (int i = 1; i < entries.Count; i++)
+            {
+                if (entries[i - 1].Path.CompareTo(entries[i].Path) >= 0)
+                    return (AddRangeResult.InvalidOrder, null, false);
+            }
+
+            if (entries[0].Path < startingHash)
+                return (AddRangeResult.InvalidOrder, null, false);
+
+            ValueHash256 lastPath = entries[entries.Count - 1].Path;
+
+            (AddRangeResult result, List<(TrieNode, TreePath)> sortedBoundaryList, bool moreChildrenToRight) =
+                FillBoundaryTree(tree, startingHash, lastPath, limitHash, expectedRootHash, proofs);
+
+            if (result != AddRangeResult.OK)
+                return (result, null, false);
+
+            tree.BulkSetAndUpdateRootHash(entries);
+
+            if (tree.RootHash.ValueHash256 != expectedRootHash)
+                return (AddRangeResult.DifferentRootHash, null, false);
+
+            return (AddRangeResult.OK, sortedBoundaryList, moreChildrenToRight);
         }
 
         [SkipLocalsInit]

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncBatch.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncBatch.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Synchronization.SnapSync
         public IByteArrayList? CodesResponse { get; set; }
 
         public AccountsToRefreshRequest? AccountsToRefreshRequest { get; set; }
-        public IByteArrayList? AccountsToRefreshResponse { get; set; }
+        public AccountsAndProofs? AccountsToRefreshResponse { get; set; }
 
         public override string ToString()
         {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDownloader.cs
@@ -41,9 +41,9 @@ namespace Nethermind.Synchronization.SnapSync
                     }
                     else if (batch.AccountsToRefreshRequest is { Paths.Count: > 0 })
                     {
-                        // Refresh a single account via GetAccountRange so its storage root is verified
-                        // against the state root. Limit = path + 1 (the protocol returns at least one
-                        // account past the limit, so start == limit must be avoided).
+                        // Refresh a single account via GetAccountRange so its storage root is verified against
+                        // the state root. Use limit = path + 1 to avoid start == limit, which some peers treat as
+                        // an empty range. (IncrementPath is a no-op only for the unreachable MaxValue path.)
                         AccountWithStorageStartingHash account = batch.AccountsToRefreshRequest.Paths[0];
                         ValueHash256 path = account.PathAndAccount.Path;
                         AccountRange range = new(batch.AccountsToRefreshRequest.RootHash, path, path.IncrementPath());

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDownloader.cs
@@ -5,8 +5,11 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Network.Contract.P2P;
+using Nethermind.State.Snap;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 
@@ -36,9 +39,15 @@ namespace Nethermind.Synchronization.SnapSync
                     {
                         batch.CodesResponse = await handler.GetByteCodes(batch.CodesRequest, cancellationToken);
                     }
-                    else if (batch.AccountsToRefreshRequest is not null)
+                    else if (batch.AccountsToRefreshRequest is { Paths.Count: > 0 })
                     {
-                        batch.AccountsToRefreshResponse = await handler.GetTrieNodes(batch.AccountsToRefreshRequest, cancellationToken);
+                        // Refresh a single account via GetAccountRange so its storage root is verified
+                        // against the state root. Limit = path + 1 (the protocol returns at least one
+                        // account past the limit, so start == limit must be avoided).
+                        AccountWithStorageStartingHash account = batch.AccountsToRefreshRequest.Paths[0];
+                        ValueHash256 path = account.PathAndAccount.Path;
+                        AccountRange range = new(batch.AccountsToRefreshRequest.RootHash, path, path.IncrementPath());
+                        batch.AccountsToRefreshResponse = await handler.GetAccountRange(range, cancellationToken);
                     }
                 }
                 catch (OperationCanceledException)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -84,7 +84,7 @@ namespace Nethermind.Synchronization.SnapSync
                 }
                 else if (batch.AccountsToRefreshResponse is not null)
                 {
-                    _snapProvider.RefreshAccounts(batch.AccountsToRefreshRequest, batch.AccountsToRefreshResponse);
+                    result = _snapProvider.RefreshAccounts(batch.AccountsToRefreshRequest, batch.AccountsToRefreshResponse);
                 }
                 else
                 {


### PR DESCRIPTION
## Changes

When a storage root mismatches during snap sync, the account was refreshed by fetching its storage-trie root node via `GetTrieNodes` and trusting the returned node's hash blindly. That refresh path is being removed in snaps/2 and never verified the new storage root against the pivot state root.

- Refresh now sends a single-account `GetAccountRange` (`startingHash = path`, `limitHash = path + 1`) and adopts the storage root only after **verifying the account against the pivot state root**.
- Verification **reconstructs the account range the same way account-range sync does** — fill the boundary proof nodes, **set the returned account(s)**, then check the recomputed root. Crucially the account leaf is set from the response, so verification does not rely on the proof containing the leaf (the range proof can omit it).
- The reconstruction runs in an **isolated, empty-backed trie** (a fresh `MemDb`-backed `PatriciaSnapTrieFactory`) and **does not commit**, so it writes nothing to the client state DB and cannot race the partition account-range sync. An incomplete proof fails verification instead of being completed from live client data.
- The shared verification core is factored into `SnapProviderHelper.BuildAndVerifyRoot`, used by both the existing `CommitRange` and the new no-commit `VerifyAccountRange`, so refresh verification is identical to account-range verification.
- Outcomes (`SnapProvider.RefreshAccounts` now returns `AddRangeResult`, so refresh responses feed `AnalyzeResponsePerPeer`): **verified** → adopt the storage root and re-queue storage; **not found** (deleted account) → terminal, no retry; **expired** (peer lacks the root) → retry; **invalid proof** → retry and score the peer.
- `ProgressTracker.DequeAccountToRefresh` dequeues one account per request (one refresh per `GetAccountRange`). Refreshes are rare, so this is fine.
- The now-unused refresh-specific `GetTrieNodes(AccountsToRefreshRequest)` overload is intentionally left in place for the snaps/2 cleanup; the generic `GetTrieNodes(GetTrieNodesRequest)` used by state healing is untouched.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added parameterized regression tests in `SnapServerTest`: `TestRefreshAccount` (correct root verifies and propagates the real storage root; wrong root is rejected with `DifferentRootHash`) and `TestRefreshAccount_LeafMissingFromProof` (proof with leaf nodes stripped still verifies, since the account is set from the response — this fails under a proof-walk that assumes the leaf is present). Full `Nethermind.Synchronization.Test` SnapSync + state-sync-feed suites pass (940 passed, 8 fixture-conditional skips), including the end-to-end `SnapSync_*` integration tests and the account/storage range tests that exercise the refactored `CommitRange`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No