### PR TITLE
feat(specs): Hegota fork scaffolding (EIP-8081)

### DIFF
--- a/src/Nethermind/Nethermind.Specs.Test/ForkTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ForkTests.cs
@@ -14,6 +14,21 @@ namespace Nethermind.Specs.Test;
 public class ForkTests
 {
     [Test]
+    public void Hegota_Inherits_Amsterdam_And_Is_Parseable()
+    {
+        NamedReleaseSpec hegota = Hegota.Instance;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(hegota.Name, Is.EqualTo("Hegota"));
+            Assert.That(hegota.Parent, Is.SameAs(Amsterdam.Instance));
+            Assert.That(hegota.IsEip7928Enabled, Is.True, "must inherit Amsterdam EIPs");
+            Assert.That(hegota.IntroducesEngineApiChange(), Is.False, "no engine API delta scheduled yet");
+            Assert.That(SpecNameParser.Parse("Hegota"), Is.SameAs(hegota));
+        }
+    }
+
+    [Test]
     public void GetLatest_Matches_FoundationJson()
     {
         // Load foundation.json — source of truth for mainnet forks

--- a/src/Nethermind/Nethermind.Specs/Forks/26_Hegota.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/26_Hegota.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Specs.Forks;
+
+/// <summary>
+/// Hegotá network upgrade (EIP-8081), following Amsterdam (Glamsterdam).
+/// </summary>
+/// <remarks>
+/// The EIP set is not final yet — EIPs are added here as they get scheduled for
+/// inclusion and implemented. See https://eips.ethereum.org/EIPS/eip-8081.
+/// </remarks>
+public class Hegota() : NamedReleaseSpec<Hegota>(Amsterdam.Instance)
+{
+    public override void Apply(NamedReleaseSpec spec) => spec.Name = "Hegota";
+}

--- a/src/Nethermind/Nethermind.Specs/SpecNameParser.cs
+++ b/src/Nethermind/Nethermind.Specs/SpecNameParser.cs
@@ -62,6 +62,7 @@ namespace Nethermind.Specs
                 "BPO4" => BPO4.Instance,
                 "BPO5" => BPO5.Instance,
                 "Amsterdam" => Amsterdam.Instance,
+                "Hegota" => Hegota.Instance,
                 _ => throw new NotSupportedException()
             };
         }


### PR DESCRIPTION
## Changes

- Add `26_Hegota.cs` named release spec for the Hegotá network upgrade ([EIP-8081](https://eips.ethereum.org/EIPS/eip-8081)), inheriting Amsterdam
- Register `Hegota` in `SpecNameParser`
- Regression test: Hegota inherits Amsterdam EIPs, has no engine-API delta yet, and is parseable by name

The fork intentionally carries **no EIP delta yet** — per-EIP flags land in their own PRs as the Hegotá EIPs are implemented (tracking: EIP-7805 FOCIL is Scheduled for Inclusion; EIP-8141 is CFI). `MainnetSpecProvider` is not touched because Amsterdam already occupies the `ulong.MaxValue` placeholder slot; Hegotá enters the mainnet schedule once real timestamps exist.

Part of the Hegotá (EIP-8081) PR series.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Nethermind.Specs.Test` ForkTests pass, including `GetLatest_Matches_FoundationJson`.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)