### PR TITLE
fix(merge): side-effect-free invalid-chain query, atomic node get-or-create

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidChainTrackerTest.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InvalidChainTracker/InvalidChainTrackerTest.cs
@@ -214,6 +214,21 @@ public class InvalidChainTrackerTest
         AssertInvalid(blockHeader.GetOrCalculateHash(), parentBlockHeader.Hash);
     }
 
+    [Test]
+    public void queryingValidHashes_shouldNotEvictRecordedInvalidChainNode()
+    {
+        List<Hash256> hashes = MakeChain(3);
+        _tracker.OnInvalidBlock(hashes[1], hashes[0]);
+        AssertInvalid(hashes[1]);
+
+        for (int i = 0; i < 4096; i++)
+        {
+            _tracker.IsOnKnownInvalidChain(Keccak.Compute($"valid-{i}"), out _);
+        }
+
+        AssertInvalid(hashes[1]);
+    }
+
     private void AssertValid(Hash256 hash) =>
         Assert.That(_tracker.IsOnKnownInvalidChain(hash, out _), Is.False);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidChainTracker.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/InvalidChainTracker/InvalidChainTracker.cs
@@ -61,16 +61,7 @@ public class InvalidChainTracker(
         }
     }
 
-    private Node GetNode(Hash256 hash)
-    {
-        if (!_tree.TryGet(hash, out Node node))
-        {
-            node = new Node();
-            _tree.Set(hash, node);
-        }
-
-        return node;
-    }
+    private Node GetNode(Hash256 hash) => _tree.SetOrGet(hash, 0, static (_, _) => new Node());
 
     private void PropagateLastValidHash(Node node)
     {
@@ -152,14 +143,14 @@ public class InvalidChainTracker(
     public bool IsOnKnownInvalidChain(Hash256 blockHash, out Hash256? lastValidHash)
     {
         lastValidHash = null;
-        Node node = GetNode(blockHash);
+        if (!_tree.TryGet(blockHash, out Node node))
+        {
+            return false;
+        }
+
         lock (node)
         {
-            if (node.LastValidHash is not null)
-            {
-                lastValidHash = node.LastValidHash;
-            }
-
+            lastValidHash = node.LastValidHash;
             return node.LastValidHash is not null;
         }
     }


### PR DESCRIPTION
## Changes

`InvalidChainTracker.IsOnKnownInvalidChain` resolved the node through `GetNode`, which get-or-creates. The callers (`NewPayloadHandler`, `ForkchoiceUpdatedHandler`) query normally-valid hashes, so every membership check inserted an empty `Node` into the 1024-entry LRU. A steady stream of such queries churned the cache and could evict a previously-recorded invalid-chain node, after which `IsOnKnownInvalidChain` recreated a fresh empty node and returned `false` for a hash that had been recorded as invalid.

`GetNode` was also a non-atomic `TryGet`-then-`Set`. The tracker is a DI singleton (`MergePlugin`) touched by engine-RPC threads and by the blockchain-processor `InvalidBlock` handler on the processing thread. Two threads racing on the same absent hash each created and `Set` a distinct `Node`, then took `lock (node)` on different instances — so the per-node lock did not serialize them and one thread's `LastValidHash` write could be lost.

This:
- makes `IsOnKnownInvalidChain` a pure `_tree.TryGet` read (absent ⇒ `false`, behavior-preserving — no caller relied on the query creating a node);
- routes node creation through the existing atomic `LruCache.SetOrGet`, so all callers share one canonical `Node` per hash under the cache lock. Nodes are now created only by the record paths (`SetChildParent` / `OnInvalidBlock` / `PropagateLastValidHash`).

### Tests
- New regression test: after recording an invalid-chain node, spraying 4096 valid-hash queries (4× the cache capacity) must not evict it. Fails on `master` (the queries churn the LRU and evict the node), passes with the pure read.
- The existing 8 `InvalidChainTrackerTest` cases continue to pass — node-creation semantics through `SetOrGet` are unchanged.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
