### PR TITLE
fix(rpc): align method-not-found message with Geth canonical phrase

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -487,7 +487,7 @@ public class JsonRpcServiceTests
 
     [Test]
     public void IncorrectMethodNameTest() =>
-        AssertJsonRpcError(TestRequest(Substitute.For<IEthRpcModule>(), "incorrect_method"), ErrorCodes.MethodNotFound, "the method incorrect_method does not exist/is not available");
+        AssertJsonRpcError(TestRequest(Substitute.For<IEthRpcModule>(), "incorrect_method"), ErrorCodes.MethodNotFound, ErrorMessages.MethodNotFound("incorrect_method"));
 
     [Test]
     public void NetVersionTest()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -487,7 +487,7 @@ public class JsonRpcServiceTests
 
     [Test]
     public void IncorrectMethodNameTest() =>
-        AssertJsonRpcError(TestRequest(Substitute.For<IEthRpcModule>(), "incorrect_method"), ErrorCodes.MethodNotFound);
+        AssertJsonRpcError(TestRequest(Substitute.For<IEthRpcModule>(), "incorrect_method"), ErrorCodes.MethodNotFound, "the method incorrect_method does not exist/is not available");
 
     [Test]
     public void NetVersionTest()

--- a/src/Nethermind/Nethermind.JsonRpc/ErrorMessages.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ErrorMessages.cs
@@ -9,4 +9,6 @@ public static class ErrorMessages
     /// EIP-4444 message for <see cref="ErrorCodes.PrunedHistoryUnavailable"/>
     /// </summary>
     public const string PrunedHistoryUnavailable = "pruned history unavailable";
+
+    public static string MethodNotFound(string methodName) => $"the method {methodName} does not exist/is not available";
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -940,7 +940,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         [MethodImpl(MethodImplOptions.NoInlining)]
         static (int? ErrorType, string ErrorMessage) GetErrorResult(string methodName, JsonRpcContext context, ModuleResolution result, string module) => result switch
         {
-            ModuleResolution.Unknown => (ErrorCodes.MethodNotFound, $"the method {methodName} does not exist/is not available"),
+            ModuleResolution.Unknown => (ErrorCodes.MethodNotFound, ErrorMessages.MethodNotFound(methodName)),
             ModuleResolution.Disabled => (ErrorCodes.InvalidRequest,
                 $"The method '{methodName}' is found but the namespace '{module}' is disabled for {context.Url?.ToString() ?? "n/a"}. Consider adding the namespace '{module}' to JsonRpc.AdditionalRpcUrls for an additional URL, or to JsonRpc.EnabledModules for the default URL."),
             ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest,

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -940,7 +940,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         [MethodImpl(MethodImplOptions.NoInlining)]
         static (int? ErrorType, string ErrorMessage) GetErrorResult(string methodName, JsonRpcContext context, ModuleResolution result, string module) => result switch
         {
-            ModuleResolution.Unknown => (ErrorCodes.MethodNotFound, $"The method '{methodName}' is not supported."),
+            ModuleResolution.Unknown => (ErrorCodes.MethodNotFound, $"the method {methodName} does not exist/is not available"),
             ModuleResolution.Disabled => (ErrorCodes.InvalidRequest,
                 $"The method '{methodName}' is found but the namespace '{module}' is disabled for {context.Url?.ToString() ?? "n/a"}. Consider adding the namespace '{module}' to JsonRpc.AdditionalRpcUrls for an additional URL, or to JsonRpc.EnabledModules for the default URL."),
             ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest,


### PR DESCRIPTION
## Summary

- Changes the error message for unknown RPC methods from `"The method 'x' is not supported."` to `"the method x does not exist/is not available"` to match Geth's canonical phrase
- ethers v6 matches `/the method .* does not exist/i` — Nethermind's previous phrase failed this regex, causing `UNKNOWN_ERROR` instead of `UNSUPPORTED_OPERATION`
- Only the `ModuleResolution.Unknown` case is changed; `EndpointDisabled` and `NotAuthenticated` messages are untouched

Closes #12165

## Test plan

- [x] Build passes: `dotnet build src/Nethermind/Nethermind.JsonRpc/Nethermind.JsonRpc.csproj -c Release --no-restore -v q`
- [x] All JsonRpc tests pass: 1868 passed, 0 failed, 22 skipped (WS server not available)