### PR TITLE
XDC Fix penalty comeback

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/PenaltyTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/PenaltyTests.cs
@@ -53,6 +53,7 @@ internal class PenaltyTests
 
         XdcBlockHeader signedHeader = (XdcBlockHeader)chain.BlockTree.FindHeader(targetHeader.Number - spec.MergeSignRange)!;
         Transaction tx = BuildSigningTx(spec, signedHeader.Number, signedHeader.Hash!, penaltyHistorySigner);
+        tx.SenderAddress = null; // to test sender recovery
         signingTxCache.SetSigningTransactions(signedHeader.Hash!, [tx]);
 
         penalties = penaltyHandler.HandlePenalties(targetHeader.Number, targetHeader.ParentHash!, masternodes);

--- a/src/Nethermind/Nethermind.Xdc/PenaltyHandler.cs
+++ b/src/Nethermind/Nethermind.Xdc/PenaltyHandler.cs
@@ -5,6 +5,7 @@ using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
+using Nethermind.Crypto;
 using Nethermind.Xdc.Spec;
 using System;
 using System.Collections.Generic;
@@ -15,6 +16,8 @@ namespace Nethermind.Xdc;
 
 internal class PenaltyHandler(IBlockTree tree, ISpecProvider specProvider, IEpochSwitchManager epochSwitchManager, ISigningTxCache signingTxCache) : IPenaltyHandler
 {
+    private readonly EthereumEcdsa _ethereumEcdsa = new(specProvider.ChainId);
+
     public Address[] GetPenalties(XdcBlockHeader header) => epochSwitchManager.GetEpochSwitchInfo(header)?.Penalties ?? [];
 
     private Address[] GetPreviousPenalties(Hash256 currentHash, IXdcReleaseSpec spec, ulong limit)
@@ -104,6 +107,7 @@ internal class PenaltyHandler(IBlockTree tree, ISpecProvider specProvider, IEpoc
                     foreach (Transaction tx in signingTxs)
                     {
                         Hash256 signedBlockHash = new(tx.Data.Span[^32..]);
+                        tx.SenderAddress ??= _ethereumEcdsa.RecoverAddress(tx);
                         Address fromSigner = tx.SenderAddress;
 
                         if (blockHashes.Contains(signedBlockHash))
@@ -152,7 +156,8 @@ internal class PenaltyHandler(IBlockTree tree, ISpecProvider specProvider, IEpoc
                     foreach (Transaction tx in signingTxs)
                     {
                         Hash256 signedBlockHash = new(tx.Data.Span[^32..]);
-                        Address fromSigner = tx.SenderAddress!;
+                        tx.SenderAddress ??= _ethereumEcdsa.RecoverAddress(tx);
+                        Address fromSigner = tx.SenderAddress;
                         if (blockHashes.Contains(signedBlockHash))
                         {
                             txSignerMap[fromSigner] = txSignerMap.TryGetValue(fromSigner, out int count) ? count + 1 : 1;

--- a/src/Nethermind/Nethermind.Xdc/SubnetPenaltyHandler.cs
+++ b/src/Nethermind/Nethermind.Xdc/SubnetPenaltyHandler.cs
@@ -7,12 +7,15 @@ using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
+using Nethermind.Crypto;
 using Nethermind.Xdc.Spec;
 
 namespace Nethermind.Xdc;
 
 internal class SubnetPenaltyHandler(IBlockTree tree, ISpecProvider specProvider, IEpochSwitchManager epochSwitchManager, ISigningTxCache signingTxCache) : IPenaltyHandler
 {
+    private readonly EthereumEcdsa _ethereumEcdsa = new(specProvider.ChainId);
+
     public Address[] HandlePenalties(long number, Hash256 parentHash, Address[] candidates)
     {
         // Triggered only at gap blocks
@@ -90,6 +93,7 @@ internal class SubnetPenaltyHandler(IBlockTree tree, ISpecProvider specProvider,
             foreach (Transaction tx in signingTxs)
             {
                 Hash256 signedBlockHash = new(tx.Data.Span[^32..]);
+                tx.SenderAddress ??= _ethereumEcdsa.RecoverAddress(tx);
                 Address fromSigner = tx.SenderAddress;
 
                 if (blockHashes.Contains(signedBlockHash))


### PR DESCRIPTION
  ### Changes
  - `PenaltyHandler` and `SubnetPenaltyHandler` now recover the signing-tx sender before using it, like `XdcRewardCalculator` already does:
    ```csharp
    tx.SenderAddress ??= _ethereumEcdsa.RecoverAddress(tx);

  Blocks are normally served from the in-memory cache, where transactions already have a recovered sender. The comeback only looks back 150 blocks, so at the chain tip everything comes from cache and works. The bug
  only shows up when those blocks are read from disk instead(after a restart).

  Types of changes

  - [x] Bugfix
