### PR TITLE
refactor(healthchecks): move background-service startup to a StartHealthChecks step

### DIFF
--- a/src/Nethermind/Nethermind.HealthChecks.Test/StartHealthChecksTests.cs
+++ b/src/Nethermind/Nethermind.HealthChecks.Test/StartHealthChecksTests.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.IO.Abstractions;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Api;
+using Nethermind.Config;
+using Nethermind.Core.Timers;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.HealthChecks.Test;
+
+public class StartHealthChecksTests
+{
+    [TestCase(true, 1)]
+    [TestCase(false, 0)]
+    public async Task Execute_starts_cl_liveness_tracker_only_when_merge_enabled(bool mergeEnabled, int expectedStartCalls)
+    {
+        IEngineRequestsTracker engineRequestsTracker = Substitute.For<IEngineRequestsTracker>();
+        StartHealthChecks step = new(
+            new HealthChecksConfig { LowStorageSpaceShutdownThreshold = 0, LowStorageSpaceWarningThreshold = 0 },
+            new MergeConfig { Enabled = mergeEnabled },
+            CreateDiskChecker(),
+            new Lazy<IEngineRequestsTracker>(() => engineRequestsTracker),
+            LimboLogs.Instance);
+
+        await step.Execute(CancellationToken.None);
+
+        await engineRequestsTracker.Received(expectedStartCalls).StartAsync();
+    }
+
+    private static FreeDiskSpaceChecker CreateDiskChecker() =>
+        new(
+            new HealthChecksConfig(),
+            new[] { Substitute.For<IDriveInfo>() },
+            TimerFactory.Default,
+            Substitute.For<IProcessExitSource>(),
+            LimboLogs.Instance);
+}

--- a/src/Nethermind/Nethermind.HealthChecks/HealthChecksPlugin.cs
+++ b/src/Nethermind/Nethermind.HealthChecks/HealthChecksPlugin.cs
@@ -1,17 +1,15 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Threading.Tasks;
 using Autofac;
 using Autofac.Core;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
+using Nethermind.Api.Steps;
 using Nethermind.Blockchain.Services;
 using Nethermind.Core;
 using Nethermind.JsonRpc.Modules;
-using Nethermind.Logging;
-using Nethermind.Merge.Plugin;
 
 namespace Nethermind.HealthChecks
 {
@@ -19,8 +17,6 @@ namespace Nethermind.HealthChecks
     {
         private INethermindApi _api;
         private IHealthChecksConfig _healthChecksConfig;
-        private ILogger _logger;
-        private IMergeConfig _mergeConfig;
 
         public string Name => "HealthChecks";
 
@@ -37,35 +33,10 @@ namespace Nethermind.HealthChecks
         {
             _api = api;
             _healthChecksConfig = _api.Config<IHealthChecksConfig>();
-            _mergeConfig = _api.Config<IMergeConfig>();
-            _logger = api.LogManager.GetClassLogger<HealthChecksPlugin>();
 
             //will throw an exception and close app or block until enough disk space is available (LowStorageCheckAwaitOnStartup)
             EnsureEnoughFreeSpace();
 
-            return Task.CompletedTask;
-        }
-
-        public Task InitRpcModules()
-        {
-            if (_healthChecksConfig.LowStorageSpaceWarningThreshold > 0 || _healthChecksConfig.LowStorageSpaceShutdownThreshold > 0)
-            {
-                try
-                {
-                    FreeDiskSpaceChecker.StartAsync(default);
-                }
-                catch (Exception ex)
-                {
-                    if (_logger.IsError) _logger.Error("Failed to initialize available disk space check module", ex);
-                }
-            }
-
-            if (_mergeConfig.Enabled)
-            {
-                _ = _api.EngineRequestsTracker.StartAsync(); // Fire and forget
-            }
-
-            if (_logger.IsInfo) _logger.Info("Health RPC Module has been enabled");
             return Task.CompletedTask;
         }
 
@@ -97,6 +68,8 @@ namespace Nethermind.HealthChecks
                 .Bind<IEngineRequestsTracker, ClHealthRequestsTracker>()
 
                 .RegisterSingletonJsonRpcModule<IHealthRpcModule, HealthRpcModule>()
+
+                .AddStep(typeof(StartHealthChecks))
                 ;
         }
     }

--- a/src/Nethermind/Nethermind.HealthChecks/Nethermind.HealthChecks.csproj
+++ b/src/Nethermind/Nethermind.HealthChecks/Nethermind.HealthChecks.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Api\Nethermind.Api.csproj" />
+    <ProjectReference Include="..\Nethermind.Init\Nethermind.Init.csproj" />
     <ProjectReference Include="..\Nethermind.Merge.Plugin\Nethermind.Merge.Plugin.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Nethermind/Nethermind.HealthChecks/StartHealthChecks.cs
+++ b/src/Nethermind/Nethermind.HealthChecks/StartHealthChecks.cs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Api;
+using Nethermind.Api.Steps;
+using Nethermind.Init.Steps;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin;
+
+namespace Nethermind.HealthChecks;
+
+/// <summary>
+/// Starts the health-check background services: the periodic free-disk-space monitor and, on merge
+/// networks, the consensus-client liveness tracker.
+/// </summary>
+/// <remarks>
+/// Depends on <see cref="RegisterRpcModules"/> so it runs after <c>InitializePlugins</c> has completed
+/// (transitively). That ordering is required: <see cref="HealthChecksPlugin.Init"/> performs the
+/// blocking startup disk guard, and the periodic <see cref="FreeDiskSpaceChecker"/> timer must not
+/// start — and potentially exit the process — until that guard has finished.
+/// </remarks>
+[RunnerStepDependencies(typeof(RegisterRpcModules))]
+public class StartHealthChecks(
+    IHealthChecksConfig healthChecksConfig,
+    IMergeConfig mergeConfig,
+    FreeDiskSpaceChecker freeDiskSpaceChecker,
+    Lazy<IEngineRequestsTracker> engineRequestsTracker,
+    ILogManager logManager) : IStep
+{
+    private readonly ILogger _logger = logManager.GetClassLogger<StartHealthChecks>();
+
+    public Task Execute(CancellationToken cancellationToken)
+    {
+        if (healthChecksConfig.LowStorageSpaceWarningThreshold > 0 || healthChecksConfig.LowStorageSpaceShutdownThreshold > 0)
+        {
+            try
+            {
+                freeDiskSpaceChecker.StartAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                if (_logger.IsError) _logger.Error("Failed to initialize available disk space check module", ex);
+            }
+        }
+
+        if (mergeConfig.Enabled)
+        {
+            _ = engineRequestsTracker.Value.StartAsync(); // Fire and forget
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -839,6 +839,7 @@
           "AspNetCore.HealthChecks.UI.InMemory.Storage": "[9.0.0, )",
           "KubernetesClient": "[19.0.2, )",
           "Nethermind.Api": "[1.39.0-unstable, )",
+          "Nethermind.Init": "[1.39.0-unstable, )",
           "Nethermind.Merge.Plugin": "[1.39.0-unstable, )"
         }
       },


### PR DESCRIPTION
## Changes

`HealthChecksPlugin.InitRpcModules()` registered **no** RPC module — the real `IHealthRpcModule` is already wired declaratively in `HealthCheckPluginModule`. The hook was only used to start two background services, which is a misuse of the RPC-registration callback.

- Add a dedicated `StartHealthChecks` `IStep` that starts the periodic free-disk-space monitor and, on merge networks, the CL-liveness tracker. Registered through the plugin module via `.AddStep(...)`, matching `StartMonitoring` / `StartLogIndex`.
- Drop the `InitRpcModules()` override from `HealthChecksPlugin` (it reverts to the interface default no-op) and remove the now-unused `_mergeConfig` / `_logger` fields and usings.
- The step declares `[RunnerStepDependencies(typeof(RegisterRpcModules))]`. `RegisterRpcModules` transitively depends on `InitializePlugins`, which runs `HealthChecksPlugin.Init()`'s **blocking** startup disk guard. The periodic disk timer must not start until that guard completes — otherwise it could `Exit(LowDiskSpace)` while `LowStorageCheckAwaitOnStartup` is still waiting for free space. This also preserves the original "runs after RPC modules are registered" ordering. Adds a `Nethermind.Init` project reference so the built-in step type is nameable (no reference cycle).
- Add a parameterized regression test asserting the CL tracker starts iff `MergeConfig.Enabled`.

> Note: activate-on-resolve (`OnActivate` / `ResolveOnServiceActivation`) was considered and rejected — the CL tracker is resolved only by `EngineRpcModule`, so tying its `StartAsync` to activation would start the liveness timer only when the engine module is first built, defeating the "not receiving ForkChoices from the CL" warning. The timers must start unconditionally at init, which is what an `IStep` does.

Scope is HealthChecks-only; the generic `INethermindPlugin.InitRpcModules` hook and other plugins that use it are untouched.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New `StartHealthChecksTests` (parameterized over `MergeConfig.Enabled`) plus the existing `Nethermind.HealthChecks.Test` suite pass (34/34). `FreeDiskSpaceChecker`'s own threshold/exit/await behavior stays covered by `FreeDiskSpaceCheckerTests`. Release build is clean (0 warnings) and `dotnet format whitespace --verify-no-changes` passes on the new/edited files.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
