### PR TITLE
fix(evm): aggregate cancellation state in CompositeTxTracer

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/CompositeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/CompositeTxTracerTests.cs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Nethermind.Evm.Tracing;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test.Tracing;
+
+[Parallelizable(ParallelScope.All)]
+public class CompositeTxTracerTests
+{
+    [Test]
+    public void Aggregates_IsCancelable_from_children()
+    {
+        CompositeTxTracer nonCancelable = new(Substitute.For<ITxTracer>(), Substitute.For<ITxTracer>());
+        Assert.That(nonCancelable.IsCancelable, Is.False);
+
+        using CancellationTokenSource cts = new();
+        CompositeTxTracer cancelable = new(Substitute.For<ITxTracer>(), new CancellationTxTracer(Substitute.For<ITxTracer>(), cts.Token));
+        Assert.That(cancelable.IsCancelable, Is.True);
+    }
+
+    [Test]
+    public void Forwards_IsCancelled_to_a_nested_cancelable_child()
+    {
+        using CancellationTokenSource cts = new();
+        CompositeTxTracer tracer = new(Substitute.For<ITxTracer>(), new CancellationTxTracer(Substitute.For<ITxTracer>(), cts.Token));
+
+        Assert.That(tracer.IsCancelled, Is.False);
+        cts.Cancel();
+        Assert.That(tracer.IsCancelled, Is.True);
+    }
+
+    [TestCase(typeof(CompositeTxTracer))]
+    [TestCase(typeof(CancellationTxTracer))]
+    public void Wrapping_tracer_implements_every_meaningful_default_interface_member(Type wrapperType)
+    {
+        string[] convenienceForwarders = ["get_IsTracing", "ReportStackPush", "ReportMemoryChange"];
+
+        MethodInfo[] defaultMembers = typeof(ITxTracer)
+            .GetMethods()
+            .Where(m => !m.IsAbstract && !m.IsStatic && !convenienceForwarders.Contains(m.Name))
+            .ToArray();
+
+        Assert.That(defaultMembers.Select(m => m.Name), Is.SupersetOf(["get_IsCancelable", "get_IsCancelled"]),
+            "the fitness scan must cover the cancellation members it exists to protect");
+
+        InterfaceMapping map = wrapperType.GetInterfaceMap(typeof(ITxTracer));
+
+        string[] inheritedDefaults = defaultMembers
+            .Where(member =>
+            {
+                int i = Array.IndexOf(map.InterfaceMethods, member);
+                return i >= 0 && map.TargetMethods[i].DeclaringType == typeof(ITxTracer);
+            })
+            .Select(m => m.Name)
+            .ToArray();
+
+        Assert.That(inheritedDefaults, Is.Empty,
+            $"{wrapperType.Name} silently inherits the default of {string.Join(", ", inheritedDefaults)}; an aggregating tracer must implement it so it is not dropped when nested.");
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -24,6 +24,7 @@ public class CompositeTxTracer : ITxTracer
         for (int index = 0; index < txTracers.Count; index++)
         {
             ITxTracer t = txTracers[index];
+            IsCancelable |= t.IsCancelable;
             IsTracingState |= t.IsTracingState;
             IsTracingReceipt |= t.IsTracingReceipt;
             IsTracingActions |= t.IsTracingActions;
@@ -39,6 +40,21 @@ public class CompositeTxTracer : ITxTracer
             IsTracingAccess |= t.IsTracingAccess;
             IsTracingFees |= t.IsTracingFees;
             IsTracingLogs |= t.IsTracingLogs;
+        }
+    }
+
+    public bool IsCancelable { get; }
+
+    public bool IsCancelled
+    {
+        get
+        {
+            for (int index = 0; index < _txTracers.Count; index++)
+            {
+                if (_txTracers[index].IsCancelled) return true;
+            }
+
+            return false;
         }
     }
 


### PR DESCRIPTION
## Changes

`CompositeTxTracer` OR-aggregated all 15 `IsTracing*` flags from its children in the constructor but left `IsCancelable` and `IsCancelled` at the `ITxTracer` default of `false`. The VM selects its compile-time cancellation specialization from `tracer.IsCancelable` (`VirtualMachine.cs:1189`), and the per-opcode poll (`DispatchSpecialized.cs`/`Stream.cs`, `TCancelable.IsActive && ... && _txTracer.IsCancelled`) is compiled out when that flag is `false`. So a `CancellationTxTracer` nested **inside** a `CompositeTxTracer` reported `IsCancelable = false`, its `IsCancelled` was never read, and cancellation was silently ignored.

- Aggregate `IsCancelable` in the constructor by OR-folding the children, alongside the existing 15 flags.
- Implement `IsCancelled` as a dynamic property that returns `true` when any child is cancelled — it cannot be cached like the static flags because the cancellation token flips during execution.
- Add `CompositeTxTracerTests`: two behavioral tests pinning the aggregation/forwarding, and a reflection fitness test asserting the aggregating wrappers (`CompositeTxTracer`, `CancellationTxTracer`) implement every meaningful `ITxTracer` default-interface member — so a future DIM cannot be silently mis-inherited and dropped when nested.

This is behavior-preserving for the two current production composites: `BlockchainBridge` applies cancellation outermost (`new CompositeTxTracer(...).WithCancellation(...)`) and `ZkGasBlockTracer` composes two non-cancelable children, so neither contains a cancelable child today. The change makes nesting correct for any future composition rather than depending on the outermost-cancellation convention.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- New `CompositeTxTracerTests` (4 cases) pass; the fitness test fails against the pre-fix `CompositeTxTracer` (which declares neither member) and passes after.
- Full `Nethermind.Evm.Test` regression: 4774 passed, 8 skipped, 0 failed.
- Both build flavors compile: default and `-p:EnableZkEvm=true` (`Nethermind.Stateless.ZiskGuest`).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
