### PR TITLE
fix(gas-estimator): use the next-block spec consistently during estimation

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -89,7 +89,7 @@ public class GasEstimator(
         UInt256 feeCap = tx.CalculateFeeCap();
         EstimationBounds bounds = CapByAllowance(new EstimationBounds(leftBound, rightBound, intrinsicGas), available, feeCap);
 
-        return BinarySearchEstimate(tx, header, gasTracer, bounds, errorMargin, token);
+        return BinarySearchEstimate(tx, header, spec, gasTracer, bounds, errorMargin, token);
     }
 
     private static EstimationResult? ValidateErrorMargin(ulong errorMargin) =>
@@ -131,15 +131,15 @@ public class GasEstimator(
     }
 
     private EstimationResult BinarySearchEstimate(
-        Transaction tx, BlockHeader header, EstimateGasTracer gasTracer,
+        Transaction tx, BlockHeader header, IReleaseSpec spec, EstimateGasTracer gasTracer,
         EstimationBounds bounds, ulong errorMargin, CancellationToken token)
     {
         // Short-circuit: simple ETH transfers need exactly the intrinsic gas.
-        if (IsSimpleTransfer(tx) && TryExecute(tx, header, bounds.IntrinsicGas, gasTracer, token, out _))
+        if (IsSimpleTransfer(tx) && TryExecute(tx, header, spec, bounds.IntrinsicGas, gasTracer, token, out _))
             return EstimationResult.Success(bounds.IntrinsicGas);
 
         // Execute at maximum gas first (Geth parity): gas-related failure → allowance error; other → surface directly.
-        if (!TryExecute(tx, header, bounds.RightBound, gasTracer, token, out bool isGasRelatedFailure))
+        if (!TryExecute(tx, header, spec, bounds.RightBound, gasTracer, token, out bool isGasRelatedFailure))
         {
             string error = (gasTracer.OutOfGas || isGasRelatedFailure)
                 ? $"{GasExceedsAllowanceMsgPrefix} ({bounds.RightBound})"
@@ -149,26 +149,26 @@ public class GasEstimator(
 
         double marginMultiplier = errorMargin == 0 ? 1d : errorMargin / BasisPointsDivisor + 1d;
         ulong cap = bounds.RightBound;
-        (ulong leftBound, ulong rightBound) = TryOptimisticEstimate(tx, header, gasTracer, bounds, OptimisticMultiplier, token);
+        (ulong leftBound, ulong rightBound) = TryOptimisticEstimate(tx, header, spec, gasTracer, bounds, OptimisticMultiplier, token);
 
         // Narrow bounds until within the error margin (Geth approach).
         while (ShouldContinueSearch(leftBound, rightBound, marginMultiplier - 1d))
         {
             ulong mid = leftBound + (rightBound - leftBound) / 2;
-            if (TryExecute(tx, header, mid, gasTracer, token, out _))
+            if (TryExecute(tx, header, spec, mid, gasTracer, token, out _))
                 rightBound = mid;
             else
                 leftBound = mid;
         }
 
-        if (rightBound == cap && !TryExecute(tx, header, rightBound, gasTracer, token, out _))
+        if (rightBound == cap && !TryExecute(tx, header, spec, rightBound, gasTracer, token, out _))
             return EstimationResult.Failure(GetError(gasTracer));
 
         return EstimationResult.Success(rightBound);
     }
 
     private (ulong Left, ulong Right) TryOptimisticEstimate(
-        Transaction tx, BlockHeader header, EstimateGasTracer gasTracer,
+        Transaction tx, BlockHeader header, IReleaseSpec spec, EstimateGasTracer gasTracer,
         EstimationBounds bounds, double optimisticMultiplier, CancellationToken token)
     {
         ulong leftBound = bounds.LeftBound;
@@ -178,7 +178,7 @@ public class GasEstimator(
         ulong optimistic = (ulong)((gasTracer.GasSpent + gasTracer.TotalRefund + GasCostOf.CallStipend) * optimisticMultiplier);
         if (optimistic > leftBound && optimistic < rightBound)
         {
-            if (TryExecute(tx, header, optimistic, gasTracer, token, out _))
+            if (TryExecute(tx, header, spec, optimistic, gasTracer, token, out _))
                 rightBound = optimistic;
             else
                 leftBound = optimistic;
@@ -187,14 +187,16 @@ public class GasEstimator(
         return (leftBound, rightBound);
     }
 
-    private bool TryExecute(Transaction transaction, BlockHeader header, ulong gasLimit,
+    private bool TryExecute(Transaction transaction, BlockHeader header, IReleaseSpec spec, ulong gasLimit,
                              EstimateGasTracer gasTracer, CancellationToken token, out bool isGasRelatedFailure)
     {
         Transaction txClone = new();
         transaction.CopyTo(txClone);
         txClone.GasLimit = gasLimit;
 
-        transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, specProvider.GetSpec(header)));
+        // Use the same spec the bounds were computed with (the block the tx would execute in, header.Number + 1),
+        // so estimation stays consistent across a fork-activation boundary instead of executing under the parent's rules.
+        transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, spec));
         TransactionResult callResult = transactionProcessor.CallAndRestore(txClone, gasTracer.WithCancellation(token));
 
         if (IsGasRelatedFailure(callResult))

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -194,8 +194,6 @@ public class GasEstimator(
         transaction.CopyTo(txClone);
         txClone.GasLimit = gasLimit;
 
-        // Use the same spec the bounds were computed with (the block the tx would execute in, header.Number + 1),
-        // so estimation stays consistent across a fork-activation boundary instead of executing under the parent's rules.
         transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, spec));
         TransactionResult callResult = transactionProcessor.CallAndRestore(txClone, gasTracer.WithCancellation(token));
 

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -280,9 +280,8 @@ namespace Nethermind.Evm.Test.Tracing
         [Test]
         public void Estimate_uses_next_block_spec_for_execution_across_fork_boundary()
         {
-            // The header is the parent; the tx would execute in the next block. With the header timestamped one
-            // slot before Cancun activates, execution must use the Cancun spec (the block the tx lands in), not
-            // the parent's pre-Cancun spec, so estimation stays consistent across the fork boundary.
+            // Estimate treats the header as the parent: the tx executes in the next block. The header sits one
+            // slot before Cancun, so execution must use the next block's spec (Cancun), not the parent's.
             BlocksConfig blocksConfig = new();
             BlockHeader header = Build.A.BlockHeader
                 .WithNumber(MainnetSpecProvider.ParisBlockNumber + 100)
@@ -305,8 +304,6 @@ namespace Nethermind.Evm.Test.Tracing
 
             sut.Estimate(tx, header, tracer, out string? _);
 
-            // Before the fix this used GetSpec(header) (pre-Cancun, EIP-4844 disabled); the fix uses the
-            // header.Number + 1 spec (Cancun, EIP-4844 enabled).
             Assert.That(captured, Is.Not.Null);
             Assert.That(captured!.Value.Spec.IsEip4844Enabled, Is.True);
         }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -277,6 +277,40 @@ namespace Nethermind.Evm.Test.Tracing
             Assert.That(err, Is.Not.Null);
         }
 
+        [Test]
+        public void Estimate_uses_next_block_spec_for_execution_across_fork_boundary()
+        {
+            // The header is the parent; the tx would execute in the next block. With the header timestamped one
+            // slot before Cancun activates, execution must use the Cancun spec (the block the tx lands in), not
+            // the parent's pre-Cancun spec, so estimation stays consistent across the fork boundary.
+            BlocksConfig blocksConfig = new();
+            BlockHeader header = Build.A.BlockHeader
+                .WithNumber(MainnetSpecProvider.ParisBlockNumber + 100)
+                .WithTimestamp(MainnetSpecProvider.CancunBlockTimestamp - blocksConfig.SecondsPerSlot)
+                .TestObject;
+
+            BlockExecutionContext? captured = null;
+            ITransactionProcessor processor = Substitute.For<ITransactionProcessor>();
+            processor.When(p => p.SetBlockExecutionContext(Arg.Any<BlockExecutionContext>()))
+                .Do(ci => captured = ci.Arg<BlockExecutionContext>());
+
+            IReadOnlyStateProvider stateProvider = Substitute.For<IReadOnlyStateProvider>();
+            stateProvider.GetBalance(Arg.Any<Address>()).Returns(UInt256.MaxValue);
+
+            GasEstimator sut = new(processor, stateProvider, MainnetSpecProvider.Instance, blocksConfig);
+
+            Transaction tx = Build.A.Transaction.WithGasLimit(30000).TestObject;
+            EstimateGasTracer tracer = new();
+            tracer.MarkAsSuccess(Address.Zero, 21000, [], []);
+
+            sut.Estimate(tx, header, tracer, out string? _);
+
+            // Before the fix this used GetSpec(header) (pre-Cancun, EIP-4844 disabled); the fix uses the
+            // header.Number + 1 spec (Cancun, EIP-4844 enabled).
+            Assert.That(captured, Is.Not.Null);
+            Assert.That(captured!.Value.Spec.IsEip4844Enabled, Is.True);
+        }
+
         [TestCase(Transaction.BaseTxGasCost, (ulong)GasEstimator.DefaultErrorMargin, false)]
         [TestCase(Transaction.BaseTxGasCost, 100UL, false)]
         [TestCase(Transaction.BaseTxGasCost, 1000UL, false)]

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -280,8 +280,6 @@ namespace Nethermind.Evm.Test.Tracing
         [Test]
         public void Estimate_uses_next_block_spec_for_execution_across_fork_boundary()
         {
-            // Estimate treats the header as the parent: the tx executes in the next block. The header sits one
-            // slot before Cancun, so execution must use the next block's spec (Cancun), not the parent's.
             BlocksConfig blocksConfig = new();
             BlockHeader header = Build.A.BlockHeader
                 .WithNumber(MainnetSpecProvider.ParisBlockNumber + 100)


### PR DESCRIPTION
## Changes

- `GasEstimator` computed the spec for the block the transaction would execute in (`header.Number + 1`) when deriving the estimation bounds (intrinsic gas, tx gas-limit cap, blob fee), but `TryExecute` re-derived `specProvider.GetSpec(header)` — the *parent* block's spec — for the actual trial execution. At a fork-activation boundary the two diverge, so `eth_estimateGas` could compute its bounds under the next block's rules while executing under the parent's rules.
- The fix threads the single already-computed `header.Number + 1` spec through `BinarySearchEstimate` / `TryOptimisticEstimate` / `TryExecute`, so bounds and execution always agree. As a side benefit, this removes the repeated `GetSpec` lookups that previously ran on every binary-search iteration.
- This is the read-only `eth_estimateGas` path; it does not affect block production or consensus.
- Added a regression test asserting the execution context uses the next-block (post-fork) spec across a Cancun activation boundary.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New test `Estimate_uses_next_block_spec_for_execution_across_fork_boundary` fails before the change (execution used the pre-Cancun spec) and passes after. Full `GasEstimationTests` suite passes (106/106).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
