### PR TITLE
fix: guard ForkChoiceUpdated against null safe/finalized hash

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -972,12 +972,19 @@ public class BlockTreeTests
         Assert.That(blockTree.Genesis!.CalculateHash(), Is.EqualTo(block0.Hash));
     }
 
-    [Test, MaxTime(Timeout.MaxTestTime)]
-    public void ForkChoiceUpdated_update_hashes()
+    // safeBlockHash is null in the AuRa-finalization-post-snap case (#11775): SafeHash has not been
+    // set yet, so ForkChoiceUpdated must tolerate a null safe (and finalized) hash without NRE'ing in
+    // HeaderStore.GetBlockNumber. The subscriber forces evaluation of the OnForkChoiceUpdated args
+    // (the GetBlockNumber lookups), which is skipped when the event has no subscribers.
+    [TestCase(true, TestName = "ForkChoiceUpdated_update_hashes")]
+    [TestCase(false, TestName = "ForkChoiceUpdated_tolerates_null_safe_hash")]
+    public void ForkChoiceUpdated_update_hashes(bool withSafeHash)
     {
         BlockTree blockTree = BuildBlockTree();
+        blockTree.OnForkChoiceUpdated += (_, _) => { };
+
         Hash256 finalizedBlockHash = TestItem.KeccakB;
-        Hash256 safeBlockHash = TestItem.KeccakC;
+        Hash256? safeBlockHash = withSafeHash ? TestItem.KeccakC : null;
         blockTree.ForkChoiceUpdated(finalizedBlockHash, safeBlockHash);
         using (Assert.EnterMultipleScope())
         {

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -1888,8 +1888,8 @@ namespace Nethermind.Blockchain
                 this,
                 new(
                     Head,
-                    _headerStore.GetBlockNumber(safeBlockHash) ?? 0,
-                    _headerStore.GetBlockNumber(FinalizedHash) ?? 0)
+                    safeBlockHash is null ? 0 : _headerStore.GetBlockNumber(safeBlockHash) ?? 0,
+                    FinalizedHash is null ? 0 : _headerStore.GetBlockNumber(FinalizedHash) ?? 0)
                 );
         }
 


### PR DESCRIPTION
## Changes

- `BlockTree.ForkChoiceUpdated` now guards the `safeBlockHash` / `FinalizedHash` arguments before passing them to `IHeaderStore.GetBlockNumber`.

AuRa retroactive finalization started routing through `BlockTree.ForkChoiceUpdated` in #11775. `AuRaBlockFinalizationManager.FinalizeBlocks` calls `ForkChoiceUpdated(finalizedBlocks[^1].Hash, _blockTree.SafeHash)`, and `SafeHash` is `null` immediately after snap sync (nothing has set it yet — AuRa has no authority over the safe block). The `OnForkChoiceUpdated` tail did:

```csharp
_headerStore.GetBlockNumber(safeBlockHash) ?? 0
```

The `?? 0` guards the *return value* but not the *null argument*: `null` flowed into `HeaderStore.GetBlockNumberFromBlockNumberDb` → `blockNumberDb.GetSpan(null)` → `NullReferenceException`. As a result every block failed to process and AuRa chains (Chiado, Gnosis) never advanced off the snap pivot.

Fixed by null-guarding the two `GetBlockNumber` calls at the call site, keeping the `IHeaderStore.GetBlockNumber` signature non-nullable.

Not present in 1.39.0-rc (cut before #11775 merged), but breaks Gnosis/Chiado sync on current `master`, so it would bite the next release branch.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `BlockTreeTests.ForkChoiceUpdated_tolerates_null_safe_hash` (parameterized alongside the existing `ForkChoiceUpdated_update_hashes`). It attaches an `OnForkChoiceUpdated` subscriber so the `GetBlockNumber` arguments are actually evaluated (they are skipped via `?.Invoke` when the event has no subscribers) — without the fix this reproduces the NRE.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)