### PR TITLE
fix(taiko): resolve one virtual machine identity per Taiko scope

### DIFF
--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoVirtualMachineRegistrationTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoVirtualMachineRegistrationTests.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Blockchain.Find;
+using Nethermind.Core;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Modules;
+using Nethermind.Evm;
+using Nethermind.Evm.GasPolicy;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Taiko.Test;
+
+public class TaikoVirtualMachineRegistrationTests
+{
+    [Test]
+    public void Both_virtual_machine_service_keys_resolve_to_the_same_Taiko_vm()
+    {
+        using IContainer container = new ContainerBuilder()
+            .AddModule(new TestNethermindModule())
+            .AddSingleton(Substitute.For<IBlockFinder>())
+            .AddModule(new TaikoModule())
+            .AddSingleton(Substitute.For<IBlockhashProvider>())
+            .AddSingleton(SpecProviderSubstitute.Create())
+            .AddSingleton(Substitute.For<IL1OriginStore>())
+            .Build();
+        using ILifetimeScope scope = container.BeginLifetimeScope();
+
+        IVirtualMachine nonGeneric = scope.Resolve<IVirtualMachine>();
+        IVirtualMachine<EthereumGasPolicy> generic = scope.Resolve<IVirtualMachine<EthereumGasPolicy>>();
+
+        Assert.That(nonGeneric, Is.InstanceOf<TaikoEthereumVirtualMachine>());
+        Assert.That(generic, Is.SameAs(nonGeneric));
+    }
+}

--- a/src/Nethermind/Nethermind.Taiko/TaikoPlugin.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoPlugin.cs
@@ -139,7 +139,8 @@ public class TaikoModule : Module
             .AddModule(new TaikoSynchronizerModule())
 
             .AddSingleton<IPrecompileProvider, TaikoPrecompileProvider>()
-            .AddScoped<IVirtualMachine<EthereumGasPolicy>, TaikoEthereumVirtualMachine>()
+            .AddScoped<IVirtualMachine, TaikoEthereumVirtualMachine>()
+            .Bind<IVirtualMachine<EthereumGasPolicy>, IVirtualMachine>()
             .AddSingleton<ISpecProvider, TaikoChainSpecBasedSpecProvider>()
             .Map<TaikoChainSpecEngineParameters, ChainSpec>(chainSpec =>
                 chainSpec.EngineChainSpecParametersProvider.GetChainSpecParameters<TaikoChainSpecEngineParameters>())

--- a/src/Nethermind/Nethermind.Taiko/TaikoVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoVirtualMachine.cs
@@ -113,6 +113,6 @@ public sealed class TaikoEthereumVirtualMachine(
     ISpecProvider? specProvider,
     IL1OriginStore l1OriginStore,
     ILogManager? logManager
-) : TaikoVirtualMachine(blockHashProvider, specProvider, l1OriginStore, logManager), IVirtualMachine<EthereumGasPolicy>
+) : TaikoVirtualMachine(blockHashProvider, specProvider, l1OriginStore, logManager), IVirtualMachine
 {
 }


### PR DESCRIPTION
## Changes

Fixes a DI regression so that a Taiko scope resolves a single virtual-machine identity.

Since #12146, `TaikoModule` registered only `IVirtualMachine<EthereumGasPolicy> -> TaikoEthereumVirtualMachine`, while the core `IVirtualMachine -> EthereumVirtualMachine` registration (`BlockProcessingModule`) stayed in place. In a Taiko scope the two service keys therefore resolved to two different machines: any consumer of the non-generic `IVirtualMachine` — the `ITransactionProcessorFactory` downcast (`IVirtualMachine` → `IVirtualMachine<TGasPolicy>`), and AuRa/Optimism-style processors that inject `IVirtualMachine` — would silently get the plain `EthereumVirtualMachine` and lose Taiko's L1-origin context-aware precompile, with no DI resolution error. Only `TaikoTransactionProcessor` (which injects the generic key directly) got the Taiko VM. Pre-#12146, Taiko registered the non-generic key, so both keys agreed.

- `TaikoEthereumVirtualMachine` now implements the non-generic `IVirtualMachine` (an empty alias of `IVirtualMachine<EthereumGasPolicy>`, so no new members — the same shape `EthereumVirtualMachine` uses).
- `TaikoModule` registers `TaikoEthereumVirtualMachine` under `IVirtualMachine` (overriding the core registration in the Taiko scope) and binds `IVirtualMachine<EthereumGasPolicy>` to it via `Bind`, so both keys resolve to the same scoped instance.
- New `TaikoVirtualMachineRegistrationTests` asserts both keys resolve to the same `TaikoEthereumVirtualMachine` in a container built from the real modules.

Non-Taiko scopes are untouched (the change is confined to `TaikoModule`). The `ITransactionProcessorFactory` downcast still holds because `TaikoEthereumVirtualMachine` is a `VirtualMachine<EthereumGasPolicy>`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- New `TaikoVirtualMachineRegistrationTests` — verified non-vacuous: it fails against the pre-fix wiring (`IVirtualMachine` resolves to `EthereumVirtualMachine`) and passes after.
- Full `Nethermind.Taiko.Test`: 266 passed, 11 skipped, 0 failed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
