### PR TITLE
refactor(GasEstimator): Separate OptimisticMultiplier from stop margin

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -36,6 +36,9 @@ public class GasEstimator(
     private const int MaxErrorMargin = 10000;
     private const double BasisPointsDivisor = 10000d;
 
+    // EIP-150: each CALL site reserves 1/64 for the caller, so the optimistic guess must use 64/63, not the search-stop margin.
+    private const double OptimisticMultiplier = 64d / 63d;
+
     private const string InvalidErrorMarginNegative = "Invalid error margin, cannot be negative.";
     private static readonly string InvalidErrorMarginTooHigh = $"Invalid error margin, must be lower than {MaxErrorMargin}.";
     private const string GasEstimationOutOfGas = "Gas estimation failed due to out of gas";
@@ -147,7 +150,7 @@ public class GasEstimator(
 
         double marginMultiplier = errorMargin == 0 ? 1d : errorMargin / BasisPointsDivisor + 1d;
         long cap = bounds.RightBound;
-        (long leftBound, long rightBound) = TryOptimisticEstimate(tx, header, gasTracer, bounds, marginMultiplier, token);
+        (long leftBound, long rightBound) = TryOptimisticEstimate(tx, header, gasTracer, bounds, OptimisticMultiplier, token);
 
         // Narrow bounds until within the error margin (Geth approach).
         while (ShouldContinueSearch(leftBound, rightBound, marginMultiplier - 1d))
@@ -215,7 +218,7 @@ public class GasEstimator(
         (rightBound - leftBound) / (double)leftBound > threshold && leftBound + 1 < rightBound;
 
     private static bool IsSimpleTransfer(Transaction tx) =>
-        tx.To is not null && tx.Data.IsEmpty;
+        tx.To is not null && tx.Data.IsEmpty && !tx.HasAuthorizationList;
 
     private static string GetError(EstimateGasTracer gasTracer, string defaultError = TransactionExecutionFails) =>
         gasTracer switch

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -170,13 +170,13 @@ public class GasEstimator(
 
     private (long Left, long Right) TryOptimisticEstimate(
         Transaction tx, BlockHeader header, EstimateGasTracer gasTracer,
-        EstimationBounds bounds, double marginMultiplier, CancellationToken token)
+        EstimationBounds bounds, double optimisticMultiplier, CancellationToken token)
     {
         long leftBound = bounds.LeftBound;
         long rightBound = bounds.RightBound;
 
         // Optimistic first guess (Geth approach): reduces binary search iterations in most cases.
-        long optimistic = (long)((gasTracer.GasSpent + gasTracer.TotalRefund + GasCostOf.CallStipend) * marginMultiplier);
+        long optimistic = (long)((gasTracer.GasSpent + gasTracer.TotalRefund + GasCostOf.CallStipend) * optimisticMultiplier);
         if (optimistic > leftBound && optimistic < rightBound)
         {
             if (TryExecute(tx, header, optimistic, gasTracer, token, out _))

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -1253,6 +1253,77 @@ namespace Nethermind.Evm.Test.Tracing
             Assert.That(err, Is.Null, "No error for caught DELEGATECALL revert");
         }
 
+        [Test]
+        public void Estimate_subcall_contract_uses_optimistic_multiplier_not_margin_multiplier()
+        {
+            using TestEnvironment testEnvironment = new();
+
+            Address innerAddress = TestItem.AddressB;
+            byte[] innerCode = Prepare.EvmCode
+                .PushData(0x01)
+                .PushData(0x00)
+                .Op(Instruction.SSTORE)
+                .Op(Instruction.STOP)
+                .Done;
+            testEnvironment.InsertContract(innerAddress, innerCode);
+
+            Address outerAddress = TestItem.AddressC;
+            byte[] outerCode = Prepare.EvmCode
+                .Call(innerAddress, 100_000)
+                .Op(Instruction.POP)
+                .PushData(0x02)
+                .PushData(0x01)
+                .Op(Instruction.SSTORE)
+                .Op(Instruction.STOP)
+                .Done;
+            testEnvironment.InsertContract(outerAddress, outerCode);
+
+            long gasLimit = 300_000;
+            Transaction tx = Build.A.Transaction
+                .WithGasLimit(gasLimit)
+                .WithTo(outerAddress)
+                .WithSenderAddress(TestItem.AddressA)
+                .TestObject;
+            Block block = Build.A.Block
+                .WithNumber(MainnetSpecProvider.ByzantiumBlockNumber + 1)
+                .WithTransactions(tx)
+                .WithGasLimit(gasLimit)
+                .TestObject;
+
+            long result = testEnvironment.estimator.Estimate(tx, block.Header, testEnvironment.tracer, out string? err);
+
+            Assert.That(err, Is.Null);
+            Assert.That(result, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void IsSimpleTransfer_returns_false_for_SetCodeTx_with_authorization_list()
+        {
+            using TestEnvironment testEnvironment = new();
+
+            Address target = TestItem.AddressB;
+
+            long gasLimit = 100_000;
+            Transaction tx = Build.A.Transaction
+                .WithType(TxType.SetCode)
+                .WithGasLimit(gasLimit)
+                .WithTo(target)
+                .WithSenderAddress(TestItem.AddressA)
+                .WithAuthorizationCode(new AuthorizationTuple(1, Address.Zero, 0, new Signature(new byte[64], 0)))
+                .TestObject;
+
+            Block block = Build.A.Block
+                .WithNumber(MainnetSpecProvider.PragueActivation.BlockNumber)
+                .WithTimestamp(MainnetSpecProvider.PragueActivation.Timestamp!.Value)
+                .WithTransactions(tx)
+                .WithGasLimit(gasLimit)
+                .TestObject;
+
+            long result = testEnvironment.estimator.Estimate(tx, block.Header, testEnvironment.tracer, out string? err);
+
+            Assert.That(result, Is.GreaterThan(Transaction.BaseTxGasCost));
+        }
+
         private class TestEnvironment : IDisposable
         {
             public ISpecProvider _specProvider;

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -1290,10 +1290,10 @@ namespace Nethermind.Evm.Test.Tracing
                 .WithGasLimit(gasLimit)
                 .TestObject;
 
-            long result = testEnvironment.estimator.Estimate(tx, block.Header, testEnvironment.tracer, out string? err);
+            long result = testEnvironment.estimator.Estimate(tx, block.Header, testEnvironment.tracer, out string? err, errorMargin: 0);
 
             Assert.That(err, Is.Null);
-            Assert.That(result, Is.GreaterThan(0));
+            Assert.That(result, Is.GreaterThan(Transaction.BaseTxGasCost));
         }
 
         [Test]
@@ -1321,6 +1321,7 @@ namespace Nethermind.Evm.Test.Tracing
 
             long result = testEnvironment.estimator.Estimate(tx, block.Header, testEnvironment.tracer, out string? err);
 
+            Assert.That(err, Is.Null, err);
             Assert.That(result, Is.GreaterThan(Transaction.BaseTxGasCost));
         }
 


### PR DESCRIPTION
Fixes #12087

## Changes

- Introduce `OptimisticMultiplier = 64d / 63d` in `GasEstimator.cs` to compensate for EIP-150's 1/64 child-call reservation, matching Geth's approach
- Pass `OptimisticMultiplier` to `TryOptimisticEstimate` instead of `marginMultiplier`, keeping `marginMultiplier` for the binary-search stop threshold only
- Fix `IsSimpleTransfer` to return `false` for EIP-7702 SetCodeTx with an `authorizationList`, ensuring those transactions go through the binary search

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Two unit tests added to `GasEstimationTests.cs`:
- `Estimate_subcall_contract_uses_optimistic_multiplier_not_margin_multiplier` — verifies the optimistic guess correctly accounts for EIP-150's child-call budget
- `IsSimpleTransfer_returns_false_for_SetCodeTx_with_authorization_list` — verifies SetCodeTx goes through the full binary search

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No