### PR TITLE
EXPB fix(merge): restore int type for MergeConfig.CollectionsPerDecommit

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/CollectionsPerDecommitTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/CollectionsPerDecommitTests.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Config;
+using Nethermind.Merge.Plugin.GC;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+[Parallelizable(ParallelScope.All)]
+public class CollectionsPerDecommitTests
+{
+    [Test]
+    public void Negative_sentinel_binds_without_overflow()
+    {
+        ConfigProvider configProvider = new();
+        configProvider.AddSource(new ArgsConfigSource(new Dictionary<string, string>
+        {
+            { "Merge.CollectionsPerDecommit", "-1" }
+        }));
+
+        IMergeConfig mergeConfig = configProvider.GetConfig<IMergeConfig>();
+
+        Assert.That(mergeConfig.CollectionsPerDecommit, Is.EqualTo(-1));
+    }
+
+    [Test]
+    public void NoGCStrategy_uses_negative_sentinel_to_disable_decommit() =>
+        Assert.That(NoGCStrategy.Instance.CollectionsPerDecommit, Is.EqualTo(-1));
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/GC/GCKeeper.cs
@@ -175,10 +175,10 @@ public class GCKeeper : IDisposable
             if (GCSettings.LatencyMode != GCLatencyMode.NoGCRegion)
             {
                 ulong forcedGcCount = Interlocked.Increment(ref _forcedGcCount);
-                ulong collectionsPerDecommit = _gcStrategy.CollectionsPerDecommit;
+                int collectionsPerDecommit = _gcStrategy.CollectionsPerDecommit;
 
                 GCCollectionMode mode = GCCollectionMode.Forced;
-                if (collectionsPerDecommit == 0 || (forcedGcCount % collectionsPerDecommit == 0))
+                if (collectionsPerDecommit == 0 || (forcedGcCount % (ulong)collectionsPerDecommit == 0))
                 {
                     // Also decommit memory back to O/S
                     mode = GCCollectionMode.Aggressive;

--- a/src/Nethermind/Nethermind.Merge.Plugin/GC/IGCStrategy.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/GC/IGCStrategy.cs
@@ -7,7 +7,7 @@ namespace Nethermind.Merge.Plugin.GC;
 
 public interface IGCStrategy
 {
-    ulong CollectionsPerDecommit { get; }
+    int CollectionsPerDecommit { get; }
     int PostBlockDelayMs { get; }
     bool CanStartNoGCRegion();
     (GcLevel Generation, GcCompaction Compacting) GetForcedGCParams();

--- a/src/Nethermind/Nethermind.Merge.Plugin/GC/NoGCStrategy.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/GC/NoGCStrategy.cs
@@ -6,7 +6,7 @@ namespace Nethermind.Merge.Plugin.GC;
 public class NoGCStrategy : IGCStrategy
 {
     public static readonly NoGCStrategy Instance = new();
-    public ulong CollectionsPerDecommit => 0UL;
+    public int CollectionsPerDecommit => -1;
     public int PostBlockDelayMs => 0;
     public bool CanStartNoGCRegion() => false;
     public (GcLevel Generation, GcCompaction Compacting) GetForcedGCParams() => (GcLevel.NoGC, GcCompaction.No);

--- a/src/Nethermind/Nethermind.Merge.Plugin/GC/NoSyncGcRegionStrategy.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/GC/NoSyncGcRegionStrategy.cs
@@ -23,7 +23,7 @@ public class NoSyncGcRegionStrategy : IGCStrategy
         PostBlockDelayMs = mergeConfig.PostBlockGcDelayMs ?? (int)((mergeConfig.SecondsPerSlot * 1000) / 8);
     }
 
-    public ulong CollectionsPerDecommit { get; }
+    public int CollectionsPerDecommit { get; }
     public int PostBlockDelayMs { get; }
 
     public bool CanStartNoGCRegion() => _canStartNoGCRegion && _syncModeSelector.Current == SyncMode.WaitingForBlock;

--- a/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
@@ -62,7 +62,7 @@ public interface IMergeConfig : IConfig
 
 
             """, DefaultValue = "25")]
-    public ulong CollectionsPerDecommit { get; set; }
+    public int CollectionsPerDecommit { get; set; }
 
     [ConfigItem(Description = "The timeout, in milliseconds, for the `engine_newPayload` method.", DefaultValue = "7000", HiddenFromDocs = true)]
     public int NewPayloadBlockProcessingTimeout { get; set; }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
@@ -29,7 +29,7 @@ namespace Nethermind.Merge.Plugin
 
         public GcCompaction CompactMemory { get; set; } = GcCompaction.Yes;
 
-        public ulong CollectionsPerDecommit { get; set; } = 25;
+        public int CollectionsPerDecommit { get; set; } = 25;
 
         public const int DefaultNewPayloadBlockProcessingTimeout = 7000;
 


### PR DESCRIPTION
## Problem

The [run-expb-reproducible-benchmarks](https://github.com/NethermindEth/nethermind/actions/workflows/run-expb-reproducible-benchmarks.yml) workflow started failing ([run 28154519066](https://github.com/NethermindEth/nethermind/actions/runs/28154519066)). The node crashes on startup before JSON-RPC comes up, and the benchmark client gives up:

```
A critical error has occurred. System.Configuration.ConfigurationErrorsException:
Could not load value MergeConfig.CollectionsPerDecommit. See inner exception for details.
 ---> System.OverflowException: Value was either too large or too small for a UInt64.
```

```
level=error event="Failed to wait for client json rpc" error="Client json rpc is not available after 1830 attempts"
```

## Root cause

PR #11937 ("Unify types with Geth") changed `MergeConfig.CollectionsPerDecommit` from `int` to `ulong` (along with the `IGCStrategy` / `NoGCStrategy` / `NoSyncGcRegionStrategy` / `GCKeeper` consumers).

This is an **internal GC-tuning knob with no Geth equivalent**, and `-1` is a documented, supported sentinel value meaning *"never decommit"*:

- The `ConfigItem` description explicitly documents `-1: No requests.`
- `NoGCStrategy.CollectionsPerDecommit` originally returned `-1`.
- In `GCKeeper`, `forcedGcCount % (ulong)(-1)` is effectively never `0`, so `-1` disabled decommit.

After the type change, supplying `-1` (used by the EXPB reproducible benchmark, and available to any deployment that wants to disable decommit for stable timing) fails config binding with `OverflowException`, crashing the node on startup.

As a side effect, `NoGCStrategy` was changed from `-1` to `0`, which **inverts** its meaning in `GCKeeper` (`0` ⇒ decommit *every* forced GC, the opposite of "no GC").

## Fix

Revert just the `CollectionsPerDecommit` field back to `int`, restoring the `-1` sentinel and the original `NoGCStrategy` behavior. Genuinely Geth-comparable fields from #11937 (e.g. `TerminalBlockNumber`) are intentionally left unchanged.

https://github.com/NethermindEth/nethermind/actions/runs/28238680378

## Verification

- `Nethermind.Merge.Plugin` builds clean (0 errors, 0 warnings).
- `-1` again binds successfully instead of overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)