### PR TITLE
fix(evm): weak-key the opcode-table spec cache; guarantee gas-charge inlining

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Reflection;
 using Nethermind.Core;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Specs.Forks;
@@ -25,5 +26,24 @@ public class EthereumGasPolicyTests
         ulong baseCost = isExternalCode ? Cancun.Instance.GasCosts.ExtCodeCost : GasCostOf.VeryLow;
         ulong expected = baseCost + GasCostOf.Memory * words;
         Assert.That(initial - EthereumGasPolicy.GetRemainingGas(in gas), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Default_gas_policy_implementations_are_aggressively_inlined()
+    {
+        int defaultImplementations = 0;
+        foreach (MethodInfo method in typeof(IGasPolicy<>).GetMethods(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (method.IsAbstract) continue;
+
+            defaultImplementations++;
+            Assert.That(
+                method.MethodImplementationFlags.HasFlag(MethodImplAttributes.AggressiveInlining),
+                Is.True,
+                $"{method} must carry [MethodImpl(MethodImplOptions.AggressiveInlining)]: without it, per-opcode gas " +
+                "charges compile to real calls in no-dynamic-PGO regimes (e.g. the NativeAOT zkEVM guest).");
+        }
+
+        Assert.That(defaultImplementations, Is.GreaterThan(0));
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineOpcodeTableCacheTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineOpcodeTableCacheTests.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+public class VirtualMachineOpcodeTableCacheTests : VirtualMachineTestsBase
+{
+    private sealed class TransientSpec(IReleaseSpec spec) : ReleaseSpecDecorator(spec);
+
+    [Test]
+    public void Opcode_table_cache_does_not_root_transient_specs()
+    {
+        WeakReference specReference = ExecuteWithTransientSpec();
+
+        for (int i = 0; i < 5 && specReference.IsAlive; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.That(specReference.IsAlive, Is.False,
+            "The process-wide opcode-table cache must not keep transient specs alive; " +
+            "eth_simulateV1 wraps the spec per simulated block (WithoutEip3607), so strong keys grow without bound.");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private WeakReference ExecuteWithTransientSpec()
+    {
+        (Block block, Transaction transaction) = PrepareTx(Activation, 100000UL, [(byte)Instruction.STOP]);
+        IReleaseSpec transientSpec = new TransientSpec(SpecProvider.GetSpec(block.Header));
+
+        _processor.Execute(transaction, new BlockExecutionContext(block.Header, transientSpec), NullTxTracer.Instance);
+
+        // The VM retains the last block execution context; overwrite it so the opcode-table
+        // cache is the only remaining candidate root for the transient spec.
+        _processor.SetBlockExecutionContext(block.Header);
+
+        return new WeakReference(transientSpec);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -14,15 +15,19 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 {
     static abstract TSelf FromULong(ulong value);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual TSelf CreateSystemTransactionIntrinsicGas(ulong blockGasLimit) => TSelf.FromULong(0);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual TSelf CreateSystemTransactionAvailableGas(ulong gasLimit, in TSelf intrinsicGas, IReleaseSpec spec) =>
         TSelf.CreateAvailableFromIntrinsic(gasLimit, in intrinsicGas, spec);
 
     static abstract ulong GetRemainingGas(in TSelf gas);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong CombineBlockGas(ulong blockRegularGas, ulong blockStateGas) => Math.Max(blockRegularGas, blockStateGas);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong ComputeBlockRegularGas(in TSelf gas, in TSelf intrinsic, ulong txGasLimit, ulong floorGas, ulong remainingRegularGas)
     {
         ulong intrinsicRegularGas = TSelf.GetRemainingGas(in intrinsic);
@@ -35,8 +40,10 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
             intrinsicRegularGas, initialRegularGas, remainingRegularGas, TSelf.GetStateGasSpill(in gas), floorGas);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong ComputeRefundedCreateStateSpillForHalt(in TSelf gas) => 0;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual (ulong spentGas, ulong blockGas, ulong blockStateGas) ComputeHaltGas(in TSelf gas, ulong txGasLimit, ulong floorGas, ulong refundedCreateStateSpillForHalt)
     {
         ulong spentGas = Math.Max(txGasLimit, floorGas);
@@ -44,19 +51,28 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     }
 
     // EIP-8037 state-cost accessors. Pre-EIP-8037 policies return the constant fallback.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong GetStorageSetStateCost() => GasCostOf.SSetState;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong GetCreateStateCost() => GasCostOf.CreateState;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong GetNewAccountStateCost() => GasCostOf.NewAccountState;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong GetPerAuthBaseStateCost() => GasCostOf.PerAuthBaseState;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong GetCodeDepositStateCost(int byteCodeLength) => GasCostOf.CodeDepositState * (ulong)byteCodeLength;
 
     // EIP-8037 state-accounting accessors. Pre-EIP-8037 policies return 0.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong GetStateReservoir(in TSelf gas) => 0;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong GetStateGasUsed(in TSelf gas) => 0;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong GetStateGasSpill(in TSelf gas) => 0;
 
     static abstract void Consume(ref TSelf gas, ulong cost);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool TryConsume(ref TSelf gas, ulong cost)
     {
         if (TSelf.GetRemainingGas(in gas) < cost) return false;
@@ -64,21 +80,27 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void Consume<TCost>(ref TSelf gas) where TCost : struct, IGasCost =>
         TSelf.Consume(ref gas, TCost.GasCost);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void Consume<TCost>(ref TSelf gas, IReleaseSpec spec) where TCost : struct, ISpecGasCost =>
         TSelf.Consume(ref gas, TCost.GasCost(spec));
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void ConsumeKeccak(ref TSelf gas, ulong words) =>
         TSelf.Consume(ref gas, GasCostOf.Sha3 + GasCostOf.Sha3Word * words);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void ConsumeMemoryCopy(ref TSelf gas, ulong words) =>
         TSelf.Consume(ref gas, GasCostOf.VeryLow + GasCostOf.VeryLow * words);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void ConsumeExpBytes(ref TSelf gas, IReleaseSpec spec, ulong exponentByteSize) =>
         TSelf.Consume(ref gas, spec.GasCosts.ExpByteCost * exponentByteSize);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool ConsumeCreateGas<TEip8037, TOpCreate>(ref TSelf gas, IReleaseSpec spec, ulong initCodeWords)
         where TEip8037 : struct, IFlag
         where TOpCreate : struct, EvmInstructions.IOpCreate
@@ -89,18 +111,23 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return TSelf.UpdateGas(ref gas, baseCost + initCodeWordCost + create2HashCost);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool ConsumeCallBaseGas(ref TSelf gas, IReleaseSpec spec) =>
         TSelf.UpdateGas(ref gas, spec.GasCosts.CallCost);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool ConsumeSStoreResetGas(ref TSelf gas, IReleaseSpec spec) =>
         TSelf.UpdateGas(ref gas, spec.GasCosts.SStoreResetCost);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool ConsumeNetMeteredSStoreGas(ref TSelf gas, IReleaseSpec spec) =>
         TSelf.UpdateGas(ref gas, spec.GasCosts.NetMeteredSStoreCost);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool ConsumeSSetFromCleanGas(ref TSelf gas) =>
         TSelf.UpdateGas(ref gas, GasCostOf.SSet - GasCostOf.SReset);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool ConsumePrecompileGas(ref TSelf gas, IPrecompile precompile, ReadOnlyMemory<byte> inputData, IReleaseSpec spec)
     {
         ulong baseGasCost = precompile.BaseGasCost(spec);
@@ -110,14 +137,18 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static abstract bool ConsumeSelfDestructGas(ref TSelf gas);
     static abstract void Refund(ref TSelf gas, in TSelf childGas);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool ConsumeCreateStateGas(ref TSelf gas) =>
         TSelf.ConsumeStateGas(ref gas, TSelf.GetCreateStateCost());
 
     // Revert path: restore the child's state gas into the parent reservoir.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void RestoreChildStateGas(ref TSelf parentGas, in TSelf childGas) { }
     // Halt path: preserve inline state-gas refunds (call chain resets to top-most failing call).
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void RestoreChildStateGasOnHalt(ref TSelf parentGas, in TSelf childGas) { }
     // Code-deposit-failure path: undo prior Refund's state-gas merge and apply halt restoration.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void RevertRefundToHalt(ref TSelf parentGas, in TSelf childGas) { }
 
     static abstract bool IsOutOfGas(in TSelf gas);
@@ -147,6 +178,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     static abstract bool UpdateMemoryCost(ref TSelf gas, in UInt256 position, in UInt256 length, ref EvmPooledMemory memory);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool UpdateMemoryCost(ref TSelf gas, in UInt256 position, ulong length, ref EvmPooledMemory memory)
     {
         UInt256 uint256Length = new(length);
@@ -156,6 +188,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static abstract bool UpdateGas(ref TSelf gas, ulong gasCost);
 
     // Pre-EIP-8037 fallback: state gas folded into regular gas.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool ConsumeStateGas(ref TSelf gas, ulong stateGasCost) => TSelf.UpdateGas(ref gas, stateGasCost);
 
     // Regular gas charged first to prevent state-gas spill-then-halt from inflating
@@ -169,25 +202,32 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         where TIsSlotCreation : struct, IFlag;
 
     // Pre-EIP-8037 fallback: refund into regular gas.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void RefundStateGas(ref TSelf gas, ulong amount, ulong stateGasFloor) => TSelf.UpdateGasUp(ref gas, amount);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void RefundStateGas(ref TSelf gas, ulong amount, ulong stateGasFloor, bool trackSpillRefund) =>
         TSelf.RefundStateGas(ref gas, amount, stateGasFloor);
 
     // Drop state-gas from block-state accounting without refunding to the gas budget;
     // reverted state charges stay paid by the tx but don't contribute to committed state gas.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong DiscardStateGas(ref TSelf gas, ulong amount, ulong stateGasFloor, bool trackSpillRefund) => amount;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void AddStateGasRefundToReservoir(ref TSelf gas, ulong amount, bool trackSpillRefund) =>
         TSelf.UpdateGasUp(ref gas, amount);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void RemoveStateGasRefundFromReservoir(ref TSelf gas, ulong amount) { }
 
     // EIP-8037 top-level halt: snap state-gas back to (R0, intrinsicStateUsed, 0); the
     // post-reset StateGasUsed feeds SpentGas so the user doesn't pay for uncommitted state.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void ResetForHalt(ref TSelf gas, ulong initialStateReservoir, ulong initialStateGasUsed) { }
 
     // EIP-8037: replenishes tx state reservoir before exec (intrinsic state gas already charged).
     // Default = the EIP-7702 code-insert regular-gas refund: (NewAccount - PerAuthBaseCost) each.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong ApplyCodeInsertRefunds(ref TSelf gas, ulong codeInsertRefunds, IReleaseSpec spec, ulong stateGasFloor) =>
         codeInsertRefunds > 0UL ? (GasCostOf.NewAccount - GasCostOf.PerAuthBaseCost) * codeInsertRefunds : 0UL;
 
@@ -196,14 +236,17 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static abstract bool ConsumeLogEmission(ref TSelf gas, ulong topicCount, ulong dataSize);
     static abstract TSelf Max(in TSelf a, in TSelf b);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual IntrinsicGas<TSelf> CalculateIntrinsicGas(Transaction tx, IReleaseSpec spec) =>
         TSelf.CalculateIntrinsicGas(tx, spec, blockGasLimit: 0);
     static abstract IntrinsicGas<TSelf> CalculateIntrinsicGas(Transaction tx, IReleaseSpec spec, ulong blockGasLimit);
 
     static abstract TSelf CreateAvailableFromIntrinsic(ulong gasLimit, in TSelf intrinsicGas, IReleaseSpec spec);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual TSelf CreateChildFrameGas(ref TSelf parentGas, ulong childRegularGas) => TSelf.FromULong(childRegularGas);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool TryReserveChildGas(ref TSelf gas, in UInt256 requestedGas, IReleaseSpec spec, out ulong childGas)
     {
         ulong gasAvailable = TSelf.GetRemainingGas(in gas);
@@ -224,6 +267,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return TSelf.UpdateGas(ref gas, childGas);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool TryReserveChildGas(ref TSelf gas, IReleaseSpec spec, out ulong childGas)
     {
         ulong gasAvailable = TSelf.GetRemainingGas(in gas);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.std.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.std.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -22,11 +22,13 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
         public delegate*<VirtualMachine<TGasPolicy>, ref EvmStack, ref TGasPolicy, ref int, EvmExceptionType>[]? Traced;
     }
 
-    private static readonly ConcurrentDictionary<IReleaseSpec, OpcodeTable> _opcodeTablesBySpec = [];
+    // Weak keys: transient spec wrappers (e.g. the per-block WithoutEip3607 decorator in
+    // eth_simulateV1) must not be retained forever by this process-wide cache.
+    private static readonly ConditionalWeakTable<IReleaseSpec, OpcodeTable> _opcodeTablesBySpec = [];
 
     private partial void PrepareOpcodes<TTracingInst>(IReleaseSpec spec) where TTracingInst : struct, IFlag
     {
-        OpcodeTable table = _opcodeTablesBySpec.GetOrAdd(spec, static _ => new OpcodeTable());
+        OpcodeTable table = _opcodeTablesBySpec.GetValue(spec, static _ => new OpcodeTable());
 
         // Check if tracing instructions are inactive.
         if (!TTracingInst.IsActive)


### PR DESCRIPTION
## Changes

- Replace the process-wide `ConcurrentDictionary<IReleaseSpec, OpcodeTable>` opcode-dispatch cache in `VirtualMachine<TGasPolicy>` with a `ConditionalWeakTable`, so cache entries die with their spec instead of strong-rooting every spec instance ever executed. `eth_simulateV1` wraps the spec per simulated block (`WithoutEip3607`), so under simulate load the old cache grew without bound (~4KB `OpcodeTable` per simulated block, plus the per-call `SystemTransactionSpec` fallback decorators). Introduced in #12146; before it, tables were cached on the spec object and died with it.
- Add `[MethodImpl(MethodImplOptions.AggressiveInlining)]` to all 43 default (`static virtual`) gas-charge implementations on `IGasPolicy<TSelf>`. #12146 moved per-opcode gas charging into default interface methods with no inlining directive. In JIT *steady state* dynamic PGO inlines them (verified by disassembly — final Tier1 machine code is instruction-identical pre/post #12146), but until PGO-driven re-JIT completes the charges execute as real interface calls, and in regimes without dynamic PGO at all (NativeAOT, including the zkEVM guest; `DOTNET_TieredCompilation=0`) they stay calls forever. **This is a measured EXPB regression**: a direct parent-child A/B on the reproducible-benchmarks host (flat/realblocks/1000 payloads/delay 0, 4 runs each, one batch) gives `bee2ac4` (parent) 27.19 +/- 0.26 ms AVG / 23.20 median vs `70bb7fc` (#12146) 28.37 +/- 0.42 / 24.15 -> **+1.18 ms AVG (+4.3%), +0.95 ms median** (run: https://github.com/NethermindEth/nethermind/actions/runs/28687903126). The cold 1000-block replay (~200k txs) runs inside the JIT warmup window, so the un-inlined charge calls tax the whole run; later same-day wins (#10652, #12218, #12219) masked it at head. The attribute folds the charges from the first compile, removing the regression (see A/B below) — and is a no-op once PGO would have caught up.
- Regression tests: a GC-based collectability test for the cache (fails on the `ConcurrentDictionary` version) and a reflection test enforcing the attribute on every `IGasPolicy<>` default implementation (fails without the attributes).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `VirtualMachineOpcodeTableCacheTests` verified red on the pre-fix code and green post-fix (also 25/25 stable across workstation GC, server GC, tiering-off and PGO-off regimes).
- `Default_gas_policy_implementations_are_aggressively_inlined` verified red without the attributes.
- Full `Nethermind.Evm.Test` suite: 4772 passed, 0 failed.
- EXPB flat/realblocks (1000 payloads, delay 0), same host, same batch, 3 runs per image — base `master-21e9ff4` vs this branch: base AVG 27.31 / 27.68 / 27.95 (mean 27.65 +/- 0.32) vs branch 26.48 / 26.83 / 26.83 (mean **26.71 +/- 0.20**) -> **-0.93 ms (-3.4%), Welch t = -4.26**; medians 23.57 -> 22.90. A second same-batch pair (single runs under dotTrace) agrees: 28.42 -> 27.71 (-2.5%). Runs: https://github.com/NethermindEth/nethermind/actions/runs/28686557763 and https://github.com/NethermindEth/nethermind/actions/runs/28686571174. Likely mechanism for the win on a cold 1000-block replay: with the attribute the charge helpers fold at the first Tier1 compile instead of waiting for dynamic-PGO re-JIT, trimming the warmup tail that feeds the AVG.
- dotTrace profile comparison (same workload, 1 run each): no hot-spot changes. No `IGasPolicy` charge frames appear in either profile (inlined in both - by PGO on base, by the attribute here), no `ConditionalWeakTable` frames surface, EVM interpreter functions are flat, and the largest deltas are idle thread-pool wait noise.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Found while auditing the Jun–Jul EXPB window for a suspected master regression: a controlled 7-image × 3-run same-host sweep (Jun 22 → Jul 3 images) showed no image-level AVG regression — the historical Jun-30 step is benchmark-host drift — but the #12146 audit surfaced these two regime-specific regressions. Possible follow-up (not this PR): `SimulateTransactionProcessorAdapter` re-wraps the spec per simulated block, so simulate still regenerates opcode tables per block; hoisting the `WithoutEip3607` wrap would let repeated simulate calls reuse tables.
