### PR TITLE
perf(flat): read the state boundary without materializing a persistence reader

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/State/StateBoundaryReadBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/StateBoundaryReadBenchmark.cs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Config;
+using Nethermind.Core.Crypto;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.State.Flat;
+using Nethermind.State.Flat.Persistence;
+
+namespace Nethermind.Benchmarks.State;
+
+/// <summary>
+/// Compares the two ways a state boundary read can obtain the persisted <see cref="StateId"/>
+/// through the production decorator stack (CarryForwardCaching over CachedReader): materializing
+/// a persistence reader versus the metadata-only <see cref="IPersistence.GetCurrentState"/>.
+/// The AfterWriteBatch variants measure the post-persist window, where the shared reader cache
+/// has just been invalidated. In-memory columns db, so the reader-path cold cost excludes the
+/// native RocksDB snapshot a real node would additionally pay.
+/// </summary>
+[MemoryDiagnoser]
+[WarmupCount(3)]
+[MinIterationCount(3)]
+[MaxIterationCount(10)]
+public class StateBoundaryReadBenchmark
+{
+    private IPersistence _stack = null!;
+    private StateId _current;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        SnapshotableMemColumnsDb<FlatDbColumns> db = new();
+        RocksDbPersistence inner = new(db, LimboLogs.Instance);
+        _stack = new CarryForwardCachingPersistence(
+            new CachedReaderPersistence(inner, new ProcessExitSource(CancellationToken.None), LimboLogs.Instance));
+
+        _current = new StateId(1, Keccak.EmptyTreeHash);
+        using (_stack.CreateWriteBatch(StateId.PreGenesis, _current)) { }
+    }
+
+    [Benchmark(Baseline = true)]
+    public StateId ReaderPath()
+    {
+        using IPersistence.IPersistenceReader reader = _stack.CreateReader();
+        return reader.CurrentState;
+    }
+
+    [Benchmark]
+    public StateId AccessorPath() => _stack.GetCurrentState();
+
+    [Benchmark]
+    public StateId ReaderPathAfterWriteBatch()
+    {
+        using (_stack.CreateWriteBatch(_current, _current)) { }
+        using IPersistence.IPersistenceReader reader = _stack.CreateReader();
+        return reader.CurrentState;
+    }
+
+    [Benchmark]
+    public StateId AccessorPathAfterWriteBatch()
+    {
+        using (_stack.CreateWriteBatch(_current, _current)) { }
+        return _stack.GetCurrentState();
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/CarryForwardCachingPersistenceTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/CarryForwardCachingPersistenceTests.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
 using Nethermind.Int256;
+using Nethermind.Logging;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.Trie;
 using NUnit.Framework;
@@ -18,6 +20,7 @@ public class CarryForwardCachingPersistenceTests
 {
     private static readonly StateId Basis0 = new(0, Keccak.EmptyTreeHash);
     private static readonly StateId Basis1 = new(1, Keccak.EmptyTreeHash);
+    private static readonly StateId PersistedState = new(1, TestItem.KeccakA);
     private static readonly Address Address = TestItem.AddressA;
 
     [TestCaseSource(nameof(SlotReadCases))]
@@ -102,6 +105,36 @@ public class CarryForwardCachingPersistenceTests
             inner.ReaderState = Basis1;
         }), 2)
         { TestName = name };
+
+    [TestCaseSource(nameof(CurrentStateCases))]
+    public void GetCurrentState_AfterScenario_MatchesPersistedPointer(Action<CarryForwardCachingPersistence> scenario, StateId expected)
+    {
+        using SnapshotableMemColumnsDb<FlatDbColumns> db = new();
+        RocksDbPersistence inner = new(db, LimboLogs.Instance);
+        CarryForwardCachingPersistence cache = new(inner);
+        using (cache.CreateWriteBatch(StateId.PreGenesis, PersistedState)) { }
+
+        scenario(cache);
+
+        Assert.That(cache.GetCurrentState(), Is.EqualTo(expected));
+        Assert.That(cache.GetCurrentState(), Is.EqualTo(inner.GetCurrentState()));
+    }
+
+    private static IEnumerable<TestCaseData> CurrentStateCases()
+    {
+        yield return new TestCaseData((Action<CarryForwardCachingPersistence>)(static _ => { }), PersistedState)
+        { TestName = "normal_batch_served_from_basis" };
+
+        // A sync batch moves the carry-forward basis to the sentinel without touching the db pointer.
+        yield return new TestCaseData((Action<CarryForwardCachingPersistence>)(static cache =>
+        {
+            using (cache.CreateWriteBatch(StateId.Sync, StateId.Sync)) { }
+        }), PersistedState)
+        { TestName = "sync_batch_falls_through_to_db_pointer" };
+
+        yield return new TestCaseData((Action<CarryForwardCachingPersistence>)(static cache => cache.Clear()), StateId.PreGenesis)
+        { TestName = "clear_resets_to_pre_genesis" };
+    }
 
     private static void ReadSlot(IPersistence persistence, UInt256 slot)
     {

--- a/src/Nethermind/Nethermind.State.Flat.Test/CarryForwardCachingPersistenceTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/CarryForwardCachingPersistenceTests.cs
@@ -124,6 +124,7 @@ public class CarryForwardCachingPersistenceTests
 
         public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None) => new Reader(this);
         public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags = WriteFlags.None) => new FakeWriteBatch();
+        public StateId GetCurrentState() => ReaderState;
         public void Flush() { }
         public void Clear() { }
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/GetCurrentStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/GetCurrentStateTests.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.State.Flat.Persistence;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test.Persistence;
+
+[TestFixture]
+public class GetCurrentStateTests
+{
+    [Test]
+    public void GetCurrentState_AfterWrite_MatchesReaderView()
+    {
+        using SnapshotableMemColumnsDb<FlatDbColumns> db = new();
+        RocksDbPersistence persistence = new(db, LimboLogs.Instance);
+        StateId persisted = new(164, TestItem.KeccakA);
+        BasePersistence.SetCurrentState(db.GetColumnDb(FlatDbColumns.Metadata), persisted);
+
+        using IPersistence.IPersistenceReader reader = persistence.CreateReader();
+
+        Assert.That(persistence.GetCurrentState(), Is.EqualTo(persisted));
+        Assert.That(persistence.GetCurrentState(), Is.EqualTo(reader.CurrentState));
+    }
+
+    [Test]
+    public void GetCurrentState_WhenNothingPersisted_ReturnsPreGenesisSentinel()
+    {
+        using SnapshotableMemColumnsDb<FlatDbColumns> db = new();
+        RocksDbPersistence persistence = new(db, LimboLogs.Instance);
+
+        Assert.That(persistence.GetCurrentState().BlockNumber, Is.EqualTo(ulong.MaxValue));
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
@@ -106,6 +106,8 @@ public class FlatTreeSyncStoreTests
     {
         public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None) => inner.CreateReader(flags);
 
+        public StateId GetCurrentState() => inner.GetCurrentState();
+
         public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags = WriteFlags.None)
         {
             if (to != StateId.Sync) log.Add("advance-pointer");

--- a/src/Nethermind/Nethermind.State.Flat/FlatStateBoundary.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatStateBoundary.cs
@@ -24,8 +24,7 @@ public class FlatStateBoundary(IPersistence persistence) : IStateBoundary
 
     private ulong? CurrentPersistedBlock()
     {
-        using IPersistence.IPersistenceReader reader = persistence.CreateReader();
-        ulong blockNumber = reader.CurrentState.BlockNumber;
+        ulong blockNumber = persistence.GetCurrentState().BlockNumber;
         return blockNumber != ulong.MaxValue ? blockNumber : null;
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CachedReaderPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CachedReaderPersistence.cs
@@ -95,6 +95,8 @@ public class CachedReaderPersistence : IPersistence, IAsyncDisposable
 
     public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags = WriteFlags.None) => new ClearCacheOnWriteBatchComplete(_inner.CreateWriteBatch(from, to, flags), this);
 
+    public StateId GetCurrentState() => _inner.GetCurrentState();
+
     public void Flush() => _inner.Flush();
 
     public void Clear()

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
@@ -57,7 +57,15 @@ public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposa
     public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags = WriteFlags.None)
         => new InvalidatingWriteBatch(this, _inner.CreateWriteBatch(from, to, flags), to);
 
-    public StateId GetCurrentState() => _inner.GetCurrentState();
+    public StateId GetCurrentState()
+    {
+        using (_lock.EnterScope())
+        {
+            if (_basis != StateId.Sync) return _basis;
+        }
+
+        return _inner.GetCurrentState();
+    }
 
     public void Flush() => _inner.Flush();
 
@@ -66,6 +74,7 @@ public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposa
         using (_lock.EnterScope())
         {
             ClearAllNoLock();
+            _basis = StateId.PreGenesis;
         }
         _inner.Clear();
     }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
@@ -57,6 +57,8 @@ public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposa
     public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags = WriteFlags.None)
         => new InvalidatingWriteBatch(this, _inner.CreateWriteBatch(from, to, flags), to);
 
+    public StateId GetCurrentState() => _inner.GetCurrentState();
+
     public void Flush() => _inner.Flush();
 
     public void Clear()

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/FlatInTriePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/FlatInTriePersistence.cs
@@ -21,6 +21,8 @@ public class FlatInTriePersistence(IColumnsDb<FlatDbColumns> db, ILogManager log
 
     public void Clear() => BasePersistence.ClearAllColumns(db);
 
+    public StateId GetCurrentState() => BasePersistence.ReadCurrentState(db.GetColumnDb(FlatDbColumns.Metadata));
+
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
         IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -20,6 +20,13 @@ public interface IPersistence
     IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None);
     IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags = WriteFlags.None);
 
+    /// <summary>
+    /// The current persisted <see cref="StateId"/>, read directly from the metadata column without
+    /// materializing a reader (no snapshot, no caching wrapper) — for high-frequency single-value
+    /// consumers such as <c>IStateBoundary</c>.
+    /// </summary>
+    StateId GetCurrentState();
+
     // Note: RocksdbPersistence already flush WAL on writing batch dispose. You don't need this unless you are skipping WAL.
     void Flush();
     void Clear();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRecordingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRecordingPersistence.cs
@@ -24,6 +24,8 @@ public class PreimageRecordingPersistence(IPersistence inner, IDb preimageDb) : 
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None) => _inner.CreateReader(flags);
 
+    public StateId GetCurrentState() => _inner.GetCurrentState();
+
     public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags)
     {
         IPersistence.IWriteBatch innerBatch = _inner.CreateWriteBatch(from, to, flags);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
@@ -33,6 +33,8 @@ public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManage
 
     public void Clear() => BasePersistence.ClearAllColumns(db);
 
+    public StateId GetCurrentState() => BasePersistence.ReadCurrentState(db.GetColumnDb(FlatDbColumns.Metadata));
+
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
         IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -17,6 +17,8 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
 
     public void Clear() => BasePersistence.ClearAllColumns(db);
 
+    public StateId GetCurrentState() => BasePersistence.ReadCurrentState(db.GetColumnDb(FlatDbColumns.Metadata));
+
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
         IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot();


### PR DESCRIPTION
## Changes

Follow-up to #12236, split out of #12260 by request. `FlatStateBoundary` answers a single-value question — the persisted `CurrentState` — but answered it by materializing a full persistence reader, which costs more than the read itself on the paths that consult the boundary:

- **A `CachingReader` wrapper allocation on every read.** `CarryForwardCachingPersistence.CreateReader` wraps the shared ref-counted reader in a new `CachingReader` whenever the reader is at basis — which in steady state is always, since the basis advances with every write batch. The boundary never reads accounts or slots, so the wrapper is pure waste. Call frequency: `BlockTree.TryUpdateSyncPivot` reads `BestPersistedState` per main-chain update and per forkchoiceUpdated; `eth_config` reads `OldestStateBlock` per RPC call.
- **A native snapshot + background task on every cache-cold read.** The shared reader cache is invalidated on every write-batch completion, so a boundary read landing right after a persist rebuilds a `RefCountingPersistenceReader`: a RocksDB snapshot plus a `Task.Run` monitor loop — for one metadata value.

The fix is a metadata-only accessor: `IPersistence.GetCurrentState()` reads the `CurrentState` key directly from the metadata column with the existing `BasePersistence.ReadCurrentState` codec. A single-key get is atomic in RocksDB (the value is written with one put inside the write batch), so no snapshot is needed for consistency. Implemented by the three layouts (same key and column in all) and forwarded by the three decorators; `FlatStateBoundary` now uses it, so boundary reads materialize nothing.

`ReaderFlags.Sync` was considered and rejected: it bypasses the shared reader cache and takes a fresh native snapshot per call, which is worse than the wrapper it avoids.

## Types of changes

- [x] Optimization

## Testing

- `GetCurrentStateTests` — the accessor matches the reader's `CurrentState` view after a write, and returns the pre-genesis sentinel on an empty DB.
- Full `Nethermind.State.Flat.Test` suite passes (534/534).

Note: once this and #12260 both land, `FlatStateBoundary.TryGetBestPersistedState` (added there) switches to this accessor in a two-line follow-up — whichever merges second picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)