### PR TITLE
perf(evm): batch per-opcode metric counters into a per-transaction flush

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/ExecutionMetricsBatchingTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ExecutionMetricsBatchingTests.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+[NonParallelizable]
+public class ExecutionMetricsBatchingTests : VirtualMachineTestsBase
+{
+    [Test]
+    public void Per_opcode_counters_flush_exact_totals()
+    {
+        byte[] code = Prepare.EvmCode
+            .PushData(1).PushData(0).Op(Instruction.SSTORE)
+            .PushData(1).PushData(1).Op(Instruction.SSTORE)
+            .PushData(1).PushData(2).Op(Instruction.SSTORE)
+            .PushData(2).PushData(0).Op(Instruction.SSTORE)
+            .PushData(0).Op(Instruction.SLOAD).Op(Instruction.POP)
+            .PushData(1).Op(Instruction.SLOAD).Op(Instruction.POP)
+            .Op(Instruction.STOP)
+            .Done;
+
+        long sstoreBefore = Metrics.SstoreOpcode;
+        long sloadBefore = Metrics.SloadOpcode;
+
+        Execute(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Metrics.SstoreOpcode - sstoreBefore, Is.EqualTo(4), "SSTORE count");
+            Assert.That(Metrics.SloadOpcode - sloadBefore, Is.EqualTo(2), "SLOAD count");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/ExecutionMetricsCounters.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionMetricsCounters.cs
@@ -67,6 +67,7 @@ internal struct ExecutionMetricsCounters
         if (ExecutionMetricsFlag.IsActive) SelfDestructs++;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Flush()
     {
         if (!ExecutionMetricsFlag.IsActive) return;

--- a/src/Nethermind/Nethermind.Evm/ExecutionMetricsCounters.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionMetricsCounters.cs
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.CompilerServices;
+
+namespace Nethermind.Evm;
+
+/// <summary>
+/// Per-transaction accumulator for the per-opcode execution counters, flushed once into the global
+/// <see cref="Metrics"/> at transaction end.
+/// </summary>
+/// <remarks>
+/// A virtual machine instance executes one transaction at a time on one thread, so increments are plain
+/// non-atomic adds — replacing the per-opcode cross-thread <see cref="System.Threading.Interlocked"/>
+/// contention (shared by every prewarm worker) with a single atomic add per counter per transaction.
+/// Increments mirror the <see cref="ExecutionMetricsFlag"/> gating of their globals.
+/// </remarks>
+internal struct ExecutionMetricsCounters
+{
+    public long SLoad;
+    public long SStore;
+    public long StorageDeleted;
+    public long Calls;
+    public long EmptyCalls;
+    public long Creates;
+    public long SelfDestructs;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementSLoad()
+    {
+        if (ExecutionMetricsFlag.IsActive) SLoad++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementSStore()
+    {
+        if (ExecutionMetricsFlag.IsActive) SStore++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementStorageDeleted()
+    {
+        if (ExecutionMetricsFlag.IsActive) StorageDeleted++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementCalls()
+    {
+        if (ExecutionMetricsFlag.IsActive) Calls++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementEmptyCalls()
+    {
+        if (ExecutionMetricsFlag.IsActive) EmptyCalls++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementCreates()
+    {
+        if (ExecutionMetricsFlag.IsActive) Creates++;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementSelfDestructs()
+    {
+        if (ExecutionMetricsFlag.IsActive) SelfDestructs++;
+    }
+
+    public void Flush()
+    {
+        if (!ExecutionMetricsFlag.IsActive) return;
+        if (SLoad != 0) Metrics.AddSLoadOpcode(SLoad);
+        if (SStore != 0) Metrics.AddSStoreOpcode(SStore);
+        if (StorageDeleted != 0) Metrics.AddStorageDeleted(StorageDeleted);
+        if (Calls != 0) Metrics.AddCalls(Calls);
+        if (EmptyCalls != 0) Metrics.AddEmptyCalls(EmptyCalls);
+        if (Creates != 0) Metrics.AddCreates(Creates);
+        if (SelfDestructs != 0) Metrics.AddSelfDestructs(SelfDestructs);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/IVirtualMachine.cs
@@ -22,6 +22,7 @@ public interface IVirtualMachine<TGasPolicy>
     void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext);
     void SetTxExecutionContext(in TxExecutionContext txExecutionContext);
     int OpCodeCount { get; }
+    void FlushMetricsCounters();
 }
 
 /// <summary>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -91,8 +91,7 @@ public static partial class EvmInstructions
         where TEip8037 : struct, IFlag
         where TEip7708 : struct, IFlag
     {
-        // Increment global call metrics.
-        Metrics.IncrementCalls();
+        vm.MetricsCounters.IncrementCalls();
 
         // Clear previous return data.
         vm.ReturnData = null;
@@ -248,7 +247,7 @@ public static partial class EvmInstructions
                 }
                 state.AddToBalanceAndCreateIfNotExists(target, TOpCall.ExecutionType, in callValue, spec);
             }
-            Metrics.IncrementEmptyCalls();
+            vm.MetricsCounters.IncrementEmptyCalls();
             vm.ReturnData = null;
             return EvmExceptionType.None;
         }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -200,8 +200,7 @@ public static partial class EvmInstructions
         where TEip8037 : struct, IFlag
         where TEip7708 : struct, IFlag
     {
-        // Increment metrics for self-destruct operations.
-        Metrics.IncrementSelfDestructs();
+        vm.MetricsCounters.IncrementSelfDestructs();
 
         VmState<TGasPolicy> vmState = vm.VmState;
         IReleaseSpec spec = vm.Spec;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
@@ -77,8 +77,7 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
         where TEip8037 : struct, IFlag
     {
-        // Increment metrics counter for contract creation operations.
-        Metrics.IncrementCreates();
+        vm.MetricsCounters.IncrementCreates();
 
         // Obtain the current EVM specification and check if the call is static (static calls cannot create contracts).
         IReleaseSpec spec = vm.Spec;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -348,7 +348,7 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Increment the SSTORE opcode metric.
-        Metrics.IncrementSStoreOpcode();
+        vm.MetricsCounters.IncrementSStore();
 
         VmState<TGasPolicy> vmState = vm.VmState;
         // Disallow storage modifications in static calls.
@@ -409,7 +409,7 @@ public static partial class EvmInstructions
             vm.WorldState.Set(in storageCell, newIsZero ? BytesZero : bytes.ToArray());
             if (newIsZero)
             {
-                Metrics.IncrementStorageDeleted();
+                vm.MetricsCounters.IncrementStorageDeleted();
             }
         }
 
@@ -457,7 +457,7 @@ public static partial class EvmInstructions
         where TEip8037 : struct, IFlag
     {
         // Increment the SSTORE opcode metric.
-        Metrics.IncrementSStoreOpcode();
+        vm.MetricsCounters.IncrementSStore();
 
         VmState<TGasPolicy> vmState = vm.VmState;
         // Disallow storage modifications in static calls.
@@ -581,7 +581,7 @@ public static partial class EvmInstructions
             vm.WorldState.Set(in storageCell, newIsZero ? BytesZero : bytes.ToArray());
             if (newIsZero)
             {
-                Metrics.IncrementStorageDeleted();
+                vm.MetricsCounters.IncrementStorageDeleted();
             }
         }
 
@@ -635,8 +635,7 @@ public static partial class EvmInstructions
     {
         IReleaseSpec spec = vm.Spec;
 
-        // Increment the SLOAD opcode metric.
-        Metrics.IncrementSLoadOpcode();
+        vm.MetricsCounters.IncrementSLoad();
 
         // Deduct the gas cost for performing an SLOAD.
         TGasPolicy.Consume<SLoadGasCost>(ref gas, spec);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -347,7 +347,6 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        // Increment the SSTORE opcode metric.
         vm.MetricsCounters.IncrementSStore();
 
         VmState<TGasPolicy> vmState = vm.VmState;
@@ -456,7 +455,6 @@ public static partial class EvmInstructions
         where TUseNetGasStipendFix : struct, IFlag
         where TEip8037 : struct, IFlag
     {
-        // Increment the SSTORE opcode metric.
         vm.MetricsCounters.IncrementSStore();
 
         VmState<TGasPolicy> vmState = vm.VmState;

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -95,12 +95,6 @@ public class Metrics
     private static CacheLinePaddedLong _otherSelfDestructs;
     [Description("Number of SELFDESTRUCT calls on main processing thread.")]
     public static long MainThreadSelfDestructs => _mainSelfDestructs.Value;
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void IncrementSelfDestructs()
-    {
-        if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSelfDestructs.Value : ref _otherSelfDestructs.Value);
-    }
 
     [CounterMetric]
     [Description("Number of calls to other contracts.")]
@@ -109,12 +103,6 @@ public class Metrics
     private static CacheLinePaddedLong _otherCalls;
     [Description("Number of calls to other contracts on main processing thread.")]
     public static long MainThreadCalls => _mainCalls.Value;
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void IncrementCalls()
-    {
-        if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainCalls.Value : ref _otherCalls.Value);
-    }
 
     [CounterMetric]
     [Description("Number of SLOAD opcodes executed.")]
@@ -123,12 +111,6 @@ public class Metrics
     private static CacheLinePaddedLong _otherSLoadOpcode;
     [Description("Number of SLOAD opcodes executed on main processing thread.")]
     public static long MainThreadSLoadOpcode => _mainSLoadOpcode.Value;
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void IncrementSLoadOpcode()
-    {
-        if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSLoadOpcode.Value : ref _otherSLoadOpcode.Value);
-    }
 
     [CounterMetric]
     [Description("Number of SSTORE opcodes executed.")]
@@ -137,12 +119,6 @@ public class Metrics
     private static CacheLinePaddedLong _otherSStoreOpcode;
     [Description("Number of SSTORE opcodes executed on main processing thread.")]
     public static long MainThreadSStoreOpcode => _mainSStoreOpcode.Value;
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void IncrementSStoreOpcode()
-    {
-        if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainSStoreOpcode.Value : ref _otherSStoreOpcode.Value);
-    }
 
     [CounterMetric]
     [Description("Number of calls made to addresses without code.")]
@@ -243,12 +219,6 @@ public class Metrics
     private static CacheLinePaddedLong _mainStorageDeleted;
     private static CacheLinePaddedLong _otherStorageDeleted;
     internal static long MainThreadStorageDeleted => _mainStorageDeleted.Value;
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void IncrementStorageDeleted()
-    {
-        if (!ExecutionMetricsFlag.IsActive) return;
-        Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainStorageDeleted.Value : ref _otherStorageDeleted.Value);
-    }
 
     [CounterMetric]
     [Description("Number of code writes during execution.")]

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -80,6 +80,14 @@ public class Metrics
         Interlocked.Add(ref IsBlockProcessingThread ? ref _mainOpCodes.Value : ref _otherOpCodes.Value, count);
     }
 
+    internal static void AddSLoadOpcode(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainSLoadOpcode.Value : ref _otherSLoadOpcode.Value, count);
+    internal static void AddSStoreOpcode(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainSStoreOpcode.Value : ref _otherSStoreOpcode.Value, count);
+    internal static void AddStorageDeleted(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStorageDeleted.Value : ref _otherStorageDeleted.Value, count);
+    internal static void AddCalls(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainCalls.Value : ref _otherCalls.Value, count);
+    internal static void AddEmptyCalls(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainEmptyCalls.Value : ref _otherEmptyCalls.Value, count);
+    internal static void AddCreates(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainCreates.Value : ref _otherCreates.Value, count);
+    internal static void AddSelfDestructs(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainSelfDestructs.Value : ref _otherSelfDestructs.Value, count);
+
     [CounterMetric]
     [Description("Number of SELFDESTRUCT calls.")]
     public static long SelfDestructs => _mainSelfDestructs.Value + _otherSelfDestructs.Value;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1236,6 +1236,7 @@ namespace Nethermind.Evm.TransactionProcessing
                     : VirtualMachine.ExecuteTransaction<OnFlag>(state, WorldState, tracer);
 
                 Metrics.IncrementOpCodes(VirtualMachine.OpCodeCount);
+                VirtualMachine.FlushMetricsCounters();
                 gasAvailable = state.Gas;
 
                 if (tracer.IsTracingAccess)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -116,6 +116,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
 
     public VmState<TGasPolicy> VmState { get => _currentState; protected set => _currentState = value; }
     public int OpCodeCount { get; set; }
+    internal ExecutionMetricsCounters MetricsCounters;
+
+    public void FlushMetricsCounters() => MetricsCounters.Flush();
 
     /// <summary>
     /// Executes a transaction by iteratively processing call frames until a top-level call returns
@@ -153,6 +156,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
         IReleaseSpec spec = BlockExecutionContext.Spec;
         PrepareOpcodes<TTracingInst>(spec);
         OpCodeCount = 0;
+        MetricsCounters = default;
         // Initialize the code repository and set up the initial execution state.
         _codeInfoRepository = TxExecutionContext.CodeInfoRepository;
         _currentState = vmState;
@@ -1130,10 +1134,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
         // If no machine code is present, treat the call as empty.
         if (codeSpan.Length == 0)
         {
-            // Increment a metric for empty calls if this is a nested call.
             if (!vmState.IsTopLevel)
             {
-                Metrics.IncrementEmptyCalls();
+                MetricsCounters.IncrementEmptyCalls();
             }
             goto Empty;
         }


### PR DESCRIPTION
## Changes

Batches the per-opcode execution-metric counters into a single per-transaction flush, removing a per-opcode atomic on globally-shared counters.

`SLOAD`/`SSTORE`/`StorageDeleted`/`CALL`/empty-`CALL`/`CREATE`/`SELFDESTRUCT` each did an `Interlocked.Increment` on a process-wide counter for every opcode execution. That counter is shared by the block-import thread and every prewarm worker, so it is a cross-thread contention point on the hot path (the same shape the `TrieStore` counters showed degrading ~70× at 10 threads).

- New `ExecutionMetricsCounters` struct on the (single-threaded-per-transaction) `VirtualMachine` instance accumulates these counts with plain non-atomic adds, gated by `ExecutionMetricsFlag` exactly like the globals.
- It is flushed once per transaction with one `Interlocked.Add` per non-zero counter, next to the existing `Metrics.IncrementOpCodes(OpCodeCount)` flush.

This mirrors two existing patterns: `VirtualMachine.OpCodeCount` (accumulate-then-flush-per-tx) and `LocalMetrics.StorageWrites` (per-scope accumulator flushed to the atomic global). The simple-transfer fast path's once-per-tx `EmptyCalls` increment stays a direct `Interlocked` — it is not on the per-opcode path.

Exported counter totals are unchanged (`ExecutionMetricsBatchingTests` pins that `SLOAD`/`SSTORE` counts flush exactly), so this is behavior-neutral; only the *timing and contention* of the counter writes change.

## Measurement

The benefit is contention reduction under parallel prewarm, which a single-threaded micro-benchmark can't capture (the single-thread effect is only the ~10–15 ns atomic per counted opcode). It should be validated with a multi-threaded reproducible **realblocks** run rather than the per-opcode micro-benchmark. I'll trigger that on this PR.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- New `ExecutionMetricsBatchingTests` pins exact counter totals through the batch + flush.
- Full `Nethermind.Evm.Test` (4770) passes; both build flavors compile (default and `-p:EnableZkEvm=true`).
- Pending: multi-threaded realblocks benchmark for the contention gain.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
