### PR TITLE
perf(state): collect storage roots from the changed set, not all touched contracts

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -219,6 +219,55 @@ public class StorageProviderTests(bool useFlat)
     }
 
     [Test]
+    public void Storage_root_collect_recomputes_all_changed_contracts_amid_warm_reads()
+    {
+        using Context ctx = new(useFlat, setInitialState: false);
+        WorldState provider = BuildStorageProvider(ctx);
+
+        Address[] written =
+        [
+            new(Keccak.Compute("w1")),
+            new(Keccak.Compute("w2")),
+            new(Keccak.Compute("w3")),
+            new(Keccak.Compute("w4")),
+        ];
+
+        Hash256 stateRoot;
+        using (provider.BeginScope(IWorldState.PreGenesis))
+        {
+            foreach (Address address in written)
+            {
+                provider.CreateAccount(address, 1);
+            }
+            provider.Commit(Frontier.Instance);
+
+            for (int i = 0; i < written.Length; i++)
+            {
+                provider.Set(new StorageCell(written[i], 1), _values[i + 1]);
+            }
+
+            for (int i = 0; i < 64; i++)
+            {
+                provider.Get(new StorageCell(new Address(Keccak.Compute($"r{i}")), 1));
+            }
+
+            provider.Commit(Frontier.Instance);
+            provider.CommitTree(0);
+            stateRoot = provider.StateRoot;
+        }
+
+        BlockHeader head = Build.A.BlockHeader.WithStateRoot(stateRoot).TestObject;
+        using (provider.BeginScope(head))
+        {
+            for (int i = 0; i < written.Length; i++)
+            {
+                Assert.That(provider.Get(new StorageCell(written[i], 1)).ToArray(), Is.EqualTo(_values[i + 1]),
+                    $"storage for written contract {i} was not persisted");
+            }
+        }
+    }
+
+    [Test]
     public void Can_commit_when_exactly_at_capacity_regression()
     {
         using Context ctx = new(useFlat);

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -235,18 +236,18 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
     private void UpdateRootHashesSingleThread(IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch)
     {
-        foreach (KeyValuePair<AddressAsKey, PerContractState> kvp in _storages)
+        foreach (KeyValuePair<AddressAsKey, bool> kvp in _toUpdateRoots)
         {
-            if (!_toUpdateRoots.TryGetValue(kvp.Key, out bool hasChanges) || !hasChanges)
+            if (!kvp.Value) continue;
+
+            if (!_storages.TryGetValue(kvp.Key, out PerContractState contractState))
             {
-                // Wasn't updated don't recalculate
+                Debug.Fail($"Storage root marked changed for {kvp.Key} but no contract state is present");
                 continue;
             }
 
-            PerContractState contractState = kvp.Value;
-
             (int writes, int skipped) = contractState.ProcessStorageChanges(
-                writeBatch.CreateStorageWriteBatch(kvp.Key, kvp.Value.EstimatedChanges));
+                writeBatch.CreateStorageWriteBatch(kvp.Key, contractState.EstimatedChanges));
 
             ReportMetrics(writes, skipped);
         }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.std.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.std.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Cpu;
@@ -29,13 +30,18 @@ internal sealed partial class PersistentStorageProvider
             IWorldStateScopeProvider.IStorageWriteBatch WriteBatch
             )> storages = new(_toUpdateRoots.Count);
 
-        foreach (KeyValuePair<AddressAsKey, PerContractState> kv in _storages)
+        foreach (KeyValuePair<AddressAsKey, bool> kv in _toUpdateRoots)
         {
-            if (!_toUpdateRoots.TryGetValue(kv.Key, out bool hasChanges) || !hasChanges) continue;
+            if (!kv.Value) continue;
+            if (!_storages.TryGetValue(kv.Key, out PerContractState contractState))
+            {
+                Debug.Fail($"Storage root marked changed for {kv.Key} but no contract state is present");
+                continue;
+            }
             storages.Add((
                 kv.Key,
-                kv.Value,
-                writeBatch.CreateStorageWriteBatch(kv.Key, kv.Value.EstimatedChanges)));
+                contractState,
+                writeBatch.CreateStorageWriteBatch(kv.Key, contractState.EstimatedChanges)));
         }
 
         if (storages.Count == 0) return;


### PR DESCRIPTION
## Changes

`PersistentStorageProvider.UpdateRootHashes`'s collect phase iterated **all** of `_storages` and filtered each entry through `_toUpdateRoots.hasChanges` (multi-thread in `PersistentStorageProvider.std.cs`, single-thread in `PersistentStorageProvider.cs`). `_storages` holds a `PerContractState` for every contract **read or warmed** — access-list / BAL prewarming and read-only `SLOAD`s all call `GetOrCreateStorage` — so it typically dwarfs `_toUpdateRoots`, which only holds the write set. The loop did `O(touched)` work to find the `O(changed)` contracts whose storage roots actually need recomputing.

This inverts both collect loops to enumerate `_toUpdateRoots` (the write set) and look the contract up in `_storages` — `O(changed)` iterations and dictionary lookups instead of `O(touched)`. The win scales with how much prewarming/reads inflate `_storages` over the write set.

**Byte-identical roots.** Every `_toUpdateRoots[k] == true` key is guaranteed present in `_storages` (each write is paired with `GetOrCreateStorage`, and `_storages` is only cleared by `ClearStorageMap` in `CommitTree`, strictly after the block-end `FlushToTree`), so the inverted enumeration yields exactly the same contract set. A `Debug.Fail` + `TryGetValue` fallback makes a future invariant violation loud in Debug builds instead of silently dropping a root; in Release the assert compiles out, leaving just the guard. The inverted enumeration stays in the single-threaded collect phase, before `ParallelUnbalancedWork` sets `_toUpdateRoots[key] = false`.

This is an algorithmic reduction rather than a micro-optimization — the absolute magnitude is modest (the loop is a few thousand cheap dictionary ops per block on mainnet), but it does strictly fewer iterations *and* fewer lookups than before, never more.

### Tests
- New regression test (runs flat + trie via the parameterized fixture): write to 4 contracts, warm 64 read-only contracts into `_storages`, commit + `CommitTree`, then re-open at the committed state root and assert every written contract's storage round-trips — guards that the inverted collect still recomputes every changed contract despite an inflated `_storages`.
- Existing `StorageProviderTests` (flat + trie) continue to pass — they pin the roots.

## Types of changes

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
