### PR TITLE
fix(evm): guard gas-policy state-gas subtractions against underflow

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
@@ -26,4 +26,30 @@ public class EthereumGasPolicyTests
         ulong expected = baseCost + GasCostOf.Memory * words;
         Assert.That(initial - EthereumGasPolicy.GetRemainingGas(in gas), Is.EqualTo(expected));
     }
+
+    [Test]
+    public void CreateAvailableFromIntrinsic_returns_out_of_gas_when_gas_limit_below_intrinsic()
+    {
+        // gasLimit sits between intrinsic regular and intrinsic regular + state reservoir, so the
+        // regular-only static check would pass but the reservoir is unaffordable.
+        EthereumGasPolicy intrinsic = new() { Value = 30_000, StateReservoir = 183_600 };
+
+        EthereumGasPolicy available = EthereumGasPolicy.CreateAvailableFromIntrinsic(30_000, in intrinsic, Amsterdam.Instance);
+
+        Assert.That(EthereumGasPolicy.IsOutOfGas(in available), Is.True);
+        Assert.That(EthereumGasPolicy.GetRemainingGas(in available), Is.EqualTo(0UL));
+        Assert.That(EthereumGasPolicy.GetStateReservoir(in available), Is.EqualTo(0UL));
+    }
+
+    [Test]
+    public void RevertRefundToHalt_saturates_state_gas_used_instead_of_wrapping()
+    {
+        EthereumGasPolicy parent = new() { StateGasUsed = 100 };
+        EthereumGasPolicy child = new() { StateGasUsed = 250 };
+
+        EthereumGasPolicy.RevertRefundToHalt(ref parent, in child);
+
+        Assert.That(EthereumGasPolicy.GetStateGasUsed(in parent), Is.EqualTo(0UL));
+        Assert.That(EthereumGasPolicy.GetStateReservoir(in parent), Is.EqualTo(250UL));
+    }
 }

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -164,7 +164,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         // the parent. Move the child's state usage back into the reservoir and remove it from
         // parent state usage because no child state growth persisted.
         parentGas.StateReservoir += childGas.StateGasUsed;
-        parentGas.StateGasUsed -= childGas.StateGasUsed;
+        parentGas.StateGasUsed = parentGas.StateGasUsed.SaturatingSub(childGas.StateGasUsed);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -497,14 +497,18 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static EthereumGasPolicy CreateAvailableFromIntrinsic(ulong gasLimit, in EthereumGasPolicy intrinsicGas, IReleaseSpec spec)
     {
-        // Callers must validate intrinsic gas against gasLimit (ValidateIntrinsicGas / Eip8037.ExceedsCap)
-        // before calling; if they don't, the subtraction wraps silently.
-        Debug.Assert(gasLimit >= intrinsicGas.Value + intrinsicGas.StateReservoir,
-            $"gasLimit ({gasLimit}) < intrinsicRegular ({intrinsicGas.Value}) + intrinsicState ({intrinsicGas.StateReservoir})");
+        // Guard the subtraction: an unvalidated caller (e.g. the SkipValidation warmup path) must get an
+        // out-of-gas frame, not a wrapped budget.
+        ulong intrinsicTotal = intrinsicGas.Value + intrinsicGas.StateReservoir;
+        if (gasLimit < intrinsicTotal)
+        {
+            return new EthereumGasPolicy { Value = 0, OutOfGas = true };
+        }
+
         Debug.Assert(!spec.IsEip8037Enabled || Eip7825Constants.DefaultTxGasLimitCap >= intrinsicGas.Value,
             "Eip8037 enabled but intrinsicRegular exceeds tx gas cap.");
 
-        ulong executionGas = gasLimit - intrinsicGas.Value - intrinsicGas.StateReservoir;
+        ulong executionGas = gasLimit - intrinsicTotal;
         ulong reservoir = 0;
 
         if (spec.IsEip8037Enabled)


### PR DESCRIPTION
## Changes

Two `EthereumGasPolicy` state-gas subtractions relied on unenforced preconditions and could underflow `ulong`, producing a wrong gas budget that feeds `header.GasUsed`. Both are now made total; behaviour is identical on every validated path.

- **`CreateAvailableFromIntrinsic`** computed `gasLimit - intrinsicRegular - intrinsicStateReservoir` guarded only by a `Debug.Assert` (stripped in Release; the old comment even noted "the subtraction wraps silently"). A caller that reaches it without validating intrinsic gas underflows and gets a ~16.7M regular budget plus a wrapped state reservoir instead of an out-of-gas frame. It is reachable on the `SkipValidation` warmup path: that path routes txs to `SystemTransactionProcessor`, whose `ValidateGas` returns `Ok` unconditionally, and `ValidateStatic` only checks `gasLimit` against the *regular* intrinsic — not regular + state reservoir. Replaced the assert with a runtime guard that returns an out-of-gas policy. Only affects EIP-8037 (pre-8037 the state reservoir is 0, so the existing regular-gas check already covers it).
- **`RevertRefundToHalt`** reduced parent `StateGasUsed` with a raw subtraction, relying on the (real but unenforced) invariant that `Refund` merged the same child `StateGasUsed` into the parent immediately before. Switched to `SaturatingSub`, matching the defensive arithmetic already used by the sibling refund methods (`RefundStateGas`, `DiscardStateGas`, `RemoveStateGasRefundFromReservoir`).

Re-introduces the kind of saturating guard that was removed as "dead code" during the #12146 refactor.

## Types of changes

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Added regression tests in `EthereumGasPolicyTests` — one asserting `CreateAvailableFromIntrinsic` returns an out-of-gas frame (not a wrapped budget) when `gasLimit` sits between the regular intrinsic and regular + state reservoir; one asserting `RevertRefundToHalt` saturates `StateGasUsed` to 0 instead of wrapping. Both fail without the corresponding guard.
- [x] `Nethermind.Evm.Test` — `EthereumGasPolicyTests` (6) and all `Eip8037*` suites (113) green.
- [ ] Full EF `GeneralStateTests` gate — recommend running in CI to confirm consensus-neutrality on the validated path.

## Notes

- Behaviour is identical on every validated execution path; the guard only changes the unvalidated / invariant-violated path.
- **Sequencing:** open PR #12214 rewrites this same EIP-8037 surface (state gas may move to signed `long`). This is a small, self-contained hardening that can either land first or be folded into #12214 — flagging to avoid a surprise conflict.