### PR TITLE
fix(db): flush all column families in ColumnsDb.Flush

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -61,8 +61,13 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         }
     }
 
-    // The base Flush only flushes WAL + the default column family; on a full flush we must also
-    // materialize every named column family's memtable (esp. for DisableWAL writes that have no WAL).
+    /// <inheritdoc/>
+    /// <remarks>
+    /// The base implementation flushes only the WAL and the default column family. On a full flush this
+    /// additionally materializes every named column family's memtable into SST, which is required for
+    /// <see cref="WriteFlags.DisableWAL"/> writes: they have no WAL entry, so unless their memtable is
+    /// flushed they are lost on restart.
+    /// </remarks>
     public override void Flush(bool onlyWal = false)
     {
         base.Flush(onlyWal);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -61,6 +61,20 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         }
     }
 
+    // The base Flush only flushes WAL + the default column family; on a full flush we must also
+    // materialize every named column family's memtable (esp. for DisableWAL writes that have no WAL).
+    public override void Flush(bool onlyWal = false)
+    {
+        base.Flush(onlyWal);
+        if (!onlyWal)
+        {
+            foreach (T key in ColumnKeys)
+            {
+                _columnDbs[key].Flush(onlyWal);
+            }
+        }
+    }
+
     private static IReadOnlyList<T> GetEnumKeys(IReadOnlyList<T> keys)
     {
         if (typeof(T).IsEnum && keys.Count == 0)

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1375,7 +1375,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
     }
 
-    public void Flush(bool onlyWal = false)
+    public virtual void Flush(bool onlyWal = false)
     {
         ObjectDisposedException.ThrowIf(_isDisposing, this);
 

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -145,4 +145,27 @@ public class ColumnsDbTests
 
         Assert.That(() => snapshot.GetColumn(ReceiptsColumns.Blocks), Throws.TypeOf<ObjectDisposedException>());
     }
+
+    [Test]
+    public void Flush_MaterializesNamedColumnFamilies_SurvivingReopen()
+    {
+        // Regression: a DisableWAL write to a NAMED column has no WAL entry, so it is only durable if
+        // Flush() materializes that column family's memtable into SST. Before the fix, ColumnsDb.Flush()
+        // flushed only the WAL and the default column family, so this write was lost after a reopen.
+        byte[] value = TestItem.KeccakA.BytesToArray();
+        _db.GetColumnDb(ReceiptsColumns.Blocks).Set(TestItem.KeccakA.Bytes, value, WriteFlags.DisableWAL);
+
+        _db.Flush();
+        _db.Dispose();
+
+        // Reopen the same on-disk DB (no DeleteOnStart) — the value must survive.
+        _db = new ColumnsDb<ReceiptsColumns>(DbPath,
+            new("Blocks", DbPath),
+            new DbConfig(),
+            new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(), LimboLogs.Instance, validateConfig: false),
+            LimboLogs.Instance,
+            Enum.GetValues<ReceiptsColumns>());
+
+        Assert.That(_db.GetColumnDb(ReceiptsColumns.Blocks).Get(TestItem.KeccakA), Is.EqualTo(value));
+    }
 }


### PR DESCRIPTION
## Changes

`ColumnsDb<T>` overrides `Compact()` to iterate every column family but never overrode `Flush()`, so `Flush()` fell through to `DbOnTheRocks.Flush()`, which flushes only the WAL and the **default** column family.

Callers that flush specifically to make `DisableWAL` (WAL-less) writes durable — `FlatSnapTrieFactory.FinalizeSync()` and the flat heal path (`FlatTreeSyncStore`), per their *"crash-durable once flushed"* contract — therefore never materialized the **named** flat column families' memtables into SST. On restart those writes were gone (no WAL entry, no SST), leaving the persisted flat columns incomplete relative to the trie (`MissingInFlat`), which surfaced as `InvalidStateRoot` / `insufficient funds` on flat + snap-sync + restart (Chiado/Gnosis).

This overrides `ColumnsDb.Flush(bool onlyWal)` to flush each named column family on a full flush (and makes `DbOnTheRocks.Flush` virtual). It keeps the `DisableWAL` fast bulk-load path while honoring the flush contract. The per-CF `ColumnDb.Flush` (→ `FlushWithColumnFamily` → `rocksdb_flush_cf`) already materializes an individual CF; this change just makes the columns DB fan out to all of them.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Validated against the Chiado flat sync + restart smoke test (`flatfix` scope): this branch **passes** with `MissingInFlat=0`, whereas `master` **fails** with `InvalidStateRoot` / insufficient-funds on the restart re-run. Two independent branches confirm the mechanism — routing the `DisableWAL` writes through the WAL (so WAL replay recovers them) also passes, while reverting the exit-flush default (#12047) does **not** (proving the gap is `ColumnsDb.Flush`, not the exit-flush mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
