### PR TITLE
test(evm): EIP-8163 reserve EXTENSION (0xae) opcode

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip8163Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8163Tests.cs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Specs;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-8163: the <c>EXTENSION (0xae)</c> opcode is reserved. On L1 it must keep
+/// behaving exactly like <c>INVALID</c> — exceptional halt consuming all remaining gas — and
+/// must not affect JUMPDEST analysis (no immediates).
+/// </summary>
+[TestFixture]
+public class Eip8163Tests : VirtualMachineTestsBase
+{
+    private const byte Extension = 0xae;
+
+    protected override ISpecProvider SpecProvider { get; } = new TestSpecProvider(Amsterdam.Instance);
+
+    [Test]
+    public void Extension_halts_exceptionally_consuming_all_gas()
+    {
+        const ulong gasLimit = 100000;
+        byte[] code = [Extension];
+
+        TestAllTracerWithOutput result = Execute(Activation, gasLimit, code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Failure));
+            Assert.That(result.GasSpent, Is.EqualTo(gasLimit), "EXTENSION must consume all gas like INVALID");
+        }
+    }
+
+    [Test]
+    public void Extension_byte_does_not_affect_jumpdest_analysis()
+    {
+        // PUSH1 0x04 JUMP | 0xae | JUMPDEST STOP — the JUMPDEST directly after the reserved
+        // byte must stay a valid destination, i.e. 0xae must not be treated as carrying
+        // immediates.
+        byte[] code = [(byte)Instruction.PUSH1, 0x04, (byte)Instruction.JUMP, Extension, (byte)Instruction.JUMPDEST, (byte)Instruction.STOP];
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -159,6 +159,10 @@ public enum Instruction : byte
     LOG3 = 0xa3,
     LOG4 = 0xa4,
 
+    // 0xae is reserved as EXTENSION by EIP-8163: on L1 it must keep halting exceptionally like
+    // INVALID (consuming all gas) and must never gain immediates that would affect JUMPDEST
+    // analysis. Do not assign 0xae to a new opcode.
+
     DUPN = 0xe6,
     SWAPN = 0xe7,
     EXCHANGE = 0xe8,


### PR DESCRIPTION
## Changes

- EIP-8163 reserves `0xae` (`EXTENSION`) so non-L1 EVM chains can use it as an extension prefix while keeping bytecode portable. On Ethereum L1 this is a **consensus no-op**: an undefined opcode already halts exceptionally and consumes all gas
- Adds a reservation comment in the `Instruction` enum so `0xae` is not accidentally assigned to a future opcode
- Adds regression tests pinning both normative properties: exceptional halt consuming all remaining gas, and no JUMPDEST-analysis impact (no immediates)

Spec: https://eips.ethereum.org/EIPS/eip-8163 (Hegotá / EIP-8081 candidate, Review status). No fork flag is needed since there is no behavior change on L1.

Part of the Hegotá (EIP-8081) PR series.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: consensus no-op reservation — comment + regression tests only

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Eip8163Tests`: all-gas exceptional halt on 0xae; JUMPDEST directly after a 0xae byte remains a valid jump destination.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)