### PR TITLE
fix(dns): don't use the udp port as RLPx dial port for ENRs without a tcp entry

### DIFF
--- a/src/Nethermind/Nethermind.Network.Dns.Test/EnrDiscoveryCreateNodeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Dns.Test/EnrDiscoveryCreateNodeTests.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Net;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Network.Enr;
+using Nethermind.Stats.Model;
+using NUnit.Framework;
+
+namespace Nethermind.Network.Dns.Test;
+
+[Parallelizable(ParallelScope.All)]
+[TestFixture]
+public class EnrDiscoveryCreateNodeTests
+{
+    private static NodeRecord CreateRecord(int? tcpPort, int? udpPort)
+    {
+        NodeRecord record = new();
+        record.SetEntry(new SecP256k1Entry(TestItem.PrivateKeyA.CompressedPublicKey));
+        record.SetEntry(new IpEntry(IPAddress.Parse("192.0.2.1")));
+        if (tcpPort is not null) record.SetEntry(new TcpEntry(tcpPort.Value));
+        if (udpPort is not null) record.SetEntry(new UdpEntry(udpPort.Value));
+        return record;
+    }
+
+    [Test]
+    public void Creates_node_with_tcp_port()
+    {
+        Node? node = EnrDiscovery.CreateNode(CreateRecord(tcpPort: 30303, udpPort: 30304));
+
+        Assert.That(node, Is.Not.Null);
+        Assert.That(node!.Port, Is.EqualTo(30303));
+    }
+
+    [Test]
+    public void Skips_record_without_tcp_port() =>
+        // A record without a tcp entry (e.g. a discovery-only bootnode) has no RLPx endpoint;
+        // its udp port must not be used as a dial port.
+        Assert.That(EnrDiscovery.CreateNode(CreateRecord(tcpPort: null, udpPort: 30303)), Is.Null);
+
+    [Test]
+    public void Skips_record_with_zero_tcp_port() =>
+        Assert.That(EnrDiscovery.CreateNode(CreateRecord(tcpPort: 0, udpPort: 30303)), Is.Null);
+}

--- a/src/Nethermind/Nethermind.Network.Dns.Test/EnrDiscoveryCreateNodeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Dns.Test/EnrDiscoveryCreateNodeTests.cs
@@ -4,7 +4,6 @@
 using System.Net;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Network.Enr;
-using Nethermind.Stats.Model;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Dns.Test;
@@ -13,32 +12,19 @@ namespace Nethermind.Network.Dns.Test;
 [TestFixture]
 public class EnrDiscoveryCreateNodeTests
 {
-    private static NodeRecord CreateRecord(int? tcpPort, int? udpPort)
+    // A record without a tcp entry (e.g. a discovery-only bootnode) has no RLPx endpoint;
+    // its udp port must not be used as a dial port.
+    [TestCase(30303, 30304, ExpectedResult = 30303)]
+    [TestCase(null, 30303, ExpectedResult = null)]
+    [TestCase(0, 30303, ExpectedResult = null)]
+    public int? Creates_node_only_for_records_with_a_nonzero_tcp_port(int? tcpPort, int? udpPort)
     {
         NodeRecord record = new();
         record.SetEntry(new SecP256k1Entry(TestItem.PrivateKeyA.CompressedPublicKey));
         record.SetEntry(new IpEntry(IPAddress.Parse("192.0.2.1")));
         if (tcpPort is not null) record.SetEntry(new TcpEntry(tcpPort.Value));
         if (udpPort is not null) record.SetEntry(new UdpEntry(udpPort.Value));
-        return record;
+
+        return EnrDiscovery.CreateNode(record)?.Port;
     }
-
-    [Test]
-    public void Creates_node_with_tcp_port()
-    {
-        Node? node = EnrDiscovery.CreateNode(CreateRecord(tcpPort: 30303, udpPort: 30304));
-
-        Assert.That(node, Is.Not.Null);
-        Assert.That(node!.Port, Is.EqualTo(30303));
-    }
-
-    [Test]
-    public void Skips_record_without_tcp_port() =>
-        // A record without a tcp entry (e.g. a discovery-only bootnode) has no RLPx endpoint;
-        // its udp port must not be used as a dial port.
-        Assert.That(EnrDiscovery.CreateNode(CreateRecord(tcpPort: null, udpPort: 30303)), Is.Null);
-
-    [Test]
-    public void Skips_record_with_zero_tcp_port() =>
-        Assert.That(EnrDiscovery.CreateNode(CreateRecord(tcpPort: 0, udpPort: 30303)), Is.Null);
 }

--- a/src/Nethermind/Nethermind.Network.Dns.Test/EnrDiscoveryCreateNodeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Dns.Test/EnrDiscoveryCreateNodeTests.cs
@@ -12,8 +12,6 @@ namespace Nethermind.Network.Dns.Test;
 [TestFixture]
 public class EnrDiscoveryCreateNodeTests
 {
-    // A record without a tcp entry (e.g. a discovery-only bootnode) has no RLPx endpoint;
-    // its udp port must not be used as a dial port.
     [TestCase(30303, 30304, ExpectedResult = 30303)]
     [TestCase(null, 30303, ExpectedResult = null)]
     [TestCase(0, 30303, ExpectedResult = null)]

--- a/src/Nethermind/Nethermind.Network.Dns/EnrDiscovery.cs
+++ b/src/Nethermind/Nethermind.Network.Dns/EnrDiscovery.cs
@@ -12,6 +12,8 @@ using Nethermind.Network.Enr;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Stats.Model;
 
+[assembly: InternalsVisibleTo("Nethermind.Network.Dns.Test")]
+
 namespace Nethermind.Network.Dns;
 
 public class EnrDiscovery : INodeSource
@@ -85,12 +87,14 @@ public class EnrDiscovery : INodeSource
         }
     }
 
-    private static Node? CreateNode(NodeRecord nodeRecord)
+    internal static Node? CreateNode(NodeRecord nodeRecord)
     {
         CompressedPublicKey? compressedPublicKey = nodeRecord.GetObj<CompressedPublicKey>(EnrContentKey.SecP256k1);
         IPAddress? ipAddress = nodeRecord.GetObj<IPAddress>(EnrContentKey.Ip);
-        int? port = nodeRecord.GetValue<int>(EnrContentKey.Tcp) ?? nodeRecord.GetValue<int>(EnrContentKey.Udp);
-        return compressedPublicKey is not null && ipAddress is not null && port is not null
+        // A record without a tcp entry advertises no RLPx endpoint (EIP-778), e.g. a
+        // discovery-only bootnode; don't fall back to dialing the discovery udp port.
+        int? port = nodeRecord.GetValue<int>(EnrContentKey.Tcp);
+        return compressedPublicKey is not null && ipAddress is not null && port is > 0
             ? new(compressedPublicKey.Decompress(), ipAddress.ToString(), port.Value)
             : null;
     }

--- a/src/Nethermind/Nethermind.Network.Dns/EnrDiscovery.cs
+++ b/src/Nethermind/Nethermind.Network.Dns/EnrDiscovery.cs
@@ -91,8 +91,6 @@ public class EnrDiscovery : INodeSource
     {
         CompressedPublicKey? compressedPublicKey = nodeRecord.GetObj<CompressedPublicKey>(EnrContentKey.SecP256k1);
         IPAddress? ipAddress = nodeRecord.GetObj<IPAddress>(EnrContentKey.Ip);
-        // A record without a tcp entry advertises no RLPx endpoint (EIP-778), e.g. a
-        // discovery-only bootnode; don't fall back to dialing the discovery udp port.
         int? port = nodeRecord.GetValue<int>(EnrContentKey.Tcp);
         return compressedPublicKey is not null && ipAddress is not null && port is > 0
             ? new(compressedPublicKey.Decompress(), ipAddress.ToString(), port.Value)


### PR DESCRIPTION
## Changes

- `EnrDiscovery` (DNS discovery) no longer falls back to the `udp` port when a
  record has no `tcp` entry, and skips records with `tcp=0`. Per EIP-778 the
  `tcp` key is optional; a record without it (e.g. a discovery-only bootnode)
  advertises no RLPx endpoint, so the fallback produced dial candidates
  pointing at a UDP port nothing TCP-listens on. Matches geth, which skips
  such records when dialing.

Bootnode bootstrap (discv4 `InitializeBootnodes`, discv5 bootstrap ENRs) does
not go through this path and is unaffected.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
