### PR TITLE
fix: build failure due to missing 'using Nethermind.Core'

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Bogota.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Bogota.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Producers;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.JsonRpc;

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Bogota.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Bogota.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Nethermind.Consensus;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;


### PR DESCRIPTION
Prevents building nethermind in hive

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [x] No