### PR TITLE
refactor(evm): dedup the EIP-8037 initial state-reservoir formula

### DIFF
--- a/src/Nethermind/Nethermind.Evm/GasPolicy/Eip8037BlockGasInclusionCheck.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/Eip8037BlockGasInclusionCheck.cs
@@ -46,6 +46,9 @@ public static class Eip8037BlockGasInclusionCheck
         return Outcome.Ok;
     }
 
+    public static ulong CalculateInitialStateReservoir(ulong txGasLimit, ulong intrinsicStateGas) =>
+        txGasLimit.SaturatingSub(intrinsicStateGas + Eip7825Constants.DefaultTxGasLimitCap);
+
     public static ulong CalculateBlockRegularGas(
         ulong intrinsicRegularGas,
         ulong initialRegularGas,

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -27,8 +27,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     {
         ulong intrinsicRegularGas = TSelf.GetRemainingGas(in intrinsic);
         ulong intrinsicStateGas = TSelf.GetStateReservoir(in intrinsic);
-        ulong totalCap = intrinsicStateGas + Eip7825Constants.DefaultTxGasLimitCap;
-        ulong initialReservoir = txGasLimit.SaturatingSub(totalCap);
+        ulong initialReservoir = Eip8037BlockGasInclusionCheck.CalculateInitialStateReservoir(txGasLimit, intrinsicStateGas);
         ulong totalSub = intrinsicRegularGas + intrinsicStateGas + initialReservoir;
         ulong initialRegularGas = txGasLimit.SaturatingSub(totalSub);
         return Eip8037BlockGasInclusionCheck.CalculateBlockRegularGas(

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1589,12 +1589,8 @@ namespace Nethermind.Evm.TransactionProcessing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ulong CalculateInitialStateReservoir(
             ulong txGasLimit,
-            in TGasPolicy intrinsicGasStandard)
-        {
-            ulong intrinsicStateGas = TGasPolicy.GetStateReservoir(in intrinsicGasStandard);
-            ulong totalCap = intrinsicStateGas + Eip7825Constants.DefaultTxGasLimitCap;
-            return txGasLimit.SaturatingSub(totalCap);
-        }
+            in TGasPolicy intrinsicGasStandard) =>
+            Eip8037BlockGasInclusionCheck.CalculateInitialStateReservoir(txGasLimit, TGasPolicy.GetStateReservoir(in intrinsicGasStandard));
 
         private (ulong spentGas, long refund) CalculateSpentGasAndRefund(
             Transaction tx,


### PR DESCRIPTION
## Changes

The EIP-8037 initial state reservoir — `R0 = txGasLimit − (intrinsicStateGas + DefaultTxGasLimitCap)`, saturating — was written token-for-token in two places:

- `TransactionProcessor.CalculateInitialStateReservoir` (halt-path state-gas refund accounting)
- the `IGasPolicy` default `ComputeBlockRegularGas` (block-regular-gas accounting)

Two copies of a consensus formula that must stay in sync is a needless divergence surface. Extracted it as `Eip8037BlockGasInclusionCheck.CalculateInitialStateReservoir(txGasLimit, intrinsicStateGas)` — alongside the other block-gas helpers — and routed both callers through it.

(`CreateAvailableFromIntrinsic` derives the same value by a different, cap-relative route; it is intentionally left as-is here to keep this change to the two literally-identical sites.)

## Types of changes

- [x] Code refactoring (no functional changes, no API changes)

## Testing

- [x] `Nethermind.Evm.Test` — all `Eip8037*` suites (113) green; behaviour is identical (pure formula extraction).
- [ ] Full EF `GeneralStateTests` gate — recommend in CI to confirm consensus-neutrality.

## Notes

Touches the EIP-8037 accounting surface that open PR #12214 is also editing — flagging the potential rebase. Small and self-contained; can land independently or be folded in.