### PR TITLE
Fix Hive eth devp2p tests

### DIFF
--- a/src/Nethermind/Nethermind.Crypto/KzgPolynomialCommitments.cs
+++ b/src/Nethermind/Nethermind.Crypto/KzgPolynomialCommitments.cs
@@ -73,6 +73,15 @@ public static partial class KzgPolynomialCommitments
     public static void ComputeCellProofs(ReadOnlySpan<byte> blob, Span<byte> cellProofs) =>
         Ckzg.ComputeCellsAndKzgProofs(new byte[Ckzg.CellsPerExtBlob * Ckzg.BytesPerCell], cellProofs, blob, _ckzgSetup);
 
+    /// <summary>
+    /// Computes a single blob KZG proof for a blob and its commitment.
+    /// </summary>
+    /// <param name="blob">The input blob data. The span must be exactly <c>BYTES_PER_BLOB</c> bytes.</param>
+    /// <param name="commitment">The KZG commitment for <paramref name="blob"/>. The span must be exactly <c>BYTES_PER_COMMITMENT</c> bytes.</param>
+    /// <param name="proof">The output span where the <c>BYTES_PER_PROOF</c> proof is written.</param>
+    public static void ComputeBlobProof(ReadOnlySpan<byte> blob, ReadOnlySpan<byte> commitment, Span<byte> proof) =>
+        Ckzg.ComputeBlobKzgProof(proof, blob, commitment, _ckzgSetup);
+
     /// <param name="blob">The input blob data.</param>
     /// <param name="cells">The output span of size <c>CELLS_PER_EXT_BLOB * BYTES_PER_CELL</c> (262144 bytes) where cells will be written.</param>
     public static void ComputeCells(ReadOnlySpan<byte> blob, Span<byte> cells) => Ckzg.ComputeCells(cells, blob, _ckzgSetup);

--- a/src/Nethermind/Nethermind.Hive.Test/HivePluginTests.cs
+++ b/src/Nethermind/Nethermind.Hive.Test/HivePluginTests.cs
@@ -10,6 +10,7 @@ using Autofac;
 using NSubstitute;
 using Nethermind.Api.Extensions;
 using Nethermind.Blockchain;
+using Nethermind.Config;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
@@ -17,7 +18,9 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.IO;
 using Nethermind.Core.Test.Modules;
 using Nethermind.Logging;
+using Nethermind.Network.Config;
 using Nethermind.Serialization.Rlp;
+using Nethermind.TxPool;
 using NUnit.Framework;
 
 namespace Nethermind.Hive.Test
@@ -45,6 +48,35 @@ namespace Nethermind.Hive.Test
                 .Build();
 
             container.Resolve<HiveStep>();
+        }
+
+        [Test]
+        public void Disables_recent_ip_filtering_for_hive_devp2p()
+        {
+            using IContainer container = new ContainerBuilder()
+                .AddModule(new TestNethermindModule(new NetworkConfig()))
+                .AddModule(new HiveModule())
+                .Build();
+
+            INetworkConfig networkConfig = container.Resolve<INetworkConfig>();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(networkConfig.FilterPeersByRecentIp, Is.False);
+            }
+        }
+
+        [Test]
+        public void Enables_blob_proof_translation_for_hive_devp2p()
+        {
+            using IContainer container = new ContainerBuilder()
+                .AddModule(new TestNethermindModule(configProvider: new ConfigProvider(new TxPoolConfig())))
+                .AddModule(new HiveModule())
+                .Build();
+
+            ITxPoolConfig txPoolConfig = container.Resolve<ITxPoolConfig>();
+
+            Assert.That(txPoolConfig.ProofsTranslationEnabled, Is.True);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Hive/HivePlugin.cs
+++ b/src/Nethermind/Nethermind.Hive/HivePlugin.cs
@@ -7,6 +7,7 @@ using Nethermind.Api.Extensions;
 using Nethermind.Api.Steps;
 using Nethermind.Core;
 using Nethermind.Core.Container;
+using Nethermind.Network.Config;
 using Nethermind.TxPool;
 
 namespace Nethermind.Hive;
@@ -29,5 +30,15 @@ public class HiveModule : Module
     protected override void Load(ContainerBuilder builder) => builder
         .AddSingleton<HiveRunner>()
         .AddStep(typeof(HiveStep))
+        .AddDecorator<INetworkConfig>((_, networkConfig) =>
+        {
+            networkConfig.FilterPeersByRecentIp = false;
+            return networkConfig;
+        })
+        .AddDecorator<ITxPoolConfig>((_, txPoolConfig) =>
+        {
+            txPoolConfig.ProofsTranslationEnabled = true;
+            return txPoolConfig;
+        })
         .ClearOrderedComponents<ITxGossipPolicy>();
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
+using Nethermind.Network.Contract.Messages;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.Subprotocols;
@@ -223,6 +224,7 @@ public class Eth68ProtocolHandlerTests
             m.Sizes.Count == 1 &&
             m.Types.Count == 1 &&
             m.Hashes[0] == tx.Hash &&
+            m.Sizes[0] == tx.GetLength() &&
             (TxType)m.Types[0] == tx.Type));
     }
 
@@ -263,7 +265,7 @@ public class Eth68ProtocolHandlerTests
             Substitute.For<ISpecProvider>(),
             _txGossipPolicy);
 
-        int maxNumberOfTxsInOneMsg = int.Min(sizeOfOneTx < TransactionsMessage.MaxPacketSize ? TransactionsMessage.MaxPacketSize / sizeOfOneTx : 1, 256);
+        int maxNumberOfTxsInOneMsg = int.Min(sizeOfOneTx <= TransactionsMessage.MaxPacketSize ? TransactionsMessage.MaxPacketSize / sizeOfOneTx : 256, 256);
         int messagesCount = numberOfTransactions / maxNumberOfTxsInOneMsg + (numberOfTransactions % maxNumberOfTxsInOneMsg == 0 ? 0 : 1);
 
         using ArrayPoolList<byte> types = new(numberOfTransactions);
@@ -282,6 +284,43 @@ public class Eth68ProtocolHandlerTests
         HandleZeroMessage(hashesMsg, Eth68MessageCode.NewPooledTransactionHashes);
 
         _session.Received(messagesCount).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m => m.EthMessage.Hashes.Count == maxNumberOfTxsInOneMsg || m.EthMessage.Hashes.Count == numberOfTransactions % maxNumberOfTxsInOneMsg));
+    }
+
+    [Test]
+    public void Should_request_oversized_announced_transactions_together()
+    {
+        using ArrayPoolList<byte> types = new(3) { 0, 0, 0 };
+        using ArrayPoolList<int> sizes = new(3) { 200_000, 200_000, 200_000 };
+        using ArrayPoolList<Hash256> hashes = new(3)
+        {
+            TestItem.KeccakA,
+            TestItem.KeccakB,
+            TestItem.KeccakC
+        };
+        using NewPooledTransactionHashesMessage68 hashesMsg = new(types, sizes, hashes);
+
+        HandleIncomingStatusMessage();
+        HandleZeroMessage(hashesMsg, Eth68MessageCode.NewPooledTransactionHashes);
+
+        _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m =>
+            m.EthMessage.Hashes.Count == 3 &&
+            m.EthMessage.Hashes[0] == TestItem.KeccakA &&
+            m.EthMessage.Hashes[1] == TestItem.KeccakB &&
+            m.EthMessage.Hashes[2] == TestItem.KeccakC));
+    }
+
+    [Test]
+    public void Should_register_requested_hashes_for_timeout_retry()
+    {
+        using NewPooledTransactionHashesMessage68 hashesMsg = new(
+            new ArrayPoolList<byte>(1) { (byte)TxType.EIP1559 },
+            new ArrayPoolList<int>(1) { 100 },
+            new ArrayPoolList<Hash256>(1) { TestItem.KeccakA });
+
+        HandleIncomingStatusMessage();
+        HandleZeroMessage(hashesMsg, Eth68MessageCode.NewPooledTransactionHashes);
+
+        _transactionPool.Received(2).NotifyAboutTx(TestItem.KeccakA, Arg.Any<IMessageHandler<PooledTransactionRequestMessage>>());
     }
 
     private void HandleIncomingStatusMessage()

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandlerTests.cs
@@ -183,8 +183,8 @@ public class Eth70ProtocolHandlerTests
     public void Should_return_expected_receipts_for_first_block_receipt_index(
         long firstBlockReceiptIndex,
         int expectedLength,
-        int expectedFirstReceiptIndex,
-        int expectedLastReceiptIndex)
+        int? expectedFirstReceiptIndex,
+        int? expectedLastReceiptIndex)
     {
         TxReceipt[] receipts = BuildSequentialReceipts(3);
 
@@ -197,8 +197,8 @@ public class Eth70ProtocolHandlerTests
         _session.Received().DeliverMessage(Arg.Is<ReceiptsMessage70>(m =>
             m.TxReceipts.Count == 1 &&
             m.TxReceipts[0].Length == expectedLength &&
-            m.TxReceipts[0][0].GasUsedTotal == receipts[expectedFirstReceiptIndex].GasUsedTotal &&
-            m.TxReceipts[0][expectedLength - 1].GasUsedTotal == receipts[expectedLastReceiptIndex].GasUsedTotal &&
+            (expectedLength == 0 || m.TxReceipts[0][0].GasUsedTotal == receipts[expectedFirstReceiptIndex!.Value].GasUsedTotal) &&
+            (expectedLength == 0 || m.TxReceipts[0][expectedLength - 1].GasUsedTotal == receipts[expectedLastReceiptIndex!.Value].GasUsedTotal) &&
             !m.LastBlockIncomplete));
     }
 
@@ -936,6 +936,34 @@ public class Eth70ProtocolHandlerTests
     }
 
     [Test]
+    public void Should_include_next_block_after_empty_first_block_completion()
+    {
+        SyncPeerProtocolHandlerBase.SoftOutgoingMessageSizeLimit = 1;
+        SyncPeerProtocolHandlerBase.HardOutgoingReceiptsMessageSizeLimit = 1000;
+
+        TxReceipt[] block1Receipts = BuildSequentialReceipts(1);
+        TxReceipt[] block2Receipts =
+        [
+            new() { GasUsedTotal = GasCostOf.Transaction, Logs = [new LogEntry(TestItem.AddressA, new byte[100], [])] },
+            new() { GasUsedTotal = GasCostOf.Transaction * 2, Logs = [new LogEntry(TestItem.AddressA, new byte[100], [])] }
+        ];
+
+        _syncManager.GetReceipts(Keccak.Zero).Returns(block1Receipts);
+        _syncManager.GetReceipts(TestItem.KeccakA).Returns(block2Receipts);
+
+        using GetReceiptsMessage70 request = new(1111, block1Receipts.Length, new[] { Keccak.Zero, TestItem.KeccakA }.ToPooledList());
+
+        HandleIncomingStatusMessage();
+        HandleZeroMessage(request, Eth70MessageCode.GetReceipts);
+
+        _session.Received().DeliverMessage(Arg.Is<ReceiptsMessage70>(m =>
+            m.TxReceipts.Count == 2 &&
+            m.TxReceipts[0].Length == 0 &&
+            m.TxReceipts[1].Length == block2Receipts.Length &&
+            !m.LastBlockIncomplete));
+    }
+
+    [Test]
     public void Should_send_single_large_block_above_soft_limit_when_below_hard_limit()
     {
         SyncPeerProtocolHandlerBase.SoftOutgoingMessageSizeLimit = 300;
@@ -1157,6 +1185,8 @@ public class Eth70ProtocolHandlerTests
             .SetName("Should_return_receipts_when_first_block_receipt_index_is_zero");
         yield return new TestCaseData(2L, 1, 2, 2)
             .SetName("Should_return_last_receipt_when_first_block_receipt_index_is_last");
+        yield return new TestCaseData(3L, 0, null, null)
+            .SetName("Should_return_empty_block_when_first_block_receipt_index_equals_receipts_count");
     }
 
     public sealed record InvalidPartialContinuationCase(
@@ -1196,12 +1226,22 @@ public class Eth70ProtocolHandlerTests
             SecondBlockGasUsed: GasCostOf.Transaction,
             ExpectedExceptionMessage: "Block gas used mismatch between receipts and header"))
             .SetName("Rejects partial continuation that completes below header gas before continuing");
+
+        yield return new TestCaseData(new InvalidPartialContinuationCase(
+            [Keccak.Zero, TestItem.KeccakA],
+            new Dictionary<long, ReceiptsPageResponse>
+            {
+                [0] = new([firstShortPage], LastBlockIncomplete: true),
+                [1] = new([Array.Empty<TxReceipt>(), nextBlock], LastBlockIncomplete: false)
+            },
+            FirstBlockGasUsed: GasCostOf.Transaction * 2,
+            SecondBlockGasUsed: GasCostOf.Transaction,
+            ExpectedExceptionMessage: "Block gas used mismatch between receipts and header"))
+            .SetName("Rejects empty partial continuation that completes below header gas before continuing");
     }
 
     private static IEnumerable<TestCaseData> InvalidFirstBlockReceiptIndexCases()
     {
-        yield return new TestCaseData(2L)
-            .SetName("Should_disconnect_when_first_block_receipt_index_equals_receipts_count");
         yield return new TestCaseData(3L)
             .SetName("Should_disconnect_when_first_block_receipt_index_exceeds_receipts_count");
     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -42,6 +42,8 @@ public class Eth68ProtocolHandler(ISession session,
     )
     : Eth67ProtocolHandler(session, serializer, nodeStatsManager, syncServer, backgroundTaskScheduler, txPool, gossipPolicy, forkInfo, logManager, transactionsGossipPolicy), IStaticProtocolInfo
 {
+    private const int MaxPooledTransactionHashesPerRequest = 256;
+
     private readonly bool _blobSupportEnabled = txPoolConfig.BlobsSupport.IsEnabled();
     private readonly long _configuredMaxTxSize = txPoolConfig.MaxTxSize ?? long.MaxValue;
 
@@ -142,16 +144,17 @@ public class Eth68ProtocolHandler(ISession session,
             if (txSize > maxTxSize)
                 continue;
 
-            if (_blobSupportEnabled || txType != TxType.Blob)
+            if (CanRequestPooledTransaction(txType))
             {
-                if ((txSize <= TransactionsMessage.MaxPacketSize && txSize > packetSizeLeft && toRequestCount > 0) || toRequestCount >= 256)
+                bool countsTowardPacketSize = txSize <= TransactionsMessage.MaxPacketSize;
+                if (ShouldSendCurrentRequest(countsTowardPacketSize, txSize, packetSizeLeft, toRequestCount))
                 {
                     SendHashesToRequest();
                 }
 
                 hashesToRequest.Add(hash);
                 _txPool.NotifyAboutTx(hash, this);
-                if (txSize <= TransactionsMessage.MaxPacketSize)
+                if (countsTowardPacketSize)
                 {
                     packetSizeLeft -= txSize;
                 }
@@ -176,6 +179,12 @@ public class Eth68ProtocolHandler(ISession session,
             toRequestCount = 0;
         }
     }
+
+    private bool CanRequestPooledTransaction(TxType txType) => _blobSupportEnabled || txType is not TxType.Blob;
+
+    private static bool ShouldSendCurrentRequest(bool countsTowardPacketSize, int txSize, int packetSizeLeft, int toRequestCount) =>
+        toRequestCount >= MaxPooledTransactionHashesPerRequest
+        || (countsTowardPacketSize && txSize > packetSizeLeft && toRequestCount > 0);
 
     private ArrayPoolListRef<int> AddMarkUnknownHashes(ReadOnlySpan<Hash256> hashes)
     {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -142,18 +142,19 @@ public class Eth68ProtocolHandler(ISession session,
             if (txSize > maxTxSize)
                 continue;
 
-            if ((txSize > packetSizeLeft && toRequestCount > 0) || toRequestCount >= 256)
-            {
-                Send(V66.Messages.GetPooledTransactionsMessage.New(hashesToRequest));
-                hashesToRequest = new ArrayPoolList<Hash256>(discoveredCount);
-                packetSizeLeft = TransactionsMessage.MaxPacketSize;
-                toRequestCount = 0;
-            }
-
             if (_blobSupportEnabled || txType != TxType.Blob)
             {
+                if ((txSize <= TransactionsMessage.MaxPacketSize && txSize > packetSizeLeft && toRequestCount > 0) || toRequestCount >= 256)
+                {
+                    SendHashesToRequest();
+                }
+
                 hashesToRequest.Add(hash);
-                packetSizeLeft -= txSize;
+                _txPool.NotifyAboutTx(hash, this);
+                if (txSize <= TransactionsMessage.MaxPacketSize)
+                {
+                    packetSizeLeft -= txSize;
+                }
                 toRequestCount++;
             }
         }
@@ -165,6 +166,14 @@ public class Eth68ProtocolHandler(ISession session,
         else
         {
             hashesToRequest.Dispose();
+        }
+
+        void SendHashesToRequest()
+        {
+            Send(V66.Messages.GetPooledTransactionsMessage.New(hashesToRequest));
+            hashesToRequest = new ArrayPoolList<Hash256>(discoveredCount);
+            packetSizeLeft = TransactionsMessage.MaxPacketSize;
+            toRequestCount = 0;
         }
     }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -160,11 +160,6 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                     continue;
                 }
 
-                if (startIndex > receipts.Length)
-                {
-                    throw new SubprotocolException($"Invalid firstBlockReceiptIndex {startIndex} for block receipts length {receipts.Length}");
-                }
-
                 ulong remainingBlockSize = GetBlockReceiptsSize(receipts, startIndex);
                 if (GetEth70ReceiptsResponseSize(
                     responseReceiptsContentSize + remainingBlockSize,

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -100,6 +100,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
         try
         {
             ulong responseReceiptsContentSize = 0;
+            bool hasNonEmptyReceiptBlock = false;
             for (int blockIndex = 0; blockIndex < hashes.Length; blockIndex++)
             {
                 if (cancellationToken.IsCancellationRequested)
@@ -143,7 +144,23 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                     continue;
                 }
 
-                if (startIndex >= receipts.Length)
+                if (startIndex == receipts.Length)
+                {
+                    ulong emptyBlockSize = GetBlockReceiptsSize(0);
+                    ulong responseSize = GetEth70ReceiptsResponseSize(
+                        responseReceiptsContentSize + emptyBlockSize,
+                        getReceiptsMessage.RequestId);
+                    if (responseSize > SoftOutgoingMessageSizeLimit && responseReceiptsContentSize > 0)
+                    {
+                        break;
+                    }
+
+                    txReceipts.Add([]);
+                    responseReceiptsContentSize += emptyBlockSize;
+                    continue;
+                }
+
+                if (startIndex > receipts.Length)
                 {
                     throw new SubprotocolException($"Invalid firstBlockReceiptIndex {startIndex} for block receipts length {receipts.Length}");
                 }
@@ -155,17 +172,19 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                 {
                     txReceipts.Add(CopyReceipts(receipts, startIndex, receipts.Length - startIndex));
                     responseReceiptsContentSize += remainingBlockSize;
+                    hasNonEmptyReceiptBlock = true;
                     continue;
                 }
 
-                if (responseReceiptsContentSize > 0)
+                if (hasNonEmptyReceiptBlock)
                 {
                     break;
                 }
 
-                if (GetEth70ReceiptsResponseSize(remainingBlockSize, getReceiptsMessage.RequestId) <= HardOutgoingReceiptsMessageSizeLimit)
+                if (GetEth70ReceiptsResponseSize(responseReceiptsContentSize + remainingBlockSize, getReceiptsMessage.RequestId) <= HardOutgoingReceiptsMessageSizeLimit)
                 {
                     txReceipts.Add(CopyReceipts(receipts, startIndex, receipts.Length - startIndex));
+                    hasNonEmptyReceiptBlock = true;
                     break;
                 }
 
@@ -178,7 +197,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                     ulong receiptSize = GetReceiptSize(receipts[receiptIndex], ref lastBlockNumber, ref behaviors);
                     ulong nextBlockReceiptsContentSize = blockReceiptsContentSize + receiptSize;
                     ulong nextBlockSize = GetBlockReceiptsSize(nextBlockReceiptsContentSize);
-                    if (GetEth70ReceiptsResponseSize(nextBlockSize, getReceiptsMessage.RequestId) > HardOutgoingReceiptsMessageSizeLimit)
+                    if (GetEth70ReceiptsResponseSize(responseReceiptsContentSize + nextBlockSize, getReceiptsMessage.RequestId) > HardOutgoingReceiptsMessageSizeLimit)
                     {
                         break;
                     }
@@ -199,6 +218,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
 
                 lastBlockIncomplete = startIndex + taken < receipts.Length;
                 txReceipts.Add(CopyReceipts(receipts, startIndex, taken));
+                hasNonEmptyReceiptBlock = true;
                 break;
             }
 
@@ -516,6 +536,8 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
             ValidateEmptyReceiptsSegment(firstReceiptIndex, isCompleteSegment);
             ValidateReceiptCount(firstReceiptIndex, blockReceipts.Length, transactions, isCompleteSegment);
             ValidateTotalReceiptsSizeAgainstBlockGasLimit(previousReceiptsContentSize, blockGasLimit);
+            ValidateSegmentGasAgainstHeader(previousGasUsed, previousLogsGas, expectedGasUsed, isCompleteSegment,
+                validateReceiptGasUpperBoundAgainstHeader, validateReceiptGasEqualToHeader);
             return new ReceiptsValidationResult(previousGasUsed, previousLogsGas, previousReceiptsContentSize);
         }
 
@@ -544,7 +566,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
 
     private static void ValidateEmptyReceiptsSegment(int firstReceiptIndex, bool isCompleteSegment)
     {
-        if (firstReceiptIndex != 0 || !isCompleteSegment)
+        if (!isCompleteSegment)
         {
             throw new SubprotocolException("Unexpected empty receipt block payload");
         }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -980,6 +980,122 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        [Test]
+        public void should_convert_cell_proofs_to_blob_proofs_if_enabled([Values(true, false)] bool isPersistentStorage, [Values(true, false)] bool isConversionEnabled)
+        {
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = isPersistentStorage ? BlobsSupportMode.Storage : BlobsSupportMode.InMemory,
+                Size = 10,
+                ProofsTranslationEnabled = isConversionEnabled
+            };
+            BlobTxStorage blobTxStorage = new();
+
+            _txPool = CreatePool(txPoolConfig, GetCancunSpecProvider(), txStorage: blobTxStorage);
+
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            // update head and set correct current proof version
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(Build.A.Block.TestObject));
+
+            Transaction blobTxAdded = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(spec: new ReleaseSpec() { IsEip7594Enabled = true })
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .WithNonce(0)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+
+            AcceptTxResult result = _txPool.SubmitTx(blobTxAdded, TxHandlingOptions.None);
+            Assert.That(result, Is.EqualTo(isConversionEnabled ? AcceptTxResult.Accepted : AcceptTxResult.Invalid));
+            Assert.That(_txPool.TryGetPendingTransaction(blobTxAdded.Hash!, out Transaction blobTxReturned), Is.EqualTo(isConversionEnabled));
+
+            if (isConversionEnabled)
+            {
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(blobTxReturned, Is.EqualTo(blobTxAdded).UsingTransactionComparer());
+                    ShardBlobNetworkWrapper wrapper = (ShardBlobNetworkWrapper)blobTxReturned.NetworkWrapper;
+                    Assert.That(wrapper.Proofs.Length, Is.EqualTo(1));
+                    Assert.That(wrapper.Version, Is.EqualTo(ProofVersion.V0));
+                    Assert.That(IBlobProofsManager.For(ProofVersion.V0).ValidateProofs(wrapper), Is.True);
+
+                    Assert.That(blobTxStorage.TryGet(blobTxAdded.Hash, blobTxAdded.SenderAddress!, blobTxAdded.Timestamp, out Transaction blobTxFromDb), Is.EqualTo(isPersistentStorage)); // additional check for persistent db
+                    if (isPersistentStorage)
+                    {
+                        Assert.That(blobTxFromDb, Is.EqualTo(blobTxAdded).UsingTransactionComparer(nameof(Transaction.GasBottleneck), nameof(Transaction.PoolIndex)));
+                    }
+                }
+            }
+            else
+            {
+                Assert.That(blobTxReturned, Is.Null);
+            }
+        }
+
+        [Test]
+        public void should_reject_malformed_blob_proofs_when_conversion_is_enabled()
+        {
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.InMemory,
+                Size = 10,
+                ProofsTranslationEnabled = true
+            };
+
+            _txPool = CreatePool(txPoolConfig, GetOsakaSpecProvider());
+
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(Build.A.Block.TestObject));
+
+            Transaction blobTxAdded = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields()
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .WithNonce(0)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+            ShardBlobNetworkWrapper wrapper = (ShardBlobNetworkWrapper)blobTxAdded.NetworkWrapper;
+            blobTxAdded.NetworkWrapper = wrapper with { Proofs = [] };
+
+            AcceptTxResult result = _txPool.SubmitTx(blobTxAdded, TxHandlingOptions.None);
+
+            Assert.That(result, Is.EqualTo(AcceptTxResult.Invalid));
+            Assert.That(_txPool.TryGetPendingTransaction(blobTxAdded.Hash!, out Transaction blobTxReturned), Is.False);
+            Assert.That(blobTxReturned, Is.Null);
+        }
+
+        [Test]
+        public void should_reject_malformed_cell_proofs_when_conversion_is_enabled()
+        {
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.InMemory,
+                Size = 10,
+                ProofsTranslationEnabled = true
+            };
+
+            _txPool = CreatePool(txPoolConfig, GetCancunSpecProvider());
+
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(Build.A.Block.TestObject));
+
+            Transaction blobTxAdded = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(spec: new ReleaseSpec() { IsEip7594Enabled = true })
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .WithNonce(0)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+            ShardBlobNetworkWrapper wrapper = (ShardBlobNetworkWrapper)blobTxAdded.NetworkWrapper;
+            blobTxAdded.NetworkWrapper = wrapper with { Commitments = [] };
+
+            AcceptTxResult result = _txPool.SubmitTx(blobTxAdded, TxHandlingOptions.None);
+
+            Assert.That(result, Is.EqualTo(AcceptTxResult.Invalid));
+            Assert.That(_txPool.TryGetPendingTransaction(blobTxAdded.Hash!, out Transaction blobTxReturned), Is.False);
+            Assert.That(blobTxReturned, Is.Null);
+        }
+
         [TestCaseSource(nameof(BlobScheduleActivationsTestCaseSource))]
         public async Task<int> should_evict_based_on_proof_version_and_fork(BlobsSupportMode poolMode, TestAction[] testActions)
         {

--- a/src/Nethermind/Nethermind.TxPool/BlobProofsTranslator.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobProofsTranslator.cs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using CkzgLib;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Crypto;
+
+namespace Nethermind.TxPool;
+
+internal static class BlobProofsTranslator
+{
+    public static bool TryTranslateToCurrentProofVersion(Transaction tx, ProofVersion currentProofVersion)
+    {
+        if (tx is not { SupportsBlobs: true, NetworkWrapper: ShardBlobNetworkWrapper wrapper }
+            || wrapper.Version == currentProofVersion)
+        {
+            return true;
+        }
+
+        if (!ValidateSourceBlobWrapper(tx, wrapper))
+        {
+            return false;
+        }
+
+        if (wrapper.Version is ProofVersion.V0 && currentProofVersion is ProofVersion.V1)
+        {
+            return TryConvertBlobProofsToCellProofs(tx, wrapper);
+        }
+
+        if (wrapper.Version is ProofVersion.V1 && currentProofVersion is ProofVersion.V0)
+        {
+            return TryConvertCellProofsToBlobProofs(tx, wrapper);
+        }
+
+        return true;
+    }
+
+    private static bool TryConvertBlobProofsToCellProofs(Transaction tx, ShardBlobNetworkWrapper wrapper)
+    {
+        byte[][] cellProofs = new byte[Ckzg.CellsPerExtBlob * wrapper.Blobs.Length][];
+
+        try
+        {
+            for (int blobIndex = 0; blobIndex < wrapper.Blobs.Length; blobIndex++)
+            {
+                using ArrayPoolSpan<byte> cellProofsOfOneBlob = new(Ckzg.CellsPerExtBlob * Ckzg.BytesPerProof);
+                KzgPolynomialCommitments.ComputeCellProofs(wrapper.Blobs[blobIndex], cellProofsOfOneBlob);
+
+                for (int i = 0; i < Ckzg.CellsPerExtBlob; i++)
+                {
+                    byte[] cellProof = new byte[Ckzg.BytesPerProof];
+                    cellProofsOfOneBlob.Slice(i * Ckzg.BytesPerProof, Ckzg.BytesPerProof).CopyTo(cellProof);
+                    cellProofs[blobIndex * Ckzg.CellsPerExtBlob + i] = cellProof;
+                }
+            }
+        }
+        catch (Exception e) when (e is ArgumentException or ApplicationException or InsufficientMemoryException)
+        {
+            return false;
+        }
+
+        tx.NetworkWrapper = wrapper with { Proofs = cellProofs, Version = ProofVersion.V1 };
+        return true;
+    }
+
+    private static bool TryConvertCellProofsToBlobProofs(Transaction tx, ShardBlobNetworkWrapper wrapper)
+    {
+        byte[][] proofs = new byte[wrapper.Blobs.Length][];
+
+        try
+        {
+            for (int i = 0; i < wrapper.Blobs.Length; i++)
+            {
+                byte[] proof = new byte[Ckzg.BytesPerProof];
+                KzgPolynomialCommitments.ComputeBlobProof(wrapper.Blobs[i], wrapper.Commitments[i], proof);
+                proofs[i] = proof;
+            }
+        }
+        catch (Exception e) when (e is ArgumentException or ApplicationException or InsufficientMemoryException)
+        {
+            return false;
+        }
+
+        tx.NetworkWrapper = wrapper with { Proofs = proofs, Version = ProofVersion.V0 };
+        return true;
+    }
+
+    private static bool ValidateSourceBlobWrapper(Transaction tx, ShardBlobNetworkWrapper wrapper)
+    {
+        if (tx.BlobVersionedHashes is null)
+        {
+            return false;
+        }
+
+        using ArrayPoolListRef<byte[]> blobVersionedHashes = new(tx.BlobVersionedHashes.Length);
+        for (int i = 0; i < tx.BlobVersionedHashes.Length; i++)
+        {
+            if (tx.BlobVersionedHashes[i] is not byte[] blobVersionedHash)
+            {
+                return false;
+            }
+
+            blobVersionedHashes.Add(blobVersionedHash);
+        }
+
+        IBlobProofsVerifier proofVerifier = IBlobProofsManager.For(wrapper.Version);
+        return proofVerifier.ValidateLengths(wrapper)
+            && proofVerifier.ValidateHashes(wrapper, blobVersionedHashes.AsSpan())
+            && proofVerifier.ValidateProofs(wrapper);
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -56,7 +56,7 @@ public interface ITxPoolConfig : IConfig
     bool CurrentBlobBaseFeeRequired { get; set; }
 
     [ConfigItem(DefaultValue = "false",
-        Description = "Enable transformation of blob txs with network wrapper in version 0x0 (blob proof) to version 0x1 (cell proofs)",
+        Description = "Enable transformation of blob txs between network wrapper version 0x0 (blob proofs) and version 0x1 (cell proofs).",
         HiddenFromDocs = true)]
     bool ProofsTranslationEnabled { get; set; }
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Autofac.Features.AttributeFilters;
-using CkzgLib;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Collections;
@@ -551,7 +550,8 @@ namespace Nethermind.TxPool
                 TraceTx(tx, handlingOptions, startBroadcast);
             }
 
-            if (!TryConvertProofVersion(tx))
+            if (_txPoolConfig.ProofsTranslationEnabled
+                && !BlobProofsTranslator.TryTranslateToCurrentProofVersion(tx, _headInfo.CurrentProofVersion))
             {
                 Metrics.PendingTransactionsDiscarded++;
                 return AcceptTxResult.Invalid;
@@ -601,95 +601,6 @@ namespace Nethermind.TxPool
                 bool managedNonce = (handlingOptions & TxHandlingOptions.ManagedNonce) == TxHandlingOptions.ManagedNonce;
                 _logger.Trace($"Adding transaction {tx.ToString("  ")} - managed nonce: {managedNonce} | persistent broadcast {startBroadcast}");
             }
-        }
-
-        private bool TryConvertProofVersion(Transaction tx)
-        {
-            if (!_txPoolConfig.ProofsTranslationEnabled
-                || tx is not { SupportsBlobs: true, NetworkWrapper: ShardBlobNetworkWrapper wrapper }
-                || wrapper.Version == _headInfo.CurrentProofVersion)
-            {
-                return true;
-            }
-
-            if (wrapper.Version is ProofVersion.V0 && _headInfo.CurrentProofVersion is ProofVersion.V1)
-            {
-                if (!ValidateSourceBlobWrapper(tx, wrapper))
-                {
-                    return false;
-                }
-
-                using ArrayPoolListRef<byte[]> cellProofs = new(Ckzg.CellsPerExtBlob * wrapper.Blobs.Length);
-
-                try
-                {
-                    foreach (byte[] blob in wrapper.Blobs)
-                    {
-                        using ArrayPoolSpan<byte> cellProofsOfOneBlob = new(Ckzg.CellsPerExtBlob * Ckzg.BytesPerProof);
-                        KzgPolynomialCommitments.ComputeCellProofs(blob, cellProofsOfOneBlob);
-                        byte[][] cellProofsSeparated = cellProofsOfOneBlob.Chunk(Ckzg.BytesPerProof).ToArray();
-                        cellProofs.AddRange(cellProofsSeparated);
-                    }
-                }
-                catch (Exception e) when (e is ArgumentException or ApplicationException or InsufficientMemoryException)
-                {
-                    return false;
-                }
-
-                tx.NetworkWrapper = wrapper with { Proofs = [.. cellProofs], Version = ProofVersion.V1 };
-                return true;
-            }
-
-            if (wrapper.Version is ProofVersion.V1 && _headInfo.CurrentProofVersion is ProofVersion.V0)
-            {
-                if (!ValidateSourceBlobWrapper(tx, wrapper))
-                {
-                    return false;
-                }
-
-                byte[][] proofs = new byte[wrapper.Blobs.Length][];
-                try
-                {
-                    for (int i = 0; i < wrapper.Blobs.Length; i++)
-                    {
-                        proofs[i] = new byte[Ckzg.BytesPerProof];
-                        KzgPolynomialCommitments.ComputeBlobProof(wrapper.Blobs[i], wrapper.Commitments[i], proofs[i]);
-                    }
-                }
-                catch (Exception e) when (e is ArgumentException or ApplicationException or InsufficientMemoryException)
-                {
-                    return false;
-                }
-
-                tx.NetworkWrapper = wrapper with { Proofs = proofs, Version = ProofVersion.V0 };
-                return true;
-            }
-
-            return true;
-        }
-
-        private static bool ValidateSourceBlobWrapper(Transaction tx, ShardBlobNetworkWrapper wrapper)
-        {
-            if (tx.BlobVersionedHashes is null)
-            {
-                return false;
-            }
-
-            byte[][] blobVersionedHashes = new byte[tx.BlobVersionedHashes.Length][];
-            for (int i = 0; i < blobVersionedHashes.Length; i++)
-            {
-                if (tx.BlobVersionedHashes[i] is not byte[] blobVersionedHash)
-                {
-                    return false;
-                }
-
-                blobVersionedHashes[i] = blobVersionedHash;
-            }
-
-            IBlobProofsVerifier proofVerifier = IBlobProofsManager.For(wrapper.Version);
-            return proofVerifier.ValidateLengths(wrapper)
-                && proofVerifier.ValidateHashes(wrapper, blobVersionedHashes)
-                && proofVerifier.ValidateProofs(wrapper);
         }
 
         public AnnounceResult NotifyAboutTx(Hash256 hash, IMessageHandler<PooledTransactionRequestMessage> retryHandler) =>

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -551,7 +551,11 @@ namespace Nethermind.TxPool
                 TraceTx(tx, handlingOptions, startBroadcast);
             }
 
-            TryConvertProofVersion(tx);
+            if (!TryConvertProofVersion(tx))
+            {
+                Metrics.PendingTransactionsDiscarded++;
+                return AcceptTxResult.Invalid;
+            }
 
             TxFilteringState state = new(tx, _accounts);
             AcceptTxResult accepted = AcceptTxResult.Invalid;
@@ -599,24 +603,93 @@ namespace Nethermind.TxPool
             }
         }
 
-        private void TryConvertProofVersion(Transaction tx)
+        private bool TryConvertProofVersion(Transaction tx)
         {
-            if (_txPoolConfig.ProofsTranslationEnabled
-                && tx is { SupportsBlobs: true, NetworkWrapper: ShardBlobNetworkWrapper { Version: ProofVersion.V0 } wrapper }
-                && _headInfo.CurrentProofVersion is ProofVersion.V1)
+            if (!_txPoolConfig.ProofsTranslationEnabled
+                || tx is not { SupportsBlobs: true, NetworkWrapper: ShardBlobNetworkWrapper wrapper }
+                || wrapper.Version == _headInfo.CurrentProofVersion)
             {
+                return true;
+            }
+
+            if (wrapper.Version is ProofVersion.V0 && _headInfo.CurrentProofVersion is ProofVersion.V1)
+            {
+                if (!ValidateSourceBlobWrapper(tx, wrapper))
+                {
+                    return false;
+                }
+
                 using ArrayPoolListRef<byte[]> cellProofs = new(Ckzg.CellsPerExtBlob * wrapper.Blobs.Length);
 
-                foreach (byte[] blob in wrapper.Blobs)
+                try
                 {
-                    using ArrayPoolSpan<byte> cellProofsOfOneBlob = new(Ckzg.CellsPerExtBlob * Ckzg.BytesPerProof);
-                    KzgPolynomialCommitments.ComputeCellProofs(blob, cellProofsOfOneBlob);
-                    byte[][] cellProofsSeparated = cellProofsOfOneBlob.Chunk(Ckzg.BytesPerProof).ToArray();
-                    cellProofs.AddRange(cellProofsSeparated);
+                    foreach (byte[] blob in wrapper.Blobs)
+                    {
+                        using ArrayPoolSpan<byte> cellProofsOfOneBlob = new(Ckzg.CellsPerExtBlob * Ckzg.BytesPerProof);
+                        KzgPolynomialCommitments.ComputeCellProofs(blob, cellProofsOfOneBlob);
+                        byte[][] cellProofsSeparated = cellProofsOfOneBlob.Chunk(Ckzg.BytesPerProof).ToArray();
+                        cellProofs.AddRange(cellProofsSeparated);
+                    }
+                }
+                catch (Exception e) when (e is ArgumentException or ApplicationException or InsufficientMemoryException)
+                {
+                    return false;
                 }
 
                 tx.NetworkWrapper = wrapper with { Proofs = [.. cellProofs], Version = ProofVersion.V1 };
+                return true;
             }
+
+            if (wrapper.Version is ProofVersion.V1 && _headInfo.CurrentProofVersion is ProofVersion.V0)
+            {
+                if (!ValidateSourceBlobWrapper(tx, wrapper))
+                {
+                    return false;
+                }
+
+                byte[][] proofs = new byte[wrapper.Blobs.Length][];
+                try
+                {
+                    for (int i = 0; i < wrapper.Blobs.Length; i++)
+                    {
+                        proofs[i] = new byte[Ckzg.BytesPerProof];
+                        KzgPolynomialCommitments.ComputeBlobProof(wrapper.Blobs[i], wrapper.Commitments[i], proofs[i]);
+                    }
+                }
+                catch (Exception e) when (e is ArgumentException or ApplicationException or InsufficientMemoryException)
+                {
+                    return false;
+                }
+
+                tx.NetworkWrapper = wrapper with { Proofs = proofs, Version = ProofVersion.V0 };
+                return true;
+            }
+
+            return true;
+        }
+
+        private static bool ValidateSourceBlobWrapper(Transaction tx, ShardBlobNetworkWrapper wrapper)
+        {
+            if (tx.BlobVersionedHashes is null)
+            {
+                return false;
+            }
+
+            byte[][] blobVersionedHashes = new byte[tx.BlobVersionedHashes.Length][];
+            for (int i = 0; i < blobVersionedHashes.Length; i++)
+            {
+                if (tx.BlobVersionedHashes[i] is not byte[] blobVersionedHash)
+                {
+                    return false;
+                }
+
+                blobVersionedHashes[i] = blobVersionedHash;
+            }
+
+            IBlobProofsVerifier proofVerifier = IBlobProofsManager.For(wrapper.Version);
+            return proofVerifier.ValidateLengths(wrapper)
+                && proofVerifier.ValidateHashes(wrapper, blobVersionedHashes)
+                && proofVerifier.ValidateProofs(wrapper);
         }
 
         public AnnounceResult NotifyAboutTx(Hash256 hash, IMessageHandler<PooledTransactionRequestMessage> retryHandler) =>
@@ -1167,4 +1240,3 @@ Db usage:
         private static void DisposeBlockAccountChanges(Block block) => block.DisposeAccountChanges();
     }
 }
-


### PR DESCRIPTION
## Changes

- Disable Hive-mode recent-IP peer filtering so devp2p simulator peers from the same container/IP can connect reliably.
- Enable Hive-mode blob proof translation and convert blob transaction network wrappers between blob-proof and cell-proof formats when a Hive peer sends the opposite proof version for the current head (hive expects conversion in both directions to work 🤷 ).
- Fix eth/68 pooled transaction handling for oversized blob announcements, sidecar-inclusive size/type validation, and retry registration for hashes that were actually requested.
- Fix eth/70 receipt fulfillment at partial-response boundaries so an empty final receipt segment can complete a block while still preserving gas/header validation.
- Add focused regression coverage for the Hive configuration, txpool proof conversion, eth/68 pooled transaction edge cases, and eth/70 receipt pagination edge cases.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Validation covered focused unit coverage for the Hive configuration, txpool proof conversion, and eth protocol edge cases. The local Hive devp2p eth suite passed after rebuilding the local client image. I also checked removing the v1-to-v0 proof conversion; that caused the Hive blob sidecar recovery cases to fail, so the fallback remains in this PR.

The main Nethermind solution passed the CI-shaped code-lint build with no warnings or errors, and the benchmark solution also built with no warnings or errors. The Ethereum Foundation solution build was not completed in this checkout because the external fixture JSON files under `src/tests` are missing.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The proof translation flag is enabled only for Hive mode, keeping the production default unchanged.