### PR TITLE
refactor(evm): keep the system-tx validate marker as private processor state

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
@@ -39,6 +39,13 @@ public enum ExecutionOptions
     BuildUp = 16,
 
     /// <summary>
+    /// High-bit marker recording that the original request wanted validation, set when a system
+    /// transaction forces <see cref="SkipValidationAndCommit"/>. Set and read only within system
+    /// transaction processing.
+    /// </summary>
+    SystemOriginalValidate = 1 << 30,
+
+    /// <summary>
     /// Skip potential fail checks and commit state after execution
     /// </summary>
     SkipValidationAndCommit = Commit | SkipValidation,

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
@@ -39,11 +39,11 @@ public enum ExecutionOptions
     BuildUp = 16,
 
     /// <summary>
-    /// High-bit marker recording that the original request wanted validation, set when a system
+    /// Marker recording that the original request wanted validation, set when a system
     /// transaction forces <see cref="SkipValidationAndCommit"/>. Set and read only within system
     /// transaction processing.
     /// </summary>
-    SystemOriginalValidate = 1 << 30,
+    SystemOriginalValidate = 32,
 
     /// <summary>
     /// Skip potential fail checks and commit state after execution

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
@@ -39,13 +39,6 @@ public enum ExecutionOptions
     BuildUp = 16,
 
     /// <summary>
-    /// Marker recording that the original request wanted validation, set when a system
-    /// transaction forces <see cref="SkipValidationAndCommit"/>. Set and read only within system
-    /// transaction processing.
-    /// </summary>
-    SystemOriginalValidate = 32,
-
-    /// <summary>
     /// Skip potential fail checks and commit state after execution
     /// </summary>
     SkipValidationAndCommit = Commit | SkipValidation,

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
@@ -23,6 +23,9 @@ public class SystemTransactionProcessor<TGasPolicy>(
     : TransactionProcessorBase<TGasPolicy>(blobBaseFeeCalculator, specProvider, worldState, virtualMachine, codeInfoRepository, logManager)
     where TGasPolicy : struct, IGasPolicy<TGasPolicy>
 {
+    // Set in Execute and read within the same synchronous base.Execute -> PayValue chain (system txs don't recurse), so a plain field needs no synchronization.
+    private bool _payOriginalValue;
+
     /// <summary>
     /// Whether to suppress BAL reads of the SYSTEM_ADDRESS account for this transaction.
     /// EIP-7928 excludes the SYSTEM_ADDRESS caller from BALs for system contract calls;
@@ -55,9 +58,9 @@ public class SystemTransactionProcessor<TGasPolicy>(
         OnBeforeSystemTransaction();
 
         ExecutionOptions coreOpts = opts & ~ExecutionOptions.Warmup;
-        return base.Execute(tx, tracer, ((coreOpts & ExecutionOptions.SkipValidation) != ExecutionOptions.SkipValidation && !coreOpts.HasFlag(ExecutionOptions.SkipValidationAndCommit))
-            ? opts | ExecutionOptions.SystemOriginalValidate | ExecutionOptions.SkipValidationAndCommit
-            : opts);
+        _payOriginalValue = (coreOpts & ExecutionOptions.SkipValidation) != ExecutionOptions.SkipValidation
+                            && !coreOpts.HasFlag(ExecutionOptions.SkipValidationAndCommit);
+        return base.Execute(tx, tracer, _payOriginalValue ? opts | ExecutionOptions.SkipValidationAndCommit : opts);
     }
 
     protected override TransactionResult BuyGas(Transaction tx, IReleaseSpec spec, ITxTracer tracer, ExecutionOptions opts,
@@ -83,7 +86,7 @@ public class SystemTransactionProcessor<TGasPolicy>(
 
     protected override void PayValue(Transaction tx, IReleaseSpec spec, ExecutionOptions opts)
     {
-        if (opts.HasFlag(ExecutionOptions.SystemOriginalValidate))
+        if (_payOriginalValue)
         {
             base.PayValue(tx, spec, opts);
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
@@ -24,12 +24,6 @@ public class SystemTransactionProcessor<TGasPolicy>(
     where TGasPolicy : struct, IGasPolicy<TGasPolicy>
 {
     /// <summary>
-    /// Hacky flag to execution options, to pass information how original validate should behave.
-    /// Needed to decide if we need to subtract transaction value.
-    /// </summary>
-    protected const int OriginalValidate = 2 << 30;
-
-    /// <summary>
     /// Whether to suppress BAL reads of the SYSTEM_ADDRESS account for this transaction.
     /// EIP-7928 excludes the SYSTEM_ADDRESS caller from BALs for system contract calls;
     /// engines that surface the system user (e.g. AuRa) override to return false.
@@ -62,7 +56,7 @@ public class SystemTransactionProcessor<TGasPolicy>(
 
         ExecutionOptions coreOpts = opts & ~ExecutionOptions.Warmup;
         return base.Execute(tx, tracer, ((coreOpts & ExecutionOptions.SkipValidation) != ExecutionOptions.SkipValidation && !coreOpts.HasFlag(ExecutionOptions.SkipValidationAndCommit))
-            ? opts | (ExecutionOptions)OriginalValidate | ExecutionOptions.SkipValidationAndCommit
+            ? opts | ExecutionOptions.SystemOriginalValidate | ExecutionOptions.SkipValidationAndCommit
             : opts);
     }
 
@@ -89,7 +83,7 @@ public class SystemTransactionProcessor<TGasPolicy>(
 
     protected override void PayValue(Transaction tx, IReleaseSpec spec, ExecutionOptions opts)
     {
-        if (opts.HasFlag((ExecutionOptions)OriginalValidate))
+        if (opts.HasFlag(ExecutionOptions.SystemOriginalValidate))
         {
             base.PayValue(tx, spec, opts);
         }


### PR DESCRIPTION
## Changes

`SystemTransactionProcessor` records whether the original request wanted validation — so its `PayValue` override knows whether to subtract the transaction value — before it forces `SkipValidationAndCommit`. It carried this through `ExecutionOptions`: originally a self-described "Hacky flag" `const int OriginalValidate = 2 << 30`, undeclared in the `[Flags]` enum and injected/read via `(ExecutionOptions)` casts. Since `ExecutionOptions` is compared elsewhere with exact-equality masks, an undeclared bit is a latent collision hazard.

Rather than declare it in the shared enum, this keeps the marker where it belongs. It isn't really an execution option — it's private cross-method state between `Execute` (which sets it) and the overridden `PayValue` (which reads it), riding through `opts` only because that's the channel `base.Execute` forwards. So:

- Replace the flag with a private `bool _payOriginalValue` field on `SystemTransactionProcessor`.
- `Execute` computes it from the incoming options and forwards `SkipValidationAndCommit` exactly as before; `PayValue` reads the field directly.
- `ExecutionOptions` is left untouched — no undeclared bit, and no system-tx-only concern leaking to every consumer of the shared type.

### Behavior-neutral

The marker was always process-local, set and read only within the synchronous `Execute → base.Execute → PayValue` chain on a single processor instance (system txs don't recurse), so moving it from an opts bit to a field changes nothing observable.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

- Behavior-neutral; covered by the system-transaction paths (EIP-4788 beacon-block-root, EIP-2935 block-hash) — 48 related tests plus full `Nethermind.Evm.Test` (4770), all passing.
- Both build flavors compile: default and `-p:EnableZkEvm=true`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

