### PR TITLE
`debug_getRawTransaction`: return `null` instead of error for missing transaction

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -142,6 +142,15 @@ public class DebugModuleTests
     }
 
     [Test]
+    public async Task DebugGetRawTransaction_WhenTransactionNotFound_ReturnsNull()
+    {
+        _debugBridge.GetTransactionFromHash(Keccak.Zero).ReturnsNull();
+
+        string serialized = await SerializedRequest("debug_getRawTransaction", Keccak.Zero);
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":null,\"id\":67}"));
+    }
+
+    [Test]
     public async Task DebugGetRawReceipts_WhenReceiptsExist_ReturnsHexArray()
     {
         TxReceipt[] receipts = [Build.A.Receipt.TestObject, Build.A.Receipt.TestObject];
@@ -484,10 +493,6 @@ public class DebugModuleTests
             (Action<IDebugBridge>)(b => b.GetBlock(new BlockParameter(Keccak.Zero)).ReturnsNull()),
             "debug_getRawBlock", (object)Keccak.Zero)
         { TestName = "RawBlock_ByHash" };
-        yield return new TestCaseData(
-            (Action<IDebugBridge>)(b => b.GetTransactionFromHash(Keccak.Zero).ReturnsNull()),
-            "debug_getRawTransaction", (object)Keccak.Zero)
-        { TestName = "RawTransaction" };
     }
 
     private static IEnumerable<TestCaseData> RawBlockAccessListErrorCases()

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -517,7 +517,7 @@ public class DebugRpcModule(
         Transaction? transaction = debugBridge.GetTransactionFromHash(transactionHash);
         if (transaction is null)
         {
-            return ResultWrapper<ArrayPoolList<byte>>.Fail($"Transaction {transactionHash} was not found", ErrorCodes.ResourceNotFound);
+            return ResultWrapper<ArrayPoolList<byte>>.Success(null);
         }
 
         RlpBehaviors encodingSettings = RlpBehaviors.SkipTypedWrapping | (transaction.IsInMempoolForm() ? RlpBehaviors.InMempoolForm : RlpBehaviors.None);


### PR DESCRIPTION
## Description

`DebugRpcModule.debug_getRawTransaction` was returning a JSON-RPC error (`-32001 ResourceNotFound`) when a transaction hash is not found. The correct behaviour — consistent with the execution-apis spec and with Nethermind's own `eth_getRawTransactionByHash` implementation — is to return a successful response with a `null` result.

## Steps to Reproduce

Call `debug_getRawTransaction` with a hash that does not exist on the node:

```json
{"jsonrpc":"2.0","method":"debug_getRawTransaction","params":["0x0000000000000000000000000000000000000000000000000000000000000000"],"id":1}
```

**Before (incorrect):**
```json
{"jsonrpc":"2.0","error":{"code":-32001,"message":"Transaction 0x000...000 was not found"},"id":1}
```

**After (correct):**
```json
{"jsonrpc":"2.0","result":null,"id":1}
```

## Root Cause

The not-found branch in `debug_getRawTransaction` called `ResultWrapper<...>.Fail(...)` instead of `ResultWrapper<...>.Success(null)`.

## Fix

- `DebugRpcModule.cs`: Replace `Fail(...)` with `Success(null)` in the null-transaction branch.
- `DebugModuleTests.cs`: Remove the "RawTransaction" case from the shared `DebugGetRaw_WhenResourceMissing_ReturnsResourceNotFound` test (which expected an error) and add a dedicated `DebugGetRawTransaction_WhenTransactionNotFound_ReturnsNull` test asserting the correct `null` result.

## References

- `eth_getRawTransactionByHash` in Nethermind already returns `null` for missing transactions (consistent behaviour).
- Execution-apis spec: transaction-by-hash methods return `null` when not found.