### PR TITLE
fix(blockchain): bound BadBlockStore by entry count, not DB byte size

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/BadBlockStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/BadBlockStoreTests.cs
@@ -6,6 +6,7 @@ using Nethermind.Blockchain.Blocks;
 using Nethermind.Core;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
 using NUnit.Framework;
 
 namespace Nethermind.Blockchain.Test.Blocks;
@@ -59,4 +60,34 @@ public class BadBlockStoreTests
         Assert.That(count, Is.EqualTo(2));
     }
 
+    [Test]
+    public void Test_LimitStoredBlock_bounds_by_entry_count_not_byte_size()
+    {
+        BadBlockStore badBlockStore = new(new ByteSizeMemDb(), 2);
+
+        List<Block> toAdd =
+        [
+            Build.A.Block.WithNumber(1).TestObject,
+            Build.A.Block.WithNumber(2).TestObject,
+            Build.A.Block.WithNumber(3).TestObject,
+        ];
+
+        foreach (Block block in toAdd)
+        {
+            badBlockStore.Insert(block);
+        }
+
+        int count = 0;
+        foreach (Block _ in badBlockStore.GetAll())
+        {
+            count++;
+        }
+
+        Assert.That(count, Is.EqualTo(2));
+    }
+
+    private sealed class ByteSizeMemDb : MemDb
+    {
+        public override IDbMeta.DbMetric GatherMetric() => new() { Size = Count * 1024 };
+    }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BadBlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BadBlockStore.cs
@@ -37,7 +37,7 @@ public class BadBlockStore(IDb blockDb, long maxSize) : IBadBlockStore
 
     private void TruncateToMaxSize()
     {
-        int toDelete = (int)(blockDb.GetAllKeys().Count() - maxSize);
+        int toDelete = (int)(blockDb.EstimatedCount - maxSize);
         if (toDelete > 0)
         {
             foreach (Block blockToDelete in GetAll().Take(toDelete))

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BadBlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BadBlockStore.cs
@@ -37,7 +37,7 @@ public class BadBlockStore(IDb blockDb, long maxSize) : IBadBlockStore
 
     private void TruncateToMaxSize()
     {
-        int toDelete = (int)(blockDb.GatherMetric().Size - maxSize!);
+        int toDelete = (int)(blockDb.GetAllKeys().Count() - maxSize);
         if (toDelete > 0)
         {
             foreach (Block blockToDelete in GetAll().Take(toDelete))

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -373,6 +373,29 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         };
     }
 
+    public long EstimatedCount
+    {
+        get
+        {
+            if (_isDisposed)
+            {
+                return 0;
+            }
+
+            try
+            {
+                return FetchTotalPropertyValue("rocksdb.estimate-num-keys");
+            }
+            catch (RocksDbSharpException e)
+            {
+                if (_logger.IsWarn)
+                    _logger.Warn($"Failed to read DB key count estimate {e.Message}");
+            }
+
+            return 0;
+        }
+    }
+
     private long GetSize()
     {
         try

--- a/src/Nethermind/Nethermind.Db/IDb.cs
+++ b/src/Nethermind/Nethermind.Db/IDb.cs
@@ -23,6 +23,8 @@ namespace Nethermind.Db
     {
         DbMetric GatherMetric() => new();
 
+        long EstimatedCount => 0;
+
         void Flush(bool onlyWal = false);
         void Clear() { }
         void Compact() { }

--- a/src/Nethermind/Nethermind.Db/MemDb.cs
+++ b/src/Nethermind/Nethermind.Db/MemDb.cs
@@ -135,6 +135,8 @@ namespace Nethermind.Db
 
         public virtual IDbMeta.DbMetric GatherMetric() => new() { Size = Count };
 
+        public long EstimatedCount => Count;
+
         private IEnumerable<KeyValuePair<byte[], byte[]?>> OrderedDb => _db.OrderBy(kvp => kvp.Key, Bytes.Comparer);
     }
 }


### PR DESCRIPTION
## Changes

`BadBlockStore.TruncateToMaxSize` computed `toDelete = blockDb.GatherMetric().Size - maxSize`, but `GatherMetric().Size` is the DB's **byte size** while `maxSize` (`BadBlocksStored`, default 100) is an **entry count** — two unrelated quantities. On RocksDB:

- while writes sit in the memtable the reported byte size is ~0, so `toDelete ≤ 0` and nothing is evicted — the store grows past the limit;
- once flushed to SST the byte size jumps, so `toDelete` balloons and `GetAll().Take(toDelete)` deletes **every** stored block.

Either way the store is never bounded to `BadBlocksStored`.

This computes `toDelete` from the actual entry count (`blockDb.GetAllKeys().Count()`), so the store keeps the newest `BadBlocksStored` blocks and evicts the oldest surplus (unchanged eviction order — `GetAll()` is key-ordered, oldest first), independent of on-disk byte size. I used an exact key count rather than an in-memory counter or a RocksDB `estimate-num-keys`: bad-block inserts are rare and the store is small, so a stateless `O(n)` count is simplest and avoids bookkeeping/approximation.

### Tests
- New regression test using a `MemDb` whose `GatherMetric().Size` reports bytes instead of the entry count. The default `MemDb` returns `Size == Count` (`MemDb.cs:136`), which masked the bug — the existing `Test_LimitStoredBlock` passes on the buggy code for exactly that reason. With the byte-size DB, inserting 3 blocks under a limit of 2 leaves `0` on the old code and exactly `2` with the fix.
- Existing `BadBlockStoreTests` continue to pass.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
