### PR TITLE
feat(evm): EIP-7709 read BLOCKHASH from storage with SLOAD gas semantics

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip7709Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip7709Constants.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// Represents the <see href="https://eips.ethereum.org/EIPS/eip-7709#specification">EIP-7709</see> parameters.
+/// </summary>
+public static class Eip7709Constants
+{
+    /// <summary>
+    /// The <c>BLOCKHASH_SERVE_WINDOW</c> parameter: BLOCKHASH keeps serving only the most
+    /// recent 256 ancestors even though the EIP-2935 ring buffer retains more.
+    /// </summary>
+    public const ulong BlockHashServeWindow = 256;
+}

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7709Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7709Tests.cs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-7709: BLOCKHASH served from the EIP-2935 history contract with full SLOAD
+/// semantics (cold/warm charge and slot warming) for in-window queries; out-of-window queries
+/// return zero at base cost.
+/// </summary>
+[TestFixture]
+public class Eip7709Tests : VirtualMachineTestsBase
+{
+    private const ulong CurrentBlockNumber = 300;
+    private static readonly Hash256 StoredHash = TestItem.KeccakA;
+
+    protected override ulong BlockNumber => CurrentBlockNumber;
+    protected override ISpecProvider SpecProvider { get; } =
+        new TestSpecProvider(new OverridableReleaseSpec(Prague.Instance) { IsEip7709Enabled = true });
+
+    // Access tracing pre-warms every touched cell, which would hide the cold/warm distinction
+    // these tests assert.
+    protected override TestAllTracerWithOutput CreateTracer() => new() { IsTracingAccess = false };
+
+    public override void Setup()
+    {
+        base.Setup();
+        TestState.CreateAccount(Eip2935Constants.BlockHashHistoryAddress, 1);
+        TestState.Set(
+            new StorageCell(Eip2935Constants.BlockHashHistoryAddress, new UInt256((CurrentBlockNumber - 1) % Eip2935Constants.RingBufferSize)),
+            StoredHash.BytesToArray());
+        TestState.Commit(SpecProvider.GenesisSpec);
+        TestState.CommitTree(0);
+    }
+
+    [Test]
+    public void In_window_query_returns_stored_hash_and_charges_cold_sload()
+    {
+        byte[] code = Prepare.EvmCode
+            .PushData(CurrentBlockNumber - 1)
+            .Op(Instruction.BLOCKHASH)
+            .PushData(0)
+            .Op(Instruction.MSTORE)
+            .PushData(32)
+            .PushData(0)
+            .Op(Instruction.RETURN)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.ReturnValue, Is.EqualTo(StoredHash.BytesToArray()));
+            // 21000 + PUSH1 + BLOCKHASH base + cold SLOAD + PUSH1 + MSTORE(+memory) + PUSH1 + PUSH1 + RETURN
+            Assert.That(result.GasSpent, Is.EqualTo(
+                GasCostOf.Transaction
+                + GasCostOf.VeryLow * 4
+                + GasCostOf.BlockHash + GasCostOf.ColdSLoad
+                + GasCostOf.VeryLow + GasCostOf.Memory));
+        }
+    }
+
+    [Test]
+    public void Second_query_of_same_slot_is_warm()
+    {
+        byte[] code = Prepare.EvmCode
+            .PushData(CurrentBlockNumber - 1)
+            .Op(Instruction.BLOCKHASH)
+            .Op(Instruction.POP)
+            .PushData(CurrentBlockNumber - 1)
+            .Op(Instruction.BLOCKHASH)
+            .Op(Instruction.POP)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.That(result.GasSpent, Is.EqualTo(
+            GasCostOf.Transaction
+            + 2 * (GasCostOf.VeryLow + GasCostOf.BlockHash + GasCostOf.Base)
+            + GasCostOf.ColdSLoad + GasCostOf.WarmStateRead));
+    }
+
+    [Test]
+    public void Out_of_window_query_returns_zero_at_base_cost()
+    {
+        // 300 - 257 = 43 is older than BLOCKHASH_SERVE_WINDOW even though within the 2935 ring.
+        byte[] code = Prepare.EvmCode
+            .PushData(CurrentBlockNumber - Eip7709Constants.BlockHashServeWindow - 1)
+            .Op(Instruction.BLOCKHASH)
+            .PushData(0)
+            .Op(Instruction.MSTORE)
+            .PushData(32)
+            .PushData(0)
+            .Op(Instruction.RETURN)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.ReturnValue, Is.EqualTo(new byte[32]));
+            Assert.That(result.GasSpent, Is.EqualTo(
+                GasCostOf.Transaction
+                + GasCostOf.VeryLow * 4
+                + GasCostOf.BlockHash
+                + GasCostOf.VeryLow + GasCostOf.Memory));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Crypto;
 using Nethermind.Evm.GasPolicy;
@@ -745,9 +747,37 @@ public static partial class EvmInstructions
 
         // Retrieve the block hash for the given block number.
         BlockHeader header = vm.BlockExecutionContext.Header;
-        Hash256? blockHash = !a.IsUint64 || a.u0 >= header.Number
-            ? null // Current block, future block, or unrepresentable block number
-            : vm.BlockHashProvider.GetBlockhash(header, a.u0, vm.Spec);
+        IReleaseSpec spec = vm.Spec;
+        Hash256? blockHash;
+        if (spec.IsEip7709Enabled)
+        {
+            // EIP-7709: in-window queries are served from the EIP-2935 history contract with
+            // full SLOAD semantics — cold/warm storage charge plus slot warming — while
+            // out-of-window queries return zero and charge only the base cost.
+            if (!a.IsUint64 || a.u0 >= header.Number || a.u0 + Eip7709Constants.BlockHashServeWindow < header.Number)
+            {
+                blockHash = null;
+            }
+            else
+            {
+                StorageCell blockHashCell = new(
+                    spec.Eip2935ContractAddress ?? Eip2935Constants.BlockHashHistoryAddress,
+                    new UInt256(a.u0 % spec.Eip2935RingBufferSize));
+                if (!TGasPolicy.ConsumeStorageAccessGas(ref gas, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, in blockHashCell, StorageAccessType.SLOAD, spec))
+                    goto OutOfGas;
+
+                // Read through the VM worldstate so the access lands in the same journaling,
+                // block-access-list, and witness capture as a regular SLOAD.
+                ReadOnlySpan<byte> data = vm.WorldState.Get(in blockHashCell);
+                blockHash = data.IsZero() ? null : Hash256.FromBytesWithPadding(data);
+            }
+        }
+        else
+        {
+            blockHash = !a.IsUint64 || a.u0 >= header.Number
+                ? null // Current block, future block, or unrepresentable block number
+                : vm.BlockHashProvider.GetBlockhash(header, a.u0, vm.Spec);
+        }
 
         // Push the block hash bytes if available; otherwise, push a 32-byte zero value.
         EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(blockHash is not null ? blockHash.Bytes : BytesZero32);
@@ -760,6 +790,8 @@ public static partial class EvmInstructions
 
         return pushResult;
         // Jump forward to be unpredicted by the branch predictor.
+    OutOfGas:
+        return EvmExceptionType.OutOfGas;
     StackUnderflow:
         return EvmExceptionType.StackUnderflow;
     }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -186,4 +186,5 @@ public class ChainParameters
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip7709TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -356,6 +356,8 @@ namespace Nethermind.Specs.ChainSpecStyle
                 releaseSpec.MaxCodeSize = CodeSizeConstants.MaxCodeSizeEip7954;
             }
 
+            releaseSpec.IsEip7709Enabled = (chainSpec.Parameters.Eip7709TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)
             {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -215,6 +215,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8024TransitionTimestamp = chainSpecJson.Params.Eip8024TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
+            Eip7709TransitionTimestamp = chainSpecJson.Params.Eip7709TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -193,6 +193,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip7709TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —


### PR DESCRIPTION
## Changes

- `InstructionBlockHash` gains an EIP-7709 path: in-window queries (`block.number - 256 <= arg < block.number`) perform a real storage read of slot `arg % HISTORY_SERVE_WINDOW` on the EIP-2935 history contract with full SLOAD semantics — cold (2100) / warm (100) charge on top of the 20 base cost, plus slot warming in the access tracker
- The read goes through `vm.WorldState` (not the blockhash provider) so it lands in the same journaling, EIP-7928 block access list, and witness capture as a regular SLOAD
- Out-of-window queries return zero at base cost with no storage access, per spec
- New `Eip7709Constants.BlockHashServeWindow = 256`
- Chainspec plumbing for `eip7709TransitionTimestamp` (the `IsEip7709Enabled` flag and state-backed resolution already existed)

Spec: https://eips.ethereum.org/EIPS/eip-7709 (Hegotá / EIP-8081 candidate). Not yet activated in any fork file — activation lands with the Hegotá fork wiring (#12226).

Part of the Hegotá (EIP-8081) PR series.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Eip7709Tests`: in-window cold charge + returned hash, warm second access, out-of-window zero at base cost. Existing `Eip2935Tests` and `BlockhashProviderTests` (22) pass unchanged.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)