### PR TITLE
fix(network): reject zero-size RLPx frames in ZeroFrameDecoder

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyFrameDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyFrameDecoderTests.cs
@@ -74,6 +74,26 @@ public class ZeroNettyFrameDecoderTests
         Assert.Throws<CorruptedFrameException>(() => zeroFrameDecoderTestWrapper.Decode(input));
     }
 
+    [Test]
+    public void Rejects_zero_size_frame()
+    {
+        (EncryptionSecrets a, EncryptionSecrets b) = NetTestVectors.GetSecretsPair();
+        using FrameMacProcessor encoderMac = new(TestItem.IgnoredPublicKey, a);
+        using FrameMacProcessor decoderMac = new(TestItem.IgnoredPublicKey, b);
+        ZeroFrameEncoderTestWrapper encoder = new(new FrameCipher(a.AesSecret), encoderMac);
+        ZeroFrameDecoderTestWrapper decoder = new(new FrameCipher(b.AesSecret), decoderMac);
+
+        byte[] zeroSizeHeader = new byte[Frame.HeaderSize];
+        zeroSizeHeader[3] = 0xc1;
+        zeroSizeHeader[4] = 0x80;
+
+        IByteBuffer rawFrame = ReferenceCountUtil.ReleaseLater(Unpooled.WrappedBuffer(zeroSizeHeader));
+        IByteBuffer encoded = ReferenceCountUtil.ReleaseLater(Unpooled.Buffer(64));
+        encoder.Encode(rawFrame, encoded);
+
+        Assert.Throws<CorruptedFrameException>(() => decoder.Decode(encoded));
+    }
+
     private void Test(string frame, Delivery delivery, string expectedOutput)
     {
         byte[] frameBytes = Bytes.FromHexString(frame);

--- a/src/Nethermind/Nethermind.Network/Rlpx/ZeroFrameDecoder.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/ZeroFrameDecoder.cs
@@ -123,6 +123,9 @@ namespace Nethermind.Network.Rlpx
             payloadSize = (payloadSize << 8) + (_decryptedBytes[1] & 0xFF);
             payloadSize = (payloadSize << 8) + (_decryptedBytes[2] & 0xFF);
 
+            if (payloadSize is 0)
+                ThrowZeroSizeFrame();
+
             if (payloadSize > _maxFrameSize)
                 ThrowFrameTooLarge(payloadSize, _maxFrameSize);
 
@@ -167,6 +170,10 @@ namespace Nethermind.Network.Rlpx
             WaitingForPayload,
             WaitingForPayloadMac
         }
+
+        [DoesNotReturn, StackTraceHidden]
+        private static void ThrowZeroSizeFrame()
+            => throw new CorruptedFrameException("Frame payload is empty");
 
         [DoesNotReturn, StackTraceHidden]
         private static void ThrowFrameTooLarge(int payloadSize, int maxFrameSize)


### PR DESCRIPTION
## Changes

`ZeroFrameDecoder.ReadFrameSize` bounded only the top of the payload size (`> _maxFrameSize`), with no lower bound. A size-0 frame header yields `_remainingPayloadBlocks == 0`, but the `WaitingForPayload` state calls `ProcessOneBlock` **unconditionally** before checking the `== 0` transition, so it decrements to `-1` and the transition never fires. The decoder then stays wedged in `WaitingForPayload`, appending every subsequent 16-byte block to the auto-growing `_innerBuffer` — without re-checking a MAC and past the frame-size cap.

This adds a symmetric lower-bound guard: `ReadFrameSize` rejects `payloadSize <= 0` with a `CorruptedFrameException`, mirroring the existing `> _maxFrameSize` check. A real devp2p message always carries at least one byte, so honest peers never emit a size-0 frame — the change is behavior-preserving.

### Changes
- `ReadFrameSize` throws `CorruptedFrameException` on `payloadSize <= 0` (new `ThrowFrameTooSmall`), next to the existing upper-bound guard.
- Regression test that feeds a MAC-valid size-0 frame and asserts `CorruptedFrameException` (mirrors `Rejects_frame_exceeding_configured_limit`).

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
