### PR TITLE
refactor(snap): sequential code-existence filter instead of per-range PLINQ

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -293,9 +293,11 @@ namespace Nethermind.Synchronization.SnapSync
         {
             foreach (ValueHash256 hash in codeHashes)
             {
-                CodesToRetrieve.Enqueue(hash);
+                EnqueueCodeHash(hash);
             }
         }
+
+        public void EnqueueCodeHash(ValueHash256 hash) => CodesToRetrieve.Enqueue(hash);
 
         public void ReportCodeRequestFinished(ReadOnlySpan<ValueHash256> codeHashes)
         {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Autofac.Features.AttributeFilters;
@@ -90,23 +89,17 @@ namespace Nethermind.Synchronization.SnapSync
                     _progressTracker.EnqueueAccountStorage(item);
                 }
 
-                try
+                foreach (ValueHash256 code in CollectionsMarshal.AsSpan(codeHashes))
                 {
-                    using ArrayPoolListRef<ValueHash256> filteredCodeHashes = codeHashes.AsParallel().Where((code) =>
+                    if (_codeExistKeyCache.Get(code)) continue;
+
+                    if (_codeDb.KeyExists(code.Bytes))
                     {
-                        if (_codeExistKeyCache.Get(code)) return false;
+                        _codeExistKeyCache.Set(code);
+                        continue;
+                    }
 
-                        bool exist = _codeDb.KeyExists(code.Bytes);
-                        if (exist) _codeExistKeyCache.Set(code);
-                        return !exist;
-                    }).ToPooledListRef(codeHashes.Count);
-
-                    _progressTracker.EnqueueCodeHashes(filteredCodeHashes.AsSpan());
-                }
-                catch (AggregateException ae) when (ae.Flatten().InnerExceptions is { Count: > 0 } inners
-                    && inners.All(e => e is ObjectDisposedException))
-                {
-                    ExceptionDispatchInfo.Capture(inners[0]).Throw();
+                    _progressTracker.EnqueueCodeHash(code);
                 }
 
                 ValueHash256 nextPath = accounts[^1].Path.IncrementPath();


### PR DESCRIPTION
## Changes

`AddAccountRange` filtered the block's code hashes with `codeHashes.AsParallel().Where(...).ToPooledListRef(...)`. But:

- The `Where` predicate is a ~97%-effective cache lookup (`_codeExistKeyCache`, documented at `SnapProvider.cs:31`) that only touches RocksDB — bloom-filtered `KeyExists` — on the ~3% miss.
- Read concurrency already exists at a coarser grain: `SimpleDispatcher` fans `HandleResponse` → `AddAccountRange` out via `Task.Run` up to `Environment.ProcessorCount`. So the per-request `AsParallel` was a **redundant second parallelism layer**, paying partition/merge/dispatch on every `AddAccountRange`.
- PLINQ wraps worker exceptions in `AggregateException`, which forced a guard clause (`catch (AggregateException) when (…all ObjectDisposedException) { ExceptionDispatchInfo… }`) that existed *only* to unwrap the shutdown-race `ObjectDisposedException` so it reaches `SimpleDispatcher.HandleResponse`'s `catch (ObjectDisposedException)` (the #11806 / #11807 fix).

This replaces the PLINQ with a plain sequential `foreach` into the pooled list (cache-hit fast path, DB `KeyExists` only on miss). `AssociativeKeyCache` is concurrency-safe either way and the enqueue order is irrelevant, so the filtered set is identical. The sequential `KeyExists` throws `ObjectDisposedException` **directly** on shutdown — it propagates unchanged through `SnapSyncFeed.HandleResponse` (which only has a `finally`) to `SimpleDispatcher.HandleResponse`'s `catch (ObjectDisposedException)` — so the `AggregateException` guard and its `ExceptionDispatchInfo` re-throw collapse while preserving the shutdown-race fix.

Net: removes a redundant parallelism layer and a guard clause. The perf delta is unmeasured and likely small (the ~3% misses are already-parallelized, bloom-filtered lookups); the certain payoff is the simplification.

### Safety / tests

Behavior-preserving — same filtered set, same shutdown-race handling — so no unit test could "fail without it". Covered by the existing `Nethermind.Synchronization.Test` snap-sync suite, all green with this change.

## Types of changes

- [x] Refactoring
- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
