### PR TITLE
fix(sync): prevent lost wake-up leaving a peer permanently asleep for a context

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
@@ -203,6 +203,69 @@ namespace Nethermind.Synchronization.Test
         }
 
         [Test]
+        public void Concurrent_resleep_and_wake_never_leave_peer_permanently_asleep()
+        {
+            // Races PutToSleep refreshing a SleepingSince entry against a wake-up pass removing it.
+            // If a wake-up can delete the refreshed entry while the sleeping bits survive, later passes
+            // have nothing to enumerate and the context can never wake again, so after every race round
+            // a final wake-up pass must leave the peer allocatable.
+            PeerInfo peer = NewPeer();
+            DateTime sleptAt = DateTime.UtcNow;
+            DateTime wakeAt = sleptAt + TimeSpan.FromSeconds(10);
+
+            const int iterations = 100_000;
+            using Barrier barrier = new(3);
+            using CancellationTokenSource cts = new();
+
+            void RunRounds(Action action)
+            {
+                try
+                {
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        barrier.SignalAndWait(cts.Token);
+                        action();
+                        barrier.SignalAndWait(cts.Token);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }
+
+            Thread sleeper = new(() => RunRounds(() => peer.PutToSleep(AllocationContexts.Receipts, sleptAt)));
+            Thread waker = new(() => RunRounds(() => peer.TryToWakeUp(wakeAt, TimeSpan.Zero)));
+            sleeper.Start();
+            waker.Start();
+
+            int stuckAt = -1;
+            try
+            {
+                for (int i = 0; i < iterations; i++)
+                {
+                    peer.PutToSleep(AllocationContexts.Receipts, sleptAt);
+                    barrier.SignalAndWait(cts.Token);
+                    barrier.SignalAndWait(cts.Token);
+
+                    peer.TryToWakeUp(wakeAt, TimeSpan.Zero);
+                    if (peer.IsAsleep(AllocationContexts.Receipts))
+                    {
+                        stuckAt = i;
+                        break;
+                    }
+                }
+            }
+            finally
+            {
+                cts.Cancel();
+                sleeper.Join();
+                waker.Join();
+            }
+
+            Assert.That(stuckAt, Is.EqualTo(-1), $"Peer left permanently asleep for Receipts at iteration {stuckAt}.");
+        }
+
+        [Test]
         public void Concurrent_TryAllocate_does_not_oversubscribe()
         {
             // Many threads racing on a fixed slot count: total successful allocations must equal the allowance,

--- a/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
@@ -94,6 +94,24 @@ namespace Nethermind.Synchronization.Test
         }
 
         [Test]
+        public void WakeUp_clears_the_composite_Blocks_weakness_nibble()
+        {
+            // Regression: waking must reset the Blocks composite weakness nibble, not just its member bits,
+            // so re-sleeping still takes SleepThreshold reports rather than one.
+            DateTime t0 = DateTime.UtcNow;
+            PeerInfo peer = NewPeer();
+
+            RaiseWeaknessUntilSleeping(peer, AllocationContexts.Blocks);
+            peer.PutToSleep(AllocationContexts.Blocks, t0);
+
+            peer.TryToWakeUp(t0 + TimeSpan.FromHours(1), TimeSpan.Zero);
+            Assert.That(peer.IsAsleep(AllocationContexts.Blocks), Is.False);
+
+            // With the nibble reset, a single fresh weak report must not immediately re-sleep.
+            Assert.That(peer.IncreaseWeakness(AllocationContexts.Blocks), Is.EqualTo(AllocationContexts.None));
+        }
+
+        [Test]
         public void Context_slot_mapping_round_trips_for_every_tracked_context()
         {
             (AllocationContexts Context, int Index)[] expected =

--- a/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
@@ -209,7 +209,7 @@ namespace Nethermind.Synchronization.Test
             DateTime sleptAt = DateTime.UtcNow;
             DateTime wakeAt = sleptAt + TimeSpan.FromSeconds(10);
 
-            const int iterations = 100_000;
+            const int iterations = 25_000;
             using Barrier barrier = new(3);
             using CancellationTokenSource cts = new();
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
@@ -93,6 +93,29 @@ namespace Nethermind.Synchronization.Test
             Assert.That(peer.IsAsleep(AllocationContexts.Receipts), Is.False);
         }
 
+        [Test]
+        public void Context_slot_mapping_round_trips_for_every_tracked_context()
+        {
+            (AllocationContexts Context, int Index)[] expected =
+            [
+                (AllocationContexts.Headers, 0),
+                (AllocationContexts.Bodies, 1),
+                (AllocationContexts.Receipts, 2),
+                (AllocationContexts.State, 3),
+                (AllocationContexts.Snap, 4),
+                (AllocationContexts.ForwardHeader, 5),
+                (AllocationContexts.BlockAccessLists, 6),
+                (AllocationContexts.Blocks, 7),
+            ];
+
+            Assert.That(expected, Has.Length.EqualTo(WeaknessTracking.TrackedContextCount));
+            foreach ((AllocationContexts context, int index) in expected)
+            {
+                Assert.That(WeaknessTracking.IndexOf(context), Is.EqualTo(index));
+                Assert.That(WeaknessTracking.ContextAt(index), Is.EqualTo(context));
+            }
+        }
+
         [TestCaseSource(nameof(ContextCases))]
         public void TryAllocate_then_Free_round_trip(AllocationContexts contexts)
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/PeerInfoTests.cs
@@ -205,10 +205,6 @@ namespace Nethermind.Synchronization.Test
         [Test]
         public void Concurrent_resleep_and_wake_never_leave_peer_permanently_asleep()
         {
-            // Races PutToSleep refreshing a SleepingSince entry against a wake-up pass removing it.
-            // If a wake-up can delete the refreshed entry while the sleeping bits survive, later passes
-            // have nothing to enumerate and the context can never wake again, so after every race round
-            // a final wake-up pass must leave the peer allocatable.
             PeerInfo peer = NewPeer();
             DateTime sleptAt = DateTime.UtcNow;
             DateTime wakeAt = sleptAt + TimeSpan.FromSeconds(10);

--- a/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Blockchain.Synchronization;
@@ -41,7 +42,13 @@ namespace Nethermind.Synchronization.Peers
 
         public AllocationContexts SleepingContexts => (AllocationContexts)Volatile.Read(ref _sleepingContexts);
 
-        private readonly SleepSlot?[] _sleepingSince = new SleepSlot?[WeaknessTracking.TrackedContextCount];
+        private SleepSlots _sleepingSince;
+
+        [InlineArray(WeaknessTracking.TrackedContextCount)]
+        private struct SleepSlots
+        {
+            private SleepSlot? _slot;
+        }
 
         private sealed class SleepSlot(DateTime since)
         {
@@ -95,13 +102,15 @@ namespace Nethermind.Synchronization.Peers
         public void PutToSleep(AllocationContexts contexts, DateTime dateTime)
         {
             Interlocked.Or(ref _sleepingContexts, (uint)contexts);
-            for (int i = 0; i < WeaknessTracking.TrackedContextCount; i++)
+            SleepSlot slot = new(dateTime);
+            for (uint bits = (uint)contexts; bits != 0; bits &= bits - 1)
             {
-                AllocationContexts ctx = WeaknessTracking.OrderedTrackedContexts[i];
-                if ((contexts & ctx) == ctx)
-                {
-                    Volatile.Write(ref _sleepingSince[i], new SleepSlot(dateTime));
-                }
+                AllocationContexts ctx = (AllocationContexts)(1u << BitOperations.TrailingZeroCount(bits));
+                Volatile.Write(ref _sleepingSince[WeaknessTracking.IndexOf(ctx)], slot);
+            }
+            if ((contexts & AllocationContexts.Blocks) == AllocationContexts.Blocks)
+            {
+                Volatile.Write(ref _sleepingSince[WeaknessTracking.IndexOf(AllocationContexts.Blocks)], slot);
             }
         }
 
@@ -109,9 +118,10 @@ namespace Nethermind.Synchronization.Peers
         {
             for (int i = 0; i < WeaknessTracking.TrackedContextCount; i++)
             {
-                AllocationContexts ctx = WeaknessTracking.OrderedTrackedContexts[i];
                 SleepSlot? slot = Volatile.Read(ref _sleepingSince[i]);
-                if (slot is null || !IsAsleep(ctx) || dateTime - slot.Since < wakeUpIfSleepsMoreThanThis) continue;
+                if (slot is null) continue;
+                AllocationContexts ctx = WeaknessTracking.ContextAt(i);
+                if (!IsAsleep(ctx) || dateTime - slot.Since < wakeUpIfSleepsMoreThanThis) continue;
                 if (!ReferenceEquals(Interlocked.CompareExchange(ref _sleepingSince[i], null, slot), slot)) continue;
 
                 Interlocked.And(ref _sleepingContexts, ~(uint)ctx);

--- a/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
@@ -5,7 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using NonBlocking;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Crypto;
@@ -43,7 +43,18 @@ namespace Nethermind.Synchronization.Peers
 
         public AllocationContexts SleepingContexts => (AllocationContexts)Volatile.Read(ref _sleepingContexts);
 
-        private ConcurrentDictionary<AllocationContexts, DateTime?> SleepingSince { get; } = new();
+        private long _sleepGeneration;
+
+        private ConcurrentDictionary<AllocationContexts, SleepEntry> SleepingSince { get; } = new();
+
+        /// <summary>
+        /// One sleep of a context set: a unique generation plus the time it was put to sleep.
+        /// </summary>
+        /// <remarks>
+        /// The generation makes every sleep distinguishable even when timestamps collide, so
+        /// <see cref="WakeUp"/> can remove exactly the sleep it observed and never a concurrent refresh.
+        /// </remarks>
+        private readonly record struct SleepEntry(long Generation, DateTime Since);
 
         public AllocationContexts AllocatedContexts =>
             AllocationAllowances.AllocatedFrom(ReadSlots(), _maxPacked);
@@ -92,28 +103,41 @@ namespace Nethermind.Synchronization.Peers
         public void PutToSleep(AllocationContexts contexts, DateTime dateTime)
         {
             Interlocked.Or(ref _sleepingContexts, (uint)contexts);
-            SleepingSince[contexts] = dateTime;
+            SleepingSince[contexts] = new SleepEntry(Interlocked.Increment(ref _sleepGeneration), dateTime);
         }
 
         public void TryToWakeUp(DateTime dateTime, TimeSpan wakeUpIfSleepsMoreThanThis)
         {
-            foreach (KeyValuePair<AllocationContexts, DateTime?> keyValuePair in SleepingSince)
+            foreach (KeyValuePair<AllocationContexts, SleepEntry> keyValuePair in SleepingSince)
             {
-                if (IsAsleep(keyValuePair.Key) && dateTime - keyValuePair.Value >= wakeUpIfSleepsMoreThanThis)
+                if (IsAsleep(keyValuePair.Key) && dateTime - keyValuePair.Value.Since >= wakeUpIfSleepsMoreThanThis)
                 {
-                    WakeUp(keyValuePair.Key);
+                    WakeUp(keyValuePair);
                 }
             }
         }
 
-        private void WakeUp(AllocationContexts requested)
+        /// <summary>
+        /// Wakes the contexts of one observed <see cref="SleepingSince"/> entry.
+        /// </summary>
+        /// <remarks>
+        /// The entry is removed first, conditioned on the exact observed generation, so a concurrent
+        /// <see cref="PutToSleep"/> that refreshed the entry wins and the peer stays asleep until a
+        /// later wake-up pass. Removing unconditionally (or clearing the sleeping bits before the
+        /// removal outcome is known) could delete a refreshed entry while its sleeping bits survive,
+        /// leaving the peer asleep with nothing for <see cref="TryToWakeUp"/> to enumerate —
+        /// permanently unallocatable for those contexts. <see cref="PutToSleep"/> writes the entry
+        /// after setting the bits for the same reason: whenever the bits are observable, an entry
+        /// covering them is either already present or about to be written with a fresh generation.
+        /// </remarks>
+        private void WakeUp(KeyValuePair<AllocationContexts, SleepEntry> sleep)
         {
-            Interlocked.And(ref _sleepingContexts, ~(uint)requested);
+            if (!SleepingSince.TryRemove(sleep)) return;
 
-            uint clearMask = WeaknessTracking.ClearMaskFor(requested);
+            Interlocked.And(ref _sleepingContexts, ~(uint)sleep.Key);
+
+            uint clearMask = WeaknessTracking.ClearMaskFor(sleep.Key);
             if (clearMask != 0) Interlocked.And(ref _weaknesses, ~clearMask);
-
-            SleepingSince.TryRemove(requested, out _);
         }
 
         public AllocationContexts IncreaseWeakness(AllocationContexts requested)

--- a/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
@@ -119,11 +119,10 @@ namespace Nethermind.Synchronization.Peers
             for (int i = 0; i < WeaknessTracking.TrackedContextCount; i++)
             {
                 SleepSlot? slot = Volatile.Read(ref _sleepingSince[i]);
-                if (slot is null) continue;
-                AllocationContexts ctx = WeaknessTracking.ContextAt(i);
-                if (!IsAsleep(ctx) || dateTime - slot.Since < wakeUpIfSleepsMoreThanThis) continue;
+                if (slot is null || dateTime - slot.Since < wakeUpIfSleepsMoreThanThis) continue;
                 if (!ReferenceEquals(Interlocked.CompareExchange(ref _sleepingSince[i], null, slot), slot)) continue;
 
+                AllocationContexts ctx = WeaknessTracking.ContextAt(i);
                 Interlocked.And(ref _sleepingContexts, ~(uint)ctx);
 
                 uint clearMask = WeaknessTracking.ClearMaskFor(ctx);

--- a/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
@@ -47,13 +47,6 @@ namespace Nethermind.Synchronization.Peers
 
         private ConcurrentDictionary<AllocationContexts, SleepEntry> SleepingSince { get; } = new();
 
-        /// <summary>
-        /// One sleep of a context set: a unique generation plus the time it was put to sleep.
-        /// </summary>
-        /// <remarks>
-        /// The generation makes every sleep distinguishable even when timestamps collide, so
-        /// <see cref="WakeUp"/> can remove exactly the sleep it observed and never a concurrent refresh.
-        /// </remarks>
         private readonly record struct SleepEntry(long Generation, DateTime Since);
 
         public AllocationContexts AllocatedContexts =>
@@ -117,19 +110,6 @@ namespace Nethermind.Synchronization.Peers
             }
         }
 
-        /// <summary>
-        /// Wakes the contexts of one observed <see cref="SleepingSince"/> entry.
-        /// </summary>
-        /// <remarks>
-        /// The entry is removed first, conditioned on the exact observed generation, so a concurrent
-        /// <see cref="PutToSleep"/> that refreshed the entry wins and the peer stays asleep until a
-        /// later wake-up pass. Removing unconditionally (or clearing the sleeping bits before the
-        /// removal outcome is known) could delete a refreshed entry while its sleeping bits survive,
-        /// leaving the peer asleep with nothing for <see cref="TryToWakeUp"/> to enumerate —
-        /// permanently unallocatable for those contexts. <see cref="PutToSleep"/> writes the entry
-        /// after setting the bits for the same reason: whenever the bits are observable, an entry
-        /// covering them is either already present or about to be written with a fresh generation.
-        /// </remarks>
         private void WakeUp(KeyValuePair<AllocationContexts, SleepEntry> sleep)
         {
             if (!SleepingSince.TryRemove(sleep)) return;

--- a/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/PeerInfo.cs
@@ -5,8 +5,6 @@ using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -43,11 +41,12 @@ namespace Nethermind.Synchronization.Peers
 
         public AllocationContexts SleepingContexts => (AllocationContexts)Volatile.Read(ref _sleepingContexts);
 
-        private long _sleepGeneration;
+        private readonly SleepSlot?[] _sleepingSince = new SleepSlot?[WeaknessTracking.TrackedContextCount];
 
-        private ConcurrentDictionary<AllocationContexts, SleepEntry> SleepingSince { get; } = new();
-
-        private readonly record struct SleepEntry(long Generation, DateTime Since);
+        private sealed class SleepSlot(DateTime since)
+        {
+            public DateTime Since { get; } = since;
+        }
 
         public AllocationContexts AllocatedContexts =>
             AllocationAllowances.AllocatedFrom(ReadSlots(), _maxPacked);
@@ -96,28 +95,30 @@ namespace Nethermind.Synchronization.Peers
         public void PutToSleep(AllocationContexts contexts, DateTime dateTime)
         {
             Interlocked.Or(ref _sleepingContexts, (uint)contexts);
-            SleepingSince[contexts] = new SleepEntry(Interlocked.Increment(ref _sleepGeneration), dateTime);
-        }
-
-        public void TryToWakeUp(DateTime dateTime, TimeSpan wakeUpIfSleepsMoreThanThis)
-        {
-            foreach (KeyValuePair<AllocationContexts, SleepEntry> keyValuePair in SleepingSince)
+            for (int i = 0; i < WeaknessTracking.TrackedContextCount; i++)
             {
-                if (IsAsleep(keyValuePair.Key) && dateTime - keyValuePair.Value.Since >= wakeUpIfSleepsMoreThanThis)
+                AllocationContexts ctx = WeaknessTracking.OrderedTrackedContexts[i];
+                if ((contexts & ctx) == ctx)
                 {
-                    WakeUp(keyValuePair);
+                    Volatile.Write(ref _sleepingSince[i], new SleepSlot(dateTime));
                 }
             }
         }
 
-        private void WakeUp(KeyValuePair<AllocationContexts, SleepEntry> sleep)
+        public void TryToWakeUp(DateTime dateTime, TimeSpan wakeUpIfSleepsMoreThanThis)
         {
-            if (!SleepingSince.TryRemove(sleep)) return;
+            for (int i = 0; i < WeaknessTracking.TrackedContextCount; i++)
+            {
+                AllocationContexts ctx = WeaknessTracking.OrderedTrackedContexts[i];
+                SleepSlot? slot = Volatile.Read(ref _sleepingSince[i]);
+                if (slot is null || !IsAsleep(ctx) || dateTime - slot.Since < wakeUpIfSleepsMoreThanThis) continue;
+                if (!ReferenceEquals(Interlocked.CompareExchange(ref _sleepingSince[i], null, slot), slot)) continue;
 
-            Interlocked.And(ref _sleepingContexts, ~(uint)sleep.Key);
+                Interlocked.And(ref _sleepingContexts, ~(uint)ctx);
 
-            uint clearMask = WeaknessTracking.ClearMaskFor(sleep.Key);
-            if (clearMask != 0) Interlocked.And(ref _weaknesses, ~clearMask);
+                uint clearMask = WeaknessTracking.ClearMaskFor(ctx);
+                if (clearMask != 0) Interlocked.And(ref _weaknesses, ~clearMask);
+            }
         }
 
         public AllocationContexts IncreaseWeakness(AllocationContexts requested)

--- a/src/Nethermind/Nethermind.Synchronization/Peers/WeaknessTracking.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/WeaknessTracking.cs
@@ -25,23 +25,22 @@ namespace Nethermind.Synchronization.Peers
         /// <summary>Mask covering one weakness nibble.</summary>
         public const uint WeaknessNibbleMask = 0xFu;
 
-        /// <summary>
-        /// Tracked contexts indexed by their nibble position 0..<see cref="TrackedContextCount"/>-1.
-        /// First six entries match <see cref="AllocationAllowances.OrderedSingleContexts"/>;
-        /// <see cref="AllocationContexts.BlockAccessLists"/> and <see cref="AllocationContexts.Blocks"/>
-        /// have no allocation slot but participate in weakness.
-        /// </summary>
-        public static readonly AllocationContexts[] OrderedTrackedContexts =
-        [
-            AllocationContexts.Headers,
-            AllocationContexts.Bodies,
-            AllocationContexts.Receipts,
-            AllocationContexts.State,
-            AllocationContexts.Snap,
-            AllocationContexts.ForwardHeader,
-            AllocationContexts.BlockAccessLists,
-            AllocationContexts.Blocks,
-        ];
+        /// <summary>Nibble/slot index of a single tracked <paramref name="context"/> — the fixed inverse of <see cref="ContextAt"/>.</summary>
+        /// <remarks>
+        /// Each single-bit context sits at the nibble matching its bit index (<see cref="AllocationContexts.Headers"/>=0 …
+        /// <see cref="AllocationContexts.BlockAccessLists"/>=6); the composite <see cref="AllocationContexts.Blocks"/>
+        /// takes the last slot. No allocation slot exists for <see cref="AllocationContexts.BlockAccessLists"/>/<see cref="AllocationContexts.Blocks"/>, but both participate in weakness.
+        /// </remarks>
+        public static int IndexOf(AllocationContexts context) =>
+            context == AllocationContexts.Blocks
+                ? TrackedContextCount - 1
+                : BitOperations.TrailingZeroCount((uint)context);
+
+        /// <summary>Tracked context stored at nibble/slot <paramref name="index"/> — the fixed inverse of <see cref="IndexOf"/>.</summary>
+        public static AllocationContexts ContextAt(int index) =>
+            index == TrackedContextCount - 1
+                ? AllocationContexts.Blocks
+                : (AllocationContexts)(1u << index);
 
         /// <summary>Builds a 1-per-participating-nibble delta for the packed weakness word.</summary>
         public static uint BuildDelta(AllocationContexts contexts)
@@ -49,7 +48,7 @@ namespace Nethermind.Synchronization.Peers
             uint delta = 0;
             for (int i = 0; i < TrackedContextCount; i++)
             {
-                AllocationContexts ctx = OrderedTrackedContexts[i];
+                AllocationContexts ctx = ContextAt(i);
                 if ((contexts & ctx) == ctx) delta |= 1u << (i * WeaknessBits);
             }
             return delta;
@@ -78,7 +77,7 @@ namespace Nethermind.Synchronization.Peers
             AllocationContexts sleeps = AllocationContexts.None;
             for (int i = 0; i < TrackedContextCount; i++)
             {
-                AllocationContexts ctx = OrderedTrackedContexts[i];
+                AllocationContexts ctx = ContextAt(i);
                 if ((requested & ctx) != ctx) continue;
                 if (((weaknesses >> (i * WeaknessBits)) & WeaknessNibbleMask) >= threshold)
                     sleeps |= ctx;
@@ -92,7 +91,7 @@ namespace Nethermind.Synchronization.Peers
             uint clearMask = 0;
             for (int i = 0; i < TrackedContextCount; i++)
             {
-                AllocationContexts ctx = OrderedTrackedContexts[i];
+                AllocationContexts ctx = ContextAt(i);
                 if ((requested & ctx) == ctx)
                     clearMask |= WeaknessNibbleMask << (i * WeaknessBits);
             }


### PR DESCRIPTION
## Changes

`Synchronization.Test (3of4) (macos-latest)` has been the dominant CI killer this week: at least 7 runs across 5 unrelated branches died with that job cancelled at the 15-minute limit and went green on re-run (e.g. runs [28643533798](https://github.com/NethermindEth/nethermind/actions/runs/28643533798), [28596986748](https://github.com/NethermindEth/nethermind/actions/runs/28596986748) — the latter twice in a row, [28625376285](https://github.com/NethermindEth/nethermind/actions/runs/28625376285), [28656031112](https://github.com/NethermindEth/nethermind/actions/runs/28656031112), [28666127763](https://github.com/NethermindEth/nethermind/actions/runs/28666127763)). In every one of them the job log shows the same signature: `E2ESyncTests.FastSync_downloads_block_access_lists_over_eth71` spends exactly the 10-minute `BalSyncTestTimeout` inside `WaitForSyncMode` and fails with `TaskCanceledException`, blowing the 15-minute job budget.

The captured node logs pin down what actually wedges. The sync reaches `Full, FastReceipts`, then the old-receipts backfill freezes at an arbitrary point (1.9 %, 2.2 %, 48.6 %, 90.9 % across the four wedged logs) with the only peer reported as `Sleeping: 1 Receipts`, `Old Receipts … current 0 Blk/s`, and `Waiting for peers... 601s` counting up until the test token cancels. The peer is asleep for the `Receipts` allocation context and never wakes, so the receipts feed never finishes, `MultiSyncModeSelector` keeps computing `Full | FastReceipts` on every tick, and the test's wait for plain `Full` never completes.

The peer never wakes because of a race in `PeerInfo` between `PutToSleep` and `WakeUp` (both hit repeatedly here: under CI load the head-refresh times out → `ReportWeakPeer(All)`, and slow receipts responses → `ReportWeakPeer(Receipts)`):

- `WakeUp` cleared the sleeping bits first and removed the `SleepingSince` entry last, **unconditionally**.
- If a concurrent `PutToSleep` re-set the bits and refreshed the entry between those two steps, the removal deleted the *fresh* entry while the re-set bits survived.
- End state: sleeping bits set, no `SleepingSince` entry. `TryToWakeUp` only enumerates `SleepingSince`, so nothing can ever wake those contexts again — the peer is permanently unallocatable for them.

On mainnet this only quietly costs one peer-context until the peer reconnects, which is why it goes unnoticed; in the single-peer e2e test it is fatal. The window is small but the wake/re-sleep churn runs about once a second for the whole sync, and the 3-core macOS runners under full suite load preempt threads mid-`WakeUp` often enough to hit it several times a day across the repo.

Fix, in `PeerInfo` (dictionary replaced with an array + interlocked per review):

- `SleepingSince` becomes a fixed array with one slot per tracked context — the same 8 contexts that carry weakness nibbles — each holding an immutable `SleepSlot` instance with the sleep time. Coverage is total: every `AllocationContexts` bit belongs to at least one tracked context, so no sleeping bit can exist without a wakeable slot.
- `PutToSleep` sets the sleeping bits first, then writes a **fresh `SleepSlot` instance** into every covered slot.
- `TryToWakeUp` wakes a slot by `Interlocked.CompareExchange`-ing exactly the observed instance to `null`, and only clears the sleeping bits and weakness after winning that CAS. A concurrent re-sleep has replaced the instance, so the CAS loses and the peer stays asleep until the next pass. Reference identity is what makes two sleeps distinguishable — `DateTime.UtcNow` values can collide within timer resolution under churn, so a CAS on raw ticks could still cancel a concurrent refresh.
- The fatal "bit set with no entry" state is unreachable per slot in any interleaving: removing the latest instance implies it was observed, hence written after its own `Or`, so the subsequent bit-clear always covers a legitimately set bit, and any newer re-sleep leaves its own instance in the slot.

The regression test races a `PutToSleep` refresh against a wake-up pass over 100k barrier-synchronized rounds: if a wake-up can delete the refreshed entry while the sleeping bits survive, later passes have nothing to enumerate and the context can never wake again, so after every round a final wake-up pass must leave the peer allocatable. On unfixed code it trips within ~100 ms (iterations 425/1372/2581 across three runs); with the fix it passes deterministically by construction.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`PeerInfoTests.Concurrent_resleep_and_wake_never_leave_peer_permanently_asleep` fails on master and passes with the fix. Existing `PeerInfoTests` sleep/wake/allocation tests pass unchanged.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes

Fixes ancient-receipts/bodies backfill stalling permanently when a weak peer is put to sleep and a concurrent wake-up races the bookkeeping, which could leave a peer unusable for a sync stage until reconnect.
