### PR TITLE
ci: pin Claude review workflow to opus model

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -146,6 +146,7 @@ jobs:
 
             Set `mergeable: false` in the structured output if any Critical, High, or Medium findings exist that have not been explicitly acknowledged with rationale in prior PR comments. Otherwise `mergeable: true`.
           claude_args: |
+            --model opus
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh:*),WebFetch"
             --json-schema '{"type":"object","properties":{"mergeable":{"type":"boolean","description":"False if any Critical, High, or Medium findings remain unresolved and unexplained"},"critical_count":{"type":"integer"},"high_count":{"type":"integer"},"medium_count":{"type":"integer"},"summary":{"type":"string"}},"required":["mergeable","critical_count","high_count","medium_count","summary"]}'
 
@@ -161,6 +162,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
+            --model opus
             --allowedTools "Bash(gh:*),WebFetch"
 
       # After a successful review, read the structured verdict from the previous step and


### PR DESCRIPTION
## Changes

- Add `--model opus` to both the review-path and mention-path `claude_args` in `.github/workflows/claude-review.yml`.

The workflow uses `anthropics/claude-code-action@v1` but set no model, so it fell through to the bundled Claude Code CLI default, which had drifted to an older model than intended. Using the `opus` alias keeps the review agent on the latest Opus tier without needing manual model-id bumps.

## Types of changes

#### What types of changes does your code introduce?

- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
