### PR TITLE
test: fix flaky SyncServerTests block range broadcast test

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -568,21 +568,24 @@ public class SyncServerTests
 
         const int blocksCount = 100;
         int startBlock = (int)localBlockTree.Head!.Number;
-        int frequencyAlignedBlocks = Enumerable.Range(startBlock + 1, blocksCount).Count(x => x % frequency == 0);
 
-        CountdownEvent[] perPeerSignals = peers.Select(_ => new CountdownEvent(frequencyAlignedBlocks)).ToArray();
-        int[] perPeerCalls = new int[peers.Length];
+        // Older in-flight range broadcasts are cancelled as the head advances, so intermediate updates
+        // may be coalesced away; only the latest range is guaranteed to reach every peer.
+        ulong genesisNumber = localBlockTree.Genesis!.Number;
+        // AddBranch adds blocks up to branchLength - 1, so the highest head is blocksCount - 1, not blocksCount.
+        ulong finalLatest = (ulong)Enumerable.Range(startBlock + 1, blocksCount - 1).Last(x => x % frequency == 0);
+
+        ManualResetEventSlim[] perPeerFinalRange = peers.Select(_ => new ManualResetEventSlim(false)).ToArray();
         for (int i = 0; i < peers.Length; i++)
         {
             int idx = i;
             peers[i].SyncPeer
                 .When(p => p.NotifyOfNewRange(Arg.Any<BlockHeader>(), Arg.Any<BlockHeader>()))
-                .Do(_ =>
+                .Do(call =>
                 {
-                    // Saturate at frequencyAlignedBlocks: Signal() throws once CurrentCount hits 0,
-                    // and the production code may emit more notifications than the countdown was sized for.
-                    if (Interlocked.Increment(ref perPeerCalls[idx]) <= frequencyAlignedBlocks)
-                        perPeerSignals[idx].Signal();
+                    if (call.ArgAt<BlockHeader>(0).Number == genesisNumber &&
+                        call.ArgAt<BlockHeader>(1).Number == finalLatest)
+                        perPeerFinalRange[idx].Set();
                 });
         }
 
@@ -592,19 +595,10 @@ public class SyncServerTests
         localBlockTree.AddBranch(blocksCount * 2 / 3, splitBlockNumber: startBlock, splitVariant: 0);
         localBlockTree.AddBranch(blocksCount, splitBlockNumber: startBlock, splitVariant: 0);
 
-        (ulong earliest, ulong latest)[] expectedUpdates = Enumerable.Range(startBlock + 1, blocksCount)
-            .Where(x => x % frequency == 0)
-            .Select(x => (earliest: localBlockTree.Genesis!.Number, latest: (ulong)x))
-            .ToArray()[^2..];
-
         for (int i = 0; i < peers.Length; i++)
         {
-            Assert.That(perPeerSignals[i].Wait(TimeSpan.FromSeconds(30)), Is.True, $"Peer {i} did not receive all expected NotifyOfNewRange calls");
-            (ulong earliest, ulong latest)[] arr = peers[i].SyncPeer.ReceivedCalls()
-                .Where(c => c.GetMethodInfo().Name == nameof(ISyncPeer.NotifyOfNewRange))
-                .Select(c => c.GetArguments().Cast<BlockHeader>().Select(b => b.Number).ToArray())
-                .Select(a => (earliest: a[0], latest: a[1])).ToArray();
-            Assert.That(arr[^2..], Is.EqualTo(expectedUpdates));
+            Assert.That(perPeerFinalRange[i].Wait(TimeSpan.FromSeconds(30)), Is.True,
+                $"Peer {i} was not notified of the latest block range (genesis -> {finalLatest})");
         }
     }
 


### PR DESCRIPTION
Fixes #10885

## Changes

- Rewrite `SyncServerTests.Broadcast_BlockRangeUpdate_when_latest_increased_enough` to assert the actual broadcast contract — **every peer is eventually notified of the latest frequency-aligned range (genesis → 96)** — instead of requiring that every intermediate range update (32, 64, 96) is delivered.

### Why it was flaky

`SyncServer.OnNewRange` cancels any in-flight broadcast of an older range, and `RangeBroadcast` honours that `CancellationToken` (returns early when cancelled). So when the head advances quickly past several frequency boundaries, the intermediate range updates are **coalesced away by design** — only the newest range is guaranteed to reach the peers. The test assumed all three updates `(0,32) (0,64) (0,96)` are delivered, so it failed whenever an intermediate one (e.g. `(0,64)`) was dropped:

```
Expected: equivalent to < (0, 64), (0, 96) >
But was:  < (0, 32), (0, 96) >
```

or, with the later `CountdownEvent` variant, the countdown never reached its expected count and the 30 s wait timed out. The final range broadcast is the one that is *never* cancelled, so keying the per-peer signal on that exact notification makes the test deterministic.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Test stabilization (flaky test fix); test-only, no production code changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

The flake was first **confirmed**, then the fix validated, on `origin/master`:

- **Baseline (unfixed):** `Broadcast_BlockRangeUpdate_when_latest_increased_enough` failed **12/12** runs (30 s countdown timeouts) — on this hardware the three `AddBranch` calls complete fast enough that `(0,32)` and `(0,64)` are always coalesced away, so only `(0,96)` is delivered.
- **Fixed, no load:** **30/30 pass** (~1.6 s each, no timeout).
- **Fixed, heavy CPU oversubscription:** **150/150 pass**.
- Full `SyncServerTests` fixture: **0 failures**.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
