### PR TITLE
perf(consensus): drop the redundant bloom pass in the BAL parallel executor

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -243,7 +243,7 @@ public partial class BlockProcessor
                 }
 
                 incrementalValidation.GetResult();
-                return CombineReceipts(receiptsTracers, len, block);
+                return CombineReceipts(receiptsTracers, len);
             }
             finally
             {
@@ -356,22 +356,17 @@ public partial class BlockProcessor
             }
         }
 
-        private static TxReceipt[] CombineReceipts(BlockReceiptsTracer[] receiptsTracers, int len, Block block)
+        private static TxReceipt[] CombineReceipts(BlockReceiptsTracer[] receiptsTracers, int len)
         {
             TxReceipt[] result = new TxReceipt[len];
             ulong cumulativeGas = 0;
-            Bloom blockBloom = new();
             for (int i = 0; i < len; i++)
             {
                 result[i] = receiptsTracers[i].TxReceipts[0];
                 result[i].Index = i;
                 cumulativeGas += result[i].GasUsed;
                 result[i].GasUsedTotal = cumulativeGas;
-                result[i].CalculateBloom();
-                blockBloom.Accumulate(result[i].Bloom!);
             }
-
-            block.Header.Bloom = blockBloom;
 
             return result;
         }


### PR DESCRIPTION
## Changes

On the `BlockAccessList` parallel-execution path, `CombineReceipts` (`BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs`) ran a serial pass that (a) computed each receipt's bloom (`result[i].CalculateBloom()`), (b) accumulated them into a local `blockBloom`, and (c) set `block.Header.Bloom = blockBloom`. All three are redundant on this path:

- **Receipt blooms are recomputed immediately after.** `ProcessBlock` calls the shared `CalculateBlooms(receipts)` right after `ProcessTransactions` returns, and `TxReceipt.CalculateBloom()` is non-memoizing (`new Bloom(Logs)` every call) — so `CombineReceipts`' pass hashed every log's address + topics a second time.
- **The header-bloom write is dead.** `ReceiptsTracer.EndBlockTrace()` unconditionally rebuilds `Block.Header.Bloom` from the same receipts for non-empty blocks; for empty blocks the processed header is already `Bloom.Empty` (and `new Bloom()` is byte-identical). Nothing reads `header.Bloom` between `CombineReceipts` and `EndBlockTrace` — the only `TransactionsExecuted` subscriber just cancels a token, and the sequential path leaves `header.Bloom` empty across that same window while working correctly.

This deletes the three bloom lines (plus the now-unused `blockBloom` local and `block` parameter), keeping only the `Index` / `GasUsedTotal` assignment. The parallel path now derives blooms from the shared `CalculateBlooms` + `EndBlockTrace`, exactly like the sequential path — so the final receipt and header blooms are **byte-identical** and the two executors are unified. It's dormant on mainnet (`BlockAccessList` is EIP-7928-gated); the saved double-hash matters on BAL devnets and the self-BAL path. No global `CalculateBloom` memoization is introduced (`ReceiptsSyncFeed` deliberately force-recomputes).

### Safety / tests

This removes provably-redundant computation, so the final receipt and header blooms are byte-identical — they are produced by the untouched shared `CalculateBlooms` + `EndBlockTrace`. A dedicated unit test isn't meaningful here: re-adding the deleted lines yields the identical result, so nothing could "fail without the change." The guarantee is the byte-identical shared bloom path plus the existing comprehensive block-processing suites that exercise blooms end-to-end on both executors and the BAL path:

- `Nethermind.Blockchain.Test` — parallel executor, receipt-trie, and log-filter/bloom cases;
- `Nethermind.BalRecorder.Test` — BAL end-to-end with real execution (exercises this exact parallel path);
- `Nethermind.Consensus.Test` — block processing.

All green with this change.

## Types of changes

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
