### PR TITLE
feat: head state cache for fast RPC reads on top of head

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/HeadStateCacheUpdaterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/HeadStateCacheUpdaterTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using Nethermind.Core;
-using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
@@ -22,6 +21,10 @@ public class HeadStateCacheUpdaterTests
 {
     private static readonly Address A = TestItem.AddressA;
 
+    // Updates are applied on a background worker, so assertions poll for the expected state.
+    private const int PollMs = 5000;
+    private const int PollEveryMs = 10;
+
     [Test]
     public void Advances_cache_from_journal_delta_on_sequential_head()
     {
@@ -30,37 +33,30 @@ public class HeadStateCacheUpdaterTests
         FakeStateReader reader = new();
         IBlockTree blockTree = Substitute.For<IBlockTree>();
 
-        _ = new HeadStateCacheUpdater(blockTree, cache, reader, LimboLogs.Instance, buffer);
-
-        // First head: no parent in cache -> flush, anchors at block0.
-        Block block0 = BlockWith(TestItem.KeccakA, parent: TestItem.KeccakH, stateRoot: TestItem.KeccakC, number: 0);
-        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block0));
-        Assert.That(cache.HeadHash, Is.EqualTo(TestItem.KeccakA));
-
-        // Warm the cache with the pre-block (block0) values for a hot account + slot.
-        StorageCell hotSlot = new(A, (UInt256)1);
-        cache.Accounts.Set(A, new Account(1, 100));
-        cache.Storage.Set(in hotSlot, [11]);
-
-        // block1 changes A's balance and slot 1; the journal delta carries both the changed account and slot.
-        Hash256 root1 = TestItem.KeccakD;
-        reader.Accounts[A] = new AccountStruct(2, (UInt256)999);
-        reader.Storage[(A, (UInt256)1)] = [99];
-        buffer.Store(1, root1, new HeadStateBlockDelta(Accounts(A), Slots(hotSlot), RequiresFlush: false));
-
-        Block block1 = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakA, stateRoot: root1, number: 1);
-
-        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block1));
-
-        using (Assert.EnterMultipleScope())
+        using (new HeadStateCacheUpdater(blockTree, cache, reader, LimboLogs.Instance, buffer))
         {
-            Assert.That(cache.HeadHash, Is.EqualTo(TestItem.KeccakB));
+            // First head: no parent in cache -> flush, anchors at block0.
+            Block block0 = BlockWith(TestItem.KeccakA, parent: TestItem.KeccakH, stateRoot: TestItem.KeccakC, number: 0);
+            blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block0));
+            Assert.That(() => cache.HeadHash, Is.EqualTo(TestItem.KeccakA).After(PollMs, PollEveryMs));
 
-            Assert.That(cache.Accounts.TryGetValue(A, out Account? account), Is.True);
-            Assert.That(account!.Balance, Is.EqualTo((UInt256)999), "changed account refreshed to new value");
+            // Warm the cache with the pre-block (block0) values for a hot account + slot (after block0 settled).
+            StorageCell hotSlot = new(A, (UInt256)1);
+            cache.Accounts.Set(A, new Account(1, 100));
+            cache.Storage.Set(in hotSlot, [11]);
 
-            Assert.That(cache.Storage.TryGetValue(in hotSlot, out byte[]? slot), Is.True);
-            Assert.That(slot, Is.EqualTo(new byte[] { 99 }), "changed slot refreshed to new value");
+            // block1 changes A's balance and slot 1; the journal delta carries both the changed account and slot.
+            Hash256 root1 = TestItem.KeccakD;
+            reader.Accounts[A] = new AccountStruct(2, (UInt256)999);
+            reader.Storage[(A, (UInt256)1)] = [99];
+            buffer.Store(1, root1, new HeadStateBlockDelta(Accounts(A), Slots(hotSlot), RequiresFlush: false));
+
+            Block block1 = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakA, stateRoot: root1, number: 1);
+            blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block1));
+
+            Assert.That(() => cache.HeadHash, Is.EqualTo(TestItem.KeccakB).After(PollMs, PollEveryMs));
+            Assert.That(() => AccountBalance(cache, A), Is.EqualTo((UInt256)999).After(PollMs, PollEveryMs), "changed account refreshed");
+            Assert.That(() => cache.Storage.TryGetValue(in hotSlot, out byte[]? v) ? v : null, Is.EqualTo(new byte[] { 99 }).After(PollMs, PollEveryMs), "changed slot refreshed");
         }
     }
 
@@ -69,26 +65,26 @@ public class HeadStateCacheUpdaterTests
     {
         HeadStateCache cache = new(depth: 2, accountSetsBits: 8, storageSetsBits: 8);
         HeadStateDeltaBuffer buffer = new();
-        FakeStateReader reader = new();
         IBlockTree blockTree = Substitute.For<IBlockTree>();
-        _ = new HeadStateCacheUpdater(blockTree, cache, reader, LimboLogs.Instance, buffer);
+        using (new HeadStateCacheUpdater(blockTree, cache, new FakeStateReader(), LimboLogs.Instance, buffer))
+        {
+            Block block0 = BlockWith(TestItem.KeccakA, parent: TestItem.KeccakH, stateRoot: TestItem.KeccakC, number: 0);
+            blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block0));
+            Assert.That(() => cache.HeadHash, Is.EqualTo(TestItem.KeccakA).After(PollMs, PollEveryMs));
 
-        Block block0 = BlockWith(TestItem.KeccakA, parent: TestItem.KeccakH, stateRoot: TestItem.KeccakC, number: 0);
-        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block0));
+            StorageCell hotSlot = new(A, (UInt256)1);
+            cache.Storage.Set(in hotSlot, [11]);
 
-        StorageCell hotSlot = new(A, (UInt256)1);
-        cache.Storage.Set(in hotSlot, [11]);
+            // RequiresFlush delta: cache must drop everything (can't enumerate cleared slots) and re-anchor.
+            Hash256 root1 = TestItem.KeccakD;
+            buffer.Store(1, root1, new HeadStateBlockDelta(FrozenSet<AddressAsKey>.Empty, FrozenSet<StorageCell>.Empty, RequiresFlush: true));
+            Block block1 = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakA, stateRoot: root1, number: 1);
+            blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block1));
 
-        // RequiresFlush delta: cache must drop everything (can't enumerate cleared slots) and re-anchor.
-        Hash256 root1 = TestItem.KeccakD;
-        buffer.Store(1, root1, new HeadStateBlockDelta(FrozenSet<AddressAsKey>.Empty, FrozenSet<StorageCell>.Empty, RequiresFlush: true));
-        Block block1 = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakA, stateRoot: root1, number: 1);
-
-        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block1));
-
-        Assert.That(cache.HeadHash, Is.EqualTo(TestItem.KeccakB), "re-anchored at new head");
-        // After a flush the slot is gone from a head (depth 0) lookup until re-read.
-        Assert.That(cache.Storage.TryGetValue(in hotSlot, out _), Is.False);
+            Assert.That(() => cache.HeadHash, Is.EqualTo(TestItem.KeccakB).After(PollMs, PollEveryMs), "re-anchored at new head");
+            // After a flush the slot is gone from a head (depth 0) lookup until re-read.
+            Assert.That(() => cache.Storage.TryGetValue(in hotSlot, out _), Is.False.After(PollMs, PollEveryMs));
+        }
     }
 
     [Test]
@@ -97,20 +93,25 @@ public class HeadStateCacheUpdaterTests
         HeadStateCache cache = new(depth: 2, accountSetsBits: 8, storageSetsBits: 8);
         HeadStateDeltaBuffer buffer = new();
         IBlockTree blockTree = Substitute.For<IBlockTree>();
-        _ = new HeadStateCacheUpdater(blockTree, cache, new FakeStateReader(), LimboLogs.Instance, buffer);
+        using (new HeadStateCacheUpdater(blockTree, cache, new FakeStateReader(), LimboLogs.Instance, buffer))
+        {
+            Block block0 = BlockWith(TestItem.KeccakA, parent: TestItem.KeccakH, stateRoot: TestItem.KeccakC, number: 0);
+            blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block0));
+            Assert.That(() => cache.HeadHash, Is.EqualTo(TestItem.KeccakA).After(PollMs, PollEveryMs));
 
-        Block block0 = BlockWith(TestItem.KeccakA, parent: TestItem.KeccakH, stateRoot: TestItem.KeccakC, number: 0);
-        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block0));
+            cache.Accounts.Set(A, new Account(1, 100));
 
-        cache.Accounts.Set(A, new Account(1, 100));
+            // Parent does not match current head -> treated as reorg/gap -> flush.
+            Block forked = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakF, stateRoot: TestItem.KeccakD, number: 1);
+            blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(forked));
 
-        // Parent does not match current head -> treated as reorg/gap -> flush.
-        Block forked = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakF, stateRoot: TestItem.KeccakD, number: 1);
-        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(forked));
-
-        Assert.That(cache.HeadHash, Is.EqualTo(TestItem.KeccakB));
-        Assert.That(cache.Accounts.TryGetValue(A, out _), Is.False, "flush cleared warmed entries");
+            Assert.That(() => cache.HeadHash, Is.EqualTo(TestItem.KeccakB).After(PollMs, PollEveryMs));
+            Assert.That(() => cache.Accounts.TryGetValue(A, out _), Is.False.After(PollMs, PollEveryMs), "flush cleared warmed entries");
+        }
     }
+
+    private static UInt256? AccountBalance(HeadStateCache cache, Address address)
+        => cache.Accounts.TryGetValue(address, out Account? account) ? account!.Balance : null;
 
     private static FrozenSet<StorageCell> Slots(params StorageCell[] cells) => new HashSet<StorageCell>(cells).ToFrozenSet();
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/HeadStateCacheUpdaterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/HeadStateCacheUpdaterTests.cs
@@ -42,14 +42,13 @@ public class HeadStateCacheUpdaterTests
         cache.Accounts.Set(A, new Account(1, 100));
         cache.Storage.Set(in hotSlot, [11]);
 
-        // block1 changes A's balance and slot 1; capture supplies the changed slot, AccountChanges the address.
+        // block1 changes A's balance and slot 1; the journal delta carries both the changed account and slot.
         Hash256 root1 = TestItem.KeccakD;
         reader.Accounts[A] = new AccountStruct(2, (UInt256)999);
         reader.Storage[(A, (UInt256)1)] = [99];
-        buffer.Store(root1, new HeadStateBlockDelta(Slots(hotSlot), RequiresFlush: false));
+        buffer.Store(1, root1, new HeadStateBlockDelta(Accounts(A), Slots(hotSlot), RequiresFlush: false));
 
         Block block1 = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakA, stateRoot: root1, number: 1);
-        block1.AccountChanges = new ArrayPoolList<AddressAsKey>(1) { A };
 
         blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block1));
 
@@ -82,9 +81,8 @@ public class HeadStateCacheUpdaterTests
 
         // RequiresFlush delta: cache must drop everything (can't enumerate cleared slots) and re-anchor.
         Hash256 root1 = TestItem.KeccakD;
-        buffer.Store(root1, new HeadStateBlockDelta(FrozenSet<StorageCell>.Empty, RequiresFlush: true));
+        buffer.Store(1, root1, new HeadStateBlockDelta(FrozenSet<AddressAsKey>.Empty, FrozenSet<StorageCell>.Empty, RequiresFlush: true));
         Block block1 = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakA, stateRoot: root1, number: 1);
-        block1.AccountChanges = new ArrayPoolList<AddressAsKey>(0);
 
         blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block1));
 
@@ -115,6 +113,13 @@ public class HeadStateCacheUpdaterTests
     }
 
     private static FrozenSet<StorageCell> Slots(params StorageCell[] cells) => new HashSet<StorageCell>(cells).ToFrozenSet();
+
+    private static FrozenSet<AddressAsKey> Accounts(params Address[] addresses)
+    {
+        HashSet<AddressAsKey> set = [];
+        foreach (Address address in addresses) set.Add(address);
+        return set.ToFrozenSet();
+    }
 
     private static Block BlockWith(Hash256 hash, Hash256 parent, Hash256 stateRoot, long number) =>
         new(Build.A.BlockHeader.WithNumber((ulong)number).WithParentHash(parent).WithStateRoot(stateRoot).WithHash(hash).TestObject);

--- a/src/Nethermind/Nethermind.Blockchain.Test/HeadStateCacheUpdaterTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/HeadStateCacheUpdaterTests.cs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.State;
+using Nethermind.Trie;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test;
+
+[Parallelizable(ParallelScope.All)]
+public class HeadStateCacheUpdaterTests
+{
+    private static readonly Address A = TestItem.AddressA;
+
+    [Test]
+    public void Advances_cache_from_journal_delta_on_sequential_head()
+    {
+        HeadStateCache cache = new(depth: 2, accountSetsBits: 8, storageSetsBits: 8);
+        HeadStateDeltaBuffer buffer = new();
+        FakeStateReader reader = new();
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+
+        _ = new HeadStateCacheUpdater(blockTree, cache, reader, LimboLogs.Instance, buffer);
+
+        // First head: no parent in cache -> flush, anchors at block0.
+        Block block0 = BlockWith(TestItem.KeccakA, parent: TestItem.KeccakH, stateRoot: TestItem.KeccakC, number: 0);
+        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block0));
+        Assert.That(cache.HeadHash, Is.EqualTo(TestItem.KeccakA));
+
+        // Warm the cache with the pre-block (block0) values for a hot account + slot.
+        StorageCell hotSlot = new(A, (UInt256)1);
+        cache.Accounts.Set(A, new Account(1, 100));
+        cache.Storage.Set(in hotSlot, [11]);
+
+        // block1 changes A's balance and slot 1; capture supplies the changed slot, AccountChanges the address.
+        Hash256 root1 = TestItem.KeccakD;
+        reader.Accounts[A] = new AccountStruct(2, (UInt256)999);
+        reader.Storage[(A, (UInt256)1)] = [99];
+        buffer.Store(root1, new HeadStateBlockDelta(Slots(hotSlot), RequiresFlush: false));
+
+        Block block1 = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakA, stateRoot: root1, number: 1);
+        block1.AccountChanges = new ArrayPoolList<AddressAsKey>(1) { A };
+
+        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block1));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(cache.HeadHash, Is.EqualTo(TestItem.KeccakB));
+
+            Assert.That(cache.Accounts.TryGetValue(A, out Account? account), Is.True);
+            Assert.That(account!.Balance, Is.EqualTo((UInt256)999), "changed account refreshed to new value");
+
+            Assert.That(cache.Storage.TryGetValue(in hotSlot, out byte[]? slot), Is.True);
+            Assert.That(slot, Is.EqualTo(new byte[] { 99 }), "changed slot refreshed to new value");
+        }
+    }
+
+    [Test]
+    public void Flushes_on_self_destruct_delta()
+    {
+        HeadStateCache cache = new(depth: 2, accountSetsBits: 8, storageSetsBits: 8);
+        HeadStateDeltaBuffer buffer = new();
+        FakeStateReader reader = new();
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        _ = new HeadStateCacheUpdater(blockTree, cache, reader, LimboLogs.Instance, buffer);
+
+        Block block0 = BlockWith(TestItem.KeccakA, parent: TestItem.KeccakH, stateRoot: TestItem.KeccakC, number: 0);
+        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block0));
+
+        StorageCell hotSlot = new(A, (UInt256)1);
+        cache.Storage.Set(in hotSlot, [11]);
+
+        // RequiresFlush delta: cache must drop everything (can't enumerate cleared slots) and re-anchor.
+        Hash256 root1 = TestItem.KeccakD;
+        buffer.Store(root1, new HeadStateBlockDelta(FrozenSet<StorageCell>.Empty, RequiresFlush: true));
+        Block block1 = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakA, stateRoot: root1, number: 1);
+        block1.AccountChanges = new ArrayPoolList<AddressAsKey>(0);
+
+        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block1));
+
+        Assert.That(cache.HeadHash, Is.EqualTo(TestItem.KeccakB), "re-anchored at new head");
+        // After a flush the slot is gone from a head (depth 0) lookup until re-read.
+        Assert.That(cache.Storage.TryGetValue(in hotSlot, out _), Is.False);
+    }
+
+    [Test]
+    public void Flushes_on_non_sequential_head()
+    {
+        HeadStateCache cache = new(depth: 2, accountSetsBits: 8, storageSetsBits: 8);
+        HeadStateDeltaBuffer buffer = new();
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        _ = new HeadStateCacheUpdater(blockTree, cache, new FakeStateReader(), LimboLogs.Instance, buffer);
+
+        Block block0 = BlockWith(TestItem.KeccakA, parent: TestItem.KeccakH, stateRoot: TestItem.KeccakC, number: 0);
+        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(block0));
+
+        cache.Accounts.Set(A, new Account(1, 100));
+
+        // Parent does not match current head -> treated as reorg/gap -> flush.
+        Block forked = BlockWith(TestItem.KeccakB, parent: TestItem.KeccakF, stateRoot: TestItem.KeccakD, number: 1);
+        blockTree.BlockAddedToMain += Raise.EventWith(new BlockReplacementEventArgs(forked));
+
+        Assert.That(cache.HeadHash, Is.EqualTo(TestItem.KeccakB));
+        Assert.That(cache.Accounts.TryGetValue(A, out _), Is.False, "flush cleared warmed entries");
+    }
+
+    private static FrozenSet<StorageCell> Slots(params StorageCell[] cells) => new HashSet<StorageCell>(cells).ToFrozenSet();
+
+    private static Block BlockWith(Hash256 hash, Hash256 parent, Hash256 stateRoot, long number) =>
+        new(Build.A.BlockHeader.WithNumber((ulong)number).WithParentHash(parent).WithStateRoot(stateRoot).WithHash(hash).TestObject);
+
+    private sealed class FakeStateReader : IStateReader
+    {
+        public Dictionary<Address, AccountStruct> Accounts { get; } = [];
+        public Dictionary<(Address, UInt256), byte[]> Storage { get; } = [];
+
+        public bool TryGetAccount(BlockHeader? baseBlock, Address address, out AccountStruct account)
+            => Accounts.TryGetValue(address, out account);
+
+        public ReadOnlySpan<byte> GetStorage(BlockHeader? baseBlock, Address address, in UInt256 index)
+            => Storage.TryGetValue((address, index), out byte[]? value) ? value : default;
+
+        public byte[]? GetCode(Hash256 codeHash) => null;
+        public byte[]? GetCode(in ValueHash256 codeHash) => null;
+        public bool HasStateForBlock(BlockHeader? baseBlock) => true;
+
+        public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, BlockHeader? baseBlock, VisitingOptions? visitingOptions = null, VisitingStats? diagnostics = null) where TCtx : struct, INodeContext<TCtx>
+            => throw new NotSupportedException();
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/HeadStateCacheUpdater.cs
+++ b/src/Nethermind/Nethermind.Blockchain/HeadStateCacheUpdater.cs
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Threading;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.State;
+
+namespace Nethermind.Blockchain;
+
+/// <summary>
+/// Keeps the <see cref="HeadStateCache"/> coherent with the canonical head. On a sequential head
+/// advance it refreshes the keys the block changed; on a reorg, gap, or self-destruct it flushes
+/// (safe: reads then rebuild lazily via backfill).
+/// </summary>
+/// <remarks>
+/// Changed accounts come from <see cref="Block.AccountChanges"/> (always populated). Changed storage
+/// cells come, in priority order, from: the per-block journal capture (<see cref="HeadStateDeltaBuffer"/>,
+/// works on any node), the consensus Block Access List, or the BAL generated during processing.
+/// </remarks>
+public sealed class HeadStateCacheUpdater : IDisposable
+{
+    private readonly IBlockTree _blockTree;
+    private readonly HeadStateCache _cache;
+    private readonly IStateReader _stateReader;
+    private readonly HeadStateDeltaBuffer? _deltaBuffer;
+    private readonly ILogger _logger;
+    private readonly Lock _lock = new();
+
+    public HeadStateCacheUpdater(IBlockTree blockTree, HeadStateCache cache, IStateReader stateReader, ILogManager logManager, HeadStateDeltaBuffer? deltaBuffer = null)
+    {
+        _blockTree = blockTree;
+        _cache = cache;
+        _stateReader = stateReader;
+        _deltaBuffer = deltaBuffer;
+        _logger = logManager.GetClassLogger<HeadStateCacheUpdater>();
+        _blockTree.BlockAddedToMain += OnBlockAddedToMain;
+    }
+
+    private void OnBlockAddedToMain(object? sender, BlockReplacementEventArgs e)
+    {
+        Block block = e.Block;
+        if (block.Hash is null) return;
+
+        lock (_lock)
+        {
+            try
+            {
+                bool sequential = e.PreviousBlock is null
+                    && _cache.HeadHash is not null
+                    && _cache.HeadHash.Equals(block.ParentHash);
+
+                if (!sequential || !TryCollectChangedKeys(block, out FrozenSet<AddressAsKey> changedAccounts, out FrozenSet<StorageCell> changedSlots))
+                {
+                    _cache.Flush(block.Hash);
+                    return;
+                }
+
+                _cache.Advance(block.Hash, changedAccounts, changedSlots, new Refresher(_stateReader, block.Header));
+            }
+            catch (Exception ex)
+            {
+                // Never serve stale state: drop everything and re-anchor at the new head.
+                if (_logger.IsWarn) _logger.Warn($"Head state cache update failed for {block.ToString(Block.Format.Short)}, flushing. {ex}");
+                if (block.Hash is not null) _cache.Flush(block.Hash);
+            }
+        }
+    }
+
+    private bool TryCollectChangedKeys(
+        Block block,
+        out FrozenSet<AddressAsKey> changedAccounts,
+        out FrozenSet<StorageCell> changedSlots)
+    {
+        changedAccounts = FrozenSet<AddressAsKey>.Empty;
+        changedSlots = FrozenSet<StorageCell>.Empty;
+
+        // 1) Journal capture: works on any node, regardless of EIP-7928 / Block Access Lists.
+        if (block.AccountChanges is { } accountChanges
+            && block.Header.StateRoot is { } stateRoot
+            && _deltaBuffer is not null
+            && _deltaBuffer.TryGet(stateRoot, out HeadStateBlockDelta delta))
+        {
+            if (delta.RequiresFlush) return false; // self-destruct: can't enumerate cleared slots
+            changedAccounts = ToAccountSet(accountChanges);
+            changedSlots = delta.ChangedSlots;
+            return true;
+        }
+
+        // 2) Consensus or processing-generated Block Access List.
+        HashSet<AddressAsKey> accounts = [];
+        HashSet<StorageCell> slots = [];
+        if (block.BlockAccessList is { } bal)
+        {
+            foreach (ReadOnlyAccountChanges ac in bal.AccountChanges)
+            {
+                // Any change (including storage, which moves the storage root) makes the account stale.
+                if (ac.HasStateChanges) accounts.Add(ac.Address);
+                foreach (UInt256 slot in ac.ChangedSlots) slots.Add(new StorageCell(ac.Address, slot));
+            }
+        }
+        else if (block.GeneratedBlockAccessList is { } generated)
+        {
+            foreach (GeneratedAccountChanges ac in generated.AccountChanges)
+            {
+                bool storageChanged = ac.StorageChanges.Count > 0;
+                if (storageChanged || ac.BalanceChanges.Count > 0 || ac.NonceChanges.Count > 0 || ac.CodeChanges.Count > 0)
+                {
+                    accounts.Add(ac.Address);
+                }
+                foreach (GeneratedSlotChanges slot in ac.StorageChanges) slots.Add(new StorageCell(ac.Address, slot.Key));
+            }
+        }
+        else
+        {
+            return false;
+        }
+
+        changedAccounts = accounts.ToFrozenSet();
+        changedSlots = slots.ToFrozenSet();
+        return true;
+    }
+
+    private static FrozenSet<AddressAsKey> ToAccountSet(ArrayPoolList<AddressAsKey> addresses)
+    {
+        HashSet<AddressAsKey> set = new(addresses.Count);
+        foreach (AddressAsKey address in addresses.AsSpan()) set.Add(address);
+        return set.ToFrozenSet();
+    }
+
+    public void Dispose() => _blockTree.BlockAddedToMain -= OnBlockAddedToMain;
+
+    private sealed class Refresher(IStateReader stateReader, BlockHeader header) : IHeadStateRefresher
+    {
+        public Account? GetAccount(Address address) =>
+            stateReader.TryGetAccount(header, address, out AccountStruct account)
+                ? new Account(account.Nonce, account.Balance, account.StorageRoot.ToCommitment(), account.CodeHash.ToCommitment())
+                : null;
+
+        public byte[] GetStorage(in StorageCell cell) =>
+            stateReader.GetStorage(header, cell.Address, cell.Index).ToArray();
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/HeadStateCacheUpdater.cs
+++ b/src/Nethermind/Nethermind.Blockchain/HeadStateCacheUpdater.cs
@@ -5,9 +5,10 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
-using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -21,9 +22,18 @@ namespace Nethermind.Blockchain;
 /// (safe: reads then rebuild lazily via backfill).
 /// </summary>
 /// <remarks>
-/// Changed accounts come from <see cref="Block.AccountChanges"/> (always populated). Changed storage
-/// cells come, in priority order, from: the per-block journal capture (<see cref="HeadStateDeltaBuffer"/>,
-/// works on any node), the consensus Block Access List, or the BAL generated during processing.
+/// <para>
+/// Updates are applied on a single background worker, not on the <see cref="IBlockTree.BlockAddedToMain"/>
+/// handler thread, so the (potentially trie-bound) refresh never delays block processing or other event
+/// subscribers. Events are enqueued in order; if the worker falls behind the bounded queue drops events,
+/// which is safe — a dropped event makes the next one non-sequential, triggering a flush + lazy rebuild.
+/// </para>
+/// <para>
+/// Changed accounts and storage come, in priority order, from: the per-block journal capture
+/// (<see cref="HeadStateDeltaBuffer"/>, works on any node), the consensus Block Access List, or the BAL
+/// generated during processing. The pooled <see cref="Block.AccountChanges"/> is deliberately not read
+/// (the TxPool owns and disposes it concurrently).
+/// </para>
 /// </remarks>
 public sealed class HeadStateCacheUpdater : IDisposable
 {
@@ -32,7 +42,14 @@ public sealed class HeadStateCacheUpdater : IDisposable
     private readonly IStateReader _stateReader;
     private readonly HeadStateDeltaBuffer? _deltaBuffer;
     private readonly ILogger _logger;
-    private readonly Lock _lock = new();
+    private readonly Channel<(Block Block, bool HadPreviousBlock)> _queue =
+        Channel.CreateBounded<(Block, bool)>(new BoundedChannelOptions(256)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true
+        });
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _worker;
 
     public HeadStateCacheUpdater(IBlockTree blockTree, HeadStateCache cache, IStateReader stateReader, ILogManager logManager, HeadStateDeltaBuffer? deltaBuffer = null)
     {
@@ -41,36 +58,52 @@ public sealed class HeadStateCacheUpdater : IDisposable
         _stateReader = stateReader;
         _deltaBuffer = deltaBuffer;
         _logger = logManager.GetClassLogger<HeadStateCacheUpdater>();
+        _worker = Task.Run(ProcessLoopAsync);
         _blockTree.BlockAddedToMain += OnBlockAddedToMain;
     }
 
     private void OnBlockAddedToMain(object? sender, BlockReplacementEventArgs e)
     {
-        Block block = e.Block;
-        if (block.Hash is null) return;
+        if (e.Block.Hash is null) return;
+        // Enqueue for off-thread processing; never block the event source. A dropped event (queue full)
+        // self-heals: the next event is non-sequential and forces a flush.
+        _queue.Writer.TryWrite((e.Block, e.PreviousBlock is not null));
+    }
 
-        lock (_lock)
+    private async Task ProcessLoopAsync()
+    {
+        try
         {
-            try
+            await foreach ((Block block, bool hadPreviousBlock) in _queue.Reader.ReadAllAsync(_cts.Token))
             {
-                bool sequential = e.PreviousBlock is null
-                    && _cache.HeadHash is not null
-                    && _cache.HeadHash.Equals(block.ParentHash);
-
-                if (!sequential || !TryCollectChangedKeys(block, out FrozenSet<AddressAsKey> changedAccounts, out FrozenSet<StorageCell> changedSlots))
-                {
-                    _cache.Flush(block.Hash);
-                    return;
-                }
-
-                _cache.Advance(block.Hash, changedAccounts, changedSlots, new Refresher(_stateReader, block.Header));
+                Apply(block, hadPreviousBlock);
             }
-            catch (Exception ex)
+        }
+        catch (OperationCanceledException) { /* shutting down */ }
+    }
+
+    private void Apply(Block block, bool hadPreviousBlock)
+    {
+        if (block.Hash is null) return;
+        try
+        {
+            bool sequential = !hadPreviousBlock
+                && _cache.HeadHash is not null
+                && _cache.HeadHash.Equals(block.ParentHash);
+
+            if (!sequential || !TryCollectChangedKeys(block, out FrozenSet<AddressAsKey> changedAccounts, out FrozenSet<StorageCell> changedSlots))
             {
-                // Never serve stale state: drop everything and re-anchor at the new head.
-                if (_logger.IsWarn) _logger.Warn($"Head state cache update failed for {block.ToString(Block.Format.Short)}, flushing. {ex}");
-                if (block.Hash is not null) _cache.Flush(block.Hash);
+                _cache.Flush(block.Hash);
+                return;
             }
+
+            _cache.Advance(block.Hash, changedAccounts, changedSlots, new Refresher(_stateReader, block.Header));
+        }
+        catch (Exception ex)
+        {
+            // Never serve stale state: drop everything and re-anchor at the new head.
+            if (_logger.IsWarn) _logger.Warn($"Head state cache update failed for {block.ToString(Block.Format.Short)}, flushing. {ex}");
+            _cache.Flush(block.Hash);
         }
     }
 
@@ -129,7 +162,14 @@ public sealed class HeadStateCacheUpdater : IDisposable
         return true;
     }
 
-    public void Dispose() => _blockTree.BlockAddedToMain -= OnBlockAddedToMain;
+    public void Dispose()
+    {
+        _blockTree.BlockAddedToMain -= OnBlockAddedToMain;
+        _queue.Writer.TryComplete();
+        _cts.Cancel();
+        try { _worker.Wait(TimeSpan.FromSeconds(1)); } catch { /* best-effort shutdown */ }
+        _cts.Dispose();
+    }
 
     private sealed class Refresher(IStateReader stateReader, BlockHeader header) : IHeadStateRefresher
     {

--- a/src/Nethermind/Nethermind.Blockchain/HeadStateCacheUpdater.cs
+++ b/src/Nethermind/Nethermind.Blockchain/HeadStateCacheUpdater.cs
@@ -82,14 +82,15 @@ public sealed class HeadStateCacheUpdater : IDisposable
         changedAccounts = FrozenSet<AddressAsKey>.Empty;
         changedSlots = FrozenSet<StorageCell>.Empty;
 
-        // 1) Journal capture: works on any node, regardless of EIP-7928 / Block Access Lists.
-        if (block.AccountChanges is { } accountChanges
-            && block.Header.StateRoot is { } stateRoot
+        // 1) Journal capture: works on any node, regardless of EIP-7928 / Block Access Lists. The delta
+        // carries both changed accounts and slots captured from processing — we do NOT read the pooled
+        // Block.AccountChanges (the TxPool owns and disposes it concurrently).
+        if (block.Header.StateRoot is { } stateRoot
             && _deltaBuffer is not null
-            && _deltaBuffer.TryGet(stateRoot, out HeadStateBlockDelta delta))
+            && _deltaBuffer.TryGet((ulong)block.Number, stateRoot, out HeadStateBlockDelta delta))
         {
             if (delta.RequiresFlush) return false; // self-destruct: can't enumerate cleared slots
-            changedAccounts = ToAccountSet(accountChanges);
+            changedAccounts = delta.ChangedAccounts;
             changedSlots = delta.ChangedSlots;
             return true;
         }
@@ -126,13 +127,6 @@ public sealed class HeadStateCacheUpdater : IDisposable
         changedAccounts = accounts.ToFrozenSet();
         changedSlots = slots.ToFrozenSet();
         return true;
-    }
-
-    private static FrozenSet<AddressAsKey> ToAccountSet(ArrayPoolList<AddressAsKey> addresses)
-    {
-        HashSet<AddressAsKey> set = new(addresses.Count);
-        foreach (AddressAsKey address in addresses.AsSpan()) set.Add(address);
-        return set.ToFrozenSet();
     }
 
     public void Dispose() => _blockTree.BlockAddedToMain -= OnBlockAddedToMain;

--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -109,5 +109,13 @@ namespace Nethermind.Config
         public long SlowBlockPerTxThresholdMs { get; set; } = -1;
 
         public ulong MaxGasLimit { get; set; } = 1_000_000_000;
+
+        public bool EnableHeadStateCache { get; set; } = false;
+
+        public int HeadStateCacheDepth { get; set; } = 2;
+
+        public int HeadStateCacheAccountSetsBits { get; set; } = 14;
+
+        public int HeadStateCacheStorageSetsBits { get; set; } = 17;
     }
 }

--- a/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
@@ -96,4 +96,28 @@ public interface IBlocksConfig : IConfig
         DefaultValue = "1000000000",
         HiddenFromDocs = true)]
     ulong MaxGasLimit { get; set; }
+
+    [ConfigItem(
+        Description = "Whether to keep a coherent, cross-block cache of state at the chain head (and the most recent ancestors) to speed up read-only RPC calls such as eth_call and debug_trace on top of the head. Experimental.",
+        DefaultValue = "false",
+        HiddenFromDocs = true)]
+    bool EnableHeadStateCache { get; set; }
+
+    [ConfigItem(
+        Description = "How many blocks behind the head the head state cache can serve directly (the X in head-X). Reads deeper than this fall back to the trie. Only used when EnableHeadStateCache is true.",
+        DefaultValue = "2",
+        HiddenFromDocs = true)]
+    int HeadStateCacheDepth { get; set; }
+
+    [ConfigItem(
+        Description = "Number of set-index bits for the head state cache account map (entries = 2^(bits+1)). Only used when EnableHeadStateCache is true.",
+        DefaultValue = "14",
+        HiddenFromDocs = true)]
+    int HeadStateCacheAccountSetsBits { get; set; }
+
+    [ConfigItem(
+        Description = "Number of set-index bits for the head state cache storage map (entries = 2^(bits+1)). Only used when EnableHeadStateCache is true.",
+        DefaultValue = "17",
+        HiddenFromDocs = true)]
+    int HeadStateCacheStorageSetsBits { get; set; }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
@@ -13,9 +13,15 @@ namespace Nethermind.Consensus.Processing;
 
 public class AutoReadOnlyTxProcessingEnvFactory(ILifetimeScope parentLifetime, IWorldStateManager worldStateManager) : IReadOnlyTxProcessingEnvFactory
 {
+    /// <summary>
+    /// Hook for decorating the read-only world state (e.g. with a head state cache). The base
+    /// implementation returns it unchanged.
+    /// </summary>
+    protected virtual IWorldStateScopeProvider DecorateWorldState(IWorldStateScopeProvider worldState) => worldState;
+
     public IReadOnlyTxProcessorSource Create()
     {
-        IWorldStateScopeProvider worldState = worldStateManager.CreateResettableWorldState();
+        IWorldStateScopeProvider worldState = DecorateWorldState(worldStateManager.CreateResettableWorldState());
         ILifetimeScope childScope = parentLifetime.BeginLifetimeScope((builder) =>
         {
             builder

--- a/src/Nethermind/Nethermind.Consensus/Processing/HeadCachedReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/HeadCachedReadOnlyTxProcessingEnvFactory.cs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Evm.State;
+using Nethermind.State;
+
+namespace Nethermind.Consensus.Processing;
+
+/// <summary>
+/// A read-only tx-processing env factory that serves state reads through the cross-block
+/// <see cref="HeadStateCache"/>. Used for the read-only RPC path (eth_call, debug_trace…) only;
+/// block processing keeps using the plain <see cref="AutoReadOnlyTxProcessingEnvFactory"/>.
+/// </summary>
+public sealed class HeadCachedReadOnlyTxProcessingEnvFactory(
+    ILifetimeScope parentLifetime,
+    IWorldStateManager worldStateManager,
+    HeadStateCache headStateCache)
+    : AutoReadOnlyTxProcessingEnvFactory(parentLifetime, worldStateManager)
+{
+    protected override IWorldStateScopeProvider DecorateWorldState(IWorldStateScopeProvider worldState)
+        => new HeadStateCacheScopeProvider(worldState, headStateCache);
+}

--- a/src/Nethermind/Nethermind.Init/Modules/HeadStateCacheModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/HeadStateCacheModule.cs
@@ -8,6 +8,7 @@ using Nethermind.Config;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
+using Nethermind.Logging;
 using Nethermind.State;
 
 namespace Nethermind.Init.Modules;
@@ -42,8 +43,15 @@ public class HeadStateCacheModule(IBlocksConfig blocksConfig) : Module
             .AddSingleton<IShareableTxProcessorSource>(ctx =>
                 new ShareableTxProcessingSource(ctx.Resolve<HeadCachedReadOnlyTxProcessingEnvFactory>()))
 
+            // Direct state RPCs (eth_getBalance/eth_getStorageAt/…) read through the head cache too.
+            // Decorates the shared IStateReader; the updater below deliberately uses the raw
+            // GlobalStateReader to avoid a refresh-reads-the-cache-it-refreshes cycle.
+            .AddDecorator<IStateReader>((ctx, inner) => new HeadCachedStateReader(inner, ctx.Resolve<HeadStateCache>()))
+
             // Keeps the cache coherent with the canonical head; activated alongside the shareable source.
-            .AddSingleton<HeadStateCacheUpdater>()
+            .AddSingleton<HeadStateCacheUpdater, IBlockTree, HeadStateCache, IWorldStateManager, ILogManager, HeadStateDeltaBuffer>(
+                (blockTree, cache, worldStateManager, logManager, deltaBuffer) =>
+                    new HeadStateCacheUpdater(blockTree, cache, worldStateManager.GlobalStateReader, logManager, deltaBuffer))
             .ResolveOnServiceActivation<HeadStateCacheUpdater, IShareableTxProcessorSource>();
     }
 }

--- a/src/Nethermind/Nethermind.Init/Modules/HeadStateCacheModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/HeadStateCacheModule.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Blockchain;
+using Nethermind.Config;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.State;
+
+namespace Nethermind.Init.Modules;
+
+/// <summary>
+/// Registers the opt-in <see cref="HeadStateCache"/> that accelerates read-only RPC calls
+/// (eth_call, debug_trace…) on top of the head. Enabled only when <see cref="IBlocksConfig.EnableHeadStateCache"/>
+/// is set; otherwise this module registers nothing.
+/// </summary>
+public class HeadStateCacheModule(IBlocksConfig blocksConfig) : Module
+{
+    protected override void Load(ContainerBuilder builder)
+    {
+        if (!blocksConfig.EnableHeadStateCache) return;
+
+        builder
+            .AddSingleton(new HeadStateCache(
+                blocksConfig.HeadStateCacheDepth,
+                blocksConfig.HeadStateCacheAccountSetsBits,
+                blocksConfig.HeadStateCacheStorageSetsBits))
+
+            // Per-block changed-storage capture from processing, so the cache works on any node
+            // independent of EIP-7928 / Block Access Lists.
+            .AddSingleton<HeadStateDeltaBuffer>()
+
+            // RPC-only: the shareable source (BlockchainBridge and friends) reads through the head cache,
+            // while block processing keeps using the plain IReadOnlyTxProcessingEnvFactory.
+            .AddSingleton<HeadCachedReadOnlyTxProcessingEnvFactory>()
+            .AddSingleton<IShareableTxProcessorSource>(ctx =>
+                new ShareableTxProcessingSource(ctx.Resolve<HeadCachedReadOnlyTxProcessingEnvFactory>()))
+
+            // Keeps the cache coherent with the canonical head; activated alongside the shareable source.
+            .AddSingleton<HeadStateCacheUpdater>()
+            .ResolveOnServiceActivation<HeadStateCacheUpdater, IShareableTxProcessorSource>();
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Modules/HeadStateCacheModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/HeadStateCacheModule.cs
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Config;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.State;
 
 namespace Nethermind.Init.Modules;
@@ -21,11 +23,14 @@ public class HeadStateCacheModule(IBlocksConfig blocksConfig) : Module
     {
         if (!blocksConfig.EnableHeadStateCache) return;
 
+        // Clamp to valid ranges so a misconfigured value degrades gracefully instead of throwing from
+        // the cache/SeqlockCache constructors and aborting node startup with an opaque error.
+        int depth = Math.Max(0, blocksConfig.HeadStateCacheDepth);
+        int accountBits = Math.Clamp(blocksConfig.HeadStateCacheAccountSetsBits, 1, SeqlockCache<AddressAsKey, Account>.MaxSetsBits);
+        int storageBits = Math.Clamp(blocksConfig.HeadStateCacheStorageSetsBits, 1, SeqlockCache<AddressAsKey, Account>.MaxSetsBits);
+
         builder
-            .AddSingleton(new HeadStateCache(
-                blocksConfig.HeadStateCacheDepth,
-                blocksConfig.HeadStateCacheAccountSetsBits,
-                blocksConfig.HeadStateCacheStorageSetsBits))
+            .AddSingleton(new HeadStateCache(depth, accountBits, storageBits))
 
             // Per-block changed-storage capture from processing, so the cache works on any node
             // independent of EIP-7928 / Block Access Lists.

--- a/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
@@ -41,6 +41,14 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
 
         worldState = new WorldStateMetricsScopeProvider(worldState, static time => Blockchain.Metrics.StateMerkleizationTime = time);
 
+        // When the head state cache is enabled, observe processing writes to capture each block's
+        // changed storage cells (keyed by post-state root) so the cache stays coherent on any node.
+        HeadStateDeltaBuffer? headStateDeltaBuffer = rootLifetimeScope.ResolveOptional<HeadStateDeltaBuffer>();
+        if (headStateDeltaBuffer is not null)
+        {
+            worldState = new HeadStateDeltaCaptureScopeProvider(worldState, headStateDeltaBuffer);
+        }
+
         ILifetimeScope innerScope = rootLifetimeScope.BeginLifetimeScope((builder) =>
         {
             builder

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -63,6 +63,7 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
             .AddSource(new ConfigRegistrationSource())
             .AddModule(new BlockProcessingModule(configProvider.GetConfig<IInitConfig>(), configProvider.GetConfig<IBlocksConfig>()))
             .AddModule(new BlockTreeModule(configProvider.GetConfig<IReceiptConfig>(), configProvider.GetConfig<ILogIndexConfig>()))
+            .AddModule(new HeadStateCacheModule(configProvider.GetConfig<IBlocksConfig>()))
             .AddModule(new MonitoringModule(configProvider.GetConfig<IMetricsConfig>()))
             .AddSingleton<ISpecProvider, ChainSpecBasedSpecProvider>()
 

--- a/src/Nethermind/Nethermind.State.Test/HeadStateCacheTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/HeadStateCacheTests.cs
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.State;
+using NUnit.Framework;
+
+#nullable enable
+
+namespace Nethermind.Store.Test;
+
+[Parallelizable(ParallelScope.All)]
+public class HeadStateCacheTests
+{
+    private static readonly Address A = TestItem.AddressA;
+    private static readonly Address B = TestItem.AddressB;
+    private static readonly Address C = TestItem.AddressC;
+
+    private sealed class Chain
+    {
+        public IWorldStateScopeProvider Provider { get; } =
+            new TrieStoreScopeProvider(new TestRawTrieStore(new TestMemDb()), new TestMemDb(), LimboLogs.Instance);
+
+        public Hash256 Commit(BlockHeader? parent, ulong number, IReadOnlyList<(Address addr, Account account, (UInt256 slot, byte[] value)[] storage)> writes)
+        {
+            using IWorldStateScopeProvider.IScope scope = Provider.BeginScope(parent, new LocalMetrics());
+            using (IWorldStateScopeProvider.IWorldStateWriteBatch batch = scope.StartWriteBatch(writes.Count))
+            {
+                foreach ((Address addr, Account account, (UInt256 slot, byte[] value)[] storage) in writes)
+                {
+                    batch.Set(addr, account);
+                    if (storage.Length > 0)
+                    {
+                        using IWorldStateScopeProvider.IStorageWriteBatch storageBatch = batch.CreateStorageWriteBatch(addr, storage.Length);
+                        foreach ((UInt256 slot, byte[] value) in storage)
+                        {
+                            storageBatch.Set(slot, value);
+                        }
+                    }
+                }
+            }
+            scope.Commit(number);
+            return scope.RootHash;
+        }
+
+        public Account? GetAccount(BlockHeader header, Address address)
+        {
+            using IWorldStateScopeProvider.IScope scope = Provider.BeginScope(header, new LocalMetrics());
+            return scope.Get(address);
+        }
+
+        public byte[] GetStorage(BlockHeader header, Address address, UInt256 slot)
+        {
+            using IWorldStateScopeProvider.IScope scope = Provider.BeginScope(header, new LocalMetrics());
+            return scope.CreateStorageTree(address).Get(slot);
+        }
+    }
+
+    private sealed class TrieRefresher(IWorldStateScopeProvider provider, BlockHeader header) : IHeadStateRefresher
+    {
+        public Account? GetAccount(Address address)
+        {
+            using IWorldStateScopeProvider.IScope scope = provider.BeginScope(header, new LocalMetrics());
+            return scope.Get(address);
+        }
+
+        public byte[] GetStorage(in StorageCell cell)
+        {
+            using IWorldStateScopeProvider.IScope scope = provider.BeginScope(header, new LocalMetrics());
+            return scope.CreateStorageTree(cell.Address).Get(cell.Index);
+        }
+    }
+
+    private static BlockHeader Header(Hash256 hash, Hash256? parent, Hash256 stateRoot, long number) =>
+        Build.A.BlockHeader.WithNumber((ulong)number).WithStateRoot(stateRoot).WithParentHash(parent!).WithHash(hash).TestObject;
+
+    private static FrozenSet<AddressAsKey> Accounts(params Address[] addresses)
+    {
+        HashSet<AddressAsKey> set = [];
+        foreach (Address a in addresses) set.Add(a);
+        return set.ToFrozenSet();
+    }
+
+    private static FrozenSet<StorageCell> Slots(params (Address addr, UInt256 slot)[] cells)
+    {
+        HashSet<StorageCell> set = [];
+        foreach ((Address addr, UInt256 slot) in cells) set.Add(new StorageCell(addr, slot));
+        return set.ToFrozenSet();
+    }
+
+    /// <summary>
+    /// Builds a 3-block chain, drives the head cache through two sequential advances, then asserts that
+    /// reading any account/storage through the cache-decorated provider at the head and each tracked
+    /// ancestor returns exactly what the undecorated trie returns — for both keys the block changed and
+    /// keys it left untouched.
+    /// </summary>
+    [Test]
+    public void Decorated_reads_match_trie_at_head_and_ancestors()
+    {
+        Chain chain = new();
+
+        // Block 0
+        Hash256 root0 = chain.Commit(null, 0,
+        [
+            (A, new Account(1, 100), [((UInt256)1, [11])]),
+            (B, new Account(1, 200), [((UInt256)1, [21]), ((UInt256)2, [22])]),
+        ]);
+        BlockHeader h0 = Header(TestItem.KeccakA, TestItem.KeccakH, root0, 0);
+
+        // Block 1: A balance + A.slot1 change, C created. B untouched.
+        Hash256 root1 = chain.Commit(h0, 1,
+        [
+            (A, new Account(2, 101), [((UInt256)1, [99])]),
+            (C, new Account(0, 50), []),
+        ]);
+        BlockHeader h1 = Header(TestItem.KeccakB, h0.Hash, root1, 1);
+
+        // Block 2: B.slot2 change. A, C untouched.
+        Hash256 root2 = chain.Commit(h1, 2,
+        [
+            (B, new Account(1, 200), [((UInt256)2, [77])]),
+        ]);
+        BlockHeader h2 = Header(TestItem.KeccakC, h1.Hash, root2, 2);
+
+        HeadStateCache cache = new(depth: 2, accountSetsBits: 8, storageSetsBits: 8);
+        HeadStateCacheScopeProvider decorated = new(chain.Provider, cache);
+
+        cache.Flush(h0.Hash!);
+        AssertMatches(chain, decorated, h0);
+
+        cache.Advance(h1.Hash!, Accounts(A, C), Slots((A, 1)), new TrieRefresher(chain.Provider, h1));
+        AssertMatches(chain, decorated, h1); // depth 0
+        AssertMatches(chain, decorated, h0); // depth 1
+
+        cache.Advance(h2.Hash!, Accounts(B), Slots((B, 2)), new TrieRefresher(chain.Provider, h2));
+        AssertMatches(chain, decorated, h2); // depth 0
+        AssertMatches(chain, decorated, h1); // depth 1
+        AssertMatches(chain, decorated, h0); // depth 2
+    }
+
+    /// <summary>
+    /// Warms the cache at the head, then a reorg flush re-anchors at an unrelated head. Reads at the old
+    /// (now non-canonical) header must still be correct via passthrough, and reads at the new head correct.
+    /// </summary>
+    [Test]
+    public void Reorg_flush_keeps_reads_correct()
+    {
+        Chain chain = new();
+
+        Hash256 root0 = chain.Commit(null, 0, [(A, new Account(1, 100), [((UInt256)1, [11])])]);
+        BlockHeader h0 = Header(TestItem.KeccakA, TestItem.KeccakH, root0, 0);
+
+        // Sibling block at the same height with different state.
+        Hash256 rootSibling = chain.Commit(null, 0, [(A, new Account(7, 777), [((UInt256)1, [55])])]);
+        BlockHeader sibling = Header(TestItem.KeccakD, TestItem.KeccakH, rootSibling, 0);
+
+        HeadStateCache cache = new(depth: 2, accountSetsBits: 8, storageSetsBits: 8);
+        HeadStateCacheScopeProvider decorated = new(chain.Provider, cache);
+
+        cache.Flush(h0.Hash!);
+        AssertMatches(chain, decorated, h0);
+
+        // Reorg to the sibling: flush re-anchors. Old header now serves via passthrough.
+        cache.Flush(sibling.Hash!);
+        AssertMatches(chain, decorated, sibling);
+        AssertMatches(chain, decorated, h0);
+    }
+
+    [Test]
+    public void Unknown_or_too_deep_header_passes_through()
+    {
+        Chain chain = new();
+        Hash256 root0 = chain.Commit(null, 0, [(A, new Account(1, 100), [((UInt256)1, [11])])]);
+        BlockHeader h0 = Header(TestItem.KeccakA, TestItem.KeccakH, root0, 0);
+        BlockHeader unknown = Header(TestItem.KeccakF, TestItem.KeccakH, root0, 0);
+
+        HeadStateCache cache = new(depth: 1, accountSetsBits: 8, storageSetsBits: 8);
+        HeadStateCacheScopeProvider decorated = new(chain.Provider, cache);
+        cache.Flush(h0.Hash!);
+
+        // Unknown header is not in the ring -> passthrough, still correct.
+        AssertMatches(chain, decorated, unknown);
+    }
+
+    [Test]
+    public void Capture_records_changed_slots_keyed_by_state_root()
+    {
+        IWorldStateScopeProvider store = new TrieStoreScopeProvider(new TestRawTrieStore(new TestMemDb()), new TestMemDb(), LimboLogs.Instance);
+        HeadStateDeltaBuffer buffer = new();
+        HeadStateDeltaCaptureScopeProvider capture = new(store, buffer);
+
+        Hash256 root;
+        using (IWorldStateScopeProvider.IScope scope = capture.BeginScope(null, new LocalMetrics()))
+        {
+            using (IWorldStateScopeProvider.IWorldStateWriteBatch batch = scope.StartWriteBatch(1))
+            {
+                batch.Set(A, new Account(1, 100));
+                using IWorldStateScopeProvider.IStorageWriteBatch storage = batch.CreateStorageWriteBatch(A, 2);
+                storage.Set(1, [9]);
+                storage.Set(2, [8]);
+            }
+            scope.Commit(1);
+            root = scope.RootHash;
+        }
+
+        Assert.That(buffer.TryGet(root, out HeadStateBlockDelta delta), Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(delta.RequiresFlush, Is.False);
+            Assert.That(delta.ChangedSlots, Does.Contain(new StorageCell(A, (UInt256)1)));
+            Assert.That(delta.ChangedSlots, Does.Contain(new StorageCell(A, (UInt256)2)));
+            Assert.That(delta.ChangedSlots, Has.Count.EqualTo(2));
+        }
+    }
+
+    [Test]
+    public void Capture_flags_flush_on_storage_clear()
+    {
+        IWorldStateScopeProvider store = new TrieStoreScopeProvider(new TestRawTrieStore(new TestMemDb()), new TestMemDb(), LimboLogs.Instance);
+        HeadStateDeltaBuffer buffer = new();
+        HeadStateDeltaCaptureScopeProvider capture = new(store, buffer);
+
+        Hash256 root;
+        using (IWorldStateScopeProvider.IScope scope = capture.BeginScope(null, new LocalMetrics()))
+        {
+            using (IWorldStateScopeProvider.IWorldStateWriteBatch batch = scope.StartWriteBatch(1))
+            {
+                batch.Set(A, new Account(1, 100));
+                using IWorldStateScopeProvider.IStorageWriteBatch storage = batch.CreateStorageWriteBatch(A, 1);
+                storage.Clear(); // self-destruct must be signalled first
+                storage.Set(1, [9]);
+            }
+            scope.Commit(1);
+            root = scope.RootHash;
+        }
+
+        Assert.That(buffer.TryGet(root, out HeadStateBlockDelta delta), Is.True);
+        Assert.That(delta.RequiresFlush, Is.True);
+    }
+
+    private static void AssertMatches(Chain chain, HeadStateCacheScopeProvider decorated, BlockHeader header)
+    {
+        // Run twice so the second pass exercises cache hits/backfill, not just first-touch misses.
+        for (int pass = 0; pass < 2; pass++)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                foreach (Address address in new[] { A, B, C })
+                {
+                    Account? expectedAccount = chain.GetAccount(header, address);
+                    Account? actualAccount = ReadAccount(decorated, header, address);
+                    Assert.That(actualAccount?.Balance, Is.EqualTo(expectedAccount?.Balance), $"{address} balance @ {header.Number} pass {pass}");
+                    Assert.That(actualAccount?.Nonce, Is.EqualTo(expectedAccount?.Nonce), $"{address} nonce @ {header.Number} pass {pass}");
+
+                    foreach (UInt256 slot in new UInt256[] { 1, 2 })
+                    {
+                        byte[] expected = chain.GetStorage(header, address, slot);
+                        byte[] actual = ReadStorage(decorated, header, address, slot);
+                        Assert.That(actual, Is.EqualTo(expected), $"{address}.{slot} @ {header.Number} pass {pass}");
+                    }
+                }
+            }
+        }
+    }
+
+    private static Account? ReadAccount(HeadStateCacheScopeProvider decorated, BlockHeader header, Address address)
+    {
+        using IWorldStateScopeProvider.IScope scope = decorated.BeginScope(header, new LocalMetrics());
+        return scope.Get(address);
+    }
+
+    private static byte[] ReadStorage(HeadStateCacheScopeProvider decorated, BlockHeader header, Address address, UInt256 slot)
+    {
+        using IWorldStateScopeProvider.IScope scope = decorated.BeginScope(header, new LocalMetrics());
+        return scope.CreateStorageTree(address).Get(slot);
+    }
+}

--- a/src/Nethermind/Nethermind.State.Test/HeadStateCacheTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/HeadStateCacheTests.cs
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
@@ -211,14 +214,56 @@ public class HeadStateCacheTests
             root = scope.RootHash;
         }
 
-        Assert.That(buffer.TryGet(root, out HeadStateBlockDelta delta), Is.True);
+        Assert.That(buffer.TryGet(1, root, out HeadStateBlockDelta delta), Is.True);
         using (Assert.EnterMultipleScope())
         {
             Assert.That(delta.RequiresFlush, Is.False);
+            Assert.That(delta.ChangedAccounts, Does.Contain((AddressAsKey)A));
             Assert.That(delta.ChangedSlots, Does.Contain(new StorageCell(A, (UInt256)1)));
             Assert.That(delta.ChangedSlots, Does.Contain(new StorageCell(A, (UInt256)2)));
             Assert.That(delta.ChangedSlots, Has.Count.EqualTo(2));
         }
+    }
+
+    [Test]
+    public void Capture_is_thread_safe_under_parallel_storage_writes()
+    {
+        // Storage-root computation runs the per-contract write batches in parallel
+        // (PersistentStorageProvider.UpdateRootHashesMultiThread); the capture must not corrupt. Driven
+        // through a no-op base so this isolates the capture's own thread-safety (the real
+        // TrieStoreScopeProvider is not built for this manual concurrent CreateStorageWriteBatch pattern).
+        HeadStateDeltaBuffer buffer = new();
+        HeadStateDeltaCaptureScopeProvider capture = new(new NoopScopeProvider(), buffer);
+
+        const int contracts = 64;
+        const int slotsPer = 50;
+        Address[] addresses = new Address[contracts];
+        for (int i = 0; i < contracts; i++)
+        {
+            byte[] addressBytes = new byte[20];
+            addressBytes[19] = (byte)i;
+            addresses[i] = new Address(addressBytes);
+        }
+
+        Hash256 root;
+        using (IWorldStateScopeProvider.IScope scope = capture.BeginScope(null, new LocalMetrics()))
+        {
+            using (IWorldStateScopeProvider.IWorldStateWriteBatch batch = scope.StartWriteBatch(contracts))
+            {
+                foreach (Address address in addresses) batch.Set(address, new Account(1, 1));
+
+                System.Threading.Tasks.Parallel.For(0, contracts, i =>
+                {
+                    using IWorldStateScopeProvider.IStorageWriteBatch storage = batch.CreateStorageWriteBatch(addresses[i], slotsPer);
+                    for (int j = 1; j <= slotsPer; j++) storage.Set((UInt256)j, [(byte)j]);
+                });
+            }
+            scope.Commit(1);
+            root = scope.RootHash;
+        }
+
+        Assert.That(buffer.TryGet(1, root, out HeadStateBlockDelta delta), Is.True);
+        Assert.That(delta.ChangedSlots, Has.Count.EqualTo(contracts * slotsPer));
     }
 
     [Test]
@@ -242,7 +287,7 @@ public class HeadStateCacheTests
             root = scope.RootHash;
         }
 
-        Assert.That(buffer.TryGet(root, out HeadStateBlockDelta delta), Is.True);
+        Assert.That(buffer.TryGet(1, root, out HeadStateBlockDelta delta), Is.True);
         Assert.That(delta.RequiresFlush, Is.True);
     }
 
@@ -281,5 +326,41 @@ public class HeadStateCacheTests
     {
         using IWorldStateScopeProvider.IScope scope = decorated.BeginScope(header, new LocalMetrics());
         return scope.CreateStorageTree(address).Get(slot);
+    }
+
+    /// <summary>Stateless, thread-safe no-op base used to isolate the capture decorator's own concurrency.</summary>
+    private sealed class NoopScopeProvider : IWorldStateScopeProvider
+    {
+        public bool HasRoot(BlockHeader? baseBlock) => true;
+        public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics) => new Scope();
+
+        private sealed class Scope : IWorldStateScopeProvider.IScope
+        {
+            public Hash256 RootHash => TestItem.KeccakA;
+            public void UpdateRootHash() { }
+            public Account? Get(Address address) => null;
+            public void HintGet(Address address, Account? account) { }
+            public IWorldStateScopeProvider.ICodeDb CodeDb => throw new NotSupportedException();
+            public IWorldStateScopeProvider.IStorageTree CreateStorageTree(Address address) => throw new NotSupportedException();
+            public IWorldStateScopeProvider.IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum) => new WriteBatch();
+            public void Commit(ulong blockNumber) { }
+            public Task HintBal(ReadOnlyBlockAccessList bal, IWorldStateScopeProvider.IAsyncBalReaderSink? sink = null) => Task.CompletedTask;
+            public void Dispose() { }
+        }
+
+        private sealed class WriteBatch : IWorldStateScopeProvider.IWorldStateWriteBatch
+        {
+            public event EventHandler<IWorldStateScopeProvider.AccountUpdated>? OnAccountUpdated { add { } remove { } }
+            public void Set(Address key, Account? account) { }
+            public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries) => new StorageWriteBatch();
+            public void Dispose() { }
+        }
+
+        private sealed class StorageWriteBatch : IWorldStateScopeProvider.IStorageWriteBatch
+        {
+            public void Set(in UInt256 index, byte[] value) { }
+            public void Clear() { }
+            public void Dispose() { }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.State/HeadCachedStateReader.cs
+++ b/src/Nethermind/Nethermind.State/HeadCachedStateReader.cs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Trie;
+
+namespace Nethermind.State;
+
+/// <summary>
+/// Decorates an <see cref="IStateReader"/> with the cross-block <see cref="HeadStateCache"/> so direct
+/// state RPCs (<c>eth_getBalance</c>, <c>eth_getStorageAt</c>, <c>eth_getTransactionCount</c>, …) that read
+/// at the head (or a tracked ancestor) are served as O(1) lookups instead of trie traversals. Reads at any
+/// other block, code reads, and tree visiting pass straight through.
+/// </summary>
+/// <remarks>
+/// Must wrap the <b>raw</b> reader and must not be used by <see cref="HeadStateCacheUpdater"/>'s refresh
+/// (which reads the new head to populate the cache) — that would be circular. The updater is wired with
+/// <see cref="IWorldStateManager.GlobalStateReader"/> (undecorated) for exactly this reason.
+/// </remarks>
+public sealed class HeadCachedStateReader(IStateReader inner, HeadStateCache cache) : IStateReader
+{
+    public bool TryGetAccount(BlockHeader? baseBlock, Address address, out AccountStruct account)
+    {
+        AddressAsKey key = address;
+        if (baseBlock?.Hash is not null
+            && cache.TrySnapshot(baseBlock.Hash, out HeadStateSnapshot snapshot)
+            && snapshot.IsCurrent
+            && !snapshot.ChangedInWindow(in key))
+        {
+            if (cache.Accounts.TryGetValue(in key, out Account? cached) && snapshot.IsCurrent)
+            {
+                account = cached?.ToStruct() ?? default;
+                return cached is not null;
+            }
+
+            bool found = inner.TryGetAccount(baseBlock, address, out account);
+            Account? toCache = found
+                ? new Account(account.Nonce, account.Balance, account.StorageRoot.ToCommitment(), account.CodeHash.ToCommitment())
+                : null;
+            cache.TryBackfillAccount(in key, toCache, snapshot.Generation);
+            return found;
+        }
+
+        return inner.TryGetAccount(baseBlock, address, out account);
+    }
+
+    public ReadOnlySpan<byte> GetStorage(BlockHeader? baseBlock, Address address, in UInt256 index)
+    {
+        StorageCell cell = new(address, in index);
+        if (baseBlock?.Hash is not null
+            && cache.TrySnapshot(baseBlock.Hash, out HeadStateSnapshot snapshot)
+            && snapshot.IsCurrent
+            && !snapshot.ChangedInWindow(in cell))
+        {
+            if (cache.Storage.TryGetValue(in cell, out byte[]? cached) && snapshot.IsCurrent)
+            {
+                return cached;
+            }
+
+            byte[] loaded = inner.GetStorage(baseBlock, address, in index).ToArray();
+            cache.TryBackfillStorage(in cell, loaded, snapshot.Generation);
+            return loaded;
+        }
+
+        return inner.GetStorage(baseBlock, address, in index);
+    }
+
+    public byte[]? GetCode(Hash256 codeHash) => inner.GetCode(codeHash);
+    public byte[]? GetCode(in ValueHash256 codeHash) => inner.GetCode(in codeHash);
+    public bool HasStateForBlock(BlockHeader? baseBlock) => inner.HasStateForBlock(baseBlock);
+
+    public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, BlockHeader? baseBlock, VisitingOptions? visitingOptions = null, VisitingStats? diagnostics = null)
+        where TCtx : struct, INodeContext<TCtx>
+        => inner.RunTreeVisitor(treeVisitor, baseBlock, visitingOptions, diagnostics);
+}

--- a/src/Nethermind/Nethermind.State/HeadStateCache.cs
+++ b/src/Nethermind/Nethermind.State/HeadStateCache.cs
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Threading;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.State;
+
+/// <summary>
+/// A cross-block, coherent cache of state at the canonical head (and the last
+/// <see cref="Depth"/> ancestors), used to accelerate read-only RPC calls (eth_call, debug_trace…)
+/// on top of the head. Account and storage values are direct O(1) lookups, skipping trie traversal.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache content is kept <b>coherent at the current head</b>: <see cref="HeadStateCacheUpdater"/>
+/// advances it by refreshing the keys a new block changed (and flushes on reorg/gap). A small ring of
+/// per-block <b>changed-key</b> sets lets a reader pinned to head-k tell whether a key is safe to serve
+/// from the head-coherent cache (unchanged across the window ⇒ head value == head-k value) or must be
+/// read from the trie at the head-k root.
+/// </para>
+/// <para>
+/// Concurrency uses a generation seqlock: <see cref="Generation"/> is even when stable and odd while the
+/// updater mutates the rings/content. A reader snapshots the generation at scope start
+/// (<see cref="TrySnapshot"/>); each access re-checks it and falls back to the trie if it changed. This
+/// keeps every individual read consistent with the header the reader pinned, even across head advances.
+/// </para>
+/// </remarks>
+public sealed class HeadStateCache
+{
+    private readonly int _depth;
+
+    private readonly SeqlockCache<AddressAsKey, Account> _accounts;
+    private readonly SeqlockCache<StorageCell, byte[]> _storage;
+
+    // Rings, mutated only under an odd generation. Index 0 == current head, index d == head-d.
+    private readonly Hash256?[] _headHashes;                 // length depth + 1
+    private readonly FrozenSet<AddressAsKey>?[] _changedAccounts; // [d] = accounts changed by block at depth d
+    private readonly FrozenSet<StorageCell>?[] _changedSlots;     // [d] = slots changed by block at depth d
+
+    private long _generation;
+
+    public HeadStateCache(int depth, int accountSetsBits, int storageSetsBits)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(depth, 0);
+        _depth = depth;
+        _accounts = new SeqlockCache<AddressAsKey, Account>(accountSetsBits);
+        _storage = new SeqlockCache<StorageCell, byte[]>(storageSetsBits);
+        _headHashes = new Hash256?[depth + 1];
+        _changedAccounts = new FrozenSet<AddressAsKey>?[depth];
+        _changedSlots = new FrozenSet<StorageCell>?[depth];
+    }
+
+    /// <summary>The maximum number of blocks behind the head that can be served (the X in head-X).</summary>
+    public int Depth => _depth;
+
+    /// <summary>Even when stable, odd while the updater is applying a block or flushing.</summary>
+    public long Generation => Volatile.Read(ref _generation);
+
+    public SeqlockCache<AddressAsKey, Account> Accounts => _accounts;
+    public SeqlockCache<StorageCell, byte[]> Storage => _storage;
+
+    /// <summary>The current head block hash, or null before the first head is set.</summary>
+    public Hash256? HeadHash => Volatile.Read(ref _headHashes[0]);
+
+    /// <summary>
+    /// Attempts to take a read snapshot for a reader pinned to <paramref name="headerHash"/>. Returns
+    /// false (the reader must pass through to the trie for the whole scope) when the cache is mid-update,
+    /// the header is not the head or one of the tracked ancestors, or the header is null.
+    /// </summary>
+    public bool TrySnapshot(Hash256? headerHash, out HeadStateSnapshot snapshot)
+    {
+        snapshot = default;
+        if (headerHash is null) return false;
+
+        long gen = Volatile.Read(ref _generation);
+        if ((gen & 1) != 0) return false; // mid-update
+
+        int depth = -1;
+        for (int d = 0; d <= _depth; d++)
+        {
+            if (headerHash.Equals(Volatile.Read(ref _headHashes[d])))
+            {
+                depth = d;
+                break;
+            }
+        }
+        if (depth < 0) return false;
+
+        // Snapshot the changed-key sets covering blocks newer than the pinned header (depths 0..depth-1).
+        FrozenSet<AddressAsKey>?[]? windowAccounts = null;
+        FrozenSet<StorageCell>?[]? windowSlots = null;
+        if (depth > 0)
+        {
+            windowAccounts = new FrozenSet<AddressAsKey>?[depth];
+            windowSlots = new FrozenSet<StorageCell>?[depth];
+            for (int d = 0; d < depth; d++)
+            {
+                windowAccounts[d] = Volatile.Read(ref _changedAccounts[d]);
+                windowSlots[d] = Volatile.Read(ref _changedSlots[d]);
+            }
+        }
+
+        // The rings are only swapped under an odd generation; if it is unchanged and still even, the
+        // depth and snapshotted sets are a consistent view.
+        if (Volatile.Read(ref _generation) != gen) return false;
+
+        snapshot = new HeadStateSnapshot(this, gen, depth, windowAccounts, windowSlots);
+        return true;
+    }
+
+    /// <summary>Advances the head to a child block, refreshing the keys it changed. Caller must ensure
+    /// <paramref name="newHeadHash"/>'s parent is the current head.</summary>
+    /// <param name="newHeadHash">The new head block hash.</param>
+    /// <param name="changedAccounts">All accounts the block mutated.</param>
+    /// <param name="changedSlots">All storage cells the block mutated.</param>
+    /// <param name="refresh">Callback that supplies the post-block value for a currently-cached changed key.</param>
+    public void Advance(
+        Hash256 newHeadHash,
+        IReadOnlyCollection<AddressAsKey> changedAccounts,
+        IReadOnlyCollection<StorageCell> changedSlots,
+        IHeadStateRefresher refresh)
+    {
+        FrozenSet<AddressAsKey> accountSet = changedAccounts as FrozenSet<AddressAsKey> ?? changedAccounts.ToFrozenSet();
+        FrozenSet<StorageCell> slotSet = changedSlots as FrozenSet<StorageCell> ?? changedSlots.ToFrozenSet();
+
+        Interlocked.Increment(ref _generation); // -> odd: readers pass through while we mutate
+
+        // Refresh only changed keys that are currently cached; uncached keys get the fresh head value
+        // lazily on the next read (backfill), so there is no stale entry to fix.
+        foreach (AddressAsKey address in accountSet)
+        {
+            if (_accounts.TryGetValue(in address, out _))
+            {
+                _accounts.Set(in address, refresh.GetAccount(address.Value));
+            }
+        }
+        foreach (StorageCell cell in slotSet)
+        {
+            StorageCell key = cell;
+            if (_storage.TryGetValue(in key, out _))
+            {
+                _storage.Set(in key, refresh.GetStorage(in key));
+            }
+        }
+
+        ShiftRings(newHeadHash, accountSet, slotSet);
+
+        Interlocked.Increment(ref _generation); // -> even: publish the new head
+    }
+
+    /// <summary>Drops all cached content and the ancestor window, re-anchoring at <paramref name="newHeadHash"/>.
+    /// Used on the first head, a reorg, or a non-sequential head jump.</summary>
+    public void Flush(Hash256 newHeadHash)
+    {
+        Interlocked.Increment(ref _generation); // -> odd
+
+        _accounts.Clear();
+        _storage.Clear();
+        for (int d = 0; d < _depth; d++)
+        {
+            Volatile.Write(ref _changedAccounts[d], null);
+            Volatile.Write(ref _changedSlots[d], null);
+        }
+        Volatile.Write(ref _headHashes[0], newHeadHash);
+        for (int d = 1; d <= _depth; d++)
+        {
+            Volatile.Write(ref _headHashes[d], null);
+        }
+
+        Interlocked.Increment(ref _generation); // -> even
+    }
+
+    private void ShiftRings(Hash256 newHeadHash, FrozenSet<AddressAsKey> accountSet, FrozenSet<StorageCell> slotSet)
+    {
+        for (int d = _depth; d >= 1; d--)
+        {
+            Volatile.Write(ref _headHashes[d], Volatile.Read(ref _headHashes[d - 1]));
+        }
+        Volatile.Write(ref _headHashes[0], newHeadHash);
+
+        for (int d = _depth - 1; d >= 1; d--)
+        {
+            Volatile.Write(ref _changedAccounts[d], Volatile.Read(ref _changedAccounts[d - 1]));
+            Volatile.Write(ref _changedSlots[d], Volatile.Read(ref _changedSlots[d - 1]));
+        }
+        if (_depth > 0)
+        {
+            Volatile.Write(ref _changedAccounts[0], accountSet);
+            Volatile.Write(ref _changedSlots[0], slotSet);
+        }
+    }
+}
+
+/// <summary>Supplies post-block values for keys the <see cref="HeadStateCache"/> needs to refresh.</summary>
+public interface IHeadStateRefresher
+{
+    Account? GetAccount(Address address);
+    byte[] GetStorage(in StorageCell cell);
+}
+
+/// <summary>
+/// A consistent read view captured by <see cref="HeadStateCache.TrySnapshot"/>. Tells the scope
+/// provider, for a given key, whether the head-coherent cache may answer the read.
+/// </summary>
+public readonly struct HeadStateSnapshot
+{
+    private readonly HeadStateCache _cache;
+    private readonly FrozenSet<AddressAsKey>?[]? _windowAccounts;
+    private readonly FrozenSet<StorageCell>?[]? _windowSlots;
+
+    internal HeadStateSnapshot(
+        HeadStateCache cache,
+        long generation,
+        int depth,
+        FrozenSet<AddressAsKey>?[]? windowAccounts,
+        FrozenSet<StorageCell>?[]? windowSlots)
+    {
+        _cache = cache;
+        Generation = generation;
+        Depth = depth;
+        _windowAccounts = windowAccounts;
+        _windowSlots = windowSlots;
+    }
+
+    public long Generation { get; }
+    public int Depth { get; }
+
+    /// <summary>True if the cache generation still matches the one captured at scope start.</summary>
+    public bool IsCurrent => _cache.Generation == Generation;
+
+    /// <summary>True if the account may have changed between the pinned header and the head, so the
+    /// head-coherent cache must not be consulted/populated for it.</summary>
+    public bool ChangedInWindow(in AddressAsKey address)
+    {
+        FrozenSet<AddressAsKey>?[]? window = _windowAccounts;
+        if (window is null) return false;
+        for (int d = 0; d < window.Length; d++)
+        {
+            if (window[d]?.Contains(address) == true) return true;
+        }
+        return false;
+    }
+
+    /// <inheritdoc cref="ChangedInWindow(in AddressAsKey)"/>
+    public bool ChangedInWindow(in StorageCell cell)
+    {
+        FrozenSet<StorageCell>?[]? window = _windowSlots;
+        if (window is null) return false;
+        for (int d = 0; d < window.Length; d++)
+        {
+            if (window[d]?.Contains(cell) == true) return true;
+        }
+        return false;
+    }
+}

--- a/src/Nethermind/Nethermind.State/HeadStateCache.cs
+++ b/src/Nethermind/Nethermind.State/HeadStateCache.cs
@@ -45,6 +45,10 @@ public sealed class HeadStateCache
 
     private long _generation;
 
+    // Serializes cache writes (backfill, Advance, Flush) so a backfill that races an Advance is
+    // rejected by the generation check instead of publishing a stale value. Reads stay lock-free.
+    private readonly Lock _writeLock = new();
+
     public HeadStateCache(int depth, int accountSetsBits, int storageSetsBits)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(depth, 0);
@@ -129,51 +133,105 @@ public sealed class HeadStateCache
         FrozenSet<AddressAsKey> accountSet = changedAccounts as FrozenSet<AddressAsKey> ?? changedAccounts.ToFrozenSet();
         FrozenSet<StorageCell> slotSet = changedSlots as FrozenSet<StorageCell> ?? changedSlots.ToFrozenSet();
 
-        Interlocked.Increment(ref _generation); // -> odd: readers pass through while we mutate
-
-        // Refresh only changed keys that are currently cached; uncached keys get the fresh head value
-        // lazily on the next read (backfill), so there is no stale entry to fix.
-        foreach (AddressAsKey address in accountSet)
+        lock (_writeLock)
         {
-            if (_accounts.TryGetValue(in address, out _))
+            // Phase 1 (may throw — trie reads): gather refreshed values for currently-cached changed
+            // keys *before* touching the generation, so a failure leaves the cache untouched and even.
+            // The lock blocks concurrent backfills, so the cached set can't grow under us here.
+            List<(AddressAsKey Key, Account? Value)> accountUpdates = [];
+            foreach (AddressAsKey address in accountSet)
             {
-                _accounts.Set(in address, refresh.GetAccount(address.Value));
+                if (_accounts.TryGetValue(in address, out _))
+                {
+                    accountUpdates.Add((address, refresh.GetAccount(address.Value)));
+                }
+            }
+            List<(StorageCell Key, byte[] Value)> slotUpdates = [];
+            foreach (StorageCell cell in slotSet)
+            {
+                StorageCell key = cell;
+                if (_storage.TryGetValue(in key, out _))
+                {
+                    slotUpdates.Add((key, refresh.GetStorage(in key)));
+                }
+            }
+
+            // Phase 2 (no throw — in-memory publish): readers see odd generation and pass through.
+            Interlocked.Increment(ref _generation);
+            try
+            {
+                foreach ((AddressAsKey key, Account? value) in accountUpdates) _accounts.Set(in key, value);
+                foreach ((StorageCell key, byte[] value) in slotUpdates) _storage.Set(in key, value);
+                ShiftRings(newHeadHash, accountSet, slotSet);
+            }
+            finally
+            {
+                Interlocked.Increment(ref _generation); // always return to even, even on the unexpected
             }
         }
-        foreach (StorageCell cell in slotSet)
-        {
-            StorageCell key = cell;
-            if (_storage.TryGetValue(in key, out _))
-            {
-                _storage.Set(in key, refresh.GetStorage(in key));
-            }
-        }
-
-        ShiftRings(newHeadHash, accountSet, slotSet);
-
-        Interlocked.Increment(ref _generation); // -> even: publish the new head
     }
 
     /// <summary>Drops all cached content and the ancestor window, re-anchoring at <paramref name="newHeadHash"/>.
     /// Used on the first head, a reorg, or a non-sequential head jump.</summary>
     public void Flush(Hash256 newHeadHash)
     {
-        Interlocked.Increment(ref _generation); // -> odd
-
-        _accounts.Clear();
-        _storage.Clear();
-        for (int d = 0; d < _depth; d++)
+        lock (_writeLock)
         {
-            Volatile.Write(ref _changedAccounts[d], null);
-            Volatile.Write(ref _changedSlots[d], null);
+            Interlocked.Increment(ref _generation); // -> odd
+            try
+            {
+                _accounts.Clear();
+                _storage.Clear();
+                for (int d = 0; d < _depth; d++)
+                {
+                    Volatile.Write(ref _changedAccounts[d], null);
+                    Volatile.Write(ref _changedSlots[d], null);
+                }
+                Volatile.Write(ref _headHashes[0], newHeadHash);
+                for (int d = 1; d <= _depth; d++)
+                {
+                    Volatile.Write(ref _headHashes[d], null);
+                }
+            }
+            finally
+            {
+                Interlocked.Increment(ref _generation); // -> even
+            }
         }
-        Volatile.Write(ref _headHashes[0], newHeadHash);
-        for (int d = 1; d <= _depth; d++)
-        {
-            Volatile.Write(ref _headHashes[d], null);
-        }
+    }
 
-        Interlocked.Increment(ref _generation); // -> even
+    /// <summary>
+    /// Backfills a value read at scope start, but only if no <see cref="Advance"/>/<see cref="Flush"/>
+    /// has happened since (generation unchanged). Run under the write lock so the check-and-set is atomic
+    /// against head changes — this prevents publishing a stale value for a key the new head changed.
+    /// </summary>
+    public void TryBackfillAccount(in AddressAsKey key, Account? value, long expectedGeneration)
+    {
+        // Non-blocking: never stall an RPC read behind an in-progress Advance/Flush. Skipping just means
+        // the value isn't cached this time; the next read re-attempts.
+        if (!_writeLock.TryEnter()) return;
+        try
+        {
+            if (Volatile.Read(ref _generation) == expectedGeneration) _accounts.Set(in key, value);
+        }
+        finally
+        {
+            _writeLock.Exit();
+        }
+    }
+
+    /// <inheritdoc cref="TryBackfillAccount"/>
+    public void TryBackfillStorage(in StorageCell key, byte[] value, long expectedGeneration)
+    {
+        if (!_writeLock.TryEnter()) return;
+        try
+        {
+            if (Volatile.Read(ref _generation) == expectedGeneration) _storage.Set(in key, value);
+        }
+        finally
+        {
+            _writeLock.Exit();
+        }
     }
 
     private void ShiftRings(Hash256 newHeadHash, FrozenSet<AddressAsKey> accountSet, FrozenSet<StorageCell> slotSet)

--- a/src/Nethermind/Nethermind.State/HeadStateCacheScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/HeadStateCacheScopeProvider.cs
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using IScope = Nethermind.Evm.State.IWorldStateScopeProvider.IScope;
+using IStorageTree = Nethermind.Evm.State.IWorldStateScopeProvider.IStorageTree;
+using ICodeDb = Nethermind.Evm.State.IWorldStateScopeProvider.ICodeDb;
+using IWorldStateWriteBatch = Nethermind.Evm.State.IWorldStateScopeProvider.IWorldStateWriteBatch;
+using IAsyncBalReaderSink = Nethermind.Evm.State.IWorldStateScopeProvider.IAsyncBalReaderSink;
+
+namespace Nethermind.State;
+
+/// <summary>
+/// Decorates a read-only <see cref="IWorldStateScopeProvider"/> with the cross-block
+/// <see cref="HeadStateCache"/>. When the scope's base block is the head (or one of the tracked
+/// ancestors) reads are served as O(1) cache lookups instead of trie traversals; otherwise the scope
+/// is a pure passthrough. Writes are never cached — the cache is maintained solely by
+/// <see cref="HeadStateCacheUpdater"/> and by read backfill.
+/// </summary>
+public sealed class HeadStateCacheScopeProvider(IWorldStateScopeProvider baseProvider, HeadStateCache cache)
+    : IWorldStateScopeProvider
+{
+    public bool HasRoot(BlockHeader? baseBlock) => baseProvider.HasRoot(baseBlock);
+
+    public IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics)
+    {
+        IScope baseScope = baseProvider.BeginScope(baseBlock, metrics);
+        return cache.TrySnapshot(baseBlock?.Hash, out HeadStateSnapshot snapshot)
+            ? new CachingScope(baseScope, cache, snapshot)
+            : baseScope; // passthrough: historical, side-branch, too-deep, or mid-update
+    }
+
+    private sealed class CachingScope(IScope baseScope, HeadStateCache cache, HeadStateSnapshot snapshot) : IScope
+    {
+        private readonly SeqlockCache<AddressAsKey, Account> _accounts = cache.Accounts;
+
+        public Account? Get(Address address)
+        {
+            AddressAsKey key = address;
+            if (!snapshot.IsCurrent || snapshot.ChangedInWindow(in key))
+            {
+                return baseScope.Get(address);
+            }
+
+            if (_accounts.TryGetValue(in key, out Account? cached) && snapshot.IsCurrent)
+            {
+                return cached;
+            }
+
+            // Miss (or raced an advance): load at the pinned header root and backfill while still current.
+            Account? loaded = baseScope.Get(address);
+            if (snapshot.IsCurrent)
+            {
+                _accounts.Set(in key, loaded);
+            }
+            return loaded;
+        }
+
+        public IStorageTree CreateStorageTree(Address address) =>
+            new CachingStorageTree(baseScope.CreateStorageTree(address), cache.Storage, address, snapshot);
+
+        // --- Everything below is a straight delegation to the base scope. ---
+
+        public Hash256 RootHash => baseScope.RootHash;
+        public void UpdateRootHash() => baseScope.UpdateRootHash();
+        public ICodeDb CodeDb => baseScope.CodeDb;
+        public void HintGet(Address address, Account? account) => baseScope.HintGet(address, account);
+        public IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum) => baseScope.StartWriteBatch(estimatedAccountNum);
+        public void Commit(ulong blockNumber) => baseScope.Commit(blockNumber);
+        public Task HintBal(ReadOnlyBlockAccessList bal, IAsyncBalReaderSink? sink = null) => baseScope.HintBal(bal, sink);
+        public void Dispose() => baseScope.Dispose();
+    }
+
+    private sealed class CachingStorageTree(
+        IStorageTree baseStorageTree,
+        SeqlockCache<StorageCell, byte[]> storage,
+        Address address,
+        HeadStateSnapshot snapshot) : IStorageTree
+    {
+        public byte[] Get(in UInt256 index)
+        {
+            StorageCell cell = new(address, in index);
+            if (!snapshot.IsCurrent || snapshot.ChangedInWindow(in cell))
+            {
+                return baseStorageTree.Get(index);
+            }
+
+            if (storage.TryGetValue(in cell, out byte[]? cached) && snapshot.IsCurrent)
+            {
+                return cached!;
+            }
+
+            byte[] loaded = baseStorageTree.Get(index);
+            if (snapshot.IsCurrent)
+            {
+                storage.Set(in cell, loaded);
+            }
+            return loaded;
+        }
+
+        public Hash256 RootHash => baseStorageTree.RootHash;
+        public void HintSet(in UInt256 index, byte[]? value) => baseStorageTree.HintSet(in index, value);
+        public byte[] Get(in ValueHash256 hash) => baseStorageTree.Get(in hash);
+    }
+}

--- a/src/Nethermind/Nethermind.State/HeadStateCacheScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/HeadStateCacheScopeProvider.cs
@@ -53,17 +53,16 @@ public sealed class HeadStateCacheScopeProvider(IWorldStateScopeProvider basePro
                 return cached;
             }
 
-            // Miss (or raced an advance): load at the pinned header root and backfill while still current.
+            // Miss (or raced an advance): load at the pinned header root and backfill. The backfill is
+            // generation-guarded inside the cache, so a value loaded at the old head is dropped (not
+            // published) if an advance happened meanwhile.
             Account? loaded = baseScope.Get(address);
-            if (snapshot.IsCurrent)
-            {
-                _accounts.Set(in key, loaded);
-            }
+            cache.TryBackfillAccount(in key, loaded, snapshot.Generation);
             return loaded;
         }
 
         public IStorageTree CreateStorageTree(Address address) =>
-            new CachingStorageTree(baseScope.CreateStorageTree(address), cache.Storage, address, snapshot);
+            new CachingStorageTree(baseScope.CreateStorageTree(address), cache, address, snapshot);
 
         // --- Everything below is a straight delegation to the base scope. ---
 
@@ -79,10 +78,12 @@ public sealed class HeadStateCacheScopeProvider(IWorldStateScopeProvider basePro
 
     private sealed class CachingStorageTree(
         IStorageTree baseStorageTree,
-        SeqlockCache<StorageCell, byte[]> storage,
+        HeadStateCache cache,
         Address address,
         HeadStateSnapshot snapshot) : IStorageTree
     {
+        private readonly SeqlockCache<StorageCell, byte[]> _storage = cache.Storage;
+
         public byte[] Get(in UInt256 index)
         {
             StorageCell cell = new(address, in index);
@@ -91,16 +92,13 @@ public sealed class HeadStateCacheScopeProvider(IWorldStateScopeProvider basePro
                 return baseStorageTree.Get(index);
             }
 
-            if (storage.TryGetValue(in cell, out byte[]? cached) && snapshot.IsCurrent)
+            if (_storage.TryGetValue(in cell, out byte[]? cached) && snapshot.IsCurrent)
             {
                 return cached!;
             }
 
             byte[] loaded = baseStorageTree.Get(index);
-            if (snapshot.IsCurrent)
-            {
-                storage.Set(in cell, loaded);
-            }
+            cache.TryBackfillStorage(in cell, loaded, snapshot.Generation);
             return loaded;
         }
 

--- a/src/Nethermind/Nethermind.State/HeadStateDeltaBuffer.cs
+++ b/src/Nethermind/Nethermind.State/HeadStateDeltaBuffer.cs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Threading;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.State;
+
+/// <summary>
+/// The set of storage cells a processed block changed, captured from the world-state write batch
+/// (see <see cref="HeadStateDeltaCaptureScopeProvider"/>) and keyed by the block's post-state root.
+/// </summary>
+/// <param name="ChangedSlots">Storage cells the block wrote. Empty when only accounts changed.</param>
+/// <param name="RequiresFlush">
+/// True when the block self-destructed/cleared an account's storage: the full set of affected slots is
+/// not enumerable, so the consumer must flush the cache rather than apply a partial delta.
+/// </param>
+public readonly record struct HeadStateBlockDelta(FrozenSet<StorageCell> ChangedSlots, bool RequiresFlush);
+
+/// <summary>
+/// A small bounded store of recent per-block storage deltas, written by the processing-side capture
+/// decorator and read by <c>HeadStateCacheUpdater</c> when the head advances. Keyed by post-state root
+/// so the consumer can match the canonical block via its <see cref="BlockHeader.StateRoot"/> regardless
+/// of when the block becomes canonical.
+/// </summary>
+public sealed class HeadStateDeltaBuffer(int capacity = 64)
+{
+    private readonly Lock _lock = new();
+    private readonly Queue<Hash256> _order = new();
+    private readonly Dictionary<Hash256, HeadStateBlockDelta> _byRoot = [];
+
+    public void Store(Hash256 stateRoot, HeadStateBlockDelta delta)
+    {
+        lock (_lock)
+        {
+            if (!_byRoot.ContainsKey(stateRoot))
+            {
+                _order.Enqueue(stateRoot);
+                while (_order.Count > capacity)
+                {
+                    _byRoot.Remove(_order.Dequeue());
+                }
+            }
+            _byRoot[stateRoot] = delta;
+        }
+    }
+
+    public bool TryGet(Hash256 stateRoot, out HeadStateBlockDelta delta)
+    {
+        lock (_lock)
+        {
+            return _byRoot.TryGetValue(stateRoot, out delta);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State/HeadStateDeltaBuffer.cs
+++ b/src/Nethermind/Nethermind.State/HeadStateDeltaBuffer.cs
@@ -10,49 +10,60 @@ using Nethermind.Core.Crypto;
 namespace Nethermind.State;
 
 /// <summary>
-/// The set of storage cells a processed block changed, captured from the world-state write batch
-/// (see <see cref="HeadStateDeltaCaptureScopeProvider"/>) and keyed by the block's post-state root.
+/// The accounts and storage cells a processed block changed, captured from the world-state write batches
+/// (see <see cref="HeadStateDeltaCaptureScopeProvider"/>).
 /// </summary>
+/// <param name="ChangedAccounts">Accounts the block mutated (balance/nonce/code or moved storage root).</param>
 /// <param name="ChangedSlots">Storage cells the block wrote. Empty when only accounts changed.</param>
 /// <param name="RequiresFlush">
 /// True when the block self-destructed/cleared an account's storage: the full set of affected slots is
 /// not enumerable, so the consumer must flush the cache rather than apply a partial delta.
 /// </param>
-public readonly record struct HeadStateBlockDelta(FrozenSet<StorageCell> ChangedSlots, bool RequiresFlush);
+public readonly record struct HeadStateBlockDelta(
+    FrozenSet<AddressAsKey> ChangedAccounts,
+    FrozenSet<StorageCell> ChangedSlots,
+    bool RequiresFlush);
 
 /// <summary>
-/// A small bounded store of recent per-block storage deltas, written by the processing-side capture
-/// decorator and read by <c>HeadStateCacheUpdater</c> when the head advances. Keyed by post-state root
-/// so the consumer can match the canonical block via its <see cref="BlockHeader.StateRoot"/> regardless
-/// of when the block becomes canonical.
+/// A small bounded store of recent per-block deltas, written by the processing-side capture decorator and
+/// read by <c>HeadStateCacheUpdater</c> when the head advances. Keyed by <c>(blockNumber, post-state root)</c>
+/// so the consumer can match the canonical block via its number + <see cref="BlockHeader.StateRoot"/>
+/// regardless of when the block becomes canonical.
 /// </summary>
+/// <remarks>
+/// The key is not perfectly collision-free: two blocks at the same number reaching the same post-state via
+/// different parents would collide. That is vanishingly rare, and the only consequence is an under-/over-
+/// inclusive delta for one block — the head cache then serves a stale head-X read at worst. The buffer is
+/// bounded; mid-block intermediate roots are evicted in insertion order.
+/// </remarks>
 public sealed class HeadStateDeltaBuffer(int capacity = 64)
 {
     private readonly Lock _lock = new();
-    private readonly Queue<Hash256> _order = new();
-    private readonly Dictionary<Hash256, HeadStateBlockDelta> _byRoot = [];
+    private readonly Queue<(long Number, Hash256 Root)> _order = new();
+    private readonly Dictionary<(long Number, Hash256 Root), HeadStateBlockDelta> _byKey = [];
 
-    public void Store(Hash256 stateRoot, HeadStateBlockDelta delta)
+    public void Store(ulong blockNumber, Hash256 stateRoot, HeadStateBlockDelta delta)
     {
+        (long, Hash256) key = ((long)blockNumber, stateRoot);
         lock (_lock)
         {
-            if (!_byRoot.ContainsKey(stateRoot))
+            if (!_byKey.ContainsKey(key))
             {
-                _order.Enqueue(stateRoot);
+                _order.Enqueue(key);
                 while (_order.Count > capacity)
                 {
-                    _byRoot.Remove(_order.Dequeue());
+                    _byKey.Remove(_order.Dequeue());
                 }
             }
-            _byRoot[stateRoot] = delta;
+            _byKey[key] = delta;
         }
     }
 
-    public bool TryGet(Hash256 stateRoot, out HeadStateBlockDelta delta)
+    public bool TryGet(ulong blockNumber, Hash256 stateRoot, out HeadStateBlockDelta delta)
     {
         lock (_lock)
         {
-            return _byRoot.TryGetValue(stateRoot, out delta);
+            return _byKey.TryGetValue(((long)blockNumber, stateRoot), out delta);
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/HeadStateDeltaCaptureScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/HeadStateDeltaCaptureScopeProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
@@ -20,11 +21,13 @@ using IAsyncBalReaderSink = Nethermind.Evm.State.IWorldStateScopeProvider.IAsync
 namespace Nethermind.State;
 
 /// <summary>
-/// Observes the main processing world state's write batches to record, per block, the storage cells
-/// that changed — captured at commit time from <see cref="IStorageWriteBatch.Set"/> (which sees only
-/// real writes, before the journal normalizes them). Records into a <see cref="HeadStateDeltaBuffer"/>
-/// keyed by the post-commit state root, so the head cache can stay coherent on any node, independent
-/// of EIP-7928/Block Access Lists. This is a pure observer: every call is forwarded unchanged.
+/// Observes the main processing world state's write batches to record, per block, the accounts and
+/// storage cells that changed — captured at commit time from <see cref="IWorldStateWriteBatch.Set"/> and
+/// <see cref="IStorageWriteBatch.Set"/> (which see only real writes, before the journal normalizes them).
+/// Records into a <see cref="HeadStateDeltaBuffer"/> keyed by <c>(blockNumber, post-state root)</c>, so the
+/// head cache can stay coherent on any node, independent of EIP-7928/Block Access Lists, without borrowing
+/// the pooled <see cref="Block.AccountChanges"/> list (which the TxPool concurrently disposes). This is a
+/// pure observer: every call is forwarded unchanged.
 /// </summary>
 public sealed class HeadStateDeltaCaptureScopeProvider(IWorldStateScopeProvider baseProvider, HeadStateDeltaBuffer buffer)
     : IWorldStateScopeProvider
@@ -45,18 +48,40 @@ public sealed class HeadStateDeltaCaptureScopeProvider(IWorldStateScopeProvider 
         // accumulated per scope (not reset per commit). Over-inclusion across a multi-block branch is
         // safe: the consumer re-reads/defers the extra cells, which is correct, just less efficient.
         private readonly HashSet<StorageCell> _slots = [];
-        private bool _requiresFlush;
+        private readonly HashSet<AddressAsKey> _accounts = [];
+        private readonly Lock _lock = new();
+        private volatile bool _requiresFlush;
 
-        internal void RecordSlot(in StorageCell cell)
+        // Storage-root computation runs the per-contract write batches in parallel
+        // (PersistentStorageProvider.UpdateRootHashesMultiThread), so merges are locked. Each batch
+        // buffers its own keys single-threaded and merges once on dispose, keeping locking
+        // per-batch rather than per-key.
+        internal void MergeSlots(List<StorageCell> cells)
         {
-            if (_requiresFlush) return;
-            if (_slots.Count >= MaxTrackedSlots)
+            if (_requiresFlush || cells.Count == 0) return;
+            lock (_lock)
             {
-                _requiresFlush = true;
-                _slots.Clear();
-                return;
+                if (_requiresFlush) return;
+                foreach (StorageCell cell in cells)
+                {
+                    if (_slots.Count >= MaxTrackedSlots)
+                    {
+                        _requiresFlush = true;
+                        _slots.Clear();
+                        return;
+                    }
+                    _slots.Add(cell);
+                }
             }
-            _slots.Add(cell);
+        }
+
+        internal void MergeAccounts(List<AddressAsKey> addresses)
+        {
+            if (addresses.Count == 0) return;
+            lock (_lock)
+            {
+                foreach (AddressAsKey address in addresses) _accounts.Add(address);
+            }
         }
 
         internal void RecordClear() => _requiresFlush = true;
@@ -65,9 +90,16 @@ public sealed class HeadStateDeltaCaptureScopeProvider(IWorldStateScopeProvider 
         {
             baseScope.Commit(blockNumber);
 
-            // RootHash now reflects the committed state; the block's final commit stores under its
-            // final state root. Snapshot so later commits don't mutate the stored set.
-            buffer.Store(baseScope.RootHash, new HeadStateBlockDelta(_slots.ToFrozenSet(), _requiresFlush));
+            // Parallel storage workers have joined by the time Commit runs; snapshot under the lock for
+            // memory visibility. The block's final commit stores under its final state root.
+            FrozenSet<StorageCell> slots;
+            FrozenSet<AddressAsKey> accounts;
+            lock (_lock)
+            {
+                slots = _slots.ToFrozenSet();
+                accounts = _accounts.ToFrozenSet();
+            }
+            buffer.Store(blockNumber, baseScope.RootHash, new HeadStateBlockDelta(accounts, slots, _requiresFlush));
         }
 
         public IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum) =>
@@ -87,25 +119,43 @@ public sealed class HeadStateDeltaCaptureScopeProvider(IWorldStateScopeProvider 
 
     private sealed class CaptureWriteBatch(IWorldStateWriteBatch baseBatch, CaptureScope scope) : IWorldStateWriteBatch
     {
+        // Account writes on a batch are single-threaded (only storage-root computation is parallel), so
+        // this list needs no locking; it is merged into the scope's shared set once on dispose.
+        private readonly List<AddressAsKey> _accounts = [];
+
         public event EventHandler<IWorldStateScopeProvider.AccountUpdated>? OnAccountUpdated
         {
             add => baseBatch.OnAccountUpdated += value;
             remove => baseBatch.OnAccountUpdated -= value;
         }
 
-        public void Set(Address key, Account? account) => baseBatch.Set(key, account);
+        public void Set(Address key, Account? account)
+        {
+            // Every account written to the trie this block changed (balance/nonce/code or — via a moved
+            // storage root — storage). Null means deletion, still a change.
+            _accounts.Add(key);
+            baseBatch.Set(key, account);
+        }
 
         public IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries) =>
             new CaptureStorageWriteBatch(baseBatch.CreateStorageWriteBatch(key, estimatedEntries), key, scope);
 
-        public void Dispose() => baseBatch.Dispose();
+        public void Dispose()
+        {
+            scope.MergeAccounts(_accounts);
+            baseBatch.Dispose();
+        }
     }
 
     private sealed class CaptureStorageWriteBatch(IStorageWriteBatch baseBatch, Address address, CaptureScope scope) : IStorageWriteBatch
     {
+        // A single storage batch is written by one worker thread, so this list needs no locking;
+        // it is merged into the scope's shared set once on dispose.
+        private readonly List<StorageCell> _cells = [];
+
         public void Set(in UInt256 index, byte[] value)
         {
-            scope.RecordSlot(new StorageCell(address, in index));
+            _cells.Add(new StorageCell(address, in index));
             baseBatch.Set(in index, value);
         }
 
@@ -117,6 +167,10 @@ public sealed class HeadStateDeltaCaptureScopeProvider(IWorldStateScopeProvider 
             baseBatch.Clear();
         }
 
-        public void Dispose() => baseBatch.Dispose();
+        public void Dispose()
+        {
+            scope.MergeSlots(_cells);
+            baseBatch.Dispose();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.State/HeadStateDeltaCaptureScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/HeadStateDeltaCaptureScopeProvider.cs
@@ -39,18 +39,22 @@ public sealed class HeadStateDeltaCaptureScopeProvider(IWorldStateScopeProvider 
 
     private sealed class CaptureScope(IScope baseScope, HeadStateDeltaBuffer buffer) : IScope
     {
-        // Cap on accumulated cells: a scope normally spans a single block near the head, but a long
-        // sync branch reuses one scope across many blocks. Past the cap we stop tracking and signal a
-        // flush rather than grow unbounded (the consumer then rebuilds lazily).
+        // Cap on a single block's tracked cells: past it we stop tracking and signal a flush rather than
+        // grow unbounded (the consumer then rebuilds lazily).
         private const int MaxTrackedSlots = 1 << 21;
 
-        // Writes precede a block's commits and a scope spans one block in the live case, so the set is
-        // accumulated per scope (not reset per commit). Over-inclusion across a multi-block branch is
-        // safe: the consumer re-reads/defers the extra cells, which is correct, just less efficient.
-        private readonly HashSet<StorageCell> _slots = [];
-        private readonly HashSet<AddressAsKey> _accounts = [];
+        // A processing scope can span multiple blocks (a sync branch), so writes are bucketed per block.
+        // "_pending*" accumulate the current commit's writes (write batches merge into them); at each
+        // Commit they fold into the per-block "_block*" set, which is reset when the block number changes.
+        // This keeps the snapshot work O(block) rather than O(branch²) and the delta per-block-accurate.
+        private readonly HashSet<StorageCell> _pendingSlots = [];
+        private readonly HashSet<AddressAsKey> _pendingAccounts = [];
+        private readonly HashSet<StorageCell> _blockSlots = [];
+        private readonly HashSet<AddressAsKey> _blockAccounts = [];
         private readonly Lock _lock = new();
-        private volatile bool _requiresFlush;
+        private long _currentBlockNumber = -1;
+        private bool _pendingFlush;
+        private bool _blockFlush;
 
         // Storage-root computation runs the per-contract write batches in parallel
         // (PersistentStorageProvider.UpdateRootHashesMultiThread), so merges are locked. Each batch
@@ -58,19 +62,19 @@ public sealed class HeadStateDeltaCaptureScopeProvider(IWorldStateScopeProvider 
         // per-batch rather than per-key.
         internal void MergeSlots(List<StorageCell> cells)
         {
-            if (_requiresFlush || cells.Count == 0) return;
+            if (cells.Count == 0) return;
             lock (_lock)
             {
-                if (_requiresFlush) return;
+                if (_pendingFlush) return;
                 foreach (StorageCell cell in cells)
                 {
-                    if (_slots.Count >= MaxTrackedSlots)
+                    if (_pendingSlots.Count >= MaxTrackedSlots)
                     {
-                        _requiresFlush = true;
-                        _slots.Clear();
+                        _pendingFlush = true;
+                        _pendingSlots.Clear();
                         return;
                     }
-                    _slots.Add(cell);
+                    _pendingSlots.Add(cell);
                 }
             }
         }
@@ -80,26 +84,51 @@ public sealed class HeadStateDeltaCaptureScopeProvider(IWorldStateScopeProvider 
             if (addresses.Count == 0) return;
             lock (_lock)
             {
-                foreach (AddressAsKey address in addresses) _accounts.Add(address);
+                foreach (AddressAsKey address in addresses) _pendingAccounts.Add(address);
             }
         }
 
-        internal void RecordClear() => _requiresFlush = true;
+        internal void RecordClear()
+        {
+            lock (_lock) _pendingFlush = true;
+        }
 
         public void Commit(ulong blockNumber)
         {
             baseScope.Commit(blockNumber);
 
-            // Parallel storage workers have joined by the time Commit runs; snapshot under the lock for
-            // memory visibility. The block's final commit stores under its final state root.
+            // Parallel storage workers have joined by the time Commit runs. Fold this commit's pending
+            // writes into the current block's set (resetting it on a new block), then snapshot.
             FrozenSet<StorageCell> slots;
             FrozenSet<AddressAsKey> accounts;
+            bool flush;
             lock (_lock)
             {
-                slots = _slots.ToFrozenSet();
-                accounts = _accounts.ToFrozenSet();
+                if ((long)blockNumber != _currentBlockNumber)
+                {
+                    _blockSlots.Clear();
+                    _blockAccounts.Clear();
+                    _blockSlots.UnionWith(_pendingSlots);
+                    _blockAccounts.UnionWith(_pendingAccounts);
+                    _blockFlush = _pendingFlush;
+                    _currentBlockNumber = (long)blockNumber;
+                }
+                else
+                {
+                    _blockSlots.UnionWith(_pendingSlots);
+                    _blockAccounts.UnionWith(_pendingAccounts);
+                    _blockFlush |= _pendingFlush;
+                }
+
+                _pendingSlots.Clear();
+                _pendingAccounts.Clear();
+                _pendingFlush = false;
+
+                slots = _blockSlots.ToFrozenSet();
+                accounts = _blockAccounts.ToFrozenSet();
+                flush = _blockFlush;
             }
-            buffer.Store(blockNumber, baseScope.RootHash, new HeadStateBlockDelta(accounts, slots, _requiresFlush));
+            buffer.Store(blockNumber, baseScope.RootHash, new HeadStateBlockDelta(accounts, slots, flush));
         }
 
         public IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum) =>

--- a/src/Nethermind/Nethermind.State/HeadStateDeltaCaptureScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/HeadStateDeltaCaptureScopeProvider.cs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using IScope = Nethermind.Evm.State.IWorldStateScopeProvider.IScope;
+using IStorageTree = Nethermind.Evm.State.IWorldStateScopeProvider.IStorageTree;
+using ICodeDb = Nethermind.Evm.State.IWorldStateScopeProvider.ICodeDb;
+using IWorldStateWriteBatch = Nethermind.Evm.State.IWorldStateScopeProvider.IWorldStateWriteBatch;
+using IStorageWriteBatch = Nethermind.Evm.State.IWorldStateScopeProvider.IStorageWriteBatch;
+using IAsyncBalReaderSink = Nethermind.Evm.State.IWorldStateScopeProvider.IAsyncBalReaderSink;
+
+namespace Nethermind.State;
+
+/// <summary>
+/// Observes the main processing world state's write batches to record, per block, the storage cells
+/// that changed — captured at commit time from <see cref="IStorageWriteBatch.Set"/> (which sees only
+/// real writes, before the journal normalizes them). Records into a <see cref="HeadStateDeltaBuffer"/>
+/// keyed by the post-commit state root, so the head cache can stay coherent on any node, independent
+/// of EIP-7928/Block Access Lists. This is a pure observer: every call is forwarded unchanged.
+/// </summary>
+public sealed class HeadStateDeltaCaptureScopeProvider(IWorldStateScopeProvider baseProvider, HeadStateDeltaBuffer buffer)
+    : IWorldStateScopeProvider
+{
+    public bool HasRoot(BlockHeader? baseBlock) => baseProvider.HasRoot(baseBlock);
+
+    public IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics) =>
+        new CaptureScope(baseProvider.BeginScope(baseBlock, metrics), buffer);
+
+    private sealed class CaptureScope(IScope baseScope, HeadStateDeltaBuffer buffer) : IScope
+    {
+        // Cap on accumulated cells: a scope normally spans a single block near the head, but a long
+        // sync branch reuses one scope across many blocks. Past the cap we stop tracking and signal a
+        // flush rather than grow unbounded (the consumer then rebuilds lazily).
+        private const int MaxTrackedSlots = 1 << 21;
+
+        // Writes precede a block's commits and a scope spans one block in the live case, so the set is
+        // accumulated per scope (not reset per commit). Over-inclusion across a multi-block branch is
+        // safe: the consumer re-reads/defers the extra cells, which is correct, just less efficient.
+        private readonly HashSet<StorageCell> _slots = [];
+        private bool _requiresFlush;
+
+        internal void RecordSlot(in StorageCell cell)
+        {
+            if (_requiresFlush) return;
+            if (_slots.Count >= MaxTrackedSlots)
+            {
+                _requiresFlush = true;
+                _slots.Clear();
+                return;
+            }
+            _slots.Add(cell);
+        }
+
+        internal void RecordClear() => _requiresFlush = true;
+
+        public void Commit(ulong blockNumber)
+        {
+            baseScope.Commit(blockNumber);
+
+            // RootHash now reflects the committed state; the block's final commit stores under its
+            // final state root. Snapshot so later commits don't mutate the stored set.
+            buffer.Store(baseScope.RootHash, new HeadStateBlockDelta(_slots.ToFrozenSet(), _requiresFlush));
+        }
+
+        public IWorldStateWriteBatch StartWriteBatch(int estimatedAccountNum) =>
+            new CaptureWriteBatch(baseScope.StartWriteBatch(estimatedAccountNum), this);
+
+        // --- Straight delegation below. ---
+
+        public Hash256 RootHash => baseScope.RootHash;
+        public void UpdateRootHash() => baseScope.UpdateRootHash();
+        public Account? Get(Address address) => baseScope.Get(address);
+        public void HintGet(Address address, Account? account) => baseScope.HintGet(address, account);
+        public ICodeDb CodeDb => baseScope.CodeDb;
+        public IStorageTree CreateStorageTree(Address address) => baseScope.CreateStorageTree(address);
+        public Task HintBal(ReadOnlyBlockAccessList bal, IAsyncBalReaderSink? sink = null) => baseScope.HintBal(bal, sink);
+        public void Dispose() => baseScope.Dispose();
+    }
+
+    private sealed class CaptureWriteBatch(IWorldStateWriteBatch baseBatch, CaptureScope scope) : IWorldStateWriteBatch
+    {
+        public event EventHandler<IWorldStateScopeProvider.AccountUpdated>? OnAccountUpdated
+        {
+            add => baseBatch.OnAccountUpdated += value;
+            remove => baseBatch.OnAccountUpdated -= value;
+        }
+
+        public void Set(Address key, Account? account) => baseBatch.Set(key, account);
+
+        public IStorageWriteBatch CreateStorageWriteBatch(Address key, int estimatedEntries) =>
+            new CaptureStorageWriteBatch(baseBatch.CreateStorageWriteBatch(key, estimatedEntries), key, scope);
+
+        public void Dispose() => baseBatch.Dispose();
+    }
+
+    private sealed class CaptureStorageWriteBatch(IStorageWriteBatch baseBatch, Address address, CaptureScope scope) : IStorageWriteBatch
+    {
+        public void Set(in UInt256 index, byte[] value)
+        {
+            scope.RecordSlot(new StorageCell(address, in index));
+            baseBatch.Set(in index, value);
+        }
+
+        public void Clear()
+        {
+            // Self-destruct wipes all of the account's slots; their keys aren't enumerable here, so
+            // signal a flush rather than risk leaving stale cached slots for this account.
+            scope.RecordClear();
+            baseBatch.Clear();
+        }
+
+        public void Dispose() => baseBatch.Dispose();
+    }
+}


### PR DESCRIPTION
## Changes

Adds an **opt-in, cross-block coherent cache of state at the canonical head** (and the last few ancestors, "head-X") to speed up read-only RPC calls on top of the tip — both the execution-path calls (`eth_call`, `eth_estimateGas`, `trace_*`, `debug_trace*`) and the direct state reads (`eth_getBalance`, `eth_getStorageAt`, `eth_getTransactionCount`, …).

Today the RPC read paths walk the trie on every call (served only by the trie-node cache + RocksDB block cache); there is no direct `address→Account` / `(address,slot)→value` cache for RPC. This PR adds one, kept coherent across blocks by applying each block's changed keys.

- `HeadStateCache` — two `SeqlockCache`s (accounts + storage) coherent at head, a head-hash ring + per-block changed-key ring for head-X. Writes (backfill / advance / flush) are serialized under a write lock; **reads stay lock-free** and are guarded by a generation seqlock (fall back to the trie if the head moves mid-call).
- `HeadStateCacheScopeProvider` — decorates the read-only world state for the execution-path RPCs: O(1) head lookups (generation-guarded backfill on miss), head-X served for keys unchanged in the window (changed keys deferred to the trie at the head-X root), pure passthrough otherwise.
- `HeadCachedStateReader` — decorates the shared `IStateReader` so `eth_getBalance`/`eth_getStorageAt`/… hit the cache for head/head-X reads.
- `HeadStateCacheUpdater` — applies head changes on a **single background worker** (off the `BlockAddedToMain` thread): refreshes the keys a block changed, flushes on reorg/gap/self-destruct. Bounded queue; a dropped event self-heals via the next non-sequential flush.
- `HeadStateDeltaCaptureScopeProvider` + `HeadStateDeltaBuffer` — capture each block's changed **accounts and storage cells** from the processing world state's write batches (works on any node, independent of EIP-7928), keyed by `(blockNumber, stateRoot)`. The consensus / generated Block Access List are fallbacks when no capture is present.
- Config (`IBlocksConfig`): `EnableHeadStateCache` (default **false**), `HeadStateCacheDepth` (default 2), cache sizing (clamped to valid ranges).

**Scope / cost:** when the flag is **on**, the capture decorator wraps the main processing world state, so each storage write does a `HashSet.Add` and each block commit a per-block `ToFrozenSet` — non-trivial but bounded per block. With the flag **off** (default) there is zero processing overhead. Reads on the RPC path become O(1) hash lookups instead of trie traversals.

## Types of changes

- [x] New feature (a non-breaking change that adds functionality)
- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `HeadStateCacheTests` (State.Test): decorated reads at depths 0..X match undecorated trie reads (changed + unchanged keys, hit + backfill); reorg-flush; passthrough; per-block capture keyed by `(number, root)`; self-destruct → flush; parallel-write capture thread-safety (mirrors the parallel storage-root workers).
- `HeadStateCacheUpdaterTests` (Blockchain.Test): journal-delta advance refreshes cached account/slot off-thread; self-destruct flush; non-sequential flush.

## Documentation

#### Requires documentation update

- [x] Yes

Config reference for the new `Blocks.EnableHeadStateCache` options (once defaults are finalized).

#### Requires explanation in Release Notes

- [ ] No

## Remarks

Opt-in, default off. Concurrency model (review-hardened): a write lock serializes cache writes so a backfill that races an `Advance` is dropped rather than published stale; `Advance` is exception-safe (generation only flips in a no-throw phase); the updater never reads the pooled `Block.AccountChanges` (TxPool owns/disposes it) — changed accounts come from the journal capture instead.

Remaining follow-ups: hit/miss metrics for observability; coverage for non-standard processing paths (AuRa/Optimism/Taiko — currently they produce no capture delta and fall back to BAL/flush, so they're correct but not journal-accelerated); on-flag processing-overhead benchmark. A documented future phase is reusing the same coherent-delta mechanism to speed up consecutive-block **processing** (deferred until the cache is proven, since a stale value there is an invalid block, not just a bad RPC response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
