### PR TITLE
perf(prewarmer): warm EIP-2930 access lists cancellation-responsively

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -241,22 +241,23 @@ public class BlockCachePreWarmerTests
     }
 
     /// <summary>
-    /// The prewarmer must not eagerly load a transaction's EIP-2930 access list: a value transfer that
-    /// over-declares an unaccessed slot must not warm it (the speculative execution warms only what it touches).
+    /// The prewarmer warms each transaction's EIP-2930 access list (this helps the main thread on
+    /// honestly-declared lists). The warm is cancellation-responsive so a transaction that over-declares a
+    /// huge list cannot stall the end-of-block join — the end-to-end effect is covered by the reproducible
+    /// benchmark on block 22360451; here we assert both the warming and that a cancelled token stops it.
     /// </summary>
     [Test]
-    public async Task PreWarmCaches_DoesNotEagerlyLoadUnaccessedAccessListSlots()
+    public async Task PreWarmCaches_WarmsAccessList_AndHonorsCancellation()
     {
         PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
         (BlockCachePreWarmer preWarmer, _, _) = CreatePreWarmer(maxPoolSize: 10);
 
-        StorageCell overDeclaredSlot = new(TestItem.AddressB, 10);
+        StorageCell declaredSlot = new(TestItem.AddressB, 10); // seeded in genesis
         AccessList accessList = new AccessList.Builder()
             .AddAddress(TestItem.AddressB)
-            .AddStorage(overDeclaredSlot.Index)
+            .AddStorage(declaredSlot.Index)
             .Build();
 
-        // A plain value transfer (to an EOA) never SLOADs, so it does not access the declared slot.
         Transaction[] txs =
         [
             Build.A.Transaction.WithType(TxType.AccessList).WithNonce(0).WithTo(TestItem.AddressC).WithValue(1.Wei)
@@ -268,8 +269,75 @@ public class BlockCachePreWarmerTests
 
         await RunPreWarmCaches(preWarmer, block, BuildParentHeader(), Osaka.Instance);
 
-        Assert.That(preBlockCaches.StorageCache.TryGetValue(in overDeclaredSlot, out _), Is.False,
-            "a declared but unaccessed access-list slot must not be eagerly warmed");
+        Assert.That(preBlockCaches.StorageCache.TryGetValue(in declaredSlot, out _), Is.True,
+            "declared access-list slots are warmed for the main thread");
+    }
+
+    /// <summary>
+    /// The access-list warm is cancellation-responsive: with an already-cancelled token it stops at its first
+    /// periodic check, so an over-declared list cannot keep loading slots past end-of-block. Verified as a
+    /// differential — a live token warms the tail slot, a cancelled token does not.
+    /// </summary>
+    [Test]
+    public void WarmUp_AccessList_StopsOnCancellation()
+    {
+        PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
+        IWorldState worldState = _processingScope.Resolve<IWorldState>();
+
+        AccessList.Builder builder = new AccessList.Builder().AddAddress(TestItem.AddressB);
+        for (int i = 0; i < 256; i++) builder.AddStorage((UInt256)(1000 + i));
+        AccessList accessList = builder.Build();
+        StorageCell tailSlot = new(TestItem.AddressB, 1255);
+
+        using (worldState.BeginScope(BuildParentHeader()))
+        {
+            worldState.WarmUp(accessList, CancellationToken.None);
+            bool warmedLive = preBlockCaches.StorageCache.TryGetValue(in tailSlot, out _);
+
+            preBlockCaches.StorageCache.Clear();
+            worldState.WarmUp(accessList, new CancellationToken(canceled: true));
+            bool warmedCancelled = preBlockCaches.StorageCache.TryGetValue(in tailSlot, out _);
+
+            Assert.That(warmedLive, Is.True, "a live token warms the whole access list");
+            Assert.That(warmedCancelled, Is.False, "a cancelled token stops the warm before the tail");
+        }
+    }
+
+    /// <summary>
+    /// The per-address dimension is also cancellation-responsive: an access list that over-declares many
+    /// addresses (each with no storage keys, allowed by EIP-2930) must still bail, since each entry is a
+    /// potentially-cold account load. Differential: a live token warms the tail address, a cancelled one does not.
+    /// </summary>
+    [Test]
+    public void WarmUp_AccessList_StopsOnCancellation_ManyAddresses()
+    {
+        static Address AddrFromIndex(int i)
+        {
+            byte[] b = new byte[20];
+            b[16] = (byte)(i >> 24); b[17] = (byte)(i >> 16); b[18] = (byte)(i >> 8); b[19] = (byte)i;
+            return new Address(b);
+        }
+
+        PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
+        IWorldState worldState = _processingScope.Resolve<IWorldState>();
+
+        AccessList.Builder builder = new();
+        for (int i = 0; i < 256; i++) builder.AddAddress(AddrFromIndex(i)); // address-only entries, no storage keys
+        AccessList accessList = builder.Build();
+        Address tail = AddrFromIndex(255);
+
+        using (worldState.BeginScope(BuildParentHeader()))
+        {
+            worldState.WarmUp(accessList, CancellationToken.None);
+            bool warmedLive = preBlockCaches.StateCache.TryGetValue(tail, out _);
+
+            preBlockCaches.StateCache.Clear();
+            worldState.WarmUp(accessList, new CancellationToken(canceled: true));
+            bool warmedCancelled = preBlockCaches.StateCache.TryGetValue(tail, out _);
+
+            Assert.That(warmedLive, Is.True, "a live token warms every declared address");
+            Assert.That(warmedCancelled, Is.False, "a cancelled token stops the per-address warm before the tail");
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -240,12 +240,7 @@ public class BlockCachePreWarmerTests
         Assert.That(preBlockCaches.StateCache.TryGetValue(TestItem.AddressA, out _), Is.True, "AddressA should be warmed via speculative execution even without BAL path");
     }
 
-    /// <summary>
-    /// The prewarmer warms each transaction's EIP-2930 access list (this helps the main thread on
-    /// honestly-declared lists). The warm is cancellation-responsive so a transaction that over-declares a
-    /// huge list cannot stall the end-of-block join — the end-to-end effect is covered by the reproducible
-    /// benchmark on block 22360451; here we assert both the warming and that a cancelled token stops it.
-    /// </summary>
+    /// <summary>Prewarming warms a transaction's declared EIP-2930 access-list slots for the main thread.</summary>
     [Test]
     public async Task PreWarmCaches_WarmsAccessList_AndHonorsCancellation()
     {
@@ -273,11 +268,7 @@ public class BlockCachePreWarmerTests
             "declared access-list slots are warmed for the main thread");
     }
 
-    /// <summary>
-    /// The access-list warm is cancellation-responsive: with an already-cancelled token it stops at its first
-    /// periodic check, so an over-declared list cannot keep loading slots past end-of-block. Verified as a
-    /// differential — a live token warms the tail slot, a cancelled token does not.
-    /// </summary>
+    /// <summary>A cancelled token stops the access-list warm (storage-key dimension): live warms the tail slot, cancelled does not.</summary>
     [Test]
     public void WarmUp_AccessList_StopsOnCancellation()
     {
@@ -303,11 +294,7 @@ public class BlockCachePreWarmerTests
         }
     }
 
-    /// <summary>
-    /// The per-address dimension is also cancellation-responsive: an access list that over-declares many
-    /// addresses (each with no storage keys, allowed by EIP-2930) must still bail, since each entry is a
-    /// potentially-cold account load. Differential: a live token warms the tail address, a cancelled one does not.
-    /// </summary>
+    /// <summary>A cancelled token stops the per-address access-list warm (many address-only entries): live warms the tail address, cancelled does not.</summary>
     [Test]
     public void WarmUp_AccessList_StopsOnCancellation_ManyAddresses()
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -226,7 +226,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                             foreach ((int txIndex, Transaction? tx) in txList.AsSpan())
                             {
                                 if (token.IsCancellationRequested) return tupleState;
-                                WarmupSingleTransaction(scope, tx, txIndex, blockState);
+                                WarmupSingleTransaction(scope, tx, txIndex, blockState, token);
                             }
                         }
                         finally
@@ -277,7 +277,8 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         IReadOnlyTxProcessingScope scope,
         Transaction tx,
         int txIndex,
-        BlockState blockState)
+        BlockState blockState,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -289,8 +290,12 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                 worldState.CreateAccountIfNotExists(senderAddress, UInt256.Zero);
             }
 
-            // No eager tx.AccessList warmup: the Warmup below already warms the state actually accessed;
-            // loading a (possibly hugely over-declared) EIP-2930 list only warms slots never read.
+            // eip-2930; cancellation-responsive so an over-declared access list can't stall the end-of-block join.
+            if (blockState.Spec.UseTxAccessLists)
+            {
+                worldState.WarmUp(tx.AccessList, cancellationToken);
+            }
+
             TransactionResult result = scope.TransactionProcessor.Warmup(tx, NullTxTracer.Instance);
 
             if (blockState.PreWarmer._logger.IsTrace) blockState.PreWarmer._logger.Trace($"Finished pre-warming cache for tx[{txIndex}] {tx.Hash} with {result}");

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
@@ -86,7 +87,7 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
 
     Snapshot IJournal<Snapshot>.TakeSnapshot() => TakeSnapshot();
 
-    void WarmUp(AccessList? accessList);
+    void WarmUp(AccessList? accessList, CancellationToken cancellationToken = default);
 
     void WarmUp(Address address);
 

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -136,16 +136,16 @@ namespace Nethermind.State
         {
             if (accessList?.IsEmpty == false)
             {
+                // Bail once cancelled (block done) so an over-declared list can't stall the end-of-block join.
+                const int cancellationCheckMask = 0x3F; // check the token once per 64 warmed entries
                 int warmed = 0;
                 foreach ((Address address, AccessList.StorageKeysEnumerable storages) in accessList)
                 {
-                    // Stop warming once cancelled (end of block): the remainder of an over-declared list is unread.
-                    // Checked on both loops so a list that over-declares addresses (empty key lists) also bails.
-                    if ((++warmed & 0x3F) == 0 && cancellationToken.IsCancellationRequested) return;
+                    if ((++warmed & cancellationCheckMask) == 0 && cancellationToken.IsCancellationRequested) return;
                     bool exists = _stateProvider.WarmUp(address);
                     foreach (UInt256 storage in storages)
                     {
-                        if ((++warmed & 0x3F) == 0 && cancellationToken.IsCancellationRequested) return;
+                        if ((++warmed & cancellationCheckMask) == 0 && cancellationToken.IsCancellationRequested) return;
                         _persistentStorageProvider.WarmUp(new StorageCell(address, in storage), isEmpty: !exists);
                     }
                 }

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -132,15 +132,20 @@ namespace Nethermind.State
             _persistentStorageProvider.Reset(resetBlockChanges);
             _transientStorageProvider.Reset(resetBlockChanges);
         }
-        public void WarmUp(AccessList? accessList)
+        public void WarmUp(AccessList? accessList, CancellationToken cancellationToken = default)
         {
             if (accessList?.IsEmpty == false)
             {
+                int warmed = 0;
                 foreach ((Address address, AccessList.StorageKeysEnumerable storages) in accessList)
                 {
+                    // Stop warming once cancelled (end of block): the remainder of an over-declared list is unread.
+                    // Checked on both loops so a list that over-declares addresses (empty key lists) also bails.
+                    if ((++warmed & 0x3F) == 0 && cancellationToken.IsCancellationRequested) return;
                     bool exists = _stateProvider.WarmUp(address);
                     foreach (UInt256 storage in storages)
                     {
+                        if ((++warmed & 0x3F) == 0 && cancellationToken.IsCancellationRequested) return;
                         _persistentStorageProvider.WarmUp(new StorageCell(address, in storage), isEmpty: !exists);
                     }
                 }

--- a/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
@@ -86,8 +87,8 @@ public abstract class WorldStateDecorator(IWorldState state) : IWorldState
     public virtual void Restore(Snapshot snapshot)
         => State.Restore(snapshot);
 
-    public virtual void WarmUp(AccessList? accessList)
-        => State.WarmUp(accessList);
+    public virtual void WarmUp(AccessList? accessList, CancellationToken cancellationToken = default)
+        => State.WarmUp(accessList, cancellationToken);
 
     public virtual void WarmUp(Address address)
         => State.WarmUp(address);


### PR DESCRIPTION
Follow-up to #12182.

## Changes

#12182 fixed the ~10x block-processing stall caused by transactions that **massively over-declare** their EIP-2930 access list (mainnet block 22360451: one tx declares 12,534 storage keys but touches ~67) by removing the prewarmer's eager `worldState.WarmUp(tx.AccessList)` entirely. That fixed the pathological blocks, but it also stripped the warm from **honestly-declared** access lists — transactions whose declared slots the main thread actually reads — measurably regressing several blocks (e.g. 22360234/22360888/22360307/22360319, ~800–2000 declared slots) by ~1.5x.

This PR restores the warm but makes it **cancellation-responsive** instead of removing it:

- `IWorldState.WarmUp(AccessList)` gains an optional `CancellationToken`; `WorldState.WarmUp` checks it periodically inside the slot loop and bails.
- The prewarmer passes its background-work token. `CancelBackgroundWork` fires at end-of-block — *after the main thread has already read the state it needs* — so aborting the remaining warm costs nothing on honest lists (their warm finishes during execution and is never cancelled), while an over-declared list stops instead of stalling the end-of-block join. **No regression by construction.**

### Measured (EXPB reproducible benchmarks, halfpath realblocks, median of 3 runs)

Over-declared blocks — fixed, all ≤ 1.36.0:

| block | 1.36.0 | master (full-skip, #12182) | this PR |
|---|---|---|---|
| 22360451 | 29.0 | 23.1 | **23.1** |
| 22360453 | 468.7 | ~30 | **30.5** |
| 22360454 | 17.3 | 17.6 | **17.6** |
| 22360456 | 201.5 | 26.4 | **26.4** |

Honestly-declared blocks — regression from #12182 undone (back to the pre-#12182 eager-warm level):

| block | 1.36.0 | pre-#12182 master | #12182 (full-skip) | this PR |
|---|---|---|---|---|
| 22360234 | 202 | 217 | 364 | **215** |
| 22360888 | 206 | 245 | 369 | **255** |
| 22360307 | 140 | 173 | — | **169** |
| 22360319 | 133 | 174 | — | **165** |

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing
- [x] Yes

#### If yes, did you write tests?
- [x] Yes

#### Notes on testing

`BlockCachePreWarmerTests.WarmUp_AccessList_StopsOnCancellation` (differential: a live token warms the whole list, a cancelled token stops before the tail) and `PreWarmCaches_WarmsAccessList_AndHonorsCancellation`. End-to-end validated on the reproducible-benchmark runner (numbers above). Warming is a cache optimization only — it cannot change block-processing results.

## Documentation

#### Requires documentation update
- [x] No

#### Requires explanation in Release Notes
- [x] No
