### PR TITLE
ci(rpc-comparison): add -L latest-block pass with head sync

### DIFF
--- a/.github/workflows/rpc-comparison.yml
+++ b/.github/workflows/rpc-comparison.yml
@@ -632,13 +632,34 @@ jobs:
           err_opt=()
           [ -n "$REFERENCE_URL" ] && [ "$IGNORE_ERROR_MESSAGES" == "true" ] && err_opt=(-E)
 
+          # Default pass: historical (non-latest) tests, which pin explicit block numbers.
           set +e
           ./build/bin/rpc_int -b "$NETWORK" -H "$host" -p "$port" $RPC_FLAG "${ext[@]}" \
             "${exclude[@]}" "${err_opt[@]}" -M "$MAX_FAILURES" -c -f -R rpc-results/report.csv | tee rpc-results/output.txt
           rc=${PIPESTATUS[0]}
           set -e
           echo "rpc_int exit code: $rc"
-          exit $rc
+
+          # Latest-block pass (-L): head-dependent tests (eth_baseFee, eth_gasPrice,
+          # eth_blockNumber, eth_maxPriorityFeePerGas, ...). rpc_int first waits until the node
+          # under test and the reference agree on the latest block (GetConsistentLatestBlock),
+          # then queries both at that same head, so the comparison is deterministic instead of
+          # racing on a one-block head skew. Only meaningful against a live reference, so it is
+          # skipped in regression mode (no REFERENCE_URL; latest fixtures carry no expected result).
+          rc_latest=0
+          if [ -n "$REFERENCE_URL" ]; then
+            set +e
+            ./build/bin/rpc_int -b "$NETWORK" -H "$host" -p "$port" $RPC_FLAG "${ext[@]}" \
+              "${exclude[@]}" "${err_opt[@]}" -L -M "$MAX_FAILURES" -c -f -R rpc-results/report-latest.csv | tee rpc-results/output-latest.txt
+            rc_latest=${PIPESTATUS[0]}
+            set -e
+            echo "rpc_int (latest) exit code: $rc_latest"
+          fi
+
+          if [ "$rc" -ne 0 ] || [ "$rc_latest" -ne 0 ]; then
+            echo "rpc_int failed (default=$rc, latest=$rc_latest)"
+            exit 1
+          fi
 
       - name: Upload rpc_int results
         if: always()


### PR DESCRIPTION
## Summary

The rpc-comparison job ran `rpc_int` **once**, in the default (non-latest) pass only. That pass **skips** the head-dependent "latest" tests (`eth_baseFee`, `eth_gasPrice`, `eth_blockNumber`, `eth_maxPriorityFeePerGas`, `eth_blobBaseFee`, …). So today those methods are either not exercised, or — when one slips into the default pass — they flake, because the node under test and the live reference are compared at whatever head each happens to be at, and a one-block skew changes the value (e.g. `eth_baseFee`: `0x153a157d` vs `0x147220ae`, ~4.2% = one EIP-1559 step).

## Change

Add a second `rpc_int` invocation with `-L` (latest-block tests), run **only when a live `REFERENCE_URL` is set**. In that mode `rpc_int` first calls `GetConsistentLatestBlock` to **wait until both nodes agree on the latest block**, then queries both at that same head — so every latest test is compared deterministically on the same block on both clients, rather than racing on head skew.

- Separate result files (`report-latest.csv` / `output-latest.txt`) so the default pass output is preserved.
- The step fails if **either** pass fails.
- Skipped in regression mode (no reference; latest fixtures carry no committed result, so there's nothing to compare against).

This gives the same head-synced treatment to **all** `latest` tests, not just `eth_baseFee`.

## Companion PR

Requires **NethermindEth/rpc-tests#30**, which adds `eth_baseFee` to the `testsOnLatest` list so it's picked up by the `-L` pass (alongside the other head-dependent fee methods already there).

## Types of changes

- [x] Build-related changes (CI)

## Testing

- [x] Yes — YAML validated; shell reviewed (paired passes, combined exit code). Real validation is the next scheduled rpc-comparison run against a reference.