### PR TITLE
XDC Fix signing old blocks

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcBlockHeaderBuilder.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcBlockHeaderBuilder.cs
@@ -111,6 +111,12 @@ public class XdcBlockHeaderBuilder : BlockHeaderBuilder
         return this;
     }
 
+    public new XdcBlockHeaderBuilder WithTimestamp(ulong timestamp)
+    {
+        TestObjectInternal.Timestamp = timestamp;
+        return this;
+    }
+
     public XdcBlockHeaderBuilder WithValidator(Signature signature)
     {
         XdcTestObjectInternal.Validator = signature.Bytes.ToArray();

--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
@@ -171,7 +171,7 @@ public class XdcTestBlockchain : TestBlockchain
             .AddSingleton((_) => BlockProducer)
             //.AddSingleton((_) => BlockProducerRunner)
             .AddSingleton<IRewardCalculator, ZeroRewardCalculator>()
-            .AddSingleton<ITimestamper>((_) => Timestamper)
+            .AddSingleton<ITimestamper>((ctx) => ctx.Resolve<ManualTimestamper>())
             .AddSingleton<IBlockProducerRunner, XdcHotStuff>()
 
             .AddSingleton<ITxPool>((ctx) =>

--- a/src/Nethermind/Nethermind.Xdc.Test/SignTransactionManagerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/SignTransactionManagerTests.cs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain;
+using Nethermind.Consensus;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.TxPool;
+using Nethermind.Xdc.Spec;
+using Nethermind.Xdc.Types;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test;
+
+[Parallelizable(ParallelScope.All)]
+internal class SignTransactionManagerTests
+{
+    // window = MergeSignRange(15) * MinePeriod(2) * MaxSignableBlockPeriods(2) = 60s.
+    [TestCase(0L, true)]
+    [TestCase(60L, true)]
+    [TestCase(61L, false)]
+    [TestCase(86_400L, false)]
+    public void OnBlockAddedToMain_SignsOnlyRecentHeadBlocks(long secondsBehind, bool shouldSign)
+    {
+        IXdcReleaseSpec spec = Substitute.For<IXdcReleaseSpec>();
+        spec.MergeSignRange.Returns(15);
+        spec.MinePeriod.Returns(2);
+
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
+
+        ManualTimestamper timestamper = new();
+
+        XdcBlockHeader header = Build.A.XdcBlockHeader()
+            .WithNumber(spec.MergeSignRange)
+            .WithTimestamp((ulong)(timestamper.UnixTime.SecondsLong - secondsBehind))
+            .WithExtraConsensusData(new ExtraFieldsV2(1, new QuorumCertificate(new BlockRoundInfo(Hash256.Zero, 0, 0), null, 0)))
+            .TestObject;
+        Block block = new(header);
+
+        ISigner signer = Substitute.For<ISigner>();
+        signer.Address.Returns(TestItem.AddressA);
+        signer.TrySign(Arg.Any<Transaction>()).Returns(true);
+
+        ITxPool txPool = Substitute.For<ITxPool>();
+        txPool.SubmitTx(Arg.Any<Transaction>(), Arg.Any<TxHandlingOptions>()).Returns(AcceptTxResult.Accepted);
+
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.WasProcessed(block.Number, block.Hash!).Returns(true);
+        blockTree.FindBestSuggestedHeader().Returns(header); // bestSuggested == head => not syncing
+        blockTree.Head.Returns(block);
+
+        ISnapshotManager snapshotManager = Substitute.For<ISnapshotManager>();
+        snapshotManager.GetSnapshotByBlockNumber(Arg.Any<long>(), Arg.Any<IXdcReleaseSpec>())
+            .Returns(new Snapshot(block.Number, TestItem.KeccakA, [TestItem.AddressA]));
+
+        SignTransactionManager manager = new(
+            new Lazy<ISigner>(() => signer),
+            new Lazy<ITxPool>(() => txPool),
+            blockTree, snapshotManager, specProvider, timestamper, LimboLogs.Instance);
+        manager.Start();
+
+        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block));
+
+        txPool.Received(shouldSign ? 1 : 0).SubmitTx(Arg.Any<Transaction>(), Arg.Any<TxHandlingOptions>());
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc/SignTransactionManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/SignTransactionManager.cs
@@ -26,6 +26,7 @@ internal class SignTransactionManager(
     IBlockTree blockTree,
     ISnapshotManager snapshotManager,
     ISpecProvider specProvider,
+    ITimestamper timestamper,
     ILogManager logManager) : ISignTransactionManager, IStartable, IDisposable
 {
     // Lazy: ISigner and ITxPool are registered during InitializeBlockchain, after this class is instantiated.
@@ -34,6 +35,7 @@ internal class SignTransactionManager(
     private readonly IBlockTree _blockTree = blockTree;
     private readonly ISnapshotManager _snapshotManager = snapshotManager;
     private readonly ISpecProvider _specProvider = specProvider;
+    private readonly ITimestamper _timestamper = timestamper;
     private readonly ILogger _logger = logManager.GetClassLogger<SignTransactionManager>();
     private readonly AssociativeKeyCache<ValueHash256> _alreadySigned = new(128);
 
@@ -74,6 +76,11 @@ internal class SignTransactionManager(
         ulong round = xdcHeader.ExtraConsensusData!.BlockRound;
         IXdcReleaseSpec spec = _specProvider.GetXdcSpec(xdcHeader, round);
         if (spec is null)
+            return;
+
+        // Sign only live head blocks; stale ones are replayed during catch-up sync.
+        long window = spec.MergeSignRange * spec.MinePeriod * XdcConstants.MaxSignableBlockPeriods;
+        if (window > 0 && (long)xdcHeader.Timestamp + window < _timestamper.UnixTime.SecondsLong)
             return;
 
         if (xdcHeader.Number % spec.MergeSignRange != 0)

--- a/src/Nethermind/Nethermind.Xdc/SignTransactionManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/SignTransactionManager.cs
@@ -78,9 +78,9 @@ internal class SignTransactionManager(
         if (spec is null)
             return;
 
-        // Sign only live head blocks; stale ones are replayed during catch-up sync.
+        // Sign only recent head blocks; older ones are replayed during catch-up.
         long window = spec.MergeSignRange * spec.MinePeriod * XdcConstants.MaxSignableBlockPeriods;
-        if (window > 0 && (long)xdcHeader.Timestamp + window < _timestamper.UnixTime.SecondsLong)
+        if ((long)xdcHeader.Timestamp + window < _timestamper.UnixTime.SecondsLong)
             return;
 
         if (xdcHeader.Number % spec.MergeSignRange != 0)

--- a/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
@@ -60,4 +60,7 @@ internal static class XdcConstants
 
     // 4-byte selector + 32-byte block number + 32-byte block hash
     public const int SignTransactionDataLength = 68;
+
+    // Skip stale blocks during sync.
+    public const int MaxSignableBlockPeriods = 2;
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
@@ -61,6 +61,6 @@ internal static class XdcConstants
     // 4-byte selector + 32-byte block number + 32-byte block hash
     public const int SignTransactionDataLength = 68;
 
-    // Skip stale blocks during sync.
+    // Only sign recent head blocks.
     public const int MaxSignableBlockPeriods = 2;
 }


### PR DESCRIPTION
 ## Changes

  XDC masternodes send a "sign" tx every `MergeSignRange` (15) blocks. This is triggered by `SignTransactionManager.OnBlockAddedToMain`, which runs for every block added to the chain — including old blocks processed while the node is
  catching up. So a node that was offline for a while would send sign txs for lots of old blocks when it syncs back.

  XDC Go client doesn't have this problem: only the head path signs, and catch-up runs through the downloader, which never signs. We could check "are we behind the peers' head?" using the sync layer, but pulling
  that into the XDC sign logic isn't worth it.
  
  So we check the block's age instead: only sign if the block's timestamp is within `MergeSignRange * MinePeriod * 2` seconds of now, about the last 2 signing rounds (~30 blocks / ~1 minute on XDC).
  
  ## Types of changes
  
  - [x] Bugfix (a non-breaking change that fixes an issue)
 
  ## Testing

  #### Requires testing

  - [x] Yes

  #### If yes, did you write tests?

  - [x] Yes
