### PR TITLE
fix(rpc): lenient QUANTITY parsing for Taiko and Surge L2 nodes

### DIFF
--- a/.github/workflows/ci-surge.yml
+++ b/.github/workflows/ci-surge.yml
@@ -138,6 +138,8 @@ jobs:
 
             yq eval '.services.l2_nmc.pull_policy = "never"' -i "$docker_compose_file"
 
+            yq eval '.services.l2_nmc.command += ["--JsonRpc.StrictHexFormat", "false"]' -i "$docker_compose_file"
+
             echo "Updated image in docker-compose.yml:"
             yq eval '.services.l2_nmc.image' "$docker_compose_file"
 

--- a/.github/workflows/ci-taiko.yml
+++ b/.github/workflows/ci-taiko.yml
@@ -138,6 +138,8 @@ jobs:
 
             yq eval '.services.l2_nmc.pull_policy = "never"' -i "$docker_compose_file"
 
+            yq eval '.services.l2_nmc.command += ["--JsonRpc.StrictHexFormat", "false"]' -i "$docker_compose_file"
+
             echo "Updated image in docker-compose.yml:"
             yq eval '.services.l2_nmc.image' "$docker_compose_file"
 

--- a/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ConfigFilesTests.cs
@@ -152,6 +152,13 @@ public class ConfigFilesTests : ConfigFileTestsBase
         Test<IJsonRpcConfig, string>(configWildcard, static c => c.Host, "127.0.0.1");
     }
 
+    [TestCase("taiko-alethia.json", false)]
+    [TestCase("taiko-hoodi.json", false)]
+    [TestCase("surge-hoodi.json", false)]
+    [TestCase("*", true)]
+    public void StrictHexFormat_is_lenient_only_for_taiko_and_surge(string configWildcard, bool strict) =>
+        Test<IJsonRpcConfig, bool>(configWildcard, static c => c.StrictHexFormat, strict);
+
     [TestCase("sepolia", DiscoveryVersion.V5)]
     [TestCase("hoodi", DiscoveryVersion.V5)]
     [TestCase("mainnet", DiscoveryVersion.All)]

--- a/src/Nethermind/Nethermind.Runner/configs/surge-hoodi.json
+++ b/src/Nethermind/Nethermind.Runner/configs/surge-hoodi.json
@@ -30,6 +30,7 @@
   },
   "JsonRpc": {
     "Enabled": true,
-    "EnginePort": 8551
+    "EnginePort": 8551,
+    "StrictHexFormat": false
   }
 }

--- a/src/Nethermind/Nethermind.Runner/configs/taiko-alethia.json
+++ b/src/Nethermind/Nethermind.Runner/configs/taiko-alethia.json
@@ -18,6 +18,7 @@
   },
   "JsonRpc": {
     "Enabled": true,
-    "EnginePort": 8551
+    "EnginePort": 8551,
+    "StrictHexFormat": false
   }
 }

--- a/src/Nethermind/Nethermind.Runner/configs/taiko-hoodi.json
+++ b/src/Nethermind/Nethermind.Runner/configs/taiko-hoodi.json
@@ -18,6 +18,7 @@
   },
   "JsonRpc": {
     "Enabled": true,
-    "EnginePort": 8551
+    "EnginePort": 8551,
+    "StrictHexFormat": false
   }
 }


### PR DESCRIPTION
## Changes

Since #12103 defaulted `JsonRpcConfig.StrictHexFormat = true`, Nethermind rejects non-canonical EIP-1474 QUANTITY hex in RPC request params with `-32602`. The taiko-client / surge driver (whose RPC layer is `taiko-geth`) sends such values, which the tolerant `taiko-geth` accepts — so strict-by-default breaks Nethermind as a drop-in L2 execution engine: the **Taiko and Surge integration suites time out**, with the L2 engine never leaving `currentBlockID=0` because the driver's setup call gets `-32602 "Invalid params"` (a numeric QUANTITY).

This PR scopes lenient QUANTITY parsing to the affected L2 networks, leaving Ethereum's strict default from #12103 unchanged:

- **L2 config defaults** — `taiko-alethia`, `taiko-hoodi`, and `surge-hoodi` set `JsonRpc.StrictHexFormat = false`, so production Nethermind Taiko/Surge nodes parse leniently like `taiko-geth`.
- **Integration CI** — the Taiko/Surge suites launch the L2 node with the driver's own `taiko-devnet.cfg` (an external config, not one of ours), so `ci-taiko.yml` / `ci-surge.yml` append `--JsonRpc.StrictHexFormat false` to that node's command. Nethermind CLI args override config-file values, so the node runs lenient regardless of what `taiko-devnet.cfg` sets:
  ```
  yq eval '.services.l2_nmc.command += ["--JsonRpc.StrictHexFormat", "false"]' -i "$docker_compose_file"
  ```
- **Regression guard** — `ConfigFilesTests.StrictHexFormat_is_lenient_only_for_taiko_and_surge` asserts the three L2 configs are lenient and every other (Ethereum) config stays strict. Each L2 file resolves to a single config (not a member of the `*` set), so deleting the key genuinely fails the test.

### Relationship to the storage-key fix (#12192)

The storage-key half of the original regression — `eth_getStorageAt` / `eth_getProof` / `eth_getStorageValues` rejecting zero-padded / leading-zero **DATA** keys, which broke the Ethereum Hive `rpc-compat` / `engine` suites on master — is a **different trigger** (`-32602 "hex number with leading zero digits"`) and has landed on master via **#12192** (geth-parity `StorageIndex` DATA parsing). This PR is now scoped to **only** the Taiko/Surge L2 numeric-QUANTITY leniency and is rebased on top of #12192.

The two triggers, for the record:

| Failure | Trigger | Error | Fixed by |
| --- | --- | --- | --- |
| Taiko / Surge integration | numeric **QUANTITY** | `Invalid params` | this PR (L2 config) |
| Ethereum Hive (`rpc-compat`, `engine`) | leading-zero **storage key** (DATA) | `hex number with leading zero digits` | #12192 (on master) |

Validation of the L2 change (Taiko / Surge integration suites): ✅ green.

Ethereum (mainnet/testnet) configs keep #12103's strict QUANTITY default. **Optimism is intentionally untouched** — there is no Optimism integration suite and `Nethermind.Optimism.Test` is green, so `op-*` (and `mode-*`/`zora-*`/`worldchain-*`, which also carry an `Optimism` section) stay strict; revisit if any is ever run as a drop-in engine.

### Why this surfaced now
The Taiko/Surge integration workflows only trigger on `Nethermind.Taiko/**` (and their own workflow files), so they never ran on #12103 — an RPC/serialization PR. The regression only appears on a PR that both touches those trigger paths and runs against post-#12103 master. Worth flagging as a CI-coverage gap for strict-parsing / serialization changes.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Build-related changes (CI workflow overrides)

## Testing

#### Requires testing
- [x] Yes

#### If yes, did you write tests?
- [x] Yes

#### Notes on testing
`ConfigFilesTests` asserts the three L2 configs are lenient and the Ethereum configs stay strict; validated end-to-end by the Taiko and Surge integration suites turning green.

## Documentation

#### Requires documentation update
- [x] No

#### Requires explanation in Release Notes
- [x] No
