### PR TITLE
fix(jsonrpc): flow JsonRpcContext.Current via AsyncLocal

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -255,6 +255,26 @@ public class JsonRpcProcessorTests
         Assert.That(AssertSingleResponse(sink.Responses).Response!.Id, Is.EqualTo(new JsonRpcId(67)));
     }
 
+    [TestCase(RpcEndpoint.IPC, true)]
+    [TestCase(RpcEndpoint.Ws, false)]
+    public async Task ProcessAsync_makes_the_request_context_current_for_the_handler(RpcEndpoint endpoint, bool expectedAuthenticated)
+    {
+        bool? seenAuthenticated = null;
+        IJsonRpcService service = CreateService(request =>
+        {
+            seenAuthenticated = JsonRpcContext.Current.Value?.IsAuthenticated;
+            return new JsonRpcSuccessResponse { Id = request.Id };
+        });
+        JsonRpcProcessor processor = CreateProcessor(service);
+
+        JsonRpcContext context = new(endpoint);
+        JsonRpcContext.Current.Value = null;
+
+        using CollectedJsonRpcResponses result = await ProcessAsync(processor, CreateRequest("1", "eth_blockNumber"), context);
+
+        Assert.That(seenAuthenticated, Is.EqualTo(expectedAuthenticated));
+    }
+
     [Test]
     public async Task Sink_processor_entry_point_reads_params_through_envelope_reader()
     {

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcContext.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcContext.cs
@@ -2,16 +2,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
 using Nethermind.JsonRpc.Modules;
 
 namespace Nethermind.JsonRpc
 {
     public class JsonRpcContext : IDisposable
     {
-        [ThreadStatic]
-        private static JsonRpcContext? _current;
-
-        public static ThreadStaticAccessor Current { get; } = new();
+        public static AsyncLocal<JsonRpcContext?> Current { get; } = new();
 
         public static JsonRpcContext Http(JsonRpcUrl url) => new(RpcEndpoint.Http, url: url);
         public static JsonRpcContext WebSocket(JsonRpcUrl url) => new(RpcEndpoint.Ws, url: url);
@@ -22,31 +20,19 @@ namespace Nethermind.JsonRpc
             DuplexClient = duplexClient;
             Url = url;
             IsAuthenticated = Url?.IsAuthenticated == true || RpcEndpoint == RpcEndpoint.IPC;
-            _current = this;
+            Current.Value = this;
         }
 
         public RpcEndpoint RpcEndpoint { get; }
         public IJsonRpcDuplexClient? DuplexClient { get; }
         public JsonRpcUrl? Url { get; }
         public bool IsAuthenticated { get; }
+
         public void Dispose()
         {
-            if (_current == this)
+            if (Current.Value == this)
             {
-                _current = null;
-            }
-        }
-
-        /// <summary>
-        /// Provides .Value accessor compatible with AsyncLocal API shape so callers
-        /// like <c>JsonRpcContext.Current.Value?.IsAuthenticated</c> continue to compile.
-        /// </summary>
-        public sealed class ThreadStaticAccessor
-        {
-            public JsonRpcContext? Value
-            {
-                get => _current;
-                set => _current = value;
+                Current.Value = null;
             }
         }
     }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -63,6 +63,8 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         JsonRpcProcessingOptions options,
         CancellationToken cancellationToken = default)
     {
+        JsonRpcContext.Current.Value = context;
+
         CancellationTokenSource? timeoutSource = context.IsAuthenticated ? null : _jsonRpcConfig.BuildTimeoutCancellationToken();
         CancellationToken timeoutToken = timeoutSource?.Token ?? CancellationToken.None;
 
@@ -76,6 +78,8 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         JsonRpcProcessingOptions options,
         CancellationToken cancellationToken = default)
     {
+        JsonRpcContext.Current.Value = context;
+
         CancellationTokenSource? timeoutSource = context.IsAuthenticated ? null : _jsonRpcConfig.BuildTimeoutCancellationToken();
         CancellationToken timeoutToken = timeoutSource?.Token ?? CancellationToken.None;
 


### PR DESCRIPTION
## Changes

`GetLogsResponse` (used by `eth_getLogs` and `eth_getFilterLogs`) decides whether to enforce `MaxLogsPerResponse` from the ambient `JsonRpcContext.Current`, which was backed by a `[ThreadStatic]`. That static is set in the per-connection `JsonRpcContext` constructor, but requests are processed on `Task.Run` worker threads (`JsonRpcSocketsClient`), so on the worker thread it read as `null` or a stale context left by a previously-processed connection — and the cap followed the wrong request's authentication.

This backs `JsonRpcContext.Current` with `AsyncLocal<JsonRpcContext>` instead of `[ThreadStatic]` (which is what it was before it was switched to a thread-static). Unlike `[ThreadStatic]`, an `AsyncLocal` value flows with the request's execution context onto whatever worker thread runs it, so `GetLogsResponse` reads the correct per-request context **even when the module instance is shared** across concurrent requests. No method needs to be made non-sharable, so there is no throughput regression.

### Changes
- `JsonRpcContext.Current` is backed by `AsyncLocal<JsonRpcContext?>` (was `[ThreadStatic]`).
- Regression test asserting `Current` is visible from a worker thread the request runs on.

Implemented per the review suggestion from @svlachakis / @LukaszRozmej.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
