### PR TITLE
feat(consensus): EIP-8253 bump nonce of zero-nonce storage accounts

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -1320,6 +1320,8 @@ public class BlockProcessorTests
         {
         }
 
+        public int ApplyEip8253Transition(IReleaseSpec spec) => 0;
+
         public void ApplyBlockhashStateChanges(BlockHeader header, IReleaseSpec spec)
         {
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Eip8253TransitionTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Eip8253TransitionTests.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Test;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test;
+
+public class Eip8253TransitionTests
+{
+    private static readonly ReleaseSpec EnabledSpec = new() { IsEip8253Enabled = true };
+    private static readonly ReleaseSpec DisabledSpec = new();
+
+    [Test]
+    public void Bumps_only_existing_zero_nonce_accounts_and_is_one_shot()
+    {
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+
+        stateProvider.CreateAccount(Eip8253Data.Accounts[0], UInt256.One);
+        stateProvider.CreateAccount(Eip8253Data.Accounts[1], UInt256.One);
+        stateProvider.CreateAccount(Eip8253Data.Accounts[2], UInt256.One);
+        stateProvider.SetNonce(Eip8253Data.Accounts[2], 5);
+        // Eip8253Data.Accounts[3] intentionally left nonexistent.
+
+        int bumped = Eip8253Transition.Apply(stateProvider, EnabledSpec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(bumped, Is.EqualTo(2));
+            Assert.That(stateProvider.GetNonce(Eip8253Data.Accounts[0]), Is.EqualTo(1ul));
+            Assert.That(stateProvider.GetNonce(Eip8253Data.Accounts[1]), Is.EqualTo(1ul));
+            Assert.That(stateProvider.GetNonce(Eip8253Data.Accounts[2]), Is.EqualTo(5ul), "non-zero nonce must not be reset");
+            Assert.That(stateProvider.AccountExists(Eip8253Data.Accounts[3]), Is.False, "nonexistent accounts must not be created");
+        }
+
+        Assert.That(Eip8253Transition.Apply(stateProvider, EnabledSpec), Is.Zero, "second application must be a no-op");
+    }
+
+    [Test]
+    public void Does_nothing_when_disabled()
+    {
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+
+        stateProvider.CreateAccount(Eip8253Data.Accounts[0], UInt256.One);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Eip8253Transition.Apply(stateProvider, DisabledSpec), Is.Zero);
+            Assert.That(stateProvider.GetNonce(Eip8253Data.Accounts[0]), Is.Zero);
+        }
+    }
+
+    [Test]
+    public void Account_list_matches_eip_asset() =>
+        Assert.That(Eip8253Data.Accounts, Has.Length.EqualTo(28));
+}

--- a/src/Nethermind/Nethermind.Blockchain/Eip8253Data.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Eip8253Data.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+
+namespace Nethermind.Blockchain;
+
+/// <summary>
+/// Accounts targeted by the EIP-8253 irregular state transition: mainnet accounts with
+/// empty code, zero nonce, and non-empty storage whose nonce is bumped to 1 at fork activation.
+/// </summary>
+/// <remarks>
+/// Source of truth: https://eips.ethereum.org/assets/eip-8253/targeted-accounts.json (28 entries).
+/// </remarks>
+public static class Eip8253Data
+{
+    public static readonly Address[] Accounts =
+    [
+        new("0xf468bcbc4a0bfdb06336e773382c5202e674db71"),
+        new("0xd8253352f6044cfe55bcc0748c3fa37b7df81f98"),
+        new("0x5983c6ac846dcf85fbbc4303f43eb91c379f79ae"),
+        new("0xde425ad4b8d2d9e0e12f65cbcd6d55f447b44083"),
+        new("0x50b1497068bae652df3562eb8ea7677ff84477fa"),
+        new("0x8398ff6c618e9515468c1c4b198d53666cbe8462"),
+        new("0x6f156dbf8ed30e53f7c9df73144e69f65cbb7e94"),
+        new("0x2c081ed1949d7dd9447f9d96e509befe576d4461"),
+        new("0xdb7c577b93baeb56dab50af4d6f86f99a06b96a2"),
+        new("0x14725085d004f1b10ee07234a4ab28c5ad2a7b9e"),
+        new("0xae3703584494ade958ad27ec2d289b7a67c19e90"),
+        new("0x7d6ae067de8d44ae1a08750e7d626d61a623c44a"),
+        new("0x4d149eb99bdeefc1f858f8fd22289c6beae99f2c"),
+        new("0x361d7a60b43587c7f6bba4f9fd9642747f65210a"),
+        new("0xb619f45637c39ca49a41ac64c11637a0a194455e"),
+        new("0x5071cb62aa170b7f66b26cae8004d90e6078bb1e"),
+        new("0xadd92e0650457c5db0c4c08cbf7ca580175d33d2"),
+        new("0x3311c08066580cb906a7287b6786e504c2ebd09f"),
+        new("0x02820e4bee488c40f7455fdca53125565148708f"),
+        new("0xe62dc49c92fa799033644d2a9afd7e3babe5a80a"),
+        new("0x5cc182fabfb81a056b6080d4200bc5150673d06f"),
+        new("0xf4a835ec1364809003de3925685f24cd360bdffe"),
+        new("0xfc4465f84b29a1f8794dc753f41bef1f4b025ed2"),
+        new("0x40490c9c468622d5c89646d6f3097f8eaf80c411"),
+        new("0xa21b22389bfc1cd6bc7ba19a4fc96adc3d0fe074"),
+        new("0x59ec0410867828e3b8c23dd8a29d9796ef523b17"),
+        new("0x19272418753b90d9a3e3efc8430b1612c55fcb3a"),
+        new("0xfee7707fa4b8c0a923a0e40399db3e7ce26069c6"),
+    ];
+}

--- a/src/Nethermind/Nethermind.Blockchain/Eip8253Transition.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Eip8253Transition.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
+
+namespace Nethermind.Blockchain;
+
+/// <summary>
+/// EIP-8253: bumps the nonce of the listed zero-nonce storage accounts to 1 at fork activation,
+/// before any pre-execution system contract calls and before any transactions.
+/// </summary>
+public static class Eip8253Transition
+{
+    /// <summary>
+    /// Applies the transition to every <see cref="Eip8253Data.Accounts"/> entry that still has
+    /// a zero nonce.
+    /// </summary>
+    /// <returns>The number of accounts bumped; 0 when the EIP is disabled or already applied.</returns>
+    /// <remarks>
+    /// The transition is keyed off state rather than the activation block: nonces never decrease
+    /// and the listed accounts cannot self-destruct (empty code), so a zero nonce is observable
+    /// only before the transition has run. This makes the check reorg-safe without needing the
+    /// parent header to detect the fork boundary. The checks use
+    /// <see cref="IWorldState.PeekNonce"/> so the per-block probe never leaks into EIP-7928
+    /// block access lists; the nonce writes go through <see cref="IWorldState.SetNonce"/> and are
+    /// therefore recorded as <c>NonceChange</c> entries at the pre-execution access index,
+    /// as the EIP requires.
+    /// </remarks>
+    public static int Apply(IWorldState worldState, IReleaseSpec spec)
+    {
+        if (!spec.IsEip8253Enabled) return 0;
+
+        int bumped = 0;
+        foreach (Address account in Eip8253Data.Accounts)
+        {
+            // PeekNonce is null for nonexistent accounts, so only existing zero-nonce accounts match.
+            if (worldState.PeekNonce(account) == 0)
+            {
+                worldState.SetNonce(account, 1);
+                bumped++;
+            }
+        }
+
+        return bumped;
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.SystemContracts.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.SystemContracts.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Consensus.ExecutionRequests;
@@ -36,6 +37,18 @@ public partial class BlockAccessListManager
 
         TxProcessorWithWorldState preExecution = _txProcessorWithWorldStateManager.GetPreExecution();
         new BlockhashStore(preExecution.WorldState).ApplyBlockhashStateChanges(header, spec);
+    }
+
+    /// <summary>
+    /// EIP-8253 nonce bumps routed through the pre-execution worldstate so the resulting
+    /// <c>NonceChange</c> entries are recorded at the pre-execution block access index.
+    /// </summary>
+    public int ApplyEip8253Transition(IReleaseSpec spec)
+    {
+        CheckInitialized();
+
+        TxProcessorWithWorldState preExecution = _txProcessorWithWorldStateManager.GetPreExecution();
+        return Eip8253Transition.Apply(preExecution.WorldState, spec);
     }
 
     public void ApplyAuRaPreprocessingChanges(IReleaseSpec spec, Address withdrawalContractAddress)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockAccessListSystemContractHandler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockAccessListSystemContractHandler.cs
@@ -40,5 +40,8 @@ public partial class BlockProcessor
 
         public void ProcessWithdrawals(Block block, IReleaseSpec spec)
             => balManager.ProcessWithdrawals(block, spec);
+
+        public int ApplyEip8253Transition(IWorldState worldState, IReleaseSpec spec)
+            => balManager.ApplyEip8253Transition(spec);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.SystemContractHandler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.SystemContractHandler.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Consensus.ExecutionRequests;
@@ -18,7 +19,15 @@ public partial class BlockProcessor
 {
     public interface ISystemContractHandler
         : IBeaconBlockRootHandler, IBlockhashStore, IWithdrawalProcessor, IExecutionRequestsProcessor
-    { }
+    {
+        /// <summary>
+        /// Applies the EIP-8253 zero-nonce storage account transition (see <see cref="Eip8253Transition"/>),
+        /// routing the writes through the world state whose changes are recorded at the
+        /// pre-execution block access index.
+        /// </summary>
+        /// <returns>The number of accounts bumped.</returns>
+        int ApplyEip8253Transition(IWorldState worldState, IReleaseSpec spec);
+    }
 
     public sealed class SystemContractHandler(
         IBeaconBlockRootHandler beaconBlockRootHandler,
@@ -46,5 +55,8 @@ public partial class BlockProcessor
 
         public void ProcessWithdrawals(Block block, IReleaseSpec spec)
             => withdrawalProcessor.ProcessWithdrawals(block, spec);
+
+        public int ApplyEip8253Transition(IWorldState worldState, IReleaseSpec spec)
+            => Eip8253Transition.Apply(worldState, spec);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -130,6 +130,9 @@ public partial class BlockProcessor(
 
         _balManager.Setup(block);
 
+        int bumpedNonces = _systemContractHandler.ApplyEip8253Transition(_stateProvider, spec);
+        if (bumpedNonces > 0 && _logger.IsInfo) _logger.Info($"Applied the EIP-8253 transition to {bumpedNonces} zero-nonce storage accounts");
+
         _systemContractHandler.StoreBeaconRoot(block, spec, NullTxTracer.Instance);
         _systemContractHandler.ApplyBlockhashStateChanges(header, spec);
         CommitState(spec);

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockAccessListManager.cs
@@ -56,6 +56,13 @@ public interface IBlockAccessListManager
     void SetBlockAccessList(Block block);
     void ValidateBlockAccessList(Block block, uint index, bool validateStorageReads = true);
     void StoreBeaconRoot(Block block, IReleaseSpec spec);
+
+    /// <summary>
+    /// EIP-8253 nonce bumps routed through the pre-execution worldstate so the resulting
+    /// <c>NonceChange</c> entries are recorded at the pre-execution block access index.
+    /// </summary>
+    /// <returns>The number of accounts bumped.</returns>
+    int ApplyEip8253Transition(IReleaseSpec spec);
     void ApplyBlockhashStateChanges(BlockHeader header, IReleaseSpec spec);
     void ProcessWithdrawals(Block block, IReleaseSpec spec);
     void ProcessExecutionRequests(Block block, TxReceipt[] txReceipts, IReleaseSpec spec);

--- a/src/Nethermind/Nethermind.Consensus/Processing/NullBlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/NullBlockAccessListManager.cs
@@ -37,6 +37,7 @@ public class NullBlockAccessListManager : IBlockAccessListManager
     public void SetBlockAccessList(Block block) { }
     public void ValidateBlockAccessList(Block block, uint index, bool validateStorageReads = true) { }
     public void StoreBeaconRoot(Block block, IReleaseSpec spec) { }
+    public int ApplyEip8253Transition(IReleaseSpec spec) => 0;
     public void ApplyBlockhashStateChanges(BlockHeader header, IReleaseSpec spec) { }
     public void ProcessWithdrawals(Block block, IReleaseSpec spec) { }
     public void ProcessExecutionRequests(Block block, TxReceipt[] txReceipts, IReleaseSpec spec) { }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -464,6 +464,12 @@ namespace Nethermind.Core.Specs
         public bool IsEip7954Enabled { get; }
 
         /// <summary>
+        /// EIP-8253: Bump nonce of zero-nonce storage accounts.
+        /// One-shot irregular state transition at fork activation.
+        /// </summary>
+        public bool IsEip8253Enabled { get; }
+
+        /// <summary>
         /// Precomputed gas cost and refund constants derived from this spec.
         /// Values are cached per spec instance (singletons per fork) to avoid
         /// repeated interface dispatch on the EVM opcode hot path.

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -117,5 +117,6 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip7843Enabled => spec.IsEip7843Enabled;
     public virtual bool IsEip7954Enabled => spec.IsEip7954Enabled;
     public virtual bool IsEip8024Enabled => spec.IsEip8024Enabled;
+    public virtual bool IsEip8253Enabled => spec.IsEip8253Enabled;
     public SpecGasCosts GasCosts => spec.GasCosts;
 }

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -132,6 +132,20 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
 
     void SetNonce(Address address, in ulong nonce);
 
+    /// <summary>
+    /// Reads an account nonce without recording the access in access-tracking decorators
+    /// (e.g. EIP-7928 block access list generation).
+    /// </summary>
+    /// <returns>The nonce, or <c>null</c> when the account does not exist.</returns>
+    /// <remarks>
+    /// Intended for protocol-internal bookkeeping (e.g. detecting whether a one-shot fork
+    /// transition has already been applied) that must stay invisible in consensus artifacts.
+    /// Decorators forward this to the wrapped state, so the read bypasses world-state-level
+    /// tracking while still reaching the underlying trie (trie-level witness capture is
+    /// unaffected).
+    /// </remarks>
+    ulong? PeekNonce(Address address) => AccountExists(address) ? GetNonce(address) : null;
+
     /* snapshots */
     void Commit(IReleaseSpec releaseSpec, IWorldStateTracer tracer, bool isGenesis = false, bool commitRoots = true);
 

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -112,6 +112,7 @@ namespace Nethermind.Specs.Test
         public ulong ElasticityMultiplier { get; set; } = spec.ElasticityMultiplier;
         public IBaseFeeCalculator BaseFeeCalculator { get; set; } = spec.BaseFeeCalculator;
         public bool IsEip8024Enabled { get; set; } = spec.IsEip8024Enabled;
+        public bool IsEip8253Enabled { get; set; } = spec.IsEip8253Enabled;
         public bool IsEip6110Enabled { get; set; } = spec.IsEip6110Enabled;
         public Address? DepositContractAddress { get; set; } = spec.DepositContractAddress;
         public bool IsEip7594Enabled { get; set; } = spec.IsEip7594Enabled;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -186,4 +186,5 @@ public class ChainParameters
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip8253TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -356,6 +356,8 @@ namespace Nethermind.Specs.ChainSpecStyle
                 releaseSpec.MaxCodeSize = CodeSizeConstants.MaxCodeSizeEip7954;
             }
 
+            releaseSpec.IsEip8253Enabled = (chainSpec.Parameters.Eip8253TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)
             {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -215,6 +215,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8024TransitionTimestamp = chainSpecJson.Params.Eip8024TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
+            Eip8253TransitionTimestamp = chainSpecJson.Params.Eip8253TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -193,6 +193,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip8253TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -169,6 +169,7 @@ public class ReleaseSpec : IReleaseSpec
 
     public bool IsEip7708Enabled { get; set; }
     public bool IsEip7954Enabled { get; set; }
+    public bool IsEip8253Enabled { get; set; }
 
     private ReleaseSpec? _systemSpec;
 

--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -82,6 +82,29 @@ public class TracedAccessWorldStateTests(bool parallel)
         }
     }
 
+    [Test]
+    public void PeekNonce_DoesNotRecordAccountRead()
+    {
+        (TracedAccessWorldState tws, IDisposable scope) = CreateTracingState(ws =>
+            ws.CreateAccount(TestItem.AddressA, 0));
+        using (scope)
+        {
+            ulong? nonce = tws.PeekNonce(TestItem.AddressA);
+            ulong? missing = tws.PeekNonce(TestItem.AddressB);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(nonce, Is.EqualTo(0ul));
+                Assert.That(missing, Is.Null);
+                Assert.That(tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA), Is.Null, "peek must stay out of the BAL");
+            }
+
+            // The traced read is the contrast case: it must create the account entry the peek didn't.
+            tws.GetNonce(TestItem.AddressA);
+            Assert.That(tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA), Is.Not.Null);
+        }
+    }
+
     [TestCase(true, 1ul, 1ul, TestName = "IncrementNonce")]
     [TestCase(false, 5ul, 5ul, TestName = "SetNonce")]
     public void NonceOp_RecordsNonceChange(

--- a/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
@@ -38,6 +38,9 @@ public abstract class WorldStateDecorator(IWorldState state) : IWorldState
     public virtual ulong GetNonce(Address address)
         => State.GetNonce(address);
 
+    public virtual ulong? PeekNonce(Address address)
+        => State.PeekNonce(address);
+
     public virtual bool IsStorageEmpty(Address address)
         => State.IsStorageEmpty(address);
 


### PR DESCRIPTION
## Changes

- `IsEip8253Enabled` spec flag + `eip8253TransitionTimestamp` chainspec parameter (full plumbing through `ChainParameters`/`ChainSpecParamsJson`/`ChainSpecLoader`/`ChainSpecBasedSpecProvider`)
- `Eip8253Data` — the 28 targeted mainnet accounts, verified against the EIP's `targeted-accounts.json` asset
- `Eip8253Transition.Apply` — bumps nonce 0 → 1 for listed accounts that exist, before pre-execution system contract calls and before any transactions
- New `IWorldState.PeekNonce` — reads a nonce without recording the access in access-tracking decorators; used for the per-block "already applied?" probe so it never leaks into EIP-7928 block access lists (regression-tested in `TracedAccessWorldStateTests`)
- BAL integration: on the BAL path the writes route through the manager's pre-execution worldstate, so the `NonceChange [0, 1]` entries are recorded at the pre-execution block access index, as the EIP requires
- The trigger is state-keyed rather than fork-boundary-keyed: nonces never decrease and the listed accounts cannot self-destruct (empty code), so a zero nonce is observable only before the transition ran — reorg-safe with no parent-header plumbing

Spec: https://eips.ethereum.org/EIPS/eip-8253 (Hegotá / EIP-8081 candidate). The flag is not yet activated in any fork file — activation lands with the Hegotá fork wiring (#12226).

Part of the Hegotá (EIP-8081) PR series.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `Eip8253TransitionTests`: bumps only existing zero-nonce accounts, one-shot idempotence, disabled no-op, list length pinned to the EIP asset
- `TracedAccessWorldStateTests.PeekNonce_DoesNotRecordAccountRead`: BAL invisibility of the probe (both sequential and parallel fixtures)
- `BlockProcessorTests` suite passes unchanged

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)