### PR TITLE
fix(xdc): reject malleable high-S signatures in votes, QC and TC 

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Crypto/SignatureTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Crypto/SignatureTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Crypto;
+using Nethermind.Int256;
 using NUnit.Framework;
 
 namespace Nethermind.Core.Test.Crypto;
@@ -68,5 +69,50 @@ public class SignatureTests
         Span<byte> publicKey = stackalloc byte[65];
         bool result = SecP256k1.RecoverKeyFromCompact(publicKey, keccak.Bytes, signatureObject.Bytes, signatureObject.RecoveryId, false);
         Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void HasLowS_AcceptsCanonicalSignature()
+    {
+        PrivateKey key = new PrivateKeyGenerator().Generate();
+        Signature signature = new EthereumEcdsa(0).Sign(key, Hash256.Zero);
+        Assert.That(signature.HasLowS(), Is.True);
+    }
+
+    [Test]
+    public void HasLowS_RejectsMalleableCounterpart()
+    {
+        PrivateKey key = new PrivateKeyGenerator().Generate();
+        Signature signature = new EthereumEcdsa(0).Sign(key, Hash256.Zero);
+        Signature flipped = FlipSignature(signature);
+        Assert.That(signature, Is.Not.EqualTo(flipped));
+        Assert.That(signature.HasLowS(), Is.True);
+        Assert.That(flipped.HasLowS(), Is.False);
+    }
+
+    [Test]
+    public void HasLowS_BoundaryAtHalfN()
+    {
+        Signature atHalf = new(in UInt256.Zero, SecP256k1Curve.HalfN, Signature.VOffset);
+        Assert.That(atHalf.HasLowS(), Is.True);
+
+        Signature overHalf = new(in UInt256.Zero, SecP256k1Curve.HalfNPlusOne, Signature.VOffset);
+        Assert.That(overHalf.HasLowS(), Is.False);
+
+        Signature minS = new(in UInt256.Zero, UInt256.One, Signature.VOffset);
+        Assert.That(minS.HasLowS(), Is.True);
+    }
+
+    private static Signature FlipSignature(Signature original)
+    {
+        ReadOnlySpan<byte> bytes = original.Bytes;
+        UInt256 s = new(bytes[32..], true);
+        UInt256 sNew = SecP256k1Curve.N - s;
+
+        byte[] result = new byte[65];
+        bytes[..32].CopyTo(result);
+        sNew.ToBigEndian(result.AsSpan(32, 32));
+        result[64] = original.V == Signature.VOffset ? (byte)28 : (byte)27;
+        return new Signature(result);
     }
 }

--- a/src/Nethermind/Nethermind.Crypto/SignatureExtensions.cs
+++ b/src/Nethermind/Nethermind.Crypto/SignatureExtensions.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+using Nethermind.Int256;
+
+namespace Nethermind.Crypto;
+
+public static class SignatureExtensions
+{
+    /// <summary>
+    /// Whether the signature's <c>s</c> value is canonical low-S (<c>s &lt;= n/2</c>),
+    /// rejecting (r, s) → (r, n−s) malleability.
+    /// </summary>
+    public static bool HasLowS(this Signature signature)
+    {
+        UInt256 s = new(signature.SAsSpan, true);
+        return s <= SecP256k1Curve.HalfN;
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/VotesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/VotesManagerTests.cs
@@ -180,6 +180,13 @@ public class VotesManagerTests
         yield return new TestCaseData(14UL, masternodes, XdcTestHelper.BuildSignedVote(blockInfo, 450, keys.First()), true)
             .SetName("ValidMessage");
 
+        // High-S malleable signature
+        Vote validVote = XdcTestHelper.BuildSignedVote(blockInfo, 450, keys.First());
+        Signature malleableSig = XdcTestHelper.CreateMalleableSignature(validVote.Signature!);
+        Vote malleableVote = new(blockInfo, 450) { Signature = malleableSig, Signer = validVote.Signer };
+        yield return new TestCaseData(14UL, masternodes, malleableVote, false)
+            .SetName("MalleableHighS");
+
         // If snapshot missing should return false
         yield return new TestCaseData(14UL, masternodes, XdcTestHelper.BuildSignedVote(blockInfo, 1350, keys.First()), false)
             .SetName("SnapshotMissing");

--- a/src/Nethermind/Nethermind.Xdc.Test/QuorumCertificateManagerTest.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/QuorumCertificateManagerTest.cs
@@ -94,6 +94,12 @@ public class QuorumCertificateManagerTest
         Signature malleable = XdcTestHelper.CreateMalleableSignature(sigs[0]);
         yield return new TestCaseData(new QuorumCertificate(roundInfo, [.. sigs, malleable], 0), headerBuilder, masterNodes, false)
             .SetName("MalleableDuplicateSigner");
+
+        Signature[] highOnlySigs = XdcTestHelper.CreateVoteSignatures(roundInfo, 0, [.. keys.Take(quorumCount)])
+            .Select(XdcTestHelper.CreateMalleableSignature)
+            .ToArray();
+        yield return new TestCaseData(new QuorumCertificate(roundInfo, highOnlySigs, 0), headerBuilder, masterNodes, false)
+            .SetName("MalleableHighSOnly");
     }
 
     [TestCaseSource(nameof(QcCases))]

--- a/src/Nethermind/Nethermind.Xdc.Test/TimeoutCertificateManagerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/TimeoutCertificateManagerTests.cs
@@ -135,6 +135,10 @@ public class TimeoutCertificateManagerTests
         Signature malleable = XdcTestHelper.CreateMalleableSignature(sigs[0]);
         yield return new TestCaseData(new TimeoutCertificate(1, [.. sigs, malleable], 0), masterNodes, false)
             .SetName("MalleableDuplicateSigner");
+
+        Signature[] highOnlySigs = sigs.Select(XdcTestHelper.CreateMalleableSignature).ToArray();
+        yield return new TestCaseData(new TimeoutCertificate(1, highOnlySigs, 0), masterNodes, false)
+            .SetName("MalleableHighSOnly");
     }
 
     [TestCaseSource(nameof(TcCases))]

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcSealValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcSealValidatorTests.cs
@@ -6,6 +6,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
+using Nethermind.Xdc.Test.Helpers;
 using Nethermind.Xdc.Spec;
 using Nethermind.Xdc.Types;
 using NSubstitute;
@@ -89,6 +90,13 @@ internal class XdcSealValidatorTests
         byte[] keyBSig = new EthereumEcdsa(0).Sign(TestItem.PrivateKeyB, header).BytesWithRecovery;
         yield return new TestCaseData(header, keyBSig)
             .SetName("WrongSignerSignature");
+
+        header = Build.A.XdcBlockHeader().TestObject;
+        header.Beneficiary = TestItem.AddressA;
+        Signature canonicalSig = new EthereumEcdsa(0).Sign(TestItem.PrivateKeyA, header);
+        byte[] malleableSig = XdcTestHelper.CreateMalleableSignature(canonicalSig).BytesWithRecovery;
+        yield return new TestCaseData(header, malleableSig)
+            .SetName("MalleableHighS");
     }
 
     [TestCaseSource(nameof(InvalidSignatureCases))]

--- a/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
@@ -253,7 +253,9 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
         Snapshot snapshot = _snapshotManager.GetSnapshotByGapNumber(timeout.GapNumber);
         if (snapshot is null || snapshot.NextEpochCandidates.Length == 0) return false;
 
-        // Verify msg signature
+        if (timeout.Signature is null || !timeout.Signature.HasLowS())
+            return false;
+
         ValueHash256 timeoutMsgHash = ComputeTimeoutMsgHash(timeout.Round, timeout.GapNumber);
         Address signer = _ethereumEcdsa.RecoverAddress(timeout.Signature, in timeoutMsgHash);
         timeout.Signer = signer;

--- a/src/Nethermind/Nethermind.Xdc/VotesManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/VotesManager.cs
@@ -237,7 +237,9 @@ internal class VotesManager(
 
         Snapshot snapshot = _snapshotManager.GetSnapshotByGapNumber(vote.GapNumber);
         if (snapshot is null) return false;
-        // Verify message signature
+        if (vote.Signature is null || !vote.Signature.HasLowS())
+            return false;
+
         vote.Signer ??= _ethereumEcdsa.RecoverVoteSigner(vote);
         return snapshot.NextEpochCandidates.Any(x => x == vote.Signer);
     }
@@ -283,6 +285,9 @@ internal class VotesManager(
         List<Signature> signatures = [];
         foreach (Vote vote in votes)
         {
+            if (vote.Signature is null || !vote.Signature.HasLowS())
+                continue;
+
             vote.Signer ??= _ethereumEcdsa.RecoverVoteSigner(vote);
 
             if (masternodeSet.Contains(vote.Signer))
@@ -316,6 +321,13 @@ internal class VotesManager(
         string? localError = null; // concurrent "overwrite" is ok, no need to synchronize
         Parallel.ForEach(signatures, (s, state) =>
         {
+            if (!s.HasLowS())
+            {
+                localError = "Certificate contains a malleable signature";
+                state.Stop();
+                return;
+            }
+
             Address signer = _ethereumEcdsa.RecoverAddress(s, messageHash);
             ref int signCount = ref CollectionsMarshal.GetValueRefOrNullRef(signedBy, signer);
 

--- a/src/Nethermind/Nethermind.Xdc/XdcSealValidator.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcSealValidator.cs
@@ -141,10 +141,14 @@ internal class XdcSealValidator(
                  || xdcHeader.Validator[64] >= 4)
                 return false;
 
+            Signature signature = new(xdcHeader.Validator.AsSpan(0, 64), xdcHeader.Validator[64]);
+            if (!signature.HasLowS())
+                return false;
+
             KeccakRlpWriter writer = new();
             _headerDecoder.Encode(ref writer, xdcHeader, RlpBehaviors.ForSealing);
             ValueHash256 hash = writer.GetValueHash();
-            Address signer = _ethereumEcdsa.RecoverAddress(new Signature(xdcHeader.Validator.AsSpan(0, 64), xdcHeader.Validator[64]), in hash);
+            Address signer = _ethereumEcdsa.RecoverAddress(signature, in hash);
 
             header.Author = signer;
         }


### PR DESCRIPTION
Adds a `HasLowS()` extension on `Signature` that checks `s <= n/2` per the secp256k1 canonical-signature rule, then enforces it at every signature-verification site in the XDC consensus layer so that high-S (r, n−s) counterparts are rejected outright rather than treated as valid votes from the same signer.