### PR TITLE
Return original debug_traceCallMany simulation errors

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceCallMany.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceCallMany.cs
@@ -214,6 +214,27 @@ public partial class DebugRpcModuleTests
     }
 
     [Test]
+    public async Task Debug_traceCallMany_with_invalid_simulation_override_returns_original_error_message()
+    {
+        using Context ctx = await CreateContext();
+        Address ecrecoverAddress = new("0x0000000000000000000000000000000000000001");
+        TransactionBundle bundle = CreateBundle(CreateTransaction());
+        bundle.StateOverrides = new Dictionary<Address, AccountOverride>
+        {
+            [ecrecoverAddress] = new() { MovePrecompileToAddress = ecrecoverAddress }
+        };
+
+        ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>> result =
+            ctx.DebugRpcModule.debug_traceCallMany([bundle], BlockParameter.Latest);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.MovePrecompileSelfReference));
+            Assert.That(result.Result.Error, Is.EqualTo("MovePrecompileToAddress referenced itself in replacement"));
+        }
+    }
+
+    [Test]
     public async Task Debug_traceCallMany_block_override_gaslimit_applies()
     {
         using Context ctx = await CreateContext();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -802,7 +802,7 @@ public class DebugRpcModule(
 
         if (simulationResult.ErrorCode != 0)
         {
-            string errorMessage = simulationResult.Result ? $"Simulation failed with error code {simulationResult.ErrorCode}." : simulationResult.Result.ToString();
+            string errorMessage = simulationResult.Result.Error ?? $"Simulation failed with error code {simulationResult.ErrorCode}.";
             if (_logger.IsWarn) _logger.Warn($"debug_traceCallMany simulation failed: Code={simulationResult.ErrorCode}, Details={errorMessage}");
             return ResultWrapper<IEnumerable<IEnumerable<GethLikeTxTrace>>>.Fail(errorMessage, simulationResult.ErrorCode);
         }


### PR DESCRIPTION
Fixes Closes Resolves #

_Please choose one of the keywords above to refer to the issue this PR solves followed by the issue number (e.g. Fixes #000). If no issue number, remove the line. Also, remove everything marked optional that is not applicable. Remove this note after reading._

## Changes

This fixes `debug_traceCallMany` error reporting for simulation failures.

When the override path returned a simulation error, `debug_traceCallMany` used `Result.ToString()` as the JSON-RPC error message. That prepended the internal `"Failure: "` wrapper to the actual error text. The method now forwards the original `Result.Error` message, while keeping the existing fallback for unexpected non-zero error codes without an error message.

A regression test was added for an invalid simulation override to ensure the RPC result preserves the original simulation error message and code.



## Types of changes

- [x] Bug fix
- [x] Tests

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

- [x] Added regression coverage for `debug_traceCallMany`
- [x] Ran `git diff --check`


#### Requires testing

- [ ] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
