### PR TITLE
 fix(discovery): flacky CI, log transport failures at Debug

### DIFF
--- a/src/Nethermind/Nethermind.Kademlia/LookupKNearestNeighbour.cs
+++ b/src/Nethermind/Nethermind.Kademlia/LookupKNearestNeighbour.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Concurrent;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Nethermind.Logging;
@@ -266,7 +267,17 @@ public class LookupKNearestNeighbour<TKey, TNode, TKadKey>(
             catch (Exception e)
             {
                 nodeHealthTracker.OnRequestFailed(node);
-                if (_logger.IsWarn) _logger.Warn($"Find neighbour op failed: {e}");
+                // Transport-level failures (e.g. unreachable network/host) are an expected part of peer
+                // discovery, equivalent to a timed-out request, so they are logged quietly without a stack trace.
+                bool shouldWarn = e is not SocketException && e.InnerException is not SocketException;
+                if (shouldWarn)
+                {
+                    if (_logger.IsWarn) _logger.Warn($"Find neighbour op failed: {e}");
+                }
+                else if (_logger.IsDebug)
+                {
+                    _logger.Debug($"Find neighbour op failed: {e.Message}");
+                }
                 return null;
             }
         }

--- a/src/Nethermind/Nethermind.Kademlia/LookupKNearestNeighbour.cs
+++ b/src/Nethermind/Nethermind.Kademlia/LookupKNearestNeighbour.cs
@@ -267,8 +267,7 @@ public class LookupKNearestNeighbour<TKey, TNode, TKadKey>(
             catch (Exception e)
             {
                 nodeHealthTracker.OnRequestFailed(node);
-                // Transport-level failures (e.g. unreachable network/host) are an expected part of peer
-                // discovery, equivalent to a timed-out request, so they are logged quietly without a stack trace.
+                // Transport failures (e.g. unreachable host) are expected during discovery, so log them quietly.
                 bool shouldWarn = e is not SocketException && e.InnerException is not SocketException;
                 if (shouldWarn)
                 {


### PR DESCRIPTION
Discovery `FindNeighbours` throws transport errors (`SocketException`) and were logged at `Warn` with a stack trace - failing [CI](https://github.com/NethermindEth/nethermind/actions/runs/28089336470/job/83163108364?pr=12034)

  ## Types of changes

  - [x] Bugfix (a non-breaking change that fixes an issue)

  ## Testing

  - Requires testing: **No**
  - Notes: Observability-only change; log levels aren't worth pinning.