### PR TITLE
fix(stateless): align stateless IO with tests-zkevm@v0.5.0

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestsProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestsProcessor.cs
@@ -114,14 +114,28 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
                     BlockErrorMessages.BuilderExitsContractEmpty, BlockErrorMessages.BuilderExitsContractFailed);
             }
 
-            block.ExecutionRequests = [.. requests];
-            block.Header.RequestsHash =
-                ExecutionRequestExtensions.CalculateHashFromFlatEncodedRequests(block.ExecutionRequests);
+            RecordRequests(block, ref requests);
         }
         finally
         {
             requests.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Records the requests derived from execution onto the block and computes the requests hash.
+    /// </summary>
+    /// <remarks>
+    /// The request system calls are always executed (their state effects matter); this only controls
+    /// whether the derived requests are written back to the block header. Stateless validation
+    /// overrides this to a no-op so the block keeps the consensus-layer-provided requests hash, which
+    /// the statelessly re-executed state transition does not re-derive.
+    /// </remarks>
+    protected virtual void RecordRequests(Block block, ref ArrayPoolListRef<byte[]> requests)
+    {
+        block.ExecutionRequests = [.. requests];
+        block.Header.RequestsHash =
+            ExecutionRequestExtensions.CalculateHashFromFlatEncodedRequests(block.ExecutionRequests);
     }
 
     private void ProcessDeposits(Block block, TxReceipt[] receipts, IReleaseSpec spec, ref ArrayPoolListRef<byte[]> requests)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.SystemContracts.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.SystemContracts.cs
@@ -4,6 +4,7 @@
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Consensus.ExecutionRequests;
+using Nethermind.Consensus.Stateless;
 using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -68,6 +69,12 @@ public partial class BlockAccessListManager
         CheckInitialized();
 
         TxProcessorWithWorldState postExecution = _txProcessorWithWorldStateManager.GetPostExecution();
-        new ExecutionRequestsProcessor(postExecution.TxProcessor).ProcessExecutionRequests(block, postExecution.WorldState, txReceipts, spec);
+        // In witness (stateless) mode the requests hash is a consensus-layer attestation that the
+        // stateless guest does not re-derive; use the stateless processor so the block keeps its
+        // provided requests hash while the request system calls still run for their state effects.
+        IExecutionRequestsProcessor executionRequestsProcessor = witnessMode
+            ? new StatelessExecutionRequestsProcessor(postExecution.TxProcessor)
+            : new ExecutionRequestsProcessor(postExecution.TxProcessor);
+        executionRequestsProcessor.ProcessExecutionRequests(block, postExecution.WorldState, txReceipts, spec);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
@@ -6,7 +6,6 @@ using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Config;
-using Nethermind.Consensus.ExecutionRequests;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Rewards;
 using Nethermind.Consensus.Validators;

--- a/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
@@ -93,7 +93,7 @@ public class StatelessBlockProcessingEnv(
             new BlockhashStore(WorldState),
             logManager,
             new WithdrawalProcessor(WorldState, logManager),
-            new ExecutionRequestsProcessor(txProcessor),
+            new StatelessExecutionRequestsProcessor(txProcessor),
             blockAccessListManager
         );
     }

--- a/src/Nethermind/Nethermind.Consensus/Stateless/StatelessExecutionRequestsProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/StatelessExecutionRequestsProcessor.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus.ExecutionRequests;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Evm.TransactionProcessing;
+
+namespace Nethermind.Consensus.Stateless;
+
+/// <summary>
+/// Execution requests processor for stateless (zkEVM) re-execution.
+/// </summary>
+/// <remarks>
+/// Runs the request system calls exactly like <see cref="ExecutionRequestsProcessor"/> so their
+/// state effects are applied, but does not write the derived requests or requests hash back to the
+/// block. The requests hash is a consensus-layer attestation the stateless guest does not re-derive;
+/// leaving the consensus-layer-provided value on the header keeps stateless validation aligned with
+/// the tests-zkevm fixtures, which treat requests-hash mismatches as statelessly valid.
+/// </remarks>
+public sealed class StatelessExecutionRequestsProcessor(ITransactionProcessor transactionProcessor)
+    : ExecutionRequestsProcessor(transactionProcessor)
+{
+    protected override void RecordRequests(Block block, ref ArrayPoolListRef<byte[]> requests)
+    {
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszExecutionPayload.cs
@@ -262,10 +262,6 @@ public partial class SszExecutionPayloadV4(ExecutionPayloadV4 payload)
 
     public override ExecutionPayloadV4 AsExecutionPayload() => Inner;
 
-    // MAX_BYTES_PER_TRANSACTION (2^30): tests-zkevm@v0.5.0 defines
-    // block_access_list as ByteList[MAX_BYTES_PER_TRANSACTION] (stateless_ssz.py),
-    // and the SSZ merkle root of NewPayloadRequest embedded in the pyspec stateless
-    // fixtures depends on this limit.
     [SszList(0x4000_0000)]
     public byte[] BlockAccessList
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszExecutionPayload.cs
@@ -262,11 +262,11 @@ public partial class SszExecutionPayloadV4(ExecutionPayloadV4 payload)
 
     public override ExecutionPayloadV4 AsExecutionPayload() => Inner;
 
-    // Keep at 0x0100_0000 (16 MiB) to match execution-spec-tests fixtures used by
-    // StatelessExecutor.InputDecoder, which embeds the SSZ merkle root of
-    // NewPayloadRequest in pyspec test data. The execution-apis #793 spec lists
-    // MAX_BAL_BYTES = MAX_BYTES_PER_TX (2^30) — divergence raised upstream.
-    [SszList(0x0100_0000)]
+    // MAX_BYTES_PER_TRANSACTION (2^30): tests-zkevm@v0.5.0 defines
+    // block_access_list as ByteList[MAX_BYTES_PER_TRANSACTION] (stateless_ssz.py),
+    // and the SSZ merkle root of NewPayloadRequest embedded in the pyspec stateless
+    // fixtures depends on this limit.
+    [SszList(0x4000_0000)]
     public byte[] BlockAccessList
     {
         get => Inner.BlockAccessList ?? [];

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/ExecutionWitness.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/ExecutionWitness.cs
@@ -10,10 +10,10 @@ namespace Nethermind.Stateless.Execution.IO;
 [SszContainer]
 public partial struct ExecutionWitness
 {
-    [SszList(0x10_0000)]
+    [SszList(0x40_0000)]
     public SszWitnessState[] State { get; set; }
 
-    [SszList(0x1_0000)]
+    [SszList(0x4_0000)]
     public SszWitnessCodes[] Codes { get; set; }
 
     [SszList(0x100)]
@@ -74,7 +74,7 @@ public partial struct ExecutionWitness
 [SszContainer(isCollectionItself: true)]
 public partial struct SszWitnessCodes
 {
-    [SszList(0x100_0000)]
+    [SszList(0x1_0000)]
     public byte[] Bytes { get; set; }
 }
 
@@ -88,6 +88,6 @@ public partial struct SszWitnessHeader
 [SszContainer(isCollectionItself: true)]
 public partial struct SszWitnessState
 {
-    [SszList(0x10_0000)]
+    [SszList(0x400)]
     public byte[] Bytes { get; set; }
 }

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/ForkIndexHelper.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/ForkIndexHelper.cs
@@ -7,6 +7,9 @@ namespace Nethermind.Stateless.Execution.IO;
 
 internal static class ForkIndexHelper
 {
+    // Indexes are the ordinals of tests-zkevm@v0.5.0's ProtocolFork enum
+    // (stateless_ssz.py: PROTOCOL_FORKS = tuple(ProtocolFork); the SSZ fork value is that
+    // tuple index). The enum is contiguous; the spec's StPetersburg maps to ConstantinopleFix.
     private static readonly Dictionary<string, ulong> _forkIndexes = new(StringComparer.Ordinal)
     {
         [Frontier.Instance.Name] = 0,
@@ -15,21 +18,21 @@ internal static class ForkIndexHelper
         [TangerineWhistle.Instance.Name] = 3,
         [SpuriousDragon.Instance.Name] = 4,
         [Byzantium.Instance.Name] = 5,
-        [ConstantinopleFix.Instance.Name] = 7, // TODO: Decrease by 1 for removed Constantinople on the next fixture release
-        [Istanbul.Instance.Name] = 8,
-        [MuirGlacier.Instance.Name] = 9,
-        [Berlin.Instance.Name] = 10,
-        [London.Instance.Name] = 11,
-        [ArrowGlacier.Instance.Name] = 12,
-        [GrayGlacier.Instance.Name] = 13,
-        [Paris.Instance.Name] = 14,
-        [Shanghai.Instance.Name] = 15,
-        [Cancun.Instance.Name] = 16,
-        [Prague.Instance.Name] = 17,
-        [Osaka.Instance.Name] = 18,
-        [BPO1.Instance.Name] = 19,
-        [BPO2.Instance.Name] = 20,
-        [Amsterdam.Instance.Name] = 24  // TODO: Decrease by 3 for removed BPOs on the next fixture release
+        [ConstantinopleFix.Instance.Name] = 6,
+        [Istanbul.Instance.Name] = 7,
+        [MuirGlacier.Instance.Name] = 8,
+        [Berlin.Instance.Name] = 9,
+        [London.Instance.Name] = 10,
+        [ArrowGlacier.Instance.Name] = 11,
+        [GrayGlacier.Instance.Name] = 12,
+        [Paris.Instance.Name] = 13,
+        [Shanghai.Instance.Name] = 14,
+        [Cancun.Instance.Name] = 15,
+        [Prague.Instance.Name] = 16,
+        [Osaka.Instance.Name] = 17,
+        [BPO1.Instance.Name] = 18,
+        [BPO2.Instance.Name] = 19,
+        [Amsterdam.Instance.Name] = 20
     };
 
     internal static ulong GetForkIndexByName(string name) =>
@@ -43,21 +46,21 @@ internal static class ForkIndexHelper
         3 => TangerineWhistle.Instance.Name,
         4 => SpuriousDragon.Instance.Name,
         5 => Byzantium.Instance.Name,
-        7 => ConstantinopleFix.Instance.Name, // TODO: Decrease by 1 for removed Constantinople on the next fixture release
-        8 => Istanbul.Instance.Name,
-        9 => MuirGlacier.Instance.Name,
-        10 => Berlin.Instance.Name,
-        11 => London.Instance.Name,
-        12 => ArrowGlacier.Instance.Name,
-        13 => GrayGlacier.Instance.Name,
-        14 => Paris.Instance.Name,
-        15 => Shanghai.Instance.Name,
-        16 => Cancun.Instance.Name,
-        17 => Prague.Instance.Name,
-        18 => Osaka.Instance.Name,
-        19 => BPO1.Instance.Name,
-        20 => BPO2.Instance.Name,
-        24 => Amsterdam.Instance.Name,  // TODO: Decrease by 3 for removed BPOs on the next fixture release
+        6 => ConstantinopleFix.Instance.Name,
+        7 => Istanbul.Instance.Name,
+        8 => MuirGlacier.Instance.Name,
+        9 => Berlin.Instance.Name,
+        10 => London.Instance.Name,
+        11 => ArrowGlacier.Instance.Name,
+        12 => GrayGlacier.Instance.Name,
+        13 => Paris.Instance.Name,
+        14 => Shanghai.Instance.Name,
+        15 => Cancun.Instance.Name,
+        16 => Prague.Instance.Name,
+        17 => Osaka.Instance.Name,
+        18 => BPO1.Instance.Name,
+        19 => BPO2.Instance.Name,
+        20 => Amsterdam.Instance.Name,
         _ => null
     };
 }

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/ForkIndexHelper.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/ForkIndexHelper.cs
@@ -7,9 +7,6 @@ namespace Nethermind.Stateless.Execution.IO;
 
 internal static class ForkIndexHelper
 {
-    // Indexes are the ordinals of tests-zkevm@v0.5.0's ProtocolFork enum
-    // (stateless_ssz.py: PROTOCOL_FORKS = tuple(ProtocolFork); the SSZ fork value is that
-    // tuple index). The enum is contiguous; the spec's StPetersburg maps to ConstantinopleFix.
     private static readonly Dictionary<string, ulong> _forkIndexes = new(StringComparer.Ordinal)
     {
         [Frontier.Instance.Name] = 0,

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/StatelessInput.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/StatelessInput.cs
@@ -16,7 +16,7 @@ public partial class StatelessInput<TExecutionPayload> where TExecutionPayload
 
     public ChainConfig ChainConfig { get; set; }
 
-    [SszList(0x10_0000)]
+    [SszList(0x8000)]
     public SszPublicKeys[] PublicKeys { get; set; } = [];
 }
 

--- a/src/Nethermind/Nethermind.Stateless.Executor/StatelessExecutor.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/StatelessExecutor.cs
@@ -20,33 +20,19 @@ namespace Nethermind.Stateless.Execution;
 
 public static class StatelessExecutor
 {
-    /// <summary>
-    /// Gets the encoded failure result of the current execution. Intended for zkVM guests.
-    /// </summary>
-    /// <remarks>
-    /// As there's no exception unwinding in the zkVM runtime, an exception thrown during execution
-    /// never reaches the catch block in <see cref="Execute(ReadOnlySpan{byte})"/>;
-    /// instead, the runtime invokes the guest's <c>ZkvmThrow</c> callback.
-    /// The failure result is therefore encoded up front, before execution begins, so the
-    /// callback can access it.
-    /// </remarks>
-    public static ReadOnlyMemory<byte> FailureOutput { get; private set; }
-
     public static byte[] Execute(ReadOnlySpan<byte> data)
     {
-        // Any failure to decode the input yields the default failed result (zeroed request root),
-        // matching the reference guest's `run_stateless_guest`. Pre-encode it so the zkVM
-        // `ZkvmThrow` callback can surface it if decoding throws.
-        byte[] output = StatelessValidationResult.Encode(CreateDefaultFailedResult());
+        byte[] output = StatelessValidationResult.Encode(_defaultFailureResult);
         FailureOutput = output;
-
         StatelessPayload payload;
+
         try
         {
             payload = InputDecoder.Decode(data);
         }
-        catch
+        catch (Exception ex)
         {
+            Debug.Fail(ex.Message);
             return output;
         }
 
@@ -155,7 +141,19 @@ public static class StatelessExecutor
         return true;
     }
 
-    private static StatelessValidationResult CreateDefaultFailedResult() => new()
+    /// <summary>
+    /// Gets the encoded failure result of the current execution. Intended for zkVM guests.
+    /// </summary>
+    /// <remarks>
+    /// As there's no exception unwinding in the zkVM runtime, an exception thrown during execution
+    /// never reaches the catch block in <see cref="Execute(ReadOnlySpan{byte})"/>;
+    /// instead, the runtime invokes the guest's <c>ZkvmThrow</c> callback.
+    /// The failure result is therefore encoded up front, before execution begins, so the
+    /// callback can access it.
+    /// </remarks>
+    public static ReadOnlyMemory<byte> FailureOutput { get; private set; }
+
+    private static readonly StatelessValidationResult _defaultFailureResult = new()
     {
         NewPayloadRequestRoot = Hash256.Zero,
         IsSuccess = false,
@@ -165,7 +163,7 @@ public static class StatelessExecutor
             ActiveFork = new ForkConfig
             {
                 Fork = 0,
-                Activation = new SszForkActivation { BlockNumber = [], Timestamp = [] },
+                Activation = new() { BlockNumber = [], Timestamp = [] },
                 BlobSchedule = []
             }
         }

--- a/src/Nethermind/Nethermind.Stateless.Executor/StatelessExecutor.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/StatelessExecutor.cs
@@ -34,7 +34,22 @@ public static class StatelessExecutor
 
     public static byte[] Execute(ReadOnlySpan<byte> data)
     {
-        StatelessPayload payload = InputDecoder.Decode(data);
+        // Any failure to decode the input yields the default failed result (zeroed request root),
+        // matching the reference guest's `run_stateless_guest`. Pre-encode it so the zkVM
+        // `ZkvmThrow` callback can surface it if decoding throws.
+        byte[] output = StatelessValidationResult.Encode(CreateDefaultFailedResult());
+        FailureOutput = output;
+
+        StatelessPayload payload;
+        try
+        {
+            payload = InputDecoder.Decode(data);
+        }
+        catch
+        {
+            return output;
+        }
+
         ReadOnlySpan<SszPublicKeys> publicKeys = payload.PublicKeys.Span;
         Transaction[] transactions = payload.Block.Transactions;
         StatelessValidationResult result = new()
@@ -43,7 +58,7 @@ public static class StatelessExecutor
             IsSuccess = false,
             ChainConfig = payload.ChainConfig
         };
-        byte[] output = StatelessValidationResult.Encode(result);
+        output = StatelessValidationResult.Encode(result);
         bool success = false;
 
         FailureOutput = output;
@@ -139,6 +154,22 @@ public static class StatelessExecutor
 
         return true;
     }
+
+    private static StatelessValidationResult CreateDefaultFailedResult() => new()
+    {
+        NewPayloadRequestRoot = Hash256.Zero,
+        IsSuccess = false,
+        ChainConfig = new ChainConfig
+        {
+            ChainId = 0,
+            ActiveFork = new ForkConfig
+            {
+                Fork = 0,
+                Activation = new SszForkActivation { BlockNumber = [], Timestamp = [] },
+                BlobSchedule = []
+            }
+        }
+    };
 
     private static ISpecProvider GetSpecProvider(ChainConfig chainConfig)
     {


### PR DESCRIPTION
## Changes

Makes the re-enabled zkEVM stateless suite (`ZkEvmPreview/ZkEvmBlockchainTests`) pass against `tests-zkevm@v0.5.0`. The suite was re-enabled + bumped to v0.5.0 earlier in the chain but failed 100%; this fixes the underlying `Nethermind.Stateless.Executor` conformance gaps.

**Schema alignment (SSZ):**
1. **`SszExecutionPayloadV4.BlockAccessList` list limit** `2^24` → `2^30` (`ByteList[MAX_BYTES_PER_TRANSACTION]`). An SSZ ByteList merkle root depends on the declared limit, so this shifted the `NewPayloadRequest` root embedded in the fixtures. Also aligns the shared engine-API SSZ type with execution-apis.
2. **`ForkIndexHelper`** remapped to v0.5.0's contiguous `ProtocolFork` ordinals (`Amsterdam = 20`, was `24`; PR #2926 pruned BPOs). The stale index decoded Amsterdam → a pre-EIP-7928 spec → `BlockLevelAccessListHashNotEnabled`.
3. **Witness / public-key SSZ list limits** updated to v0.5.0 (PR #2919).

**Validation scope:**
4. **Invalid input bytes** (PR #2918): malformed stateless input now yields the default failed result (zeroed request root) instead of throwing, matching the reference guest's `run_stateless_guest`.
5. **Requests-hash scope**: the execution-layer requests hash is a consensus-layer attestation the stateless guest does not re-derive; blocks with a mismatching requests hash (full-consensus `INVALID_REQUESTS`) are statelessly valid per the fixtures. Request system calls still run for their state effects; only the derived-hash write-back is skipped (`ExecutionRequestsProcessor.RecordRequests` virtual hook + `StatelessExecutionRequestsProcessor`, used on the witness-mode path).

## Testing

`StatelessExecutorOutputMatchesFixture` verified locally against v0.5.0 fixtures:
- `for_bpo2toamsterdamattime15k` fork-transition: **76/76**
- `eip7928_block_level_access_lists`: **1013/1013**
- `eip8037_state_creation_gas_cost_increase`: **590/590**
- `eip8025_optional_proofs` (invalid-input rejection): **761/761**
- `eip7685...multi_type_requests` (incl. builder deposit/exit): **376/376**
- `eip8282_builder_execution_requests` (valid): **27/27**

Regression checks: engine-API SSZ `SszRest` **107/107**; `Nethermind.Consensus.Test` `ExecutionProcessorTests` pass (normal request processing unchanged).

Note: running all ~3029 stateless fixtures in a single process OOMs locally (harness memory accumulation, not correctness) — CI shards the pyspec suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)