### PR TITLE
fix(sync): reconcile lowest inserted beacon header on startup

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -3040,6 +3040,39 @@ public class BlockTreeTests
         }
     }
 
+    [Test]
+    public void RecalculateTreeLevels_WhenKnownHeadersSitBelowLowestInsertedBeaconHeader_MovesPointerToSuggestedChainBoundary()
+    {
+        BlockTree tree = Build.A.BlockTree().OfChainLength(5).TestObject;
+        BlockTreeInsertHeaderOptions beaconInsert = BlockTreeInsertHeaderOptions.BeaconHeaderInsert | BlockTreeInsertHeaderOptions.TotalDifficultyNotNeeded;
+
+        BlockHeader header5 = Build.A.BlockHeader.WithNumber(5).WithParent(tree.Head!.Header).TestObject;
+        BlockHeader header6 = Build.A.BlockHeader.WithNumber(6).WithParent(header5).TestObject;
+        BlockHeader header7 = Build.A.BlockHeader.WithNumber(7).WithParent(header6).TestObject;
+        tree.Insert(header5, beaconInsert);
+        tree.Insert(header6, beaconInsert);
+        tree.Insert(header7, beaconInsert);
+        // An interrupted backfill persists the pointer above headers it already inserted.
+        tree.LowestInsertedBeaconHeader = header7;
+
+        tree.RecalculateTreeLevels();
+
+        Assert.That(tree.LowestInsertedBeaconHeader?.Number, Is.EqualTo(5UL));
+    }
+
+    [Test]
+    public void RecalculateTreeLevels_WhenBeaconHeaderParentIsUnknown_KeepsPointer()
+    {
+        BlockTree tree = Build.A.BlockTree().OfChainLength(5).TestObject;
+
+        BlockHeader detached = Build.A.BlockHeader.WithNumber(7).WithParentHash(TestItem.KeccakA).TestObject;
+        tree.Insert(detached, BlockTreeInsertHeaderOptions.BeaconHeaderInsert | BlockTreeInsertHeaderOptions.TotalDifficultyNotNeeded);
+
+        tree.RecalculateTreeLevels();
+
+        Assert.That(tree.LowestInsertedBeaconHeader?.Number, Is.EqualTo(7UL));
+    }
+
     private static void AssertSuggestNotifications(AddBlockResult result, bool hasNotified, bool hasNotifiedNewSuggested)
     {
         using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -25,12 +25,6 @@ public partial class BlockTree
         FixLowestInsertedBeaconHeader();
     }
 
-    /// <summary>
-    /// An interrupted beacon-header backfill can leave the persisted pointer above headers that already
-    /// exist: the feed stops inserting at the first known header without moving the pointer. Beacon sync
-    /// then never reports the header sync as finished, because the pointer's parent stays above the best
-    /// suggested header, and the node deadlocks in BeaconHeaders mode with a dormant feed.
-    /// </summary>
     private void FixLowestInsertedBeaconHeader()
     {
         BlockHeader? lowest = _lowestInsertedBeaconHeader;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -22,6 +22,41 @@ public partial class BlockTree
         LoadBestKnown();
         LoadBeaconBestKnown();
         LoadForkChoiceInfo();
+        FixLowestInsertedBeaconHeader();
+    }
+
+    /// <summary>
+    /// An interrupted beacon-header backfill can leave the persisted pointer above headers that already
+    /// exist: the feed stops inserting at the first known header without moving the pointer. Beacon sync
+    /// then never reports the header sync as finished, because the pointer's parent stays above the best
+    /// suggested header, and the node deadlocks in BeaconHeaders mode with a dormant feed.
+    /// </summary>
+    private void FixLowestInsertedBeaconHeader()
+    {
+        BlockHeader? lowest = _lowestInsertedBeaconHeader;
+        ulong stopAt = (BestSuggestedHeader?.Number ?? 0) + 1;
+        if (lowest is null || lowest.Number <= stopAt)
+        {
+            return;
+        }
+
+        BlockHeader current = lowest;
+        while (current.Number > stopAt)
+        {
+            BlockHeader? parent = FindHeader(current.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+            if (parent is null)
+            {
+                break;
+            }
+
+            current = parent;
+        }
+
+        if (!ReferenceEquals(current, lowest))
+        {
+            if (Logger.IsInfo) Logger.Info($"Lowest inserted beacon header moved from {lowest.Number} down to {current.Number} through already known headers");
+            LowestInsertedBeaconHeader = current;
+        }
     }
 
     public static ulong? BinarySearchBlockNumber(ulong left, ulong right, Func<ulong, bool, bool> isBlockFound,


### PR DESCRIPTION
Split 2/5 of #12260 (recovery after unclean shutdown with flat state ahead of head).

## Problem
An interrupted beacon-header backfill leaves the persisted `LowestInsertedBeaconHeader` pointer above headers that already exist: the feed stops inserting at the first known header without moving the pointer, and its in-memory chain-merged flag dies with the process. After restart `IsBeaconSyncHeadersFinished` is false forever (off by exactly one), the feed is dormant, and the selector sits in `BeaconHeaders` mode with `Active: None | Sleeping: All`.

## Fix
At startup (`RecalculateTreeLevels`), walk the pointer down through already-known headers by parent hash until it reaches the suggested-chain boundary, then persist it. Stops (keeps the pointer) if a parent is missing.

## Tests
`BlockTreeTests` — pointer moves down through known headers; pointer kept when the beacon parent is unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)