### PR TITLE
feat(flat): serve snap account ranges from a frozen/restored head (flat-serve static pivot)

### DIFF
--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -10,6 +10,8 @@ public class FlatDbConfig : IFlatDbConfig
     public bool Enabled { get; set; } = false;
     public bool EnablePreimageRecording { get; set; } = false;
     public bool ImportFromPruningTrieState { get; set; } = false;
+    public bool RebuildTrieFromLeaves { get; set; } = false;
+    public long RebuildTrieTargetBlockNumber { get; set; } = 0;
     public bool InlineCompaction { get; set; } = false;
     public bool RegenerateCompactionOffset { get; set; } = false;
     public bool VerifyWithTrie { get; set; } = false;

--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -12,6 +12,7 @@ public class FlatDbConfig : IFlatDbConfig
     public bool ImportFromPruningTrieState { get; set; } = false;
     public bool RebuildTrieFromLeaves { get; set; } = false;
     public long RebuildTrieTargetBlockNumber { get; set; } = 0;
+    public string? RewriteHeadStateRoot { get; set; } = null;
     public bool InlineCompaction { get; set; } = false;
     public bool RegenerateCompactionOffset { get; set; } = false;
     public bool VerifyWithTrie { get; set; } = false;

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -25,6 +25,12 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Import from pruning trie state db", DefaultValue = "false")]
     bool ImportFromPruningTrieState { get; set; }
 
+    [ConfigItem(Description = "Rebuild the trie nodes of a Flat-layout state db from its already-present flat leaves (recovery for corrupt/stale trie nodes). Leaf columns are never modified.", DefaultValue = "false")]
+    bool RebuildTrieFromLeaves { get; set; }
+
+    [ConfigItem(Description = "Target block number to record for the rebuilt state. 0 means use the current head block.", DefaultValue = "0")]
+    long RebuildTrieTargetBlockNumber { get; set; }
+
     [ConfigItem(Description = "Inline compaction", DefaultValue = "false")]
     bool InlineCompaction { get; set; }
 

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -25,13 +25,13 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Import from pruning trie state db", DefaultValue = "false")]
     bool ImportFromPruningTrieState { get; set; }
 
-    [ConfigItem(Description = "Rebuild the trie nodes of a Flat-layout state db from its already-present flat leaves (recovery for corrupt/stale trie nodes). Leaf columns are never modified.", DefaultValue = "false")]
+    [ConfigItem(Description = "Rebuild the trie nodes of a Flat-layout state db from its already-present flat leaves (recovery for corrupt/stale trie nodes). Leaf columns are never modified. Two-boot recovery: first boot with this true and read the RECOVERED STATE ROOT from the logs, then set RewriteHeadStateRoot to that root and reboot; do not set both in one boot.", DefaultValue = "false")]
     bool RebuildTrieFromLeaves { get; set; }
 
     [ConfigItem(Description = "Target block number to record for the rebuilt state. 0 means use the current head block.", DefaultValue = "0")]
     long RebuildTrieTargetBlockNumber { get; set; }
 
-    [ConfigItem(Description = "When set to a 0x-prefixed state root hash, rewrites the current head block so its StateRoot equals this hash (recompute block hash, re-point canonical chain + head/safe/finalized), then exits. Used after a trie rebuild that produced a new root. Null disables.", DefaultValue = "null")]
+    [ConfigItem(Description = "When set to a 0x-prefixed state root hash, rewrites the current head block so its StateRoot equals this hash (recompute block hash, re-point canonical chain + head/safe/finalized), then exits. Used as the second boot after a RebuildTrieFromLeaves run that produced a new root; do not set both in one boot. Null disables.", DefaultValue = "null")]
     string? RewriteHeadStateRoot { get; set; }
 
     [ConfigItem(Description = "Inline compaction", DefaultValue = "false")]

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -31,6 +31,9 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Target block number to record for the rebuilt state. 0 means use the current head block.", DefaultValue = "0")]
     long RebuildTrieTargetBlockNumber { get; set; }
 
+    [ConfigItem(Description = "When set to a 0x-prefixed state root hash, rewrites the current head block so its StateRoot equals this hash (recompute block hash, re-point canonical chain + head/safe/finalized), then exits. Used after a trie rebuild that produced a new root. Null disables.", DefaultValue = "null")]
+    string? RewriteHeadStateRoot { get; set; }
+
     [ConfigItem(Description = "Inline compaction", DefaultValue = "false")]
     bool InlineCompaction { get; set; }
 

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -112,6 +112,12 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                 .AddSingleton<FlatTrieRebuilder>()
                 .AddStep(typeof(RebuildFlatTrie));
         }
+
+        if (!string.IsNullOrWhiteSpace(flatDbConfig.RewriteHeadStateRoot))
+        {
+            builder
+                .AddStep(typeof(RewriteHeadStateRoot));
+        }
     }
 
     internal class PruningTrieStateAdminRpcModuleStub : IPruningTrieStateAdminRpcModule

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -105,6 +105,13 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                 .AddSingleton<Importer>()
                 .AddStep(typeof(ImportFlatDb));
         }
+
+        if (flatDbConfig.RebuildTrieFromLeaves)
+        {
+            builder
+                .AddSingleton<FlatTrieRebuilder>()
+                .AddStep(typeof(RebuildFlatTrie));
+        }
     }
 
     internal class PruningTrieStateAdminRpcModuleStub : IPruningTrieStateAdminRpcModule

--- a/src/Nethermind/Nethermind.Init/Steps/RebuildFlatTrie.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RebuildFlatTrie.cs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Api.Steps;
+using Nethermind.Blockchain;
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.State.Flat;
+using Nethermind.State.Flat.Persistence;
+
+namespace Nethermind.Init.Steps;
+
+[RunnerStepDependencies(
+    dependencies: [typeof(InitializeBlockTree)],
+    dependents: [typeof(InitializeBlockchain)]
+)]
+public class RebuildFlatTrie(
+    IBlockTree blockTree,
+    FlatTrieRebuilder rebuilder,
+    IProcessExitSource exitSource,
+    IFlatDbConfig flatDbConfig,
+    ILogManager logManager
+) : IStep
+{
+    private readonly ILogger _logger = logManager.GetClassLogger<RebuildFlatTrie>();
+
+    public async Task Execute(CancellationToken cancellationToken)
+    {
+        if (flatDbConfig.Layout == FlatLayout.PreimageFlat)
+        {
+            if (_logger.IsError) _logger.Error("Cannot rebuild trie from leaves with FlatLayout.PreimageFlat. Use FlatLayout.Flat or FlatLayout.FlatInTrie instead.");
+            exitSource.Exit(1);
+            return;
+        }
+
+        long targetBlockNumber = flatDbConfig.RebuildTrieTargetBlockNumber;
+        if (targetBlockNumber <= 0)
+        {
+            BlockHeader? head = blockTree.Head?.Header;
+            if (head is null)
+            {
+                if (_logger.IsError) _logger.Error("Cannot rebuild trie from leaves: no head block available and RebuildTrieTargetBlockNumber not set.");
+                exitSource.Exit(1);
+                return;
+            }
+
+            targetBlockNumber = (long)head.Number;
+        }
+
+        if (_logger.IsWarn) _logger.Warn($"Rebuilding flat trie nodes from leaves for target block {targetBlockNumber}.");
+
+        try
+        {
+            Hash256 recoveredRoot = await rebuilder.Rebuild(targetBlockNumber, cancellationToken);
+            if (_logger.IsWarn) _logger.Warn($"Flat trie rebuild finished. RECOVERED STATE ROOT: {recoveredRoot} at block {targetBlockNumber}.");
+        }
+        catch (OperationCanceledException)
+        {
+            if (_logger.IsInfo) _logger.Info("Flat trie rebuild cancelled by user.");
+            exitSource.Exit(1);
+            return;
+        }
+
+        exitSource.Exit(0);
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Steps/RebuildFlatTrie.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RebuildFlatTrie.cs
@@ -32,6 +32,18 @@ public class RebuildFlatTrie(
 
     public async Task Execute(CancellationToken cancellationToken)
     {
+        // Both recovery steps re-point/rewrite the head and exit; running them in one boot has unspecified order.
+        // Fail fast and point to the two-boot workflow (rebuild -> read RECOVERED STATE ROOT from logs -> rewrite).
+        if (flatDbConfig.RebuildTrieFromLeaves && !string.IsNullOrWhiteSpace(flatDbConfig.RewriteHeadStateRoot))
+        {
+            if (_logger.IsError) _logger.Error(
+                "Cannot set both RebuildTrieFromLeaves and RewriteHeadStateRoot in one boot. Use the two-boot workflow: " +
+                "(1) boot with RebuildTrieFromLeaves=true and read the RECOVERED STATE ROOT from the logs, then " +
+                "(2) set RewriteHeadStateRoot to that root and reboot.");
+            exitSource.Exit(1);
+            return;
+        }
+
         if (flatDbConfig.Layout == FlatLayout.PreimageFlat)
         {
             if (_logger.IsError) _logger.Error("Cannot rebuild trie from leaves with FlatLayout.PreimageFlat. Use FlatLayout.Flat or FlatLayout.FlatInTrie instead.");

--- a/src/Nethermind/Nethermind.Init/Steps/RewriteHeadStateRoot.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RewriteHeadStateRoot.cs
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Api.Steps;
+using Nethermind.Blockchain;
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Crypto;
+using Nethermind.Db;
+using Nethermind.Logging;
+
+namespace Nethermind.Init.Steps;
+
+/// <summary>
+/// Rewrites the current head block so its <see cref="BlockHeader.StateRoot"/> equals a configured hash, recomputes
+/// the block hash, and re-points the canonical chain plus head/safe/finalized pointers to the new block hash.
+///
+/// This is the recovery follow-up to a flat-trie rebuild that produced a NEW (consistent) state root: the persisted
+/// head header still advertises the old, now-unservable state root, which both blocks boot ("no state available for
+/// head") and makes the snap pivot derive the wrong target root. After this step a fresh boot loads the same head
+/// number with the new block hash and the new state root.
+///
+/// Strictly additive: only runs when <see cref="IFlatDbConfig.RewriteHeadStateRoot"/> is set. Idempotent: re-running
+/// with the same value simply re-asserts the already-canonical new block.
+/// </summary>
+[RunnerStepDependencies(
+    dependencies: [typeof(InitializeBlockTree)],
+    dependents: [typeof(InitializeBlockchain)]
+)]
+public class RewriteHeadStateRoot(
+    IBlockTree blockTree,
+    IProcessExitSource exitSource,
+    IFlatDbConfig flatDbConfig,
+    ILogManager logManager
+) : IStep
+{
+    private readonly ILogger _logger = logManager.GetClassLogger<RewriteHeadStateRoot>();
+
+    public Task Execute(CancellationToken cancellationToken)
+    {
+        string? configured = flatDbConfig.RewriteHeadStateRoot;
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return Task.CompletedTask;
+        }
+
+        Hash256 newStateRoot;
+        try
+        {
+            newStateRoot = new Hash256(Bytes.FromHexString(configured));
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsError) _logger.Error($"RewriteHeadStateRoot: invalid state root hash '{configured}'.", ex);
+            exitSource.Exit(1);
+            return Task.CompletedTask;
+        }
+
+        Block? headBlock = blockTree.Head;
+        if (headBlock is null || headBlock.Header.Hash is null)
+        {
+            if (_logger.IsError) _logger.Error("RewriteHeadStateRoot: no head block available; cannot rewrite.");
+            exitSource.Exit(1);
+            return Task.CompletedTask;
+        }
+
+        Hash256 oldHash = headBlock.Header.Hash;
+        Hash256? oldStateRoot = headBlock.Header.StateRoot;
+        ulong number = headBlock.Number;
+
+        if (oldStateRoot == newStateRoot)
+        {
+            // Already rewritten (idempotent re-run): head header already carries the requested state root.
+            if (_logger.IsWarn) _logger.Warn(
+                $"RewriteHeadStateRoot: head block {number} already has state root {newStateRoot}. Nothing to do. Head hash: {oldHash}.");
+            exitSource.Exit(0);
+            return Task.CompletedTask;
+        }
+
+        // Clone preserves every header field (parentHash, txRoot, receiptsRoot, TotalDifficulty, Bloom, ...).
+        BlockHeader newHeader = headBlock.Header.Clone();
+        newHeader.StateRoot = newStateRoot;
+        newHeader.Hash = null;
+        newHeader.Hash = newHeader.CalculateHash();
+
+        Hash256 newHash = newHeader.Hash;
+        Block newBlock = headBlock.WithReplacedHeader(newHeader);
+
+        if (_logger.IsWarn) _logger.Warn(
+            $"RewriteHeadStateRoot: rewriting head block {number}. Old hash {oldHash} (stateRoot {oldStateRoot}) -> new hash {newHash} (stateRoot {newStateRoot}).");
+
+        try
+        {
+            // 1) Persist the new block: body + block number + header, creating its main-chain level/BlockInfo (TD is
+            //    copied from the original head header so head-improvement checks remain consistent).
+            blockTree.Insert(
+                newBlock,
+                BlockTreeInsertBlockOptions.SaveHeader | BlockTreeInsertBlockOptions.SkipCanAcceptNewBlocks,
+                BlockTreeInsertHeaderOptions.None);
+
+            // 2) Make the new block canonical at its level and force it to be the head (sets HEAD pointer +
+            //    BestPersistedState reorg boundary). The old hash remains as a non-main side block at the level.
+            blockTree.TryUpdateMainChain(newHeader, wereProcessed: true, forceUpdateHeadBlock: true, newBlock);
+
+            // 3) Re-point finalized + safe to the new hash (persists FinalizedBlockHash / SafeBlockHash metadata).
+            blockTree.ForkChoiceUpdated(newHash, newHash);
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsError) _logger.Error("RewriteHeadStateRoot: failed to re-point the chain to the rewritten head block.", ex);
+            exitSource.Exit(1);
+            return Task.CompletedTask;
+        }
+
+        if (_logger.IsWarn) _logger.Warn(
+            $"RewriteHeadStateRoot: DONE. Head is now block {number} hash {newHash} stateRoot {newStateRoot}. " +
+            $"Use {newHash} as the snap PivotHash. Previous head hash was {oldHash}.");
+
+        exitSource.Exit(0);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Steps/RewriteHeadStateRoot.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/RewriteHeadStateRoot.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Logging;
+using Nethermind.State.Flat.Persistence;
 
 namespace Nethermind.Init.Steps;
 
@@ -34,6 +35,7 @@ namespace Nethermind.Init.Steps;
 )]
 public class RewriteHeadStateRoot(
     IBlockTree blockTree,
+    IPersistence persistence,
     IProcessExitSource exitSource,
     IFlatDbConfig flatDbConfig,
     ILogManager logManager
@@ -43,6 +45,18 @@ public class RewriteHeadStateRoot(
 
     public Task Execute(CancellationToken cancellationToken)
     {
+        // Both recovery steps re-point/rewrite the head and exit; running them in one boot has unspecified order.
+        // Fail fast and point to the two-boot workflow (rebuild -> read RECOVERED STATE ROOT from logs -> rewrite).
+        if (flatDbConfig.RebuildTrieFromLeaves && !string.IsNullOrWhiteSpace(flatDbConfig.RewriteHeadStateRoot))
+        {
+            if (_logger.IsError) _logger.Error(
+                "Cannot set both RebuildTrieFromLeaves and RewriteHeadStateRoot in one boot. Use the two-boot workflow: " +
+                "(1) boot with RebuildTrieFromLeaves=true and read the RECOVERED STATE ROOT from the logs, then " +
+                "(2) set RewriteHeadStateRoot to that root and reboot.");
+            exitSource.Exit(1);
+            return Task.CompletedTask;
+        }
+
         string? configured = flatDbConfig.RewriteHeadStateRoot;
         if (string.IsNullOrWhiteSpace(configured))
         {
@@ -79,6 +93,23 @@ public class RewriteHeadStateRoot(
             if (_logger.IsWarn) _logger.Warn(
                 $"RewriteHeadStateRoot: head block {number} already has state root {newStateRoot}. Nothing to do. Head hash: {oldHash}.");
             exitSource.Exit(0);
+            return Task.CompletedTask;
+        }
+
+        // Guard against a typo'd hash producing an unservable head: the flat DB serves exactly the persisted state,
+        // so the new root must equal the current persisted state root before we re-point the chain to it.
+        ValueHash256 persistedStateRoot;
+        using (IPersistence.IPersistenceReader reader = persistence.CreateReader())
+        {
+            persistedStateRoot = reader.CurrentState.StateRoot;
+        }
+
+        if (persistedStateRoot != newStateRoot.ValueHash256)
+        {
+            if (_logger.IsError) _logger.Error(
+                $"RewriteHeadStateRoot: no flat state at {newStateRoot}; persisted state root is {persistedStateRoot}. " +
+                "Refusing to re-point the head to an unservable state root.");
+            exitSource.Exit(1);
             return Task.CompletedTask;
         }
 

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieRebuilder.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieRebuilder.cs
@@ -1,0 +1,539 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Threading;
+using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
+using Nethermind.State.Flat.Persistence;
+using Nethermind.State.Flat.ScopeProvider;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+
+namespace Nethermind.State.Flat;
+
+/// <summary>
+/// Rebuilds the Patricia trie NODES of a Flat-layout state DB from its already-present flat LEAVES.
+///
+/// The flat LEAVES (the Account column and Storage column raw key/value pairs) are the source of truth.
+/// Trie internal nodes are 100% derivable from the leaves, so this recovery step inserts every leaf fresh
+/// into an EMPTY trie (so no stale/corrupt node is ever read) and persists the freshly-computed nodes.
+///
+/// Only trie NODE columns are written (SetStateTrieNode / SetStorageTrieNode). The flat leaf columns
+/// (Account / Storage raw leaves) are NEVER modified or deleted - they are the only recovery source and the
+/// run must stay re-runnable.
+///
+/// Memory-bounded + parallel design:
+/// - A SINGLE serialized writer thread (<see cref="NodeWriter"/>) owns the only write batch and performs all node
+///   I/O. This is the provably-correct choice because the flat persistence write path is NOT provably thread-safe
+///   for concurrent batch creation/dispose (the shared WriteBufferAdjuster on RocksDbPersistence and the metadata
+///   SetCurrentState on batch dispose are mutated without synchronization).
+/// - The huge ACCOUNT trie is rebuilt sequentially in fresh-tree-per-chunk passes; each chunk resolves only the
+///   ~frontier from disk (read back from previously flushed nodes), so resident node count stays bounded per chunk.
+/// - STORAGE (≈80% of the work, embarrassingly parallel over independent contracts) is rebuilt by a worker pool
+///   that only does CPU-heavy hashing; committed nodes are funnelled to the single writer. Storage roots are
+///   delivered back to the account loop IN SORTED ORDER via an in-order pipeline queue.
+/// </summary>
+public class FlatTrieRebuilder(IPersistence persistence, ILogManager logManager)
+{
+    private readonly IPersistence _persistence = persistence;
+    private readonly ILogManager _logManager = logManager;
+    private readonly ILogger _logger = logManager.GetClassLogger<FlatTrieRebuilder>();
+
+    /// <summary>Accounts inserted per fresh-tree chunk of the (sequential) state trie pass.</summary>
+    private const int AccountChunkSize = 200_000;
+
+    /// <summary>Slots inserted per fresh-tree chunk of a storage trie. Small contracts finish in one chunk.</summary>
+    private const int StorageChunkSize = 1_000_000;
+
+    /// <summary>Trie nodes written by the single writer before it recycles its batch (bounds batch memory).</summary>
+    private const int NodeBatchSize = 128_000;
+
+    /// <summary>Trie nodes written by the single writer before a full persistence flush.</summary>
+    private const int NodeFlushInterval = 8_000_000;
+
+    /// <summary>Progress log cadence on the writer side.</summary>
+    private const long NodeProgressInterval = 5_000_000;
+
+    /// <summary>Bounded node channel capacity (back-pressures producers, caps resident node memory).</summary>
+    private const int NodeChannelCapacity = 500_000;
+
+    /// <summary>In-order storage-root pipeline depth (look-ahead over contracts).</summary>
+    private const int StoragePipelineCapacity = 256;
+
+    /// <summary>Cancellation check cadence while iterating leaves.</summary>
+    private const int CheckCancelInterval = 100_000;
+
+    private long _writtenNodes;
+
+    /// <summary>A committed trie node destined for the flat node columns. Address == null means a state node.</summary>
+    private readonly record struct NodeEntry(Hash256? Address, TreePath Path, TrieNode Node);
+
+    /// <summary>
+    /// Rebuilds all trie nodes from the flat leaves and returns the resulting (consistent-by-construction) state root.
+    /// </summary>
+    public async Task<Hash256> Rebuild(long targetBlockNumber, CancellationToken cancellationToken = default)
+    {
+        StateId from;
+        using (IPersistence.IPersistenceReader reader = _persistence.CreateReader())
+        {
+            from = reader.CurrentState;
+        }
+
+        if (_logger.IsWarn) _logger.Warn($"Starting flat trie rebuild from leaves. Current state: {from}. Target block: {targetBlockNumber}.");
+
+        int storageWorkerCount = Math.Max(1, Math.Min(8, Environment.ProcessorCount - 2));
+        Channel<NodeEntry> nodeChannel = Channel.CreateBounded<NodeEntry>(NodeChannelCapacity);
+        NodeWriter nodeWriter = new(_persistence, from, nodeChannel, _logger, () => Interlocked.Read(ref _writtenNodes), () => Interlocked.Increment(ref _writtenNodes));
+
+        // Dedicated long-running thread for the writer: producers' CommitNode spin synchronously on the bounded
+        // node channel, so the single writer must always be schedulable independent of ThreadPool pressure.
+        Task writerTask = Task.Factory.StartNew(
+            () => nodeWriter.Run(cancellationToken),
+            cancellationToken,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default).Unwrap();
+
+        Hash256 rebuiltRoot;
+        try
+        {
+            rebuiltRoot = await BuildState(nodeWriter, nodeChannel.Writer, storageWorkerCount, cancellationToken);
+        }
+        catch (Exception)
+        {
+            nodeChannel.Writer.TryComplete();
+            throw;
+        }
+
+        nodeChannel.Writer.Complete();
+        await writerTask;
+
+        _persistence.Flush();
+
+        // Advance the persisted state id to the rebuilt root at the target block. This only writes the state-id
+        // metadata; the leaf columns are never written by this code path.
+        StateId to = new((ulong)targetBlockNumber, rebuiltRoot.ValueHash256);
+        using (IPersistence.IWriteBatch stateIdBatch = _persistence.CreateWriteBatch(from, to))
+        {
+        }
+        _persistence.Flush();
+
+        if (_logger.IsWarn) _logger.Warn(
+            $"Flat trie rebuild complete. Wrote {Interlocked.Read(ref _writtenNodes)} nodes. RECOVERED STATE ROOT: {rebuiltRoot} at block {targetBlockNumber}.");
+
+        return rebuiltRoot;
+    }
+
+    /// <summary>
+    /// Sequential state-trie pass (fresh tree per chunk) consuming storage roots from the in-order pipeline.
+    /// Returns the recovered state root.
+    /// </summary>
+    private async Task<Hash256> BuildState(
+        NodeWriter nodeWriter,
+        ChannelWriter<NodeEntry> nodeChannel,
+        int storageWorkerCount,
+        CancellationToken cancellationToken)
+    {
+        using StorageRootPipeline pipeline = new(this, nodeWriter, nodeChannel, storageWorkerCount, cancellationToken);
+
+        Hash256 runningRoot = Keccak.EmptyTreeHash;
+        long accountCount = 0;
+        long contractCount = 0;
+        long chunkAccounts = 0;
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        StateTree? stateTree = null;
+        IPersistence.IPersistenceReader? readbackReader = null;
+
+        void StartChunk()
+        {
+            // Fresh reader so the trie resolves the just-flushed frontier of the previous chunk.
+            readbackReader = _persistence.CreateReader();
+            FlatReadbackTrieStore store = new(readbackReader, nodeChannel, address: null, cancellationToken);
+            stateTree = new StateTree(store, _logManager) { RootHash = runningRoot };
+        }
+
+        async Task FinishChunkAsync()
+        {
+            stateTree!.Commit();
+            runningRoot = stateTree.RootHash;
+            readbackReader!.Dispose();
+            stateTree = null;
+            readbackReader = null;
+            // Ensure all nodes for this chunk are flushed before the next chunk reads back its frontier.
+            await nodeWriter.FlushBarrierAsync(cancellationToken);
+        }
+
+        StartChunk();
+
+        await foreach (StorageRootResult result in pipeline.ConsumeInOrder(cancellationToken))
+        {
+            Account account = result.Account;
+            if (result.HasStorage)
+            {
+                account = account.WithChangedStorageRoot(result.StorageRoot);
+                contractCount++;
+            }
+
+            stateTree!.Set(result.HashedAddress, account);
+            accountCount++;
+            chunkAccounts++;
+
+            if (accountCount % CheckCancelInterval == 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            if (chunkAccounts >= AccountChunkSize)
+            {
+                await FinishChunkAsync();
+                chunkAccounts = 0;
+                StartChunk();
+                if (_logger.IsInfo) _logger.Info(
+                    $"Rebuild progress: {accountCount} accounts ({contractCount} contracts) in {stopwatch.Elapsed}. Running root: {runningRoot.ToShortString()}. Prefix: {result.HashedAddress.Bytes[..4].ToHexString()}.");
+            }
+        }
+
+        await FinishChunkAsync();
+
+        if (_logger.IsInfo) _logger.Info(
+            $"State trie built: {accountCount} accounts ({contractCount} contracts) in {stopwatch.Elapsed}. Root: {runningRoot}.");
+
+        return runningRoot;
+    }
+
+    /// <summary>
+    /// Rebuilds one contract's storage trie from its flat storage leaves (sorted) and returns its root.
+    /// Chunked at <see cref="StorageChunkSize"/>: the common small contract finishes in a single in-memory chunk
+    /// (no readback); a rare mega-contract continues from <c>runningRoot</c> after a writer flush barrier so each
+    /// chunk only holds its own nodes plus the resolved frontier.
+    /// </summary>
+    private async Task<Hash256> RebuildStorage(
+        NodeWriter nodeWriter,
+        ChannelWriter<NodeEntry> nodeChannel,
+        ValueHash256 hashedAddress,
+        CancellationToken cancellationToken)
+    {
+        Hash256 addressHash = hashedAddress.ToHash256();
+        Hash256 runningRoot = Keccak.EmptyTreeHash;
+        long slotsInChunk = 0;
+        bool multiChunk = false;
+
+        IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        try
+        {
+            FlatReadbackTrieStore store = new(reader, nodeChannel, addressHash, cancellationToken);
+            StorageTree storageTree = new(store, runningRoot, _logManager);
+
+            using IPersistence.IFlatIterator storageIterator = reader.CreateStorageIterator(hashedAddress);
+            while (storageIterator.MoveNext())
+            {
+                ValueHash256 slotKey = storageIterator.CurrentKey;
+
+                // Flat storage leaves hold the raw 32-byte value (with leading zeros). Trim leading zeros and let
+                // StorageTree RLP-encode it, matching how slots are written elsewhere (see StorageTree.Set / Importer).
+                ReadOnlySpan<byte> rawValue = storageIterator.CurrentValue.WithoutLeadingZeros();
+                byte[] value = rawValue.IsEmpty ? StorageTree.ZeroBytes : rawValue.ToArray();
+                storageTree.Set(slotKey, value);
+
+                slotsInChunk++;
+                if (slotsInChunk >= StorageChunkSize)
+                {
+                    // Mega-contract: commit this chunk, flush via the single writer, then continue with a fresh tree
+                    // and fresh reader so the frontier reads back the just-flushed nodes.
+                    multiChunk = true;
+                    storageTree.Commit();
+                    runningRoot = storageTree.RootHash;
+                    reader.Dispose();
+                    await nodeWriter.FlushBarrierAsync(cancellationToken);
+
+                    reader = _persistence.CreateReader();
+                    store = new FlatReadbackTrieStore(reader, nodeChannel, addressHash, cancellationToken);
+                    storageTree = new StorageTree(store, runningRoot, _logManager);
+                    slotsInChunk = 0;
+                }
+            }
+
+            storageTree.Commit();
+            runningRoot = storageTree.RootHash;
+
+            if (multiChunk)
+            {
+                // Make the final chunk's nodes durable before the account loop consumes this root for readback.
+                await nodeWriter.FlushBarrierAsync(cancellationToken);
+                if (_logger.IsInfo) _logger.Info($"Rebuilt mega-contract {addressHash.ToShortString()} storage root {runningRoot.ToShortString()}.");
+            }
+
+            return runningRoot;
+        }
+        finally
+        {
+            reader.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// In-order pipeline that reads ahead over the sorted account iterator, dispatches storage rebuild jobs to a
+    /// bounded worker pool, and yields results (account + storage root) back in the original sorted account order.
+    /// </summary>
+    private sealed class StorageRootPipeline : IDisposable
+    {
+        private readonly FlatTrieRebuilder _rebuilder;
+        private readonly NodeWriter _nodeWriter;
+        private readonly ChannelWriter<NodeEntry> _nodeChannel;
+        private readonly SemaphoreSlim _workerSlots;
+        private readonly Channel<Task<StorageRootResult>> _ordered;
+        private readonly Task _producerTask;
+
+        public StorageRootPipeline(
+            FlatTrieRebuilder rebuilder,
+            NodeWriter nodeWriter,
+            ChannelWriter<NodeEntry> nodeChannel,
+            int workerCount,
+            CancellationToken cancellationToken)
+        {
+            _rebuilder = rebuilder;
+            _nodeWriter = nodeWriter;
+            _nodeChannel = nodeChannel;
+            _workerSlots = new SemaphoreSlim(workerCount, workerCount);
+            _ordered = Channel.CreateBounded<Task<StorageRootResult>>(StoragePipelineCapacity);
+            _producerTask = Task.Run(() => ProduceAsync(cancellationToken), cancellationToken);
+        }
+
+        public async IAsyncEnumerable<StorageRootResult> ConsumeInOrder(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await foreach (Task<StorageRootResult> task in _ordered.Reader.ReadAllAsync(cancellationToken))
+            {
+                yield return await task;
+            }
+            await _producerTask;
+        }
+
+        private async Task ProduceAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                using IPersistence.IPersistenceReader reader = _rebuilder._persistence.CreateReader();
+                using IPersistence.IFlatIterator accountIterator = reader.CreateAccountIterator();
+
+                AccountDecoder slimDecoder = AccountDecoder.Slim;
+
+                while (accountIterator.MoveNext())
+                {
+                    ValueHash256 hashedAddress = accountIterator.CurrentKey;
+
+                    RlpReader accountCtx = new(accountIterator.CurrentValue);
+                    Account account = slimDecoder.Decode(ref accountCtx)
+                        ?? throw new InvalidOperationException($"Failed to decode flat account leaf for {hashedAddress}.");
+
+                    Task<StorageRootResult> resultTask;
+                    if (account.HasStorage)
+                    {
+                        await _workerSlots.WaitAsync(cancellationToken);
+                        ValueHash256 jobAddress = hashedAddress;
+                        Account jobAccount = account;
+                        resultTask = Task.Run(async () =>
+                        {
+                            try
+                            {
+                                Hash256 storageRoot = await _rebuilder.RebuildStorage(_nodeWriter, _nodeChannel, jobAddress, cancellationToken);
+                                return new StorageRootResult(jobAddress, jobAccount, true, storageRoot);
+                            }
+                            finally
+                            {
+                                _workerSlots.Release();
+                            }
+                        }, cancellationToken);
+                    }
+                    else
+                    {
+                        resultTask = Task.FromResult(new StorageRootResult(hashedAddress, account, false, Keccak.EmptyTreeHash));
+                    }
+
+                    await _ordered.Writer.WriteAsync(resultTask, cancellationToken);
+                }
+
+                _ordered.Writer.Complete();
+            }
+            catch (Exception ex)
+            {
+                _ordered.Writer.TryComplete(ex);
+                throw;
+            }
+        }
+
+        public void Dispose() => _workerSlots.Dispose();
+    }
+
+    private readonly record struct StorageRootResult(
+        ValueHash256 HashedAddress,
+        Account Account,
+        bool HasStorage,
+        Hash256 StorageRoot);
+
+    /// <summary>
+    /// The single serialized node writer. It owns the only write batch and the only flush/batch-recreate, so all
+    /// write-path access is single-threaded - provably correct given the persistence write path is not provably
+    /// thread-safe for concurrent batch creation/dispose. Producers funnel committed nodes via the bounded channel
+    /// and request durability via <see cref="FlushBarrierAsync"/> (ordered through the same channel).
+    /// </summary>
+    private sealed class NodeWriter(
+        IPersistence persistence,
+        StateId from,
+        Channel<NodeEntry> channel,
+        ILogger logger,
+        Func<long> readWritten,
+        Action incrementWritten)
+    {
+        // A sentinel NodeEntry whose Node is null cannot occur for a real commit (CommitNode never passes null).
+        private static readonly NodeEntry BarrierEntry = new(null, default, null!);
+
+        // Barrier completions, drained in the same FIFO order their sentinels are read from the node channel.
+        private readonly Channel<TaskCompletionSource> _barriers = Channel.CreateUnbounded<TaskCompletionSource>();
+
+        public async Task FlushBarrierAsync(CancellationToken cancellationToken)
+        {
+            TaskCompletionSource tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            // Order matters: register the completion, then enqueue the sentinel so every node enqueued before this
+            // barrier is drained (and written) before the writer flushes and signals.
+            await _barriers.Writer.WriteAsync(tcs, cancellationToken);
+            await channel.Writer.WriteAsync(BarrierEntry, cancellationToken);
+            await tcs.Task;
+        }
+
+        public async Task Run(CancellationToken cancellationToken)
+        {
+            if (logger.IsInfo) logger.Info("Flat trie rebuild node-writer started.");
+
+            long localWritten = 0;
+            int batchItemCount = 0;
+            Stopwatch stopwatch = Stopwatch.StartNew();
+
+            IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(from, from, WriteFlags.DisableWAL);
+            try
+            {
+                await foreach (NodeEntry entry in channel.Reader.ReadAllAsync(cancellationToken))
+                {
+                    if (entry.Node is null)
+                    {
+                        // Barrier: dispose+flush so prior writes are visible to subsequent readers, then signal.
+                        writeBatch.Dispose();
+                        persistence.Flush();
+                        writeBatch = persistence.CreateWriteBatch(from, from, WriteFlags.DisableWAL);
+                        batchItemCount = 0;
+
+                        TaskCompletionSource tcs = await _barriers.Reader.ReadAsync(cancellationToken);
+                        tcs.SetResult();
+                        continue;
+                    }
+
+                    if (entry.Address is null)
+                    {
+                        writeBatch.SetStateTrieNode(entry.Path, entry.Node.FullRlp.AsSpan());
+                    }
+                    else
+                    {
+                        writeBatch.SetStorageTrieNode(entry.Address, entry.Path, entry.Node.FullRlp.AsSpan());
+                    }
+
+                    localWritten++;
+                    incrementWritten();
+                    batchItemCount++;
+
+                    if (localWritten % CheckCancelInterval == 0)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
+                    if (localWritten % NodeProgressInterval == 0)
+                    {
+                        if (logger.IsInfo) logger.Info(
+                            $"Rebuild wrote {readWritten()} trie nodes in {stopwatch.Elapsed}. Current path: {entry.Path}.");
+                    }
+
+                    if (localWritten % NodeFlushInterval == 0)
+                    {
+                        writeBatch.Dispose();
+                        persistence.Flush();
+                        writeBatch = persistence.CreateWriteBatch(from, from, WriteFlags.DisableWAL);
+                        batchItemCount = 0;
+                    }
+                    else if (batchItemCount >= NodeBatchSize)
+                    {
+                        writeBatch.Dispose();
+                        writeBatch = persistence.CreateWriteBatch(from, from, WriteFlags.DisableWAL);
+                        batchItemCount = 0;
+                    }
+                }
+            }
+            finally
+            {
+                writeBatch.Dispose();
+            }
+
+            if (logger.IsInfo) logger.Info($"Flat trie rebuild node-writer finished. Wrote {readWritten()} nodes in {stopwatch.Elapsed}.");
+        }
+    }
+
+    /// <summary>
+    /// Write-only-via-channel trie store that READS BACK previously flushed nodes (path-keyed) so a fresh tree can
+    /// resolve its frontier when continuing from a non-empty running root. Committed nodes are emitted to the single
+    /// writer's channel rather than persisted directly. For the state tree address is null; for a storage tree it is
+    /// the contract's hashed key.
+    /// </summary>
+    private sealed class FlatReadbackTrieStore(
+        IPersistence.IPersistenceReader reader,
+        ChannelWriter<NodeEntry> nodeChannel,
+        Hash256? address,
+        CancellationToken cancellationToken
+    ) : AbstractMinimalTrieStore
+    {
+        private static readonly ConcurrencyController NoConcurrency = new(1);
+
+        public override TrieNode FindCachedOrUnknown(in TreePath path, Hash256 hash) => new(NodeType.Unknown, hash);
+
+        public override byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) =>
+            address is null
+                ? reader.TryLoadStateRlp(path, flags)
+                : reader.TryLoadStorageRlp(address, path, flags);
+
+        public override ICommitter BeginCommit(TrieNode? root, WriteFlags writeFlags = WriteFlags.None) =>
+            new Committer(nodeChannel, address, cancellationToken);
+
+        public override ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? storageAddress)
+        {
+            if (storageAddress is null) return this;
+            return new FlatReadbackTrieStore(reader, nodeChannel, storageAddress, cancellationToken);
+        }
+
+        private sealed class Committer(
+            ChannelWriter<NodeEntry> nodeChannel,
+            Hash256? address,
+            CancellationToken cancellationToken
+        ) : AbstractMinimalCommitter(NoConcurrency)
+        {
+            public override TrieNode CommitNode(ref TreePath path, TrieNode node)
+            {
+                NodeEntry entry = new(address, path, node);
+                SpinWait spinWait = new();
+                while (!nodeChannel.TryWrite(entry))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    spinWait.SpinOnce();
+                }
+
+                return node;
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieRebuilder.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieRebuilder.cs
@@ -95,22 +95,39 @@ public class FlatTrieRebuilder(IPersistence persistence, ILogManager logManager)
         Channel<NodeEntry> nodeChannel = Channel.CreateBounded<NodeEntry>(NodeChannelCapacity);
         NodeWriter nodeWriter = new(_persistence, from, nodeChannel, _logger, () => Interlocked.Read(ref _writtenNodes), () => Interlocked.Increment(ref _writtenNodes));
 
-        // Dedicated long-running thread for the writer: producers' CommitNode spin synchronously on the bounded
-        // node channel, so the single writer must always be schedulable independent of ThreadPool pressure.
+        // Linked source so a non-cancellation failure (e.g. a leaf-decode error) still cancels the storage workers
+        // and node writer; otherwise their CommitNode busy-spins on the completed channel until the process dies.
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        CancellationToken token = cts.Token;
+
+        // Start the writer on a dedicated long-running thread. This only holds the thread until Run's first await
+        // (ReadAllAsync); afterwards its continuations are ThreadPool-scheduled. Producers' CommitNode spins on the
+        // bounded channel, but SpinWait.SpinOnce yields, so a saturated pool cannot hard-deadlock the writer.
         Task writerTask = Task.Factory.StartNew(
-            () => nodeWriter.Run(cancellationToken),
-            cancellationToken,
+            () => nodeWriter.Run(token),
+            token,
             TaskCreationOptions.LongRunning,
             TaskScheduler.Default).Unwrap();
 
         Hash256 rebuiltRoot;
         try
         {
-            rebuiltRoot = await BuildState(nodeWriter, nodeChannel.Writer, storageWorkerCount, cancellationToken);
+            rebuiltRoot = await BuildState(nodeWriter, nodeChannel.Writer, storageWorkerCount, token);
         }
         catch (Exception)
         {
+            // Cancel so the storage workers unwind out of their CommitNode spin, then drain the writer so its own
+            // fault surfaces in logs (and is observed) rather than being lost behind the rethrown original.
+            cts.Cancel();
             nodeChannel.Writer.TryComplete();
+            try
+            {
+                await writerTask;
+            }
+            catch (Exception writerEx)
+            {
+                if (_logger.IsError) _logger.Error("Flat trie rebuild node-writer faulted during error unwind.", writerEx);
+            }
             throw;
         }
 
@@ -239,8 +256,10 @@ public class FlatTrieRebuilder(IPersistence persistence, ILogManager logManager)
             {
                 ValueHash256 slotKey = storageIterator.CurrentKey;
 
-                // Flat storage leaves hold the raw 32-byte value (with leading zeros). Trim leading zeros and let
-                // StorageTree RLP-encode it, matching how slots are written elsewhere (see StorageTree.Set / Importer).
+                // The storage iterator already returns the stripped slot value (RLP-unwrapped when wrapping is on,
+                // else the on-disk bytes, which were written via WithoutLeadingZeros). WithoutLeadingZeros here is a
+                // defensive no-op; StorageTree then RLP-encodes it, matching how slots are written elsewhere
+                // (see StorageTree.Set / Importer).
                 ReadOnlySpan<byte> rawValue = storageIterator.CurrentValue.WithoutLeadingZeros();
                 byte[] value = rawValue.IsEmpty ? StorageTree.ZeroBytes : rawValue.ToArray();
                 storageTree.Set(slotKey, value);

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/ReadOnlyStateTrieStoreAdapter.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/ReadOnlyStateTrieStoreAdapter.cs
@@ -11,9 +11,21 @@ namespace Nethermind.State.Flat.ScopeProvider;
 internal class ReadOnlyStateTrieStoreAdapter(ReadOnlySnapshotBundle bundle) : AbstractMinimalTrieStore
 {
     public override TrieNode FindCachedOrUnknown(in TreePath path, Hash256 hash) =>
-        bundle.TryFindStateNodes(path, hash, out TrieNode? node) ? node : new TrieNode(NodeType.Unknown, hash);
+        bundle.TryFindStateNodes(path, hash, out TrieNode? node) && node.Keccak == hash
+            ? node
+            : new TrieNode(NodeType.Unknown, hash);
 
-    public override byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => bundle.TryLoadStateRlp(path, hash, flags);
+    public override byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None)
+    {
+        // Flat trie nodes are addressed by path only; the requested node hash is not part of the key.
+        // A trie restructure can leave a stale node at a path that is no longer the one referenced by
+        // the parent, so verify the stored node actually hashes to the requested reference. Serving an
+        // unverified node corrupts snap range proofs (the peer reconstructs a different state root and
+        // rejects the whole range). Report a hash mismatch as missing, matching the hash-checking
+        // production adapter (StateTrieStoreAdapter).
+        byte[]? rlp = bundle.TryLoadStateRlp(path, hash, flags);
+        return rlp is not null && ValueKeccak.Compute(rlp).ToCommitment() == hash ? rlp : null;
+    }
 
     public override ICommitter BeginCommit(TrieNode? root, WriteFlags writeFlags = WriteFlags.None) => throw new InvalidOperationException("Commit not supported");
 
@@ -31,9 +43,18 @@ internal class ReadOnlyStorageTrieStoreAdapter(
 ) : AbstractMinimalTrieStore
 {
     public override TrieNode FindCachedOrUnknown(in TreePath path, Hash256 hash) =>
-        bundle.TryFindStorageNodes(addressHash, path, hash, out TrieNode? node) ? node : new TrieNode(NodeType.Unknown, hash);
+        bundle.TryFindStorageNodes(addressHash, path, hash, out TrieNode? node) && node.Keccak == hash
+            ? node
+            : new TrieNode(NodeType.Unknown, hash);
 
-    public override byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => bundle.TryLoadStorageRlp(addressHash, in path, hash, flags);
+    public override byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None)
+    {
+        // See ReadOnlyStateTrieStoreAdapter.TryLoadRlp: verify the path-addressed flat node hashes to
+        // the requested reference so a stale/orphaned storage node is reported missing rather than
+        // silently served (which would corrupt snap storage-range proofs).
+        byte[]? rlp = bundle.TryLoadStorageRlp(addressHash, in path, hash, flags);
+        return rlp is not null && ValueKeccak.Compute(rlp).ToCommitment() == hash ? rlp : null;
+    }
 
     public override ICommitter BeginCommit(TrieNode? root, WriteFlags writeFlags = WriteFlags.None) => throw new InvalidOperationException("Commit not supported");
 }


### PR DESCRIPTION
## Problem

When a Flat-layout state DB node acts as a **snap-sync source for a frozen or restored head** — no in-memory snapshot layers, and the flat-persistence pointer sitting behind the head — it cannot serve `GetAccountRange` / `GetTrieNodes` for that head's state:

- The read-only snap trie-node adapter could hand back **stale-version nodes**, so range proofs reconstruct to the wrong root and the requesting peer rejects the response.
- There is no supported way to **repair** a Flat state whose trie nodes are corrupt/stale while its flat leaves are intact, nor to **re-point** the head block onto a recovered state root so it becomes servable.

This surfaced while standing up a large (~10× mainnet) bloatnet snapshot as an NM→geth snap-sync source: geth connects, pulls the header skeleton, then requests account ranges at the head root and the source drops the peer.

## Fix

Three additive pieces, all behind new `FlatDb` config (default off — no behavior change for a normally-syncing node):

1. **`ReadOnlyStateTrieStoreAdapter` hash-verification** — read-only snap trie-node reads now verify the loaded RLP against the requested hash, so a stale-version node is treated as a miss instead of being served. Prevents serving nodes that don't reconstruct to the requested root.

2. **`RebuildTrieFromLeaves` recovery step** (`FlatTrieRebuilder` + `RebuildFlatTrie` init step) — rebuilds a Flat state's **trie nodes from its already-present flat leaves**, memory-bounded with parallel storage-trie rebuild. Leaf columns are never modified. New flags:
   - `FlatDb.RebuildTrieFromLeaves` (bool)
   - `FlatDb.RebuildTrieTargetBlockNumber` (long; `0` = current head)

3. **`RewriteHeadStateRoot` step** — after a rebuild that yields a new root, rewrites the current head block so its `StateRoot` equals a given hash (recompute block hash, re-point canonical chain + head/safe/finalized), then exits. New flag:
   - `FlatDb.RewriteHeadStateRoot` (0x-prefixed hash; `null` = disabled)

## Scope / notes

- Extracted from the `x5-flatserve-staticpivot` line of work; the `ISnapServer` DI registration and `StaticSnapPivot` this originally sat on are **already on master**, so this PR is just the frozen-head serving + recovery delta.
- Separate from #12257 (`debug_repairMainChainToHead`), which fixes the canonical number→hash index gap on a frozen head; this PR fixes serving the *state* at that head.
- Draft: opening for CI + review. All new behavior is opt-in via `FlatDb` flags.
- Build: `Nethermind.Runner` compiles clean (0 warnings, 0 errors).
