### PR TITLE
refactor(evm): remove dead RlpCache and the Evm->Trie dependency

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
+++ b/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
@@ -9,6 +9,5 @@
     <ProjectReference Include="..\Nethermind.Crypto\Nethermind.Crypto.csproj" />
     <ProjectReference Include="..\Nethermind.Serialization.Rlp\Nethermind.Serialization.Rlp.csproj" />
     <ProjectReference Include="..\Nethermind.Specs\Nethermind.Specs.csproj" />
-    <ProjectReference Include="..\Nethermind.Trie\Nethermind.Trie.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Nethermind/Nethermind.Evm/State/PreBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/PreBlockCaches.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
-using Nethermind.Trie;
 
 using CollectionExtensions = Nethermind.Core.Collections.CollectionExtensions;
 
@@ -22,7 +21,6 @@ public class PreBlockCaches
 
     private readonly SeqlockCache<StorageCell, byte[]> _storageCache;
     private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
-    private readonly SeqlockCache<NodeKey, byte[]?> _rlpCache = new();
     private readonly ConcurrentDictionary<PrecompileCacheKey, Result<byte[]>> _precompileCache = new(LockPartitions, InitialCapacity);
 
     public PreBlockCaches() : this(new PreBlockCachesConfig()) { }
@@ -40,7 +38,6 @@ public class PreBlockCaches
 
     public SeqlockCache<StorageCell, byte[]> StorageCache => _storageCache;
     public SeqlockCache<AddressAsKey, Account> StateCache => _stateCache;
-    public SeqlockCache<NodeKey, byte[]?> RlpCache => _rlpCache;
     public ConcurrentDictionary<PrecompileCacheKey, Result<byte[]>> PrecompileCache => _precompileCache;
 
     public CacheType ClearCaches()


### PR DESCRIPTION
## Changes

- Removes `PreBlockCaches.RlpCache` and its backing field. The cache had no readers anywhere in the repo and was never added to the per-block clear list. The RLP trie-node cache role was migrated to a separate `NodeStorageCache` (used via `PreCachedTrieStore` and `PruningTrieStateFactory`), leaving this field a vestige.
- `NodeKey` (from `Nethermind.Trie`) was the only `Nethermind.Trie` type used anywhere in `Nethermind.Evm`, and only by the removed cache, so this drops the `Nethermind.Trie` `ProjectReference` from `Nethermind.Evm.csproj`. The interpreter core no longer links the trie/storage layer.
- `CacheType.Rlp` is kept: it is still used by `BlockCachePreWarmer` to flag a `NodeStorageCache` clear.

`Nethermind.Trie` remains in the application closure via `Nethermind.State -> Nethermind.Trie`; nothing loads it reflectively and no trimming/single-file publish is configured, so there is no packaging or runtime-plugin impact.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

- Whole-solution `Nethermind.slnx` build: 0 errors (rules out any project relying on the transitive `Evm -> Trie` edge).
- zkEVM guest build (`-p:EnableZkEvm=true`): 0 errors.
- `Nethermind.Evm.Test` 4770, `BlockCachePreWarmerTests` 17, `Nethermind.State.Test` storage/world-state 93 — all pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
