### PR TITLE
ci: drop op-mainnet from master-validation sync check

### DIFF
--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -78,8 +78,8 @@ jobs:
               ;;
           esac
 
-          # Filter testnet-matrix.json to master-validation chains only
-          MASTER_CHAINS='["mainnet","gnosis","op-mainnet"]'
+          # master-validation chains; op-mainnet dropped to cut Linode cost (kept in sync-supported-chains)
+          MASTER_CHAINS='["mainnet","gnosis"]'
 
           matrix=$(cat scripts/config/testnet-matrix.json | jq \
             --argjson chains "$MASTER_CHAINS" \


### PR DESCRIPTION
## Changes

`sync-master-validation.yml` runs automatically on every master Docker publish. Its chain set (`MASTER_CHAINS`) included `op-mainnet`, which — under the default `Both` mode — spins up **two** `g6-standard-8` Linode instances (HalfPath + Flat), each capped at **600 minutes (10h)**. That made op-mainnet the single largest contributor to this workflow's recurring Linode spend (~20 VM-hours of the priciest plan per publish, before the mainnet/gnosis legs).

This PR removes `op-mainnet` from `MASTER_CHAINS`, so the per-publish check now validates **mainnet** and **gnosis** only.

No coverage is lost: `op-mainnet` (both layouts) remains in `scripts/config/testnet-matrix.json` and is still exercised by the manual `sync-supported-chains` sweep.

## Types of changes

- [x] Maintenance (CI / cost reduction; no production code change)

## Testing

No code change — workflow config only. The `MASTER_CHAINS` JSON array still parses via the existing `jq` filter; mainnet (incl. the mainnet+Flat→360 timeout override) and gnosis legs are unaffected.