### PR TITLE
fix(shutter): validate encrypted message length before decoding

### DIFF
--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterCryptoTests.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterCryptoTests.cs
@@ -218,4 +218,16 @@ class ShutterCryptoTests
 
         Assert.That(chunk[0], Is.EqualTo(UInt256.Zero));
     }
+
+    [Test]
+    // IndexOutOfRangeException escapes ShutterTxLoader's catch list — too-short input must surface as ShutterCryptoException.
+    public void DecodeEncryptedMessage_throws_ShutterCryptoException_on_too_short_input(
+        [Values(0, 1, 97, 128)] int length)
+    {
+        byte[] tooShort = new byte[length];
+        if (length > 0) tooShort[0] = 0x03;
+
+        Assert.That(() => ShutterCrypto.DecodeEncryptedMessage(tooShort),
+            Throws.TypeOf<ShutterCrypto.ShutterCryptoException>());
+    }
 }

--- a/src/Nethermind/Nethermind.Shutter/ShutterCrypto.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterCrypto.cs
@@ -69,12 +69,18 @@ public static class ShutterCrypto
 
     public static EncryptedMessage DecodeEncryptedMessage(ReadOnlySpan<byte> bytes)
     {
+        const int minLength = 1 + 96 + 32;
+        if (bytes.Length < minLength)
+        {
+            throw new ShutterCryptoException($"Encrypted Shutter message too short: expected at least {minLength} bytes, found {bytes.Length}.");
+        }
+
         if (bytes[0] != CryptoVersion)
         {
             throw new ShutterCryptoException($"Encrypted message had wrong Shutter crypto version. Expected version {CryptoVersion}, found {bytes[0]}.");
         }
 
-        ReadOnlySpan<byte> c3 = bytes[(1 + 96 + 32)..];
+        ReadOnlySpan<byte> c3 = bytes[minLength..];
 
         if (c3.Length == 0 || c3.Length % 32 != 0)
         {


### PR DESCRIPTION
## Changes

- `ShutterCrypto.DecodeEncryptedMessage` now validates the input is at least `1 + 96 + 32` bytes before indexing. Previously an empty or too-short encrypted message (sourced from on-chain sequencer logs) threw an unhandled `IndexOutOfRangeException` from `bytes[0]`. Because that type is not an `ArgumentException`, it escaped `ShutterTxLoader.DecryptSequencedTransaction`'s catch list and propagated out of the `.AsParallel()` decrypt pipeline as an `AggregateException`, disrupting Shutter transaction loading.
- The guard throws `ShutterCryptoException` (which `ShutterTxLoader` already catches), so malformed input is handled gracefully.
- Added a parameterized regression test covering empty and too-short inputs.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New test `DecodeEncryptedMessage_throws_ShutterCryptoException_on_too_short_input` fails before the change (throws `IndexOutOfRangeException`/`ArgumentOutOfRangeException`) and passes after. Full `Nethermind.Shutter.Test` suite passes (40/40).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
