### PR TITLE
feat(debug): emit struct-log returnData in geth opcode tracers

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/AlwaysCancelTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/AlwaysCancelTxTracer.cs
@@ -37,6 +37,7 @@ public class AlwaysCancelTxTracer : ITxTracer
     public bool IsTracingMemory => true;
     public bool IsTracingInstructions => true;
     public bool IsTracingRefunds => true;
+    public bool IsTracingReturnData => true;
     public bool IsTracingCode => true;
     public bool IsTracingStack => true;
     public bool IsTracingState => true;
@@ -59,6 +60,7 @@ public class AlwaysCancelTxTracer : ITxTracer
     public void ReportLog(LogEntry log) => throw new OperationCanceledException(ErrorMessage);
 
     public void SetOperationMemorySize(ulong newSize) => throw new OperationCanceledException(ErrorMessage);
+    public void SetOperationReturnData(ReadOnlyMemory<byte> returnData) => throw new OperationCanceledException(ErrorMessage);
 
     public void ReportMemoryChange(long offset, in ReadOnlySpan<byte> data) => throw new OperationCanceledException(ErrorMessage);
     public void ReportStorageChange(in ReadOnlySpan<byte> key, in ReadOnlySpan<byte> value) => throw new OperationCanceledException(ErrorMessage);

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -24,6 +24,7 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     public bool IsTracingMemory => _currentTxTracer.IsTracingMemory;
     public bool IsTracingInstructions => _currentTxTracer.IsTracingInstructions;
     public bool IsTracingRefunds => _currentTxTracer.IsTracingRefunds;
+    public bool IsTracingReturnData => _currentTxTracer.IsTracingReturnData;
     public bool IsTracingCode => _currentTxTracer.IsTracingCode;
     public bool IsTracingStack => _currentTxTracer.IsTracingStack;
     public bool IsTracingState => _currentTxTracer.IsTracingState;
@@ -165,6 +166,9 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
 
     public void SetOperationMemorySize(ulong newSize) =>
         _currentTxTracer.SetOperationMemorySize(newSize);
+
+    public void SetOperationReturnData(ReadOnlyMemory<byte> returnData) =>
+        _currentTxTracer.SetOperationReturnData(returnData);
 
     public void ReportMemoryChange(long offset, in ReadOnlySpan<byte> data) =>
         _currentTxTracer.ReportMemoryChange(offset, data);

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
@@ -58,6 +58,9 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
     private byte[]? _memoryBuffer;
     private int _memoryByteCount;
 
+    private byte[]? _returnDataBuffer;
+    private int _returnDataByteCount;
+
     private ArrayPoolList<PooledDictionary<UInt256, UInt256>>? _storageByDepth;
     private int _activeStorageDepth;
 
@@ -103,6 +106,7 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         _refundCheckpoints.Clear();
         _stackByteCount = 0;
         _memoryByteCount = 0;
+        _returnDataByteCount = 0;
         if (_storageByDepth is not null)
         {
             for (int i = 0; i < _activeStorageDepth; i++) _storageByDepth[i].Clear();
@@ -137,6 +141,7 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         _gasCostAlreadySet = false;
         _stackByteCount = 0;
         _memoryByteCount = 0;
+        _returnDataByteCount = 0;
     }
 
     public override void ReportOperationRemainingGas(long gas)
@@ -196,6 +201,18 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         top[storageIndex] = new UInt256(newValue, isBigEndian: true);
     }
 
+    public override void SetOperationReturnData(ReadOnlyMemory<byte> returnData)
+    {
+        if (!_hasPendingOpcode) return;
+        int needed = returnData.Length;
+        if (needed == 0) { _returnDataByteCount = 0; return; }
+
+        // The source buffer is reused across opcodes, so copy the bytes into our own scratch.
+        EnsureBuffer(ref _returnDataBuffer, needed);
+        returnData.Span.CopyTo(_returnDataBuffer.AsSpan(0, needed));
+        _returnDataByteCount = needed;
+    }
+
     public override GethLikeTxTrace BuildResult()
     {
         FinalizePendingOpcode();
@@ -246,6 +263,7 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
     {
         if (_stackBuffer is not null) { ArrayPool<byte>.Shared.Return(_stackBuffer); _stackBuffer = null; }
         if (_memoryBuffer is not null) { ArrayPool<byte>.Shared.Return(_memoryBuffer); _memoryBuffer = null; }
+        if (_returnDataBuffer is not null) { ArrayPool<byte>.Shared.Return(_returnDataBuffer); _returnDataBuffer = null; }
         if (_storageByDepth is not null)
         {
             for (int i = 0; i < _storageByDepth.Count; i++) _storageByDepth[i].Dispose();
@@ -279,6 +297,8 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         if (IsTracingStack) WriteStackArrayIfPresent();
         if (IsTracingFullMemory) WriteMemoryArrayIfPresent();
         if (IsTracingOpLevelStorage) WriteStorageObjectIfPresent();
+        if (IsTracingReturnData && _returnDataByteCount > 0)
+            _writer.WriteString("returnData"u8, _returnDataBuffer.AsSpan(0, _returnDataByteCount).ToHexString(true));
 
         _writer.WriteEndObject();
     }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
@@ -60,6 +60,7 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
 
     private byte[]? _returnDataBuffer;
     private int _returnDataByteCount;
+    private byte[]? _returnDataHexBuffer;
 
     private ArrayPoolList<PooledDictionary<UInt256, UInt256>>? _storageByDepth;
     private int _activeStorageDepth;
@@ -264,6 +265,7 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         if (_stackBuffer is not null) { ArrayPool<byte>.Shared.Return(_stackBuffer); _stackBuffer = null; }
         if (_memoryBuffer is not null) { ArrayPool<byte>.Shared.Return(_memoryBuffer); _memoryBuffer = null; }
         if (_returnDataBuffer is not null) { ArrayPool<byte>.Shared.Return(_returnDataBuffer); _returnDataBuffer = null; }
+        if (_returnDataHexBuffer is not null) { ArrayPool<byte>.Shared.Return(_returnDataHexBuffer); _returnDataHexBuffer = null; }
         if (_storageByDepth is not null)
         {
             for (int i = 0; i < _storageByDepth.Count; i++) _storageByDepth[i].Dispose();
@@ -297,10 +299,28 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         if (IsTracingStack) WriteStackArrayIfPresent();
         if (IsTracingFullMemory) WriteMemoryArrayIfPresent();
         if (IsTracingOpLevelStorage) WriteStorageObjectIfPresent();
-        if (IsTracingReturnData && _returnDataByteCount > 0)
-            _writer.WriteString("returnData"u8, _returnDataBuffer.AsSpan(0, _returnDataByteCount).ToHexString(true));
+        if (IsTracingReturnData && _returnDataByteCount > 0) WriteReturnDataValue();
 
         _writer.WriteEndObject();
+    }
+
+    private void WriteReturnDataValue()
+    {
+        // Encode "0x"-prefixed hex straight into a pooled scratch buffer and emit it as a raw JSON
+        // string, avoiding the intermediate string allocation on every traced opcode after a call.
+        int hexLength = _returnDataByteCount * 2;
+        int tokenLength = hexLength + 4; // quotes + "0x"
+        EnsureBuffer(ref _returnDataHexBuffer, tokenLength);
+
+        Span<byte> token = _returnDataHexBuffer.AsSpan(0, tokenLength);
+        token[0] = (byte)'"';
+        token[1] = (byte)'0';
+        token[2] = (byte)'x';
+        _returnDataBuffer.AsSpan(0, _returnDataByteCount).OutputBytesToByteHex(token.Slice(3, hexLength), extraNibble: false);
+        token[tokenLength - 1] = (byte)'"';
+
+        _writer.WritePropertyName("returnData"u8);
+        _writer.WriteRawValue(token, skipInputValidation: true);
     }
 
     private void WriteStackArrayIfPresent()

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxMemoryTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxMemoryTracer.cs
@@ -89,6 +89,12 @@ public class GethLikeTxMemoryTracer : GethLikeTxTracer<GethTxMemoryTraceEntry>
         }
     }
 
+    public override void SetOperationReturnData(ReadOnlyMemory<byte> returnData)
+    {
+        if (CurrentTraceEntry is not null && !returnData.IsEmpty)
+            CurrentTraceEntry.ReturnData = returnData.Span.ToHexString(true);
+    }
+
     public override void ReportRefund(long refund) => _refund += refund;
 
     public override void ReportAction(long gas, UInt256 value, Address from, Address to, ReadOnlyMemory<byte> input, ExecutionType callType, bool isPrecompileCall = false)

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTracer.cs
@@ -19,6 +19,7 @@ public abstract class GethLikeTxTracer : TxTracer
         IsTracingOpLevelStorage = !options.DisableStorage;
         IsTracingStack = !options.DisableStack;
         IsTracingFullMemory = options.EnableMemory;
+        IsTracingReturnData = options.EnableReturnData;
         IsTracing = IsTracing || IsTracingFullMemory;
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTraceOptions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTraceOptions.cs
@@ -20,6 +20,8 @@ public record GethTraceOptions
 
     public bool EnableMemory { get; init; }
 
+    public bool EnableReturnData { get; init; }
+
     public bool DisableStack { get; init; }
 
     [JsonConverter(typeof(CustomTimeDurationConverter))]

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTxTraceEntry.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTxTraceEntry.cs
@@ -42,5 +42,9 @@ public class GethTxTraceEntry
 
     public Dictionary<string, string>? Storage { get; set; }
 
+    [JsonPropertyName("returnData")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReturnData { get; set; }
+
     internal virtual void UpdateMemorySize(ulong size) { }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
@@ -409,6 +409,7 @@ public class MyTracer : ITxTracer, IDisposable
     public bool IsTracingDetailedMemory { get; set; } = true;
     public bool IsTracingInstructions => true;
     public bool IsTracingRefunds { get; } = false;
+    public bool IsTracingReturnData { get; } = false;
     public bool IsTracingCode => true;
     public bool IsTracingStack { get; set; } = true;
     public bool IsTracingState => false;
@@ -463,6 +464,10 @@ public class MyTracer : ITxTracer, IDisposable
     public void SetOperationMemory(TraceMemory memoryTrace) => lastmemline = string.Concat("0x", string.Join("", memoryTrace.ToHexWordList().Select(static mt => mt.Replace("0x", string.Empty))));
 
     public void SetOperationMemorySize(ulong newSize)
+    {
+    }
+
+    public void SetOperationReturnData(ReadOnlyMemory<byte> returnData)
     {
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxDirectStreamingTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxDirectStreamingTracerTests.cs
@@ -46,16 +46,42 @@ public class GethLikeTxDirectStreamingTracerTests : VirtualMachineTestsBase
 
     private static long? RefundAt(IEnumerable<StructLog> logs, string opcode) => logs.Single(l => l.Op == opcode).Refund;
 
-    private List<StructLog> ExecuteAndStream(bool clearingFrameReverts)
+    [Test]
+    public void Streams_returndata_when_enabled()
     {
-        byte[] code = clearingFrameReverts ? RevertingCallCode() : ClearingSstoreCode();
+        const string word = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+        List<StructLog> logs = StreamLogs(ReturnDataCallCode(word), GethTraceOptions.Default with { EnableReturnData = true });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(logs.Last(l => l.Op == "CALL").ReturnData, Is.Null, "no return data before the call executes");
+            Assert.That(logs.Last(l => l.Op == "STOP" && l.Depth == 1).ReturnData, Is.EqualTo($"0x{word}"));
+        }
+    }
+
+    [Test]
+    public void Omits_returndata_when_not_enabled()
+    {
+        const string word = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+        List<StructLog> logs = StreamLogs(ReturnDataCallCode(word), GethTraceOptions.Default);
+
+        Assert.That(logs.All(l => l.ReturnData is null), Is.True);
+    }
+
+    private List<StructLog> ExecuteAndStream(bool clearingFrameReverts) =>
+        StreamLogs(clearingFrameReverts ? RevertingCallCode() : ClearingSstoreCode(), GethTraceOptions.Default);
+
+    private List<StructLog> StreamLogs(byte[] code, GethTraceOptions options)
+    {
         (Block block, Transaction transaction) = PrepareTx(Activation, 100000, code);
 
         using MemoryStream stream = new();
         using (Utf8JsonWriter writer = new(stream))
         {
             writer.WriteStartArray();
-            GethLikeTxDirectStreamingTracer tracer = new(transaction, GethTraceOptions.Default, writer, null, CancellationToken.None);
+            GethLikeTxDirectStreamingTracer tracer = new(transaction, options, writer, null, CancellationToken.None);
             _processor.Execute(transaction, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
             tracer.BuildResult();
             writer.WriteEndArray();
@@ -65,7 +91,25 @@ public class GethLikeTxDirectStreamingTracerTests : VirtualMachineTestsBase
         return [.. document.RootElement.EnumerateArray().Select(static e => new StructLog(
             e.GetProperty("op").GetString()!,
             e.GetProperty("depth").GetInt32(),
-            e.TryGetProperty("refund", out JsonElement refund) ? refund.GetInt64() : null))];
+            e.TryGetProperty("refund", out JsonElement refund) ? refund.GetInt64() : null,
+            e.TryGetProperty("returnData", out JsonElement returnData) ? returnData.GetString() : null))];
+    }
+
+    private byte[] ReturnDataCallCode(string word)
+    {
+        byte[] calleeCode = Prepare.EvmCode
+            .StoreDataInMemory(0, word)
+            .Return(32, 0)
+            .Done;
+
+        TestState.CreateAccount(TestItem.AddressC, 1.Ether);
+        TestState.InsertCode(TestItem.AddressC, calleeCode, Spec);
+        TestState.Commit(Spec);
+
+        return Prepare.EvmCode
+            .Call(TestItem.AddressC, 50000)
+            .Op(Instruction.STOP)
+            .Done;
     }
 
     private byte[] ClearingSstoreCode()
@@ -100,5 +144,5 @@ public class GethLikeTxDirectStreamingTracerTests : VirtualMachineTestsBase
             .Done;
     }
 
-    private readonly record struct StructLog(string Op, int Depth, long? Refund);
+    private readonly record struct StructLog(string Op, int Depth, long? Refund, string? ReturnData);
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxMemoryTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeTxMemoryTracerTests.cs
@@ -495,6 +495,62 @@ public class GethLikeTxMemoryTracerTests : VirtualMachineTestsBase
         }
     }
 
+    [Test]
+    public void Can_trace_returndata_when_enabled()
+    {
+        const string word = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+        byte[] calleeCode = Prepare.EvmCode
+            .StoreDataInMemory(0, word)
+            .Return(32, 0)
+            .Done;
+
+        TestState.CreateAccount(TestItem.AddressC, 1.Ether);
+        TestState.InsertCode(TestItem.AddressC, calleeCode, Spec);
+        TestState.Commit(Spec);
+
+        byte[] code = Prepare.EvmCode
+            .Call(TestItem.AddressC, 50000)
+            .Op(Instruction.STOP)
+            .Done;
+
+        GethLikeTxTrace trace = ExecuteAndTrace(GethTraceOptions.Default with { EnableReturnData = true }, code);
+
+        GethTxTraceEntry call = trace.Entries.Last(e => e.Opcode == "CALL");
+        GethTxTraceEntry topLevelStop = trace.Entries.Last(e => e.Opcode == "STOP" && e.Depth == 1);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(call.ReturnData, Is.Null, "no return data before the call executes");
+            Assert.That(topLevelStop.ReturnData, Is.EqualTo($"0x{word}"), "return data visible after the inner call returns");
+        }
+    }
+
+    [Test]
+    public void ReturnData_is_omitted_when_not_enabled()
+    {
+        const string word = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+        byte[] calleeCode = Prepare.EvmCode
+            .StoreDataInMemory(0, word)
+            .Return(32, 0)
+            .Done;
+
+        TestState.CreateAccount(TestItem.AddressC, 1.Ether);
+        TestState.InsertCode(TestItem.AddressC, calleeCode, Spec);
+        TestState.Commit(Spec);
+
+        byte[] code = Prepare.EvmCode
+            .Call(TestItem.AddressC, 50000)
+            .Op(Instruction.STOP)
+            .Done;
+
+        // Default options leave EnableReturnData off, so the field must never be populated.
+        GethLikeTxTrace trace = ExecuteAndTrace(code);
+
+        Assert.That(trace.Entries.All(e => e.ReturnData is null), Is.True);
+    }
+
     private static void AssertEntry(GethTxTraceEntry entry, long expectedPc, string expectedOpcode, string expectedStackTop, int expectedStackCount)
     {
         using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTestsBase.cs
@@ -87,6 +87,14 @@ public abstract class VirtualMachineTestsBase
         return tracer.BuildResult();
     }
 
+    protected GethLikeTxTrace ExecuteAndTrace(GethTraceOptions options, params byte[] code)
+    {
+        (Block block, Transaction transaction) = PrepareTx(Activation, 100000, code);
+        GethLikeTxMemoryTracer tracer = new(transaction, options);
+        _processor.Execute(transaction, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+        return tracer.BuildResult();
+    }
+
     protected GethLikeTxTrace ExecuteAndTrace(long blockNumber, long gasLimit, params byte[] code)
     {
         (Block block, Transaction transaction) = PrepareTx((blockNumber, Timestamp), gasLimit, code);

--- a/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
@@ -19,6 +19,7 @@ public class CancellationTxTracer(ITxTracer innerTracer, CancellationToken token
     private readonly bool _isTracingMemory;
     private readonly bool _isTracingInstructions;
     private readonly bool _isTracingRefunds;
+    private readonly bool _isTracingReturnData;
     private readonly bool _isTracingCode;
     private readonly bool _isTracingStack;
     private readonly bool _isTracingState;
@@ -67,6 +68,12 @@ public class CancellationTxTracer(ITxTracer innerTracer, CancellationToken token
     {
         get => _isTracingRefunds || innerTracer.IsTracingRefunds;
         init => _isTracingRefunds = value;
+    }
+
+    public bool IsTracingReturnData
+    {
+        get => _isTracingReturnData || innerTracer.IsTracingReturnData;
+        init => _isTracingReturnData = value;
     }
 
     public bool IsTracingCode
@@ -277,6 +284,15 @@ public class CancellationTxTracer(ITxTracer innerTracer, CancellationToken token
         if (innerTracer.IsTracingMemory)
         {
             innerTracer.SetOperationMemorySize(newSize);
+        }
+    }
+
+    public void SetOperationReturnData(ReadOnlyMemory<byte> returnData)
+    {
+        token.ThrowIfCancellationRequested();
+        if (innerTracer.IsTracingReturnData)
+        {
+            innerTracer.SetOperationReturnData(returnData);
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -31,6 +31,7 @@ public class CompositeTxTracer : ITxTracer
             IsTracingMemory |= t.IsTracingMemory;
             IsTracingInstructions |= t.IsTracingInstructions;
             IsTracingRefunds |= t.IsTracingRefunds;
+            IsTracingReturnData |= t.IsTracingReturnData;
             IsTracingCode |= t.IsTracingCode;
             IsTracingStack |= t.IsTracingStack;
             IsTracingBlockHash |= t.IsTracingBlockHash;
@@ -49,6 +50,7 @@ public class CompositeTxTracer : ITxTracer
     public bool IsTracingMemory { get; }
     public bool IsTracingInstructions { get; }
     public bool IsTracingRefunds { get; }
+    public bool IsTracingReturnData { get; }
     public bool IsTracingCode { get; }
     public bool IsTracingStack { get; }
     public bool IsTracingBlockHash { get; }
@@ -268,6 +270,18 @@ public class CompositeTxTracer : ITxTracer
             if (innerTracer.IsTracingMemory)
             {
                 innerTracer.SetOperationMemorySize(newSize);
+            }
+        }
+    }
+
+    public void SetOperationReturnData(ReadOnlyMemory<byte> returnData)
+    {
+        for (int index = 0; index < _txTracers.Count; index++)
+        {
+            ITxTracer innerTracer = _txTracers[index];
+            if (innerTracer.IsTracingReturnData)
+            {
+                innerTracer.SetOperationReturnData(returnData);
             }
         }
     }

--- a/src/Nethermind/Nethermind.Evm/Tracing/Debugger/DebugTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/Debugger/DebugTracer.cs
@@ -42,6 +42,7 @@ public class DebugTracer<TGasPolicy>(ITxTracer tracer) : ITxTracer, ITxTracerWra
     public bool IsTracingInstructions => InnerTracer.IsTracingInstructions;
 
     public bool IsTracingRefunds => InnerTracer.IsTracingRefunds;
+    public bool IsTracingReturnData => InnerTracer.IsTracingReturnData;
 
     public bool IsTracingCode => InnerTracer.IsTracingCode;
 
@@ -214,6 +215,9 @@ public class DebugTracer<TGasPolicy>(ITxTracer tracer) : ITxTracer, ITxTracerWra
 
     public void SetOperationMemorySize(ulong newSize)
         => InnerTracer.SetOperationMemorySize(newSize);
+
+    public void SetOperationReturnData(ReadOnlyMemory<byte> returnData)
+        => InnerTracer.SetOperationReturnData(returnData);
 
     public void ReportMemoryChange(long offset, in ReadOnlySpan<byte> data)
         => InnerTracer.ReportMemoryChange(offset, data);

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -152,6 +152,7 @@ public interface ITxTracer : IWorldStateTracer, IDisposable
                       || IsTracingMemory
                       || IsTracingInstructions
                       || IsTracingRefunds
+                      || IsTracingReturnData
                       || IsTracingCode
                       || IsTracingStack
                       || IsTracingBlockHash

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -84,6 +84,15 @@ public interface ITxTracer : IWorldStateTracer, IDisposable
     bool IsTracingRefunds { get; }
 
     /// <summary>
+    /// Per-opcode return-data buffer (the output of the most recent inner call/create).
+    /// </summary>
+    /// <remarks>
+    /// Controls
+    /// - <see cref="SetOperationReturnData"/>
+    /// </remarks>
+    bool IsTracingReturnData { get; }
+
+    /// <summary>
     /// Code deployment
     /// </summary>
     /// <remarks>
@@ -244,6 +253,14 @@ public interface ITxTracer : IWorldStateTracer, IDisposable
     /// <param name="newSize"></param>
     /// <remarks>Depends on <see cref="IsTracingMemory"/></remarks>
     void SetOperationMemorySize(ulong newSize);
+
+    /// <summary>
+    /// Reports the return-data buffer visible to the current opcode (the output of the most
+    /// recent inner call or create).
+    /// </summary>
+    /// <param name="returnData">The current return-data buffer.</param>
+    /// <remarks>Depends on <see cref="IsTracingReturnData"/></remarks>
+    void SetOperationReturnData(ReadOnlyMemory<byte> returnData);
 
     /// <summary>
     ///

--- a/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
@@ -38,6 +38,7 @@ public abstract class TxTracer : ITxTracer
     public virtual bool IsTracingMemory { get; protected set; }
     public virtual bool IsTracingInstructions { get; protected set; }
     public virtual bool IsTracingRefunds { get; protected set; }
+    public virtual bool IsTracingReturnData { get; protected set; }
     public virtual bool IsTracingCode { get; protected set; }
     public virtual bool IsTracingStack { get; protected set; }
     public virtual bool IsTracingBlockHash { get; protected set; }
@@ -62,6 +63,7 @@ public abstract class TxTracer : ITxTracer
     public virtual void ReportStackPush(in ReadOnlySpan<byte> stackItem) { }
     public virtual void SetOperationMemory(TraceMemory memoryTrace) { }
     public virtual void SetOperationMemorySize(ulong newSize) { }
+    public virtual void SetOperationReturnData(ReadOnlyMemory<byte> returnData) { }
     public virtual void ReportMemoryChange(long offset, in ReadOnlySpan<byte> data) { }
     public virtual void SetOperationStorage(Address address, UInt256 storageIndex, ReadOnlySpan<byte> newValue, ReadOnlySpan<byte> currentValue) { }
     public virtual void LoadOperationStorage(Address address, UInt256 storageIndex, ReadOnlySpan<byte> value) { }

--- a/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
@@ -22,6 +22,7 @@ public abstract class TxTracer : ITxTracer
                               || IsTracingMemory
                               || IsTracingInstructions
                               || IsTracingRefunds
+                              || IsTracingReturnData
                               || IsTracingCode
                               || IsTracingStack
                               || IsTracingBlockHash

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1432,6 +1432,11 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
         {
             _txTracer.SetOperationStack(new TraceStack(vmState.MemoryStacks(stackValue.Head)));
         }
+
+        if (_txTracer.IsTracingReturnData)
+        {
+            _txTracer.SetOperationReturnData(ReturnDataBuffer);
+        }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
@@ -26,6 +26,7 @@ public class StateTestTxTracer : ITxTracer, IDisposable
     public bool IsTracingDetailedMemory { get; set; } = true;
     public bool IsTracingInstructions => true;
     public bool IsTracingRefunds { get; } = false;
+    public bool IsTracingReturnData { get; } = false;
     public bool IsTracingCode => false;
     public bool IsTracingStack { get; set; } = true;
     public bool IsTracingState => false;
@@ -147,6 +148,10 @@ public class StateTestTxTracer : ITxTracer, IDisposable
             if (diff > 0)
                 _traceEntry.Memory += new string('0', diff);
         }
+    }
+
+    public void SetOperationReturnData(ReadOnlyMemory<byte> returnData)
+    {
     }
 
     public void ReportMemoryChange(long offset, in ReadOnlySpan<byte> data)


### PR DESCRIPTION
## Changes

The default `debug_trace*` opcode (struct) logger never exposed the per-step return-data buffer, unlike geth/Besu/Erigon/Reth, which emit `returnData` when the `enableReturnData` flag is set. This completes #12057 (the refund counter landed in #12081).

- Add the `EnableReturnData` option to `GethTraceOptions` (mirrors geth's `enableReturnData` tracer config key; off by default).
- Add a gated op-level tracer hook `ITxTracer.SetOperationReturnData` (with `IsTracingReturnData`), fed from the VM's return-data buffer in `StartInstructionTrace`. Wired through the `TxTracer` base and the forwarding tracers (`Cancellation`, `Composite`, `BlockReceipts`, `AlwaysCancel`).
- Emit `returnData` as a hex string (only when non-empty) from both the in-memory (`GethLikeTxMemoryTracer`) and streaming (`GethLikeTxDirectStreamingTracer`) geth tracers; the streaming path copies the bytes into a pooled scratch buffer since the source is reused across opcodes.

Because the flag defaults to off, the hook is never invoked and existing traces are byte-for-byte unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `Can_trace_returndata_when_enabled` / `ReturnData_is_omitted_when_not_enabled` (in-memory) and `Streams_returndata_when_enabled` / `Omits_returndata_when_not_enabled` (streaming), asserting the buffer is captured after an inner call returns and stays absent by default. Verified no regressions across the geth tracing (403), `debug_trace*` JSON-RPC (116), and streaming blockchain-test runner suites.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

When `enableReturnData` is set, the `debug_traceTransaction` / `debug_traceBlock*` default (struct) tracer now includes the `returnData` field (hex, when non-empty) on each step, aligning the opcode trace output with geth/Besu/Erigon/Reth.
