### PR TITLE
test(sync): stabilize flaky Test_release_before_processing_complete

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -364,6 +364,7 @@ public class SyncDispatcherTests
     [TestCase(true, 1, 1, 24)]
     [TestCase(true, 2, 1, 32)]
     [TestCase(true, 1, 2, 32)]
+    [NonParallelizable]
     public async Task Test_release_before_processing_complete(bool isMultiSync, int processingThread, int peerCount, int expectedHighestRequest)
     {
         TestSyncFeed syncFeed = new(isMultiSync, 999999);


### PR DESCRIPTION
## Changes

- Mark `SyncDispatcherTests.Test_release_before_processing_complete` as `[NonParallelizable]`.

The test drives the dispatcher to a specific `HighestRequested` plateau, which relies on its `Task.Run` download/`HandleResponse` continuations being scheduled promptly so that peer/processing slots fill up. Under the class-level `[Parallelizable(ParallelScope.All)]`, it competes with the rest of the suite for thread-pool capacity; on slow CI those continuations can be starved long enough that `HighestRequested` never reaches the target within the 30s budget, producing a `TimeoutException` at `SyncDispatcherTests.cs:387`.

This mirrors the exact fix already applied to the sibling tests `Simple_test_sync` and `When_ConcurrentHandleResponseIsRunning_Then_BlockDispose` in #11850.

Observed failure (unrelated PR, CI `Nethermind.Synchronization.Test [no-intrinsics]`):

```
failed Test_release_before_processing_complete(True,2,1,32) (30s 434ms)
  System.TimeoutException : The operation has timed out.
```

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

This is a flaky-test stabilization; the affected test cases pass locally (4/4). No new test — the change only adjusts test parallelization.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
