### PR TITLE
refactor: remove unused TrieNode.GetChildHashOrInlineValue

### DIFF
--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -594,41 +594,6 @@ namespace Nethermind.Trie
             return length == 32 ? rlpReader.DecodeKeccak() : null;
         }
 
-        /// Gets child hash or the Value of the node in case it's an inline.
-        public byte[]? GetChildHashOrInlineValue(int i)
-        {
-            CappedArray<byte> rlp = ReadRlp();
-            if (rlp.IsNull)
-            {
-                return null;
-            }
-
-            RlpReader rlpReader = new(rlp);
-            SeekChild(ref rlpReader, i);
-
-            int prefix = rlpReader.PeekByte();
-
-            // If it's a hash (32 bytes), decode and return it
-            if (prefix == 160)
-            {
-                return rlpReader.DecodeKeccak().Bytes.ToArray();
-            }
-
-            int prefixValue = rlpReader.PeekByte();
-            if (prefixValue < 192)
-            {
-                return null;
-            }
-            else
-            {
-                // If it's an RLP list (inline node), return the full item as a byte array
-                rlpReader.PeekNextItem();
-                rlpReader.SkipLength();
-                rlpReader.SkipItem();
-                return rlpReader.DecodeByteArraySpan().ToArray();
-            }
-        }
-
         public byte[]? GetInlineNodeRlp(int i)
         {
             CappedArray<byte> rlp = ReadRlp();


### PR DESCRIPTION
## Changes

- Remove `TrieNode.GetChildHashOrInlineValue(int)`, which has no references anywhere in `src/` or `tools/` — the only occurrence is the definition itself. The similarly-named `GetInlineNodeRlp` is the one actually used (`SnapProviderHelper.cs:265`); this method is not.
- The removed method also read the prefix byte twice via `PeekByte()` (which does not advance the stream), so its second read was dead regardless. It relied only on shared helpers (`ReadRlp`, `SeekChild`, …) that other methods still use, so nothing is orphaned by the removal.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Pure dead-code removal — no behavior change. The build proves no caller breaks, and `Nethermind.Trie.Test` passes locally (455 passed, 0 failed, 7 pre-existing skips).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The method is `public` on `TrieNode`, so strictly this removes a public member. It is a low-level Merkle-Patricia-trie helper with zero in-tree consumers and was never wired up, so external consumption is highly unlikely — flagging for awareness.