### PR TITLE
feat(evm): EIP-7851 code-controlled EOA delegation (SETSELFDELEGATE)

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip7851Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip7851Constants.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// Represents the <see href="https://eips.ethereum.org/EIPS/eip-7851">EIP-7851</see>
+/// (code-controlled EOA delegation) parameters.
+/// </summary>
+public static class Eip7851Constants
+{
+    private static readonly byte[] _delegationHeader = [0xef, 0x01, 0x01];
+
+    /// <summary>
+    /// The ECDSA-disabled delegation designator prefix. Accounts whose code is exactly
+    /// <c>0xef0101 || delegate_address</c> can no longer authorize transactions or EIP-7702
+    /// delegation changes with their ECDSA key; only the delegated wallet code can update the
+    /// delegation via SETSELFDELEGATE.
+    /// </summary>
+    public static ReadOnlySpan<byte> DelegationHeader => _delegationHeader.AsSpan();
+
+    public static bool IsEcdsaDisabledDelegatedCode(ReadOnlySpan<byte> code) =>
+        code.Length == _delegationHeader.Length + Address.Size
+        && DelegationHeader.SequenceEqual(code[.._delegationHeader.Length]);
+}

--- a/src/Nethermind/Nethermind.Core/GasCostOf.cs
+++ b/src/Nethermind/Nethermind.Core/GasCostOf.cs
@@ -69,6 +69,7 @@ namespace Nethermind.Core
         public const ulong PerAuthBaseCost = Eip7702Constants.PerAuthBaseCost;
         public const ulong TotalCostFloorPerTokenEip7623 = 10; // eip-7623
         public const ulong TotalCostFloorPerTokenEip7976 = 16; // eip-7976
+        public const ulong SetSelfDelegate = 9500; // eip-7851
 
         public const ulong CostPerStateByte = 1530; // eip-8037
         public const ulong StateBytesPerStorageSet = 64; // eip-8037

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -464,6 +464,12 @@ namespace Nethermind.Core.Specs
         public bool IsEip7954Enabled { get; }
 
         /// <summary>
+        /// EIP-7851: Code-Controlled EOA Delegation.
+        /// SETSELFDELEGATE opcode and the 0xef0101 ECDSA-disabled delegation designator.
+        /// </summary>
+        public bool IsEip7851Enabled { get; }
+
+        /// <summary>
         /// Precomputed gas cost and refund constants derived from this spec.
         /// Values are cached per spec instance (singletons per fork) to avoid
         /// repeated interface dispatch on the EVM opcode hot path.

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -117,5 +117,6 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip7843Enabled => spec.IsEip7843Enabled;
     public virtual bool IsEip7954Enabled => spec.IsEip7954Enabled;
     public virtual bool IsEip8024Enabled => spec.IsEip8024Enabled;
+    public virtual bool IsEip7851Enabled => spec.IsEip7851Enabled;
     public SpecGasCosts GasCosts => spec.GasCosts;
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7851Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7851Tests.cs
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain.Tracing;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-7851: SETSELFDELEGATE opcode and the 0xef0101 ECDSA-disabled delegation
+/// designator.
+/// </summary>
+[TestFixture]
+public class Eip7851Tests : VirtualMachineTestsBase
+{
+    private static readonly Address NewDelegate = TestItem.AddressC;
+    // Must differ from the harness defaults (sender = AddressA, recipient = AddressB).
+    private static readonly Address Eoa = TestItem.PrivateKeyD.Address;
+    private static readonly Address Wallet = TestItem.AddressE;
+
+    private readonly EthereumEcdsa _ecdsa = new(1);
+
+    protected override ISpecProvider SpecProvider { get; } =
+        new TestSpecProvider(new OverridableReleaseSpec(Prague.Instance) { IsEip7851Enabled = true });
+
+    [SetUp]
+    public override void Setup()
+    {
+        base.Setup();
+        TestState.CreateAccount(TestItem.PrivateKeyA.Address, 1000.Ether);
+        TestState.Commit(SpecProvider.GenesisSpec);
+        TestState.CommitTree(0);
+    }
+
+    private void SetCode(Address account, byte[] code)
+    {
+        if (!TestState.AccountExists(account))
+        {
+            TestState.CreateAccount(account, 0);
+        }
+
+        TestState.InsertCode(account, ValueKeccak.Compute(code), code, Spec);
+        TestState.Commit(Spec);
+    }
+
+    private static byte[] Designator(ReadOnlySpan<byte> header, Address delegate_) =>
+        [.. header, .. delegate_.Bytes];
+
+    private byte[] WalletCodeSettingDelegate(Address delegateAddress) => Prepare.EvmCode
+        .PushData(delegateAddress)
+        .Op(Instruction.SETSELFDELEGATE)
+        .PushData(0)
+        .Op(Instruction.MSTORE)
+        .PushData(32)
+        .PushData(0)
+        .Op(Instruction.RETURN)
+        .Done;
+
+    private byte[] CallEoa(PrivateKey sender = null, ulong nonce = 0)
+    {
+        Transaction tx = Build.A.Transaction
+            .To(Eoa)
+            .WithNonce(nonce)
+            .WithGasLimit(100000)
+            .SignedAndResolved(_ecdsa, sender ?? TestItem.PrivateKeyA)
+            .TestObject;
+        Block block = Build.A.Block.WithNumber(BlockNumber).WithTimestamp(Timestamp).WithTransactions(tx).WithGasLimit(1000000).TestObject;
+        CallOutputTracer tracer = new();
+        _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+        return tracer.ReturnValue;
+    }
+
+    [Test]
+    public void SetSelfDelegate_from_7702_context_disables_ecdsa_and_updates_delegate()
+    {
+        SetCode(Wallet, WalletCodeSettingDelegate(NewDelegate));
+        SetCode(Eoa, Designator(Eip7702Constants.DelegationHeader, Wallet));
+
+        byte[] returnValue = CallEoa();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(returnValue, Is.EqualTo(UInt256.One.ToBigEndian()), "must push 1 on success");
+            Assert.That(TestState.GetCode(Eoa), Is.EqualTo(Designator(Eip7851Constants.DelegationHeader, NewDelegate)));
+        }
+    }
+
+    [Test]
+    public void SetSelfDelegate_from_ecdsa_disabled_context_updates_delegate()
+    {
+        SetCode(Wallet, WalletCodeSettingDelegate(NewDelegate));
+        SetCode(Eoa, Designator(Eip7851Constants.DelegationHeader, Wallet));
+
+        byte[] returnValue = CallEoa();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(returnValue, Is.EqualTo(UInt256.One.ToBigEndian()));
+            Assert.That(TestState.GetCode(Eoa), Is.EqualTo(Designator(Eip7851Constants.DelegationHeader, NewDelegate)));
+        }
+    }
+
+    [Test]
+    public void SetSelfDelegate_with_zero_delegate_fails_without_state_change()
+    {
+        SetCode(Wallet, WalletCodeSettingDelegate(Address.Zero));
+        byte[] designator = Designator(Eip7702Constants.DelegationHeader, Wallet);
+        SetCode(Eoa, designator);
+
+        byte[] returnValue = CallEoa();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(returnValue, Is.EqualTo(UInt256.Zero.ToBigEndian()), "must push 0 for zero delegate");
+            Assert.That(TestState.GetCode(Eoa), Is.EqualTo(designator), "state must not change");
+        }
+    }
+
+    [Test]
+    public void SetSelfDelegate_outside_delegated_context_fails()
+    {
+        // The wallet executes its own code directly — the executing account's code is not a
+        // 23-byte designator, so the opcode must fail with 0.
+        byte[] walletCode = WalletCodeSettingDelegate(NewDelegate);
+        SetCode(Wallet, walletCode);
+
+        TestAllTracerWithOutput result = Execute(Prepare.EvmCode
+            .Call(Wallet, 50000)
+            .Op(Instruction.STOP)
+            .Done);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+            Assert.That(TestState.GetCode(Wallet), Is.EqualTo(walletCode), "wallet code must not change");
+        }
+    }
+
+    [Test]
+    public void SetSelfDelegate_in_static_context_halts_exceptionally()
+    {
+        SetCode(Wallet, WalletCodeSettingDelegate(NewDelegate));
+        byte[] designator = Designator(Eip7702Constants.DelegationHeader, Wallet);
+        SetCode(Eoa, designator);
+
+        // STATICCALL into the delegated EOA must fail (returns 0 on the caller's stack).
+        byte[] outer = Prepare.EvmCode
+            .PushData(0).PushData(0).PushData(0).PushData(0)
+            .PushData(Eoa)
+            .PushData(50000)
+            .Op(Instruction.STATICCALL)
+            .PushData(0)
+            .Op(Instruction.MSTORE)
+            .PushData(32)
+            .PushData(0)
+            .Op(Instruction.RETURN)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(outer);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.ReturnValue, Is.EqualTo(UInt256.Zero.ToBigEndian()), "STATICCALL must report failure");
+            Assert.That(TestState.GetCode(Eoa), Is.EqualTo(designator), "state must not change");
+        }
+    }
+
+    [Test]
+    public void Ecdsa_disabled_sender_transaction_is_rejected()
+    {
+        SetCode(Eoa, Designator(Eip7851Constants.DelegationHeader, Wallet));
+        TestState.AddToBalance(Eoa, 1.Ether, Spec);
+        TestState.Commit(Spec);
+
+        Transaction tx = Build.A.Transaction
+            .To(TestItem.AddressF)
+            .WithGasLimit(100000)
+            .SignedAndResolved(_ecdsa, TestItem.PrivateKeyD)
+            .TestObject;
+        Block block = Build.A.Block.WithNumber(BlockNumber).WithTimestamp(Timestamp).WithTransactions(tx).WithGasLimit(1000000).TestObject;
+
+        TransactionResult result = _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), NullTxTracer.Instance);
+
+        Assert.That(result.TransactionExecuted, Is.False, "ECDSA-authenticated tx from an 0xef0101 account must be invalid");
+    }
+
+    [Test]
+    public void Authorization_from_ecdsa_disabled_account_is_skipped()
+    {
+        byte[] designator = Designator(Eip7851Constants.DelegationHeader, Wallet);
+        SetCode(Eoa, designator);
+
+        AuthorizationTuple authorization = _ecdsa.Sign(TestItem.PrivateKeyD, 1, NewDelegate, TestState.GetNonce(Eoa));
+        Transaction tx = Build.A.Transaction
+            .WithType(TxType.SetCode)
+            .To(TestItem.AddressF)
+            .WithAuthorizationCode([authorization])
+            .WithMaxFeePerGas(1.GWei)
+            .WithMaxPriorityFeePerGas(1.GWei)
+            .WithGasLimit(200000)
+            .SignedAndResolved(_ecdsa, TestItem.PrivateKeyA)
+            .TestObject;
+        Block block = Build.A.Block.WithNumber(BlockNumber).WithTimestamp(Timestamp).WithTransactions(tx).WithGasLimit(1000000).TestObject;
+
+        TransactionResult result = _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), NullTxTracer.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(TestState.GetCode(Eoa), Is.EqualTo(designator), "authorization from an ECDSA-disabled account must not change its delegation");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
@@ -19,12 +19,14 @@ public interface ICodeInfoRepository
     bool TryGetDelegation(Address address, IReleaseSpec spec, [NotNullWhen(true)] out Address? delegatedAddress);
 
     /// <remarks>
-    /// Parses delegation code to extract the contained address.
+    /// Parses delegation code to extract the contained address. Accepts both the EIP-7702
+    /// (<c>0xef0100</c>) and the EIP-7851 ECDSA-disabled (<c>0xef0101</c>) designators — calls
+    /// to an ECDSA-disabled account still execute its delegate.
     /// <b>Assumes </b><paramref name="code"/> <b>is delegation code!</b>
     /// </remarks>
     static bool TryGetDelegatedAddress(ReadOnlySpan<byte> code, [NotNullWhen(true)] out Address? address)
     {
-        if (Eip7702Constants.IsDelegatedCode(code))
+        if (Eip7702Constants.IsDelegatedCode(code) || Eip7851Constants.IsEcdsaDisabledDelegatedCode(code))
         {
             address = new Address(code[Eip7702Constants.DelegationHeader.Length..]);
             return true;

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -169,6 +169,7 @@ public enum Instruction : byte
     RETURN = 0xf3,
     DELEGATECALL = 0xf4,
     CREATE2 = 0xf5,
+    SETSELFDELEGATE = 0xf6, // EIP-7851 (opcode value TBD in the spec; placeholder)
     STATICCALL = 0xfa,
     REVERT = 0xfd,
     INVALID = 0xfe,

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
@@ -275,6 +276,57 @@ public static partial class EvmInstructions
         // Jump forward to be unpredicted by the branch predictor.
     Stop:
         return EvmExceptionType.Stop;
+    OutOfGas:
+        return EvmExceptionType.OutOfGas;
+    StackUnderflow:
+        return EvmExceptionType.StackUnderflow;
+    StaticCallViolation:
+        return EvmExceptionType.StaticCallViolation;
+    }
+
+    /// <summary>
+    /// Executes the SETSELFDELEGATE opcode (EIP-7851).
+    /// Updates the executing account's delegation designator to the ECDSA-disabled form
+    /// <c>0xef0101 || delegate</c>, permanently disabling its ECDSA authority.
+    /// </summary>
+    /// <remarks>
+    /// Pushes 1 on success. Pushes 0 without any state change when the delegate address is zero
+    /// or the executing account's state code is not a 23-byte EIP-7702/EIP-7851 delegation
+    /// designator (i.e. the code is not running in a delegated EOA's own context).
+    /// </remarks>
+    [SkipLocalsInit]
+    public static EvmExceptionType InstructionSetSelfDelegate<TGasPolicy, TTracingInst>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        where TTracingInst : struct, IFlag
+    {
+        VmState<TGasPolicy> vmState = vm.VmState;
+        if (vmState.IsStatic)
+            goto StaticCallViolation;
+
+        if (!TGasPolicy.UpdateGas(ref gas, GasCostOf.SetSelfDelegate))
+            goto OutOfGas;
+
+        Address delegateAddress = stack.PopAddress();
+        if (delegateAddress is null)
+            goto StackUnderflow;
+
+        IWorldState state = vm.WorldState;
+        Address executingAccount = vmState.Env.ExecutingAccount;
+        byte[]? currentCode = state.GetCode(executingAccount);
+        bool isDelegatedContext = currentCode is not null
+            && (Eip7702Constants.IsDelegatedCode(currentCode) || Eip7851Constants.IsEcdsaDisabledDelegatedCode(currentCode));
+
+        if (delegateAddress == Address.Zero || !isDelegatedContext)
+            return stack.PushZero<TTracingInst>();
+
+        byte[] newCode = new byte[Eip7851Constants.DelegationHeader.Length + Address.Size];
+        Eip7851Constants.DelegationHeader.CopyTo(newCode);
+        delegateAddress.Bytes.CopyTo(newCode.AsSpan(Eip7851Constants.DelegationHeader.Length));
+        ValueHash256 codeHash = ValueKeccak.Compute(newCode);
+        state.InsertCode(executingAccount, in codeHash, newCode, vm.Spec);
+
+        return stack.PushOne<TTracingInst>();
+        // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;
     StackUnderflow:

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -318,6 +318,11 @@ public static unsafe partial class EvmInstructions
             lookup[(int)Instruction.REVERT] = &InstructionRevert;
         }
 
+        if (spec.IsEip7851Enabled)
+        {
+            lookup[(int)Instruction.SETSELFDELEGATE] = &InstructionSetSelfDelegate<TGasPolicy, TTracingInst>;
+        }
+
         // Final opcodes.
         lookup[(int)Instruction.INVALID] = &InstructionInvalid;
         lookup[(int)Instruction.SELFDESTRUCT] = (spec.IsEip8037Enabled, spec.IsEip7708Enabled) switch

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -751,10 +751,21 @@ namespace Nethermind.Evm.TransactionProcessing
 
             accessTracker.WarmUp(authorizationTuple.Authority);
 
-            if (WorldState.HasCode(authorizationTuple.Authority) && !_codeInfoRepository.TryGetDelegation(authorizationTuple.Authority, spec, out _))
+            if (WorldState.HasCode(authorizationTuple.Authority))
             {
-                error = $"Authority ({authorizationTuple.Authority}) has code deployed.";
-                return AuthorizationTupleResult.InvalidAsCodeDeployed;
+                // EIP-7851: an ECDSA-disabled account (0xef0101 designator) can never authorize
+                // delegation changes again, even though its code parses as a delegation.
+                if (spec.IsEip7851Enabled && Eip7851Constants.IsEcdsaDisabledDelegatedCode(WorldState.GetCode(authorizationTuple.Authority)))
+                {
+                    error = $"Authority ({authorizationTuple.Authority}) has permanently disabled its ECDSA authority.";
+                    return AuthorizationTupleResult.InvalidAsCodeDeployed;
+                }
+
+                if (!_codeInfoRepository.TryGetDelegation(authorizationTuple.Authority, spec, out _))
+                {
+                    error = $"Authority ({authorizationTuple.Authority}) has code deployed.";
+                    return AuthorizationTupleResult.InvalidAsCodeDeployed;
+                }
             }
 
             ulong authNonce = WorldState.GetNonce(authorizationTuple.Authority);

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -112,6 +112,7 @@ namespace Nethermind.Specs.Test
         public ulong ElasticityMultiplier { get; set; } = spec.ElasticityMultiplier;
         public IBaseFeeCalculator BaseFeeCalculator { get; set; } = spec.BaseFeeCalculator;
         public bool IsEip8024Enabled { get; set; } = spec.IsEip8024Enabled;
+        public bool IsEip7851Enabled { get; set; } = spec.IsEip7851Enabled;
         public bool IsEip6110Enabled { get; set; } = spec.IsEip6110Enabled;
         public Address? DepositContractAddress { get; set; } = spec.DepositContractAddress;
         public bool IsEip7594Enabled { get; set; } = spec.IsEip7594Enabled;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -186,4 +186,5 @@ public class ChainParameters
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip7851TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -356,6 +356,8 @@ namespace Nethermind.Specs.ChainSpecStyle
                 releaseSpec.MaxCodeSize = CodeSizeConstants.MaxCodeSizeEip7954;
             }
 
+            releaseSpec.IsEip7851Enabled = (chainSpec.Parameters.Eip7851TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)
             {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -215,6 +215,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8024TransitionTimestamp = chainSpecJson.Params.Eip8024TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
+            Eip7851TransitionTimestamp = chainSpecJson.Params.Eip7851TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -193,6 +193,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip7851TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -169,6 +169,7 @@ public class ReleaseSpec : IReleaseSpec
 
     public bool IsEip7708Enabled { get; set; }
     public bool IsEip7954Enabled { get; set; }
+    public bool IsEip7851Enabled { get; set; }
 
     private ReleaseSpec? _systemSpec;
 


### PR DESCRIPTION
## Changes

- New `SETSELFDELEGATE` opcode (`0xf6` placeholder — value is TBD in the spec; 9500 gas), gated by `IsEip7851Enabled`: pops a delegate address, rewrites the executing account's designator to `0xef0101 || delegate` and pushes 1; pushes 0 without state change for a zero delegate or when the executing account's state code is not a 23-byte designator; exceptional halt in static context
- `Eip7851Constants` with the `0xef0101` ECDSA-disabled designator helpers
- Delegation **following** (`ICodeInfoRepository.TryGetDelegatedAddress`) now accepts both `0xef0100` and `0xef0101`, so calls to an ECDSA-disabled EOA still execute its delegate
- EIP-7702 authorization processing explicitly rejects tuples whose authority is ECDSA-disabled (the broader delegation parsing would otherwise have validated them)
- Sender validation and txpool filters already use the strict `0xef0100` check, so ECDSA-authenticated transactions from `0xef0101` accounts are rejected as contract senders — covered by regression tests
- `IsEip7851Enabled` flag + `eip7851TransitionTimestamp` chainspec plumbing

Spec: https://eips.ethereum.org/EIPS/eip-7851 (Hegotá / EIP-8081 candidate). Not yet activated in any fork file — activation lands with the Hegotá fork wiring (#12226).

Part of the Hegotá (EIP-8081) PR series.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Eip7851Tests` (7): success from 0xef0100 and 0xef0101 contexts, zero-delegate failure, non-delegated-context failure, static-context halt, ECDSA-disabled sender rejection, ECDSA-disabled authorization skip. Existing 7702/delegation/transaction-processor suites pass unchanged (119 tests).

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

## Remarks

The opcode value is marked TBD in the EIP; `0xf6` is a placeholder to revisit when the spec assigns one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)