### PR TITLE
fix(jsonrpc): derive eth_simulateV1 block spec from the overridden number/timestamp

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateBridgeHelper.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateBridgeHelper.cs
@@ -299,7 +299,7 @@ public class SimulateBridgeHelper(IBlocksConfig blocksConfig, ISpecProvider spec
             result.IsPostMerge = false;
         }
 
-        IReleaseSpec spec = specProvider.GetSpec(result);
+        IReleaseSpec spec = specProvider.GetSpec(GetSimulatedActivation(block.BlockOverrides, result));
 
         if (spec.WithdrawalsEnabled) result.WithdrawalsRoot = Keccak.EmptyTreeHash;
         if (spec.IsBeaconBlockRootAvailable) result.ParentBeaconBlockRoot = Hash256.Zero;
@@ -322,4 +322,7 @@ public class SimulateBridgeHelper(IBlocksConfig blocksConfig, ISpecProvider spec
 
         return (result, spec);
     }
+
+    private static ForkActivation GetSimulatedActivation(BlockOverride? overrides, BlockHeader header) =>
+        new(overrides?.Number ?? (ulong)header.Number, overrides?.Time ?? header.Timestamp);
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -9,6 +9,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Evm;
@@ -229,6 +230,51 @@ public class EthSimulateTestsBlocksAndTransactions
 
         Assert.That((bool)result.Result, Is.False);
         Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.ClientLimitExceededError));
+    }
+
+    [Test]
+    public async Task Test_eth_simulateV1_block_time_override_crossing_a_fork_uses_the_post_fork_spec()
+    {
+        const ulong shanghaiTimestamp = 2_000_000_000;
+        CustomSpecProvider specProvider = new(
+            ((ForkActivation)0, Paris.Instance),
+            (ForkActivation.TimestampOnly(shanghaiTimestamp), Shanghai.Instance));
+        specProvider.UpdateMergeTransitionInfo(0, 0);
+
+        TestRpcBlockchain chain = await TestRpcBlockchain.ForTest(new GenesisOnlyRpcBlockchain()).Build(specProvider);
+        Assert.That(chain.BlockFinder.Head!.Header.Timestamp, Is.LessThan(shanghaiTimestamp));
+
+        Address contract = new("0xc200000000000000000000000000000000000000");
+        SimulatePayload<TransactionForRpc> payload = new()
+        {
+            BlockStateCalls =
+            [
+                new()
+                {
+                    BlockOverrides = new BlockOverride { Time = shanghaiTimestamp },
+                    StateOverrides = new Dictionary<Address, AccountOverride>
+                    {
+                        { contract, new AccountOverride { Code = Bytes.FromHexString("0x5f00") } }
+                    },
+                    Calls =
+                    [
+                        new LegacyTransactionForRpc { From = TestItem.AddressA, To = contract, Gas = 100_000, GasPrice = 0 }
+                    ]
+                }
+            ]
+        };
+
+        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
+            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
+
+        Assert.That(result.Result.ResultType, Is.EqualTo(Core.ResultType.Success), result.Result.ToString());
+        SimulateCallResult callResult = result.Data.First().Calls.First();
+        Assert.That(callResult.Status, Is.EqualTo((ulong)ResultType.Success), callResult.Error?.Message);
+    }
+
+    private sealed class GenesisOnlyRpcBlockchain : TestRpcBlockchain
+    {
+        protected override Task AddBlocksOnStart() => Task.CompletedTask;
     }
 
     /// <summary>


### PR DESCRIPTION
## Changes

`SimulateBridgeHelper.GetCallHeader` selected the release spec with `specProvider.GetSpec(result)` **before** `block.BlockOverrides.ApplyOverrides(result)` applied the block overrides. At that point `result` still carries the *pre-override* number/timestamp (`parent.Number + 1`, `parent.Timestamp + secondsPerSlot`), so a simulated block whose `BlockOverrides.Time` jumps across a **timestamp-activated fork boundary** (Shanghai / Cancun / Prague / Osaka) executed under the **pre-fork** spec — even though its effective header timestamp is post-fork.

Post-Merge every fork is timestamp-gated, so this is a current, observable bug: a fork-crossing `eth_simulateV1` ran the crossing block under the wrong rules (opcode availability, gas schedule, EIP gating), and the spec-derived header fields (`WithdrawalsRoot`, `ParentBeaconBlockRoot`, `ExcessBlobGas`, lines 304-319) were computed from the wrong spec.

This computes the spec from the **effective (post-override) number and timestamp**:

```csharp
IReleaseSpec spec = specProvider.GetSpec(
    block.BlockOverrides?.Number ?? (ulong)result.Number,
    block.BlockOverrides?.Time ?? result.Timestamp);
```

`ApplyOverrides` is deliberately **not** reordered — it sets `BaseFeePerGas` and must still override the spec-computed value at line 312, so only the spec *source* changes. Behavior is identical when no override crosses a fork boundary (the override values equal the derived ones); the executor always sets `BlockOverrides.Number`/`Time` before this runs.

### Tests
- New regression test: a `Paris → Shanghai (by timestamp)` chain; a block whose `BlockOverrides.Time` crosses into Shanghai runs `PUSH0` (EIP-3855 — `BadInstruction` pre-Shanghai, valid from Shanghai) and asserts the call succeeds. It **fails on the old code** (`Status 0` — PUSH0 rejected under the pre-fork Paris spec) and passes with the fix.
- The existing 103 simulate tests pass unchanged (behavior-preserving for non-crossing simulations).

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
