### PR TITLE
test(sync): unflake BlockDownloaderTests.Merge_Happy_path

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -934,16 +934,22 @@ public partial class BlockDownloaderTests
                 .Do((c) => peerSemaphore.Release());
         }
 
+        private static readonly TimeSpan SyncUntilNoRequestTimeout = TimeSpan.FromMinutes(2);
+
         public async Task SyncUntilNoRequest(SyncFeedComponent<BlocksRequest> component, PeerInfo peerInfo)
         {
-            using AutoCancelTokenSource cts = AutoCancelTokenSource.ThatCancelAfter(TimeSpan.FromSeconds(10));
+            using AutoCancelTokenSource cts = AutoCancelTokenSource.ThatCancelAfter(SyncUntilNoRequestTimeout);
 
             while (true)
             {
-                cts.Token.ThrowIfCancellationRequested();
-
                 BlocksRequest? blockRequest = await component.Feed.PrepareRequest(cts.Token);
-                if (blockRequest is null) break;
+                if (blockRequest is null)
+                {
+                    Assert.That(cts.Token.IsCancellationRequested, Is.False,
+                        "Timed out waiting for the sync feed to run out of requests.");
+                    break;
+                }
+
                 await component.Downloader.Dispatch(peerInfo, blockRequest, cts.Token);
                 component.Feed.HandleResponse(blockRequest, peerInfo);
             }

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -882,6 +882,8 @@ public partial class BlockDownloaderTests
 
     private record Context
     {
+        private static readonly TimeSpan SyncUntilNoRequestTimeout = TimeSpan.FromMinutes(2);
+
         private readonly ConcurrentDictionary<Hash256, bool> _wasSuggested = new();
         public ActivatedSyncFeed<BlocksRequest> Feed => (ActivatedSyncFeed<BlocksRequest>)FullSyncFeedComponent.Feed;
         public ResponseBuilder ResponseBuilder { get; init; }
@@ -933,8 +935,6 @@ public partial class BlockDownloaderTests
                 .When((p) => p.Free(peerAllocation))
                 .Do((c) => peerSemaphore.Release());
         }
-
-        private static readonly TimeSpan SyncUntilNoRequestTimeout = TimeSpan.FromMinutes(2);
 
         public async Task SyncUntilNoRequest(SyncFeedComponent<BlocksRequest> component, PeerInfo peerInfo)
         {


### PR DESCRIPTION
## Changes

`BlockDownloaderTests.Merge_Happy_path(16,1024,False,32,1008)` flakes on loaded CI runners (e.g. [this run](https://github.com/NethermindEth/nethermind/actions/runs/28653069423), `Synchronization.Test (2of4)` on `ubuntu-24.04-arm`), failing twice in a row in two different shapes:

- `OperationCanceledException` at the top of `Context.SyncUntilNoRequest`, and
- `BestSuggestedHeader.Number` expected `1008` but was `644` at `BlockDownloaderTests.Merge.cs:101`.

Both come from the same cause: `SyncUntilNoRequest` gives the *entire* sync one 10-second wall-clock budget, and the 1024-block test cases don't fit into it on a slow, contended runner. When the token fires, `BlockDownloader.PrepareRequest` returns `null` on cancellation (checked at `BlockDownloader.cs:156`, plus the catch-all at `:127`), so the loop either throws at the top or — worse — breaks out looking like a *completed* sync and fails later on an unrelated progress assertion (the confusing 644-vs-1008 shape). The observed failing durations (24 s, 17 s) are both past the 10-second budget, and the queue-full early-`null` path is not reachable here (the cap is ≥ ~2 000 blocks vs 1 008 in the test).

Fix:

- Raise the budget to 2 minutes. It is failure-path-only: the loop always exits via "feed has no more requests" when healthy, so the timeout only bounds how long a genuinely wedged test takes to fail.
- Assert that the token has not fired when `PrepareRequest` returns `null`, so a timed-out sync now fails with an explicit "Timed out waiting for the sync feed to run out of requests." instead of a misleading downstream progress assertion.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Test-only change. All 6 `Merge_Happy_path` cases pass locally in release.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
