### PR TITLE
refactor(di): wire block GossipPolicy and ProcessedTransactionsDbCleaner through DI

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -147,7 +147,7 @@ public abstract class BlockchainTestBase
         // base HeaderValidator does not enforce, and which legacy invalid-block fixtures rely on.
         if (isEngineTest || isPostMerge)
         {
-            containerBuilder.AddModule(new TestMergeModule(configProvider));
+            containerBuilder.AddModule(new TestMergeModule());
         }
 
         // Seed the optional test tracer into the main processor via the BlockchainProcessor constructor.

--- a/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithNetwork.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.Network;
@@ -15,7 +14,6 @@ namespace Nethermind.Api
         (IApiWithNetwork GetFromApi, IApiWithNetwork SetInApi) ForNetwork => (this, this);
 
         IIPResolver IpResolver { get; }
-        IGossipPolicy GossipPolicy { get; set; }
         IProtocolsManager? ProtocolsManager { get; }
 
         [SkipServiceCollection]

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -69,7 +69,6 @@ namespace Nethermind.Api
         public EthereumJsonSerializer EthereumJsonSerializer => _dependencies.JsonSerializer;
         public IKeyStore? KeyStore { get; set; }
         public ILogManager LogManager => _dependencies.LogManager;
-        public IGossipPolicy GossipPolicy { get; set; } = Policy.FullGossip;
         public IProtocolsManager? ProtocolsManager => Context.Resolve<IProtocolsManager>();
         public IReceiptFinder ReceiptFinder => Context.Resolve<IReceiptFinder>();
         public IRpcModuleProvider? RpcModuleProvider => Context.Resolve<IRpcModuleProvider>();

--- a/src/Nethermind/Nethermind.BalRecorder.Test/BalRecorderE2ETests.cs
+++ b/src/Nethermind/Nethermind.BalRecorder.Test/BalRecorderE2ETests.cs
@@ -132,7 +132,7 @@ public class BalRecorderE2ETests
         return new ContainerBuilder()
             .AddModule(new PseudoNethermindModule(spec, configProvider, LimboLogs.Instance))
             .AddModule(new TestEnvironmentModule(TestItem.PrivateKeyA, $"bal-e2e-{Guid.NewGuid():N}"))
-            .AddModule(new TestMergeModule(configProvider))
+            .AddModule(new TestMergeModule())
             .AddModule(new BalRecorderModule())
             .AddSingleton(timestamper)
             .AddSingleton<BlockBuilder>()

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestMergeModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestMergeModule.cs
@@ -4,28 +4,15 @@
 using Autofac;
 using Autofac.Core;
 using Nethermind.Api;
-using Nethermind.Blockchain;
-using Nethermind.Config;
 using Nethermind.Consensus.Rewards;
-using Nethermind.Db;
-using Nethermind.Logging;
 using Nethermind.Merge.Plugin;
 using Nethermind.Merge.Plugin.BlockProduction;
-using Nethermind.TxPool;
 
 namespace Nethermind.Core.Test.Modules;
 
-public class TestMergeModule(ITxPoolConfig txPoolConfig, IModule? mergeModule) : Module
+public class TestMergeModule(IModule? mergeModule) : Module
 {
-    public TestMergeModule(ITxPoolConfig txPoolConfig) : this(txPoolConfig, new MergePluginModule())
-    {
-    }
-
-    public TestMergeModule(IConfigProvider configProvider) : this(configProvider.GetConfig<ITxPoolConfig>(), new MergePluginModule())
-    {
-    }
-
-    public TestMergeModule(IConfigProvider configProvider, IModule? mergeModule) : this(configProvider.GetConfig<ITxPoolConfig>(), mergeModule)
+    public TestMergeModule() : this(new MergePluginModule())
     {
     }
 
@@ -46,14 +33,5 @@ public class TestMergeModule(ITxPoolConfig txPoolConfig, IModule? mergeModule) :
             // Engine rpc
             .AddSingleton<IEngineRequestsTracker, NoEngineRequestsTracker>()
             ;
-
-        if (txPoolConfig.BlobsSupport.SupportsReorgs())
-        {
-            builder.AddSingleton<ProcessedTransactionsDbCleaner, IBlockTree, IDbProvider, ILogManager>(
-                static (blockTree, dbProvider, logManager) => new ProcessedTransactionsDbCleaner(
-                    blockTree,
-                    dbProvider.BlobTransactionsDb.GetColumnDb(BlobTxsColumns.ProcessedTxs),
-                    logManager));
-        }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestMergeModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestMergeModule.cs
@@ -6,7 +6,6 @@ using Autofac.Core;
 using Nethermind.Api;
 using Nethermind.Blockchain;
 using Nethermind.Config;
-using Nethermind.Consensus;
 using Nethermind.Consensus.Rewards;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -40,9 +39,6 @@ public class TestMergeModule(ITxPoolConfig txPoolConfig, IModule? mergeModule) :
 
         builder
             .AddDecorator<IRewardCalculatorSource, MergeRewardCalculatorSource>()
-
-            // Validators
-            .AddDecorator<IGossipPolicy, MergeGossipPolicy>()
 
             // Block production related.
             .AddScoped<PostMergeBlockProducerFactory>()

--- a/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NetworkModule.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Autofac;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
+using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Container;
 using Nethermind.Core.Timers;
@@ -45,6 +46,9 @@ public class NetworkModule(IConfigProvider configProvider) : Module
             .AddLast<ITxGossipPolicy>(ctx => ctx.Resolve<SyncedTxGossipPolicy>())
             .AddSingleton<ITxGossipPolicySource, TxGossipPolicySource>()
             .AddCompositeOrderedComponents<ITxGossipPolicy, CompositeTxGossipPolicy>(singleInstance: true)
+
+            // Default block-gossip policy. Merge decorates it (MergeGossipPolicy); Optimism/Taiko replace it.
+            .AddSingleton<IGossipPolicy>(Policy.FullGossip)
             .AddSingleton<IIPResolver, IPResolver>()
 
             .AddSingleton<EnodeProvider>()

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Autofac;
 using Autofac.Core;
 using Nethermind.Api;
+using Nethermind.Blockchain;
 using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa;
 using Nethermind.Api.Steps;
@@ -104,6 +105,10 @@ namespace Nethermind.Merge.AuRa
                 // Merge-aware override: skips wiring the branch processor on post-merge chains so
                 // the AuRa finalization manager's startup catch-up walk never runs.
                 .AddStep(typeof(InitializeBlockchainAuRaMerge))
+
+                // See MergePluginModule: activate the blob-tx cleaner (registered in BaseMergePluginModule)
+                // once the block tree is up. It self-disables unless blob-tx reorg support is enabled.
+                .ResolveOnServiceActivation<ProcessedTransactionsDbCleaner, IBlockTree>()
                 ;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
@@ -95,6 +95,8 @@ namespace Nethermind.Merge.AuRa
                 .AddDecorator<ISealValidator, MergeSealValidator>()
                 .AddDecorator<ISealer, MergeSealer>()
 
+                .AddDecorator<IGossipPolicy, MergeGossipPolicy>()
+
                 // Disposes the AuRa finalization manager at the merge transition. Resolved eagerly in
                 // InitializeBlockchainAuRaMerge for its constructor side-effect; Autofac owns disposal.
                 .AddSingleton<AuRaTerminalBlockDisposer>()

--- a/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/AuRaMergePlugin.cs
@@ -106,8 +106,6 @@ namespace Nethermind.Merge.AuRa
                 // the AuRa finalization manager's startup catch-up walk never runs.
                 .AddStep(typeof(InitializeBlockchainAuRaMerge))
 
-                // See MergePluginModule: activate the blob-tx cleaner (registered in BaseMergePluginModule)
-                // once the block tree is up. It self-disables unless blob-tx reorg support is enabled.
                 .ResolveOnServiceActivation<ProcessedTransactionsDbCleaner, IBlockTree>()
                 ;
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -228,7 +228,7 @@ public abstract partial class BaseEngineModuleTests
         protected override ContainerBuilder ConfigureContainer(ContainerBuilder builder, IConfigProvider configProvider) =>
             base.ConfigureContainer(builder, configProvider)
                 .AddScoped<IWithdrawalProcessor, WithdrawalProcessor>()
-                .AddModule(new TestMergeModule(configProvider, MergeModule))
+                .AddModule(new TestMergeModule(MergeModule))
                 .AddDecorator<IBranchProcessor>((_, branchProcessor) => new TestBranchProcessorInterceptor(branchProcessor, _blockProcessingThrottle))
                 .AddDecorator<IBlockImprovementContextFactory>((_, factory) =>
                 {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/MergePluginTests.cs
@@ -190,7 +190,7 @@ public class MergePluginTests
         await _plugin.Init(api);
         ISyncConfig syncConfig = api.Config<ISyncConfig>();
         Assert.That(syncConfig.NetworkingEnabled, Is.True);
-        Assert.That(api.GossipPolicy.CanGossipBlocks, Is.True);
+        Assert.That(container.Resolve<IGossipPolicy>().CanGossipBlocks, Is.True);
         IBlockProducer blockProducer = container.Resolve<IBlockProducerFactory>().InitBlockProducer();
         Assert.That(blockProducer, Is.InstanceOf<MergeBlockProducer>());
         Assert.That(container.Resolve<IBlockProductionPolicy>(), Is.InstanceOf<MergeBlockProductionPolicy>());

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/ProcessedTransactionsDbCleanerTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/ProcessedTransactionsDbCleanerTests.cs
@@ -47,7 +47,9 @@ public class ProcessedTransactionsDbCleanerTests
         Assert.That(returnedTxs!.Length, Is.EqualTo(2));
 
         IBlockTree blockTree = Substitute.For<IBlockTree>();
-        ProcessedTransactionsDbCleaner dbCleaner = new(blockTree, columnsDb.GetColumnDb(BlobTxsColumns.ProcessedTxs), _logManager);
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.BlobTransactionsDb.Returns(columnsDb);
+        ProcessedTransactionsDbCleaner dbCleaner = new(blockTree, dbProvider, _logManager, new TxPoolConfig());
 
         blockTree.BlocksFinalized += Raise.EventWith(
             new FinalizeEventArgs(Build.A.BlockHeader.WithNumber(finalizedBlock).TestObject));

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -9,6 +9,7 @@ using Autofac;
 using Autofac.Core;
 using Nethermind.Api;
 using Nethermind.Api.Extensions;
+using Nethermind.Blockchain;
 using Nethermind.Blockchain.Services;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
@@ -23,7 +24,6 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Exceptions;
-using Nethermind.Db;
 using Nethermind.Facade.Proxy;
 using Nethermind.HealthChecks;
 using Nethermind.JsonRpc;
@@ -53,7 +53,6 @@ public class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) : INethe
     private ILogger _logger;
     private ISyncConfig _syncConfig = null!;
     protected IBlocksConfig _blocksConfig = null!;
-    protected ITxPoolConfig _txPoolConfig = null!;
     protected IPoSSwitcher _poSSwitcher = NoPoS.Instance;
     private InvalidChainTracker.InvalidChainTracker _invalidChainTracker = null!;
 
@@ -72,7 +71,6 @@ public class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) : INethe
         EthereumJsonSerializer.AddTypeInfoResolver(EngineApiJsonContext.Default, JsonTypeInfoResolverPriority.EngineApi);
         _syncConfig = nethermindApi.Config<ISyncConfig>();
         _blocksConfig = nethermindApi.Config<IBlocksConfig>();
-        _txPoolConfig = nethermindApi.Config<ITxPoolConfig>();
 
         MigrateSecondsPerSlot(_blocksConfig, mergeConfig);
 
@@ -89,11 +87,6 @@ public class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) : INethe
 
             _poSSwitcher = _api.Context.Resolve<IPoSSwitcher>();
             _invalidChainTracker = _api.Context.Resolve<InvalidChainTracker.InvalidChainTracker>();
-            if (_txPoolConfig.BlobsSupport.SupportsReorgs())
-            {
-                ProcessedTransactionsDbCleaner processedTransactionsDbCleaner = new(_api.BlockTree!, _api.DbProvider.BlobTransactionsDb.GetColumnDb(BlobTxsColumns.ProcessedTxs), _api.LogManager);
-                _api.DisposeStack.Push(processedTransactionsDbCleaner);
-            }
         }
 
         return Task.CompletedTask;
@@ -210,7 +203,12 @@ public class MergePluginModule : Module
 
             .AddLast<IP2PCapabilityResolver, MergeP2PCapabilityResolver>()
 
-            .AddModule(new BaseMergePluginModule());
+            .AddModule(new BaseMergePluginModule())
+
+            // Activate the blob-tx cleaner once the block tree is up so its constructor can subscribe to
+            // BlocksFinalized (container owns disposal). The block tree is passed as a resolve parameter, so
+            // the cleaner does not re-resolve it — which would recurse into this same activation hook.
+            .ResolveOnServiceActivation<ProcessedTransactionsDbCleaner, IBlockTree>();
 }
 
 /// <summary>
@@ -237,6 +235,11 @@ public class BaseMergePluginModule : Module
             }))
 
             .AddSingleton<IPoSSwitcher, PoSSwitcher>()
+
+            // Registered here for reuse; only activated (via ResolveOnServiceActivation) by the merge/AuRa-merge
+            // modules. Optimism/Taiko never resolve it. Self-disables unless blob-tx reorg support is enabled.
+            .AddSingleton<ProcessedTransactionsDbCleaner>()
+
             // AddLast (not AddFirst) so RecoverSignatures stays ahead of it, matching the pre-DI ordering.
             .AddLast<IBlockPreprocessorStep, MergeProcessingRecoveryStep>()
             .AddDecorator<IBetterPeerStrategy, MergeBetterPeerStrategy>()

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -205,9 +205,6 @@ public class MergePluginModule : Module
 
             .AddModule(new BaseMergePluginModule())
 
-            // Activate the blob-tx cleaner once the block tree is up so its constructor can subscribe to
-            // BlocksFinalized (container owns disposal). The block tree is passed as a resolve parameter, so
-            // the cleaner does not re-resolve it — which would recurse into this same activation hook.
             .ResolveOnServiceActivation<ProcessedTransactionsDbCleaner, IBlockTree>();
 }
 
@@ -236,8 +233,6 @@ public class BaseMergePluginModule : Module
 
             .AddSingleton<IPoSSwitcher, PoSSwitcher>()
 
-            // Registered here for reuse; only activated (via ResolveOnServiceActivation) by the merge/AuRa-merge
-            // modules. Optimism/Taiko never resolve it. Self-disables unless blob-tx reorg support is enabled.
             .AddSingleton<ProcessedTransactionsDbCleaner>()
 
             // AddLast (not AddFirst) so RecoverSignatures stays ahead of it, matching the pre-DI ordering.

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -55,7 +55,6 @@ public class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) : INethe
     protected IBlocksConfig _blocksConfig = null!;
     protected ITxPoolConfig _txPoolConfig = null!;
     protected IPoSSwitcher _poSSwitcher = NoPoS.Instance;
-    private IBlockCacheService _blockCacheService = null!;
     private InvalidChainTracker.InvalidChainTracker _invalidChainTracker = null!;
 
     public virtual string Name => "Merge";
@@ -88,7 +87,6 @@ public class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) : INethe
 
             EnsureJsonRpcUrl();
 
-            _blockCacheService = _api.Context.Resolve<IBlockCacheService>();
             _poSSwitcher = _api.Context.Resolve<IPoSSwitcher>();
             _invalidChainTracker = _api.Context.Resolve<InvalidChainTracker.InvalidChainTracker>();
             if (_txPoolConfig.BlobsSupport.SupportsReorgs())
@@ -96,8 +94,6 @@ public class MergePlugin(ChainSpec chainSpec, IMergeConfig mergeConfig) : INethe
                 ProcessedTransactionsDbCleaner processedTransactionsDbCleaner = new(_api.BlockTree!, _api.DbProvider.BlobTransactionsDb.GetColumnDb(BlobTxsColumns.ProcessedTxs), _api.LogManager);
                 _api.DisposeStack.Push(processedTransactionsDbCleaner);
             }
-
-            _api.GossipPolicy = new MergeGossipPolicy(_api.GossipPolicy, _poSSwitcher, _blockCacheService);
         }
 
         return Task.CompletedTask;
@@ -209,6 +205,8 @@ public class MergePluginModule : Module
             .AddDecorator<IBlockProducerFactory, MergeBlockProducerFactory>()
             .AddDecorator<IBlockProducerRunnerFactory, MergeBlockProducerRunnerFactory>()
             .AddDecorator<IBlockProductionPolicy, MergeBlockProductionPolicy>()
+
+            .AddDecorator<IGossipPolicy, MergeGossipPolicy>()
 
             .AddLast<IP2PCapabilityResolver, MergeP2PCapabilityResolver>()
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/ProcessedTransactionsDbCleaner.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/ProcessedTransactionsDbCleaner.cs
@@ -8,6 +8,7 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Logging;
+using Nethermind.TxPool;
 
 namespace Nethermind.Merge.Plugin;
 
@@ -19,13 +20,16 @@ public class ProcessedTransactionsDbCleaner : IDisposable
     private ulong _lastFinalizedBlock = 0;
     public Task CleaningTask { get; private set; } = Task.CompletedTask;
 
-    public ProcessedTransactionsDbCleaner(IBlockTree blockTree, IDb processedTxsDb, ILogManager logManager)
+    public ProcessedTransactionsDbCleaner(IBlockTree blockTree, IDbProvider dbProvider, ILogManager logManager, ITxPoolConfig txPoolConfig)
     {
+        ArgumentNullException.ThrowIfNull(dbProvider);
         _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
-        _processedTxsDb = processedTxsDb ?? throw new ArgumentNullException(nameof(processedTxsDb));
+        _processedTxsDb = dbProvider.BlobTransactionsDb.GetColumnDb(BlobTxsColumns.ProcessedTxs);
         _logger = logManager?.GetClassLogger<ProcessedTransactionsDbCleaner>() ?? throw new ArgumentNullException(nameof(logManager));
 
-        _blockTree.BlocksFinalized += OnBlocksFinalized;
+        // Only blob-tx reorg support persists processed txs, so there is nothing to clean otherwise.
+        if (txPoolConfig.BlobsSupport.SupportsReorgs())
+            _blockTree.BlocksFinalized += OnBlocksFinalized;
     }
 
     private void OnBlocksFinalized(object? sender, FinalizeEventArgs e)

--- a/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismPlugin.cs
@@ -74,8 +74,6 @@ public class OptimismPlugin(ChainSpec chainSpec, IOptimismConfig optimismConfig)
 
         ArgumentNullException.ThrowIfNull(_api.SpecProvider);
 
-        _api.GossipPolicy = ShouldNotGossip.Instance;
-
         return Task.CompletedTask;
     }
 
@@ -112,6 +110,7 @@ public class OptimismModule(ChainSpec chainSpec, IOptimismConfig optimismConfig)
             .AddSingleton<IBlockProductionPolicy>(AlwaysStartBlockProductionPolicy.Instance)
 
             .AddSingleton<IPoSSwitcher, OptimismPoSSwitcher>()
+            .AddSingleton<IGossipPolicy>(ShouldNotGossip.Instance)
             .AddSingleton<StartingSyncPivotUpdater, UnsafeStartingSyncPivotUpdater>()
 
             // Step override

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.Merge.cs
@@ -332,7 +332,7 @@ public partial class BlockDownloaderTests
         return CreateNode((builder) =>
         {
             builder
-                .AddModule(new TestMergeModule(configProvider))
+                .AddModule(new TestMergeModule())
                 .AddSingleton<PostMergeContext>();
             configurer?.Invoke(builder);
         }, configProvider);

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -309,7 +309,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             // Activate configured mainnet future EIP
             ManualTimestamper timestamper = new(PostMergeStartTime);
             builder
-                .AddModule(new TestMergeModule(configProvider.GetConfig<ITxPoolConfig>()))
+                .AddModule(new TestMergeModule())
                 .AddSingleton<ManualTimestamper>(timestamper) // Used by test code
                 .AddDecorator<ITestEnv, PostMergeTestEnv>()
                 .AddLast<IP2PCapabilityResolver, PostMergeCapabilitiesResolver>()

--- a/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.Merge.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.Merge.cs
@@ -129,7 +129,7 @@ public partial class ForwardHeaderProviderTests
         return CreateNode((builder) =>
         {
             builder
-                .AddModule(new TestMergeModule(configProvider))
+                .AddModule(new TestMergeModule())
                 .AddSingleton<PostMergeContext>();
             configurer?.Invoke(builder);
         }, configProvider);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerTests.cs
@@ -303,7 +303,7 @@ public class SynchronizerTests(SynchronizerType synchronizerType)
 
             if (IsMerge(synchronizerType))
             {
-                builder.RegisterModule(new TestMergeModule(configProvider));
+                builder.RegisterModule(new TestMergeModule());
             }
 
             Container = builder.Build();

--- a/src/Nethermind/Nethermind.Taiko/TaikoPlugin.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoPlugin.cs
@@ -60,8 +60,6 @@ public class TaikoPlugin(ChainSpec chainSpec) : IConsensusPlugin
     {
         _api = (TaikoNethermindApi)api;
 
-        _api.GossipPolicy = ShouldNotGossip.Instance;
-
         InitializeL1Precompiles();
 
         return Task.CompletedTask;
@@ -154,6 +152,7 @@ public class TaikoModule : Module
 
             // Sync modification
             .AddSingleton<IPoSSwitcher>(AlwaysPoS.Instance)
+            .AddSingleton<IGossipPolicy>(ShouldNotGossip.Instance)
             .AddSingleton<StartingSyncPivotUpdater, UnsafeStartingSyncPivotUpdater>()
 
             // Validators

--- a/src/Nethermind/Nethermind.Xdc/XdcPlugin.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcPlugin.cs
@@ -11,7 +11,6 @@ namespace Nethermind.Xdc;
 
 public class XdcPlugin(ChainSpec chainSpec) : IConsensusPlugin
 {
-    private INethermindApi _nethermindApi;
     public const string Xdc = "Xdc";
     public string Author => "Nethermind";
     public string Name => Xdc;
@@ -20,9 +19,5 @@ public class XdcPlugin(ChainSpec chainSpec) : IConsensusPlugin
     public string SealEngineType => XdcConstants.XDPoS;
     public IModule Module => new XdcModule();
 
-    public Task Init(INethermindApi nethermindApi)
-    {
-        _nethermindApi = nethermindApi;
-        return Task.CompletedTask;
-    }
+    public Task Init(INethermindApi nethermindApi) => Task.CompletedTask;
 }


### PR DESCRIPTION
## Changes

Continues the plugin `Init(INethermindApi)` → Autofac DI migration by moving two pieces of imperative wiring out of `MergePlugin.Init` (and the Optimism/Taiko plugin `Init` methods) into declarative DI modules. The `FallbackToFieldFromApi` reflection bridge is no longer needed for the block-gossip policy.

**1. Block `IGossipPolicy` → DI**
- Register the default `IGossipPolicy` (`Policy.FullGossip`) in `NetworkModule`, next to `ITxGossipPolicy`.
- Remove the mutable `GossipPolicy { get; set; }` property from `IApiWithNetwork` / `NethermindApi` (this is what the `FallbackToFieldFromApi` guard asks for — a service must not have both a DI registration and an api setter).
- `MergePluginModule` / `AuRaMergeModule` decorate it with `MergeGossipPolicy`; `OptimismModule` / `TaikoModule` replace it with `ShouldNotGossip` (last-wins).
- Drop the imperative `api.GossipPolicy = …` assignments from the plugins' `Init`.

Behavior is unchanged: merge chains resolve `MergeGossipPolicy(FullGossip)`, Optimism/Taiko resolve `ShouldNotGossip`, all other chains resolve `FullGossip`.

**2. `ProcessedTransactionsDbCleaner` → DI**
- Register it in `BaseMergePluginModule` and activate it via `ResolveOnServiceActivation<ProcessedTransactionsDbCleaner, IBlockTree>()` from `MergePluginModule` / `AuRaMergeModule`; the container now owns its disposal (replacing the manual `DisposeStack.Push`).
- The blob-tx reorg gate moves into the cleaner itself: it now takes `IDbProvider` + `ITxPoolConfig`, resolves the `ProcessedTxs` column internally, and only subscribes to `BlocksFinalized` when blob-tx reorg support is enabled. This makes it reflection-activatable so the block tree can be supplied as a resolve parameter (avoiding a re-resolution that would recurse into the activation hook and stack-overflow).

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Full `Nethermind.slnx` release build is clean (0 warnings, 0 errors). `Nethermind.Merge.Plugin.Test`, `Nethermind.Merge.AuRa.Test`, `Nethermind.Optimism.Test`, and `Nethermind.Taiko.Test` pass; `MergePluginTests` and `ProcessedTransactionsDbCleanerTests` updated to resolve/construct through the new DI wiring. The only full-suite failures were pre-existing timing/contention flakes (`getPayloadV1_does_not_wait_for_improvement_when_block_is_not_empty`, `Witness_includes_bytecode_and_storage_proof_for_a_called_contract`) which pass in isolation.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
