### PR TITLE
perf(evm): O(1) per-tx EIP-2929 warm/cold reset (exploratory)

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Collections/VersionedJournalSetTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Collections/VersionedJournalSetTests.cs
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Linq;
+using Nethermind.Core.Collections;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Collections
+{
+    [Parallelizable(ParallelScope.All)]
+    public class VersionedJournalSetTests
+    {
+        private static VersionedJournalSet<int> CreateSet() => new(EqualityComparer<int>.Default);
+
+        [Test]
+        public void Can_restore_snapshot()
+        {
+            VersionedJournalSet<int> set = CreateSet();
+            set.AddRange(Enumerable.Range(0, 10));
+            int snapshot = set.TakeSnapshot();
+            set.AddRange(Enumerable.Range(10, 10));
+            set.Restore(snapshot);
+            Assert.That(set, Is.EqualTo(Enumerable.Range(0, 10)));
+        }
+
+        [Test]
+        public void Can_restore_empty_snapshot_on_empty()
+        {
+            VersionedJournalSet<int> set = CreateSet();
+            int snapshot = set.TakeSnapshot();
+            set.Restore(snapshot);
+            set.Restore(snapshot);
+            Assert.That(set, Is.EqualTo(Enumerable.Empty<int>()));
+        }
+
+        [Test]
+        public void Can_restore_empty_snapshot()
+        {
+            VersionedJournalSet<int> set = CreateSet();
+            int snapshot = set.TakeSnapshot();
+            set.AddRange(Enumerable.Range(0, 10));
+            set.Restore(snapshot);
+            set.Restore(snapshot);
+            Assert.That(set, Is.EqualTo(Enumerable.Empty<int>()));
+        }
+
+        [Test]
+        public void Snapshots_behave_as_sets()
+        {
+            VersionedJournalSet<int> set = CreateSet();
+            set.AddRange(Enumerable.Range(0, 10));
+            int snapshot = set.TakeSnapshot();
+            set.AddRange(Enumerable.Range(0, 20));
+            set.Restore(snapshot);
+            Assert.That(set, Is.EqualTo(Enumerable.Range(0, 10)));
+        }
+
+        [Test]
+        public void Add_returns_true_only_on_cold_to_warm_transition()
+        {
+            VersionedJournalSet<int> set = CreateSet();
+            Assert.That(set.Add(1), Is.True);
+            Assert.That(set.Add(1), Is.False);
+            Assert.That(set.Contains(1), Is.True);
+        }
+
+        [Test]
+        public void Reset_makes_all_items_cold()
+        {
+            VersionedJournalSet<int> set = CreateSet();
+            set.AddRange(Enumerable.Range(0, 10));
+            set.Reset();
+            Assert.That(set.Count, Is.EqualTo(0));
+            Assert.That(set, Is.EqualTo(Enumerable.Empty<int>()));
+            Assert.That(set.Contains(5), Is.False);
+            // Retained entries re-warm correctly in the new epoch.
+            Assert.That(set.Add(5), Is.True);
+            Assert.That(set.Contains(5), Is.True);
+            Assert.That(set.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Restore_works_after_reset_with_retained_entries()
+        {
+            VersionedJournalSet<int> set = CreateSet();
+            set.AddRange(Enumerable.Range(0, 10));
+            set.Reset();
+
+            set.AddRange(Enumerable.Range(5, 5));
+            int snapshot = set.TakeSnapshot();
+            set.AddRange(Enumerable.Range(10, 5));
+            set.Restore(snapshot);
+
+            Assert.That(set, Is.EqualTo(Enumerable.Range(5, 5)));
+            Assert.That(set.Contains(12), Is.False);
+            Assert.That(set.Add(12), Is.True);
+        }
+
+        [Test]
+        public void Restored_items_can_be_added_again_in_same_epoch()
+        {
+            VersionedJournalSet<int> set = CreateSet();
+            set.Add(1);
+            int snapshot = set.TakeSnapshot();
+            set.Add(2);
+            set.Restore(snapshot);
+
+            Assert.That(set.Contains(2), Is.False);
+            Assert.That(set.Add(2), Is.True);
+            Assert.That(set, Is.EqualTo(new[] { 1, 2 }));
+        }
+
+        [Test]
+        public void Clear_drops_everything()
+        {
+            VersionedJournalSet<int> set = CreateSet();
+            set.AddRange(Enumerable.Range(0, 10));
+            set.Clear();
+            Assert.That(set.Count, Is.EqualTo(0));
+            Assert.That(set.Contains(1), Is.False);
+            Assert.That(set.Add(1), Is.True);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Collections/VersionedJournalSet.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/VersionedJournalSet.cs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Core.Collections
+{
+    /// <summary>
+    /// A snapshot/restore set like <see cref="JournalSet{T}"/> whose <see cref="Reset"/> empties it
+    /// without touching hash storage: membership means "stamped with the current epoch", so advancing
+    /// the epoch makes every retained entry cold again.
+    /// </summary>
+    /// <typeparam name="T">Item type; constrained to <c>struct</c> so keys are never null.</typeparam>
+    /// <remarks>
+    /// Designed for the per-transaction EIP-2929 warm/cold sets: instead of clearing (O(high-water
+    /// capacity) for a <see cref="HashSet{T}"/>) and re-inserting recurring keys every transaction,
+    /// entries persist across <see cref="Reset"/> with an epoch stamp and re-warming a known key is a
+    /// single lookup plus stamp write. The journal list tracks the order of cold-to-warm transitions
+    /// in the current epoch, enabling <see cref="Restore"/> and warm-items-only enumeration.
+    /// Due to snapshots <see cref="Remove"/> is not supported.
+    /// </remarks>
+    public sealed class VersionedJournalSet<T>(EqualityComparer<T> equalityComparer) : ICollection<T>, IJournal<int>
+        where T : struct
+    {
+        private const int ColdEpoch = 0;
+
+        /// <summary>
+        /// Bound on entries retained across <see cref="Reset"/> before hash storage is dropped,
+        /// keeping long-lived (pooled) instances from growing without limit.
+        /// </summary>
+        private const int RetainedEntriesLimit = 1 << 16;
+
+        private readonly Dictionary<T, int> _warmedAt = new(GenericEqualityComparer.GetOptimized(equalityComparer));
+        private readonly List<T> _journal = [];
+        private int _epoch = 1;
+
+        public int TakeSnapshot() => Position;
+
+        private int Position => Count - 1;
+
+        [SkipLocalsInit]
+        public void Restore(int snapshot)
+        {
+            if (snapshot >= Count)
+            {
+                ThrowInvalidRestore(snapshot);
+            }
+
+            // Items journaled after the snapshot were cold at snapshot time in this epoch,
+            // so any stamp other than the current epoch marks them cold again.
+            foreach (T item in CollectionsMarshal.AsSpan(_journal)[(snapshot + 1)..])
+            {
+                CollectionsMarshal.GetValueRefOrNullRef(_warmedAt, item) = ColdEpoch;
+            }
+
+            CollectionsMarshal.SetCount(_journal, snapshot + 1);
+        }
+
+        [DoesNotReturn, StackTraceHidden]
+        private void ThrowInvalidRestore(int snapshot)
+            => throw new InvalidOperationException($"{nameof(VersionedJournalSet<T>)} tried to restore snapshot {snapshot} beyond current position {Count}");
+
+        public bool Add(T item)
+        {
+            ref int epoch = ref CollectionsMarshal.GetValueRefOrAddDefault(_warmedAt, item, out _);
+            if (epoch == _epoch)
+            {
+                return false;
+            }
+
+            epoch = _epoch;
+            _journal.Add(item);
+            return true;
+        }
+
+        /// <summary>
+        /// Empties the set in O(items added this epoch) by advancing the epoch; hash entries are
+        /// retained (up to <see cref="RetainedEntriesLimit"/>) so recurring keys re-warm cheaply.
+        /// </summary>
+        public void Reset()
+        {
+            _journal.Clear();
+            if (++_epoch == int.MaxValue || _warmedAt.Count > RetainedEntriesLimit)
+            {
+                _warmedAt.Clear();
+                _epoch = 1;
+            }
+        }
+
+        /// <summary>Fully clears the set including retained hash storage; prefer <see cref="Reset"/>.</summary>
+        public void Clear()
+        {
+            _journal.Clear();
+            _warmedAt.Clear();
+            _epoch = 1;
+        }
+
+        public List<T>.Enumerator GetEnumerator() => _journal.GetEnumerator();
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        public bool Remove(T item) => throw new NotSupportedException("Cannot remove from Journal, use Restore(int snapshot) instead.");
+        public int Count => _journal.Count;
+        public bool IsReadOnly => false;
+        void ICollection<T>.Add(T item) => Add(item);
+        public bool Contains(T item) => _warmedAt.TryGetValue(item, out int epoch) && epoch == _epoch;
+        public void CopyTo(T[] array, int arrayIndex) => _journal.CopyTo(array, arrayIndex);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Benchmark/AccessTrackerResetBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/AccessTrackerResetBenchmark.cs
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System;
+using System.Buffers.Binary;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+using Nethermind.Core;
+using Nethermind.Int256;
+
+namespace Nethermind.Evm.Benchmark;
+
+/// <summary>
+/// Isolates the per-transaction EIP-2929 warm/cold reset primitive: rent a
+/// <see cref="StackAccessTracker"/> from the pool, warm a number of distinct
+/// addresses and storage cells, then dispose (which clears every set and
+/// returns the tracker to the pool) — exactly what happens once per transaction
+/// in <c>TransactionProcessor.ExecuteCore</c>.
+/// </summary>
+/// <remarks>
+/// Two costs are measured separately:
+/// <list type="bullet">
+/// <item><see cref="WarmAllThenReset"/> — a tx warming <see cref="WarmedEntries"/>
+/// entries: insert cost + O(warm-set) clear on dispose.</item>
+/// <item><see cref="WarmFewThenReset_AfterHighWaterMark"/> — a small tx (8 cells,
+/// 2 addresses) reusing a pooled tracker whose <see cref="System.Collections.Generic.HashSet{T}"/>
+/// capacity was inflated to <see cref="WarmedEntries"/> by an earlier large tx.
+/// <c>HashSet.Clear</c> zeroes the full bucket array, so the clear cost is
+/// O(high-water capacity), not O(entries warmed by this tx).</item>
+/// </list>
+/// </remarks>
+[Config(typeof(ResetConfig))]
+[MemoryDiagnoser]
+[JsonExporterAttribute.FullCompressed]
+public class AccessTrackerResetBenchmark
+{
+    private class ResetConfig : ManualConfig
+    {
+        public ResetConfig()
+        {
+            AddJob(Job.Default
+                .WithToolchain(InProcessNoEmitToolchain.Instance)
+                .WithLaunchCount(1)
+                .WithWarmupCount(3)
+                .WithIterationCount(10));
+            AddColumn(StatisticColumn.Min);
+            AddColumn(StatisticColumn.Max);
+            AddColumn(StatisticColumn.Median);
+        }
+    }
+
+    private const int OpsPerInvoke = 100;
+    private const int SmallTxCells = 8;
+    private const int SmallTxAddresses = 2;
+    private const int MaxEntries = 4096;
+
+    [Params(64, 512, 4096)]
+    public int WarmedEntries { get; set; }
+
+    private Address[] _addresses = null!;
+    private StorageCell[] _cells = null!;
+
+    private void SharedSetup()
+    {
+        _addresses = new Address[MaxEntries / 16 + SmallTxAddresses];
+        for (int i = 0; i < _addresses.Length; i++)
+        {
+            byte[] bytes = new byte[Address.Size];
+            BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(Address.Size - sizeof(int)), i + 1);
+            _addresses[i] = new Address(bytes);
+        }
+
+        // Distinct cells spread over a handful of addresses, mimicking a tx touching
+        // many slots of a few contracts.
+        _cells = new StorageCell[MaxEntries];
+        for (int i = 0; i < _cells.Length; i++)
+        {
+            UInt256 index = (UInt256)i;
+            _cells[i] = new StorageCell(_addresses[i & 15], in index);
+        }
+
+        DrainTrackerPool();
+    }
+
+    [GlobalSetup(Target = nameof(WarmAllThenReset))]
+    public void SetupWarmAll() => SharedSetup();
+
+    [GlobalSetup(Target = nameof(WarmFewThenReset_AfterHighWaterMark))]
+    public void SetupWarmFew()
+    {
+        SharedSetup();
+        // Inflate the single pooled TrackingState's capacity to WarmedEntries,
+        // simulating one large tx earlier in the block.
+        using StackAccessTracker tracker = new();
+        Warm(in tracker, WarmedEntries, WarmedEntries / 16);
+    }
+
+    /// <summary>
+    /// Removes instances left in the static tracker pool by other benchmarks in the
+    /// same process, so each case starts from freshly-sized sets.
+    /// </summary>
+    private static void DrainTrackerPool()
+    {
+        // Renting without disposing drops the pooled TrackingState instances.
+        for (int i = 0; i < 64; i++)
+        {
+            _ = new StackAccessTracker();
+        }
+    }
+
+    private void Warm(in StackAccessTracker tracker, int cells, int addresses)
+    {
+        for (int i = 0; i < addresses; i++)
+        {
+            tracker.WarmUp(_addresses[i]);
+        }
+
+        for (int i = 0; i < cells; i++)
+        {
+            tracker.WarmUp(in _cells[i]);
+        }
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = OpsPerInvoke)]
+    public void WarmAllThenReset()
+    {
+        for (int op = 0; op < OpsPerInvoke; op++)
+        {
+            using StackAccessTracker tracker = new();
+            Warm(in tracker, WarmedEntries, Math.Max(SmallTxAddresses, WarmedEntries / 16));
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = OpsPerInvoke)]
+    public void WarmFewThenReset_AfterHighWaterMark()
+    {
+        for (int op = 0; op < OpsPerInvoke; op++)
+        {
+            using StackAccessTracker tracker = new();
+            Warm(in tracker, SmallTxCells, SmallTxAddresses);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Benchmark/FixedTotalSlotsBlockBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/FixedTotalSlotsBlockBenchmark.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+
+namespace Nethermind.Evm.Benchmark;
+
+/// <summary>
+/// Holds total EVM work constant (6000 SLOADs per block) while splitting it into
+/// 50, 150 or 300 transactions, so any cost growth with <see cref="TxCountParam"/>
+/// is pure per-transaction overhead.
+/// </summary>
+[Config(typeof(SyntheticBlockConfig))]
+[MemoryDiagnoser]
+[JsonExporterAttribute.FullCompressed]
+public class FixedTotalSlotsBlockBenchmark : SyntheticStorageBlockBenchmarkBase
+{
+    private const int TotalSlots = 6000;
+
+    [Params(50, 150, 300)]
+    public int TxCountParam { get; set; }
+
+    protected override int TxCount => TxCountParam;
+    protected override int SlotsPerTx => TotalSlots / TxCountParam;
+
+    [Benchmark(OperationsPerInvoke = OpsPerInvoke)]
+    public Block[] ProcessBlock() => ProcessBlockCore();
+}

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StorageWarmSetBlockBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StorageWarmSetBlockBenchmark.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+
+namespace Nethermind.Evm.Benchmark;
+
+/// <summary>
+/// Sweeps per-tx warm-set size independently of tx count.
+/// </summary>
+/// <remarks>
+/// <see cref="SlotsPerTxParam"/> = 4 is the control: many light txs whose warm sets stay
+/// tiny (and whose slot keys are shared by every tx). If block cost at fixed tx count
+/// grows with slots-per-tx faster than the added SLOAD gas explains, the per-tx
+/// O(warm-set) reset is implicated; if the control is expensive at high tx count
+/// despite tiny warm sets, the overhead is fixed per-tx (pool churn, per-tx setup).
+/// </remarks>
+[Config(typeof(SyntheticBlockConfig))]
+[MemoryDiagnoser]
+[JsonExporterAttribute.FullCompressed]
+public class StorageWarmSetBlockBenchmark : SyntheticStorageBlockBenchmarkBase
+{
+    [Params(50, 150, 300)]
+    public int TxCountParam { get; set; }
+
+    [Params(4, 20, 100)]
+    public int SlotsPerTxParam { get; set; }
+
+    protected override int TxCount => TxCountParam;
+    protected override int SlotsPerTx => SlotsPerTxParam;
+
+    [Benchmark(OperationsPerInvoke = OpsPerInvoke)]
+    public Block[] ProcessBlock() => ProcessBlockCore();
+}

--- a/src/Nethermind/Nethermind.Evm.Benchmark/SyntheticStorageBlockBenchmarkBase.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/SyntheticStorageBlockBenchmarkBase.cs
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using Autofac;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+using Nethermind.Blockchain.Tracing;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Container;
+using Nethermind.Core.Test.Db;
+using Nethermind.Core.Test.Modules;
+using Nethermind.Db;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+
+namespace Nethermind.Evm.Benchmark;
+
+/// <summary>
+/// Shared infrastructure for block benchmarks that stress per-transaction
+/// warm/cold (EIP-2929) tracking cost: a block of <see cref="TxCount"/> calls to a
+/// contract that SLOADs <see cref="SlotsPerTx"/> distinct storage slots, so each tx
+/// builds a warm set of that size which is cleared on tx dispose.
+/// </summary>
+/// <remarks>
+/// Mirrors <see cref="BlockProcessingBenchmark"/>: full <see cref="BranchProcessor"/>
+/// pipeline (including pre-warming) under <see cref="Osaka"/> rules, one world state
+/// built in GlobalSetup, fresh scope per <c>Process</c> call. Slot keys are the same
+/// for every tx, so state-cache noise stays flat while the per-tx warm-set size is
+/// controlled exactly by <see cref="SlotsPerTx"/>.
+/// </remarks>
+public abstract class SyntheticStorageBlockBenchmarkBase
+{
+    protected class SyntheticBlockConfig : ManualConfig
+    {
+        public SyntheticBlockConfig()
+        {
+            AddJob(Job.Default
+                .WithToolchain(InProcessNoEmitToolchain.Instance)
+                .WithInvocationCount(1)
+                .WithUnrollFactor(1)
+                .WithLaunchCount(1)
+                .WithWarmupCount(2)
+                .WithIterationCount(8)
+                .WithGcForce(true));
+            AddColumn(StatisticColumn.Min);
+            AddColumn(StatisticColumn.Max);
+            AddColumn(StatisticColumn.Median);
+            AddColumn(StatisticColumn.P90);
+        }
+    }
+
+    protected const int OpsPerInvoke = 128;
+
+    private static readonly IReleaseSpec Spec = Osaka.Instance;
+
+    // Minimal bytecode (STOP) for system contract stubs
+    private static readonly byte[] StopCode = [0x00];
+
+    // High enough that even 300 txs x ~230k gas fit; block gas limit is not the subject here.
+    private const long BlockGasLimit = 1_000_000_000;
+
+    // Per slot: PUSH2 (3) + SLOAD cold (2100) + POP (2)
+    private const ulong GasPerSlot = 2105;
+
+    private readonly PrivateKey _senderKey = TestItem.PrivateKeyA;
+
+    private IContainer _container = null!;
+    private ILifetimeScope _processingScope = null!;
+    private IBranchProcessor _branchProcessor = null!;
+    private BlockHeader _parentHeader = null!;
+    private Block _block = null!;
+
+    /// <summary>Number of transactions in the benchmarked block.</summary>
+    protected abstract int TxCount { get; }
+
+    /// <summary>Distinct storage slots each transaction SLOADs (per-tx warm-set size).</summary>
+    protected abstract int SlotsPerTx { get; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        // Pin to a single core to reduce OS scheduler jitter (same as BlockProcessingBenchmark)
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
+        {
+            Process.GetCurrentProcess().ProcessorAffinity = new IntPtr(1);
+        }
+
+        BlockHeader header = Build.A.BlockHeader
+            .WithNumber(1)
+            .WithGasLimit(BlockGasLimit)
+            .WithBaseFee(1.GWei)
+            .WithTimestamp(1)
+            .TestObject;
+
+        _block = Build.A.Block
+            .WithHeader(header)
+            .WithTransactions(BuildContractCalls(TxCount, SlotsPerTx))
+            .TestObject;
+
+        _container = new ContainerBuilder()
+            .AddModule(new TestNethermindModule(Osaka.Instance))
+            .Build();
+
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        IWorldStateManager wsm = TestWorldStateFactory.CreateWorldStateManagerForTest(dbProvider, LimboLogs.Instance);
+        IWorldStateScopeProvider scopeProvider = wsm.GlobalWorldState;
+
+        IBlockValidationModule[] validationModules = _container.Resolve<IBlockValidationModule[]>();
+        IMainProcessingModule[] mainProcessingModules = _container.Resolve<IMainProcessingModule[]>();
+        _processingScope = _container.BeginLifetimeScope(b =>
+        {
+            b.RegisterInstance(scopeProvider).As<IWorldStateScopeProvider>().ExternallyOwned();
+            b.RegisterInstance(wsm).As<IWorldStateManager>().ExternallyOwned();
+            b.AddModule(validationModules);
+            b.AddModule(mainProcessingModules);
+        });
+
+        IWorldState stateProvider = _processingScope.Resolve<IWorldState>();
+
+        using (stateProvider.BeginScope(IWorldState.PreGenesis))
+        {
+            stateProvider.CreateAccount(_senderKey.Address, 1_000_000.Ether);
+
+            stateProvider.CreateAccount(TestItem.AddressB, UInt256.Zero);
+            stateProvider.InsertCode(TestItem.AddressB, BuildSloadCode(SlotsPerTx), Spec);
+
+            stateProvider.CreateAccount(Eip7002Constants.WithdrawalRequestPredeployAddress, UInt256.Zero);
+            stateProvider.InsertCode(Eip7002Constants.WithdrawalRequestPredeployAddress, StopCode, Spec);
+            stateProvider.CreateAccount(Eip7251Constants.ConsolidationRequestPredeployAddress, UInt256.Zero);
+            stateProvider.InsertCode(Eip7251Constants.ConsolidationRequestPredeployAddress, StopCode, Spec);
+
+            stateProvider.Commit(Spec);
+            stateProvider.CommitTree(0);
+
+            _parentHeader = Build.A.BlockHeader
+                .WithNumber(0)
+                .WithStateRoot(stateProvider.StateRoot)
+                .WithGasLimit(BlockGasLimit)
+                .TestObject;
+        }
+
+        _branchProcessor = _processingScope.Resolve<IBranchProcessor>();
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _processingScope.Dispose();
+        _container.Dispose();
+    }
+
+    protected Block[] ProcessBlockCore()
+    {
+        Block[] result = null!;
+        for (int i = 0; i < OpsPerInvoke; i++)
+            result = _branchProcessor.Process(_parentHeader, [_block],
+                ProcessingOptions.NoValidation, NullBlockTracer.Instance);
+        return result;
+    }
+
+    /// <summary>Straight-line code SLOADing <paramref name="slots"/> distinct keys: (PUSH2 i, SLOAD, POP)* STOP.</summary>
+    private static byte[] BuildSloadCode(int slots)
+    {
+        byte[] code = new byte[slots * 5 + 1];
+        int p = 0;
+        for (int i = 0; i < slots; i++)
+        {
+            code[p++] = (byte)Instruction.PUSH2;
+            code[p++] = (byte)(i >> 8);
+            code[p++] = (byte)i;
+            code[p++] = (byte)Instruction.SLOAD;
+            code[p++] = (byte)Instruction.POP;
+        }
+        code[p] = (byte)Instruction.STOP;
+        return code;
+    }
+
+    private Transaction[] BuildContractCalls(int count, int slots)
+    {
+        ulong gasLimit = GasTransaction + (ulong)slots * GasPerSlot + GasMargin;
+        Transaction[] txs = new Transaction[count];
+        for (int i = 0; i < count; i++)
+        {
+            txs[i] = Build.A.Transaction
+                .WithNonce((ulong)i)
+                .WithTo(TestItem.AddressB)
+                .WithGasLimit(gasLimit)
+                .WithGasPrice(2.GWei)
+                .SignedAndResolved(_senderKey)
+                .TestObject;
+        }
+        return txs;
+    }
+
+    private const ulong GasTransaction = 21_000;
+    private const ulong GasMargin = 2_000;
+}

--- a/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
+++ b/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
@@ -16,7 +16,7 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
     public StackAccessTracker() : this(false) { }
 
     public readonly JournalSet<Address> AccessedAddresses => _trackingState.AccessedAddresses;
-    public readonly JournalSet<StorageCell> AccessedStorageCells => _trackingState.AccessedStorageCells;
+    public readonly VersionedJournalSet<StorageCell> AccessedStorageCells => _trackingState.AccessedStorageCells;
     public readonly JournalCollection<LogEntry> Logs => _trackingState.Logs;
     public readonly JournalSet<Address> DestroyList => _trackingState.DestroyList;
     public readonly HashSet<AddressAsKey> CreateList => _trackingState.CreateList;
@@ -98,7 +98,7 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
         }
 
         public JournalSet<Address> AccessedAddresses { get; } = new(Address.EqualityComparer);
-        public JournalSet<StorageCell> AccessedStorageCells { get; } = new(StorageCell.EqualityComparer);
+        public VersionedJournalSet<StorageCell> AccessedStorageCells { get; } = new(StorageCell.EqualityComparer);
         public JournalCollection<LogEntry> Logs { get; } = [];
         public JournalSet<Address> DestroyList { get; } = new(Address.EqualityComparer);
         public HashSet<AddressAsKey> CreateList { get; } = new(AddressAsKey.EqualityComparer);
@@ -106,7 +106,8 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
         private void Clear()
         {
             AccessedAddresses.Clear();
-            AccessedStorageCells.Clear();
+            // O(1)-ish per-tx reset: epoch bump instead of clearing the (potentially large) hash storage.
+            AccessedStorageCells.Reset();
             Logs.Clear();
             DestroyList.Clear();
             CreateList.Clear();


### PR DESCRIPTION
> **Draft / exploratory.** Opened to capture WIP. This is a small, correct micro-optimization with an honest, bounded impact — see Remarks before considering merge.

## Changes

- Add `VersionedJournalSet<T>` (`Nethermind.Core/Collections`): an epoch-stamped set where "warm" ⇔ `storedEpoch == currentEpoch`, so the per-transaction EIP-2929 reset is **O(1)** (journal-list clear + epoch bump) instead of clearing the backing hash storage. Supports the existing snapshot/restore (sub-frame revert stamps entries back to a cold sentinel) and warm-only enumeration; retained entries are bounded (2^16) with an amortized full clear.
- Use it for the storage warm/cold set in `StackAccessTracker` (`AccessedStorageCells`). The **address** set intentionally stays `JournalSet` — EIP-7702 can legally add a `null` authority, which a dictionary-keyed versioned set cannot hold without throwing (consensus-crash vector). `Add`/`Contains`/snapshot semantics are byte-identical.
- Add BenchmarkDotNet coverage that isolates the per-tx reset cost: `AccessTrackerResetBenchmark` (rent→warm-K→dispose primitive), `StorageWarmSetBlockBenchmark` + `SyntheticStorageBlockBenchmarkBase` (full `BranchProcessor` blocks, TxCount×SlotsPerTx grid), `FixedTotalSlotsBlockBenchmark` (constant total SLOADs split across N txs).

## Types of changes

- [x] Optimization
- [x] Other: adds benchmark coverage

## Testing

#### Requires testing
- [x] Yes

#### If yes, did you write tests?
- [x] Yes

#### Notes on testing

- New `VersionedJournalSetTests` (9/9) cover add/contains, per-epoch reset, snapshot/restore-to-cold, and retained-entry bound.
- `Nethermind.Evm.Test` green (all EIP-2929 / access-list / gas tests pass). Measured interleaved on an i7-12700H laptop (thermal drift is real — only back-to-back interleaved A/B with a no-op canary was trusted).

## Remarks — honest impact (read this)

This was an investigation into why Reth pulls ahead of Nethermind as block **transaction count** rises (mainnet reference-node data: ~5 ms per +100 tx at fixed gas). Findings:

- **The O(1) reset is real but small.** The isolated primitive is ~2× faster (K=64 −57%, K=512 −41%, K=4096 −61%, zero allocs). On realistic blocks it only shows on **storage-heavy** shapes (many distinct slots/tx): **−2…−7%** (crossing significance at 50tx×100slots −6.7% and fixed-total-150tx −7.6%), no regressions. On typical shapes (transfers, plain calls, small access lists, mixed) it is **within noise** — the warm sets are tiny/empty and simple transfers bypass the tracker entirely.
- **It does _not_ explain the mainnet gap.** Total local per-tx overhead is ~2.5 µs — ~20× smaller than the ~5 ms/100tx figure. The gap lives elsewhere (state-root / trie-commit per-tx effects and the storage layer), which local in-memory BDN cannot model.
- **Merge caveat:** retained dict entries accumulate across blocks per pooled instance (bounded 2^16 ≈ a few MB/instance); BDN reuses keys so it cannot capture large-retained-dict cache-miss effects on the SLOAD hot path. **An expb realblocks run is needed before this is merge-ready.** The cap is trivially tunable.
