### PR TITLE
perf: skip redundant receipt bloom recompute on parallel execution path

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -218,7 +218,12 @@ public partial class BlockProcessor(
             receipts,
             static (i, receipts) =>
             {
-                receipts[i].CalculateBloom();
+                // Parallel BAL execution precomputes the bloom; skip recomputing it here.
+                TxReceipt receipt = receipts[i];
+                if (!receipt.IsBloomCalculated)
+                {
+                    receipt.CalculateBloom();
+                }
                 return receipts;
             });
     }

--- a/src/Nethermind/Nethermind.Core.Test/TransactionReceiptTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TransactionReceiptTests.cs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Test.Builders;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test;
+
+[TestFixture]
+public class TransactionReceiptTests
+{
+    private static LogEntry[] SampleLogs() =>
+        [Build.A.LogEntry.WithAddress(TestItem.AddressA).TestObject];
+
+    [Test]
+    public void IsBloomCalculated_is_false_until_computed_then_true()
+    {
+        TxReceipt receipt = new() { Logs = SampleLogs() };
+
+        Assert.That(receipt.IsBloomCalculated, Is.False, "bloom should not be computed yet");
+
+        receipt.CalculateBloom();
+
+        Assert.That(receipt.IsBloomCalculated, Is.True, "bloom should be marked computed after CalculateBloom");
+    }
+
+    [Test]
+    public void IsBloomCalculated_is_true_after_bloom_assigned()
+    {
+        TxReceipt receipt = new() { Logs = SampleLogs(), Bloom = Bloom.Empty };
+
+        Assert.That(receipt.IsBloomCalculated, Is.True);
+    }
+
+    [Test]
+    public void Reading_Bloom_lazily_computes_it_and_marks_calculated()
+    {
+        TxReceipt receipt = new() { Logs = SampleLogs() };
+
+        Bloom? bloom = receipt.Bloom;
+
+        Assert.That(bloom, Is.EqualTo(new Bloom(receipt.Logs)));
+        Assert.That(receipt.IsBloomCalculated, Is.True);
+    }
+
+    [Test]
+    public void CalculateBloom_force_recomputes_even_when_bloom_already_set()
+    {
+        // Guards the NormalizeZeroBlooms contract: an explicit call must always recompute.
+        TxReceipt receipt = new() { Logs = SampleLogs(), Bloom = Bloom.Empty };
+
+        Bloom recomputed = receipt.CalculateBloom();
+
+        Assert.That(recomputed, Is.EqualTo(new Bloom(receipt.Logs)));
+        Assert.That(recomputed, Is.Not.EqualTo(Bloom.Empty));
+    }
+}

--- a/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TransactionReceipt.cs
@@ -89,6 +89,9 @@ namespace Nethermind.Core
 
         public Bloom CalculateBloom()
             => _bloom = Logs?.Length == 0 ? Bloom.Empty : new Bloom(Logs);
+
+        /// <summary>Whether the bloom is already set; unlike <see cref="Bloom"/>, reading this does not compute it.</summary>
+        internal bool IsBloomCalculated => _bloom is not null;
     }
 
     public ref struct TxReceiptStructRef(TxReceipt receipt)


### PR DESCRIPTION
## Changes

- On the parallel block-access-list (EIP-7928) execution path, `CombineReceipts` already computes every receipt's bloom while assembling the block bloom. `BlockProcessor.ProcessBlock` then unconditionally re-ran `CalculateBlooms` over all receipts, re-hashing every log a second time because `TxReceipt.CalculateBloom()` always recomputes from scratch.
- `CalculateBlooms` now skips receipts whose bloom is already populated, via a new `internal TxReceipt.IsBloomCalculated` peek that does not trigger lazy computation. Sequential execution paths leave the bloom unset and still compute it here.
- `CalculateBloom()`'s force-recompute semantics are unchanged, preserving the `ReceiptsSyncFeed.NormalizeZeroBlooms` contract that depends on them.
- Blooms, receipts root and the header bloom comparison are bit-identical — only the duplicate hashing on the parallel path is removed.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `TransactionReceiptTests` covering the new `IsBloomCalculated` peek and that `CalculateBloom()` still force-recomputes when a bloom is already set (the `NormalizeZeroBlooms` contract). Verified locally on `net10.0`/arm64: `TransactionReceiptTests` 4/4, `ReceiptsSyncFeedTests.NormalizeZeroBlooms` 3/3, `BlockProcessorTests` 42/42.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No