### PR TITLE
fix(test): reduce BAL e2e sync chain length to avoid macOS CI timeout flakiness

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -94,7 +94,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
     private const int ChainLength = 1000;
     private const ulong HeadPivotDistance = 500;
     private static TimeSpan BalSyncTestTimeout = TimeSpan.FromMinutes(10);
-    private const int BalSyncChainLength = 15_000;
+    private const int BalSyncChainLength = 5_000;
     private const int PartialBalSyncChainLength = 1_000;
     private const int PartialBalActivationBlock = 400;
     private const ulong PartialBalSyncHeadPivotDistance = 500;


### PR DESCRIPTION
## Changes

`E2ESyncTests.FastSync_downloads_block_access_lists_over_eth71` intermittently times out on slow CI runners (observed on `macos-latest`), failing with `Sync feeds dispose timeout` at ~10m05s — i.e. it hits the 10-minute `BalSyncTestTimeout`.

The run's progress log shows the server finishes building all 15,000 blocks and the pivot is computed (`head 15000, pivot 14500`), but no verification-progress lines appear, so it times out during the **client fast-sync phase** (downloading ~14,500 blocks' headers/bodies/BALs). The feeds are still active when the timeout cancels them, hence the dispose warning. It is slow-but-progressing under load, not a deterministic hang.

- Reduced `BalSyncChainLength` from `15_000` to `5_000`. The fast-sync download scales with the chain length, so this gives ample headroom under the 10-minute budget while still exercising multi-batch BAL fast-sync (pivot at head − 500, BALs verified down to block 1 — the same regression coverage).

Locally the test now completes in tens of seconds (whole filtered run incl. build ~1 min), versus hitting the 10-minute cap at 15,000. The test keeps its existing `[Category("Flaky"), Retry(2)]`; this addresses the underlying cause (per-attempt cost exceeding the budget) rather than relying on retries.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: test stability fix (flaky CI)

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Ran `FastSync_downloads_block_access_lists_over_eth71` locally at the reduced chain length — it passes, with the sync completing in tens of seconds.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
