### PR TITLE
Optimise sorted pool lookup

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/Collections/SortedPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/Collections/SortedPoolTests.cs
@@ -105,6 +105,27 @@ namespace Nethermind.TxPool.Test.Collections
             Assert.That(_sortedPool.TryGetBucket(tx.SenderAddress, out _), Is.False);
         }
 
+        [Test]
+        public void GetBest_returns_first_transaction_without_removing_it()
+        {
+            Transaction lowPriority = Build.A.Transaction
+                .WithGasPrice(1)
+                .WithSenderAddress(TestItem.AddressA)
+                .TestObject;
+            lowPriority.Hash = lowPriority.CalculateHash();
+            Transaction highPriority = Build.A.Transaction
+                .WithGasPrice(2)
+                .WithSenderAddress(TestItem.AddressB)
+                .TestObject;
+            highPriority.Hash = highPriority.CalculateHash();
+
+            _sortedPool.TryInsert(lowPriority.Hash, lowPriority);
+            _sortedPool.TryInsert(highPriority.Hash, highPriority);
+
+            Assert.That(_sortedPool.GetBest(), Is.EqualTo(highPriority));
+            Assert.That(_sortedPool.Count, Is.EqualTo(2));
+        }
+
         private static IEnumerable<TestCaseData> VisitBucketCases()
         {
             yield return new TestCaseData(Array.Empty<int>(), int.MaxValue, Array.Empty<int>())

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -192,8 +192,11 @@ namespace Nethermind.TxPool.Collections
         /// </summary>
         public bool TryTakeFirst(out TValue? first)
         {
-            if (GetFirsts().Min is TValue min)
+            if (GetBest() is TValue min)
+            {
                 return TryRemove(GetKey(min), out first);
+            }
+
             first = default;
             return false;
         }

--- a/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/SortedPool.cs
@@ -217,7 +217,29 @@ namespace Nethermind.TxPool.Collections
         /// <summary>
         /// Returns best overall element as per supplied comparer order.
         /// </summary>
-        public TValue? GetBest() => GetFirsts().Min;
+        public TValue? GetBest()
+        {
+            using McsLock.Disposable lockRelease = Lock.Acquire();
+
+            TValue? best = default;
+            bool hasBest = false;
+            foreach (KeyValuePair<TGroupKey, EnhancedSortedSet<TValue>> bucket in _buckets)
+            {
+                TValue? candidate = bucket.Value.Min;
+                if (candidate is null)
+                {
+                    continue;
+                }
+
+                if (!hasBest || _sortedComparer.Compare(candidate, best!) < 0)
+                {
+                    best = candidate;
+                    hasBest = true;
+                }
+            }
+
+            return best;
+        }
 
         /// <summary>
         /// Gets last element in supplied comparer order.


### PR DESCRIPTION
## Changes

- Optimise `SortedPool.GetBest()` by scanning bucket minima directly instead of allocating and sorting a temporary set of first transactions.
- Optimise `SortedPool.TryTakeFirst()` by reusing the allocation-free best lookup before removing the selected transaction.
- Add focused sorted pool coverage for the non-removing best lookup behavior.
- Keep benchmark files out of this branch.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Focused sorted pool tests passed. Nethermind solution and Benchmarks solution builds passed with warnings as errors. Code-lint-shaped analyzer build and diff checks passed. EthereumTests solution was not run to completion in this checkout because the external `src/tests/...` JSON fixtures are missing.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No