### PR TITLE
perf(kzg): pool the discarded cells buffer in ComputeCellProofs

### DIFF
--- a/src/Nethermind/Nethermind.Crypto/KzgPolynomialCommitments.cs
+++ b/src/Nethermind/Nethermind.Crypto/KzgPolynomialCommitments.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using CkzgLib;
+using Nethermind.Core.Collections;
 using Nethermind.Int256;
 using Nethermind.Logging;
 
@@ -70,8 +71,11 @@ public static partial class KzgPolynomialCommitments
         ReadOnlySpan<byte> proof
     );
 
-    public static void ComputeCellProofs(ReadOnlySpan<byte> blob, Span<byte> cellProofs) =>
-        Ckzg.ComputeCellsAndKzgProofs(new byte[Ckzg.CellsPerExtBlob * Ckzg.BytesPerCell], cellProofs, blob, _ckzgSetup);
+    public static void ComputeCellProofs(ReadOnlySpan<byte> blob, Span<byte> cellProofs)
+    {
+        using ArrayPoolSpan<byte> cells = new(Ckzg.CellsPerExtBlob * Ckzg.BytesPerCell);
+        Ckzg.ComputeCellsAndKzgProofs(cells, cellProofs, blob, _ckzgSetup);
+    }
 
     /// <param name="blob">The input blob data.</param>
     /// <param name="cells">The output span of size <c>CELLS_PER_EXT_BLOB * BYTES_PER_CELL</c> (262144 bytes) where cells will be written.</param>


### PR DESCRIPTION
## Changes

`KzgPolynomialCommitments.ComputeCellProofs` only needs the cell proofs, but it passed a freshly allocated `byte[Ckzg.CellsPerExtBlob * Ckzg.BytesPerCell]` (128 × 2048 = **256 KiB**) as the `cells` output buffer and then discarded it. That is a Large Object Heap allocation on every call — once per blob of every V0→V1 proof conversion (`TxPool.TryConvertProofVersion`) — adding avoidable Gen2 GC pressure.

Rent the scratch buffer from the array pool (`ArrayPoolSpan<byte>`) instead. This mirrors `BlobProofsManagerV1.ComputeProofsAndCommitments`, which already pools the identical buffer for the same `Ckzg.ComputeCellsAndKzgProofs` call. `cells` is a write-only scratch output, so the computed `cellProofs` are unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] No — behavior-preserving; covered by existing tests

#### Notes on testing

`cells` is a write-only scratch buffer for `ComputeCellsAndKzgProofs`; pooling it rather than heap-allocating it does not change the computed proofs. The existing `TxPoolTests.Blobs.should_convert_blob_proofs_to_cell_proofs_if_enabled` test drives `ComputeCellProofs` through the V0→V1 conversion and asserts the resulting cell proofs (count and `ProofVersion.V1`); it passes with this change.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
