### PR TITLE
fix(evm): align insufficient-funds-for-transfer message with Geth

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -286,7 +286,7 @@ public partial class TransactionProcessorTests(bool eip155Enabled)
         else if (txValue + (UInt256)gasLimit > AccountBalance)
         {
             Assert.That(err, Is.Not.Null); // Should have error
-            Assert.That(err, Is.EqualTo("insufficient sender balance for transfer"));
+            Assert.That(err, Is.EqualTo("insufficient funds for transfer"));
         }
         else
         {

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -286,7 +286,7 @@ public partial class TransactionProcessorTests(bool eip155Enabled)
         else if (txValue + (UInt256)gasLimit > AccountBalance)
         {
             Assert.That(err, Is.Not.Null); // Should have error
-            Assert.That(err, Is.EqualTo("insufficient funds for transfer"));
+            Assert.That(err, Is.EqualTo(GasEstimator.InsufficientBalance));
         }
         else
         {

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -28,7 +28,7 @@ public class GasEstimator(
     public const string GasExceedsAllowanceMsgPrefix = "gas required exceeds allowance";
 
     /// <summary>Message emitted when the sender has insufficient balance.</summary>
-    public const string InsufficientBalance = "insufficient sender balance for transfer";
+    public const string InsufficientBalance = "insufficient funds for transfer";
 
     /// <summary>Message emitted when the sender cannot cover gas * price + value.</summary>
     public const string InsufficientFundsForGas = "insufficient funds for gas * price + value";

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.TransactionProcessing;
@@ -28,7 +29,7 @@ public class GasEstimator(
     public const string GasExceedsAllowanceMsgPrefix = "gas required exceeds allowance";
 
     /// <summary>Message emitted when the sender has insufficient balance.</summary>
-    public const string InsufficientBalance = "insufficient funds for transfer";
+    public const string InsufficientBalance = TxErrorMessages.InsufficientFundsForTransfer;
 
     /// <summary>Message emitted when the sender cannot cover gas * price + value.</summary>
     public const string InsufficientFundsForGas = "insufficient funds for gas * price + value";

--- a/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
+++ b/src/Nethermind/Nethermind.Core/Messages/TxErrorMessages.cs
@@ -11,6 +11,8 @@ public static class TxErrorMessages
         "intrinsic gas too low";
     public const string GasBelowFloorDataCost =
         "gas below floor data cost";
+    public const string InsufficientFundsForTransfer =
+        "insufficient funds for transfer";
     public const string TxMissingTo =
         "blob transaction of type create";
 

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Evm.Test.Tracing
             testEnvironment.tracer.ReportActionEnd(600, Array.Empty<byte>());
 
             Assert.That(testEnvironment.estimator.Estimate(tx, block.Header, testEnvironment.tracer, out string? err), Is.EqualTo(0));
-            Assert.That(err, Is.EqualTo("insufficient sender balance for transfer"));
+            Assert.That(err, Is.EqualTo("insufficient funds for transfer"));
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace Nethermind.Evm.Test.Tracing
             testEnvironment.tracer.ReportActionEnd(600, Array.Empty<byte>());
 
             Assert.That(testEnvironment.estimator.Estimate(tx, block.Header, testEnvironment.tracer, out string? err), Is.EqualTo(0));
-            Assert.That(err, Is.EqualTo("insufficient sender balance for transfer"));
+            Assert.That(err, Is.EqualTo("insufficient funds for transfer"));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Evm.Test.Tracing
             testEnvironment.tracer.ReportActionEnd(600, Array.Empty<byte>());
 
             Assert.That(testEnvironment.estimator.Estimate(tx, block.Header, testEnvironment.tracer, out string? err), Is.EqualTo(0));
-            Assert.That(err, Is.EqualTo("insufficient funds for transfer"));
+            Assert.That(err, Is.EqualTo(GasEstimator.InsufficientBalance));
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace Nethermind.Evm.Test.Tracing
             testEnvironment.tracer.ReportActionEnd(600, Array.Empty<byte>());
 
             Assert.That(testEnvironment.estimator.Estimate(tx, block.Header, testEnvironment.tracer, out string? err), Is.EqualTo(0));
-            Assert.That(err, Is.EqualTo("insufficient funds for transfer"));
+            Assert.That(err, Is.EqualTo(GasEstimator.InsufficientBalance));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1749,7 +1749,7 @@ namespace Nethermind.Evm.TransactionProcessing
         public static readonly TransactionResult GasLimitBelowIntrinsicGas = new(ErrorType.GasLimitBelowIntrinsicGas, errorDescription: "intrinsic gas too low");
         public static readonly TransactionResult GasLimitBelowFloorGas = new(ErrorType.GasLimitBelowFloorGas, errorDescription: "gas below floor data cost");
         public static readonly TransactionResult InsufficientMaxFeePerGasForSenderBalance = new(ErrorType.InsufficientMaxFeePerGasForSenderBalance, errorDescription: "insufficient funds for gas * price + value");
-        public static readonly TransactionResult InsufficientSenderBalance = new(ErrorType.InsufficientSenderBalance, errorDescription: "insufficient sender balance for transfer");
+        public static readonly TransactionResult InsufficientSenderBalance = new(ErrorType.InsufficientSenderBalance, errorDescription: "insufficient funds for transfer");
         public static readonly TransactionResult MalformedTransaction = new(ErrorType.MalformedTransaction, errorDescription: "malformed");
         public static readonly TransactionResult MinerPremiumNegative = new(ErrorType.MinerPremiumNegative, errorDescription: "miner premium is negative");
         public static readonly TransactionResult NonceOverflow = new(ErrorType.NonceOverflow, errorDescription: "nonce overflow");

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1749,7 +1749,7 @@ namespace Nethermind.Evm.TransactionProcessing
         public static readonly TransactionResult GasLimitBelowIntrinsicGas = new(ErrorType.GasLimitBelowIntrinsicGas, errorDescription: "intrinsic gas too low");
         public static readonly TransactionResult GasLimitBelowFloorGas = new(ErrorType.GasLimitBelowFloorGas, errorDescription: "gas below floor data cost");
         public static readonly TransactionResult InsufficientMaxFeePerGasForSenderBalance = new(ErrorType.InsufficientMaxFeePerGasForSenderBalance, errorDescription: "insufficient funds for gas * price + value");
-        public static readonly TransactionResult InsufficientSenderBalance = new(ErrorType.InsufficientSenderBalance, errorDescription: "insufficient funds for transfer");
+        public static readonly TransactionResult InsufficientSenderBalance = new(ErrorType.InsufficientSenderBalance, errorDescription: TxErrorMessages.InsufficientFundsForTransfer);
         public static readonly TransactionResult MalformedTransaction = new(ErrorType.MalformedTransaction, errorDescription: "malformed");
         public static readonly TransactionResult MinerPremiumNegative = new(ErrorType.MinerPremiumNegative, errorDescription: "miner premium is negative");
         public static readonly TransactionResult NonceOverflow = new(ErrorType.NonceOverflow, errorDescription: "nonce overflow");

--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -429,7 +429,7 @@ public class BlockchainBridgeTests
 
         CallOutput callOutput = _blockchainBridge.Call(header, tx);
 
-        Assert.That(callOutput.Error, Is.EqualTo("insufficient sender balance for transfer"));
+        Assert.That(callOutput.Error, Is.EqualTo("insufficient funds for transfer"));
     }
 
     [Test]
@@ -443,7 +443,7 @@ public class BlockchainBridgeTests
 
         CallOutput callOutput = _blockchainBridge.EstimateGas(header, tx, 1);
 
-        Assert.That(callOutput.Error, Is.EqualTo("insufficient sender balance for transfer"));
+        Assert.That(callOutput.Error, Is.EqualTo("insufficient funds for transfer"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/BlockchainBridgeTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
+using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -429,7 +430,7 @@ public class BlockchainBridgeTests
 
         CallOutput callOutput = _blockchainBridge.Call(header, tx);
 
-        Assert.That(callOutput.Error, Is.EqualTo("insufficient funds for transfer"));
+        Assert.That(callOutput.Error, Is.EqualTo(GasEstimator.InsufficientBalance));
     }
 
     [Test]
@@ -443,7 +444,7 @@ public class BlockchainBridgeTests
 
         CallOutput callOutput = _blockchainBridge.EstimateGas(header, tx, 1);
 
-        Assert.That(callOutput.Error, Is.EqualTo("insufficient funds for transfer"));
+        Assert.That(callOutput.Error, Is.EqualTo(GasEstimator.InsufficientBalance));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -38,7 +38,7 @@ public partial class EthRpcModuleTests
         string serialized =
             await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
         Assert.That(
-            serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"insufficient sender balance for transfer\"},\"id\":67}"));
+            serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"insufficient funds for transfer\"},\"id\":67}"));
         AssertAccountDoesNotExist(ctx, TestAccount);
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/StructLogEnvelopeWriter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/StructLogEnvelopeWriter.cs
@@ -109,7 +109,6 @@ internal static class StructLogEnvelopeWriter
         string detail = result.ErrorDescription;
         return result.Error switch
         {
-            ErrorType.InsufficientSenderBalance => ReplacePrefix(detail, "insufficient sender balance for transfer", "insufficient funds for transfer"),
             ErrorType.InsufficientMaxFeePerGasForSenderBalance => detail,
             ErrorType.SenderHasDeployedCode => ReplacePrefix(detail, "sender has deployed code", "sender not an eoa"),
             ErrorType.NonceOverflow => ReplacePrefix(detail, "nonce overflow", "nonce has max value"),

--- a/src/Nethermind/Nethermind.State/InsufficientBalanceException.cs
+++ b/src/Nethermind/Nethermind.State/InsufficientBalanceException.cs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Messages;
 
 namespace Nethermind.State
 {
-    public class InsufficientBalanceException(Address address) : StateException($"insufficient funds for transfer: address {address}")
+    public class InsufficientBalanceException(Address address) : StateException($"{TxErrorMessages.InsufficientFundsForTransfer}: address {address}")
     {
     }
 }

--- a/src/Nethermind/Nethermind.State/InsufficientBalanceException.cs
+++ b/src/Nethermind/Nethermind.State/InsufficientBalanceException.cs
@@ -5,7 +5,7 @@ using Nethermind.Core;
 
 namespace Nethermind.State
 {
-    public class InsufficientBalanceException(Address address) : StateException($"insufficient sender balance for transfer: address {address}")
+    public class InsufficientBalanceException(Address address) : StateException($"insufficient funds for transfer: address {address}")
     {
     }
 }


### PR DESCRIPTION
## Summary

Fixes #12164.

- Changes the error message for insufficient balance on value transfer from `"insufficient sender balance for transfer"` to `"insufficient funds for transfer"` to match Geth's output
- Removes the now-redundant string replacement in `StructLogEnvelopeWriter` since the message is correct at the source
- Updates all test assertions to use the new message string

## Why

viem, ethers, and other client libraries regex-match on `"insufficient funds"` to detect this error. Nethermind's non-standard message caused false negatives in those libraries.