### PR TITLE
feat(flatdb): warn to use FlatInTrie layout on low-RAM machines

### DIFF
--- a/src/Nethermind/Nethermind.Init/FlatStateActivationPolicy.cs
+++ b/src/Nethermind/Nethermind.Init/FlatStateActivationPolicy.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Linq;
 using Autofac.Features.AttributeFilters;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State.Flat;
@@ -13,15 +15,37 @@ namespace Nethermind.Init;
 
 internal sealed class FlatStateActivationPolicy(
     IFlatDbConfig flatDbConfig,
+    IHardwareInfo hardwareInfo,
     Lazy<IPersistence> flatPersistence,
     [KeyFilter(DbNames.State)] Lazy<IDb> patriciaStateDb,
     ILogManager logManager)
 {
-    private readonly bool _result = Compute(flatDbConfig, flatPersistence, patriciaStateDb, logManager.GetClassLogger<FlatStateActivationPolicy>());
+    private static readonly long LowMemoryLayoutThreshold = 16.GiB;
+
+    private readonly bool _result = Compute(flatDbConfig, hardwareInfo, flatPersistence, patriciaStateDb, logManager.GetClassLogger<FlatStateActivationPolicy>());
 
     public bool ShouldTurnOnFlatDb() => _result;
 
-    private static bool Compute(IFlatDbConfig flatDbConfig, Lazy<IPersistence> flatPersistence, Lazy<IDb> patriciaStateDb, ILogger logger)
+    private static bool Compute(IFlatDbConfig flatDbConfig, IHardwareInfo hardwareInfo, Lazy<IPersistence> flatPersistence, Lazy<IDb> patriciaStateDb, ILogger logger)
+    {
+        bool activateFlat = DecideBackend(flatDbConfig, flatPersistence, patriciaStateDb, logger);
+        if (activateFlat) AdviseLayoutForMemory(flatDbConfig, hardwareInfo, logger);
+        return activateFlat;
+    }
+
+    private static void AdviseLayoutForMemory(IFlatDbConfig flatDbConfig, IHardwareInfo hardwareInfo, ILogger logger)
+    {
+        if (flatDbConfig.Layout == FlatLayout.FlatInTrie) return;
+        if (hardwareInfo.AvailableMemoryBytes >= LowMemoryLayoutThreshold) return;
+        if (!logger.IsWarn) return;
+
+        logger.Warn(
+            $"Detected {hardwareInfo.AvailableMemoryBytes / 1.GiB} GB of available memory while running the flat DB with the '{flatDbConfig.Layout}' layout. " +
+            $"The '{nameof(FlatLayout.FlatInTrie)}' layout is recommended for machines with less than {LowMemoryLayoutThreshold / 1.GiB} GB of RAM. " +
+            $"Set '--FlatDb.Layout {nameof(FlatLayout.FlatInTrie)}' to switch (requires a fresh flat DB sync).");
+    }
+
+    private static bool DecideBackend(IFlatDbConfig flatDbConfig, Lazy<IPersistence> flatPersistence, Lazy<IDb> patriciaStateDb, ILogger logger)
     {
         if (!flatDbConfig.Enabled)
         {

--- a/src/Nethermind/Nethermind.Runner.Test/Module/FlatStateActivationPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/FlatStateActivationPolicyTests.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Linq;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Db;
 using Nethermind.Init;
 using Nethermind.Logging;
@@ -38,20 +41,62 @@ public class FlatStateActivationPolicyTests
     [TestCase(Flags.Enabled, true, Description = "Fresh node, flat enabled → true")]
     public void ShouldTurnOnFlatDb_ReturnsExpected(Flags flags, bool expected)
     {
+        FlatStateActivationPolicy policy = CreatePolicy(
+            enabled: flags.HasFlag(Flags.Enabled),
+            importFromPruning: flags.HasFlag(Flags.ImportFromPruningTrieState),
+            flatHasData: flags.HasFlag(Flags.FlatHasData),
+            patriciaHasData: flags.HasFlag(Flags.PatriciaHasData),
+            layout: FlatLayout.Flat,
+            availableMemoryBytes: 32.GiB,
+            logManager: LimboLogs.Instance);
+
+        Assert.That(policy.ShouldTurnOnFlatDb(), Is.EqualTo(expected));
+    }
+
+    // Advisory fires only when flat is actually activated, the layout is not FlatInTrie, and available memory < 16 GB.
+    [TestCase(true, FlatLayout.Flat, 8, true, Description = "Flat active, Flat layout, low RAM → warn")]
+    [TestCase(true, FlatLayout.FlatInTrie, 8, false, Description = "Already FlatInTrie → no warn")]
+    [TestCase(true, FlatLayout.Flat, 32, false, Description = "Ample RAM → no warn")]
+    [TestCase(false, FlatLayout.Flat, 8, false, Description = "Flat disabled (patricia) → no warn")]
+    public void AdvisesFlatInTrieLayout_OnlyWhenLowMemoryAndFlatActive(bool enabled, FlatLayout layout, int availableMemoryGiB, bool expectWarn)
+    {
+        TestLogger testLogger = new();
+        FlatStateActivationPolicy policy = CreatePolicy(
+            enabled: enabled,
+            importFromPruning: false,
+            flatHasData: false,
+            patriciaHasData: false,
+            layout: layout,
+            availableMemoryBytes: availableMemoryGiB.GiB,
+            logManager: new OneLoggerLogManager(new ILogger(testLogger)));
+
+        bool warned = testLogger.LogList.Any(l => l.Contains("--FlatDb.Layout") && l.Contains(nameof(FlatLayout.FlatInTrie)));
+        Assert.That(warned, Is.EqualTo(expectWarn));
+    }
+
+    private static FlatStateActivationPolicy CreatePolicy(
+        bool enabled, bool importFromPruning, bool flatHasData, bool patriciaHasData,
+        FlatLayout layout, long availableMemoryBytes, ILogManager logManager)
+    {
         IFlatDbConfig flatDbConfig = Substitute.For<IFlatDbConfig>();
-        flatDbConfig.Enabled.Returns(flags.HasFlag(Flags.Enabled));
-        flatDbConfig.ImportFromPruningTrieState.Returns(flags.HasFlag(Flags.ImportFromPruningTrieState));
+        flatDbConfig.Enabled.Returns(enabled);
+        flatDbConfig.ImportFromPruningTrieState.Returns(importFromPruning);
+        flatDbConfig.Layout.Returns(layout);
 
         IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
-        reader.CurrentState.Returns(flags.HasFlag(Flags.FlatHasData) ? new StateId(1, Nethermind.Core.Crypto.Keccak.Zero) : StateId.PreGenesis);
+        reader.CurrentState.Returns(flatHasData ? new StateId(1, Nethermind.Core.Crypto.Keccak.Zero) : StateId.PreGenesis);
         IPersistence flatPersistence = Substitute.For<IPersistence>();
         flatPersistence.CreateReader().Returns(reader);
 
         MemDb patriciaDb = new();
-        if (flags.HasFlag(Flags.PatriciaHasData))
+        if (patriciaHasData)
             patriciaDb.Set([1], [1]);
 
-        FlatStateActivationPolicy policy = new(flatDbConfig, new Lazy<IPersistence>(() => flatPersistence), new Lazy<IDb>(() => patriciaDb), LimboLogs.Instance);
-        Assert.That(policy.ShouldTurnOnFlatDb(), Is.EqualTo(expected));
+        return new FlatStateActivationPolicy(
+            flatDbConfig,
+            new TestHardwareInfo(availableMemoryBytes),
+            new Lazy<IPersistence>(() => flatPersistence),
+            new Lazy<IDb>(() => patriciaDb),
+            logManager);
     }
 }


### PR DESCRIPTION
## Changes

- When the flat DB is **activated** with a non-`FlatInTrie` layout and the detected available memory is **under 16 GB**, log a startup `WARN` recommending the `FlatInTrie` layout and giving the exact parameter to switch (`--FlatDb.Layout FlatInTrie`).
- The advisory lives in `FlatStateActivationPolicy`, next to the existing `"State backend: flat …"` startup lines. It fires only when flat is actually going to run (not when flat is enabled but the node falls back to patricia). It reuses `IHardwareInfo.AvailableMemoryBytes` — the same GC-based memory signal the existing 20 GiB `StateDbLargerMemoryThreshold` check uses.
- The flat-vs-patricia decision logic is unchanged (extracted verbatim into `DecideBackend`).

Example message:

> Detected 8 GB of available memory while running the flat DB with the 'Flat' layout. The 'FlatInTrie' layout is recommended for machines with less than 16 GB of RAM. Set '--FlatDb.Layout FlatInTrie' to switch (requires a fresh flat DB sync).

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Extended `FlatStateActivationPolicyTests` with a parameterized test covering the advisory: low RAM + `Flat` layout → warns; already `FlatInTrie` → no warn; ample RAM → no warn; flat disabled (patricia) → no warn. The existing DI-level `WorldStateDbDeciderModuleTests` continues to pass unchanged.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
