### PR TITLE
feat(jsonrpc): add debug_repairMainChainToHead

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -469,6 +469,16 @@ public class DebugModuleTests
         _debugBridge.Received().UpdateHeadBlock(TestItem.KeccakA);
     }
 
+    [Test]
+    public async Task DebugRepairMainChainToHead_WhenInvoked_DelegatesToBridge()
+    {
+        _debugBridge.RepairMainChainToHead().Returns(true);
+
+        string response = await SerializedRequest("debug_repairMainChainToHead");
+        _debugBridge.Received().RepairMainChainToHead();
+        Assert.That(response, Does.Contain("\"result\":true"));
+    }
+
     private static IEnumerable<IEnumerable<GethLikeTxTrace>> StreamBundles(CancellationToken token)
     {
         yield return YieldTrace(token);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -20,6 +20,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Db;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Crypto;
+using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Reporting;
@@ -39,6 +40,7 @@ public class DebugBridge : IDebugBridge
     private readonly IBadBlockStore _badBlockStore;
     private readonly IBlockStore _blockStore;
     private readonly Dictionary<string, IDb> _dbMappings;
+    private readonly ILogger _logger;
 
     public DebugBridge(
         IConfigProvider configProvider,
@@ -49,7 +51,8 @@ public class DebugBridge : IDebugBridge
         IReceiptsMigration receiptsMigration,
         ISpecProvider specProvider,
         ISyncModeSelector syncModeSelector,
-        IBadBlockStore badBlockStore)
+        IBadBlockStore badBlockStore,
+        ILogManager logManager)
     {
         _configProvider = configProvider ?? throw new ArgumentNullException(nameof(configProvider));
         _tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
@@ -59,6 +62,7 @@ public class DebugBridge : IDebugBridge
         _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
         _syncModeSelector = syncModeSelector ?? throw new ArgumentNullException(nameof(syncModeSelector));
         _badBlockStore = badBlockStore;
+        _logger = logManager?.GetClassLogger<DebugBridge>() ?? throw new ArgumentNullException(nameof(logManager));
         dbProvider = dbProvider ?? throw new ArgumentNullException(nameof(dbProvider));
         IDb blockInfosDb = dbProvider.BlockInfosDb ?? throw new ArgumentNullException(nameof(dbProvider.BlockInfosDb));
         IDb blocksDb = dbProvider.BlocksDb ?? throw new ArgumentNullException(nameof(dbProvider.BlocksDb));
@@ -94,6 +98,20 @@ public class DebugBridge : IDebugBridge
     public int DeleteChainSlice(ulong startNumber, bool force = false) => _blockTree.DeleteChainSlice(startNumber, force: force);
 
     public void UpdateHeadBlock(Hash256 blockHash) => _blockTree.UpdateHeadBlock(blockHash);
+
+    public bool RepairMainChainToHead()
+    {
+        Block? head = _blockTree.Head;
+        if (head is null)
+        {
+            if (_logger.IsWarn) _logger.Warn("Cannot repair main chain: no head block is set.");
+            return false;
+        }
+
+        bool updated = _blockTree.TryUpdateMainChain(head.Header, wereProcessed: false);
+        if (!updated && _logger.IsWarn) _logger.Warn($"Could not canonicalize head level {head.Number} ({head.Hash}); the head body may be missing.");
+        return updated;
+    }
 
     public Task<bool> MigrateReceipts(ulong from, ulong to) => _receiptsMigration.Run(from, to);
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -515,6 +515,9 @@ public class DebugRpcModule(
         return ResultWrapper<bool>.Success(true);
     }
 
+    public ResultWrapper<bool> debug_repairMainChainToHead() =>
+        ResultWrapper<bool>.Success(debugBridge.RepairMainChainToHead());
+
     public ResultWrapper<ArrayPoolList<byte>> debug_getRawTransaction(Hash256 transactionHash)
     {
         Transaction? transaction = debugBridge.GetTransactionFromHash(transactionHash);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugBridge.cs
@@ -34,6 +34,7 @@ public interface IDebugBridge
     ChainLevelInfo GetLevelInfo(ulong number);
     int DeleteChainSlice(ulong startNumber, bool force = false);
     void UpdateHeadBlock(Hash256 blockHash);
+    bool RepairMainChainToHead();
     Task<bool> MigrateReceipts(ulong from, ulong to);
     void InsertReceipts(BlockParameter blockParameter, TxReceipt[] receipts);
     SyncReportSummary GetCurrentSyncStage();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/IDebugRpcModule.cs
@@ -30,6 +30,11 @@ public interface IDebugRpcModule : IRpcModule
         IsSharable = true)]
     ResultWrapper<bool> debug_resetHead(Hash256 blockHash);
 
+    [JsonRpcMethod(
+        Description = "Walks from the current head down to the last block already on the main chain, marking each level canonical (header-only, no re-execution). Useful after restoring a snapshot where the head is set but the canonical number->hash index below it was not fully persisted, so eth_getBlockByNumber and p2p header serving return empty for that range. Returns true when the head level is (re)marked canonical, i.e. the head branch is canonicalized (not necessarily that a gap was found and fixed); returns false when there is no head (Nethermind specific).",
+        IsSharable = true)]
+    ResultWrapper<bool> debug_repairMainChainToHead();
+
     [JsonRpcMethod(Description = "This method will attempt to run the transaction in the exact same manner as it was executed on the network. It will replay any transaction that may have been executed prior to this one before it will finally attempt to execute the transaction that corresponds to the given hash.", IsImplemented = true, IsSharable = false)]
     ResultWrapper<GethLikeTxTrace> debug_traceTransaction(Hash256 transactionHash, GethTraceOptions options = null);
 


### PR DESCRIPTION
## What

Adds a debug JSON-RPC method **`debug_repairMainChainToHead`** that canonicalizes the head branch — from the current `Head` down to the last block already on the main chain — **header-only and without re-execution**, by reusing `BlockTree.TryUpdateMainChain(head.Header, wereProcessed: false)`.

Returns `true` if the head branch was (re)canonicalized.

## Why

Recovers a node whose `Head` is set but whose canonical `number -> hash` index for the range **below** the head was never fully persisted — e.g. after restoring a state/DB snapshot that was not gracefully flushed all the way up to the head block. In that state:

- `eth_getBlockByNumber` / `eth_getBlockByHash`-by-number lookups return empty for the un-canonicalized range, and
- p2p header serving (`GetBlockHeaders`) returns nothing for that range,

so a peer trying to snap/fast-sync the **header skeleton** from this node fails (`No headers delivered`) and drops the connection, even though the node holds every block and the head state.

Encountered while standing up a frozen large-state snapshot node as a snap-sync source: the node boots at the correct head with the correct state root, but the canonical levels between the last flushed milestone and the head are missing, so it cannot serve the skeleton. Calling `debug_repairMainChainToHead` once backfills the canonical markers and the node serves headers normally.

## How it works

`TryUpdateMainChain` already walks back from the given head collecting **only headers** (cheap regardless of reorg depth), stops at the first ancestor already on the main chain, and marks the branch canonical in a single batch. This endpoint simply invokes it against the current head with `wereProcessed: false` (no state re-processing, head unchanged). No new `BlockTree` API is introduced.

## Scope

- `IDebugBridge` / `DebugBridge`: `RepairMainChainToHead()` -> `_blockTree.TryUpdateMainChain(Head.Header, wereProcessed: false)`.
- `IDebugRpcModule` / `DebugRpcModule`: `debug_repairMainChainToHead()`.

4 files, +15 lines. `IsSharable = true`, consistent with the sibling recovery method `debug_resetHead`.

## Test plan

- [x] `Nethermind.JsonRpc` builds clean (Release, 0 warnings / 0 errors).
- [ ] Add a `DebugModuleTests` case asserting the endpoint delegates to the bridge / returns the result.
- [ ] Integration check: on a node with a canonical gap below head, `debug_repairMainChainToHead` returns `true` and subsequent `eth_getBlockByNumber` for the previously-empty range resolves.

Draft — opening for early review of the approach (reusing `TryUpdateMainChain` vs. a dedicated repair walk) and the method name/namespace before adding tests.