### PR TITLE
perf(sync): anchor forward sync at the download front

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.ChainLevelHelper.cs
@@ -96,4 +96,16 @@ public partial class BlockTreeTests
             .SuggestBlocksUsingChainLevels(20)
             .AssertChainLevel(0, 4)
             .AssertForceNewBeaconSync();
+
+    [Test]
+    public void Can_sync_using_chain_levels_over_large_gap_anchoring_at_front() =>
+        BlockTreeTestScenario.GoesLikeThis()
+            .WithBlockTrees(4, 34)
+            .InsertBeaconPivot(7)
+            .InsertBeaconHeaders(4, 6)
+            .InsertBeaconBlocks(8, 33)
+            .SuggestBlocksUsingChainLevels()
+            .AssertBestKnownNumber(33)
+            .AssertBestSuggestedHeader(33)
+            .AssertBestSuggestedBody(33);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -223,13 +223,6 @@ public class ChainLevelHelper(
         return (startingPoint, parentBlockInfo.BlockHash);
     }
 
-    /// <summary>
-    /// The backward walk in <see cref="GetStartingPoint"/> is O(distance between the process destination and
-    /// the download front). After a long offline period the destination sits at the chain tip, millions of
-    /// levels above the front, and re-walking that distance for every header batch stalls forward sync.
-    /// The beacon-header backfill inserts hash-linked infos, so verifying the single link above the front
-    /// proves the same connectivity the walk establishes level by level.
-    /// </summary>
     private bool TryAnchorAtForwardFront(ulong startingPoint, out ulong anchorNumber, out Hash256? anchorHash)
     {
         anchorNumber = 0;
@@ -239,6 +232,12 @@ public class ChainLevelHelper(
         Block? bestSuggested = _blockTree.BestSuggestedBody;
         Block? front = (bestSuggested?.Number ?? 0) >= (head?.Number ?? 0) ? bestSuggested : head;
         if (front?.Hash is null || front.Number + 1 >= startingPoint)
+        {
+            return false;
+        }
+
+        // Parity with the walk's pivot clamp: never anchor below the fast-sync pivot.
+        if (_syncConfig.FastSync && front.Number < _beaconPivot.PivotDestinationNumber)
         {
             return false;
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/ChainLevelHelper.cs
@@ -161,7 +161,6 @@ public class ChainLevelHelper(
     /// Returns a number BEFORE the lowest beacon info where the forward beacon sync should start, or the latest
     /// block that was processed where we should continue processing.
     /// </summary>
-    /// <returns></returns>
     private (ulong?, Hash256?) GetStartingPoint()
     {
         ulong startingPoint = Math.Min(_blockTree.BestKnownNumber + 1, _beaconPivot.ProcessDestination?.Number ?? ulong.MaxValue);
@@ -180,6 +179,12 @@ public class ChainLevelHelper(
         {
             return (startingPoint, beaconMainChainBlock.BlockHash);
         }
+
+        if (TryAnchorAtForwardFront(startingPoint, out ulong anchorNumber, out Hash256? anchorHash))
+        {
+            return (anchorNumber, anchorHash);
+        }
+
         BlockInfo? parentBlockInfo = null;
         Hash256 currentHash = beaconMainChainBlock.BlockHash;
         // in normal situation we will have one iteration of this loop, in some cases a few. Thanks to that we don't need to add extra pointer to manage forward syncing
@@ -216,6 +221,50 @@ public class ChainLevelHelper(
         } while (shouldContinue);
 
         return (startingPoint, parentBlockInfo.BlockHash);
+    }
+
+    /// <summary>
+    /// The backward walk in <see cref="GetStartingPoint"/> is O(distance between the process destination and
+    /// the download front). After a long offline period the destination sits at the chain tip, millions of
+    /// levels above the front, and re-walking that distance for every header batch stalls forward sync.
+    /// The beacon-header backfill inserts hash-linked infos, so verifying the single link above the front
+    /// proves the same connectivity the walk establishes level by level.
+    /// </summary>
+    private bool TryAnchorAtForwardFront(ulong startingPoint, out ulong anchorNumber, out Hash256? anchorHash)
+    {
+        anchorNumber = 0;
+        anchorHash = null;
+
+        Block? head = _blockTree.Head;
+        Block? bestSuggested = _blockTree.BestSuggestedBody;
+        Block? front = (bestSuggested?.Number ?? 0) >= (head?.Number ?? 0) ? bestSuggested : head;
+        if (front?.Hash is null || front.Number + 1 >= startingPoint)
+        {
+            return false;
+        }
+
+        BlockInfo? frontInfo = _blockTree.GetInfo(front.Number, front.Hash).Info;
+        if (frontInfo is null || frontInfo.IsBeaconInfo)
+        {
+            return false;
+        }
+
+        BlockInfo? successor = _blockTree.FindLevel(front.Number + 1)?.BeaconMainChainBlock;
+        if (successor is null || !successor.IsBeaconInfo)
+        {
+            return false;
+        }
+
+        BlockHeader? successorHeader = _blockTree.FindHeader(successor.BlockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+        if (successorHeader is null || successorHeader.ParentHash != front.Hash)
+        {
+            return false;
+        }
+
+        if (_logger.IsDebug) _logger.Debug($"Anchoring forward sync at front {front.Number} instead of walking down from {startingPoint}");
+        anchorNumber = front.Number;
+        anchorHash = front.Hash;
+        return true;
     }
 
     private BlockInfo? GetBeaconMainChainBlockInfo(ulong startingPoint)


### PR DESCRIPTION
Split 5/5 of #12260 (the "Bonus" in that PR's description).

## Problem
`ChainLevelHelper.GetStartingPoint` walked beacon levels down from the process destination (the chain tip) — millions of levels per header batch after a long offline period, with the cache invalidated by every incoming payload, stalling forward sync.

## Fix
The beacon-header backfill inserts hash-linked infos, so verifying the single link above the download front proves the same connectivity the walk establishes level by level. Anchor at the front in O(1) when the beacon chain links to it by parent hash, falling back to the walk otherwise.

## Tests
Exercised by the existing `Can_sync_using_chain_levels*` scenarios (Merge.Plugin.Test, 1547 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)