### PR TITLE
feat(engine): move SSZ-REST fork selection into Eth-Execution-Version header

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -2179,9 +2179,6 @@ public partial class EngineModuleTests
             .Warn(Arg.Any<string>());
     }
 
-    // Since execution-apis#793 moved the fork into the Eth-Execution-Version header, fork-scoped
-    // routes are advertised once (fork-less). Each array lists the distinct REST paths first
-    // introduced at that fork; later fork method versions reuse the same paths and add nothing.
     private static readonly string[] SszRestPathsParis =
     [
         SszRestPaths.PostPayloads,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -2179,54 +2179,41 @@ public partial class EngineModuleTests
             .Warn(Arg.Any<string>());
     }
 
+    // Since execution-apis#793 moved the fork into the Eth-Execution-Version header, fork-scoped
+    // routes are advertised once (fork-less). Each array lists the distinct REST paths first
+    // introduced at that fork; later fork method versions reuse the same paths and add nothing.
     private static readonly string[] SszRestPathsParis =
     [
-        SszRestPaths.PostV1Payloads,
-        SszRestPaths.GetV1Payloads,
-        SszRestPaths.PostV1Forkchoice,
-        SszRestPaths.PostV1Capabilities,
-        SszRestPaths.PostV1ClientVersion,
+        SszRestPaths.PostPayloads,
+        SszRestPaths.GetPayloads,
+        SszRestPaths.PostForkchoice,
+        SszRestPaths.GetCapabilities,
+        SszRestPaths.GetIdentity,
     ];
 
     private static readonly string[] SszRestPathsShanghai =
     [
-        SszRestPaths.PostV2Payloads,
-        SszRestPaths.GetV2Payloads,
-        SszRestPaths.PostV2Forkchoice,
-        SszRestPaths.PostV1PayloadBodiesByHash,
-        SszRestPaths.GetV1PayloadBodiesByRange,
+        SszRestPaths.PostBodiesByHash,
+        SszRestPaths.GetBodiesByRange,
     ];
 
     private static readonly string[] SszRestPathsCancun =
     [
-        SszRestPaths.PostV3Payloads,
-        SszRestPaths.GetV3Payloads,
-        SszRestPaths.PostV3Forkchoice,
-        SszRestPaths.PostV1Blobs,
+        SszRestPaths.PostBlobsV1,
     ];
 
-    private static readonly string[] SszRestPathsPrague =
-    [
-        SszRestPaths.PostV4Payloads,
-        SszRestPaths.GetV4Payloads,
-    ];
+    // Prague adds new method versions (newPayloadV4/getPayloadV4) but no new REST path.
+    private static readonly string[] SszRestPathsPrague = [];
 
     private static readonly string[] SszRestPathsOsaka =
     [
-        SszRestPaths.GetV5Payloads,
-        SszRestPaths.PostV2Blobs,
-        SszRestPaths.PostV3Blobs,
-        SszRestPaths.PostV4Blobs,
+        SszRestPaths.PostBlobsV2,
+        SszRestPaths.PostBlobsV3,
+        SszRestPaths.PostBlobsV4,
     ];
 
-    private static readonly string[] SszRestPathsAmsterdam =
-    [
-        SszRestPaths.PostV5Payloads,
-        SszRestPaths.GetV6Payloads,
-        SszRestPaths.PostV4Forkchoice,
-        SszRestPaths.PostV2PayloadBodiesByHash,
-        SszRestPaths.GetV2PayloadBodiesByRange,
-    ];
+    // Amsterdam adds new method versions (newPayloadV5/getPayloadV6/fcuV4/bodies V2) but no new REST path.
+    private static readonly string[] SszRestPathsAmsterdam = [];
 
     public static IEnumerable<TestCaseData> SszRestPathsAdvertisedCases()
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -49,11 +49,11 @@ public class SszMiddlewareTests
         ".eyJpYXQiOjE2NDQ5OTQ5NzF9" +
         ".RmIbZajyYGF9fhAq7A9YrTetdf15ebHIJiSdAhX7PME";
 
-    private static readonly string ParisUrl = Paris.Instance.EngineApiUrlSegment!;
-    private static readonly string ShanghaiUrl = Shanghai.Instance.EngineApiUrlSegment!;
-    private static readonly string CancunUrl = Cancun.Instance.EngineApiUrlSegment!;
-    private static readonly string OsakaUrl = Osaka.Instance.EngineApiUrlSegment!;
-    private static readonly string AmsterdamUrl = Amsterdam.Instance.EngineApiUrlSegment!;
+    private static readonly string ParisFork = Paris.Instance.EngineApiForkName!;
+    private static readonly string ShanghaiFork = Shanghai.Instance.EngineApiForkName!;
+    private static readonly string CancunFork = Cancun.Instance.EngineApiForkName!;
+    private static readonly string OsakaFork = Osaka.Instance.EngineApiForkName!;
+    private static readonly string AmsterdamFork = Amsterdam.Instance.EngineApiForkName!;
 
     [SetUp]
     public void SetUp()
@@ -163,8 +163,8 @@ public class SszMiddlewareTests
 
     private static readonly object[] NewPayloadRoutingCases =
     [
-        new object[] { EngineApiVersions.NewPayload.V1, ParisUrl },
-        new object[] { EngineApiVersions.NewPayload.V2, ShanghaiUrl },
+        new object[] { EngineApiVersions.NewPayload.V1, ParisFork },
+        new object[] { EngineApiVersions.NewPayload.V2, ShanghaiFork },
     ];
 
     [TestCaseSource(nameof(NewPayloadRoutingCases))]
@@ -189,8 +189,8 @@ public class SszMiddlewareTests
 
     private static readonly object[] GetPayloadRoutingCases =
     [
-        new object[] { EngineApiVersions.GetPayload.V1, ParisUrl },
-        new object[] { EngineApiVersions.GetPayload.V2, ShanghaiUrl },
+        new object[] { EngineApiVersions.GetPayload.V1, ParisFork },
+        new object[] { EngineApiVersions.GetPayload.V2, ShanghaiFork },
     ];
 
     [TestCaseSource(nameof(GetPayloadRoutingCases))]
@@ -212,10 +212,10 @@ public class SszMiddlewareTests
 
     private static readonly object[] ForkchoiceRoutingCases =
     [
-        new object[] { ParisUrl, EngineApiVersions.Fcu.V1 },
-        new object[] { ShanghaiUrl, EngineApiVersions.Fcu.V2 },
-        new object[] { CancunUrl, EngineApiVersions.Fcu.V3 },
-        new object[] { AmsterdamUrl, EngineApiVersions.Fcu.V4 },
+        new object[] { ParisFork, EngineApiVersions.Fcu.V1 },
+        new object[] { ShanghaiFork, EngineApiVersions.Fcu.V2 },
+        new object[] { CancunFork, EngineApiVersions.Fcu.V3 },
+        new object[] { AmsterdamFork, EngineApiVersions.Fcu.V4 },
     ];
 
     [TestCaseSource(nameof(ForkchoiceRoutingCases))]
@@ -311,8 +311,8 @@ public class SszMiddlewareTests
 
     private static readonly object[] BodiesByHashRoutingCases =
     [
-        new object[] { EngineApiVersions.PayloadBodiesByHash.V1, ShanghaiUrl },
-        new object[] { EngineApiVersions.PayloadBodiesByHash.V2, AmsterdamUrl },
+        new object[] { EngineApiVersions.PayloadBodiesByHash.V1, ShanghaiFork },
+        new object[] { EngineApiVersions.PayloadBodiesByHash.V2, AmsterdamFork },
     ];
 
     [TestCaseSource(nameof(BodiesByHashRoutingCases))]
@@ -352,7 +352,7 @@ public class SszMiddlewareTests
         _specProvider.GetSpec(Arg.Is<ForkActivation>(fa => fa.Timestamp == 2_000UL)).Returns(Cancun.Instance);
 
         byte[] body = BuildPayloadBodiesByHashRequest([inFork, outOfFork]);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash", body, fork: ShanghaiUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash", body, fork: ShanghaiFork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -370,8 +370,8 @@ public class SszMiddlewareTests
 
     private static readonly object[] BodiesByRangeRoutingCases =
     [
-        new object[] { EngineApiVersions.PayloadBodiesByRange.V1, ShanghaiUrl },
-        new object[] { EngineApiVersions.PayloadBodiesByRange.V2, AmsterdamUrl },
+        new object[] { EngineApiVersions.PayloadBodiesByRange.V1, ShanghaiFork },
+        new object[] { EngineApiVersions.PayloadBodiesByRange.V2, AmsterdamFork },
     ];
 
     [TestCaseSource(nameof(BodiesByRangeRoutingCases))]
@@ -474,7 +474,7 @@ public class SszMiddlewareTests
         _auth.Authenticate(Arg.Any<string>()).Returns(false);
 
         byte[] body = BuildMinimalV1NewPayloadRequest();
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: ParisUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: ParisFork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -485,7 +485,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Oversized_body_returns_413_without_calling_engine_module()
     {
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", [], fork: ParisUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", [], fork: ParisFork);
         ctx.Request.ContentLength = SszMiddleware.MaxBodySize + 1;
         ctx.Request.Body = new MemoryStream(new byte[1]);
 
@@ -500,7 +500,7 @@ public class SszMiddlewareTests
     {
         bool nextInvoked = false;
         SszMiddleware mw = BuildMiddleware(_ => { nextInvoked = true; return Task.CompletedTask; });
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/unknown-resource", [], fork: ParisUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/unknown-resource", [], fork: ParisFork);
 
         await mw.InvokeAsync(ctx);
 
@@ -514,7 +514,7 @@ public class SszMiddlewareTests
     [TestCase("/engine/v2/payloads//abc", TestName = "Consecutive_slashes_404")]
     public async Task POST_with_malformed_path_returns_404(string path)
     {
-        DefaultHttpContext ctx = MakePostContext(path, [], fork: ParisUrl);
+        DefaultHttpContext ctx = MakePostContext(path, [], fork: ParisFork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -528,7 +528,7 @@ public class SszMiddlewareTests
         byte[] garbage = new byte[64];
         new Random(42).NextBytes(garbage);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: ParisUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: ParisFork);
 
         Func<Task> act = () => _middleware.InvokeAsync(ctx);
 
@@ -541,7 +541,7 @@ public class SszMiddlewareTests
     public async Task Truncated_body_with_overstated_content_length_returns_400()
     {
         byte[] body = new byte[16];
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: ParisUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: ParisFork);
         // Declare more bytes than the stream will deliver — ReadAtLeastAsync returns short.
         ctx.Request.ContentLength = body.Length + 64;
 
@@ -587,7 +587,7 @@ public class SszMiddlewareTests
         _engineModule.engine_newPayloadV1(Arg.Any<ExecutionPayload>())
             .Returns<Task<ResultWrapper<PayloadStatusV1>>>(_ => throw new InvalidOperationException("simulated server error"));
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", BuildMinimalV1NewPayloadRequest(), fork: ParisUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", BuildMinimalV1NewPayloadRequest(), fork: ParisFork);
 
         // Simulate the encode-failure → ctx.Abort() effect by pre-cancelling RequestAborted.
         // DefaultHttpContext's Abort() is a no-op without a real lifetime feature, so we
@@ -615,7 +615,7 @@ public class SszMiddlewareTests
         SszMiddleware middleware = new(
             _ => Task.CompletedTask, _urlCollection, _auth, [handler], _processExitSource, LimboLogs.Instance);
 
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ZeroLengthEncodeHandler.ResourceName}", [], fork: ParisUrl);
+        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ZeroLengthEncodeHandler.ResourceName}", [], fork: ParisFork);
 
         await middleware.InvokeAsync(ctx);
 
@@ -782,7 +782,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: CancunUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: CancunFork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -813,7 +813,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: CancunUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: CancunFork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -856,7 +856,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: OsakaUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: OsakaFork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -904,7 +904,7 @@ public class SszMiddlewareTests
     [
         new object?[] { "GET", "/engine/v2/capabilities/foo", true, null },
         new object?[] { "GET", "/engine/v2/identity/foo", true, null },
-        new object?[] { "POST", "/engine/v2/forkchoice/whatever", false, CancunUrl },
+        new object?[] { "POST", "/engine/v2/forkchoice/whatever", false, CancunFork },
     ];
 
     [TestCaseSource(nameof(MalformedPathCases))]
@@ -947,7 +947,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getPayloadV2(Arg.Any<byte[]>())
             .Returns(ResultWrapper<GetPayloadV2Result?>.Success(new GetPayloadV2Result(MakeMinimalBlock(), UInt256.One)));
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0x0102030405060708/", fork: ParisUrl);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0x0102030405060708/", fork: ParisFork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -980,6 +980,22 @@ public class SszMiddlewareTests
     }
 
     [Test]
+    public async Task Fork_that_predates_endpoint_returns_400_unsupported_fork()
+    {
+        // Paris is a supported fork but predates getPayloadBodies (introduced in Shanghai), so the
+        // endpoint is recognised yet unavailable for this fork — 400 unsupported-fork, not 404.
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash",
+            BuildPayloadBodiesByHashRequest([TestItem.KeccakA]), fork: ParisFork);
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+        string body = System.Text.Encoding.UTF8.GetString(ResponseBytes(ctx));
+        Assert.That(body, Does.Contain("unsupported-fork"));
+        _engineModule.DidNotReceive().engine_getPayloadBodiesByHashV1(Arg.Any<IReadOnlyList<Hash256>>());
+    }
+
+    [Test]
     public async Task Unknown_blob_version_returns_404()
     {
         DefaultHttpContext ctx = MakePostContext("/engine/v2/blobs/v99", []);
@@ -992,7 +1008,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Invalid_payload_id_in_path_returns_400()
     {
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0xZZZZZZZZZZZZZZZZ", fork: ParisUrl);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0xZZZZZZZZZZZZZZZZ", fork: ParisFork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1002,7 +1018,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task GetPayloadBodiesByRange_over_limit_returns_413_request_too_large()
     {
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: ShanghaiUrl);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: ShanghaiFork);
         ctx.Request.QueryString = new QueryString("?from=1&count=1000");
 
         await _middleware.InvokeAsync(ctx);
@@ -1018,7 +1034,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getPayloadBodiesByRangeV1(Arg.Any<ulong>(), Arg.Any<ulong>())
             .Returns(ResultWrapper<IReadOnlyList<ExecutionPayloadBodyV1Result?>>.Success([]));
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: ShanghaiUrl);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: ShanghaiFork);
         ctx.Request.QueryString = new QueryString("?from=0&count=1");
 
         await _middleware.InvokeAsync(ctx);
@@ -1032,7 +1048,7 @@ public class SszMiddlewareTests
     {
         byte[] garbage = new byte[64];
         new Random(42).NextBytes(garbage);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: ParisUrl);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: ParisFork);
 
         await _middleware.InvokeAsync(ctx);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -134,20 +134,22 @@ public class SszMiddlewareTests
         return ctx;
     }
 
-    private static DefaultHttpContext MakePostContext(string path, byte[] body, int port = AuthenticatedPort)
+    private static DefaultHttpContext MakePostContext(string path, byte[] body, int port = AuthenticatedPort, string? fork = null)
     {
         DefaultHttpContext ctx = MakeBaseContext("POST", path, port);
         ctx.Request.ContentType = OctetStream;
         ctx.Request.ContentLength = body.Length;
         ctx.Request.Body = new MemoryStream(body);
+        if (fork is not null) ctx.Request.Headers[SszMiddleware.ForkHeaderName] = fork;
         return ctx;
     }
 
-    private static DefaultHttpContext MakeGetContext(string path, int port = AuthenticatedPort)
+    private static DefaultHttpContext MakeGetContext(string path, int port = AuthenticatedPort, string? fork = null)
     {
         DefaultHttpContext ctx = MakeBaseContext("GET", path, port);
         ctx.Request.Headers.Accept = OctetStream;
         ctx.Request.Body = Stream.Null;
+        if (fork is not null) ctx.Request.Headers[SszMiddleware.ForkHeaderName] = fork;
         return ctx;
     }
 
@@ -161,12 +163,12 @@ public class SszMiddlewareTests
 
     private static readonly object[] NewPayloadRoutingCases =
     [
-        new object[] { EngineApiVersions.NewPayload.V1, $"/engine/v2/{ParisUrl}/payloads" },
-        new object[] { EngineApiVersions.NewPayload.V2, $"/engine/v2/{ShanghaiUrl}/payloads" },
+        new object[] { EngineApiVersions.NewPayload.V1, ParisUrl },
+        new object[] { EngineApiVersions.NewPayload.V2, ShanghaiUrl },
     ];
 
     [TestCaseSource(nameof(NewPayloadRoutingCases))]
-    public async Task NewPayload_routes_to_correct_engine_module_version(int version, string path)
+    public async Task NewPayload_routes_to_correct_engine_module_version(int version, string fork)
     {
         PayloadStatusV1 status = new() { Status = PayloadStatus.Valid, LatestValidHash = TestItem.KeccakA };
         _engineModule.engine_newPayloadV1(Arg.Any<ExecutionPayload>())
@@ -175,7 +177,7 @@ public class SszMiddlewareTests
             .Returns(ResultWrapper<PayloadStatusV1>.Success(status));
 
         byte[] body = version == 1 ? BuildMinimalV1NewPayloadRequest() : BuildMinimalV2NewPayloadRequest();
-        DefaultHttpContext ctx = MakePostContext(path, body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: fork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -187,18 +189,18 @@ public class SszMiddlewareTests
 
     private static readonly object[] GetPayloadRoutingCases =
     [
-        new object[] { EngineApiVersions.GetPayload.V1, $"/engine/v2/{ParisUrl}/payloads/0x0102030405060708" },
-        new object[] { EngineApiVersions.GetPayload.V2, $"/engine/v2/{ShanghaiUrl}/payloads/0x0102030405060708" },
+        new object[] { EngineApiVersions.GetPayload.V1, ParisUrl },
+        new object[] { EngineApiVersions.GetPayload.V2, ShanghaiUrl },
     ];
 
     [TestCaseSource(nameof(GetPayloadRoutingCases))]
-    public async Task GetPayload_routes_to_correct_handler_with_no_store_header(int version, string path)
+    public async Task GetPayload_routes_to_correct_handler_with_no_store_header(int version, string fork)
     {
         // BuiltPayloadParis needs block_value, sourced from engine_getPayloadV2.
         _engineModule.engine_getPayloadV2(Arg.Any<byte[]>())
             .Returns(ResultWrapper<GetPayloadV2Result?>.Success(new GetPayloadV2Result(MakeMinimalBlock(), UInt256.One)));
 
-        DefaultHttpContext ctx = MakeGetContext(path);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0x0102030405060708", fork: fork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -210,14 +212,14 @@ public class SszMiddlewareTests
 
     private static readonly object[] ForkchoiceRoutingCases =
     [
-        new object[] { $"/engine/v2/{ParisUrl}/forkchoice", EngineApiVersions.Fcu.V1 },
-        new object[] { $"/engine/v2/{ShanghaiUrl}/forkchoice", EngineApiVersions.Fcu.V2 },
-        new object[] { $"/engine/v2/{CancunUrl}/forkchoice", EngineApiVersions.Fcu.V3 },
-        new object[] { $"/engine/v2/{AmsterdamUrl}/forkchoice", EngineApiVersions.Fcu.V4 },
+        new object[] { ParisUrl, EngineApiVersions.Fcu.V1 },
+        new object[] { ShanghaiUrl, EngineApiVersions.Fcu.V2 },
+        new object[] { CancunUrl, EngineApiVersions.Fcu.V3 },
+        new object[] { AmsterdamUrl, EngineApiVersions.Fcu.V4 },
     ];
 
     [TestCaseSource(nameof(ForkchoiceRoutingCases))]
-    public async Task Forkchoice_calls_correct_engine_module_version(string path, int version)
+    public async Task Forkchoice_calls_correct_engine_module_version(string fork, int version)
     {
         ForkchoiceUpdatedV1Result fcuResult = new()
         {
@@ -233,7 +235,7 @@ public class SszMiddlewareTests
             .Returns(ResultWrapper<ForkchoiceUpdatedV1Result>.Success(fcuResult));
 
         byte[] body = version == 4 ? BuildForkchoiceV4Request() : BuildForkchoiceRequest();
-        DefaultHttpContext ctx = MakePostContext(path, body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: fork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -309,12 +311,12 @@ public class SszMiddlewareTests
 
     private static readonly object[] BodiesByHashRoutingCases =
     [
-        new object[] { EngineApiVersions.PayloadBodiesByHash.V1, $"/engine/v2/{ShanghaiUrl}/bodies/hash" },
-        new object[] { EngineApiVersions.PayloadBodiesByHash.V2, $"/engine/v2/{AmsterdamUrl}/bodies/hash" },
+        new object[] { EngineApiVersions.PayloadBodiesByHash.V1, ShanghaiUrl },
+        new object[] { EngineApiVersions.PayloadBodiesByHash.V2, AmsterdamUrl },
     ];
 
     [TestCaseSource(nameof(BodiesByHashRoutingCases))]
-    public async Task GetPayloadBodiesByHash_routes_to_correct_engine_method(int version, string path)
+    public async Task GetPayloadBodiesByHash_routes_to_correct_engine_method(int version, string fork)
     {
         _engineModule.engine_getPayloadBodiesByHashV1(Arg.Any<IReadOnlyList<Hash256>>())
             .Returns(ResultWrapper<IReadOnlyList<ExecutionPayloadBodyV1Result?>>.Success(
@@ -324,7 +326,7 @@ public class SszMiddlewareTests
                 [new ExecutionPayloadBodyV2Result([], null, null)]));
 
         byte[] body = BuildPayloadBodiesByHashRequest([TestItem.KeccakA]);
-        DefaultHttpContext ctx = MakePostContext(path, body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash", body, fork: fork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -350,7 +352,7 @@ public class SszMiddlewareTests
         _specProvider.GetSpec(Arg.Is<ForkActivation>(fa => fa.Timestamp == 2_000UL)).Returns(Cancun.Instance);
 
         byte[] body = BuildPayloadBodiesByHashRequest([inFork, outOfFork]);
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ShanghaiUrl}/bodies/hash", body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash", body, fork: ShanghaiUrl);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -368,12 +370,12 @@ public class SszMiddlewareTests
 
     private static readonly object[] BodiesByRangeRoutingCases =
     [
-        new object[] { EngineApiVersions.PayloadBodiesByRange.V1, $"/engine/v2/{ShanghaiUrl}/bodies" },
-        new object[] { EngineApiVersions.PayloadBodiesByRange.V2, $"/engine/v2/{AmsterdamUrl}/bodies" },
+        new object[] { EngineApiVersions.PayloadBodiesByRange.V1, ShanghaiUrl },
+        new object[] { EngineApiVersions.PayloadBodiesByRange.V2, AmsterdamUrl },
     ];
 
     [TestCaseSource(nameof(BodiesByRangeRoutingCases))]
-    public async Task GetPayloadBodiesByRange_routes_to_correct_engine_method_with_correct_args(int version, string path)
+    public async Task GetPayloadBodiesByRange_routes_to_correct_engine_method_with_correct_args(int version, string fork)
     {
         const ulong expectedStart = 7;
         const ulong expectedCount = 3;
@@ -389,7 +391,7 @@ public class SszMiddlewareTests
             .Returns(ResultWrapper<IReadOnlyList<ExecutionPayloadBodyV2Result?>>.Success([]));
 
         // The range endpoint is now GET with from/count as query parameters.
-        DefaultHttpContext ctx = MakeGetContext(path);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: fork);
         ctx.Request.QueryString = new QueryString($"?from={expectedStart}&count={expectedCount}");
 
         await _middleware.InvokeAsync(ctx);
@@ -472,7 +474,7 @@ public class SszMiddlewareTests
         _auth.Authenticate(Arg.Any<string>()).Returns(false);
 
         byte[] body = BuildMinimalV1NewPayloadRequest();
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ParisUrl}/payloads", body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: ParisUrl);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -483,7 +485,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Oversized_body_returns_413_without_calling_engine_module()
     {
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ParisUrl}/payloads", []);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", [], fork: ParisUrl);
         ctx.Request.ContentLength = SszMiddleware.MaxBodySize + 1;
         ctx.Request.Body = new MemoryStream(new byte[1]);
 
@@ -498,7 +500,7 @@ public class SszMiddlewareTests
     {
         bool nextInvoked = false;
         SszMiddleware mw = BuildMiddleware(_ => { nextInvoked = true; return Task.CompletedTask; });
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ParisUrl}/unknown-resource", []);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/unknown-resource", [], fork: ParisUrl);
 
         await mw.InvokeAsync(ctx);
 
@@ -506,13 +508,13 @@ public class SszMiddlewareTests
         Assert.That(nextInvoked, Is.False, "SSZ middleware should reply 404 itself, not delegate to JSON-RPC");
     }
 
-    // Each case is a different routing rejection that must NOT reach the engine module: unknown resource,
+    // Each case is a different routing rejection that must NOT reach the engine module:
     // extra segments on a non-AcceptsPathExtra handler, runs of '/' inside the path.
-    [TestCase("/payloads/foo/bar", TestName = "Extra_segments_on_non_path_handler_404")]
-    [TestCase("/payloads//abc", TestName = "Consecutive_slashes_404")]
-    public async Task POST_with_malformed_fork_path_returns_404(string suffix)
+    [TestCase("/engine/v2/payloads/foo/bar", TestName = "Extra_segments_on_non_path_handler_404")]
+    [TestCase("/engine/v2/payloads//abc", TestName = "Consecutive_slashes_404")]
+    public async Task POST_with_malformed_path_returns_404(string path)
     {
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ParisUrl}{suffix}", []);
+        DefaultHttpContext ctx = MakePostContext(path, [], fork: ParisUrl);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -526,7 +528,7 @@ public class SszMiddlewareTests
         byte[] garbage = new byte[64];
         new Random(42).NextBytes(garbage);
 
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ParisUrl}/payloads", garbage);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: ParisUrl);
 
         Func<Task> act = () => _middleware.InvokeAsync(ctx);
 
@@ -539,7 +541,7 @@ public class SszMiddlewareTests
     public async Task Truncated_body_with_overstated_content_length_returns_400()
     {
         byte[] body = new byte[16];
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ParisUrl}/payloads", body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: ParisUrl);
         // Declare more bytes than the stream will deliver — ReadAtLeastAsync returns short.
         ctx.Request.ContentLength = body.Length + 64;
 
@@ -585,7 +587,7 @@ public class SszMiddlewareTests
         _engineModule.engine_newPayloadV1(Arg.Any<ExecutionPayload>())
             .Returns<Task<ResultWrapper<PayloadStatusV1>>>(_ => throw new InvalidOperationException("simulated server error"));
 
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ParisUrl}/payloads", BuildMinimalV1NewPayloadRequest());
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", BuildMinimalV1NewPayloadRequest(), fork: ParisUrl);
 
         // Simulate the encode-failure → ctx.Abort() effect by pre-cancelling RequestAborted.
         // DefaultHttpContext's Abort() is a no-op without a real lifetime feature, so we
@@ -613,7 +615,7 @@ public class SszMiddlewareTests
         SszMiddleware middleware = new(
             _ => Task.CompletedTask, _urlCollection, _auth, [handler], _processExitSource, LimboLogs.Instance);
 
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ParisUrl}/{ZeroLengthEncodeHandler.ResourceName}", []);
+        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ZeroLengthEncodeHandler.ResourceName}", [], fork: ParisUrl);
 
         await middleware.InvokeAsync(ctx);
 
@@ -780,7 +782,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{CancunUrl}/forkchoice", body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: CancunUrl);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -811,7 +813,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{CancunUrl}/forkchoice", body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: CancunUrl);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -854,7 +856,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{OsakaUrl}/forkchoice", body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: OsakaUrl);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -900,16 +902,16 @@ public class SszMiddlewareTests
     // Unknown extra path segments still 404; trailing slashes are accepted (covered below).
     private static readonly object[] MalformedPathCases =
     [
-        new object[] { "GET", "/engine/v2/capabilities/foo", true },
-        new object[] { "GET", "/engine/v2/identity/foo", true },
-        new object[] { "POST", $"/engine/v2/{CancunUrl}/forkchoice/whatever", false },
+        new object?[] { "GET", "/engine/v2/capabilities/foo", true, null },
+        new object?[] { "GET", "/engine/v2/identity/foo", true, null },
+        new object?[] { "POST", "/engine/v2/forkchoice/whatever", false, CancunUrl },
     ];
 
     [TestCaseSource(nameof(MalformedPathCases))]
-    public async Task Malformed_or_trailing_path_returns_404(string method, string path, bool assertMethodNotFoundBody)
+    public async Task Malformed_or_trailing_path_returns_404(string method, string path, bool assertMethodNotFoundBody, string? fork)
     {
         DefaultHttpContext ctx = method == "POST"
-            ? MakePostContext(path, [])
+            ? MakePostContext(path, [], fork: fork)
             : MakeBaseContext("GET", path, AuthenticatedPort);
         if (method == "GET")
         {
@@ -945,7 +947,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getPayloadV2(Arg.Any<byte[]>())
             .Returns(ResultWrapper<GetPayloadV2Result?>.Success(new GetPayloadV2Result(MakeMinimalBlock(), UInt256.One)));
 
-        DefaultHttpContext ctx = MakeGetContext($"/engine/v2/{ParisUrl}/payloads/0x0102030405060708/");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0x0102030405060708/", fork: ParisUrl);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -953,15 +955,28 @@ public class SszMiddlewareTests
     }
 
     [Test]
-    public async Task Unknown_fork_in_path_returns_400_unsupported_fork()
+    public async Task Unknown_fork_in_header_returns_400_unsupported_fork()
     {
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/atlantis/payloads", []);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", [], fork: "atlantis");
 
         await _middleware.InvokeAsync(ctx);
 
         Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
         string body = System.Text.Encoding.UTF8.GetString(ResponseBytes(ctx));
         Assert.That(body, Does.Contain("unsupported-fork"));
+    }
+
+    [Test]
+    public async Task Missing_fork_header_on_fork_scoped_endpoint_returns_400()
+    {
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", BuildMinimalV1NewPayloadRequest());
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+        string body = System.Text.Encoding.UTF8.GetString(ResponseBytes(ctx));
+        Assert.That(body, Does.Contain("invalid-request"));
+        await _engineModule.DidNotReceive().engine_newPayloadV1(Arg.Any<ExecutionPayload>());
     }
 
     [Test]
@@ -977,7 +992,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Invalid_payload_id_in_path_returns_400()
     {
-        DefaultHttpContext ctx = MakeGetContext($"/engine/v2/{ParisUrl}/payloads/0xZZZZZZZZZZZZZZZZ");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0xZZZZZZZZZZZZZZZZ", fork: ParisUrl);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -987,7 +1002,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task GetPayloadBodiesByRange_over_limit_returns_413_request_too_large()
     {
-        DefaultHttpContext ctx = MakeGetContext($"/engine/v2/{ShanghaiUrl}/bodies");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: ShanghaiUrl);
         ctx.Request.QueryString = new QueryString("?from=1&count=1000");
 
         await _middleware.InvokeAsync(ctx);
@@ -1003,7 +1018,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getPayloadBodiesByRangeV1(Arg.Any<ulong>(), Arg.Any<ulong>())
             .Returns(ResultWrapper<IReadOnlyList<ExecutionPayloadBodyV1Result?>>.Success([]));
 
-        DefaultHttpContext ctx = MakeGetContext($"/engine/v2/{ShanghaiUrl}/bodies");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: ShanghaiUrl);
         ctx.Request.QueryString = new QueryString("?from=0&count=1");
 
         await _middleware.InvokeAsync(ctx);
@@ -1017,7 +1032,7 @@ public class SszMiddlewareTests
     {
         byte[] garbage = new byte[64];
         new Random(42).NextBytes(garbage);
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ParisUrl}/payloads", garbage);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: ParisUrl);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1032,7 +1047,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Error_response_has_correct_RFC7807_shape_with_detail_for_non_canned_errors()
     {
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/atlantis/payloads", []);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", [], fork: "atlantis");
 
         await _middleware.InvokeAsync(ctx);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -49,12 +49,6 @@ public class SszMiddlewareTests
         ".eyJpYXQiOjE2NDQ5OTQ5NzF9" +
         ".RmIbZajyYGF9fhAq7A9YrTetdf15ebHIJiSdAhX7PME";
 
-    private static readonly string ParisFork = Paris.Instance.EngineApiForkName!;
-    private static readonly string ShanghaiFork = Shanghai.Instance.EngineApiForkName!;
-    private static readonly string CancunFork = Cancun.Instance.EngineApiForkName!;
-    private static readonly string OsakaFork = Osaka.Instance.EngineApiForkName!;
-    private static readonly string AmsterdamFork = Amsterdam.Instance.EngineApiForkName!;
-
     [SetUp]
     public void SetUp()
     {
@@ -161,10 +155,10 @@ public class SszMiddlewareTests
         return ms.ToArray();
     }
 
-    private static readonly object[] NewPayloadRoutingCases =
+    private static readonly TestCaseData[] NewPayloadRoutingCases =
     [
-        new object[] { EngineApiVersions.NewPayload.V1, ParisFork },
-        new object[] { EngineApiVersions.NewPayload.V2, ShanghaiFork },
+        new TestCaseData(EngineApiVersions.NewPayload.V1, "paris").SetName("NewPayload_paris_routes_to_V1"),
+        new TestCaseData(EngineApiVersions.NewPayload.V2, "shanghai").SetName("NewPayload_shanghai_routes_to_V2"),
     ];
 
     [TestCaseSource(nameof(NewPayloadRoutingCases))]
@@ -187,10 +181,10 @@ public class SszMiddlewareTests
         await _engineModule.Received(version == 2 ? 1 : 0).engine_newPayloadV2(Arg.Any<ExecutionPayload>());
     }
 
-    private static readonly object[] GetPayloadRoutingCases =
+    private static readonly TestCaseData[] GetPayloadRoutingCases =
     [
-        new object[] { EngineApiVersions.GetPayload.V1, ParisFork },
-        new object[] { EngineApiVersions.GetPayload.V2, ShanghaiFork },
+        new TestCaseData(EngineApiVersions.GetPayload.V1, "paris").SetName("GetPayload_paris_routes_to_V1"),
+        new TestCaseData(EngineApiVersions.GetPayload.V2, "shanghai").SetName("GetPayload_shanghai_routes_to_V2"),
     ];
 
     [TestCaseSource(nameof(GetPayloadRoutingCases))]
@@ -210,12 +204,12 @@ public class SszMiddlewareTests
         await _engineModule.Received(1).engine_getPayloadV2(Arg.Any<byte[]>());
     }
 
-    private static readonly object[] ForkchoiceRoutingCases =
+    private static readonly TestCaseData[] ForkchoiceRoutingCases =
     [
-        new object[] { ParisFork, EngineApiVersions.Fcu.V1 },
-        new object[] { ShanghaiFork, EngineApiVersions.Fcu.V2 },
-        new object[] { CancunFork, EngineApiVersions.Fcu.V3 },
-        new object[] { AmsterdamFork, EngineApiVersions.Fcu.V4 },
+        new TestCaseData("paris", EngineApiVersions.Fcu.V1).SetName("Forkchoice_paris_routes_to_V1"),
+        new TestCaseData("shanghai", EngineApiVersions.Fcu.V2).SetName("Forkchoice_shanghai_routes_to_V2"),
+        new TestCaseData("cancun", EngineApiVersions.Fcu.V3).SetName("Forkchoice_cancun_routes_to_V3"),
+        new TestCaseData("amsterdam", EngineApiVersions.Fcu.V4).SetName("Forkchoice_amsterdam_routes_to_V4"),
     ];
 
     [TestCaseSource(nameof(ForkchoiceRoutingCases))]
@@ -309,10 +303,10 @@ public class SszMiddlewareTests
         await _engineModule.Received(1).engine_getBlobsV4(Arg.Any<byte[][]>(), Arg.Any<System.Collections.BitArray>());
     }
 
-    private static readonly object[] BodiesByHashRoutingCases =
+    private static readonly TestCaseData[] BodiesByHashRoutingCases =
     [
-        new object[] { EngineApiVersions.PayloadBodiesByHash.V1, ShanghaiFork },
-        new object[] { EngineApiVersions.PayloadBodiesByHash.V2, AmsterdamFork },
+        new TestCaseData(EngineApiVersions.PayloadBodiesByHash.V1, "shanghai").SetName("BodiesByHash_shanghai_routes_to_V1"),
+        new TestCaseData(EngineApiVersions.PayloadBodiesByHash.V2, "amsterdam").SetName("BodiesByHash_amsterdam_routes_to_V2"),
     ];
 
     [TestCaseSource(nameof(BodiesByHashRoutingCases))]
@@ -352,7 +346,7 @@ public class SszMiddlewareTests
         _specProvider.GetSpec(Arg.Is<ForkActivation>(fa => fa.Timestamp == 2_000UL)).Returns(Cancun.Instance);
 
         byte[] body = BuildPayloadBodiesByHashRequest([inFork, outOfFork]);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash", body, fork: ShanghaiFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash", body, fork: "shanghai");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -368,10 +362,10 @@ public class SszMiddlewareTests
         }
     }
 
-    private static readonly object[] BodiesByRangeRoutingCases =
+    private static readonly TestCaseData[] BodiesByRangeRoutingCases =
     [
-        new object[] { EngineApiVersions.PayloadBodiesByRange.V1, ShanghaiFork },
-        new object[] { EngineApiVersions.PayloadBodiesByRange.V2, AmsterdamFork },
+        new TestCaseData(EngineApiVersions.PayloadBodiesByRange.V1, "shanghai").SetName("BodiesByRange_shanghai_routes_to_V1"),
+        new TestCaseData(EngineApiVersions.PayloadBodiesByRange.V2, "amsterdam").SetName("BodiesByRange_amsterdam_routes_to_V2"),
     ];
 
     [TestCaseSource(nameof(BodiesByRangeRoutingCases))]
@@ -474,7 +468,7 @@ public class SszMiddlewareTests
         _auth.Authenticate(Arg.Any<string>()).Returns(false);
 
         byte[] body = BuildMinimalV1NewPayloadRequest();
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: ParisFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -485,7 +479,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Oversized_body_returns_413_without_calling_engine_module()
     {
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", [], fork: ParisFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", [], fork: "paris");
         ctx.Request.ContentLength = SszMiddleware.MaxBodySize + 1;
         ctx.Request.Body = new MemoryStream(new byte[1]);
 
@@ -500,7 +494,7 @@ public class SszMiddlewareTests
     {
         bool nextInvoked = false;
         SszMiddleware mw = BuildMiddleware(_ => { nextInvoked = true; return Task.CompletedTask; });
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/unknown-resource", [], fork: ParisFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/unknown-resource", [], fork: "paris");
 
         await mw.InvokeAsync(ctx);
 
@@ -514,7 +508,7 @@ public class SszMiddlewareTests
     [TestCase("/engine/v2/payloads//abc", TestName = "Consecutive_slashes_404")]
     public async Task POST_with_malformed_path_returns_404(string path)
     {
-        DefaultHttpContext ctx = MakePostContext(path, [], fork: ParisFork);
+        DefaultHttpContext ctx = MakePostContext(path, [], fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -528,7 +522,7 @@ public class SszMiddlewareTests
         byte[] garbage = new byte[64];
         new Random(42).NextBytes(garbage);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: ParisFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: "paris");
 
         Func<Task> act = () => _middleware.InvokeAsync(ctx);
 
@@ -541,7 +535,7 @@ public class SszMiddlewareTests
     public async Task Truncated_body_with_overstated_content_length_returns_400()
     {
         byte[] body = new byte[16];
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: ParisFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: "paris");
         // Declare more bytes than the stream will deliver — ReadAtLeastAsync returns short.
         ctx.Request.ContentLength = body.Length + 64;
 
@@ -587,7 +581,7 @@ public class SszMiddlewareTests
         _engineModule.engine_newPayloadV1(Arg.Any<ExecutionPayload>())
             .Returns<Task<ResultWrapper<PayloadStatusV1>>>(_ => throw new InvalidOperationException("simulated server error"));
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", BuildMinimalV1NewPayloadRequest(), fork: ParisFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", BuildMinimalV1NewPayloadRequest(), fork: "paris");
 
         // Simulate the encode-failure → ctx.Abort() effect by pre-cancelling RequestAborted.
         // DefaultHttpContext's Abort() is a no-op without a real lifetime feature, so we
@@ -615,7 +609,7 @@ public class SszMiddlewareTests
         SszMiddleware middleware = new(
             _ => Task.CompletedTask, _urlCollection, _auth, [handler], _processExitSource, LimboLogs.Instance);
 
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ZeroLengthEncodeHandler.ResourceName}", [], fork: ParisFork);
+        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ZeroLengthEncodeHandler.ResourceName}", [], fork: "paris");
 
         await middleware.InvokeAsync(ctx);
 
@@ -782,7 +776,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: CancunFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: "cancun");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -813,7 +807,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: CancunFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: "cancun");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -856,7 +850,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: OsakaFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: "osaka");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -900,11 +894,11 @@ public class SszMiddlewareTests
     }
 
     // Unknown extra path segments still 404; trailing slashes are accepted (covered below).
-    private static readonly object[] MalformedPathCases =
+    private static readonly TestCaseData[] MalformedPathCases =
     [
-        new object?[] { "GET", "/engine/v2/capabilities/foo", true, null },
-        new object?[] { "GET", "/engine/v2/identity/foo", true, null },
-        new object?[] { "POST", "/engine/v2/forkchoice/whatever", false, CancunFork },
+        new TestCaseData("GET", "/engine/v2/capabilities/foo", true, null).SetName("Malformed_capabilities_extra_segment_404"),
+        new TestCaseData("GET", "/engine/v2/identity/foo", true, null).SetName("Malformed_identity_extra_segment_404"),
+        new TestCaseData("POST", "/engine/v2/forkchoice/whatever", false, "cancun").SetName("Malformed_forkchoice_extra_segment_404"),
     ];
 
     [TestCaseSource(nameof(MalformedPathCases))]
@@ -947,7 +941,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getPayloadV2(Arg.Any<byte[]>())
             .Returns(ResultWrapper<GetPayloadV2Result?>.Success(new GetPayloadV2Result(MakeMinimalBlock(), UInt256.One)));
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0x0102030405060708/", fork: ParisFork);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0x0102030405060708/", fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -985,7 +979,7 @@ public class SszMiddlewareTests
         // Paris is a supported fork but predates getPayloadBodies (introduced in Shanghai), so the
         // endpoint is recognised yet unavailable for this fork — 400 unsupported-fork, not 404.
         DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash",
-            BuildPayloadBodiesByHashRequest([TestItem.KeccakA]), fork: ParisFork);
+            BuildPayloadBodiesByHashRequest([TestItem.KeccakA]), fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1008,7 +1002,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Invalid_payload_id_in_path_returns_400()
     {
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0xZZZZZZZZZZZZZZZZ", fork: ParisFork);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0xZZZZZZZZZZZZZZZZ", fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1018,7 +1012,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task GetPayloadBodiesByRange_over_limit_returns_413_request_too_large()
     {
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: ShanghaiFork);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: "shanghai");
         ctx.Request.QueryString = new QueryString("?from=1&count=1000");
 
         await _middleware.InvokeAsync(ctx);
@@ -1034,7 +1028,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getPayloadBodiesByRangeV1(Arg.Any<ulong>(), Arg.Any<ulong>())
             .Returns(ResultWrapper<IReadOnlyList<ExecutionPayloadBodyV1Result?>>.Success([]));
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: ShanghaiFork);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: "shanghai");
         ctx.Request.QueryString = new QueryString("?from=0&count=1");
 
         await _middleware.InvokeAsync(ctx);
@@ -1048,7 +1042,7 @@ public class SszMiddlewareTests
     {
         byte[] garbage = new byte[64];
         new Random(42).NextBytes(garbage);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: ParisFork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -923,16 +923,19 @@ public class SszMiddlewareTests
         }
     }
 
-    [Test]
-    public async Task Trailing_slash_on_capabilities_resolves_normally()
+    // Unscoped endpoints are exact paths: a trailing slash is rejected just like an extra segment,
+    // so /capabilities/ behaves consistently with /capabilities/foo (both 404).
+    [TestCase("/engine/v2/capabilities/")]
+    [TestCase("/engine/v2/identity/")]
+    public async Task Trailing_slash_on_unscoped_endpoint_returns_404(string path)
     {
-        DefaultHttpContext ctx = MakeBaseContext("GET", "/engine/v2/capabilities/", AuthenticatedPort);
+        DefaultHttpContext ctx = MakeBaseContext("GET", path, AuthenticatedPort);
         ctx.Request.Headers.Accept = "application/json";
         ctx.Request.Body = Stream.Null;
 
         await _middleware.InvokeAsync(ctx);
 
-        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -923,8 +923,6 @@ public class SszMiddlewareTests
         }
     }
 
-    // Unscoped endpoints are exact paths: a trailing slash is rejected just like an extra segment,
-    // so /capabilities/ behaves consistently with /capabilities/foo (both 404).
     [TestCase("/engine/v2/capabilities/")]
     [TestCase("/engine/v2/identity/")]
     public async Task Trailing_slash_on_unscoped_endpoint_returns_404(string path)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
@@ -30,7 +30,7 @@ public class EngineRpcCapabilitiesProvider(ISpecProvider specProvider) : IRpcCap
         return Volatile.Read(ref _jsonRpc)!;
     }
 
-    /// <summary>SSZ-REST path capabilities only (e.g. <c>"POST /engine/v1/payloads"</c>).</summary>
+    /// <summary>SSZ-REST path capabilities only (e.g. <c>"POST /engine/v2/payloads"</c>).</summary>
     public FrozenDictionary<string, RpcCapabilityOptions> GetSszRestPaths()
     {
         EnsureBuilt();
@@ -82,48 +82,54 @@ public class EngineRpcCapabilitiesProvider(ISpecProvider specProvider) : IRpcCap
         void Configure(string method, string path, RpcCapabilityOptions options)
         {
             jsonLocal[method] = options;
-            sszLocal[path] = options & ~WarnIfMissing;
+            // Since execution-apis#793 the fork is a request header, so several method versions
+            // (e.g. newPayloadV1..V5) share one fork-less REST path. Accumulate with OR so the
+            // path is advertised as enabled whenever any contributing version is enabled.
+            RpcCapabilityOptions sszOptions = options & ~WarnIfMissing;
+            sszLocal[path] = sszLocal.TryGetValue(path, out RpcCapabilityOptions existing)
+                ? existing | sszOptions
+                : sszOptions;
         }
 
         // The Merge
         jsonLocal[nameof(IEngineRpcModule.engine_exchangeTransitionConfigurationV1)] = Gate(preCancun);
-        Configure(nameof(IEngineRpcModule.engine_forkchoiceUpdatedV1), SszRestPaths.PostV1Forkchoice, Enabled);
-        Configure(nameof(IEngineRpcModule.engine_getPayloadV1), SszRestPaths.GetV1Payloads, Enabled);
-        Configure(nameof(IEngineRpcModule.engine_newPayloadV1), SszRestPaths.PostV1Payloads, Enabled);
-        Configure(nameof(IEngineRpcModule.engine_getClientVersionV1), SszRestPaths.PostV1ClientVersion, Enabled);
+        Configure(nameof(IEngineRpcModule.engine_forkchoiceUpdatedV1), SszRestPaths.PostForkchoice, Enabled);
+        Configure(nameof(IEngineRpcModule.engine_getPayloadV1), SszRestPaths.GetPayloads, Enabled);
+        Configure(nameof(IEngineRpcModule.engine_newPayloadV1), SszRestPaths.PostPayloads, Enabled);
+        Configure(nameof(IEngineRpcModule.engine_getClientVersionV1), SszRestPaths.GetIdentity, Enabled);
         // SSZ-only: engine_exchangeCapabilities is the meta-method (not advertised in the JSON-RPC
         // capabilities list itself), but its SSZ-REST equivalent IS an explicit endpoint.
-        sszLocal[SszRestPaths.PostV1Capabilities] = Enabled;
+        sszLocal[SszRestPaths.GetCapabilities] = Enabled;
 
         // Shanghai
-        Configure(nameof(IEngineRpcModule.engine_forkchoiceUpdatedV2), SszRestPaths.PostV2Forkchoice, Gate(spec.WithdrawalsEnabled));
-        Configure(nameof(IEngineRpcModule.engine_getPayloadV2), SszRestPaths.GetV2Payloads, Gate(spec.WithdrawalsEnabled));
-        Configure(nameof(IEngineRpcModule.engine_newPayloadV2), SszRestPaths.PostV2Payloads, Gate(spec.WithdrawalsEnabled));
-        Configure(nameof(IEngineRpcModule.engine_getPayloadBodiesByHashV1), SszRestPaths.PostV1PayloadBodiesByHash, Gate(spec.WithdrawalsEnabled));
-        Configure(nameof(IEngineRpcModule.engine_getPayloadBodiesByRangeV1), SszRestPaths.GetV1PayloadBodiesByRange, Gate(spec.WithdrawalsEnabled));
+        Configure(nameof(IEngineRpcModule.engine_forkchoiceUpdatedV2), SszRestPaths.PostForkchoice, Gate(spec.WithdrawalsEnabled));
+        Configure(nameof(IEngineRpcModule.engine_getPayloadV2), SszRestPaths.GetPayloads, Gate(spec.WithdrawalsEnabled));
+        Configure(nameof(IEngineRpcModule.engine_newPayloadV2), SszRestPaths.PostPayloads, Gate(spec.WithdrawalsEnabled));
+        Configure(nameof(IEngineRpcModule.engine_getPayloadBodiesByHashV1), SszRestPaths.PostBodiesByHash, Gate(spec.WithdrawalsEnabled));
+        Configure(nameof(IEngineRpcModule.engine_getPayloadBodiesByRangeV1), SszRestPaths.GetBodiesByRange, Gate(spec.WithdrawalsEnabled));
 
         // Cancun
-        Configure(nameof(IEngineRpcModule.engine_getPayloadV3), SszRestPaths.GetV3Payloads, GateWithWarn(spec.IsEip4844Enabled));
-        Configure(nameof(IEngineRpcModule.engine_forkchoiceUpdatedV3), SszRestPaths.PostV3Forkchoice, GateWithWarn(spec.IsEip4844Enabled));
-        Configure(nameof(IEngineRpcModule.engine_newPayloadV3), SszRestPaths.PostV3Payloads, GateWithWarn(spec.IsEip4844Enabled));
-        Configure(nameof(IEngineRpcModule.engine_getBlobsV1), SszRestPaths.PostV1Blobs, Gate(spec.IsEip4844Enabled));
+        Configure(nameof(IEngineRpcModule.engine_getPayloadV3), SszRestPaths.GetPayloads, GateWithWarn(spec.IsEip4844Enabled));
+        Configure(nameof(IEngineRpcModule.engine_forkchoiceUpdatedV3), SszRestPaths.PostForkchoice, GateWithWarn(spec.IsEip4844Enabled));
+        Configure(nameof(IEngineRpcModule.engine_newPayloadV3), SszRestPaths.PostPayloads, GateWithWarn(spec.IsEip4844Enabled));
+        Configure(nameof(IEngineRpcModule.engine_getBlobsV1), SszRestPaths.PostBlobsV1, Gate(spec.IsEip4844Enabled));
 
         // Prague
-        Configure(nameof(IEngineRpcModule.engine_getPayloadV4), SszRestPaths.GetV4Payloads, GateWithWarn(v4));
-        Configure(nameof(IEngineRpcModule.engine_newPayloadV4), SszRestPaths.PostV4Payloads, GateWithWarn(v4));
+        Configure(nameof(IEngineRpcModule.engine_getPayloadV4), SszRestPaths.GetPayloads, GateWithWarn(v4));
+        Configure(nameof(IEngineRpcModule.engine_newPayloadV4), SszRestPaths.PostPayloads, GateWithWarn(v4));
 
         // Osaka
-        Configure(nameof(IEngineRpcModule.engine_getPayloadV5), SszRestPaths.GetV5Payloads, GateWithWarn(spec.IsEip7594Enabled));
-        Configure(nameof(IEngineRpcModule.engine_getBlobsV2), SszRestPaths.PostV2Blobs, Gate(spec.IsEip7594Enabled));
-        Configure(nameof(IEngineRpcModule.engine_getBlobsV3), SszRestPaths.PostV3Blobs, Gate(spec.IsEip7594Enabled));
-        Configure(nameof(IEngineRpcModule.engine_getBlobsV4), SszRestPaths.PostV4Blobs, Gate(spec.IsEip7594Enabled));
+        Configure(nameof(IEngineRpcModule.engine_getPayloadV5), SszRestPaths.GetPayloads, GateWithWarn(spec.IsEip7594Enabled));
+        Configure(nameof(IEngineRpcModule.engine_getBlobsV2), SszRestPaths.PostBlobsV2, Gate(spec.IsEip7594Enabled));
+        Configure(nameof(IEngineRpcModule.engine_getBlobsV3), SszRestPaths.PostBlobsV3, Gate(spec.IsEip7594Enabled));
+        Configure(nameof(IEngineRpcModule.engine_getBlobsV4), SszRestPaths.PostBlobsV4, Gate(spec.IsEip7594Enabled));
 
         // Amsterdam
-        Configure(nameof(IEngineRpcModule.engine_getPayloadV6), SszRestPaths.GetV6Payloads, GateWithWarn(spec.IsEip7928Enabled));
-        Configure(nameof(IEngineRpcModule.engine_newPayloadV5), SszRestPaths.PostV5Payloads, GateWithWarn(spec.IsEip7928Enabled));
-        Configure(nameof(IEngineRpcModule.engine_forkchoiceUpdatedV4), SszRestPaths.PostV4Forkchoice, GateWithWarn(spec.IsEip7843Enabled));
-        Configure(nameof(IEngineRpcModule.engine_getPayloadBodiesByHashV2), SszRestPaths.PostV2PayloadBodiesByHash, GateWithWarn(spec.IsEip7928Enabled));
-        Configure(nameof(IEngineRpcModule.engine_getPayloadBodiesByRangeV2), SszRestPaths.GetV2PayloadBodiesByRange, GateWithWarn(spec.IsEip7928Enabled));
+        Configure(nameof(IEngineRpcModule.engine_getPayloadV6), SszRestPaths.GetPayloads, GateWithWarn(spec.IsEip7928Enabled));
+        Configure(nameof(IEngineRpcModule.engine_newPayloadV5), SszRestPaths.PostPayloads, GateWithWarn(spec.IsEip7928Enabled));
+        Configure(nameof(IEngineRpcModule.engine_forkchoiceUpdatedV4), SszRestPaths.PostForkchoice, GateWithWarn(spec.IsEip7843Enabled));
+        Configure(nameof(IEngineRpcModule.engine_getPayloadBodiesByHashV2), SszRestPaths.PostBodiesByHash, GateWithWarn(spec.IsEip7928Enabled));
+        Configure(nameof(IEngineRpcModule.engine_getPayloadBodiesByRangeV2), SszRestPaths.GetBodiesByRange, GateWithWarn(spec.IsEip7928Enabled));
 
         json = jsonLocal;
         ssz = sszLocal;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
@@ -82,9 +82,6 @@ public class EngineRpcCapabilitiesProvider(ISpecProvider specProvider) : IRpcCap
         void Configure(string method, string path, RpcCapabilityOptions options)
         {
             jsonLocal[method] = options;
-            // Since execution-apis#793 the fork is a request header, so several method versions
-            // (e.g. newPayloadV1..V5) share one fork-less REST path. Accumulate with OR so the
-            // path is advertised as enabled whenever any contributing version is enabled.
             RpcCapabilityOptions sszOptions = options & ~WarnIfMissing;
             sszLocal[path] = sszLocal.TryGetValue(path, out RpcCapabilityOptions existing)
                 ? existing | sszOptions

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/BodiesForkFilter.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/BodiesForkFilter.cs
@@ -11,10 +11,10 @@ using Nethermind.Core.Specs;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Per execution-apis #793, <c>/engine/v2/{fork}/bodies/...</c> responses MUST mark
-/// blocks whose timestamp falls outside the URL fork as <c>available=false</c>.
-/// Applied at the SSZ-REST boundary because the underlying engine handler is shared
-/// with the un-scoped JSON-RPC <c>engine_getPayloadBodies*</c> methods.
+/// Per execution-apis #793, <c>/engine/v2/bodies/...</c> responses MUST mark blocks whose
+/// timestamp falls outside the fork requested via the <c>Eth-Execution-Version</c> header as
+/// <c>available=false</c>. Applied at the SSZ-REST boundary because the underlying engine handler
+/// is shared with the un-scoped JSON-RPC <c>engine_getPayloadBodies*</c> methods.
 /// </summary>
 internal static class BodiesForkFilter
 {

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/BodiesForkFilter.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/BodiesForkFilter.cs
@@ -21,7 +21,7 @@ internal static class BodiesForkFilter
     public static TResult?[] FilterByHash<TResult>(
         IReadOnlyList<TResult?> bodies,
         IReadOnlyList<Hash256> hashes,
-        string urlFork,
+        string requestedFork,
         IBlockFinder blockFinder,
         ISpecProvider specProvider)
         where TResult : class
@@ -32,7 +32,7 @@ internal static class BodiesForkFilter
             TResult? body = bodies[i];
             if (body is null) continue;
             BlockHeader? header = blockFinder.FindHeader(hashes[i]);
-            if (header is not null && Matches(header, urlFork, specProvider))
+            if (header is not null && Matches(header, requestedFork, specProvider))
                 result[i] = body;
         }
         return result;
@@ -41,7 +41,7 @@ internal static class BodiesForkFilter
     public static TResult?[] FilterByRange<TResult>(
         IReadOnlyList<TResult?> bodies,
         ulong start,
-        string urlFork,
+        string requestedFork,
         IBlockFinder blockFinder,
         ISpecProvider specProvider)
         where TResult : class
@@ -52,15 +52,15 @@ internal static class BodiesForkFilter
             TResult? body = bodies[i];
             if (body is null) continue;
             BlockHeader? header = blockFinder.FindHeader(start + (ulong)i);
-            if (header is not null && Matches(header, urlFork, specProvider))
+            if (header is not null && Matches(header, requestedFork, specProvider))
                 result[i] = body;
         }
         return result;
     }
 
-    private static bool Matches(BlockHeader header, string urlFork, ISpecProvider specProvider)
+    private static bool Matches(BlockHeader header, string requestedFork, ISpecProvider specProvider)
     {
         IReleaseSpec spec = specProvider.GetSpec(header);
-        return string.Equals(SszRestPaths.GetEngineApiUrlSegment(spec), urlFork, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(SszRestPaths.GetEngineApiForkName(spec), requestedFork, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
@@ -53,7 +53,7 @@ public sealed class ForkchoiceUpdatedSszHandler<TVersion, TWire>(IEngineRpcModul
             return null;
 
         IReleaseSpec payloadSpec = specProvider.GetSpec(ForkActivation.TimestampOnly(timestamp.Value));
-        string? payloadForkSegment = SszRestPaths.GetEngineApiUrlSegment(payloadSpec);
+        string? payloadForkSegment = SszRestPaths.GetEngineApiForkName(payloadSpec);
         return string.Equals(payloadForkSegment, requestedFork, StringComparison.OrdinalIgnoreCase)
             ? null
             : $"Eth-Execution-Version fork '{requestedFork}' does not match the fork for timestamp {timestamp.Value}";

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
@@ -13,9 +13,10 @@ using Nethermind.Serialization.Ssz;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>POST /engine/v{N}/forkchoice</c>, the SSZ-REST equivalent of
-/// <c>engine_forkchoiceUpdatedV{N}</c>. Generic over a per-version descriptor
-/// so adding V5 is one new descriptor struct + one DI line — no version switch.
+/// Handles <c>POST /engine/v2/forkchoice</c>, the SSZ-REST equivalent of
+/// <c>engine_forkchoiceUpdatedV{N}</c> (the version is selected by the <c>Eth-Execution-Version</c>
+/// header). Generic over a per-version descriptor so adding V5 is one new descriptor struct + one
+/// DI line — no version switch.
 /// </summary>
 public sealed class ForkchoiceUpdatedSszHandler<TVersion, TWire>(IEngineRpcModule engineModule, ISpecProvider specProvider) : SszEndpointHandlerBase
     where TVersion : struct, IForkchoiceUpdatedVersion<TWire>
@@ -29,7 +30,7 @@ public sealed class ForkchoiceUpdatedSszHandler<TVersion, TWire>(IEngineRpcModul
     {
         TWire.Decode(body, out TWire wire);
 
-        if (GetUrlForkMismatchMessage(ctx, TVersion.GetTimestamp(wire)) is { } mismatch)
+        if (GetForkMismatchMessage(ctx, TVersion.GetTimestamp(wire)) is { } mismatch)
         {
             await WriteErrorAsync(ctx, StatusCodes.Status400BadRequest, mismatch, MergeErrorCodes.UnsupportedFork);
             return;
@@ -40,20 +41,21 @@ public sealed class ForkchoiceUpdatedSszHandler<TVersion, TWire>(IEngineRpcModul
     }
 
     /// <summary>
-    /// Returns an error message if the payload's timestamp fork doesn't match the URL <c>{fork}</c>
-    /// segment, or <c>null</c> when the check doesn't apply (no payload attributes / no route fork).
+    /// Returns an error message if the payload's timestamp fork doesn't match the fork requested via
+    /// the <c>Eth-Execution-Version</c> header, or <c>null</c> when the check doesn't apply (no
+    /// payload attributes / no route fork).
     /// </summary>
-    private string? GetUrlForkMismatchMessage(HttpContext ctx, ulong? timestamp)
+    private string? GetForkMismatchMessage(HttpContext ctx, ulong? timestamp)
     {
         if (!timestamp.HasValue
             || !ctx.Items.TryGetValue("SszRouteFork", out object? forkObj)
-            || forkObj is not string urlFork)
+            || forkObj is not string requestedFork)
             return null;
 
         IReleaseSpec payloadSpec = specProvider.GetSpec(ForkActivation.TimestampOnly(timestamp.Value));
         string? payloadForkSegment = SszRestPaths.GetEngineApiUrlSegment(payloadSpec);
-        return string.Equals(payloadForkSegment, urlFork, StringComparison.OrdinalIgnoreCase)
+        return string.Equals(payloadForkSegment, requestedFork, StringComparison.OrdinalIgnoreCase)
             ? null
-            : $"URL fork '{urlFork}' does not match the fork for timestamp {timestamp.Value}";
+            : $"Eth-Execution-Version fork '{requestedFork}' does not match the fork for timestamp {timestamp.Value}";
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
@@ -47,9 +47,7 @@ public sealed class ForkchoiceUpdatedSszHandler<TVersion, TWire>(IEngineRpcModul
     /// </summary>
     private string? GetForkMismatchMessage(HttpContext ctx, ulong? timestamp)
     {
-        if (!timestamp.HasValue
-            || !ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? forkObj)
-            || forkObj is not string requestedFork)
+        if (!timestamp.HasValue || GetRequestedFork(ctx) is not { } requestedFork)
             return null;
 
         IReleaseSpec payloadSpec = specProvider.GetSpec(ForkActivation.TimestampOnly(timestamp.Value));

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
@@ -48,7 +48,7 @@ public sealed class ForkchoiceUpdatedSszHandler<TVersion, TWire>(IEngineRpcModul
     private string? GetForkMismatchMessage(HttpContext ctx, ulong? timestamp)
     {
         if (!timestamp.HasValue
-            || !ctx.Items.TryGetValue("SszRouteFork", out object? forkObj)
+            || !ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? forkObj)
             || forkObj is not string requestedFork)
             return null;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
@@ -15,8 +15,9 @@ using Nethermind.JsonRpc;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>POST /engine/v{N}/payloads/bodies/by-hash</c>, the SSZ-REST equivalent
-/// of <c>engine_getPayloadBodiesByHashV{N}</c>. Generic over a per-version descriptor
+/// Handles <c>POST /engine/v2/bodies/hash</c>, the SSZ-REST equivalent
+/// of <c>engine_getPayloadBodiesByHashV{N}</c> (the version is selected by the
+/// <c>Eth-Execution-Version</c> header). Generic over a per-version descriptor
 /// so adding a Vn+1 endpoint is one new descriptor + one DI line.
 /// </summary>
 public sealed class GetPayloadBodiesByHashSszHandler<TVersion, TResult>(

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
@@ -45,7 +45,7 @@ public sealed class GetPayloadBodiesByHashSszHandler<TVersion, TResult>(
         ResultWrapper<IReadOnlyList<TResult?>> result = await TVersion.Call(engineModule, hashes);
         if (result.Result.ResultType == ResultType.Success && result.Data is { Count: > 0 } data)
         {
-            string? urlFork = ctx.Items.TryGetValue("SszRouteFork", out object? f) ? f as string : null;
+            string? urlFork = ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? f) ? f as string : null;
             if (urlFork is not null)
             {
                 TResult?[] filtered = BodiesForkFilter.FilterByHash(data, hashes, urlFork, blockFinder, specProvider);

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
@@ -45,7 +45,7 @@ public sealed class GetPayloadBodiesByHashSszHandler<TVersion, TResult>(
         ResultWrapper<IReadOnlyList<TResult?>> result = await TVersion.Call(engineModule, hashes);
         if (result.Result.ResultType == ResultType.Success && result.Data is { Count: > 0 } data)
         {
-            string? requestedFork = ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? f) ? f as string : null;
+            string? requestedFork = GetRequestedFork(ctx);
             if (requestedFork is not null)
             {
                 TResult?[] filtered = BodiesForkFilter.FilterByHash(data, hashes, requestedFork, blockFinder, specProvider);

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
@@ -45,10 +45,10 @@ public sealed class GetPayloadBodiesByHashSszHandler<TVersion, TResult>(
         ResultWrapper<IReadOnlyList<TResult?>> result = await TVersion.Call(engineModule, hashes);
         if (result.Result.ResultType == ResultType.Success && result.Data is { Count: > 0 } data)
         {
-            string? urlFork = ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? f) ? f as string : null;
-            if (urlFork is not null)
+            string? requestedFork = ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? f) ? f as string : null;
+            if (requestedFork is not null)
             {
-                TResult?[] filtered = BodiesForkFilter.FilterByHash(data, hashes, urlFork, blockFinder, specProvider);
+                TResult?[] filtered = BodiesForkFilter.FilterByHash(data, hashes, requestedFork, blockFinder, specProvider);
                 ResultWrapper<IReadOnlyList<TResult?>> wrapped = ResultWrapper<IReadOnlyList<TResult?>>.Success(filtered);
                 wrapped.AddDisposable(result.Dispose);
                 result = wrapped;

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByRangeSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByRangeSszHandler.cs
@@ -14,8 +14,9 @@ using Nethermind.JsonRpc;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>GET /engine/v2/{fork}/bodies?from=N&amp;count=M</c>, the SSZ-REST equivalent
-/// of <c>engine_getPayloadBodiesByRangeV{N}</c>. Generic over a per-version descriptor
+/// Handles <c>GET /engine/v2/bodies?from=N&amp;count=M</c>, the SSZ-REST equivalent
+/// of <c>engine_getPayloadBodiesByRangeV{N}</c> (the version is selected by the
+/// <c>Eth-Execution-Version</c> header). Generic over a per-version descriptor
 /// so adding a Vn+1 endpoint is one new descriptor + one DI line.
 /// </summary>
 public sealed class GetPayloadBodiesByRangeSszHandler<TVersion, TResult>(

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByRangeSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByRangeSszHandler.cs
@@ -54,7 +54,7 @@ public sealed class GetPayloadBodiesByRangeSszHandler<TVersion, TResult>(
             return;
         }
         ResultWrapper<IReadOnlyList<TResult?>> result = await TVersion.Call(engineModule, start, count);
-        string? requestedFork = ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? f) ? f as string : null;
+        string? requestedFork = GetRequestedFork(ctx);
         if (requestedFork is not null && result.Result.ResultType == ResultType.Success && result.Data is { Count: > 0 } data)
         {
             TResult?[] filtered = BodiesForkFilter.FilterByRange(data, start, requestedFork, blockFinder, specProvider);

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByRangeSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByRangeSszHandler.cs
@@ -54,10 +54,10 @@ public sealed class GetPayloadBodiesByRangeSszHandler<TVersion, TResult>(
             return;
         }
         ResultWrapper<IReadOnlyList<TResult?>> result = await TVersion.Call(engineModule, start, count);
-        string? urlFork = ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? f) ? f as string : null;
-        if (urlFork is not null && result.Result.ResultType == ResultType.Success && result.Data is { Count: > 0 } data)
+        string? requestedFork = ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? f) ? f as string : null;
+        if (requestedFork is not null && result.Result.ResultType == ResultType.Success && result.Data is { Count: > 0 } data)
         {
-            TResult?[] filtered = BodiesForkFilter.FilterByRange(data, start, urlFork, blockFinder, specProvider);
+            TResult?[] filtered = BodiesForkFilter.FilterByRange(data, start, requestedFork, blockFinder, specProvider);
             ResultWrapper<IReadOnlyList<TResult?>> wrapped = ResultWrapper<IReadOnlyList<TResult?>>.Success(filtered);
             wrapped.AddDisposable(result.Dispose);
             result = wrapped;

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByRangeSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByRangeSszHandler.cs
@@ -54,7 +54,7 @@ public sealed class GetPayloadBodiesByRangeSszHandler<TVersion, TResult>(
             return;
         }
         ResultWrapper<IReadOnlyList<TResult?>> result = await TVersion.Call(engineModule, start, count);
-        string? urlFork = ctx.Items.TryGetValue("SszRouteFork", out object? f) ? f as string : null;
+        string? urlFork = ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? f) ? f as string : null;
         if (urlFork is not null && result.Result.ResultType == ResultType.Success && result.Data is { Count: > 0 } data)
         {
             TResult?[] filtered = BodiesForkFilter.FilterByRange(data, start, urlFork, blockFinder, specProvider);

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadSszHandler.cs
@@ -9,8 +9,8 @@ using Microsoft.AspNetCore.Http;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>GET /engine/v{N}/payloads/{payloadId}</c>, the SSZ-REST equivalent of
-/// <c>engine_getPayloadV{N}</c>.
+/// Handles <c>GET /engine/v2/payloads/{payload_id}</c>, the SSZ-REST equivalent of
+/// <c>engine_getPayloadV{N}</c> (the version is selected by the <c>Eth-Execution-Version</c> header).
 /// </summary>
 public sealed class GetPayloadSszHandler<TVersion, TResult>(IEngineRpcModule engine)
     : SszEndpointHandlerBase

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadSszHandler.cs
@@ -12,9 +12,10 @@ using Nethermind.Serialization.Ssz;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>POST /engine/v{N}/payloads</c>, the SSZ-REST equivalent of
-/// <c>engine_newPayloadV{N}</c>. Generic over a per-version descriptor so
-/// adding V6 is one new descriptor struct + one DI line — no version switch.
+/// Handles <c>POST /engine/v2/payloads</c>, the SSZ-REST equivalent of
+/// <c>engine_newPayloadV{N}</c> (the version is selected by the <c>Eth-Execution-Version</c>
+/// header). Generic over a per-version descriptor so adding V6 is one new descriptor struct +
+/// one DI line — no version switch.
 /// </summary>
 public sealed class NewPayloadSszHandler<TVersion, TWire>(IEngineRpcModule engineModule) : SszEndpointHandlerBase
     where TVersion : struct, INewPayloadVersion<TWire>

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadSszHandler.cs
@@ -28,9 +28,6 @@ public sealed class NewPayloadSszHandler<TVersion, TWire>(IEngineRpcModule engin
     public override async Task HandleAsync(HttpContext ctx, int version, ReadOnlyMemory<char> extra, ReadOnlySequence<byte> body)
     {
         TWire.Decode(body, out TWire wire);
-        // Unlike forkchoiceUpdated, no explicit Eth-Execution-Version-vs-payload-fork check here:
-        // a mismatched header selects the wrong wire type (→ ssz-decode-error) and engine_newPayloadV{N}
-        // performs its own timestamp/fork validation on the decoded payload.
         ResultWrapper<PayloadStatusV1> result = await TVersion.Call(engineModule, wire);
         await WriteSszResultAsync(ctx, result, SszCodec.EncodePayloadStatus);
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadSszHandler.cs
@@ -28,6 +28,9 @@ public sealed class NewPayloadSszHandler<TVersion, TWire>(IEngineRpcModule engin
     public override async Task HandleAsync(HttpContext ctx, int version, ReadOnlyMemory<char> extra, ReadOnlySequence<byte> body)
     {
         TWire.Decode(body, out TWire wire);
+        // Unlike forkchoiceUpdated, no explicit Eth-Execution-Version-vs-payload-fork check here:
+        // a mismatched header selects the wrong wire type (→ ssz-decode-error) and engine_newPayloadV{N}
+        // performs its own timestamp/fork validation on the decoded payload.
         ResultWrapper<PayloadStatusV1> result = await TVersion.Call(engineModule, wire);
         await WriteSszResultAsync(ctx, result, SszCodec.EncodePayloadStatus);
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszEndpointHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszEndpointHandlerBase.cs
@@ -32,6 +32,13 @@ public abstract class SszEndpointHandlerBase : ISszEndpointHandler
     /// <inheritdoc/>
     public abstract Task HandleAsync(HttpContext ctx, int version, ReadOnlyMemory<char> extra, ReadOnlySequence<byte> body);
 
+    /// <summary>
+    /// The fork requested via the <c>Eth-Execution-Version</c> header for this fork-scoped request,
+    /// as stashed by <see cref="SszMiddleware"/>, or <c>null</c> for unscoped/blob endpoints.
+    /// </summary>
+    protected static string? GetRequestedFork(HttpContext ctx) =>
+        ctx.Items.TryGetValue(SszMiddleware.RouteForkItemKey, out object? fork) ? fork as string : null;
+
     private static async Task WriteSszAsync<T>(HttpContext ctx, T value, Func<T, IBufferWriter<byte>, int> encode)
     {
         // GetSpan/Advance buffer into the response pipe without starting the response;

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Nethermind.Core.Specs;
 using Nethermind.Specs.Forks;
 using Forks = Nethermind.Specs.Forks;
@@ -136,9 +137,9 @@ public static class SszRestPaths
     public static int? MapForkToVersion(string fork, ReadOnlySpan<char> resource, string httpMethod, out bool recognizedResource)
     {
         Func<Forks.NamedReleaseSpec, int?>? selectVersion = null;
-        if (string.Equals(httpMethod, "POST", StringComparison.Ordinal))
+        if (HttpMethods.IsPost(httpMethod))
             _postVersionLookup.TryGetValue(resource, out selectVersion);
-        else if (string.Equals(httpMethod, "GET", StringComparison.Ordinal))
+        else if (HttpMethods.IsGet(httpMethod))
             _getVersionLookup.TryGetValue(resource, out selectVersion);
 
         recognizedResource = selectVersion is not null;

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
@@ -12,13 +12,6 @@ namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 public static class SszRestPaths
 {
-    private static readonly string _paris = Forks.Paris.Instance.EngineApiUrlSegment!;
-    private static readonly string _shanghai = Forks.Shanghai.Instance.EngineApiUrlSegment!;
-    private static readonly string _cancun = Forks.Cancun.Instance.EngineApiUrlSegment!;
-    private static readonly string _prague = Forks.Prague.Instance.EngineApiUrlSegment!;
-    private static readonly string _osaka = Forks.Osaka.Instance.EngineApiUrlSegment!;
-    private static readonly string _amsterdam = Forks.Amsterdam.Instance.EngineApiUrlSegment!;
-
     /// <summary>
     /// Single source of truth: URL fork segment → <see cref="Forks.NamedReleaseSpec"/>. Built by
     /// walking back from the latest fork via <see cref="Forks.NamedReleaseSpec.Parent"/> and
@@ -54,13 +47,6 @@ public static class SszRestPaths
     public static readonly FrozenSet<string> SupportedForks =
         SupportedForksOrdered.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>
-    /// Cached <see cref="ReadOnlySpan{Char}"/> alternate lookup for <see cref="SupportedForks"/>,
-    /// so the per-request <c>GetAlternateLookup</c> call in <c>SszMiddleware.TryRoute</c> is avoided.
-    /// </summary>
-    public static readonly FrozenSet<string>.AlternateLookup<ReadOnlySpan<char>> SupportedForksSpanLookup =
-        SupportedForks.GetAlternateLookup<ReadOnlySpan<char>>();
-
     public const string Payloads = "payloads";
 
     public const string Forkchoice = "forkchoice";
@@ -76,38 +62,21 @@ public static class SszRestPaths
     public const string Blobs = "blobs";
 
     // Documentation strings for the SSZ-REST routes — used by EngineRpcCapabilitiesProvider
-    // (registration) and EngineModuleTests (coverage assertions). Built at static-init time from
-    // each fork's EngineApiUrlSegment so the route docs stay in sync with the routing layer.
-    public static readonly string PostV1Payloads = $"POST /engine/v2/{_paris}/payloads";
-    public static readonly string GetV1Payloads = $"GET /engine/v2/{_paris}/payloads/{{payload_id}}";
-    public static readonly string PostV1Forkchoice = $"POST /engine/v2/{_paris}/forkchoice";
-    public const string PostV1Capabilities = "GET /engine/v2/capabilities";
-    public const string PostV1ClientVersion = "GET /engine/v2/identity";
-
-    public static readonly string PostV2Payloads = $"POST /engine/v2/{_shanghai}/payloads";
-    public static readonly string PostV2Forkchoice = $"POST /engine/v2/{_shanghai}/forkchoice";
-    public static readonly string GetV2Payloads = $"GET /engine/v2/{_shanghai}/payloads/{{payload_id}}";
-    public static readonly string PostV1PayloadBodiesByHash = $"POST /engine/v2/{_shanghai}/bodies/hash";
-    public static readonly string GetV1PayloadBodiesByRange = $"GET /engine/v2/{_shanghai}/bodies";
-
-    public static readonly string PostV3Payloads = $"POST /engine/v2/{_cancun}/payloads";
-    public static readonly string PostV3Forkchoice = $"POST /engine/v2/{_cancun}/forkchoice";
-    public static readonly string GetV3Payloads = $"GET /engine/v2/{_cancun}/payloads/{{payload_id}}";
-    public const string PostV1Blobs = "POST /engine/v2/blobs/v1";
-
-    public static readonly string PostV4Payloads = $"POST /engine/v2/{_prague}/payloads";
-    public static readonly string GetV4Payloads = $"GET /engine/v2/{_prague}/payloads/{{payload_id}}";
-
-    public static readonly string GetV5Payloads = $"GET /engine/v2/{_osaka}/payloads/{{payload_id}}";
-    public const string PostV2Blobs = "POST /engine/v2/blobs/v2";
-    public const string PostV3Blobs = "POST /engine/v2/blobs/v3";
-
-    public static readonly string PostV5Payloads = $"POST /engine/v2/{_amsterdam}/payloads";
-    public static readonly string GetV6Payloads = $"GET /engine/v2/{_amsterdam}/payloads/{{payload_id}}";
-    public static readonly string PostV4Forkchoice = $"POST /engine/v2/{_amsterdam}/forkchoice";
-    public static readonly string PostV2PayloadBodiesByHash = $"POST /engine/v2/{_amsterdam}/bodies/hash";
-    public static readonly string GetV2PayloadBodiesByRange = $"GET /engine/v2/{_amsterdam}/bodies";
-    public const string PostV4Blobs = "POST /engine/v2/blobs/v4";
+    // (registration) and EngineModuleTests (coverage assertions). Since execution-apis#793 moved
+    // the fork out of the path and into the Eth-Execution-Version header, each fork-scoped route is
+    // advertised once: fork selection is a request header, not a distinct path. Blobs remain
+    // independently path-versioned, and identity/capabilities stay unscoped.
+    public const string PostPayloads = "POST /engine/v2/payloads";
+    public const string GetPayloads = "GET /engine/v2/payloads/{payload_id}";
+    public const string PostForkchoice = "POST /engine/v2/forkchoice";
+    public const string PostBodiesByHash = "POST /engine/v2/bodies/hash";
+    public const string GetBodiesByRange = "GET /engine/v2/bodies";
+    public const string GetCapabilities = "GET /engine/v2/capabilities";
+    public const string GetIdentity = "GET /engine/v2/identity";
+    public const string PostBlobsV1 = "POST /engine/v2/blobs/v1";
+    public const string PostBlobsV2 = "POST /engine/v2/blobs/v2";
+    public const string PostBlobsV3 = "POST /engine/v2/blobs/v3";
+    public const string PostBlobsV4 = "POST /engine/v2/blobs/v4";
 
     /// <summary>
     /// Resolves the per-fork engine API method version for the given <paramref name="resource"/>

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
@@ -151,16 +151,17 @@ public static class SszRestPaths
     }
 
     /// <summary>
-    /// Returns the fork name (<c>Eth-Execution-Version</c> value) that owns <paramref name="spec"/>'s
-    /// engine API surface, walking up the parent chain so BPO forks resolve to their parent
-    /// (e.g. <c>bpo1 → osaka</c>).
+    /// Returns the fork name that owns <paramref name="spec"/>'s engine API surface, walking up the
+    /// parent chain so BPO forks resolve to their parent (e.g. <c>bpo1 → osaka</c>). Matched
+    /// case-insensitively against the <c>Eth-Execution-Version</c> value, so it is returned as-is
+    /// (no per-call lowercasing).
     /// </summary>
     public static string? GetEngineApiForkName(IReleaseSpec spec)
     {
         for (Forks.NamedReleaseSpec? n = spec as Forks.NamedReleaseSpec; n is not null; n = n.Parent)
         {
-            if (ForkName(n) is { } forkName && _forkSpecByUrl.ContainsKey(forkName))
-                return forkName;
+            if (n.Name is { } name && _forkSpecByUrl.ContainsKey(name))
+                return name;
         }
         return null;
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 public static class SszRestPaths
 {
     /// <summary>
-    /// Single source of truth: URL fork segment → <see cref="Forks.NamedReleaseSpec"/>. Built by
+    /// Single source of truth: fork name (Eth-Execution-Version value) → <see cref="Forks.NamedReleaseSpec"/>. Built by
     /// walking back from the latest fork via <see cref="Forks.NamedReleaseSpec.Parent"/> and
     /// keeping every fork that introduces an engine-API method-version change vs. its parent.
     /// BPO blob-parameter override forks inherit all engine-API versions and so are filtered out.
@@ -38,7 +38,7 @@ public static class SszRestPaths
 
         Dictionary<string, Forks.NamedReleaseSpec> result = new(StringComparer.OrdinalIgnoreCase);
         foreach (Forks.NamedReleaseSpec spec in ordered)
-            result[spec.EngineApiUrlSegment!] = spec;
+            result[spec.EngineApiForkName!] = spec;
         return result;
     }
 
@@ -84,22 +84,29 @@ public static class SszRestPaths
     /// Each fork only declares the versions it changes vs. its parent; values flow forward through
     /// the spec inheritance chain.
     /// </summary>
-    public static int? MapForkToVersion(string fork, ReadOnlySpan<char> resource, string httpMethod)
+    /// <param name="recognizedResource">
+    /// <c>true</c> when <paramref name="resource"/> + <paramref name="httpMethod"/> name a known
+    /// fork-scoped endpoint, even if this fork has no version for it (e.g. <c>paris</c> + <c>bodies</c>).
+    /// Lets the caller distinguish "endpoint not available for this fork" (400) from "unknown
+    /// endpoint" (404) when the returned version is <c>null</c>.
+    /// </param>
+    public static int? MapForkToVersion(string fork, ReadOnlySpan<char> resource, string httpMethod, out bool recognizedResource)
     {
+        recognizedResource = false;
         if (!_forkSpecByUrl.TryGetValue(fork, out Forks.NamedReleaseSpec? spec)) return null;
 
-        // Resource comparisons are case-insensitive (URL segments are lowercase per spec,
+        // Resource comparisons are case-insensitive (fork names are lowercase per spec,
         // but routing accepts any case).
         if (string.Equals(httpMethod, "POST", StringComparison.Ordinal))
         {
-            if (Eq(resource, Payloads)) return spec.EngineApiNewPayloadVersion;
-            if (Eq(resource, Forkchoice)) return spec.EngineApiForkchoiceVersion;
-            if (Eq(resource, PayloadBodiesByHash)) return spec.EngineApiPayloadBodiesByHashVersion;
+            if (Eq(resource, Payloads)) { recognizedResource = true; return spec.EngineApiNewPayloadVersion; }
+            if (Eq(resource, Forkchoice)) { recognizedResource = true; return spec.EngineApiForkchoiceVersion; }
+            if (Eq(resource, PayloadBodiesByHash)) { recognizedResource = true; return spec.EngineApiPayloadBodiesByHashVersion; }
         }
         else if (string.Equals(httpMethod, "GET", StringComparison.Ordinal))
         {
-            if (Eq(resource, Payloads)) return spec.EngineApiGetPayloadVersion;
-            if (Eq(resource, PayloadBodiesByRange)) return spec.EngineApiPayloadBodiesByRangeVersion;
+            if (Eq(resource, Payloads)) { recognizedResource = true; return spec.EngineApiGetPayloadVersion; }
+            if (Eq(resource, PayloadBodiesByRange)) { recognizedResource = true; return spec.EngineApiPayloadBodiesByRangeVersion; }
         }
 
         return null;
@@ -108,15 +115,16 @@ public static class SszRestPaths
     }
 
     /// <summary>
-    /// Returns the URL fork segment that owns <paramref name="spec"/>'s engine API surface,
-    /// walking up the parent chain so BPO forks resolve to their parent (e.g. <c>bpo1 → osaka</c>).
+    /// Returns the fork name (<c>Eth-Execution-Version</c> value) that owns <paramref name="spec"/>'s
+    /// engine API surface, walking up the parent chain so BPO forks resolve to their parent
+    /// (e.g. <c>bpo1 → osaka</c>).
     /// </summary>
-    public static string? GetEngineApiUrlSegment(IReleaseSpec spec)
+    public static string? GetEngineApiForkName(IReleaseSpec spec)
     {
         for (Forks.NamedReleaseSpec? n = spec as Forks.NamedReleaseSpec; n is not null; n = n.Parent)
         {
-            if (n.EngineApiUrlSegment is { } seg && _forkSpecByUrl.ContainsKey(seg))
-                return seg;
+            if (n.EngineApiForkName is { } forkName && _forkSpecByUrl.ContainsKey(forkName))
+                return forkName;
         }
         return null;
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
@@ -38,9 +38,15 @@ public static class SszRestPaths
 
         Dictionary<string, Forks.NamedReleaseSpec> result = new(StringComparer.OrdinalIgnoreCase);
         foreach (Forks.NamedReleaseSpec spec in ordered)
-            result[spec.EngineApiForkName!] = spec;
+            result[ForkName(spec)!] = spec;
         return result;
     }
+
+    /// <summary>Lowercase fork name used as the <c>Eth-Execution-Version</c> header value.</summary>
+    private static string? ForkName(Forks.NamedReleaseSpec spec) => spec.Name?.ToLowerInvariant();
+
+    private static bool ResourceEquals(ReadOnlySpan<char> resource, string name) =>
+        resource.Equals(name.AsSpan(), StringComparison.OrdinalIgnoreCase);
 
     public static readonly IReadOnlyList<string> SupportedForksOrdered = [.. _forkSpecByUrl.Keys];
 
@@ -61,11 +67,25 @@ public static class SszRestPaths
 
     public const string Blobs = "blobs";
 
-    // Documentation strings for the SSZ-REST routes — used by EngineRpcCapabilitiesProvider
-    // (registration) and EngineModuleTests (coverage assertions). Since execution-apis#793 moved
-    // the fork out of the path and into the Eth-Execution-Version header, each fork-scoped route is
-    // advertised once: fork selection is a request header, not a distinct path. Blobs remain
-    // independently path-versioned, and identity/capabilities stay unscoped.
+    /// <summary>How a resource's fork and version are determined by <c>SszMiddleware</c>.</summary>
+    public enum ResourceScoping
+    {
+        /// <summary>Fork (and thus method version) comes from the <c>Eth-Execution-Version</c> header.</summary>
+        ForkScoped,
+        /// <summary>Version comes from a trailing <c>/v{N}</c> path segment; no fork header (blobs).</summary>
+        PathVersioned,
+        /// <summary>No fork and no version — a single endpoint (capabilities, identity).</summary>
+        Unscoped
+    }
+
+    /// <summary>Classifies how the given first path <paramref name="resource"/> segment is routed.</summary>
+    public static ResourceScoping GetScoping(ReadOnlySpan<char> resource)
+    {
+        if (ResourceEquals(resource, Capabilities) || ResourceEquals(resource, ClientVersion)) return ResourceScoping.Unscoped;
+        if (ResourceEquals(resource, Blobs)) return ResourceScoping.PathVersioned;
+        return ResourceScoping.ForkScoped;
+    }
+
     public const string PostPayloads = "POST /engine/v2/payloads";
     public const string GetPayloads = "GET /engine/v2/payloads/{payload_id}";
     public const string PostForkchoice = "POST /engine/v2/forkchoice";
@@ -92,26 +112,42 @@ public static class SszRestPaths
     /// </param>
     public static int? MapForkToVersion(string fork, ReadOnlySpan<char> resource, string httpMethod, out bool recognizedResource)
     {
-        recognizedResource = false;
-        if (!_forkSpecByUrl.TryGetValue(fork, out Forks.NamedReleaseSpec? spec)) return null;
+        ForkScopedMethod method = ClassifyMethod(resource, httpMethod);
+        recognizedResource = method != ForkScopedMethod.None;
+        if (!recognizedResource || !_forkSpecByUrl.TryGetValue(fork, out Forks.NamedReleaseSpec? spec))
+            return null;
 
-        // Resource comparisons are case-insensitive (fork names are lowercase per spec,
+        return method switch
+        {
+            ForkScopedMethod.NewPayload => spec.EngineApiNewPayloadVersion,
+            ForkScopedMethod.GetPayload => spec.EngineApiGetPayloadVersion,
+            ForkScopedMethod.Forkchoice => spec.EngineApiForkchoiceVersion,
+            ForkScopedMethod.BodiesByHash => spec.EngineApiPayloadBodiesByHashVersion,
+            ForkScopedMethod.BodiesByRange => spec.EngineApiPayloadBodiesByRangeVersion,
+            _ => null
+        };
+    }
+
+    private enum ForkScopedMethod { None, NewPayload, GetPayload, Forkchoice, BodiesByHash, BodiesByRange }
+
+    /// <summary>Maps a fork-scoped (<paramref name="resource"/>, <paramref name="httpMethod"/>) pair
+    /// to the engine method it targets, or <see cref="ForkScopedMethod.None"/> if unrecognized.</summary>
+    private static ForkScopedMethod ClassifyMethod(ReadOnlySpan<char> resource, string httpMethod)
+    {
+        // Resource comparisons are case-insensitive (fork/resource names are lowercase per spec,
         // but routing accepts any case).
         if (string.Equals(httpMethod, "POST", StringComparison.Ordinal))
         {
-            if (Eq(resource, Payloads)) { recognizedResource = true; return spec.EngineApiNewPayloadVersion; }
-            if (Eq(resource, Forkchoice)) { recognizedResource = true; return spec.EngineApiForkchoiceVersion; }
-            if (Eq(resource, PayloadBodiesByHash)) { recognizedResource = true; return spec.EngineApiPayloadBodiesByHashVersion; }
+            if (ResourceEquals(resource, Payloads)) return ForkScopedMethod.NewPayload;
+            if (ResourceEquals(resource, Forkchoice)) return ForkScopedMethod.Forkchoice;
+            if (ResourceEquals(resource, PayloadBodiesByHash)) return ForkScopedMethod.BodiesByHash;
         }
         else if (string.Equals(httpMethod, "GET", StringComparison.Ordinal))
         {
-            if (Eq(resource, Payloads)) { recognizedResource = true; return spec.EngineApiGetPayloadVersion; }
-            if (Eq(resource, PayloadBodiesByRange)) { recognizedResource = true; return spec.EngineApiPayloadBodiesByRangeVersion; }
+            if (ResourceEquals(resource, Payloads)) return ForkScopedMethod.GetPayload;
+            if (ResourceEquals(resource, PayloadBodiesByRange)) return ForkScopedMethod.BodiesByRange;
         }
-
-        return null;
-
-        static bool Eq(ReadOnlySpan<char> a, string b) => a.Equals(b.AsSpan(), StringComparison.OrdinalIgnoreCase);
+        return ForkScopedMethod.None;
     }
 
     /// <summary>
@@ -123,7 +159,7 @@ public static class SszRestPaths
     {
         for (Forks.NamedReleaseSpec? n = spec as Forks.NamedReleaseSpec; n is not null; n = n.Parent)
         {
-            if (n.EngineApiForkName is { } forkName && _forkSpecByUrl.ContainsKey(forkName))
+            if (ForkName(n) is { } forkName && _forkSpecByUrl.ContainsKey(forkName))
                 return forkName;
         }
         return null;

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
@@ -98,6 +98,29 @@ public static class SszRestPaths
     public const string PostBlobsV3 = "POST /engine/v2/blobs/v3";
     public const string PostBlobsV4 = "POST /engine/v2/blobs/v4";
 
+    // Fork-scoped endpoint → selector pulling its method version off a fork spec, keyed by resource
+    // (one table per HTTP method). Presence in the table means the (method, resource) pair is a
+    // recognized endpoint, even when the selector returns null because this fork predates it.
+    private static readonly FrozenDictionary<string, Func<Forks.NamedReleaseSpec, int?>> _postVersionByResource =
+        new Dictionary<string, Func<Forks.NamedReleaseSpec, int?>>(StringComparer.OrdinalIgnoreCase)
+        {
+            [Payloads] = static spec => spec.EngineApiNewPayloadVersion,
+            [Forkchoice] = static spec => spec.EngineApiForkchoiceVersion,
+            [PayloadBodiesByHash] = static spec => spec.EngineApiPayloadBodiesByHashVersion,
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly FrozenDictionary<string, Func<Forks.NamedReleaseSpec, int?>> _getVersionByResource =
+        new Dictionary<string, Func<Forks.NamedReleaseSpec, int?>>(StringComparer.OrdinalIgnoreCase)
+        {
+            [Payloads] = static spec => spec.EngineApiGetPayloadVersion,
+            [PayloadBodiesByRange] = static spec => spec.EngineApiPayloadBodiesByRangeVersion,
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly FrozenDictionary<string, Func<Forks.NamedReleaseSpec, int?>>.AlternateLookup<ReadOnlySpan<char>> _postVersionLookup =
+        _postVersionByResource.GetAlternateLookup<ReadOnlySpan<char>>();
+    private static readonly FrozenDictionary<string, Func<Forks.NamedReleaseSpec, int?>>.AlternateLookup<ReadOnlySpan<char>> _getVersionLookup =
+        _getVersionByResource.GetAlternateLookup<ReadOnlySpan<char>>();
+
     /// <summary>
     /// Resolves the per-fork engine API method version for the given <paramref name="resource"/>
     /// + <paramref name="httpMethod"/> by looking it up on the fork's <see cref="Forks.NamedReleaseSpec"/>.
@@ -112,42 +135,16 @@ public static class SszRestPaths
     /// </param>
     public static int? MapForkToVersion(string fork, ReadOnlySpan<char> resource, string httpMethod, out bool recognizedResource)
     {
-        ForkScopedMethod method = ClassifyMethod(resource, httpMethod);
-        recognizedResource = method != ForkScopedMethod.None;
-        if (!recognizedResource || !_forkSpecByUrl.TryGetValue(fork, out Forks.NamedReleaseSpec? spec))
-            return null;
-
-        return method switch
-        {
-            ForkScopedMethod.NewPayload => spec.EngineApiNewPayloadVersion,
-            ForkScopedMethod.GetPayload => spec.EngineApiGetPayloadVersion,
-            ForkScopedMethod.Forkchoice => spec.EngineApiForkchoiceVersion,
-            ForkScopedMethod.BodiesByHash => spec.EngineApiPayloadBodiesByHashVersion,
-            ForkScopedMethod.BodiesByRange => spec.EngineApiPayloadBodiesByRangeVersion,
-            _ => null
-        };
-    }
-
-    private enum ForkScopedMethod { None, NewPayload, GetPayload, Forkchoice, BodiesByHash, BodiesByRange }
-
-    /// <summary>Maps a fork-scoped (<paramref name="resource"/>, <paramref name="httpMethod"/>) pair
-    /// to the engine method it targets, or <see cref="ForkScopedMethod.None"/> if unrecognized.</summary>
-    private static ForkScopedMethod ClassifyMethod(ReadOnlySpan<char> resource, string httpMethod)
-    {
-        // Resource comparisons are case-insensitive (fork/resource names are lowercase per spec,
-        // but routing accepts any case).
+        Func<Forks.NamedReleaseSpec, int?>? selectVersion = null;
         if (string.Equals(httpMethod, "POST", StringComparison.Ordinal))
-        {
-            if (ResourceEquals(resource, Payloads)) return ForkScopedMethod.NewPayload;
-            if (ResourceEquals(resource, Forkchoice)) return ForkScopedMethod.Forkchoice;
-            if (ResourceEquals(resource, PayloadBodiesByHash)) return ForkScopedMethod.BodiesByHash;
-        }
+            _postVersionLookup.TryGetValue(resource, out selectVersion);
         else if (string.Equals(httpMethod, "GET", StringComparison.Ordinal))
-        {
-            if (ResourceEquals(resource, Payloads)) return ForkScopedMethod.GetPayload;
-            if (ResourceEquals(resource, PayloadBodiesByRange)) return ForkScopedMethod.BodiesByRange;
-        }
-        return ForkScopedMethod.None;
+            _getVersionLookup.TryGetValue(resource, out selectVersion);
+
+        recognizedResource = selectVersion is not null;
+        return recognizedResource && _forkSpecByUrl.TryGetValue(fork, out Forks.NamedReleaseSpec? spec)
+            ? selectVersion!(spec)
+            : null;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -294,8 +294,6 @@ public sealed class SszMiddleware
         switch (SszRestPaths.GetScoping(resource))
         {
             case SszRestPaths.ResourceScoping.Unscoped:
-                // Exact fixed paths (e.g. /capabilities, /identity): reject any extra segment or
-                // trailing slash so /capabilities and /capabilities/ don't diverge from /capabilities/foo.
                 if (!rest.IsEmpty || hadTrailingSlash) return false;
                 pathSegment = path.AsMemory(offset, pathLen - offset);
                 return true;

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -168,8 +168,6 @@ public sealed class SszMiddleware
         else if (!TryResolveHandler(ctx.Request.Method, pathSegment, version, fork, out ISszEndpointHandler? handler, out ReadOnlyMemory<char> extra, out bool endpointNotAvailableForFork))
         {
             Metrics.SszRestRequestsClientErrorTotal++;
-            // Use .Span in the interpolation: ROM<char>.ToString() would allocate a separate
-            // intermediate string; appending the span goes straight into the format buffer.
             if (endpointNotAvailableForFork)
             {
                 await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
@@ -287,40 +285,35 @@ public sealed class SszMiddleware
         span = span[offset..];
         if (span.IsEmpty) return false;
 
-        if (span.Equals("identity".AsSpan(), StringComparison.OrdinalIgnoreCase)
-            || span.Equals("capabilities".AsSpan(), StringComparison.OrdinalIgnoreCase))
-        {
-            pathSegment = path.AsMemory(offset, pathLen - offset);
-            return true;
-        }
-        // Unscoped endpoints don't accept path extras — reject "/identity/foo" / "/capabilities/foo"
-        // as 404 method-not-found rather than letting them fall through to resource parsing.
-        if (span.StartsWith("identity/".AsSpan(), StringComparison.OrdinalIgnoreCase)
-            || span.StartsWith("capabilities/".AsSpan(), StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
+        // The first path segment is the resource; its scoping decides how fork/version are found.
+        int slash = span.IndexOf('/');
+        ReadOnlySpan<char> resource = slash < 0 ? span : span[..slash];
+        ReadOnlySpan<char> rest = slash < 0 ? default : span[(slash + 1)..];
 
-        if (span.StartsWith("blobs/".AsSpan(), StringComparison.OrdinalIgnoreCase))
+        switch (SszRestPaths.GetScoping(resource))
         {
-            ReadOnlySpan<char> sub = span["blobs/".Length..];
-            if (sub.StartsWith("v", StringComparison.OrdinalIgnoreCase))
-            {
-                if (int.TryParse(sub[1..], out int blobVer))
+            case SszRestPaths.ResourceScoping.Unscoped:
+                // No fork, no version, no extra segments (e.g. /capabilities, /identity).
+                if (!rest.IsEmpty) return false;
+                pathSegment = path.AsMemory(offset, pathLen - offset);
+                return true;
+
+            case SszRestPaths.ResourceScoping.PathVersioned:
+                // Version travels in a trailing /v{N} segment (e.g. /blobs/v1); no fork header.
+                if (rest.StartsWith("v", StringComparison.OrdinalIgnoreCase) && int.TryParse(rest[1..], out int parsed))
                 {
-                    version = blobVer;
-                    pathSegment = path.AsMemory(offset, "blobs".Length);
+                    version = parsed;
+                    pathSegment = path.AsMemory(offset, resource.Length);
                     return true;
                 }
-            }
-            return false;
-        }
+                return false;
 
-        // Everything remaining is a fork-scoped resource: /{resource}[/{extra}]. The fork (and thus
-        // the method version) is resolved from the Eth-Execution-Version header, not the path.
-        forkScoped = true;
-        pathSegment = path.AsMemory(offset, pathLen - offset);
-        return true;
+            default:
+                // Fork-scoped: fork (and thus version) is resolved later from the Eth-Execution-Version header.
+                forkScoped = true;
+                pathSegment = path.AsMemory(offset, pathLen - offset);
+                return true;
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -32,8 +32,15 @@ public sealed class SszMiddleware
     private readonly ILogger _logger;
     private readonly CancellationToken _processExitToken;
 
-    // Path: /engine/v2/{fork}/{resource}[/{extra}]
+    // Path: /engine/v2/{resource}[/{extra}]. Since execution-apis#793 the fork is no longer a
+    // path segment — fork-scoped endpoints select their container shape via the request header below.
     private const string EnginePrefix = "/engine/v2/";
+
+    /// <summary>
+    /// Request header that selects the fork (and thus the SSZ container shape) for fork-scoped
+    /// endpoints, per execution-apis#793 (e.g. <c>Eth-Execution-Version: cancun</c>).
+    /// </summary>
+    public const string ForkHeaderName = "Eth-Execution-Version";
 
     /// <summary>
     /// Maximum allowed request body size in bytes (64 MiB).
@@ -129,6 +136,8 @@ public sealed class SszMiddleware
 
     private async Task ProcessSszRequestAsync(HttpContext ctx)
     {
+        string? fork = null;
+        Task? forkError = null;
         string? authHeader = ctx.Request.Headers.Authorization;
         if (authHeader is null || !await _auth.Authenticate(authHeader))
         {
@@ -136,21 +145,17 @@ public sealed class SszMiddleware
             await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status401Unauthorized,
                 "Authentication error");
         }
-        else if (!TryRoute(ctx.Request.Path.Value ?? string.Empty, out int version, out string? fork,
-                     out ReadOnlyMemory<char> pathSegment, out bool unsupportedFork))
+        else if (!TryRoute(ctx.Request.Path.Value ?? string.Empty, out int version,
+                     out ReadOnlyMemory<char> pathSegment, out bool forkScoped))
         {
             Metrics.SszRestRequestsClientErrorTotal++;
-            if (unsupportedFork)
-            {
-                await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
-                    $"Fork '{fork}' is not supported by this EL",
-                    MergeErrorCodes.UnsupportedFork);
-            }
-            else
-            {
-                await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status404NotFound,
-                    "Unknown SSZ endpoint", SszRestErrorCodes.MethodNotFound);
-            }
+            await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status404NotFound,
+                "Unknown SSZ endpoint", SszRestErrorCodes.MethodNotFound);
+        }
+        else if (forkScoped && !TryResolveFork(ctx, out fork, out forkError))
+        {
+            Metrics.SszRestRequestsClientErrorTotal++;
+            await forkError!;
         }
         else if (!TryResolveHandler(ctx.Request.Method, pathSegment, version, fork, out ISszEndpointHandler? handler, out ReadOnlyMemory<char> extra))
         {
@@ -241,13 +246,12 @@ public sealed class SszMiddleware
         }
     }
 
-    private static bool TryRoute(string path, out int version, out string? fork,
-        out ReadOnlyMemory<char> pathSegment, out bool unsupportedFork)
+    private static bool TryRoute(string path, out int version,
+        out ReadOnlyMemory<char> pathSegment, out bool forkScoped)
     {
         version = 1;
-        fork = null;
         pathSegment = default;
-        unsupportedFork = false;
+        forkScoped = false;
 
         ReadOnlySpan<char> span = path.AsSpan();
         if (!span.StartsWith(EnginePrefix.AsSpan(), StringComparison.OrdinalIgnoreCase))
@@ -273,7 +277,7 @@ public sealed class SszMiddleware
             return true;
         }
         // Unscoped endpoints don't accept path extras — reject "/identity/foo" / "/capabilities/foo"
-        // as 404 method-not-found rather than letting them fall through to fork parsing.
+        // as 404 method-not-found rather than letting them fall through to resource parsing.
         if (span.StartsWith("identity/".AsSpan(), StringComparison.OrdinalIgnoreCase)
             || span.StartsWith("capabilities/".AsSpan(), StringComparison.OrdinalIgnoreCase))
         {
@@ -295,44 +299,40 @@ public sealed class SszMiddleware
             return false;
         }
 
-        // Everything remaining should be a fork-scoped path: /{fork}/{resource}[/{extra}]
-        int nextSlash = span.IndexOf('/');
-        if (nextSlash <= 0)
-        {
-            // E.g. bodies query or payloads query without extra path segment
-            nextSlash = span.Length;
-        }
+        // Everything remaining is a fork-scoped resource: /{resource}[/{extra}]. The fork (and thus
+        // the method version) is resolved from the Eth-Execution-Version header, not the path.
+        forkScoped = true;
+        pathSegment = path.AsMemory(offset, pathLen - offset);
+        return true;
+    }
 
-        ReadOnlySpan<char> forkSpan = span[..nextSlash];
-        // SszRestPaths.SupportedForks uses OrdinalIgnoreCase, so no lowercasing needed.
-        if (!SszRestPaths.SupportedForksSpanLookup.Contains(forkSpan))
-        {
-            // Reject `/engine/v2/v<N>/...` (looks like a version-only path with no fork) before
-            // emitting an unsupported-fork error — let the caller produce a 404 instead.
-            if (forkSpan.Length > 1
-                && (forkSpan[0] == 'v' || forkSpan[0] == 'V')
-                && int.TryParse(forkSpan[1..], out _))
-            {
-                return false;
-            }
+    /// <summary>
+    /// Resolves the fork for a fork-scoped endpoint from the <see cref="ForkHeaderName"/> request
+    /// header. Returns <c>false</c> and sets <paramref name="error"/> to a ready-to-await 400
+    /// response when the header is missing or names a fork this EL does not support.
+    /// </summary>
+    private static bool TryResolveFork(HttpContext ctx, out string? fork, out Task? error)
+    {
+        fork = null;
+        error = null;
 
-            fork = forkSpan.ToString();
-            unsupportedFork = true;
+        string headerValue = ctx.Request.Headers[ForkHeaderName].ToString();
+        if (string.IsNullOrEmpty(headerValue))
+        {
+            error = SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
+                $"Missing required '{ForkHeaderName}' header", SszRestErrorCodes.InvalidRequest);
             return false;
         }
 
-        fork = forkSpan.ToString();
-        if (nextSlash < span.Length)
+        // SszRestPaths.SupportedForks uses OrdinalIgnoreCase, so header casing is accepted as-is.
+        if (!SszRestPaths.SupportedForks.Contains(headerValue))
         {
-            offset += nextSlash + 1;
-            pathSegment = path.AsMemory(offset, pathLen - offset);
-        }
-        else
-        {
-            // Recognised fork but missing resource segment, e.g. /engine/v2/cancun — not
-            // a valid endpoint; leave unsupportedFork = false so the caller uses 404.
+            error = SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
+                $"Fork '{headerValue}' is not supported by this EL", MergeErrorCodes.UnsupportedFork);
             return false;
         }
+
+        fork = headerValue;
         return true;
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -326,9 +326,6 @@ public sealed class SszMiddleware
         fork = null;
         error = null;
 
-        // Exactly one fork header is expected. Read the StringValues directly: indexing the single
-        // value avoids the per-request string join that .ToString() performs on multi-valued headers,
-        // and a 0- or multi-valued header is rejected as a bad request rather than silently joined.
         StringValues headerValues = ctx.Request.Headers[ForkHeaderName];
         string? headerValue = headerValues.Count == 1 ? headerValues[0] : null;
         if (string.IsNullOrEmpty(headerValue))
@@ -338,7 +335,6 @@ public sealed class SszMiddleware
             return false;
         }
 
-        // SszRestPaths.SupportedForks uses OrdinalIgnoreCase, so header casing is accepted as-is.
         if (!SszRestPaths.SupportedForks.Contains(headerValue))
         {
             error = SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -275,7 +275,8 @@ public sealed class SszMiddleware
         // Collapse a trailing slash so `/foo` and `/foo/` route identically; `pathLen` then
         // bounds every subsequent `path.AsMemory(...)` slice so the slash never reaches `extra`.
         int pathLen = path.Length;
-        if (pathLen > EnginePrefix.Length && path[pathLen - 1] == '/')
+        bool hadTrailingSlash = pathLen > EnginePrefix.Length && path[pathLen - 1] == '/';
+        if (hadTrailingSlash)
         {
             pathLen--;
             span = span[..pathLen];
@@ -293,8 +294,9 @@ public sealed class SszMiddleware
         switch (SszRestPaths.GetScoping(resource))
         {
             case SszRestPaths.ResourceScoping.Unscoped:
-                // No fork, no version, no extra segments (e.g. /capabilities, /identity).
-                if (!rest.IsEmpty) return false;
+                // Exact fixed paths (e.g. /capabilities, /identity): reject any extra segment or
+                // trailing slash so /capabilities and /capabilities/ don't diverge from /capabilities/foo.
+                if (!rest.IsEmpty || hadTrailingSlash) return false;
                 pathSegment = path.AsMemory(offset, pathLen - offset);
                 return true;
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -43,6 +43,13 @@ public sealed class SszMiddleware
     public const string ForkHeaderName = "Eth-Execution-Version";
 
     /// <summary>
+    /// <see cref="HttpContext.Items"/> key under which the resolved fork is stashed for fork-scoped
+    /// endpoints, so handlers can read it back without re-parsing the request. A typo in a reader
+    /// would silently disable fork filtering, hence the single shared constant.
+    /// </summary>
+    internal const string RouteForkItemKey = "SszRouteFork";
+
+    /// <summary>
     /// Maximum allowed request body size in bytes (64 MiB).
     /// Mirrors the <c>payload.max_bytes</c> example value advertised in the Engine API
     /// SSZ-REST spec capabilities response (see https://github.com/ethereum/execution-apis/pull/793).
@@ -170,7 +177,7 @@ public sealed class SszMiddleware
         {
             if (fork is not null)
             {
-                ctx.Items["SszRouteFork"] = fork;
+                ctx.Items[RouteForkItemKey] = fork;
             }
 
             if (_logger.IsTrace)

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -11,6 +11,7 @@ using System.Net.Mime;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 using Nethermind.Config;
 using Nethermind.Core.Authentication;
 using Nethermind.JsonRpc;
@@ -164,14 +165,23 @@ public sealed class SszMiddleware
             Metrics.SszRestRequestsClientErrorTotal++;
             await forkError!;
         }
-        else if (!TryResolveHandler(ctx.Request.Method, pathSegment, version, fork, out ISszEndpointHandler? handler, out ReadOnlyMemory<char> extra))
+        else if (!TryResolveHandler(ctx.Request.Method, pathSegment, version, fork, out ISszEndpointHandler? handler, out ReadOnlyMemory<char> extra, out bool endpointNotAvailableForFork))
         {
             Metrics.SszRestRequestsClientErrorTotal++;
             // Use .Span in the interpolation: ROM<char>.ToString() would allocate a separate
             // intermediate string; appending the span goes straight into the format buffer.
-            await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status404NotFound,
-                $"Unknown method: {ctx.Request.Method} /engine/v2/{pathSegment.Span}",
-                SszRestErrorCodes.MethodNotFound);
+            if (endpointNotAvailableForFork)
+            {
+                await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
+                    $"Fork '{fork}' does not support {ctx.Request.Method} /engine/v2/{pathSegment.Span}",
+                    MergeErrorCodes.UnsupportedFork);
+            }
+            else
+            {
+                await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status404NotFound,
+                    $"Unknown method: {ctx.Request.Method} /engine/v2/{pathSegment.Span}",
+                    SszRestErrorCodes.MethodNotFound);
+            }
         }
         else
         {
@@ -323,11 +333,15 @@ public sealed class SszMiddleware
         fork = null;
         error = null;
 
-        string headerValue = ctx.Request.Headers[ForkHeaderName].ToString();
+        // Exactly one fork header is expected. Read the StringValues directly: indexing the single
+        // value avoids the per-request string join that .ToString() performs on multi-valued headers,
+        // and a 0- or multi-valued header is rejected as a bad request rather than silently joined.
+        StringValues headerValues = ctx.Request.Headers[ForkHeaderName];
+        string? headerValue = headerValues.Count == 1 ? headerValues[0] : null;
         if (string.IsNullOrEmpty(headerValue))
         {
             error = SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
-                $"Missing required '{ForkHeaderName}' header", SszRestErrorCodes.InvalidRequest);
+                $"Request must carry exactly one '{ForkHeaderName}' header", SszRestErrorCodes.InvalidRequest);
             return false;
         }
 
@@ -344,10 +358,11 @@ public sealed class SszMiddleware
     }
 
     private bool TryResolveHandler(string method, ReadOnlyMemory<char> pathSegment, int version, string? fork,
-        out ISszEndpointHandler? handler, out ReadOnlyMemory<char> extra)
+        out ISszEndpointHandler? handler, out ReadOnlyMemory<char> extra, out bool endpointNotAvailableForFork)
     {
         handler = null;
         extra = default;
+        endpointNotAvailableForFork = false;
 
         bool isPost = HttpMethods.IsPost(method);
         bool isGet = !isPost && HttpMethods.IsGet(method);
@@ -371,8 +386,14 @@ public sealed class SszMiddleware
 
         if (fork is not null)
         {
-            int? mappedVersion = SszRestPaths.MapForkToVersion(fork, resource.Span, method);
-            if (mappedVersion is null) return false;
+            int? mappedVersion = SszRestPaths.MapForkToVersion(fork, resource.Span, method, out bool recognizedResource);
+            if (mappedVersion is null)
+            {
+                // Known endpoint the requested fork predates (e.g. paris + bodies) → let the caller
+                // emit 400 unsupported-fork; a genuinely unknown resource stays 404 method-not-found.
+                endpointNotAvailableForFork = recognizedResource;
+                return false;
+            }
             version = mappedVersion.Value;
         }
 

--- a/src/Nethermind/Nethermind.Specs/Forks/NamedReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/NamedReleaseSpec.cs
@@ -55,14 +55,6 @@ public abstract class NamedReleaseSpec : ReleaseSpec
     /// <inheritdoc cref="EngineApiNewPayloadVersion"/>
     public int? EngineApiPayloadBodiesByRangeVersion { get; set; }
 
-    /// <summary>
-    /// Fork name for the SSZ-REST Engine API surface — the lowercase fork class name
-    /// (e.g. <c>"paris"</c>), used as the <c>Eth-Execution-Version</c> header value per
-    /// execution-apis#793. Whether the fork is actually served is decided by the engine-API
-    /// layer's supported-fork set, not here.
-    /// </summary>
-    public string? EngineApiForkName => Name?.ToLowerInvariant();
-
     protected NamedReleaseSpec(NamedReleaseSpec? parent)
     {
         Parent = parent;

--- a/src/Nethermind/Nethermind.Specs/Forks/NamedReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/NamedReleaseSpec.cs
@@ -56,11 +56,12 @@ public abstract class NamedReleaseSpec : ReleaseSpec
     public int? EngineApiPayloadBodiesByRangeVersion { get; set; }
 
     /// <summary>
-    /// URL <c>{fork}</c> segment for the SSZ-REST Engine API surface — the lowercase fork class name
-    /// (e.g. <c>"paris"</c>). Whether the segment is actually routable is decided by the engine-API
+    /// Fork name for the SSZ-REST Engine API surface — the lowercase fork class name
+    /// (e.g. <c>"paris"</c>), used as the <c>Eth-Execution-Version</c> header value per
+    /// execution-apis#793. Whether the fork is actually served is decided by the engine-API
     /// layer's supported-fork set, not here.
     /// </summary>
-    public string? EngineApiUrlSegment => Name?.ToLowerInvariant();
+    public string? EngineApiForkName => Name?.ToLowerInvariant();
 
     protected NamedReleaseSpec(NamedReleaseSpec? parent)
     {


### PR DESCRIPTION
## Changes

Aligns the SSZ-REST Engine API transport with the latest [execution-apis#793](https://github.com/ethereum/execution-apis/pull/793) revision (commit `d39e9a2`, _"move fork into header out of path"_).

- Fork-scoped endpoints (`payloads`, `forkchoice`, `bodies`) drop the `{fork}` URL segment. The fork — and thus the SSZ container shape and engine method version — is now negotiated via the **`Eth-Execution-Version`** request header (e.g. `Eth-Execution-Version: cancun`).
- Routes become `POST /engine/v2/payloads`, `POST /engine/v2/forkchoice`, `GET /engine/v2/payloads/{payload_id}`, `POST /engine/v2/bodies/hash`, `GET /engine/v2/bodies`.
- Blobs remain independently path-versioned (`/engine/v2/blobs/v1..v4`) and `identity`/`capabilities` remain unscoped, per spec.
- `engine_exchangeCapabilities` now advertises each distinct fork-less REST path once (OR-ing enablement across the method versions that share it); per-fork availability continues to be expressed via `supported_forks` in the `GET /engine/v2/capabilities` body.
- Error mapping: a missing `Eth-Execution-Version` header on a fork-scoped endpoint returns **400 `invalid-request`**; an unknown fork returns **400 `unsupported-fork`**.

### Notes for reviewers

The relevant spec section is still a working draft and does not pin the URL prefix, whether the header is echoed in responses, or the status codes for a missing/unsupported fork. The choices here — keeping the `/engine/v2/` prefix and returning `400` — are pragmatic defaults and easy to revisit. `SszRestPaths.GetEngineApiUrlSegment` / `NamedReleaseSpec.EngineApiUrlSegment` keep their names although the value is now a header rather than a URL segment.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Other: 

## Testing

Requires testing

- [x] Yes
- [ ] No

If yes, did you write tests?

- [x] Yes
- [ ] No

`Nethermind.Merge.Plugin.Test`: `SszMiddlewareTests` (converted to header-based routing, with new missing-header and unknown-fork-in-header cases) and the `SszRestPathsAreAdvertised` coverage set were updated. 104 SSZ-REST tests and 23 capability tests pass; build is clean with no new warnings.

## Documentation

Requires documentation update

- [ ] Yes
- [x] No
