### PR TITLE
perf(rlp): cap the item-count walk at limit+1 in DecodeArray decoders

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -25,6 +25,26 @@ namespace Nethermind.Core.Test
         }
 
         [Test]
+        public void DecodeArray_rejects_more_items_than_the_limit()
+        {
+            RlpLimit limit = new(4);
+
+            byte[] atLimit = Rlp.Encode(Enumerable.Range(0, limit.Limit).Select(i => Rlp.Encode(i)).ToArray()).Bytes;
+            Assert.That(() =>
+            {
+                RlpReader reader = new(atLimit);
+                reader.DecodeArray(static (ref RlpReader c) => c.DecodeInt(), limit: limit);
+            }, Throws.Nothing);
+
+            byte[] overLimit = Rlp.Encode(Enumerable.Range(0, limit.Limit + 1).Select(i => Rlp.Encode(i)).ToArray()).Bytes;
+            Assert.That(() =>
+            {
+                RlpReader reader = new(overLimit);
+                reader.DecodeArray(static (ref RlpReader c) => c.DecodeInt(), limit: limit);
+            }, Throws.TypeOf<RlpLimitException>());
+        }
+
+        [Test]
         public void Serializing_sequences()
         {
             Rlp output = Rlp.Encode(

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -56,7 +56,7 @@ namespace Nethermind.Serialization.Rlp
 
             int lastCheck = ctx.ReadSequenceLength() + ctx.Position;
 
-            int numberOfReceipts = ctx.PeekNumberOfItemsRemaining(lastCheck);
+            int numberOfReceipts = ctx.PeekNumberOfItemsRemaining(lastCheck, LogsRlpLimit.Limit + 1);
             ctx.GuardLimit(numberOfReceipts, LogsRlpLimit);
             LogEntry[] entries = new LogEntry[numberOfReceipts];
             for (int i = 0; i < numberOfReceipts; i++)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -121,7 +121,7 @@ namespace Nethermind.Serialization.Rlp
             try
             {
                 int checkPosition = decoderContext.ReadSequenceLength() + decoderContext.Position;
-                int length = decoderContext.PeekNumberOfItemsRemaining(checkPosition);
+                int length = decoderContext.PeekNumberOfItemsRemaining(checkPosition, (limit ?? RlpLimit.DefaultLimit).Limit + 1);
                 decoderContext.GuardLimit(length, limit);
                 result = new(length);
                 for (int i = 0; i < length; i++)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpDecoder.cs
@@ -60,7 +60,7 @@ public abstract class RlpDecoder<T> : IRlpDecoder<T>
     public virtual T[] DecodeArray(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None, RlpLimit? limit = null)
     {
         int checkPosition = decoderContext.ReadSequenceLength() + decoderContext.Position;
-        int length = decoderContext.PeekNumberOfItemsRemaining(checkPosition);
+        int length = decoderContext.PeekNumberOfItemsRemaining(checkPosition, (limit ?? RlpLimit.DefaultLimit).Limit + 1);
         decoderContext.GuardLimit(length, limit);
         T[] result = new T[length];
         for (int i = 0; i < result.Length; i++)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -935,7 +935,7 @@ public ref struct RlpReader
             ?? throw new RlpException($"{nameof(Rlp)} does not support length of {nameof(T)}");
 
         int positionCheck = ReadSequenceLength() + Position;
-        int count = PeekNumberOfItemsRemaining(checkPositions ? positionCheck : null);
+        int count = PeekNumberOfItemsRemaining(checkPositions ? positionCheck : null, (limit ?? RlpLimit.DefaultLimit).Limit + 1);
         GuardLimit(count, limit);
         T[] result = new T[count];
         for (int i = 0; i < result.Length; i++)
@@ -968,7 +968,7 @@ public ref struct RlpReader
     public T[] DecodeArray<T>(DecodeRlpValue<T> decodeItem, bool checkPositions = true, T defaultElement = default, RlpLimit? limit = null)
     {
         int positionCheck = ReadSequenceLength() + Position;
-        int count = PeekNumberOfItemsRemaining(checkPositions ? positionCheck : null);
+        int count = PeekNumberOfItemsRemaining(checkPositions ? positionCheck : null, (limit ?? RlpLimit.DefaultLimit).Limit + 1);
         GuardLimit(count, limit);
         T[] result = new T[count];
         for (int i = 0; i < result.Length; i++)
@@ -995,7 +995,7 @@ public ref struct RlpReader
     public ArrayPoolList<T> DecodeArrayPoolList<T>(DecodeRlpValue<T> decodeItem, bool checkPositions = true, T defaultElement = default, RlpLimit? limit = null)
     {
         int positionCheck = ReadSequenceLength() + Position;
-        int count = PeekNumberOfItemsRemaining(checkPositions ? positionCheck : null);
+        int count = PeekNumberOfItemsRemaining(checkPositions ? positionCheck : null, (limit ?? RlpLimit.DefaultLimit).Limit + 1);
         GuardLimit(count, limit);
         ArrayPoolList<T> result = new(count, count);
         int i = 0;


### PR DESCRIPTION
## Changes

The `DecodeArray`-family decoders called `PeekNumberOfItemsRemaining` with no `maxSearch` (defaulting to `int.MaxValue`), so a sequence of many single-byte items (`0x80`/`0xc0`) was walked in full before `GuardLimit` rejected it. The sibling `DecodeByteArrays` (`RlpReader.cs:832`), `RlpByteArrayList`, `TrieNode` and `BlockBodyDecoder` already cap the identical walk at `(limit).Limit + 1` — this completes that established in-repo convention at the six sites that still lacked it.

This passes `(limit ?? RlpLimit.DefaultLimit).Limit + 1` (or `LogsRlpLimit.Limit + 1`) as `maxSearch`:
- `RlpReader.DecodeArray` (the three overloads, `:938/:971/:998`)
- `Rlp.DecodeArrayPool` (`:124`)
- `RlpDecoder.DecodeArray` (`:63`)
- `ReceiptMessageDecoder` (`:59`, which guards against `LogsRlpLimit`)

The change is behavior-preserving: for valid input `count <= limit < maxSearch`, so the walk terminates naturally and the count is byte-for-byte unchanged; for an over-limit sequence the count clamps to `limit + 1` and `GuardLimit` throws the same `RlpLimitException` (before any allocation), now without walking the whole message.

### Tests
- Boundary test: exactly `limit` items decode, `limit + 1` throws `RlpLimitException` (validates the `+ 1` — `> limit` is still rejected).
- Existing serializer round-trip and limit tests (e.g. `BlockAccessListsMessageSerializerTests`) continue to pass, covering both valid decode and the over-limit throw at these sites.

## Types of changes

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
