### PR TITLE
feat(evm): EIP-4758 deactivate SELFDESTRUCT (SENDALL)

### DIFF
--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -464,6 +464,13 @@ namespace Nethermind.Core.Specs
         public bool IsEip7954Enabled { get; }
 
         /// <summary>
+        /// EIP-4758: Deactivate SELFDESTRUCT (SENDALL).
+        /// SELFDESTRUCT only moves the whole balance to the target and never destroys the
+        /// account, removing the same-transaction destruction that EIP-6780 still allowed.
+        /// </summary>
+        public bool IsEip4758Enabled { get; }
+
+        /// <summary>
         /// Precomputed gas cost and refund constants derived from this spec.
         /// Values are cached per spec instance (singletons per fork) to avoid
         /// repeated interface dispatch on the EVM opcode hot path.

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -117,5 +117,6 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip7843Enabled => spec.IsEip7843Enabled;
     public virtual bool IsEip7954Enabled => spec.IsEip7954Enabled;
     public virtual bool IsEip8024Enabled => spec.IsEip8024Enabled;
+    public virtual bool IsEip4758Enabled => spec.IsEip4758Enabled;
     public SpecGasCosts GasCosts => spec.GasCosts;
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip4758Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip4758Tests.cs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-4758: SELFDESTRUCT acts as SENDALL — the account is never destroyed, not
+/// even when created in the same transaction (the case EIP-6780 still destroys).
+/// </summary>
+[TestFixture]
+public class Eip4758Tests : VirtualMachineTestsBase
+{
+    protected override ISpecProvider SpecProvider { get; } =
+        new TestSpecProvider(new OverridableReleaseSpec(Cancun.Instance) { IsEip4758Enabled = true });
+
+    private byte[] _selfDestructCode;
+    private Address _contractAddress;
+    private byte[] _initCode;
+    private const ulong GasLimit = 1000000;
+    private readonly EthereumEcdsa _ecdsa = new(1);
+
+    [SetUp]
+    public override void Setup()
+    {
+        base.Setup();
+        TestState.CreateAccount(TestItem.PrivateKeyA.Address, 1000.Ether);
+        TestState.Commit(SpecProvider.GenesisSpec);
+        TestState.CommitTree(0);
+        _selfDestructCode = Prepare.EvmCode
+            .SELFDESTRUCT(TestItem.PrivateKeyB.Address)
+            .Done;
+        _contractAddress = ContractAddress.From(TestItem.PrivateKeyA.Address, 0);
+        _initCode = Prepare.EvmCode
+            .ForInitOf(_selfDestructCode)
+            .Done;
+    }
+
+    [Test]
+    public void Self_destruct_in_same_transaction_does_not_destroy()
+    {
+        byte[] salt = new UInt256(123).ToBigEndian();
+        Address createTxAddress = ContractAddress.From(TestItem.PrivateKeyA.Address, 0);
+        _contractAddress = ContractAddress.From(createTxAddress, salt, _initCode);
+        byte[] code = Prepare.EvmCode
+            .Create2(_initCode, salt, 99.Ether)
+            .Call(_contractAddress, 100000)
+            .STOP()
+            .Done;
+
+        ExecuteTx(Build.A.Transaction.WithCode(code).WithValue(100.Ether).WithGasLimit(GasLimit).SignedAndResolved(_ecdsa, TestItem.PrivateKeyA).TestObject);
+
+        using (Assert.EnterMultipleScope())
+        {
+            AssertNotDestroyed();
+            AssertSendAll();
+        }
+    }
+
+    [Test]
+    public void Self_destruct_in_later_transaction_does_not_destroy()
+    {
+        byte[] contractCall = Prepare.EvmCode
+            .Call(_contractAddress, 100000)
+            .Op(Instruction.STOP).Done;
+
+        ExecuteTx(Build.A.Transaction.WithCode(_initCode).WithValue(99.Ether).WithGasLimit(GasLimit).SignedAndResolved(_ecdsa, TestItem.PrivateKeyA).TestObject);
+        ExecuteTx(Build.A.Transaction.WithCode(contractCall).WithGasLimit(GasLimit).WithNonce(1).SignedAndResolved(_ecdsa, TestItem.PrivateKeyA).TestObject);
+
+        using (Assert.EnterMultipleScope())
+        {
+            AssertNotDestroyed();
+            AssertSendAll();
+        }
+    }
+
+    [Test]
+    public void Self_destruct_to_self_does_not_burn()
+    {
+        _selfDestructCode = Prepare.EvmCode
+            .SELFDESTRUCT(_contractAddress)
+            .Done;
+        _initCode = Prepare.EvmCode
+            .ForInitOf(_selfDestructCode)
+            .Done;
+        byte[] contractCall = Prepare.EvmCode
+            .Call(_contractAddress, 100000)
+            .Op(Instruction.STOP).Done;
+
+        ExecuteTx(Build.A.Transaction.WithCode(_initCode).WithValue(99.Ether).WithGasLimit(GasLimit).SignedAndResolved(_ecdsa, TestItem.PrivateKeyA).TestObject);
+        ExecuteTx(Build.A.Transaction.WithCode(contractCall).WithGasLimit(GasLimit).WithNonce(1).SignedAndResolved(_ecdsa, TestItem.PrivateKeyA).TestObject);
+
+        using (Assert.EnterMultipleScope())
+        {
+            AssertNotDestroyed();
+            Assert.That(TestState.GetBalance(_contractAddress), Is.EqualTo(99.Ether), "self-inheriting SENDALL must not burn");
+        }
+    }
+
+    private void ExecuteTx(Transaction tx)
+    {
+        Block block = Build.A.Block.WithNumber(BlockNumber)
+            .WithTimestamp(Timestamp)
+            .WithTransactions(tx).WithGasLimit(2 * GasLimit).TestObject;
+        _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), NullTxTracer.Instance);
+    }
+
+    private void AssertNotDestroyed()
+    {
+        Assert.That(TestState.AccountExists(_contractAddress), Is.True);
+        AssertCodeHash(_contractAddress, Keccak.Compute(_selfDestructCode.AsSpan()));
+    }
+
+    private void AssertSendAll()
+    {
+        Assert.That(TestState.GetBalance(_contractAddress), Is.EqualTo(UInt256.Zero));
+        Assert.That(TestState.GetBalance(TestItem.PrivateKeyB.Address), Is.EqualTo(99.Ether));
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -230,8 +230,11 @@ public static partial class EvmInstructions
         Address executingAccount = vmState.Env.ExecutingAccount;
         bool createInSameTx = vmState.AccessTracker.CreateList.Contains(executingAccount);
         bool selfdestructOnlyOnSameTx = spec.SelfdestructOnlyOnSameTransaction;
+        // EIP-4758 (SENDALL): the account is never destroyed, not even when created in the
+        // same transaction — the opcode only moves the whole balance to the inheritor.
+        bool neverDestroys = spec.IsEip4758Enabled;
         // Mark the executing account for destruction if allowed.
-        if (!selfdestructOnlyOnSameTx || createInSameTx)
+        if (!neverDestroys && (!selfdestructOnlyOnSameTx || createInSameTx))
             vmState.AccessTracker.ToBeDestroyed(executingAccount);
 
         // Retrieve the current balance for transfer.
@@ -262,9 +265,10 @@ public static partial class EvmInstructions
             state.AddToBalance(inheritor, result, spec);
         }
 
-        // Special handling when SELFDESTRUCT is limited to the same transaction.
+        // Special handling when the account survives the opcode (EIP-6780 outside the creation
+        // transaction, or always under EIP-4758) and inherits from itself.
         // No ETH moves and no log is emitted for this no-op case.
-        if (selfdestructOnlyOnSameTx && !createInSameTx && inheritor.Equals(executingAccount))
+        if ((neverDestroys || (selfdestructOnlyOnSameTx && !createInSameTx)) && inheritor.Equals(executingAccount))
             goto Stop;
 
         vm.AddSelfDestructLog<TEip8037, TEip7708>(executingAccount, inheritor, result);

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -112,6 +112,7 @@ namespace Nethermind.Specs.Test
         public ulong ElasticityMultiplier { get; set; } = spec.ElasticityMultiplier;
         public IBaseFeeCalculator BaseFeeCalculator { get; set; } = spec.BaseFeeCalculator;
         public bool IsEip8024Enabled { get; set; } = spec.IsEip8024Enabled;
+        public bool IsEip4758Enabled { get; set; } = spec.IsEip4758Enabled;
         public bool IsEip6110Enabled { get; set; } = spec.IsEip6110Enabled;
         public Address? DepositContractAddress { get; set; } = spec.DepositContractAddress;
         public bool IsEip7594Enabled { get; set; } = spec.IsEip7594Enabled;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -186,4 +186,5 @@ public class ChainParameters
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip4758TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -356,6 +356,8 @@ namespace Nethermind.Specs.ChainSpecStyle
                 releaseSpec.MaxCodeSize = CodeSizeConstants.MaxCodeSizeEip7954;
             }
 
+            releaseSpec.IsEip4758Enabled = (chainSpec.Parameters.Eip4758TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)
             {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -215,6 +215,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8024TransitionTimestamp = chainSpecJson.Params.Eip8024TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
+            Eip4758TransitionTimestamp = chainSpecJson.Params.Eip4758TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -193,6 +193,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip4758TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -169,6 +169,7 @@ public class ReleaseSpec : IReleaseSpec
 
     public bool IsEip7708Enabled { get; set; }
     public bool IsEip7954Enabled { get; set; }
+    public bool IsEip4758Enabled { get; set; }
 
     private ReleaseSpec? _systemSpec;
 


### PR DESCRIPTION
## Changes

- `IsEip4758Enabled` spec flag + `eip4758TransitionTimestamp` chainspec parameter (full plumbing)
- `InstructionSelfDestruct`: when active, the executing account is never marked for destruction — including the created-in-same-transaction case that EIP-6780 still destroys — so the opcode degenerates to SENDALL
- Self-inheriting SENDALL keeps the existing surviving-account no-op semantics (no burn, no transfer log)
- SELFDESTRUCT refunds were already removed by EIP-3529, so no gas changes are needed

Spec: https://eips.ethereum.org/EIPS/eip-4758 (Hegotá / EIP-8081 candidate; Stagnant but listed as Proposed for Inclusion in EIP-8081). Not yet activated in any fork file — activation lands with the Hegotá fork wiring (#12226).

Part of the Hegotá (EIP-8081) PR series.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Eip4758Tests`: same-transaction creation survives with code intact and full balance sent; later-transaction SENDALL; self-inheriting SENDALL does not burn. Existing `Eip6780Tests` and `StorageAndSelfDestructTests` pass unchanged (29 total).

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)