### PR TITLE
fix(discovery): deflake KademliaAdapterTests ENR refresh tests

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/Kademlia/KademliaAdapterTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/Kademlia/KademliaAdapterTests.cs
@@ -38,6 +38,20 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
             SendEnrRequest
         }
 
+        /// <summary>
+        /// Request timeout for tests whose mocks answer inline, where timeouts act only as a failsafe.
+        /// </summary>
+        /// <remarks>
+        /// Must stay well above CI scheduling jitter: a timed-out request can be cancelled before it is even sent,
+        /// and a timed-out ENR refresh is skipped silently, flaking the refresh assertions on slow runners.
+        /// </remarks>
+        private const int FailsafeRequestTimeoutMs = 10_000;
+
+        /// <summary>
+        /// Request timeout for tests that assert timeout behavior and need requests to expire quickly.
+        /// </summary>
+        private const int ExpiringRequestTimeoutMs = 100;
+
         private IKademliaAdapter _adapter = null!;
 
         private IKademlia<PublicKey, Node> _kademliaMessageReceiver = null!;
@@ -49,6 +63,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
         private ITimestamper _timestamper = null!;
         private IMsgSender _msgSender = null!;
         private INodeStatsManager _nodeStatsManager = null!;
+        private INodeRecordProvider _nodeRecordProvider = null!;
         private Node _testNode = null!;
         private PublicKey _testPublicKey = null!;
 
@@ -111,29 +126,38 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
             builder.WithDiscovery(TestItem.PrivateKeyB);
             _receiverSerializationManager = builder.TestObject;
 
-            INodeRecordProvider nodeRecordProvider = Substitute.For<INodeRecordProvider>();
-            nodeRecordProvider.GetCurrentAsync(Arg.Any<CancellationToken>()).Returns(new ValueTask<NodeRecord>(_selfNodeRecord));
+            _nodeRecordProvider = Substitute.For<INodeRecordProvider>();
+            _nodeRecordProvider.GetCurrentAsync(Arg.Any<CancellationToken>()).Returns(new ValueTask<NodeRecord>(_selfNodeRecord));
             _nodeStatsManager = Substitute.For<INodeStatsManager>();
             _nodeStatsManager.GetOrAdd(Arg.Any<Node>()).Returns(Substitute.For<INodeStats>());
 
-            _adapter = new KademliaAdapter(
-                new Lazy<IKademlia<PublicKey, Node>>(() => _kademliaMessageReceiver),
-                new Lazy<INodeHealthTracker<Node>>(() => _nodeHealthTracker),
-                new DiscoveryConfig
-                {
-                    EnrTimeout = 100,
-                    PingTimeout = 100,
-                    SendNodeTimeout = 100,
-                    BondWaitTime = 1,
-                },
-                _kademliaConfig,
-                nodeRecordProvider,
-                _nodeStatsManager,
-                _timestamper,
-                Substitute.For<IProcessExitSource>(),
-                _logManager
-            );
-            _adapter.MsgSender = _msgSender;
+            _adapter = CreateAdapter(FailsafeRequestTimeoutMs);
+        }
+
+        private KademliaAdapter CreateAdapter(int requestTimeoutMs) => new(
+            new Lazy<IKademlia<PublicKey, Node>>(() => _kademliaMessageReceiver),
+            new Lazy<INodeHealthTracker<Node>>(() => _nodeHealthTracker),
+            new DiscoveryConfig
+            {
+                EnrTimeout = requestTimeoutMs,
+                PingTimeout = requestTimeoutMs,
+                SendNodeTimeout = requestTimeoutMs,
+                BondWaitTime = 1,
+            },
+            _kademliaConfig,
+            _nodeRecordProvider,
+            _nodeStatsManager,
+            _timestamper,
+            Substitute.For<IProcessExitSource>(),
+            _logManager)
+        {
+            MsgSender = _msgSender,
+        };
+
+        private async Task UseExpiringRequestTimeouts()
+        {
+            await _adapter.DisposeAsync();
+            _adapter = CreateAdapter(ExpiringRequestTimeoutMs);
         }
 
         [Test]
@@ -284,6 +308,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
         [CancelAfter(10000)]
         public async Task SendEnrRequest_should_reject_unsolicited_response_with_wrong_keccak(CancellationToken token)
         {
+            await UseExpiringRequestTimeouts();
             ConfigureBondCallback();
 
             _msgSender
@@ -353,6 +378,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
         [CancelAfter(10000)]
         public async Task Timed_out_response_handler_should_not_consume_later_unsolicited_message(CancellationToken token)
         {
+            await UseExpiringRequestTimeouts();
             ConfigureBondCallback();
 
             PingMsg pingMsg = new(_receiver.Address, _timestamper.UnixTime.SecondsLong + 20, _kademliaConfig.CurrentNodeId.Address);
@@ -397,6 +423,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
         [CancelAfter(10000)]
         public async Task Request_timeout_should_return_no_response_and_record_failure_once(NoResponseRequest request, CancellationToken token)
         {
+            await UseExpiringRequestTimeouts();
             if (request is not NoResponseRequest.Ping)
             {
                 ConfigureBondCallback();
@@ -412,6 +439,8 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
         [CancelAfter(10000)]
         public async Task FindNeighbours_should_not_send_find_node_when_bond_ping_times_out(CancellationToken token)
         {
+            await UseExpiringRequestTimeouts();
+
             Node[]? result = await _adapter.FindNeighbours(_receiver, TestItem.PublicKeyC, token);
 
             Assert.That(result, Is.Null);


### PR DESCRIPTION
## Changes

- `KademliaAdapterTests` configured all discovery request timeouts at 100 ms against the wall clock, even though the NSubstitute mocks deliver responses inline. On slow CI runners (macOS ARM especially), scheduling jitter could expire a request before it was even sent: `KademliaAdapter.CallAndWaitForResponse` swallows a timeout that fires during the outbound rate-limiter wait and resolves the request as "no response", and a failed ENR refresh is non-fatal — so `Ping` returned `true` while the expected `EnrRequestMsg` was never sent, failing `Ping_should_refresh_remote_enr_from_advertised_sequence` cases intermittently (e.g. [this run](https://github.com/NethermindEth/nethermind/actions/runs/28749967072), where two different cases failed on the two retry attempts).
- The fixture now builds the adapter with a generous 10 s failsafe timeout (mocks answer inline, so the happy path never waits on it), via a shared `CreateAdapter` helper.
- The four tests that genuinely assert timeout behavior (`Request_timeout_should_return_no_response_and_record_failure_once`, `Timed_out_response_handler_should_not_consume_later_unsolicited_message`, `SendEnrRequest_should_reject_unsolicited_response_with_wrong_keccak`, `FindNeighbours_should_not_send_find_node_when_bond_ping_times_out`) switch to a short-timeout (100 ms) adapter so they still expire quickly.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] No

#### Notes on testing

Test-only change. Full `KademliaAdapterTests` suite (35 tests) run 5× locally in release — all green, ~1.7 s per run, so the timeout-asserting tests remain fast.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No