### PR TITLE
Fix contradictions, fabricated APIs, and stale facts in agent rules and skills

### DIFF
--- a/.agents/rules/agent-skills.md
+++ b/.agents/rules/agent-skills.md
@@ -18,3 +18,5 @@ mkdir -p .agents/skills/<name>
 ln -s ../../.agents/skills/<name> .claude/skills/<name>
 ln -s ../../.agents/skills/<name> .cursor/skills/<name>
 ```
+
+On Windows, symlinks require `git config core.symlinks true` plus Developer Mode (or an elevated shell); otherwise `ln -s` and checkouts silently produce plain text stubs and the skills never load. Verify with `Get-Item` (`LinkType` must be `SymbolicLink`) — the fix procedure is in `.claude/CLAUDE.md`.

--- a/.agents/rules/di-patterns.md
+++ b/.agents/rules/di-patterns.md
@@ -16,11 +16,13 @@ Nethermind uses Autofac for DI with a custom DSL defined in `Nethermind.Core/Con
 | `WorldStateModule` | `IWorldStateManager`, `IStateReader`, trie store, node storage | New state backend or pruning strategy |
 | `BlockProcessingModule` | `ITransactionProcessor`, `IBlockProcessor`, `IVirtualMachine`, validators | New transaction type or block processing hook |
 | `BlockTreeModule` | `IBlockTree`, `IBlockStore`, `IHeaderStore`, `IReceiptStorage` | New chain storage or receipt backend |
-| `NetworkModule` | Message serializers (Eth62–Eth69, Snap, Witness), RLPx host | New protocol version or message type |
+| `NetworkModule` | devp2p message serializers and protocol handlers (eth, snap), RLPx host | New protocol version or message type |
 | `DiscoveryModule` | Peer discovery, `INodeSource` | Discovery protocol changes |
 | `RpcModules` | JSON-RPC modules (`Eth`, `Debug`, `Admin`, etc.) | New RPC method module |
 | `PrewarmerModule` | State prewarming for block production | Prewarmer tuning |
 | `BuiltInStepsModule` | Node initialization step chain | New startup step |
+
+The table is not exhaustive — list `Nethermind.Init/Modules/` for the current set (e.g. flat-state, pruning, and monitoring modules are registered there too).
 
 ## WorldState Architecture
 
@@ -93,23 +95,16 @@ builder
 
 ## Test setup pattern (preferred: direct DI)
 
-This is the canonical container setup — test-infrastructure.md references it rather than repeating it. Unit tests use `PseudoNethermindModule` (full production wiring without init steps); benchmarks use the full `NethermindModule` with MemDb overrides.
+This is the canonical container setup — test-infrastructure.md references it rather than repeating it. Both unit tests and benchmarks use `PseudoNethermindModule` (wraps the full production `NethermindModule` without running init steps) plus `TestEnvironmentModule` (MemDb via `MemDbFactory`, test logging, in-process channels):
 
 ```csharp
-// Unit tests
 IContainer container = new ContainerBuilder()
     .AddModule(new PseudoNethermindModule(spec, configProvider, logManager))
     .AddModule(new TestEnvironmentModule(nodeKey, null))
     .Build();
-
-// Benchmarks
-IContainer container = new ContainerBuilder()
-    .AddModule(new NethermindModule(spec, configProvider, logManager))
-    .AddModule(new TestEnvironmentModule(nodeKey, null))  // wires MemDb, test logging
-    .Build();
 ```
 
-`TestNethermindModule` is a convenience wrapper that combines `PseudoNethermindModule` + `TestEnvironmentModule` in one module (used by `Nethermind.Evm.Benchmark`).
+`TestNethermindModule` combines both in one module with a `TestSpecProvider` default — the preferred shorthand, and what `Nethermind.Evm.Benchmark` uses (`new TestNethermindModule(Osaka.Instance)`).
 
 ## Anti-pattern
 - Using the form `.Add<IFoo>(ctx => new Foo(ctx.Resolve<Dep1>(), ctx.Resolve<Dep2>()))` is an anti-pattern. It will cause changes to the wiring when `Foo` adds new dependencies, which increases review load.

--- a/.agents/rules/di-patterns.md
+++ b/.agents/rules/di-patterns.md
@@ -93,15 +93,23 @@ builder
 
 ## Test setup pattern (preferred: direct DI)
 
+This is the canonical container setup — test-infrastructure.md references it rather than repeating it. Unit tests use `PseudoNethermindModule` (full production wiring without init steps); benchmarks use the full `NethermindModule` with MemDb overrides.
+
 ```csharp
-// Preferred — use production modules directly with test overrides
+// Unit tests
+IContainer container = new ContainerBuilder()
+    .AddModule(new PseudoNethermindModule(spec, configProvider, logManager))
+    .AddModule(new TestEnvironmentModule(nodeKey, null))
+    .Build();
+
+// Benchmarks
 IContainer container = new ContainerBuilder()
     .AddModule(new NethermindModule(spec, configProvider, logManager))
-    .AddModule(new TestEnvironmentModule(nodeKey, null))
+    .AddModule(new TestEnvironmentModule(nodeKey, null))  // wires MemDb, test logging
     .Build();
 ```
 
-Never add test-specific code to production modules. Overrides belong in `TestEnvironmentModule`, `TestBlockProcessingModule`, or a new test module passed to `Build`.
+`TestNethermindModule` is a convenience wrapper that combines `PseudoNethermindModule` + `TestEnvironmentModule` in one module (used by `Nethermind.Evm.Benchmark`).
 
 ## Anti-pattern
 - Using the form `.Add<IFoo>(ctx => new Foo(ctx.Resolve<Dep1>(), ctx.Resolve<Dep2>()))` is an anti-pattern. It will cause changes to the wiring when `Foo` adds new dependencies, which increases review load.

--- a/.agents/rules/git.md
+++ b/.agents/rules/git.md
@@ -7,3 +7,4 @@ Rules to follow when performing tasks around git version control, creating branc
 - Be wary of force pushing to branches, always confirm with the user beforehand.
 - When performing a merge, ensure that no features are silently removed. If you are unsure which code to keep when resolving a merge conflict consult the user in an interactive manner.
 - When creating a new branch, follow the convention of starting the branch name with: `perf/`, `feature/`, `test/`, `fix/` or `refactor/`.
+- When opening a PR non-interactively (`gh pr create --body ...`), GitHub's template auto-fill does not apply — populate the body from [.github/pull_request_template.md](../../.github/pull_request_template.md) yourself (Changes list, type-of-change checkboxes, Testing/Documentation sections). The checkboxes drive automatic PR labeling.

--- a/.agents/rules/test-infrastructure.md
+++ b/.agents/rules/test-infrastructure.md
@@ -27,17 +27,7 @@ Multi-instance setup for sync testing. Reference for setting up full component s
 
 ## Benchmark setup
 
-For benchmarks, use production DI modules with `DiagnosticMode.MemDb` overrides. Don't manually construct `WorldState`, `TrieStore`, `BlockProcessor` etc.
-
-Example from `Nethermind.Evm.Benchmark` (correct pattern):
-
-```csharp
-// Use production modules; override only what you need
-IContainer container = new ContainerBuilder()
-    .AddModule(new NethermindModule(spec, configProvider, logManager))
-    .AddModule(new TestEnvironmentModule(nodeKey, null))  // wires MemDb, test logging
-    .Build();
-```
+For benchmarks, use production DI modules with `DiagnosticMode.MemDb` overrides — see the canonical container setup in [di-patterns.md](di-patterns.md) "Test setup pattern". `Nethermind.Evm.Benchmark` uses the `TestNethermindModule` convenience wrapper (wires `PseudoNethermindModule` + `TestEnvironmentModule` in one module). Don't manually construct `WorldState`, `TrieStore`, `BlockProcessor` etc.
 
 ## DI anti-pattern — never manually new up infrastructure
 
@@ -48,21 +38,7 @@ ITransactionProcessor txProcessor = new TransactionProcessor(specProvider, world
 IBlockProcessor blockProcessor = new BlockProcessor(..., txProcessor, worldState, ...);
 ```
 
-**Correct — use DI with targeted overrides:**
-
-```csharp
-// Unit tests: direct DI with targeted overrides
-IContainer container = new ContainerBuilder()
-    .AddModule(new PseudoNethermindModule(spec, configProvider, logManager))
-    .AddModule(new TestEnvironmentModule(nodeKey, null))
-    .Build();
-
-// Benchmarks: production modules + DiagnosticMode.MemDb
-IContainer container = new ContainerBuilder()
-    .AddModule(new NethermindModule(spec, configProvider, LimboLogs.Instance))
-    .AddModule(new TestEnvironmentModule(nodeKey, null))
-    .Build();
-```
+**Correct** — direct DI with targeted overrides: `PseudoNethermindModule` for unit tests, full `NethermindModule` for benchmarks; the canonical snippets are in [di-patterns.md](di-patterns.md) "Test setup pattern".
 
 The rule: **if production modules already wire a component, use them — don't construct it yourself**.
 

--- a/.agents/rules/test-infrastructure.md
+++ b/.agents/rules/test-infrastructure.md
@@ -4,17 +4,16 @@ This is the single rule for all test and benchmark projects. It applies to any `
 
 ## TestBlockchain (`Nethermind.Core.Test/Blockchain/TestBlockchain.cs`)
 
-Legacy wrapper around DI. Prefer direct `ContainerBuilder` + production modules for new tests. If you do use `TestBlockchain`, always dispose with `using`:
+Legacy wrapper around DI. Prefer direct `ContainerBuilder` + production modules for new tests. `TestBlockchain.Build` is `protected` — construct via a subclass factory such as `BasicTestBlockchain.Create(...)`, and always dispose with `using`:
 
 ```csharp
 // Basic usage — always use `using` for disposal
-using TestBlockchain chain = await TestBlockchain.ForMainnet().Build();
+using BasicTestBlockchain chain = await BasicTestBlockchain.Create();
 
-// With customization
-using TestBlockchain chain = await TestBlockchain.ForMainnet()
-    .Build(builder => builder
-        .AddSingleton<ISpecProvider>(mySpecProvider)
-        .AddDecorator<ISpecProvider>((ctx, sp) => WrapSpecProvider(sp)));
+// With customization — pass a container configurer
+using BasicTestBlockchain chain = await BasicTestBlockchain.Create(builder => builder
+    .AddSingleton<ISpecProvider>(mySpecProvider)
+    .AddDecorator<ISpecProvider>((ctx, sp) => WrapSpecProvider(sp)));
 ```
 
 **Provides**: `BlockTree`, `StateReader`, `TxPool`, `BlockProcessor`, `MainProcessingContext`, and 30+ other components — all wired via `PseudoNethermindModule`.
@@ -27,7 +26,7 @@ Multi-instance setup for sync testing. Reference for setting up full component s
 
 ## Benchmark setup
 
-For benchmarks, use production DI modules with `DiagnosticMode.MemDb` overrides — see the canonical container setup in [di-patterns.md](di-patterns.md) "Test setup pattern". `Nethermind.Evm.Benchmark` uses the `TestNethermindModule` convenience wrapper (wires `PseudoNethermindModule` + `TestEnvironmentModule` in one module). Don't manually construct `WorldState`, `TrieStore`, `BlockProcessor` etc.
+For benchmarks, use production DI modules with in-memory DB overrides (`TestEnvironmentModule` swaps `IDbFactory` for `MemDbFactory`) — see the canonical container setup in [di-patterns.md](di-patterns.md) "Test setup pattern". `Nethermind.Evm.Benchmark` uses the `TestNethermindModule` convenience wrapper (wires `PseudoNethermindModule` + `TestEnvironmentModule` in one module). Don't manually construct `WorldState`, `TrieStore`, `BlockProcessor` etc.
 
 ## DI anti-pattern — never manually new up infrastructure
 
@@ -38,9 +37,15 @@ ITransactionProcessor txProcessor = new TransactionProcessor(specProvider, world
 IBlockProcessor blockProcessor = new BlockProcessor(..., txProcessor, worldState, ...);
 ```
 
-**Correct** — direct DI with targeted overrides: `PseudoNethermindModule` for unit tests, full `NethermindModule` for benchmarks; the canonical snippets are in [di-patterns.md](di-patterns.md) "Test setup pattern".
+**Correct** — direct DI with targeted overrides: `PseudoNethermindModule` + `TestEnvironmentModule` (or the `TestNethermindModule` wrapper) for both unit tests and benchmarks; the canonical snippet is in [di-patterns.md](di-patterns.md) "Test setup pattern".
 
 The rule: **if production modules already wire a component, use them — don't construct it yourself**.
+
+## Running tests (.NET 10 / Microsoft.Testing.Platform)
+
+- `dotnet test --project <path>.csproj -c release -- --filter "FullyQualifiedName~Name"`
+- Do NOT pass `--nologo` or `-v q` — MTP treats unknown arguments as filter tokens and reports **zero tests ran**, which reads as a false green. Verify the output names the tests it executed.
+- Run test projects sequentially, or `dotnet build` once up front — parallel `dotnet test` invocations collide on locked DLLs.
 
 ## Test guidelines
 

--- a/.agents/skills/fix-nethtest/SKILL.md
+++ b/.agents/skills/fix-nethtest/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
     Grep,
     Glob,
     Edit,
-    Agent,
+    Write,
   ]
 ---
 
@@ -100,7 +100,7 @@ This is the most common failure pattern for new forks. Follow these steps:
    - These guards fail when the test harness doesn't set the header field
 
 5. **Check the test harness header construction**:
-   - **State tests:** `src/Nethermind/Ethereum.Test.Base/GeneralTestBase.cs` — look at the `BlockHeader` initializer (around line 115-138)
+   - **State tests:** `src/Nethermind/Ethereum.Test.Base/GeneralStateTestBase.cs` — look at the `BlockHeader` initializer
    - **Blockchain tests:** `src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs`
    - Look for conditional defaults that use **type checks** (`is Cancun`, `is Prague`) instead of **spec flag checks** (`IsEip4844Enabled`, `IsEip7702Enabled`) — type checks only match the exact class, not subclasses or later forks
    - Look for missing defaults for new fork fields (e.g., `ExcessBlobGas`, `RequestsHash`, `BlockAccessListHash`)
@@ -144,7 +144,8 @@ This is the most common failure pattern for new forks. Follow these steps:
    - Re-read the trace output
    - Return to Phase 2 with the new trace
    - Repeat until pass or root cause is confirmed as upstream
-4. **Report the result** — include:
+4. **Add a regression test** when the root cause was a Nethermind bug (AGENTS.md requires one for every bug fix) — extend an existing test file with a `[TestCase]` where possible; create a new test file only if no suitable one exists
+5. **Report the result** — include:
    - Root cause (one sentence)
    - What was fixed (file:line)
    - Verification result (pass/fail + new state root)
@@ -157,7 +158,7 @@ This is the most common failure pattern for new forks. Follow these steps:
 | Purpose | Path (relative to `src/Nethermind/`) |
 |---|---|
 | Test runner CLI | `Nethermind.Test.Runner/Program.cs` |
-| State test execution + header | `Ethereum.Test.Base/GeneralTestBase.cs` |
+| State test execution + header | `Ethereum.Test.Base/GeneralStateTestBase.cs` |
 | Blockchain test execution | `Ethereum.Test.Base/BlockchainTestBase.cs` |
 | Test JSON parsing | `Ethereum.Test.Base/JsonToEthereumTest.cs` |
 | Opcode registration + spec gates | `Nethermind.Evm/Instructions/EvmInstructions.cs` |
@@ -176,10 +177,10 @@ This is the most common failure pattern for new forks. Follow these steps:
 
 3. **State root mismatch** — execution completes without EVM errors but produces the wrong state root. Causes include: incorrect storage writes (wrong slot or value), wrong balance updates (fee burning, coinbase rewards, value transfer edge cases), missing or extra account touches that affect empty-account cleanup (EIP-158), or wrong nonce increments.
 
-4. **Missing header field default** — new EIPs add nullable fields to `BlockHeader`. The test harness must default them for forks that enable them when the test JSON doesn't provide them (e.g., `ExcessBlobGas = 0` for EIP-4844+ forks).
+4. **Missing header field default** — covered in Phase 3, "Check the test harness header construction".
 
-5. **Instruction runtime guard** — an opcode can be registered in the lookup table but still fail if its implementation checks a header field that wasn't set (e.g., `BLOBBASEFEE` checks `ExcessBlobGas.HasValue`).
+5. **Instruction runtime guard** — covered in Phase 3, "For BadInstruction failures" step 4.
 
 6. **Validation errors** — missing validation that should reject invalid data (e.g., not checking transaction type constraints, accepting out-of-range values) or overly strict validation that rejects valid inputs (e.g., rejecting new transaction fields not yet accounted for, wrong bounds on EIP-introduced parameters). For blockchain tests, check block and transaction validators. For state tests, check `TransactionProcessor` validation and `BlockValidator`.
 
-7. **Missing blob schedule override** — test JSON `config.blobSchedule` overrides blob parameters per fork. If `JsonToEthereumTest.LoadSpec()` doesn't handle the fork name, parameters revert to defaults.
+7. **Missing blob schedule override** — covered in Phase 3, "For state root mismatches" step 5.

--- a/.agents/skills/gas-benchmark/SKILL.md
+++ b/.agents/skills/gas-benchmark/SKILL.md
@@ -6,11 +6,10 @@ allowed-tools:
   - Bash(gh workflow run *)
   - Bash(gh release *)
   - Bash(gh api repos/NethermindEth/*)
+  - Bash(MSYS_NO_PATHCONV=1 gh *)
   - Bash(git branch *)
   - Bash(git log *)
   - Bash(git status *)
-  - Bash(cd *)
-  - Bash(ls *)
   - Bash(mkdir *)
   - Bash(find *)
   - Bash(unzip *)
@@ -18,7 +17,6 @@ allowed-tools:
   - Bash(tar *)
   - Bash(wc *)
   - Bash(sleep *)
-  - Bash(until *)
   - Bash(date *)
   - Bash(bash *)
   - Bash(sed *)
@@ -27,6 +25,11 @@ allowed-tools:
   - Bash(sort *)
   - Bash(head *)
   - Bash(tail *)
+  - Bash(tr *)
+  - Bash(xargs *)
+  - Bash(base64 *)
+  - Bash(echo *)
+  - Bash(printf *)
   - Read
   - Grep
   - Glob
@@ -167,6 +170,8 @@ Map network to genesis filename:
 - `jochemnet` → `generator-amsterdam-jochemnet.json`
 - `mainnet` → (no genesis_file flag)
 
+The genesis filename embeds the fork name. For a fork other than `amsterdam`, list the release assets (Step 0a command) and pick the matching `generator-<fork>-<network>.json` instead of the mapping above.
+
 ### Step 0e: Confirm with user
 
 Before proceeding, show the resolved configuration:
@@ -273,6 +278,8 @@ Report the run URL to the user immediately after triggering.
 
 **THIS PHASE IS MANDATORY. Always run it in full, even if the workflow reported success. Never skip or abbreviate it. A "success" workflow conclusion does NOT mean the blocks processed correctly — Nethermind exceptions can occur mid-run without failing the workflow.**
 
+All snippets in this phase are working-directory-independent (absolute paths, no `cd`). Keep them that way: the Bash tool's working directory persists across tool calls while variables do not — rely on neither.
+
 ### 4a. Exception scan (NEVER SKIP)
 
 Fetch job logs: `gh run view --job=<job-id> --repo NethermindEth/gas-benchmarks --log`
@@ -305,28 +312,29 @@ Note: do NOT exclude `dotnet` — real Nethermind exceptions contain .NET runtim
 mkdir -p /tmp/gb-results
 gh run download <run-id> --repo NethermindEth/gas-benchmarks \
   -n "results-1-nethermind-<cleaned-test-path>" -D /tmp/gb-results
-cd /tmp/gb-results && unzip -o *.zip
+for z in /tmp/gb-results/*.zip; do unzip -o "$z" -d /tmp/gb-results; done
 ```
 
 **Step 2 — Extract per-test timings from result files:**
 Each test produces a `nethermind_results_1_<test-name>.txt` file containing the `engine_newPayloadV<N>` timing (the actual block processing time). The newPayload version is fork-dependent — detect it from the files rather than hardcoding:
 
 ```bash
-cd /tmp/gb-results/results
-NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" nethermind_results_1_*.txt | head -1)
+R=/tmp/gb-results/results
+NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" "$R"/nethermind_results_1_*.txt | head -1)
 [ -n "$NP" ] || { echo "No engine_newPayloadV<N> timing found in result files" >&2; exit 1; }
-ls nethermind_results_1_*.txt | while IFS= read -r f; do
+for f in "$R"/nethermind_results_1_*.txt; do
   ms=$(grep -A3 "$NP:" "$f" | grep "Average:" | awk '{print $2}')
-  name=$(echo "$f" | sed 's/nethermind_results_1_//;s/\.txt$//')
+  name="${f##*/}"; name="${name#nethermind_results_1_}"; name="${name%.txt}"
   echo "$ms $name"
 done | sort -rn
 ```
 
-**Step 3 — Compute aggregates** (re-derive `NP` — shell state does not persist between tool calls):
+**Step 3 — Compute aggregates** (re-derive `R` and `NP` — variables do not persist between tool calls):
 ```bash
-NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" nethermind_results_1_*.txt | head -1)
+R=/tmp/gb-results/results
+NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" "$R"/nethermind_results_1_*.txt | head -1)
 [ -n "$NP" ] || { echo "No engine_newPayloadV<N> timing found in result files" >&2; exit 1; }
-ls nethermind_results_1_*.txt | while IFS= read -r f; do
+for f in "$R"/nethermind_results_1_*.txt; do
   ms=$(grep -A3 "$NP:" "$f" | grep "Average:" | awk '{print $2}')
   [ -n "$ms" ] && echo "$ms"
 done | awk '{sum+=$1; vals[NR]=$1; n=NR} END {
@@ -347,20 +355,20 @@ gh run download <pr-run-id> --repo NethermindEth/gas-benchmarks \
   -n "results-1-nethermind-<cleaned-test-path>" -D /tmp/gb-pr
 gh run download <base-run-id> --repo NethermindEth/gas-benchmarks \
   -n "results-1-nethermind-<cleaned-test-path>" -D /tmp/gb-base
-cd /tmp/gb-pr && unzip -o *.zip
-cd /tmp/gb-base && unzip -o *.zip
+for z in /tmp/gb-pr/*.zip; do unzip -o "$z" -d /tmp/gb-pr; done
+for z in /tmp/gb-base/*.zip; do unzip -o "$z" -d /tmp/gb-base; done
 
 # Compare per-test (sorted by delta); detect the newPayload version PER RUN — the two runs may target different forks
-cd /tmp/gb-pr/results
-PR_NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" nethermind_results_1_*.txt | head -1)
-BASE_NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" /tmp/gb-base/results/nethermind_results_1_*.txt | head -1)
+PR=/tmp/gb-pr/results; BASE=/tmp/gb-base/results
+PR_NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" "$PR"/nethermind_results_1_*.txt | head -1)
+BASE_NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" "$BASE"/nethermind_results_1_*.txt | head -1)
 [ -n "$PR_NP" ] && [ -n "$BASE_NP" ] || { echo "newPayload timing not found in one of the runs" >&2; exit 1; }
-ls nethermind_results_1_*.txt | while IFS= read -r f; do
+for f in "$PR"/nethermind_results_1_*.txt; do
   pr_ms=$(grep -A3 "$PR_NP:" "$f" | grep "Average:" | awk '{print $2}')
-  base_ms=$(grep -A3 "$BASE_NP:" "/tmp/gb-base/results/$f" 2>/dev/null \
+  base_ms=$(grep -A3 "$BASE_NP:" "$BASE/${f##*/}" 2>/dev/null \
     | grep "Average:" | awk '{print $2}')
   if [ -n "$pr_ms" ] && [ -n "$base_ms" ]; then
-    short=$(echo "$f" | sed 's/nethermind_results_1_//;s/\.txt$//')
+    short="${f##*/}"; short="${short#nethermind_results_1_}"; short="${short%.txt}"
     delta=$(awk "BEGIN{printf \"%.1f\", (($pr_ms-$base_ms)/$base_ms)*100}")
     echo "$delta|$pr_ms|$base_ms|$short"
   fi
@@ -409,7 +417,7 @@ If present:
    find /tmp/dottrace-<run-id> -name "*.xml" -not -name "*pattern*" -not -name "*conversion*"
    ```
 
-3. **Top hotspots** — show the top 20 functions by OwnTime (self-time excluding callees):
+3. **Top hotspots** — show the top 20 functions by OwnTime (self-time excluding callees). The script path is relative to the nethermind repo root (the Bash tool's default working directory — Phase 4 snippets never change it):
    ```
    bash scripts/dottrace-report.sh top <report.xml> 20
    ```

--- a/.agents/skills/gas-benchmark/SKILL.md
+++ b/.agents/skills/gas-benchmark/SKILL.md
@@ -30,7 +30,7 @@ allowed-tools:
   - Read
   - Grep
   - Glob
-argument-hint: "[--branch NAME] [--image NAME] [--filter PATTERN] [--network NETWORK] [--fork FORK] [--dottrace] [--analyze-run RUN_ID] [--compare RUN_ID]"
+argument-hint: "[--branch NAME] [--image NAME] [--filter PATTERN] [--network NETWORK] [--fork FORK] [--dottrace|--no-dottrace] [--gas-size SIZE] [--no-restart] [--release TAG] [--gas-benchmarks-ref REF] [--analyze-run RUN_ID] [--compare RUN_ID]"
 ---
 
 # Gas Benchmark Pipeline
@@ -53,13 +53,7 @@ When called without arguments (`/gas-benchmark`), do NOT proceed with defaults. 
 3. **Ask for the network**: "Which network? (`perf-devnet-3`, `jochemnet`, `mainnet`)"
 
 4. **Ask for filter** — help the user discover available tests first:
-   a. After the release and network are known, list available test categories:
-      ```
-      gh release download <tag> --repo NethermindEth/gas-benchmarks \
-        --pattern "generated-tests-stateful-<network>.tar.gz" -D /tmp/gb-tests --clobber
-      tar tzf /tmp/gb-tests/generated-tests-stateful-<network>.tar.gz \
-        | sed 's|.*/||' | sed 's/\.txt$//' | sed 's/\[.*//' | sort -u | grep -v "^$\|funding\|gas-bump"
-      ```
+   a. After the release and network are known, list available test categories using the commands in "Filter reference — How to discover available tests" below.
    b. Show the user a categorized list of available tests. Example output:
       ```
       Available test categories for perf-devnet-3:
@@ -73,11 +67,7 @@ When called without arguments (`/gas-benchmark`), do NOT proceed with defaults. 
       - Describe what you're interested in (e.g., 'storage write scenarios with existing slots')
       - Leave empty to run all tests"
    d. If the user gives a natural-language description, map it to the right filter pattern by inspecting the test parameter names in the archive (e.g., `existing_slots_True`, `write_new_value_False`, `CacheStrategy.NO_CACHE`).
-   e. To show the user the full parameter space for a category:
-      ```
-      tar tzf /tmp/gb-tests/generated-tests-stateful-<network>.tar.gz \
-        | grep "setup/.*<category>" | sed 's|.*/setup/||; s/\.txt$//' | head -20
-      ```
+   e. To show the user the full parameter space for a category, use "Filter reference — How to explore parameters" below.
 
 5. **Ask about dotTrace**: "Do you want dotTrace profiling? (requires building a diag image, adds ~2min to build)"
 
@@ -96,7 +86,7 @@ Parse `$ARGUMENTS` for these flags:
 | `--filter` | (none) | Test filter pattern passed to repricing workflow |
 | `--network` | `perf-devnet-3` | Network name (perf-devnet-3, jochemnet, mainnet) |
 | `--fork` | `amsterdam` | Fork name (amsterdam, osaka) |
-| `--dottrace` | (ask user) | Enable dotTrace profiling — builds diag image, passes diagnostics flags |
+| `--dottrace` / `--no-dottrace` | interactive: ask; non-interactive: off | dotTrace profiling — builds diag image, passes diagnostics flags. Non-interactive runs enable it only when `--dottrace` is passed (the CI workflow defaults dottrace to true and passes `--dottrace` explicitly; it omits the flag when disabled). |
 | `--gas-size` | `100M` | Gas size filter (appended as `benchmark_<size>` to filter). Default 100M. |
 | `--no-restart` | (false) | Disable restart-before-testing for stateful tests (restart is on by default) |
 | `--release` | (discovered) | Override release tag — skips interactive selection |
@@ -319,21 +309,25 @@ cd /tmp/gb-results && unzip -o *.zip
 ```
 
 **Step 2 — Extract per-test timings from result files:**
-Each test produces a `nethermind_results_1_<test-name>.txt` file containing `engine_newPayloadV5` timing (the actual block processing time).
+Each test produces a `nethermind_results_1_<test-name>.txt` file containing the `engine_newPayloadV<N>` timing (the actual block processing time). The newPayload version is fork-dependent — detect it from the files rather than hardcoding:
 
 ```bash
 cd /tmp/gb-results/results
+NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" nethermind_results_1_*.txt | head -1)
+[ -n "$NP" ] || { echo "No engine_newPayloadV<N> timing found in result files" >&2; exit 1; }
 ls nethermind_results_1_*.txt | while IFS= read -r f; do
-  ms=$(grep -A3 "engine_newPayloadV5:" "$f" | grep "Average:" | awk '{print $2}')
+  ms=$(grep -A3 "$NP:" "$f" | grep "Average:" | awk '{print $2}')
   name=$(echo "$f" | sed 's/nethermind_results_1_//;s/\.txt$//')
   echo "$ms $name"
 done | sort -rn
 ```
 
-**Step 3 — Compute aggregates:**
+**Step 3 — Compute aggregates** (re-derive `NP` — shell state does not persist between tool calls):
 ```bash
+NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" nethermind_results_1_*.txt | head -1)
+[ -n "$NP" ] || { echo "No engine_newPayloadV<N> timing found in result files" >&2; exit 1; }
 ls nethermind_results_1_*.txt | while IFS= read -r f; do
-  ms=$(grep -A3 "engine_newPayloadV5:" "$f" | grep "Average:" | awk '{print $2}')
+  ms=$(grep -A3 "$NP:" "$f" | grep "Average:" | awk '{print $2}')
   [ -n "$ms" ] && echo "$ms"
 done | awk '{sum+=$1; vals[NR]=$1; n=NR} END {
   asort(vals)
@@ -356,11 +350,14 @@ gh run download <base-run-id> --repo NethermindEth/gas-benchmarks \
 cd /tmp/gb-pr && unzip -o *.zip
 cd /tmp/gb-base && unzip -o *.zip
 
-# Compare per-test (sorted by delta)
+# Compare per-test (sorted by delta); detect the newPayload version PER RUN — the two runs may target different forks
 cd /tmp/gb-pr/results
+PR_NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" nethermind_results_1_*.txt | head -1)
+BASE_NP=$(grep -ohm1 "engine_newPayloadV[0-9]*" /tmp/gb-base/results/nethermind_results_1_*.txt | head -1)
+[ -n "$PR_NP" ] && [ -n "$BASE_NP" ] || { echo "newPayload timing not found in one of the runs" >&2; exit 1; }
 ls nethermind_results_1_*.txt | while IFS= read -r f; do
-  pr_ms=$(grep -A3 "engine_newPayloadV5:" "$f" | grep "Average:" | awk '{print $2}')
-  base_ms=$(grep -A3 "engine_newPayloadV5:" "/tmp/gb-base/results/$f" 2>/dev/null \
+  pr_ms=$(grep -A3 "$PR_NP:" "$f" | grep "Average:" | awk '{print $2}')
+  base_ms=$(grep -A3 "$BASE_NP:" "/tmp/gb-base/results/$f" 2>/dev/null \
     | grep "Average:" | awk '{print $2}')
   if [ -n "$pr_ms" ] && [ -n "$base_ms" ]; then
     short=$(echo "$f" | sed 's/nethermind_results_1_//;s/\.txt$//')
@@ -378,6 +375,7 @@ Present results as a markdown table sorted by delta, then show aggregates (AVG, 
 
 Extract block operation counts:
 ```
+# the -v filter drops known noise rows from non-test blocks; the whitespace in "sstore     10" is exact and intentional
 grep -E "Block.*sload|Block.*sstore" <logs> | grep -v "sstore     10"
 ```
 Report sload/sstore/create counts for the heaviest test blocks.
@@ -440,15 +438,15 @@ If present:
 
 ## Phase 5 — Report
 
-Always include the block phase breakdown first:
+Always include the block phase breakdown first. Ranges and counts come from the run's logs — they differ per release; the values below are placeholders, not expected numbers:
 
 ```
 ### Block Phases
 | Phase | Block Range | Count | Description |
 |-------|------------|-------|-------------|
-| Gas bump | 24358001–24363001 | 5001 | Empty gas-limit ramp blocks |
-| Setup | 24363002–24363003 | 180 | Pre-state preparation |
-| Testing | 24363004–24363183 | 180 | Actual benchmark execution |
+| Gas bump | <first>-<last> | N | Empty gas-limit ramp blocks |
+| Setup | <first>-<last> | N | Pre-state preparation |
+| Testing | <first>-<last> | N | Actual benchmark execution |
 ```
 
 If testing block count is 0, display prominently:
@@ -470,8 +468,8 @@ Then the summary table (timings ONLY from testing blocks):
 | Testing blocks | N |
 | AVG processing | X ms |
 | MEDIAN | X ms |
+| P90 | X ms |
 | P95 | X ms |
-| P99 | X ms |
 | MAX | X ms |
 ```
 
@@ -481,43 +479,7 @@ If comparing against a baseline, include both timings and the delta/speedup perc
 
 ## CI integration
 
-The workflow `.github/workflows/gas-benchmark-analysis.yml` runs the full gas-benchmark pipeline in CI via Claude Code. It executes ALL phases (build → trigger → wait → analyze) and posts results as a PR comment.
-
-**Authorization:** Only members of the `NethermindEth/core` GitHub team can trigger via PR comments (verified via API team membership check).
-
-### Trigger 1: PR comment (full run)
-Comment on a PR to run the complete pipeline on the PR branch:
-```
-@claude-bench                                  # full run, all tests, dotTrace enabled
-@claude-bench --filter sstore_bloated          # full run with test filter
-@claude-bench --no-dottrace                    # full run without dotTrace
-@claude-bench --image nethermindeth/nethermind:my-tag  # skip build, use existing image
-```
-
-### Trigger 1b: PR comment (analyze-only)
-To analyze an already-completed run instead of starting a new one:
-```
-@claude-bench --analyze-run 25725558942
-@claude-bench --analyze-run 25725558942 --compare 25700000000
-```
-
-### Trigger 2: Manual dispatch
-```
-gh workflow run gas-benchmark-analysis.yml \
-  -f branch=my-feature-branch \
-  -f filter=sstore_bloated \
-  -f dottrace=true \
-  -f pr_number=12345
-```
-
-### Trigger 3: Repository dispatch (from gas-benchmarks repo)
-```
-gh api repos/NethermindEth/nethermind/dispatches \
-  -f event_type=gas-benchmark-analysis \
-  -f 'client_payload={"branch":"my-branch","filter":"bloated","pr_number":"12345"}'
-```
-
-All modes run this skill with the appropriate flags and post results as a PR comment (if a PR number is available) or to the workflow step summary.
+`.github/workflows/gas-benchmark-analysis.yml` runs this skill in CI via Claude Code — triggered by `@claude-bench` PR comments (restricted to `NethermindEth/core` team members), manual dispatch, or repository dispatch from the gas-benchmarks repo. CI passes the skill flags through verbatim; results are posted as a PR comment when a PR number is available, otherwise to the workflow step summary. The primary CI mode is `--analyze-run <RUN_ID>` (see "Analyze-only mode"); trigger syntax details live in the workflow file.
 
 ## Filter reference
 

--- a/.agents/skills/gas-benchmark/SKILL.md
+++ b/.agents/skills/gas-benchmark/SKILL.md
@@ -278,7 +278,7 @@ Report the run URL to the user immediately after triggering.
 
 **THIS PHASE IS MANDATORY. Always run it in full, even if the workflow reported success. Never skip or abbreviate it. A "success" workflow conclusion does NOT mean the blocks processed correctly — Nethermind exceptions can occur mid-run without failing the workflow.**
 
-All snippets in this phase are working-directory-independent (absolute paths, no `cd`). Keep them that way: the Bash tool's working directory persists across tool calls while variables do not — rely on neither.
+Snippets in this phase never change the working directory (artifact paths are absolute `/tmp/...`; the one repo-relative path, `scripts/dottrace-report.sh`, keeps resolving because the cwd stays at the repo root). Keep them that way: the Bash tool's working directory persists across tool calls while variables do not — rely on neither.
 
 ### 4a. Exception scan (NEVER SKIP)
 
@@ -312,7 +312,10 @@ Note: do NOT exclude `dotnet` — real Nethermind exceptions contain .NET runtim
 mkdir -p /tmp/gb-results
 gh run download <run-id> --repo NethermindEth/gas-benchmarks \
   -n "results-1-nethermind-<cleaned-test-path>" -D /tmp/gb-results
-for z in /tmp/gb-results/*.zip; do unzip -o "$z" -d /tmp/gb-results; done
+for z in /tmp/gb-results/*.zip; do
+  [ -e "$z" ] || { echo "No results zip in /tmp/gb-results — check the artifact name" >&2; exit 1; }
+  unzip -o "$z" -d /tmp/gb-results
+done
 ```
 
 **Step 2 — Extract per-test timings from result files:**
@@ -355,8 +358,14 @@ gh run download <pr-run-id> --repo NethermindEth/gas-benchmarks \
   -n "results-1-nethermind-<cleaned-test-path>" -D /tmp/gb-pr
 gh run download <base-run-id> --repo NethermindEth/gas-benchmarks \
   -n "results-1-nethermind-<cleaned-test-path>" -D /tmp/gb-base
-for z in /tmp/gb-pr/*.zip; do unzip -o "$z" -d /tmp/gb-pr; done
-for z in /tmp/gb-base/*.zip; do unzip -o "$z" -d /tmp/gb-base; done
+for z in /tmp/gb-pr/*.zip; do
+  [ -e "$z" ] || { echo "No results zip in /tmp/gb-pr — check the artifact name" >&2; exit 1; }
+  unzip -o "$z" -d /tmp/gb-pr
+done
+for z in /tmp/gb-base/*.zip; do
+  [ -e "$z" ] || { echo "No results zip in /tmp/gb-base — check the artifact name" >&2; exit 1; }
+  unzip -o "$z" -d /tmp/gb-base
+done
 
 # Compare per-test (sorted by delta); detect the newPayload version PER RUN — the two runs may target different forks
 PR=/tmp/gb-pr/results; BASE=/tmp/gb-base/results

--- a/.agents/skills/resource-leak-audit/SKILL.md
+++ b/.agents/skills/resource-leak-audit/SKILL.md
@@ -17,7 +17,7 @@ Determine the audit scope before starting:
 Audit only files changed in the PR. Use `git diff` to get the changed files, then apply the full methodology to those files plus their immediate callers/callees.
 
 Steps:
-1. Get changed files: `git diff origin/master...HEAD --name-only` (three-dot diff uses the merge-base, so it works correctly both locally and in CI even if master has advanced)
+1. Get changed files: `git diff origin/master...HEAD --name-only` (three-dot diff uses the merge-base, so it works correctly both locally and in CI even if master has advanced). If the file list looks implausibly large, the local `origin/master` ref may be stale — verify with `git ls-remote origin refs/heads/master` (see the review skill's stale-ref procedure).
 2. Filter to non-test C# files (exclude `*.Test*`, `*.Benchmark*`)
 3. For each changed file, also read classes it inherits from and interfaces it implements
 4. Apply Phase 1 search only for categories relevant to the changed code
@@ -33,7 +33,7 @@ Audit all non-test code in `src/Nethermind/`. This is the exhaustive mode — us
 
 Read these — they define conventions and inform what counts as a leak:
 
-1. **All rule files** in `.agents/rules/` — always list the directory rather than relying on a fixed list
+1. The rule files in `.agents/rules/` relevant to resource management — `robustness.md`, `performance.md`, `di-patterns.md` (list the directory to catch newly added rule files; skip clearly unrelated ones like `git.md` or `github-workflows.md`)
 2. **`CONTRIBUTING.md`** and **`.editorconfig`**
 
 ## Methodology — Two-Phase Audit with Reviewer Gate
@@ -217,7 +217,7 @@ COSMETIC means: technically violates a best practice but has zero quantified run
 - **Read actual code** — don't report based on grep matches alone
 - **Prove triggerability** — "could theoretically race" is not enough
 - **Config-gated is NOT dead** — report with config dependency noted
-- **Check GitHub before reporting** — prevent duplicate work
+- **Check GitHub before reporting CRITICAL/HIGH in the final report** (Phase 2 step D) — prevent duplicate work. Phase 1 recording deliberately skips this; MEDIUM/LOW findings reported without deep validation are marked as such.
 - **Ownership transfers are not leaks** — verify the receiver cleans up
 - **GC finalization is not proper disposal** — still report, but quantify the actual impact (finalizer queue pressure vs. zero impact)
 - **`using` declarations (C# 8+)** are valid disposal

--- a/.agents/skills/resource-leak-audit/references/pattern-categories.md
+++ b/.agents/skills/resource-leak-audit/references/pattern-categories.md
@@ -62,29 +62,13 @@ Search ALL of these (Full Audit Mode) or the relevant subset (PR Mode).
 - [ ] **String interning** — string.Intern() or static dictionaries of strings.
 - [ ] **async void** — exceptions crash process, skip finally, leak resources.
 - [ ] **Lazy\<T\> with disposable** — Lazy caches forever. If T is IDisposable, never cleaned up.
+- [ ] **GC.SuppressFinalize without Dispose** — suppression without disposal skips cleanup entirely.
 
-## Additional Search Strategies
+## Safe-Wrapper Bypass (backward search)
 
-### Pattern-Based
-- Prior leak-fix PRs via `git log --grep="dispose" --grep="leak" --all-match`
-- Cancel() without Dispose() on CTS fields
-- Empty/incomplete Dispose() bodies
-- Compound expressions creating multiple disposables
-- Overridden methods discarding disposable parameters
-- `_disposed` flags without Interlocked
-- Factory methods returning disposables (`Create*`, `Open*`, `Build*`)
-- `Task.Run` / `Task.Factory.StartNew` closures
-- `GC.SuppressFinalize` without Dispose
-- WeakReference / ConditionalWeakTable accumulation
+Using the safe patterns discovered in Step 0b, search for code using the raw pattern instead:
 
-### Safe-Wrapper Bypass
 - Raw pool rental without codebase's disposable wrapper
 - Manual `.Dispose()` on locals instead of `using var`
 - `.SetResult()` instead of `.TrySetResult()` on TCS
 - `bool _disposed` when codebase convention is `Interlocked.Exchange`
-
-### Interaction-Tracing
-- `Task.WhenAll` launching async loops — cross-task calls during shutdown
-- `CancellationToken` parameters never referenced in method body
-- Dispose chains across ownership boundaries (A creates, passes to C, who disposes?)
-- `finally` blocks in async loops — do they complete channels/TCS or just log?

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -7,6 +7,8 @@ allowed-tools:
     Bash(git merge-base*),
     Bash(git log*),
     Bash(git status*),
+    Bash(git ls-remote*),
+    Bash(git fetch origin*),
     Read,
     Grep,
     Glob,
@@ -17,10 +19,12 @@ allowed-tools:
 
 Nethermind is an Ethereum execution client built on .NET. Consensus correctness is non-negotiable — a wrong opcode, a missed fork condition, or an Engine API violation means invalid blocks on a live network.
 
-**Only comment when you have HIGH CONFIDENCE (>80%) that a real issue exists.**
-Be concise: one sentence per comment when possible. If uncertain, stay silent.
+**For domain findings, only comment when you have HIGH CONFIDENCE (>80%) that a real issue exists — if uncertain, stay silent. Rule violations found by the project rules check are exempt from this threshold: always report them (see "When to stay silent").**
+Be concise: one sentence per comment when possible.
 
-**Subagent warning:** Subagents do not inherit full review context automatically. If you launch subagents for this review, you **must** paste the `Codebase Rules` and all applicable domain review sections from this skill into the subagent prompt. After receiving subagent output, cross-check their findings against the rules in your own context.
+`Codebase Rules` means the rule files under `.agents/rules/` (indexed in AGENTS.md).
+
+**Subagent warning:** Subagents do not inherit full review context automatically. If you launch subagents for this review, you **must** paste the relevant `Codebase Rules` files and all applicable domain review sections from this skill into the subagent prompt. After receiving subagent output, cross-check their findings against the rules in your own context.
 
 ---
 
@@ -78,8 +82,8 @@ Review each changed `.cs` file independently. Read the diff, check it, report fi
 - **Minimize context reads:** Only read files outside the diff to verify a specific finding (e.g., confirming a DI module registration). Do not speculatively read files "for context".
 - **Stay in the diff:** Findings must only come from changed files.
 - **Batch verification reads:** If reviewing a file surfaces multiple findings that each need a different context file, read all context files in one parallel batch — don't round-trip one at a time.
-- **Never fabricate:** If a category does not apply, write "N/A".
-- **MANDATORY: Never invent exceptions to rules.** If a `Codebase Rules` rule covers a pattern and the code matches that pattern, report it. Do not dismiss a violation by reasoning that the context "probably" justifies it — that is the author's call, not yours. If the rule is wrong, flag the violation and note the rule may need updating. If you believe the rule is wrong for this case, report the violation AND add a note that the rule may need an exception — but the violation still appears in the count.
+- **Never fabricate:** at checkpoints, state findings or "no findings" per category — never invent a finding to fill one. (The final report omits clean categories; checkpoints do not.)
+- **Never invent exceptions to rules** — see "When to stay silent". If a `Codebase Rules` rule covers a pattern and the code matches, report it; dismissing it is the author's call, not yours.
 
 ### Tool call discipline
 
@@ -170,8 +174,8 @@ Wrong EVM behaviour produces invalid blocks, causing chain desync and validators
 
 - EVM opcode with incorrect gas cost, wrong stack effect, or wrong memory expansion rule
 - Fork/EIP activation condition checked by block number when it should use timestamp (all forks from Cancun onward activate by timestamp), or applied at the wrong boundary
-- Engine API payload accepted or rejected contrary to the spec — each version has distinct required fields: `engine_newPayloadV1` (pre-Shanghai), `engine_newPayloadV2` (+ `withdrawals`), `engine_newPayloadV3` (+ `blobGasUsed`, `excessBlobGas`, `parentBeaconBlockRoot`), `engine_newPayloadV4` (+ `executionRequests`)
-- Blob transaction (EIP-4844) handling with incorrect blob gas accounting, wrong blob base fee calculation, missing KZG commitment verification, or blob gas limit not enforced (6 blobs per block pre-Electra)
+- Engine API payload accepted or rejected contrary to the spec — each version adds required fields (V2 + `withdrawals`; V3 + `blobGasUsed`, `excessBlobGas`, `parentBeaconBlockRoot`; V4 + `executionRequests`; newer versions per fork) — verify against the Engine API spec for the target fork
+- Blob transaction (EIP-4844) handling with incorrect blob gas accounting, wrong blob base fee calculation, missing KZG commitment verification, or per-fork blob limits not enforced (limits come from the active fork's blob schedule)
 - Wrong state root computation — trie updates, storage root recomputation, or nonce/balance changes that don't match the block header's `stateRoot`; this is the ground truth for block validity
 - Incorrect receipt fields (`cumulativeGasUsed`, bloom filter, logs, status) — receipts are hashed into `receiptsRoot` in the block header; wrong values propagate as invalid blocks to peers
 - System-level withdrawal processing (EIP-4895) applied out of order, to the wrong address, or with wrong amounts — withdrawals bypass the gas system and any error corrupts the state root
@@ -184,8 +188,8 @@ Wrong EVM behaviour produces invalid blocks, causing chain desync and validators
 
 ### Key code locations
 
-- EVM instruction handlers: `src/Nethermind/Nethermind.Evm/VirtualMachine.cs`
-- Gas cost tables: `src/Nethermind/Nethermind.Evm/GasCostOf.cs`
+- EVM instruction handlers: `src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.*.cs` (dispatch in `VirtualMachine.cs`)
+- Gas cost tables: `src/Nethermind/Nethermind.Core/GasCostOf.cs`
 - Engine API handlers: `src/Nethermind/Nethermind.Merge.Plugin/Handlers/`
 - Fork activation specs: `src/Nethermind/Nethermind.Specs/`
 - State root computation: `src/Nethermind/Nethermind.State/`

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
     Bash(git status*),
     Bash(git ls-remote*),
     Bash(git fetch origin*),
+    Bash(sort*),
     Read,
     Grep,
     Glob,
@@ -60,7 +61,7 @@ This warning is mandatory — do not skip it even if the untracked files appear 
 **Step 2: Filter the file list.** From the file list, remove:
 
 - Binary/compressed: `.zst`, `.zip`, `.gz`, `.tar`, `.bin`, `.png`, `.jpg`, `.wasm`, `.dll`, `.exe`, `.dat`, Git LFS pointers
-- Auto-generated: `Chains/*.json`, runner configs
+- Bulk chainspec data: allocation/bootnode-only changes in `Chains/*.json`, runner configs. A chainspec change touching fork activations or `params` is consensus-critical — keep it in scope
 - If merge commits exist: run `git log --no-merges --format="" --name-only <base>..HEAD | sort -u` to get only files touched by the PR author's commits. Files only in the full list but not in the author-only list came in through merges — skip them unless the PR description says otherwise.
 
 List skipped files and reason in scope.
@@ -69,7 +70,7 @@ List skipped files and reason in scope.
 
 **Step 4: Size the diffs.** Run `git diff <base> HEAD --stat` to get per-file changed-line counts.
 
-**Step 4a: Fetch small diffs.** Files with **≤1000 changed lines**. Fetch in a single `git diff <base> HEAD -- file1 file2 ...` call. If the combined output exceeds **8000 lines**, split into two calls.
+**Step 4a: Fetch small diffs.** Files with **≤1000 changed lines**. Fetch in a single `git diff <base> HEAD -- file1 file2 ...` call. If the combined output would exceed **8000 lines**, split into multiple calls of at most ~8000 lines each.
 
 **Step 4b: Delegate large diffs.** Files with **>1000 changed lines** go to subagents (see Subagent warning). Each subagent runs the full diff, reviews it, and returns only findings. Group 2–3 related large files per subagent when possible. Collect subagent findings for the verification pass (Plan step 7).
 
@@ -173,7 +174,7 @@ Only flag when it genuinely affects correctness or usability:
 Wrong EVM behaviour produces invalid blocks, causing chain desync and validators building on an invalid chain — leading to missed attestations and potential safety failures.
 
 - EVM opcode with incorrect gas cost, wrong stack effect, or wrong memory expansion rule
-- Fork/EIP activation condition checked by block number when it should use timestamp (all forks from Cancun onward activate by timestamp), or applied at the wrong boundary
+- Fork/EIP activation condition checked by block number when it should use timestamp (Shanghai and all later forks activate by timestamp), or applied at the wrong boundary
 - Engine API payload accepted or rejected contrary to the spec — each version adds required fields (V2 + `withdrawals`; V3 + `blobGasUsed`, `excessBlobGas`, `parentBeaconBlockRoot`; V4 + `executionRequests`; newer versions per fork) — verify against the Engine API spec for the target fork
 - Blob transaction (EIP-4844) handling with incorrect blob gas accounting, wrong blob base fee calculation, missing KZG commitment verification, or per-fork blob limits not enforced (limits come from the active fork's blob schedule)
 - Wrong state root computation — trie updates, storage root recomputation, or nonce/balance changes that don't match the block header's `stateRoot`; this is the ground truth for block validity

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,1 +1,7 @@
 @../AGENTS.md
+@../.agents/rules/coding-style.md
+@../.agents/rules/robustness.md
+
+The two rule files above (coding-style, robustness) are already loaded - do not Read them again. Load the other `.agents/rules/` files on demand per the index in AGENTS.md.
+
+Skills: the entries under `.claude/skills/` are git symlinks into `.agents/skills/`. If those skills (fix-nethtest, gas-benchmark, resource-leak-audit, review) are missing from your available-skills list on Windows, the checkout has `core.symlinks=false` and the entries are text stubs (`Get-Item` shows an empty LinkType). Fix: `git config core.symlinks true`, delete the stub files, then `git checkout -- .claude/skills` (requires Windows Developer Mode or an elevated shell).

--- a/.github/workflows/gas-benchmark-analysis.yml
+++ b/.github/workflows/gas-benchmark-analysis.yml
@@ -263,4 +263,4 @@ jobs:
             If no PR number is available, just output the report — it will appear in the
             workflow step summary.
           claude_args: |
-            --allowedTools "Bash(gh:*),Bash(sed:*),Bash(grep:*),Bash(awk:*),Bash(sort:*),Bash(wc:*),Bash(head:*),Bash(tail:*),Bash(cat:*),Bash(tar:*),Bash(find:*),Bash(date:*),Bash(mkdir:*),Bash(bash:*),Bash(sleep:*),Bash(MSYS_NO_PATHCONV:*),Read,Grep,Glob"
+            --allowedTools "Bash(gh:*),Bash(sed:*),Bash(grep:*),Bash(awk:*),Bash(sort:*),Bash(wc:*),Bash(head:*),Bash(tail:*),Bash(cat:*),Bash(tar:*),Bash(find:*),Bash(date:*),Bash(mkdir:*),Bash(bash:*),Bash(sleep:*),Bash(unzip:*),Bash(tr:*),Bash(xargs:*),Bash(base64:*),Bash(echo:*),Bash(printf:*),Bash(git branch:*),Bash(MSYS_NO_PATHCONV:*),Read,Grep,Glob"


### PR DESCRIPTION
## Changes

- `.agents/rules/test-infrastructure.md`: replace the nonexistent `TestBlockchain.ForMainnet().Build()` snippet with the real `BasicTestBlockchain.Create(configurer)` API; correct the MemDb-override attribution (`TestEnvironmentModule`/`MemDbFactory`, not `DiagnosticMode.MemDb`); add Microsoft.Testing.Platform pitfalls (`--nologo`/`-v q` become filter tokens and report zero tests ran; parallel `dotnet test` DLL lock collisions)
- `.agents/rules/di-patterns.md`: fix the `NetworkModule` row (claimed "Eth62-Eth69, Snap, Witness" - no Witness devp2p protocol exists and handlers now span Eth66-Eth71) and make it version-agnostic; note the module table is not exhaustive; unify the test/benchmark container snippet on `PseudoNethermindModule` + `TestEnvironmentModule` / `TestNethermindModule`, matching what `Nethermind.Evm.Benchmark` actually does; single canonical container snippet referenced from test-infrastructure.md instead of duplicated
- `.agents/skills/review/SKILL.md`: Shanghai (not Cancun) is the first timestamp-activated fork; scope the `Chains/*.json` review exclusion to bulk allocation/bootnode data - chainspec fork/`params` changes are consensus-critical and stay in scope; correct `GasCostOf.cs` and instruction-handler locations; scope the 80% confidence threshold to domain findings; allow `git ls-remote`/`git fetch`/`sort` used by the skill's own steps
- `.agents/skills/gas-benchmark/SKILL.md`: detect the `engine_newPayloadV<N>` version per run instead of hardcoding; reconcile `allowed-tools` with the commands the body actually runs (`MSYS_NO_PATHCONV=1 gh` prefix, `tr`, `xargs`, `base64`, `echo`, `printf`; drop unused `cd`/`ls`/`until`); rewrite Phase 4 snippets to be working-directory-independent so the repo-relative `dottrace-report.sh` call cannot break after an earlier `cd`; align report metrics with the aggregation script; note the genesis filename embeds the fork name
- `.agents/skills/fix-nethtest/SKILL.md`: correct `GeneralStateTestBase.cs` path; add the mandatory regression-test step (AGENTS.md requires one per bug fix) and the `Write` tool it needs; dedupe bug patterns into Phase 3 pointers
- `.agents/skills/resource-leak-audit/`: scope rule-file reading and the GitHub existing-work check; fold duplicate search-strategy lists into the tier checklist
- `.github/workflows/gas-benchmark-analysis.yml`: extend `--allowedTools` with `unzip`, `tr`, `xargs`, `base64`, `echo`, `printf`, `git branch` so both analyze-run and full CI modes can execute the skill's snippets
- `.agents/rules/git.md`: direct non-interactive PR creation (`gh pr create --body`) to populate the body from `.github/pull_request_template.md` - the CLI bypasses GitHub's template auto-fill and the checkboxes drive automatic labeling
- `.agents/rules/agent-skills.md` / `.claude/CLAUDE.md`: warn that Windows checkouts without `core.symlinks` materialize tracked symlinks as silent text stubs, with the self-diagnosis/fix procedure; eager-load the always-needed rule files via imports

Every factual claim in the touched files was verified against the repo (cited source files, workflow YAMLs, `scripts/dottrace-report.sh`) rather than trusted. Findings were cross-reviewed by two independent reviewers (Codex and a separate Claude agent) briefed to check external ground truth; all of their findings were re-verified against the repo before being applied.

## Types of changes

#### What types of changes does your code introduce?

- [x] Documentation update
- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Docs-only apart from the CI allowlist extension. The rewritten gas-benchmark bash snippets were syntax-checked (`bash -n`) and the new name-derivation verified to produce output identical to the old pipeline.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
