### PR TITLE
IProcessingEnvBuilder: a DSL for block-processing environments

### DIFF
--- a/.agents/rules/di-patterns.md
+++ b/.agents/rules/di-patterns.md
@@ -53,6 +53,12 @@ builder.AddSingleton<IWorldState, WorldState>();
 5. If one type should be aliased to another already-registered type, use `Bind<TTo, TFrom>()`.
 6. Never register test-specific stubs or `MemDb` overrides in a production module — put them in `TestEnvironmentModule` or `TestBlockProcessingModule`.
 
+## Overriding or intercepting components
+- On a per case basis, one can override any component by opening a new child lifetime and using `AddSingleton` on the lifetime configuration.
+- In a lot more case, one need to intercept calls while preserving previous behavior.
+  - In this case, DO NOT subclass the implementation as plugin is likely going to replace them.
+  - Rather make a decorator, which then calls a dedicated store class that can be resolved separately.
+
 ## Test modules (`Nethermind.Core.Test/Modules/`)
 
 | Module | Purpose | File |

--- a/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Evm.State;
@@ -11,29 +10,24 @@ using Nethermind.State;
 
 namespace Nethermind.Consensus.Processing;
 
-public class AutoReadOnlyTxProcessingEnvFactory(ILifetimeScope parentLifetime, IWorldStateManager worldStateManager) : IReadOnlyTxProcessingEnvFactory
+public class AutoReadOnlyTxProcessingEnvFactory(Func<IProcessingEnvBuilder> envBuilder, IWorldStateManager worldStateManager) : IReadOnlyTxProcessingEnvFactory
 {
-    public IReadOnlyTxProcessorSource Create()
-    {
-        IWorldStateScopeProvider worldState = worldStateManager.CreateResettableWorldState();
-        ILifetimeScope childScope = parentLifetime.BeginLifetimeScope((builder) =>
-        {
-            builder
-                .AddSingleton<IWorldStateScopeProvider>(worldState)
-                .AddSingleton<AutoReadOnlyTxProcessingEnv>();
-        });
+    public IReadOnlyTxProcessorSource Create() =>
+        new AutoReadOnlyTxProcessingEnv(envBuilder()
+            .WithWorldState(worldStateManager.CreateResettableWorldState())
+            .BuildAs<AutoReadOnlyTxProcessingEnv.IEnv>());
 
-        return childScope.Resolve<AutoReadOnlyTxProcessingEnv>();
-    }
-
-    public class AutoReadOnlyTxProcessingEnv(ITransactionProcessor transactionProcessor, IWorldState worldState, ILifetimeScope lifetimeScope) : IReadOnlyTxProcessorSource
+    public class AutoReadOnlyTxProcessingEnv(AutoReadOnlyTxProcessingEnv.IEnv env) : IReadOnlyTxProcessorSource
     {
-        public IReadOnlyTxProcessingScope Build(BlockHeader? header)
+        public interface IEnv : IDisposable
         {
-            IDisposable closer = worldState.BeginScope(header);
-            return new ReadOnlyTxProcessingScope(transactionProcessor, closer, worldState);
+            ITransactionProcessor TransactionProcessor { get; }
+            IWorldState WorldState { get; }
         }
 
-        public void Dispose() => lifetimeScope.Dispose();
+        public IReadOnlyTxProcessingScope Build(BlockHeader? header) =>
+            new ReadOnlyTxProcessingScope(env.TransactionProcessor, env.WorldState.BeginScope(header), env.WorldState);
+
+        public void Dispose() => env.Dispose();
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
@@ -10,10 +10,10 @@ using Nethermind.State;
 
 namespace Nethermind.Consensus.Processing;
 
-public class AutoReadOnlyTxProcessingEnvFactory(Func<IProcessingEnvBuilder> envBuilder, IWorldStateManager worldStateManager) : IReadOnlyTxProcessingEnvFactory
+public class AutoReadOnlyTxProcessingEnvFactory(IProcessingEnvBuilder envBuilder, IWorldStateManager worldStateManager) : IReadOnlyTxProcessingEnvFactory
 {
     public IReadOnlyTxProcessorSource Create() =>
-        new AutoReadOnlyTxProcessingEnv(envBuilder()
+        new AutoReadOnlyTxProcessingEnv(envBuilder.NewEnv()
             .WithWorldState(worldStateManager.CreateResettableWorldState())
             .BuildAs<AutoReadOnlyTxProcessingEnv.IEnv>());
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/AutoReadOnlyTxProcessingEnvFactory.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Consensus.Processing;
 public class AutoReadOnlyTxProcessingEnvFactory(IProcessingEnvBuilder envBuilder, IWorldStateManager worldStateManager) : IReadOnlyTxProcessingEnvFactory
 {
     public IReadOnlyTxProcessorSource Create() =>
-        new AutoReadOnlyTxProcessingEnv(envBuilder.NewEnv()
+        new AutoReadOnlyTxProcessingEnv(envBuilder
             .WithWorldState(worldStateManager.CreateResettableWorldState())
             .BuildAs<AutoReadOnlyTxProcessingEnv.IEnv>());
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -8,49 +8,41 @@ using Nethermind.State.OverridableEnv;
 
 namespace Nethermind.Consensus.Processing;
 
-/// <summary>
-/// Fluent builder for an isolated block-processing environment. It configures an Autofac child lifetime
-/// scope (overriding the world state and/or individual components) and exposes the resolved graph through
-/// <see cref="BuildAs{TWrapper}"/>.
-/// </summary>
-/// <remarks>
-/// <para>
-/// <c>TWrapper</c> must be a simple, getter-only interface (read-only properties, no methods) that the
-/// caller defines, and it must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/>.
-/// The returned wrapper owns the environment's child scope, so it must be disposed once the environment
-/// is no longer needed — disposing it disposes the scope and everything it owns.
-/// </para>
-/// <para>
-/// A builder is single-use and not thread-safe: accumulate the configuration with the <c>With*</c> /
-/// <see cref="Configure"/> methods (a world state is mandatory), then call <see cref="BuildAs{TWrapper}"/>
-/// once. Resolve a fresh builder (or inject <see cref="Func{IProcessingEnvBuilder}"/>) for each
-/// environment. Because the components come from a real child scope, all plugin registrations, decorators
-/// and composites in the parent container are honoured — unlike a hand-built processing stack.
-/// </para>
-/// </remarks>
+/// <summary>Source of fresh <see cref="IDsl"/> instances, one per block-processing environment.</summary>
 public interface IProcessingEnvBuilder
 {
-    IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState);
+    IDsl NewEnv();
 
-    IProcessingEnvBuilder WithWorldState(IWorldState worldState);
+    /// <summary>
+    /// Fluent builder for an isolated block-processing environment. It configures an Autofac child lifetime
+    /// scope and returns the resolved graph as <c>TWrapper</c> — a caller-defined, getter-only interface that
+    /// must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> and be disposed when the
+    /// environment is no longer needed (disposing it disposes the scope).
+    /// </summary>
+    public interface IDsl
+    {
+        IDsl WithWorldState(IWorldStateScopeProvider worldState);
 
-    IProcessingEnvBuilder WithOverridableEnv(IOverridableEnv env);
+        IDsl WithWorldState(IWorldState worldState);
 
-    IProcessingEnvBuilder WithOverridableEnv();
+        IDsl WithOverridableEnv(IOverridableEnv env);
 
-    IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class;
+        IDsl WithOverridableEnv();
 
-    IProcessingEnvBuilder WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull;
+        IDsl WithReplacedComponent<T>(T instance) where T : class;
 
-    IProcessingEnvBuilder WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class;
+        IDsl WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull;
 
-    IProcessingEnvBuilder WithComponent<T>(T instance) where T : class;
+        IDsl WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class;
 
-    IProcessingEnvBuilder ThatDisposes(IDisposable disposable);
+        IDsl WithComponent<T>(T instance) where T : class;
 
-    IProcessingEnvBuilder WithBlockValidationConfiguration();
+        IDsl ThatDisposes(IDisposable disposable);
 
-    IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure);
+        IDsl WithBlockValidationConfiguration();
 
-    TWrapper BuildAs<TWrapper>() where TWrapper : class;
+        IDsl Configure(Action<ContainerBuilder> configure);
+
+        TWrapper BuildAs<TWrapper>() where TWrapper : class;
+    }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -15,8 +15,9 @@ namespace Nethermind.Consensus.Processing;
 /// environment is no longer needed (disposing it disposes the scope).
 /// </summary>
 /// <remarks>
-/// Copy-on-mutate: each method returns a new builder, so a single injected instance can be reused — and
-/// forked concurrently — to build independent environments.
+/// The DI-registered instance is immutable and can be reused — and forked concurrently — to build
+/// independent environments; the first configuring call forks a private mutable builder that the rest of
+/// the fluent chain accumulates into.
 /// </remarks>
 public interface IProcessingEnvBuilder
 {

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -63,11 +63,11 @@ public interface IProcessingEnvBuilder
     /// </remarks>
     IProcessingEnvBuilder OwnedByParentLifetime();
 
-    TWrapper BuildAs<TWrapper>() where TWrapper : class;
-
     /// <summary>
-    /// Builds the environment and resolves <typeparamref name="T"/> from its scope. Requires
-    /// <see cref="OwnedByParentLifetime"/>, since the returned component cannot dispose the scope itself.
+    /// Builds the environment and returns it as <typeparamref name="TWrapper"/>. If <typeparamref name="TWrapper"/>
+    /// is registered in the scope (via a <c>With*</c> call) it is resolved and returned directly, which
+    /// requires <see cref="OwnedByParentLifetime"/> since a plain component cannot dispose its scope;
+    /// otherwise a wrapper implementing it is synthesized.
     /// </summary>
-    T Build<T>() where T : notnull;
+    TWrapper BuildAs<TWrapper>() where TWrapper : class;
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -26,25 +26,50 @@ public interface IProcessingEnvBuilder
     /// components (<see cref="IWorldState"/>, the transaction processor, etc.) are built over it.
     /// </summary>
     /// <remarks>
-    /// This is the common case — pass a provider from <c>IWorldStateManager</c> (e.g.
-    /// <c>CreateResettableWorldState()</c>, <c>GlobalWorldState</c>, or
-    /// <c>CreateOverridableWorldScope().WorldState</c>). One of the <see cref="WithWorldState(IWorldStateScopeProvider)"/>
-    /// / <see cref="WithWorldState(IWorldState)"/> overloads must be called before
-    /// <see cref="BuildAs{TWrapper}"/>. The provider is externally owned and is not disposed with the scope.
+    /// Pass a provider from <c>IWorldStateManager</c> (e.g. <c>CreateResettableWorldState()</c>,
+    /// <c>GlobalWorldState</c>, or <c>CreateOverridableWorldScope().WorldState</c>). One of the
+    /// <see cref="WithWorldState(IWorldStateScopeProvider, bool)"/> / <see cref="WithWorldState(IWorldState, bool)"/>
+    /// overloads must be called before <see cref="BuildAs{TWrapper}"/>. Pass
+    /// <paramref name="externallyOwned"/> <c>true</c> for a shared/manager-owned provider (e.g.
+    /// <c>GlobalWorldState</c>) that must never be disposed by the environment.
     /// </remarks>
-    IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState);
+    /// <param name="externallyOwned">When <c>false</c> (default) the environment owns the instance and
+    /// disposes it (if disposable) when the wrapper is disposed.</param>
+    IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState, bool externallyOwned = false);
 
     /// <summary>
     /// Binds the environment to an already-built <see cref="IWorldState"/> instance, registered
     /// directly (the witness / stateless case where a wrapping world state is constructed by hand).
     /// </summary>
-    IProcessingEnvBuilder WithWorldState(IWorldState worldState);
+    /// <inheritdoc cref="WithWorldState(IWorldStateScopeProvider, bool)" path="/param"/>
+    IProcessingEnvBuilder WithWorldState(IWorldState worldState, bool externallyOwned = false);
 
     /// <summary>
     /// Replaces the registration of <typeparamref name="T"/> within the environment's scope with
-    /// <paramref name="instance"/>. The instance is externally owned and is not disposed with the scope.
+    /// <paramref name="instance"/>.
     /// </summary>
-    IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class;
+    /// <param name="externallyOwned">When <c>false</c> (default) the environment owns the instance and
+    /// disposes it (if disposable) when the wrapper is disposed; pass <c>true</c> for a shared instance.</param>
+    IProcessingEnvBuilder WithReplacedComponent<T>(T instance, bool externallyOwned = false) where T : class;
+
+    /// <summary>
+    /// Replaces the registration of <typeparamref name="TService"/> within the environment's scope with
+    /// a fresh, scope-owned <typeparamref name="TImpl"/>.
+    /// </summary>
+    IProcessingEnvBuilder WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull;
+
+    /// <summary>
+    /// Replaces the registration of <typeparamref name="T"/> within the environment's scope with a
+    /// scope-owned instance produced by <paramref name="factory"/>.
+    /// </summary>
+    IProcessingEnvBuilder WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class;
+
+    /// <summary>
+    /// Adds <paramref name="instance"/> as a component of the environment's scope (a service the base
+    /// graph does not provide).
+    /// </summary>
+    /// <inheritdoc cref="WithReplacedComponent{T}(T, bool)" path="/param"/>
+    IProcessingEnvBuilder WithComponent<T>(T instance, bool externallyOwned = false) where T : class;
 
     /// <summary>
     /// Escape hatch to apply arbitrary registrations to the environment's child scope (decorators,

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -44,16 +44,4 @@ public interface IProcessingEnvBuilder
     IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure);
 
     TWrapper BuildAs<TWrapper>() where TWrapper : class;
-
-    /// <summary>
-    /// Builds the environment and returns its <see cref="IOverridableEnv{T}"/>; disposing the returned
-    /// handle disposes the underlying scope. Use for the state-override RPC envs whose world state comes
-    /// from <see cref="WithOverridableEnv(IOverridableEnv)"/>.
-    /// </summary>
-    IOverridableEnvHandle<T> BuildAsOverridableEnv<T>();
-}
-
-/// <summary>An <see cref="IOverridableEnv{T}"/> that owns and asynchronously disposes its environment scope.</summary>
-public interface IOverridableEnvHandle<T> : IOverridableEnv<T>, IAsyncDisposable
-{
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -8,41 +8,39 @@ using Nethermind.State.OverridableEnv;
 
 namespace Nethermind.Consensus.Processing;
 
-/// <summary>Source of fresh <see cref="IDsl"/> instances, one per block-processing environment.</summary>
+/// <summary>
+/// Fluent builder for an isolated block-processing environment. It configures an Autofac child lifetime
+/// scope and returns the resolved graph as <c>TWrapper</c> — a caller-defined, getter-only interface that
+/// must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> and be disposed when the
+/// environment is no longer needed (disposing it disposes the scope).
+/// </summary>
+/// <remarks>
+/// Copy-on-mutate: each method returns a new builder, so a single injected instance can be reused — and
+/// forked concurrently — to build independent environments.
+/// </remarks>
 public interface IProcessingEnvBuilder
 {
-    IDsl NewEnv();
+    IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState);
 
-    /// <summary>
-    /// Fluent builder for an isolated block-processing environment. It configures an Autofac child lifetime
-    /// scope and returns the resolved graph as <c>TWrapper</c> — a caller-defined, getter-only interface that
-    /// must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> and be disposed when the
-    /// environment is no longer needed (disposing it disposes the scope).
-    /// </summary>
-    public interface IDsl
-    {
-        IDsl WithWorldState(IWorldStateScopeProvider worldState);
+    IProcessingEnvBuilder WithWorldState(IWorldState worldState);
 
-        IDsl WithWorldState(IWorldState worldState);
+    IProcessingEnvBuilder WithOverridableEnv(IOverridableEnv env);
 
-        IDsl WithOverridableEnv(IOverridableEnv env);
+    IProcessingEnvBuilder WithOverridableEnv();
 
-        IDsl WithOverridableEnv();
+    IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class;
 
-        IDsl WithReplacedComponent<T>(T instance) where T : class;
+    IProcessingEnvBuilder WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull;
 
-        IDsl WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull;
+    IProcessingEnvBuilder WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class;
 
-        IDsl WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class;
+    IProcessingEnvBuilder WithComponent<T>(T instance) where T : class;
 
-        IDsl WithComponent<T>(T instance) where T : class;
+    IProcessingEnvBuilder ThatDisposes(IDisposable disposable);
 
-        IDsl ThatDisposes(IDisposable disposable);
+    IProcessingEnvBuilder WithBlockValidationConfiguration();
 
-        IDsl WithBlockValidationConfiguration();
+    IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure);
 
-        IDsl Configure(Action<ContainerBuilder> configure);
-
-        TWrapper BuildAs<TWrapper>() where TWrapper : class;
-    }
+    TWrapper BuildAs<TWrapper>() where TWrapper : class;
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -79,6 +79,14 @@ public interface IProcessingEnvBuilder
     IProcessingEnvBuilder ThatDisposes(IDisposable disposable);
 
     /// <summary>
+    /// Applies the registered <c>IBlockValidationModule</c>s (the validation transaction executor and
+    /// related wiring) to the environment's scope; everything else is inherited from the parent scope
+    /// and re-resolved against the environment's world state. The modules are resolved from the builder's
+    /// parent scope, so callers do not pass them.
+    /// </summary>
+    IProcessingEnvBuilder WithBlockValidationConfiguration();
+
+    /// <summary>
     /// Escape hatch to apply arbitrary registrations to the environment's child scope (decorators,
     /// composites, whole modules) that the typed shortcuts do not cover.
     /// </summary>

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -4,107 +4,53 @@
 using System;
 using Autofac;
 using Nethermind.Evm.State;
+using Nethermind.State.OverridableEnv;
 
 namespace Nethermind.Consensus.Processing;
 
 /// <summary>
-/// Fluent builder for an isolated block-processing environment. It configures an Autofac child
-/// lifetime scope (overriding the world state and/or individual components) and exposes the resolved
-/// graph through a caller-defined wrapper interface produced by <see cref="BuildAs{TWrapper}"/>.
+/// Fluent builder for an isolated block-processing environment. It configures an Autofac child lifetime
+/// scope (overriding the world state and/or individual components) and exposes the resolved graph through
+/// <see cref="BuildAs{TWrapper}"/>.
 /// </summary>
 /// <remarks>
+/// <para>
+/// <c>TWrapper</c> must be a simple, getter-only interface (read-only properties, no methods) that the
+/// caller defines, and it must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/>.
+/// The returned wrapper owns the environment's child scope, so it must be disposed once the environment
+/// is no longer needed — disposing it disposes the scope and everything it owns.
+/// </para>
+/// <para>
 /// A builder is single-use and not thread-safe: accumulate the configuration with the <c>With*</c> /
-/// <see cref="Configure"/> methods, then call <see cref="BuildAs{TWrapper}"/> once. Resolve a fresh
-/// builder (or inject <see cref="Func{IProcessingEnvBuilder}"/>) for each environment. Because the
-/// components come from a real child scope, all plugin registrations, decorators and composites in the
-/// parent container are honoured — unlike a hand-built processing stack.
+/// <see cref="Configure"/> methods (a world state is mandatory), then call <see cref="BuildAs{TWrapper}"/>
+/// once. Resolve a fresh builder (or inject <see cref="Func{IProcessingEnvBuilder}"/>) for each
+/// environment. Because the components come from a real child scope, all plugin registrations, decorators
+/// and composites in the parent container are honoured — unlike a hand-built processing stack.
+/// </para>
 /// </remarks>
 public interface IProcessingEnvBuilder
 {
-    /// <summary>
-    /// Binds the environment's world state to <paramref name="worldState"/>. Downstream scoped
-    /// components (<see cref="IWorldState"/>, the transaction processor, etc.) are built over it.
-    /// </summary>
-    /// <remarks>
-    /// Pass a provider from <c>IWorldStateManager</c> (e.g. <c>CreateResettableWorldState()</c>,
-    /// <c>GlobalWorldState</c>, or <c>CreateOverridableWorldScope().WorldState</c>). One of the
-    /// <see cref="WithWorldState(IWorldStateScopeProvider)"/> / <see cref="WithWorldState(IWorldState)"/>
-    /// overloads must be called before <see cref="BuildAs{TWrapper}"/>. The provider is registered but
-    /// not disposed by the environment; use <see cref="ThatDisposes"/> if the environment owns it.
-    /// </remarks>
     IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState);
 
-    /// <summary>
-    /// Binds the environment to an already-built <see cref="IWorldState"/> instance, registered
-    /// directly (the witness / stateless case where a wrapping world state is constructed by hand).
-    /// </summary>
     IProcessingEnvBuilder WithWorldState(IWorldState worldState);
 
-    /// <summary>
-    /// Replaces the registration of <typeparamref name="T"/> within the environment's scope with
-    /// <paramref name="instance"/>. The instance is registered but not disposed by the environment; use
-    /// <see cref="ThatDisposes"/> if the environment owns it.
-    /// </summary>
+    IProcessingEnvBuilder WithOverridableEnv(IOverridableEnv env);
+
+    IProcessingEnvBuilder WithOverridableEnv();
+
     IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class;
 
-    /// <summary>
-    /// Replaces the registration of <typeparamref name="TService"/> within the environment's scope with
-    /// a fresh, scope-owned <typeparamref name="TImpl"/>.
-    /// </summary>
     IProcessingEnvBuilder WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull;
 
-    /// <summary>
-    /// Replaces the registration of <typeparamref name="T"/> within the environment's scope with a
-    /// scope-owned instance produced by <paramref name="factory"/>.
-    /// </summary>
     IProcessingEnvBuilder WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class;
 
-    /// <summary>
-    /// Adds <paramref name="instance"/> as a component of the environment's scope (a service the base
-    /// graph does not provide). The instance is registered but not disposed by the environment; use
-    /// <see cref="ThatDisposes"/> if the environment owns it.
-    /// </summary>
     IProcessingEnvBuilder WithComponent<T>(T instance) where T : class;
 
-    /// <summary>
-    /// Declares that <paramref name="disposable"/> is owned by the environment and must be disposed when
-    /// the environment (its child scope) is disposed.
-    /// </summary>
-    /// <remarks>
-    /// Use for resources the environment owns that Autofac does not otherwise track — e.g. a
-    /// manually-created read-only trie store that no scope component resolves. Registering a component
-    /// with <see cref="WithComponent"/> / <see cref="WithReplacedComponent{T}(T)"/> does not imply
-    /// disposal; ownership is declared here, explicitly.
-    /// </remarks>
     IProcessingEnvBuilder ThatDisposes(IDisposable disposable);
 
-    /// <summary>
-    /// Applies the registered <c>IBlockValidationModule</c>s (the validation transaction executor and
-    /// related wiring) to the environment's scope; everything else is inherited from the parent scope
-    /// and re-resolved against the environment's world state. The modules are resolved from the builder's
-    /// parent scope, so callers do not pass them.
-    /// </summary>
     IProcessingEnvBuilder WithBlockValidationConfiguration();
 
-    /// <summary>
-    /// Escape hatch to apply arbitrary registrations to the environment's child scope (decorators,
-    /// composites, whole modules) that the typed shortcuts do not cover.
-    /// </summary>
-    /// <remarks>Configuration actions are applied in the order they were added.</remarks>
     IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure);
 
-    /// <summary>
-    /// Builds the child scope and returns an implementation of <typeparamref name="TWrapper"/> whose
-    /// property getters resolve components from the scope. Disposing the returned wrapper disposes the
-    /// scope.
-    /// </summary>
-    /// <remarks>
-    /// <typeparamref name="TWrapper"/> must be a <b>public</b> interface exposing only read-only
-    /// properties plus <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> (so the scope is
-    /// released); the implementation is generated once per interface at runtime and cached. Every
-    /// property is resolved from the scope when the wrapper is constructed, so a missing registration
-    /// surfaces here (fail-fast).
-    /// </remarks>
-    /// <exception cref="InvalidOperationException">No world state was specified via <c>WithWorldState</c>.</exception>
     TWrapper BuildAs<TWrapper>() where TWrapper : class;
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -60,10 +60,11 @@ public interface IProcessingEnvBuilder
     /// </summary>
     /// <remarks>
     /// <typeparamref name="TWrapper"/> must be a <b>public</b> interface exposing only read-only
-    /// properties plus <see cref="IDisposable"/>; the implementation is generated once per interface at
-    /// runtime and cached. Every property is resolved from the scope when the wrapper is constructed, so
-    /// a missing registration surfaces here (fail-fast).
+    /// properties plus <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> (so the scope is
+    /// released); the implementation is generated once per interface at runtime and cached. Every
+    /// property is resolved from the scope when the wrapper is constructed, so a missing registration
+    /// surfaces here (fail-fast).
     /// </remarks>
     /// <exception cref="InvalidOperationException">No world state was specified via <c>WithWorldState</c>.</exception>
-    TWrapper BuildAs<TWrapper>() where TWrapper : class, IDisposable;
+    TWrapper BuildAs<TWrapper>() where TWrapper : class;
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Autofac;
+using Nethermind.Evm.State;
+
+namespace Nethermind.Consensus.Processing;
+
+/// <summary>
+/// Fluent builder for an isolated block-processing environment. It configures an Autofac child
+/// lifetime scope (overriding the world state and/or individual components) and exposes the resolved
+/// graph through a caller-defined wrapper interface produced by <see cref="BuildAs{TWrapper}"/>.
+/// </summary>
+/// <remarks>
+/// A builder is single-use and not thread-safe: accumulate the configuration with the <c>With*</c> /
+/// <see cref="Configure"/> methods, then call <see cref="BuildAs{TWrapper}"/> once. Resolve a fresh
+/// builder (or inject <see cref="Func{IProcessingEnvBuilder}"/>) for each environment. Because the
+/// components come from a real child scope, all plugin registrations, decorators and composites in the
+/// parent container are honoured — unlike a hand-built processing stack.
+/// </remarks>
+public interface IProcessingEnvBuilder
+{
+    /// <summary>
+    /// Binds the environment's world state to <paramref name="worldState"/>. Downstream scoped
+    /// components (<see cref="IWorldState"/>, the transaction processor, etc.) are built over it.
+    /// </summary>
+    /// <remarks>
+    /// This is the common case — pass a provider from <c>IWorldStateManager</c> (e.g.
+    /// <c>CreateResettableWorldState()</c>, <c>GlobalWorldState</c>, or
+    /// <c>CreateOverridableWorldScope().WorldState</c>). One of the <see cref="WithWorldState(IWorldStateScopeProvider)"/>
+    /// / <see cref="WithWorldState(IWorldState)"/> overloads must be called before
+    /// <see cref="BuildAs{TWrapper}"/>. The provider is externally owned and is not disposed with the scope.
+    /// </remarks>
+    IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState);
+
+    /// <summary>
+    /// Binds the environment to an already-built <see cref="IWorldState"/> instance, registered
+    /// directly (the witness / stateless case where a wrapping world state is constructed by hand).
+    /// </summary>
+    IProcessingEnvBuilder WithWorldState(IWorldState worldState);
+
+    /// <summary>
+    /// Replaces the registration of <typeparamref name="T"/> within the environment's scope with
+    /// <paramref name="instance"/>. The instance is externally owned and is not disposed with the scope.
+    /// </summary>
+    IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class;
+
+    /// <summary>
+    /// Escape hatch to apply arbitrary registrations to the environment's child scope (decorators,
+    /// composites, whole modules) that the typed shortcuts do not cover.
+    /// </summary>
+    /// <remarks>Configuration actions are applied in the order they were added.</remarks>
+    IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure);
+
+    /// <summary>
+    /// Builds the child scope and returns an implementation of <typeparamref name="TWrapper"/> whose
+    /// property getters resolve components from the scope. Disposing the returned wrapper disposes the
+    /// scope.
+    /// </summary>
+    /// <remarks>
+    /// <typeparamref name="TWrapper"/> must be a <b>public</b> interface exposing only read-only
+    /// properties plus <see cref="IDisposable"/>; the implementation is generated once per interface at
+    /// runtime and cached. Every property is resolved from the scope when the wrapper is constructed, so
+    /// a missing registration surfaces here (fail-fast).
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">No world state was specified via <c>WithWorldState</c>.</exception>
+    TWrapper BuildAs<TWrapper>() where TWrapper : class, IDisposable;
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -41,6 +41,10 @@ public interface IProcessingEnvBuilder
 
     IProcessingEnvBuilder WithComponent<T>() where T : notnull;
 
+    IProcessingEnvBuilder WithComponent<TService, TImpl>() where TImpl : TService where TService : notnull;
+
+    IProcessingEnvBuilder WithDecorator<TService, TDecorator>() where TService : class where TDecorator : TService;
+
     IProcessingEnvBuilder ThatDisposes(IDisposable disposable);
 
     IProcessingEnvBuilder WithBlockValidationConfiguration();
@@ -60,4 +64,10 @@ public interface IProcessingEnvBuilder
     IProcessingEnvBuilder OwnedByParentLifetime();
 
     TWrapper BuildAs<TWrapper>() where TWrapper : class;
+
+    /// <summary>
+    /// Builds the environment and resolves <typeparamref name="T"/> from its scope. Requires
+    /// <see cref="OwnedByParentLifetime"/>, since the returned component cannot dispose the scope itself.
+    /// </summary>
+    T Build<T>() where T : notnull;
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -43,4 +43,16 @@ public interface IProcessingEnvBuilder
     IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure);
 
     TWrapper BuildAs<TWrapper>() where TWrapper : class;
+
+    /// <summary>
+    /// Builds the environment and returns its <see cref="IOverridableEnv{T}"/>; disposing the returned
+    /// handle disposes the underlying scope. Use for the state-override RPC envs whose world state comes
+    /// from <see cref="WithOverridableEnv(IOverridableEnv)"/>.
+    /// </summary>
+    IOverridableEnvHandle<T> BuildAsOverridableEnv<T>();
+}
+
+/// <summary>An <see cref="IOverridableEnv{T}"/> that owns and asynchronously disposes its environment scope.</summary>
+public interface IOverridableEnvHandle<T> : IOverridableEnv<T>, IAsyncDisposable
+{
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -39,6 +39,8 @@ public interface IProcessingEnvBuilder
 
     IProcessingEnvBuilder WithComponent<T>(T instance) where T : class;
 
+    IProcessingEnvBuilder WithComponent<T>() where T : notnull;
+
     IProcessingEnvBuilder ThatDisposes(IDisposable disposable);
 
     IProcessingEnvBuilder WithBlockValidationConfiguration();

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -10,9 +10,11 @@ namespace Nethermind.Consensus.Processing;
 
 /// <summary>
 /// Fluent builder for an isolated block-processing environment. It configures an Autofac child lifetime
-/// scope and returns the resolved graph as <c>TWrapper</c> — a caller-defined, getter-only interface that
-/// must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> and be disposed when the
-/// environment is no longer needed (disposing it disposes the scope).
+/// scope and returns the resolved graph as <c>TWrapper</c> — a caller-defined, getter-only interface.
+/// <c>TWrapper</c> must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> and be
+/// disposed when the environment is no longer needed (disposing it disposes the scope) — unless the
+/// environment is built with <see cref="OwnedByParentLifetime"/>, in which case <c>TWrapper</c> must
+/// <b>not</b> implement them, because the parent lifetime owns disposal.
 /// </summary>
 /// <remarks>
 /// The DI-registered instance is immutable and can be reused — and forked concurrently — to build
@@ -42,6 +44,18 @@ public interface IProcessingEnvBuilder
     IProcessingEnvBuilder WithBlockValidationConfiguration();
 
     IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure);
+
+    /// <summary>
+    /// Ties the built environment's scope to the builder's parent lifetime scope: the scope is registered
+    /// with the parent's disposer, so the caller never disposes the result. <c>TWrapper</c> must then
+    /// <b>not</b> implement <see cref="IDisposable"/>/<see cref="IAsyncDisposable"/> — the parent owns disposal.
+    /// </summary>
+    /// <remarks>
+    /// Warning: the environment (and its world state) then lives as long as the parent scope — which for a
+    /// root-resolved builder is the whole application lifetime. Use only for long-lived environments, never
+    /// per-request ones.
+    /// </remarks>
+    IProcessingEnvBuilder OwnedByParentLifetime();
 
     TWrapper BuildAs<TWrapper>() where TWrapper : class;
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IProcessingEnvBuilder.cs
@@ -28,29 +28,24 @@ public interface IProcessingEnvBuilder
     /// <remarks>
     /// Pass a provider from <c>IWorldStateManager</c> (e.g. <c>CreateResettableWorldState()</c>,
     /// <c>GlobalWorldState</c>, or <c>CreateOverridableWorldScope().WorldState</c>). One of the
-    /// <see cref="WithWorldState(IWorldStateScopeProvider, bool)"/> / <see cref="WithWorldState(IWorldState, bool)"/>
-    /// overloads must be called before <see cref="BuildAs{TWrapper}"/>. Pass
-    /// <paramref name="externallyOwned"/> <c>true</c> for a shared/manager-owned provider (e.g.
-    /// <c>GlobalWorldState</c>) that must never be disposed by the environment.
+    /// <see cref="WithWorldState(IWorldStateScopeProvider)"/> / <see cref="WithWorldState(IWorldState)"/>
+    /// overloads must be called before <see cref="BuildAs{TWrapper}"/>. The provider is registered but
+    /// not disposed by the environment; use <see cref="ThatDisposes"/> if the environment owns it.
     /// </remarks>
-    /// <param name="externallyOwned">When <c>false</c> (default) the environment owns the instance and
-    /// disposes it (if disposable) when the wrapper is disposed.</param>
-    IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState, bool externallyOwned = false);
+    IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState);
 
     /// <summary>
     /// Binds the environment to an already-built <see cref="IWorldState"/> instance, registered
     /// directly (the witness / stateless case where a wrapping world state is constructed by hand).
     /// </summary>
-    /// <inheritdoc cref="WithWorldState(IWorldStateScopeProvider, bool)" path="/param"/>
-    IProcessingEnvBuilder WithWorldState(IWorldState worldState, bool externallyOwned = false);
+    IProcessingEnvBuilder WithWorldState(IWorldState worldState);
 
     /// <summary>
     /// Replaces the registration of <typeparamref name="T"/> within the environment's scope with
-    /// <paramref name="instance"/>.
+    /// <paramref name="instance"/>. The instance is registered but not disposed by the environment; use
+    /// <see cref="ThatDisposes"/> if the environment owns it.
     /// </summary>
-    /// <param name="externallyOwned">When <c>false</c> (default) the environment owns the instance and
-    /// disposes it (if disposable) when the wrapper is disposed; pass <c>true</c> for a shared instance.</param>
-    IProcessingEnvBuilder WithReplacedComponent<T>(T instance, bool externallyOwned = false) where T : class;
+    IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class;
 
     /// <summary>
     /// Replaces the registration of <typeparamref name="TService"/> within the environment's scope with
@@ -66,10 +61,22 @@ public interface IProcessingEnvBuilder
 
     /// <summary>
     /// Adds <paramref name="instance"/> as a component of the environment's scope (a service the base
-    /// graph does not provide).
+    /// graph does not provide). The instance is registered but not disposed by the environment; use
+    /// <see cref="ThatDisposes"/> if the environment owns it.
     /// </summary>
-    /// <inheritdoc cref="WithReplacedComponent{T}(T, bool)" path="/param"/>
-    IProcessingEnvBuilder WithComponent<T>(T instance, bool externallyOwned = false) where T : class;
+    IProcessingEnvBuilder WithComponent<T>(T instance) where T : class;
+
+    /// <summary>
+    /// Declares that <paramref name="disposable"/> is owned by the environment and must be disposed when
+    /// the environment (its child scope) is disposed.
+    /// </summary>
+    /// <remarks>
+    /// Use for resources the environment owns that Autofac does not otherwise track — e.g. a
+    /// manually-created read-only trie store that no scope component resolves. Registering a component
+    /// with <see cref="WithComponent"/> / <see cref="WithReplacedComponent{T}(T)"/> does not imply
+    /// disposal; ownership is declared here, explicitly.
+    /// </remarks>
+    IProcessingEnvBuilder ThatDisposes(IDisposable disposable);
 
     /// <summary>
     /// Escape hatch to apply arbitrary registrations to the environment's child scope (decorators,

--- a/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
@@ -12,7 +12,7 @@ public class PrewarmerEnvFactory(IWorldStateManager worldStateManager, ILogManag
 {
     public IReadOnlyTxProcessorSource Create(PreBlockCaches preBlockCaches) =>
         new AutoReadOnlyTxProcessingEnvFactory.AutoReadOnlyTxProcessingEnv(
-            envBuilder.NewEnv()
+            envBuilder
                 .WithWorldState(new PrewarmerScopeProvider(
                     worldStateManager.CreateResettableWorldState(),
                     preBlockCaches,

--- a/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
@@ -1,33 +1,23 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Autofac;
+using System;
 using Nethermind.Blockchain;
-using Nethermind.Core;
 using Nethermind.Evm.State;
 using Nethermind.Logging;
 using Nethermind.State;
 
 namespace Nethermind.Consensus.Processing;
 
-public class PrewarmerEnvFactory(IWorldStateManager worldStateManager, ILogManager logManager, ILifetimeScope parentLifetime)
+public class PrewarmerEnvFactory(IWorldStateManager worldStateManager, ILogManager logManager, Func<IProcessingEnvBuilder> envBuilder)
 {
-    public IReadOnlyTxProcessorSource Create(PreBlockCaches preBlockCaches)
-    {
-        PrewarmerScopeProvider worldState = new(
-            worldStateManager.CreateResettableWorldState(),
-            preBlockCaches,
-            logManager,
-            isPrewarmer: true
-        );
-
-        ILifetimeScope childScope = parentLifetime.BeginLifetimeScope((builder) =>
-        {
-            builder
-                .AddSingleton<IWorldStateScopeProvider>(worldState)
-                .AddSingleton<AutoReadOnlyTxProcessingEnvFactory.AutoReadOnlyTxProcessingEnv>();
-        });
-
-        return childScope.Resolve<AutoReadOnlyTxProcessingEnvFactory.AutoReadOnlyTxProcessingEnv>();
-    }
+    public IReadOnlyTxProcessorSource Create(PreBlockCaches preBlockCaches) =>
+        new AutoReadOnlyTxProcessingEnvFactory.AutoReadOnlyTxProcessingEnv(
+            envBuilder()
+                .WithWorldState(new PrewarmerScopeProvider(
+                    worldStateManager.CreateResettableWorldState(),
+                    preBlockCaches,
+                    logManager,
+                    isPrewarmer: true))
+                .BuildAs<AutoReadOnlyTxProcessingEnvFactory.AutoReadOnlyTxProcessingEnv.IEnv>());
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerEnvFactory.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Nethermind.Blockchain;
 using Nethermind.Evm.State;
 using Nethermind.Logging;
@@ -9,11 +8,11 @@ using Nethermind.State;
 
 namespace Nethermind.Consensus.Processing;
 
-public class PrewarmerEnvFactory(IWorldStateManager worldStateManager, ILogManager logManager, Func<IProcessingEnvBuilder> envBuilder)
+public class PrewarmerEnvFactory(IWorldStateManager worldStateManager, ILogManager logManager, IProcessingEnvBuilder envBuilder)
 {
     public IReadOnlyTxProcessorSource Create(PreBlockCaches preBlockCaches) =>
         new AutoReadOnlyTxProcessingEnvFactory.AutoReadOnlyTxProcessingEnv(
-            envBuilder()
+            envBuilder.NewEnv()
                 .WithWorldState(new PrewarmerScopeProvider(
                     worldStateManager.CreateResettableWorldState(),
                     preBlockCaches,

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Autofac;
+using Nethermind.Core;
+using Nethermind.Evm.State;
+
+namespace Nethermind.Consensus.Processing;
+
+/// <inheritdoc cref="IProcessingEnvBuilder"/>
+/// <remarks>
+/// Every typed shortcut funnels into <see cref="Configure"/>, so <see cref="BuildAs{TWrapper}"/> simply
+/// replays the accumulated actions against a fresh child of <paramref name="parentScope"/>.
+/// </remarks>
+public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBuilder
+{
+    private readonly List<Action<ContainerBuilder>> _configure = [];
+    private bool _worldStateConfigured;
+
+    public IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure)
+    {
+        _configure.Add(configure);
+        return this;
+    }
+
+    public IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState)
+    {
+        _worldStateConfigured = true;
+        return Configure(builder => builder.AddScoped<IWorldStateScopeProvider>(worldState));
+    }
+
+    public IProcessingEnvBuilder WithWorldState(IWorldState worldState)
+    {
+        _worldStateConfigured = true;
+        return Configure(builder => builder.AddScoped<IWorldState>(worldState));
+    }
+
+    public IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class =>
+        Configure(builder => builder.AddScoped<T>(instance));
+
+    public TWrapper BuildAs<TWrapper>() where TWrapper : class, IDisposable
+    {
+        if (!_worldStateConfigured)
+            throw new InvalidOperationException(
+                $"A world state must be specified with {nameof(WithWorldState)} before building a processing environment.");
+
+        return ProcessingEnvWrapperFactory.Create<TWrapper>(parentScope.BeginLifetimeScope(builder =>
+        {
+            foreach (Action<ContainerBuilder> configure in _configure) configure(builder);
+        }));
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -12,11 +12,14 @@ namespace Nethermind.Consensus.Processing;
 /// <inheritdoc cref="IProcessingEnvBuilder"/>
 /// <remarks>
 /// Every typed shortcut funnels into <see cref="Configure"/>, so <see cref="BuildAs{TWrapper}"/> simply
-/// replays the accumulated actions against a fresh child of <paramref name="parentScope"/>.
+/// replays the accumulated actions against a fresh child of <paramref name="parentScope"/>. Instances
+/// registered as owned (the default) are tracked and disposed with the scope, regardless of whether the
+/// wrapper ever resolves them.
 /// </remarks>
 public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBuilder
 {
     private readonly List<Action<ContainerBuilder>> _configure = [];
+    private readonly List<object> _ownedInstances = [];
     private bool _worldStateConfigured;
 
     public IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure)
@@ -25,20 +28,29 @@ public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBu
         return this;
     }
 
-    public IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState)
+    public IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState, bool externallyOwned = false)
     {
         _worldStateConfigured = true;
-        return Configure(builder => builder.AddScoped<IWorldStateScopeProvider>(worldState));
+        return AddInstance(worldState, externallyOwned);
     }
 
-    public IProcessingEnvBuilder WithWorldState(IWorldState worldState)
+    public IProcessingEnvBuilder WithWorldState(IWorldState worldState, bool externallyOwned = false)
     {
         _worldStateConfigured = true;
-        return Configure(builder => builder.AddScoped<IWorldState>(worldState));
+        return AddInstance(worldState, externallyOwned);
     }
 
-    public IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class =>
-        Configure(builder => builder.AddScoped<T>(instance));
+    public IProcessingEnvBuilder WithReplacedComponent<T>(T instance, bool externallyOwned = false) where T : class =>
+        AddInstance(instance, externallyOwned);
+
+    public IProcessingEnvBuilder WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull =>
+        Configure(builder => builder.AddScoped<TService, TImpl>());
+
+    public IProcessingEnvBuilder WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class =>
+        Configure(builder => builder.AddScoped<T>(factory));
+
+    public IProcessingEnvBuilder WithComponent<T>(T instance, bool externallyOwned = false) where T : class =>
+        AddInstance(instance, externallyOwned);
 
     public TWrapper BuildAs<TWrapper>() where TWrapper : class
     {
@@ -46,9 +58,33 @@ public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBu
             throw new InvalidOperationException(
                 $"A world state must be specified with {nameof(WithWorldState)} before building a processing environment.");
 
-        return ProcessingEnvWrapperFactory.Create<TWrapper>(parentScope.BeginLifetimeScope(builder =>
+        ILifetimeScope scope = parentScope.BeginLifetimeScope(builder =>
         {
             foreach (Action<ContainerBuilder> configure in _configure) configure(builder);
-        }));
+        });
+
+        // Registrations for provided instances are externally owned at the Autofac level, so give the
+        // scope ownership of the ones the caller kept by adding them to its disposer directly — this
+        // disposes them even when the wrapper never resolves them.
+        foreach (object owned in _ownedInstances)
+        {
+            switch (owned)
+            {
+                case IAsyncDisposable asyncDisposable:
+                    scope.Disposer.AddInstanceForAsyncDisposal(asyncDisposable);
+                    break;
+                case IDisposable disposable:
+                    scope.Disposer.AddInstanceForDisposal(disposable);
+                    break;
+            }
+        }
+
+        return ProcessingEnvWrapperFactory.Create<TWrapper>(scope);
+    }
+
+    private IProcessingEnvBuilder AddInstance<T>(T instance, bool externallyOwned) where T : class
+    {
+        if (!externallyOwned) _ownedInstances.Add(instance);
+        return Configure(builder => builder.AddScoped<T>(instance));
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -2,105 +2,96 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using Autofac;
 using Nethermind.Core;
 using Nethermind.Core.Container;
 using Nethermind.Evm.State;
 using Nethermind.State.OverridableEnv;
-using IDsl = Nethermind.Consensus.Processing.IProcessingEnvBuilder.IDsl;
 
 namespace Nethermind.Consensus.Processing;
 
 /// <inheritdoc cref="IProcessingEnvBuilder"/>
-public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBuilder
+public class ProcessingEnvBuilder : IProcessingEnvBuilder
 {
-    public IDsl NewEnv() => new Dsl(parentScope);
+    private readonly ILifetimeScope _parentScope;
+    private readonly Action<ContainerBuilder>[] _configure;
+    private readonly IDisposable[] _disposables;
+    private readonly bool _worldStateConfigured;
 
-    /// <inheritdoc cref="IProcessingEnvBuilder.IDsl"/>
-    /// <remarks>
-    /// Single-use and not thread-safe; obtain one from <see cref="NewEnv"/> per environment.
-    /// <see cref="BuildAs{TWrapper}"/> replays the accumulated configuration against a fresh child of the
-    /// parent scope.
-    /// </remarks>
-    private sealed class Dsl(ILifetimeScope parentScope) : IDsl
+    public ProcessingEnvBuilder(ILifetimeScope parentScope) : this(parentScope, [], [], false) { }
+
+    private ProcessingEnvBuilder(
+        ILifetimeScope parentScope,
+        Action<ContainerBuilder>[] configure,
+        IDisposable[] disposables,
+        bool worldStateConfigured)
     {
-        private readonly List<Action<ContainerBuilder>> _configure = [];
-        private readonly List<IDisposable> _disposables = [];
-        private bool _worldStateConfigured;
-
-        public IDsl Configure(Action<ContainerBuilder> configure)
-        {
-            _configure.Add(configure);
-            return this;
-        }
-
-        public IDsl ThatDisposes(IDisposable disposable)
-        {
-            _disposables.Add(disposable);
-            return this;
-        }
-
-        public IDsl WithWorldState(IWorldStateScopeProvider worldState)
-        {
-            _worldStateConfigured = true;
-            return Configure(builder => builder.AddScoped<IWorldStateScopeProvider>(worldState));
-        }
-
-        public IDsl WithWorldState(IWorldState worldState)
-        {
-            _worldStateConfigured = true;
-            return Configure(builder => builder.AddScoped<IWorldState>(worldState));
-        }
-
-        public IDsl WithOverridableEnv(IOverridableEnv env)
-        {
-            _worldStateConfigured = true; // the env module supplies the (overridden) world state
-            return Configure(builder => builder.AddModule(env));
-        }
-
-        public IDsl WithOverridableEnv()
-        {
-            // Create and own an env from the world-state manager: the environment disposes both the env
-            // and its opened (un-overridden) world-state scope when it is disposed.
-            IOverridableEnv env = parentScope.Resolve<IOverridableEnvFactory>().Create();
-            if (env is IDisposable disposableEnv) ThatDisposes(disposableEnv); // added first → disposed last
-            ThatDisposes(env.BuildAndOverride(null));                          // added last → disposed first
-            return WithOverridableEnv(env);
-        }
-
-        public IDsl WithReplacedComponent<T>(T instance) where T : class =>
-            Configure(builder => builder.AddScoped<T>(instance));
-
-        public IDsl WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull =>
-            Configure(builder => builder.AddScoped<TService, TImpl>());
-
-        public IDsl WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class =>
-            Configure(builder => builder.AddScoped<T>(factory));
-
-        public IDsl WithComponent<T>(T instance) where T : class =>
-            Configure(builder => builder.AddScoped<T>(instance));
-
-        public IDsl WithBlockValidationConfiguration() =>
-            Configure(builder => builder.AddModule(parentScope.Resolve<IBlockValidationModule[]>()));
-
-        public TWrapper BuildAs<TWrapper>() where TWrapper : class
-        {
-            if (!_worldStateConfigured)
-                throw new InvalidOperationException(
-                    $"A world state must be specified with {nameof(WithWorldState)} before building a processing environment.");
-
-            ILifetimeScope scope = parentScope.BeginLifetimeScope(builder =>
-            {
-                foreach (Action<ContainerBuilder> configure in _configure) configure(builder);
-            });
-
-            // Give the scope ownership of the caller-declared resources so they are disposed with it, even
-            // when no scope component ever resolves them.
-            foreach (IDisposable disposable in _disposables)
-                scope.Disposer.AddInstanceForDisposal(disposable);
-
-            return ProcessingEnvWrapperFactory.Create<TWrapper>(scope);
-        }
+        _parentScope = parentScope;
+        _configure = configure;
+        _disposables = disposables;
+        _worldStateConfigured = worldStateConfigured;
     }
+
+    public IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure) =>
+        new ProcessingEnvBuilder(_parentScope, [.. _configure, configure], _disposables, _worldStateConfigured);
+
+    public IProcessingEnvBuilder ThatDisposes(IDisposable disposable) =>
+        new ProcessingEnvBuilder(_parentScope, _configure, [.. _disposables, disposable], _worldStateConfigured);
+
+    public IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState) =>
+        WithWorldStateConfigured(builder => builder.AddScoped<IWorldStateScopeProvider>(worldState));
+
+    public IProcessingEnvBuilder WithWorldState(IWorldState worldState) =>
+        WithWorldStateConfigured(builder => builder.AddScoped<IWorldState>(worldState));
+
+    public IProcessingEnvBuilder WithOverridableEnv(IOverridableEnv env) =>
+        WithWorldStateConfigured(builder => builder.AddModule(env)); // the env module supplies the (overridden) world state
+
+    public IProcessingEnvBuilder WithOverridableEnv()
+    {
+        // Create and own an env from the world-state manager: the environment disposes both the env and
+        // its opened (un-overridden) world-state scope when it is disposed.
+        IOverridableEnv env = _parentScope.Resolve<IOverridableEnvFactory>().Create();
+        IProcessingEnvBuilder result = env is IDisposable disposableEnv ? ThatDisposes(disposableEnv) : this; // disposed last
+        return result
+            .ThatDisposes(env.BuildAndOverride(null)) // disposed before the env
+            .WithOverridableEnv(env);
+    }
+
+    public IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class =>
+        Configure(builder => builder.AddScoped<T>(instance));
+
+    public IProcessingEnvBuilder WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull =>
+        Configure(builder => builder.AddScoped<TService, TImpl>());
+
+    public IProcessingEnvBuilder WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class =>
+        Configure(builder => builder.AddScoped<T>(factory));
+
+    public IProcessingEnvBuilder WithComponent<T>(T instance) where T : class =>
+        Configure(builder => builder.AddScoped<T>(instance));
+
+    public IProcessingEnvBuilder WithBlockValidationConfiguration() =>
+        Configure(builder => builder.AddModule(_parentScope.Resolve<IBlockValidationModule[]>()));
+
+    public TWrapper BuildAs<TWrapper>() where TWrapper : class
+    {
+        if (!_worldStateConfigured)
+            throw new InvalidOperationException(
+                $"A world state must be specified with {nameof(WithWorldState)} before building a processing environment.");
+
+        ILifetimeScope scope = _parentScope.BeginLifetimeScope(builder =>
+        {
+            foreach (Action<ContainerBuilder> configure in _configure) configure(builder);
+        });
+
+        // Give the scope ownership of the caller-declared resources so they are disposed with it, even
+        // when no scope component ever resolves them.
+        foreach (IDisposable disposable in _disposables)
+            scope.Disposer.AddInstanceForDisposal(disposable);
+
+        return ProcessingEnvWrapperFactory.Create<TWrapper>(scope);
+    }
+
+    private IProcessingEnvBuilder WithWorldStateConfigured(Action<ContainerBuilder> configure) =>
+        new ProcessingEnvBuilder(_parentScope, [.. _configure, configure], _disposables, worldStateConfigured: true);
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -7,6 +7,7 @@ using Autofac;
 using Nethermind.Core;
 using Nethermind.Core.Container;
 using Nethermind.Evm.State;
+using Nethermind.State.OverridableEnv;
 
 namespace Nethermind.Consensus.Processing;
 
@@ -45,6 +46,22 @@ public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBu
     {
         _worldStateConfigured = true;
         return Configure(builder => builder.AddScoped<IWorldState>(worldState));
+    }
+
+    public IProcessingEnvBuilder WithOverridableEnv(IOverridableEnv env)
+    {
+        _worldStateConfigured = true; // the env module supplies the (overridden) world state
+        return Configure(builder => builder.AddModule(env));
+    }
+
+    public IProcessingEnvBuilder WithOverridableEnv()
+    {
+        // Create and own an env from the world-state manager: the environment disposes both the env and
+        // its opened (un-overridden) world-state scope when it is disposed.
+        IOverridableEnv env = parentScope.Resolve<IOverridableEnvFactory>().Create();
+        if (env is IDisposable disposableEnv) ThatDisposes(disposableEnv); // added first → disposed last
+        ThatDisposes(env.BuildAndOverride(null));                          // added last → disposed first
+        return WithOverridableEnv(env);
     }
 
     public IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class =>

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -8,93 +8,99 @@ using Nethermind.Core;
 using Nethermind.Core.Container;
 using Nethermind.Evm.State;
 using Nethermind.State.OverridableEnv;
+using IDsl = Nethermind.Consensus.Processing.IProcessingEnvBuilder.IDsl;
 
 namespace Nethermind.Consensus.Processing;
 
 /// <inheritdoc cref="IProcessingEnvBuilder"/>
-/// <remarks>
-/// Every typed shortcut funnels into <see cref="Configure"/>, so <see cref="BuildAs{TWrapper}"/> simply
-/// replays the accumulated actions against a fresh child of <paramref name="parentScope"/>. Instances
-/// passed to the <c>With*</c> methods are registered but never disposed by the builder; ownership is
-/// declared explicitly with <see cref="ThatDisposes"/>.
-/// </remarks>
 public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBuilder
 {
-    private readonly List<Action<ContainerBuilder>> _configure = [];
-    private readonly List<IDisposable> _disposables = [];
-    private bool _worldStateConfigured;
+    public IDsl NewEnv() => new Dsl(parentScope);
 
-    public IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure)
+    /// <inheritdoc cref="IProcessingEnvBuilder.IDsl"/>
+    /// <remarks>
+    /// Single-use and not thread-safe; obtain one from <see cref="NewEnv"/> per environment.
+    /// <see cref="BuildAs{TWrapper}"/> replays the accumulated configuration against a fresh child of the
+    /// parent scope.
+    /// </remarks>
+    private sealed class Dsl(ILifetimeScope parentScope) : IDsl
     {
-        _configure.Add(configure);
-        return this;
-    }
+        private readonly List<Action<ContainerBuilder>> _configure = [];
+        private readonly List<IDisposable> _disposables = [];
+        private bool _worldStateConfigured;
 
-    public IProcessingEnvBuilder ThatDisposes(IDisposable disposable)
-    {
-        _disposables.Add(disposable);
-        return this;
-    }
-
-    public IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState)
-    {
-        _worldStateConfigured = true;
-        return Configure(builder => builder.AddScoped<IWorldStateScopeProvider>(worldState));
-    }
-
-    public IProcessingEnvBuilder WithWorldState(IWorldState worldState)
-    {
-        _worldStateConfigured = true;
-        return Configure(builder => builder.AddScoped<IWorldState>(worldState));
-    }
-
-    public IProcessingEnvBuilder WithOverridableEnv(IOverridableEnv env)
-    {
-        _worldStateConfigured = true; // the env module supplies the (overridden) world state
-        return Configure(builder => builder.AddModule(env));
-    }
-
-    public IProcessingEnvBuilder WithOverridableEnv()
-    {
-        // Create and own an env from the world-state manager: the environment disposes both the env and
-        // its opened (un-overridden) world-state scope when it is disposed.
-        IOverridableEnv env = parentScope.Resolve<IOverridableEnvFactory>().Create();
-        if (env is IDisposable disposableEnv) ThatDisposes(disposableEnv); // added first → disposed last
-        ThatDisposes(env.BuildAndOverride(null));                          // added last → disposed first
-        return WithOverridableEnv(env);
-    }
-
-    public IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class =>
-        Configure(builder => builder.AddScoped<T>(instance));
-
-    public IProcessingEnvBuilder WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull =>
-        Configure(builder => builder.AddScoped<TService, TImpl>());
-
-    public IProcessingEnvBuilder WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class =>
-        Configure(builder => builder.AddScoped<T>(factory));
-
-    public IProcessingEnvBuilder WithComponent<T>(T instance) where T : class =>
-        Configure(builder => builder.AddScoped<T>(instance));
-
-    public IProcessingEnvBuilder WithBlockValidationConfiguration() =>
-        Configure(builder => builder.AddModule(parentScope.Resolve<IBlockValidationModule[]>()));
-
-    public TWrapper BuildAs<TWrapper>() where TWrapper : class
-    {
-        if (!_worldStateConfigured)
-            throw new InvalidOperationException(
-                $"A world state must be specified with {nameof(WithWorldState)} before building a processing environment.");
-
-        ILifetimeScope scope = parentScope.BeginLifetimeScope(builder =>
+        public IDsl Configure(Action<ContainerBuilder> configure)
         {
-            foreach (Action<ContainerBuilder> configure in _configure) configure(builder);
-        });
+            _configure.Add(configure);
+            return this;
+        }
 
-        // Give the scope ownership of the caller-declared resources so they are disposed with it, even
-        // when no scope component ever resolves them.
-        foreach (IDisposable disposable in _disposables)
-            scope.Disposer.AddInstanceForDisposal(disposable);
+        public IDsl ThatDisposes(IDisposable disposable)
+        {
+            _disposables.Add(disposable);
+            return this;
+        }
 
-        return ProcessingEnvWrapperFactory.Create<TWrapper>(scope);
+        public IDsl WithWorldState(IWorldStateScopeProvider worldState)
+        {
+            _worldStateConfigured = true;
+            return Configure(builder => builder.AddScoped<IWorldStateScopeProvider>(worldState));
+        }
+
+        public IDsl WithWorldState(IWorldState worldState)
+        {
+            _worldStateConfigured = true;
+            return Configure(builder => builder.AddScoped<IWorldState>(worldState));
+        }
+
+        public IDsl WithOverridableEnv(IOverridableEnv env)
+        {
+            _worldStateConfigured = true; // the env module supplies the (overridden) world state
+            return Configure(builder => builder.AddModule(env));
+        }
+
+        public IDsl WithOverridableEnv()
+        {
+            // Create and own an env from the world-state manager: the environment disposes both the env
+            // and its opened (un-overridden) world-state scope when it is disposed.
+            IOverridableEnv env = parentScope.Resolve<IOverridableEnvFactory>().Create();
+            if (env is IDisposable disposableEnv) ThatDisposes(disposableEnv); // added first → disposed last
+            ThatDisposes(env.BuildAndOverride(null));                          // added last → disposed first
+            return WithOverridableEnv(env);
+        }
+
+        public IDsl WithReplacedComponent<T>(T instance) where T : class =>
+            Configure(builder => builder.AddScoped<T>(instance));
+
+        public IDsl WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull =>
+            Configure(builder => builder.AddScoped<TService, TImpl>());
+
+        public IDsl WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class =>
+            Configure(builder => builder.AddScoped<T>(factory));
+
+        public IDsl WithComponent<T>(T instance) where T : class =>
+            Configure(builder => builder.AddScoped<T>(instance));
+
+        public IDsl WithBlockValidationConfiguration() =>
+            Configure(builder => builder.AddModule(parentScope.Resolve<IBlockValidationModule[]>()));
+
+        public TWrapper BuildAs<TWrapper>() where TWrapper : class
+        {
+            if (!_worldStateConfigured)
+                throw new InvalidOperationException(
+                    $"A world state must be specified with {nameof(WithWorldState)} before building a processing environment.");
+
+            ILifetimeScope scope = parentScope.BeginLifetimeScope(builder =>
+            {
+                foreach (Action<ContainerBuilder> configure in _configure) configure(builder);
+            });
+
+            // Give the scope ownership of the caller-declared resources so they are disposed with it, even
+            // when no scope component ever resolves them.
+            foreach (IDisposable disposable in _disposables)
+                scope.Disposer.AddInstanceForDisposal(disposable);
+
+            return ProcessingEnvWrapperFactory.Create<TWrapper>(scope);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -81,6 +81,12 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
     public IProcessingEnvBuilder WithComponent<T>() where T : notnull =>
         Configure(builder => builder.AddScoped<T>());
 
+    public IProcessingEnvBuilder WithComponent<TService, TImpl>() where TImpl : TService where TService : notnull =>
+        Configure(builder => builder.AddScoped<TService, TImpl>());
+
+    public IProcessingEnvBuilder WithDecorator<TService, TDecorator>() where TService : class where TDecorator : TService =>
+        Configure(builder => builder.AddDecorator<TService, TDecorator>());
+
     public IProcessingEnvBuilder WithBlockValidationConfiguration() =>
         Configure(builder => builder.AddModule(_parentScope.Resolve<IBlockValidationModule[]>()));
 
@@ -93,6 +99,14 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
 
     public TWrapper BuildAs<TWrapper>() where TWrapper : class =>
         ProcessingEnvWrapperFactory.Create<TWrapper>(BuildScope(), ownedExternally: _ownedByParent);
+
+    public T Build<T>() where T : notnull
+    {
+        if (!_ownedByParent)
+            throw new InvalidOperationException(
+                $"{nameof(Build)}<T> returns a resolved component that cannot dispose its scope; call {nameof(OwnedByParentLifetime)} so the parent lifetime owns it.");
+        return BuildScope().Resolve<T>();
+    }
 
     private ILifetimeScope BuildScope()
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -18,29 +18,36 @@ namespace Nethermind.Consensus.Processing;
 public class ProcessingEnvBuilder : IProcessingEnvBuilder
 {
     private readonly ILifetimeScope _parentScope;
-    private readonly Action<ContainerBuilder>[] _configure;
-    private readonly IDisposable[] _disposables;
-    private readonly bool _worldStateConfigured;
+    private readonly bool _mutable;
+    private readonly List<Action<ContainerBuilder>> _configure = [];
+    private readonly List<IDisposable> _disposables = [];
+    private bool _worldStateConfigured;
 
-    public ProcessingEnvBuilder(ILifetimeScope parentScope) : this(parentScope, [], [], false) { }
+    public ProcessingEnvBuilder(ILifetimeScope parentScope) : this(parentScope, mutable: false) { }
 
-    private ProcessingEnvBuilder(
-        ILifetimeScope parentScope,
-        Action<ContainerBuilder>[] configure,
-        IDisposable[] disposables,
-        bool worldStateConfigured)
+    private ProcessingEnvBuilder(ILifetimeScope parentScope, bool mutable)
     {
         _parentScope = parentScope;
-        _configure = configure;
-        _disposables = disposables;
-        _worldStateConfigured = worldStateConfigured;
+        _mutable = mutable;
     }
 
-    public IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure) =>
-        new ProcessingEnvBuilder(_parentScope, [.. _configure, configure], _disposables, _worldStateConfigured);
+    // The DI-registered instance is immutable so it can be reused and forked concurrently; the first
+    // configuring call forks a private mutable builder that subsequent calls accumulate into in place.
+    private ProcessingEnvBuilder Mutable() => _mutable ? this : new ProcessingEnvBuilder(_parentScope, mutable: true);
 
-    public IProcessingEnvBuilder ThatDisposes(IDisposable disposable) =>
-        new ProcessingEnvBuilder(_parentScope, _configure, [.. _disposables, disposable], _worldStateConfigured);
+    public IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure)
+    {
+        ProcessingEnvBuilder builder = Mutable();
+        builder._configure.Add(configure);
+        return builder;
+    }
+
+    public IProcessingEnvBuilder ThatDisposes(IDisposable disposable)
+    {
+        ProcessingEnvBuilder builder = Mutable();
+        builder._disposables.Add(disposable);
+        return builder;
+    }
 
     public IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState) =>
         WithWorldStateConfigured(builder => builder.AddScoped<IWorldStateScopeProvider>(worldState));
@@ -105,8 +112,13 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
         return scope;
     }
 
-    private IProcessingEnvBuilder WithWorldStateConfigured(Action<ContainerBuilder> configure) =>
-        new ProcessingEnvBuilder(_parentScope, [.. _configure, configure], _disposables, worldStateConfigured: true);
+    private IProcessingEnvBuilder WithWorldStateConfigured(Action<ContainerBuilder> configure)
+    {
+        ProcessingEnvBuilder builder = Mutable();
+        builder._configure.Add(configure);
+        builder._worldStateConfigured = true;
+        return builder;
+    }
 
     private sealed class OverridableEnvHandle<T>(ILifetimeScope scope, IOverridableEnv<T> env) : IOverridableEnvHandle<T>
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Core;
 using Nethermind.Core.Container;
+using Nethermind.Core.Specs;
+using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.State.OverridableEnv;
 
@@ -73,7 +77,16 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
     public IProcessingEnvBuilder WithBlockValidationConfiguration() =>
         Configure(builder => builder.AddModule(_parentScope.Resolve<IBlockValidationModule[]>()));
 
-    public TWrapper BuildAs<TWrapper>() where TWrapper : class
+    public TWrapper BuildAs<TWrapper>() where TWrapper : class =>
+        ProcessingEnvWrapperFactory.Create<TWrapper>(BuildScope());
+
+    public IOverridableEnvHandle<T> BuildAsOverridableEnv<T>()
+    {
+        ILifetimeScope scope = BuildScope();
+        return new OverridableEnvHandle<T>(scope, scope.Resolve<IOverridableEnv<T>>());
+    }
+
+    private ILifetimeScope BuildScope()
     {
         if (!_worldStateConfigured)
             throw new InvalidOperationException(
@@ -89,9 +102,17 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
         foreach (IDisposable disposable in _disposables)
             scope.Disposer.AddInstanceForDisposal(disposable);
 
-        return ProcessingEnvWrapperFactory.Create<TWrapper>(scope);
+        return scope;
     }
 
     private IProcessingEnvBuilder WithWorldStateConfigured(Action<ContainerBuilder> configure) =>
         new ProcessingEnvBuilder(_parentScope, [.. _configure, configure], _disposables, worldStateConfigured: true);
+
+    private sealed class OverridableEnvHandle<T>(ILifetimeScope scope, IOverridableEnv<T> env) : IOverridableEnvHandle<T>
+    {
+        public Scope<T> BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null, IReleaseSpec? specOverride = null, BlockOverride? blockOverride = null) =>
+            env.BuildAndOverride(header, stateOverride, specOverride, blockOverride);
+
+        public ValueTask DisposeAsync() => scope.DisposeAsync();
+    }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -97,15 +97,24 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
         return builder;
     }
 
-    public TWrapper BuildAs<TWrapper>() where TWrapper : class =>
-        ProcessingEnvWrapperFactory.Create<TWrapper>(BuildScope(), ownedExternally: _ownedByParent);
-
-    public T Build<T>() where T : notnull
+    public TWrapper BuildAs<TWrapper>() where TWrapper : class
     {
-        if (!_ownedByParent)
-            throw new InvalidOperationException(
-                $"{nameof(Build)}<T> returns a resolved component that cannot dispose its scope; call {nameof(OwnedByParentLifetime)} so the parent lifetime owns it.");
-        return BuildScope().Resolve<T>();
+        ILifetimeScope scope = BuildScope();
+
+        // A type registered in the scope (via With*/Configure) is the caller's real component, so resolve it.
+        // Otherwise TWrapper is a caller-defined interface to surface the scope through, so synthesize it.
+        if (scope.IsRegistered<TWrapper>())
+        {
+            if (!_ownedByParent)
+            {
+                scope.Dispose();
+                throw new InvalidOperationException(
+                    $"A component resolved by {nameof(BuildAs)}<T> cannot dispose its scope; call {nameof(OwnedByParentLifetime)} so the parent lifetime owns it.");
+            }
+            return scope.Resolve<TWrapper>();
+        }
+
+        return ProcessingEnvWrapperFactory.Create<TWrapper>(scope, ownedExternally: _ownedByParent);
     }
 
     private ILifetimeScope BuildScope()

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -78,6 +78,9 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
     public IProcessingEnvBuilder WithComponent<T>(T instance) where T : class =>
         Configure(builder => builder.AddScoped<T>(instance));
 
+    public IProcessingEnvBuilder WithComponent<T>() where T : notnull =>
+        Configure(builder => builder.AddScoped<T>());
+
     public IProcessingEnvBuilder WithBlockValidationConfiguration() =>
         Configure(builder => builder.AddModule(_parentScope.Resolve<IBlockValidationModule[]>()));
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -3,12 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Core;
 using Nethermind.Core.Container;
-using Nethermind.Core.Specs;
-using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.State.OverridableEnv;
 
@@ -87,12 +84,6 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
     public TWrapper BuildAs<TWrapper>() where TWrapper : class =>
         ProcessingEnvWrapperFactory.Create<TWrapper>(BuildScope());
 
-    public IOverridableEnvHandle<T> BuildAsOverridableEnv<T>()
-    {
-        ILifetimeScope scope = BuildScope();
-        return new OverridableEnvHandle<T>(scope, scope.Resolve<IOverridableEnv<T>>());
-    }
-
     private ILifetimeScope BuildScope()
     {
         if (!_worldStateConfigured)
@@ -118,13 +109,5 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
         builder._configure.Add(configure);
         builder._worldStateConfigured = true;
         return builder;
-    }
-
-    private sealed class OverridableEnvHandle<T>(ILifetimeScope scope, IOverridableEnv<T> env) : IOverridableEnvHandle<T>
-    {
-        public Scope<T> BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null, IReleaseSpec? specOverride = null, BlockOverride? blockOverride = null) =>
-            env.BuildAndOverride(header, stateOverride, specOverride, blockOverride);
-
-        public ValueTask DisposeAsync() => scope.DisposeAsync();
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -58,13 +58,12 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
 
     public IProcessingEnvBuilder WithOverridableEnv()
     {
-        // Create and own an env from the world-state manager: the environment disposes both the env and
-        // its opened (un-overridden) world-state scope when it is disposed.
+        // Create and own an env from the world-state manager (the environment disposes it). Unlike the
+        // parameterized overload this owns the env's disposal; the caller opens the world-state scope on
+        // demand through the resolved IOverridableEnv<T> rather than it being built up front.
         IOverridableEnv env = _parentScope.Resolve<IOverridableEnvFactory>().Create();
-        IProcessingEnvBuilder result = env is IDisposable disposableEnv ? ThatDisposes(disposableEnv) : this; // disposed last
-        return result
-            .ThatDisposes(env.BuildAndOverride(null)) // disposed before the env
-            .WithOverridableEnv(env);
+        IProcessingEnvBuilder result = env is IDisposable disposableEnv ? ThatDisposes(disposableEnv) : this;
+        return result.WithOverridableEnv(env);
     }
 
     public IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class =>

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -19,6 +19,7 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
     private readonly List<Action<ContainerBuilder>> _configure = [];
     private readonly List<IDisposable> _disposables = [];
     private bool _worldStateConfigured;
+    private bool _ownedByParent;
 
     public ProcessingEnvBuilder(ILifetimeScope parentScope) : this(parentScope, mutable: false) { }
 
@@ -81,8 +82,15 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
     public IProcessingEnvBuilder WithBlockValidationConfiguration() =>
         Configure(builder => builder.AddModule(_parentScope.Resolve<IBlockValidationModule[]>()));
 
+    public IProcessingEnvBuilder OwnedByParentLifetime()
+    {
+        ProcessingEnvBuilder builder = Mutable();
+        builder._ownedByParent = true;
+        return builder;
+    }
+
     public TWrapper BuildAs<TWrapper>() where TWrapper : class =>
-        ProcessingEnvWrapperFactory.Create<TWrapper>(BuildScope());
+        ProcessingEnvWrapperFactory.Create<TWrapper>(BuildScope(), ownedExternally: _ownedByParent);
 
     private ILifetimeScope BuildScope()
     {
@@ -99,6 +107,11 @@ public class ProcessingEnvBuilder : IProcessingEnvBuilder
         // when no scope component ever resolves them.
         foreach (IDisposable disposable in _disposables)
             scope.Disposer.AddInstanceForDisposal(disposable);
+
+        // When owned by the parent lifetime, hand the scope to the parent's disposer so the caller never
+        // disposes it and the wrapper need not be disposable.
+        if (_ownedByParent)
+            _parentScope.Disposer.AddInstanceForAsyncDisposal(scope);
 
         return scope;
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Autofac;
 using Nethermind.Core;
+using Nethermind.Core.Container;
 using Nethermind.Evm.State;
 
 namespace Nethermind.Consensus.Processing;
@@ -57,6 +58,9 @@ public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBu
 
     public IProcessingEnvBuilder WithComponent<T>(T instance) where T : class =>
         Configure(builder => builder.AddScoped<T>(instance));
+
+    public IProcessingEnvBuilder WithBlockValidationConfiguration() =>
+        Configure(builder => builder.AddModule(parentScope.Resolve<IBlockValidationModule[]>()));
 
     public TWrapper BuildAs<TWrapper>() where TWrapper : class
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -40,7 +40,7 @@ public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBu
     public IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class =>
         Configure(builder => builder.AddScoped<T>(instance));
 
-    public TWrapper BuildAs<TWrapper>() where TWrapper : class, IDisposable
+    public TWrapper BuildAs<TWrapper>() where TWrapper : class
     {
         if (!_worldStateConfigured)
             throw new InvalidOperationException(

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvBuilder.cs
@@ -13,13 +13,13 @@ namespace Nethermind.Consensus.Processing;
 /// <remarks>
 /// Every typed shortcut funnels into <see cref="Configure"/>, so <see cref="BuildAs{TWrapper}"/> simply
 /// replays the accumulated actions against a fresh child of <paramref name="parentScope"/>. Instances
-/// registered as owned (the default) are tracked and disposed with the scope, regardless of whether the
-/// wrapper ever resolves them.
+/// passed to the <c>With*</c> methods are registered but never disposed by the builder; ownership is
+/// declared explicitly with <see cref="ThatDisposes"/>.
 /// </remarks>
 public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBuilder
 {
     private readonly List<Action<ContainerBuilder>> _configure = [];
-    private readonly List<object> _ownedInstances = [];
+    private readonly List<IDisposable> _disposables = [];
     private bool _worldStateConfigured;
 
     public IProcessingEnvBuilder Configure(Action<ContainerBuilder> configure)
@@ -28,20 +28,26 @@ public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBu
         return this;
     }
 
-    public IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState, bool externallyOwned = false)
+    public IProcessingEnvBuilder ThatDisposes(IDisposable disposable)
     {
-        _worldStateConfigured = true;
-        return AddInstance(worldState, externallyOwned);
+        _disposables.Add(disposable);
+        return this;
     }
 
-    public IProcessingEnvBuilder WithWorldState(IWorldState worldState, bool externallyOwned = false)
+    public IProcessingEnvBuilder WithWorldState(IWorldStateScopeProvider worldState)
     {
         _worldStateConfigured = true;
-        return AddInstance(worldState, externallyOwned);
+        return Configure(builder => builder.AddScoped<IWorldStateScopeProvider>(worldState));
     }
 
-    public IProcessingEnvBuilder WithReplacedComponent<T>(T instance, bool externallyOwned = false) where T : class =>
-        AddInstance(instance, externallyOwned);
+    public IProcessingEnvBuilder WithWorldState(IWorldState worldState)
+    {
+        _worldStateConfigured = true;
+        return Configure(builder => builder.AddScoped<IWorldState>(worldState));
+    }
+
+    public IProcessingEnvBuilder WithReplacedComponent<T>(T instance) where T : class =>
+        Configure(builder => builder.AddScoped<T>(instance));
 
     public IProcessingEnvBuilder WithReplacedComponent<TService, TImpl>() where TImpl : TService where TService : notnull =>
         Configure(builder => builder.AddScoped<TService, TImpl>());
@@ -49,8 +55,8 @@ public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBu
     public IProcessingEnvBuilder WithReplacedComponent<T>(Func<IComponentContext, T> factory) where T : class =>
         Configure(builder => builder.AddScoped<T>(factory));
 
-    public IProcessingEnvBuilder WithComponent<T>(T instance, bool externallyOwned = false) where T : class =>
-        AddInstance(instance, externallyOwned);
+    public IProcessingEnvBuilder WithComponent<T>(T instance) where T : class =>
+        Configure(builder => builder.AddScoped<T>(instance));
 
     public TWrapper BuildAs<TWrapper>() where TWrapper : class
     {
@@ -63,28 +69,11 @@ public class ProcessingEnvBuilder(ILifetimeScope parentScope) : IProcessingEnvBu
             foreach (Action<ContainerBuilder> configure in _configure) configure(builder);
         });
 
-        // Registrations for provided instances are externally owned at the Autofac level, so give the
-        // scope ownership of the ones the caller kept by adding them to its disposer directly — this
-        // disposes them even when the wrapper never resolves them.
-        foreach (object owned in _ownedInstances)
-        {
-            switch (owned)
-            {
-                case IAsyncDisposable asyncDisposable:
-                    scope.Disposer.AddInstanceForAsyncDisposal(asyncDisposable);
-                    break;
-                case IDisposable disposable:
-                    scope.Disposer.AddInstanceForDisposal(disposable);
-                    break;
-            }
-        }
+        // Give the scope ownership of the caller-declared resources so they are disposed with it, even
+        // when no scope component ever resolves them.
+        foreach (IDisposable disposable in _disposables)
+            scope.Disposer.AddInstanceForDisposal(disposable);
 
         return ProcessingEnvWrapperFactory.Create<TWrapper>(scope);
-    }
-
-    private IProcessingEnvBuilder AddInstance<T>(T instance, bool externallyOwned) where T : class
-    {
-        if (!externallyOwned) _ownedInstances.Add(instance);
-        return Configure(builder => builder.AddScoped<T>(instance));
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvWrapperFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvWrapperFactory.cs
@@ -16,15 +16,17 @@ namespace Nethermind.Consensus.Processing;
 
 /// <summary>
 /// Generates and caches, once per wrapper interface, a concrete class that surfaces an Autofac
-/// <see cref="ILifetimeScope"/> as that interface: the constructor resolves every read-only property
-/// from the scope into a backing field, each getter returns that field, and
-/// <see cref="IDisposable.Dispose"/> / <see cref="IAsyncDisposable.DisposeAsync"/> dispose the scope.
+/// <see cref="ILifetimeScope"/> as that interface: each read-only property is resolved from the scope into
+/// a backing field and returned by its getter, each method inherited from a base interface is forwarded to
+/// that interface resolved from the scope, and <see cref="IDisposable.Dispose"/> /
+/// <see cref="IAsyncDisposable.DisposeAsync"/> dispose the scope.
 /// </summary>
 /// <remarks>
 /// The generated type lives in a dynamic assembly, so a wrapper interface must be <b>public</b>, and it
-/// must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> so the scope is
-/// released. Components are resolved eagerly at construction (like the constructor-injected
-/// <c>record</c> bundles this replaces), so any missing registration surfaces when the wrapper is built.
+/// must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> so the scope is released.
+/// A non-getter method declared directly on the wrapper interface has no component to forward to and is
+/// rejected when the wrapper is built. Components and forwarding targets are resolved eagerly at
+/// construction, so any missing registration surfaces then.
 /// </remarks>
 internal static class ProcessingEnvWrapperFactory
 {
@@ -60,6 +62,11 @@ internal static class ProcessingEnvWrapperFactory
     private static bool IsDisposeAsync(MethodInfo method) =>
         method.Name == nameof(IAsyncDisposable.DisposeAsync) && method.ReturnType == typeof(ValueTask) && method.GetParameters().Length == 0;
 
+    // A method inherited from a base interface (other than a getter or IDisposable/IAsyncDisposable) is
+    // forwarded to that interface resolved from the scope; a method declared on the wrapper has no target.
+    private static bool IsForwarded(Type iface, MethodInfo method) =>
+        method.DeclaringType != iface && !IsGetter(method) && !IsDispose(method) && !IsDisposeAsync(method);
+
     private static Func<ILifetimeScope, object> Emit(Type iface)
     {
         if (!typeof(IDisposable).IsAssignableFrom(iface) && !typeof(IAsyncDisposable).IsAssignableFrom(iface))
@@ -67,11 +74,11 @@ internal static class ProcessingEnvWrapperFactory
 
         MethodInfo[] methods = [.. new[] { iface }.Concat(iface.GetInterfaces()).SelectMany(i => i.GetMethods())];
 
-        // Validate the whole interface up front so an unsupported member fails when the wrapper is built, not when it is called.
+        // Validate up front so an unsupported member fails when the wrapper is built, not when it is called.
         foreach (MethodInfo method in methods)
-            if (!IsGetter(method) && !IsDispose(method) && !IsDisposeAsync(method))
+            if (!IsGetter(method) && !IsDispose(method) && !IsDisposeAsync(method) && !IsForwarded(iface, method))
                 throw new ArgumentException(
-                    $"'{iface}' cannot be a processing-env wrapper: '{method.Name}' is neither a read-only property nor IDisposable/IAsyncDisposable.", nameof(iface));
+                    $"'{iface}' cannot be a processing-env wrapper: '{method.Name}' is declared on the wrapper itself but is not a read-only property. Only getters, methods inherited from a base interface, and IDisposable/IAsyncDisposable are supported.", nameof(iface));
 
         // Unique suffix so a concurrent GetOrAdd re-entry never collides on the module type name.
         TypeBuilder type = Module.DefineType(
@@ -80,16 +87,21 @@ internal static class ProcessingEnvWrapperFactory
 
         FieldBuilder scope = type.DefineField("_scope", typeof(ILifetimeScope), FieldAttributes.Private | FieldAttributes.InitOnly);
 
-        // A backing field per getter, holding the component resolved in the constructor.
-        Dictionary<MethodInfo, FieldBuilder> fields = [];
+        // A backing field per getter (the component) and per forwarded interface (the delegate target),
+        // all resolved from the scope in the constructor.
+        Dictionary<MethodInfo, FieldBuilder> getters = [];
         foreach (MethodInfo getter in methods.Where(IsGetter))
-            fields[getter] = type.DefineField(
-                $"_{getter.Name}", getter.ReturnType, FieldAttributes.Private | FieldAttributes.InitOnly);
+            getters[getter] = type.DefineField($"_{getter.Name}", getter.ReturnType, FieldAttributes.Private | FieldAttributes.InitOnly);
 
-        EmitConstructor(type, scope, fields);
+        Dictionary<Type, FieldBuilder> forwardTargets = [];
+        foreach (MethodInfo method in methods.Where(m => IsForwarded(iface, m)))
+            if (!forwardTargets.ContainsKey(method.DeclaringType!))
+                forwardTargets[method.DeclaringType!] = type.DefineField($"_forward{forwardTargets.Count}", method.DeclaringType!, FieldAttributes.Private | FieldAttributes.InitOnly);
+
+        EmitConstructor(type, scope, [.. getters.Values, .. forwardTargets.Values]);
 
         foreach (MethodInfo method in methods)
-            EmitMethod(type, scope, fields, method);
+            EmitMethod(type, scope, getters, forwardTargets, method);
 
         Type generated = type.CreateType()!;
         ConstructorInfo ctor = generated.GetConstructor([typeof(ILifetimeScope)])!;
@@ -98,7 +110,7 @@ internal static class ProcessingEnvWrapperFactory
     }
 
     // .ctor(ILifetimeScope scope) { _scope = scope; _X = (TX)scope.Resolve(typeof(TX)); ... }
-    private static void EmitConstructor(TypeBuilder type, FieldBuilder scope, Dictionary<MethodInfo, FieldBuilder> fields)
+    private static void EmitConstructor(TypeBuilder type, FieldBuilder scope, IEnumerable<FieldBuilder> resolvedFields)
     {
         ILGenerator il = type
             .DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, [typeof(ILifetimeScope)])
@@ -110,7 +122,7 @@ internal static class ProcessingEnvWrapperFactory
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Stfld, scope);
 
-        foreach (FieldBuilder field in fields.Values)
+        foreach (FieldBuilder field in resolvedFields)
         {
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);                              // scope (IComponentContext)
@@ -124,7 +136,7 @@ internal static class ProcessingEnvWrapperFactory
         il.Emit(OpCodes.Ret);
     }
 
-    private static void EmitMethod(TypeBuilder type, FieldBuilder scope, Dictionary<MethodInfo, FieldBuilder> fields, MethodInfo method)
+    private static void EmitMethod(TypeBuilder type, FieldBuilder scope, Dictionary<MethodInfo, FieldBuilder> getters, Dictionary<Type, FieldBuilder> forwardTargets, MethodInfo method)
     {
         MethodBuilder impl = type.DefineMethod(method.Name,
             MethodAttributes.Private | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
@@ -148,13 +160,18 @@ internal static class ProcessingEnvWrapperFactory
         else if (IsGetter(method))
         {
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldfld, fields[method]);
+            il.Emit(OpCodes.Ldfld, getters[method]);
             il.Emit(OpCodes.Ret);
         }
         else
         {
-            // Unreachable: Emit rejects unsupported members before any method is generated.
-            throw new InvalidOperationException($"Unexpected member '{method.Name}' on a processing-env wrapper.");
+            // Forward to the component resolved for the method's declaring interface.
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, forwardTargets[method.DeclaringType!]);
+            for (int i = 0; i < method.GetParameters().Length; i++)
+                il.Emit(OpCodes.Ldarg_S, (byte)(i + 1));
+            il.Emit(OpCodes.Callvirt, method);
+            il.Emit(OpCodes.Ret);
         }
 
         type.DefineMethodOverride(impl, method);

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvWrapperFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvWrapperFactory.cs
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading;
+using System.Threading.Tasks;
 using Autofac;
 
 namespace Nethermind.Consensus.Processing;
@@ -17,12 +18,13 @@ namespace Nethermind.Consensus.Processing;
 /// Generates and caches, once per wrapper interface, a concrete class that surfaces an Autofac
 /// <see cref="ILifetimeScope"/> as that interface: the constructor resolves every read-only property
 /// from the scope into a backing field, each getter returns that field, and
-/// <see cref="IDisposable.Dispose"/> disposes the scope.
+/// <see cref="IDisposable.Dispose"/> / <see cref="IAsyncDisposable.DisposeAsync"/> dispose the scope.
 /// </summary>
 /// <remarks>
-/// The generated type lives in a dynamic assembly, so a wrapper interface must be <b>public</b>.
-/// Components are resolved eagerly at construction (like the constructor-injected <c>record</c> bundles
-/// this replaces), so any missing registration surfaces when the wrapper is built.
+/// The generated type lives in a dynamic assembly, so a wrapper interface must be <b>public</b>, and it
+/// must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> so the scope is
+/// released. Components are resolved eagerly at construction (like the constructor-injected
+/// <c>record</c> bundles this replaces), so any missing registration surfaces when the wrapper is built.
 /// </remarks>
 internal static class ProcessingEnvWrapperFactory
 {
@@ -40,6 +42,8 @@ internal static class ProcessingEnvWrapperFactory
         typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle))!;
     private static readonly MethodInfo DisposeMethod =
         typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose))!;
+    private static readonly MethodInfo DisposeAsyncMethod =
+        typeof(IAsyncDisposable).GetMethod(nameof(IAsyncDisposable.DisposeAsync))!;
 
     /// <summary>
     /// Returns an implementation of <typeparamref name="TWrapper"/> backed by <paramref name="scope"/>.
@@ -53,8 +57,14 @@ internal static class ProcessingEnvWrapperFactory
     private static bool IsDispose(MethodInfo method) =>
         method.Name == nameof(IDisposable.Dispose) && method.ReturnType == typeof(void) && method.GetParameters().Length == 0;
 
+    private static bool IsDisposeAsync(MethodInfo method) =>
+        method.Name == nameof(IAsyncDisposable.DisposeAsync) && method.ReturnType == typeof(ValueTask) && method.GetParameters().Length == 0;
+
     private static Func<ILifetimeScope, object> Emit(Type iface)
     {
+        if (!typeof(IDisposable).IsAssignableFrom(iface) && !typeof(IAsyncDisposable).IsAssignableFrom(iface))
+            throw new ArgumentException($"'{iface}' must implement IDisposable or IAsyncDisposable so its backing scope is released.", nameof(iface));
+
         // Unique suffix so a concurrent GetOrAdd re-entry never collides on the module type name.
         TypeBuilder type = Module.DefineType(
             $"{iface.Name}_Env_{Interlocked.Increment(ref _typeCounter)}",
@@ -120,6 +130,13 @@ internal static class ProcessingEnvWrapperFactory
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, scope);
             il.Emit(OpCodes.Callvirt, DisposeMethod);
+            il.Emit(OpCodes.Ret);
+        }
+        else if (IsDisposeAsync(method))
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, scope);
+            il.Emit(OpCodes.Callvirt, DisposeAsyncMethod);
             il.Emit(OpCodes.Ret);
         }
         else if (IsGetter(method))

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvWrapperFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvWrapperFactory.cs
@@ -22,8 +22,9 @@ namespace Nethermind.Consensus.Processing;
 /// <see cref="IAsyncDisposable.DisposeAsync"/> dispose the scope.
 /// </summary>
 /// <remarks>
-/// The generated type lives in a dynamic assembly, so a wrapper interface must be <b>public</b>, and it
-/// must implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> so the scope is released.
+/// The generated type lives in a dynamic assembly, so a wrapper interface must be <b>public</b>. It must
+/// implement <see cref="IDisposable"/> and/or <see cref="IAsyncDisposable"/> so the scope is released —
+/// or, when its scope is owned externally, must <b>not</b> implement them, as the owner disposes the scope.
 /// A non-getter method declared directly on the wrapper interface has no component to forward to and is
 /// rejected when the wrapper is built. Components and forwarding targets are resolved eagerly at
 /// construction, so any missing registration surfaces then.
@@ -50,8 +51,24 @@ internal static class ProcessingEnvWrapperFactory
     /// <summary>
     /// Returns an implementation of <typeparamref name="TWrapper"/> backed by <paramref name="scope"/>.
     /// </summary>
-    public static TWrapper Create<TWrapper>(ILifetimeScope scope) where TWrapper : class =>
-        (TWrapper)Factories.GetOrAdd(typeof(TWrapper), Emit)(scope);
+    /// <param name="ownedExternally">
+    /// When <c>true</c> the scope's disposal is owned elsewhere (e.g. a parent lifetime), so
+    /// <typeparamref name="TWrapper"/> must <b>not</b> implement <see cref="IDisposable"/>/<see cref="IAsyncDisposable"/>;
+    /// when <c>false</c> it must, so the caller can release the scope.
+    /// </param>
+    public static TWrapper Create<TWrapper>(ILifetimeScope scope, bool ownedExternally) where TWrapper : class
+    {
+        Type iface = typeof(TWrapper);
+        bool disposable = typeof(IDisposable).IsAssignableFrom(iface) || typeof(IAsyncDisposable).IsAssignableFrom(iface);
+        if (ownedExternally && disposable)
+            throw new ArgumentException(
+                $"'{iface}' must not implement IDisposable/IAsyncDisposable when built with {nameof(IProcessingEnvBuilder.OwnedByParentLifetime)}; the parent lifetime owns and disposes the scope.", nameof(iface));
+        if (!ownedExternally && !disposable)
+            throw new ArgumentException(
+                $"'{iface}' must implement IDisposable or IAsyncDisposable so its backing scope is released, or be built with {nameof(IProcessingEnvBuilder.OwnedByParentLifetime)}.", nameof(iface));
+
+        return (TWrapper)Factories.GetOrAdd(iface, Emit)(scope);
+    }
 
     private static bool IsGetter(MethodInfo method) =>
         method.IsSpecialName && method.Name.StartsWith("get_", StringComparison.Ordinal) && method.GetParameters().Length == 0;
@@ -69,9 +86,6 @@ internal static class ProcessingEnvWrapperFactory
 
     private static Func<ILifetimeScope, object> Emit(Type iface)
     {
-        if (!typeof(IDisposable).IsAssignableFrom(iface) && !typeof(IAsyncDisposable).IsAssignableFrom(iface))
-            throw new ArgumentException($"'{iface}' must implement IDisposable or IAsyncDisposable so its backing scope is released.", nameof(iface));
-
         MethodInfo[] methods = [.. new[] { iface }.Concat(iface.GetInterfaces()).SelectMany(i => i.GetMethods())];
 
         // Validate up front so an unsupported member fails when the wrapper is built, not when it is called.

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvWrapperFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvWrapperFactory.cs
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
+using Autofac;
+
+namespace Nethermind.Consensus.Processing;
+
+/// <summary>
+/// Generates and caches, once per wrapper interface, a concrete class that surfaces an Autofac
+/// <see cref="ILifetimeScope"/> as that interface: the constructor resolves every read-only property
+/// from the scope into a backing field, each getter returns that field, and
+/// <see cref="IDisposable.Dispose"/> disposes the scope.
+/// </summary>
+/// <remarks>
+/// The generated type lives in a dynamic assembly, so a wrapper interface must be <b>public</b>.
+/// Components are resolved eagerly at construction (like the constructor-injected <c>record</c> bundles
+/// this replaces), so any missing registration surfaces when the wrapper is built.
+/// </remarks>
+internal static class ProcessingEnvWrapperFactory
+{
+    private static readonly ModuleBuilder Module =
+        AssemblyBuilder
+            .DefineDynamicAssembly(new AssemblyName("Nethermind.Consensus.Processing.Generated"), AssemblyBuilderAccess.Run)
+            .DefineDynamicModule("Main");
+
+    private static readonly ConcurrentDictionary<Type, Func<ILifetimeScope, object>> Factories = new();
+    private static int _typeCounter;
+
+    private static readonly MethodInfo ResolveMethod =
+        typeof(ResolutionExtensions).GetMethod(nameof(ResolutionExtensions.Resolve), [typeof(IComponentContext), typeof(Type)])!;
+    private static readonly MethodInfo GetTypeFromHandle =
+        typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle))!;
+    private static readonly MethodInfo DisposeMethod =
+        typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose))!;
+
+    /// <summary>
+    /// Returns an implementation of <typeparamref name="TWrapper"/> backed by <paramref name="scope"/>.
+    /// </summary>
+    public static TWrapper Create<TWrapper>(ILifetimeScope scope) where TWrapper : class =>
+        (TWrapper)Factories.GetOrAdd(typeof(TWrapper), Emit)(scope);
+
+    private static bool IsGetter(MethodInfo method) =>
+        method.IsSpecialName && method.Name.StartsWith("get_", StringComparison.Ordinal) && method.GetParameters().Length == 0;
+
+    private static bool IsDispose(MethodInfo method) =>
+        method.Name == nameof(IDisposable.Dispose) && method.ReturnType == typeof(void) && method.GetParameters().Length == 0;
+
+    private static Func<ILifetimeScope, object> Emit(Type iface)
+    {
+        // Unique suffix so a concurrent GetOrAdd re-entry never collides on the module type name.
+        TypeBuilder type = Module.DefineType(
+            $"{iface.Name}_Env_{Interlocked.Increment(ref _typeCounter)}",
+            TypeAttributes.Public | TypeAttributes.Sealed, typeof(object), [iface]);
+
+        FieldBuilder scope = type.DefineField("_scope", typeof(ILifetimeScope), FieldAttributes.Private | FieldAttributes.InitOnly);
+
+        MethodInfo[] methods = [.. new[] { iface }.Concat(iface.GetInterfaces()).SelectMany(i => i.GetMethods())];
+
+        // A backing field per getter, holding the component resolved in the constructor.
+        Dictionary<MethodInfo, FieldBuilder> fields = [];
+        foreach (MethodInfo getter in methods.Where(IsGetter))
+            fields[getter] = type.DefineField(
+                $"_{getter.Name}", getter.ReturnType, FieldAttributes.Private | FieldAttributes.InitOnly);
+
+        EmitConstructor(type, scope, fields);
+
+        foreach (MethodInfo method in methods)
+            EmitMethod(type, scope, fields, method);
+
+        Type generated = type.CreateType()!;
+        ConstructorInfo ctor = generated.GetConstructor([typeof(ILifetimeScope)])!;
+        ParameterExpression scopeArg = Expression.Parameter(typeof(ILifetimeScope), "scope");
+        return Expression.Lambda<Func<ILifetimeScope, object>>(Expression.New(ctor, scopeArg), scopeArg).Compile();
+    }
+
+    // .ctor(ILifetimeScope scope) { _scope = scope; _X = (TX)scope.Resolve(typeof(TX)); ... }
+    private static void EmitConstructor(TypeBuilder type, FieldBuilder scope, Dictionary<MethodInfo, FieldBuilder> fields)
+    {
+        ILGenerator il = type
+            .DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, [typeof(ILifetimeScope)])
+            .GetILGenerator();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, typeof(object).GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stfld, scope);
+
+        foreach (FieldBuilder field in fields.Values)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);                              // scope (IComponentContext)
+            il.Emit(OpCodes.Ldtoken, field.FieldType);            // typeof(TX)
+            il.Emit(OpCodes.Call, GetTypeFromHandle);
+            il.Emit(OpCodes.Call, ResolveMethod);                 // object
+            il.Emit(field.FieldType.IsValueType ? OpCodes.Unbox_Any : OpCodes.Castclass, field.FieldType);
+            il.Emit(OpCodes.Stfld, field);
+        }
+
+        il.Emit(OpCodes.Ret);
+    }
+
+    private static void EmitMethod(TypeBuilder type, FieldBuilder scope, Dictionary<MethodInfo, FieldBuilder> fields, MethodInfo method)
+    {
+        MethodBuilder impl = type.DefineMethod(method.Name,
+            MethodAttributes.Private | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            method.ReturnType, [.. method.GetParameters().Select(p => p.ParameterType)]);
+        ILGenerator il = impl.GetILGenerator();
+
+        if (IsDispose(method))
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, scope);
+            il.Emit(OpCodes.Callvirt, DisposeMethod);
+            il.Emit(OpCodes.Ret);
+        }
+        else if (IsGetter(method))
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, fields[method]);
+            il.Emit(OpCodes.Ret);
+        }
+        else
+        {
+            // Keep the type verifiable but reject non-property members at call time.
+            il.Emit(OpCodes.Ldstr, $"'{method.Name}' is not supported on a processing-env wrapper; only read-only properties and IDisposable.Dispose are.");
+            il.Emit(OpCodes.Newobj, typeof(NotSupportedException).GetConstructor([typeof(string)])!);
+            il.Emit(OpCodes.Throw);
+        }
+
+        type.DefineMethodOverride(impl, method);
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvWrapperFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingEnvWrapperFactory.cs
@@ -65,14 +65,20 @@ internal static class ProcessingEnvWrapperFactory
         if (!typeof(IDisposable).IsAssignableFrom(iface) && !typeof(IAsyncDisposable).IsAssignableFrom(iface))
             throw new ArgumentException($"'{iface}' must implement IDisposable or IAsyncDisposable so its backing scope is released.", nameof(iface));
 
+        MethodInfo[] methods = [.. new[] { iface }.Concat(iface.GetInterfaces()).SelectMany(i => i.GetMethods())];
+
+        // Validate the whole interface up front so an unsupported member fails when the wrapper is built, not when it is called.
+        foreach (MethodInfo method in methods)
+            if (!IsGetter(method) && !IsDispose(method) && !IsDisposeAsync(method))
+                throw new ArgumentException(
+                    $"'{iface}' cannot be a processing-env wrapper: '{method.Name}' is neither a read-only property nor IDisposable/IAsyncDisposable.", nameof(iface));
+
         // Unique suffix so a concurrent GetOrAdd re-entry never collides on the module type name.
         TypeBuilder type = Module.DefineType(
             $"{iface.Name}_Env_{Interlocked.Increment(ref _typeCounter)}",
             TypeAttributes.Public | TypeAttributes.Sealed, typeof(object), [iface]);
 
         FieldBuilder scope = type.DefineField("_scope", typeof(ILifetimeScope), FieldAttributes.Private | FieldAttributes.InitOnly);
-
-        MethodInfo[] methods = [.. new[] { iface }.Concat(iface.GetInterfaces()).SelectMany(i => i.GetMethods())];
 
         // A backing field per getter, holding the component resolved in the constructor.
         Dictionary<MethodInfo, FieldBuilder> fields = [];
@@ -147,10 +153,8 @@ internal static class ProcessingEnvWrapperFactory
         }
         else
         {
-            // Keep the type verifiable but reject non-property members at call time.
-            il.Emit(OpCodes.Ldstr, $"'{method.Name}' is not supported on a processing-env wrapper; only read-only properties and IDisposable.Dispose are.");
-            il.Emit(OpCodes.Newobj, typeof(NotSupportedException).GetConstructor([typeof(string)])!);
-            il.Emit(OpCodes.Throw);
+            // Unreachable: Emit rejects unsupported members before any method is generated.
+            throw new InvalidOperationException($"Unexpected member '{method.Name}' on a processing-env wrapper.");
         }
 
         type.DefineMethodOverride(impl, method);

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProducerEnvFactory.cs
@@ -12,9 +12,10 @@ namespace Nethermind.Consensus.Producers
 {
     public class BlockProducerEnvFactory(
         ILifetimeScope rootLifetime,
+        IProcessingEnvBuilder envBuilder,
         IWorldStateManager worldStateManager,
         IBlockProducerTxSourceFactory txSourceFactory
-    ) : GlobalWorldStateBlockProducerEnvFactory(rootLifetime, worldStateManager, txSourceFactory)
+    ) : GlobalWorldStateBlockProducerEnvFactory(rootLifetime, envBuilder, worldStateManager, txSourceFactory)
     {
         protected override ContainerBuilder ConfigureBuilder(ContainerBuilder builder) =>
             base.ConfigureBuilder(builder)

--- a/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
@@ -50,8 +50,7 @@ namespace Nethermind.Consensus.Producers
 
         private IEnvHandle BeginScope() =>
             new ProcessingEnvBuilder(rootLifetime)
-                // May be the shared GlobalWorldState, which the environment must never dispose.
-                .WithWorldState(CreateWorldState(), externallyOwned: true)
+                .WithWorldState(CreateWorldState())
                 .Configure(builder => ConfigureBuilder(builder))
                 .BuildAs<IEnvHandle>();
 

--- a/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
@@ -50,7 +50,7 @@ namespace Nethermind.Consensus.Producers
         }
 
         private IEnvHandle BeginScope() =>
-            envBuilder.NewEnv()
+            envBuilder
                 .WithWorldState(CreateWorldState())
                 .Configure(builder => ConfigureBuilder(builder))
                 .BuildAs<IEnvHandle>();

--- a/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
@@ -50,7 +50,8 @@ namespace Nethermind.Consensus.Producers
 
         private IEnvHandle BeginScope() =>
             new ProcessingEnvBuilder(rootLifetime)
-                .WithWorldState(CreateWorldState())
+                // May be the shared GlobalWorldState, which the environment must never dispose.
+                .WithWorldState(CreateWorldState(), externallyOwned: true)
                 .Configure(builder => ConfigureBuilder(builder))
                 .BuildAs<IEnvHandle>();
 

--- a/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
@@ -18,6 +18,7 @@ namespace Nethermind.Consensus.Producers
     /// </summary>
     public class GlobalWorldStateBlockProducerEnvFactory(
         ILifetimeScope rootLifetime,
+        IProcessingEnvBuilder envBuilder,
         IWorldStateManager worldStateManager,
         IBlockProducerTxSourceFactory txSourceFactory)
         : IMainStateBlockProducerEnvFactory
@@ -49,7 +50,7 @@ namespace Nethermind.Consensus.Producers
         }
 
         private IEnvHandle BeginScope() =>
-            new ProcessingEnvBuilder(rootLifetime)
+            envBuilder.NewEnv()
                 .WithWorldState(CreateWorldState())
                 .Configure(builder => ConfigureBuilder(builder))
                 .BuildAs<IEnvHandle>();

--- a/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/GlobalWorldStateBlockProducerEnvFactory.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Autofac;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Withdrawals;
@@ -36,23 +37,27 @@ namespace Nethermind.Consensus.Producers
 
         public IBlockProducerEnv CreatePersistent()
         {
-            ILifetimeScope scope = BeginScope(out IBlockProducerEnv blockProducerEnv);
-            rootLifetime.Disposer.AddInstanceForAsyncDisposal(scope);
-            return blockProducerEnv;
+            IEnvHandle handle = BeginScope();
+            rootLifetime.Disposer.AddInstanceForAsyncDisposal(handle);
+            return handle.Env;
         }
 
         public ScopedBlockProducerEnv CreateTransient()
         {
-            ILifetimeScope scope = BeginScope(out IBlockProducerEnv blockProducerEnv);
-            return new ScopedBlockProducerEnv(blockProducerEnv, scope);
+            IEnvHandle handle = BeginScope();
+            return new ScopedBlockProducerEnv(handle.Env, handle);
         }
 
-        private ILifetimeScope BeginScope(out IBlockProducerEnv blockProducerEnv)
+        private IEnvHandle BeginScope() =>
+            new ProcessingEnvBuilder(rootLifetime)
+                .WithWorldState(CreateWorldState())
+                .Configure(builder => ConfigureBuilder(builder))
+                .BuildAs<IEnvHandle>();
+
+        /// <summary>Owns the block-producer child scope; disposing it (async) disposes the scope.</summary>
+        public interface IEnvHandle : IAsyncDisposable
         {
-            IWorldStateScopeProvider worldState = CreateWorldState();
-            ILifetimeScope scope = rootLifetime.BeginLifetimeScope(builder => ConfigureBuilder(builder).AddScoped(worldState));
-            blockProducerEnv = scope.Resolve<IBlockProducerEnv>();
-            return scope;
+            IBlockProducerEnv Env { get; }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
@@ -33,11 +33,12 @@ namespace Nethermind.Consensus.Stateless;
 /// </remarks>
 public sealed class WitnessCapturingBlockProcessingEnv(
     ILifetimeScope rootLifetimeScope,
+    IProcessingEnvBuilder envBuilder,
     IWorldStateManager worldStateManager,
     IHeaderStore headerStore) : IDisposable
 {
     private readonly Lazy<IGraph> _graph = new(() =>
-        Build(rootLifetimeScope, worldStateManager, headerStore));
+        Build(rootLifetimeScope, envBuilder, worldStateManager, headerStore));
 
     /// <summary>The witness-wired block processor; the same instance is reused for every witnessed block.</summary>
     public IBlockProcessor Processor => _graph.Value.Processor;
@@ -61,6 +62,7 @@ public sealed class WitnessCapturingBlockProcessingEnv(
 
     private static IGraph Build(
         ILifetimeScope rootLifetimeScope,
+        IProcessingEnvBuilder envBuilder,
         IWorldStateManager worldStateManager,
         IHeaderStore headerStore)
     {
@@ -76,7 +78,7 @@ public sealed class WitnessCapturingBlockProcessingEnv(
             headerStore);
         WitnessCapturingHeaderFinder recordingFinder = new(headerStore, headerRecorder);
 
-        return new ProcessingEnvBuilder(rootLifetimeScope)
+        return envBuilder.NewEnv()
             .WithWorldState(recorder)
             .WithComponent(recorder)
             .WithComponent(headerRecorder)

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
@@ -82,10 +82,10 @@ public sealed class WitnessCapturingBlockProcessingEnv(
         // Off the root scope (not the main-processing child) to avoid inheriting the selector decorator; the recorder is
         // registered by instance so the decorator wraps the captured parent rather than re-resolving itself (no cycle).
         return new ProcessingEnvBuilder(rootLifetimeScope)
-            .WithWorldState(recorder, externallyOwned: true) // wraps the shared main-pipeline world state
-            .WithComponent(recorder, externallyOwned: true)  // exposed as WitnessGeneratingWorldState
+            .WithWorldState(recorder)                        // wraps the shared main-pipeline world state
+            .WithComponent(recorder)                         // exposed as WitnessGeneratingWorldState
             .WithComponent(headerRecorder)
-            .WithComponent(trieStore)                         // owned: disposed with the scope
+            .ThatDisposes(trieStore)                         // the env owns the witness-walk trie store
             .WithReplacedComponent<IHeaderFinder>(recordingFinder)
             .WithReplacedComponent<IBlockhashCache, BlockhashCache>()
             .WithReplacedComponent<ICodeInfoRepository, CodeInfoRepository>()

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
@@ -79,46 +79,52 @@ public sealed class WitnessCapturingBlockProcessingEnv(
             headerStore);
         WitnessCapturingHeaderFinder recordingFinder = new(headerStore, headerRecorder);
 
-        ILifetimeScope scope = rootLifetimeScope.BeginLifetimeScope(builder => builder
-            // Registered by instance, so the decorator wraps the captured parent instance rather than re-resolving itself (no cycle).
-            .AddScoped<IWorldState>(recorder)
-            .AddScoped<IHeaderFinder>(recordingFinder)
-            .AddScoped<IBlockhashCache, BlockhashCache>()
-            .AddScoped<ICodeInfoRepository, CodeInfoRepository>()
-            .AddScoped<IBlockAccessListManager>(ctx => new BlockAccessListManager(
-                ctx.Resolve<IWorldState>(),
-                ctx.Resolve<ISpecProvider>(),
-                ctx.Resolve<IBlockhashProvider>(),
-                ctx.Resolve<ILogManager>(),
-                ctx.Resolve<IBlocksConfig>(),
-                ctx.Resolve<IWithdrawalProcessorFactory>(),
-                codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
-                transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
-            // Validation tx executor; everything else is inherited from root and re-resolved against the overridden world state.
-            .AddModule(validationModules));
+        // Off the root scope (not the main-processing child) to avoid inheriting the selector decorator; the recorder is
+        // registered by instance so the decorator wraps the captured parent rather than re-resolving itself (no cycle).
+        IWitnessGraph env = new ProcessingEnvBuilder(rootLifetimeScope)
+            .WithWorldState(recorder)
+            .Configure(builder => builder
+                .AddScoped<IHeaderFinder>(recordingFinder)
+                .AddScoped<IBlockhashCache, BlockhashCache>()
+                .AddScoped<ICodeInfoRepository, CodeInfoRepository>()
+                .AddScoped<IBlockAccessListManager>(ctx => new BlockAccessListManager(
+                    ctx.Resolve<IWorldState>(),
+                    ctx.Resolve<ISpecProvider>(),
+                    ctx.Resolve<IBlockhashProvider>(),
+                    ctx.Resolve<ILogManager>(),
+                    ctx.Resolve<IBlocksConfig>(),
+                    ctx.Resolve<IWithdrawalProcessorFactory>(),
+                    codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
+                    transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
+                // Validation tx executor; everything else is inherited from root and re-resolved against the overridden world state.
+                .AddModule(validationModules))
+            .BuildAs<IWitnessGraph>();
 
-        IBlockProcessor processor = scope.Resolve<IBlockProcessor>();
-        IBlockhashCache blockhashCache = scope.Resolve<IBlockhashCache>();
-        return new Graph(scope, trieStore, recorder, headerRecorder, processor, blockhashCache);
+        return new Graph(env, trieStore, recorder, headerRecorder);
     }
 
-    /// <summary>The witness bundle plus the scope and witness-walk trie store whose lifetime it owns.</summary>
+    /// <summary>The resolved witness components; disposing it disposes the underlying child scope.</summary>
+    public interface IWitnessGraph : IDisposable
+    {
+        IBlockProcessor Processor { get; }
+        IBlockhashCache BlockhashCache { get; }
+    }
+
+    /// <summary>The witness bundle plus the witness-walk trie store whose lifetime it owns alongside the env scope.</summary>
     private sealed class Graph(
-        ILifetimeScope scope,
+        IWitnessGraph env,
         IReadOnlyTrieStore trieStore,
         WitnessGeneratingWorldState recorder,
-        WitnessHeaderRecorder headerRecorder,
-        IBlockProcessor processor,
-        IBlockhashCache blockhashCache) : IDisposable
+        WitnessHeaderRecorder headerRecorder) : IDisposable
     {
         public WitnessGeneratingWorldState Recorder => recorder;
         public WitnessHeaderRecorder HeaderRecorder => headerRecorder;
-        public IBlockProcessor Processor => processor;
-        public IBlockhashCache BlockhashCache => blockhashCache;
+        public IBlockProcessor Processor => env.Processor;
+        public IBlockhashCache BlockhashCache => env.BlockhashCache;
 
         public void Dispose()
         {
-            try { scope.Dispose(); }
+            try { env.Dispose(); }
             finally { trieStore.Dispose(); }
         }
     }

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
@@ -38,7 +38,7 @@ public sealed class WitnessCapturingBlockProcessingEnv(
     IHeaderStore headerStore,
     IBlockValidationModule[] validationModules) : IDisposable
 {
-    private readonly Lazy<Graph> _graph = new(() =>
+    private readonly Lazy<IGraph> _graph = new(() =>
         Build(rootLifetimeScope, worldStateManager, headerStore, validationModules));
 
     /// <summary>The witness-wired block processor; the same instance is reused for every witnessed block.</summary>
@@ -47,7 +47,7 @@ public sealed class WitnessCapturingBlockProcessingEnv(
     /// <summary>Clears the recorder accumulators so the next witnessed block starts from a clean slate.</summary>
     public void ResetForBlock()
     {
-        Graph graph = _graph.Value;
+        IGraph graph = _graph.Value;
         graph.Recorder.Reset();
         graph.HeaderRecorder.Reset();
         graph.BlockhashCache.Clear();
@@ -61,7 +61,7 @@ public sealed class WitnessCapturingBlockProcessingEnv(
         if (_graph.IsValueCreated) _graph.Value.Dispose();
     }
 
-    private static Graph Build(
+    private static IGraph Build(
         ILifetimeScope rootLifetimeScope,
         IWorldStateManager worldStateManager,
         IHeaderStore headerStore,
@@ -81,51 +81,37 @@ public sealed class WitnessCapturingBlockProcessingEnv(
 
         // Off the root scope (not the main-processing child) to avoid inheriting the selector decorator; the recorder is
         // registered by instance so the decorator wraps the captured parent rather than re-resolving itself (no cycle).
-        IWitnessGraph env = new ProcessingEnvBuilder(rootLifetimeScope)
-            .WithWorldState(recorder)
-            .Configure(builder => builder
-                .AddScoped<IHeaderFinder>(recordingFinder)
-                .AddScoped<IBlockhashCache, BlockhashCache>()
-                .AddScoped<ICodeInfoRepository, CodeInfoRepository>()
-                .AddScoped<IBlockAccessListManager>(ctx => new BlockAccessListManager(
-                    ctx.Resolve<IWorldState>(),
-                    ctx.Resolve<ISpecProvider>(),
-                    ctx.Resolve<IBlockhashProvider>(),
-                    ctx.Resolve<ILogManager>(),
-                    ctx.Resolve<IBlocksConfig>(),
-                    ctx.Resolve<IWithdrawalProcessorFactory>(),
-                    codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
-                    transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
-                // Validation tx executor; everything else is inherited from root and re-resolved against the overridden world state.
-                .AddModule(validationModules))
-            .BuildAs<IWitnessGraph>();
-
-        return new Graph(env, trieStore, recorder, headerRecorder);
+        return new ProcessingEnvBuilder(rootLifetimeScope)
+            .WithWorldState(recorder, externallyOwned: true) // wraps the shared main-pipeline world state
+            .WithComponent(recorder, externallyOwned: true)  // exposed as WitnessGeneratingWorldState
+            .WithComponent(headerRecorder)
+            .WithComponent(trieStore)                         // owned: disposed with the scope
+            .WithReplacedComponent<IHeaderFinder>(recordingFinder)
+            .WithReplacedComponent<IBlockhashCache, BlockhashCache>()
+            .WithReplacedComponent<ICodeInfoRepository, CodeInfoRepository>()
+            .WithReplacedComponent<IBlockAccessListManager>(ctx => new BlockAccessListManager(
+                ctx.Resolve<IWorldState>(),
+                ctx.Resolve<ISpecProvider>(),
+                ctx.Resolve<IBlockhashProvider>(),
+                ctx.Resolve<ILogManager>(),
+                ctx.Resolve<IBlocksConfig>(),
+                ctx.Resolve<IWithdrawalProcessorFactory>(),
+                codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
+                transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
+            // Validation tx executor; everything else is inherited from root and re-resolved against the overridden world state.
+            .Configure(builder => builder.AddModule(validationModules))
+            .BuildAs<IGraph>();
     }
 
-    /// <summary>The resolved witness components; disposing it disposes the underlying child scope.</summary>
-    public interface IWitnessGraph : IDisposable
+    /// <summary>
+    /// The resolved witness components (plus the scope-owned witness-walk trie store); disposing it
+    /// disposes the underlying child scope and everything it owns.
+    /// </summary>
+    public interface IGraph : IDisposable
     {
         IBlockProcessor Processor { get; }
         IBlockhashCache BlockhashCache { get; }
-    }
-
-    /// <summary>The witness bundle plus the witness-walk trie store whose lifetime it owns alongside the env scope.</summary>
-    private sealed class Graph(
-        IWitnessGraph env,
-        IReadOnlyTrieStore trieStore,
-        WitnessGeneratingWorldState recorder,
-        WitnessHeaderRecorder headerRecorder) : IDisposable
-    {
-        public WitnessGeneratingWorldState Recorder => recorder;
-        public WitnessHeaderRecorder HeaderRecorder => headerRecorder;
-        public IBlockProcessor Processor => env.Processor;
-        public IBlockhashCache BlockhashCache => env.BlockhashCache;
-
-        public void Dispose()
-        {
-            try { env.Dispose(); }
-            finally { trieStore.Dispose(); }
-        }
+        WitnessGeneratingWorldState Recorder { get; }
+        WitnessHeaderRecorder HeaderRecorder { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
@@ -9,7 +9,6 @@ using Nethermind.Config;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
-using Nethermind.Core.Container;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
@@ -35,11 +34,10 @@ namespace Nethermind.Consensus.Stateless;
 public sealed class WitnessCapturingBlockProcessingEnv(
     ILifetimeScope rootLifetimeScope,
     IWorldStateManager worldStateManager,
-    IHeaderStore headerStore,
-    IBlockValidationModule[] validationModules) : IDisposable
+    IHeaderStore headerStore) : IDisposable
 {
     private readonly Lazy<IGraph> _graph = new(() =>
-        Build(rootLifetimeScope, worldStateManager, headerStore, validationModules));
+        Build(rootLifetimeScope, worldStateManager, headerStore));
 
     /// <summary>The witness-wired block processor; the same instance is reused for every witnessed block.</summary>
     public IBlockProcessor Processor => _graph.Value.Processor;
@@ -64,8 +62,7 @@ public sealed class WitnessCapturingBlockProcessingEnv(
     private static IGraph Build(
         ILifetimeScope rootLifetimeScope,
         IWorldStateManager worldStateManager,
-        IHeaderStore headerStore,
-        IBlockValidationModule[] validationModules)
+        IHeaderStore headerStore)
     {
         IWorldState parentWorldState = rootLifetimeScope.Resolve<IMainProcessingContext>().WorldState;
 
@@ -79,13 +76,11 @@ public sealed class WitnessCapturingBlockProcessingEnv(
             headerStore);
         WitnessCapturingHeaderFinder recordingFinder = new(headerStore, headerRecorder);
 
-        // Off the root scope (not the main-processing child) to avoid inheriting the selector decorator; the recorder is
-        // registered by instance so the decorator wraps the captured parent rather than re-resolving itself (no cycle).
         return new ProcessingEnvBuilder(rootLifetimeScope)
-            .WithWorldState(recorder)                        // wraps the shared main-pipeline world state
-            .WithComponent(recorder)                         // exposed as WitnessGeneratingWorldState
+            .WithWorldState(recorder)
+            .WithComponent(recorder)
             .WithComponent(headerRecorder)
-            .ThatDisposes(trieStore)                         // the env owns the witness-walk trie store
+            .ThatDisposes(trieStore)
             .WithReplacedComponent<IHeaderFinder>(recordingFinder)
             .WithReplacedComponent<IBlockhashCache, BlockhashCache>()
             .WithReplacedComponent<ICodeInfoRepository, CodeInfoRepository>()
@@ -98,8 +93,7 @@ public sealed class WitnessCapturingBlockProcessingEnv(
                 ctx.Resolve<IWithdrawalProcessorFactory>(),
                 codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
                 transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
-            // Validation tx executor; everything else is inherited from root and re-resolved against the overridden world state.
-            .Configure(builder => builder.AddModule(validationModules))
+            .WithBlockValidationConfiguration()
             .BuildAs<IGraph>();
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
@@ -78,7 +78,7 @@ public sealed class WitnessCapturingBlockProcessingEnv(
             headerStore);
         WitnessCapturingHeaderFinder recordingFinder = new(headerStore, headerRecorder);
 
-        return envBuilder.NewEnv()
+        return envBuilder
             .WithWorldState(recorder)
             .WithComponent(recorder)
             .WithComponent(headerRecorder)

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
@@ -37,6 +37,7 @@ public interface IWitnessGeneratingBlockProcessingEnvFactory
 /// <remarks>Entries are reset on return; the pool is soft-capped, with surplus and poisoned entries disposed rather than pooled.</remarks>
 public class WitnessGeneratingBlockProcessingEnvFactory(
     ILifetimeScope rootLifetimeScope,
+    IProcessingEnvBuilder envBuilder,
     IWorldStateManager worldStateManager,
     IDbProvider dbProvider,
     ILogManager logManager) : IWitnessGeneratingBlockProcessingEnvFactory, IDisposable
@@ -82,7 +83,7 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
         WitnessGeneratingWorldState witnessWorldState = new(
             baseWorldState, worldStateManager.GlobalStateReader, trieStore, headerRecorder, headerStore);
 
-        IEnvComponents graph = new ProcessingEnvBuilder(rootLifetimeScope)
+        IEnvComponents graph = envBuilder.NewEnv()
             .WithWorldState(witnessWorldState)
             .WithReplacedComponent<IStateReader>(stateReader)
             .WithReplacedComponent<WitnessGeneratingWorldState>(witnessWorldState)

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
@@ -83,7 +83,7 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
         WitnessGeneratingWorldState witnessWorldState = new(
             baseWorldState, worldStateManager.GlobalStateReader, trieStore, headerRecorder, headerStore);
 
-        IEnvComponents graph = envBuilder.NewEnv()
+        IEnvComponents graph = envBuilder
             .WithWorldState(witnessWorldState)
             .WithReplacedComponent<IStateReader>(stateReader)
             .WithReplacedComponent<WitnessGeneratingWorldState>(witnessWorldState)

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
@@ -90,7 +90,7 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
             .WithReplacedComponent<WitnessGeneratingWorldState>(witnessWorldState)
             .WithReplacedComponent<IHeaderFinder>(capturingHeaderFinder)
             .WithReplacedComponent<IBlockhashCache, BlockhashCache>()
-            .WithReplacedComponent<IReceiptStorage>(NullReceiptStorage.Instance, externallyOwned: true)
+            .WithReplacedComponent<IReceiptStorage>(NullReceiptStorage.Instance)
             .WithReplacedComponent<ICodeInfoRepository, CodeInfoRepository>()
             .WithReplacedComponent<IBlockAccessListManager>(ctx => new BlockAccessListManager(
                 ctx.Resolve<IWorldState>(),

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
@@ -84,29 +84,36 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
         WitnessGeneratingWorldState witnessWorldState = new(
             baseWorldState, worldStateManager.GlobalStateReader, trieStore, headerRecorder, headerStore);
 
-        ILifetimeScope envLifetimeScope = rootLifetimeScope.BeginLifetimeScope(builder => builder
-            .AddScoped<IStateReader>(stateReader)
-            .AddScoped<IWorldState>(witnessWorldState)
-            .AddScoped<WitnessGeneratingWorldState>(witnessWorldState)
-            .AddScoped<IHeaderFinder>(capturingHeaderFinder)
-            .AddScoped<IBlockhashCache, BlockhashCache>()
-            .AddScoped<IReceiptStorage>(NullReceiptStorage.Instance)
-            .AddScoped<ICodeInfoRepository, CodeInfoRepository>()
-            .AddScoped<IBlockAccessListManager>(ctx => new BlockAccessListManager(
-                ctx.Resolve<IWorldState>(),
-                ctx.Resolve<ISpecProvider>(),
-                ctx.Resolve<IBlockhashProvider>(),
-                ctx.Resolve<ILogManager>(),
-                ctx.Resolve<IBlocksConfig>(),
-                ctx.Resolve<IWithdrawalProcessorFactory>(),
-                codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
-                transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
-            .AddModule(validationModules)
-            .AddScoped<IWitnessGeneratingBlockProcessingEnv, WitnessGeneratingBlockProcessingEnv>());
+        IEnvComponents graph = new ProcessingEnvBuilder(rootLifetimeScope)
+            .WithWorldState(witnessWorldState)
+            .Configure(builder => builder
+                .AddScoped<IStateReader>(stateReader)
+                .AddScoped<WitnessGeneratingWorldState>(witnessWorldState)
+                .AddScoped<IHeaderFinder>(capturingHeaderFinder)
+                .AddScoped<IBlockhashCache, BlockhashCache>()
+                .AddScoped<IReceiptStorage>(NullReceiptStorage.Instance)
+                .AddScoped<ICodeInfoRepository, CodeInfoRepository>()
+                .AddScoped<IBlockAccessListManager>(ctx => new BlockAccessListManager(
+                    ctx.Resolve<IWorldState>(),
+                    ctx.Resolve<ISpecProvider>(),
+                    ctx.Resolve<IBlockhashProvider>(),
+                    ctx.Resolve<ILogManager>(),
+                    ctx.Resolve<IBlocksConfig>(),
+                    ctx.Resolve<IWithdrawalProcessorFactory>(),
+                    codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
+                    transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
+                .AddModule(validationModules)
+                .AddScoped<IWitnessGeneratingBlockProcessingEnv, WitnessGeneratingBlockProcessingEnv>())
+            .BuildAs<IEnvComponents>();
 
-        IWitnessGeneratingBlockProcessingEnv env = envLifetimeScope.Resolve<IWitnessGeneratingBlockProcessingEnv>();
-        IBlockhashCache blockhashCache = envLifetimeScope.Resolve<IBlockhashCache>();
-        return new PooledEntry(envLifetimeScope, trieStore, readOnlyDbProvider, headerRecorder, witnessWorldState, blockhashCache, env);
+        return new PooledEntry(graph, trieStore, readOnlyDbProvider, headerRecorder, witnessWorldState);
+    }
+
+    /// <summary>The resolved env components; disposing it disposes the underlying child scope.</summary>
+    public interface IEnvComponents : IDisposable
+    {
+        IWitnessGeneratingBlockProcessingEnv Env { get; }
+        IBlockhashCache BlockhashCache { get; }
     }
 
     private void Return(PooledEntry entry)
@@ -154,21 +161,18 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
     }
 
     private sealed class PooledEntry(
-        ILifetimeScope scope,
+        IEnvComponents graph,
         IReadOnlyTrieStore trieStore,
         IReadOnlyDbProvider dbProvider,
         WitnessHeaderRecorder headerRecorder,
-        WitnessGeneratingWorldState worldState,
-        IBlockhashCache blockhashCache,
-        IWitnessGeneratingBlockProcessingEnv env) : IDisposable
+        WitnessGeneratingWorldState worldState) : IDisposable
     {
-        public ILifetimeScope Scope { get; } = scope;
-        public IWitnessGeneratingBlockProcessingEnv Env { get; } = env;
+        public IWitnessGeneratingBlockProcessingEnv Env => graph.Env;
 
         /// <summary>Tears down the Autofac scope first, then the manually-created read-only trie store it borrowed.</summary>
         public void Dispose()
         {
-            Scope.Dispose();
+            graph.Dispose();
             trieStore.Dispose();
         }
 
@@ -179,7 +183,7 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
             headerRecorder.Reset();
             worldState.Reset();
             dbProvider.ClearTempChanges();
-            blockhashCache.Clear();
+            graph.BlockhashCache.Clear();
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
@@ -12,7 +12,6 @@ using Nethermind.Config;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
-using Nethermind.Core.Container;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
 using Nethermind.Evm;
@@ -40,7 +39,6 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
     ILifetimeScope rootLifetimeScope,
     IWorldStateManager worldStateManager,
     IDbProvider dbProvider,
-    IBlockValidationModule[] validationModules,
     ILogManager logManager) : IWitnessGeneratingBlockProcessingEnvFactory, IDisposable
 {
     // LIFO so the warmest (most-recently-returned) entry is reused first.
@@ -102,7 +100,7 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
                 codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
                 transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
             .WithReplacedComponent<IWitnessGeneratingBlockProcessingEnv, WitnessGeneratingBlockProcessingEnv>()
-            .Configure(builder => builder.AddModule(validationModules))
+            .WithBlockValidationConfiguration()
             .BuildAs<IEnvComponents>();
 
         return new PooledEntry(graph, trieStore, readOnlyDbProvider, headerRecorder, witnessWorldState);

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
@@ -86,24 +86,23 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
 
         IEnvComponents graph = new ProcessingEnvBuilder(rootLifetimeScope)
             .WithWorldState(witnessWorldState)
-            .Configure(builder => builder
-                .AddScoped<IStateReader>(stateReader)
-                .AddScoped<WitnessGeneratingWorldState>(witnessWorldState)
-                .AddScoped<IHeaderFinder>(capturingHeaderFinder)
-                .AddScoped<IBlockhashCache, BlockhashCache>()
-                .AddScoped<IReceiptStorage>(NullReceiptStorage.Instance)
-                .AddScoped<ICodeInfoRepository, CodeInfoRepository>()
-                .AddScoped<IBlockAccessListManager>(ctx => new BlockAccessListManager(
-                    ctx.Resolve<IWorldState>(),
-                    ctx.Resolve<ISpecProvider>(),
-                    ctx.Resolve<IBlockhashProvider>(),
-                    ctx.Resolve<ILogManager>(),
-                    ctx.Resolve<IBlocksConfig>(),
-                    ctx.Resolve<IWithdrawalProcessorFactory>(),
-                    codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
-                    transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
-                .AddModule(validationModules)
-                .AddScoped<IWitnessGeneratingBlockProcessingEnv, WitnessGeneratingBlockProcessingEnv>())
+            .WithReplacedComponent<IStateReader>(stateReader)
+            .WithReplacedComponent<WitnessGeneratingWorldState>(witnessWorldState)
+            .WithReplacedComponent<IHeaderFinder>(capturingHeaderFinder)
+            .WithReplacedComponent<IBlockhashCache, BlockhashCache>()
+            .WithReplacedComponent<IReceiptStorage>(NullReceiptStorage.Instance, externallyOwned: true)
+            .WithReplacedComponent<ICodeInfoRepository, CodeInfoRepository>()
+            .WithReplacedComponent<IBlockAccessListManager>(ctx => new BlockAccessListManager(
+                ctx.Resolve<IWorldState>(),
+                ctx.Resolve<ISpecProvider>(),
+                ctx.Resolve<IBlockhashProvider>(),
+                ctx.Resolve<ILogManager>(),
+                ctx.Resolve<IBlocksConfig>(),
+                ctx.Resolve<IWithdrawalProcessorFactory>(),
+                codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
+                transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
+            .WithReplacedComponent<IWitnessGeneratingBlockProcessingEnv, WitnessGeneratingBlockProcessingEnv>()
+            .Configure(builder => builder.AddModule(validationModules))
             .BuildAs<IEnvComponents>();
 
         return new PooledEntry(graph, trieStore, readOnlyDbProvider, headerRecorder, witnessWorldState);

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -141,6 +141,19 @@ public class ProcessingEnvBuilderTests
     }
 
     [Test]
+    public void WithComponent_type_overload_registers_the_scoped_type()
+    {
+        using IContainer container = BuildContainer();
+
+        using ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
+            .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+            .WithComponent<TrackingDisposable>()
+            .BuildAs<ITrackerEnv>();
+
+        Assert.That(env.Tracker, Is.Not.Null);
+    }
+
+    [Test]
     public void WithComponent_registers_but_does_not_dispose_the_instance()
     {
         using IContainer container = BuildContainer();

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -96,17 +96,16 @@ public class ProcessingEnvBuilderTests
     }
 
     [Test]
-    public void WithComponent_owns_the_instance_by_default_and_disposes_it()
+    public void ThatDisposes_disposes_the_instance_with_the_scope()
     {
         using IContainer container = BuildContainer();
         TrackingDisposable owned = new();
 
-        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
+        using (IEnvWithMethod env = container.Resolve<IProcessingEnvBuilder>()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
-                   .WithComponent(owned)
-                   .BuildAs<ITrackerEnv>())
+                   .ThatDisposes(owned)
+                   .BuildAs<IEnvWithMethod>())
         {
-            Assert.That(env.Tracker, Is.SameAs(owned));
             Assert.That(owned.Disposed, Is.False);
         }
 
@@ -114,20 +113,20 @@ public class ProcessingEnvBuilderTests
     }
 
     [Test]
-    public void WithComponent_externallyOwned_does_not_dispose_the_instance()
+    public void WithComponent_registers_but_does_not_dispose_the_instance()
     {
         using IContainer container = BuildContainer();
-        TrackingDisposable external = new();
+        TrackingDisposable component = new();
 
         using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
-                   .WithComponent(external, externallyOwned: true)
+                   .WithComponent(component)
                    .BuildAs<ITrackerEnv>())
         {
-            Assert.That(env.Tracker, Is.SameAs(external));
+            Assert.That(env.Tracker, Is.SameAs(component));
         }
 
-        Assert.That(external.Disposed, Is.False);
+        Assert.That(component.Disposed, Is.False);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -48,6 +48,11 @@ public interface IEnvWithMethod : IDisposable
     void DoSomething();
 }
 
+// Inherits IOverridableEnv<T>.BuildAndOverride, which the wrapper forwards to the resolved env.
+public interface IOverridableWorldStateEnv : IOverridableEnv<IWorldState>, IAsyncDisposable
+{
+}
+
 [Parallelizable(ParallelScope.All)]
 public class ProcessingEnvBuilderTests
 {
@@ -154,21 +159,21 @@ public class ProcessingEnvBuilderTests
     }
 
     [Test]
-    public async Task BuildAsOverridableEnv_returns_an_overridable_env_and_disposes_the_scope()
+    public async Task BuildAs_forwards_overridable_env_methods_and_disposes_the_scope()
     {
         using IContainer container = BuildContainer();
         IOverridableEnv overridableEnv = container.Resolve<IOverridableEnvFactory>().Create();
 
-        IOverridableEnvHandle<IWorldState> handle = container.Resolve<IProcessingEnvBuilder>()
+        IOverridableWorldStateEnv env = container.Resolve<IProcessingEnvBuilder>()
             .WithOverridableEnv(overridableEnv)
-            .BuildAsOverridableEnv<IWorldState>();
+            .BuildAs<IOverridableWorldStateEnv>();
 
-        using (Scope<IWorldState> scope = handle.BuildAndOverride(null))
+        using (Scope<IWorldState> scope = env.BuildAndOverride(null))
         {
             Assert.That(scope.Component, Is.Not.Null);
         }
 
-        await handle.DisposeAsync();
+        await env.DisposeAsync();
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.State;
+using Nethermind.State.OverridableEnv;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -30,6 +31,16 @@ public interface ITrackerEnv : IDisposable
 public interface IAsyncTrackerEnv : IAsyncDisposable
 {
     ProcessingEnvBuilderTests.TrackingDisposable Tracker { get; }
+}
+
+public interface IEmptyEnv : IDisposable
+{
+}
+
+public interface IOverridableTestEnv : IDisposable
+{
+    IWorldState WorldState { get; }
+    ICodeInfoRepository CodeInfoRepository { get; }
 }
 
 public interface IEnvWithMethod : IDisposable
@@ -101,10 +112,10 @@ public class ProcessingEnvBuilderTests
         using IContainer container = BuildContainer();
         TrackingDisposable owned = new();
 
-        using (IEnvWithMethod env = container.Resolve<IProcessingEnvBuilder>()
+        using (IEmptyEnv env = container.Resolve<IProcessingEnvBuilder>()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
                    .ThatDisposes(owned)
-                   .BuildAs<IEnvWithMethod>())
+                   .BuildAs<IEmptyEnv>())
         {
             Assert.That(owned.Disposed, Is.False);
         }
@@ -130,14 +141,26 @@ public class ProcessingEnvBuilderTests
     }
 
     [Test]
-    public void Non_property_member_throws_NotSupported()
+    public void WithOverridableEnv_auto_creates_the_env_and_resolves_its_components()
     {
         using IContainer container = BuildContainer();
-        using IEnvWithMethod env = container.Resolve<IProcessingEnvBuilder>()
-            .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
-            .BuildAs<IEnvWithMethod>();
 
-        Assert.That(env.DoSomething, Throws.TypeOf<NotSupportedException>());
+        using IOverridableTestEnv env = container.Resolve<IProcessingEnvBuilder>()
+            .WithOverridableEnv()
+            .BuildAs<IOverridableTestEnv>();
+
+        Assert.That(env.WorldState, Is.Not.Null);
+        Assert.That(env.CodeInfoRepository, Is.Not.Null);
+    }
+
+    [Test]
+    public void Non_property_member_throws_during_build()
+    {
+        using IContainer container = BuildContainer();
+        IProcessingEnvBuilder builder = container.Resolve<IProcessingEnvBuilder>()
+            .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState());
+
+        Assert.That(() => builder.BuildAs<IEnvWithMethod>(), Throws.TypeOf<ArgumentException>());
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -65,6 +65,11 @@ public interface IOwnedTrackerEnv
     ProcessingEnvBuilderTests.TrackingDisposable Tracker { get; }
 }
 
+public interface IGreeterEnv : IDisposable
+{
+    ProcessingEnvBuilderTests.IGreeter Greeter { get; }
+}
+
 [Parallelizable(ParallelScope.All)]
 public class ProcessingEnvBuilderTests
 {
@@ -266,6 +271,47 @@ public class ProcessingEnvBuilderTests
     }
 
     [Test]
+    public void WithComponent_type_impl_registers_the_service_and_WithDecorator_wraps_it()
+    {
+        using IContainer container = BuildContainer();
+
+        using IGreeterEnv env = container.Resolve<IProcessingEnvBuilder>()
+            .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+            .WithComponent<IGreeter, Greeter>()
+            .WithDecorator<IGreeter, ShoutingGreeter>()
+            .BuildAs<IGreeterEnv>();
+
+        Assert.That(env.Greeter.Greet(), Is.EqualTo("HI")); // ShoutingGreeter wraps Greeter
+    }
+
+    [Test]
+    public void Build_resolves_the_component_but_requires_owned_by_parent_lifetime()
+    {
+        using IContainer container = BuildContainer();
+
+        // Build<T> returns a bare component that cannot dispose its scope, so it needs OwnedByParentLifetime.
+        Assert.That(
+            () => container.Resolve<IProcessingEnvBuilder>()
+                .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+                .Build<IWorldState>(),
+            Throws.TypeOf<InvalidOperationException>());
+
+        TrackingDisposable tracker;
+        using (ILifetimeScope parent = container.BeginLifetimeScope())
+        {
+            tracker = parent.Resolve<IProcessingEnvBuilder>()
+                .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+                .WithComponent<TrackingDisposable>()
+                .OwnedByParentLifetime()
+                .Build<TrackingDisposable>();
+
+            Assert.That(tracker.Disposed, Is.False);
+        }
+
+        Assert.That(tracker.Disposed, Is.True); // the built component's scope was disposed with the parent
+    }
+
+    [Test]
     public void Non_property_member_throws_during_build()
     {
         using IContainer container = BuildContainer();
@@ -288,5 +334,20 @@ public class ProcessingEnvBuilderTests
     {
         public bool Disposed { get; private set; }
         public void Dispose() => Disposed = true;
+    }
+
+    public interface IGreeter
+    {
+        string Greet();
+    }
+
+    public sealed class Greeter : IGreeter
+    {
+        public string Greet() => "hi";
+    }
+
+    public sealed class ShoutingGreeter(IGreeter inner) : IGreeter
+    {
+        public string Greet() => inner.Greet().ToUpperInvariant();
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Core;
 using Nethermind.Core.Test.Modules;
@@ -22,6 +23,11 @@ public interface ITestProcessingEnv : IDisposable
 }
 
 public interface ITrackerEnv : IDisposable
+{
+    ProcessingEnvBuilderTests.TrackingDisposable Tracker { get; }
+}
+
+public interface IAsyncTrackerEnv : IAsyncDisposable
 {
     ProcessingEnvBuilderTests.TrackingDisposable Tracker { get; }
 }
@@ -65,6 +71,24 @@ public class ProcessingEnvBuilderTests
                    .BuildAs<ITrackerEnv>())
         {
             tracker = env.Tracker; // force construction inside the scope
+            Assert.That(tracker.Disposed, Is.False);
+        }
+
+        Assert.That(tracker.Disposed, Is.True);
+    }
+
+    [Test]
+    public async Task DisposeAsync_disposes_the_child_scope()
+    {
+        using IContainer container = BuildContainer();
+
+        TrackingDisposable tracker;
+        await using (IAsyncTrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
+                   .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+                   .Configure(builder => builder.AddScoped<TrackingDisposable>())
+                   .BuildAs<IAsyncTrackerEnv>())
+        {
+            tracker = env.Tracker;
             Assert.That(tracker.Disposed, Is.False);
         }
 

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -61,7 +61,7 @@ public class ProcessingEnvBuilderTests
         IWorldStateScopeProvider provider = container.Resolve<IWorldStateManager>().CreateResettableWorldState();
         ITransactionProcessor fakeProcessor = Substitute.For<ITransactionProcessor>();
 
-        using ITestProcessingEnv env = container.Resolve<IProcessingEnvBuilder>()
+        using ITestProcessingEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
             .WithWorldState(provider)
             .WithReplacedComponent<ITransactionProcessor>(fakeProcessor)
             .BuildAs<ITestProcessingEnv>();
@@ -76,7 +76,7 @@ public class ProcessingEnvBuilderTests
         using IContainer container = BuildContainer();
 
         TrackingDisposable tracker;
-        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
+        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
                    .Configure(builder => builder.AddScoped<TrackingDisposable>())
                    .BuildAs<ITrackerEnv>())
@@ -94,7 +94,7 @@ public class ProcessingEnvBuilderTests
         using IContainer container = BuildContainer();
 
         TrackingDisposable tracker;
-        await using (IAsyncTrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
+        await using (IAsyncTrackerEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
                    .Configure(builder => builder.AddScoped<TrackingDisposable>())
                    .BuildAs<IAsyncTrackerEnv>())
@@ -112,7 +112,7 @@ public class ProcessingEnvBuilderTests
         using IContainer container = BuildContainer();
         TrackingDisposable owned = new();
 
-        using (IEmptyEnv env = container.Resolve<IProcessingEnvBuilder>()
+        using (IEmptyEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
                    .ThatDisposes(owned)
                    .BuildAs<IEmptyEnv>())
@@ -129,7 +129,7 @@ public class ProcessingEnvBuilderTests
         using IContainer container = BuildContainer();
         TrackingDisposable component = new();
 
-        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
+        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
                    .WithComponent(component)
                    .BuildAs<ITrackerEnv>())
@@ -145,7 +145,7 @@ public class ProcessingEnvBuilderTests
     {
         using IContainer container = BuildContainer();
 
-        using IOverridableTestEnv env = container.Resolve<IProcessingEnvBuilder>()
+        using IOverridableTestEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
             .WithOverridableEnv()
             .BuildAs<IOverridableTestEnv>();
 
@@ -157,7 +157,7 @@ public class ProcessingEnvBuilderTests
     public void Non_property_member_throws_during_build()
     {
         using IContainer container = BuildContainer();
-        IProcessingEnvBuilder builder = container.Resolve<IProcessingEnvBuilder>()
+        IProcessingEnvBuilder.IDsl builder = container.Resolve<IProcessingEnvBuilder>().NewEnv()
             .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState());
 
         Assert.That(() => builder.BuildAs<IEnvWithMethod>(), Throws.TypeOf<ArgumentException>());
@@ -167,7 +167,7 @@ public class ProcessingEnvBuilderTests
     public void BuildAs_without_world_state_throws()
     {
         using IContainer container = BuildContainer();
-        IProcessingEnvBuilder builder = container.Resolve<IProcessingEnvBuilder>();
+        IProcessingEnvBuilder.IDsl builder = container.Resolve<IProcessingEnvBuilder>().NewEnv();
 
         Assert.That(() => builder.BuildAs<IEnvWithMethod>(), Throws.InstanceOf<InvalidOperationException>());
     }

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Autofac;
+using Nethermind.Core;
+using Nethermind.Core.Test.Modules;
+using Nethermind.Consensus.Processing;
+using Nethermind.Evm.State;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.State;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test.ProcessingEnv;
+
+// Wrapper interfaces must be public so the emitted implementation (in a dynamic assembly) can see them.
+public interface ITestProcessingEnv : IDisposable
+{
+    IWorldState WorldState { get; }
+    ITransactionProcessor TransactionProcessor { get; }
+}
+
+public interface ITrackerEnv : IDisposable
+{
+    ProcessingEnvBuilderTests.TrackingDisposable Tracker { get; }
+}
+
+public interface IEnvWithMethod : IDisposable
+{
+    void DoSomething();
+}
+
+[Parallelizable(ParallelScope.All)]
+public class ProcessingEnvBuilderTests
+{
+    private static IContainer BuildContainer() =>
+        new ContainerBuilder().AddModule(new TestNethermindModule()).Build();
+
+    [Test]
+    public void BuildAs_binds_world_state_and_replaced_component()
+    {
+        using IContainer container = BuildContainer();
+        IWorldStateScopeProvider provider = container.Resolve<IWorldStateManager>().CreateResettableWorldState();
+        ITransactionProcessor fakeProcessor = Substitute.For<ITransactionProcessor>();
+
+        using ITestProcessingEnv env = container.Resolve<IProcessingEnvBuilder>()
+            .WithWorldState(provider)
+            .WithReplacedComponent<ITransactionProcessor>(fakeProcessor)
+            .BuildAs<ITestProcessingEnv>();
+
+        Assert.That(env.TransactionProcessor, Is.SameAs(fakeProcessor));
+        Assert.That(env.WorldState.ScopeProvider, Is.SameAs(provider));
+    }
+
+    [Test]
+    public void Dispose_disposes_the_child_scope()
+    {
+        using IContainer container = BuildContainer();
+
+        TrackingDisposable tracker;
+        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
+                   .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+                   .Configure(builder => builder.AddScoped<TrackingDisposable>())
+                   .BuildAs<ITrackerEnv>())
+        {
+            tracker = env.Tracker; // force construction inside the scope
+            Assert.That(tracker.Disposed, Is.False);
+        }
+
+        Assert.That(tracker.Disposed, Is.True);
+    }
+
+    [Test]
+    public void Non_property_member_throws_NotSupported()
+    {
+        using IContainer container = BuildContainer();
+        using IEnvWithMethod env = container.Resolve<IProcessingEnvBuilder>()
+            .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+            .BuildAs<IEnvWithMethod>();
+
+        Assert.That(env.DoSomething, Throws.TypeOf<NotSupportedException>());
+    }
+
+    [Test]
+    public void BuildAs_without_world_state_throws()
+    {
+        using IContainer container = BuildContainer();
+        IProcessingEnvBuilder builder = container.Resolve<IProcessingEnvBuilder>();
+
+        Assert.That(() => builder.BuildAs<IEnvWithMethod>(), Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    public sealed class TrackingDisposable : IDisposable
+    {
+        public bool Disposed { get; private set; }
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -154,6 +154,24 @@ public class ProcessingEnvBuilderTests
     }
 
     [Test]
+    public async Task BuildAsOverridableEnv_returns_an_overridable_env_and_disposes_the_scope()
+    {
+        using IContainer container = BuildContainer();
+        IOverridableEnv overridableEnv = container.Resolve<IOverridableEnvFactory>().Create();
+
+        IOverridableEnvHandle<IWorldState> handle = container.Resolve<IProcessingEnvBuilder>()
+            .WithOverridableEnv(overridableEnv)
+            .BuildAsOverridableEnv<IWorldState>();
+
+        using (Scope<IWorldState> scope = handle.BuildAndOverride(null))
+        {
+            Assert.That(scope.Component, Is.Not.Null);
+        }
+
+        await handle.DisposeAsync();
+    }
+
+    [Test]
     public void Non_property_member_throws_during_build()
     {
         using IContainer container = BuildContainer();

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -285,15 +285,17 @@ public class ProcessingEnvBuilderTests
     }
 
     [Test]
-    public void Build_resolves_the_component_but_requires_owned_by_parent_lifetime()
+    public void BuildAs_resolves_a_registered_component_but_requires_owned_by_parent_lifetime()
     {
         using IContainer container = BuildContainer();
 
-        // Build<T> returns a bare component that cannot dispose its scope, so it needs OwnedByParentLifetime.
+        // BuildAs<T> of a registered component returns a bare instance that cannot dispose its scope, so it
+        // needs OwnedByParentLifetime.
         Assert.That(
             () => container.Resolve<IProcessingEnvBuilder>()
                 .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
-                .Build<IWorldState>(),
+                .WithComponent<TrackingDisposable>()
+                .BuildAs<TrackingDisposable>(),
             Throws.TypeOf<InvalidOperationException>());
 
         TrackingDisposable tracker;
@@ -303,7 +305,7 @@ public class ProcessingEnvBuilderTests
                 .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
                 .WithComponent<TrackingDisposable>()
                 .OwnedByParentLifetime()
-                .Build<TrackingDisposable>();
+                .BuildAs<TrackingDisposable>();
 
             Assert.That(tracker.Disposed, Is.False);
         }

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -96,6 +96,41 @@ public class ProcessingEnvBuilderTests
     }
 
     [Test]
+    public void WithComponent_owns_the_instance_by_default_and_disposes_it()
+    {
+        using IContainer container = BuildContainer();
+        TrackingDisposable owned = new();
+
+        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
+                   .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+                   .WithComponent(owned)
+                   .BuildAs<ITrackerEnv>())
+        {
+            Assert.That(env.Tracker, Is.SameAs(owned));
+            Assert.That(owned.Disposed, Is.False);
+        }
+
+        Assert.That(owned.Disposed, Is.True);
+    }
+
+    [Test]
+    public void WithComponent_externallyOwned_does_not_dispose_the_instance()
+    {
+        using IContainer container = BuildContainer();
+        TrackingDisposable external = new();
+
+        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
+                   .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+                   .WithComponent(external, externallyOwned: true)
+                   .BuildAs<ITrackerEnv>())
+        {
+            Assert.That(env.Tracker, Is.SameAs(external));
+        }
+
+        Assert.That(external.Disposed, Is.False);
+    }
+
+    [Test]
     public void Non_property_member_throws_NotSupported()
     {
         using IContainer container = BuildContainer();

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -61,7 +61,7 @@ public class ProcessingEnvBuilderTests
         IWorldStateScopeProvider provider = container.Resolve<IWorldStateManager>().CreateResettableWorldState();
         ITransactionProcessor fakeProcessor = Substitute.For<ITransactionProcessor>();
 
-        using ITestProcessingEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
+        using ITestProcessingEnv env = container.Resolve<IProcessingEnvBuilder>()
             .WithWorldState(provider)
             .WithReplacedComponent<ITransactionProcessor>(fakeProcessor)
             .BuildAs<ITestProcessingEnv>();
@@ -76,7 +76,7 @@ public class ProcessingEnvBuilderTests
         using IContainer container = BuildContainer();
 
         TrackingDisposable tracker;
-        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
+        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
                    .Configure(builder => builder.AddScoped<TrackingDisposable>())
                    .BuildAs<ITrackerEnv>())
@@ -94,7 +94,7 @@ public class ProcessingEnvBuilderTests
         using IContainer container = BuildContainer();
 
         TrackingDisposable tracker;
-        await using (IAsyncTrackerEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
+        await using (IAsyncTrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
                    .Configure(builder => builder.AddScoped<TrackingDisposable>())
                    .BuildAs<IAsyncTrackerEnv>())
@@ -112,7 +112,7 @@ public class ProcessingEnvBuilderTests
         using IContainer container = BuildContainer();
         TrackingDisposable owned = new();
 
-        using (IEmptyEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
+        using (IEmptyEnv env = container.Resolve<IProcessingEnvBuilder>()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
                    .ThatDisposes(owned)
                    .BuildAs<IEmptyEnv>())
@@ -129,7 +129,7 @@ public class ProcessingEnvBuilderTests
         using IContainer container = BuildContainer();
         TrackingDisposable component = new();
 
-        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
+        using (ITrackerEnv env = container.Resolve<IProcessingEnvBuilder>()
                    .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
                    .WithComponent(component)
                    .BuildAs<ITrackerEnv>())
@@ -145,7 +145,7 @@ public class ProcessingEnvBuilderTests
     {
         using IContainer container = BuildContainer();
 
-        using IOverridableTestEnv env = container.Resolve<IProcessingEnvBuilder>().NewEnv()
+        using IOverridableTestEnv env = container.Resolve<IProcessingEnvBuilder>()
             .WithOverridableEnv()
             .BuildAs<IOverridableTestEnv>();
 
@@ -157,7 +157,7 @@ public class ProcessingEnvBuilderTests
     public void Non_property_member_throws_during_build()
     {
         using IContainer container = BuildContainer();
-        IProcessingEnvBuilder.IDsl builder = container.Resolve<IProcessingEnvBuilder>().NewEnv()
+        IProcessingEnvBuilder builder = container.Resolve<IProcessingEnvBuilder>()
             .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState());
 
         Assert.That(() => builder.BuildAs<IEnvWithMethod>(), Throws.TypeOf<ArgumentException>());
@@ -167,7 +167,7 @@ public class ProcessingEnvBuilderTests
     public void BuildAs_without_world_state_throws()
     {
         using IContainer container = BuildContainer();
-        IProcessingEnvBuilder.IDsl builder = container.Resolve<IProcessingEnvBuilder>().NewEnv();
+        IProcessingEnvBuilder builder = container.Resolve<IProcessingEnvBuilder>();
 
         Assert.That(() => builder.BuildAs<IEnvWithMethod>(), Throws.InstanceOf<InvalidOperationException>());
     }

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -53,6 +53,12 @@ public interface IOverridableWorldStateEnv : IOverridableEnv<IWorldState>, IAsyn
 {
 }
 
+// Uses the Null placeholder component; the wrapper forwards BuildAndOverride and resolves the getter.
+public interface INullComponentEnv : IOverridableEnv<Null>, IDisposable
+{
+    IWorldState WorldState { get; }
+}
+
 // No IDisposable: only valid with OwnedByParentLifetime, which hands scope disposal to the parent.
 public interface IOwnedTrackerEnv
 {
@@ -162,6 +168,34 @@ public class ProcessingEnvBuilderTests
 
         Assert.That(env.WorldState, Is.Not.Null);
         Assert.That(env.CodeInfoRepository, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task WithOverridableEnv_builds_the_world_state_scope_on_demand()
+    {
+        using IContainer container = BuildContainer();
+
+        await using IOverridableWorldStateEnv env = container.Resolve<IProcessingEnvBuilder>()
+            .WithOverridableEnv()
+            .BuildAs<IOverridableWorldStateEnv>();
+
+        // The no-arg overload must not open the world-state scope up front: were it eager, this on-demand
+        // build would throw because the env's single scope would already be open.
+        using Scope<IWorldState> scope = env.BuildAndOverride(null);
+        Assert.That(scope.Component, Is.Not.Null);
+    }
+
+    [Test]
+    public void BuildAs_supports_a_null_component_overridable_env_with_getters()
+    {
+        using IContainer container = BuildContainer();
+
+        using INullComponentEnv env = container.Resolve<IProcessingEnvBuilder>()
+            .WithOverridableEnv()
+            .BuildAs<INullComponentEnv>();
+
+        using (env.BuildAndOverride(null)) // Scope<Null>; only the scope lifetime matters
+            Assert.That(env.WorldState, Is.Not.Null);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ProcessingEnv/ProcessingEnvBuilderTests.cs
@@ -53,6 +53,12 @@ public interface IOverridableWorldStateEnv : IOverridableEnv<IWorldState>, IAsyn
 {
 }
 
+// No IDisposable: only valid with OwnedByParentLifetime, which hands scope disposal to the parent.
+public interface IOwnedTrackerEnv
+{
+    ProcessingEnvBuilderTests.TrackingDisposable Tracker { get; }
+}
+
 [Parallelizable(ParallelScope.All)]
 public class ProcessingEnvBuilderTests
 {
@@ -174,6 +180,42 @@ public class ProcessingEnvBuilderTests
         }
 
         await env.DisposeAsync();
+    }
+
+    [Test]
+    public void OwnedByParentLifetime_allows_non_disposable_wrapper_and_disposes_scope_with_parent()
+    {
+        using IContainer container = BuildContainer();
+
+        // A non-disposable wrapper is rejected unless its scope is owned by the parent lifetime.
+        Assert.That(
+            () => container.Resolve<IProcessingEnvBuilder>()
+                .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+                .BuildAs<IOwnedTrackerEnv>(),
+            Throws.TypeOf<ArgumentException>());
+
+        // Conversely, a disposable wrapper is rejected when owned by the parent lifetime.
+        Assert.That(
+            () => container.Resolve<IProcessingEnvBuilder>()
+                .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+                .OwnedByParentLifetime()
+                .BuildAs<IEmptyEnv>(),
+            Throws.TypeOf<ArgumentException>());
+
+        TrackingDisposable tracker;
+        using (ILifetimeScope parent = container.BeginLifetimeScope())
+        {
+            IOwnedTrackerEnv env = parent.Resolve<IProcessingEnvBuilder>()
+                .WithWorldState(container.Resolve<IWorldStateManager>().CreateResettableWorldState())
+                .Configure(builder => builder.AddScoped<TrackingDisposable>())
+                .OwnedByParentLifetime()
+                .BuildAs<IOwnedTrackerEnv>();
+
+            tracker = env.Tracker; // force construction inside the env scope
+            Assert.That(tracker.Disposed, Is.False);
+        }
+
+        Assert.That(tracker.Disposed, Is.True); // the env scope was disposed together with the parent scope
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
@@ -63,7 +63,7 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
             .Configure((builder) => builder.BindScoped<IBlobBaseFeeOverrideProvider, SimulateRequestState>())
             .WithComponent<ISimulateReadOnlyBlocksProcessingEnv, SimulateReadOnlyBlocksProcessingEnv>()
             .OwnedByParentLifetime()
-            .Build<ISimulateReadOnlyBlocksProcessingEnv>();
+            .BuildAs<ISimulateReadOnlyBlocksProcessingEnv>();
     }
 
     private static BlockTree CreateTempBlockTree(

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Generic;
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Blocks;
@@ -12,7 +11,6 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
-using Nethermind.Core.Container;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
 using Nethermind.Evm;
@@ -20,24 +18,20 @@ using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State;
-using Nethermind.State.OverridableEnv;
 using Nethermind.State.Repositories;
 
 namespace Nethermind.Facade.Simulate;
 
 public class SimulateReadOnlyBlocksProcessingEnvFactory(
-    IOverridableEnvFactory overridableEnvFactory,
-    ILifetimeScope rootLifetimeScope,
+    IProcessingEnvBuilder envBuilder,
     IReadOnlyBlockTree baseBlockTree,
     IDbProvider dbProvider,
     ISpecProvider specProvider,
-    IReadOnlyList<IBlockValidationModule> validationModules,
     ILogManager? logManager = null) : ISimulateReadOnlyBlocksProcessingEnvFactory
 {
     public ISimulateReadOnlyBlocksProcessingEnv Create()
     {
         IReadOnlyDbProvider editableDbProvider = new ReadOnlyDbProvider(dbProvider, true);
-        IOverridableEnv overridableEnv = overridableEnvFactory.Create();
 
         IHeaderStore mainHeaderStore = new HeaderStore(editableDbProvider.HeadersDb, editableDbProvider.BlockNumbersDb, (IHeaderDecoder)Rlp.GetDecoderOrThrow<BlockHeader>());
         SimulateDictionaryHeaderStore tmpHeaderStore = new(mainHeaderStore);
@@ -47,29 +41,38 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
         BlockTree tempBlockTree = CreateTempBlockTree(editableDbProvider, specProvider, logManager, editableDbProvider, tmpHeaderStore, mainBalStore);
         BlockTreeOverlay overrideBlockTree = new(baseBlockTree, tempBlockTree);
 
-        ILifetimeScope envLifetimeScope = rootLifetimeScope.BeginLifetimeScope((builder) => builder
-            .AddModule(overridableEnv) // worldstate related override here
-            .AddSingleton<IReadOnlyDbProvider>(editableDbProvider)
-            .AddSingleton<IBlockTree>(overrideBlockTree)
-            .AddSingleton<BlockTreeOverlay>(overrideBlockTree)
-            .AddSingleton<IHeaderStore>(tmpHeaderStore)
-            .AddSingleton<IHeaderFinder>(c => c.Resolve<IHeaderStore>())
-            .AddSingleton<IBlockhashCache, BlockhashCache>()
-            .AddModule(validationModules)
-            .AddSingleton<IUnresolvedBlockhashPolicy, NullUnresolvedBlockhashPolicy>()
-            .AddDecorator<IBlockhashProvider, SimulateBlockhashProvider>()
-            .AddDecorator<IBlockValidator, SimulateBlockValidatorProxy>()
-            .AddDecorator<ITransactionProcessor.IBlobBaseFeeCalculator, BlobBaseFeeOverrideCalculatorDecorator>()
-            .AddDecorator<IBlockProcessor.IBlockTransactionsExecutor, SimulateBlockValidationTransactionsExecutor>()
-            .AddSingleton<ITransactionProcessorAdapter, SimulateTransactionProcessorAdapter>()
-            .AddSingleton<IReceiptStorage>(NullReceiptStorage.Instance)
-            .AddScoped<SimulateRequestState>()
-            .BindScoped<IBlobBaseFeeOverrideProvider, SimulateRequestState>()
-            .AddScoped<SimulateReadOnlyBlocksProcessingEnv>());
+        IEnv env = envBuilder
+            .WithOverridableEnv() // worldstate related override here
+            .ThatDisposes(editableDbProvider)
+            .WithComponent<IReadOnlyDbProvider>(editableDbProvider)
+            .WithComponent<IBlockTree>(overrideBlockTree)
+            .WithComponent<BlockTreeOverlay>(overrideBlockTree)
+            .WithComponent<IHeaderStore>(tmpHeaderStore)
+            .WithReplacedComponent<IHeaderFinder>(c => c.Resolve<IHeaderStore>())
+            .WithReplacedComponent<IBlockhashCache, BlockhashCache>()
+            .WithBlockValidationConfiguration()
+            .WithReplacedComponent<IUnresolvedBlockhashPolicy, NullUnresolvedBlockhashPolicy>()
+            // Decorators and Bind have no With* equivalent, so they stay in Configure.
+            .Configure((builder) => builder
+                .AddDecorator<IBlockhashProvider, SimulateBlockhashProvider>()
+                .AddDecorator<IBlockValidator, SimulateBlockValidatorProxy>()
+                .AddDecorator<ITransactionProcessor.IBlobBaseFeeCalculator, BlobBaseFeeOverrideCalculatorDecorator>()
+                .AddDecorator<IBlockProcessor.IBlockTransactionsExecutor, SimulateBlockValidationTransactionsExecutor>())
+            .WithReplacedComponent<ITransactionProcessorAdapter, SimulateTransactionProcessorAdapter>()
+            .WithComponent<IReceiptStorage>(NullReceiptStorage.Instance)
+            .WithComponent<SimulateRequestState>()
+            .Configure((builder) => builder.BindScoped<IBlobBaseFeeOverrideProvider, SimulateRequestState>())
+            .WithComponent<SimulateReadOnlyBlocksProcessingEnv>()
+            .OwnedByParentLifetime()
+            .BuildAs<IEnv>();
 
-        envLifetimeScope.Disposer.AddInstanceForDisposal(editableDbProvider);
-        rootLifetimeScope.Disposer.AddInstanceForAsyncDisposal(envLifetimeScope);
-        return envLifetimeScope.Resolve<SimulateReadOnlyBlocksProcessingEnv>();
+        return env.Env;
+    }
+
+    // The built scope is owned by the parent lifetime; the wrapper only surfaces the resolved env.
+    public interface IEnv
+    {
+        SimulateReadOnlyBlocksProcessingEnv Env { get; }
     }
 
     private static BlockTree CreateTempBlockTree(

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
@@ -41,7 +41,7 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
         BlockTree tempBlockTree = CreateTempBlockTree(editableDbProvider, specProvider, logManager, editableDbProvider, tmpHeaderStore, mainBalStore);
         BlockTreeOverlay overrideBlockTree = new(baseBlockTree, tempBlockTree);
 
-        IEnv env = envBuilder
+        return envBuilder
             .WithOverridableEnv() // worldstate related override here
             .ThatDisposes(editableDbProvider)
             .WithComponent<IReadOnlyDbProvider>(editableDbProvider)
@@ -52,27 +52,18 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
             .WithReplacedComponent<IBlockhashCache, BlockhashCache>()
             .WithBlockValidationConfiguration()
             .WithReplacedComponent<IUnresolvedBlockhashPolicy, NullUnresolvedBlockhashPolicy>()
-            // Decorators and Bind have no With* equivalent, so they stay in Configure.
-            .Configure((builder) => builder
-                .AddDecorator<IBlockhashProvider, SimulateBlockhashProvider>()
-                .AddDecorator<IBlockValidator, SimulateBlockValidatorProxy>()
-                .AddDecorator<ITransactionProcessor.IBlobBaseFeeCalculator, BlobBaseFeeOverrideCalculatorDecorator>()
-                .AddDecorator<IBlockProcessor.IBlockTransactionsExecutor, SimulateBlockValidationTransactionsExecutor>())
+            .WithDecorator<IBlockhashProvider, SimulateBlockhashProvider>()
+            .WithDecorator<IBlockValidator, SimulateBlockValidatorProxy>()
+            .WithDecorator<ITransactionProcessor.IBlobBaseFeeCalculator, BlobBaseFeeOverrideCalculatorDecorator>()
+            .WithDecorator<IBlockProcessor.IBlockTransactionsExecutor, SimulateBlockValidationTransactionsExecutor>()
             .WithReplacedComponent<ITransactionProcessorAdapter, SimulateTransactionProcessorAdapter>()
             .WithComponent<IReceiptStorage>(NullReceiptStorage.Instance)
             .WithComponent<SimulateRequestState>()
+            // BindScoped has no With* equivalent: IBlobBaseFeeOverrideProvider must share the SimulateRequestState instance.
             .Configure((builder) => builder.BindScoped<IBlobBaseFeeOverrideProvider, SimulateRequestState>())
-            .WithComponent<SimulateReadOnlyBlocksProcessingEnv>()
+            .WithComponent<ISimulateReadOnlyBlocksProcessingEnv, SimulateReadOnlyBlocksProcessingEnv>()
             .OwnedByParentLifetime()
-            .BuildAs<IEnv>();
-
-        return env.Env;
-    }
-
-    // The built scope is owned by the parent lifetime; the wrapper only surfaces the resolved env.
-    public interface IEnv
-    {
-        SimulateReadOnlyBlocksProcessingEnv Env { get; }
+            .Build<ISimulateReadOnlyBlocksProcessingEnv>();
     }
 
     private static BlockTree CreateTempBlockTree(

--- a/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
@@ -31,12 +32,12 @@ namespace Nethermind.Flashbots.Modules.Flashbots
     {
         public override IFlashbotsRpcModule Create()
         {
-            IOverridableEnvHandle<ValidateSubmissionHandler.ProcessingEnv> env = envBuilder
+            IEnv env = envBuilder
                 .WithOverridableEnv(overridableEnvFactory.Create())
                 .WithBlockValidationConfiguration()
                 .WithReplacedComponent<IReceiptStorage>(NullReceiptStorage.Instance)
                 .Configure(builder => builder.AddScoped<ValidateSubmissionHandler.ProcessingEnv>())
-                .BuildAsOverridableEnv<ValidateSubmissionHandler.ProcessingEnv>();
+                .BuildAs<IEnv>();
 
             rootLifetime.Disposer.AddInstanceForAsyncDisposal(env);
             ValidateSubmissionHandler validateSubmissionHandler = new(
@@ -51,6 +52,11 @@ namespace Nethermind.Flashbots.Modules.Flashbots
             );
 
             return new FlashbotsRpcModule(validateSubmissionHandler);
+        }
+
+        // The wrapper forwards BuildAndOverride to the resolved env and DisposeAsync to the built scope.
+        public interface IEnv : IOverridableEnv<ValidateSubmissionHandler.ProcessingEnv>, IAsyncDisposable
+        {
         }
     }
 }

--- a/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
+using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
-using Nethermind.Core.Container;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Flashbots.Handlers;
@@ -18,6 +19,7 @@ namespace Nethermind.Flashbots.Modules.Flashbots
 {
     public class FlashbotsRpcModuleFactory(
         ILifetimeScope rootLifetime,
+        IProcessingEnvBuilder envBuilder,
         IOverridableEnvFactory overridableEnvFactory,
         IHeaderValidator headerValidator,
         IBlockTree blockTree,
@@ -25,26 +27,24 @@ namespace Nethermind.Flashbots.Modules.Flashbots
         ILogManager logManager,
         ISpecProvider specProvider,
         IFlashbotsConfig flashbotsConfig,
-        IEthereumEcdsa ethereumEcdsa,
-        IBlockValidationModule[] validationBlockProcessingModules
+        IEthereumEcdsa ethereumEcdsa
     ) : ModuleFactoryBase<IFlashbotsRpcModule>
     {
         public override IFlashbotsRpcModule Create()
         {
-            IOverridableEnv overridableEnv = overridableEnvFactory.Create();
+            IEnv env = envBuilder
+                .WithOverridableEnv(overridableEnvFactory.Create())
+                .WithBlockValidationConfiguration()
+                .WithReplacedComponent<IReceiptStorage>(NullReceiptStorage.Instance)
+                .Configure(builder => builder.AddScoped<ValidateSubmissionHandler.ProcessingEnv>())
+                .BuildAs<IEnv>();
 
-            ILifetimeScope moduleLifetime = rootLifetime.BeginLifetimeScope((builder) => builder
-                .AddModule(validationBlockProcessingModules)
-                .AddSingleton<IReceiptStorage>(NullReceiptStorage.Instance)
-                .AddScoped<ValidateSubmissionHandler.ProcessingEnv>()
-                .AddModule(overridableEnv));
-
-            rootLifetime.Disposer.AddInstanceForAsyncDisposal(moduleLifetime);
+            rootLifetime.Disposer.AddInstanceForAsyncDisposal(env);
             ValidateSubmissionHandler validateSubmissionHandler = new(
                 headerValidator,
                 blockTree,
                 blockValidator,
-                moduleLifetime.Resolve<IOverridableEnv<ValidateSubmissionHandler.ProcessingEnv>>(),
+                env.Env,
                 logManager,
                 specProvider,
                 flashbotsConfig,
@@ -52,6 +52,11 @@ namespace Nethermind.Flashbots.Modules.Flashbots
             );
 
             return new FlashbotsRpcModule(validateSubmissionHandler);
+        }
+
+        public interface IEnv : IAsyncDisposable
+        {
+            IOverridableEnv<ValidateSubmissionHandler.ProcessingEnv> Env { get; }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
@@ -20,7 +20,6 @@ namespace Nethermind.Flashbots.Modules.Flashbots
     public class FlashbotsRpcModuleFactory(
         ILifetimeScope rootLifetime,
         IProcessingEnvBuilder envBuilder,
-        IOverridableEnvFactory overridableEnvFactory,
         IHeaderValidator headerValidator,
         IBlockTree blockTree,
         IBlockValidator blockValidator,
@@ -33,7 +32,7 @@ namespace Nethermind.Flashbots.Modules.Flashbots
         public override IFlashbotsRpcModule Create()
         {
             IEnv env = envBuilder
-                .WithOverridableEnv(overridableEnvFactory.Create())
+                .WithOverridableEnv()
                 .WithBlockValidationConfiguration()
                 .WithReplacedComponent<IReceiptStorage>(NullReceiptStorage.Instance)
                 .Configure(builder => builder.AddScoped<ValidateSubmissionHandler.ProcessingEnv>())

--- a/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
@@ -1,13 +1,10 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
-using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Validators;
-using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Flashbots.Handlers;
@@ -18,7 +15,6 @@ using Nethermind.State.OverridableEnv;
 namespace Nethermind.Flashbots.Modules.Flashbots
 {
     public class FlashbotsRpcModuleFactory(
-        ILifetimeScope rootLifetime,
         IProcessingEnvBuilder envBuilder,
         IHeaderValidator headerValidator,
         IBlockTree blockTree,
@@ -35,10 +31,10 @@ namespace Nethermind.Flashbots.Modules.Flashbots
                 .WithOverridableEnv()
                 .WithBlockValidationConfiguration()
                 .WithReplacedComponent<IReceiptStorage>(NullReceiptStorage.Instance)
-                .Configure(builder => builder.AddScoped<ValidateSubmissionHandler.ProcessingEnv>())
+                .WithComponent<ValidateSubmissionHandler.ProcessingEnv>()
+                .OwnedByParentLifetime()
                 .BuildAs<IEnv>();
 
-            rootLifetime.Disposer.AddInstanceForAsyncDisposal(env);
             ValidateSubmissionHandler validateSubmissionHandler = new(
                 headerValidator,
                 blockTree,
@@ -53,8 +49,8 @@ namespace Nethermind.Flashbots.Modules.Flashbots
             return new FlashbotsRpcModule(validateSubmissionHandler);
         }
 
-        // The wrapper forwards BuildAndOverride to the resolved env and DisposeAsync to the built scope.
-        public interface IEnv : IOverridableEnv<ValidateSubmissionHandler.ProcessingEnv>, IAsyncDisposable
+        // The wrapper forwards BuildAndOverride to the resolved env; the built scope is owned by the parent lifetime.
+        public interface IEnv : IOverridableEnv<ValidateSubmissionHandler.ProcessingEnv>
         {
         }
     }

--- a/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Modules/Flashbots/FlashbotsRpcModuleFactory.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Autofac;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
@@ -32,19 +31,19 @@ namespace Nethermind.Flashbots.Modules.Flashbots
     {
         public override IFlashbotsRpcModule Create()
         {
-            IEnv env = envBuilder
+            IOverridableEnvHandle<ValidateSubmissionHandler.ProcessingEnv> env = envBuilder
                 .WithOverridableEnv(overridableEnvFactory.Create())
                 .WithBlockValidationConfiguration()
                 .WithReplacedComponent<IReceiptStorage>(NullReceiptStorage.Instance)
                 .Configure(builder => builder.AddScoped<ValidateSubmissionHandler.ProcessingEnv>())
-                .BuildAs<IEnv>();
+                .BuildAsOverridableEnv<ValidateSubmissionHandler.ProcessingEnv>();
 
             rootLifetime.Disposer.AddInstanceForAsyncDisposal(env);
             ValidateSubmissionHandler validateSubmissionHandler = new(
                 headerValidator,
                 blockTree,
                 blockValidator,
-                env.Env,
+                env,
                 logManager,
                 specProvider,
                 flashbotsConfig,
@@ -52,11 +51,6 @@ namespace Nethermind.Flashbots.Modules.Flashbots
             );
 
             return new FlashbotsRpcModule(validateSubmissionHandler);
-        }
-
-        public interface IEnv : IAsyncDisposable
-        {
-            IOverridableEnv<ValidateSubmissionHandler.ProcessingEnv> Env { get; }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
@@ -81,6 +81,7 @@ public class BlockProcessingModule(IInitConfig initConfig, IBlocksConfig blocksC
 
             .AddSingleton<IOverridableEnvFactory, OverridableEnvFactory>()
             .AddScopedOpenGeneric(typeof(IOverridableEnv<>), typeof(DisposableScopeOverridableEnv<>))
+            .AddScoped<Null>() // placeholder component for IOverridableEnv<Null> (scope-lifetime only)
             .Add<IProcessingEnvBuilder, ProcessingEnvBuilder>()
 
             // The main block processing pipeline, anything that requires the use of the main IWorldState is wrapped

--- a/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
@@ -81,6 +81,7 @@ public class BlockProcessingModule(IInitConfig initConfig, IBlocksConfig blocksC
 
             .AddSingleton<IOverridableEnvFactory, OverridableEnvFactory>()
             .AddScopedOpenGeneric(typeof(IOverridableEnv<>), typeof(DisposableScopeOverridableEnv<>))
+            .Add<IProcessingEnvBuilder, ProcessingEnvBuilder>()
 
             // The main block processing pipeline, anything that requires the use of the main IWorldState is wrapped
             // in a `IMainProcessingContext`.

--- a/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
@@ -23,10 +23,9 @@ namespace Nethermind.Init.Modules;
 public class MainProcessingContext : IMainProcessingContext, BlockProcessor.BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler, IAsyncDisposable
 {
     public MainProcessingContext(
-        ILifetimeScope rootLifetimeScope,
+        IProcessingEnvBuilder envBuilder,
         IReceiptConfig receiptConfig,
         IInitConfig initConfig,
-        IBlockValidationModule[] blockValidationModules,
         IMainProcessingModule[] mainProcessingModules,
         IWorldStateManager worldStateManager,
         CompositeBlockPreprocessorStep compositeBlockPreprocessorStep,
@@ -34,7 +33,6 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
         IProcessExitSource processExitSource,
         ILogManager logManager)
     {
-
         IWorldStateScopeProvider worldState = worldStateManager.GlobalWorldState;
         if (logManager.GetClassLogger<WorldStateScopeOperationLogger>().IsTrace)
         {
@@ -43,15 +41,12 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
 
         worldState = new WorldStateMetricsScopeProvider(worldState, static time => Blockchain.Metrics.StateMerkleizationTime = time);
 
-        ILifetimeScope innerScope = rootLifetimeScope.BeginLifetimeScope((builder) =>
-        {
-            builder
-                // These are main block processing specific
-                .AddSingleton<IWorldStateScopeProvider>(worldState)
-                .AddModule(blockValidationModules)
-                .AddSingleton<BlockProcessor.BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler>(this)
+        _components = envBuilder.NewEnv()
+            .WithWorldState(worldState)
+            .WithBlockValidationConfiguration()
+            .WithComponent<BlockProcessor.BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler>(this)
+            .Configure(builder => builder
                 .AddModule(mainProcessingModules)
-
                 .AddScoped<BlockchainProcessor, IBranchProcessor, IProcessingStats, IEnumerable<IBlockTracer>>((branchProcessor, processingStats, blockTracers) =>
                     new BlockchainProcessor(
                         blockTree,
@@ -70,13 +65,8 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
                         IsMainProcessor = true // Manual construction because of this flag
                     })
                 .AddScoped<IBlockchainProcessor>(ctx => ctx.Resolve<BlockchainProcessor>())
-                .AddScoped<IBlockProcessingQueue>(ctx => ctx.Resolve<BlockchainProcessor>())
-                // And finally, to wrap things up.
-                .AddScoped<Components>()
-                ;
-        });
-
-        _components = innerScope.Resolve<Components>();
+                .AddScoped<IBlockProcessingQueue>(ctx => ctx.Resolve<BlockchainProcessor>()))
+            .BuildAs<IComponents>();
 
         if (initConfig.ExitOnInvalidBlock)
         {
@@ -87,14 +77,12 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
                 processExitSource.Exit(ExitCodes.InvalidBlock);
             };
         }
-
-        LifetimeScope = innerScope;
     }
 
-    public async ValueTask DisposeAsync() => await LifetimeScope.DisposeAsync();
+    public ValueTask DisposeAsync() => _components.DisposeAsync();
 
-    private readonly Components _components;
-    public ILifetimeScope LifetimeScope { get; init; }
+    private readonly IComponents _components;
+    public ILifetimeScope LifetimeScope => _components.LifetimeScope;
     public IBlockchainProcessor BlockchainProcessor => _components.BlockchainProcessor;
     public IBlockProcessingQueue BlockProcessingQueue => _components.BlockProcessingQueue;
     public IWorldState WorldState => _components.WorldState;
@@ -105,13 +93,16 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
     public event EventHandler<TxProcessedEventArgs>? TransactionProcessed;
     public void OnTransactionProcessed(TxProcessedEventArgs txProcessedEventArgs) => TransactionProcessed?.Invoke(this, txProcessedEventArgs);
 
-    private record Components(
-        ITransactionProcessor TransactionProcessor,
-        IBranchProcessor BranchProcessor,
-        IBlockProcessor BlockProcessor,
-        IBlockchainProcessor BlockchainProcessor,
-        IBlockProcessingQueue BlockProcessingQueue,
-        IWorldState WorldState,
-        IGenesisLoader GenesisLoader
-    );
+    /// <summary>The main-pipeline components resolved from the child scope; disposing it disposes the scope.</summary>
+    public interface IComponents : IAsyncDisposable
+    {
+        ITransactionProcessor TransactionProcessor { get; }
+        IBranchProcessor BranchProcessor { get; }
+        IBlockProcessor BlockProcessor { get; }
+        IBlockchainProcessor BlockchainProcessor { get; }
+        IBlockProcessingQueue BlockProcessingQueue { get; }
+        IWorldState WorldState { get; }
+        IGenesisLoader GenesisLoader { get; }
+        ILifetimeScope LifetimeScope { get; }
+    }
 }

--- a/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/MainProcessingContext.cs
@@ -41,7 +41,7 @@ public class MainProcessingContext : IMainProcessingContext, BlockProcessor.Bloc
 
         worldState = new WorldStateMetricsScopeProvider(worldState, static time => Blockchain.Metrics.StateMerkleizationTime = time);
 
-        _components = envBuilder.NewEnv()
+        _components = envBuilder
             .WithWorldState(worldState)
             .WithBlockValidationConfiguration()
             .WithComponent<BlockProcessor.BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler>(this)

--- a/src/Nethermind/Nethermind.Init/Steps/EvmWarmer.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EvmWarmer.cs
@@ -18,7 +18,7 @@ public class EvmWarmer(IProcessingEnvBuilder envBuilder) : IStep
 {
     public Task Execute(CancellationToken cancellationToken)
     {
-        using IWarmupEnv warmupEnv = envBuilder.NewEnv()
+        using IWarmupEnv warmupEnv = envBuilder
             .WithOverridableEnv()
             .BuildAs<IWarmupEnv>();
 

--- a/src/Nethermind/Nethermind.Init/Steps/EvmWarmer.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EvmWarmer.cs
@@ -4,31 +4,32 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Autofac;
 using Nethermind.Api.Steps;
+using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Init.Steps;
-using Nethermind.State.OverridableEnv;
 
 [RunnerStepDependencies(
     typeof(InitializeBlockchain)
 )]
-public class EvmWarmer(IOverridableEnvFactory envFactory, ILifetimeScope rootScope) : IStep
+public class EvmWarmer(IProcessingEnvBuilder envBuilder) : IStep
 {
     public Task Execute(CancellationToken cancellationToken)
     {
-        IOverridableEnv env = envFactory.Create();
-        using IDisposable envScope = env.BuildAndOverride(null, null);
+        using IWarmupEnv warmupEnv = envBuilder
+            .WithOverridableEnv()
+            .BuildAs<IWarmupEnv>();
 
-        using ILifetimeScope childContainerScope = rootScope.BeginLifetimeScope((builder) =>
-        {
-            builder.AddModule(env);
-        });
-
-        EthereumVirtualMachine.WarmUpEvmInstructions(childContainerScope.Resolve<IWorldState>(), childContainerScope.Resolve<ICodeInfoRepository>());
+        EthereumVirtualMachine.WarmUpEvmInstructions(warmupEnv.WorldState, warmupEnv.CodeInfoRepository);
 
         return Task.CompletedTask;
+    }
+
+    public interface IWarmupEnv : IDisposable
+    {
+        IWorldState WorldState { get; }
+        ICodeInfoRepository CodeInfoRepository { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Init/Steps/EvmWarmer.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EvmWarmer.cs
@@ -10,6 +10,7 @@ using Nethermind.Core;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Init.Steps;
+using Nethermind.State.OverridableEnv;
 
 [RunnerStepDependencies(
     typeof(InitializeBlockchain)
@@ -22,12 +23,13 @@ public class EvmWarmer(IProcessingEnvBuilder envBuilder) : IStep
             .WithOverridableEnv()
             .BuildAs<IWarmupEnv>();
 
-        EthereumVirtualMachine.WarmUpEvmInstructions(warmupEnv.WorldState, warmupEnv.CodeInfoRepository);
+        using (warmupEnv.BuildAndOverride(null)) // Scope<Null>; only the override scope's lifetime is needed
+            EthereumVirtualMachine.WarmUpEvmInstructions(warmupEnv.WorldState, warmupEnv.CodeInfoRepository);
 
         return Task.CompletedTask;
     }
 
-    public interface IWarmupEnv : IDisposable
+    public interface IWarmupEnv : IOverridableEnv<Null>, IDisposable
     {
         IWorldState WorldState { get; }
         ICodeInfoRepository CodeInfoRepository { get; }

--- a/src/Nethermind/Nethermind.Init/Steps/EvmWarmer.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EvmWarmer.cs
@@ -18,7 +18,7 @@ public class EvmWarmer(IProcessingEnvBuilder envBuilder) : IStep
 {
     public Task Execute(CancellationToken cancellationToken)
     {
-        using IWarmupEnv warmupEnv = envBuilder
+        using IWarmupEnv warmupEnv = envBuilder.NewEnv()
             .WithOverridableEnv()
             .BuildAs<IWarmupEnv>();
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
@@ -5,21 +5,19 @@ using Autofac;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Tracing;
 using Nethermind.Core;
-using Nethermind.State.OverridableEnv;
 using Nethermind.Evm.TransactionProcessing;
 
 namespace Nethermind.JsonRpc.Modules.DebugModule;
 
 public class DebugModuleFactory(
     IProcessingEnvBuilder envBuilder,
-    IOverridableEnvFactory envFactory,
     ILifetimeScope rootLifetimeScope
 ) : IRpcModuleFactory<IDebugRpcModule>
 {
     public IDebugRpcModule Create()
     {
         IEnv tracer = envBuilder
-            .WithOverridableEnv(envFactory.Create())
+            .WithOverridableEnv()
             // Standard configuration; not overriding `IReceiptStorage` to null.
             .WithBlockValidationConfiguration()
             .WithReplacedComponent<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Autofac;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Tracing;
@@ -27,20 +26,20 @@ public class DebugModuleFactory(
             // So the debug rpc can change the adapter sometime.
             .WithReplacedComponent<ITransactionProcessorAdapter, ChangeableTransactionProcessorAdapter>()
             .Configure(builder => builder.AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>())
+            // The tracer is a long-lived singleton, so let the root lifetime own its scope.
+            .OwnedByParentLifetime()
             .BuildAs<IEnv>();
 
         // Pass only `IGethStyleTracer` into the debug rpc lifetime to prevent leaking processor or world
         // state accidentally. `GethStyleTracer` must be very careful to always dispose overridable env.
         ILifetimeScope debugRpcModuleLifetime = rootLifetimeScope.BeginLifetimeScope((builder) => builder
             .AddScoped<IGethStyleTracer>(tracer.Tracer));
-
-        debugRpcModuleLifetime.Disposer.AddInstanceForAsyncDisposal(tracer);
-        rootLifetimeScope.Disposer.AddInstanceForAsyncDisposal(debugRpcModuleLifetime);
+        rootLifetimeScope.Disposer.AddInstanceForDisposal(debugRpcModuleLifetime);
 
         return debugRpcModuleLifetime.Resolve<IDebugRpcModule>();
     }
 
-    public interface IEnv : IAsyncDisposable
+    public interface IEnv
     {
         IGethStyleTracer Tracer { get; }
     }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugModuleFactory.cs
@@ -1,50 +1,47 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Autofac;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Tracing;
 using Nethermind.Core;
-using Nethermind.Core.Container;
 using Nethermind.State.OverridableEnv;
 using Nethermind.Evm.TransactionProcessing;
 
 namespace Nethermind.JsonRpc.Modules.DebugModule;
 
 public class DebugModuleFactory(
+    IProcessingEnvBuilder envBuilder,
     IOverridableEnvFactory envFactory,
-    ILifetimeScope rootLifetimeScope,
-    IBlockValidationModule[] validationBlockProcessingModules
+    ILifetimeScope rootLifetimeScope
 ) : IRpcModuleFactory<IDebugRpcModule>
 {
-    private ContainerBuilder ConfigureTracerContainer(ContainerBuilder builder) =>
-        builder
-            // Standard configuration
-            // Note: Not overriding `IReceiptStorage` to null.
-            .AddModule(validationBlockProcessingModules)
-            .AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>()
-            .AddScoped<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)
-
-            // So the debug rpc change the adapter sometime.
-            .AddScoped<ITransactionProcessorAdapter, ChangeableTransactionProcessorAdapter>();
-
     public IDebugRpcModule Create()
     {
-        IOverridableEnv env = envFactory.Create();
+        IEnv tracer = envBuilder
+            .WithOverridableEnv(envFactory.Create())
+            // Standard configuration; not overriding `IReceiptStorage` to null.
+            .WithBlockValidationConfiguration()
+            .WithReplacedComponent<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)
+            // So the debug rpc can change the adapter sometime.
+            .WithReplacedComponent<ITransactionProcessorAdapter, ChangeableTransactionProcessorAdapter>()
+            .Configure(builder => builder.AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>())
+            .BuildAs<IEnv>();
 
-        ILifetimeScope tracerLifecycle = rootLifetimeScope.BeginLifetimeScope((builder) =>
-            ConfigureTracerContainer(builder)
-                .AddModule(env));
-
-        // Pass only `IGethStyleTracer` into the debug rpc lifetime.
-        // This is to prevent leaking processor or world state accidentally.
-        // `GethStyleTracer` must be very careful to always dispose overridable env.
+        // Pass only `IGethStyleTracer` into the debug rpc lifetime to prevent leaking processor or world
+        // state accidentally. `GethStyleTracer` must be very careful to always dispose overridable env.
         ILifetimeScope debugRpcModuleLifetime = rootLifetimeScope.BeginLifetimeScope((builder) => builder
-            .AddScoped<IGethStyleTracer>(tracerLifecycle.Resolve<IGethStyleTracer>()));
+            .AddScoped<IGethStyleTracer>(tracer.Tracer));
 
-        debugRpcModuleLifetime.Disposer.AddInstanceForAsyncDisposal(tracerLifecycle);
+        debugRpcModuleLifetime.Disposer.AddInstanceForAsyncDisposal(tracer);
         rootLifetimeScope.Disposer.AddInstanceForAsyncDisposal(debugRpcModuleLifetime);
 
         return debugRpcModuleLifetime.Resolve<IDebugRpcModule>();
+    }
+
+    public interface IEnv : IAsyncDisposable
+    {
+        IGethStyleTracer Tracer { get; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Autofac;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.Processing;
@@ -21,7 +22,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
     {
         public override IProofRpcModule Create()
         {
-            IOverridableEnvHandle<ITracer> tracer = envBuilder
+            IEnv tracer = envBuilder
                 .WithOverridableEnv(overridableEnvFactory.Create())
                 // Standard read only chain setting
                 .WithBlockValidationConfiguration()
@@ -33,7 +34,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
                 .WithReplacedComponent<IRewardCalculator>(NoBlockRewards.Instance)
                 .WithReplacedComponent<ITracer, Tracer>()
                 .Configure(builder => builder.AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>())
-                .BuildAsOverridableEnv<ITracer>();
+                .BuildAs<IEnv>();
 
             // The tracer needs an in-memory receipts store while the proof RPC does not; keep them separate.
             // IWitnessGeneratingBlockProcessingEnvFactory used by proof_call is resolved from the parent scope.
@@ -44,6 +45,11 @@ namespace Nethermind.JsonRpc.Modules.Proof
             rootLifetimeScope.Disposer.AddInstanceForDisposal(proofRpcScope);
 
             return proofRpcScope.Resolve<IProofRpcModule>();
+        }
+
+        // The wrapper forwards BuildAndOverride to the resolved env and DisposeAsync to the built scope.
+        public interface IEnv : IOverridableEnv<ITracer>, IAsyncDisposable
+        {
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
@@ -16,14 +16,13 @@ namespace Nethermind.JsonRpc.Modules.Proof
 {
     public class ProofModuleFactory(
         ILifetimeScope rootLifetimeScope,
-        IProcessingEnvBuilder envBuilder,
-        IOverridableEnvFactory overridableEnvFactory
+        IProcessingEnvBuilder envBuilder
     ) : ModuleFactoryBase<IProofRpcModule>
     {
         public override IProofRpcModule Create()
         {
             IEnv tracer = envBuilder
-                .WithOverridableEnv(overridableEnvFactory.Create())
+                .WithOverridableEnv()
                 // Standard read only chain setting
                 .WithBlockValidationConfiguration()
                 .WithReplacedComponent<ITransactionProcessorAdapter, TraceTransactionProcessorAdapter>()

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Autofac;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.Processing;
@@ -33,6 +32,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
                 .WithReplacedComponent<IRewardCalculator>(NoBlockRewards.Instance)
                 .WithReplacedComponent<ITracer, Tracer>()
                 .Configure(builder => builder.AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>())
+                .OwnedByParentLifetime()
                 .BuildAs<IEnv>();
 
             // The tracer needs an in-memory receipts store while the proof RPC does not; keep them separate.
@@ -40,14 +40,13 @@ namespace Nethermind.JsonRpc.Modules.Proof
             ILifetimeScope proofRpcScope = rootLifetimeScope.BeginLifetimeScope((builder) => builder
                 .AddSingleton<IOverridableEnv<ITracer>>(tracer));
 
-            proofRpcScope.Disposer.AddInstanceForAsyncDisposal(tracer);
             rootLifetimeScope.Disposer.AddInstanceForDisposal(proofRpcScope);
 
             return proofRpcScope.Resolve<IProofRpcModule>();
         }
 
-        // The wrapper forwards BuildAndOverride to the resolved env and DisposeAsync to the built scope.
-        public interface IEnv : IOverridableEnv<ITracer>, IAsyncDisposable
+        // The wrapper forwards BuildAndOverride to the resolved env; the built scope is owned by the parent lifetime.
+        public interface IEnv : IOverridableEnv<ITracer>
         {
         }
     }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Generic;
+using System;
 using Autofac;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.Processing;
@@ -9,7 +9,6 @@ using Nethermind.Consensus.Rewards;
 using Nethermind.Consensus.Tracing;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
-using Nethermind.Core.Container;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.State.OverridableEnv;
 
@@ -17,41 +16,40 @@ namespace Nethermind.JsonRpc.Modules.Proof
 {
     public class ProofModuleFactory(
         ILifetimeScope rootLifetimeScope,
-        IOverridableEnvFactory overridableEnvFactory,
-        IReadOnlyList<IBlockValidationModule> validationBlockProcessingModules
+        IProcessingEnvBuilder envBuilder,
+        IOverridableEnvFactory overridableEnvFactory
     ) : ModuleFactoryBase<IProofRpcModule>
     {
-
         public override IProofRpcModule Create()
         {
-            IOverridableEnv overridableEnv = overridableEnvFactory.Create();
-
-            ILifetimeScope tracerScope = rootLifetimeScope.BeginLifetimeScope((builder) => builder
-                .AddModule(overridableEnv)
-
+            IEnv tracer = envBuilder
+                .WithOverridableEnv(overridableEnvFactory.Create())
                 // Standard read only chain setting
-                .AddModule(validationBlockProcessingModules)
-                .AddScoped<ITransactionProcessorAdapter, TraceTransactionProcessorAdapter>()
-                .AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>()
-                .AddScoped<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)
-                .AddScoped<IBlockValidator>(Always.Valid) // Why?
-
+                .WithBlockValidationConfiguration()
+                .WithReplacedComponent<ITransactionProcessorAdapter, TraceTransactionProcessorAdapter>()
+                .WithReplacedComponent<BlockchainProcessor.Options>(BlockchainProcessor.Options.NoReceipts)
+                .WithReplacedComponent<IBlockValidator>(Always.Valid)
                 // Specific for proof rpc
-                .AddScoped<IReceiptStorage>(new InMemoryReceiptStorage()) // Umm.... not `NullReceiptStorage`?
-                .AddScoped<IRewardCalculator>(NoBlockRewards.Instance)
+                .WithReplacedComponent<IReceiptStorage>(new InMemoryReceiptStorage())
+                .WithReplacedComponent<IRewardCalculator>(NoBlockRewards.Instance)
+                .WithReplacedComponent<ITracer, Tracer>()
+                .Configure(builder => builder.AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>())
+                .BuildAs<IEnv>();
 
-                .AddScoped<ITracer, Tracer>());
-
-            // The tracer need a in memory receipts while the proof RPC does not.
-            // Eh, its a good idea to separate what need block processing and what does not anyway.
+            // The tracer needs an in-memory receipts store while the proof RPC does not; keep them separate.
             // IWitnessGeneratingBlockProcessingEnvFactory used by proof_call is resolved from the parent scope.
             ILifetimeScope proofRpcScope = rootLifetimeScope.BeginLifetimeScope((builder) => builder
-                .AddSingleton<IOverridableEnv<ITracer>>(tracerScope.Resolve<IOverridableEnv<ITracer>>()));
+                .AddSingleton<IOverridableEnv<ITracer>>(tracer.Env));
 
-            proofRpcScope.Disposer.AddInstanceForAsyncDisposal(tracerScope);
+            proofRpcScope.Disposer.AddInstanceForAsyncDisposal(tracer);
             rootLifetimeScope.Disposer.AddInstanceForDisposal(proofRpcScope);
 
             return proofRpcScope.Resolve<IProofRpcModule>();
+        }
+
+        public interface IEnv : IAsyncDisposable
+        {
+            IOverridableEnv<ITracer> Env { get; }
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofModuleFactory.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Autofac;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.Processing;
@@ -22,7 +21,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
     {
         public override IProofRpcModule Create()
         {
-            IEnv tracer = envBuilder
+            IOverridableEnvHandle<ITracer> tracer = envBuilder
                 .WithOverridableEnv(overridableEnvFactory.Create())
                 // Standard read only chain setting
                 .WithBlockValidationConfiguration()
@@ -34,22 +33,17 @@ namespace Nethermind.JsonRpc.Modules.Proof
                 .WithReplacedComponent<IRewardCalculator>(NoBlockRewards.Instance)
                 .WithReplacedComponent<ITracer, Tracer>()
                 .Configure(builder => builder.AddDecorator<IBlockchainProcessor, OneTimeChainProcessor>())
-                .BuildAs<IEnv>();
+                .BuildAsOverridableEnv<ITracer>();
 
             // The tracer needs an in-memory receipts store while the proof RPC does not; keep them separate.
             // IWitnessGeneratingBlockProcessingEnvFactory used by proof_call is resolved from the parent scope.
             ILifetimeScope proofRpcScope = rootLifetimeScope.BeginLifetimeScope((builder) => builder
-                .AddSingleton<IOverridableEnv<ITracer>>(tracer.Env));
+                .AddSingleton<IOverridableEnv<ITracer>>(tracer));
 
             proofRpcScope.Disposer.AddInstanceForAsyncDisposal(tracer);
             rootLifetimeScope.Disposer.AddInstanceForDisposal(proofRpcScope);
 
             return proofRpcScope.Resolve<IProofRpcModule>();
-        }
-
-        public interface IEnv : IAsyncDisposable
-        {
-            IOverridableEnv<ITracer> Env { get; }
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/OverridableEnv/Null.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/Null.cs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.State.OverridableEnv;
+
+/// <summary>
+/// Placeholder component for an <see cref="IOverridableEnv{T}"/> whose caller only needs the override
+/// scope's lifetime, not a resolved component bundle — <c>Scope&lt;Null&gt;.Component</c> is unused.
+/// </summary>
+public sealed class Null { }

--- a/src/Nethermind/Nethermind.Taiko/TaikoBlockProductionEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoBlockProductionEnvFactory.cs
@@ -11,7 +11,7 @@ using Nethermind.Taiko.ZkGas;
 
 namespace Nethermind.Taiko;
 
-public class TaikoBlockProductionEnvFactory(ILifetimeScope rootLifetime, IWorldStateManager worldStateManager, IBlockProducerTxSourceFactory txSourceFactory) : BlockProducerEnvFactory(rootLifetime, worldStateManager, txSourceFactory)
+public class TaikoBlockProductionEnvFactory(ILifetimeScope rootLifetime, IProcessingEnvBuilder envBuilder, IWorldStateManager worldStateManager, IBlockProducerTxSourceFactory txSourceFactory) : BlockProducerEnvFactory(rootLifetime, envBuilder, worldStateManager, txSourceFactory)
 {
     protected override ContainerBuilder ConfigureBuilder(ContainerBuilder builder) =>
         // Taiko does not seems to use `BlockProductionTransactionsExecutor`

--- a/src/Nethermind/Nethermind.Xdc.Test/Contracts/MasternodeVotingContractTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Contracts/MasternodeVotingContractTests.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Autofac;
 using Nethermind.Abi;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Processing;
@@ -69,7 +68,10 @@ internal class MasternodeVotingContractTests
         VirtualMachine virtualMachine = new(new TestBlockhashProvider(specProvider), specProvider, LimboLogs.Instance);
         EthereumTransactionProcessor transactionProcessor = new(BlobBaseFeeCalculator.Instance, specProvider, stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);
 
-        AutoReadOnlyTxProcessingEnv autoReadOnlyTxProcessingEnv = new(transactionProcessor, stateProvider, Substitute.For<ILifetimeScope>());
+        AutoReadOnlyTxProcessingEnv.IEnv env = Substitute.For<AutoReadOnlyTxProcessingEnv.IEnv>();
+        env.TransactionProcessor.Returns(transactionProcessor);
+        env.WorldState.Returns(stateProvider);
+        AutoReadOnlyTxProcessingEnv autoReadOnlyTxProcessingEnv = new(env);
 
         IReadOnlyTxProcessingEnvFactory readOnlyTxProcessingEnvFactory = Substitute.For<IReadOnlyTxProcessingEnvFactory>();
 


### PR DESCRIPTION
## Changes

Introduces **`IProcessingEnvBuilder`**, a small fluent DSL that replaces the hand-rolled Autofac child-lifetime-scope boilerplate used to build block-processing "environments".

Previously each env factory copy-pasted the same recipe — `parent.BeginLifetimeScope(b => b.AddScoped<IWorldStateScopeProvider>(...) + overrides)` → resolve a private `record` bundle → forward properties → dispose the scope + manual `Disposer.AddInstance...` calls. Because that recipe is unintuitive, some code went the other way and rebuilt the execution stack by hand, silently ignoring plugin-registered overrides/decorators. This DSL makes building an env from a child scope uniform, terse, and plugin-compatible.

**The builder** (`Nethermind.Consensus/Processing/`):

- `WithWorldState(...)` / `WithOverridableEnv()` / `WithOverridableEnv(env)` — the world-state source (the no-arg overload creates, owns, and disposes an overridable env; it builds the world scope on demand).
- `WithReplacedComponent<...>(...)` / `WithComponent<...>(...)` — component overrides and additions (instance, type, type→impl, or factory).
- `WithDecorator<TService, TDecorator>()` — decorator registration.
- `WithBlockValidationConfiguration()` — the registered validation modules.
- `ThatDisposes(IDisposable)` — explicit ownership of a caller-created disposable.
- `OwnedByParentLifetime()` — tie the scope to the builder's parent lifetime, so no manual `Disposer` calls are needed (and the wrapper need not be disposable).
- `Configure(Action<ContainerBuilder>)` — escape hatch for what has no `With*` (e.g. `BindScoped`).
- `BuildAs<T>()` — resolves `T` directly if it is registered in the scope (a real component); otherwise synthesizes a getter-only / `IOverridableEnv`-forwarding wrapper via `System.Reflection.Emit`, cached per interface. The DI-registered builder is immutable and forks a mutable builder on first `With*`, so a single injected instance is reusable and forkable.

**Migrated consumers** off the hand-rolled pattern: `AutoReadOnlyTxProcessingEnvFactory`, `PrewarmerEnvFactory`, the witness (capturing + generating) envs, the block-producer envs (Global/Taiko), `MainProcessingContext`, `EvmWarmer`, the **Debug/Proof/Flashbots** RPC module factories, and the **Simulate** env factory. Several of these migrations also fix latent leaks where the overridable env's child lifetime scope was never disposed.

Still hand-rolled and left as follow-ups: `TraceModuleFactory` and `BlockchainBridgeFactory`.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New `ProcessingEnvBuilderTests` covers world-state binding, component/decorator registration, disposal + `OwnedByParentLifetime` ownership rules, wrapper synthesis (getters, `IOverridableEnv` forwarding, the `Null` placeholder), and the resolve-vs-synthesize behavior of `BuildAs`. Ran the builder, Debug/Proof/Flashbots, Simulate, and Facade/BlockchainBridge suites locally — all green.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
