### PR TITLE
fix(persistence): correct range deletion bounds for full trie nodes

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
@@ -765,9 +765,13 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         using (Assert.EnterMultipleScope())
+        {
             foreach ((string p, bool del) in RangeDeleteNodes)
-                Assert.That(reader.TryLoadStateRlp(TreePath.FromHexString(p), ReadFlags.None),
-                    del ? Is.Null : Is.EqualTo(rlp), p);
+            {
+                byte[]? node = reader.TryLoadStateRlp(TreePath.FromHexString(p), ReadFlags.None);
+                Assert.That(node, del ? Is.Null : Is.EqualTo(rlp), p);
+            }
+        }
     }
 
     [Test]
@@ -784,9 +788,13 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         using (Assert.EnterMultipleScope())
+        {
             foreach ((string p, bool del) in RangeDeleteNodes)
-                Assert.That(reader.TryLoadStorageRlp(account, TreePath.FromHexString(p), ReadFlags.None),
-                    del ? Is.Null : Is.EqualTo(rlp), p);
+            {
+                byte[]? node = reader.TryLoadStorageRlp(account, TreePath.FromHexString(p), ReadFlags.None);
+                Assert.That(node, del ? Is.Null : Is.EqualTo(rlp), p);
+            }
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
@@ -750,7 +750,7 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
         ("aa".PadRight(64,'0'), false), ("ac".PadRight(64, '0'), false),
     ];
     private static readonly TreePath RangeDeleteFrom = TreePath.FromHexString("ab".PadRight(64, '0'));
-    private static readonly TreePath RangeDeleteTo   = TreePath.FromHexString("ab".PadRight(64, 'f'));
+    private static readonly TreePath RangeDeleteTo = TreePath.FromHexString("ab".PadRight(64, 'f'));
 
     [Test]
     public void TestDeleteStateTrieNodeRange()

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
@@ -736,11 +736,8 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
         }
     }
 
-    // Two nodes per column (low/high inside the "ab" subtree, below/above outside).
-    // Lengths cover all storage columns: 4 → StateNodesTop, 10 → StateNodes/StorageNodes,
-    // 32 and 64 → FallbackNodes. The 64-nibble pair sits at the exact from/to boundaries
-    // (MPT leaf-path length), exercising the same lower-bound encoding that the 32-nibble
-    // regression caught.
+    // Nodes across all columns (lengths 4/10/32/64), in-range pairs under "ab" and
+    // out-of-range neighbours (aa/ac), to verify the range bounds delete only in-range nodes.
     private static readonly (string Path, bool Deleted)[] RangeDeleteNodes =
     [
         ("ab00",                true),  ("abffff",               true),

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
@@ -736,6 +736,62 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
         }
     }
 
+    // Two nodes per column (low/high inside the "ab" subtree, below/above outside).
+    // Lengths cover all storage columns: 4 → StateNodesTop, 10 → StateNodes/StorageNodes,
+    // 32 and 64 → FallbackNodes. The 64-nibble pair sits at the exact from/to boundaries
+    // (MPT leaf-path length), exercising the same lower-bound encoding that the 32-nibble
+    // regression caught.
+    private static readonly (string Path, bool Deleted)[] RangeDeleteNodes =
+    [
+        ("ab00",                true),  ("abffff",               true),
+        ("ab00000000",          true),  ("abffffffffffff",        true),
+        ("ab".PadRight(32,'0'), true),  ("ab".PadRight(32, 'f'), true),
+        ("ab".PadRight(64,'0'), true),  ("ab".PadRight(64, 'f'), true),
+        ("aa00",                false), ("ac00",                  false),
+        ("aa00000000",          false), ("ac00000000",            false),
+        ("aa".PadRight(32,'0'), false), ("ac".PadRight(32, '0'), false),
+        ("aa".PadRight(64,'0'), false), ("ac".PadRight(64, '0'), false),
+    ];
+    private static readonly TreePath RangeDeleteFrom = TreePath.FromHexString("ab".PadRight(64, '0'));
+    private static readonly TreePath RangeDeleteTo   = TreePath.FromHexString("ab".PadRight(64, 'f'));
+
+    [Test]
+    public void TestDeleteStateTrieNodeRange()
+    {
+        byte[] rlp = [0xc1, 0x11];
+
+        using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis))
+            foreach ((string p, _) in RangeDeleteNodes) writer.SetStateTrieNode(TreePath.FromHexString(p), rlp);
+
+        using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis))
+            writer.DeleteStateTrieNodeRange(RangeDeleteFrom, RangeDeleteTo);
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        using (Assert.EnterMultipleScope())
+            foreach ((string p, bool del) in RangeDeleteNodes)
+                Assert.That(reader.TryLoadStateRlp(TreePath.FromHexString(p), ReadFlags.None),
+                    del ? Is.Null : Is.EqualTo(rlp), p);
+    }
+
+    [Test]
+    public void TestDeleteStorageTrieNodeRange()
+    {
+        Hash256 account = TestItem.KeccakA;
+        byte[] rlp = [0xc1, 0x11];
+
+        using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis))
+            foreach ((string p, _) in RangeDeleteNodes) writer.SetStorageTrieNode(account, TreePath.FromHexString(p), rlp);
+
+        using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis))
+            writer.DeleteStorageTrieNodeRange(new ValueHash256(account.Bytes), RangeDeleteFrom, RangeDeleteTo);
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        using (Assert.EnterMultipleScope())
+            foreach ((string p, bool del) in RangeDeleteNodes)
+                Assert.That(reader.TryLoadStorageRlp(account, TreePath.FromHexString(p), ReadFlags.None),
+                    del ? Is.Null : Is.EqualTo(rlp), p);
+    }
+
     [Test]
     public void TestAccountIterator_EnumeratesAllAccounts()
     {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseTriePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseTriePersistence.cs
@@ -224,6 +224,7 @@ public static class BaseTriePersistence
 
             // Delete from FallbackNodes (path length 16+, prefix 0x00)
             EncodeFullStateNodeKey(firstKeyBuf, fromPath);
+            firstKeyBuf[1 + FullPathLength] = 0;
             EncodeFullStateNodeKey(lastKeyBuf[..FullStateNodesKeyLength], toPath);
             lastKeyBuf[FullStateNodesKeyLength] = 0;
             BasePersistence.DeleteMatchingKeys(fallbackNodesSnap, fallbackNodes,
@@ -254,6 +255,7 @@ public static class BaseTriePersistence
 
             // Delete from FallbackNodes (path length 16+, prefix 0x01)
             EncodeFullStorageNodeKey(firstKeyBuf, address, fromPath);
+            firstKeyBuf[1 + StoragePrefixPortion + FullPathLength] = 0;
             EncodeFullStorageNodeKey(lastKeyBuf[..FullStorageNodesKeyLength], address, toPath);
             lastKeyBuf[FullStorageNodesKeyLength] = 0;
             BasePersistence.DeleteMatchingKeys(fallbackNodesSnap, fallbackNodes,


### PR DESCRIPTION
Changes

- Fix the lower-bound key encoding in DeleteStateTrieNodeRange and DeleteStorageTrieNodeRange for the FallbackNodes column (path length 16+).

Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

Testing

Requires testing

- [x] Yes

If yes, did you write tests?

- [x] Yes