### PR TITLE
feat(evm): EIP-7979 call and return opcodes (CALLSUB/ENTERSUB/RETURNSUB)

### DIFF
--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -464,6 +464,11 @@ namespace Nethermind.Core.Specs
         public bool IsEip7954Enabled { get; }
 
         /// <summary>
+        /// EIP-7979: Call and Return Opcodes for the EVM (CALLSUB, ENTERSUB, RETURNSUB).
+        /// </summary>
+        public bool IsEip7979Enabled { get; }
+
+        /// <summary>
         /// Precomputed gas cost and refund constants derived from this spec.
         /// Values are cached per spec instance (singletons per fork) to avoid
         /// repeated interface dispatch on the EVM opcode hot path.

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -117,5 +117,6 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip7843Enabled => spec.IsEip7843Enabled;
     public virtual bool IsEip7954Enabled => spec.IsEip7954Enabled;
     public virtual bool IsEip8024Enabled => spec.IsEip8024Enabled;
+    public virtual bool IsEip7979Enabled => spec.IsEip7979Enabled;
     public SpecGasCosts GasCosts => spec.GasCosts;
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7979Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7979Tests.cs
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-7979: CALLSUB, ENTERSUB, and RETURNSUB subroutine opcodes.
+/// </summary>
+[TestFixture]
+public class Eip7979Tests : VirtualMachineTestsBase
+{
+    protected override ISpecProvider SpecProvider { get; } =
+        new TestSpecProvider(new OverridableReleaseSpec(Prague.Instance) { IsEip7979Enabled = true });
+
+    [Test]
+    public void CallSub_executes_subroutine_and_returns()
+    {
+        byte[] code =
+        [
+            (byte)Instruction.PUSH1, 0x07,      // 0..1: subroutine offset
+            (byte)Instruction.CALLSUB,          // 2: jumps to 7, pushes 3
+            (byte)Instruction.PUSH1, 0x00,      // 3..4: MSTORE offset
+            (byte)Instruction.MSTORE,           // 5: stores subroutine result at 0
+            (byte)Instruction.STOP,             // 6
+            (byte)Instruction.ENTERSUB,         // 7: subroutine entry
+            (byte)Instruction.PUSH1, 0x2a,      // 8..9: result
+            (byte)Instruction.RETURNSUB,        // 10: returns to 3
+        ];
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+            // Total: PUSH1(3) + CALLSUB(8) + ENTERSUB(1) + PUSH1(3) + RETURNSUB(5) + PUSH1(3) + MSTORE(3+3 memory)
+            Assert.That(result.GasSpent, Is.EqualTo(GasCostOf.Transaction
+                + GasCostOf.VeryLow + GasCostOf.Mid + GasCostOf.JumpDest + GasCostOf.VeryLow
+                + GasCostOf.Low + GasCostOf.VeryLow + GasCostOf.VeryLow + GasCostOf.Memory));
+        }
+    }
+
+    [Test]
+    public void Nested_subroutine_calls_return_in_order()
+    {
+        byte[] code =
+        [
+            (byte)Instruction.PUSH1, 0x05,      // outer subroutine at 5
+            (byte)Instruction.CALLSUB,          // 2: pushes 3
+            (byte)Instruction.STOP,             // 3: final return lands here
+            (byte)Instruction.STOP,             // 4: padding
+            (byte)Instruction.ENTERSUB,         // 5: outer entry
+            (byte)Instruction.PUSH1, 0x0b,      // 6..7: inner subroutine at 11
+            (byte)Instruction.CALLSUB,          // 8: pushes 9
+            (byte)Instruction.RETURNSUB,        // 9: returns to 3 (STOP)
+            (byte)Instruction.STOP,             // 10
+            (byte)Instruction.ENTERSUB,         // 11: inner entry
+            (byte)Instruction.RETURNSUB,        // 12: returns to 9
+        ];
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+    }
+
+    [Test]
+    public void CallSub_to_non_entersub_destination_halts()
+    {
+        byte[] code =
+        [
+            (byte)Instruction.PUSH1, 0x04,
+            (byte)Instruction.CALLSUB,
+            (byte)Instruction.STOP,
+            (byte)Instruction.JUMPDEST,         // 4: not an ENTERSUB
+        ];
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Failure));
+    }
+
+    [Test]
+    public void CallSub_into_push_data_halts()
+    {
+        byte[] code =
+        [
+            (byte)Instruction.PUSH1, 0x04,
+            (byte)Instruction.CALLSUB,
+            (byte)Instruction.PUSH1, (byte)Instruction.ENTERSUB, // 4: ENTERSUB byte inside push data
+            (byte)Instruction.STOP,
+        ];
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Failure));
+    }
+
+    [Test]
+    public void ReturnSub_with_empty_return_stack_halts()
+    {
+        byte[] code = [(byte)Instruction.RETURNSUB];
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Failure));
+    }
+
+    [Test]
+    public void EnterSub_reached_by_fallthrough_is_a_noop()
+    {
+        byte[] code =
+        [
+            (byte)Instruction.ENTERSUB,
+            (byte)Instruction.STOP,
+        ];
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+            Assert.That(result.GasSpent, Is.EqualTo(GasCostOf.Transaction + GasCostOf.JumpDest));
+        }
+    }
+
+}

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -139,6 +139,10 @@ public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
     public bool ValidateJump(int destination)
         => _analyzer?.ValidateJump(destination) ?? false;
 
+    /// <summary>EIP-7979: whether <paramref name="destination"/> is a valid CALLSUB target (an ENTERSUB outside push data).</summary>
+    public bool ValidateEnterSub(int destination)
+        => _analyzer?.ValidateEnterSub(destination) ?? false;
+
     void IThreadPoolWorkItem.Execute()
         => _analyzer?.Execute();
 

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -39,6 +39,39 @@ public sealed class JumpDestinationAnalyzer(CodeInfo codeInfo, bool skipAnalysis
         return (uint)destination < (uint)MachineCode.Length && IsJumpDestination(_jumpDestinationBitmap, destination);
     }
 
+    // EIP-7979: valid ENTERSUB positions (code segment only, push immediates excluded). Built
+    // lazily on the first CALLSUB against this code and cached; JUMP/JUMPI paths are unaffected.
+    // The benign ??= race mirrors the jump-destination bitmap: concurrent builders compute the
+    // same content.
+    private long[]? _enterSubBitmap;
+
+    public bool ValidateEnterSub(int destination)
+    {
+        long[] bitmap = _enterSubBitmap ??= CreateEnterSubBitmap();
+        return (uint)destination < (uint)MachineCode.Length
+            && (bitmap[destination >> BitShiftPerInt64] & (1L << (destination & 63))) != 0;
+    }
+
+    private long[] CreateEnterSubBitmap()
+    {
+        ReadOnlySpan<byte> code = MachineCode.Span;
+        long[] bitmap = CreateBitmap(code.Length);
+        for (int pc = 0; pc < code.Length; pc++)
+        {
+            int op = code[pc];
+            if (op == (int)Instruction.ENTERSUB)
+            {
+                bitmap[pc >> BitShiftPerInt64] |= 1L << (pc & 63);
+            }
+            else if (op >= PUSH1 && op <= (int)Instruction.PUSH32)
+            {
+                pc += op - PUSHx;
+            }
+        }
+
+        return bitmap;
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private long[] CreateOrWaitForJumpDestinationBitmap()
     {

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -159,6 +159,11 @@ public enum Instruction : byte
     LOG3 = 0xa3,
     LOG4 = 0xa4,
 
+    // EIP-7979 (opcode values TBD in the spec; placeholders)
+    CALLSUB = 0xb0,
+    ENTERSUB = 0xb1,
+    RETURNSUB = 0xb2,
+
     DUPN = 0xe6,
     SWAPN = 0xe7,
     EXCHANGE = 0xe8,

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -283,6 +283,79 @@ public static partial class EvmInstructions
         return EvmExceptionType.StaticCallViolation;
     }
 
+    /// <summary>Upper bound for the EIP-7979 return stack depth.</summary>
+    private const int MaxReturnStackDepth = 1024;
+
+    /// <summary>
+    /// Executes the CALLSUB opcode (EIP-7979).
+    /// Pops the subroutine destination, pushes the return address (the instruction after
+    /// CALLSUB) onto the frame's return stack, and jumps to the destination, which must be a
+    /// valid ENTERSUB (outside push data).
+    /// </summary>
+    [SkipLocalsInit]
+    public static EvmExceptionType InstructionCallSub<TGasPolicy>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+    {
+        TGasPolicy.Consume(ref gas, GasCostOf.Mid);
+        if (!stack.PopUInt256(out UInt256 destination)) goto StackUnderflow;
+
+        VmState<TGasPolicy> vmState = vm.VmState;
+        if (!destination.IsUint64 || destination.u0 > int.MaxValue || !vmState.Env.CodeInfo.ValidateEnterSub((int)destination.u0))
+            goto InvalidJumpDestination;
+
+        if (vmState.ReturnStackHead >= MaxReturnStackDepth)
+            goto StackOverflow;
+
+        // programCounter is already advanced past CALLSUB, i.e. it holds PC + 1.
+        (vmState.ReturnStack ??= new int[MaxReturnStackDepth])[vmState.ReturnStackHead++] = programCounter;
+        programCounter = (int)destination.u0;
+
+        return EvmExceptionType.None;
+        // Jump forward to be unpredicted by the branch predictor.
+    StackUnderflow:
+        return EvmExceptionType.StackUnderflow;
+    InvalidJumpDestination:
+        return EvmExceptionType.InvalidJumpDestination;
+    StackOverflow:
+        return EvmExceptionType.StackOverflow;
+    }
+
+    /// <summary>
+    /// Executes the ENTERSUB opcode (EIP-7979).
+    /// Marks a valid CALLSUB destination; at runtime it only charges the jump-destination cost.
+    /// </summary>
+    [SkipLocalsInit]
+    public static EvmExceptionType InstructionEnterSub<TGasPolicy>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+    {
+        TGasPolicy.Consume(ref gas, GasCostOf.JumpDest);
+
+        return EvmExceptionType.None;
+    }
+
+    /// <summary>
+    /// Executes the RETURNSUB opcode (EIP-7979).
+    /// Pops the frame's return stack into the program counter; halts exceptionally when the
+    /// return stack is empty.
+    /// </summary>
+    [SkipLocalsInit]
+    public static EvmExceptionType InstructionReturnSub<TGasPolicy>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+    {
+        TGasPolicy.Consume(ref gas, GasCostOf.Low);
+
+        VmState<TGasPolicy> vmState = vm.VmState;
+        if (vmState.ReturnStackHead == 0)
+            goto StackUnderflow;
+
+        programCounter = vmState.ReturnStack![--vmState.ReturnStackHead];
+
+        return EvmExceptionType.None;
+        // Jump forward to be unpredicted by the branch predictor.
+    StackUnderflow:
+        return EvmExceptionType.StackUnderflow;
+    }
+
     /// <summary>
     /// Handles invalid opcodes by deducting a high gas cost and returning a BadInstruction error.
     /// </summary>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -318,6 +318,13 @@ public static unsafe partial class EvmInstructions
             lookup[(int)Instruction.REVERT] = &InstructionRevert;
         }
 
+        if (spec.IsEip7979Enabled)
+        {
+            lookup[(int)Instruction.CALLSUB] = &InstructionCallSub<TGasPolicy>;
+            lookup[(int)Instruction.ENTERSUB] = &InstructionEnterSub<TGasPolicy>;
+            lookup[(int)Instruction.RETURNSUB] = &InstructionReturnSub<TGasPolicy>;
+        }
+
         // Final opcodes.
         lookup[(int)Instruction.INVALID] = &InstructionInvalid;
         lookup[(int)Instruction.SELFDESTRUCT] = (spec.IsEip8037Enabled, spec.IsEip7708Enabled) switch

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -31,6 +31,12 @@ public class VmState<TGasPolicy> : IDisposable
     private static readonly StackPool _stackPool = new();
 
     public byte[]? DataStack;
+    /// <summary>
+    /// EIP-7979 return stack, lazily allocated on the first CALLSUB of the frame and kept for
+    /// reuse across poolings (only <see cref="ReturnStackHead"/> is reset).
+    /// </summary>
+    public int[]? ReturnStack;
+    public int ReturnStackHead;
     public TGasPolicy Gas;
     public ulong InitialStateGasUsed;
     public ulong StateGasRefundPending;
@@ -154,6 +160,7 @@ public class VmState<TGasPolicy> : IDisposable
         OutputLength = outputLength;
         Refund = 0;
         DataStackHead = 0;
+        ReturnStackHead = 0;
         ProgramCounter = 0;
         ExecutionType = executionType;
         IsTopLevel = isTopLevel;

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -112,6 +112,7 @@ namespace Nethermind.Specs.Test
         public ulong ElasticityMultiplier { get; set; } = spec.ElasticityMultiplier;
         public IBaseFeeCalculator BaseFeeCalculator { get; set; } = spec.BaseFeeCalculator;
         public bool IsEip8024Enabled { get; set; } = spec.IsEip8024Enabled;
+        public bool IsEip7979Enabled { get; set; } = spec.IsEip7979Enabled;
         public bool IsEip6110Enabled { get; set; } = spec.IsEip6110Enabled;
         public Address? DepositContractAddress { get; set; } = spec.DepositContractAddress;
         public bool IsEip7594Enabled { get; set; } = spec.IsEip7594Enabled;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -186,4 +186,5 @@ public class ChainParameters
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip7979TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -356,6 +356,8 @@ namespace Nethermind.Specs.ChainSpecStyle
                 releaseSpec.MaxCodeSize = CodeSizeConstants.MaxCodeSizeEip7954;
             }
 
+            releaseSpec.IsEip7979Enabled = (chainSpec.Parameters.Eip7979TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)
             {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -215,6 +215,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8024TransitionTimestamp = chainSpecJson.Params.Eip8024TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
+            Eip7979TransitionTimestamp = chainSpecJson.Params.Eip7979TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -193,6 +193,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip7979TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -169,6 +169,7 @@ public class ReleaseSpec : IReleaseSpec
 
     public bool IsEip7708Enabled { get; set; }
     public bool IsEip7954Enabled { get; set; }
+    public bool IsEip7979Enabled { get; set; }
 
     private ReleaseSpec? _systemSpec;
 


### PR DESCRIPTION
## Changes

- `CALLSUB` (0xb0, 8 gas): pops the destination — must be a valid `ENTERSUB` outside push data, else `InvalidJumpDestination` — pushes `PC + 1` to a per-frame **return stack** (bounded at 1024, overflow halts) and jumps
- `ENTERSUB` (0xb1, 1 gas): subroutine entry marker, runtime no-op (fallthrough allowed)
- `RETURNSUB` (0xb2, 5 gas): pops the return stack into the program counter; empty return stack halts exceptionally
- `VmState` gains a lazily allocated, pooled-reuse return stack; `JumpDestinationAnalyzer` gains a **separate** lazily built ENTERSUB bitmap so JUMP/JUMPI hot paths and the SIMD jump-destination analysis are untouched (the bitmap is only built when CALLSUB actually executes)
- All three gated by `IsEip7979Enabled` + `eip7979TransitionTimestamp` chainspec plumbing
- Opcode values are placeholders — the EIP marks them TBD

Spec: https://eips.ethereum.org/EIPS/eip-7979 (Hegotá / EIP-8081 candidate). The EIP's optional 0xEF MAGIC static-validation section is not implemented (it does not apply to legacy code). Not yet activated in any fork file — activation lands with the Hegotá fork wiring (#12226).

Part of the Hegotá (EIP-8081) PR series.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Eip7979Tests` (6): call/return round trip with exact gas accounting, nested subroutines, non-ENTERSUB destination halt, push-data destination halt, empty-return-stack halt, fallthrough ENTERSUB no-op. `InvalidOpcodeTests` pass unchanged (opcodes stay invalid pre-fork).

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)