### PR TITLE
perf: reuse already-read nonce when deriving CREATE address

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
@@ -182,7 +182,7 @@ public static partial class EvmInstructions
         // - For CREATE: based on the executing account and its current nonce.
         // - For CREATE2: based on the executing account, the provided salt, and the init code.
         Address contractAddress = typeof(TOpCreate) == typeof(OpCreate)
-            ? ContractAddress.From(env.ExecutingAccount, state.GetNonce(env.ExecutingAccount))
+            ? ContractAddress.From(env.ExecutingAccount, in accountNonce)
             : ContractAddress.From(env.ExecutingAccount, salt, initCode.Span);
 
         // For EIP-2929 support, pre-warm the contract address in the access tracker to account for hot/cold storage costs.


### PR DESCRIPTION
## Changes

- The `CREATE` opcode handler read the executing account's nonce twice: once into `accountNonce` (for the max-nonce guard at `EvmInstructions.Create.cs:159`) and again via `state.GetNonce(...)` when deriving the contract address (`:185`). Nothing mutates the nonce between the two reads — `IncrementNonce` runs afterwards at `:195` — so the second state-provider lookup is redundant.
- Reuse the already-read `accountNonce` (passed by `in`) in the `ContractAddress.From(Address?, in UInt256)` call. The derived contract address is identical; this just removes one `GetNonce` lookup per `CREATE`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Behavior-identical dedup — the derived contract address is unchanged, so no new test is added. The CREATE address-derivation path is already covered by the existing `Nethermind.Evm.Test` suite (Eip1014/CREATE2, Eip3860, Eip7928, self-destruct, …) and the EEST state tests in CI. Verified locally on `net10.0`/arm64: full `Nethermind.Evm.Test` passes (4652 passed, 0 failed, 8 pre-existing skips).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No