### PR TITLE
Run EXPB auto-benchmarks 3x per payload set and report mean of runs

### DIFF
--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -226,7 +226,7 @@ jobs:
             additional_extra_flags=""
             cleanup_grace_seconds="90"
             rebuild_docker="true"
-            run_count="1"
+            run_count="3"
             dottrace="false"
           else
             branch="${PUSH_BRANCH}"
@@ -241,7 +241,7 @@ jobs:
             additional_extra_flags=""
             cleanup_grace_seconds="90"
             rebuild_docker="true"
-            run_count="1"
+            run_count="3"
             dottrace="false"
           fi
 
@@ -536,16 +536,6 @@ jobs:
           echo "Publish docker workflow triggered: ${{ needs.resolve.outputs.should_trigger_publish_docker }}"
           echo "Cleanup grace period (s): ${CLEANUP_GRACE_SECONDS}"
           echo "Scenario name: ${SCENARIO_NAME}"
-
-      - name: Restore cached master metrics
-        id: restore-master-metrics
-        if: github.event_name == 'pull_request'
-        uses: actions/cache/restore@v4
-        with:
-          path: /tmp/expb-master-metrics-cache-${{ matrix.payload_set }}
-          key: expb-master-metrics-v3-${{ matrix.payload_set }}-${{ github.event.pull_request.base.sha }}
-          restore-keys: |
-            expb-master-metrics-v3-${{ matrix.payload_set }}-
 
       - name: Ensure EXPB config file exists
         shell: bash
@@ -944,21 +934,6 @@ jobs:
           path: ${{ steps.analyze.outputs.metrics_file }}
           retention-days: 30
 
-      - name: Prepare master metrics cache
-        if: github.event_name == 'push' && github.ref_name == 'master' && steps.analyze.outputs.exception_found != 'true' && steps.analyze.outputs.invalid_block_found != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "/tmp/expb-master-metrics-cache-${{ matrix.payload_set }}"
-          cp "${{ steps.analyze.outputs.metrics_file }}" "/tmp/expb-master-metrics-cache-${{ matrix.payload_set }}/master-metrics.env"
-
-      - name: Save master metrics cache
-        if: github.event_name == 'push' && github.ref_name == 'master' && steps.analyze.outputs.exception_found != 'true' && steps.analyze.outputs.invalid_block_found != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/expb-master-metrics-cache-${{ matrix.payload_set }}
-          key: expb-master-metrics-v3-${{ matrix.payload_set }}-${{ github.run_id }}
-
       - name: Enforce run quality gates
         if: always()
         shell: bash
@@ -1060,9 +1035,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: /tmp/expb-master-metrics-cache-superblocks
-          key: expb-master-metrics-v3-superblocks-${{ github.event.pull_request.base.sha }}
+          key: expb-master-metrics-v4-superblocks-${{ github.event.pull_request.base.sha }}
           restore-keys: |
-            expb-master-metrics-v3-superblocks-
+            expb-master-metrics-v4-superblocks-
 
       - name: Restore master metrics (realblocks)
         id: restore-master-realblocks
@@ -1070,9 +1045,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: /tmp/expb-master-metrics-cache-realblocks
-          key: expb-master-metrics-v3-realblocks-${{ github.event.pull_request.base.sha }}
+          key: expb-master-metrics-v4-realblocks-${{ github.event.pull_request.base.sha }}
           restore-keys: |
-            expb-master-metrics-v3-realblocks-
+            expb-master-metrics-v4-realblocks-
 
       - name: Build PR comparison comment
         id: pr-comment
@@ -1082,6 +1057,7 @@ jobs:
           MASTER_SUPERBLOCKS: /tmp/expb-master-metrics-cache-superblocks/master-metrics.env
           MASTER_REALBLOCKS: /tmp/expb-master-metrics-cache-realblocks/master-metrics.env
           PAYLOAD_SETS: ${{ needs.resolve.outputs.payload_sets }}
+          RUN_COUNT: ${{ needs.resolve.outputs.run_count }}
           STATE_LAYOUT: ${{ needs.resolve.outputs.state_layout }}
           CLEAN_BRANCH: ${{ needs.resolve.outputs.clean_branch }}
           DELAY_SECONDS: ${{ needs.resolve.outputs.delay_seconds }}
@@ -1092,6 +1068,30 @@ jobs:
           marker="<!-- expb-reproducible-benchmark-report -->"
           comment_file="${RUNNER_TEMP}/expb-pr-comment.md"
           : > "${comment_file}"
+          run_count="${RUN_COUNT:-1}"
+
+          # Mean of each stat across run metric files; RUNS records how many runs contributed.
+          aggregate_runs() {
+            local out="$1"
+            shift
+            local files=("$@")
+            local prefix key values f v mean
+            : > "${out}"
+            for prefix in "" "TTFB_"; do
+              for key in COUNT AVG MEDIAN P90 P95 P99 MIN MAX; do
+                values=""
+                for f in "${files[@]}"; do
+                  v=$(grep -E "^${prefix}${key}=" "${f}" | head -n 1 | cut -d'=' -f2- || true)
+                  if [[ -n "${v}" ]]; then values+="${v} "; fi
+                done
+                if [[ -n "${values}" ]]; then
+                  mean=$(echo "${values}" | tr ' ' '\n' | awk 'NF {sum += $1; n++} END {printf "%.2f", sum/n}')
+                  echo "${prefix}${key}=${mean}" >> "${out}"
+                fi
+              done
+            done
+            echo "RUNS=${#files[@]}" >> "${out}"
+          }
 
           load_metric() {
             local file="$1"
@@ -1140,7 +1140,7 @@ jobs:
             local metrics=("AVG" "MEDIAN" "P90" "P95" "P99" "MIN" "MAX")
 
             if [[ ! -f "${master_metrics}" ]] || ! grep -q "^${prefix}AVG=" "${master_metrics}" 2>/dev/null; then
-              append_line "| Metric | PR |"
+              append_line "| Metric | ${PR_COL} |"
               append_line "|---|---:|"
               for m in "${metrics[@]}"; do
                 local val
@@ -1151,7 +1151,7 @@ jobs:
               return
             fi
 
-            append_line "| Metric | PR | Master (cached) | Delta |"
+            append_line "| Metric | ${PR_COL} | ${MASTER_COL} | Delta |"
             append_line "|---|---:|---:|---:|"
             for m in "${metrics[@]}"; do
               local cv mv
@@ -1180,6 +1180,18 @@ jobs:
 
             append_line "Scenario: \`${scenario_name}\`"
 
+            local pr_runs master_runs
+            pr_runs="$(load_metric "${current_metrics}" "RUNS")"
+            master_runs="$(load_metric "${master_metrics}" "RUNS")"
+            PR_COL="PR"
+            if [[ -n "${pr_runs}" && "${pr_runs}" -gt 1 ]]; then
+              PR_COL="PR (mean of ${pr_runs} runs)"
+            fi
+            MASTER_COL="Master (cached)"
+            if [[ -n "${master_runs}" && "${master_runs}" -gt 1 ]]; then
+              MASTER_COL="Master (cached, mean of ${master_runs} runs)"
+            fi
+
             if [[ ! -f "${master_metrics}" ]]; then
               append_line "No cached master baseline for \`${payload_set}\`. A baseline will be created from the next successful \`master\` push run."
             fi
@@ -1191,6 +1203,26 @@ jobs:
             fi
             append_blank
             emit_metrics_section "Processing" "${current_metrics}" "${master_metrics}" ""
+
+            # Per-run breakdown behind the mean-of-runs comparison table
+            if [[ "${run_count}" -gt 1 ]]; then
+              append_blank
+              append_line "<details><summary>Per-run breakdown</summary>"
+              append_blank
+              append_line "| Run | AVG (ms) | Median (ms) | P90 (ms) | P95 (ms) | P99 (ms) | Min (ms) | Max (ms) |"
+              append_line "|---:|---:|---:|---:|---:|---:|---:|---:|"
+              local r rf
+              for (( r=1; r<=run_count; r++ )); do
+                rf="${METRICS_DIR}/expb-single-metrics-${payload_set}-run${r}/expb-metrics.env"
+                if [[ ! -f "${rf}" ]]; then
+                  append_line "| ${r} | - | - | - | - | - | - | - |"
+                  continue
+                fi
+                append_line "| ${r} | $(load_metric "${rf}" "AVG") | $(load_metric "${rf}" "MEDIAN") | $(load_metric "${rf}" "P90") | $(load_metric "${rf}" "P95") | $(load_metric "${rf}" "P99") | $(load_metric "${rf}" "MIN") | $(load_metric "${rf}" "MAX") |"
+              done
+              append_blank
+              append_line "</details>"
+            fi
 
             # Secondary: K6 TTFB metrics (only shown when SSE data was primary)
             if grep -q "^TTFB_AVG=" "${current_metrics}" 2>/dev/null; then
@@ -1212,8 +1244,20 @@ jobs:
           mapfile -t payload_sets < <(echo "${PAYLOAD_SETS}" | jq -r '.[]')
 
           for ps in "${payload_sets[@]}"; do
-            # Find the PR metrics artifact (run 1 by default)
-            current_metrics="${METRICS_DIR}/expb-single-metrics-${ps}-run1/expb-metrics.env"
+            # Aggregate PR metrics across all runs (mean per stat)
+            run_files=()
+            for (( r=1; r<=run_count; r++ )); do
+              f="${METRICS_DIR}/expb-single-metrics-${ps}-run${r}/expb-metrics.env"
+              [[ -f "${f}" ]] && run_files+=("${f}")
+            done
+
+            current_metrics="${RUNNER_TEMP}/expb-pr-metrics-${ps}.env"
+            if [[ "${#run_files[@]}" -gt 0 ]]; then
+              aggregate_runs "${current_metrics}" "${run_files[@]}"
+            else
+              # Leave the file absent so build_table reports missing metrics
+              rm -f "${current_metrics}"
+            fi
 
             # Master metrics from cache
             if [[ "${ps}" == "superblocks" ]]; then
@@ -1268,6 +1312,92 @@ jobs:
                 body,
               });
             }
+
+  # ---------------------------------------------------------------------------
+  # Master baseline: aggregate all runs (mean per metric) and cache for PR comparisons.
+  # Runs only when every benchmark job passed its quality gates (implicit success()).
+  # ---------------------------------------------------------------------------
+
+  save-master-baseline:
+    needs: [resolve, benchmark]
+    if: github.event_name == 'push' && github.ref_name == 'master' && needs.resolve.outputs.should_run == 'true' && needs.resolve.outputs.mode == 'single'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all metrics artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/all-metrics
+          pattern: expb-single-metrics-*
+
+      - name: Aggregate runs into master baseline
+        id: aggregate
+        shell: bash
+        env:
+          METRICS_DIR: ${{ runner.temp }}/all-metrics
+          PAYLOAD_SETS: ${{ needs.resolve.outputs.payload_sets }}
+          RUN_COUNT: ${{ needs.resolve.outputs.run_count }}
+        run: |
+          set -euo pipefail
+          run_count="${RUN_COUNT:-1}"
+
+          # Mean of each stat across run metric files; RUNS records how many runs contributed.
+          aggregate_runs() {
+            local out="$1"
+            shift
+            local files=("$@")
+            local prefix key values f v mean
+            : > "${out}"
+            for prefix in "" "TTFB_"; do
+              for key in COUNT AVG MEDIAN P90 P95 P99 MIN MAX; do
+                values=""
+                for f in "${files[@]}"; do
+                  v=$(grep -E "^${prefix}${key}=" "${f}" | head -n 1 | cut -d'=' -f2- || true)
+                  if [[ -n "${v}" ]]; then values+="${v} "; fi
+                done
+                if [[ -n "${values}" ]]; then
+                  mean=$(echo "${values}" | tr ' ' '\n' | awk 'NF {sum += $1; n++} END {printf "%.2f", sum/n}')
+                  echo "${prefix}${key}=${mean}" >> "${out}"
+                fi
+              done
+            done
+            echo "RUNS=${#files[@]}" >> "${out}"
+          }
+
+          mapfile -t payload_sets < <(echo "${PAYLOAD_SETS}" | jq -r '.[]')
+
+          for ps in "${payload_sets[@]}"; do
+            run_files=()
+            for (( r=1; r<=run_count; r++ )); do
+              f="${METRICS_DIR}/expb-single-metrics-${ps}-run${r}/expb-metrics.env"
+              [[ -f "${f}" ]] && run_files+=("${f}")
+            done
+
+            if [[ "${#run_files[@]}" -eq 0 ]]; then
+              echo "No metrics found for '${ps}'; skipping baseline update."
+              echo "save_${ps}=false" >> "${GITHUB_OUTPUT}"
+              continue
+            fi
+
+            mkdir -p "/tmp/expb-master-metrics-cache-${ps}"
+            aggregate_runs "/tmp/expb-master-metrics-cache-${ps}/master-metrics.env" "${run_files[@]}"
+            echo "Baseline for '${ps}' (mean of ${#run_files[@]} run(s)):"
+            cat "/tmp/expb-master-metrics-cache-${ps}/master-metrics.env"
+            echo "save_${ps}=true" >> "${GITHUB_OUTPUT}"
+          done
+
+      - name: Save master metrics cache (superblocks)
+        if: steps.aggregate.outputs.save_superblocks == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/expb-master-metrics-cache-superblocks
+          key: expb-master-metrics-v4-superblocks-${{ github.run_id }}
+
+      - name: Save master metrics cache (realblocks)
+        if: steps.aggregate.outputs.save_realblocks == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/expb-master-metrics-cache-realblocks
+          key: expb-master-metrics-v4-realblocks-${{ github.run_id }}
 
   # ---------------------------------------------------------------------------
   # Single-image summary: aggregates all runs × payload_sets into GITHUB_STEP_SUMMARY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ This repository contains a dedicated workflow for reproducible payload benchmark
 - Runs `expb execute-scenarios` with per-payload metrics and logs.
 - Handles termination gracefully with cleanup grace period.
 - Metrics source: prefers SSE client metrics (`[payload-server] client_metric` lines — Nethermind internal processing times) over K6 TTFB. Falls back to the per-payload pipe table when SSE data is unavailable.
-- On successful `master` push runs, caches timing aggregates (AVG/MEDIAN/P90-P99/MIN/MAX). On PR runs, posts a comparison comment.
+- On successful `master` push runs, the `save-master-baseline` job aggregates all runs (mean per metric) and caches the timing baseline (AVG/MEDIAN/P90-P99/MIN/MAX). On PR runs, posts a comparison comment where PR and master values are means across runs, with a collapsible per-run breakdown.
 - The `single-summary` job aggregates across runs and payload sets into `GITHUB_STEP_SUMMARY` (per-run table + mean/best/worst when `run_count > 1`).
 - When `dottrace` input is enabled, passes `--dottrace` to expb. dotTrace snapshots (`.dtp` + chunk files) are zipped and uploaded as artifacts. A downstream Windows job (`generate-dottrace-reports`) runs Reporter.exe to produce XML reports (`*-report.xml`) uploaded as the `dottrace-reports` artifact. Each report contains `<Function>` nodes with `FQN`, `TotalTime`, `OwnTime`, `Calls`, and full call stacks — sort by `OwnTime` for hot spots, use `CallStack` attributes for call tree analysis.
 
@@ -201,7 +201,7 @@ This repository contains a dedicated workflow for reproducible payload benchmark
 ### Notes for agents
 
 - The benchmark config is rendered to a temporary file and removed afterward; no source config revert is required.
-- For `pull_request` and `push` auto-runs, default mode is `flat` layout with both `superblocks` and `realblocks` payload sets.
+- For `pull_request` and `push` auto-runs, default mode is `flat` layout with both `superblocks` and `realblocks` payload sets, 3 runs each; reported comparisons use the mean of the runs.
 - Keep benchmark-related changes isolated to the workflow and benchmark guidance unless explicitly asked otherwise.
 - Optional low-variance mode: pass `-f expb_env="EXPB_EVM_WARMUP=1"` to enable expb's per-block EVM warmup (`eth_simulateV1` before each measured block). It serves the measured block's reads from warm caches, which lowers both run-to-run CV (~1.8%→~0.55% on flat-realblocks) and AVG. Pair it with a raised RPC gas cap — `-f additional_extra_flags="--JsonRpc.GasCap=1000000000000"` — otherwise the per-request gas budget (default 100M) is exhausted on dense blocks and the warmup `eth_simulateV1` calls fail with `-38013` (intrinsic gas), silently leaving those blocks un-warmed. Caveat: warmup minimizes cold RocksDB/storage interaction, so it is a low-variance *compute* signal, not a substitute for the default cold benchmark — don't use it when measuring storage-layer changes.
 - dotTrace XML reports are 50-70MB. **Never load full XML into context.** Use [`scripts/dottrace-report.sh`](./scripts/dottrace-report.sh): `top <report.xml> [N]` for hot spots, `compare <a.xml> <b.xml> [N]` for regressions/improvements. Runs in <2 seconds via grep+awk.


### PR DESCRIPTION
## Changes

- `pull_request` and `push` (master) auto-runs of `run-expb-reproducible-benchmarks.yml` now execute **3 runs per payload set** (`run_count=3`, was 1) for both `superblocks` and `realblocks`.
- New `save-master-baseline` job: on successful master pushes it aggregates all runs (mean per metric, with a `RUNS=N` marker) and saves a single cached baseline per payload set. This replaces the per-matrix-job cache save, which would collide across runs on the same key and store an arbitrary single run. It only runs when every benchmark job passed its quality gates (no exceptions / invalid blocks).
- PR comparison comment now aggregates all runs (mean per stat) instead of reading only run 1. Table columns are labeled explicitly (`PR (mean of 3 runs)` vs `Master (cached, mean of 3 runs)`), and a collapsible **Per-run breakdown** table shows each run's numbers. Missing runs degrade gracefully (mean over available runs, `-` rows). The K6 TTFB details section is aggregated the same way.
- Master metrics cache key bumped `v3` → `v4` (baseline format/semantics changed to aggregated means).
- Removed an unused `Restore cached master metrics` step in the benchmark job (nothing consumed it; the report job does its own restore).
- Updated the workflow description in `AGENTS.md` accordingly.

The `single-summary` job needed no changes — it already renders a per-run table plus Mean/Best/Worst aggregate when `run_count > 1`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Workflow YAML validated with a parser. Both embedded bash scripts (PR report and baseline aggregation) were extracted from the final YAML and executed locally against synthetic 3-run metrics, verifying: correct mean-of-3 values and deltas, graceful fallback to mean-of-2 with a `-` row when a run is missing, the "no cached baseline" message, and the skip path when a payload set produced no metrics. Full end-to-end verification will come from the first label-triggered PR run and master push after merge.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

- Wall-clock time of auto-runs roughly triples (6 sequential benchmarks per PR label / master push on the `reproducible-benchmarks` runner).
- Because of the `v3` → `v4` cache key bump, the first PR benchmarked after merge will show "no cached master baseline" until the next master push repopulates it with an aggregated baseline.