### PR TITLE
ci(expb): fix retrospective pagination drift; allow disabling the flat write-buffer floor

### DIFF
--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -1526,13 +1526,11 @@ jobs:
             page_size=100
             remaining="${LAST}"
 
+            # Always request full pages: Docker Hub paginates by page_size x page, so shrinking
+            # page_size on the last page shifts the window (duplicating mid-range tags and
+            # dropping the oldest ones). Trim to LAST after collecting.
             while [[ "${remaining}" -gt 0 ]]; do
-              fetch_size="${page_size}"
-              if [[ "${remaining}" -lt "${page_size}" ]]; then
-                fetch_size="${remaining}"
-              fi
-
-              url="https://hub.docker.com/v2/repositories/nethermindeth/nethermind/tags?page_size=${fetch_size}&page=${page}&name=master-"
+              url="https://hub.docker.com/v2/repositories/nethermindeth/nethermind/tags?page_size=${page_size}&page=${page}&name=master-"
               response=$(curl -sf "${url}" || echo '{"results":[]}')
 
               mapfile -t page_tags < <(echo "${response}" | jq -r '.results[] | select(.name | test("^master-[0-9a-f]{7}$")) | .name')
@@ -1552,6 +1550,12 @@ jobs:
               remaining=$(( remaining - page_size ))
               page=$(( page + 1 ))
             done
+
+            if [[ "${#all_tags[@]}" -gt "${LAST}" ]]; then
+              all_tags=("${all_tags[@]:0:LAST}")
+              all_images=("${all_images[@]:0:LAST}")
+              all_dates=("${all_dates[@]:0:LAST}")
+            fi
 
             echo "Found ${#all_tags[@]} master-* images on Docker Hub."
 

--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -192,6 +192,11 @@ jobs:
             fi
             additional_extra_flags="${DISPATCH_ADDITIONAL_EXTRA_FLAGS:-}"
             flat_write_buffer_floor="${DISPATCH_FLAT_WRITE_BUFFER_FLOOR-67108864}"
+            # "off" disables the floor injection entirely (an empty dispatch input falls back to the default,
+            # so it cannot express "no floor"; needed to benchmark images predating the config key).
+            if [[ "${flat_write_buffer_floor}" == "off" ]]; then
+              flat_write_buffer_floor=""
+            fi
             expb_env="${DISPATCH_EXPB_ENV:-}"
             cleanup_grace_seconds="90"
             rebuild_docker="${DISPATCH_REBUILD_DOCKER:-true}"


### PR DESCRIPTION
## Changes

- **Retrospective mode pagination fix**: Docker Hub paginates by `page_size x page`; shrinking `page_size` on the last page shifts the request window backwards. A 256-image retrospective scan actually benchmarked ~56 duplicated mid-range images and silently dropped the oldest ~56 (observed on runs 28685874975/28685894268/28685910101). Always request full pages and trim afterwards.
- **`flat_write_buffer_floor: off`**: an empty `workflow_dispatch` input falls back to the input default, so there was no way to run a flat benchmark without injecting `--FlatDb.PersistenceWriteBufferFloor` - and images predating that config key (before 6ff112117b, Jun 16) dump CLI help and never start, wedging the runner until the 12h job timeout (observed twice). `off` now disables the injection so older images can be benchmarked with an internally-consistent no-floor configuration.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

`off` handling validated on this branch: run 28710134407 dispatched with `--ref ci/expb-floor-off-input` and `flat_write_buffer_floor=off` benchmarked 18 pre-floor images (54 jobs) without the floor flag and without wedging - the same images hang indefinitely when dispatched from master. The pagination fix is validated by the duplicate/missing tag analysis of the runs above.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No