### PR TITLE
fix(shutter): bound-check keyper signer index from decryption keys

### DIFF
--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterKeyValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterKeyValidatorTests.cs
@@ -41,29 +41,19 @@ class ShutterKeyValidatorTests
         Assert.That(api.KeysValidated, Is.EqualTo(1));
     }
 
-    [Test]
-    public void Rejects_decryption_keys_with_out_of_range_signer_index()
+    private static IEnumerable<TestCaseData> MalformedDecryptionKeysCases()
     {
-        Random rnd = new(ShutterTestsCommon.Seed);
-        ShutterApiSimulator api = ShutterTestsCommon.InitApi(rnd);
-
-        (List<ShutterEventSimulator.Event> _, Dto.DecryptionKeys keys) = api.AdvanceSlot(5);
-        Assert.That(api.KeysValidated, Is.EqualTo(1));
-
-        // Re-target a fresh slot so the message is not skipped, then point the first signer index
-        // past the keyper address list. Previously this hit an unchecked array access in
-        // CheckDecryptionKeys and threw IndexOutOfRangeException; it must now be rejected gracefully.
-        keys.Gnosis.Slot += 1;
-        keys.Gnosis.SignerIndices[0] = ulong.MaxValue;
-
-        IShutterKeyValidator.ValidatedKeys? result = null;
-        Assert.DoesNotThrow(() => result = api.KeyValidator.ValidateKeys(keys));
-        Assert.That(result, Is.Null);
-        Assert.That(api.KeysValidated, Is.EqualTo(1));
+        yield return new TestCaseData((Action<Dto.DecryptionKeys>)(keys => keys.Gnosis.SignerIndices[0] = ulong.MaxValue))
+            .SetName("signer index out of range");
+        yield return new TestCaseData((Action<Dto.DecryptionKeys>)(keys => keys.Gnosis.Signatures[0] = ByteString.CopyFrom(new byte[10])))
+            .SetName("wrong-length signature");
     }
 
-    [Test]
-    public void Rejects_decryption_keys_with_wrong_length_signature()
+    // Each corruption targets an attacker-controlled field that previously hit an unchecked access in
+    // CheckDecryptionKeys (Addresses[signerIndex] / signatureBytes[64]) and threw IndexOutOfRangeException;
+    // both must now be rejected gracefully (ValidateKeys returns null instead of throwing).
+    [TestCaseSource(nameof(MalformedDecryptionKeysCases))]
+    public void Rejects_malformed_decryption_keys(Action<Dto.DecryptionKeys> corrupt)
     {
         Random rnd = new(ShutterTestsCommon.Seed);
         ShutterApiSimulator api = ShutterTestsCommon.InitApi(rnd);
@@ -71,10 +61,8 @@ class ShutterKeyValidatorTests
         (List<ShutterEventSimulator.Event> _, Dto.DecryptionKeys keys) = api.AdvanceSlot(5);
         Assert.That(api.KeysValidated, Is.EqualTo(1));
 
-        // Re-target a fresh slot, then truncate the first signature. CheckSlotDecryptionIdentitiesSignature
-        // indexes signatureBytes[64]; a short signature previously threw IndexOutOfRangeException.
-        keys.Gnosis.Slot += 1;
-        keys.Gnosis.Signatures[0] = ByteString.CopyFrom(new byte[10]);
+        keys.Gnosis.Slot += 1; // a fresh slot so the message is not skipped
+        corrupt(keys);
 
         IShutterKeyValidator.ValidatedKeys? result = null;
         Assert.DoesNotThrow(() => result = api.KeyValidator.ValidateKeys(keys));

--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterKeyValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterKeyValidatorTests.cs
@@ -49,9 +49,6 @@ class ShutterKeyValidatorTests
             .SetName("wrong-length signature");
     }
 
-    // Each corruption targets an attacker-controlled field that previously hit an unchecked access in
-    // CheckDecryptionKeys (Addresses[signerIndex] / signatureBytes[64]) and threw IndexOutOfRangeException;
-    // both must now be rejected gracefully (ValidateKeys returns null instead of throwing).
     [TestCaseSource(nameof(MalformedDecryptionKeysCases))]
     public void Rejects_malformed_decryption_keys(Action<Dto.DecryptionKeys> corrupt)
     {
@@ -61,7 +58,7 @@ class ShutterKeyValidatorTests
         (List<ShutterEventSimulator.Event> _, Dto.DecryptionKeys keys) = api.AdvanceSlot(5);
         Assert.That(api.KeysValidated, Is.EqualTo(1));
 
-        keys.Gnosis.Slot += 1; // a fresh slot so the message is not skipped
+        keys.Gnosis.Slot += 1;
         corrupt(keys);
 
         IShutterKeyValidator.ValidatedKeys? result = null;

--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterKeyValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterKeyValidatorTests.cs
@@ -39,4 +39,25 @@ class ShutterKeyValidatorTests
 
         Assert.That(api.KeysValidated, Is.EqualTo(1));
     }
+
+    [Test]
+    public void Rejects_decryption_keys_with_out_of_range_signer_index()
+    {
+        Random rnd = new(ShutterTestsCommon.Seed);
+        ShutterApiSimulator api = ShutterTestsCommon.InitApi(rnd);
+
+        (List<ShutterEventSimulator.Event> _, Dto.DecryptionKeys keys) = api.AdvanceSlot(5);
+        Assert.That(api.KeysValidated, Is.EqualTo(1));
+
+        // Re-target a fresh slot so the message is not skipped, then point the first signer index
+        // past the keyper address list. Previously this hit an unchecked array access in
+        // CheckDecryptionKeys and threw IndexOutOfRangeException; it must now be rejected gracefully.
+        keys.Gnosis.Slot += 1;
+        keys.Gnosis.SignerIndices[0] = ulong.MaxValue;
+
+        IShutterKeyValidator.ValidatedKeys? result = null;
+        Assert.DoesNotThrow(() => result = api.KeyValidator.ValidateKeys(keys));
+        Assert.That(result, Is.Null);
+        Assert.That(api.KeysValidated, Is.EqualTo(1));
+    }
 }

--- a/src/Nethermind/Nethermind.Shutter.Test/ShutterKeyValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Shutter.Test/ShutterKeyValidatorTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Google.Protobuf;
 using NUnit.Framework;
 
 namespace Nethermind.Shutter.Test;
@@ -54,6 +55,26 @@ class ShutterKeyValidatorTests
         // CheckDecryptionKeys and threw IndexOutOfRangeException; it must now be rejected gracefully.
         keys.Gnosis.Slot += 1;
         keys.Gnosis.SignerIndices[0] = ulong.MaxValue;
+
+        IShutterKeyValidator.ValidatedKeys? result = null;
+        Assert.DoesNotThrow(() => result = api.KeyValidator.ValidateKeys(keys));
+        Assert.That(result, Is.Null);
+        Assert.That(api.KeysValidated, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Rejects_decryption_keys_with_wrong_length_signature()
+    {
+        Random rnd = new(ShutterTestsCommon.Seed);
+        ShutterApiSimulator api = ShutterTestsCommon.InitApi(rnd);
+
+        (List<ShutterEventSimulator.Event> _, Dto.DecryptionKeys keys) = api.AdvanceSlot(5);
+        Assert.That(api.KeysValidated, Is.EqualTo(1));
+
+        // Re-target a fresh slot, then truncate the first signature. CheckSlotDecryptionIdentitiesSignature
+        // indexes signatureBytes[64]; a short signature previously threw IndexOutOfRangeException.
+        keys.Gnosis.Slot += 1;
+        keys.Gnosis.Signatures[0] = ByteString.CopyFrom(new byte[10]);
 
         IShutterKeyValidator.ValidatedKeys? result = null;
         Assert.DoesNotThrow(() => result = api.KeyValidator.ValidateKeys(keys));

--- a/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
 using Nethermind.Shutter.Config;
 using Nethermind.Logging;
@@ -149,10 +150,10 @@ public class ShutterKeyValidator(
             Address keyperAddress = eonInfo.Addresses[signerIndex];
 
             // signature is attacker-controlled; CheckSlotDecryptionIdentitiesSignature indexes signatureBytes[64],
-            // so reject a wrong-sized signature here to avoid an IndexOutOfRangeException (an ECDSA signature is 65 bytes).
-            if (signature.Length != 65)
+            // so reject a wrong-sized signature here to avoid an IndexOutOfRangeException.
+            if (signature.Length != Signature.Size)
             {
-                if (_logger.IsDebug) _logger.Debug($"Invalid Shutter decryption keys received: signature length {signature.Length} (expected 65).");
+                if (_logger.IsDebug) _logger.Debug($"Invalid Shutter decryption keys received: signature length {signature.Length} (expected {Signature.Size}).");
                 return false;
             }
 

--- a/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
@@ -138,6 +138,14 @@ public class ShutterKeyValidator(
 
         foreach ((ulong signerIndex, ByteString signature) in decryptionKeys.Gnosis.SignerIndices.Zip(decryptionKeys.Gnosis.Signatures))
         {
+            // signerIndex is attacker-controlled (gossiped over P2P); the checks above bound the
+            // count but not the values, so guard the array access to avoid an IndexOutOfRangeException.
+            if (signerIndex >= (ulong)eonInfo.Addresses.Length)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Invalid Shutter decryption keys received: signer index {signerIndex} out of range ({eonInfo.Addresses.Length} keyper addresses).");
+                return false;
+            }
+
             Address keyperAddress = eonInfo.Addresses[signerIndex];
 
             if (!ShutterCrypto.CheckSlotDecryptionIdentitiesSignature(_instanceId, eonInfo.Eon, decryptionKeys.Gnosis.Slot, decryptionKeys.Gnosis.TxPointer, identityPreimages, signature.Span, keyperAddress))

--- a/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
@@ -148,6 +148,14 @@ public class ShutterKeyValidator(
 
             Address keyperAddress = eonInfo.Addresses[signerIndex];
 
+            // signature is attacker-controlled; CheckSlotDecryptionIdentitiesSignature indexes signatureBytes[64],
+            // so reject a wrong-sized signature here to avoid an IndexOutOfRangeException (an ECDSA signature is 65 bytes).
+            if (signature.Length != 65)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Invalid Shutter decryption keys received: signature length {signature.Length} (expected 65).");
+                return false;
+            }
+
             if (!ShutterCrypto.CheckSlotDecryptionIdentitiesSignature(_instanceId, eonInfo.Eon, decryptionKeys.Gnosis.Slot, decryptionKeys.Gnosis.TxPointer, identityPreimages, signature.Span, keyperAddress))
             {
                 if (_logger.IsDebug) _logger.Debug($"Invalid Shutter decryption keys received: bad signature.");

--- a/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterKeyValidator.cs
@@ -139,8 +139,6 @@ public class ShutterKeyValidator(
 
         foreach ((ulong signerIndex, ByteString signature) in decryptionKeys.Gnosis.SignerIndices.Zip(decryptionKeys.Gnosis.Signatures))
         {
-            // signerIndex is attacker-controlled (gossiped over P2P); the checks above bound the
-            // count but not the values, so guard the array access to avoid an IndexOutOfRangeException.
             if (signerIndex >= (ulong)eonInfo.Addresses.Length)
             {
                 if (_logger.IsDebug) _logger.Debug($"Invalid Shutter decryption keys received: signer index {signerIndex} out of range ({eonInfo.Addresses.Length} keyper addresses).");
@@ -149,8 +147,6 @@ public class ShutterKeyValidator(
 
             Address keyperAddress = eonInfo.Addresses[signerIndex];
 
-            // signature is attacker-controlled; CheckSlotDecryptionIdentitiesSignature indexes signatureBytes[64],
-            // so reject a wrong-sized signature here to avoid an IndexOutOfRangeException.
             if (signature.Length != Signature.Size)
             {
                 if (_logger.IsDebug) _logger.Debug($"Invalid Shutter decryption keys received: signature length {signature.Length} (expected {Signature.Size}).");


### PR DESCRIPTION
## Changes

- `ShutterKeyValidator.CheckDecryptionKeys` now bounds-checks each `signerIndex` against `eonInfo.Addresses.Length` before indexing the keyper address array. The surrounding checks bound the *count* of signer indices (duplicates, count vs. signatures, count vs. threshold) but not their *values*, so a crafted decryption-keys message gossiped over the Shutter P2P network could reach `eonInfo.Addresses[signerIndex]` with an out-of-range index and throw `IndexOutOfRangeException`. That exception was not caught on the `ProcessP2PMessage` path (which only catches `InvalidProtocolBufferException`) and was rethrown as `ShutterP2PException` out of the Shutter processing loop — a remotely-triggerable DoS of the Shutter subsystem on Gnosis.
- Out-of-range indices are now rejected gracefully (the message is treated as invalid).
- Added a regression test.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New test `Rejects_decryption_keys_with_out_of_range_signer_index` fails before the change (throws `IndexOutOfRangeException`) and passes after. Full `Nethermind.Shutter.Test` suite passes (37/37).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
