### PR TITLE
test(bench): add eth_getLogs receipt-decode + topic-filter benchmark

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Receipts/ReceiptLogFilterBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Receipts/ReceiptLogFilterBenchmark.cs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using BenchmarkDotNet.Attributes;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Facade.Filters;
+using Nethermind.Facade.Filters.Topics;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.Benchmarks.Receipts
+{
+    [MemoryDiagnoser]
+    public class ReceiptLogFilterBenchmark
+    {
+        private readonly ReceiptStorageDecoder _decoder = new();
+        private byte[] _receiptRlp = null!;
+        private AddressFilter _addressFilter = null!;
+        private SequenceTopicsFilter _topicsFilter = null!;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _receiptRlp = _decoder.Encode(BuildReceipt(), RlpBehaviors.Storage).Bytes;
+            _addressFilter = new AddressFilter(TestItem.AddressA);
+            _topicsFilter = new SequenceTopicsFilter(new SpecificTopic(TestItem.KeccakA));
+        }
+
+        [Benchmark]
+        public int DecodeAndFilter()
+        {
+            RlpReader reader = new(_receiptRlp);
+            _decoder.DecodeStructRef(ref reader, RlpBehaviors.Storage, out TxReceiptStructRef receipt);
+
+            int matched = 0;
+            LogEntriesIterator logs = new(receipt.LogsRlp, _decoder);
+            while (logs.TryGetNext(out LogEntryStructRef log))
+            {
+                if (_addressFilter.Accepts(ref log.Address) && _topicsFilter.Accepts(ref log))
+                {
+                    matched++;
+                }
+            }
+
+            return matched;
+        }
+
+        private static TxReceipt BuildReceipt()
+        {
+            byte[] data32 = new byte[32];
+            byte[] data64 = new byte[64];
+            byte[] data128 = new byte[128];
+
+            LogEntry[] logs =
+            [
+                new LogEntry(TestItem.AddressA, data32, [TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC]),
+                new LogEntry(TestItem.AddressB, data32, [TestItem.KeccakA, TestItem.KeccakE]),
+                new LogEntry(TestItem.AddressA, data64, [TestItem.KeccakD, TestItem.KeccakF]),
+                new LogEntry(TestItem.AddressA, data32, [TestItem.KeccakA, TestItem.KeccakG, TestItem.KeccakH]),
+                new LogEntry(TestItem.AddressC, data128, [TestItem.KeccakD]),
+                new LogEntry(TestItem.AddressA, data32, [TestItem.KeccakA]),
+            ];
+
+            return new TxReceipt
+            {
+                TxType = TxType.EIP1559,
+                StatusCode = 1,
+                BlockNumber = 21_000_000,
+                BlockHash = TestItem.KeccakH,
+                Index = 7,
+                Sender = TestItem.AddressD,
+                Recipient = TestItem.AddressA,
+                ContractAddress = TestItem.AddressF,
+                GasUsed = 84_000,
+                GasUsedTotal = 1_250_000,
+                TxHash = TestItem.KeccakG,
+                Logs = logs,
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Changes

The `eth_getLogs` receipt-decode → topic-filter loop had **no benchmark coverage**. The only receipt-decode benchmark, `RlpDecodeKeccakBenchmark`, measures `DecodeKeccak()` (a heap `Hash256`) — not this path, which decodes into zero-copy `Hash256StructRef`/`AddressStructRef` views over the source RLP.

This adds `ReceiptLogFilterBenchmark` (`Nethermind.Benchmark/Receipts/`), measuring the exact hot path end-to-end:

```
new RlpReader(blob) -> ReceiptStorageDecoder.DecodeStructRef -> LogEntriesIterator
    -> per-log AddressFilter.Accepts(ref …Address) + SequenceTopicsFilter.Accepts(ref log)
```

(the topics filter drives `KeccaksIterator` + `SpecificTopic`), over one storage-encoded EIP-1559 receipt with 6 logs (mixed topic counts and data sizes). `[MemoryDiagnoser]` is on. No production code is touched, and no Runner/csproj wiring is needed (the `Nethermind.Benchmark` assembly is already loaded).

**Baseline** (Apple M2 Pro, .NET 10 Arm64): **~252 ns/op, 0 B/op** — the struct-ref path allocates nothing per op, which is the key property to preserve.

### Why now
This is the missing gate for the `Hash256StructRef`/`AddressStructRef` → `ValueHash256`/`ValueAddress` type unification (part of #11937): migrating the leaf slots replaces a zero-copy span *view* with a per-item 32/20-byte *copy* in exactly this loop, so a measured baseline is needed **before** that change to confirm decode + filter throughput and allocations stay flat.

Run: `dotnet run -c Release --project src/Nethermind/Nethermind.Benchmark.Runner/Nethermind.Benchmark.Runner.csproj -- --filter '*ReceiptLogFilter*' --quick`

## Types of changes

- [x] Other: _Benchmark coverage (no production code change)_

## Testing

#### Requires testing

- [x] No

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
