### PR TITLE
perf(evm): reuse the EIP-7702 delegation lookup from validation

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -683,7 +683,7 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 Address authority = (authTuple.Authority ??= Ecdsa.RecoverAddress(authTuple))!;
 
-                AuthorizationTupleResult authorizationResult = IsValidForExecution(authTuple, accessTracker, spec, out string? error);
+                AuthorizationTupleResult authorizationResult = IsValidForExecution(authTuple, accessTracker, spec, out bool hasDelegation, out string? error);
                 if (authorizationResult != AuthorizationTupleResult.Valid)
                 {
                     if (Logger.IsDebug) Logger.Debug($"Delegation {authTuple} is invalid with error: {error}");
@@ -691,7 +691,6 @@ namespace Nethermind.Evm.TransactionProcessing
                 else
                 {
                     bool accountExists = WorldState.AccountExists(authority);
-                    bool hasDelegation = accountExists && _codeInfoRepository.TryGetDelegation(authority, spec, out _);
                     bool clearsDelegation = authTuple.CodeAddress == Address.Zero;
 
                     if (!accountExists)
@@ -730,8 +729,10 @@ namespace Nethermind.Evm.TransactionProcessing
             AuthorizationTuple authorizationTuple,
             in StackAccessTracker accessTracker,
             IReleaseSpec spec,
+            out bool hasDelegation,
             [NotNullWhen(false)] out string? error)
         {
+            hasDelegation = false;
             if (authorizationTuple.ChainId != 0 && SpecProvider.ChainId != authorizationTuple.ChainId)
             {
                 error = $"Chain id ({authorizationTuple.ChainId}) does not match.";
@@ -756,10 +757,14 @@ namespace Nethermind.Evm.TransactionProcessing
 
             accessTracker.WarmUp(authorizationTuple.Authority);
 
-            if (WorldState.HasCode(authorizationTuple.Authority) && !_codeInfoRepository.TryGetDelegation(authorizationTuple.Authority, spec, out _))
+            if (WorldState.HasCode(authorizationTuple.Authority))
             {
-                error = $"Authority ({authorizationTuple.Authority}) has code deployed.";
-                return AuthorizationTupleResult.InvalidAsCodeDeployed;
+                hasDelegation = _codeInfoRepository.TryGetDelegation(authorizationTuple.Authority, spec, out _);
+                if (!hasDelegation)
+                {
+                    error = $"Authority ({authorizationTuple.Authority}) has code deployed.";
+                    return AuthorizationTupleResult.InvalidAsCodeDeployed;
+                }
             }
 
             ulong authNonce = WorldState.GetNonce(authorizationTuple.Authority);


### PR DESCRIPTION
## Changes

Removes a redundant EIP-7702 delegation lookup in authorization processing.

For each **valid** authorization tuple, `ProcessDelegations` recomputed `TryGetDelegation(authority)` — a `HasCode` check, a code-hash read, and a code fetch — even though `IsValidForExecution` had just performed the same lookup to decide validity (`if (HasCode(authority) && !TryGetDelegation(authority)) → InvalidAsCodeDeployed`). This doubled the code resolution per valid tuple, on authorization lists that can be gas-budget-sized.

- `IsValidForExecution` now returns the delegation status via an `out bool hasDelegation`, computed from the `HasCode` + `TryGetDelegation` it already does.
- `ProcessDelegations` reuses it instead of recomputing.

### Why it's behavior-neutral

On the valid path, `IsValidForExecution`'s `hasDelegation` equals `HasCode(authority) && isDelegation`. The removed line computed `accountExists && TryGetDelegation(authority)`; `TryGetDelegation` returns `false` when the authority has no code, and having code implies the account exists, so `accountExists && TryGetDelegation ≡ HasCode && isDelegation`. No code is mutated between the validation call and the old recompute (only `WarmUp`/`AccountExists`/`GetNonce` reads run in between), and for multi-tuple lists both the old and new lookups observe the same state (after any prior tuple's `SetDelegation`, before this tuple's own mutations). The value feeds only the `authBaseRefunds` count, which is unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

- Behavior-neutral; covered by the existing EIP-7702 / authorization / delegation suites (86 tests) and full `Nethermind.Evm.Test` (4770), all passing.
- Both build flavors compile: default and `-p:EnableZkEvm=true`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
