### PR TITLE
refactor(evm): require ICodeInfoRepository.IsCodeOverridable explicitly

### DIFF
--- a/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
@@ -46,6 +46,8 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
         return cachedCodeInfo;
     }
 
+    public bool IsCodeOverridable => _inner.IsCodeOverridable;
+
     public CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec, out Address? delegationAddress) =>
         _inner.GetCachedCodeInfo(codeSource, followDelegation, vmSpec, out delegationAddress);
 

--- a/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
@@ -53,6 +53,8 @@ public class CodeInfoRepository : ICodeInfoRepository
 #endif
     }
 
+    public bool IsCodeOverridable => false;
+
     public CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec, out Address? delegationAddress)
     {
         delegationAddress = null;

--- a/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
@@ -12,7 +12,7 @@ public interface ICodeInfoRepository
 {
     /// <summary>Whether account code may be overridden (e.g. <c>eth_call</c> state overrides), disabling the simple-transfer fast path.</summary>
     /// <remarks>Wrapping implementations must forward this, else the fast path is wrongly taken under overrides.</remarks>
-    bool IsCodeOverridable => false;
+    bool IsCodeOverridable { get; }
     CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec, out Address? delegationAddress);
     void InsertCode(ReadOnlyMemory<byte> code, Address codeOwner, IReleaseSpec spec);
     void SetDelegation(Address codeSource, Address authority, IReleaseSpec spec);


### PR DESCRIPTION
## Changes

Makes `ICodeInfoRepository.IsCodeOverridable` a required member instead of a default-`false` interface member.

The flag gates the simple-transfer fast path (`TransactionProcessor` snapshots it and skips code resolution when it's false). As a default-`false` DIM, a wrapping repository that forgot to forward it silently inherited `false` and would wrongly take the fast path under `eth_call` state overrides — a wrong result with no diagnostic. Making the member required turns "forgot to forward" from a silent bug into a compile error.

- `ICodeInfoRepository`: `bool IsCodeOverridable => false;` → `bool IsCodeOverridable { get; }`.
- `CodeInfoRepository` (terminal repo, no override storage): declares `=> false`.
- `CacheCodeInfoRepository` (caching wrapper): forwards `_inner.IsCodeOverridable`, matching how it delegates every other member.
- `OverridableCodeInfoRepository` (`=> true`) and `PrecompileCachedCodeInfoRepository` (forwards its base) already declared it — unchanged.

The full-solution build confirms these were the only concrete implementers; the behavior this flag gates is exercised by the simple-transfer differential suite (#12278).

## Note on the breaking-change classification

`ICodeInfoRepository` is deep EVM plumbing (the supported plugin surface is `INethermindPlugin`), but its public metadata does ship via the `Nethermind.ReferenceAssemblies` package, so removing the default is source/binary-breaking for any external implementer that relied on it. There are no known external implementers. If the interface is not intended as external surface, this can be reclassified as a plain refactor; alternatively the same in-repo safety could be had non-breaking via a reflection fitness test (asserting each in-repo implementer declares the member) at the cost of losing the compile-time guarantee. Ticking the box to be honest about the surface change — happy to adjust.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

- Compile-time enforced (the member is now required); behavior-neutral (the two terminal repos already returned `false` via the default).
- Full `Nethermind.slnx` build: 0 errors. zkEVM guest build (`-p:EnableZkEvm=true`): 0 errors.
- `Nethermind.Evm.Test` 4770, `PrecompileCachedCodeInfoRepositoryTests` 15 — all pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

_If `ICodeInfoRepository` is treated as external surface, note the now-required `IsCodeOverridable` member._
