### PR TITLE
perf(requests): reuse a stack buffer for deposit request decoding

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestsProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestsProcessor.cs
@@ -96,6 +96,7 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
         using ArrayPoolListRef<byte> depositRequests = new(receipts.Length * 2 + 1);
         depositRequests.Add((byte)ExecutionRequestType.Deposit);
 
+        Span<byte> depositRequestBuffer = stackalloc byte[ExecutionRequestExtensions.DepositRequestsBytesSize];
         for (int i = 0; i < receipts.Length; i++)
         {
             LogEntry[]? logEntries = receipts[i].Logs;
@@ -106,9 +107,8 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
                     LogEntry log = logEntries[j];
                     if (log.Address == spec.DepositContractAddress && log.Topics.Length >= 1 && log.Topics[0] == DepositEventAbi.Hash)
                     {
-                        Span<byte> depositRequestBuffer = new byte[ExecutionRequestExtensions.DepositRequestsBytesSize];
                         DecodeDepositRequest(block, log, depositRequestBuffer);
-                        depositRequests.AddRange(depositRequestBuffer.ToArray());
+                        depositRequests.AddRange(depositRequestBuffer);
                     }
                 }
             }


### PR DESCRIPTION
## Changes

`ExecutionRequestsProcessor.ProcessDeposits` allocated a `new byte[ExecutionRequestExtensions.DepositRequestsBytesSize]` (192 bytes) for **every** EIP-6110 deposit event and then called `.ToArray()` on it before `AddRange` — two 192-byte heap allocations per deposit, on every block once deposits are enabled.

`DecodeDepositRequest` always overwrites the whole buffer (`ValidateLayout` enforces the exact 48 + 32 + 8 + 96 + 8 = 192-byte layout or throws), so the buffer is safe to reuse:

- Hoist a single `stackalloc byte[DepositRequestsBytesSize]` scratch buffer above the loop.
- Pass the span straight to `AddRange`, which already has a `params ReadOnlySpan<T>` overload, removing the `.ToArray()` copy.

No heap allocation per deposit; the encoded deposit requests are unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] No — behavior-preserving; covered by existing tests

#### Notes on testing

The existing `ExecutionProcessorTests` exercise deposit-request decoding and the flat-encoded requests hash; they pass with this change. `DecodeDepositRequest` fully rewrites the reused buffer on every call, so reuse cannot leak a previous deposit's bytes.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
