### PR TITLE
fix(txpool): single-source pending-delegation accounting through pool events

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2178,6 +2178,52 @@ namespace Nethermind.TxPool.Test
             Assert.That(result, Is.EqualTo(lastExpectation));
         }
 
+        [Test]
+        public void Pending_delegation_guard_survives_removing_one_of_two_same_authority_delegations()
+        {
+            ISpecProvider specProvider = GetPragueSpecProvider();
+            TxPoolConfig txPoolConfig = new() { Size = 30, PersistentBlobStorageSize = 0 };
+            _txPool = CreatePool(txPoolConfig, specProvider);
+
+            PrivateKey authority = TestItem.PrivateKeyA;
+            PrivateKey sponsorA = TestItem.PrivateKeyB;
+            PrivateKey sponsorB = TestItem.PrivateKeyC;
+            _stateProvider.CreateAccount(authority.Address, UInt256.MaxValue);
+            _stateProvider.CreateAccount(sponsorA.Address, UInt256.MaxValue);
+            _stateProvider.CreateAccount(sponsorB.Address, UInt256.MaxValue);
+
+            EthereumEcdsa ecdsa = new(_specProvider.ChainId);
+
+            Transaction Delegation(PrivateKey sponsor) => Build.A.Transaction
+                .WithNonce(0)
+                .WithType(TxType.SetCode)
+                .WithMaxFeePerGas(9.GWei)
+                .WithMaxPriorityFeePerGas(9.GWei)
+                .WithGasLimit(100_000)
+                .WithAuthorizationCode(ecdsa.Sign(authority, specProvider.ChainId, TestItem.AddressD, 0))
+                .WithTo(TestItem.AddressB)
+                .SignedAndResolved(_ethereumEcdsa, sponsor).TestObject;
+
+            Transaction firstDelegation = Delegation(sponsorA);
+            Transaction secondDelegation = Delegation(sponsorB);
+            Assert.That(_txPool.SubmitTx(firstDelegation, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(secondDelegation, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            _txPool.RemoveTransaction(firstDelegation.Hash);
+
+            Transaction AuthorityTx(ulong nonce) => Build.A.Transaction
+                .WithNonce(nonce)
+                .WithType(TxType.EIP1559)
+                .WithMaxFeePerGas(9.GWei)
+                .WithMaxPriorityFeePerGas(9.GWei)
+                .WithGasLimit(GasCostOf.Transaction)
+                .WithTo(TestItem.AddressB)
+                .SignedAndResolved(_ethereumEcdsa, authority).TestObject;
+
+            Assert.That(_txPool.SubmitTx(AuthorityTx(0), TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(AuthorityTx(1), TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.NotCurrentNonceForDelegation));
+        }
+
         [TestCase(1ul, 2ul)]
         [TestCase(0ul, 0ul)]
         [TestCase(ulong.MaxValue, ulong.MaxValue)]

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -135,6 +135,7 @@ namespace Nethermind.TxPool
             TxPoolHeadChanged += _broadcaster.OnNewHead;
 
             _transactions = new TxDistinctSortedPool(txPoolConfig.Size, comparer, logManager);
+            _transactions.Inserted += OnInsertedTx;
             _transactions.Removed += OnRemovedTx;
 
             _blobTransactions = txPoolConfig.BlobsSupport.IsPersistentStorage()
@@ -231,6 +232,7 @@ namespace Nethermind.TxPool
             Span<byte[]?> blobs, Span<ReadOnlyMemory<byte[]>> proofs)
             => _blobTransactions.TryGetBlobsAndProofsV1(requestedBlobVersionedHashes, blobs, proofs);
 
+        private void OnInsertedTx(object? sender, SortedPool<ValueHash256, Transaction, AddressAsKey>.SortedPoolEventArgs args) => AddPendingDelegations(args.Value);
         private void OnRemovedTx(object? sender, SortedPool<ValueHash256, Transaction, AddressAsKey>.SortedPoolRemovedEventArgs args) => RemovePendingDelegations(args.Value);
         private void OnHeadChange(object? sender, BlockReplacementEventArgs e)
         {
@@ -678,7 +680,6 @@ namespace Nethermind.TxPool
 
             if (removed is not null)
             {
-                RemovePendingDelegations(removed);
                 EvictedPending?.Invoke(this, new TxEventArgs(removed));
                 // transaction which was on last position in sorted TxPool and was deleted to give
                 // a place for a newly added tx (with higher priority) is now removed from hashCache
@@ -686,8 +687,6 @@ namespace Nethermind.TxPool
                 _hashCache.DeleteFromLongTerm(removed.Hash!);
                 Metrics.PendingTransactionsEvicted++;
             }
-
-            AddPendingDelegations(tx);
 
             _broadcaster.Broadcast(tx, isPersistentBroadcast);
 
@@ -893,8 +892,6 @@ namespace Nethermind.TxPool
 
             RemovedPending?.Invoke(this, new TxEventArgs(transaction));
 
-            RemovePendingDelegations(transaction);
-
             _broadcaster.StopBroadcast(hash);
 
             if (_logger.IsTrace) _logger.Trace($"Removed a transaction: {hash}");
@@ -991,6 +988,7 @@ namespace Nethermind.TxPool
             _broadcaster.Dispose();
             _headInfo.HeadChanged -= OnHeadChange;
             _headBlocksChannel.Writer.Complete();
+            _transactions.Inserted -= OnInsertedTx;
             _transactions.Removed -= OnRemovedTx;
 
             await _retryCache.DisposeAsync();


### PR DESCRIPTION
## Changes

The EIP-7702 pending-delegation counter (`DelegationCache`, read by `DelegatedAccountFilter` to enforce next-nonce-only for an authority that has a pooled delegation) was accounted asymmetrically:
- **Incremented once**, in `AddCore` (`AddPendingDelegations`).
- **Decremented** on every standard-pool `Removed` event (`OnRemovedTx`) **and** explicitly again in `AddCore`'s eviction branch and in `RemoveTransaction`.

Since `SortedPool` fires `Removed` for both eviction and `TryRemove`, eviction and removal decremented the counter twice while an insert incremented it once. `DelegationCache` drops a key at count 0, so an authority with two pooled delegations became absent after a single removal — `HasPending` then wrongly returned `false` and the filter stopped enforcing next-nonce-only for that authority.

This drives the counter symmetrically from the standard pool's own events:
- Increment on `Inserted`, decrement on `Removed`.
- Deletes the three explicit `AddPendingDelegations` / `RemovePendingDelegations` calls (`AddCore` ×2, `RemoveTransaction`).

Insert → immediate-evict now nets to 0, and eviction/removal each decrement exactly once. The blob pool stays unsubscribed (delegations only apply to the standard pool, and SetCode txs never go to the blob pool).

### Tests
- New regression test: with two same-authority delegations pooled, removing one keeps that authority's next-nonce-only restriction in force (a following non-current-nonce tx from it is rejected `NotCurrentNonceForDelegation`).
- Existing SetCode / delegation tests (replacement, removal-of-one, self-sponsored) continue to pass.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
