### PR TITLE
fix(dns): validate enrtree-root fields and skip malformed records

### DIFF
--- a/src/Nethermind/Nethermind.Network.Dns.Test/EnrTreeParserTests.cs
+++ b/src/Nethermind/Nethermind.Network.Dns.Test/EnrTreeParserTests.cs
@@ -42,8 +42,7 @@ public class EnrTreeParserTests
         Assert.That(leaf.NodeRecord, Is.EqualTo(enr.Substring(4)));
     }
 
-    // A malformed enrtree-root from an untrusted DNS record must surface as a FormatException
-    // (caught and skipped by the crawler), never an unhandled ArgumentOutOfRangeException that aborts the crawl.
+    // Malformed input must surface as a FormatException the crawler can catch, not an unhandled exception that aborts the crawl.
     [TestCase("enrtree-root:v1", TestName = "all fields missing")]
     [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=2779sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "no space after seq value")]
     [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "seq field missing")]

--- a/src/Nethermind/Nethermind.Network.Dns.Test/EnrTreeParserTests.cs
+++ b/src/Nethermind/Nethermind.Network.Dns.Test/EnrTreeParserTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Dns.Test;
@@ -40,6 +41,16 @@ public class EnrTreeParserTests
         Assert.That(leaf.Records[0], Is.EqualTo(enr));
         Assert.That(leaf.NodeRecord, Is.EqualTo(enr.Substring(4)));
     }
+
+    // A malformed enrtree-root from an untrusted DNS record must surface as a FormatException
+    // (caught and skipped by the crawler), never an unhandled ArgumentOutOfRangeException that aborts the crawl.
+    [TestCase("enrtree-root:v1", TestName = "all fields missing")]
+    [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=2779sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "no space after seq value")]
+    [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "seq field missing")]
+    [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=2779 sig=SHORT", TestName = "truncated sig field")]
+    [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=notanumber sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "non-numeric seq value")]
+    public void Malformed_enrtree_root_throws_FormatException(string malformedRoot)
+        => Assert.That(() => EnrTreeParser.ParseEnrRoot(malformedRoot), Throws.TypeOf<FormatException>());
 
     [TestCase("enrtree://all.mainnet.ethdisco.net")]
     [TestCase("enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.mainnet.ethdisco.net")]

--- a/src/Nethermind/Nethermind.Network.Dns.Test/EnrTreeParserTests.cs
+++ b/src/Nethermind/Nethermind.Network.Dns.Test/EnrTreeParserTests.cs
@@ -49,6 +49,8 @@ public class EnrTreeParserTests
     [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "seq field missing")]
     [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=2779 sig=SHORT", TestName = "truncated sig field")]
     [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=notanumber sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "non-numeric seq value")]
+    [TestCase("enrtree-root:v1 l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=2779 sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "e field missing")]
+    [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM seq=2779 sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "l field missing")]
     public void Malformed_enrtree_root_throws_FormatException(string malformedRoot)
         => Assert.That(() => EnrTreeParser.ParseEnrRoot(malformedRoot), Throws.TypeOf<FormatException>());
 

--- a/src/Nethermind/Nethermind.Network.Dns.Test/EnrTreeParserTests.cs
+++ b/src/Nethermind/Nethermind.Network.Dns.Test/EnrTreeParserTests.cs
@@ -50,6 +50,10 @@ public class EnrTreeParserTests
     [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=notanumber sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "non-numeric seq value")]
     [TestCase("enrtree-root:v1 l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=2779 sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "e field missing")]
     [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM seq=2779 sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "l field missing")]
+    [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=2779 sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "duplicate e field")]
+    [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=2779 sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "duplicate l field")]
+    [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=2779 seq=2779 sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "duplicate seq field")]
+    [TestCase("enrtree-root:v1 e=TPLRUM3FAKJZIRMXADWOHSU3PM l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=2779 sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE sig=CNoJofW_lNh7QFQkaVGhEX2ifbEZ3UkiBQCVyZCkM_I-72cEh8Bfd21cSS9BP5tyAqWF3jMVov8duUCdSByEQAE", TestName = "duplicate sig field")]
     public void Malformed_enrtree_root_throws_FormatException(string malformedRoot)
         => Assert.That(() => EnrTreeParser.ParseEnrRoot(malformedRoot), Throws.TypeOf<FormatException>());
 

--- a/src/Nethermind/Nethermind.Network.Dns/EnrTreeCrawler.cs
+++ b/src/Nethermind/Nethermind.Network.Dns/EnrTreeCrawler.cs
@@ -53,7 +53,18 @@ public class EnrTreeCrawler(ILogger logger)
             IEnumerable<string> lookupResult = await client.Lookup(query, cancellationToken);
             foreach (string node in lookupResult)
             {
-                EnrTreeNode treeNode = EnrTreeParser.ParseNode(node);
+                EnrTreeNode treeNode;
+                try
+                {
+                    treeNode = EnrTreeParser.ParseNode(node);
+                }
+                catch (Exception e) when (e is FormatException or NotSupportedException or ArgumentException)
+                {
+                    // A single malformed record from an untrusted DNS server must not abort the whole crawl.
+                    if (_logger.IsDebug) _logger.Debug($"Skipping malformed ENR tree record from DNS query '{query}': {e.Message}");
+                    continue;
+                }
+
                 foreach (string link in treeNode.Links)
                 {
                     DnsClient linkedTreeLookup = new(link);

--- a/src/Nethermind/Nethermind.Network.Dns/EnrTreeCrawler.cs
+++ b/src/Nethermind/Nethermind.Network.Dns/EnrTreeCrawler.cs
@@ -58,7 +58,7 @@ public class EnrTreeCrawler(ILogger logger)
                 {
                     treeNode = EnrTreeParser.ParseNode(node);
                 }
-                catch (Exception e) when (e is FormatException or NotSupportedException or ArgumentException)
+                catch (Exception e) when (e is FormatException or NotSupportedException)
                 {
                     // A single malformed record from an untrusted DNS server must not abort the whole crawl.
                     if (_logger.IsDebug) _logger.Debug($"Skipping malformed ENR tree record from DNS query '{query}': {e.Message}");

--- a/src/Nethermind/Nethermind.Network.Dns/EnrTreeParser.cs
+++ b/src/Nethermind/Nethermind.Network.Dns/EnrTreeParser.cs
@@ -63,21 +63,50 @@ public static class EnrTreeParser
     {
         ArgumentNullException.ThrowIfNull(enrTreeRootText);
 
-        EnrTreeRoot enrTreeRoot = new();
-
-        int ensRootIndex = enrTreeRootText.IndexOf("e=", StringComparison.Ordinal);
-        enrTreeRoot.EnrRoot = enrTreeRootText.Substring(ensRootIndex + 2, HashLengthBase32);
-
-        int linkRootIndex = enrTreeRootText.IndexOf("l=", StringComparison.Ordinal);
-        enrTreeRoot.LinkRoot = enrTreeRootText.Substring(linkRootIndex + 2, HashLengthBase32);
-
-        int seqIndex = enrTreeRootText.IndexOf("seq=", StringComparison.Ordinal);
-        int seqLength = enrTreeRootText.IndexOf(' ', seqIndex) - (seqIndex + 4);
-        enrTreeRoot.Sequence = int.Parse(enrTreeRootText.AsSpan(seqIndex + 4, seqLength));
-
-        int sigIndex = enrTreeRootText.IndexOf("sig=", StringComparison.Ordinal);
-        enrTreeRoot.Signature = enrTreeRootText.Substring(sigIndex + 4, SigLengthBase32);
+        // enrTreeRootText comes from an untrusted DNS TXT record (parsed before any signature check),
+        // so validate every field's presence and length before slicing to avoid an unhandled exception.
+        EnrTreeRoot enrTreeRoot = new()
+        {
+            EnrRoot = ExtractFixedField(enrTreeRootText, "e=", HashLengthBase32),
+            LinkRoot = ExtractFixedField(enrTreeRootText, "l=", HashLengthBase32),
+            Sequence = ExtractSequence(enrTreeRootText),
+            Signature = ExtractFixedField(enrTreeRootText, "sig=", SigLengthBase32),
+        };
 
         return enrTreeRoot;
+
+        static string ExtractFixedField(string text, string key, int length)
+        {
+            int index = text.IndexOf(key, StringComparison.Ordinal);
+            if (index < 0 || index + key.Length + length > text.Length)
+            {
+                throw new FormatException($"Malformed enrtree-root: '{key}' field is missing or too short.");
+            }
+
+            return text.Substring(index + key.Length, length);
+        }
+
+        static int ExtractSequence(string text)
+        {
+            int index = text.IndexOf("seq=", StringComparison.Ordinal);
+            if (index < 0)
+            {
+                throw new FormatException("Malformed enrtree-root: 'seq=' field is missing.");
+            }
+
+            int start = index + "seq=".Length;
+            int end = text.IndexOf(' ', start);
+            if (end < 0)
+            {
+                throw new FormatException("Malformed enrtree-root: 'seq=' field is not terminated.");
+            }
+
+            if (!int.TryParse(text.AsSpan(start, end - start), out int sequence))
+            {
+                throw new FormatException("Malformed enrtree-root: 'seq=' value is not a valid number.");
+            }
+
+            return sequence;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Dns/EnrTreeParser.cs
+++ b/src/Nethermind/Nethermind.Network.Dns/EnrTreeParser.cs
@@ -83,6 +83,11 @@ public static class EnrTreeParser
                 throw new FormatException($"Malformed enrtree-root: '{key}' field is missing or too short.");
             }
 
+            if (text.IndexOf(key, index + key.Length, StringComparison.Ordinal) >= 0)
+            {
+                throw new FormatException($"Malformed enrtree-root: '{key}' field appears more than once.");
+            }
+
             return text.Substring(index + key.Length, length);
         }
 
@@ -92,6 +97,11 @@ public static class EnrTreeParser
             if (index < 0)
             {
                 throw new FormatException("Malformed enrtree-root: 'seq=' field is missing.");
+            }
+
+            if (text.IndexOf("seq=", index + "seq=".Length, StringComparison.Ordinal) >= 0)
+            {
+                throw new FormatException("Malformed enrtree-root: 'seq=' field appears more than once.");
             }
 
             int start = index + "seq=".Length;


### PR DESCRIPTION
## Changes

- `EnrTreeParser.ParseEnrRoot` now validates the presence and length of all four fields (`e=`, `l=`, `seq=`, `sig=`) in an untrusted DNS TXT record before slicing, and uses `int.TryParse` for the sequence. Previously a malformed record (missing field, no space after the `seq=` value, truncated `sig=`, non-numeric `seq=`) threw an unhandled `ArgumentOutOfRangeException`/`FormatException` from the raw `IndexOf`/`Substring` calls. Because this parsing happens *before* any ENR signature verification, a spoofed or malformed record could abort the entire DNS-discovery crawl.
- `EnrTreeCrawler.SearchNode` now catches a parse failure for a single record (`FormatException`/`NotSupportedException`/`ArgumentException`), logs it at debug, and continues the crawl instead of aborting it.
- Added regression tests covering the malformed-root cases.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New `Malformed_enrtree_root_throws_FormatException` cases fail before the change (unhandled `ArgumentOutOfRangeException`) and pass after. Full `Nethermind.Network.Dns.Test` suite passes.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
