### PR TITLE
perf(evm): cache the last ECRecover result per thread

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Precompiles/ECRecoverPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/ECRecoverPrecompile.cs
@@ -25,6 +25,9 @@ public class ECRecoverPrecompile : IPrecompile<ECRecoverPrecompile>
 
     private const int InputLength = 128;
 
+    [ThreadStatic] private static byte[]? cachedInput;
+    [ThreadStatic] private static Result<byte[]> cachedResult;
+
     public ulong DataGasCost(ReadOnlyMemory<byte> inputData, IReleaseSpec releaseSpec) => 0UL;
 
     public ulong BaseGasCost(IReleaseSpec releaseSpec) => 3000UL;
@@ -45,7 +48,20 @@ public class ECRecoverPrecompile : IPrecompile<ECRecoverPrecompile>
 #if !ZK_EVM
         Metrics.ECRecoverPrecompile++;
 #endif
-        return inputData.Length >= 128 ? RunInternal(inputData.Span) : RunInternal(inputData);
+        if (inputData.Length < InputLength)
+            return RunInternal(inputData);
+
+        ReadOnlySpan<byte> effectiveInput = inputData.Span[..InputLength];
+        byte[]? lastInput = cachedInput;
+        if (lastInput is not null && effectiveInput.SequenceEqual(lastInput))
+            return cachedResult;
+
+        Result<byte[]> result = RunInternal(effectiveInput);
+
+        lastInput ??= cachedInput = new byte[InputLength];
+        effectiveInput.CopyTo(lastInput);
+        cachedResult = result;
+        return result;
     }
 
     private Result<byte[]> RunInternal(ReadOnlyMemory<byte> inputData)

--- a/src/Nethermind/Nethermind.Evm.Test/ECRecoverPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ECRecoverPrecompileTests.cs
@@ -1,13 +1,36 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using Nethermind.Core;
 using Nethermind.Evm.Precompiles;
+using Nethermind.Specs.Forks;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;
 
 public class ECRecoverPrecompileTests : PrecompileTests<ECRecoverPrecompile, ECRecoverPrecompileTests>
 {
+    [Test]
+    public void Repeated_input_returns_cached_result()
+    {
+        byte[] input = Convert.FromHexString(
+            "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e" +
+            "000000000000000000000000000000000000000000000000000000000000001b" +
+            "38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e" +
+            "789d1dd423d25f0772d2748d60f7e4b81bb14d086eba8e8e8efb6dcff8a4ae02");
+        byte[] repeatedInput = (byte[])input.Clone();
+
+        Result<byte[]> first = ECRecoverPrecompile.Instance.Run(input, Prague.Instance);
+        Result<byte[]> second = ECRecoverPrecompile.Instance.Run(repeatedInput, Prague.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(first.IsSuccess, Is.True);
+            Assert.That(second.Data, Is.SameAs(first.Data));
+        }
+    }
+
     [TestCase("38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e000000000000000000000000000000000000000000000000000000000000001b38d18acb67d25c8bb9942764b62f18e17054f66a817bd4295423adf9ed98873e789d1dd423d25f0772d2748d60f7e4b81bb14d086eba8e8e8efb6dcff8a4ae02", "000000000000000000000000ceaccac640adf55b2028469bd36ba501f28b699d", true)]
     [TestCase("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c000000000000000000000000000000000000000000000000000000000000001c73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75feeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549", "000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b", true)]
     [TestCase("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "", true)]


### PR DESCRIPTION
## Changes

Split-out, simplified rework of the ECRecover-caching part of #11918.

Adds a thread-static last-input/last-result cache to `ECRecoverPrecompile`. When a signature (the first 128 bytes — message, v, r, s) repeats on the same thread, the recovered address is returned directly and the secp256k1 recovery is skipped.

Deliberately minimal vs. #11918: no cross-thread shared slot, no decomposed-hash key class, no separate "has value" flag — just a `byte[]` last input compared with `SequenceEqual`. This also resolves the #11918 review notes about the redundant `t_hasCachedResult` flag and the single-slot cross-thread global (both removed). Short <128-byte inputs still bypass the cache (vanishingly rare).

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Unit test: repeated input returns the same cached result. Full ECRecover suite plus the precompile/signature regression tests pass.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No