### PR TITLE
Publish Nethermind.Kademlia package

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -145,7 +145,7 @@ jobs:
           gh pr create -B main -H $head_branch -t "$message" -b "Auto-updated Homebrew formula for Nethermind v${{ github.event.release.tag_name }}"
 
   publish-nuget:
-    name: Publish Nethermind.ReferenceAssemblies
+    name: Publish NuGet packages
     runs-on: ubuntu-latest
     if: ${{ !github.event.release.prerelease }}
     steps:
@@ -169,12 +169,18 @@ jobs:
           echo "asset-name=$name" >> $GITHUB_OUTPUT
 
       - name: Submit package
-        working-directory: src/Nethermind/Nethermind.ReferenceAssemblies
+        working-directory: src/Nethermind
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          dotnet pack -c release
-          dotnet nuget push ../artifacts/**/*.nupkg -k "$NUGET_API_KEY" -s https://api.nuget.org/v3/index.json
+          package_output="$(mktemp -d)"
+          dotnet pack Nethermind.ReferenceAssemblies/Nethermind.ReferenceAssemblies.csproj -c release -p:SaveDiskSpace=true --output "$package_output"
+          dotnet pack Nethermind.Kademlia/Nethermind.Kademlia.csproj -c release -p:SaveDiskSpace=true --output "$package_output"
+          test -n "$(find "$package_output" -maxdepth 1 -name 'Nethermind.ReferenceAssemblies.*.nupkg' -print -quit)"
+          test -n "$(find "$package_output" -maxdepth 1 -name 'Nethermind.Kademlia.*.nupkg' -print -quit)"
+          for package in "$package_output"/*.nupkg; do
+            dotnet nuget push "$package" -k "$NUGET_API_KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate
+          done
 
       - name: Create GitHub app token
         id: gh-app

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -178,7 +178,9 @@ jobs:
           dotnet pack Nethermind.Kademlia/Nethermind.Kademlia.csproj -c release -p:SaveDiskSpace=true --output "$package_output"
           test -n "$(find "$package_output" -maxdepth 1 -name 'Nethermind.ReferenceAssemblies.*.nupkg' -print -quit)"
           test -n "$(find "$package_output" -maxdepth 1 -name 'Nethermind.Kademlia.*.nupkg' -print -quit)"
-          for package in "$package_output"/*.nupkg; do
+          test -n "$(find "$package_output" -maxdepth 1 -name 'Nethermind.Kademlia.*.snupkg' -print -quit)"
+          for package in "$package_output"/*.nupkg "$package_output"/*.snupkg; do
+            test -e "$package" || continue
             dotnet nuget push "$package" -k "$NUGET_API_KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate
           done
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,6 +50,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="Nethermind.Crypto.Bls" Version="1.0.5" />

--- a/src/Nethermind/Nethermind.Kademlia/Nethermind.Kademlia.csproj
+++ b/src/Nethermind/Nethermind.Kademlia/Nethermind.Kademlia.csproj
@@ -14,12 +14,13 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/nethermindeth/nethermind</RepositoryUrl>
+    <RepositoryUrl>https://github.com/NethermindEth/nethermind</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Collections.Pooled" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Kademlia/Nethermind.Kademlia.csproj
+++ b/src/Nethermind/Nethermind.Kademlia/Nethermind.Kademlia.csproj
@@ -10,6 +10,9 @@
     <PackageProjectUrl>https://nethermind.io/nethermind-client</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>nethermind;ethereum;kademlia;dht;peer-discovery</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/nethermindeth/nethermind</RepositoryUrl>
   </PropertyGroup>

--- a/src/Nethermind/Nethermind.Kademlia/Nethermind.Kademlia.csproj
+++ b/src/Nethermind/Nethermind.Kademlia/Nethermind.Kademlia.csproj
@@ -1,13 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Authors>Nethermind</Authors>
+    <Description>Generic Kademlia routing table, lookup, and active discovery primitives used by Nethermind peer discovery.</Description>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageId>Nethermind.Kademlia</PackageId>
+    <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
+    <PackageProjectUrl>https://nethermind.io/nethermind-client</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>nethermind;ethereum;kademlia;dht;peer-discovery</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/nethermindeth/nethermind</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Collections.Pooled" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Nethermind/Nethermind.Kademlia/README.md
+++ b/src/Nethermind/Nethermind.Kademlia/README.md
@@ -53,6 +53,8 @@ ILookupAlgo<MyNode, MyKadKey> lookup =
 
 IKademlia<MyKey, MyNode> kademlia =
     new Kademlia<MyKey, MyNode, MyKadKey>(keyOperator, sender, routingTable, lookup, healthTracker, config, loggerFactory);
+IKademliaDiscovery<MyKey, MyNode> discovery =
+    new RandomWalkKademliaDiscovery<MyKey, MyNode, MyKadKey>(kademlia, keyOperator, distance, config, loggerFactory);
 ```
 
 Call `AddOrRefresh` when an authenticated node sends a valid protocol message, and call `Remove` when a node must be dropped from the table. Start periodic bootstrap and bucket refresh with `Run(token)`.

--- a/src/Nethermind/Nethermind.Kademlia/README.md
+++ b/src/Nethermind/Nethermind.Kademlia/README.md
@@ -1,0 +1,62 @@
+# Nethermind.Kademlia
+
+Generic Kademlia routing-table and lookup primitives used by Nethermind peer discovery.
+
+The package does not own transport, authentication, node records, or peer admission. It gives a protocol implementation the shared table, lookup, node-health, and random-walk discovery mechanics while the caller supplies key hashing, XOR-distance operations, and wire messages.
+
+## Install
+
+```bash
+dotnet add package Nethermind.Kademlia
+```
+
+## Main types
+
+- `IKademlia<TKey, TNode>` is the routing table and lookup facade.
+- `Kademlia<TKey, TNode, TKadKey>` is the default implementation.
+- `KBucketTree<TNode, TKadKey>` stores nodes in Kademlia buckets.
+- `LookupKNearestNeighbour<TKey, TNode, TKadKey>` runs iterative closest-node lookups.
+- `NodeHealthTracker<TKey, TNode, TKadKey>` tracks request failures and bucket refresh pings.
+- `RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` streams candidates from active random lookups.
+
+## Integration surface
+
+Provide these protocol-specific pieces:
+
+- `IKeyOperator<TKey, TNode, TKadKey>` maps your node and lookup key types into the Kademlia key space.
+- `IKademliaDistance<TKadKey>` implements XOR log distance, key comparison by distance, and bit operations for the key type.
+- `IKademliaMessageSender<TKey, TNode>` sends `Ping` and `FindNeighbours` over your protocol transport.
+- `KademliaConfig<TNode>` sets the local node, bootnodes, k-bucket size, lookup parallelism, and refresh timing.
+
+## Composition
+
+```csharp
+KademliaConfig<MyNode> config = new()
+{
+    CurrentNodeId = selfNode,
+    BootNodes = bootNodes,
+};
+
+IKeyOperator<MyKey, MyNode, MyKadKey> keyOperator = new MyKeyOperator();
+IKademliaDistance<MyKadKey> distance = new MyKadKeyDistance();
+IKademliaMessageSender<MyKey, MyNode> sender = new MyKadMessageSender();
+ILoggerFactory loggerFactory = NullLoggerFactory.Instance;
+
+INodeHashProvider<MyNode, MyKadKey> nodeHashProvider =
+    new FromKeyNodeHashProvider<MyKey, MyNode, MyKadKey>(keyOperator);
+IRoutingTable<MyNode, MyKadKey> routingTable =
+    new KBucketTree<MyNode, MyKadKey>(config, nodeHashProvider, distance, loggerFactory);
+NodeHealthTracker<MyKey, MyNode, MyKadKey> healthTracker =
+    new NodeHealthTracker<MyKey, MyNode, MyKadKey>(config, routingTable, nodeHashProvider, sender, loggerFactory);
+ILookupAlgo<MyNode, MyKadKey> lookup =
+    new LookupKNearestNeighbour<MyKey, MyNode, MyKadKey>(routingTable, nodeHashProvider, distance, healthTracker, config, loggerFactory);
+
+IKademlia<MyKey, MyNode> kademlia =
+    new Kademlia<MyKey, MyNode, MyKadKey>(keyOperator, sender, routingTable, lookup, healthTracker, config, loggerFactory);
+```
+
+Call `AddOrRefresh` when an authenticated node sends a valid protocol message, and call `Remove` when a node must be dropped from the table. Start periodic bootstrap and bucket refresh with `Run(token)`.
+
+Use `LookupNodesClosest(key, token)` when the caller needs the final closest set. Use `LookupNodes(key, token, maxResults)` or `IKademliaDiscovery<TKey, TNode>.DiscoverNodes(...)` when the caller wants candidates streamed as soon as lookups find them.
+
+Dispose `NodeHealthTracker<TKey, TNode, TKadKey>` when the host shuts down, or let the dependency-injection container that owns it dispose it.


### PR DESCRIPTION
## Changes

- Add NuGet package metadata for `Nethermind.Kademlia`, including license, project/repository URLs, tags, and README packaging.
- Add a package README covering purpose, installation, key types, integration points, composition, and `NodeHealthTracker` disposal ownership.
- Extend the release NuGet publishing job so it packs `Nethermind.Kademlia` alongside `Nethermind.ReferenceAssemblies`, verifies both expected packages were produced, and uses duplicate-safe package pushes for reruns.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Validated the Kademlia project build, package creation, package README/nuspec contents, and whitespace diff checks locally. The full GitHub release workflow and NuGet publishing were not run.

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

The package README is included in this PR.

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

`Nethermind.Kademlia` is prepared for NuGet publishing as a public package.

## Remarks

Created as a draft because actual NuGet publishing has not been run.