### PR TITLE
fix(core): cache NoEip158/NoEip3607 spec wrappers per spec instance

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/IReleaseSpecExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/IReleaseSpecExtensionsTests.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Specs;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test;
+
+public class IReleaseSpecExtensionsTests
+{
+    [Test]
+    public void WithoutEip158_returns_the_same_cached_wrapper_per_spec() => AssertWrapperIsCachedPerSpec(
+        enable: static (spec, value) => spec.IsEip158Enabled.Returns(value),
+        wrap: static spec => spec.WithoutEip158(),
+        isEnabled: static spec => spec.IsEip158Enabled);
+
+    [Test]
+    public void WithoutEip3607_returns_the_same_cached_wrapper_per_spec() => AssertWrapperIsCachedPerSpec(
+        enable: static (spec, value) => spec.IsEip3607Enabled.Returns(value),
+        wrap: static spec => spec.WithoutEip3607(),
+        isEnabled: static spec => spec.IsEip3607Enabled);
+
+    private static void AssertWrapperIsCachedPerSpec(
+        Action<IReleaseSpec, bool> enable,
+        Func<IReleaseSpec, IReleaseSpec> wrap,
+        Func<IReleaseSpec, bool> isEnabled)
+    {
+        IReleaseSpec disabledSpec = ReleaseSpecSubstitute.Create();
+        enable(disabledSpec, false);
+        Assert.That(wrap(disabledSpec), Is.SameAs(disabledSpec));
+
+        IReleaseSpec spec = ReleaseSpecSubstitute.Create();
+        enable(spec, true);
+        IReleaseSpec wrapper = wrap(spec);
+        Assert.That(wrapper, Is.Not.SameAs(spec));
+        Assert.That(isEnabled(wrapper), Is.False);
+        Assert.That(wrap(spec), Is.SameAs(wrapper));
+        Assert.That(wrap(wrapper), Is.SameAs(wrapper));
+
+        IReleaseSpec otherSpec = ReleaseSpecSubstitute.Create();
+        enable(otherSpec, true);
+        Assert.That(wrap(otherSpec), Is.Not.SameAs(wrapper));
+
+        enable(spec, false);
+        Assert.That(wrap(spec), Is.SameAs(spec));
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.cs
@@ -1,10 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#if !ZK_EVM
-using System.Runtime.CompilerServices;
-#endif
-
 namespace Nethermind.Core.Specs;
 
 /// <summary>
@@ -13,11 +9,6 @@ namespace Nethermind.Core.Specs;
 /// </summary>
 public static partial class IReleaseSpecExtensions
 {
-#if !ZK_EVM
-    private static readonly ConditionalWeakTable<IReleaseSpec, IReleaseSpec> _noEip158Specs = [];
-    private static readonly ConditionalWeakTable<IReleaseSpec, IReleaseSpec> _noEip3607Specs = [];
-#endif
-
     extension(IReleaseSpec spec)
     {
         //EIP-3860: Limit and meter initcode
@@ -77,18 +68,4 @@ public static partial class IReleaseSpecExtensions
         public IReleaseSpec WithoutEip3607() =>
             spec.IsEip3607Enabled ? GetNoEip3607Spec(spec) : spec;
     }
-
-    private static IReleaseSpec GetNoEip158Spec(IReleaseSpec spec) =>
-#if ZK_EVM
-        new NoEip158Spec(spec);
-#else
-        _noEip158Specs.GetValue(spec, static s => new NoEip158Spec(s));
-#endif
-
-    private static IReleaseSpec GetNoEip3607Spec(IReleaseSpec spec) =>
-#if ZK_EVM
-        new NoEip3607Spec(spec);
-#else
-        _noEip3607Specs.GetValue(spec, static s => new NoEip3607Spec(s));
-#endif
 }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.cs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+#if !ZK_EVM
+using System.Runtime.CompilerServices;
+#endif
+
 namespace Nethermind.Core.Specs;
 
 /// <summary>
@@ -9,6 +13,11 @@ namespace Nethermind.Core.Specs;
 /// </summary>
 public static partial class IReleaseSpecExtensions
 {
+#if !ZK_EVM
+    private static readonly ConditionalWeakTable<IReleaseSpec, IReleaseSpec> _noEip158Specs = [];
+    private static readonly ConditionalWeakTable<IReleaseSpec, IReleaseSpec> _noEip3607Specs = [];
+#endif
+
     extension(IReleaseSpec spec)
     {
         //EIP-3860: Limit and meter initcode
@@ -59,13 +68,27 @@ public static partial class IReleaseSpecExtensions
         /// Used when applying state overrides to preserve EIP-7610 CREATE collision detection.
         /// </summary>
         public IReleaseSpec WithoutEip158() =>
-            spec.IsEip158Enabled ? new NoEip158Spec(spec) : spec;
+            spec.IsEip158Enabled ? GetNoEip158Spec(spec) : spec;
 
         /// <summary>
         /// Returns a spec with EIP-3607 disabled, allowing contract addresses to act as transaction senders.
         /// Used in <c>eth_simulateV1</c> where state-overridden contracts may be the <c>from</c> address.
         /// </summary>
         public IReleaseSpec WithoutEip3607() =>
-            spec.IsEip3607Enabled ? new NoEip3607Spec(spec) : spec;
+            spec.IsEip3607Enabled ? GetNoEip3607Spec(spec) : spec;
     }
+
+    private static IReleaseSpec GetNoEip158Spec(IReleaseSpec spec) =>
+#if ZK_EVM
+        new NoEip158Spec(spec);
+#else
+        _noEip158Specs.GetValue(spec, static s => new NoEip158Spec(s));
+#endif
+
+    private static IReleaseSpec GetNoEip3607Spec(IReleaseSpec spec) =>
+#if ZK_EVM
+        new NoEip3607Spec(spec);
+#else
+        _noEip3607Specs.GetValue(spec, static s => new NoEip3607Spec(s));
+#endif
 }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.std.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.std.cs
@@ -1,10 +1,21 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Runtime.CompilerServices;
+
 namespace Nethermind.Core.Specs;
 
 public static partial class IReleaseSpecExtensions
 {
+    private static readonly ConditionalWeakTable<IReleaseSpec, IReleaseSpec> _noEip158Specs = [];
+    private static readonly ConditionalWeakTable<IReleaseSpec, IReleaseSpec> _noEip3607Specs = [];
+
+    private static IReleaseSpec GetNoEip158Spec(IReleaseSpec spec) =>
+        _noEip158Specs.GetValue(spec, static s => new NoEip158Spec(s));
+
+    private static IReleaseSpec GetNoEip3607Spec(IReleaseSpec spec) =>
+        _noEip3607Specs.GetValue(spec, static s => new NoEip3607Spec(s));
+
     extension(IReleaseSpec spec)
     {
         public bool ClearEmptyAccountWhenTouched => spec.IsEip158Enabled;

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.zkevm.cs
@@ -7,8 +7,6 @@ namespace Nethermind.Core.Specs;
 
 public static partial class IReleaseSpecExtensions
 {
-    // The zkVM guest validates one block, so the memoization that the std build uses to bound the
-    // opcode-table cache is unnecessary; allocate the wrapper directly.
     private static IReleaseSpec GetNoEip158Spec(IReleaseSpec spec) => new NoEip158Spec(spec);
     private static IReleaseSpec GetNoEip3607Spec(IReleaseSpec spec) => new NoEip3607Spec(spec);
 

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.zkevm.cs
@@ -7,6 +7,11 @@ namespace Nethermind.Core.Specs;
 
 public static partial class IReleaseSpecExtensions
 {
+    // The zkVM guest validates one block, so the memoization that the std build uses to bound the
+    // opcode-table cache is unnecessary; allocate the wrapper directly.
+    private static IReleaseSpec GetNoEip158Spec(IReleaseSpec spec) => new NoEip158Spec(spec);
+    private static IReleaseSpec GetNoEip3607Spec(IReleaseSpec spec) => new NoEip3607Spec(spec);
+
     // Precompile membership as a bitmask instead of a FrozenSet hash+probe.
     // The set is fork-fixed, so it is built once per spec; a single slot suffices
     // because the zkVM guest validates one block (one spec).


### PR DESCRIPTION
## Changes

- `IReleaseSpec.WithoutEip158()` / `WithoutEip3607()` now return one cached wrapper per underlying spec instance (`ConditionalWeakTable`-backed) instead of allocating a fresh `NoEip158Spec` / `NoEip3607Spec` decorator on every call.
- In the zkEVM guest build (`ZK_EVM`), the helpers keep the previous allocate-per-call behavior: `ConditionalWeakTable` relies on GC dependent handles that are unavailable in the ZisK guest (the same constraint that shaped 0160095af9), and these code paths are not exercised there.
- New `IReleaseSpecExtensionsTests` pin the contract: pass-through when the EIP flag is off, stable wrapper identity per spec instance, distinct wrappers for distinct specs, re-wrap idempotence (no decorator nesting), and the live flag check winning over the cache when a spec's flag changes.

Since #12146, `VirtualMachine<TGasPolicy>` keys its opcode dispatch tables by spec reference in a process-wide `ConcurrentDictionary` with no eviction, on the premise that only a handful of spec instances are ever live. `SimulateTransactionProcessorAdapter.SetBlockExecutionContext` broke that premise: it calls `Spec.WithoutEip3607()` for every simulated block, and each call produced a brand-new decorator instance, so every `eth_simulateV1` block added a permanently retained dictionary entry (~2 KB of function-pointer tables each, up to `MaxSimulateBlocksCap` = 256 per request, accumulating across requests for the process lifetime). With the wrappers memoized, the same underlying spec always maps to the same wrapper, so the opcode-table cache stays bounded by the spec-provider set, restoring the pre-#12146 memory behavior. The `trace_*` fork-override and state-override paths already pass provider-owned spec singletons, so this was the only unbounded feeder.

The weak-keyed table itself adds no retention: entries live exactly as long as the underlying spec. The decorators are stateless views, so sharing one instance across concurrent requests is safe, and `ConditionalWeakTable.GetValue` guarantees all racing callers observe the same stored instance.

An alternative considered was resolving the opcode table once per block in `SetBlockExecutionContext` and reverting the cache itself to a weak table; that touches the per-transaction dispatch path and overlaps with #12214, so this PR takes the narrower fix at the wrapper source instead.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- New: `IReleaseSpecExtensionsTests` (wrapper identity/caching contract, both EIPs).
- Passing locally: `Nethermind.Core.Test` (new tests), `Nethermind.JsonRpc.Test` `~Simulate` (105), `Nethermind.Facade.Test` (116).
- Both build flavors compile: default and `-p:EnableZkEvm=true` (`Nethermind.Stateless.ZiskGuest`).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No