### PR TITLE
feat(evm): EIP-8151 ECDSA authority deactivation aware ecRecover

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip7851Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip7851Constants.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// Represents the <see href="https://eips.ethereum.org/EIPS/eip-7851">EIP-7851</see>
+/// (code-controlled EOA delegation) parameters.
+/// </summary>
+public static class Eip7851Constants
+{
+    private static readonly byte[] _delegationHeader = [0xef, 0x01, 0x01];
+
+    /// <summary>
+    /// The ECDSA-disabled delegation designator prefix. Accounts whose code is exactly
+    /// <c>0xef0101 || delegate_address</c> can no longer authorize transactions or EIP-7702
+    /// delegation changes with their ECDSA key; only the delegated wallet code can update the
+    /// delegation via SETSELFDELEGATE.
+    /// </summary>
+    public static ReadOnlySpan<byte> DelegationHeader => _delegationHeader.AsSpan();
+
+    public static bool IsEcdsaDisabledDelegatedCode(ReadOnlySpan<byte> code) =>
+        code.Length == _delegationHeader.Length + Address.Size
+        && DelegationHeader.SequenceEqual(code[.._delegationHeader.Length]);
+}

--- a/src/Nethermind/Nethermind.Core/GasCostOf.cs
+++ b/src/Nethermind/Nethermind.Core/GasCostOf.cs
@@ -69,6 +69,7 @@ namespace Nethermind.Core
         public const ulong PerAuthBaseCost = Eip7702Constants.PerAuthBaseCost;
         public const ulong TotalCostFloorPerTokenEip7623 = 10; // eip-7623
         public const ulong TotalCostFloorPerTokenEip7976 = 16; // eip-7976
+        public const ulong SetSelfDelegate = 9500; // eip-7851
 
         public const ulong CostPerStateByte = 1530; // eip-8037
         public const ulong StateBytesPerStorageSet = 64; // eip-8037

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -464,6 +464,12 @@ namespace Nethermind.Core.Specs
         public bool IsEip7954Enabled { get; }
 
         /// <summary>
+        /// EIP-7851: Code-Controlled EOA Delegation.
+        /// SETSELFDELEGATE opcode and the 0xef0101 ECDSA-disabled delegation designator.
+        /// </summary>
+        public bool IsEip7851Enabled { get; }
+
+        /// <summary>
         /// Precomputed gas cost and refund constants derived from this spec.
         /// Values are cached per spec instance (singletons per fork) to avoid
         /// repeated interface dispatch on the EVM opcode hot path.

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -470,6 +470,13 @@ namespace Nethermind.Core.Specs
         public bool IsEip7851Enabled { get; }
 
         /// <summary>
+        /// EIP-8151: ECDSA Authority Deactivation Aware ecRecover.
+        /// ecRecover charges an account access on the recovered address and returns zero for
+        /// EIP-7851 ECDSA-disabled accounts.
+        /// </summary>
+        public bool IsEip8151Enabled { get; }
+
+        /// <summary>
         /// Precomputed gas cost and refund constants derived from this spec.
         /// Values are cached per spec instance (singletons per fork) to avoid
         /// repeated interface dispatch on the EVM opcode hot path.

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -117,5 +117,6 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip7843Enabled => spec.IsEip7843Enabled;
     public virtual bool IsEip7954Enabled => spec.IsEip7954Enabled;
     public virtual bool IsEip8024Enabled => spec.IsEip8024Enabled;
+    public virtual bool IsEip7851Enabled => spec.IsEip7851Enabled;
     public SpecGasCosts GasCosts => spec.GasCosts;
 }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -118,5 +118,6 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip7954Enabled => spec.IsEip7954Enabled;
     public virtual bool IsEip8024Enabled => spec.IsEip8024Enabled;
     public virtual bool IsEip7851Enabled => spec.IsEip7851Enabled;
+    public virtual bool IsEip8151Enabled => spec.IsEip8151Enabled;
     public SpecGasCosts GasCosts => spec.GasCosts;
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7851Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7851Tests.cs
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain.Tracing;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-7851: SETSELFDELEGATE opcode and the 0xef0101 ECDSA-disabled delegation
+/// designator.
+/// </summary>
+[TestFixture]
+public class Eip7851Tests : VirtualMachineTestsBase
+{
+    private static readonly Address NewDelegate = TestItem.AddressC;
+    // Must differ from the harness defaults (sender = AddressA, recipient = AddressB).
+    private static readonly Address Eoa = TestItem.PrivateKeyD.Address;
+    private static readonly Address Wallet = TestItem.AddressE;
+
+    private readonly EthereumEcdsa _ecdsa = new(1);
+
+    protected override ISpecProvider SpecProvider { get; } =
+        new TestSpecProvider(new OverridableReleaseSpec(Prague.Instance) { IsEip7851Enabled = true });
+
+    [SetUp]
+    public override void Setup()
+    {
+        base.Setup();
+        TestState.CreateAccount(TestItem.PrivateKeyA.Address, 1000.Ether);
+        TestState.Commit(SpecProvider.GenesisSpec);
+        TestState.CommitTree(0);
+    }
+
+    private void SetCode(Address account, byte[] code)
+    {
+        if (!TestState.AccountExists(account))
+        {
+            TestState.CreateAccount(account, 0);
+        }
+
+        TestState.InsertCode(account, ValueKeccak.Compute(code), code, Spec);
+        TestState.Commit(Spec);
+    }
+
+    private static byte[] Designator(ReadOnlySpan<byte> header, Address delegate_) =>
+        [.. header, .. delegate_.Bytes];
+
+    private byte[] WalletCodeSettingDelegate(Address delegateAddress) => Prepare.EvmCode
+        .PushData(delegateAddress)
+        .Op(Instruction.SETSELFDELEGATE)
+        .PushData(0)
+        .Op(Instruction.MSTORE)
+        .PushData(32)
+        .PushData(0)
+        .Op(Instruction.RETURN)
+        .Done;
+
+    private byte[] CallEoa(PrivateKey sender = null, ulong nonce = 0)
+    {
+        Transaction tx = Build.A.Transaction
+            .To(Eoa)
+            .WithNonce(nonce)
+            .WithGasLimit(100000)
+            .SignedAndResolved(_ecdsa, sender ?? TestItem.PrivateKeyA)
+            .TestObject;
+        Block block = Build.A.Block.WithNumber(BlockNumber).WithTimestamp(Timestamp).WithTransactions(tx).WithGasLimit(1000000).TestObject;
+        CallOutputTracer tracer = new();
+        _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+        return tracer.ReturnValue;
+    }
+
+    [Test]
+    public void SetSelfDelegate_from_7702_context_disables_ecdsa_and_updates_delegate()
+    {
+        SetCode(Wallet, WalletCodeSettingDelegate(NewDelegate));
+        SetCode(Eoa, Designator(Eip7702Constants.DelegationHeader, Wallet));
+
+        byte[] returnValue = CallEoa();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(returnValue, Is.EqualTo(UInt256.One.ToBigEndian()), "must push 1 on success");
+            Assert.That(TestState.GetCode(Eoa), Is.EqualTo(Designator(Eip7851Constants.DelegationHeader, NewDelegate)));
+        }
+    }
+
+    [Test]
+    public void SetSelfDelegate_from_ecdsa_disabled_context_updates_delegate()
+    {
+        SetCode(Wallet, WalletCodeSettingDelegate(NewDelegate));
+        SetCode(Eoa, Designator(Eip7851Constants.DelegationHeader, Wallet));
+
+        byte[] returnValue = CallEoa();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(returnValue, Is.EqualTo(UInt256.One.ToBigEndian()));
+            Assert.That(TestState.GetCode(Eoa), Is.EqualTo(Designator(Eip7851Constants.DelegationHeader, NewDelegate)));
+        }
+    }
+
+    [Test]
+    public void SetSelfDelegate_with_zero_delegate_fails_without_state_change()
+    {
+        SetCode(Wallet, WalletCodeSettingDelegate(Address.Zero));
+        byte[] designator = Designator(Eip7702Constants.DelegationHeader, Wallet);
+        SetCode(Eoa, designator);
+
+        byte[] returnValue = CallEoa();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(returnValue, Is.EqualTo(UInt256.Zero.ToBigEndian()), "must push 0 for zero delegate");
+            Assert.That(TestState.GetCode(Eoa), Is.EqualTo(designator), "state must not change");
+        }
+    }
+
+    [Test]
+    public void SetSelfDelegate_outside_delegated_context_fails()
+    {
+        // The wallet executes its own code directly — the executing account's code is not a
+        // 23-byte designator, so the opcode must fail with 0.
+        byte[] walletCode = WalletCodeSettingDelegate(NewDelegate);
+        SetCode(Wallet, walletCode);
+
+        TestAllTracerWithOutput result = Execute(Prepare.EvmCode
+            .Call(Wallet, 50000)
+            .Op(Instruction.STOP)
+            .Done);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+            Assert.That(TestState.GetCode(Wallet), Is.EqualTo(walletCode), "wallet code must not change");
+        }
+    }
+
+    [Test]
+    public void SetSelfDelegate_in_static_context_halts_exceptionally()
+    {
+        SetCode(Wallet, WalletCodeSettingDelegate(NewDelegate));
+        byte[] designator = Designator(Eip7702Constants.DelegationHeader, Wallet);
+        SetCode(Eoa, designator);
+
+        // STATICCALL into the delegated EOA must fail (returns 0 on the caller's stack).
+        byte[] outer = Prepare.EvmCode
+            .PushData(0).PushData(0).PushData(0).PushData(0)
+            .PushData(Eoa)
+            .PushData(50000)
+            .Op(Instruction.STATICCALL)
+            .PushData(0)
+            .Op(Instruction.MSTORE)
+            .PushData(32)
+            .PushData(0)
+            .Op(Instruction.RETURN)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(outer);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.ReturnValue, Is.EqualTo(UInt256.Zero.ToBigEndian()), "STATICCALL must report failure");
+            Assert.That(TestState.GetCode(Eoa), Is.EqualTo(designator), "state must not change");
+        }
+    }
+
+    [Test]
+    public void Ecdsa_disabled_sender_transaction_is_rejected()
+    {
+        SetCode(Eoa, Designator(Eip7851Constants.DelegationHeader, Wallet));
+        TestState.AddToBalance(Eoa, 1.Ether, Spec);
+        TestState.Commit(Spec);
+
+        Transaction tx = Build.A.Transaction
+            .To(TestItem.AddressF)
+            .WithGasLimit(100000)
+            .SignedAndResolved(_ecdsa, TestItem.PrivateKeyD)
+            .TestObject;
+        Block block = Build.A.Block.WithNumber(BlockNumber).WithTimestamp(Timestamp).WithTransactions(tx).WithGasLimit(1000000).TestObject;
+
+        TransactionResult result = _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), NullTxTracer.Instance);
+
+        Assert.That(result.TransactionExecuted, Is.False, "ECDSA-authenticated tx from an 0xef0101 account must be invalid");
+    }
+
+    [Test]
+    public void Authorization_from_ecdsa_disabled_account_is_skipped()
+    {
+        byte[] designator = Designator(Eip7851Constants.DelegationHeader, Wallet);
+        SetCode(Eoa, designator);
+
+        AuthorizationTuple authorization = _ecdsa.Sign(TestItem.PrivateKeyD, 1, NewDelegate, TestState.GetNonce(Eoa));
+        Transaction tx = Build.A.Transaction
+            .WithType(TxType.SetCode)
+            .To(TestItem.AddressF)
+            .WithAuthorizationCode([authorization])
+            .WithMaxFeePerGas(1.GWei)
+            .WithMaxPriorityFeePerGas(1.GWei)
+            .WithGasLimit(200000)
+            .SignedAndResolved(_ecdsa, TestItem.PrivateKeyA)
+            .TestObject;
+        Block block = Build.A.Block.WithNumber(BlockNumber).WithTimestamp(Timestamp).WithTransactions(tx).WithGasLimit(1000000).TestObject;
+
+        TransactionResult result = _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), NullTxTracer.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(TestState.GetCode(Eoa), Is.EqualTo(designator), "authorization from an ECDSA-disabled account must not change its delegation");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8151Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8151Tests.cs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-8151: ecRecover charges an EIP-2929 account access on the recovered address
+/// (warming it) and returns zero when the address has permanently disabled its ECDSA authority
+/// (EIP-7851 <c>0xef0101</c> designator).
+/// </summary>
+[TestFixture]
+public class Eip8151Tests : VirtualMachineTestsBase
+{
+    // Known-good vector shared with ECRecoverPrecompileTests.
+    private const string InputHex =
+        "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e" +
+        "000000000000000000000000000000000000000000000000000000000000001b" +
+        "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e" +
+        "789d1dd423d25f0772d2748d60f7e4b81bb14d086eba8e8e8efb6dcff8a4ae02";
+
+    private static readonly Address RecoveredAddress = new("0xceaccac640adf55b2028469bd36ba501f28b699d");
+
+    // Measured region: 6 PUSH1/PUSH3 (18) + PUSH0 (2) + CALL (100 warm precompile + 3000
+    // ecRecover base) + POP (2) + GAS (2).
+    private const ulong MeasuredOverhead = 6 * GasCostOf.VeryLow + GasCostOf.Base + GasCostOf.WarmStateRead + 3000 + GasCostOf.Base + GasCostOf.Base;
+
+    protected override ISpecProvider SpecProvider { get; } = new TestSpecProvider(
+        new OverridableReleaseSpec(Prague.Instance) { IsEip7851Enabled = true, IsEip8151Enabled = true });
+
+    // Access tracing pre-warms every touched account, which would hide the cold/warm
+    // distinction these tests assert.
+    protected override TestAllTracerWithOutput CreateTracer() => new() { IsTracingAccess = false };
+
+    /// <summary>
+    /// Writes the 128-byte input at memory 0x20, then runs <paramref name="calls"/> measured
+    /// ecRecover calls. The output word of the last call lands at return offset 0; the i-th
+    /// call's measured gas delta lands at return offset 0x20 + 32i.
+    /// </summary>
+    private static byte[] BuildMeasuredEcRecoverCode(int calls)
+    {
+        byte[] input = Bytes.FromHexString(InputHex);
+        Prepare code = Prepare.EvmCode
+            .PushData(input.AsSpan(0, 32).ToArray()).PushData(0x20).Op(Instruction.MSTORE)
+            .PushData(input.AsSpan(32, 32).ToArray()).PushData(0x40).Op(Instruction.MSTORE)
+            .PushData(input.AsSpan(64, 32).ToArray()).PushData(0x60).Op(Instruction.MSTORE)
+            .PushData(input.AsSpan(96, 32).ToArray()).PushData(0x80).Op(Instruction.MSTORE)
+            // Pre-touch the memory used for deltas so the measured region has no expansion cost.
+            .PushData(1).PushData(0xc0 + 32 * (calls - 1)).Op(Instruction.MSTORE);
+
+        for (int i = 0; i < calls; i++)
+        {
+            code = code
+                .Op(Instruction.GAS)            // snapshot below the call arguments
+                .PushData(0x20).PushData(0xa0)  // retLength, retOffset
+                .PushData(0x80).PushData(0x20)  // argsLength, argsOffset
+                .Op(Instruction.PUSH0)          // value (PUSH0 for a deterministic width)
+                .PushData(1)                    // ecRecover
+                .PushData(200000)               // forwarded gas (PUSH3)
+                .Op(Instruction.CALL)
+                .Op(Instruction.POP)
+                .Op(Instruction.GAS)
+                .Op(Instruction.SWAP1)
+                .Op(Instruction.SUB)
+                .PushData(0xc0 + 32 * i).Op(Instruction.MSTORE);
+        }
+
+        return code
+            .PushData(0x20 + 32 * calls).PushData(0xa0).Op(Instruction.RETURN)
+            .Done;
+    }
+
+    private static UInt256 Delta(byte[] returnValue, int call) =>
+        new(returnValue.AsSpan(0x20 + 32 * call, 32), isBigEndian: true);
+
+    [Test]
+    public void Successful_recovery_charges_cold_account_access()
+    {
+        TestAllTracerWithOutput result = Execute(BuildMeasuredEcRecoverCode(calls: 1));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.ReturnValue.AsSpan(12, 20).ToArray(), Is.EqualTo(RecoveredAddress.Bytes.ToArray()));
+            Assert.That(Delta(result.ReturnValue, 0), Is.EqualTo((UInt256)(MeasuredOverhead + GasCostOf.ColdAccountAccess)));
+        }
+    }
+
+    [Test]
+    public void Second_recovery_of_same_address_is_warm()
+    {
+        TestAllTracerWithOutput result = Execute(BuildMeasuredEcRecoverCode(calls: 2));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Delta(result.ReturnValue, 0), Is.EqualTo((UInt256)(MeasuredOverhead + GasCostOf.ColdAccountAccess)));
+            Assert.That(Delta(result.ReturnValue, 1), Is.EqualTo((UInt256)(MeasuredOverhead + GasCostOf.WarmStateRead)));
+        }
+    }
+
+    [Test]
+    public void Ecdsa_disabled_recovered_address_returns_zero()
+    {
+        byte[] designator = [.. Eip7851Constants.DelegationHeader, .. TestItem.AddressE.Bytes];
+        TestState.CreateAccount(RecoveredAddress, 0);
+        TestState.InsertCode(RecoveredAddress, ValueKeccak.Compute(designator), designator, Spec);
+        TestState.Commit(Spec);
+
+        TestAllTracerWithOutput result = Execute(BuildMeasuredEcRecoverCode(calls: 1));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.ReturnValue.AsSpan(0, 32).ToArray(), Is.EqualTo(new byte[32]), "must return zero for a deactivated authority");
+            Assert.That(Delta(result.ReturnValue, 0), Is.EqualTo((UInt256)(MeasuredOverhead + GasCostOf.ColdAccountAccess)));
+        }
+    }
+
+    [Test]
+    public void Non_disabled_delegated_recovered_address_is_returned()
+    {
+        byte[] designator = [.. Eip7702Constants.DelegationHeader, .. TestItem.AddressE.Bytes];
+        TestState.CreateAccount(RecoveredAddress, 0);
+        TestState.InsertCode(RecoveredAddress, ValueKeccak.Compute(designator), designator, Spec);
+        TestState.Commit(Spec);
+
+        TestAllTracerWithOutput result = Execute(BuildMeasuredEcRecoverCode(calls: 1));
+
+        Assert.That(result.ReturnValue.AsSpan(12, 20).ToArray(), Is.EqualTo(RecoveredAddress.Bytes.ToArray()),
+            "a live 0xef0100 delegation must not be treated as deactivated");
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
@@ -19,12 +19,14 @@ public interface ICodeInfoRepository
     bool TryGetDelegation(Address address, IReleaseSpec spec, [NotNullWhen(true)] out Address? delegatedAddress);
 
     /// <remarks>
-    /// Parses delegation code to extract the contained address.
+    /// Parses delegation code to extract the contained address. Accepts both the EIP-7702
+    /// (<c>0xef0100</c>) and the EIP-7851 ECDSA-disabled (<c>0xef0101</c>) designators — calls
+    /// to an ECDSA-disabled account still execute its delegate.
     /// <b>Assumes </b><paramref name="code"/> <b>is delegation code!</b>
     /// </remarks>
     static bool TryGetDelegatedAddress(ReadOnlySpan<byte> code, [NotNullWhen(true)] out Address? address)
     {
-        if (Eip7702Constants.IsDelegatedCode(code))
+        if (Eip7702Constants.IsDelegatedCode(code) || Eip7851Constants.IsEcdsaDisabledDelegatedCode(code))
         {
             address = new Address(code[Eip7702Constants.DelegationHeader.Length..]);
             return true;

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -169,6 +169,7 @@ public enum Instruction : byte
     RETURN = 0xf3,
     DELEGATECALL = 0xf4,
     CREATE2 = 0xf5,
+    SETSELFDELEGATE = 0xf6, // EIP-7851 (opcode value TBD in the spec; placeholder)
     STATICCALL = 0xfa,
     REVERT = 0xfd,
     INVALID = 0xfe,

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
@@ -275,6 +276,57 @@ public static partial class EvmInstructions
         // Jump forward to be unpredicted by the branch predictor.
     Stop:
         return EvmExceptionType.Stop;
+    OutOfGas:
+        return EvmExceptionType.OutOfGas;
+    StackUnderflow:
+        return EvmExceptionType.StackUnderflow;
+    StaticCallViolation:
+        return EvmExceptionType.StaticCallViolation;
+    }
+
+    /// <summary>
+    /// Executes the SETSELFDELEGATE opcode (EIP-7851).
+    /// Updates the executing account's delegation designator to the ECDSA-disabled form
+    /// <c>0xef0101 || delegate</c>, permanently disabling its ECDSA authority.
+    /// </summary>
+    /// <remarks>
+    /// Pushes 1 on success. Pushes 0 without any state change when the delegate address is zero
+    /// or the executing account's state code is not a 23-byte EIP-7702/EIP-7851 delegation
+    /// designator (i.e. the code is not running in a delegated EOA's own context).
+    /// </remarks>
+    [SkipLocalsInit]
+    public static EvmExceptionType InstructionSetSelfDelegate<TGasPolicy, TTracingInst>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        where TTracingInst : struct, IFlag
+    {
+        VmState<TGasPolicy> vmState = vm.VmState;
+        if (vmState.IsStatic)
+            goto StaticCallViolation;
+
+        if (!TGasPolicy.UpdateGas(ref gas, GasCostOf.SetSelfDelegate))
+            goto OutOfGas;
+
+        Address delegateAddress = stack.PopAddress();
+        if (delegateAddress is null)
+            goto StackUnderflow;
+
+        IWorldState state = vm.WorldState;
+        Address executingAccount = vmState.Env.ExecutingAccount;
+        byte[]? currentCode = state.GetCode(executingAccount);
+        bool isDelegatedContext = currentCode is not null
+            && (Eip7702Constants.IsDelegatedCode(currentCode) || Eip7851Constants.IsEcdsaDisabledDelegatedCode(currentCode));
+
+        if (delegateAddress == Address.Zero || !isDelegatedContext)
+            return stack.PushZero<TTracingInst>();
+
+        byte[] newCode = new byte[Eip7851Constants.DelegationHeader.Length + Address.Size];
+        Eip7851Constants.DelegationHeader.CopyTo(newCode);
+        delegateAddress.Bytes.CopyTo(newCode.AsSpan(Eip7851Constants.DelegationHeader.Length));
+        ValueHash256 codeHash = ValueKeccak.Compute(newCode);
+        state.InsertCode(executingAccount, in codeHash, newCode, vm.Spec);
+
+        return stack.PushOne<TTracingInst>();
+        // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;
     StackUnderflow:

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -318,6 +318,11 @@ public static unsafe partial class EvmInstructions
             lookup[(int)Instruction.REVERT] = &InstructionRevert;
         }
 
+        if (spec.IsEip7851Enabled)
+        {
+            lookup[(int)Instruction.SETSELFDELEGATE] = &InstructionSetSelfDelegate<TGasPolicy, TTracingInst>;
+        }
+
         // Final opcodes.
         lookup[(int)Instruction.INVALID] = &InstructionInvalid;
         lookup[(int)Instruction.SELFDESTRUCT] = (spec.IsEip8037Enabled, spec.IsEip7708Enabled) switch

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -751,10 +751,21 @@ namespace Nethermind.Evm.TransactionProcessing
 
             accessTracker.WarmUp(authorizationTuple.Authority);
 
-            if (WorldState.HasCode(authorizationTuple.Authority) && !_codeInfoRepository.TryGetDelegation(authorizationTuple.Authority, spec, out _))
+            if (WorldState.HasCode(authorizationTuple.Authority))
             {
-                error = $"Authority ({authorizationTuple.Authority}) has code deployed.";
-                return AuthorizationTupleResult.InvalidAsCodeDeployed;
+                // EIP-7851: an ECDSA-disabled account (0xef0101 designator) can never authorize
+                // delegation changes again, even though its code parses as a delegation.
+                if (spec.IsEip7851Enabled && Eip7851Constants.IsEcdsaDisabledDelegatedCode(WorldState.GetCode(authorizationTuple.Authority)))
+                {
+                    error = $"Authority ({authorizationTuple.Authority}) has permanently disabled its ECDSA authority.";
+                    return AuthorizationTupleResult.InvalidAsCodeDeployed;
+                }
+
+                if (!_codeInfoRepository.TryGetDelegation(authorizationTuple.Authority, spec, out _))
+                {
+                    error = $"Authority ({authorizationTuple.Authority}) has code deployed.";
+                    return AuthorizationTupleResult.InvalidAsCodeDeployed;
+                }
             }
 
             ulong authNonce = WorldState.GetNonce(authorizationTuple.Authority);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Core.Precompiles;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -1021,7 +1022,31 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
 
         state.Gas = gas;
 
-        return ExecutePrecompileCall(state, precompile, callData, spec);
+        CallResult callResult = ExecutePrecompileCall(state, precompile, callData, spec);
+
+        // EIP-8151: a successful ecRecover additionally charges (and warms) an account access
+        // on the recovered address and returns zero when the address has permanently disabled
+        // its ECDSA authority (EIP-7851 0xef0101 designator).
+        if (spec.IsEip8151Enabled
+            && callResult.PrecompileSuccess == true
+            && callResult.Output.Length == 32
+            && state.Env.CodeSource == PrecompiledAddresses.ECRecover)
+        {
+            Address recoveredAddress = new(callResult.Output.Span[12..]);
+            gas = state.Gas;
+            if (!TGasPolicy.ConsumeAccountAccessGas(ref gas, spec, in state.AccessTracker, _txTracer.IsTracingAccess, recoveredAddress))
+            {
+                return new(default, precompileSuccess: false, shouldRevert: true, EvmExceptionType.OutOfGas);
+            }
+
+            state.Gas = gas;
+            if (Eip7851Constants.IsEcdsaDisabledDelegatedCode(_worldState.GetCode(recoveredAddress)))
+            {
+                callResult = new(new byte[32], precompileSuccess: true);
+            }
+        }
+
+        return callResult;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -112,6 +112,7 @@ namespace Nethermind.Specs.Test
         public ulong ElasticityMultiplier { get; set; } = spec.ElasticityMultiplier;
         public IBaseFeeCalculator BaseFeeCalculator { get; set; } = spec.BaseFeeCalculator;
         public bool IsEip8024Enabled { get; set; } = spec.IsEip8024Enabled;
+        public bool IsEip7851Enabled { get; set; } = spec.IsEip7851Enabled;
         public bool IsEip6110Enabled { get; set; } = spec.IsEip6110Enabled;
         public Address? DepositContractAddress { get; set; } = spec.DepositContractAddress;
         public bool IsEip7594Enabled { get; set; } = spec.IsEip7594Enabled;

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -113,6 +113,7 @@ namespace Nethermind.Specs.Test
         public IBaseFeeCalculator BaseFeeCalculator { get; set; } = spec.BaseFeeCalculator;
         public bool IsEip8024Enabled { get; set; } = spec.IsEip8024Enabled;
         public bool IsEip7851Enabled { get; set; } = spec.IsEip7851Enabled;
+        public bool IsEip8151Enabled { get; set; } = spec.IsEip8151Enabled;
         public bool IsEip6110Enabled { get; set; } = spec.IsEip6110Enabled;
         public Address? DepositContractAddress { get; set; } = spec.DepositContractAddress;
         public bool IsEip7594Enabled { get; set; } = spec.IsEip7594Enabled;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -186,4 +186,5 @@ public class ChainParameters
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip7851TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -187,4 +187,5 @@ public class ChainParameters
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip7851TransitionTimestamp { get; set; }
+    public ulong? Eip8151TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -357,6 +357,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             }
 
             releaseSpec.IsEip7851Enabled = (chainSpec.Parameters.Eip7851TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+            releaseSpec.IsEip8151Enabled = (chainSpec.Parameters.Eip8151TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -356,6 +356,8 @@ namespace Nethermind.Specs.ChainSpecStyle
                 releaseSpec.MaxCodeSize = CodeSizeConstants.MaxCodeSizeEip7954;
             }
 
+            releaseSpec.IsEip7851Enabled = (chainSpec.Parameters.Eip7851TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)
             {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -215,6 +215,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8024TransitionTimestamp = chainSpecJson.Params.Eip8024TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
+            Eip7851TransitionTimestamp = chainSpecJson.Params.Eip7851TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -216,6 +216,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
             Eip7851TransitionTimestamp = chainSpecJson.Params.Eip7851TransitionTimestamp,
+            Eip8151TransitionTimestamp = chainSpecJson.Params.Eip8151TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -194,6 +194,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip7851TransitionTimestamp { get; set; }
+    public ulong? Eip8151TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -193,6 +193,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip7851TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -170,6 +170,7 @@ public class ReleaseSpec : IReleaseSpec
     public bool IsEip7708Enabled { get; set; }
     public bool IsEip7954Enabled { get; set; }
     public bool IsEip7851Enabled { get; set; }
+    public bool IsEip8151Enabled { get; set; }
 
     private ReleaseSpec? _systemSpec;
 

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -169,6 +169,7 @@ public class ReleaseSpec : IReleaseSpec
 
     public bool IsEip7708Enabled { get; set; }
     public bool IsEip7954Enabled { get; set; }
+    public bool IsEip7851Enabled { get; set; }
 
     private ReleaseSpec? _systemSpec;
 


### PR DESCRIPTION
## Changes

- After a successful ecRecover (address `0x01`) run, the VM charges an EIP-2929 account access on the recovered address — 2600 cold / 100 warm, warming it in the access set — and, when the account's code is the EIP-7851 `0xef0101` ECDSA-disabled designator, replaces the output with 32 zero bytes
- Failed recoveries keep the flat 3000 gas with no account access, per spec
- Implemented in `VirtualMachine.RunPrecompile` (not the precompile class) because the extra gas depends on the execution result and the transaction access set, which `IPrecompile` cannot express
- `IsEip8151Enabled` flag + `eip8151TransitionTimestamp` chainspec plumbing

**Stacked on #12239 (EIP-7851)** — includes its commit since it needs the `0xef0101` designator helpers; review only the last commit until that merges.

Spec: https://eips.ethereum.org/EIPS/eip-8151 (Hegotá / EIP-8081 candidate). Not yet activated in any fork file — activation lands with the Hegotá fork wiring (#12226).

Part of the Hegotá (EIP-8081) PR series.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Eip8151Tests` (4): exact cold-access gas measured in-EVM via GAS-delta bytecode, warm second recovery, zero output for a deactivated authority (with gas still charged), and live `0xef0100` delegation not treated as deactivated. Raw `ECRecoverPrecompileTests` pass unchanged.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)