### PR TITLE
More RLP checks for txs, receipts, snap

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/CompactReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/CompactReceiptDecoderTests.cs
@@ -236,6 +236,26 @@ namespace Nethermind.Core.Test.Encoding
             AssertStorageReceipt(txReceipt, deserialized);
         }
 
+        [Test]
+        public void Rejects_compact_receipt_with_oversized_log_data()
+        {
+            CompactReceiptStorageDecoder decoder = new();
+
+            Assert.Throws<RlpLimitException>(() =>
+            {
+                RlpReader ctx = new(CreateCompactReceipt(CreateMalformedCompactLogEntry(RlpLimit.DefaultLimit.Limit + 1L)).Bytes);
+                decoder.Decode(ref ctx, RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts);
+            });
+        }
+
+        [Test]
+        public void Rejects_compact_log_entry_struct_ref_with_oversized_log_data() =>
+            Assert.Throws<RlpLimitException>(() =>
+            {
+                RlpReader ctx = new(CreateMalformedCompactLogEntry(RlpLimit.DefaultLimit.Limit + 1L).Bytes);
+                CompactLogEntryDecoder.DecodeLogEntryStructRef(ref ctx, RlpBehaviors.Storage, out _);
+            });
+
         private void AssertStorageReceipt(TxReceipt txReceipt, TxReceipt? deserialized)
         {
             using (Assert.EnterMultipleScope())
@@ -254,23 +274,17 @@ namespace Nethermind.Core.Test.Encoding
             }
         }
 
-        private void AssertStorageLegacyReceipt(TxReceipt txReceipt, TxReceipt deserialized)
-        {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(deserialized.TxType, Is.EqualTo(txReceipt.TxType), "tx type");
-                Assert.That(deserialized.BlockHash, Is.EqualTo(txReceipt.BlockHash), "block hash");
-                Assert.That(deserialized.BlockNumber, Is.EqualTo(txReceipt.BlockNumber), "block number");
-                Assert.That(deserialized.Index, Is.EqualTo(txReceipt.Index), "index");
-                Assert.That(deserialized.ContractAddress, Is.EqualTo(txReceipt.ContractAddress), "contract");
-                Assert.That(deserialized.Sender, Is.EqualTo(txReceipt.Sender), "sender");
-                Assert.That(deserialized.GasUsed, Is.EqualTo(txReceipt.GasUsed), "gas used");
-                Assert.That(deserialized.GasUsedTotal, Is.EqualTo(txReceipt.GasUsedTotal), "gas used total");
-                Assert.That(deserialized.Bloom, Is.EqualTo(txReceipt.Bloom), "bloom");
-                Assert.That(deserialized.Recipient, Is.EqualTo(txReceipt.Recipient), "recipient");
-                Assert.That(deserialized.StatusCode, Is.EqualTo(txReceipt.StatusCode), "status");
-            }
-        }
+        private static Rlp CreateCompactReceipt(Rlp logEntry) => Rlp.Encode(
+            Rlp.Encode(1),
+            Rlp.Encode(TestItem.AddressA.Bytes),
+            Rlp.Encode(1L),
+            Rlp.Encode(new[] { logEntry }));
+
+        private static Rlp CreateMalformedCompactLogEntry(long zeroPrefix) => Rlp.Encode(
+            Rlp.Encode(TestItem.AddressA.Bytes),
+            Rlp.OfEmptyList,
+            Rlp.Encode(zeroPrefix),
+            Rlp.OfEmptyByteArray);
 
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/TxDecoderTests.cs
@@ -305,6 +305,36 @@ namespace Nethermind.Core.Test.Encoding
             Assert.That(DecodeContext, Throws.InstanceOf(exceptionType).With.Message.Contains(error).IgnoreCase);
         }
 
+        [Test]
+        public void Rejects_trailing_bytes_for_skip_typed_wrapping_transactions()
+        {
+            Transaction tx = BuildTypedTransaction();
+            byte[] malformed = AppendTrailingByte(_txDecoder.Encode(tx, RlpBehaviors.SkipTypedWrapping).Bytes);
+
+            void Decode()
+            {
+                RlpReader ctx = new(malformed);
+                _txDecoder.DecodeGuardNotNull(ref ctx, RlpBehaviors.SkipTypedWrapping);
+            }
+
+            Assert.That(Decode, Throws.InstanceOf<RlpException>());
+        }
+
+        [Test]
+        public void Rejects_trailing_bytes_for_wrapped_typed_transactions()
+        {
+            Transaction tx = BuildTypedTransaction();
+            byte[] malformedWrapped = Rlp.Encode(AppendTrailingByte(_txDecoder.Encode(tx, RlpBehaviors.SkipTypedWrapping).Bytes)).Bytes;
+
+            void Decode()
+            {
+                RlpReader ctx = new(malformedWrapped);
+                _txDecoder.DecodeGuardNotNull(ref ctx, RlpBehaviors.InMempoolForm);
+            }
+
+            Assert.That(Decode, Throws.InstanceOf<RlpException>());
+        }
+
         public static IEnumerable<(string, Hash256)> SkipTypedWrappingTestCases()
         {
             yield return
@@ -445,5 +475,20 @@ namespace Nethermind.Core.Test.Encoding
             GasLimit = 21000,
             AuthorizationList = new AuthorizationTuple[authCount]
         }, RlpBehaviors.SkipTypedWrapping).Bytes;
+
+        private static Transaction BuildTypedTransaction() => Build.A.Transaction
+            .WithType(TxType.EIP1559)
+            .WithChainId(TestBlockchainIds.ChainId)
+            .WithTo(TestItem.AddressA)
+            .SignedAndResolved(new EthereumEcdsa(TestBlockchainIds.ChainId), TestItem.PrivateKeyA)
+            .TestObject;
+
+        private static byte[] AppendTrailingByte(byte[] encoded)
+        {
+            byte[] malformed = new byte[encoded.Length + 1];
+            encoded.CopyTo(malformed, 0);
+            malformed[^1] = Rlp.EmptyByteArrayByte;
+            return malformed;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/SnapProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SnapProtocolHandlerTests.cs
@@ -12,6 +12,7 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Messages;
@@ -156,6 +157,60 @@ public class SnapProtocolHandlerTests
     [TestCase(0L, 1L)]
     [TestCase(-1L, 1L)]
     public void ClampResponseBytes_clamps_to_valid_range(long input, long expected) => Assert.That(SnapMessageLimits.ClampResponseBytes(input), Is.EqualTo(expected));
+
+    [Test]
+    public void GetTrieNodes_forwards_requested_byte_budget_to_snap_server()
+    {
+        ISnapServer snapServer = Substitute.For<ISnapServer>();
+        snapServer.CanServe.Returns(true);
+        snapServer.GetTrieNodes(Arg.Any<IReadOnlyList<PathGroup>>(), Arg.Any<Hash256>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(EmptyByteArrayList.Instance);
+        ISession session = Substitute.For<ISession>();
+        session.Node.Returns(new Node(TestItem.PublicKeyA, "127.0.0.1", 30303));
+
+        IMessageSerializationService serializer = new MessageSerializationService(
+            SerializerInfo.Create(new GetTrieNodesMessageSerializer()),
+            SerializerInfo.Create(new TrieNodesMessageSerializer()));
+
+        SnapProtocolHandler handler = new(
+            session,
+            Substitute.For<INodeStatsManager>(),
+            serializer,
+            RunImmediatelyScheduler.Instance,
+            LimboLogs.Instance,
+            new SyncConfig(),
+            snapServer);
+
+        using GetTrieNodesMessage request = new()
+        {
+            RequestId = 1,
+            RootHash = Keccak.Zero,
+            Paths = PathGroup.EncodeToRlpPathGroupList([]),
+            Bytes = 1234
+        };
+
+        IByteBuffer? buffer = serializer.ZeroSerialize(request);
+        try
+        {
+            buffer.ReadByte();
+            ZeroPacket packet = new(buffer) { PacketType = SnapMessageCode.GetTrieNodes };
+            buffer = null;
+            try
+            {
+                handler.HandleMessage(packet);
+            }
+            finally
+            {
+                ReferenceCountUtil.Release(packet);
+            }
+        }
+        finally
+        {
+            buffer?.SafeRelease();
+        }
+
+        snapServer.Received(1).GetTrieNodes(Arg.Any<IReadOnlyList<PathGroup>>(), request.RootHash, request.Bytes, Arg.Any<CancellationToken>());
+    }
 
     [Test]
     [Explicit]

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/Messages/StorageRangesMessageSerializer.cs
@@ -76,7 +76,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.Messages
                     {
                         int length = innerCtx.ReadSequenceLength();
                         int checkPosition = innerCtx.Position + length;
-                        Hash256 path = innerCtx.DecodeKeccak();
+                        Hash256 path = innerCtx.DecodeKeccak() ?? throw new RlpException("Storage slot path cannot be null.");
                         byte[] value = innerCtx.DecodeByteArray(StorageSlotValueRlpLimit);
                         innerCtx.Check(checkPosition);
                         return new PathWithStorageSlot(in path.ValueHash256, value);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/SnapProtocolHandler.cs
@@ -172,7 +172,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap
 
         private TrieNodesMessage FulfillTrieNodesMessage(GetTrieNodesMessage getTrieNodesMessage, CancellationToken cancellationToken)
         {
-            IByteArrayList? trieNodes = SyncServer.GetTrieNodes(getTrieNodesMessage.Paths, getTrieNodesMessage.RootHash, cancellationToken);
+            IByteArrayList? trieNodes = SyncServer.GetTrieNodes(getTrieNodesMessage.Paths, getTrieNodesMessage.RootHash, getTrieNodesMessage.Bytes, cancellationToken);
             return new TrieNodesMessage(trieNodes);
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
@@ -106,6 +106,7 @@ public sealed class BlockBodyDecoder(IHeaderDecoder? headerDecoder = null) : Rlp
             withdrawals = ctx.DecodeArray(_withdrawalDecoderDecoder, limit: WithdrawalsCountLimit);
         }
 
+        ctx.Check(lastPosition);
         return new BlockBody(transactions, uncles, withdrawals);
     }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactLogEntryDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactLogEntryDecoder.cs
@@ -13,6 +13,7 @@ namespace Nethermind.Serialization.Rlp
     public class CompactLogEntryDecoder : RlpDecoder<LogEntry?>
     {
         private static readonly RlpLimit RlpLimit = RlpLimit.For<LogEntry>((int)16.MB, nameof(LogEntry));
+        private static readonly RlpLimit LogEntryDataRlpLimit = RlpLimit.For<LogEntry>(RlpLimit.DefaultLimit.Limit, nameof(LogEntry.Data));
         public static CompactLogEntryDecoder Instance { get; } = new();
 
         protected override LogEntry? DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -122,7 +123,7 @@ namespace Nethermind.Serialization.Rlp
             int zeroPrefix = decoderContext.DecodePositiveInt();
             ReadOnlySpan<byte> rlpData = decoderContext.DecodeByteArraySpan();
 
-            Rlp.GuardLimit(zeroPrefix, RlpLimit.Limit - rlpData.Length, RlpLimit);
+            Rlp.GuardLimit(zeroPrefix, LogEntryDataRlpLimit.Limit - rlpData.Length, LogEntryDataRlpLimit);
 
             byte[] data = new byte[zeroPrefix + rlpData.Length];
             rlpData.CopyTo(data.AsSpan(zeroPrefix));

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -123,6 +123,11 @@ public class TxDecoder<T> : RlpDecoder<T> where T : Transaction, new()
         }
 
         GetDecoder(txType).Decode(ref Unsafe.As<T, Transaction>(ref transaction), txSequenceStart, transactionSequence, ref decoderContext, rlpBehaviors);
+
+        if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) == 0)
+        {
+            decoderContext.Check(txSequenceStart + transactionSequence.Length);
+        }
     }
 
     public override void Encode<TWriter>(ref TWriter writer, T? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
@@ -42,7 +42,10 @@ public class FlatSnapServer(
         return true;
     }
 
-    public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken)
+    public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken) =>
+        GetTrieNodes(pathSet, rootHash, long.MaxValue, cancellationToken);
+
+    public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, long byteLimit, CancellationToken cancellationToken)
     {
         if (!TryGetBundle(rootHash, out ReadOnlySnapshotBundle bundle, out StateId stateId))
             return EmptyByteArrayList.Instance;
@@ -51,6 +54,7 @@ public class FlatSnapServer(
         {
             if (_logger.IsDebug) _logger.Debug($"Get trie nodes {pathSet.Count}");
 
+            byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
             int pathLength = pathSet.Count;
             ArrayPoolList<byte[]> response = new(pathLength);
             ReadOnlyStateTrieStoreAdapter trieStore = new(bundle);
@@ -58,7 +62,7 @@ public class FlatSnapServer(
             bool abort = false;
             long responseSize = 0;
 
-            for (int i = 0; i < pathLength && !abort && responseSize < HardResponseByteLimit && !cancellationToken.IsCancellationRequested; i++)
+            for (int i = 0; i < pathLength && !abort && responseSize < byteLimit && !cancellationToken.IsCancellationRequested; i++)
             {
                 byte[][]? requestedPath = pathSet[i].Group;
                 switch (requestedPath.Length)
@@ -91,7 +95,7 @@ public class FlatSnapServer(
                                 Hash256? storageRoot = account.StorageRoot;
                                 StorageTree sTree = new(trieStore.GetStorageTrieStore(storagePath), storageRoot, logManager);
 
-                                for (int reqStorage = 1; reqStorage < requestedPath.Length && responseSize < HardResponseByteLimit && !cancellationToken.IsCancellationRequested; reqStorage++)
+                                for (int reqStorage = 1; reqStorage < requestedPath.Length && responseSize < byteLimit && !cancellationToken.IsCancellationRequested; reqStorage++)
                                 {
                                     byte[]? sRlp = sTree.GetNodeByPath(Nibbles.CompactToHexEncode(requestedPath[reqStorage]));
                                     response.Add(sRlp ?? []);

--- a/src/Nethermind/Nethermind.State/SnapServer/ISnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/ISnapServer.cs
@@ -26,7 +26,11 @@ namespace Nethermind.State.SnapServer;
 public interface ISnapServer
 {
     bool CanServe { get; }
-    IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken);
+    IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken) =>
+        GetTrieNodes(pathSet, rootHash, long.MaxValue, cancellationToken);
+
+    IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, long byteLimit, CancellationToken cancellationToken);
+
     IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken);
 
     (IOwnedReadOnlyList<PathWithAccount>, IByteArrayList) GetAccountRanges(Hash256 rootHash,

--- a/src/Nethermind/Nethermind.State/SnapServer/NoopSnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/NoopSnapServer.cs
@@ -18,6 +18,9 @@ public class NoopSnapServer : ISnapServer
     public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken) =>
         EmptyByteArrayList.Instance;
 
+    public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, long byteLimit, CancellationToken cancellationToken) =>
+        EmptyByteArrayList.Instance;
+
     public IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken) =>
         EmptyByteArrayList.Instance;
 

--- a/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
@@ -68,12 +68,13 @@ public class SnapServer : ISnapServer
 
     private bool IsRootMissing(Hash256 stateRoot) => (!_store.HasRoot(stateRoot)) || _lastNStateRootTracker?.HasStateRoot(stateRoot) == false;
 
-    public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken)
+    public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, long byteLimit, CancellationToken cancellationToken)
     {
         if (IsRootMissing(rootHash)) return EmptyByteArrayList.Instance;
 
         if (_logger.IsDebug) _logger.Debug($"Get trie nodes {pathSet.Count}");
         // TODO: use cache to reduce node retrieval from disk
+        byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
         int pathLength = pathSet.Count;
         using DeferredRlpItemList.Builder builder = new(pathLength);
         DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer();
@@ -81,7 +82,7 @@ public class SnapServer : ISnapServer
         bool abort = false;
         long responseSize = 0;
 
-        for (int i = 0; i < pathLength && !abort && responseSize < HardResponseByteLimit && !cancellationToken.IsCancellationRequested; i++)
+        for (int i = 0; i < pathLength && !abort && responseSize < byteLimit && !cancellationToken.IsCancellationRequested; i++)
         {
             byte[][]? requestedPath = pathSet[i].Group;
             switch (requestedPath.Length)
@@ -114,7 +115,7 @@ public class SnapServer : ISnapServer
                             Hash256? storageRoot = account.StorageRoot;
                             StorageTree sTree = new(_store.GetTrieStore(storagePath), storageRoot, _logManager);
 
-                            for (int reqStorage = 1; reqStorage < requestedPath.Length && responseSize < HardResponseByteLimit && !cancellationToken.IsCancellationRequested; reqStorage++)
+                            for (int reqStorage = 1; reqStorage < requestedPath.Length && responseSize < byteLimit && !cancellationToken.IsCancellationRequested; reqStorage++)
                             {
                                 byte[]? sRlp = sTree.GetNodeByPath(Nibbles.CompactToHexEncode(requestedPath[reqStorage]));
                                 writer.WriteValue(sRlp);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -358,6 +358,23 @@ public class SnapServerTest
         Assert.That(result.Count, Is.LessThan(requestCount));
     }
 
+    [Test]
+    public void TestGetTrieNodes_RespectsRequestedResponseByteLimit()
+    {
+        using ISnapServerContext context = CreateContext();
+        FillMultipleAccounts(context, 1000);
+
+        int requestCount = 5000;
+        PathGroup[] groups = new PathGroup[requestCount];
+        for (int i = 0; i < requestCount; i++)
+            groups[i] = new PathGroup { Group = [[]] };
+
+        using RlpPathGroupList pathSet = PathGroup.EncodeToRlpPathGroupList(groups);
+        using IByteArrayList result = context.Server.GetTrieNodes(pathSet, context.RootHash, 1, default)!;
+
+        Assert.That(result.Count, Is.EqualTo(1));
+    }
+
     [TestCase(true)]
     [TestCase(false)]
     public void TestNoState(bool withLastNStateTracker)


### PR DESCRIPTION
## Changes

- Reject extra trailing bytes when decoding typed transactions.
- Add stricter compact receipt/log entry RLP data limits.
- Reject null storage slot paths during snap storage range decoding.
- Forward requested snap trie-node response byte budgets through the protocol handler and snap servers.
- Add regression coverage for the new RLP and snap byte-budget checks.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Targeted regression tests passed, and the full release solution build with warnings as errors passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This reapplies the RLP and snap hardening that was present in the 1.38.x release line onto current master.
