### PR TITLE
fix(discovery): publish correct ENR endpoint for IPv6 and unresolved external IPs

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodeRecordProviderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodeRecordProviderTests.cs
@@ -108,67 +108,28 @@ public class NodeRecordProviderTests
         Assert.That(currentRecord.EnrSequence, Is.EqualTo(initialRecord.EnrSequence));
     }
 
-    [Test]
-    public async Task GetCurrentAsync_PublishesIpv4EndpointEntries()
+    [TestCase("192.0.2.1", "192.0.2.1", null)]
+    [TestCase("::ffff:192.0.2.1", "192.0.2.1", null)]
+    [TestCase("2001:db8::1", null, "2001:db8::1")]
+    [TestCase("255.255.255.255", null, null)] // IPAddress.None: unresolved external IP
+    public async Task GetCurrentAsync_PublishesEndpointEntriesMatchingExternalIpFamily(
+        string externalIp, string? expectedIp, string? expectedIp6)
     {
-        NodeRecord record = await CreateRecord(IPAddress.Parse("192.0.2.1"));
+        Block head = Build.A.Block.WithNumber(1).WithTimestamp(10).TestObject;
+        NodeRecordProvider provider = CreateProvider(head, new NetworkForkId(0x01020304, 20), IPAddress.Parse(externalIp));
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(record.GetObj<IPAddress>(EnrContentKey.Ip), Is.EqualTo(IPAddress.Parse("192.0.2.1")));
-            Assert.That(record.GetValue<int>(EnrContentKey.Tcp), Is.EqualTo(30303));
-            Assert.That(record.GetValue<int>(EnrContentKey.Udp), Is.EqualTo(30303));
-            Assert.That(record.GetObj<IPAddress>(EnrContentKey.Ip6), Is.Null);
-        }
-    }
-
-    [Test]
-    public async Task GetCurrentAsync_PublishesIpv4EntriesForIpv4MappedIpv6ExternalIp()
-    {
-        NodeRecord record = await CreateRecord(IPAddress.Parse("::ffff:192.0.2.1"));
+        NodeRecord record = await provider.GetCurrentAsync();
         NodeRecord decoded = NodeRecord.FromEnrString(record.ToString());
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(decoded.GetObj<IPAddress>(EnrContentKey.Ip), Is.EqualTo(IPAddress.Parse("192.0.2.1")));
-            Assert.That(decoded.GetValue<int>(EnrContentKey.Tcp), Is.EqualTo(30303));
-            Assert.That(decoded.GetValue<int>(EnrContentKey.Udp), Is.EqualTo(30303));
-            Assert.That(decoded.GetObj<IPAddress>(EnrContentKey.Ip6), Is.Null);
+            Assert.That(decoded.GetObj<IPAddress>(EnrContentKey.Ip), Is.EqualTo(expectedIp is null ? null : IPAddress.Parse(expectedIp)));
+            Assert.That(decoded.GetValue<int>(EnrContentKey.Tcp), Is.EqualTo(expectedIp is null ? null : (int?)30303));
+            Assert.That(decoded.GetValue<int>(EnrContentKey.Udp), Is.EqualTo(expectedIp is null ? null : (int?)30303));
+            Assert.That(decoded.GetObj<IPAddress>(EnrContentKey.Ip6), Is.EqualTo(expectedIp6 is null ? null : IPAddress.Parse(expectedIp6)));
+            Assert.That(decoded.GetValue<int>(EnrContentKey.Tcp6), Is.EqualTo(expectedIp6 is null ? null : (int?)30303));
+            Assert.That(decoded.GetValue<int>(EnrContentKey.Udp6), Is.EqualTo(expectedIp6 is null ? null : (int?)30303));
         }
-    }
-
-    [Test]
-    public async Task GetCurrentAsync_PublishesIp6EntriesForIpv6ExternalIp()
-    {
-        NodeRecord record = await CreateRecord(IPAddress.Parse("2001:db8::1"));
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(record.GetObj<IPAddress>(EnrContentKey.Ip6), Is.EqualTo(IPAddress.Parse("2001:db8::1")));
-            Assert.That(record.GetValue<int>(EnrContentKey.Tcp6), Is.EqualTo(30303));
-            Assert.That(record.GetValue<int>(EnrContentKey.Udp6), Is.EqualTo(30303));
-            Assert.That(record.GetObj<IPAddress>(EnrContentKey.Ip), Is.Null);
-        }
-    }
-
-    [Test]
-    public async Task GetCurrentAsync_OmitsEndpointEntriesForUnresolvedExternalIp()
-    {
-        NodeRecord record = await CreateRecord(IPAddress.None);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(record.GetObj<IPAddress>(EnrContentKey.Ip), Is.Null);
-            Assert.That(record.GetValue<int>(EnrContentKey.Tcp), Is.Null);
-            Assert.That(record.GetValue<int>(EnrContentKey.Udp), Is.Null);
-        }
-    }
-
-    private static async Task<NodeRecord> CreateRecord(IPAddress externalIp)
-    {
-        Block head = Build.A.Block.WithNumber(1).WithTimestamp(10).TestObject;
-        NodeRecordProvider provider = CreateProvider(head, new NetworkForkId(0x01020304, 20), externalIp);
-        return await provider.GetCurrentAsync();
     }
 
     private static NodeRecordProvider CreateProvider(Block head, NetworkForkId forkId, IPAddress externalIp)

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodeRecordProviderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodeRecordProviderTests.cs
@@ -123,6 +123,21 @@ public class NodeRecordProviderTests
     }
 
     [Test]
+    public async Task GetCurrentAsync_PublishesIpv4EntriesForIpv4MappedIpv6ExternalIp()
+    {
+        NodeRecord record = await CreateRecord(IPAddress.Parse("::ffff:192.0.2.1"));
+        NodeRecord decoded = NodeRecord.FromEnrString(record.ToString());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.GetObj<IPAddress>(EnrContentKey.Ip), Is.EqualTo(IPAddress.Parse("192.0.2.1")));
+            Assert.That(decoded.GetValue<int>(EnrContentKey.Tcp), Is.EqualTo(30303));
+            Assert.That(decoded.GetValue<int>(EnrContentKey.Udp), Is.EqualTo(30303));
+            Assert.That(decoded.GetObj<IPAddress>(EnrContentKey.Ip6), Is.Null);
+        }
+    }
+
+    [Test]
     public async Task GetCurrentAsync_PublishesIp6EntriesForIpv6ExternalIp()
     {
         NodeRecord record = await CreateRecord(IPAddress.Parse("2001:db8::1"));

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NodeRecordProviderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NodeRecordProviderTests.cs
@@ -108,6 +108,54 @@ public class NodeRecordProviderTests
         Assert.That(currentRecord.EnrSequence, Is.EqualTo(initialRecord.EnrSequence));
     }
 
+    [Test]
+    public async Task GetCurrentAsync_PublishesIpv4EndpointEntries()
+    {
+        NodeRecord record = await CreateRecord(IPAddress.Parse("192.0.2.1"));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(record.GetObj<IPAddress>(EnrContentKey.Ip), Is.EqualTo(IPAddress.Parse("192.0.2.1")));
+            Assert.That(record.GetValue<int>(EnrContentKey.Tcp), Is.EqualTo(30303));
+            Assert.That(record.GetValue<int>(EnrContentKey.Udp), Is.EqualTo(30303));
+            Assert.That(record.GetObj<IPAddress>(EnrContentKey.Ip6), Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task GetCurrentAsync_PublishesIp6EntriesForIpv6ExternalIp()
+    {
+        NodeRecord record = await CreateRecord(IPAddress.Parse("2001:db8::1"));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(record.GetObj<IPAddress>(EnrContentKey.Ip6), Is.EqualTo(IPAddress.Parse("2001:db8::1")));
+            Assert.That(record.GetValue<int>(EnrContentKey.Tcp6), Is.EqualTo(30303));
+            Assert.That(record.GetValue<int>(EnrContentKey.Udp6), Is.EqualTo(30303));
+            Assert.That(record.GetObj<IPAddress>(EnrContentKey.Ip), Is.Null);
+        }
+    }
+
+    [Test]
+    public async Task GetCurrentAsync_OmitsEndpointEntriesForUnresolvedExternalIp()
+    {
+        NodeRecord record = await CreateRecord(IPAddress.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(record.GetObj<IPAddress>(EnrContentKey.Ip), Is.Null);
+            Assert.That(record.GetValue<int>(EnrContentKey.Tcp), Is.Null);
+            Assert.That(record.GetValue<int>(EnrContentKey.Udp), Is.Null);
+        }
+    }
+
+    private static async Task<NodeRecord> CreateRecord(IPAddress externalIp)
+    {
+        Block head = Build.A.Block.WithNumber(1).WithTimestamp(10).TestObject;
+        NodeRecordProvider provider = CreateProvider(head, new NetworkForkId(0x01020304, 20), externalIp);
+        return await provider.GetCurrentAsync();
+    }
+
     private static NodeRecordProvider CreateProvider(Block head, NetworkForkId forkId, IPAddress externalIp)
     {
         IBlockTree blockTree = Substitute.For<IBlockTree>();

--- a/src/Nethermind/Nethermind.Network.Discovery/NodeRecordProvider.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/NodeRecordProvider.cs
@@ -9,6 +9,7 @@ using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.Enr;
 using System.Net;
+using System.Net.Sockets;
 using NetworkForkId = Nethermind.Network.ForkId;
 
 namespace Nethermind.Network.Discovery;
@@ -112,9 +113,18 @@ public sealed class NodeRecordProvider(
     {
         NodeRecord selfNodeRecord = new();
         selfNodeRecord.SetEntry(new EthEntry(state.ForkId.HashBytes, state.ForkId.Next));
-        selfNodeRecord.SetEntry(new IpEntry(state.ExternalIp));
-        selfNodeRecord.SetEntry(new TcpEntry(state.TcpPort));
-        selfNodeRecord.SetEntry(new UdpEntry(state.UdpPort));
+        if (state.ExternalIp.AddressFamily == AddressFamily.InterNetworkV6 && !state.ExternalIp.IsIPv4MappedToIPv6)
+        {
+            selfNodeRecord.SetEntry(new Ip6Entry(state.ExternalIp));
+            selfNodeRecord.SetEntry(new Tcp6Entry(state.TcpPort));
+            selfNodeRecord.SetEntry(new Udp6Entry(state.UdpPort));
+        }
+        else if (!Equals(state.ExternalIp, IPAddress.None))
+        {
+            selfNodeRecord.SetEntry(new IpEntry(state.ExternalIp));
+            selfNodeRecord.SetEntry(new TcpEntry(state.TcpPort));
+            selfNodeRecord.SetEntry(new UdpEntry(state.UdpPort));
+        }
         selfNodeRecord.SetEntry(new SecP256k1Entry(nodeKey.CompressedPublicKey));
         selfNodeRecord.EnrSequence = sequence;
         _enrSigner.Sign(selfNodeRecord);


### PR DESCRIPTION
## Changes

- The local ENR always wrote v4 `ip`/`tcp`/`udp` entries. A genuinely IPv6
  external address (e.g. configured via `--Network.ExternalIp`) went through
  `IpEntry`'s `MapToIPv4()`, signing a garbage IPv4 built from the low 32 bits
  of the v6 address; a failed external IP resolution signed `255.255.255.255`
  (`IPAddress.None`). IPv6 addresses are now published as `ip6`/`tcp6`/`udp6`
  entries, and the endpoint entries are omitted entirely when the external IP
  is unresolved (matching geth, which omits endpoint keys it doesn't know).
  IPv4 and IPv4-mapped addresses are unchanged.

The record advertises one address family, because `IPResolver` resolves a
single external IP. Dual-stack advertising (both families in one record, as
geth and reth do) is a larger feature across the resolver, listeners, and the
single-endpoint `Node` model — out of scope here; this change only stops
signing incorrect entries.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
