### PR TITLE
fix(state): fsync block tree DBs before advancing flat persisted state

### DIFF
--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -55,6 +55,7 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
             .AddSingleton<ICompactionSchedule, CompactionSchedule>()
             .AddSingleton<ISnapshotCompactor, SnapshotCompactor>()
             .AddSingleton<IPersistenceManager, PersistenceManager>()
+            .AddSingleton<IPersistenceBarrier, BlockTreeDurabilityBarrier>()
             .AddSingleton<ISnapshotRepository, SnapshotRepository>()
             .AddSingleton<ITrieWarmer>(flatDbConfig.TrieWarmerWorkerCount == 0
                 ? _ => new NoopTrieWarmer()

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -443,6 +443,33 @@ public class PersistenceManagerTests
     }
 
     [Test]
+    public void PersistSnapshot_Always_InvokesBarrierBeforeCreatingWriteBatch()
+    {
+        StateId from = Block0;
+        StateId to = CreateStateId(16);
+        using Snapshot snapshot = CreateSnapshot(from, to);
+
+        IPersistenceBarrier barrier = Substitute.For<IPersistenceBarrier>();
+        _persistence.CreateWriteBatch(from, to).Returns(new FakeWriteBatch());
+        PersistenceManager pm = new(
+            _config,
+            ScheduleHelper.CreateWithOffset(_config, 0),
+            _finalizedStateProvider,
+            _persistence,
+            _snapshotRepository,
+            barrier,
+            LimboLogs.Instance);
+
+        pm.PersistSnapshot(snapshot);
+
+        Received.InOrder(() =>
+        {
+            barrier.BeforePersistedStateAdvance();
+            _persistence.CreateWriteBatch(from, to);
+        });
+    }
+
+    [Test]
     public void PersistSnapshot_WithSelfDestructedAddresses_CallsSelfDestruct()
     {
         // Arrange

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -52,6 +52,7 @@ public class PersistenceManagerTests
             _finalizedStateProvider,
             _persistence,
             _snapshotRepository,
+            NullPersistenceBarrier.Instance,
             LimboLogs.Instance);
     }
 
@@ -150,7 +151,7 @@ public class PersistenceManagerTests
         persistence.CreateReader().Returns(reader);
 
         ICompactionSchedule scheduler = ScheduleHelper.CreateWithOffset(_config, 0);
-        PersistenceManager pm = new(_config, scheduler, _finalizedStateProvider, persistence, _snapshotRepository, LimboLogs.Instance);
+        PersistenceManager pm = new(_config, scheduler, _finalizedStateProvider, persistence, _snapshotRepository, NullPersistenceBarrier.Instance, LimboLogs.Instance);
 
         // Depth 101 is past MinReorgDepth + CompactSize (80) but below the MaxReorgDepth force limit (256),
         // so only the finalized branch can produce a snapshot here.
@@ -350,7 +351,7 @@ public class PersistenceManagerTests
         IPersistence persistence = Substitute.For<IPersistence>();
         persistence.CreateReader().Returns(reader);
 
-        PersistenceManager pm = new(_config, ScheduleHelper.CreateWithOffset(_config, 0), _finalizedStateProvider, persistence, _snapshotRepository, LimboLogs.Instance);
+        PersistenceManager pm = new(_config, ScheduleHelper.CreateWithOffset(_config, 0), _finalizedStateProvider, persistence, _snapshotRepository, NullPersistenceBarrier.Instance, LimboLogs.Instance);
 
         // Latest snapshot (50) is below the persisted block (100); finalized far behind so the force-persist
         // branch would be taken on underflow. Stage a head-ancestor snapshot the buggy path would return.
@@ -526,6 +527,7 @@ public class PersistenceManagerTests
             _finalizedStateProvider,
             _persistence,
             _snapshotRepository,
+            NullPersistenceBarrier.Instance,
             LimboLogs.Instance);
 
         StateId target = CreateStateId(expectedTargetBlock);

--- a/src/Nethermind/Nethermind.State.Flat/BlockTreeDurabilityBarrier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/BlockTreeDurabilityBarrier.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Db;
+
+namespace Nethermind.State.Flat;
+
+/// <summary>
+/// Fsyncs the block tree databases before the persisted flat state pointer advances
+/// (per checkpoint, not per block).
+/// </summary>
+public sealed class BlockTreeDurabilityBarrier(IDbProvider dbProvider) : IPersistenceBarrier
+{
+    public void BeforePersistedStateAdvance()
+    {
+        dbProvider.HeadersDb.Flush(onlyWal: true);
+        dbProvider.BlockInfosDb.Flush(onlyWal: true);
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/BlockTreeDurabilityBarrier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/BlockTreeDurabilityBarrier.cs
@@ -11,6 +11,7 @@ namespace Nethermind.State.Flat;
 /// </summary>
 public sealed class BlockTreeDurabilityBarrier(IDbProvider dbProvider) : IPersistenceBarrier
 {
+    /// <inheritdoc/>
     public void BeforePersistedStateAdvance()
     {
         dbProvider.HeadersDb.Flush(onlyWal: true);

--- a/src/Nethermind/Nethermind.State.Flat/IPersistenceBarrier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/IPersistenceBarrier.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.State.Flat;
+
+/// <summary>
+/// Invoked before the persisted flat state pointer advances, so implementations can make what it
+/// depends on durable first — the DBs are separate RocksDB instances with no cross-DB ordering,
+/// and an unclean shutdown must not leave persisted state ahead of the durable block tree.
+/// </summary>
+public interface IPersistenceBarrier
+{
+    void BeforePersistedStateAdvance();
+}

--- a/src/Nethermind/Nethermind.State.Flat/NullPersistenceBarrier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/NullPersistenceBarrier.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.State.Flat;
+
+public sealed class NullPersistenceBarrier : IPersistenceBarrier
+{
+    public static readonly NullPersistenceBarrier Instance = new();
+
+    private NullPersistenceBarrier() { }
+
+    public void BeforePersistedStateAdvance() { }
+}

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -26,6 +26,7 @@ public class PersistenceManager(
     IFinalizedStateProvider finalizedStateProvider,
     IPersistence persistence,
     ISnapshotRepository snapshotRepository,
+    IPersistenceBarrier persistenceBarrier,
     ILogManager logManager) : IPersistenceManager
 {
     private readonly ILogger _logger = logManager.GetClassLogger<PersistenceManager>();
@@ -257,6 +258,8 @@ public class PersistenceManager(
 
     internal void PersistSnapshot(Snapshot snapshot)
     {
+        persistenceBarrier.BeforePersistedStateAdvance();
+
         ulong compactLength = snapshot.To.BlockNumber - snapshot.From.BlockNumber;
 
         // Usually at the start of the application


### PR DESCRIPTION
Root-cause prevention for flat state waking up ahead of the best known header after an unclean shutdown (the incident behind #12260 and its splits; follows the discussion in #12272 with @LukaszRozmej and @asdacap).

## Problem

Headers/block-infos and flat state live in separate RocksDB instances with no cross-DB write ordering. An unclean shutdown can lose the last un-fsynced header writes while the flat WAL keeps its own — the node wakes up with persisted flat state ahead of its best known header, and the block tree cannot recover the gap on its own because flat cannot roll back.

Note this is durability skew, not write logic: at the moment the flat checkpoint was written the headers *did* exist, so a value check at persist time ("don't persist above best header") would pass and fix nothing. The fix has to be ordering + durability.

## Fix

Before the flat persisted-state pointer advances (`PersistenceManager.PersistSnapshot`, the single choke point ahead of the `CurrentState` metadata write), a barrier makes the block tree databases durable:

- `IPersistenceBarrier` — narrow interface invoked before the pointer advances; the flat layer stays ignorant of what is made durable (no block tree values are read, no decisions depend on them — consistent with keeping the state layer free of block tree coupling per #12272's review).
- `BlockTreeDurabilityBarrier` — WAL-fsyncs the Headers and BlockInfos DBs. WAL sync is sufficient for durability; the pointer advances per flat checkpoint, not per block, so this is one fsync per checkpoint and stays off the hot path.

Guarantee: `persisted flat state ≤ durable block tree`. After a crash only the benign direction (headers ahead of state) can survive.

## Relation to the other splits

This is prevention for the known cause (WAL loss). It does not heal databases already in the skewed state and does not cover causes we didn't predict (disk corruption, restores) — that remains the job of the recovery splits: #12272 (sync mode selector tolerance) and #12275 (fast-forward through already-persisted blocks).

## Testing

`Nethermind.State.Flat.Test`: 542 tests, 0 failures (`NullPersistenceBarrier` keeps existing tests unaffected; production wiring registered in `FlatWorldStateModule`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)