### PR TITLE
refactor(tracing): dedup geth struct-tracer hex/word-size primitives

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxDirectStreamingTracer.cs
@@ -28,7 +28,7 @@ namespace Nethermind.Blockchain.Tracing.GethStyle;
 public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
 {
     private const int DefaultFlushIntervalEntries = 8192;
-    private const int EvmWordSize = 32;
+    private const int EvmWordSize = EvmPooledMemory.WordSize;
     private static readonly JsonEncodedText ZeroMemoryWord = JsonEncodedText.Encode("0x" + new string('0', EvmWordSize * 2));
     private const int InitialStorageMapCapacity = 8;
 
@@ -351,8 +351,7 @@ public sealed class GethLikeTxDirectStreamingTracer : GethLikeTxTracer
         _writer.WriteStartObject("storage"u8);
         foreach (KeyValuePair<UInt256, UInt256> kv in _pendingStorageMap!)
         {
-            HexWriter.WriteUInt256HexPropertyName(_writer, kv.Key, zeroPadded: true, addHexPrefix: true);
-            HexWriter.WriteUInt256HexRawValue(_writer, kv.Value, zeroPadded: true, addHexPrefix: true);
+            HexWriter.WriteUInt256StorageSlot(_writer, kv.Key, kv.Value);
         }
         _writer.WriteEndObject();
     }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTraceJsonLinesConverter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTraceJsonLinesConverter.cs
@@ -5,7 +5,7 @@ using System;
 using System.Buffers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Nethermind.Core.Extensions;
+using Nethermind.Evm;
 using Nethermind.Int256;
 using Nethermind.Serialization.Json;
 
@@ -49,10 +49,10 @@ internal class GethLikeTxTraceJsonLinesConverter : JsonConverter<GethTxFileTrace
         writer.WriteNumberValue((byte)value.OpcodeRaw);
 
         writer.WritePropertyName("gas");
-        WriteHexLong(writer, value.Gas);
+        HexWriter.WriteUlongHexStringValue(writer, value.Gas);
 
         writer.WritePropertyName("gasCost");
-        WriteHexLong(writer, value.GasCost);
+        HexWriter.WriteUlongHexStringValue(writer, value.GasCost);
 
         writer.WritePropertyName("memSize");
         writer.WriteNumberValue(value.MemorySize ?? 0UL);
@@ -102,40 +102,22 @@ internal class GethLikeTxTraceJsonLinesConverter : JsonConverter<GethTxFileTrace
         writer.Reset();
     }
 
-    private static void WriteHexLong(Utf8JsonWriter writer, ulong v)
-    {
-        Span<char> buf = stackalloc char[18]; // "0x" + up to 16 hex digits
-        buf[0] = '0';
-        buf[1] = 'x';
-        v.TryFormat(buf[2..], out int written, "x");
-        writer.WriteStringValue(buf[..(2 + written)]);
-    }
-
-    private const int WordSize = 32;
-
-    // The file format renders memory as a single contiguous 0x-prefixed hex blob (not a per-word array),
-    // so the words are encoded straight into a UTF-8 buffer and written as one JSON string.
+    // The file format renders memory as a single contiguous 0x-prefixed hex blob, not a per-word array.
     private static void WriteMemoryBlob(Utf8JsonWriter writer, UInt256[] words)
     {
-        int rawLength = words.Length * WordSize;
+        int rawLength = words.Length * EvmPooledMemory.WordSize;
         byte[] raw = ArrayPool<byte>.Shared.Rent(rawLength);
-        byte[] hex = ArrayPool<byte>.Shared.Rent(2 + rawLength * 2);
         try
         {
             Span<byte> rawSpan = raw.AsSpan(0, rawLength);
             for (int i = 0; i < words.Length; i++)
-                words[i].ToBigEndian(rawSpan.Slice(i * WordSize, WordSize));
+                words[i].ToBigEndian(rawSpan.Slice(i * EvmPooledMemory.WordSize, EvmPooledMemory.WordSize));
 
-            hex[0] = (byte)'0';
-            hex[1] = (byte)'x';
-            ((ReadOnlySpan<byte>)rawSpan).OutputBytesToByteHex(hex.AsSpan(2, rawLength * 2), extraNibble: false);
-
-            writer.WriteStringValue(hex.AsSpan(0, 2 + rawLength * 2));
+            HexWriter.WriteHexStringValue(writer, rawSpan);
         }
         finally
         {
             ArrayPool<byte>.Shared.Return(raw);
-            ArrayPool<byte>.Shared.Return(hex);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/StorageHexConverter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/StorageHexConverter.cs
@@ -23,8 +23,7 @@ public sealed class StorageHexConverter : JsonConverter<Dictionary<UInt256, UInt
         writer.WriteStartObject();
         foreach (KeyValuePair<UInt256, UInt256> slot in value)
         {
-            HexWriter.WriteUInt256HexPropertyName(writer, slot.Key, zeroPadded: true, addHexPrefix: true);
-            HexWriter.WriteUInt256HexRawValue(writer, slot.Value, zeroPadded: true, addHexPrefix: true);
+            HexWriter.WriteUInt256StorageSlot(writer, slot.Key, slot.Value);
         }
         writer.WriteEndObject();
     }

--- a/src/Nethermind/Nethermind.Serialization.Json/HexWriter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/HexWriter.cs
@@ -210,6 +210,17 @@ public static class HexWriter
             skipInputValidation: true);
     }
 
+    public static void WriteUlongHexStringValue(Utf8JsonWriter writer, ulong value)
+    {
+        if (value == 0)
+        {
+            writer.WriteRawValue("\"0x0\""u8, skipInputValidation: true);
+            return;
+        }
+
+        WriteUlongHexRawValue(writer, value);
+    }
+
     /// <summary>Writes a <see cref="UInt256"/> as a JSON string of lowercase hex chars.</summary>
     /// <param name="addHexPrefix">Whether to emit the leading <c>0x</c>. Defaults to <see langword="true"/>.</param>
     [SkipLocalsInit]
@@ -253,6 +264,12 @@ public static class HexWriter
 
         writer.WritePropertyName(
             MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref buffer, spanStart), spanLength));
+    }
+
+    public static void WriteUInt256StorageSlot(Utf8JsonWriter writer, in UInt256 key, in UInt256 value)
+    {
+        WriteUInt256HexPropertyName(writer, key, zeroPadded: true, addHexPrefix: true);
+        WriteUInt256HexRawValue(writer, value, zeroPadded: true, addHexPrefix: true);
     }
 
     // Buffer layout (logical): [opening "?][0x?][64 hex chars][closing "?].
@@ -416,6 +433,26 @@ public static class HexWriter
         value.TryFormat(buffer[3..], out int bytesWritten, "x");
         buffer[bytesWritten + 3] = (byte)'"';
         writer.Advance(bytesWritten + 4);
+    }
+
+    [SkipLocalsInit]
+    public static void WriteHexStringValue(Utf8JsonWriter writer, ReadOnlySpan<byte> data)
+    {
+        int tokenLength = 4 + data.Length * 2;
+        byte[] rented = ArrayPool<byte>.Shared.Rent(tokenLength);
+        try
+        {
+            rented[0] = (byte)'"';
+            rented[1] = (byte)'0';
+            rented[2] = (byte)'x';
+            EncodeToHex(data, ref rented[3]);
+            rented[tokenLength - 1] = (byte)'"';
+            writer.WriteRawValue(rented.AsSpan(0, tokenLength), skipInputValidation: true);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
     }
 
     private static void EncodeToHex(ReadOnlySpan<byte> src, ref byte dest)

--- a/src/Nethermind/Nethermind.Serialization.Json/HexWriter.cs
+++ b/src/Nethermind/Nethermind.Serialization.Json/HexWriter.cs
@@ -438,20 +438,23 @@ public static class HexWriter
     [SkipLocalsInit]
     public static void WriteHexStringValue(Utf8JsonWriter writer, ReadOnlySpan<byte> data)
     {
+        const int StackThreshold = 512;
         int tokenLength = 4 + data.Length * 2;
-        byte[] rented = ArrayPool<byte>.Shared.Rent(tokenLength);
+        // data is unbounded (e.g. a whole memory snapshot), so only stay on the stack while small.
+        byte[] rented = tokenLength > StackThreshold ? ArrayPool<byte>.Shared.Rent(tokenLength) : null;
+        Span<byte> token = rented is not null ? rented : stackalloc byte[StackThreshold];
         try
         {
-            rented[0] = (byte)'"';
-            rented[1] = (byte)'0';
-            rented[2] = (byte)'x';
-            EncodeToHex(data, ref rented[3]);
-            rented[tokenLength - 1] = (byte)'"';
-            writer.WriteRawValue(rented.AsSpan(0, tokenLength), skipInputValidation: true);
+            token[0] = (byte)'"';
+            token[1] = (byte)'0';
+            token[2] = (byte)'x';
+            EncodeToHex(data, ref token[3]);
+            token[tokenLength - 1] = (byte)'"';
+            writer.WriteRawValue(token[..tokenLength], skipInputValidation: true);
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(rented);
+            if (rented is not null) ArrayPool<byte>.Shared.Return(rented);
         }
     }
 


### PR DESCRIPTION
Stacked on top of #12056. Pure refactor — **no behavioral change** (struct-log output is byte-identical).

Consolidates the hex-writing primitives the #12056 struct tracer introduced so there's a single source of truth, addressing review feedback about duplicated constants and converter-local hex code.

## Changes

- **Word size**: reuse `EvmPooledMemory.WordSize` instead of redeclaring the `32`-byte word size in `GethLikeTxDirectStreamingTracer` and `GethLikeTxTraceJsonLinesConverter`.
- **Hex primitives → `HexWriter`**: move the file converter's private `WriteHexLong` and `WriteMemoryBlob` hex encoding into `HexWriter` (`WriteUlongHexStringValue`, `WriteHexStringValue`). The file tracer now shares the same hex encoder as the other paths and drops one of its two pooled `ArrayPool` buffers per memory-bearing entry.
- **Storage slot formatting**: add `HexWriter.WriteUInt256StorageSlot` and route both `GethLikeTxDirectStreamingTracer` and `StorageHexConverter` through it, so the byte-identity-critical slot formatting (`0x`-prefixed, zero-padded 32-byte key/value) lives in exactly one place and can't drift between the two tracer paths.

## Testing

- `Nethermind.Evm.Test` GethLike suite: 130 passed, 1 skipped, 0 failed.
- `Nethermind.JsonRpc.Test` Debug suite: 157 passed, 0 failed.
- All affected projects build with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)