### PR TITLE
fix(snap): reject malformed range proofs instead of throwing

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromAccountRangesTests.cs
@@ -167,6 +167,25 @@ public class RecreateStateFromAccountRangesTests
         Assert.That(helper.TrieNodeKeyExists(rootHash), Is.False); // the root node is NOT a part of the proof nodes
     }
 
+    [TestCase("ffffffff", TestName = "undecodable RLP")]
+    [TestCase("c28080", TestName = "valid RLP list, invalid trie node")]
+    public void AddAccountRange_with_malformed_proof_is_rejected_and_does_not_throw(string corruptProofNodeHex)
+    {
+        Hash256 rootHash = _inputTree.RootHash;
+
+        byte[][] firstProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[0].Path.Bytes);
+        byte[][] lastProof = CreateProofForPath(TestItem.Tree.AccountsWithPaths[5].Path.Bytes);
+        firstProof[0] = Bytes.FromHexString(corruptProofNodeHex);
+
+        using IContainer container = CreateContainer();
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+
+        AddRangeResult result = snapProvider.AddAccountRange(1, rootHash, TestItem.Tree.AccountsWithPaths[0].Path, TestItem.Tree.AccountsWithPaths,
+            new ByteArrayListAdapter(new ArrayPoolList<byte[]>(firstProof.Length + lastProof.Length, firstProof.Concat(lastProof))));
+
+        Assert.That(result, Is.EqualTo(AddRangeResult.InvalidProof));
+    }
+
     [Test]
     public void RecreateAccountStateFromMultipleRange()
     {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/AddRangeResult.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/AddRangeResult.cs
@@ -11,6 +11,7 @@ namespace Nethermind.Synchronization.SnapSync
         ExpiredRootHash,
         InvalidOrder,
         OutOfBounds,
-        EmptyRange
+        EmptyRange,
+        InvalidProof
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -121,6 +121,7 @@ namespace Nethermind.Synchronization.SnapSync
                     AddRangeResult.InvalidOrder => $"SNAP - AddAccountRange failed, accounts are not in sorted order, startingHash:{startingHash}",
                     AddRangeResult.OutOfBounds => $"SNAP - AddAccountRange failed, accounts are out of bounds, startingHash:{startingHash}",
                     AddRangeResult.EmptyRange => $"SNAP - AddAccountRange failed, empty accounts, startingHash:{startingHash}",
+                    AddRangeResult.InvalidProof => $"SNAP - AddAccountRange failed, invalid proof, startingHash:{startingHash}",
                     _ => null
                 };
                 if (message is not null)
@@ -225,6 +226,7 @@ namespace Nethermind.Synchronization.SnapSync
                         AddRangeResult.InvalidOrder => $"SNAP - AddStorageRange failed, slots are not in sorted order, startingHash:{request.StartingHash}",
                         AddRangeResult.OutOfBounds => $"SNAP - AddStorageRange failed, slots are out of bounds, startingHash:{request.StartingHash}",
                         AddRangeResult.EmptyRange => $"SNAP - AddStorageRange failed, slots list is empty, startingHash:{request.StartingHash}",
+                        AddRangeResult.InvalidProof => $"SNAP - AddStorageRange failed, invalid proof, startingHash:{request.StartingHash}",
                         _ => null
                     };
                     if (message is not null)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProviderHelper.cs
@@ -152,8 +152,18 @@ namespace Nethermind.Synchronization.SnapSync
 
             ValueHash256 lastPath = entries[entries.Count - 1].Path;
 
-            (AddRangeResult result, List<(TrieNode, TreePath)> sortedBoundaryList, bool moreChildrenToRight) =
-                FillBoundaryTree(tree, startingHash, lastPath, limitHash, expectedRootHash, proofs);
+            AddRangeResult result;
+            List<(TrieNode, TreePath)> sortedBoundaryList;
+            bool moreChildrenToRight;
+            try
+            {
+                (result, sortedBoundaryList, moreChildrenToRight) =
+                    FillBoundaryTree(tree, startingHash, lastPath, limitHash, expectedRootHash, proofs);
+            }
+            catch (Exception)
+            {
+                return (AddRangeResult.InvalidProof, null, false);
+            }
 
             if (result != AddRangeResult.OK)
                 return (result, null, false);


### PR DESCRIPTION
## Changes

Snap sync validates each account/storage range response against boundary proofs supplied by the peer. Those proofs are raw, untrusted RLP that Nethermind decodes lazily during verification (`SnapProviderHelper.BuildAndVerifyRoot` → `FillBoundaryTree` → `CreateProofDict` → `TrieNode.ResolveNode`).

A proof that fails to decode threw out of `AddAccountRange`/`AddStorageRange` and their `SnapSyncFeed.HandleResponse` caller — which wraps the call in `try { … } finally { batch.Dispose(); }` with **no `catch`** — so the throw skipped `ProgressTracker.ReportAccountRangePartitionFinished` / `ReportFullStorageRequestFinished`. Those are the only place the active-request counter (`_activeAccountRequests` / `_activeStorageRequests`) is decremented and the range partition re-enqueued, and `IsSnapGetRangesFinished()` requires the counter to reach `0`. So **a single undecodable proof from one peer permanently leaked a request slot and stranded the range — snap sync could not complete** (an untrusted-input DoS on syncing nodes; no funds/consensus impact, and already-synced nodes are unaffected).

**Fix:** guard the boundary-proof assembly in `BuildAndVerifyRoot` and return the new `AddRangeResult.InvalidProof` on any failure. The catch is intentionally **broad**: decoding untrusted proof RLP can fail with more than `RlpException`/`TrieNodeException` — e.g. a *valid* RLP list that is not a valid trie node (`0xc2 0x80 0x80`) makes `HexPrefix.FromBytes` throw `IndexOutOfRangeException` — so any decode/assembly failure of the untrusted proof must be treated as an invalid response, never a crash. `FillBoundaryTree` builds an in-memory scratch tree *before* `tree.Commit`, so catching there cannot leave a half-applied write. The bad response then flows down the normal non-OK path: the counter is released, the partition is re-enqueued for retry, and the peer is penalized. The fix is in the shared helper, so both the account-range and storage-range paths are covered.

### Aligns with go-ethereum

In geth any proof-verification error is an ordinary error, never a crash — `trie.VerifyRangeProof` returns an error and the handler reschedules the request to another peer:

```go
// go-ethereum eth/protocols/snap/sync.go (OnAccounts / OnStorage)
if err != nil {
    logger.Warn("Account range failed proof", "err", err)
    s.scheduleRevertAccountRequest(req) // reschedule to another peer
    return err                          // graceful error, no panic
}
```

The devp2p `snap` spec leaves proof-validation error handling implementation-defined, so this is a robustness fix, not a protocol change.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`AddAccountRange_with_malformed_proof_is_rejected_and_does_not_throw` is parameterized over two malformed proofs: `ffffffff` (undecodable RLP → `RlpException`) and `c28080` (valid RLP list that is not a valid trie node → `IndexOutOfRangeException` from `HexPrefix.FromBytes`). Both throw out of `AddAccountRange` on the pre-fix code and return `InvalidProof` with the fix. The full `Nethermind.Synchronization.Test` SnapSync suite passes.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
