### PR TITLE
fix(flatdb): lease the read-only bundle for in-flight trie warmer jobs

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
@@ -876,7 +876,7 @@ public class FlatWorldStateScopeProviderTests
         // Queues a state-trie warmup job whose traversal blocks inside the persistence reader,
         // simulating the slow cold read that is in flight when a restart-replay scope is disposed.
         scope.HintGet(TestItem.AddressA, null);
-        Assert.That(reader.ReadEntered.Wait(5000), Is.True, "Warmup job should reach the persistence reader");
+        Assert.That(reader.ReadEntered.Wait(30_000), Is.True, "Warmup job should reach the persistence reader");
 
         Task disposeTask = Task.Run(() => scope.Dispose());
         await disposeTask.WaitAsync(TimeSpan.FromSeconds(10));
@@ -906,7 +906,7 @@ public class FlatWorldStateScopeProviderTests
             try
             {
                 ReadEntered.Set();
-                ResumeReads.Wait(TimeSpan.FromSeconds(10));
+                ResumeReads.Wait(TimeSpan.FromSeconds(60));
                 return null;
             }
             finally
@@ -919,6 +919,8 @@ public class FlatWorldStateScopeProviderTests
         {
             if (Volatile.Read(ref _activeReads) != 0) _disposedDuringActiveRead = true;
             _isDisposed = true;
+            ReadEntered.Dispose();
+            ResumeReads.Dispose();
         }
 
         public Account? GetAccount(Address address) => null;

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
@@ -854,4 +854,81 @@ public class FlatWorldStateScopeProviderTests
         Assert.That(disposeTask.IsCompletedSuccessfully, Is.True);
     }
 
+    [Test]
+    public async Task Dispose_GivesUpWaiting_ReaderOutlivesInFlightWarmup()
+    {
+        BlockingPersistenceReader reader = new();
+        ReadOnlySnapshotBundle readOnlyBundle = new(new SnapshotPooledList(0), reader, recordDetailedMetrics: false);
+        FlatDbConfig config = new();
+        ResourcePool resourcePool = new(config);
+        SnapshotBundle bundle = new(readOnlyBundle, Substitute.For<ITrieNodeCache>(), resourcePool, ResourcePool.Usage.MainBlockProcessing);
+        await using TrieWarmer warmer = new(LimboLogs.Instance, config);
+
+        FlatWorldStateScope scope = new(
+            new StateId(0, TestItem.KeccakA),
+            bundle,
+            new TrieStoreScopeProvider.KeyValueWithBatchingBackedCodeDb(new TestMemDb()),
+            Substitute.For<IFlatCommitTarget>(),
+            config,
+            warmer,
+            LimboLogs.Instance);
+
+        // Queues a state-trie warmup job whose traversal blocks inside the persistence reader,
+        // simulating the slow cold read that is in flight when a restart-replay scope is disposed.
+        scope.HintGet(TestItem.AddressA, null);
+        Assert.That(reader.ReadEntered.Wait(5000), Is.True, "Warmup job should reach the persistence reader");
+
+        Task disposeTask = Task.Run(() => scope.Dispose());
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.That(reader.DisposedDuringActiveRead, Is.False, "Reader must not be disposed while a read is in flight");
+        Assert.That(reader.IsDisposed, Is.False, "In-flight warmup lease should keep the reader alive past scope dispose");
+
+        reader.ResumeReads.Set();
+
+        Assert.That(() => reader.IsDisposed, Is.True.After(5000, 50), "Reader should be disposed once the warmup job completes");
+    }
+
+    private sealed class BlockingPersistenceReader : IPersistence.IPersistenceReader
+    {
+        private int _activeReads;
+        private volatile bool _isDisposed;
+        private volatile bool _disposedDuringActiveRead;
+
+        public ManualResetEventSlim ReadEntered { get; } = new(false);
+        public ManualResetEventSlim ResumeReads { get; } = new(false);
+        public bool IsDisposed => _isDisposed;
+        public bool DisposedDuringActiveRead => _disposedDuringActiveRead;
+
+        public byte[]? TryLoadStateRlp(in TreePath path, ReadFlags flags)
+        {
+            Interlocked.Increment(ref _activeReads);
+            try
+            {
+                ReadEntered.Set();
+                ResumeReads.Wait(TimeSpan.FromSeconds(10));
+                return null;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _activeReads);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Volatile.Read(ref _activeReads) != 0) _disposedDuringActiveRead = true;
+            _isDisposed = true;
+        }
+
+        public Account? GetAccount(Address address) => null;
+        public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue) => false;
+        public StateId CurrentState => new(0, Keccak.EmptyTreeHash);
+        public byte[]? TryLoadStorageRlp(Hash256 address, in TreePath path, ReadFlags flags) => null;
+        public byte[]? GetAccountRaw(in ValueHash256 addrHash) => null;
+        public bool TryGetStorageRaw(in ValueHash256 addrHash, in ValueHash256 slotHash, ref SlotValue value) => false;
+        public IPersistence.IFlatIterator CreateAccountIterator(in ValueHash256 startKey, in ValueHash256 endKey) => throw new NotSupportedException();
+        public IPersistence.IFlatIterator CreateStorageIterator(in ValueHash256 accountKey, in ValueHash256 startSlotKey, in ValueHash256 endSlotKey) => throw new NotSupportedException();
+        public bool IsPreimageMode => false;
+    }
 }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
@@ -110,13 +110,25 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
                 return false;
             }
 
-            // Note: storage tree root not changed after write batch. Also not cleared. So the result is not correct.
-            // this is just to warm up the nodes.
-            ValueHash256 key = ValueKeccak.Zero;
-            StorageTree.ComputeKeyWithLookup(index, ref key);
+            if (!_bundle.TryLeaseReadOnlyBundle())
+            {
+                return false;
+            }
 
-            _warmupStorageTree.WarmUpPath(key.BytesAsSpan);
-            return true;
+            try
+            {
+                // Note: storage tree root not changed after write batch. Also not cleared. So the result is not correct.
+                // this is just to warm up the nodes.
+                ValueHash256 key = ValueKeccak.Zero;
+                StorageTree.ComputeKeyWithLookup(index, ref key);
+
+                _warmupStorageTree.WarmUpPath(key.BytesAsSpan);
+                return true;
+            }
+            finally
+            {
+                _bundle.ReleaseReadOnlyBundleLease();
+            }
         }
         finally
         {

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -318,12 +318,20 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         try
         {
             if (_hintSequenceId != sequenceId || _pausePrewarmer) return false;
+            if (!_snapshotBundle.TryLeaseReadOnlyBundle()) return false;
 
-            // Note: tree root not changed after writing batch. Also, not cleared. So the result is not correct.
-            // this is just for warming up
-            _warmupStateTree.WarmUpPath(address.ToAccountPath.Bytes);
+            try
+            {
+                // Note: tree root not changed after writing batch. Also, not cleared. So the result is not correct.
+                // this is just for warming up
+                _warmupStateTree.WarmUpPath(address.ToAccountPath.Bytes);
 
-            return true;
+                return true;
+            }
+            finally
+            {
+                _snapshotBundle.ReleaseReadOnlyBundleLease();
+            }
         }
         finally
         {

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -387,6 +387,20 @@ public sealed class SnapshotBundle : IDisposable
     // as most of the slot should already be queued by prewarmer.
     public bool ShouldQueuePrewarm(Address address, UInt256? slot = null) => _transientResource.ShouldPrewarm(address, slot);
 
+    /// <summary>
+    /// Takes a lease on the underlying <see cref="ReadOnlySnapshotBundle"/> for the duration of a trie warmer traversal.
+    /// </summary>
+    /// <remarks>
+    /// Warmer jobs race scope disposal by design; the managed fallout is caught in the warmer, but a read that is
+    /// already inside the persistence reader when the last lease is released would touch a freed native RocksDB
+    /// snapshot and crash the process. Holding a lease per in-flight traversal defers that release until the job ends.
+    /// </remarks>
+    /// <returns><c>false</c> when the bundle is already fully disposed; the caller must skip the traversal.</returns>
+    internal bool TryLeaseReadOnlyBundle() => _readOnlySnapshotBundle.TryLease();
+
+    /// <summary>Releases a lease taken with <see cref="TryLeaseReadOnlyBundle"/>.</summary>
+    internal void ReleaseReadOnlyBundleLease() => _readOnlySnapshotBundle.Dispose();
+
     public (Snapshot?, TransientResource?) CollectAndApplySnapshot(StateId from, StateId to, bool returnSnapshot = true)
     {
         // When assembling the snapshot, we straight up pass the _currentPooledContent into the new snapshot


### PR DESCRIPTION
Fixes #12079

## Changes

`FlatWorldStateScope.Dispose` waits up to 1 s for outstanding trie warmer jobs (#11394) and then proceeds anyway. A warmup job still inside a persistence read at that point keeps using the RocksDB snapshot that `SnapshotBundle.Dispose` → `ReadOnlySnapshotBundle.CleanUp` releases underneath it. The managed side of this race is already tolerated — `TrieWarmer.HandleJob` catches `ObjectDisposedException` and `NullReferenceException` from disposed scopes — but a read that is already executing inside the native snapshot cannot throw: it dereferences freed native memory and kills the process with a SIGSEGV and no managed trace.

This is what kills restarts of fully-synced FlatDb nodes (#12079). The startup replay after a restart ("Rerunning block after reorg or pruning") runs with an empty snapshot repository and cold caches on a database still busy with post-shutdown WAL replay and compaction, so every warmup traversal goes through the persistence reader and routinely exceeds the 1 s drain window — the give-up fires exactly when a straggler is mid-read in native code (`ColumnDbSnapshot.Dispose` destroys the shared `ReadOptions` handles and releases the snapshot while a `Get` may still be executing against them). In steady state warmup jobs drain in microseconds and the window never trips, which is why the crash is restart-specific.

The window is wider than a single scope: `CachedReaderPersistence` shares one `RefCountingPersistenceReader` — one native snapshot — across all bundles created between its 5 s cache clears, so a straggler from one scope can also crash when a *different* scope drops the last lease. The per-job lease covers that too: job → its bundle's lease → the bundle's reader lease keeps the shared snapshot pinned.

- `SnapshotBundle` exposes `TryLeaseReadOnlyBundle`/`ReleaseReadOnlyBundleLease`, forwarding to the `ReadOnlySnapshotBundle` ref count.
- `FlatWorldStateScope.WarmUpStateTrie` and `FlatStorageTree.WarmUpStorageTrie` take that lease for the duration of the warmup traversal (after the cheap sequence-id check, so invalidated jobs still exit with zero extra cost). The last lease release — and with it the native snapshot dispose — is thereby deferred until the straggler job completes. `RefCountingDisposable`'s resurrection semantics make the acquisition race-free against a concurrent disposer: a `TryLease` that wins at count 0 defers `CleanUp` to its own release, and one that loses returns `false` and the job is skipped.
- The bounded 1 s wait in `Dispose` stays; giving up is now safe. The same holds for the 1 s give-up in `TrieWarmer.DisposeAsync` at shutdown.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Dispose_GivesUpWaiting_ReaderOutlivesInFlightWarmup` reproduces the exact interleaving with a persistence reader stub that blocks inside `TryLoadStateRlp`: a real `TrieWarmer` job enters the reader, the scope is disposed (waits 1 s, gives up), and the test asserts the reader is neither disposed mid-read nor disposed at all until the job finishes, and that it is disposed exactly once afterwards. Without the fix the test fails with the reader disposed while a read is in flight — the managed rendering of the production segfault.

Full `Nethermind.State.Flat.Test` suite passes (537 tests).

The real-world verification is the `_Flat` post-merge smoke lanes from the issue: restart a fully-synced `--FlatDb.Enabled=true` node and confirm the replay completes instead of exiting 139.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes

Fixes a crash (exit code 139) on restart of a fully-synced node running the experimental FlatDb backend.

## Remarks

The per-job lease only pins the native-owning `ReadOnlySnapshotBundle`. The pooled managed state (`SnapshotContent`, `TransientResource`) intentionally keeps its existing tolerated-race semantics — stale warmup jobs reading recycled managed maps at worst throw the exceptions `TrieWarmer.HandleJob` already catches, and warm wrong-but-harmless cache entries. Making those immutable-per-scope would be a larger change with a real allocation cost on the hot path, for no correctness gain in committed state.
