### PR TITLE
fix(synchronization): verify hash of snap-heal recovered trie node

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
@@ -162,6 +162,15 @@ public class RecoveryTests
         Assert.That(response, Is.Null);
     }
 
+    [Test]
+    public async Task cannot_recover_eth67_hash_mismatch()
+    {
+        _snapSyncPeer.GetTrieNodes(Arg.Any<GetTrieNodesRequest>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IByteArrayList>(new ByteArrayListAdapter(new ArrayPoolList<byte[]>(1) { new byte[] { 5, 6, 7 } })));
+        IOwnedReadOnlyList<(TreePath, byte[])>? response = await Recover(_nodeDataDataRecovery, _peerEth67);
+        Assert.That(response, Is.Null);
+    }
+
     private Task<IOwnedReadOnlyList<(TreePath, byte[])>?> Recover(IPathRecovery recovery, params PeerInfo[] peers)
     {
         _syncPeerPool.InitializedPeers.Returns(peers);

--- a/src/Nethermind/Nethermind.Synchronization/Trie/NodeDataRecovery.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/NodeDataRecovery.cs
@@ -160,7 +160,7 @@ public class NodeDataRecovery(ISyncPeerPool peerPool, INodeStorage nodeStorage, 
                 AccountAndStoragePaths = PathGroup.EncodeToRlpPathGroupList([group]),
             }, cancellationToken);
 
-            if (item is not null && item.Count > 0)
+            if (item is not null && item.Count > 0 && ValueKeccak.Compute(item[0]) == hash)
             {
                 return item[0].ToArray();
             }


### PR DESCRIPTION
## Changes

`NodeDataRecovery.RecoverNodeFromPeer`'s eth67+ snap (`GetTrieNodes`) branch returned the peer's bytes without checking `keccak(bytes) == requestedHash`, unlike its sibling legacy-eth branch (which gates on `Keccak.Compute(data[0]) == hash`) and `SnapRangeRecovery` (which validates every proof). The unverified bytes were then used and persisted by their own hash.

- The snap branch now returns the node only when `Keccak.Compute(item[0]) == hash`, else `null` (which reports the peer weak), mirroring the eth branch.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`cannot_recover_eth67_hash_mismatch` stubs `GetTrieNodes` to return wrong-hash bytes and asserts `NodeDataRecovery` recovery yields `null` (no persisted node, no throw).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
