### PR TITLE
fix(rpc): serialize eth_capabilities retentionBlocks as hex QUANTITY

### DIFF
--- a/scripts/known-failing-hive-tests.txt
+++ b/scripts/known-failing-hive-tests.txt
@@ -2,7 +2,6 @@
 
 testing_buildBlockV1/build-block-empty-transactions (nethermind)
 testing_buildBlockV1/build-block-with-transactions (nethermind)
-eth_capabilities/get-capabilities (nethermind)
 
 # graphql
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.Capabilities.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.Capabilities.cs
@@ -366,7 +366,7 @@ public partial class EthRpcModuleTests
                   "required": ["type", "retentionBlocks"],
                   "properties": {
                     "type": { "type": "string", "enum": ["window"] },
-                    "retentionBlocks": { "type": "integer", "minimum": 0 }
+                    "retentionBlocks": { "type": "string", "pattern": "^0x[0-9a-fA-F]+$" }
                   }
                 }
               }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthCapabilities.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthCapabilities.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json.Serialization;
 using Nethermind.Core.Crypto;
-using Nethermind.Serialization.Json;
 
 namespace Nethermind.JsonRpc.Modules.Eth;
 
@@ -53,7 +52,7 @@ public readonly record struct ResourceAvailability(
 
 /// <summary>Rolling-window deletion strategy for a resource.</summary>
 /// <param name="Type">Strategy type — currently always <c>"window"</c>; the spec uses <c>oneOf</c> to leave room for future strategies.</param>
-/// <param name="RetentionBlocks">Number of recent blocks retained. Per spec this is a JSON integer (not a hex quantity).</param>
+/// <param name="RetentionBlocks">Number of recent blocks retained, serialized as a hex QUANTITY string per the spec's <c>uint</c> type.</param>
 public readonly record struct DeleteStrategy(
     string Type,
-    [property: JsonConverter(typeof(ULongRawJsonConverter))] ulong RetentionBlocks);
+    ulong RetentionBlocks);


### PR DESCRIPTION
## Summary

`eth_capabilities` returned `state.deleteStrategy.retentionBlocks` as a **raw JSON integer**, but the spec ([ethereum/execution-apis#755](https://github.com/ethereum/execution-apis/pull/755), merged) types it as `uint` — a hex QUANTITY **string**. The Hive `eth_capabilities/get-capabilities` test fails schema validation:

```
'/state/deleteStrategy/retentionBlocks' does not validate ... expected string
response does not conform to eth_capabilities result schema
```

## Fix

- **`EthCapabilities.cs`** — dropped the `[JsonConverter(typeof(ULongRawJsonConverter))]` override on `DeleteStrategy.RetentionBlocks` (that converter calls `WriteNumberValue`). It now serializes via the default `ulong` QUANTITY converter — a hex string like `"0x15f90"`, matching the spec's `uint` type and the sibling `oldestBlock`/`head.number` fields. Also removed the now-unused `using` and corrected the misleading doc comment.
- **`EthRpcModuleTests.Capabilities.cs`** — the test's embedded JSON schema asserted `"retentionBlocks": { "type": "integer" }`, which mirrored the bug and kept CI green while the real spec schema failed. Corrected to the hex QUANTITY string form.

## Behaviour / performance

- Allocation-neutral: the default QUANTITY path (`NumericConverterHelper.Write` → `HexWriter.WriteUlongHexRawValue`) writes hex digits directly to the `Utf8JsonWriter` buffer — no string allocation, same as the other QUANTITY fields in the same response. `eth_capabilities` is not a hot path regardless.
- `Eth_capabilities_json_matches_spec_schema` passes against the corrected schema.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

- [x] Yes — existing `EthRpcModuleTests.Capabilities` suite (schema now matches spec)
- [x] Hive Job — https://github.com/NethermindEth/nethermind/actions/runs/28589904935 

🤖 Generated with [Claude Code](https://claude.com/claude-code)