### PR TITLE
fix: flaky eth/62 test

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -748,28 +748,29 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
                 txs[i] = Build.A.Transaction.WithData(new byte[dataSize]).SignedAndResolved(Build.A.PrivateKey.TestObject).TestObject;
             }
 
-            int sizeOfOneTx = txs[0].GetLength();
-            int numberOfTxsInOneMsg = Math.Max(TransactionsMessage.MaxPacketSize / sizeOfOneTx, 1);
-            int nonFullMsgTxsCount = txCount % numberOfTxsInOneMsg;
-            int messagesCount = txCount / numberOfTxsInOneMsg + (nonFullMsgTxsCount > 0 ? 1 : 0);
+            List<(int Count, int SerializedSize)> deliveries = [];
+            CountdownEvent delivered = new(txCount);
 
-            CountdownEvent delivered = new(messagesCount);
-            int matchingDeliveries = 0;
             _session.When(s => s.DeliverMessage(Arg.Any<TransactionsMessage>()))
                 .Do(call =>
                 {
                     TransactionsMessage msg = (TransactionsMessage)call[0];
-                    if (msg.Transactions.Count == numberOfTxsInOneMsg || msg.Transactions.Count == nonFullMsgTxsCount)
-                    {
-                        Interlocked.Increment(ref matchingDeliveries);
-                        if (!delivered.IsSet) delivered.Signal();
-                    }
+                    int serializedSize = msg.Transactions.Sum(static tx => tx.GetLength());
+                    lock (deliveries) deliveries.Add((msg.Transactions.Count, serializedSize));
+                    delivered.Signal(msg.Transactions.Count);
                 });
 
             _handler.SendNewTransactions(txs);
 
             Assert.That(delivered.Wait(TimeSpan.FromSeconds(30)), Is.True, "Not all expected messages were delivered within 30s");
-            Assert.That(matchingDeliveries, Is.EqualTo(messagesCount));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(deliveries.Sum(static d => d.Count), Is.EqualTo(txCount), "Every transaction must be delivered exactly once");
+                Assert.That(deliveries, Is.All.Matches<(int Count, int SerializedSize)>(
+                    static d => d.Count == 1 || d.SerializedSize <= TransactionsMessage.MaxPacketSize),
+                    "Each message must fit within MaxPacketSize unless it carries a single transaction");
+            }
         }
 
         private void HandleZeroMessage<T>(T msg, int messageCode) where T : MessageBase


### PR DESCRIPTION
## Changes

- Fixes flaky `should_send_single_transaction_even_if_exceed_MaxPacketSize`
  The test assumed all 512 transactions had the same serialized size, so it predicted how many would fit per message by measuring only the first one. This was wrong as each tx is signed with a different random key, and ECDSA signatures vary in length by a byte or two (leading zeros get stripped). Test was failing approximately once per 256 runs.
  Assertions are changed a bit, but total count and packet size validation are included.
   
## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

