### PR TITLE
chore: Update required SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.300",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   },


### PR DESCRIPTION
## Changes

Bumps required .NET SDK to 10.0.300:
- It's already used in Docker builds.
- [Microsoft.CodeAnalysis.CSharp update](https://github.com/NethermindEth/nethermind/pull/11149) made 10.0.200+ a requirement.
  Without bump, building on a machine without newer SDK versions produces ambigious error:
  ```
  CSC : error CS9057: Analyzer assembly '/workspaces/Source/Nethermind/nethermind/src/Nethermind/artifacts/bin/Nethermind.Analyzers/release/Nethermind.Analyzers.dll' cannot be used because it references version '5.3.0.0' of the compiler, which is newer than the currently running version '5.0.0.0'. [/workspaces/Source/Nethermind/nethermind/src/Nethermind/Nethermind.Logging/Nethermind.Logging.csproj]
    ```
    while after:
    ```
    A compatible .NET SDK was not found.

  Requested SDK version: 10.0.300
  global.json file: /workspaces/Source/Nethermind/nethermind/global.json
  
  Installed SDKs:
  10.0.100 [/usr/share/dotnet/sdk]

  Install the [10.0.300] .NET SDK or update [/workspaces/Source/Nethermind/nethermind/global.json] to match an installed SDK.
  ```
    

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: improve build error message

