### PR TITLE
Fix FlatDB persistence edge cases from the signed/unsigned type unification

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -167,9 +168,10 @@ public class CompactionScheduleTests
 
         for (ulong block = 1UL; block <= 64UL; block++)
         {
+            StateId state = new(block, Hash256.Zero);
             Assert.That(large.GetCompactSize(block), Is.EqualTo(small.GetCompactSize(block)),
                 $"Tier mismatch at block {block} between offset {smallOffset} and {largeOffset}");
-            Assert.That(large.NextFullCompactionAfter(block), Is.EqualTo(small.NextFullCompactionAfter(block)),
+            Assert.That(large.NextFullCompactionAfter(state), Is.EqualTo(small.NextFullCompactionAfter(state)),
                 $"Next boundary mismatch from block {block} between offset {smallOffset} and {largeOffset}");
         }
     }
@@ -185,7 +187,7 @@ public class CompactionScheduleTests
         FlatDbConfig config = new() { CompactSize = 16 };
         CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, offset);
 
-        Assert.That(schedule.NextFullCompactionAfter(from), Is.EqualTo(expected));
+        Assert.That(schedule.NextFullCompactionAfter(new StateId(from, Hash256.Zero)), Is.EqualTo(expected));
     }
 
     [Test]
@@ -194,7 +196,7 @@ public class CompactionScheduleTests
         FlatDbConfig config = new() { CompactSize = 1 };
         CompactionSchedule schedule = new(new MemDb(), config, LimboLogs.Instance);
 
-        Assert.That(schedule.NextFullCompactionAfter(0), Is.EqualTo(ulong.MaxValue));
+        Assert.That(schedule.NextFullCompactionAfter(new StateId(0, Hash256.Zero)), Is.EqualTo(ulong.MaxValue));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
@@ -190,17 +190,15 @@ public class CompactionScheduleTests
         Assert.That(schedule.NextFullCompactionAfter(new StateId(from, Hash256.Zero)), Is.EqualTo(expected));
     }
 
-    [TestCase(0)]
-    [TestCase(3)]
-    [TestCase(7)]
-    public void NextFullCompactionAfter_PreGenesis_AnchorsAtGenesis(int offset)
+    [TestCase(0, 16UL)] // offset 0 -> next full at 16
+    [TestCase(3, 13UL)] // offset 3 -> 0+(16-3) = 13
+    [TestCase(7, 9UL)]  // offset 7 -> 0+(16-7) = 9
+    public void NextFullCompactionAfter_PreGenesis_AnchorsAtGenesis(int offset, ulong expected)
     {
         FlatDbConfig config = new() { CompactSize = 16 };
         CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, offset);
 
-        Assert.That(
-            schedule.NextFullCompactionAfter(StateId.PreGenesis),
-            Is.EqualTo(schedule.NextFullCompactionAfter(new StateId(0, Hash256.Zero))));
+        Assert.That(schedule.NextFullCompactionAfter(StateId.PreGenesis), Is.EqualTo(expected));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/CompactionScheduleTests.cs
@@ -190,6 +190,19 @@ public class CompactionScheduleTests
         Assert.That(schedule.NextFullCompactionAfter(new StateId(from, Hash256.Zero)), Is.EqualTo(expected));
     }
 
+    [TestCase(0)]
+    [TestCase(3)]
+    [TestCase(7)]
+    public void NextFullCompactionAfter_PreGenesis_AnchorsAtGenesis(int offset)
+    {
+        FlatDbConfig config = new() { CompactSize = 16 };
+        CompactionSchedule schedule = ScheduleHelper.CreateWithOffset(config, offset);
+
+        Assert.That(
+            schedule.NextFullCompactionAfter(StateId.PreGenesis),
+            Is.EqualTo(schedule.NextFullCompactionAfter(new StateId(0, Hash256.Zero))));
+    }
+
     [Test]
     public void NextFullCompactionAfter_CompactSizeDisabled_ReturnsLongMaxValue()
     {

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -337,6 +337,37 @@ public class PersistenceManagerTests
     }
 
     [Test]
+    public void DetermineSnapshotToPersist_LatestSnapshotBelowPersistedBlock_ReturnsNullWithoutUnderflow()
+    {
+        // A deep reorg below a force-persisted unfinalized block can leave the latest snapshot
+        // behind the last persisted block. The in-memory depth must saturate to 0 (not underflow to ~2^64),
+        // so the keep-in-memory guard returns null early instead of force-persisting a stale head ancestor.
+        StateId persisted = CreateStateId(100);
+
+        IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
+        reader.CurrentState.Returns(persisted);
+
+        IPersistence persistence = Substitute.For<IPersistence>();
+        persistence.CreateReader().Returns(reader);
+
+        PersistenceManager pm = new(_config, ScheduleHelper.CreateWithOffset(_config, 0), _finalizedStateProvider, persistence, _snapshotRepository, LimboLogs.Instance);
+
+        // Latest snapshot (50) is below the persisted block (100); finalized far behind so the force-persist
+        // branch would be taken on underflow. Stage a head-ancestor snapshot the buggy path would return.
+        StateId latest = CreateStateId(50);
+        StateId headAncestor = CreateStateId(101);
+        _finalizedStateProvider.SetFinalizedBlockNumber(10);
+
+        using Snapshot staged = CreateSnapshot(persisted, headAncestor, compacted: false);
+        _snapshotRepository.SetLastCommittedStateId(headAncestor);
+
+        Snapshot? result = pm.DetermineSnapshotToPersist(latest);
+        using Snapshot? _ = result; // dispose if the buggy underflow path returned a snapshot
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
     public void DetermineSnapshotToPersist_ExactlyAtMinimumBoundary_ReturnsNull()
     {
         // Setup: persisted at Block0 (0), latest at 79

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -138,6 +138,40 @@ public class PersistenceManagerTests
 
     #endregion
 
+    #region Fresh DB (nothing persisted) Tests
+
+    [Test]
+    public void DetermineSnapshotToPersist_FreshDbBelowForceLimit_PersistsFinalizedBoundary()
+    {
+        IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
+        reader.CurrentState.Returns(StateId.PreGenesis);
+
+        IPersistence persistence = Substitute.For<IPersistence>();
+        persistence.CreateReader().Returns(reader);
+
+        ICompactionSchedule scheduler = ScheduleHelper.CreateWithOffset(_config, 0);
+        PersistenceManager pm = new(_config, scheduler, _finalizedStateProvider, persistence, _snapshotRepository, LimboLogs.Instance);
+
+        // Depth 101 is past MinReorgDepth + CompactSize (80) but below the MaxReorgDepth force limit (256),
+        // so only the finalized branch can produce a snapshot here.
+        StateId target = CreateStateId(16);
+        StateId latest = CreateStateId(100);
+        _finalizedStateProvider.SetFinalizedBlockNumber(100);
+        _finalizedStateProvider.SetFinalizedStateRootAt(16, new Hash256(target.StateRoot.Bytes));
+
+        using Snapshot expected = CreateSnapshot(StateId.PreGenesis, target, compacted: true);
+
+        Snapshot? result = pm.DetermineSnapshotToPersist(latest);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.From, Is.EqualTo(StateId.PreGenesis));
+        Assert.That(result.To, Is.EqualTo(target));
+
+        result.Dispose();
+    }
+
+    #endregion
+
     #region Unfinalized State Tests
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
+++ b/src/Nethermind/Nethermind.State.Flat/CompactionSchedule.cs
@@ -43,14 +43,14 @@ public sealed class CompactionSchedule : ICompactionSchedule
         return Math.Min(lowestBit, _compactSize);
     }
 
-    public ulong NextFullCompactionAfter(ulong from)
+    public ulong NextFullCompactionAfter(in StateId from)
     {
         if (_compactSize <= 1) return ulong.MaxValue;
-        if (from == ulong.MaxValue) return ulong.MaxValue;
 
-        ulong mod = (from + _offset) % _compactSize;
+        ulong blockNumber = from == StateId.PreGenesis ? 0UL : from.BlockNumber;
+        ulong mod = (blockNumber + _offset) % _compactSize;
         ulong distance = mod == 0 ? _compactSize : _compactSize - mod;
-        return from > ulong.MaxValue - distance ? ulong.MaxValue : from + distance;
+        return blockNumber > ulong.MaxValue - distance ? ulong.MaxValue : blockNumber + distance;
     }
 
     private ulong ResolveOffset(IDb metadataDb, IFlatDbConfig config, ILogger logger)

--- a/src/Nethermind/Nethermind.State.Flat/ICompactionSchedule.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ICompactionSchedule.cs
@@ -14,9 +14,11 @@ public interface ICompactionSchedule
     ulong GetCompactSize(ulong blockNumber);
 
     /// <summary>
-    /// The next block strictly greater than <paramref name="from"/> at which a full-size
-    /// compaction (and hence a persistence boundary) will occur. Returns <see cref="long.MaxValue"/>
-    /// when compaction is disabled.
+    /// The next block strictly greater than <paramref name="from"/>'s block number at which a full-size
+    /// compaction (and hence a persistence boundary) will occur. Returns <see cref="ulong.MaxValue"/>
+    /// when compaction is disabled. <see cref="StateId.PreGenesis"/> is treated as the slot before genesis,
+    /// so the boundary is anchored at block 0 instead of colliding with the <see cref="ulong.MaxValue"/>
+    /// "no further boundary" sentinel.
     /// </summary>
     ulong NextFullCompactionAfter(in StateId from);
 }

--- a/src/Nethermind/Nethermind.State.Flat/ICompactionSchedule.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ICompactionSchedule.cs
@@ -18,5 +18,5 @@ public interface ICompactionSchedule
     /// compaction (and hence a persistence boundary) will occur. Returns <see cref="long.MaxValue"/>
     /// when compaction is disabled.
     /// </summary>
-    ulong NextFullCompactionAfter(ulong from);
+    ulong NextFullCompactionAfter(in StateId from);
 }

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -125,7 +125,7 @@ public class PersistenceManager(
             "Latest snapshot must be at or ahead of the last persisted block.");
         ulong inMemoryStateDepth = currentPersistedState == StateId.PreGenesis
             ? lastSnapshotNumber + 1
-            : lastSnapshotNumber - currentPersistedState.BlockNumber;
+            : lastSnapshotNumber.SaturatingSub(currentPersistedState.BlockNumber);
 
         if (inMemoryStateDepth.SaturatingSub(_compactSize) < _minReorgDepth)
         {

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -134,7 +134,7 @@ public class PersistenceManager(
 
         Snapshot? snapshotToPersist;
 
-        ulong nextCompactedBoundary = _schedule.NextFullCompactionAfter(currentPersistedState.BlockNumber);
+        ulong nextCompactedBoundary = _schedule.NextFullCompactionAfter(in currentPersistedState);
         if (nextCompactedBoundary > finalizedBlockNumber)
         {
             if (inMemoryStateDepth <= _maxReorgDepth)
@@ -202,7 +202,7 @@ public class PersistenceManager(
         // Persist all snapshots from current persisted state to latest
         while (currentPersistedState == StateId.PreGenesis || currentPersistedState.BlockNumber < latestStateId.Value.BlockNumber)
         {
-            ulong nextCompactedBoundary = _schedule.NextFullCompactionAfter(currentPersistedState.BlockNumber);
+            ulong nextCompactedBoundary = _schedule.NextFullCompactionAfter(in currentPersistedState);
 
             // Try finalized snapshots first (compacted, then non-compacted)
             Snapshot? snapshotToPersist = GetFinalizedSnapshotAtBlockNumber(

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -121,8 +121,12 @@ public class PersistenceManager(
         StateId currentPersistedState = GetCurrentPersistedStateId();
         ulong finalizedBlockNumber = finalizedStateProvider.FinalizedBlockNumber;
 
-        Debug.Assert(currentPersistedState == StateId.PreGenesis || lastSnapshotNumber >= currentPersistedState.BlockNumber,
-            "Latest snapshot must be at or ahead of the last persisted block.");
+        // Latest below the persisted block means a deep reorg stranded the persisted base on an orphaned
+        // fork; persistence can only stall until the chain climbs back. Saturate the depth to 0 to avoid a
+        // ulong underflow so the keep-in-memory guard returns early.
+        if (currentPersistedState != StateId.PreGenesis && lastSnapshotNumber < currentPersistedState.BlockNumber && _logger.IsWarn)
+            _logger.Warn($"Latest snapshot {latestSnapshot} is below persisted state {currentPersistedState}; persisted base may be on an orphaned fork. Skipping persistence.");
+
         ulong inMemoryStateDepth = currentPersistedState == StateId.PreGenesis
             ? lastSnapshotNumber + 1
             : lastSnapshotNumber.SaturatingSub(currentPersistedState.BlockNumber);


### PR DESCRIPTION
# Fix FlatDB persistence edge cases from the signed→unsigned type unification

## Changes

Two follow-up fixes to `Nethermind.State.Flat` persistence, both regressions introduced by the `long → ulong` / `PreGenesis` sentinel migration. The root cause in each is that `StateId.PreGenesis.BlockNumber` is now `ulong.MaxValue`, which collides with unsigned arithmetic that used to be safe when the sentinel was `-1`.

- **Anchor the compaction schedule at genesis when nothing is persisted.**
  - `ICompactionSchedule.NextFullCompactionAfter` now takes `in StateId from` instead of `ulong from`, and `CompactionSchedule` maps `PreGenesis → block 0` internally (removing the `if (from == ulong.MaxValue) return ulong.MaxValue;` short-circuit).
  - `PersistenceManager` passes the `StateId` (`in currentPersistedState`) at both call sites (`DetermineSnapshotToPersist`, `FlushToPersistence`).
  - **Why:** on a fresh DB (`currentPersistedState == PreGenesis`), feeding the sentinel's `ulong.MaxValue` block number into the schedule made `nextCompactedBoundary == ulong.MaxValue`, which is `> finalizedBlockNumber` for any real chain. That forced the first persist down the unfinalized/head-ancestor branch, delaying it from depth `MinReorgDepth + CompactSize` until depth exceeded `MaxReorgDepth`, and emitting a misleading "Very long unfinalized state" warning on a healthy node. Anchoring at genesis lets the branch be chosen by real finalization status. Self-correcting and one-time per database lifetime, but noisy and memory-heavy at cold start.

- **Saturate `inMemoryStateDepth` to avoid a `ulong` underflow.**
  - `PersistenceManager.DetermineSnapshotToPersist` computes the non-`PreGenesis` depth with `lastSnapshotNumber.SaturatingSub(currentPersistedState.BlockNumber)` instead of a raw `ulong` subtraction.
  - **Why:** if the latest snapshot is below the persisted block — reachable only via a deep reorg below a force-persisted *unfinalized* block — the result wrapped to ≈2⁶⁴, defeating both keep-in-memory early-returns and emitting two spurious warnings before returning `null` anyway. Saturating the subtraction floors the depth at `0` so the existing guard returns `null` early and silently, matching the old signed behavior.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Both fixes are scoped to FlatDB cold-start / persistence-edge behavior; neither changes consensus-visible behavior, on-disk format, or steady-state operation.
