### PR TITLE
Guard EraE/eth_subscribe overflow, drop pre-ulong leftovers, cover gas-limit reject arm

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
@@ -228,8 +229,11 @@ public class HeaderValidatorTests
         Assert.That(result, Is.EqualTo(expectedResult));
     }
 
-    [Test, MaxTime(Timeout.MaxTestTime)]
-    public void When_gas_limit_is_long_max_value()
+    [MaxTime(Timeout.MaxTestTime)]
+    [TestCase(0x7FFFFFFFFFFFFFFFUL, true, TestName = "When_gas_limit_at_protocol_cap")]
+    [TestCase(0x8000000000000000UL, false, TestName = "When_gas_limit_just_above_protocol_cap")]
+    [TestCase(ulong.MaxValue, false, TestName = "When_gas_limit_is_ulong_max")]
+    public void When_gas_limit_around_protocol_cap(ulong gasLimit, bool expectedResult)
     {
         _validator = new HeaderValidator(_blockTree, _ethash, _specProvider, new OneLoggerLogManager(new(_testLogger)));
         _parentBlock = Build.A.Block.WithDifficulty(1)
@@ -239,14 +243,18 @@ public class HeaderValidatorTests
         _block = Build.A.Block.WithParent(_parentBlock)
             .WithDifficulty(131072)
             .WithMixHash(new Hash256("0xd7db5fdd332d3a65d6ac9c4c530929369905734d3ef7a91e373e81d0f010b8e8"))
-            .WithGasLimit(long.MaxValue)
+            .WithGasLimit(gasLimit)
             .WithNumber(_parentBlock.Number + 1)
             .WithNonce(0).TestObject;
         _block.Header.Hash = _block.CalculateHash();
 
-        bool result = _validator.Validate(_block.Header, _parentBlock.Header);
+        bool result = _validator.Validate(_block.Header, _parentBlock.Header, false, out string? error);
 
-        Assert.That(result, Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(expectedResult));
+            Assert.That(error, expectedResult ? Is.Null : Is.EqualTo(BlockErrorMessages.InvalidGasLimit));
+        }
     }
 
 

--- a/src/Nethermind/Nethermind.EraE/Import/EraImporter.cs
+++ b/src/Nethermind/Nethermind.EraE/Import/EraImporter.cs
@@ -92,7 +92,10 @@ public sealed class EraImporter(
         using ProgressReporter progress = new("EraE import", logManager, to - from + 1);
         ulong blocksProcessed = 0;
 
-        using BlockTreeSuggestPacer pacer = new(blockTree, eraConfig.ImportBlocksBufferSize, eraConfig.ImportBlocksBufferSize - 1024UL);
+        ulong resumeBatchSize = eraConfig.ImportBlocksBufferSize > 1024UL
+            ? eraConfig.ImportBlocksBufferSize - 1024UL
+            : eraConfig.ImportBlocksBufferSize / 2;
+        using BlockTreeSuggestPacer pacer = new(blockTree, eraConfig.ImportBlocksBufferSize, resumeBatchSize);
         ulong blockNumber = from;
 
         ulong suggestFromBlock = (blockTree.Head?.Number ?? 0UL) + 1;

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsIntegrationTests.cs
@@ -23,16 +23,16 @@ namespace Nethermind.EthStats.Test;
 
 public class EthStatsIntegrationTests
 {
-    [TestCase(3UL, 1UL, 1UL, 3UL, TestName = "TryNormalizeHistoryRange_swaps_min_and_max")]
-    [TestCase(0UL, 100UL, 37UL, 100UL, TestName = "TryNormalizeHistoryRange_limits_oversized_range")]
-    [TestCase(ulong.MaxValue - 63, ulong.MaxValue, ulong.MaxValue - 63, ulong.MaxValue, TestName = "TryNormalizeHistoryRange_handles_max_ulong_without_overflow")]
-    public void TryNormalizeHistoryRange_handles_edges(
+    [TestCase(3UL, 1UL, 1UL, 3UL, TestName = "NormalizeHistoryRange_swaps_min_and_max")]
+    [TestCase(0UL, 100UL, 37UL, 100UL, TestName = "NormalizeHistoryRange_limits_oversized_range")]
+    [TestCase(ulong.MaxValue - 63, ulong.MaxValue, ulong.MaxValue - 63, ulong.MaxValue, TestName = "NormalizeHistoryRange_handles_max_ulong_without_overflow")]
+    public void NormalizeHistoryRange_handles_edges(
         ulong requestMin,
         ulong requestMax,
         ulong expectedMin,
         ulong expectedMax)
     {
-        EthStatsIntegration.TryNormalizeHistoryRange(
+        EthStatsIntegration.NormalizeHistoryRange(
             new EthStatsHistoryRequest(requestMin, requestMax),
             out ulong min,
             out ulong max);

--- a/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
+++ b/src/Nethermind/Nethermind.EthStats/Integrations/EthStatsIntegration.cs
@@ -195,11 +195,7 @@ namespace Nethermind.EthStats.Integrations
 
         private Task SendHistoryAsync(EthStatsHistoryRequest request)
         {
-            if (!TryNormalizeHistoryRange(request, out ulong min, out ulong max))
-            {
-                if (_logger.IsDebug) _logger.Debug($"Ignoring invalid ETH Stats history range {request.Min}-{request.Max}.");
-                return Task.CompletedTask;
-            }
+            NormalizeHistoryRange(request, out ulong min, out ulong max);
 
             List<EthStatsBlock> history = new((int)(max - min + 1));
             for (ulong blockNumber = min; blockNumber <= max; blockNumber++)
@@ -300,26 +296,15 @@ namespace Nethermind.EthStats.Integrations
             return Task.CompletedTask;
         }
 
-        internal static bool TryNormalizeHistoryRange(EthStatsHistoryRequest request, out ulong min, out ulong max)
+        internal static void NormalizeHistoryRange(EthStatsHistoryRequest request, out ulong min, out ulong max)
         {
             min = Math.Min(request.Min, request.Max);
             max = Math.Max(request.Min, request.Max);
-
-            if (max < 0)
-            {
-                min = 0;
-                max = 0;
-                return false;
-            }
-
-            min = Math.Max(0, min);
 
             if (max - min >= MaxHistoryBlocks)
             {
                 min = max - MaxHistoryBlocks + 1;
             }
-
-            return true;
         }
 
         private static EthStatsBlock CreateBlockModel(CoreBlock block)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -467,12 +467,17 @@ namespace Nethermind.JsonRpc.Test.Modules
             Assert.That(expectedResult, Is.EqualTo(serialized));
         }
 
-        [Test]
-        public async Task LogsSubscription_with_invalid_arguments_creating_result()
+        [TestCase("invalid_param")]
+        [TestCase("{\"fromBlock\":\"-1\"}")]
+        [TestCase("{\"fromBlock\":\"0x10000000000000000\"}")]
+        [TestCase("{\"toBlock\":\"notanumber\"}")]
+        [TestCase("{\"address\":\"0xzz705ae4c6f81b66cdb323c65f4e8133690fc099\"}")]
+        [TestCase("{\"blockHash\":\"0xzz783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760\"}")]
+        public async Task LogsSubscription_with_malformed_args_returns_invalid_params(string args)
         {
-            string serialized = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "logs", "invalid_param");
+            string serialized = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "logs", args);
             string expectedResult = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32602,\"message\":\"Invalid params\"},\"id\":67}";
-            Assert.That(expectedResult, Is.EqualTo(serialized));
+            Assert.That(expectedResult, Is.EqualTo(serialized), "malformed eth_subscribe/logs args should map to InvalidParams, not InternalError");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscribeRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscribeRpcModule.cs
@@ -26,7 +26,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
             {
                 return ResultWrapper<string>.Fail($"Invalid params", ErrorCodes.InvalidParams, e.Message);
             }
-            catch (JsonException)
+            catch (Exception e) when (e is JsonException or FormatException or OverflowException)
             {
                 return ResultWrapper<string>.Fail($"Invalid params", ErrorCodes.InvalidParams);
             }

--- a/src/Nethermind/Nethermind.Optimism/Rpc/OptimismPayloadAttributes.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/OptimismPayloadAttributes.cs
@@ -74,7 +74,7 @@ public class OptimismPayloadAttributes : PayloadAttributes
         base.ComputePayloadIdMembersSize()
         + sizeof(bool) // noTxPool
         + (Keccak.Size * TransactionsLength) // Txs
-        + sizeof(long) // gasLimit
+        + sizeof(ulong) // gasLimit
         + ((EIP1559Params?.Length * sizeof(byte)) ?? 0); // eip1559Params
 
     protected override int WritePayloadIdMembers(BlockHeader parentHeader, Span<byte> inputSpan)


### PR DESCRIPTION
Follow-up hardening and cleanup for the `long → ulong` type-unification. Three production-relevant edge cases that the unification left exposed are guarded, the dead pre-`ulong` scaffolding it superseded is removed, and the consensus gas-limit cap regains its missing reject-arm test coverage. No behavioral change for valid inputs.

## Changes

**Bugfixes — unsigned overflow/underflow at boundaries**

- **EraE import resume buffer underflow** (`Nethermind.EraE/Import/EraImporter.cs`): the `BlockTreeSuggestPacer` resume batch size was computed as `ImportBlocksBufferSize - 1024UL`, which wraps to ~2^64 when `ImportBlocksBufferSize <= 1024`. Now guarded — subtract `1024` only when the buffer exceeds it, otherwise fall back to `ImportBlocksBufferSize / 2`. Brings EraE in line with the Era1 importer's underflow handling.
- **`eth_subscribe` over-width / malformed params** (`Nethermind.JsonRpc/Modules/Subscribe/SubscribeRpcModule.cs`): the subscription-args parse only caught `JsonException`, so an over-width or negative block parameter (e.g. `fromBlock: "0x10000000000000000"` = 2^64, or `"-1"`) surfaced as an `OverflowException`/`FormatException` and escaped as an InternalError. The catch now also handles `FormatException` and `OverflowException`, mapping these to the standard `InvalidParams` (-32602).

**Refactor — remove leftovers of pre-`ulong` times**

- **EthStats history-range normalization** (`Nethermind.EthStats/Integrations/EthStatsIntegration.cs`): with `min`/`max` now `ulong`, the `if (max < 0)` guard is unreachable and `min = Math.Max(0, min)` is a no-op. Removed both. Since normalization can no longer fail, `TryNormalizeHistoryRange` (returning `bool`) becomes `NormalizeHistoryRange` (returning `void`), and the dead "invalid range" early-return in `SendHistoryAsync` is dropped. Behavior-preserving.
- **Optimism payload-id buffer size** (`Nethermind.Optimism/Rpc/OptimismPayloadAttributes.cs`): `ComputePayloadIdMembersSize` reserved `sizeof(long)` for the now-`ulong` `gasLimit`; changed to `sizeof(ulong)`. Both are 8 bytes — purely cosmetic alignment with the write path, no payload-id change.
- **HeaderValidator gas-limit cap reject arm** (`Nethermind.Blockchain.Test/Validators/HeaderValidatorTests.cs`): the unification replaced the dead signed `< 0` checks with an explicit `GasLimit > 2^63-1` consensus cap (`ValidateFieldLimit`), but only the accept boundary (`== 2^63-1`) was covered. Converted the single accept-only test into a parameterized boundary sweep `When_gas_limit_around_protocol_cap` that also exercises the reject arm at `2^63` and `ulong.MaxValue`, asserting the rejection is attributed to `BlockErrorMessages.InvalidGasLimit`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
