### PR TITLE
Partial archive mode: rolling window of historical state (Sync.PartialArchiveEnabled)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveNodeTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveNodeTrackerTests.cs
@@ -138,6 +138,22 @@ public class PartialArchiveNodeTrackerTests
     }
 
     [Test]
+    public void Prune_executes_only_at_persistence_barriers()
+    {
+        PersistNode(null, in PathA, V1, 1);
+        PersistNode(null, in PathA, V2, 2);
+        _tracker.OnSnapshotPersisted(5);
+
+        // A request alone must not delete anything: deletions are deferred to the next barrier,
+        // where the persistence thread is parked and cannot race them.
+        Assert.That(_tracker.RequestPrune(5), Is.True);
+        Assert.That(NodeExists(null, in PathA, V1), Is.True);
+
+        _tracker.OnSnapshotPersisted(5);
+        Assert.That(NodeExists(null, in PathA, V1), Is.False);
+    }
+
+    [Test]
     public void Prune_cutoff_is_capped_by_last_persisted_snapshot()
     {
         PersistNode(null, in PathA, V1, 1);

--- a/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveNodeTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveNodeTrackerTests.cs
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain.PartialArchive;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.Trie;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.PartialArchive;
+
+public class PartialArchiveNodeTrackerTests
+{
+    private MemColumnsDb<PartialArchiveColumns> _archiveDb = null!;
+    private MemDb _stateDb = null!;
+    private NodeStorage _nodeStorage = null!;
+    private PartialArchiveNodeTracker _tracker = null!;
+
+    private static readonly TreePath PathA = TreePath.FromPath(TestItem.KeccakA.Bytes);
+    private static readonly TreePath PathB = TreePath.FromPath(TestItem.KeccakB.Bytes);
+    private static readonly Hash256 V1 = TestItem.KeccakC;
+    private static readonly Hash256 V2 = TestItem.KeccakD;
+    private static readonly Hash256 V3 = TestItem.KeccakE;
+
+    [SetUp]
+    public void Setup()
+    {
+        _archiveDb = new MemColumnsDb<PartialArchiveColumns>();
+        _stateDb = new MemDb();
+        _nodeStorage = new NodeStorage(_stateDb);
+        _tracker = new PartialArchiveNodeTracker(_archiveDb, _nodeStorage, LimboLogs.Instance);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _tracker.Dispose();
+        _archiveDb.Dispose();
+        _stateDb.Dispose();
+    }
+
+    private void PersistNode(Hash256? address, in TreePath path, Hash256 keccak, ulong blockNumber)
+    {
+        _nodeStorage.Set(address, in path, keccak, [1, 2, 3]);
+        _tracker.OnNodePersisted(address, in path, keccak, blockNumber);
+    }
+
+    private bool NodeExists(Hash256? address, in TreePath path, Hash256 keccak) =>
+        _nodeStorage.Get(address, in path, keccak) is not null;
+
+    private void PruneAndDrain(ulong cutoff, ulong barrierBlock)
+    {
+        // Barrier both marks the snapshot boundary (prune cutoff cap) and drains the queue;
+        // the second barrier guarantees the prune command itself has been executed.
+        _tracker.OnSnapshotPersisted(barrierBlock);
+        Assert.That(_tracker.RequestPrune(cutoff), Is.True);
+        _tracker.OnSnapshotPersisted(barrierBlock);
+    }
+
+    [Test]
+    public void Deletes_superseded_version_when_it_leaves_the_window()
+    {
+        PersistNode(null, in PathA, V1, 1);
+        PersistNode(null, in PathA, V2, 2);
+
+        PruneAndDrain(cutoff: 5, barrierBlock: 5);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(NodeExists(null, in PathA, V1), Is.False, "superseded version should be deleted");
+            Assert.That(NodeExists(null, in PathA, V2), Is.True, "current version must survive");
+            Assert.That(_tracker.OldestRetainedBlock, Is.EqualTo(2UL));
+        }
+    }
+
+    [Test]
+    public void Keeps_superseded_version_while_inside_the_window()
+    {
+        PersistNode(null, in PathA, V1, 10);
+        PersistNode(null, in PathA, V2, 20);
+
+        PruneAndDrain(cutoff: 15, barrierBlock: 20);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(NodeExists(null, in PathA, V1), Is.True, "still needed by blocks 10..19");
+            Assert.That(NodeExists(null, in PathA, V2), Is.True);
+        }
+    }
+
+    [Test]
+    public void Keeps_resurrected_version_and_deletes_the_intermediate_one()
+    {
+        PersistNode(null, in PathA, V1, 1);
+        PersistNode(null, in PathA, V2, 2);
+        PersistNode(null, in PathA, V1, 3);
+
+        PruneAndDrain(cutoff: 10, barrierBlock: 10);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(NodeExists(null, in PathA, V1), Is.True, "resurrected version is current and must be kept");
+            Assert.That(NodeExists(null, in PathA, V2), Is.False, "intermediate version should be deleted");
+        }
+    }
+
+    [Test]
+    public void Handles_out_of_order_events_recommit_overtaking_persistence()
+    {
+        // Block 3 re-commits V1 (reported at commit time) before blocks 1 and 2 are persisted.
+        _nodeStorage.Set(null, in PathA, V1, [1, 2, 3]);
+        _tracker.OnNodeRecommitted(null, in PathA, V1, 3);
+        _tracker.OnNodePersisted(null, in PathA, V1, 1);
+        PersistNode(null, in PathA, V2, 2);
+
+        PruneAndDrain(cutoff: 10, barrierBlock: 10);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(NodeExists(null, in PathA, V1), Is.True, "V1 is current again since block 3");
+            Assert.That(NodeExists(null, in PathA, V2), Is.False, "V2 was superseded at block 3");
+        }
+    }
+
+    [Test]
+    public void Never_deletes_base_versions_it_has_not_seen()
+    {
+        // V1 pre-exists (e.g. from snap sync) and is unknown to the tracker.
+        _nodeStorage.Set(null, in PathA, V1, [9, 9, 9]);
+
+        PersistNode(null, in PathA, V2, 5);
+        PruneAndDrain(cutoff: 100, barrierBlock: 100);
+
+        Assert.That(NodeExists(null, in PathA, V1), Is.True, "unknown base versions are leaked, never deleted");
+    }
+
+    [Test]
+    public void Prune_cutoff_is_capped_by_last_persisted_snapshot()
+    {
+        PersistNode(null, in PathA, V1, 1);
+        PersistNode(null, in PathA, V2, 2);
+
+        // No barrier yet -> nothing is provably persisted -> nothing may be pruned.
+        Assert.That(_tracker.RequestPrune(100), Is.True);
+        _tracker.OnSnapshotPersisted(0);
+
+        Assert.That(NodeExists(null, in PathA, V1), Is.True);
+    }
+
+    [Test]
+    public void Tracks_storage_trie_nodes_independently_per_address()
+    {
+        Hash256 addressA = TestItem.KeccakF;
+
+        PersistNode(addressA, in PathA, V1, 1);
+        PersistNode(null, in PathA, V1, 1);
+        PersistNode(addressA, in PathA, V2, 2);
+
+        PruneAndDrain(cutoff: 10, barrierBlock: 10);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(NodeExists(addressA, in PathA, V1), Is.False, "superseded storage node should be deleted");
+            Assert.That(NodeExists(addressA, in PathA, V2), Is.True);
+            Assert.That(NodeExists(null, in PathA, V1), Is.True, "state-trie node at the same path is unrelated");
+        }
+    }
+
+    [Test]
+    public void Persists_retention_floor_across_restarts()
+    {
+        PersistNode(null, in PathA, V1, 1);
+        PersistNode(null, in PathA, V2, 2);
+        PersistNode(null, in PathB, V1, 3);
+        PersistNode(null, in PathB, V3, 4);
+
+        PruneAndDrain(cutoff: 10, barrierBlock: 10);
+        ulong floor = _tracker.OldestRetainedBlock;
+        Assert.That(floor, Is.EqualTo(4UL));
+
+        _tracker.Dispose();
+        _tracker = new PartialArchiveNodeTracker(_archiveDb, _nodeStorage, LimboLogs.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_tracker.OldestRetainedBlock, Is.EqualTo(floor));
+            Assert.That(_tracker.LastSnapshotBlock, Is.EqualTo(10UL));
+        }
+    }
+
+    [Test]
+    public void Alternating_versions_are_kept_while_referenced_inside_the_window()
+    {
+        // A path toggling between two values: both versions are referenced by blocks inside the
+        // window, so neither may be deleted even though each was "superseded" long ago.
+        for (ulong block = 1; block <= 10; block++)
+        {
+            PersistNode(null, in PathA, block % 2 == 0 ? V2 : V1, block);
+        }
+
+        PruneAndDrain(cutoff: 9, barrierBlock: 10);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // V1's latest supersession is block 10 (> cutoff); V2's is block 9 (<= cutoff, so
+            // V2 is not needed by any block >= 9 where the value is V1... except block 10 flips
+            // back to V2, which re-supersedes V1 — V2 is current and must survive regardless.
+            Assert.That(NodeExists(null, in PathA, V2), Is.True, "current version");
+            Assert.That(NodeExists(null, in PathA, V1), Is.True, "superseded at block 10, still inside window");
+        }
+
+        PruneAndDrain(cutoff: 10, barrierBlock: 11);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(NodeExists(null, in PathA, V2), Is.True, "still current");
+            Assert.That(NodeExists(null, in PathA, V1), Is.False, "last supersession (block 10) left the window");
+        }
+    }
+
+    [Test]
+    public void Same_version_persisted_at_multiple_blocks_is_not_journaled()
+    {
+        PersistNode(null, in PathA, V1, 1);
+        _tracker.OnNodePersisted(null, in PathA, V1, 5);
+
+        PruneAndDrain(cutoff: 100, barrierBlock: 100);
+
+        Assert.That(NodeExists(null, in PathA, V1), Is.True);
+    }
+
+    [Test]
+    public void Large_backlog_is_pruned_in_self_rescheduling_slices()
+    {
+        int count = PartialArchiveNodeTracker.PruneRowBudget + 100;
+        Span<byte> pathBytes = stackalloc byte[32];
+        for (int i = 0; i < count; i++)
+        {
+            System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(pathBytes, i);
+            TreePath path = TreePath.FromPath(pathBytes);
+            PersistNode(null, in path, V1, 1);
+            PersistNode(null, in path, V2, 2);
+        }
+
+        PruneAndDrain(cutoff: 10, barrierBlock: 10);
+        // The follow-up slice was self-enqueued; drain it too.
+        _tracker.OnSnapshotPersisted(10);
+        _tracker.OnSnapshotPersisted(10);
+
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(pathBytes, count - 1);
+        TreePath lastPath = TreePath.FromPath(pathBytes);
+        Assert.That(NodeExists(null, in lastPath, V1), Is.False, "backlog beyond one slice should still be pruned");
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveNodeTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveNodeTrackerTests.cs
@@ -31,7 +31,7 @@ public class PartialArchiveNodeTrackerTests
         _archiveDb = new MemColumnsDb<PartialArchiveColumns>();
         _stateDb = new MemDb();
         _nodeStorage = new NodeStorage(_stateDb);
-        _tracker = new PartialArchiveNodeTracker(_archiveDb, _nodeStorage, LimboLogs.Instance);
+        _tracker = CreateTracker();
     }
 
     [TearDown]
@@ -41,6 +41,9 @@ public class PartialArchiveNodeTrackerTests
         _archiveDb.Dispose();
         _stateDb.Dispose();
     }
+
+    private PartialArchiveNodeTracker CreateTracker() =>
+        new(_archiveDb, new SingleStateDbProvider(_stateDb), _nodeStorage, LimboLogs.Instance);
 
     private void PersistNode(Hash256? address, in TreePath path, Hash256 keccak, ulong blockNumber)
     {
@@ -198,13 +201,31 @@ public class PartialArchiveNodeTrackerTests
         Assert.That(floor, Is.EqualTo(4UL));
 
         _tracker.Dispose();
-        _tracker = new PartialArchiveNodeTracker(_archiveDb, _nodeStorage, LimboLogs.Instance);
+        _tracker = CreateTracker();
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(_tracker.OldestRetainedBlock, Is.EqualTo(floor));
             Assert.That(_tracker.LastSnapshotBlock, Is.EqualTo(10UL));
         }
+    }
+
+    [Test]
+    public void Resets_tracking_when_state_database_identity_changes()
+    {
+        PersistNode(null, in PathA, V1, 1);
+        PersistNode(null, in PathA, V2, 2);
+        _tracker.OnSnapshotPersisted(5);
+        _tracker.Dispose();
+
+        // Full pruning / resync drops the stamp from the state DB.
+        _stateDb.Remove(PartialArchiveNodeTracker.StateStampKey);
+        _tracker = CreateTracker();
+
+        Assert.That(_tracker.LastSnapshotBlock, Is.EqualTo(0UL));
+
+        PruneAndDrain(cutoff: 10, barrierBlock: 10);
+        Assert.That(NodeExists(null, in PathA, V1), Is.True, "stale journal must be discarded, not applied");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveStateWindowTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveStateWindowTests.cs
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nethermind.Blockchain.PartialArchive;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.PartialArchive;
+
+/// <summary>
+/// End-to-end partial archive behavior at the <see cref="TrieStore"/> level: per-block
+/// persistence keeps every historical root readable, the window pruner deletes state that left
+/// the retention window, and values that alternate between blocks survive as long as any block
+/// inside the window references them.
+/// </summary>
+public class PartialArchiveStateWindowTests
+{
+    private sealed class PruneEveryCommitStrategy : IPruningStrategy
+    {
+        public bool DeleteObsoleteKeys => false;
+        public bool ShouldPruneDirtyNode(TrieStoreState state) => true;
+        public bool ShouldPrunePersistedNode(TrieStoreState state) => false;
+    }
+
+    private sealed class RecordingFinalizedStateProvider : IFinalizedStateProvider
+    {
+        private readonly Dictionary<ulong, Hash256> _roots = new();
+        public ulong FinalizedBlockNumber { get; private set; }
+
+        public void MarkFinalized(ulong blockNumber, Hash256 stateRoot)
+        {
+            _roots[blockNumber] = stateRoot;
+            FinalizedBlockNumber = blockNumber;
+        }
+
+        public Hash256? GetFinalizedStateRootAt(ulong blockNumber) =>
+            _roots.TryGetValue(blockNumber, out Hash256? root) ? root : null;
+    }
+
+    [Test]
+    public async Task Serves_historical_state_within_window_and_prunes_outside()
+    {
+        using MemDb stateDb = new();
+        NodeStorage nodeStorage = new(stateDb);
+        using MemColumnsDb<PartialArchiveColumns> archiveDb = new();
+        using PartialArchiveNodeTracker tracker = new(archiveDb, nodeStorage, LimboLogs.Instance);
+        RecordingFinalizedStateProvider finalized = new();
+        PruningConfig pruningConfig = new()
+        {
+            TrackPastKeys = false,
+            PruningBoundary = 2,
+            PruneDelayMilliseconds = 0,
+        };
+
+        byte[] slotKey = TestItem.KeccakA.BytesToArray();
+        byte[] togglingKey = TestItem.KeccakB.BytesToArray();
+        byte[][] toggleValues = [TestItem.KeccakC.BytesToArray(), TestItem.KeccakD.BytesToArray()];
+        const ulong chainLength = 40;
+        const ulong lastPersistedBlock = chainLength - 2; // finalization lags by PruningBoundary
+
+        Dictionary<ulong, Hash256> roots = new();
+        using (TrieStore trieStore = new(
+            nodeStorage,
+            new PruneEveryCommitStrategy(),
+            Persist.EveryNBlock(1),
+            finalized,
+            pruningConfig,
+            LimboLogs.Instance,
+            tracker))
+        {
+            PatriciaTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
+            BlockHeader? baseBlock = null;
+            for (ulong i = 1; i <= chainLength; i++)
+            {
+                using (trieStore.BeginScope(baseBlock))
+                {
+                    tree.Set(slotKey, ValueFor(i));
+                    tree.Set(togglingKey, toggleValues[i % 2]);
+                    using (trieStore.BeginBlockCommit(i))
+                    {
+                        tree.Commit();
+                    }
+
+                    roots[i] = tree.RootHash;
+                    baseBlock = Build.A.BlockHeader.WithParentOptional(baseBlock).WithStateRoot(tree.RootHash).TestObject;
+                }
+
+                finalized.MarkFinalized(i, roots[i]);
+                await Task.Yield();
+                trieStore.WaitForPruning();
+            }
+
+            AssertHistoricalReads(nodeStorage, roots, slotKey, togglingKey, toggleValues, 1, lastPersistedBlock);
+
+            const ulong cutoff = 30;
+            Assert.That(tracker.RequestPrune(cutoff), Is.True);
+            // Barrier drains the queue, guaranteeing the prune command has executed.
+            tracker.OnSnapshotPersisted(tracker.LastSnapshotBlock);
+
+            using (Assert.EnterMultipleScope())
+            {
+                // Root of block b is superseded at b+1, so it is deletable once b+1 <= cutoff.
+                for (ulong i = 1; i < cutoff; i++)
+                {
+                    Assert.That(RootOnDisk(nodeStorage, roots[i]), Is.False, $"root of block {i} should be pruned");
+                }
+
+                for (ulong i = cutoff; i <= lastPersistedBlock; i++)
+                {
+                    Assert.That(RootOnDisk(nodeStorage, roots[i]), Is.True, $"root of block {i} must stay within the window");
+                }
+
+                Assert.That(tracker.OldestRetainedBlock, Is.EqualTo(cutoff));
+            }
+
+            AssertHistoricalReads(nodeStorage, roots, slotKey, togglingKey, toggleValues, cutoff, lastPersistedBlock);
+        }
+    }
+
+    private static byte[] ValueFor(ulong blockNumber) => TestItem.Keccaks[(int)blockNumber].BytesToArray();
+
+    private static bool RootOnDisk(NodeStorage nodeStorage, Hash256 root) =>
+        nodeStorage.Get(null, TreePath.Empty, root) is not null;
+
+    /// <summary>Reads through a fresh store (empty caches) so assertions reflect the on-disk state.</summary>
+    private static void AssertHistoricalReads(
+        NodeStorage nodeStorage,
+        Dictionary<ulong, Hash256> roots,
+        byte[] slotKey,
+        byte[] togglingKey,
+        byte[][] toggleValues,
+        ulong fromBlock,
+        ulong toBlock)
+    {
+        using TrieStore readStore = new(
+            nodeStorage,
+            No.Pruning,
+            No.Persistence,
+            new RecordingFinalizedStateProvider(),
+            new PruningConfig { TrackPastKeys = false },
+            LimboLogs.Instance);
+        PatriciaTree reader = new(readStore.GetTrieStore(null), LimboLogs.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            for (ulong i = fromBlock; i <= toBlock; i++)
+            {
+                Assert.That(reader.Get(slotKey, roots[i]).ToArray(), Is.EqualTo(ValueFor(i)), $"slot value at block {i}");
+                Assert.That(reader.Get(togglingKey, roots[i]).ToArray(), Is.EqualTo(toggleValues[i % 2]), $"toggling value at block {i}");
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveStateWindowTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveStateWindowTests.cs
@@ -53,7 +53,7 @@ public class PartialArchiveStateWindowTests
         using MemDb stateDb = new();
         NodeStorage nodeStorage = new(stateDb);
         using MemColumnsDb<PartialArchiveColumns> archiveDb = new();
-        using PartialArchiveNodeTracker tracker = new(archiveDb, nodeStorage, LimboLogs.Instance);
+        using PartialArchiveNodeTracker tracker = new(archiveDb, new SingleStateDbProvider(stateDb), nodeStorage, LimboLogs.Instance);
         RecordingFinalizedStateProvider finalized = new();
         PruningConfig pruningConfig = new()
         {

--- a/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveStateWindowTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveStateWindowTests.cs
@@ -32,7 +32,7 @@ public class PartialArchiveStateWindowTests
 
     private sealed class RecordingFinalizedStateProvider : IFinalizedStateProvider
     {
-        private readonly Dictionary<ulong, Hash256> _roots = new();
+        private readonly Dictionary<ulong, Hash256> _roots = [];
         public ulong FinalizedBlockNumber { get; private set; }
 
         public void MarkFinalized(ulong blockNumber, Hash256 stateRoot)
@@ -66,63 +66,62 @@ public class PartialArchiveStateWindowTests
         const ulong chainLength = 40;
         const ulong lastPersistedBlock = chainLength - 2; // finalization lags by PruningBoundary
 
-        Dictionary<ulong, Hash256> roots = new();
-        using (TrieStore trieStore = new(
+        Dictionary<ulong, Hash256> roots = [];
+        using TrieStore trieStore = new(
             nodeStorage,
             new PruneEveryCommitStrategy(),
             Persist.EveryNBlock(1),
             finalized,
             pruningConfig,
             LimboLogs.Instance,
-            tracker))
+            tracker);
+
+        PatriciaTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
+        BlockHeader? baseBlock = null;
+        for (ulong i = 1; i <= chainLength; i++)
         {
-            PatriciaTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
-            BlockHeader? baseBlock = null;
-            for (ulong i = 1; i <= chainLength; i++)
+            using (trieStore.BeginScope(baseBlock))
             {
-                using (trieStore.BeginScope(baseBlock))
+                tree.Set(slotKey, ValueFor(i));
+                tree.Set(togglingKey, toggleValues[i % 2]);
+                using (trieStore.BeginBlockCommit(i))
                 {
-                    tree.Set(slotKey, ValueFor(i));
-                    tree.Set(togglingKey, toggleValues[i % 2]);
-                    using (trieStore.BeginBlockCommit(i))
-                    {
-                        tree.Commit();
-                    }
-
-                    roots[i] = tree.RootHash;
-                    baseBlock = Build.A.BlockHeader.WithParentOptional(baseBlock).WithStateRoot(tree.RootHash).TestObject;
+                    tree.Commit();
                 }
 
-                finalized.MarkFinalized(i, roots[i]);
-                await Task.Yield();
-                trieStore.WaitForPruning();
+                roots[i] = tree.RootHash;
+                baseBlock = Build.A.BlockHeader.WithParentOptional(baseBlock).WithStateRoot(tree.RootHash).TestObject;
             }
 
-            AssertHistoricalReads(nodeStorage, roots, slotKey, togglingKey, toggleValues, 1, lastPersistedBlock);
-
-            const ulong cutoff = 30;
-            Assert.That(tracker.RequestPrune(cutoff), Is.True);
-            // Barrier drains the queue, guaranteeing the prune command has executed.
-            tracker.OnSnapshotPersisted(tracker.LastSnapshotBlock);
-
-            using (Assert.EnterMultipleScope())
-            {
-                // Root of block b is superseded at b+1, so it is deletable once b+1 <= cutoff.
-                for (ulong i = 1; i < cutoff; i++)
-                {
-                    Assert.That(RootOnDisk(nodeStorage, roots[i]), Is.False, $"root of block {i} should be pruned");
-                }
-
-                for (ulong i = cutoff; i <= lastPersistedBlock; i++)
-                {
-                    Assert.That(RootOnDisk(nodeStorage, roots[i]), Is.True, $"root of block {i} must stay within the window");
-                }
-
-                Assert.That(tracker.OldestRetainedBlock, Is.EqualTo(cutoff));
-            }
-
-            AssertHistoricalReads(nodeStorage, roots, slotKey, togglingKey, toggleValues, cutoff, lastPersistedBlock);
+            finalized.MarkFinalized(i, roots[i]);
+            await Task.Yield();
+            trieStore.WaitForPruning();
         }
+
+        AssertHistoricalReads(nodeStorage, roots, slotKey, togglingKey, toggleValues, 1, lastPersistedBlock);
+
+        const ulong cutoff = 30;
+        Assert.That(tracker.RequestPrune(cutoff), Is.True);
+        // Barrier drains the queue, guaranteeing the prune command has executed.
+        tracker.OnSnapshotPersisted(tracker.LastSnapshotBlock);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Root of block b is superseded at b+1, so it is deletable once b+1 <= cutoff.
+            for (ulong i = 1; i < cutoff; i++)
+            {
+                Assert.That(RootOnDisk(nodeStorage, roots[i]), Is.False, $"root of block {i} should be pruned");
+            }
+
+            for (ulong i = cutoff; i <= lastPersistedBlock; i++)
+            {
+                Assert.That(RootOnDisk(nodeStorage, roots[i]), Is.True, $"root of block {i} must stay within the window");
+            }
+
+            Assert.That(tracker.OldestRetainedBlock, Is.EqualTo(cutoff));
+        }
+
+        AssertHistoricalReads(nodeStorage, roots, slotKey, togglingKey, toggleValues, cutoff, lastPersistedBlock);
     }
 
     private static byte[] ValueFor(ulong blockNumber) => TestItem.Keccaks[(int)blockNumber].BytesToArray();

--- a/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveStateWindowTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/PartialArchiveStateWindowTests.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.PartialArchive;
 using Nethermind.Core;
@@ -122,6 +124,64 @@ public class PartialArchiveStateWindowTests
         }
 
         AssertHistoricalReads(nodeStorage, roots, slotKey, togglingKey, toggleValues, cutoff, lastPersistedBlock);
+    }
+
+    private sealed class RecordingObserver : IPersistedNodeObserver
+    {
+        public readonly ConcurrentBag<ulong> PersistedBlocks = [];
+        public void OnNodePersisted(Hash256? address, in TreePath path, Hash256 keccak, ulong blockNumber) => PersistedBlocks.Add(blockNumber);
+        public void OnNodeRecommitted(Hash256? address, in TreePath path, Hash256 keccak, ulong blockNumber) { }
+        public void OnSnapshotPersisted(ulong lastPersistedBlockNumber) { }
+    }
+
+    [Test]
+    public async Task Does_not_report_non_canonical_commit_sets_to_the_observer()
+    {
+        using MemDb stateDb = new();
+        NodeStorage nodeStorage = new(stateDb);
+        RecordingObserver observer = new();
+        RecordingFinalizedStateProvider finalized = new();
+        using TrieStore trieStore = new(
+            nodeStorage,
+            new PruneEveryCommitStrategy(),
+            Persist.EveryNBlock(1),
+            finalized,
+            new PruningConfig { TrackPastKeys = false, PruningBoundary = 2, PruneDelayMilliseconds = 0 },
+            LimboLogs.Instance,
+            observer);
+
+        PatriciaTree tree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
+        byte[] slotKey = TestItem.KeccakA.BytesToArray();
+        const ulong nonCanonicalBlock = 5;
+
+        BlockHeader? baseBlock = null;
+        for (ulong i = 1; i <= 10; i++)
+        {
+            using (trieStore.BeginScope(baseBlock))
+            {
+                tree.Set(slotKey, ValueFor(i));
+                using (trieStore.BeginBlockCommit(i))
+                {
+                    tree.Commit();
+                }
+
+                // A reorged (non-canonical) set is simulated by registering a different root as
+                // the canonical one at that height; the set is still persisted, but must not be
+                // reported as superseding — the canonical chain may still need the old versions.
+                finalized.MarkFinalized(i, i == nonCanonicalBlock ? TestItem.KeccakF : tree.RootHash);
+                baseBlock = Build.A.BlockHeader.WithParentOptional(baseBlock).WithStateRoot(tree.RootHash).TestObject;
+            }
+
+            await Task.Yield();
+            trieStore.WaitForPruning();
+        }
+
+        ulong[] reportedBlocks = [.. observer.PersistedBlocks.Distinct().Order()];
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reportedBlocks, Does.Not.Contain(nonCanonicalBlock), "non-canonical set must not be reported");
+            Assert.That(reportedBlocks, Does.Contain(4UL).And.Contain(6UL), "canonical sets must be reported");
+        }
     }
 
     private static byte[] ValueFor(ulong blockNumber) => TestItem.Keccaks[(int)blockNumber].BytesToArray();

--- a/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/SingleStateDbProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PartialArchive/SingleStateDbProvider.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Db;
+
+namespace Nethermind.Blockchain.Test.PartialArchive;
+
+internal sealed class SingleStateDbProvider(IDb stateDb) : IDbProvider
+{
+    public T GetDb<T>(string dbName) where T : class, IDb => (T)stateDb;
+    public IColumnsDb<T> GetColumnDb<T>(string dbName) => throw new NotSupportedException();
+    public void Dispose() { }
+}

--- a/src/Nethermind/Nethermind.Blockchain/PartialArchive/PartialArchiveKeys.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PartialArchive/PartialArchiveKeys.cs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers.Binary;
+using Nethermind.Core.Crypto;
+using Nethermind.Trie;
+
+namespace Nethermind.Blockchain.PartialArchive;
+
+/// <summary>
+/// Key/value encodings for the partial archive database columns.
+/// </summary>
+/// <remarks>
+/// Unlike the HalfPath node-storage keys, path keys here contain the full 32-byte path so that
+/// distinct paths never collide. Layouts:
+/// <list type="bullet">
+/// <item>path key (state): <c>0x00 | path(32) | nibbleLength(1)</c> — 34 bytes</item>
+/// <item>path key (storage): <c>0x01 | address(32) | path(32) | nibbleLength(1)</c> — 66 bytes</item>
+/// <item>latest-version value: <c>keccak(32) | blockNumber(8, BE)</c></item>
+/// <item>journal key: <c>blockNumber(8, BE) | pathKey | keccak(32)</c> — big-endian block prefix
+/// makes ordered iteration process journals in ascending block order</item>
+/// </list>
+/// </remarks>
+internal static class PartialArchiveKeys
+{
+    private const byte StateFlag = 0;
+    private const byte StorageFlag = 1;
+
+    public const int StatePathKeyLength = 1 + 32 + 1;
+    public const int StoragePathKeyLength = 1 + 32 + 32 + 1;
+    public const int MaxPathKeyLength = StoragePathKeyLength;
+    public const int VersionValueLength = 32 + sizeof(ulong);
+    public const int MaxJournalKeyLength = sizeof(ulong) + MaxPathKeyLength + 32;
+
+    public static int WritePathKey(Span<byte> buffer, Hash256? address, in TreePath path)
+    {
+        int offset = 1;
+        if (address is null)
+        {
+            buffer[0] = StateFlag;
+        }
+        else
+        {
+            buffer[0] = StorageFlag;
+            address.Bytes.CopyTo(buffer[offset..]);
+            offset += 32;
+        }
+
+        path.Path.Bytes.CopyTo(buffer[offset..]);
+        offset += 32;
+        buffer[offset] = (byte)path.Length;
+        return offset + 1;
+    }
+
+    public static void WriteVersionValue(Span<byte> buffer, Hash256 keccak, ulong blockNumber)
+    {
+        keccak.Bytes.CopyTo(buffer);
+        BinaryPrimitives.WriteUInt64BigEndian(buffer[32..], blockNumber);
+    }
+
+    public static (ValueHash256 Keccak, ulong BlockNumber) ReadVersionValue(ReadOnlySpan<byte> value) =>
+        (new ValueHash256(value[..32]), BinaryPrimitives.ReadUInt64BigEndian(value[32..]));
+
+    public static ulong ReadJournalBlockNumber(ReadOnlySpan<byte> journalKey) =>
+        BinaryPrimitives.ReadUInt64BigEndian(journalKey);
+
+    /// <summary>Superseded-at key: <c>pathKey | keccak(32)</c> — the journal key without its block prefix.</summary>
+    public static int WriteSupersededKey(Span<byte> buffer, ReadOnlySpan<byte> pathKey, in ValueHash256 keccak)
+    {
+        pathKey.CopyTo(buffer);
+        keccak.Bytes.CopyTo(buffer[pathKey.Length..]);
+        return pathKey.Length + 32;
+    }
+
+    public static ReadOnlySpan<byte> JournalKeyToSupersededKey(ReadOnlySpan<byte> journalKey) =>
+        journalKey[sizeof(ulong)..];
+
+    public static byte[] BlockNumberValue(ulong blockNumber)
+    {
+        byte[] buffer = new byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, blockNumber);
+        return buffer;
+    }
+
+    public static ulong ReadBlockNumberValue(ReadOnlySpan<byte> value) =>
+        BinaryPrimitives.ReadUInt64BigEndian(value);
+
+    public static bool TryParseJournalKey(
+        ReadOnlySpan<byte> journalKey,
+        out ulong blockNumber,
+        out Hash256? address,
+        out TreePath path,
+        out ValueHash256 keccak)
+    {
+        blockNumber = 0;
+        address = null;
+        path = TreePath.Empty;
+        keccak = default;
+
+        if (journalKey.Length != sizeof(ulong) + StatePathKeyLength + 32
+            && journalKey.Length != sizeof(ulong) + StoragePathKeyLength + 32)
+        {
+            return false;
+        }
+
+        blockNumber = BinaryPrimitives.ReadUInt64BigEndian(journalKey);
+        ReadOnlySpan<byte> rest = journalKey[sizeof(ulong)..];
+
+        int offset = 1;
+        switch (rest[0])
+        {
+            case StateFlag:
+                if (rest.Length != StatePathKeyLength + 32) return false;
+                break;
+            case StorageFlag:
+                if (rest.Length != StoragePathKeyLength + 32) return false;
+                address = new Hash256(rest.Slice(offset, 32));
+                offset += 32;
+                break;
+            default:
+                return false;
+        }
+
+        int nibbleLength = rest[offset + 32];
+        if (nibbleLength > 64) return false;
+        path = new TreePath(new ValueHash256(rest.Slice(offset, 32)), nibbleLength);
+        keccak = new ValueHash256(rest.Slice(offset + 32 + 1, 32));
+        return true;
+    }
+
+    public static ReadOnlySpan<byte> JournalPathKey(ReadOnlySpan<byte> journalKey) =>
+        journalKey[sizeof(ulong)..^32];
+}

--- a/src/Nethermind/Nethermind.Blockchain/PartialArchive/PartialArchiveNodeTracker.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PartialArchive/PartialArchiveNodeTracker.cs
@@ -33,7 +33,10 @@ namespace Nethermind.Blockchain.PartialArchive;
 /// number. Pruning then deletes journal entries whose block left the window, guarded against
 /// resurrected nodes (a re-created node with an identical keccak must not be deleted).
 /// All index reads and writes, including prune execution, happen on a single consumer task, so
-/// event application and prune verification are strictly ordered.
+/// event application and prune verification are strictly ordered. Prune slices additionally run
+/// only inside the persistence barrier (<see cref="OnSnapshotPersisted"/>), while the
+/// persistence thread is parked waiting for the drain — so a node-key deletion can never race a
+/// concurrent persistence write of the same re-created key.
 /// Failure bias is towards leaking keys (never deleting) rather than deleting live state: on any
 /// tracking gap that could make deletion unsafe the tracker poisons itself durably and pruning
 /// halts until the state is resynced.
@@ -45,6 +48,8 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
     internal const int PruneRowBudget = 200_000;
     private static readonly TimeSpan BarrierTimeout = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan DisposeTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan PersistEnqueueTimeout = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan RecommitEnqueueTimeout = TimeSpan.FromMilliseconds(250);
 
     private static readonly byte[] FloorKey = [1];
     private static readonly byte[] LastSnapshotBlockKey = [2];
@@ -75,6 +80,7 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
     private volatile bool _poisoned;
     private ulong _lastSnapshotBlock;
     private ulong _oldestRetainedBlock;
+    private ulong _pendingPruneCutoff;
     private long _droppedPersistEvents;
 
     public PartialArchiveNodeTracker(
@@ -117,28 +123,43 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
         Message message = Message.Node(address, in path, keccak, blockNumber);
         if (_messages.Writer.TryWrite(message)) return;
 
-        // Persistence threads run in the background; block briefly rather than lose supersession
-        // info. Losing a persist event only leaks a key, but the backlog should never last.
+        // Persistence threads run in the background; wait rather than lose supersession info.
+        // Losing a persist event only leaks a key, so give up with a warning after a deadline.
+        long deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency * (long)PersistEnqueueTimeout.TotalSeconds;
         SpinWait spin = default;
-        while (!_disposed && !_poisoned)
+        while (!_disposed && !_poisoned && Stopwatch.GetTimestamp() < deadline)
         {
             spin.SpinOnce();
             if (_messages.Writer.TryWrite(message)) return;
         }
 
-        Interlocked.Increment(ref _droppedPersistEvents);
+        if (Interlocked.Increment(ref _droppedPersistEvents) == 1 && _logger.IsWarn)
+        {
+            _logger.Warn("Partial archive tracker is not keeping up with node persistence; some superseded keys will not be reclaimed.");
+        }
     }
 
     public void OnNodeRecommitted(Hash256? address, in TreePath path, Hash256 keccak, ulong blockNumber)
     {
         if (_disposed || _poisoned) return;
 
-        // Called on the block-processing path — must not block. A lost recommit can make the
-        // index treat a live node as superseded, after which deleting it would corrupt state,
-        // so pruning is permanently disabled instead.
-        if (!_messages.Writer.TryWrite(Message.Node(address, in path, keccak, blockNumber)))
+        Message message = Message.Node(address, in path, keccak, blockNumber);
+        if (_messages.Writer.TryWrite(message)) return;
+
+        // Called on the block-processing path. A lost recommit can make the index treat a live
+        // node as superseded, after which deleting it would corrupt state — so ride out a
+        // transient backlog with a short bounded wait, and only then permanently disable pruning.
+        long deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency * (long)RecommitEnqueueTimeout.TotalMilliseconds / 1000;
+        SpinWait spin = default;
+        while (!_disposed && !_poisoned && Stopwatch.GetTimestamp() < deadline)
         {
-            Poison("a node recommit event was dropped because the tracking queue is full", null);
+            spin.SpinOnce();
+            if (_messages.Writer.TryWrite(message)) return;
+        }
+
+        if (!_disposed && !_poisoned)
+        {
+            Poison($"a node recommit event could not be enqueued within {RecommitEnqueueTimeout.TotalMilliseconds}ms (queue full)", null);
         }
     }
 
@@ -163,12 +184,26 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
 
     /// <summary>
     /// Requests deletion of superseded node keys journaled at or below <paramref name="cutoffBlockNumber"/>.
-    /// Executed asynchronously on the consumer task; large backlogs are processed in self-rescheduling slices.
     /// </summary>
+    /// <remarks>
+    /// Deletion is deferred to the next persistence barrier (<see cref="OnSnapshotPersisted"/>):
+    /// at that point the persistence thread is parked waiting for the tracker to drain, so a
+    /// prune's node-key deletions can never race a concurrent persistence write of the same
+    /// re-created key. Large backlogs are processed in bounded slices across barriers.
+    /// </remarks>
     public bool RequestPrune(ulong cutoffBlockNumber)
     {
         if (_disposed || _poisoned) return false;
-        return _messages.Writer.TryWrite(Message.Prune(cutoffBlockNumber));
+
+        ulong current = Volatile.Read(ref _pendingPruneCutoff);
+        while (cutoffBlockNumber > current)
+        {
+            ulong seen = Interlocked.CompareExchange(ref _pendingPruneCutoff, cutoffBlockNumber, current);
+            if (seen == current) break;
+            current = seen;
+        }
+
+        return true;
     }
 
     public void Dispose()
@@ -223,11 +258,10 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
                     case MessageKind.Barrier:
                         FlushBatch();
                         UpdateLastSnapshotBlock(message.BlockNumber);
+                        // Prune while the persistence thread is parked on this barrier: node-key
+                        // deletions cannot race a persistence write of the same re-created key.
+                        ExecutePendingPruneSlice();
                         SignalBarrier(message);
-                        break;
-                    case MessageKind.Prune:
-                        FlushBatch();
-                        ExecutePruneSlice(message.BlockNumber);
                         break;
                 }
             }
@@ -397,8 +431,11 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
         }
     }
 
-    private void ExecutePruneSlice(ulong requestedCutoff)
+    private void ExecutePendingPruneSlice()
     {
+        ulong requestedCutoff = Volatile.Read(ref _pendingPruneCutoff);
+        if (requestedCutoff == 0) return;
+
         // Journals are complete only up to the last finished persistence pass.
         ulong cutoff = Math.Min(requestedCutoff, Volatile.Read(ref _lastSnapshotBlock));
         if (cutoff == 0) return;
@@ -447,6 +484,15 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
                 journalBatch.Remove(journalKey);
                 floor = blockNumber;
             }
+
+            if (floor > Volatile.Read(ref _oldestRetainedBlock))
+            {
+                // In the same batch as the journal removal: the advertised floor may never get
+                // ahead of what was actually pruned, even across a crash.
+                Span<byte> floorValue = stackalloc byte[sizeof(ulong)];
+                BinaryPrimitives.WriteUInt64BigEndian(floorValue, floor);
+                archiveBatch.GetColumnBatch(PartialArchiveColumns.Metadata).Set(FloorKey, floorValue.ToArray());
+            }
         }
         finally
         {
@@ -459,7 +505,6 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
         if (floor > Volatile.Read(ref _oldestRetainedBlock))
         {
             Volatile.Write(ref _oldestRetainedBlock, floor);
-            WriteMetadataUlong(FloorKey, floor);
         }
 
         if (_logger.IsInfo && scanned > 0)
@@ -468,11 +513,10 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
             _logger.Info($"Partial archive prune: deleted {deleted} superseded node keys ({resurrected} kept as resurrected), retention floor {floor}, cutoff {cutoff}, took {elapsedMs}ms.");
         }
 
-        if (!exhausted)
+        if (exhausted)
         {
-            // Re-enqueue behind pending node events so a large backlog is drained in slices
-            // without starving event processing. If the queue is full the next trigger retries.
-            _messages.Writer.TryWrite(Message.Prune(requestedCutoff));
+            // Newer requests may have arrived while pruning; only clear the one we satisfied.
+            Interlocked.CompareExchange(ref _pendingPruneCutoff, 0, requestedCutoff);
         }
     }
 
@@ -512,7 +556,6 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
     {
         Node,
         Barrier,
-        Prune,
     }
 
     private readonly struct Message
@@ -529,8 +572,5 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
 
         public static Message BarrierMessage(ManualResetEventSlim barrier, ulong blockNumber) =>
             new() { Kind = MessageKind.Barrier, Barrier = barrier, BlockNumber = blockNumber };
-
-        public static Message Prune(ulong cutoffBlockNumber) =>
-            new() { Kind = MessageKind.Prune, BlockNumber = cutoffBlockNumber };
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/PartialArchive/PartialArchiveNodeTracker.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PartialArchive/PartialArchiveNodeTracker.cs
@@ -1,0 +1,536 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.Blockchain.PartialArchive;
+
+/// <summary>
+/// Maintains the bookkeeping that makes a rolling window of historical state possible: a
+/// per-path latest-version index and a per-block expiry journal of superseded node keys, and
+/// executes the window prune that deletes superseded keys once they fall out of the retention
+/// window.
+/// </summary>
+/// <remarks>
+/// With the HalfPath key scheme, node keys are qualified by the node keccak, so all versions of
+/// a path coexist on disk and historical state reads work through the regular
+/// <see cref="INodeStorage"/> as long as superseded keys are not deleted. This class receives
+/// <see cref="IPersistedNodeObserver"/> events from the <see cref="TrieStore"/>, derives which
+/// previously persisted key each write supersedes, and journals it under the superseding block
+/// number. Pruning then deletes journal entries whose block left the window, guarded against
+/// resurrected nodes (a re-created node with an identical keccak must not be deleted).
+/// All index reads and writes, including prune execution, happen on a single consumer task, so
+/// event application and prune verification are strictly ordered.
+/// Failure bias is towards leaking keys (never deleting) rather than deleting live state: on any
+/// tracking gap that could make deletion unsafe the tracker poisons itself durably and pruning
+/// halts until the state is resynced.
+/// </remarks>
+public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposable
+{
+    private const int ChannelCapacity = 1 << 20;
+    private const int FlushThreshold = 1 << 15;
+    internal const int PruneRowBudget = 200_000;
+    private static readonly TimeSpan BarrierTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan DisposeTimeout = TimeSpan.FromSeconds(30);
+
+    private static readonly byte[] FloorKey = [1];
+    private static readonly byte[] LastSnapshotBlockKey = [2];
+    private static readonly byte[] PoisonedKey = [3];
+
+    private readonly IColumnsDb<PartialArchiveColumns> _db;
+    private readonly IDb _mapDb;
+    private readonly IDb _supersededDb;
+    private readonly IDb _journalDb;
+    private readonly IDb _metadataDb;
+    private readonly INodeStorage _nodeStorage;
+    private readonly ILogger _logger;
+
+    private readonly Channel<Message> _messages = Channel.CreateBounded<Message>(
+        new BoundedChannelOptions(ChannelCapacity) { SingleReader = true, SingleWriter = false });
+    private readonly Task _consumerTask;
+
+    // Read-your-own-writes view of index entries buffered in the current write batch.
+    private readonly Dictionary<byte[], byte[]> _pendingMap = new(Bytes.EqualityComparer);
+    private readonly Dictionary<byte[], byte[]?> _pendingSuperseded = new(Bytes.EqualityComparer);
+    private IColumnsWriteBatch<PartialArchiveColumns>? _batch;
+    private IWriteBatch? _mapBatch;
+    private IWriteBatch? _supersededBatch;
+    private IWriteBatch? _journalBatch;
+    private int _batchedWrites;
+
+    private volatile bool _disposed;
+    private volatile bool _poisoned;
+    private ulong _lastSnapshotBlock;
+    private ulong _oldestRetainedBlock;
+    private long _droppedPersistEvents;
+
+    public PartialArchiveNodeTracker(
+        IColumnsDb<PartialArchiveColumns> db,
+        INodeStorage nodeStorage,
+        ILogManager logManager)
+    {
+        _db = db;
+        _mapDb = db.GetColumnDb(PartialArchiveColumns.LatestVersion);
+        _supersededDb = db.GetColumnDb(PartialArchiveColumns.SupersededAt);
+        _journalDb = db.GetColumnDb(PartialArchiveColumns.ExpiryJournal);
+        _metadataDb = db.GetColumnDb(PartialArchiveColumns.Metadata);
+        _nodeStorage = nodeStorage;
+        _logger = logManager.GetClassLogger<PartialArchiveNodeTracker>();
+
+        _lastSnapshotBlock = ReadMetadataUlong(LastSnapshotBlockKey) ?? 0;
+        _oldestRetainedBlock = ReadMetadataUlong(FloorKey) ?? 0;
+        _poisoned = _metadataDb.Get(PoisonedKey) is not null;
+        if (_poisoned && _logger.IsError)
+        {
+            _logger.Error("Partial archive tracking was previously poisoned; window pruning stays disabled. Resync or full-prune the state to recover.");
+        }
+
+        _consumerTask = Task.Run(RunConsumer);
+    }
+
+    /// <summary>Oldest block whose historical state is still fully retained, or 0 when pruning has not run yet.</summary>
+    public ulong OldestRetainedBlock => Volatile.Read(ref _oldestRetainedBlock);
+
+    /// <summary>Highest block covered by a completed persistence pass; prune cutoffs are capped by it.</summary>
+    public ulong LastSnapshotBlock => Volatile.Read(ref _lastSnapshotBlock);
+
+    /// <summary>Whether tracking hit an unrecoverable gap; when set, pruning is permanently halted.</summary>
+    public bool IsPoisoned => _poisoned;
+
+    public void OnNodePersisted(Hash256? address, in TreePath path, Hash256 keccak, ulong blockNumber)
+    {
+        if (_disposed || _poisoned) return;
+
+        Message message = Message.Node(address, in path, keccak, blockNumber);
+        if (_messages.Writer.TryWrite(message)) return;
+
+        // Persistence threads run in the background; block briefly rather than lose supersession
+        // info. Losing a persist event only leaks a key, but the backlog should never last.
+        SpinWait spin = default;
+        while (!_disposed && !_poisoned)
+        {
+            spin.SpinOnce();
+            if (_messages.Writer.TryWrite(message)) return;
+        }
+
+        Interlocked.Increment(ref _droppedPersistEvents);
+    }
+
+    public void OnNodeRecommitted(Hash256? address, in TreePath path, Hash256 keccak, ulong blockNumber)
+    {
+        if (_disposed || _poisoned) return;
+
+        // Called on the block-processing path — must not block. A lost recommit can make the
+        // index treat a live node as superseded, after which deleting it would corrupt state,
+        // so pruning is permanently disabled instead.
+        if (!_messages.Writer.TryWrite(Message.Node(address, in path, keccak, blockNumber)))
+        {
+            Poison("a node recommit event was dropped because the tracking queue is full", null);
+        }
+    }
+
+    public void OnSnapshotPersisted(ulong lastPersistedBlockNumber)
+    {
+        if (_disposed || _poisoned) return;
+
+        ManualResetEventSlim barrier = new(false);
+        try
+        {
+            if (!TryWriteBlocking(Message.BarrierMessage(barrier, lastPersistedBlockNumber))) return;
+            if (!barrier.Wait(BarrierTimeout) && _logger.IsWarn)
+            {
+                _logger.Warn($"Partial archive tracker did not drain within {BarrierTimeout.TotalSeconds}s after persisting up to block {lastPersistedBlockNumber}.");
+            }
+        }
+        finally
+        {
+            barrier.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Requests deletion of superseded node keys journaled at or below <paramref name="cutoffBlockNumber"/>.
+    /// Executed asynchronously on the consumer task; large backlogs are processed in self-rescheduling slices.
+    /// </summary>
+    public bool RequestPrune(ulong cutoffBlockNumber)
+    {
+        if (_disposed || _poisoned) return false;
+        return _messages.Writer.TryWrite(Message.Prune(cutoffBlockNumber));
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _messages.Writer.TryComplete();
+        try
+        {
+            if (!_consumerTask.Wait(DisposeTimeout) && _logger.IsWarn)
+            {
+                _logger.Warn("Partial archive tracker consumer did not stop in time.");
+            }
+        }
+        catch (AggregateException e)
+        {
+            if (_logger.IsError) _logger.Error("Partial archive tracker consumer failed during shutdown.", e);
+        }
+    }
+
+    private bool TryWriteBlocking(in Message message)
+    {
+        if (_messages.Writer.TryWrite(message)) return true;
+        SpinWait spin = default;
+        while (!_disposed)
+        {
+            spin.SpinOnce();
+            if (_messages.Writer.TryWrite(message)) return true;
+        }
+
+        return false;
+    }
+
+    private async Task RunConsumer()
+    {
+        await foreach (Message message in _messages.Reader.ReadAllAsync().ConfigureAwait(false))
+        {
+            try
+            {
+                if (_poisoned)
+                {
+                    SignalBarrier(message);
+                    continue;
+                }
+
+                switch (message.Kind)
+                {
+                    case MessageKind.Node:
+                        ProcessNode(in message);
+                        if (_batchedWrites >= FlushThreshold) FlushBatch();
+                        break;
+                    case MessageKind.Barrier:
+                        FlushBatch();
+                        UpdateLastSnapshotBlock(message.BlockNumber);
+                        SignalBarrier(message);
+                        break;
+                    case MessageKind.Prune:
+                        FlushBatch();
+                        ExecutePruneSlice(message.BlockNumber);
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                Poison($"processing failed: {e.Message}", e);
+                SignalBarrier(message);
+            }
+        }
+
+        try
+        {
+            FlushBatch();
+        }
+        catch (Exception e)
+        {
+            long dropped = Interlocked.Read(ref _droppedPersistEvents);
+            if (_logger.IsWarn) _logger.Warn($"Partial archive tracker final flush failed ({dropped} events dropped): {e}");
+        }
+    }
+
+    private void SignalBarrier(in Message message)
+    {
+        try
+        {
+            message.Barrier?.Set();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The waiter timed out and disposed the barrier; nothing left to signal.
+        }
+    }
+
+    private void ProcessNode(in Message message)
+    {
+        Span<byte> keyBuffer = stackalloc byte[PartialArchiveKeys.MaxPathKeyLength];
+        TreePath path = message.Path;
+        int keyLength = PartialArchiveKeys.WritePathKey(keyBuffer, message.Address, in path);
+        byte[] pathKey = keyBuffer[..keyLength].ToArray();
+
+        if (!_pendingMap.TryGetValue(pathKey, out byte[]? currentValue))
+        {
+            currentValue = _mapDb.Get(pathKey);
+        }
+
+        Hash256 keccak = message.Keccak!;
+        if (currentValue is null)
+        {
+            // First version seen for this path. The pre-existing (e.g. snap-synced) version, if
+            // any, is unknown and intentionally never journaled: bias towards leaking a key over
+            // deleting one that may still be referenced.
+            WriteMapEntry(pathKey, keccak, message.BlockNumber);
+            return;
+        }
+
+        (ValueHash256 currentKeccak, ulong currentBlock) = PartialArchiveKeys.ReadVersionValue(currentValue);
+        if (currentKeccak == keccak.ValueHash256)
+        {
+            if (message.BlockNumber > currentBlock)
+            {
+                WriteMapEntry(pathKey, keccak, message.BlockNumber);
+            }
+            return;
+        }
+
+        if (message.BlockNumber >= currentBlock)
+        {
+            Supersede(pathKey, in currentKeccak, message.BlockNumber);
+            WriteMapEntry(pathKey, keccak, message.BlockNumber);
+        }
+        else
+        {
+            // Events can arrive out of block order (commit-time recommits overtake persistence);
+            // the reported version is the older one, superseded at the currently indexed block.
+            Supersede(pathKey, keccak.ValueHash256, currentBlock);
+        }
+    }
+
+    /// <summary>
+    /// Records that the node version <paramref name="keccak"/> at this path was superseded at
+    /// <paramref name="blockNumber"/>. Only the latest supersession per node key is kept: a
+    /// re-created version moves forward, so it is never deleted while any block inside the
+    /// retention window can still reference it.
+    /// </summary>
+    private void Supersede(byte[] pathKey, in ValueHash256 keccak, ulong blockNumber)
+    {
+        Span<byte> keyBuffer = stackalloc byte[PartialArchiveKeys.MaxPathKeyLength + 32];
+        int length = PartialArchiveKeys.WriteSupersededKey(keyBuffer, pathKey, in keccak);
+        byte[] supersededKey = keyBuffer[..length].ToArray();
+
+        if (!_pendingSuperseded.TryGetValue(supersededKey, out byte[]? previousValue))
+        {
+            previousValue = _supersededDb.Get(supersededKey);
+        }
+
+        if (previousValue is not null)
+        {
+            ulong previousBlock = PartialArchiveKeys.ReadBlockNumberValue(previousValue);
+            if (previousBlock == blockNumber) return;
+            RemoveJournalRow(previousBlock, supersededKey);
+        }
+
+        EnsureBatch();
+        _supersededBatch!.Set(supersededKey, PartialArchiveKeys.BlockNumberValue(blockNumber));
+        _pendingSuperseded[supersededKey] = PartialArchiveKeys.BlockNumberValue(blockNumber);
+        AppendJournalRow(blockNumber, supersededKey);
+        _batchedWrites += 2;
+    }
+
+    private void AppendJournalRow(ulong blockNumber, ReadOnlySpan<byte> supersededKey)
+    {
+        Span<byte> keyBuffer = stackalloc byte[PartialArchiveKeys.MaxJournalKeyLength];
+        BinaryPrimitives.WriteUInt64BigEndian(keyBuffer, blockNumber);
+        supersededKey.CopyTo(keyBuffer[sizeof(ulong)..]);
+        EnsureBatch();
+        _journalBatch!.Set(keyBuffer[..(sizeof(ulong) + supersededKey.Length)], []);
+    }
+
+    private void RemoveJournalRow(ulong blockNumber, ReadOnlySpan<byte> supersededKey)
+    {
+        Span<byte> keyBuffer = stackalloc byte[PartialArchiveKeys.MaxJournalKeyLength];
+        BinaryPrimitives.WriteUInt64BigEndian(keyBuffer, blockNumber);
+        supersededKey.CopyTo(keyBuffer[sizeof(ulong)..]);
+        EnsureBatch();
+        _journalBatch!.Remove(keyBuffer[..(sizeof(ulong) + supersededKey.Length)]);
+    }
+
+    private void WriteMapEntry(byte[] pathKey, Hash256 keccak, ulong blockNumber)
+    {
+        byte[] value = new byte[PartialArchiveKeys.VersionValueLength];
+        PartialArchiveKeys.WriteVersionValue(value, keccak, blockNumber);
+        EnsureBatch();
+        _mapBatch!.Set(pathKey, value);
+        _pendingMap[pathKey] = value;
+        _batchedWrites++;
+    }
+
+    private void EnsureBatch()
+    {
+        if (_batch is not null) return;
+        _batch = _db.StartWriteBatch();
+        _mapBatch = _batch.GetColumnBatch(PartialArchiveColumns.LatestVersion);
+        _supersededBatch = _batch.GetColumnBatch(PartialArchiveColumns.SupersededAt);
+        _journalBatch = _batch.GetColumnBatch(PartialArchiveColumns.ExpiryJournal);
+    }
+
+    private void FlushBatch()
+    {
+        if (_batch is null) return;
+        _mapBatch = null;
+        _supersededBatch = null;
+        _journalBatch = null;
+        IColumnsWriteBatch<PartialArchiveColumns> batch = _batch;
+        _batch = null;
+        batch.Dispose();
+        _pendingMap.Clear();
+        _pendingSuperseded.Clear();
+        _batchedWrites = 0;
+    }
+
+    private void UpdateLastSnapshotBlock(ulong blockNumber)
+    {
+        if (blockNumber > Volatile.Read(ref _lastSnapshotBlock))
+        {
+            Volatile.Write(ref _lastSnapshotBlock, blockNumber);
+            WriteMetadataUlong(LastSnapshotBlockKey, blockNumber);
+        }
+    }
+
+    private void ExecutePruneSlice(ulong requestedCutoff)
+    {
+        // Journals are complete only up to the last finished persistence pass.
+        ulong cutoff = Math.Min(requestedCutoff, Volatile.Read(ref _lastSnapshotBlock));
+        if (cutoff == 0) return;
+
+        long startTimestamp = Stopwatch.GetTimestamp();
+        int deleted = 0;
+        int resurrected = 0;
+        int scanned = 0;
+        ulong floor = Volatile.Read(ref _oldestRetainedBlock);
+        bool exhausted = true;
+
+        INodeStorage.IWriteBatch nodeBatch = _nodeStorage.StartWriteBatch();
+        IColumnsWriteBatch<PartialArchiveColumns> archiveBatch = _db.StartWriteBatch();
+        try
+        {
+            IWriteBatch journalBatch = archiveBatch.GetColumnBatch(PartialArchiveColumns.ExpiryJournal);
+            IWriteBatch supersededBatch = archiveBatch.GetColumnBatch(PartialArchiveColumns.SupersededAt);
+            foreach (KeyValuePair<byte[], byte[]?> row in _journalDb.GetAll(ordered: true))
+            {
+                byte[] journalKey = row.Key;
+                ulong blockNumber = PartialArchiveKeys.ReadJournalBlockNumber(journalKey);
+                if (blockNumber > cutoff) break;
+                if (++scanned > PruneRowBudget)
+                {
+                    exhausted = false;
+                    break;
+                }
+
+                if (PartialArchiveKeys.TryParseJournalKey(journalKey, out _, out Hash256? address, out TreePath path, out ValueHash256 keccak))
+                {
+                    byte[]? currentValue = _mapDb.Get(PartialArchiveKeys.JournalPathKey(journalKey));
+                    if (currentValue is not null && PartialArchiveKeys.ReadVersionValue(currentValue).Keccak == keccak)
+                    {
+                        // The exact same node was re-created after being superseded; it is the
+                        // current version again and must be kept.
+                        resurrected++;
+                    }
+                    else
+                    {
+                        nodeBatch.Set(address, in path, in keccak, default, WriteFlags.LowPriority);
+                        deleted++;
+                    }
+                }
+
+                supersededBatch.Remove(PartialArchiveKeys.JournalKeyToSupersededKey(journalKey));
+                journalBatch.Remove(journalKey);
+                floor = blockNumber;
+            }
+        }
+        finally
+        {
+            // Node deletions land before journal rows are removed: a crash in between only causes
+            // idempotent re-deletion on the next pass.
+            nodeBatch.Dispose();
+            archiveBatch.Dispose();
+        }
+
+        if (floor > Volatile.Read(ref _oldestRetainedBlock))
+        {
+            Volatile.Write(ref _oldestRetainedBlock, floor);
+            WriteMetadataUlong(FloorKey, floor);
+        }
+
+        if (_logger.IsInfo && scanned > 0)
+        {
+            long elapsedMs = (long)Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+            _logger.Info($"Partial archive prune: deleted {deleted} superseded node keys ({resurrected} kept as resurrected), retention floor {floor}, cutoff {cutoff}, took {elapsedMs}ms.");
+        }
+
+        if (!exhausted)
+        {
+            // Re-enqueue behind pending node events so a large backlog is drained in slices
+            // without starving event processing. If the queue is full the next trigger retries.
+            _messages.Writer.TryWrite(Message.Prune(requestedCutoff));
+        }
+    }
+
+    private void Poison(string reason, Exception? exception)
+    {
+        if (_poisoned) return;
+        _poisoned = true;
+        if (_logger.IsError)
+        {
+            _logger.Error($"Partial archive tracking disabled: {reason}. Window pruning is halted; superseded state will no longer be deleted. Resync or full-prune the state to recover.", exception);
+        }
+
+        try
+        {
+            _metadataDb.Set(PoisonedKey, [1]);
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsError) _logger.Error("Failed to persist the partial archive poison marker.", e);
+        }
+    }
+
+    private ulong? ReadMetadataUlong(byte[] key)
+    {
+        byte[]? value = _metadataDb.Get(key);
+        return value is { Length: sizeof(ulong) } ? BinaryPrimitives.ReadUInt64BigEndian(value) : null;
+    }
+
+    private void WriteMetadataUlong(byte[] key, ulong value)
+    {
+        byte[] buffer = new byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, value);
+        _metadataDb.Set(key, buffer);
+    }
+
+    private enum MessageKind : byte
+    {
+        Node,
+        Barrier,
+        Prune,
+    }
+
+    private readonly struct Message
+    {
+        public MessageKind Kind { get; private init; }
+        public Hash256? Address { get; private init; }
+        public TreePath Path { get; private init; }
+        public Hash256? Keccak { get; private init; }
+        public ulong BlockNumber { get; private init; }
+        public ManualResetEventSlim? Barrier { get; private init; }
+
+        public static Message Node(Hash256? address, in TreePath path, Hash256 keccak, ulong blockNumber) =>
+            new() { Kind = MessageKind.Node, Address = address, Path = path, Keccak = keccak, BlockNumber = blockNumber };
+
+        public static Message BarrierMessage(ManualResetEventSlim barrier, ulong blockNumber) =>
+            new() { Kind = MessageKind.Barrier, Barrier = barrier, BlockNumber = blockNumber };
+
+        public static Message Prune(ulong cutoffBlockNumber) =>
+            new() { Kind = MessageKind.Prune, BlockNumber = cutoffBlockNumber };
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/PartialArchive/PartialArchiveNodeTracker.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PartialArchive/PartialArchiveNodeTracker.cs
@@ -55,6 +55,10 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
     private static readonly byte[] LastSnapshotBlockKey = [2];
     private static readonly byte[] PoisonedKey = [3];
 
+    // Written to both the state DB and tracker metadata; full pruning/resync drops the state-side
+    // copy, signalling that the tracking data is stale and must be reset.
+    internal static readonly byte[] StateStampKey = Keccak.Compute("PartialArchiveStateStamp").BytesToArray();
+
     private readonly IColumnsDb<PartialArchiveColumns> _db;
     private readonly IDb _mapDb;
     private readonly IDb _supersededDb;
@@ -85,6 +89,7 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
 
     public PartialArchiveNodeTracker(
         IColumnsDb<PartialArchiveColumns> db,
+        IDbProvider dbProvider,
         INodeStorage nodeStorage,
         ILogManager logManager)
     {
@@ -95,6 +100,8 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
         _metadataDb = db.GetColumnDb(PartialArchiveColumns.Metadata);
         _nodeStorage = nodeStorage;
         _logger = logManager.GetClassLogger<PartialArchiveNodeTracker>();
+
+        EnsureStateDatabaseIdentity(dbProvider.StateDb);
 
         _lastSnapshotBlock = ReadMetadataUlong(LastSnapshotBlockKey) ?? 0;
         _oldestRetainedBlock = ReadMetadataUlong(FloorKey) ?? 0;
@@ -537,6 +544,26 @@ public sealed class PartialArchiveNodeTracker : IPersistedNodeObserver, IDisposa
         {
             if (_logger.IsError) _logger.Error("Failed to persist the partial archive poison marker.", e);
         }
+    }
+
+    private void EnsureStateDatabaseIdentity(IKeyValueStore stateDb)
+    {
+        byte[]? stateStamp = stateDb[StateStampKey];
+        byte[]? trackedStamp = _metadataDb.Get(StateStampKey);
+        if (stateStamp is not null && trackedStamp is not null && Bytes.AreEqual(stateStamp, trackedStamp)) return;
+
+        if (trackedStamp is not null || _metadataDb.Get(FloorKey) is not null || _metadataDb.Get(LastSnapshotBlockKey) is not null)
+        {
+            _mapDb.Clear();
+            _supersededDb.Clear();
+            _journalDb.Clear();
+            _metadataDb.Clear();
+            if (_logger.IsInfo) _logger.Info("State database changed since partial archive tracking data was written (full pruning or resync); tracking was reset.");
+        }
+
+        byte[] stamp = stateStamp ?? Guid.NewGuid().ToByteArray();
+        stateDb[StateStampKey] = stamp;
+        _metadataDb.Set(StateStampKey, stamp);
     }
 
     private ulong? ReadMetadataUlong(byte[] key)

--- a/src/Nethermind/Nethermind.Blockchain/PartialArchive/PartialArchivePruneTrigger.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PartialArchive/PartialArchivePruneTrigger.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core;
+using Nethermind.Logging;
+using Nethermind.State;
+
+namespace Nethermind.Blockchain.PartialArchive;
+
+/// <summary>
+/// Schedules partial archive window pruning: every <see cref="ISyncConfig.PartialArchivePruneInterval"/>
+/// blocks it asks the <see cref="PartialArchiveNodeTracker"/> to delete state versions older than
+/// <see cref="ISyncConfig.PartialArchiveRange"/> blocks behind the head, and publishes the
+/// resulting retention floor to the state availability boundary.
+/// </summary>
+public sealed class PartialArchivePruneTrigger : IDisposable
+{
+    private readonly PartialArchiveNodeTracker _tracker;
+    private readonly IBlockTree _blockTree;
+    private readonly IStateBoundaryWriter? _stateBoundaryWriter;
+    private readonly ulong _range;
+    private readonly ulong _interval;
+    private ulong _lastRequestHead;
+
+    public PartialArchivePruneTrigger(
+        PartialArchiveNodeTracker tracker,
+        IBlockTree blockTree,
+        ISyncConfig syncConfig,
+        IStateBoundaryWriter? stateBoundaryWriter,
+        ILogManager logManager)
+    {
+        _tracker = tracker;
+        _blockTree = blockTree;
+        _stateBoundaryWriter = stateBoundaryWriter;
+        _range = Math.Max(1, syncConfig.PartialArchiveRange);
+        _interval = Math.Max(1, syncConfig.PartialArchivePruneInterval);
+
+        _blockTree.NewHeadBlock += OnNewHeadBlock;
+    }
+
+    private void OnNewHeadBlock(object? sender, BlockEventArgs e)
+    {
+        ulong head = e.Block.Number;
+
+        ulong floor = _tracker.OldestRetainedBlock;
+        if (floor > 0 && _stateBoundaryWriter is not null)
+        {
+            // Monotonic no-op when unchanged; keeps eth_capabilities in sync with actual pruning.
+            _stateBoundaryWriter.OldestStateBlock = floor;
+        }
+
+        if (head <= _range || head < _lastRequestHead + _interval) return;
+
+        if (_tracker.RequestPrune(head - _range))
+        {
+            _lastRequestHead = head;
+        }
+    }
+
+    public void Dispose() => _blockTree.NewHeadBlock -= OnNewHeadBlock;
+}

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -222,4 +222,10 @@ public interface ISyncConfig : IConfig
 
     [ConfigItem(Description = $"The number of blocks between partial archive pruning passes when `{nameof(PartialArchiveEnabled)}` is `true`.", DefaultValue = "64")]
     ulong PartialArchivePruneInterval { get; set; }
+
+    [ConfigItem(Description = $"How long, in minutes, a fresh partial archive node looks for a peer able to serve snap state at `head - {nameof(PartialArchiveRange)}` before falling back to the regular head pivot. Syncing from such an old pivot fills the whole historical window at sync completion instead of growing it forward one block per slot. `0` disables the fast fill.", DefaultValue = "60")]
+    ulong PartialArchiveFastFillWaitMinutes { get; set; }
+
+    [ConfigItem(Description = $"A comma-separated list of trusted feeder node URLs expected to serve historical snap state for the partial archive fast fill (e.g. archive or partial archive nodes with a raised `{nameof(SnapServingMaxDepth)}`). Added to static peers.", DefaultValue = "null")]
+    string? PartialArchiveFeeders { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -213,4 +213,13 @@ public interface ISyncConfig : IConfig
 
     [ConfigItem(Description = "_Technical._ Estimated max size of blocks in block processing queue before stop downloading.", DefaultValue = "200000000", HiddenFromDocs = true)]
     long ForwardSyncBlockProcessingQueueMemoryBudget { get; set; }
+
+    [ConfigItem(Description = $"Whether to retain the full historical state (a rolling partial archive) for at least `{nameof(PartialArchiveRange)}` most recent blocks, starting from the moment the node is synced. The retained window serves historical state queries, such as `eth_getProof`, at native speed. Requires the HalfPath state layout and in-memory pruning.", DefaultValue = "false")]
+    bool PartialArchiveEnabled { get; set; }
+
+    [ConfigItem(Description = $"The minimum number of most recent blocks with the full historical state retained when `{nameof(PartialArchiveEnabled)}` is `true`. The window can be temporarily larger between pruning passes.", DefaultValue = "10000")]
+    ulong PartialArchiveRange { get; set; }
+
+    [ConfigItem(Description = $"The number of blocks between partial archive pruning passes when `{nameof(PartialArchiveEnabled)}` is `true`.", DefaultValue = "64")]
+    ulong PartialArchivePruneInterval { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -97,6 +97,9 @@ namespace Nethermind.Blockchain.Synchronization
         public bool EnableSnapDoubleWriteCheck { get; set; } = false;
         public long ForwardSyncDownloadBufferMemoryBudget { get; set; } = 200.MiB;
         public long ForwardSyncBlockProcessingQueueMemoryBudget { get; set; } = 200.MiB;
+        public bool PartialArchiveEnabled { get; set; } = false;
+        public ulong PartialArchiveRange { get; set; } = 10_000;
+        public ulong PartialArchivePruneInterval { get; set; } = 64;
 
         public override string ToString() =>
             $"SyncConfig details. FastSync {FastSync}, PivotNumber: {PivotNumber} DownloadHeadersInFastSync {DownloadHeadersInFastSync}, DownloadBodiesInFastSync {DownloadBodiesInFastSync}, DownloadReceiptsInFastSync {DownloadReceiptsInFastSync}, AncientBodiesBarrier {AncientBodiesBarrier}, AncientReceiptsBarrier {AncientReceiptsBarrier}";

--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/SyncConfig.cs
@@ -100,6 +100,8 @@ namespace Nethermind.Blockchain.Synchronization
         public bool PartialArchiveEnabled { get; set; } = false;
         public ulong PartialArchiveRange { get; set; } = 10_000;
         public ulong PartialArchivePruneInterval { get; set; } = 64;
+        public ulong PartialArchiveFastFillWaitMinutes { get; set; } = 60;
+        public string? PartialArchiveFeeders { get; set; }
 
         public override string ToString() =>
             $"SyncConfig details. FastSync {FastSync}, PivotNumber: {PivotNumber} DownloadHeadersInFastSync {DownloadHeadersInFastSync}, DownloadBodiesInFastSync {DownloadBodiesInFastSync}, DownloadReceiptsInFastSync {DownloadReceiptsInFastSync}, AncientBodiesBarrier {AncientBodiesBarrier}, AncientReceiptsBarrier {AncientReceiptsBarrier}";

--- a/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
@@ -17,6 +17,7 @@ using Nethermind.Db.Rocks;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Init.Modules;
 using Nethermind.Logging;
+using Nethermind.Network.Config;
 using NUnit.Framework;
 using Testably.Abstractions;
 

--- a/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
@@ -86,7 +86,7 @@ public class StandardDbInitializerTests
             {
                 DownloadReceiptsInFastSync = useReceipts
             }))
-            .AddModule(new PruningTrieStoreModule(initConfig, new SyncConfig())) // For the full pruning db
+            .AddModule(new PruningTrieStoreModule(initConfig, new SyncConfig(), new NetworkConfig())) // For the full pruning db
             .AddSingleton<IPruningConfig>(new PruningConfig())
             .AddSingleton<IDbConfig>(new DbConfig())
             .AddSingleton<IInitConfig>(initConfig)

--- a/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/StandardDbInitializerTests.cs
@@ -86,7 +86,7 @@ public class StandardDbInitializerTests
             {
                 DownloadReceiptsInFastSync = useReceipts
             }))
-            .AddModule(new PruningTrieStoreModule(initConfig)) // For the full pruning db
+            .AddModule(new PruningTrieStoreModule(initConfig, new SyncConfig())) // For the full pruning db
             .AddSingleton<IPruningConfig>(new PruningConfig())
             .AddSingleton<IDbConfig>(new DbConfig())
             .AddSingleton<IInitConfig>(initConfig)

--- a/src/Nethermind/Nethermind.Db/DbNames.cs
+++ b/src/Nethermind/Nethermind.Db/DbNames.cs
@@ -23,5 +23,6 @@ namespace Nethermind.Db
         public const string PeersDb = "peers";
         public const string LogIndex = "logIndex";
         public const string Preimage = "preimage";
+        public const string PartialArchive = "partialArchive";
     }
 }

--- a/src/Nethermind/Nethermind.Db/PartialArchiveColumns.cs
+++ b/src/Nethermind/Nethermind.Db/PartialArchiveColumns.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Db
+{
+    /// <summary>
+    /// Column families of the partial archive database (see <see cref="DbNames.PartialArchive"/>),
+    /// which tracks superseded trie-node keys so a rolling window of historical state can be
+    /// retained and pruned.
+    /// </summary>
+    public enum PartialArchiveColumns
+    {
+        /// <summary>Per trie path: keccak and block number of the latest persisted node version.</summary>
+        LatestVersion,
+
+        /// <summary>Per node key: the block of its most recent supersession. Re-created versions move forward here, invalidating older expiry rows.</summary>
+        SupersededAt,
+
+        /// <summary>Block-ordered index of supersessions: node keys deletable once their (latest) supersession block leaves the retention window.</summary>
+        ExpiryJournal,
+
+        /// <summary>Bookkeeping: retention floor, last persisted snapshot block.</summary>
+        Metadata,
+    }
+}

--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -257,17 +257,20 @@ public class HistoryPrunerTests
         CheckHeadPreserved(testBlockchain, blocks);
     }
 
-    [TestCase(0UL, 100000u, 0UL, 3533u, false)]
-    [TestCase(100UL, 10u, 0UL, 3533u, true)]      // block retention below min
-    [TestCase(0UL, 100000u, 3533UL, 3000u, true)] // BAL retention below min
-    [TestCase(0UL, 100000u, 3533UL, 3533u, false)] // BAL retention exactly at min
-    public void Validates_config(ulong minHistoryRetentionEpochs, uint retentionEpochs, ulong minBalRetentionEpochs, uint balRetentionEpochs, bool shouldThrow)
+    [TestCase(0UL, 100000u, 0UL, 3533u, false, false)]
+    [TestCase(100UL, 10u, 0UL, 3533u, false, true)]      // block retention below min
+    [TestCase(0UL, 100000u, 3533UL, 3000u, false, true)] // BAL retention below min
+    [TestCase(0UL, 100000u, 3533UL, 3533u, false, false)] // BAL retention exactly at min
+    [TestCase(100UL, 10u, 0UL, 3533u, true, false)]      // below min allowed by explicit override
+    [TestCase(0UL, 100000u, 3533UL, 3000u, true, false)] // BAL below min allowed by explicit override
+    public void Validates_config(ulong minHistoryRetentionEpochs, uint retentionEpochs, ulong minBalRetentionEpochs, uint balRetentionEpochs, bool allowBelowMinRetention, bool shouldThrow)
     {
         IHistoryConfig historyConfig = new HistoryConfig
         {
             Pruning = PruningModes.Rolling,
             RetentionEpochs = retentionEpochs,
             BalRetentionEpochs = balRetentionEpochs,
+            AllowBelowMinRetention = allowBelowMinRetention,
         };
         ISpecProvider specProvider = new TestSpecProvider(new ReleaseSpec
         {

--- a/src/Nethermind/Nethermind.History/HistoryConfig.cs
+++ b/src/Nethermind/Nethermind.History/HistoryConfig.cs
@@ -10,4 +10,5 @@ public class HistoryConfig : IHistoryConfig
     public uint BalRetentionEpochs { get; set; } = 3533;
     public ulong PruningInterval { get; set; } = 8;
     public uint PruningTimeoutSeconds { get; set; } = 2;
+    public bool AllowBelowMinRetention { get; set; } = false;
 }

--- a/src/Nethermind/Nethermind.History/HistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/HistoryPruner.cs
@@ -336,13 +336,22 @@ public class HistoryPruner : IHistoryPruner
 
     private void CheckConfig()
     {
+        if (_historyConfig.AllowBelowMinRetention)
+        {
+            if ((_historyConfig.RetentionEpochs < _minHistoryRetentionEpochs || _historyConfig.BalRetentionEpochs < _minBalRetentionEpochs) && _logger.IsWarn)
+            {
+                _logger.Warn($"History retention ({_historyConfig.RetentionEpochs} epochs) is below the chain minimum ({_minHistoryRetentionEpochs}). This node will not serve the network-expected history range.");
+            }
+            return;
+        }
+
         if (_historyConfig.RetentionEpochs < _minHistoryRetentionEpochs)
         {
-            throw new HistoryPrunerException($"HistoryRetentionEpochs must be at least {_minHistoryRetentionEpochs}.");
+            throw new HistoryPrunerException($"HistoryRetentionEpochs must be at least {_minHistoryRetentionEpochs}. Set {nameof(IHistoryConfig)}.{nameof(IHistoryConfig.AllowBelowMinRetention)} to override.");
         }
         if (_historyConfig.BalRetentionEpochs < _minBalRetentionEpochs)
         {
-            throw new HistoryPrunerException($"BalRetentionEpochs must be at least {_minBalRetentionEpochs}.");
+            throw new HistoryPrunerException($"BalRetentionEpochs must be at least {_minBalRetentionEpochs}. Set {nameof(IHistoryConfig)}.{nameof(IHistoryConfig.AllowBelowMinRetention)} to override.");
         }
     }
 

--- a/src/Nethermind/Nethermind.History/IHistoryConfig.cs
+++ b/src/Nethermind/Nethermind.History/IHistoryConfig.cs
@@ -37,6 +37,11 @@ public interface IHistoryConfig : IConfig
         DefaultValue = "2")]
     uint PruningTimeoutSeconds { get; set; }
 
+    [ConfigItem(
+        Description = "Whether to allow retention windows below the chain's required minimum (EIP-4444). WARNING: nodes retaining less history than the network minimum may fail to serve peers and violate protocol expectations; intended for dedicated RPC nodes such as rolling partial archives.",
+        DefaultValue = "false")]
+    bool AllowBelowMinRetention { get; set; }
+
     // This member needs to be a method instead of a property
     // not to be picked up by the configuration handler
     bool Enabled() => Pruning != PruningModes.Disabled;

--- a/src/Nethermind/Nethermind.Init/FullPrunerFactory.cs
+++ b/src/Nethermind/Nethermind.Init/FullPrunerFactory.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Nethermind.Api;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.FullPruning;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Timers;
@@ -22,6 +23,7 @@ namespace Nethermind.Init;
 public class FullPrunerFactory(
     IInitConfig initConfig,
     IPruningConfig pruningConfig,
+    ISyncConfig syncConfig,
     IDbProvider dbProvider,
     IBlockTree blockTree,
     INodeStorageFactory nodeStorageFactory,
@@ -39,6 +41,13 @@ public class FullPrunerFactory(
     public FullPruner? Create(IWorldStateManager worldStateManager, IPruningTrieStore trieStore)
     {
         IDb stateDb = dbProvider.StateDb;
+
+        if (syncConfig.PartialArchiveEnabled)
+        {
+            // Full pruning copies only the head state, which would discard the historical window.
+            if (_logger.IsInfo) _logger.Info("Full pruning is disabled because partial archive mode is enabled.");
+            return null;
+        }
 
         if (!pruningConfig.Mode.IsFull() || stateDb is not IFullPruningDb fullPruningDb) return null;
 

--- a/src/Nethermind/Nethermind.Init/Modules/DbModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DbModule.cs
@@ -69,6 +69,7 @@ public class DbModule(
 
             .AddColumnDatabase<ReceiptsColumns>(DbNames.Receipts)
             .AddColumnDatabase<BlobTxsColumns>(DbNames.BlobTransactions)
+            .AddColumnDatabase<PartialArchiveColumns>(DbNames.PartialArchive)
 
             .AddSingleton<HyperClockCacheWrapper>((ctx) => new HyperClockCacheWrapper(ctx.Resolve<IDbConfig>().SharedBlockCacheSize))
             ;

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -51,7 +51,7 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
             ))
             .AddModule(new DbMonitoringModule())
             .AddModule(new WorldStateModule())
-            .AddModule(new PruningTrieStoreModule(configProvider.GetConfig<IInitConfig>()))
+            .AddModule(new PruningTrieStoreModule(configProvider.GetConfig<IInitConfig>(), configProvider.GetConfig<ISyncConfig>()))
             .AddModule(new FlatWorldStateModule(configProvider.GetConfig<IFlatDbConfig>()))
             .AddModule(new WorldStateDbDeciderModule())
             .AddModule(new PrewarmerModule(configProvider.GetConfig<IBlocksConfig>()))

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -51,7 +51,7 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
             ))
             .AddModule(new DbMonitoringModule())
             .AddModule(new WorldStateModule())
-            .AddModule(new PruningTrieStoreModule(configProvider.GetConfig<IInitConfig>(), configProvider.GetConfig<ISyncConfig>()))
+            .AddModule(new PruningTrieStoreModule(configProvider.GetConfig<IInitConfig>(), configProvider.GetConfig<ISyncConfig>(), configProvider.GetConfig<INetworkConfig>()))
             .AddModule(new FlatWorldStateModule(configProvider.GetConfig<IFlatDbConfig>()))
             .AddModule(new WorldStateDbDeciderModule())
             .AddModule(new PrewarmerModule(configProvider.GetConfig<IBlocksConfig>()))

--- a/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
@@ -7,6 +7,7 @@ using Autofac;
 using Nethermind.Api;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain.FullPruning;
+using Nethermind.Blockchain.PartialArchive;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Db;
@@ -21,13 +22,21 @@ using Nethermind.Synchronization.Peers;
 using Nethermind.Synchronization.SnapSync;
 using Nethermind.Synchronization.Trie;
 using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Init.Modules;
 
-public class PruningTrieStoreModule(IInitConfig initConfig) : Module
+public class PruningTrieStoreModule(IInitConfig initConfig, ISyncConfig syncConfig) : Module
 {
     protected override void Load(ContainerBuilder builder)
     {
+        if (syncConfig.PartialArchiveEnabled)
+        {
+            builder
+                .AddSingleton<PartialArchiveNodeTracker>()
+                .Bind<IPersistedNodeObserver, PartialArchiveNodeTracker>();
+        }
+
         builder
 
             // Special case for state db with pruning trie state.

--- a/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/PruningTrieStoreModule.cs
@@ -14,6 +14,7 @@ using Nethermind.Db;
 using Nethermind.Db.FullPruning;
 using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.Logging;
+using Nethermind.Network.Config;
 using Nethermind.State;
 using Nethermind.State.Healing;
 using Nethermind.Synchronization.FastSync;
@@ -26,7 +27,7 @@ using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Init.Modules;
 
-public class PruningTrieStoreModule(IInitConfig initConfig, ISyncConfig syncConfig) : Module
+public class PruningTrieStoreModule(IInitConfig initConfig, ISyncConfig syncConfig, INetworkConfig networkConfig) : Module
 {
     protected override void Load(ContainerBuilder builder)
     {
@@ -35,6 +36,14 @@ public class PruningTrieStoreModule(IInitConfig initConfig, ISyncConfig syncConf
             builder
                 .AddSingleton<PartialArchiveNodeTracker>()
                 .Bind<IPersistedNodeObserver, PartialArchiveNodeTracker>();
+
+            if (!string.IsNullOrEmpty(syncConfig.PartialArchiveFeeders))
+            {
+                // Feeders must be persistent connections so the fast-fill pivot probe can reach them.
+                networkConfig.StaticPeers = string.IsNullOrEmpty(networkConfig.StaticPeers)
+                    ? syncConfig.PartialArchiveFeeders
+                    : $"{networkConfig.StaticPeers},{syncConfig.PartialArchiveFeeders}";
+            }
         }
 
         builder

--- a/src/Nethermind/Nethermind.Init/Modules/WorldStateDbDeciderModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/WorldStateDbDeciderModule.cs
@@ -5,6 +5,7 @@ using System;
 using Autofac;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
+using Nethermind.Core.Exceptions;
 using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.State;
 using Nethermind.State.Flat.ScopeProvider;
@@ -26,6 +27,11 @@ internal class WorldStateDbDeciderModule : Module
                 (policy, syncConfig, flatFactory, patriciaFactory) =>
                 {
                     if (!policy.ShouldTurnOnFlatDb()) return patriciaFactory().WorldStateManager;
+                    if (syncConfig.PartialArchiveEnabled)
+                    {
+                        throw new InvalidConfigurationException(
+                            $"{nameof(ISyncConfig.PartialArchiveEnabled)} is not supported with the flat state layout; use the HalfPath trie layout.", -1);
+                    }
                     // Flat state can always serve snap requests; set before InitializeNetwork registers capabilities.
                     syncConfig.SnapServingEnabled ??= true;
                     return flatFactory();

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -4,6 +4,7 @@
 using System;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.FullPruning;
+using Nethermind.Blockchain.PartialArchive;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Blockchain.Utils;
 using Nethermind.Config;
@@ -38,7 +39,8 @@ public class PruningTrieStateFactory(
     CompositePruningTrigger compositePruningTrigger,
     Lazy<IPathRecovery> pathRecovery,
     ILogManager logManager,
-    NodeStorageCache? nodeStorageCache = null
+    NodeStorageCache? nodeStorageCache = null,
+    PartialArchiveNodeTracker? partialArchiveTracker = null
 )
 {
     private readonly ILogger _logger = logManager.GetClassLogger<PruningTrieStateFactory>();
@@ -74,9 +76,29 @@ public class PruningTrieStateFactory(
             dbProvider,
             logManager,
             pruningConfig,
-            new LastNStateRootTracker(blockTree, syncConfig.SnapServingMaxDepth));
+            new LastNStateRootTracker(blockTree, syncConfig.SnapServingMaxDepth),
+            retentionWindowBlocksOverride: syncConfig.PartialArchiveEnabled ? syncConfig.PartialArchiveRange : null);
+
+        if (partialArchiveTracker is not null)
+        {
+            // Pushed before the trie store so it is disposed after it (LIFO): the trie store's
+            // shutdown persistence still reports events through the tracker.
+            disposeStack.Push(partialArchiveTracker);
+        }
 
         disposeStack.Push(mainWorldTrieStore);
+
+        if (partialArchiveTracker is not null)
+        {
+            PartialArchivePruneTrigger pruneTrigger = new(
+                partialArchiveTracker,
+                blockTree,
+                syncConfig,
+                stateManager as IStateBoundaryWriter,
+                logManager);
+            disposeStack.Push(pruneTrigger);
+            if (_logger.IsInfo) _logger.Info($"Partial archive mode enabled: retaining historical state for at least {syncConfig.PartialArchiveRange} blocks, pruning every {syncConfig.PartialArchivePruneInterval} blocks.");
+        }
 
         FullPruner? fullPruner = fullPrunerFactory.Create(stateManager, trieStore);
         if (fullPruner is not null)
@@ -113,7 +135,8 @@ public class MainPruningTrieStoreFactory
         IDbConfig dbConfig,
         ILogIndexConfig logIndexConfig,
         IHardwareInfo hardwareInfo,
-        ILogManager logManager
+        ILogManager logManager,
+        IPersistedNodeObserver? persistedNodeObserver = null
     )
     {
         _logger = logManager.GetClassLogger<MainPruningTrieStoreFactory>();
@@ -135,8 +158,16 @@ public class MainPruningTrieStoreFactory
         }
 
         IDb stateDb = dbProvider.StateDb;
+        bool partialArchive = syncConfig.PartialArchiveEnabled;
+
         IPersistenceStrategy persistenceStrategy;
-        if (pruningConfig.Mode.IsMemory())
+        if (partialArchive)
+        {
+            // The rolling historical window requires every block's state on disk; the window
+            // pruner deletes superseded keys once they leave the window.
+            persistenceStrategy = Persist.EveryNBlock(1);
+        }
+        else if (pruningConfig.Mode.IsMemory())
         {
             persistenceStrategy = No.Persistence;
         }
@@ -151,7 +182,9 @@ public class MainPruningTrieStoreFactory
             .WhenLastPersistedBlockIsTooOld(pruningConfig.MaxUnpersistedBlockCount, pruningConfig.PruningBoundary)
             .UnlessLastPersistedBlockIsTooNew(pruningConfig.MinUnpersistedBlockCount, pruningConfig.PruningBoundary);
 
-        if (!pruningConfig.Mode.IsMemory())
+        // Partial archive defers obsolete-key deletion to its window pruner, so the in-memory
+        // prune must not delete superseded keys eagerly.
+        if (!pruningConfig.Mode.IsMemory() || partialArchive)
         {
             pruningStrategy = pruningStrategy
                 .DontDeleteObsoleteNode();
@@ -164,6 +197,11 @@ public class MainPruningTrieStoreFactory
 
         INodeStorage mainNodeStorage = nodeStorageFactory.WrapKeyValueStore(stateDb);
 
+        if (partialArchive)
+        {
+            ValidatePartialArchiveConfig(syncConfig, pruningConfig, mainNodeStorage);
+        }
+
         if (pruningConfig.SimulateLongFinalizationDepth != 0UL)
         {
             finalizedStateProvider = new DelayedFinalizedStateProvider(finalizedStateProvider, blockTree, pruningConfig.SimulateLongFinalizationDepth);
@@ -175,7 +213,31 @@ public class MainPruningTrieStoreFactory
             persistenceStrategy,
             finalizedStateProvider,
             pruningConfig,
-            logManager);
+            logManager,
+            partialArchive ? persistedNodeObserver : null);
+    }
+
+    private void ValidatePartialArchiveConfig(ISyncConfig syncConfig, IPruningConfig pruningConfig, INodeStorage nodeStorage)
+    {
+        if (nodeStorage.Scheme is not INodeStorage.KeyScheme.HalfPath)
+        {
+            // Hash-keyed nodes are deduplicated across the whole trie, so a superseded key may
+            // still be referenced by another live subtree and cannot be safely deleted.
+            throw new InvalidConfigurationException(
+                $"{nameof(ISyncConfig.PartialArchiveEnabled)} requires the HalfPath state layout, but the state database uses the {nodeStorage.Scheme} scheme.", -1);
+        }
+
+        if (pruningConfig.FullPruningTrigger is not FullPruningTrigger.Manual)
+        {
+            throw new InvalidConfigurationException(
+                $"{nameof(ISyncConfig.PartialArchiveEnabled)} is incompatible with automatic full pruning (full pruning discards the historical window). Set {nameof(IPruningConfig)}.{nameof(IPruningConfig.FullPruningTrigger)} to {nameof(FullPruningTrigger.Manual)}.", -1);
+        }
+
+        if (syncConfig.PartialArchiveRange < pruningConfig.PruningBoundary)
+        {
+            if (_logger.IsWarn) _logger.Warn($"{nameof(ISyncConfig.PartialArchiveRange)} ({syncConfig.PartialArchiveRange}) is smaller than the pruning boundary ({pruningConfig.PruningBoundary}); raising it to the boundary.");
+            syncConfig.PartialArchiveRange = pruningConfig.PruningBoundary;
+        }
     }
 
     private void AdviseConfig(IPruningConfig pruningConfig, IDbConfig dbConfig, IHardwareInfo hardwareInfo)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
@@ -50,6 +50,7 @@ public class StartingSyncPivotUpdater(
     private DateTimeOffset _fastFillDeadline;
     private bool _fastFillAbandoned;
     private BlockHeader? _fastFillTarget;
+    private (int SnapCapable, int Empty, int Timeouts) _fastFillProbeStats;
 
     private enum FastFillAttemptResult
     {
@@ -197,7 +198,8 @@ public class StartingSyncPivotUpdater(
         if (_logger.IsInfo && (_maxAttempts - _attemptsLeft) % 10 == 0)
         {
             TimeSpan left = _fastFillDeadline - DateTimeOffset.UtcNow;
-            _logger.Info($"Partial archive fast fill: still probing for a peer serving state at block {targetNumber} (target header {(target is null ? "not resolved yet" : "resolved")}, {_syncPeerPool.InitializedPeersCount} peers connected, fallback in {left.TotalMinutes:F0}m).");
+            (int snapCapable, int empty, int timeouts) = _fastFillProbeStats;
+            _logger.Info($"Partial archive fast fill: still probing for a peer serving state at block {targetNumber} (target header {(target is null ? "not resolved yet" : "resolved")}; {_syncPeerPool.InitializedPeersCount} peers, {snapCapable} snap-capable, last pass: {empty} without the state, {timeouts} timeouts; fallback in {left.TotalMinutes:F0}m).");
         }
 
         return FastFillAttemptResult.KeepWaiting;
@@ -254,26 +256,39 @@ public class StartingSyncPivotUpdater(
 
     private async Task<ISyncPeer?> TryFindPeerServingStateAt(BlockHeader target, CancellationToken cancellationToken)
     {
-        foreach (PeerInfo peer in _syncPeerPool.InitializedPeers)
+        int snapCapable = 0;
+        int empty = 0;
+        int timeouts = 0;
+        try
         {
-            if (cancellationToken.IsCancellationRequested) return null;
-            if (!peer.SyncPeer.TryGetSatelliteProtocol(Protocol.Snap, out ISnapSyncPeer snapPeer)) continue;
-
-            try
+            foreach (PeerInfo peer in _syncPeerPool.InitializedPeers)
             {
-                AccountRange probe = new(target.StateRoot!, ValueKeccak.Zero, ValueKeccak.Zero, target.Number);
-                using AccountsAndProofs response = await snapPeer.GetAccountRange(probe, cancellationToken);
-                if (response.PathAndAccounts.Count > 0 || response.Proofs.Count > 0)
+                if (cancellationToken.IsCancellationRequested) return null;
+                if (!peer.SyncPeer.TryGetSatelliteProtocol(Protocol.Snap, out ISnapSyncPeer snapPeer)) continue;
+
+                snapCapable++;
+                try
                 {
-                    return peer.SyncPeer;
-                }
+                    AccountRange probe = new(target.StateRoot!, ValueKeccak.Zero, ValueKeccak.Zero, target.Number);
+                    using AccountsAndProofs response = await snapPeer.GetAccountRange(probe, cancellationToken);
+                    if (response.PathAndAccounts.Count > 0 || response.Proofs.Count > 0)
+                    {
+                        return peer.SyncPeer;
+                    }
 
-                if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: peer {peer.SyncPeer.Node.ClientId} returned no data for state root {target.StateRoot} at block {target.Number}.");
+                    empty++;
+                    if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: peer {peer.SyncPeer.Node.ClientId} returned no data for state root {target.StateRoot} at block {target.Number}.");
+                }
+                catch (Exception e) when (e is TimeoutException or OperationCanceledException)
+                {
+                    timeouts++;
+                    if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: snap probe to {peer.SyncPeer.Node.ClientId} failed. {e.Message}");
+                }
             }
-            catch (Exception e) when (e is TimeoutException or OperationCanceledException)
-            {
-                if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: snap probe to {peer.SyncPeer.Node.ClientId} failed. {e.Message}");
-            }
+        }
+        finally
+        {
+            _fastFillProbeStats = (snapCapable, empty, timeouts);
         }
 
         return null;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
@@ -8,10 +8,12 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Handlers;
+using Nethermind.Network.Contract.P2P;
 using Nethermind.State.Snap;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.ParallelSync;
@@ -44,6 +46,17 @@ public class StartingSyncPivotUpdater(
     private int _maxAttempts = syncConfig.MaxAttemptsToUpdatePivot;
     private int _attemptsLeft = syncConfig.MaxAttemptsToUpdatePivot;
     private Hash256 _alreadyAnnouncedNewPivotHash = Keccak.Zero;
+
+    private DateTimeOffset _fastFillDeadline;
+    private bool _fastFillAbandoned;
+    private BlockHeader? _fastFillTarget;
+
+    private enum FastFillAttemptResult
+    {
+        PivotSet,
+        KeepWaiting,
+        GiveUp,
+    }
 
     public async Task EnsureSyncPivot(CancellationToken cancellationToken)
     {
@@ -108,7 +121,162 @@ public class StartingSyncPivotUpdater(
             return false;
         }
 
+        if (PartialArchiveFastFillActive)
+        {
+            switch (await TrySetPartialArchiveFastFillPivot(potentialPivotData.Value.Number, cancellationToken))
+            {
+                case FastFillAttemptResult.PivotSet:
+                    return true;
+                case FastFillAttemptResult.KeepWaiting:
+                    return false;
+                case FastFillAttemptResult.GiveUp:
+                    _fastFillAbandoned = true;
+                    break;
+            }
+        }
+
         return TryOverwritePivot(potentialPivotData.Value.Hash, potentialPivotData.Value.Number);
+    }
+
+    private bool PartialArchiveFastFillActive =>
+        !_fastFillAbandoned
+        && _syncConfig.PartialArchiveEnabled
+        && _syncConfig.PartialArchiveFastFillWaitMinutes > 0
+        && _syncConfig.SnapSync
+        && !_syncConfig.StaticSnapPivot;
+
+    /// <summary>
+    /// Attempts to pin the sync pivot <see cref="ISyncConfig.PartialArchiveRange"/> blocks behind
+    /// the CL anchor so the whole historical window is filled at sync completion. Requires a peer
+    /// (typically a configured feeder) able to serve snap state at that old root; falls back to
+    /// the regular head pivot after <see cref="ISyncConfig.PartialArchiveFastFillWaitMinutes"/>.
+    /// </summary>
+    private async Task<FastFillAttemptResult> TrySetPartialArchiveFastFillPivot(ulong anchorNumber, CancellationToken cancellationToken)
+    {
+        ulong range = _syncConfig.PartialArchiveRange;
+        if (anchorNumber <= range)
+        {
+            if (_logger.IsInfo) _logger.Info($"Partial archive fast fill: chain head ({anchorNumber}) is within the archive range ({range}); using the regular pivot.");
+            return FastFillAttemptResult.GiveUp;
+        }
+
+        if (_fastFillDeadline == default)
+        {
+            _fastFillDeadline = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(_syncConfig.PartialArchiveFastFillWaitMinutes);
+            if (_logger.IsInfo) _logger.Info($"Partial archive fast fill: looking for a peer serving snap state at block {anchorNumber - range} (head - {range}) for up to {_syncConfig.PartialArchiveFastFillWaitMinutes} minutes before falling back to forward filling.");
+        }
+
+        ulong targetNumber = anchorNumber - range;
+        BlockHeader? target = _fastFillTarget;
+        if (target is null || target.Number != targetNumber)
+        {
+            target = await TryGetFastFillTargetHeader(targetNumber, cancellationToken);
+            _fastFillTarget = target;
+        }
+
+        if (target?.StateRoot is not null)
+        {
+            ISyncPeer? servingPeer = await TryFindPeerServingStateAt(target, cancellationToken);
+            if (servingPeer is not null)
+            {
+                if (_logger.IsInfo) _logger.Info($"Partial archive fast fill: peer {servingPeer.Node?.ClientId} serves historical state at block {target.Number} ({target.Hash}); pinning it as a static snap pivot. The full {range}-block window will be available once forward sync reaches the head.");
+                _syncConfig.PivotNumber = target.Number;
+                _syncConfig.PivotHash = target.Hash!.ToString();
+                _syncConfig.StaticSnapPivot = true;
+                UpdateConfigValues(target.Hash!, target.Number);
+                return FastFillAttemptResult.PivotSet;
+            }
+        }
+
+        if (DateTimeOffset.UtcNow >= _fastFillDeadline)
+        {
+            if (_logger.IsWarn) _logger.Warn($"Partial archive fast fill: no peer served snap state at block {targetNumber} within {_syncConfig.PartialArchiveFastFillWaitMinutes} minutes; falling back to the regular head pivot. The historical window will fill forward, one block per slot.");
+            return FastFillAttemptResult.GiveUp;
+        }
+
+        if (_logger.IsInfo && (_maxAttempts - _attemptsLeft) % 10 == 0)
+        {
+            TimeSpan left = _fastFillDeadline - DateTimeOffset.UtcNow;
+            _logger.Info($"Partial archive fast fill: still probing for a peer serving state at block {targetNumber} (target header {(target is null ? "not resolved yet" : "resolved")}, {_syncPeerPool.InitializedPeersCount} peers connected, fallback in {left.TotalMinutes:F0}m).");
+        }
+
+        return FastFillAttemptResult.KeepWaiting;
+    }
+
+    /// <summary>
+    /// Resolves the fast-fill target header by number, requiring two distinct peers to agree on
+    /// the hash (a single peer is trusted only when it is the only one connected, e.g. a feeder).
+    /// A wrong header cannot corrupt state — snap data is verified against its state root — but
+    /// would waste the fast-fill attempt.
+    /// </summary>
+    private async Task<BlockHeader?> TryGetFastFillTargetHeader(ulong targetNumber, CancellationToken cancellationToken)
+    {
+        BlockHeader? candidate = null;
+        int agreements = 0;
+        int peersAsked = 0;
+
+        foreach (PeerInfo peer in _syncPeerPool.InitializedPeers)
+        {
+            if (cancellationToken.IsCancellationRequested) return null;
+            try
+            {
+                using IOwnedReadOnlyList<BlockHeader>? headers = await peer.SyncPeer.GetBlockHeaders(targetNumber, 1, 0, cancellationToken);
+                peersAsked++;
+                BlockHeader? header = headers is { Count: > 0 } ? headers[0] : null;
+                if (header is null || header.Number != targetNumber || !HeaderValidator.ValidateHash(header)) continue;
+
+                if (candidate is null)
+                {
+                    candidate = header;
+                    agreements = 1;
+                }
+                else if (candidate.Hash == header.Hash)
+                {
+                    agreements++;
+                }
+                else
+                {
+                    if (_logger.IsWarn) _logger.Warn($"Partial archive fast fill: peers disagree on block {targetNumber} ({candidate.Hash} vs {header.Hash}); retrying.");
+                    return null;
+                }
+
+                if (agreements >= 2) return candidate;
+            }
+            catch (Exception e) when (e is TimeoutException or OperationCanceledException)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: peer {peer.SyncPeer.Node.ClientId} did not answer the header request for {targetNumber}. {e.Message}");
+            }
+        }
+
+        // With a single connected peer (e.g. only the feeder) accept its answer.
+        return peersAsked == 1 && agreements == 1 ? candidate : null;
+    }
+
+    private async Task<ISyncPeer?> TryFindPeerServingStateAt(BlockHeader target, CancellationToken cancellationToken)
+    {
+        foreach (PeerInfo peer in _syncPeerPool.InitializedPeers)
+        {
+            if (cancellationToken.IsCancellationRequested) return null;
+            if (!peer.SyncPeer.TryGetSatelliteProtocol(Protocol.Snap, out ISnapSyncPeer snapPeer)) continue;
+
+            try
+            {
+                AccountRange probe = new(target.StateRoot!, ValueKeccak.Zero, ValueKeccak.Zero, target.Number);
+                using AccountsAndProofs response = await snapPeer.GetAccountRange(probe, cancellationToken);
+                if (response.PathAndAccounts.Count > 0 || response.Proofs.Count > 0)
+                {
+                    return peer.SyncPeer;
+                }
+
+                if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: peer {peer.SyncPeer.Node.ClientId} returned no data for state root {target.StateRoot} at block {target.Number}.");
+            }
+            catch (Exception e) when (e is TimeoutException or OperationCanceledException)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: snap probe to {peer.SyncPeer.Node.ClientId} failed. {e.Message}");
+            }
+        }
+
+        return null;
     }
 
     protected virtual async Task<(Hash256 Hash, ulong Number)?> TryGetPivotData(CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
@@ -244,9 +244,14 @@ public class StartingSyncPivotUpdater(
 
                 if (agreements >= 2) return candidate;
             }
-            catch (Exception e) when (e is TimeoutException or OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: peer {peer.SyncPeer.Node.ClientId} did not answer the header request for {targetNumber}. {e.Message}");
+                return null;
+            }
+            catch (Exception e)
+            {
+                // Best-effort probe over untrusted peers: skip the peer, keep probing.
+                if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: header request for {targetNumber} to {peer.SyncPeer.Node.ClientId} failed. {e.Message}");
             }
         }
 
@@ -279,7 +284,11 @@ public class StartingSyncPivotUpdater(
                     empty++;
                     if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: peer {peer.SyncPeer.Node.ClientId} returned no data for state root {target.StateRoot} at block {target.Number}.");
                 }
-                catch (Exception e) when (e is TimeoutException or OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return null;
+                }
+                catch (Exception e)
                 {
                     timeouts++;
                     if (_logger.IsDebug) _logger.Debug($"Partial archive fast fill: snap probe to {peer.SyncPeer.Node.ClientId} failed. {e.Message}");

--- a/src/Nethermind/Nethermind.State/WorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateManager.cs
@@ -30,7 +30,8 @@ public class WorldStateManager : IWorldStateManager, IStateBoundaryWriter
         IDbProvider dbProvider,
         ILogManager logManager,
         IPruningConfig pruningConfig,
-        ILastNStateRootTracker lastNStateRootTracker = null
+        ILastNStateRootTracker lastNStateRootTracker = null,
+        ulong? retentionWindowBlocksOverride = null
     )
     {
         _dbProvider = dbProvider;
@@ -49,7 +50,7 @@ public class WorldStateManager : IWorldStateManager, IStateBoundaryWriter
             ? NoopSnapServer.Instance
             : new SnapServer.SnapServer(_readOnlyTrieStore, _readaOnlyCodeCb, _logManager, _lastNStateRootTracker);
 
-        RetentionWindowBlocks = pruningConfig.Mode.IsMemory() ? pruningConfig.PruningBoundary : (ulong?)null;
+        RetentionWindowBlocks = retentionWindowBlocksOverride ?? (pruningConfig.Mode.IsMemory() ? pruningConfig.PruningBoundary : (ulong?)null);
     }
 
     public ulong? RetentionWindowBlocks { get; }

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/FullStateFinderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/FullStateFinderTests.cs
@@ -33,6 +33,22 @@ public class FullStateFinderTests
     }
 
     [Test]
+    public void TestWillCheckSyncPivotWhenStateIsDeeperThanLookback()
+    {
+        IBlockTree blockTree = Build.A.BlockTree()
+            .WithStateRoot((b) => b.Number == 100 ? _goodRoot : _badRoot)
+            .OfChainLength(1000)
+            .TestObject;
+        blockTree.SyncPivot = (100, blockTree.FindHeader(100, BlockTreeLookupOptions.None)!.Hash!);
+
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        stateReader.HasStateForBlock(Arg.Is<BlockHeader>((header) => header.StateRoot == _goodRoot)).Returns(true);
+
+        FullStateFinder finder = new(blockTree, stateReader);
+        Assert.That(finder.FindBestFullState(), Is.EqualTo(100));
+    }
+
+    [Test]
     public void TestWillCheckForStateWhenItWasPreviouslyFound()
     {
         IBlockTree blockTree = Build.A.BlockTree()

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/StateSyncPivot.cs
@@ -54,7 +54,15 @@ namespace Nethermind.Synchronization.FastSync
             BlockHeader bestHeader = blockTree.FindHeader(targetBlockNumber);
             if (bestHeader is not null)
             {
-                if (_logger.IsInfo) _logger.Info($"Snap - {msg} - Pivot changed from {_bestHeader?.Number} to {bestHeader.Number}");
+                if (_bestHeader?.Number != bestHeader.Number)
+                {
+                    if (_logger.IsInfo) _logger.Info($"Snap - {msg} - Pivot changed from {_bestHeader?.Number} to {bestHeader.Number}");
+                }
+                else if (_logger.IsDebug)
+                {
+                    _logger.Debug($"Snap - {msg} - pivot kept at {bestHeader.Number}");
+                }
+
                 _bestHeader = bestHeader;
             }
             else if (syncConfig.StaticSnapPivot && _logger.IsDebug)

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/FullStateFinder.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/FullStateFinder.cs
@@ -55,6 +55,21 @@ public class FullStateFinder(
             }
         }
 
+        if (bestFullState == 0)
+        {
+            // State synced at a deep static pivot (e.g. partial archive fast fill) lies further
+            // behind the best header than the bounded look-back reaches.
+            (ulong pivotNumber, Hash256 pivotHash) = _blockTree.SyncPivot;
+            if (pivotNumber > 0)
+            {
+                BlockHeader? pivotHeader = _blockTree.FindHeader(pivotNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+                if (pivotHeader is not null && pivotHeader.Hash == pivotHash && IsFullySynced(pivotHeader))
+                {
+                    bestFullState = pivotHeader.Number;
+                }
+            }
+        }
+
         if (bestFullState != 0)
         {
             _lastKnownState = bestFullState;

--- a/src/Nethermind/Nethermind.Trie/Pruning/IPersistedNodeObserver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/IPersistedNodeObserver.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Trie.Pruning;
+
+/// <summary>
+/// Receives notifications about trie nodes written to, or re-referenced in, the underlying
+/// <see cref="INodeStorage"/> as block commit sets are persisted by <see cref="TrieStore"/>.
+/// </summary>
+/// <remarks>
+/// Used by the partial archive mode to maintain a per-path latest-version index and an expiry
+/// journal of superseded node keys, enabling a rolling window of historical state on disk.
+/// Thread-safety: <see cref="OnNodePersisted"/> is invoked concurrently from parallel
+/// persistence tasks; <see cref="OnNodeRecommitted"/> is invoked on the block-processing path
+/// and must be non-blocking; <see cref="OnSnapshotPersisted"/> is invoked on the pruning thread
+/// after a persistence pass completes and acts as a barrier — implementations should durably
+/// apply all previously reported events before returning.
+/// </remarks>
+public interface IPersistedNodeObserver
+{
+    /// <summary>
+    /// Reports a node written to node storage while persisting the commit set of
+    /// <paramref name="blockNumber"/>. Only called for nodes with a non-null keccak
+    /// (nodes inlined in their parent RLP are not stored separately).
+    /// </summary>
+    void OnNodePersisted(Hash256? address, in TreePath path, Hash256 keccak, ulong blockNumber);
+
+    /// <summary>
+    /// Reports a committed node that deduplicated against an existing dirty-cache record,
+    /// i.e. the exact same node (address, path, keccak) is live again at
+    /// <paramref name="blockNumber"/>. Such nodes are skipped by persistence, so without this
+    /// signal a re-created node could be mistaken for a superseded one.
+    /// </summary>
+    void OnNodeRecommitted(Hash256? address, in TreePath path, Hash256 keccak, ulong blockNumber);
+
+    /// <summary>
+    /// Barrier invoked after a persistence pass has written all commit sets up to
+    /// <paramref name="lastPersistedBlockNumber"/> to node storage.
+    /// </summary>
+    void OnSnapshotPersisted(ulong lastPersistedBlockNumber);
+}

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -763,7 +763,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             BlockCommitSet blockCommitSet = candidateSets[index];
             if (_logger.IsDebug) _logger.Debug($"Elevated pruning for candidate {blockCommitSet.BlockNumber}");
             maxPersistedBlock = Math.Max(maxPersistedBlock, blockCommitSet.BlockNumber);
-            ParallelPersistBlockCommitSet(blockCommitSet, ComposeRecorderWithObserver(persistedNodeRecorder, blockCommitSet.BlockNumber));
+            ParallelPersistBlockCommitSet(blockCommitSet, ComposeRecorderWithObserver(persistedNodeRecorder, blockCommitSet));
         }
 
         if (candidateSets.Count > 0)
@@ -923,14 +923,28 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
     /// <summary>
     /// Wraps a persisted-node recorder so <see cref="IPersistedNodeObserver.OnNodePersisted"/> also
-    /// fires for every stored node of the commit set being persisted at <paramref name="blockNumber"/>.
+    /// fires for every stored node of the commit set being persisted.
     /// </summary>
+    /// <remarks>
+    /// Only provably canonical sets are reported: non-canonical (reorged) sets are persisted too,
+    /// and registering their nodes as superseding would let the window pruner delete versions the
+    /// canonical chain still references. When canonicality cannot be confirmed the set is skipped,
+    /// which at worst leaks keys.
+    /// </remarks>
     private Action<TreePath, Hash256?, TrieNode> ComposeRecorderWithObserver(
-        Action<TreePath, Hash256?, TrieNode> recorder, ulong blockNumber)
+        Action<TreePath, Hash256?, TrieNode> recorder, BlockCommitSet commitSet)
     {
         IPersistedNodeObserver? observer = _persistedNodeObserver;
         if (observer is null) return recorder;
 
+        Hash256? canonicalRoot = _finalizedStateProvider.GetFinalizedStateRootAt(commitSet.BlockNumber);
+        if (canonicalRoot is null || canonicalRoot != commitSet.StateRoot)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Not reporting persisted nodes of block {commitSet.BlockNumber} ({commitSet.StateRoot}) to the partial archive: {(canonicalRoot is null ? "canonicality unknown" : "not canonical")}.");
+            return recorder;
+        }
+
+        ulong blockNumber = commitSet.BlockNumber;
         return (path, address, tn) =>
         {
             recorder(path, address, tn);
@@ -1331,7 +1345,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             BlockCommitSet blockCommitSet = candidateSets[index];
             if (_logger.IsDebug) _logger.Debug($"Persisting on disposal {blockCommitSet} (cache memory at {MemoryUsedByDirtyCache})");
             maxPersistedBlock = Math.Max(maxPersistedBlock, blockCommitSet.BlockNumber);
-            ParallelPersistBlockCommitSet(blockCommitSet, ComposeRecorderWithObserver(_persistedNodeRecorderNoop, blockCommitSet.BlockNumber));
+            ParallelPersistBlockCommitSet(blockCommitSet, ComposeRecorderWithObserver(_persistedNodeRecorderNoop, blockCommitSet));
         }
 
         if (candidateSets.Count > 0)

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -78,6 +78,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     private Task _pruningTask = Task.CompletedTask;
     private readonly CancellationTokenSource _pruningTaskCancellationTokenSource = new();
     private readonly IFinalizedStateProvider _finalizedStateProvider;
+    private readonly IPersistedNodeObserver? _persistedNodeObserver;
 
     public TrieStore(
         INodeStorage nodeStorage,
@@ -85,13 +86,15 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         IPersistenceStrategy persistenceStrategy,
         IFinalizedStateProvider finalizedStateProvider,
         IPruningConfig pruningConfig,
-        ILogManager logManager)
+        ILogManager logManager,
+        IPersistedNodeObserver? persistedNodeObserver = null)
     {
         _logger = logManager.GetClassLogger<TrieStore>();
         _nodeStorage = nodeStorage;
         _pruningStrategy = pruningStrategy;
         _persistenceStrategy = persistenceStrategy;
         _finalizedStateProvider = finalizedStateProvider;
+        _persistedNodeObserver = persistedNodeObserver;
 
         _publicStore = new TrieKeyValueStore(this);
         _persistedNodeRecorder = PersistedNodeRecorder;
@@ -320,6 +323,20 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         if (!ReferenceEquals(cachedNodeCopy, node))
         {
             Metrics.ReplacedNodesCount++;
+            if (_persistedNodeObserver is not null)
+            {
+                // The same (address, path, keccak) is live again at this block. Persistence skips
+                // deduplicated nodes, so without this signal the partial archive could treat the
+                // current version as superseded and eventually delete it.
+                _persistedNodeObserver.OnNodeRecommitted(address, in path, node.Keccak, blockNumber);
+                if (cachedNodeCopy.IsPersisted)
+                {
+                    // Force a re-persist: the window pruner may have deleted (or be about to
+                    // delete) this key based on an older supersession record; re-writing it on the
+                    // next persistence pass restores the on-disk copy.
+                    cachedNodeCopy.IsPersisted = false;
+                }
+            }
         }
         else
         {
@@ -740,11 +757,18 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         Action<TreePath, Hash256?, TrieNode> persistedNodeRecorder = shouldTrackPastKey ? _persistedNodeRecorder : _persistedNodeRecorderNoop;
 
+        ulong maxPersistedBlock = 0;
         for (int index = 0; index < candidateSets.Count; index++)
         {
             BlockCommitSet blockCommitSet = candidateSets[index];
             if (_logger.IsDebug) _logger.Debug($"Elevated pruning for candidate {blockCommitSet.BlockNumber}");
-            ParallelPersistBlockCommitSet(blockCommitSet, persistedNodeRecorder);
+            maxPersistedBlock = Math.Max(maxPersistedBlock, blockCommitSet.BlockNumber);
+            ParallelPersistBlockCommitSet(blockCommitSet, ComposeRecorderWithObserver(persistedNodeRecorder, blockCommitSet.BlockNumber));
+        }
+
+        if (candidateSets.Count > 0)
+        {
+            _persistedNodeObserver?.OnSnapshotPersisted(maxPersistedBlock);
         }
 
         AnnounceReorgBoundaries();
@@ -895,6 +919,24 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
     private void PersistedNodeRecorderNoop(TreePath treePath, Hash256 address, TrieNode tn)
     {
+    }
+
+    /// <summary>
+    /// Wraps a persisted-node recorder so <see cref="IPersistedNodeObserver.OnNodePersisted"/> also
+    /// fires for every stored node of the commit set being persisted at <paramref name="blockNumber"/>.
+    /// </summary>
+    private Action<TreePath, Hash256?, TrieNode> ComposeRecorderWithObserver(
+        Action<TreePath, Hash256?, TrieNode> recorder, ulong blockNumber)
+    {
+        IPersistedNodeObserver? observer = _persistedNodeObserver;
+        if (observer is null) return recorder;
+
+        return (path, address, tn) =>
+        {
+            recorder(path, address, tn);
+            // Nodes without keccak are inlined in the parent RLP and never stored separately.
+            if (tn.Keccak is not null) observer.OnNodePersisted(address, in path, tn.Keccak, blockNumber);
+        };
     }
 
     private int _lastPrunedShardIdx = 0;
@@ -1283,12 +1325,20 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         if (_logger.IsDebug) _logger.Debug($"On shutdown persisting {candidateSets.Count} commit sets. Finalized block is {finalizedBlockNumber}.");
 
+        ulong maxPersistedBlock = 0;
         for (int index = 0; index < candidateSets.Count; index++)
         {
             BlockCommitSet blockCommitSet = candidateSets[index];
             if (_logger.IsDebug) _logger.Debug($"Persisting on disposal {blockCommitSet} (cache memory at {MemoryUsedByDirtyCache})");
-            ParallelPersistBlockCommitSet(blockCommitSet, _persistedNodeRecorderNoop);
+            maxPersistedBlock = Math.Max(maxPersistedBlock, blockCommitSet.BlockNumber);
+            ParallelPersistBlockCommitSet(blockCommitSet, ComposeRecorderWithObserver(_persistedNodeRecorderNoop, blockCommitSet.BlockNumber));
         }
+
+        if (candidateSets.Count > 0)
+        {
+            _persistedNodeObserver?.OnSnapshotPersisted(maxPersistedBlock);
+        }
+
         _nodeStorage.Flush(onlyWal: false);
 
         if (candidateSets.Count == 0)


### PR DESCRIPTION
## Changes

Adds a **partial archive mode**: a snap-synced node that retains the full historical state for at least the last `Sync.PartialArchiveRange` blocks (default 10000) with a rolling prune every `Sync.PartialArchivePruneInterval` blocks (default 64). Within the window, historical `eth_getProof` / state queries run through the **unchanged HalfPath read path at native speed**.

**How it works** — with the HalfPath scheme, node-storage keys are qualified by the node keccak, so all versions of a trie path coexist on disk. Partial archive therefore is:

1. Persist **every** block's commit set (`Persist.EveryNBlock(1)`, archive-style) and never delete obsolete keys eagerly (`DontDeleteObsoleteNode`), so every state root in the window stays resolvable — no new read path, `HasRoot` degrades naturally to a physical root-key check.
2. A new `IPersistedNodeObserver` hook on `TrieStore` reports persisted nodes (and commit-time re-commits of already-persisted nodes) to a `PartialArchiveNodeTracker`, which maintains in a new `partialArchive` column DB:
   - `LatestVersion` — per full path: current keccak + block;
   - `SupersededAt` — per (path, keccak): block of its **latest** supersession (upserted; re-created versions move forward, invalidating older expiry rows — this keeps values that alternate between blocks alive while any block inside the window references them);
   - `ExpiryJournal` — block-ordered index of supersessions.
3. The window pruner deletes a node key only when its latest supersession left the window and the key is not current again. Prune slices run **only inside the persistence barrier** (while the persistence thread is parked waiting for the tracker drain), so a deletion can never race a persistence write of the same re-created key; a re-commit of a persisted node additionally clears `IsPersisted` to force a re-persist.
4. **Only provably canonical commit sets register supersessions**: `TrieStore` persists reorged sets below the finalized block too, and treating their nodes as superseding would mark versions the canonical chain still references as deletable. Sets whose state root does not match `IFinalizedStateProvider.GetFinalizedStateRootAt(number)` are not reported (found on a live Sepolia soak as a `MissingTrieNodeException` at head after a reorg + window slide; regression-tested).
5. Safety bias is *leak, never corrupt*: base (snap-synced) versions are never deleted, the retention floor is committed atomically with the journal removal (capabilities can't over-advertise after a crash), and any tracking gap that could make deletion unsafe durably poisons the tracker and halts pruning with an error log.
6. Guards: requires HalfPath (hash scheme has deduplicated keys — deletion is unsafe; flat layout rejected at startup), disables full pruning (it would discard the window), reports the window through `IStateBoundary` → `eth_capabilities`.

**Fast fill** (`Sync.PartialArchiveFastFillWaitMinutes`, default 60; `Sync.PartialArchiveFeeders`): the window otherwise fills forward one block per slot (state below the snap pivot cannot be obtained from the network — snap peers only serve recent roots). On a fresh node, the pivot updater instead resolves the header at `head − Range` (two peers must agree on the hash; one suffices when it is the only peer, e.g. a lone feeder), probes connected peers with a minimal `GetAccountRange` at that root, and — if a peer serves it — pins it as a static snap pivot: the node snap-syncs the *old* state and forward-executes into a **fully filled window at sync completion**. Feeder enodes are merged into static peers; peers able to serve are typically partial-archive nodes themselves with a raised `Sync.SnapServingMaxDepth` (so partial archives can bootstrap partial archives — no full archive needed anywhere). After the deadline it falls back to the regular head pivot with a clear warning; the periodic log reports probe statistics (snap-capable peers, empty responses, timeouts).

**History pairing** (`History.AllowBelowMinRetention`, default false): allows `History.RetentionEpochs` below the chainspec's EIP-4444 minimum (with a startup warning), so a partial archive node can retain exactly the window it serves (e.g. 313 epochs ≈ 10k blocks of bodies/receipts); the OldBodies/OldReceipts backfill is bounded by the same retention window.

Costs: state-DB write amplification equals a regular archive node's (proven path); steady-state disk overhead ≈ window depth of state diffs + not-yet-pruned garbage + the tracking index (132MB after 2h on Sepolia). Known accepted leaks (same class as today's live-prune): replaced snap-base keys, non-canonical-set nodes, and deleted-contract storage subtrees are reclaimed only by resync.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `PartialArchiveNodeTrackerTests` — supersession/window/resurrection semantics incl. the alternating-versions case, out-of-order event arrival, barrier-gated prune execution, floor persistence across restarts, backlog slicing.
- `PartialArchiveStateWindowTests` — TrieStore-level E2E (historical reads verified against every root before/after pruning, per-block toggling values survive) + the non-canonical-commit-set regression.
- `HistoryPrunerTests.Validates_config` extended with the `AllowBelowMinRetention` override cases.
- **Live validation** on this branch:
  - Sepolia snap sync (23 min) + Lighthouse; `eth_getProof` OK across the whole window at native latency, `-32002` outside; `eth_capabilities` reports `oldestBlock`/window `deleteStrategy` exactly; live prune passes: `deleted 154924 superseded node keys (18 kept as resurrected) ... took 1077ms`, floor advancing exactly by the prune interval; resurrection guard confirmed on real chain data.
  - Mainnet snap sync (38 min) with 10k state + 10k history windows; probes correct at the pivot edge; long soak in progress.
  - The live soak caught the non-canonical supersession bug (a reorg + window slide deleted a live node) — fixed and regression-tested; this class of bug is not reachable by unit tests alone.
  - Fast-fill probing validated live (auto target resolution, probe statistics, static-pivot pinning path); feeder-served old-pivot sync E2E in progress.

## Documentation

#### Requires documentation update

- [x] Yes

_New config options: `Sync.PartialArchiveEnabled`, `Sync.PartialArchiveRange`, `Sync.PartialArchivePruneInterval`, `Sync.PartialArchiveFastFillWaitMinutes`, `Sync.PartialArchiveFeeders`, `History.AllowBelowMinRetention`._

#### Requires explanation in Release Notes

- [x] Yes

_Partial archive mode: retain a rolling window (default 10000 blocks) of full historical state on a snap-synced node, serving historical `eth_getProof` at native speed with bounded disk usage; optional fast fill from feeder nodes yields a fully populated window right at sync completion._
