### PR TITLE
perf(prewarmer): don't eagerly load EIP-2930 access lists when warming

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -15,6 +15,7 @@ using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Container;
+using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
@@ -237,6 +238,38 @@ public class BlockCachePreWarmerTests
         // AddressA should still be warmed via speculative tx execution (not BAL path)
         // since it's a sender in the transactions
         Assert.That(preBlockCaches.StateCache.TryGetValue(TestItem.AddressA, out _), Is.True, "AddressA should be warmed via speculative execution even without BAL path");
+    }
+
+    /// <summary>
+    /// The prewarmer must not eagerly load a transaction's EIP-2930 access list: a value transfer that
+    /// over-declares an unaccessed slot must not warm it (the speculative execution warms only what it touches).
+    /// </summary>
+    [Test]
+    public async Task PreWarmCaches_DoesNotEagerlyLoadUnaccessedAccessListSlots()
+    {
+        PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
+        (BlockCachePreWarmer preWarmer, _, _) = CreatePreWarmer(maxPoolSize: 10);
+
+        StorageCell overDeclaredSlot = new(TestItem.AddressB, 10);
+        AccessList accessList = new AccessList.Builder()
+            .AddAddress(TestItem.AddressB)
+            .AddStorage(overDeclaredSlot.Index)
+            .Build();
+
+        // A plain value transfer (to an EOA) never SLOADs, so it does not access the declared slot.
+        Transaction[] txs =
+        [
+            Build.A.Transaction.WithType(TxType.AccessList).WithNonce(0).WithTo(TestItem.AddressC).WithValue(1.Wei)
+                .WithAccessList(accessList).SignedAndResolved(TestItem.PrivateKeyA).TestObject,
+            Build.A.Transaction.WithNonce(0).WithTo(TestItem.AddressC).WithValue(1.Wei)
+                .SignedAndResolved(TestItem.PrivateKeyB).TestObject,
+        ];
+        Block block = Build.A.Block.WithTransactions(txs).WithGasLimit(30_000_000).TestObject;
+
+        await RunPreWarmCaches(preWarmer, block, BuildParentHeader(), Osaka.Instance);
+
+        Assert.That(preBlockCaches.StorageCache.TryGetValue(in overDeclaredSlot, out _), Is.False,
+            "a declared but unaccessed access-list slot must not be eagerly warmed");
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -289,11 +289,8 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                 worldState.CreateAccountIfNotExists(senderAddress, UInt256.Zero);
             }
 
-            if (blockState.Spec.UseTxAccessLists)
-            {
-                worldState.WarmUp(tx.AccessList); // eip-2930
-            }
-
+            // No eager tx.AccessList warmup: the Warmup below already warms the state actually accessed;
+            // loading a (possibly hugely over-declared) EIP-2930 list only warms slots never read.
             TransactionResult result = scope.TransactionProcessor.Warmup(tx, NullTxTracer.Instance);
 
             if (blockState.PreWarmer._logger.IsTrace) blockState.PreWarmer._logger.Trace($"Finished pre-warming cache for tx[{txIndex}] {tx.Hash} with {result}");


### PR DESCRIPTION
## Changes

The block prewarmer warmed each transaction by first eagerly loading **every** slot/address declared in its EIP-2930 access list (`worldState.WarmUp(tx.AccessList)`) and then speculatively executing it. The speculative execution already warms exactly the state the transaction touches, so the eager access-list load only adds slots that are *declared but never accessed* — which the main thread never reads either.

A transaction can over-declare its access list massively. Mainnet block **22360451**'s index-0 transaction declares **12,534 storage keys** but accesses **~67**. On the trie-backed **HalfPath** store that eager load is ~12.5k node resolves (~700 ms) that warm nothing useful; the main thread processes the block in ~22 ms and then **stalls at the end-of-block prewarm join** waiting for the prewarmer to drain.

This PR removes the eager access-list load from the prewarmer and relies on the speculative warmup execution to warm accessed state.

- `BlockCachePreWarmer.WarmupSingleTransaction`: drop `worldState.WarmUp(tx.AccessList)`.
- Add a regression test asserting a declared-but-unaccessed access-list slot is not eagerly warmed.

### Measured impact (EXPB reproducible benchmarks, realblocks, delay 0)

| block | HalfPath before | HalfPath after | flat before | flat after |
|---|---|---|---|---|
| 22360451 | ~770–855 ms | **22.6 ms** | ~56 ms | **18.8 ms** |
| 22360453 | ~419 ms | **31.2 ms** | — | — |
| 22360454 | ~420 ms | **18.0 ms** | ~44 ms | **12.7 ms** |
| 22360456 | ~539 ms | **14.7 ms** | — | — |

Aggregate (HalfPath): AVG 48.18 → **46.58 ms**, P90 90.2 → **80.1**, P99 269 → **267**, MAX 856 → **439**. flat AVG 27.8 → **27.7** (unchanged). State-heavy blocks (22360050/22360308, tiny access lists) and all other blocks are unchanged — the only blocks affected are those with over-declared access lists. No regressions on either state layout.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing
- [x] Yes

#### If yes, did you write tests?
- [x] Yes

#### Notes on testing

Added `PreWarmCaches_DoesNotEagerlyLoadUnaccessedAccessListSlots` (fails if the eager load is reintroduced; verified). Validated end-to-end on the EXPB reproducible-benchmark runner on both HalfPath and flat state layouts (numbers above). This is a warming-cache optimization only — it cannot change block-processing results.

## Documentation

#### Requires documentation update
- [x] No

#### Requires explanation in Release Notes
- [x] No
