### PR TITLE
fix(jsonrpc): bound eth_simulateV1 total block expansion, not just each gap

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -210,6 +210,27 @@ public class EthSimulateTestsBlocksAndTransactions
         Assert.That(result.Result.Error, Is.EqualTo(SimulateErrorMessages.EmptyBlockStateCalls));
     }
 
+    [Test]
+    public async Task Test_eth_simulateV1_gap_expansion_exceeding_cap_returns_error()
+    {
+        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain();
+
+        SimulatePayload<TransactionForRpc> payload = new()
+        {
+            BlockStateCalls =
+            [
+                new() { BlockOverrides = new BlockOverride { Number = checked(chain.Bridge.HeadBlock.Number + 130) }, Calls = [] },
+                new() { BlockOverrides = new BlockOverride { Number = checked(chain.Bridge.HeadBlock.Number + 260) }, Calls = [] }
+            ]
+        };
+
+        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
+            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
+
+        Assert.That((bool)result.Result, Is.False);
+        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.ClientLimitExceededError));
+    }
+
     /// <summary>
     ///     This test verifies that a temporary forked blockchain can make transactions, blocks and report on them
     ///     We test on blocks before current head and after it,

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/SimulateTxExecutor.cs
@@ -136,8 +136,7 @@ public class SimulateTxExecutor<TTrace>(
                 if (givenNumber <= lastBlockNumber)
                     return ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>>.Fail(SimulateErrorMessages.BlockNumberNotIncreasing, ErrorCodes.InvalidInputBlocksOutOfOrder);
 
-                // if the no. of filler blocks are greater than maximum simulate blocks cap
-                if (givenNumber - lastBlockNumber > (ulong)_blocksLimit)
+                if (givenNumber - header.Number > (ulong)_blocksLimit)
                     return ResultWrapper<IReadOnlyList<SimulateBlockResult<TTrace>>>.Fail($"too many blocks", ErrorCodes.ClientLimitExceededError);
 
                 for (ulong fillBlockNumber = lastBlockNumber + 1; fillBlockNumber < givenNumber; fillBlockNumber++)


### PR DESCRIPTION
## Changes

`SimulateTxExecutor` (used by `eth_simulateV1` / `debug_simulateV1` / `trace_simulateV1`) capped:
- the user-supplied `BlockStateCalls.Count` (≤ `MaxSimulateBlocksCap`, default 256), and
- each single inter-block gap: `givenNumber - lastBlockNumber > _blocksLimit`, where `lastBlockNumber` is reassigned to `givenNumber` on every iteration.

It never bounded the **cumulative** number of blocks the gap fillers expand to. The filler loop appends one empty `BlockStateCall` per skipped block number with no running total, and every materialized block — filler or not — goes through `GetCallHeader` + state prep + `ProcessOne` + `CommitTree` + `SuggestBlock`. With up to 256 user blocks each stepping up to 256, one request expands to ~65,536 simulated blocks.

This bounds the cumulative distance from the base header rather than the per-step gap:

```
givenNumber - header.Number > _blocksLimit
```

Because block numbers are strictly increasing (enforced just above) and every gap is filled, that distance equals the total materialized block count — so the check caps the whole expansion at `_blocksLimit`. This matches go-ethereum's `sanitizeChain` (`block.Number - base.Number > maxSimulateBlocks`). The cumulative bound subsumes the previous per-step check, and single-block requests are unaffected (`lastBlockNumber == header.Number` on the first block).

### Tests
- New regression test: two blocks whose per-step gaps are each within the cap but whose combined expansion from the base crosses it → rejected with `ClientLimitExceededError`. Fails on `master`, where the per-step check passes both blocks and the request expands past the cap.
- Existing `EthSimulateTestsBlocksAndTransactions` cases (including the multi-block `Head+10` / `123` case) continue to pass.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
