### PR TITLE
refactor(api): remove dead InitNetworkProtocol plugin hook

### DIFF
--- a/src/Nethermind/Nethermind.Api.Test/TestPlugin.cs
+++ b/src/Nethermind/Nethermind.Api.Test/TestPlugin.cs
@@ -13,8 +13,6 @@ namespace Nethermind.Api.Test
         public string Author { get; }
         public Task Init(INethermindApi nethermindApi) => throw new System.NotImplementedException();
 
-        public Task InitNetworkProtocol() => throw new System.NotImplementedException();
-
         public Task InitRpcModules() => throw new System.NotImplementedException();
 
         public bool Enabled => true;

--- a/src/Nethermind/Nethermind.Api.Test/TestPlugin2.cs
+++ b/src/Nethermind/Nethermind.Api.Test/TestPlugin2.cs
@@ -13,8 +13,6 @@ namespace Nethermind.Api.Test
         public string Author { get; }
         public Task Init(INethermindApi nethermindApi) => throw new System.NotImplementedException();
 
-        public Task InitNetworkProtocol() => throw new System.NotImplementedException();
-
         public Task InitRpcModules() => throw new System.NotImplementedException();
 
         public bool Enabled => true;

--- a/src/Nethermind/Nethermind.Api/Extensions/INethermindPlugin.cs
+++ b/src/Nethermind/Nethermind.Api/Extensions/INethermindPlugin.cs
@@ -18,8 +18,6 @@ public interface INethermindPlugin
 
     Task Init(INethermindApi nethermindApi) => Task.CompletedTask;
 
-    Task InitNetworkProtocol() => Task.CompletedTask;
-
     Task InitRpcModules() => Task.CompletedTask;
     bool MustInitialize => false;
     bool Enabled { get; }

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
@@ -23,7 +23,6 @@ public class EthStatsPluginTests
 
         Assert.DoesNotThrow(() => _plugin.InitTxTypesAndRlpDecoders(_context));
         Assert.DoesNotThrowAsync(async () => await _plugin.Init(_context));
-        Assert.DoesNotThrowAsync(async () => await _plugin.InitNetworkProtocol());
         Assert.DoesNotThrowAsync(async () => await _plugin.InitRpcModules());
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeNetwork.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api;
-using Nethermind.Api.Extensions;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
@@ -54,7 +53,6 @@ public class InitializeNetwork : IStep
     private readonly IStaticNodesManager _staticNodesManager;
     private readonly ITrustedNodesManager _trustedNodesManager;
     private readonly IEnode _enode;
-    private readonly INethermindPlugin[] _plugins;
     private readonly Lazy<IProtocolsManager> _protocolsManager;
 
     private readonly NodeSourceToDiscV4Feeder _enrDiscoveryAppFeeder;
@@ -78,7 +76,6 @@ public class InitializeNetwork : IStep
         IStaticNodesManager staticNodesManager,
         ITrustedNodesManager trustedNodesManager,
         IEnode enode,
-        INethermindPlugin[] plugins,
         Lazy<IProtocolsManager> protocolsManager,
         INetworkConfig networkConfig,
         ISyncConfig syncConfig,
@@ -98,7 +95,6 @@ public class InitializeNetwork : IStep
         _staticNodesManager = staticNodesManager;
         _trustedNodesManager = trustedNodesManager;
         _enode = enode;
-        _plugins = plugins;
         _protocolsManager = protocolsManager;
         _networkConfig = networkConfig;
         _syncConfig = syncConfig;
@@ -254,11 +250,6 @@ public class InitializeNetwork : IStep
         {
             // Feed some nodes into discoveryApp in case all bootnodes is faulty.
             _ = _enrDiscoveryAppFeeder.Run();
-        }
-
-        foreach (INethermindPlugin plugin in _plugins)
-        {
-            await plugin.InitNetworkProtocol();
         }
 
         // Capabilities must be resolved before the RLPx listener accepts peers. Otherwise

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
@@ -146,7 +146,6 @@ public class MergePluginTests
         _mergeConfig.TerminalTotalDifficulty = enabled ? "0" : null;
         Assert.DoesNotThrowAsync(async () => await _consensusPlugin!.Init(api));
         Assert.DoesNotThrowAsync(async () => await _plugin.Init(api));
-        Assert.DoesNotThrowAsync(async () => await _plugin.InitNetworkProtocol());
         Assert.DoesNotThrow(() => container.Resolve<IBlockProducerFactory>().InitBlockProducer());
     }
 
@@ -189,7 +188,6 @@ public class MergePluginTests
         INethermindApi api = container.Resolve<INethermindApi>();
         Assert.DoesNotThrowAsync(async () => await _consensusPlugin!.Init(api));
         await _plugin.Init(api);
-        await _plugin.InitNetworkProtocol();
         ISyncConfig syncConfig = api.Config<ISyncConfig>();
         Assert.That(syncConfig.NetworkingEnabled, Is.True);
         Assert.That(api.GossipPolicy.CanGossipBlocks, Is.True);

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -184,16 +184,6 @@ public class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) : INethe
 
     private bool HasTtd() => _api.SpecProvider?.TerminalTotalDifficulty is not null || mergeConfig.TerminalTotalDifficulty is not null;
 
-    public Task InitNetworkProtocol()
-    {
-        if (MergeEnabled)
-        {
-            ArgumentNullException.ThrowIfNull(_api.SpecProvider);
-        }
-
-        return Task.CompletedTask;
-    }
-
     public bool MustInitialize { get => true; }
 
     public virtual IModule Module => new MergePluginModule();

--- a/src/Nethermind/Nethermind.Runner.Test/Module/NetworkModuleTest.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/NetworkModuleTest.cs
@@ -6,33 +6,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Autofac;
-using Nethermind.Api;
-using Nethermind.Api.Extensions;
-using Nethermind.Blockchain;
-using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Modules;
-using Nethermind.Init.Steps;
 using Nethermind.Network;
-using Nethermind.Network.Config;
 using Nethermind.Network.Contract.P2P;
-using Nethermind.Network.Discovery.Discv4;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.Subprotocols.Eth.V71;
 using Nethermind.Network.P2P.Analyzers;
 using Nethermind.Network.P2P.ProtocolHandlers;
-using Nethermind.Network.Rlpx;
 using Nethermind.Logging;
-using Nethermind.Synchronization;
-using Nethermind.Synchronization.Peers;
 using Nethermind.Stats.Model;
 using NSubstitute;
-using NSubstitute.Core;
 using NUnit.Framework;
 
 namespace Nethermind.Runner.Test.Module;
@@ -143,41 +131,6 @@ public class NetworkModuleTest
         handler?.Dispose();
     }
 
-    [Test]
-    public async Task Initialize_network_registers_plugin_capabilities_before_starting_rlpx()
-    {
-        SubstitutionContext.Current?.ThreadContext?.DequeueAllArgumentSpecifications();
-
-        List<string> callOrder = [];
-        IRlpxHost rlpxHost = Substitute.For<IRlpxHost>();
-        IStaticNodesManager staticNodesManager = Substitute.For<IStaticNodesManager>();
-        ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        IProtocolsManager protocolsManager = Substitute.For<IProtocolsManager>();
-        INethermindPlugin plugin = new RecordingPlugin(() => callOrder.Add("plugin"));
-
-        rlpxHost.Init().Returns(_ =>
-        {
-            callOrder.Add("rlpx");
-            return Task.CompletedTask;
-        });
-        staticNodesManager.InitAsync().Returns(Task.CompletedTask);
-        trustedNodesManager.InitAsync().Returns(Task.CompletedTask);
-
-        TestInitializeNetwork initializeNetwork = new(
-            rlpxHost,
-            staticNodesManager,
-            trustedNodesManager,
-            protocolsManager,
-            [plugin],
-            new NetworkConfig { DisableDiscV4DnsFeeder = true },
-            new SyncConfig(),
-            LimboLogs.Instance);
-
-        await initializeNetwork.RunInitPeer();
-
-        Assert.That(callOrder, Is.EqualTo(new[] { "plugin", "rlpx" }));
-    }
-
     private IEnumerable<(Type MessageType, Type SerializerType)> FindSerializersInAssembly(Assembly assembly)
     {
         foreach (Type type in assembly.GetExportedTypes())
@@ -211,49 +164,4 @@ public class NetworkModuleTest
         }
     }
 
-    private sealed class RecordingPlugin(Action onInitNetworkProtocol) : INethermindPlugin
-    {
-        public string Name => nameof(RecordingPlugin);
-        public string Description => nameof(RecordingPlugin);
-        public string Author => nameof(RecordingPlugin);
-        public bool Enabled => true;
-
-        public Task InitNetworkProtocol()
-        {
-            onInitNetworkProtocol();
-            return Task.CompletedTask;
-        }
-    }
-
-    private sealed class TestInitializeNetwork(
-        IRlpxHost rlpxHost,
-        IStaticNodesManager staticNodesManager,
-        ITrustedNodesManager trustedNodesManager,
-        IProtocolsManager protocolsManager,
-        INethermindPlugin[] plugins,
-        INetworkConfig networkConfig,
-        ISyncConfig syncConfig,
-        ILogManager logManager) : InitializeNetwork(
-                Substitute.For<ISyncServer>(),
-                Substitute.For<ISynchronizer>(),
-                Substitute.For<ISyncPeerPool>(),
-                new NodeSourceToDiscV4Feeder(Substitute.For<INodeSource>(), Substitute.For<IDiscoveryApp>(), Substitute.For<IProcessExitSource>()),
-                Substitute.For<IDiscoveryApp>(),
-                new Lazy<IPeerPool>(() => Substitute.For<IPeerPool>()),
-                Substitute.For<IBlockTree>(),
-                rlpxHost,
-                Substitute.For<IPeerManager>(),
-                Substitute.For<ISessionMonitor>(),
-                staticNodesManager,
-                trustedNodesManager,
-                Substitute.For<IEnode>(),
-                plugins,
-                new Lazy<IProtocolsManager>(() => protocolsManager),
-                networkConfig,
-                syncConfig,
-                Substitute.For<IInitConfig>(),
-                logManager)
-    {
-        public Task RunInitPeer() => InitPeer();
-    }
 }


### PR DESCRIPTION
## Changes

Removes the dead `INethermindPlugin.InitNetworkProtocol` lifecycle hook.

The hook no longer performs any real work: p2p capability registration now happens through DI via `IP2PCapabilityResolver`, so the only remaining production implementer was `MergePlugin`, whose override merely asserted `SpecProvider` is non-null. The per-plugin invocation loop in `InitializeNetwork` was therefore a no-op for every plugin.

- Remove `InitNetworkProtocol()` from `INethermindPlugin`.
- Remove the `foreach (plugin) await plugin.InitNetworkProtocol()` loop in `InitializeNetwork`, along with its now-unused `INethermindPlugin[]` constructor dependency.
- Remove the `MergePlugin` override.
- Drop the obsolete test scaffolding: the `Initialize_network_registers_plugin_capabilities_before_starting_rlpx` test (its premise no longer holds) plus the plugin-override stubs/assertions in the plugin tests.

Net result: 8 files, 120 deletions, 0 insertions.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Pure removal. Full solution builds clean (0 warnings, 0 errors). The updated plugin test suites (`Nethermind.Api.Test`, `Nethermind.EthStats.Test`, `Nethermind.Merge.Plugin.Test`, `Nethermind.Runner.Test`) pass. The only red in `Nethermind.Runner.Test` under parallel load is the pre-existing `ConfigFilesTests.Arena_order_is_default` flake (another test's `MemoryHintMan` mutates `NettyArenaOrder`); it passes in isolation and is unrelated to this change.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`InitNetworkProtocol` is part of the public `INethermindPlugin` surface. Because it is implemented implicitly (not via `override`), external plugins that defined an `InitNetworkProtocol` method will still compile — the method simply stops being invoked. There are no in-tree callers left after this change.
