### PR TITLE
fix(test): unflake PersistentReceiptStorage index-prune assertion

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -324,9 +324,11 @@ public class PersistentReceiptStorageTests(bool useCompactReceipts)
         CreateStorage();
         _blockTree.BlockAddedToMain +=
             Raise.EventWith(new BlockReplacementEventArgs(Build.A.Block.WithNumber(blockNumber).TestObject));
+        // Pruning runs on a fire-and-forget Task.Run, so the positive case polls generously to avoid
+        // CI-load flakiness; the negative case is already satisfied (FindBlock is never issued).
         Assert.That(() => _blockTree.ReceivedCalls()
             .Where(static call => call.GetMethodInfo().Name.EndsWith(nameof(_blockTree.FindBlock))),
-            willPruneOldIndices ? Is.Not.Empty.After(100, 10) : Is.Empty.After(100, 10));
+            willPruneOldIndices ? Is.Not.Empty.After(10000, 50) : Is.Empty.After(100, 10));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/PersistentReceiptStorageTests.cs
@@ -324,8 +324,6 @@ public class PersistentReceiptStorageTests(bool useCompactReceipts)
         CreateStorage();
         _blockTree.BlockAddedToMain +=
             Raise.EventWith(new BlockReplacementEventArgs(Build.A.Block.WithNumber(blockNumber).TestObject));
-        // Pruning runs on a fire-and-forget Task.Run, so the positive case polls generously to avoid
-        // CI-load flakiness; the negative case is already satisfied (FindBlock is never issued).
         Assert.That(() => _blockTree.ReceivedCalls()
             .Where(static call => call.GetMethodInfo().Name.EndsWith(nameof(_blockTree.FindBlock))),
             willPruneOldIndices ? Is.Not.Empty.After(10000, 50) : Is.Empty.After(100, 10));


### PR DESCRIPTION
## Summary

`PersistentReceiptStorage` prunes old tx-index entries on a fire-and-forget `Task.Run` when `BlockAddedToMain` fires (`PersistentReceiptStorage.cs:81`). `Should_only_prune_index_tx_hashes_if_blockNumber_is_bigger_than_lookupLimit` raised the event and then polled for the resulting `FindBlock` call with only a **100 ms** budget — too tight under CI load, so the positive case (`blockNumber = 11`) intermittently failed with `Expected: not <empty> / But was: <empty>`.

Fix: give the positive case a generous **10 s / 50 ms** poll window. NUnit's `DelayedConstraint` returns as soon as the condition holds, so the happy path stays fast — the larger budget only adds load-resilience. The negative cases keep `100 ms` (they are satisfied immediately; `FindBlock` is never issued).

Verified with 6/6 clean local runs of the parameterized test.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

- [x] Yes
- [ ] No

Test-only change; the fixed test is itself the regression net (no new test needed).

## Documentation

- [ ] Requires documentation update — No
- [ ] Requires explanation in Release Notes — No

🤖 Generated with [Claude Code](https://claude.com/claude-code)