### PR TITLE
perf(txpool): hoist the head-spec EIP-1559 flag out of the gas-bottleneck loop

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -744,6 +744,7 @@ namespace Nethermind.TxPool
             int i = 0;
             UInt256 cumulativeCost = 0;
             IReleaseSpec headSpec = _specProvider.GetCurrentHeadSpec();
+            bool isEip1559 = headSpec.IsEip1559Enabled;
             bool evictNextTxs = false;
 
             foreach (Transaction tx in transactions)
@@ -767,7 +768,7 @@ namespace Nethermind.TxPool
                     }
 
                     previousTxBottleneck ??= tx.CalculateAffordableGasPrice(
-                        _specProvider.GetCurrentHeadSpec().IsEip1559Enabled,
+                        isEip1559,
                         _headInfo.CurrentBaseFee, balance);
 
                     // it is not affecting non-blob txs - for them MaxFeePerBlobGas is null, so check is skipped
@@ -778,7 +779,7 @@ namespace Nethermind.TxPool
                     else if (tx.Nonce == currentNonce + (ulong)i)
                     {
                         UInt256 effectiveGasPrice =
-                            tx.CalculateEffectiveGasPrice(_specProvider.GetCurrentHeadSpec().IsEip1559Enabled,
+                            tx.CalculateEffectiveGasPrice(isEip1559,
                                 _headInfo.CurrentBaseFee);
 
                         if (tx.CheckForNotEnoughBalance(cumulativeCost, balance, out cumulativeCost))


### PR DESCRIPTION
## Changes

`UpdateGasBottleneckAndMarkForEviction` hoists `headSpec` (`_specProvider.GetCurrentHeadSpec()`) once and uses it for the `IsWellFormed` check — but the per-tx loop re-called `_specProvider.GetCurrentHeadSpec().IsEip1559Enabled` twice more (feeding `CalculateAffordableGasPrice` and `CalculateEffectiveGasPrice`).

`GetCurrentHeadSpec()` is not a field read: on `IChainHeadSpecProvider` it runs `FindBestSuggestedHeader()` (an `IBlockFinder` interface dispatch → `BlockTree.BestSuggestedHeader`) + `Volatile.Read` + a record `.Number` compare on every call, and the JIT can't CSE it across the loop (interface dispatch + a `Volatile.Write` side effect on cache miss).

This caches `headSpec.IsEip1559Enabled` in a local beside the existing hoist and uses it at both sites — matching the precedent already in `AddCore`. The head is stable while the method runs, so behavior is unchanged; it also makes the two sites consistent with the `IsWellFormed` check (which already uses the hoisted `headSpec`) rather than re-resolving the best header mid-loop.

### Safety / tests

Behavior-preserving hoist of a value that is stable across the loop, so no unit test could "fail without it" (re-adding the re-fetch yields the same result). The existing `Nethermind.TxPool.Test` gas-bottleneck / effective-gas-price assertions pin the equivalence — all green with this change.

## Types of changes

- [x] Optimization
- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
