### PR TITLE
feat(evm): EIP-8131 unified transaction content floor

### DIFF
--- a/src/Nethermind/Nethermind.Core/GasCostOf.cs
+++ b/src/Nethermind/Nethermind.Core/GasCostOf.cs
@@ -69,6 +69,9 @@ namespace Nethermind.Core
         public const ulong PerAuthBaseCost = Eip7702Constants.PerAuthBaseCost;
         public const ulong TotalCostFloorPerTokenEip7623 = 10; // eip-7623
         public const ulong TotalCostFloorPerTokenEip7976 = 16; // eip-7976
+        public const ulong FloorGasPerByteEip8131 = 64; // eip-8131
+        public const ulong AuthTupleBytesEip8131 = 108; // eip-8131
+        public const ulong BlobVersionedHashBytesEip8131 = 32; // eip-8131
 
         public const ulong CostPerStateByte = 1530; // eip-8037
         public const ulong StateBytesPerStorageSet = 64; // eip-8037

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -464,6 +464,13 @@ namespace Nethermind.Core.Specs
         public bool IsEip7954Enabled { get; }
 
         /// <summary>
+        /// EIP-8131: Unified Transaction Content Floor.
+        /// One per-byte floor rule across calldata, access lists, authorizations, and blob
+        /// versioned hashes, replacing the EIP-7623/EIP-7976/EIP-7981 floor rules.
+        /// </summary>
+        public bool IsEip8131Enabled { get; }
+
+        /// <summary>
         /// Precomputed gas cost and refund constants derived from this spec.
         /// Values are cached per spec instance (singletons per fork) to avoid
         /// repeated interface dispatch on the EVM opcode hot path.

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -117,5 +117,6 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip7843Enabled => spec.IsEip7843Enabled;
     public virtual bool IsEip7954Enabled => spec.IsEip7954Enabled;
     public virtual bool IsEip8024Enabled => spec.IsEip8024Enabled;
+    public virtual bool IsEip8131Enabled => spec.IsEip8131Enabled;
     public SpecGasCosts GasCosts => spec.GasCosts;
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8131Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8131Tests.cs
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Eip2930;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-8131: unified transaction content floor — one per-byte floor rule across
+/// calldata, access lists, authorization tuples, and blob versioned hashes, replacing the
+/// EIP-7623/EIP-7976/EIP-7981 floor rules.
+/// </summary>
+[TestFixture]
+public class Eip8131Tests
+{
+    private static readonly IReleaseSpec Spec = new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8131Enabled = true };
+
+    private static ulong Floor(ulong contentBytes) => GasCostOf.Transaction + contentBytes * GasCostOf.FloorGasPerByteEip8131;
+
+    [TestCase(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, TestName = "10 zero bytes")]
+    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, TestName = "10 non-zero bytes")]
+    public void Calldata_floor_is_flat_per_byte(byte[] data)
+    {
+        Transaction transaction = new() { To = Address.Zero, Data = data };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        // Zero and non-zero bytes price identically under the unified floor.
+        Assert.That(cost.FloorGas, Is.EqualTo(Floor((ulong)data.Length)));
+    }
+
+    [Test]
+    public void Access_list_floor_uses_byte_sizes_and_standard_cost_drops_eip7981_surcharge()
+    {
+        AccessList accessList = new AccessList.Builder()
+            .AddAddress(Address.Zero)
+            .AddStorage(UInt256.Zero)
+            .AddStorage(UInt256.One)
+            .Build();
+        Transaction transaction = new() { To = Address.Zero, AccessList = accessList };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // 20 address bytes + 2 × 32 storage key bytes = 84 content bytes.
+            Assert.That(cost.FloorGas, Is.EqualTo(Floor(84)));
+            // EIP-8131 replaces EIP-7981, so the standard cost reverts to plain EIP-2930 pricing.
+            Assert.That(cost.Standard, Is.EqualTo(
+                GasCostOf.Transaction + GasCostOf.AccessAccountListEntry + 2 * GasCostOf.AccessStorageListEntry));
+        }
+    }
+
+    [Test]
+    public void Authorization_tuples_are_floor_priced_at_108_bytes_each()
+    {
+        AuthorizationTuple[] authList =
+        [
+            new AuthorizationTuple(1, TestItem.AddressA, 0, 0, UInt256.One, UInt256.One),
+            new AuthorizationTuple(1, TestItem.AddressB, 1, 1, UInt256.One, UInt256.One),
+        ];
+        Transaction transaction = Build.A.Transaction.WithAuthorizationCode(authList).TestObject;
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        Assert.That(cost.FloorGas, Is.EqualTo(Floor(2 * GasCostOf.AuthTupleBytesEip8131)));
+    }
+
+    [Test]
+    public void Blob_versioned_hashes_are_floor_priced_at_32_bytes_each()
+    {
+        Transaction transaction = new()
+        {
+            To = Address.Zero,
+            Type = TxType.Blob,
+            BlobVersionedHashes = [new byte[32], new byte[32], new byte[32]],
+        };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        Assert.That(cost.FloorGas, Is.EqualTo(Floor(3 * GasCostOf.BlobVersionedHashBytesEip8131)));
+    }
+
+    [Test]
+    public void Combined_content_sums_all_components()
+    {
+        AccessList accessList = new AccessList.Builder().AddAddress(Address.Zero).Build();
+        Transaction transaction = new()
+        {
+            To = Address.Zero,
+            Data = new byte[5],
+            AccessList = accessList,
+            Type = TxType.Blob,
+            BlobVersionedHashes = [new byte[32]],
+        };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        // 5 calldata + 20 address + 32 blob hash = 57 content bytes.
+        Assert.That(cost.FloorGas, Is.EqualTo(Floor(57)));
+    }
+
+    [Test]
+    public void Before_eip8131_blob_hashes_and_auth_tuples_are_not_floor_priced()
+    {
+        Transaction transaction = new()
+        {
+            To = Address.Zero,
+            Type = TxType.Blob,
+            BlobVersionedHashes = [new byte[32]],
+        };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Amsterdam.Instance);
+
+        Assert.That(cost.FloorGas, Is.EqualTo(GasCostOf.Transaction), "pre-8131 floor must ignore blob hashes");
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -164,9 +164,10 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return (ulong)totalZeros + (ulong)(data.Length - totalZeros) * spec.GasCosts.TxDataNonZeroMultiplier;
     }
 
-    // 0 when floor pricing is not active.
+    // 0 when floor pricing is not active. EIP-8131 replaces the EIP-7981 access-list floor
+    // surcharge, so the tokens are only counted while EIP-7981 is the prevailing floor rule.
     public static ulong CalculateFloorTokensInAccessList(Transaction transaction, IReleaseSpec spec) =>
-        spec.IsEip7981Enabled && transaction.AccessList is { Count: (int addressesCount, int storageKeysCount) }
+        spec.IsEip7981Enabled && !spec.IsEip8131Enabled && transaction.AccessList is { Count: (int addressesCount, int storageKeysCount) }
             ? (ulong)(addressesCount * Address.Size + storageKeysCount * AccessList.StorageKeySize) * spec.GasCosts.TxDataNonZeroMultiplier
             : 0;
 
@@ -219,8 +220,34 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     private static ulong CalculateFloorTokensInCallData(Transaction transaction, IReleaseSpec spec) =>
         (ulong)transaction.Data.Length * spec.GasCosts.TxDataNonZeroMultiplier;
 
+    // EIP-8131: every floor-priced content byte of the transaction — calldata, access list
+    // entries, authorization tuples, and blob versioned hashes — under one per-byte rule.
+    private static ulong CalculateContentBytesEip8131(Transaction transaction)
+    {
+        ulong contentBytes = (ulong)transaction.Data.Length;
+
+        if (transaction.AccessList is { Count: (int addressesCount, int storageKeysCount) })
+        {
+            contentBytes += (ulong)(addressesCount * Address.Size + storageKeysCount * AccessList.StorageKeySize);
+        }
+
+        if (transaction.AuthorizationList is { } authorizationList)
+        {
+            contentBytes += (ulong)authorizationList.Length * GasCostOf.AuthTupleBytesEip8131;
+        }
+
+        if (transaction.BlobVersionedHashes is { } blobVersionedHashes)
+        {
+            contentBytes += (ulong)blobVersionedHashes.Length * GasCostOf.BlobVersionedHashBytesEip8131;
+        }
+
+        return contentBytes;
+    }
+
     protected static ulong CalculateFloorCost(Transaction transaction, IReleaseSpec spec, ulong tokensInCallData, ulong floorTokensInAccessList) => spec switch
     {
+        // EIP-8131 replaces the EIP-7623/EIP-7976/EIP-7981 floor rules with one per-byte rule.
+        { IsEip8131Enabled: true } => GasCostOf.Transaction + CalculateContentBytesEip8131(transaction) * GasCostOf.FloorGasPerByteEip8131,
         { IsEip7976Enabled: true } => GasCostOf.Transaction + (CalculateFloorTokensInCallData(transaction, spec) + floorTokensInAccessList) * spec.GasCosts.TotalCostFloorPerToken,
         { IsEip7623Enabled: true } => GasCostOf.Transaction + tokensInCallData * spec.GasCosts.TotalCostFloorPerToken,
         _ => 0

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -112,6 +112,7 @@ namespace Nethermind.Specs.Test
         public ulong ElasticityMultiplier { get; set; } = spec.ElasticityMultiplier;
         public IBaseFeeCalculator BaseFeeCalculator { get; set; } = spec.BaseFeeCalculator;
         public bool IsEip8024Enabled { get; set; } = spec.IsEip8024Enabled;
+        public bool IsEip8131Enabled { get; set; } = spec.IsEip8131Enabled;
         public bool IsEip6110Enabled { get; set; } = spec.IsEip6110Enabled;
         public Address? DepositContractAddress { get; set; } = spec.DepositContractAddress;
         public bool IsEip7594Enabled { get; set; } = spec.IsEip7594Enabled;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -186,4 +186,5 @@ public class ChainParameters
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip8131TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -356,6 +356,8 @@ namespace Nethermind.Specs.ChainSpecStyle
                 releaseSpec.MaxCodeSize = CodeSizeConstants.MaxCodeSizeEip7954;
             }
 
+            releaseSpec.IsEip8131Enabled = (chainSpec.Parameters.Eip8131TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)
             {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -215,6 +215,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8024TransitionTimestamp = chainSpecJson.Params.Eip8024TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
+            Eip8131TransitionTimestamp = chainSpecJson.Params.Eip8131TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -193,6 +193,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip8131TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -169,6 +169,7 @@ public class ReleaseSpec : IReleaseSpec
 
     public bool IsEip7708Enabled { get; set; }
     public bool IsEip7954Enabled { get; set; }
+    public bool IsEip8131Enabled { get; set; }
 
     private ReleaseSpec? _systemSpec;
 


### PR DESCRIPTION
## Changes

- `IsEip8131Enabled` spec flag + `eip8131TransitionTimestamp` chainspec parameter (full plumbing)
- New floor arm in `IGasPolicy.CalculateFloorCost`: `tx_floor = 21000 + 64 × (len(data) + 20·al_addresses + 32·al_keys + 108·auth_tuples + 32·blob_hashes)` — flat per byte, no zero/non-zero token distinction
- Constants: `FloorGasPerByteEip8131 = 64`, `AuthTupleBytesEip8131 = 108`, `BlobVersionedHashBytesEip8131 = 32`
- EIP-8131 supersedes the EIP-7623/EIP-7976/EIP-7981 floor arms (switch ordering) and drops the EIP-7981 access-list surcharge from standard intrinsic gas while active
- Validity (`tx.gas >= max(intrinsic, floor)`) and `gasUsed = max(execution, floor)` reuse the existing EIP-7623 floor machinery unchanged

Spec: https://eips.ethereum.org/EIPS/eip-8131 (Hegotá / EIP-8081 candidate). Not yet activated in any fork file — activation lands with the Hegotá fork wiring (#12226).

Part of the Hegotá (EIP-8081) PR series.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Eip8131Tests`: flat per-byte calldata floor (zero vs non-zero parity), access-list byte pricing + EIP-7981 surcharge removal, 108 B auth tuples, 32 B blob hashes, combined content, and pre-fork behavior. Existing `Eip7623/7976/7981/IntrinsicGasCalculator` suites pass unchanged (44 tests).

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)