### PR TITLE
fix(engine): exclude SSZ-REST paths from missing-capabilities warning

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -2156,6 +2156,30 @@ public partial class EngineModuleTests
                 a.Contains(nameof(IEngineRpcModule.engine_getPayloadV4), StringComparison.Ordinal)));
     }
 
+    [Test]
+    public async Task Should_not_warn_for_missing_ssz_rest_paths()
+    {
+        ILogManager loggerManager = Substitute.For<ILogManager>();
+        InterfaceLogger iLogger = Substitute.For<InterfaceLogger>();
+        iLogger.IsWarn.Returns(true);
+        ILogger logger = new(iLogger);
+        loggerManager.GetClassLogger<ExchangeCapabilitiesHandler>().Returns(logger);
+
+        using MergeTestBlockchain chain = await CreateBaseBlockchain()
+            .BuildMergeTestBlockchain(configurer: builder => builder
+                .AddSingleton<ISpecProvider>(new TestSingleReleaseSpecProvider(Prague.Instance))
+                .AddSingleton<ILogManager>(loggerManager));
+
+        // The CL advertises every enabled JSON-RPC method but no SSZ-REST paths (as a real CL does).
+        EngineRpcCapabilitiesProvider provider = new(new TestSingleReleaseSpecProvider(Prague.Instance));
+        string[] list = [.. provider.GetJsonRpcCapabilities().Where(kv => kv.Value.IsEnabled()).Select(kv => kv.Key)];
+
+        chain.EngineRpcModule.engine_exchangeCapabilities(list);
+
+        chain.LogManager.GetClassLogger<ExchangeCapabilitiesHandler>().UnderlyingLogger.DidNotReceive()
+            .Warn(Arg.Any<string>());
+    }
+
     private static readonly string[] SszRestPathsParis =
     [
         SszRestPaths.PostV1Payloads,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -2170,7 +2170,6 @@ public partial class EngineModuleTests
                 .AddSingleton<ISpecProvider>(new TestSingleReleaseSpecProvider(Prague.Instance))
                 .AddSingleton<ILogManager>(loggerManager));
 
-        // The CL advertises every enabled JSON-RPC method but no SSZ-REST paths (as a real CL does).
         EngineRpcCapabilitiesProvider provider = new(new TestSingleReleaseSpecProvider(Prague.Instance));
         string[] list = [.. provider.GetJsonRpcCapabilities().Where(kv => kv.Value.IsEnabled()).Select(kv => kv.Key)];
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
@@ -79,11 +79,6 @@ public class EngineRpcCapabilitiesProvider(ISpecProvider specProvider) : IRpcCap
         Dictionary<string, RpcCapabilityOptions> jsonLocal = [];
         Dictionary<string, RpcCapabilityOptions> sszLocal = [];
 
-        // Configure adds the same options under both the JSON-RPC method name and the
-        // SSZ-REST path — so updates to the gate stay in sync by construction.
-        // WarnIfMissing is stripped from the SSZ-REST entry: engine_exchangeCapabilities
-        // only exchanges JSON-RPC method names, so the CL never advertises REST paths and
-        // they must not be reported as missing.
         void Configure(string method, string path, RpcCapabilityOptions options)
         {
             jsonLocal[method] = options;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
@@ -81,10 +81,13 @@ public class EngineRpcCapabilitiesProvider(ISpecProvider specProvider) : IRpcCap
 
         // Configure adds the same options under both the JSON-RPC method name and the
         // SSZ-REST path — so updates to the gate stay in sync by construction.
+        // WarnIfMissing is stripped from the SSZ-REST entry: engine_exchangeCapabilities
+        // only exchanges JSON-RPC method names, so the CL never advertises REST paths and
+        // they must not be reported as missing.
         void Configure(string method, string path, RpcCapabilityOptions options)
         {
             jsonLocal[method] = options;
-            sszLocal[path] = options;
+            sszLocal[path] = options & ~WarnIfMissing;
         }
 
         // The Merge


### PR DESCRIPTION
## Changes

The "Consensus client missing capabilities" warning logged by `ExchangeCapabilitiesHandler` was falsely flagging SSZ-REST path capabilities (e.g. `POST /engine/v1/payloads`). `engine_exchangeCapabilities` only exchanges JSON-RPC method names, so a consensus client never advertises REST paths — yet any REST path gated via `GateWithWarn` was always reported as missing.

The fix strips the `WarnIfMissing` flag from the SSZ-REST entry in `EngineRpcCapabilitiesProvider.Configure`, so REST paths remain advertised (`Enabled`) but never trigger the warning. Added a regression test (`Should_not_warn_for_missing_ssz_rest_paths`).

## Types of changes

- [x] Bugfix (non-breaking change that fixes an issue)

## Testing

New regression test plus existing capability tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)