### PR TITLE
fix(network): dial ENR-backed peers at their tcp port

### DIFF
--- a/src/Nethermind/Nethermind.Config/NetworkNode.cs
+++ b/src/Nethermind/Nethermind.Config/NetworkNode.cs
@@ -90,7 +90,7 @@ public class NetworkNode
     public PublicKey NodeId => IsEnode ? Enode.PublicKey : GetEnrPublicKey();
     public string Host => IsEnode ? Enode.HostIp.ToString() : HostIp.ToString();
     public IPAddress HostIp => IsEnode ? Enode.HostIp : Enr!.DiscoveryIp ?? IPAddress.None;
-    public int Port => IsEnode ? Enode.Port : Enr!.DiscoveryPort ?? 0;
+    public int Port => IsEnode ? Enode.Port : Enr!.TcpPort ?? 0;
     public int DiscoveryPort => IsEnode ? Enode.DiscoveryPort : Enr!.DiscoveryPort ?? 0;
     public long Reputation { get; set; }
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/DiscoveryPersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/DiscoveryPersistenceManagerTests.cs
@@ -214,7 +214,8 @@ namespace Nethermind.Network.Discovery.Test.Discv4
                 Assert.That(persistedEnr!.ToString(), Is.EqualTo(enr.ToString()));
                 Assert.That(persistedNode.NodeId, Is.EqualTo(TestItem.PrivateKeyA.PublicKey));
                 Assert.That(persistedNode.Host, Is.EqualTo("8.8.8.8"));
-                Assert.That(persistedNode.Port, Is.EqualTo(30304));
+                Assert.That(persistedNode.Port, Is.EqualTo(30303));
+                Assert.That(persistedNode.DiscoveryPort, Is.EqualTo(30304));
             }
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/Kademlia/DiscoveryPersistenceManager.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Kademlia/DiscoveryPersistenceManager.cs
@@ -54,7 +54,7 @@ public sealed class DiscoveryPersistenceManager(
             Node node;
             try
             {
-                node = new Node(networkNode);
+                node = new Node(networkNode.NodeId, networkNode.Host, networkNode.DiscoveryPort);
             }
             catch (Exception e)
             {

--- a/src/Nethermind/Nethermind.Network.Test/NetworkNodeDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NetworkNodeDecoderTests.cs
@@ -79,7 +79,7 @@ namespace Nethermind.Network.Test
                 Assert.That(decodedEnr!.ToString(), Is.EqualTo(enr.ToString()));
                 Assert.That(decoded.NodeId, Is.EqualTo(node.NodeId));
                 Assert.That(decoded.Host, Is.EqualTo("8.8.8.8"));
-                Assert.That(decoded.Port, Is.EqualTo(30304));
+                Assert.That(decoded.Port, Is.EqualTo(30303));
                 Assert.That(decoded.Reputation, Is.EqualTo(node.Reputation));
             }
         }

--- a/src/Nethermind/Nethermind.Network.Test/NetworkNodePortTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NetworkNodePortTests.cs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Net;
+using Nethermind.Config;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Network.Enr;
+using Nethermind.Stats.Model;
+using NUnit.Framework;
+
+namespace Nethermind.Network.Test;
+
+[Parallelizable(ParallelScope.All)]
+public class NetworkNodePortTests
+{
+    private static NetworkNode CreateEnrNetworkNode(int? tcpPort, int udpPort)
+    {
+        NodeRecord enr = new();
+        enr.SetEntry(new IpEntry(IPAddress.Parse("192.0.2.1")));
+        enr.SetEntry(new SecP256k1Entry(TestItem.PrivateKeyA.CompressedPublicKey));
+        if (tcpPort is { } tcp) enr.SetEntry(new TcpEntry(tcp));
+        enr.SetEntry(new UdpEntry(udpPort));
+        enr.EnrSequence = 1;
+        new NodeRecordSigner(new EthereumEcdsa(0), TestItem.PrivateKeyA).Sign(enr);
+        return new NetworkNode(enr.ToString());
+    }
+
+    [TestCase(30303, 30301, ExpectedResult = 30303)]
+    [TestCase(null, 30301, ExpectedResult = 0)]
+    public int Port_of_enr_backed_node_is_the_rlpx_tcp_port(int? tcpPort, int udpPort) =>
+        CreateEnrNetworkNode(tcpPort, udpPort).Port;
+
+    [TestCase(30303, 30301, ExpectedResult = 30301)]
+    [TestCase(null, 30301, ExpectedResult = 30301)]
+    public int DiscoveryPort_of_enr_backed_node_is_the_udp_port(int? tcpPort, int udpPort) =>
+        CreateEnrNetworkNode(tcpPort, udpPort).DiscoveryPort;
+
+    [Test]
+    public void Node_created_from_enr_backed_network_node_dials_the_tcp_port()
+    {
+        Node node = new(CreateEnrNetworkNode(tcpPort: 30303, udpPort: 30301));
+
+        Assert.That(node.Port, Is.EqualTo(30303));
+    }
+
+    [TestCase("enode://{0}@192.0.2.1:30303", 30303, 30303)]
+    [TestCase("enode://{0}@192.0.2.1:30303?discport=30301", 30303, 30301)]
+    [TestCase("enode://{0}@192.0.2.1:0?discport=30301", 0, 30301)]
+    public void Enode_backed_node_keeps_single_port_and_discport_semantics(
+        string enodeFormat, int expectedPort, int expectedDiscoveryPort)
+    {
+        NetworkNode networkNode = new(string.Format(enodeFormat, TestItem.PublicKeyA.ToString(false)));
+
+        Assert.That(networkNode.Port, Is.EqualTo(expectedPort));
+        Assert.That(networkNode.DiscoveryPort, Is.EqualTo(expectedDiscoveryPort));
+    }
+}


### PR DESCRIPTION
## Changes

- `NetworkNode.Port` for ENR-format entries returned the ENR's udp
  (discovery) port, and `Node(NetworkNode)` uses that as the RLPx dial
  port — so ENR entries from static-nodes, `admin_addPeer`, trusted-nodes,
  and the peers db were dialed at a port nothing TCP-listens on (static
  peers bypass the zero-port filter, so they were redialed indefinitely).
  `Port` now returns the ENR's tcp port (0 when absent, so undialable
  records are filtered/fail fast); `DiscoveryPort` is unchanged.
- `DiscoveryPersistenceManager` restore now uses `DiscoveryPort`
  explicitly, which is identical for all legacy stored entries
  (single-port enodes set `DiscoveryPort == Port`) and keeps discovery
  semantics for any ENR-format entry.

Same bug class as #12302, which fixed the DNS discovery conversion; this
covers the `NetworkNode`-based entry points.

Enode-format entries are unaffected: the single-port and `?discport=`
semantics are unchanged and now covered by tests. Two existing test
assertions that encoded the old udp-as-Port behavior were updated
(`Can_do_enr_roundtrip`, `RunDiscoveryPersistenceCommit_Should_Preserve_Enr_In_Common_Storage`).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
