### PR TITLE
Fix EraE export for pure PoS genesis blocks

### DIFF
--- a/src/Nethermind/Nethermind.EraE.Test/EraETestModule.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/EraETestModule.cs
@@ -4,6 +4,7 @@
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
+using Nethermind.Consensus;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
@@ -50,6 +51,7 @@ public class EraETestModule(bool useRealValidator = false) : Module
 
         return new ContainerBuilder()
             .AddModule(new EraETestModule())
+            .AddSingleton<IPoSSwitcher>(AlwaysPoS.Instance)
             .AddSingleton<ITimestamper>(PostMerge)
             .AddSingleton<IBlockTree>(blockTreeBuilder.TestObject)
             .OnBuild(ctx =>
@@ -93,6 +95,7 @@ public class EraETestModule(bool useRealValidator = false) : Module
             .AddModule(TestNethermindModule.CreateWithRealChainSpec())
             .AddModule(new EraEModule())
             .AddSingleton<IFileSystem>(new RealFileSystem())
+            .AddSingleton<IPoSSwitcher>(NoPoS.Instance)
             .AddSingleton<IEraEConfig>(new EraEConfig()
             {
                 MaxEraSize = 16,

--- a/src/Nethermind/Nethermind.EraE.Test/Export/EraExporterTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/Export/EraExporterTests.cs
@@ -4,6 +4,7 @@
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
+using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
 using NSubstitute;
@@ -191,10 +192,39 @@ public class EraExporterTests
         string[] eraFiles = Directory.GetFiles(tmpDirectory, $"*{EraPathUtils.FileExtension}");
         Assert.That(eraFiles, Has.Length.EqualTo(1), "one epoch for blocks 1-15");
 
-        List<ushort> types = EraFileFormatComplianceTests.ReadAllEntries(eraFiles[0]).Select(e => e.Type).ToList();
-        Assert.That(types, Does.Not.Contain(EntryTypes.Proof), "post-merge epochs have no Proof entries");
-        Assert.That(types, Does.Not.Contain(EntryTypes.TotalDifficulty), "post-merge epochs have no TotalDifficulty entries");
-        Assert.That(types, Does.Not.Contain(EntryTypes.AccumulatorRoot), "post-merge epochs have no AccumulatorRoot entry");
+        AssertNoPreMergeEntries(eraFiles[0]);
+    }
+
+    [Test]
+    public async Task Export_WhenPoSSwitcherMarksGenesisPostMerge_ProducesEpochWithNoTdProofOrAccumulatorEntries()
+    {
+        Block genesis = Build.A.Block.Genesis
+            .WithTimestamp(1_742_212_800)
+            .WithDifficulty(BlockHeaderBuilder.DefaultDifficulty)
+            .TestObject;
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(genesis);
+        blockTree.FindBlock(0UL, BlockTreeLookupOptions.DoNotCreateLevelIfMissing).Returns(genesis);
+
+        IReceiptStorage receiptStorage = Substitute.For<IReceiptStorage>();
+        receiptStorage.Get(genesis, true, false).Returns([]);
+
+        IPoSSwitcher poSSwitcher = Substitute.For<IPoSSwitcher>();
+        poSSwitcher.IsPostMerge(genesis.Header).Returns(true);
+
+        await using IContainer container = EraETestModule.BuildContainerBuilder()
+            .AddSingleton<IBlockTree>(blockTree)
+            .AddSingleton<IReceiptStorage>(receiptStorage)
+            .AddSingleton<IPoSSwitcher>(poSSwitcher)
+            .AddSingleton<IEraEConfig>(new EraEConfig { MaxEraSize = 16, NetworkName = EraETestModule.TestNetwork })
+            .Build();
+
+        string tmpDirectory = container.ResolveTempDirPath();
+        await container.Resolve<IEraExporter>().Export(tmpDirectory, 0UL, 0UL);
+
+        string eraFile = Directory.GetFiles(tmpDirectory, $"*{EraPathUtils.FileExtension}").Single();
+        AssertNoPreMergeEntries(eraFile);
+        poSSwitcher.Received(1).IsPostMerge(genesis.Header);
     }
 
     [Test]
@@ -227,5 +257,18 @@ public class EraExporterTests
 
         string[] eraFiles = System.IO.Directory.GetFiles(tmpDirectory, $"*{EraPathUtils.FileExtension}");
         Assert.That(eraFiles.Length, Is.EqualTo(1), "only one epoch covers blocks 16-31");
+    }
+
+    private static void AssertNoPreMergeEntries(string eraFile)
+    {
+        List<ushort> types = [];
+        foreach (EraFileFormatComplianceTests.EntryRecord entry in EraFileFormatComplianceTests.ReadAllEntries(eraFile))
+        {
+            types.Add(entry.Type);
+        }
+
+        Assert.That(types, Does.Not.Contain(EntryTypes.Proof), "post-merge epochs have no Proof entries");
+        Assert.That(types, Does.Not.Contain(EntryTypes.TotalDifficulty), "post-merge epochs have no TotalDifficulty entries");
+        Assert.That(types, Does.Not.Contain(EntryTypes.AccumulatorRoot), "post-merge epochs have no AccumulatorRoot entry");
     }
 }

--- a/src/Nethermind/Nethermind.EraE/Export/EraExporter.cs
+++ b/src/Nethermind/Nethermind.EraE/Export/EraExporter.cs
@@ -4,6 +4,7 @@
 using System.IO.Abstractions;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
+using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -26,6 +27,7 @@ public sealed class EraExporter(
     ISpecProvider specProvider,
     IEraEConfig eraConfig,
     ILogManager logManager,
+    IPoSSwitcher poSSwitcher,
     IBeaconRootsProvider? beaconRootsProvider = null)
     : IEraExporter
 {
@@ -135,9 +137,7 @@ public sealed class EraExporter(
                     Block block = blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.DoNotCreateLevelIfMissing)
                         ?? throw new EraException($"Could not find block {blockNumber}. The node may not have finished syncing block bodies for this range.");
 
-                    // IsPostMerge is not part of the RLP encoding and defaults to false when read from
-                    // the block store. Restore it from Difficulty (EIP-3675: post-merge Difficulty == 0).
-                    block.Header.IsPostMerge = block.Header.Difficulty == 0;
+                    block.Header.IsPostMerge = poSSwitcher.IsPostMerge(block.Header);
 
                     TxReceipt[]? receipts = receiptStorage.Get(block, true, false);
                     if (receipts is null || (block.Header.ReceiptsRoot != Keccak.EmptyTreeHash && receipts.Length == 0))

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PoSSwitcherTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PoSSwitcherTests.cs
@@ -48,6 +48,59 @@ namespace Nethermind.Merge.Plugin.Test
             Assert.That(specProvider.MergeBlockNumber?.BlockNumber, Is.EqualTo(101));
         }
 
+        [Test]
+        public void GetBlockSwitchInfo_returns_post_merge_for_ttd_zero_genesis_without_total_difficulty()
+        {
+            ChainSpecFileLoader loader = new(new EthereumJsonSerializer(), LimboLogs.Instance);
+            ChainSpec chainSpec = loader.LoadEmbeddedOrFromFile(FindHoodiChainSpecPath());
+            ChainSpecBasedSpecProvider specProvider = new(chainSpec);
+            IBlockTree blockTree = Substitute.For<IBlockTree>();
+            PoSSwitcher poSSwitcher = new(new MergeConfig(), new SyncConfig(), new MemDb(), blockTree, specProvider, chainSpec, LimboLogs.Instance);
+
+            Block genesis = Build.A.Block.Genesis
+                .WithTimestamp(1_742_212_800)
+                .WithDifficulty(BlockHeaderBuilder.DefaultDifficulty)
+                .WithTotalDifficulty((UInt256?)null)
+                .TestObject;
+
+            (bool isTerminal, bool isPostMerge) = poSSwitcher.GetBlockConsensusInfo(genesis.Header);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(chainSpec.Parameters.TerminalTotalDifficulty?.IsZero, Is.True);
+                Assert.That(specProvider.TerminalTotalDifficulty?.IsZero, Is.True);
+                Assert.That(specProvider.MergeBlockNumber, Is.Null);
+                Assert.That(isTerminal, Is.False);
+                Assert.That(isPostMerge, Is.True);
+                Assert.That(genesis.Header.IsPostMerge, Is.True);
+            }
+        }
+
+        [Test]
+        public void GetBlockSwitchInfo_does_not_mark_genesis_post_merge_for_config_only_ttd_zero()
+        {
+            TestSpecProvider specProvider = new(London.Instance);
+            IBlockTree blockTree = Substitute.For<IBlockTree>();
+            ChainSpec chainSpec = new();
+            PoSSwitcher poSSwitcher = new(new MergeConfig() { TerminalTotalDifficulty = "0" }, new SyncConfig(), new MemDb(), blockTree, specProvider, chainSpec, LimboLogs.Instance);
+
+            Block genesis = Build.A.Block.Genesis
+                .WithDifficulty(BlockHeaderBuilder.DefaultDifficulty)
+                .WithTotalDifficulty((UInt256?)null)
+                .TestObject;
+
+            (bool isTerminal, bool isPostMerge) = poSSwitcher.GetBlockConsensusInfo(genesis.Header);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(specProvider.TerminalTotalDifficulty?.IsZero, Is.True);
+                Assert.That(chainSpec.Parameters?.TerminalTotalDifficulty?.IsZero, Is.Not.True);
+                Assert.That(isTerminal, Is.False);
+                Assert.That(isPostMerge, Is.False);
+                Assert.That(genesis.Header.IsPostMerge, Is.False);
+            }
+        }
+
         [TestCase(5000000)]
         [TestCase(4900000)]
         public void IsTerminalBlock_returning_expected_results(long terminalTotalDifficulty)
@@ -258,6 +311,21 @@ namespace Nethermind.Merge.Plugin.Test
             db ??= new MemDb();
             MergeConfig? mergeConfig = new() { };
             return new PoSSwitcher(mergeConfig, new SyncConfig(), db, blockTree, specProvider ?? MainnetSpecProvider.Instance, new ChainSpec(), LimboLogs.Instance);
+        }
+
+        private static string FindHoodiChainSpecPath()
+        {
+            string? directory = TestContext.CurrentContext.WorkDirectory;
+            while (directory is not null)
+            {
+                string path = Path.Combine(directory, "Chains", "hoodi.json");
+                if (File.Exists(path))
+                    return path;
+
+                directory = Directory.GetParent(directory)?.FullName;
+            }
+
+            throw new FileNotFoundException($"Could not find Chains/hoodi.json from {TestContext.CurrentContext.WorkDirectory}.");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
@@ -172,6 +172,12 @@ namespace Nethermind.Merge.Plugin
                 isTerminal = false;
                 isPostMerge = false;
             }
+            else if (IsPostMergeGenesis(header))
+            {
+                // EIP-3675 chains with chain-spec TTD == 0 are post-merge from genesis.
+                isTerminal = false;
+                isPostMerge = true;
+            }
             else if (header.TotalDifficulty is not null && header.TotalDifficulty < _specProvider.TerminalTotalDifficulty) // pre TTD blocks
             {
                 // In a hive test, a block is requested from EL with total difficulty < TTD. so IsPostMerge does not work.
@@ -211,6 +217,11 @@ namespace Nethermind.Merge.Plugin
 
         public bool IsPostMerge(BlockHeader header) =>
             GetBlockConsensusInfo(header).IsPostMerge;
+
+        // Use chain-spec TTD, not effective spec-provider TTD, so MergeConfig test overrides
+        // do not change genesis classification.
+        private bool IsPostMergeGenesis(BlockHeader header) =>
+            header.IsGenesis && _chainSpec?.Parameters?.TerminalTotalDifficulty?.IsZero == true;
 
         public bool HasEverReachedTerminalBlock() => _hasEverReachedTerminalDifficulty;
 


### PR DESCRIPTION
Noticed that erae cannot be exported for hoodi starting from genesis, and appears hoodi is very special with its difficulty=1 in post merge genesis. Another way to fix it just for erae, let me know if it's funnier

## Changes

- Pass `IPoSSwitcher` into EraE export and use it to restore decoded header `IsPostMerge` before `EraWriter` decides which sections to emit.
- Add a Hoodi/chain-spec TTD-zero genesis special case to `PoSSwitcher`, keeping config-only TTD-zero overrides out of that special case.
- Add focused coverage for the exporter switcher handoff and the PoSSwitcher Hoodi/config-only genesis behavior.
- Register explicit EraE test switchers: `NoPoS` for base/pre-merge test containers and `AlwaysPoS` for the shared synthetic post-merge test helper.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet test --project src\Nethermind\Nethermind.EraE.Test\Nethermind.EraE.Test.csproj -c release -p:SaveDiskSpace=true` (170 passed, 3 skipped)
- `dotnet test --project src\Nethermind\Nethermind.Merge.Plugin.Test\Nethermind.Merge.Plugin.Test.csproj -c release -p:SaveDiskSpace=true -- --filter "FullyQualifiedName~PoSSwitcherTests"` (26 passed)
- `dotnet build src\Nethermind\Nethermind.slnx -c release -warnaserror -p:SaveDiskSpace=true` (0 warnings, 0 errors)
- `git diff --check`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Root cause: EraE export restored decoded post-merge state from `Difficulty == 0`, which misclassified Hoodi genesis as pre-merge because Hoodi is post-merge from genesis but has non-zero genesis difficulty. The export path now reuses `IPoSSwitcher`, and `PoSSwitcher` handles chain specs that declare `TerminalTotalDifficulty == 0` at genesis while leaving config-only TTD-zero test/override paths unchanged.