### PR TITLE
fix(sync): preserve block-info metadata when re-inserting the same hash into a chain level

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -567,7 +567,7 @@ namespace Nethermind.Blockchain
                         if (Logger.IsInfo) Logger.Info($"Missing block info - creating level in {nameof(FindHeader)} scope when head is {Head?.ToString(Block.Format.Short)}. BlockHeader {header.ToString(BlockHeader.Format.FullHashAndNumber)}, CreateLevelIfMissing: {createLevelIfMissing}. BestKnownBeaconNumber: {BestKnownBeaconNumber}, BestKnownNumber: {BestKnownNumber}");
                         SetTotalDifficulty(header);
                         blockInfo = new BlockInfo(header.Hash, header.TotalDifficulty ?? UInt256.Zero);
-                        level = UpdateOrCreateLevel(header.Number, blockInfo);
+                        level = UpdateOrCreateLevel(header.Number, blockInfo, keepExistingMetadata: true);
                     }
                 }
                 else
@@ -1453,7 +1453,7 @@ namespace Nethermind.Blockchain
             return new BlockEventArgs(block);
         }
 
-        private ChainLevelInfo UpdateOrCreateLevel(ulong number, BlockInfo blockInfo, bool setAsMain = false)
+        private ChainLevelInfo UpdateOrCreateLevel(ulong number, BlockInfo blockInfo, bool setAsMain = false, bool keepExistingMetadata = false)
         {
             using BatchWrite? batch = _chainLevelInfoRepository.StartBatch();
 
@@ -1466,7 +1466,7 @@ namespace Nethermind.Blockchain
 
             if (level is not null)
             {
-                level.InsertBlockInfo(blockInfo.BlockHash, blockInfo, setAsMain);
+                level.InsertBlockInfo(blockInfo.BlockHash, blockInfo, setAsMain, keepExistingMetadata);
             }
             else
             {
@@ -1608,7 +1608,7 @@ namespace Nethermind.Blockchain
                         if (Logger.IsInfo) Logger.Info($"Missing block info - creating level in {nameof(FindBlock)} scope when head is {Head?.ToString(Block.Format.Short)}. BlockHeader {block.ToString(Block.Format.FullHashAndNumber)}, CreateLevelIfMissing: {createLevelIfMissing}. BestKnownBeaconNumber: {BestKnownBeaconNumber}, BestKnownNumber: {BestKnownNumber}");
                         SetTotalDifficulty(block.Header);
                         blockInfo = new BlockInfo(block.Hash, block.TotalDifficulty ?? UInt256.Zero);
-                        level = UpdateOrCreateLevel(block.Number, blockInfo);
+                        level = UpdateOrCreateLevel(block.Number, blockInfo, keepExistingMetadata: true);
                     }
                 }
                 else
@@ -1705,14 +1705,14 @@ namespace Nethermind.Blockchain
                     current.TotalDifficulty = current.Difficulty;
                     BlockInfo blockInfo = new(current.Hash, current.Difficulty);
                     blockInfo.WasProcessed = true;
-                    UpdateOrCreateLevel(current.Number, blockInfo);
+                    UpdateOrCreateLevel(current.Number, blockInfo, keepExistingMetadata: true);
                 }
 
                 while (stack.TryPop(out BlockHeader child))
                 {
                     child.TotalDifficulty = current.TotalDifficulty + child.Difficulty;
                     BlockInfo blockInfo = new(child.Hash, child.TotalDifficulty.Value);
-                    UpdateOrCreateLevel(child.Number, blockInfo);
+                    UpdateOrCreateLevel(child.Number, blockInfo, keepExistingMetadata: true);
                     if (Logger.IsTrace)
                         Logger.Trace($"Calculated total difficulty for {child} is {child.TotalDifficulty}");
                     current = child;

--- a/src/Nethermind/Nethermind.Core.Test/ChainLevelInfoTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/ChainLevelInfoTests.cs
@@ -16,14 +16,35 @@ public class ChainLevelInfoTests
     [TestCase(BlockMetadata.None, BlockMetadata.BeaconHeader | BlockMetadata.BeaconMainChain)]
     [TestCase(BlockMetadata.BeaconMainChain, BlockMetadata.BeaconHeader)]
     [TestCase(BlockMetadata.Finalized, BlockMetadata.None)]
-    public void Reinserting_block_info_merges_metadata(BlockMetadata existingMetadata, BlockMetadata newMetadata)
+    public void Reinserting_block_info_with_keep_existing_metadata_merges_metadata(BlockMetadata existingMetadata, BlockMetadata newMetadata)
     {
         ChainLevelInfo level = new(false, new BlockInfo(_hash, 0, existingMetadata));
 
-        level.InsertBlockInfo(_hash, new BlockInfo(_hash, 0, newMetadata), setAsMain: false);
+        level.InsertBlockInfo(_hash, new BlockInfo(_hash, 0, newMetadata), setAsMain: false, keepExistingMetadata: true);
 
         Assert.That(level.BlockInfos, Has.Length.EqualTo(1));
         Assert.That(level.BlockInfos[0].Metadata, Is.EqualTo(existingMetadata | newMetadata));
+    }
+
+    [Test]
+    public void Reinserting_non_beacon_block_info_clears_beacon_metadata_by_default()
+    {
+        ChainLevelInfo level = new(false, new BlockInfo(_hash, 0, BlockMetadata.BeaconHeader | BlockMetadata.BeaconMainChain));
+
+        level.InsertBlockInfo(_hash, new BlockInfo(_hash, 0), setAsMain: false);
+
+        Assert.That(level.BlockInfos[0].Metadata, Is.EqualTo(BlockMetadata.None));
+    }
+
+    [Test]
+    public void Reinserting_beacon_block_info_keeps_beacon_main_chain_flag_by_default()
+    {
+        ChainLevelInfo level = new(false, new BlockInfo(_hash, 0, BlockMetadata.BeaconHeader | BlockMetadata.BeaconMainChain));
+
+        level.InsertBlockInfo(_hash, new BlockInfo(_hash, 0, BlockMetadata.BeaconHeader | BlockMetadata.BeaconBody), setAsMain: false);
+
+        Assert.That(level.BlockInfos[0].Metadata,
+            Is.EqualTo(BlockMetadata.BeaconHeader | BlockMetadata.BeaconBody | BlockMetadata.BeaconMainChain));
     }
 
     [Test]
@@ -31,7 +52,7 @@ public class ChainLevelInfoTests
     {
         ChainLevelInfo level = new(false, new BlockInfo(_hash, 0, BlockMetadata.BeaconHeader) { WasProcessed = true });
 
-        level.InsertBlockInfo(_hash, new BlockInfo(_hash, 0), setAsMain: false);
+        level.InsertBlockInfo(_hash, new BlockInfo(_hash, 0), setAsMain: false, keepExistingMetadata: true);
 
         Assert.That(level.BlockInfos[0].WasProcessed, Is.True);
     }
@@ -41,7 +62,7 @@ public class ChainLevelInfoTests
     {
         ChainLevelInfo level = new(false, new BlockInfo(_hash, 0));
 
-        level.InsertBlockInfo(TestItem.KeccakB, new BlockInfo(TestItem.KeccakB, 0, BlockMetadata.BeaconHeader), setAsMain: false);
+        level.InsertBlockInfo(TestItem.KeccakB, new BlockInfo(TestItem.KeccakB, 0, BlockMetadata.BeaconHeader), setAsMain: false, keepExistingMetadata: true);
 
         Assert.That(level.BlockInfos, Has.Length.EqualTo(2));
         Assert.That(level.FindBlockInfo(TestItem.KeccakB)!.Metadata, Is.EqualTo(BlockMetadata.BeaconHeader));

--- a/src/Nethermind/Nethermind.Core.Test/ChainLevelInfoTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/ChainLevelInfoTests.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test;
+
+public class ChainLevelInfoTests
+{
+    private static readonly Hash256 _hash = TestItem.KeccakA;
+
+    [TestCase(BlockMetadata.BeaconHeader | BlockMetadata.BeaconMainChain, BlockMetadata.None)]
+    [TestCase(BlockMetadata.BeaconHeader | BlockMetadata.BeaconBody | BlockMetadata.BeaconMainChain, BlockMetadata.None)]
+    [TestCase(BlockMetadata.None, BlockMetadata.BeaconHeader | BlockMetadata.BeaconMainChain)]
+    [TestCase(BlockMetadata.BeaconMainChain, BlockMetadata.BeaconHeader)]
+    [TestCase(BlockMetadata.Finalized, BlockMetadata.None)]
+    public void Reinserting_block_info_merges_metadata(BlockMetadata existingMetadata, BlockMetadata newMetadata)
+    {
+        ChainLevelInfo level = new(false, new BlockInfo(_hash, 0, existingMetadata));
+
+        level.InsertBlockInfo(_hash, new BlockInfo(_hash, 0, newMetadata), setAsMain: false);
+
+        Assert.That(level.BlockInfos, Has.Length.EqualTo(1));
+        Assert.That(level.BlockInfos[0].Metadata, Is.EqualTo(existingMetadata | newMetadata));
+    }
+
+    [Test]
+    public void Reinserting_block_info_keeps_processed_flag()
+    {
+        ChainLevelInfo level = new(false, new BlockInfo(_hash, 0, BlockMetadata.BeaconHeader) { WasProcessed = true });
+
+        level.InsertBlockInfo(_hash, new BlockInfo(_hash, 0), setAsMain: false);
+
+        Assert.That(level.BlockInfos[0].WasProcessed, Is.True);
+    }
+
+    [Test]
+    public void Inserting_new_block_info_appends_to_level()
+    {
+        ChainLevelInfo level = new(false, new BlockInfo(_hash, 0));
+
+        level.InsertBlockInfo(TestItem.KeccakB, new BlockInfo(TestItem.KeccakB, 0, BlockMetadata.BeaconHeader), setAsMain: false);
+
+        Assert.That(level.BlockInfos, Has.Length.EqualTo(2));
+        Assert.That(level.FindBlockInfo(TestItem.KeccakB)!.Metadata, Is.EqualTo(BlockMetadata.BeaconHeader));
+    }
+}

--- a/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
@@ -89,7 +89,7 @@ namespace Nethermind.Core
             return index.HasValue ? BlockInfos[index.Value] : null;
         }
 
-        public void InsertBlockInfo(Hash256 hash, BlockInfo blockInfo, bool setAsMain)
+        public void InsertBlockInfo(Hash256 hash, BlockInfo blockInfo, bool setAsMain, bool keepExistingMetadata = false)
         {
             BlockInfo[] blockInfos = BlockInfos;
 
@@ -100,10 +100,10 @@ namespace Nethermind.Core
             }
             else
             {
-                // Metadata flags are recorded by independent writers (e.g. beacon sync inserting the same
-                // hash that FindHeader concurrently created a level entry for); an upsert that lacks a flag
-                // must not erase it. Intentional clearing mutates level entries directly, never through here.
-                blockInfo.Metadata |= blockInfos[foundIndex.Value].Metadata;
+                if (keepExistingMetadata)
+                    blockInfo.Metadata |= blockInfos[foundIndex.Value].Metadata;
+                else if (blockInfo.IsBeaconInfo && blockInfos[foundIndex.Value].IsBeaconMainChain)
+                    blockInfo.Metadata |= BlockMetadata.BeaconMainChain;
 
                 if (blockInfo.EqualsIgnoringWasProcessed(blockInfos[foundIndex.Value]))
                     blockInfo.WasProcessed |= blockInfos[foundIndex.Value].WasProcessed;

--- a/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
+++ b/src/Nethermind/Nethermind.Core/ChainLevelInfo.cs
@@ -100,8 +100,10 @@ namespace Nethermind.Core
             }
             else
             {
-                if (blockInfo.IsBeaconInfo && blockInfos[foundIndex.Value].IsBeaconMainChain)
-                    blockInfo.Metadata |= BlockMetadata.BeaconMainChain;
+                // Metadata flags are recorded by independent writers (e.g. beacon sync inserting the same
+                // hash that FindHeader concurrently created a level entry for); an upsert that lacks a flag
+                // must not erase it. Intentional clearing mutates level entries directly, never through here.
+                blockInfo.Metadata |= blockInfos[foundIndex.Value].Metadata;
 
                 if (blockInfo.EqualsIgnoringWasProcessed(blockInfos[foundIndex.Value]))
                     blockInfo.WasProcessed |= blockInfos[foundIndex.Value].WasProcessed;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
@@ -206,24 +206,6 @@ public partial class BlockTreeTests
     }
 
     [Test]
-    public void Beacon_metadata_survives_racing_plain_header_insert()
-    {
-        (BlockTree notSyncedTree, BlockTree syncedTree) = BuildBlockTrees(10, 20);
-
-        BlockHeader beaconHeader = syncedTree.FindHeader(14, BlockTreeLookupOptions.None)!;
-        notSyncedTree.Insert(beaconHeader,
-            BlockTreeInsertHeaderOptions.BeaconHeaderInsert | BlockTreeInsertHeaderOptions.TotalDifficultyNotNeeded);
-
-        // A FindHeader racing the beacon insert re-creates the level entry without beacon metadata;
-        // Insert with no options takes the same plain UpdateOrCreateLevel path.
-        notSyncedTree.Insert(beaconHeader);
-
-        BlockInfo? info = notSyncedTree.GetInfo(beaconHeader.Number, beaconHeader.Hash!).Info;
-        Assert.That(info!.Metadata & (BlockMetadata.BeaconHeader | BlockMetadata.BeaconMainChain),
-            Is.EqualTo(BlockMetadata.BeaconHeader | BlockMetadata.BeaconMainChain));
-    }
-
-    [Test]
     public void Can_fill_beacon_headers_gap()
     {
         (BlockTree notSyncedTree, BlockTree syncedTree) = BuildBlockTrees(10, 20);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeTests.cs
@@ -206,6 +206,24 @@ public partial class BlockTreeTests
     }
 
     [Test]
+    public void Beacon_metadata_survives_racing_plain_header_insert()
+    {
+        (BlockTree notSyncedTree, BlockTree syncedTree) = BuildBlockTrees(10, 20);
+
+        BlockHeader beaconHeader = syncedTree.FindHeader(14, BlockTreeLookupOptions.None)!;
+        notSyncedTree.Insert(beaconHeader,
+            BlockTreeInsertHeaderOptions.BeaconHeaderInsert | BlockTreeInsertHeaderOptions.TotalDifficultyNotNeeded);
+
+        // A FindHeader racing the beacon insert re-creates the level entry without beacon metadata;
+        // Insert with no options takes the same plain UpdateOrCreateLevel path.
+        notSyncedTree.Insert(beaconHeader);
+
+        BlockInfo? info = notSyncedTree.GetInfo(beaconHeader.Number, beaconHeader.Hash!).Info;
+        Assert.That(info!.Metadata & (BlockMetadata.BeaconHeader | BlockMetadata.BeaconMainChain),
+            Is.EqualTo(BlockMetadata.BeaconHeader | BlockMetadata.BeaconMainChain));
+    }
+
+    [Test]
     public void Can_fill_beacon_headers_gap()
     {
         (BlockTree notSyncedTree, BlockTree syncedTree) = BuildBlockTrees(10, 20);


### PR DESCRIPTION
## Changes

- `ChainLevelInfo.InsertBlockInfo` gains a `keepExistingMetadata` flag that merges the existing entry's metadata into the incoming `BlockInfo` on a same-hash re-insert. Only the level-repair writers opt in: the `FindHeader`/`FindBlock` missing-level creation and `SetTotalDifficultyDeep` — the writers that can race a beacon-header insert and previously erased its flags.
- Default semantics are unchanged: a non-beacon re-insert still clears beacon flags (that is how a synced beacon block graduates to a regular block, and `ChainLevelHelper.GetStartingPoint` relies on it to stop walking back at the processed boundary), and the one-way `BeaconMainChain` carry-over for beacon re-inserts stays as before.
- Adds `ChainLevelInfoTests` covering the repair-writer merge, the default clearing/carry-over semantics, processed-flag retention, and plain appends.

## Why

Root cause of the intermittent `Invalid Missing Ancestor Syncing ReOrg, StateRoot, EmptyTxs=True, CanonicalReOrg=True` hive failure ([run 28785858320](https://github.com/NethermindEth/nethermind/actions/runs/28785858320)), where the node stays SYNCING forever instead of syncing the side chain and reporting the invalid ancestor.

Block data storage is not transactional: `BlockTree.Insert(header, …)` writes the header store first and the chain level after. A concurrent `FindHeader` that needs the total difficulty can observe the header without its level and creates the missing level entry itself with `Metadata.None` (the log fingerprint is `Missing block info - creating level in FindHeader scope`). The existing `isSearchingForBeaconBlock` guard suppresses that creation only when `BestKnownBeaconNumber > BestKnownNumber` — during a **same-height re-org via sync** (client already at head N, side-chain tip also at N) the guard is inactive, and the fcU handler's parent lookup regularly races the beacon-header backfill for exactly the block below the pivot.

`InsertBlockInfo` then let whichever writer landed last replace the other's `BlockInfo`, so the level entry for a beacon-main-chain block could end up with no beacon metadata. Downstream, `ChainLevelHelper.GetStartingPoint` stops walking back at the first non-beacon block info, so the forward beacon sync anchors directly below the already-known head, finds nothing to download or process, and `BlockDownloader` keeps returning empty requests (`Forward header starting block number did not changed`). Nothing ever recovers: every subsequent `newPayload` answers `Syncing… Block already known in blockTree`, which is the 100-second loop visible in the failing run's client log until the hive test times out.

The failure needs the fcU/NP lookup to land inside the header-write→level-write window *and* the level writes to land in the unlucky order, which is why the variant only fails occasionally and only for `CanonicalReOrg=True` (a fresh syncing node has `BestKnownBeaconNumber > BestKnownNumber`, so the guard covers it).

Merging metadata for the repair writers makes both race orderings converge to the same state: if the repair write lands last it no longer erases the beacon flags, and if the beacon insert lands last it replaces the plain entry as it always did. Intentional flag clearing is unaffected — `UpdateBeaconMainChain`, the `IsFinalized` setter, and `MoveHeaderToMain` mutate stored level entries directly, and the graduation path (plain `Suggest`/`Insert`) keeps its clearing semantics.

The `Incomplete Transactions` variant that failed in [run 28789431083](https://github.com/NethermindEth/nethermind/actions/runs/28789431083) is a separate, test-side issue (the invalidation is a no-op when the base payload happens to be built empty) and is addressed upstream in ethereum/hive; #12304 covers CI in the meantime.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- New `ChainLevelInfoTests` pin both the repair-writer merge and the unchanged default semantics.
- Run locally after the review rework: `Nethermind.Core.Test`, `Nethermind.Blockchain.Test` (1493 passed), `Nethermind.Merge.Plugin.Test` (1616 passed — this suite hung on CI with the previous unconditional-merge version) and `Nethermind.Synchronization.Test` full suites.
- The `test/hive-invalid-missing-ancestor` branch loops the affected hive variants with sync trace logging for before/after validation.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
