### PR TITLE
feat(evm): EIP-8279 block access list byte floor

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip8279Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8279Constants.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// Represents the <see href="https://eips.ethereum.org/EIPS/eip-8279">EIP-8279</see>
+/// (block access list byte floor) parameters.
+/// </summary>
+public static class Eip8279Constants
+{
+    public const ulong FloorGasPerByte = 64;
+    public const ulong BalBytesPerAddress = 20;
+    public const ulong BalBytesPerStorageKey = 32;
+    public const ulong BalBytesPerStorageValue = 32;
+    public const ulong BalBytesPerNonce = 8;
+    public const ulong DelegationCodeBytes = 23;
+
+    /// <summary>
+    /// BAL bytes statically attributable to one EIP-7702 authorization tuple:
+    /// authority address + delegation designator code + nonce.
+    /// </summary>
+    public const ulong AuthorizationBalBytes = BalBytesPerAddress + DelegationCodeBytes + BalBytesPerNonce;
+}

--- a/src/Nethermind/Nethermind.Core/GasCostOf.cs
+++ b/src/Nethermind/Nethermind.Core/GasCostOf.cs
@@ -69,6 +69,9 @@ namespace Nethermind.Core
         public const ulong PerAuthBaseCost = Eip7702Constants.PerAuthBaseCost;
         public const ulong TotalCostFloorPerTokenEip7623 = 10; // eip-7623
         public const ulong TotalCostFloorPerTokenEip7976 = 16; // eip-7976
+        public const ulong FloorGasPerByteEip8131 = 64; // eip-8131
+        public const ulong AuthTupleBytesEip8131 = 108; // eip-8131
+        public const ulong BlobVersionedHashBytesEip8131 = 32; // eip-8131
 
         public const ulong CostPerStateByte = 1530; // eip-8037
         public const ulong StateBytesPerStorageSet = 64; // eip-8037

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -471,6 +471,13 @@ namespace Nethermind.Core.Specs
         public bool IsEip8131Enabled { get; }
 
         /// <summary>
+        /// EIP-8279: Block Access List Byte Floor.
+        /// Runtime metering of the bytes a transaction contributes to the EIP-7928 block
+        /// access list, priced into the transaction gas floor.
+        /// </summary>
+        public bool IsEip8279Enabled { get; }
+
+        /// <summary>
         /// Precomputed gas cost and refund constants derived from this spec.
         /// Values are cached per spec instance (singletons per fork) to avoid
         /// repeated interface dispatch on the EVM opcode hot path.

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -464,6 +464,13 @@ namespace Nethermind.Core.Specs
         public bool IsEip7954Enabled { get; }
 
         /// <summary>
+        /// EIP-8131: Unified Transaction Content Floor.
+        /// One per-byte floor rule across calldata, access lists, authorizations, and blob
+        /// versioned hashes, replacing the EIP-7623/EIP-7976/EIP-7981 floor rules.
+        /// </summary>
+        public bool IsEip8131Enabled { get; }
+
+        /// <summary>
         /// Precomputed gas cost and refund constants derived from this spec.
         /// Values are cached per spec instance (singletons per fork) to avoid
         /// repeated interface dispatch on the EVM opcode hot path.

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -118,5 +118,6 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip7954Enabled => spec.IsEip7954Enabled;
     public virtual bool IsEip8024Enabled => spec.IsEip8024Enabled;
     public virtual bool IsEip8131Enabled => spec.IsEip8131Enabled;
+    public virtual bool IsEip8279Enabled => spec.IsEip8279Enabled;
     public SpecGasCosts GasCosts => spec.GasCosts;
 }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -117,5 +117,6 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip7843Enabled => spec.IsEip7843Enabled;
     public virtual bool IsEip7954Enabled => spec.IsEip7954Enabled;
     public virtual bool IsEip8024Enabled => spec.IsEip8024Enabled;
+    public virtual bool IsEip8131Enabled => spec.IsEip8131Enabled;
     public SpecGasCosts GasCosts => spec.GasCosts;
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8131Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8131Tests.cs
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Eip2930;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-8131: unified transaction content floor — one per-byte floor rule across
+/// calldata, access lists, authorization tuples, and blob versioned hashes, replacing the
+/// EIP-7623/EIP-7976/EIP-7981 floor rules.
+/// </summary>
+[TestFixture]
+public class Eip8131Tests
+{
+    private static readonly IReleaseSpec Spec = new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8131Enabled = true };
+
+    private static ulong Floor(ulong contentBytes) => GasCostOf.Transaction + contentBytes * GasCostOf.FloorGasPerByteEip8131;
+
+    [TestCase(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, TestName = "10 zero bytes")]
+    [TestCase(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, TestName = "10 non-zero bytes")]
+    public void Calldata_floor_is_flat_per_byte(byte[] data)
+    {
+        Transaction transaction = new() { To = Address.Zero, Data = data };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        // Zero and non-zero bytes price identically under the unified floor.
+        Assert.That(cost.FloorGas, Is.EqualTo(Floor((ulong)data.Length)));
+    }
+
+    [Test]
+    public void Access_list_floor_uses_byte_sizes_and_standard_cost_drops_eip7981_surcharge()
+    {
+        AccessList accessList = new AccessList.Builder()
+            .AddAddress(Address.Zero)
+            .AddStorage(UInt256.Zero)
+            .AddStorage(UInt256.One)
+            .Build();
+        Transaction transaction = new() { To = Address.Zero, AccessList = accessList };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // 20 address bytes + 2 × 32 storage key bytes = 84 content bytes.
+            Assert.That(cost.FloorGas, Is.EqualTo(Floor(84)));
+            // EIP-8131 replaces EIP-7981, so the standard cost reverts to plain EIP-2930 pricing.
+            Assert.That(cost.Standard, Is.EqualTo(
+                GasCostOf.Transaction + GasCostOf.AccessAccountListEntry + 2 * GasCostOf.AccessStorageListEntry));
+        }
+    }
+
+    [Test]
+    public void Authorization_tuples_are_floor_priced_at_108_bytes_each()
+    {
+        AuthorizationTuple[] authList =
+        [
+            new AuthorizationTuple(1, TestItem.AddressA, 0, 0, UInt256.One, UInt256.One),
+            new AuthorizationTuple(1, TestItem.AddressB, 1, 1, UInt256.One, UInt256.One),
+        ];
+        Transaction transaction = Build.A.Transaction.WithAuthorizationCode(authList).TestObject;
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        Assert.That(cost.FloorGas, Is.EqualTo(Floor(2 * GasCostOf.AuthTupleBytesEip8131)));
+    }
+
+    [Test]
+    public void Blob_versioned_hashes_are_floor_priced_at_32_bytes_each()
+    {
+        Transaction transaction = new()
+        {
+            To = Address.Zero,
+            Type = TxType.Blob,
+            BlobVersionedHashes = [new byte[32], new byte[32], new byte[32]],
+        };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        Assert.That(cost.FloorGas, Is.EqualTo(Floor(3 * GasCostOf.BlobVersionedHashBytesEip8131)));
+    }
+
+    [Test]
+    public void Combined_content_sums_all_components()
+    {
+        AccessList accessList = new AccessList.Builder().AddAddress(Address.Zero).Build();
+        Transaction transaction = new()
+        {
+            To = Address.Zero,
+            Data = new byte[5],
+            AccessList = accessList,
+            Type = TxType.Blob,
+            BlobVersionedHashes = [new byte[32]],
+        };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Spec);
+
+        // 5 calldata + 20 address + 32 blob hash = 57 content bytes.
+        Assert.That(cost.FloorGas, Is.EqualTo(Floor(57)));
+    }
+
+    [Test]
+    public void Before_eip8131_blob_hashes_and_auth_tuples_are_not_floor_priced()
+    {
+        Transaction transaction = new()
+        {
+            To = Address.Zero,
+            Type = TxType.Blob,
+            BlobVersionedHashes = [new byte[32]],
+        };
+        EthereumIntrinsicGas cost = IntrinsicGasCalculator.Calculate(transaction, Amsterdam.Instance);
+
+        Assert.That(cost.FloorGas, Is.EqualTo(GasCostOf.Transaction), "pre-8131 floor must ignore blob hashes");
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8279Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8279Tests.cs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-8279: the transaction gas floor grows with the bytes the transaction
+/// contributes to the EIP-7928 block access list, and <c>gasUsed = max(execution, floor)</c>.
+/// </summary>
+/// <remarks>
+/// The observable scenario is refund-driven: clearing pre-existing storage slots earns
+/// EIP-3529 refunds that push execution gas below the BAL byte floor (each cleared slot
+/// contributes 32 key + 32 value bytes = 4096 floor gas).
+/// </remarks>
+[TestFixture(true)]
+[TestFixture(false)]
+public class Eip8279Tests(bool eip8279Enabled) : VirtualMachineTestsBase
+{
+    private const int SlotCount = 10;
+
+    protected override ISpecProvider SpecProvider { get; } = new TestSpecProvider(
+        new OverridableReleaseSpec(Prague.Instance) { IsEip8131Enabled = true, IsEip8279Enabled = eip8279Enabled });
+
+    protected override TestAllTracerWithOutput CreateTracer() => new() { IsTracingAccess = false };
+
+    [Test]
+    public void Storage_clearing_gas_is_floored_by_bal_bytes()
+    {
+        // Pre-populate the slots the contract will clear.
+        TestState.CreateAccount(SenderRecipientAndMiner.Default.Recipient, 1);
+        for (int i = 0; i < SlotCount; i++)
+        {
+            TestState.Set(new StorageCell(SenderRecipientAndMiner.Default.Recipient, (UInt256)i), [1]);
+        }
+
+        TestState.Commit(Spec);
+        TestState.CommitTree(0);
+
+        Prepare code = Prepare.EvmCode;
+        for (int i = 0; i < SlotCount; i++)
+        {
+            code = code
+                .PushData(0)
+                .PushData(i)
+                .Op(Instruction.SSTORE);
+        }
+
+        TestAllTracerWithOutput result = Execute(code.Op(Instruction.STOP).Done);
+
+        // Execution: 21000 + 10 × (PUSH1 + PUSH1 + cold SSTORE clear) with the EIP-3529
+        // refund capped at spent / 5.
+        const ulong executionSpent = GasCostOf.Transaction + SlotCount * (2 * GasCostOf.VeryLow + GasCostOf.ColdSLoad + 2900);
+        const ulong refunded = executionSpent / 5; // 10 × 4800 refund, capped
+        const ulong netExecution = executionSpent - refunded;
+        // Floor: 21000 + 10 slots × (32 key + 32 value bytes) × 64 gas/byte.
+        const ulong floor = GasCostOf.Transaction
+            + SlotCount * (Eip8279Constants.BalBytesPerStorageKey + Eip8279Constants.BalBytesPerStorageValue) * Eip8279Constants.FloorGasPerByte;
+
+        Assert.That(floor, Is.GreaterThan(netExecution), "test setup must make the floor dominate");
+        Assert.That(result.GasSpent, Is.EqualTo(eip8279Enabled ? floor : netExecution));
+    }
+
+    [Test]
+    public void Restored_slot_refunds_its_value_bytes()
+    {
+        TestState.CreateAccount(SenderRecipientAndMiner.Default.Recipient, 1);
+        TestState.Set(new StorageCell(SenderRecipientAndMiner.Default.Recipient, UInt256.Zero), [1]);
+        TestState.Commit(Spec);
+        TestState.CommitTree(0);
+
+        // Clear slot 0, then restore it to its pre-transaction value: only the key bytes may
+        // remain in the floor.
+        byte[] code = Prepare.EvmCode
+            .PushData(0).PushData(0).Op(Instruction.SSTORE)
+            .PushData(1).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        // Execution: clear (cold, 2100 + 2900) then restore (warm dirty, 100 + 100... net
+        // metered warm write) with reversal refunds — always above the tiny floor, so the
+        // result must equal plain execution gas in both fixtures.
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+        Assert.That(result.GasSpent, Is.LessThan(30000UL));
+    }
+
+    [Test]
+    public void Meter_arithmetic()
+    {
+        BalFloorMeter meter = new(staticFloor: 21000, gasLimit: 30000);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(meter.FloorGasUsed, Is.EqualTo(21000UL));
+            Assert.That(meter.TryMeter(64), Is.True);
+            Assert.That(meter.FloorGasUsed, Is.EqualTo(21000UL + 64 * 64));
+            meter.Refund(32);
+            Assert.That(meter.FloorGasUsed, Is.EqualTo(21000UL + 32 * 64));
+            Assert.That(meter.TryMeter(200), Is.False, "floor above the gas limit must be out of gas");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/BalFloorMeter.cs
+++ b/src/Nethermind/Nethermind.Evm/BalFloorMeter.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+
+namespace Nethermind.Evm;
+
+/// <summary>
+/// EIP-8279 per-transaction meter of bytes the transaction contributes to the EIP-7928 block
+/// access list. The floor grows as new BAL bytes are metered and the transaction runs out of
+/// gas the moment the floor exceeds its gas limit.
+/// </summary>
+/// <remarks>
+/// Metered bytes are never rolled back on frame reverts — reverted frames keep their BAL
+/// accesses under EIP-7928 — except for the explicit storage-value refund when a slot returns
+/// to its pre-transaction value, matching EIP-7928's no-op-write deduplication.
+/// </remarks>
+public sealed class BalFloorMeter(ulong staticFloor, ulong gasLimit)
+{
+    private readonly ulong _gasLimit = gasLimit;
+
+    public ulong StaticFloor { get; } = staticFloor;
+    public ulong BalDataBytes { get; private set; }
+
+    /// <summary>The current floor: <c>static_floor + bal_data_bytes * FLOOR_GAS_PER_BYTE</c>.</summary>
+    public ulong FloorGasUsed { get; private set; } = staticFloor;
+
+    /// <returns><c>false</c> when the new floor exceeds the transaction gas limit (out of gas).</returns>
+    public bool TryMeter(ulong balBytes)
+    {
+        BalDataBytes += balBytes;
+        ulong newFloor = StaticFloor + BalDataBytes * Eip8279Constants.FloorGasPerByte;
+        if (newFloor > _gasLimit)
+        {
+            return false;
+        }
+
+        FloorGasUsed = newFloor;
+        return true;
+    }
+
+    /// <summary>Refunds storage-value bytes when a slot returns to its pre-transaction value.</summary>
+    public void Refund(ulong balBytes)
+    {
+        BalDataBytes -= balBytes;
+        FloorGasUsed = StaticFloor + BalDataBytes * Eip8279Constants.FloorGasPerByte;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -256,7 +256,9 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
 
         return (!spec.IsPrecompile(address) && accessTracker.WarmUp(address)) switch
         {
-            true => UpdateGas(ref gas, GasCostOf.ColdAccountAccess),
+            // EIP-8279: a cold account access contributes the address bytes to the BAL floor.
+            true => (accessTracker.BalFloorMeter?.TryMeter(Eip8279Constants.BalBytesPerAddress) ?? true)
+                && UpdateGas(ref gas, GasCostOf.ColdAccountAccess),
             false when kind == AccountAccessKind.SelfDestructBeneficiary => true,
             false => UpdateGas(ref gas, GasCostOf.WarmStateRead)
         };
@@ -277,7 +279,12 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         }
 
         if (accessTracker.WarmUp(in storageCell))
-            return UpdateGas(ref gas, GasCostOf.ColdSLoad);
+        {
+            // EIP-8279: a cold storage access contributes the storage key bytes to the BAL floor.
+            return (accessTracker.BalFloorMeter?.TryMeter(Eip8279Constants.BalBytesPerStorageKey) ?? true)
+                && UpdateGas(ref gas, GasCostOf.ColdSLoad);
+        }
+
         if (storageAccessType == StorageAccessType.SLOAD)
             return UpdateGas(ref gas, GasCostOf.WarmStateRead);
         return true;

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -164,9 +164,10 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return (ulong)totalZeros + (ulong)(data.Length - totalZeros) * spec.GasCosts.TxDataNonZeroMultiplier;
     }
 
-    // 0 when floor pricing is not active.
+    // 0 when floor pricing is not active. EIP-8131 replaces the EIP-7981 access-list floor
+    // surcharge, so the tokens are only counted while EIP-7981 is the prevailing floor rule.
     public static ulong CalculateFloorTokensInAccessList(Transaction transaction, IReleaseSpec spec) =>
-        spec.IsEip7981Enabled && transaction.AccessList is { Count: (int addressesCount, int storageKeysCount) }
+        spec.IsEip7981Enabled && !spec.IsEip8131Enabled && transaction.AccessList is { Count: (int addressesCount, int storageKeysCount) }
             ? (ulong)(addressesCount * Address.Size + storageKeysCount * AccessList.StorageKeySize) * spec.GasCosts.TxDataNonZeroMultiplier
             : 0;
 
@@ -219,8 +220,34 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     private static ulong CalculateFloorTokensInCallData(Transaction transaction, IReleaseSpec spec) =>
         (ulong)transaction.Data.Length * spec.GasCosts.TxDataNonZeroMultiplier;
 
+    // EIP-8131: every floor-priced content byte of the transaction — calldata, access list
+    // entries, authorization tuples, and blob versioned hashes — under one per-byte rule.
+    private static ulong CalculateContentBytesEip8131(Transaction transaction)
+    {
+        ulong contentBytes = (ulong)transaction.Data.Length;
+
+        if (transaction.AccessList is { Count: (int addressesCount, int storageKeysCount) })
+        {
+            contentBytes += (ulong)(addressesCount * Address.Size + storageKeysCount * AccessList.StorageKeySize);
+        }
+
+        if (transaction.AuthorizationList is { } authorizationList)
+        {
+            contentBytes += (ulong)authorizationList.Length * GasCostOf.AuthTupleBytesEip8131;
+        }
+
+        if (transaction.BlobVersionedHashes is { } blobVersionedHashes)
+        {
+            contentBytes += (ulong)blobVersionedHashes.Length * GasCostOf.BlobVersionedHashBytesEip8131;
+        }
+
+        return contentBytes;
+    }
+
     protected static ulong CalculateFloorCost(Transaction transaction, IReleaseSpec spec, ulong tokensInCallData, ulong floorTokensInAccessList) => spec switch
     {
+        // EIP-8131 replaces the EIP-7623/EIP-7976/EIP-7981 floor rules with one per-byte rule.
+        { IsEip8131Enabled: true } => GasCostOf.Transaction + CalculateContentBytesEip8131(transaction) * GasCostOf.FloorGasPerByteEip8131,
         { IsEip7976Enabled: true } => GasCostOf.Transaction + (CalculateFloorTokensInCallData(transaction, spec) + floorTokensInAccessList) * spec.GasCosts.TotalCostFloorPerToken,
         { IsEip7623Enabled: true } => GasCostOf.Transaction + tokensInCallData * spec.GasCosts.TotalCostFloorPerToken,
         _ => 0

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -244,10 +244,19 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return contentBytes;
     }
 
+    // EIP-8279: BAL bytes statically attributable to the transaction — per-authorization
+    // authority address, delegation designator code, and nonce — priced into the static floor.
+    private static ulong CalculateStaticBalBytesEip8279(Transaction transaction, IReleaseSpec spec) =>
+        spec.IsEip8279Enabled && transaction.AuthorizationList is { } authorizationList
+            ? (ulong)authorizationList.Length * Eip8279Constants.AuthorizationBalBytes
+            : 0;
+
     protected static ulong CalculateFloorCost(Transaction transaction, IReleaseSpec spec, ulong tokensInCallData, ulong floorTokensInAccessList) => spec switch
     {
         // EIP-8131 replaces the EIP-7623/EIP-7976/EIP-7981 floor rules with one per-byte rule.
-        { IsEip8131Enabled: true } => GasCostOf.Transaction + CalculateContentBytesEip8131(transaction) * GasCostOf.FloorGasPerByteEip8131,
+        // EIP-8279 shares the same per-byte price for its statically known BAL bytes.
+        { IsEip8131Enabled: true } => GasCostOf.Transaction
+            + (CalculateContentBytesEip8131(transaction) + CalculateStaticBalBytesEip8279(transaction, spec)) * GasCostOf.FloorGasPerByteEip8131,
         { IsEip7976Enabled: true } => GasCostOf.Transaction + (CalculateFloorTokensInCallData(transaction, spec) + floorTokensInAccessList) * spec.GasCosts.TotalCostFloorPerToken,
         { IsEip7623Enabled: true } => GasCostOf.Transaction + tokensInCallData * spec.GasCosts.TotalCostFloorPerToken,
         _ => 0

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -142,6 +142,12 @@ public static partial class EvmInstructions
         if (hasValueTransfer && !TGasPolicy.ConsumeCallValueTransfer(ref gas))
             goto OutOfGas;
 
+        // EIP-8279: a value transfer to a different account contributes the balance-change
+        // value bytes to the BAL floor.
+        if (hasValueTransfer && !target.Equals(caller)
+            && vm.VmState.AccessTracker.BalFloorMeter is { } balMeter && !balMeter.TryMeter(Eip8279Constants.BalBytesPerStorageValue))
+            goto OutOfGas;
+
         IReleaseSpec spec = vm.Spec;
         IWorldState state = vm.WorldState;
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -237,6 +237,12 @@ public static partial class EvmInstructions
         // Retrieve the current balance for transfer.
         UInt256 result = state.GetBalance(executingAccount);
 
+        // EIP-8279: a SELFDESTRUCT sweep to a different beneficiary contributes the
+        // balance-change value bytes to the BAL floor.
+        if (!result.IsZero && !inheritor.Equals(executingAccount)
+            && vmState.AccessTracker.BalFloorMeter is { } balMeter && !balMeter.TryMeter(Eip8279Constants.BalBytesPerStorageValue))
+            goto OutOfGas;
+
         if (vm.TxTracer.IsTracingActions)
             vm.TxTracer.ReportSelfDestruct(executingAccount, result, inheritor);
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
@@ -190,6 +190,12 @@ public static partial class EvmInstructions
             vm.VmState.AccessTracker.WarmUp(contractAddress);
         }
 
+        // EIP-8279: the new account's nonce (and endowment balance change, when non-zero)
+        // contribute their BAL bytes to the floor.
+        if (vm.VmState.AccessTracker.BalFloorMeter is { } balMeter
+            && !balMeter.TryMeter(Eip8279Constants.BalBytesPerNonce + (value.IsZero ? 0 : Eip8279Constants.BalBytesPerStorageValue)))
+            goto OutOfGas;
+
         // Increment the nonce of the executing account to reflect the contract creation.
         state.IncrementNonce(env.ExecutingAccount);
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -514,6 +514,11 @@ public static partial class EvmInstructions
 
             if (currentSameAsOriginal)
             {
+                // EIP-8279: the first change of this slot from its pre-transaction value
+                // contributes the storage value bytes to the BAL floor.
+                if (vmState.AccessTracker.BalFloorMeter is { } balMeter && !balMeter.TryMeter(Eip8279Constants.BalBytesPerStorageValue))
+                    goto OutOfGas;
+
                 if (currentIsZero)
                 {
                     bool ssetOutOfGas = !TGasPolicy.ConsumeStorageWrite<TEip8037, OnFlag>(ref gas, spec);
@@ -560,6 +565,10 @@ public static partial class EvmInstructions
                 bool newSameAsOriginal = Bytes.AreEqual(originalValue, bytes);
                 if (newSameAsOriginal)
                 {
+                    // EIP-8279: the slot returns to its pre-transaction value — refund its
+                    // value bytes, matching EIP-7928's no-op-write deduplication.
+                    vmState.AccessTracker.BalFloorMeter?.Refund(Eip8279Constants.BalBytesPerStorageValue);
+
                     long refundFromReversal = (long)gasCosts.RefundFromReversal(originalIsZero);
 
                     if (TEip8037.IsActive && originalIsZero)

--- a/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
+++ b/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
@@ -28,6 +28,11 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
     private int _destroyListSnapshots;
     private int _logsSnapshots;
 
+    /// <summary>EIP-8279 per-transaction BAL byte meter; <c>null</c> when the EIP is not active.</summary>
+    public readonly BalFloorMeter? BalFloorMeter => _trackingState.BalFloorMeter;
+
+    public readonly void SetBalFloorMeter(BalFloorMeter meter) => _trackingState.BalFloorMeter = meter;
+
     public readonly bool IsCold(Address? address) => !_trackingState.AccessedAddresses.Contains(address);
 
     public readonly bool IsCold(in StorageCell storageCell) => !_trackingState.AccessedStorageCells.Contains(storageCell);
@@ -112,6 +117,7 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
         public JournalCollection<LogEntry> Logs { get; } = [];
         public JournalSet<Address> DestroyList { get; } = new(Address.EqualityComparer);
         public HashSet<AddressAsKey> CreateList { get; } = new(AddressAsKey.EqualityComparer);
+        public BalFloorMeter? BalFloorMeter { get; set; }
 
         private void Clear()
         {
@@ -120,6 +126,7 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
             Logs.Clear();
             DestroyList.Clear();
             CreateList.Clear();
+            BalFloorMeter = null;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -285,6 +285,13 @@ namespace Nethermind.Evm.TransactionProcessing
             if (tx.IsContractCreation) Metrics.IncrementCreates();
             // substate.Logs contains a reference to accessTracker.Logs so we can't Dispose until end of the method
             using StackAccessTracker accessTracker = new(tracer.IsTracingAccess);
+            if (spec.IsEip8279Enabled)
+            {
+                // EIP-8279: the static floor is the EIP-8131 tx floor (which already prices the
+                // per-authorization BAL bytes when EIP-8279 is active).
+                accessTracker.SetBalFloorMeter(new BalFloorMeter(
+                    TGasPolicy.GetRemainingGas(intrinsicGas.FloorGas), (ulong)tx.GasLimit));
+            }
             ulong delegationRefunds = 0UL;
             ulong delegationAuthBaseRefunds = 0UL;
             TransactionResult result;
@@ -1288,7 +1295,11 @@ namespace Nethermind.Evm.TransactionProcessing
                 }
             }
 
-            gasConsumed = Refund(tx, header, spec, opts, in substate, gasAvailable, VirtualMachine.TxExecutionContext.GasPrice, delegationRefunds, gas.FloorGas, gas.Standard, postIntrinsicStateReservoir);
+            // EIP-8279: the dynamic BAL byte floor supersedes the static floor in spent-gas accounting.
+            TGasPolicy floorGas = accessedItems.BalFloorMeter is { } balFloorMeter
+                ? TGasPolicy.FromULong(balFloorMeter.FloorGasUsed)
+                : gas.FloorGas;
+            gasConsumed = Refund(tx, header, spec, opts, in substate, gasAvailable, VirtualMachine.TxExecutionContext.GasPrice, delegationRefunds, floorGas, gas.Standard, postIntrinsicStateReservoir);
             goto Complete;
         FailContractCreate:
             if (Logger.IsTrace) Logger.Trace("Restoring state from before transaction");

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -437,6 +437,15 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
         bool hasEnoughGas = gasAvailableForCodeDeposit >= regularDepositCost + stateSpill;
         bool chargedCodeDeposit = false;
 
+        // EIP-8279: deployed code bytes contribute to the BAL floor; when they push the floor
+        // past the gas limit the deposit fails like an out-of-gas code deposit.
+        if (hasEnoughGas && !invalidCode && code.Length > 0
+            && _currentState.AccessTracker.BalFloorMeter is { } balMeter
+            && !balMeter.TryMeter((ulong)code.Length))
+        {
+            hasEnoughGas = false;
+        }
+
         if (hasEnoughGas && !invalidCode)
         {
             TGasPolicy gasAfterCodeDeposit = _currentState.Gas;

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -112,6 +112,7 @@ namespace Nethermind.Specs.Test
         public ulong ElasticityMultiplier { get; set; } = spec.ElasticityMultiplier;
         public IBaseFeeCalculator BaseFeeCalculator { get; set; } = spec.BaseFeeCalculator;
         public bool IsEip8024Enabled { get; set; } = spec.IsEip8024Enabled;
+        public bool IsEip8131Enabled { get; set; } = spec.IsEip8131Enabled;
         public bool IsEip6110Enabled { get; set; } = spec.IsEip6110Enabled;
         public Address? DepositContractAddress { get; set; } = spec.DepositContractAddress;
         public bool IsEip7594Enabled { get; set; } = spec.IsEip7594Enabled;

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -113,6 +113,7 @@ namespace Nethermind.Specs.Test
         public IBaseFeeCalculator BaseFeeCalculator { get; set; } = spec.BaseFeeCalculator;
         public bool IsEip8024Enabled { get; set; } = spec.IsEip8024Enabled;
         public bool IsEip8131Enabled { get; set; } = spec.IsEip8131Enabled;
+        public bool IsEip8279Enabled { get; set; } = spec.IsEip8279Enabled;
         public bool IsEip6110Enabled { get; set; } = spec.IsEip6110Enabled;
         public Address? DepositContractAddress { get; set; } = spec.DepositContractAddress;
         public bool IsEip7594Enabled { get; set; } = spec.IsEip7594Enabled;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -187,4 +187,5 @@ public class ChainParameters
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip8131TransitionTimestamp { get; set; }
+    public ulong? Eip8279TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -186,4 +186,5 @@ public class ChainParameters
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip8131TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -356,6 +356,8 @@ namespace Nethermind.Specs.ChainSpecStyle
                 releaseSpec.MaxCodeSize = CodeSizeConstants.MaxCodeSizeEip7954;
             }
 
+            releaseSpec.IsEip8131Enabled = (chainSpec.Parameters.Eip8131TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)
             {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -357,6 +357,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             }
 
             releaseSpec.IsEip8131Enabled = (chainSpec.Parameters.Eip8131TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+            releaseSpec.IsEip8279Enabled = (chainSpec.Parameters.Eip8279TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             foreach (IChainSpecEngineParameters item in _chainSpec.EngineChainSpecParametersProvider
                          .AllChainSpecParameters)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -216,6 +216,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
             Eip8131TransitionTimestamp = chainSpecJson.Params.Eip8131TransitionTimestamp,
+            Eip8279TransitionTimestamp = chainSpecJson.Params.Eip8279TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -215,6 +215,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8024TransitionTimestamp = chainSpecJson.Params.Eip8024TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
+            Eip8131TransitionTimestamp = chainSpecJson.Params.Eip8131TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -193,6 +193,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip8131TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -194,6 +194,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip8131TransitionTimestamp { get; set; }
+    public ulong? Eip8279TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -170,6 +170,7 @@ public class ReleaseSpec : IReleaseSpec
     public bool IsEip7708Enabled { get; set; }
     public bool IsEip7954Enabled { get; set; }
     public bool IsEip8131Enabled { get; set; }
+    public bool IsEip8279Enabled { get; set; }
 
     private ReleaseSpec? _systemSpec;
 

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -169,6 +169,7 @@ public class ReleaseSpec : IReleaseSpec
 
     public bool IsEip7708Enabled { get; set; }
     public bool IsEip7954Enabled { get; set; }
+    public bool IsEip8131Enabled { get; set; }
 
     private ReleaseSpec? _systemSpec;
 


### PR DESCRIPTION
## Changes

- `BalFloorMeter` — per-transaction counter of BAL bytes with the spec's `meter_bal_data` semantics: floor = `static_floor + bal_data_bytes × 64`, out-of-gas the moment the floor exceeds the tx gas limit, called before the matching BAL insertion/state mutation
- Metering sites per the spec table: cold account access (20 B) and cold storage access (32 B) in the gas policy, first storage value change from pre-tx value (+32 B) and restore (−32 B) in net-metered SSTORE, CALL value transfer to a different account (32 B), SELFDESTRUCT sweep to a different beneficiary (32 B), CREATE nonce (8 B) + non-zero endowment (32 B), deployed code (`len` bytes, failing the deposit like OOG when over)
- Static floor: the EIP-8131 `tx_floor` extended by `(20 + 23 + 8) × num_authorizations` bytes, priced into the intrinsic floor so gas-limit validation covers it upfront
- `gasUsed = max(execution_gas_used, floor_gas_used)` — the dynamic floor supersedes the static floor in spent-gas accounting
- The meter rides on `StackAccessTracker` (tx-scoped), is `null` unless `IsEip8279Enabled`, and costs nothing on existing paths
- Flag + `eip8279TransitionTimestamp` chainspec plumbing

**Stacked on #12228 (EIP-8131)** — the static floor is defined in terms of the EIP-8131 tx floor; review only the last commit until that merges.

Spec: https://eips.ethereum.org/EIPS/eip-8279 (Hegotá / EIP-8081 candidate). Not yet activated in any fork file — activation lands with the Hegotá fork wiring (#12226).

Part of the Hegotá (EIP-8081) PR series.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Eip8279Tests` (paired enabled/disabled fixtures): refund-driven floor dominance on storage clears with exact gas assertions (floor binds only when enabled), restored-slot value-byte refund, and meter arithmetic incl. the out-of-gas boundary. Storage/SSTORE/CREATE/refund/SELFDESTRUCT suites pass unchanged (73 tests).

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

## Remarks

Frame-revert interaction: metered bytes are intentionally not rolled back on reverts (reverted frames keep their BAL accesses under EIP-7928), except the explicit storage-value restore refund. Deployed-code bytes of a create frame whose deposit later fails stay metered — a documented over-count in a pathological edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)