### PR TITLE
fix(txpool): fix data race that broadcasts a null transaction

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -721,6 +722,71 @@ public class TxBroadcasterTests
 
         // Assert
         Assert.That(result, Is.EqualTo(versionMatches), "LightTransaction from blob transaction should be gossiped when proof version matches.");
+    }
+
+    [Test]
+    public async Task Should_not_send_null_tx_when_adding_concurrently_with_timer_swap()
+    {
+        // Regression for the gossip NRE seen on gnosis+Flat: BroadcastOnce used to lock on the
+        // _accumulatedTemporaryTxs instance while the timer swapped that field by reference without taking the same
+        // lock. A concurrent Add could then mutate the swapped-out List<T> and leave a null hole, later dereferenced
+        // while gossiping (NullReferenceException in CompositeTxGossipPolicy.ShouldGossipTransaction).
+        ITimer timer = Substitute.For<ITimer>();
+        ITimerFactory timerFactory = Substitute.For<ITimerFactory>();
+        timerFactory.CreateTimer(Arg.Any<TimeSpan>()).Returns(timer);
+
+        _broadcaster = new TxBroadcaster(_comparer, timerFactory, _txPoolConfig, _headInfo, _logManager);
+
+        RecordingPeer peer = new(TestItem.PublicKeyA);
+        _broadcaster.AddPeer(peer);
+
+        const int txCount = 30_000;
+        Transaction[] transactions = new Transaction[txCount];
+        for (int i = 0; i < txCount; i++)
+        {
+            transactions[i] = Build.A.Transaction.WithNonce((ulong)i).TestObject;
+        }
+
+        using System.Threading.CancellationTokenSource cts = new();
+
+        // Keep firing the timer so NotifyPeers repeatedly swaps and flushes the accumulator while transactions are
+        // still being added from other threads - this is the window the old lock failed to guard.
+        Task ticker = Task.Run(() =>
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                timer.Elapsed += Raise.Event<EventHandler>(timer, EventArgs.Empty);
+            }
+        });
+
+        Parallel.For(0, txCount, i => _broadcaster.Broadcast(transactions[i], isPersistent: false));
+
+        cts.Cancel();
+        await ticker;
+        // Final flush of whatever was still accumulated after the adders finished.
+        timer.Elapsed += Raise.Event<EventHandler>(timer, EventArgs.Empty);
+
+        Assert.That(peer.SawNull, Is.False, "A null transaction reached the peer - the accumulated tx list was corrupted by a data race.");
+        Assert.That(peer.Sent.Count, Is.EqualTo(txCount), "Every broadcast transaction should be sent exactly once.");
+        Assert.That(peer.Sent.Distinct().Count(), Is.EqualTo(txCount), "No transaction should be sent more than once.");
+    }
+
+    private sealed class RecordingPeer(PublicKey id) : ITxPoolPeer
+    {
+        private readonly ConcurrentBag<Transaction> _sent = [];
+        public PublicKey Id => id;
+        public ulong HeadNumber { get; set; }
+        public bool SawNull { get; private set; }
+        public IReadOnlyCollection<Transaction> Sent => _sent;
+
+        public void SendNewTransactions(IEnumerable<Transaction> txs, bool sendFullTx)
+        {
+            foreach (Transaction tx in txs)
+            {
+                if (tx is null) SawNull = true;
+                else _sent.Add(tx);
+            }
+        }
     }
 
     private (IList<Transaction> expectedTxs, IList<Hash256> expectedHashes) GetTxsAndHashesExpectedToBroadcast(Transaction[] transactions, int expectedCountTotal)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -756,6 +756,7 @@ public class TxBroadcasterTests
             while (!cts.IsCancellationRequested)
             {
                 timer.Elapsed += Raise.Event<EventHandler>(timer, EventArgs.Empty);
+                System.Threading.Thread.Yield();
             }
         });
 

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -53,13 +53,6 @@ namespace Nethermind.TxPool
         /// </summary>
         private ResettableList<Transaction> _txsToSend;
 
-        /// <summary>
-        /// Guards both appending to <see cref="_accumulatedTemporaryTxs"/> and swapping it with
-        /// <see cref="_txsToSend"/>. A dedicated lock is required because the two lists are swapped by
-        /// reference: locking on the list instance itself would not serialise an <see cref="ResettableList{T}.Add"/>
-        /// against a concurrent swap, letting two threads mutate the same <see cref="List{T}"/> at once and leave a
-        /// null hole in it (later dereferenced while gossiping).
-        /// </summary>
         private readonly Lock _accumulatedTxsLock = new();
 
         /// <summary>
@@ -304,9 +297,6 @@ namespace Nethermind.TxPool
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             void NotifyPeers()
             {
-                // Swap under the same lock used by BroadcastOnce so an in-flight Add can never target the list we are
-                // about to enumerate/Reset. After the swap, BroadcastOnce only ever touches _accumulatedTemporaryTxs
-                // (now the empty buffer), while we exclusively own _txsToSend here.
                 lock (_accumulatedTxsLock)
                 {
                     (_accumulatedTemporaryTxs, _txsToSend) = (_txsToSend, _accumulatedTemporaryTxs);

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -53,6 +53,14 @@ namespace Nethermind.TxPool
         /// </summary>
         private ResettableList<Transaction> _txsToSend;
 
+        /// <summary>
+        /// Guards both appending to <see cref="_accumulatedTemporaryTxs"/> and swapping it with
+        /// <see cref="_txsToSend"/>. A dedicated lock is required because the two lists are swapped by
+        /// reference: locking on the list instance itself would not serialise an <see cref="ResettableList{T}.Add"/>
+        /// against a concurrent swap, letting two threads mutate the same <see cref="List{T}"/> at once and leave a
+        /// null hole in it (later dereferenced while gossiping).
+        /// </summary>
+        private readonly Lock _accumulatedTxsLock = new();
 
         /// <summary>
         /// Minimal value of MaxFeePerGas of local tx to be broadcasted immediately after receiving it
@@ -131,7 +139,7 @@ namespace Nethermind.TxPool
 
         private void BroadcastOnce(Transaction tx)
         {
-            lock (_accumulatedTemporaryTxs)
+            lock (_accumulatedTxsLock)
             {
                 _accumulatedTemporaryTxs.Add(tx);
             }
@@ -296,7 +304,13 @@ namespace Nethermind.TxPool
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             void NotifyPeers()
             {
-                _txsToSend = Interlocked.Exchange(ref _accumulatedTemporaryTxs, _txsToSend);
+                // Swap under the same lock used by BroadcastOnce so an in-flight Add can never target the list we are
+                // about to enumerate/Reset. After the swap, BroadcastOnce only ever touches _accumulatedTemporaryTxs
+                // (now the empty buffer), while we exclusively own _txsToSend here.
+                lock (_accumulatedTxsLock)
+                {
+                    (_accumulatedTemporaryTxs, _txsToSend) = (_txsToSend, _accumulatedTemporaryTxs);
+                }
 
                 if (_logger.IsTrace) _logger.Trace($"Broadcasting transactions to all peers");
 


### PR DESCRIPTION
## Changes

Fixes a data race in `TxBroadcaster` that occasionally broadcasts a **null transaction**, which then crashes tx gossip with a `NullReferenceException` in `CompositeTxGossipPolicy.ShouldGossipTransaction`:

```
Failed to notify [Peer|eth69|...] about transactions. System.NullReferenceException
   at Nethermind.TxPool.CompositeTxGossipPolicy.ShouldGossipTransaction(Transaction tx) in ITxGossipPolicy.cs:line 58
   at ...SyncPeerProtocolHandlerBase.TxsToSendAndMarkAsNotified+MoveNext()
   at ...Eth68ProtocolHandler.SendNewTransactionsCore(...)
   at Nethermind.TxPool.TxBroadcaster.Notify(...)
```

**Root cause:** `BroadcastOnce` locked on the `_accumulatedTemporaryTxs` *instance* while `TimerOnElapsed` swapped that field by reference (`Interlocked.Exchange`) **without** taking the same lock. A monitor only serialises sections that lock the same stable object, so the swap let two threads hold monitors on two *different* `ResettableList` instances while both `Add()`-ing to the same underlying `List<T>`. A concurrent `Add` during a resize leaves a null hole in the list, later read lazily through `txs.Where(_gossipFilter)` and dereferenced by `SpecDrivenTxGossipPolicy` (the first gossip policy that touches the transaction).

**Fix:** use a dedicated, never-reassigned lock for both the append and the swap. After the swap, `BroadcastOnce` only touches the new (empty) accumulator while the timer exclusively owns the buffer being sent, so the two lists are never mutated concurrently. The `ResettableList` reuse/swap design is preserved to avoid per-broadcast allocations during sync.

The race is pre-existing; it surfaced as a fatal crash on **gnosis + Flat** sync, where finalization-driven background work shifts scheduling enough to hit the window.

- `TxBroadcaster`: add `_accumulatedTxsLock`; guard both `BroadcastOnce`'s `Add` and the timer swap with it.
- Add a concurrency regression test (`Should_not_send_null_tx_when_adding_concurrently_with_timer_swap`) that drives `BroadcastOnce` against repeated timer swaps and asserts no null reaches the peer and every tx is sent exactly once. Fails reliably on the old code, passes on the fix.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New concurrency regression test fails 5/5 on the pre-fix code (`peer.SawNull == True`) and passes on the fix. Full `Nethermind.TxPool.Test` suite: 590 passed, 1 pre-existing skip.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
