### PR TITLE
perf(state): SLOADs - skip journaling storage reads

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -705,3 +705,5 @@ public static partial class EvmInstructions
         return EvmExceptionType.StackUnderflow;
     }
 }
+
+// Benchmark trigger: temporary no-op to run the EVM opcode diff job on this PR; reverted after the run.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -705,5 +705,3 @@ public static partial class EvmInstructions
         return EvmExceptionType.StackUnderflow;
     }
 }
-
-// Benchmark trigger: temporary no-op to run the EVM opcode diff job on this PR; reverted after the run.

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -18,6 +18,7 @@ using Nethermind.Logging;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
 using Nethermind.State;
+using Nethermind.Evm.Tracing.State;
 using NUnit.Framework;
 
 namespace Nethermind.Store.Test;
@@ -657,6 +658,28 @@ public class StorageProviderTests(bool useFlat)
     }
 
     [Test]
+    public void Commit_ReadOnlyRound_ReportsStorageReadsToTracer()
+    {
+        using Context ctx = new(useFlat);
+        WorldState provider = BuildStorageProvider(ctx);
+        StorageCell readCell = new(TestItem.AddressA, 1);
+
+        provider.Get(readCell);
+
+        ReadCollectingStorageTracer tracer = new();
+        provider.Commit(Frontier.Instance, tracer);
+
+        Assert.That(tracer.Reads, Does.Contain(readCell));
+
+        // The round's read capture must be cleared by the read-only commit:
+        // a subsequent commit without new reads reports nothing.
+        ReadCollectingStorageTracer secondRoundTracer = new();
+        provider.Commit(Frontier.Instance, secondRoundTracer);
+
+        Assert.That(secondRoundTracer.Reads, Is.Empty);
+    }
+
+    [Test]
     public void Eip161_empty_account_with_storage_does_not_throw_on_commit()
     {
         using Context ctx = new(useFlat, setInitialState: false);
@@ -912,5 +935,21 @@ public class StorageProviderTests(bool useFlat)
                 writtenData.SelfDestructed[address] = true;
             }
         }
+    }
+
+    private sealed class ReadCollectingStorageTracer : IWorldStateTracer
+    {
+        public System.Collections.Generic.List<StorageCell> Reads { get; } = [];
+
+        public bool IsTracingState => false;
+        public bool IsTracingStorage => true;
+
+        public void ReportBalanceChange(Address address, UInt256? before, UInt256? after) { }
+        public void ReportCodeChange(Address address, byte[] before, byte[] after) { }
+        public void ReportNonceChange(Address address, UInt256? before, UInt256? after) { }
+        public void ReportAccountRead(Address address) { }
+        public void ReportStorageChange(in ReadOnlySpan<byte> key, in ReadOnlySpan<byte> value) { }
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after) { }
+        public void ReportStorageRead(in StorageCell storageCell) => Reads.Add(storageCell);
     }
 }

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -134,7 +134,7 @@ namespace Nethermind.State
         /// Commit persistent storage
         /// </summary>
         /// <param name="stateTracer">State tracer</param>
-        public void Commit(IStorageTracer tracer)
+        public virtual void Commit(IStorageTracer tracer)
         {
             if (_changes.Count == 0)
             {

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -337,10 +337,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     }
 
     /// <summary>
-    /// Clear all storage at specified address
-    /// </summary>
-    /// <param name="address">Contract address</param>
-    /// <summary>
     /// Reads are not journaled, so a commit round can have an empty change list while cells were
     /// still read this round: those reads must be reported to storage tracers and the round's
     /// original-value capture must be cleared, which the change-driven commit otherwise does.
@@ -364,6 +360,10 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         base.Commit(tracer);
     }
 
+    /// <summary>
+    /// Clear all storage at specified address
+    /// </summary>
+    /// <param name="address">Contract address</param>
     public override void ClearStorage(Address address)
     {
         // Reads are not journaled, so the base registry walk below only zeroes written cells.

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -135,24 +135,9 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         for (int i = 0; i <= currentPosition; i++)
         {
             Change change = _changes[currentPosition - i];
-            if (!isTracing && change!.ChangeType == ChangeType.JustCache)
-            {
-                continue;
-            }
-
             if (_committedThisRound.Contains(change!.StorageCell))
             {
-                if (isTracing && change.ChangeType == ChangeType.JustCache)
-                {
-                    trace![change.StorageCell] = new StorageChangeTrace(change.Value, trace[change.StorageCell].After);
-                }
-
                 continue;
-            }
-
-            if (isTracing && change.ChangeType == ChangeType.JustCache)
-            {
-                tracer!.ReportStorageRead(change.StorageCell);
             }
 
             _committedThisRound.Add(change.StorageCell);
@@ -210,6 +195,24 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             }
         }
         toUpdateRoots.Clear();
+
+        if (isTracing)
+        {
+            // Reads no longer journal, so read reporting is reconstructed from the captured
+            // original values: cells also written this round get their pre-round value as the
+            // trace's Before; read-only cells are reported as reads.
+            foreach ((StorageCell cell, byte[] originalValue) in _originalValues)
+            {
+                if (trace!.TryGetValue(cell, out StorageChangeTrace changeTrace))
+                {
+                    trace[cell] = new StorageChangeTrace(originalValue, changeTrace.After);
+                }
+                else
+                {
+                    tracer.ReportStorageRead(cell);
+                }
+            }
+        }
 
         base.CommitCore(tracer);
         _originalValues.Clear();
@@ -304,12 +307,19 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     private ReadOnlySpan<byte> LoadFromTree(in StorageCell storageCell) =>
         GetOrCreateStorage(storageCell.Address).LoadFromTree(storageCell);
 
-    private void PushToRegistryOnly(in StorageCell cell, byte[] value)
+    /// <summary>
+    /// Reads skip the registry/change journal that writes use: repeat reads are served by
+    /// <see cref="PerContractState.BlockChange"/>, which is inherently revert-safe (reads have
+    /// no side effects). Only the first-loaded value is captured here, backing
+    /// <see cref="GetOriginal"/> and commit-time <see cref="IStorageTracer.ReportStorageRead"/>.
+    /// </summary>
+    private void CaptureOriginalValue(in StorageCell cell, byte[] value)
     {
-        StackList<int> stack = SetupRegistry(cell);
-        _originalValues[cell] = value;
-        stack.Push(_changes.Count);
-        _changes.Add(new Change(in cell, value, ChangeType.JustCache));
+        ref byte[]? slot = ref CollectionsMarshal.GetValueRefOrAddDefault(_originalValues, cell, out bool exists);
+        if (!exists)
+        {
+            slot = value;
+        }
     }
 
     private static void ReportChanges(IStorageTracer tracer, Dictionary<StorageCell, StorageChangeTrace> trace)
@@ -330,8 +340,44 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// Clear all storage at specified address
     /// </summary>
     /// <param name="address">Contract address</param>
+    /// <summary>
+    /// Reads are not journaled, so a commit round can have an empty change list while cells were
+    /// still read this round: those reads must be reported to storage tracers and the round's
+    /// original-value capture must be cleared, which the change-driven commit otherwise does.
+    /// </summary>
+    public override void Commit(IStorageTracer tracer)
+    {
+        if (_changes.Count == 0 && _originalValues.Count != 0)
+        {
+            if (tracer.IsTracingStorage)
+            {
+                foreach (StorageCell cell in _originalValues.Keys)
+                {
+                    tracer.ReportStorageRead(cell);
+                }
+            }
+
+            _originalValues.Clear();
+            return;
+        }
+
+        base.Commit(tracer);
+    }
+
     public override void ClearStorage(Address address)
     {
+        // Reads are not journaled, so the base registry walk below only zeroes written cells.
+        // Zero the read cells from the original-value capture for the same reason: reads after
+        // the destruct (including CREATE2 revival in the same block) must not observe
+        // pre-destruct values through the block or pre-warm caches.
+        foreach (KeyValuePair<StorageCell, byte[]> readCell in _originalValues)
+        {
+            if (readCell.Key.Address == address)
+            {
+                Set(readCell.Key, StorageTree.ZeroBytes);
+            }
+        }
+
         base.ClearStorage(address);
 
         _toUpdateRoots.TryAdd(address, true);
@@ -509,7 +555,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 _provider._metrics.IncrementStorageTreeCache();
             }
 
-            if (!storageCell.IsHash) _provider.PushToRegistryOnly(storageCell, valueChange.After);
+            if (!storageCell.IsHash) _provider.CaptureOriginalValue(storageCell, valueChange.After);
             return valueChange.After;
         }
 

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -198,9 +198,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         if (isTracing)
         {
-            // Reads no longer journal, so read reporting is reconstructed from the captured
-            // original values: cells also written this round get their pre-round value as the
-            // trace's Before; read-only cells are reported as reads.
             foreach ((StorageCell cell, byte[] originalValue) in _originalValues)
             {
                 if (trace!.TryGetValue(cell, out StorageChangeTrace changeTrace))

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -363,10 +363,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// <param name="address">Contract address</param>
     public override void ClearStorage(Address address)
     {
-        // Reads are not journaled, so the base registry walk below only zeroes written cells.
-        // Zero the read cells from the original-value capture for the same reason: reads after
-        // the destruct (including CREATE2 revival in the same block) must not observe
-        // pre-destruct values through the block or pre-warm caches.
         foreach (KeyValuePair<StorageCell, byte[]> readCell in _originalValues)
         {
             if (readCell.Key.Address == address)


### PR DESCRIPTION
## What

Storage reads no longer create journal entries. Previously every first read of a slot in a commit round journaled a `JustCache` change: a per-cell `StackList<int>` registry allocation, a change-list entry, and an original-value capture. The journal's read-related services are provided elsewhere at lower cost, so reads now only capture the first-loaded value (a single dictionary insert), and the journal tracks writes exclusively.

## Numbers

`EvmOpcodesBenchmark` (Apple M1, median-of-30, outliers removed; CI x64 diff job on this PR will give the authoritative table):

| Opcode | Mean before | Mean after | Δ | Alloc before | Alloc after |
|---|---:|---:|---:|---:|---:|
| SLOAD | 1548.7 ns | **784.0 ns** | **−49% (2.0×)** | 226 B/op | 190 B/op |
| SSTORE | 1149.0 ns | 1031.1 ns | −10% | 226 B/op | 190 B/op |

The after-run's max (950 ns) is ~40% below the before-run's mean — not a noise artifact. The removed work (registry allocation + multiple 52-byte cell hashings + change-list growth per cold read) is also paid on the block-processing critical path for every unique slot touched in every block.

## Why it's correct — the journal's five read-related jobs, one by one

1. **Revert (`Restore`)**: reads have no side effects, so there is nothing to revert. Repeat reads are served by `PerContractState.BlockChange`, which survives reverts inherently — that is exactly what the old `_keptInCache` mechanism laboriously re-implemented at the journal level for `JustCache` entries.
2. **Read-after-write in the same round**: writes journal exactly as before and `TryGetCachedValue` is consulted *before* the block cache, so written cells still resolve from the journal.
3. **EIP-2200 `GetOriginal`**: the `_originalValues` capture is populated by the same code path at the same moment with the same value as before — answers are bit-identical (the snapshot-peek path for cells written in later transactions of the same block only ever inspected write entries).
4. **Storage tracers (`ReportStorageRead`, e.g. `ProofTxTracer`)**: reconstructed at commit from the captured read set — same cells, order-insensitive. Read-only commit rounds (empty change list) are handled by a `Commit` override, since the base guard short-circuits before `CommitCore`.
5. **SELFDESTRUCT**: `ClearStorage` previously zeroed all journaled cells of the destroyed contract so post-destruct reads / same-block CREATE2 revivals cannot observe pre-destruct values through block or pre-warm caches. Read cells are now zeroed from the original-value capture instead — same cells, same effect.

Cases 4 and 5 were each caught by the existing test suites during development (`ProofTxTracerTests`, `StorageProviderTests.Selfdestruct_persist_between_commit`) and are covered by the fixes above — the suites act as regression pins for exactly these semantics.

## Testing

- `Nethermind.State.Test`: 1126 tests, 0 failures (incl. Restore/Commit/original-value/selfdestruct suites)
- `Nethermind.Evm.Test`: 4778 tests, 0 failures (incl. EIP-2200 net metering and proof-tracer suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)