### PR TITLE
fix(tests): make discv5 WireTests EmbeddedChannel access thread-safe

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv5/WireTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv5/WireTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -241,6 +243,8 @@ public class WireTests
         IKademlia<PublicKey, Node> kademlia = Substitute.For<IKademlia<PublicKey, Node>>();
         NettyDiscoveryV5Handler handler = new(new TestLogManager());
         EmbeddedChannel channel = new();
+        OutboundDatagramCapture outbound = new();
+        channel.Pipeline.AddLast(outbound);
         handler.InitializeChannel(channel);
 
         TestNodeRecordProvider nodeRecordProvider = new(privateKey, endpoint, includeEndpointInRecord, enrSequence);
@@ -261,7 +265,7 @@ public class WireTests
             ExecutionLayerDiscv5RecordFilter.Instance,
             LimboLogs.Instance);
 
-        return new TestPeer(adapter, handler, channel, packetCodec, kademlia, nodeRecordProvider, endpoint);
+        return new TestPeer(adapter, handler, channel, outbound, packetCodec, kademlia, nodeRecordProvider, endpoint);
     }
 
     private static async Task PumpUntilComplete(Task task, TestPeer peerA, TestPeer peerB, CancellationToken token)
@@ -325,7 +329,7 @@ public class WireTests
 
     private static void Pump(TestPeer from, TestPeer to)
     {
-        while (from.Channel.ReadOutbound<DatagramPacket>() is { } packet)
+        while (from.Outbound.TryDequeue(out DatagramPacket? packet))
         {
             try
             {
@@ -344,6 +348,7 @@ public class WireTests
         KademliaAdapter Adapter,
         NettyDiscoveryV5Handler Handler,
         EmbeddedChannel Channel,
+        OutboundDatagramCapture Outbound,
         PacketCodec PacketCodec,
         IKademlia<PublicKey, Node> Kademlia,
         TestNodeRecordProvider NodeRecordProvider,
@@ -359,12 +364,46 @@ public class WireTests
             {
                 try
                 {
+                    Outbound.ReleaseAll();
                     Channel.FinishAndReleaseAll();
                 }
                 finally
                 {
                     PacketCodec.Dispose();
                 }
+            }
+        }
+    }
+
+    /// <summary>Captures outbound datagrams into a thread-safe queue, bypassing the embedded channel's non-thread-safe <c>ChannelOutboundBuffer</c> so packet workers can send concurrently with the test thread's pumping and disposal.</summary>
+    private sealed class OutboundDatagramCapture : ChannelHandlerAdapter
+    {
+        private readonly ConcurrentQueue<DatagramPacket> _queue = new();
+
+        public override Task WriteAsync(IChannelHandlerContext context, object message)
+        {
+            // discv5 only writes DatagramPackets; anything else would reach the suppressed-flush buffer and re-introduce the race.
+            if (message is not DatagramPacket packet)
+            {
+                throw new NotSupportedException($"Unexpected outbound message type: {message?.GetType()}.");
+            }
+
+            _queue.Enqueue(packet);
+            return Task.CompletedTask;
+        }
+
+        public override void Flush(IChannelHandlerContext context)
+        {
+            // Datagrams are captured in WriteAsync; there is nothing to flush to the embedded buffer.
+        }
+
+        public bool TryDequeue([NotNullWhen(true)] out DatagramPacket? packet) => _queue.TryDequeue(out packet);
+
+        public void ReleaseAll()
+        {
+            while (_queue.TryDequeue(out DatagramPacket? packet))
+            {
+                ReferenceCountUtil.Release(packet);
             }
         }
     }


### PR DESCRIPTION
## Changes

Fixes flaky `Nethermind.Network.Discovery.Test.Discv5.WireTests` (e.g. [run 28430391930](https://github.com/NethermindEth/nethermind/actions/runs/28430391930/job/84243405514), PR #11788). The failures are **not specific to any PR** — the same class fails on unrelated branches and on `master` (e.g. run `28390601791`).

- Install a small `OutboundDatagramCapture : ChannelHandlerAdapter` in each test peer's pipeline that diverts outbound discv5 datagrams into a lock-guarded queue (and no-ops `Flush`), so writes never reach the non-thread-safe `ChannelOutboundBuffer`.
- `Pump` now drains that queue instead of `channel.ReadOutbound`, and `DisposeAsync` releases any captured packets.
- All changes are confined to `WireTests.cs`.

### Root cause

The tests simulate two discv5 peers over DotNetty `EmbeddedChannel`s. Each peer's `KademliaAdapter.RunAsync` runs packet workers on **thread-pool threads**; when a worker handles an inbound packet it calls `NettyDiscoveryV5Handler.SendAsync` → `Channel.WriteAndFlushAsync(...)`. Meanwhile the **test thread** drives `Pump` (`channel.ReadOutbound`), the `Ping` call (also writes), and `DisposeAsync` (`channel.FinishAndReleaseAll`).

`EmbeddedChannel` is not thread-safe, and its `EmbeddedEventLoop` reports `InEventLoop == true` for every thread, so writes run **inline on the caller's thread** instead of being marshalled onto a single event-loop thread (which is what makes real socket channels safe in production). Concurrent writers + the pump therefore corrupt the channel's `ChannelOutboundBuffer` / its `ThreadLocalPool` object recycler, surfacing as either:

- `NullReferenceException` at `DotNetty.Common.ThreadLocalPool.Take()` during `WriteAndFlushAsync`, or
- `InvalidOperationException: close() must be invoked after all flushed writes are handled` at `EmbeddedChannel.FinishAndReleaseAll()` on disposal.

This is purely a **test-harness** concurrency issue; production code is unaffected (real channels marshal writes onto the event loop). Diverting outbound writes into a lock-guarded queue keeps the unsafe buffer untouched and makes the simulation deterministic.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

This fixes flakiness in existing tests, so no new tests are added. Verified locally:

- A temporary stress harness running the rehandshake scenario 64×200 reproduced the `NullReferenceException` at ~1% (**138 failures**) on the unpatched code; with this fix the same 64×200 and a heavier 128×150 config both report **0 race failures**.
- Full `Nethermind.Network.Discovery.Test` assembly: **262 passed, 0 failed** (1 pre-existing skip).
- The two previously-flaky tests looped 120× back-to-back: **0 failures**.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No