### PR TITLE
perf(evm): sample the code cache's eviction-ticker refresh

### DIFF
--- a/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
@@ -77,9 +77,22 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
 
     private sealed class CodeLruCache
     {
+        private const uint RefreshSampleMask = 63;
+
+        [ThreadStatic] private static uint _refreshSampler;
+
         private readonly AssociativeCache<ValueHash256, CodeInfo> _cache = new(MemoryAllowance.CodeCacheSize);
 
-        public CodeInfo? Get(in ValueHash256 codeHash) => _cache.Get(in codeHash);
+        public CodeInfo? Get(in ValueHash256 codeHash)
+        {
+            if ((_refreshSampler++ & RefreshSampleMask) == 0)
+            {
+                return _cache.Get(in codeHash);
+            }
+
+            _cache.TryGetNoRefresh(in codeHash, out CodeInfo? codeInfo);
+            return codeInfo;
+        }
 
         public void Set(in ValueHash256 codeHash, CodeInfo codeInfo)
         {


### PR DESCRIPTION
## Changes

Reduces cross-thread coherency traffic on the process-wide EVM code cache.

`AssociativeCache.Get` refreshes an entry's eviction ticker on every hit — an `Interlocked.Increment` on a single global counter plus a store to the entry's cache line. On the code cache that happens per code fetch (per `CALL`), and the same hot contract is read concurrently by the block-import thread and all prewarm workers, so the ticker store bounces that cache line between cores.

`CodeLruCache.Get` now refreshes the ticker on roughly one hit in 64, using a per-thread `[ThreadStatic]` sampler and the cache's existing `TryGetNoRefresh` lookup for the rest:

```csharp
public CodeInfo? Get(in ValueHash256 codeHash)
{
    if ((_refreshSampler++ & RefreshSampleMask) == 0) return _cache.Get(in codeHash);
    _cache.TryGetNoRefresh(in codeHash, out CodeInfo? codeInfo);
    return codeInfo;
}
```

`TryGetNoRefresh` returns the identical value/hit result; only the ticker side effect is skipped. So lookups are unchanged — only eviction **recency** becomes sampled. That is safe: hot entries are hit far more than 1-in-64 so they stay high-ranked, and eviction is already approximate (3-random within an 8-way set), so a mis-ranked entry only ever forces a re-fetch from world state, never a wrong result.

The `[ThreadStatic]` sampler degrades to a plain static in the single-threaded zkEVM guest (via the existing `NoopThreadStaticAttribute` alias), which is fine.

**Measurement:** the change is behavior-safe and removes the CAS + cache-line write from ~63/64 of code-cache hits; the block-level gain is directional and best confirmed with a reproducible realblocks A/B (the effect concentrates on the prewarm-contended path, so a single-threaded microbenchmark understates it).

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

- Behavior-neutral for lookups; `AssociativeCache` tests (28) and full `Nethermind.Evm.Test` (4770) pass.
- Both build flavors compile: default and `-p:EnableZkEvm=true`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
