### PR TITLE
fix(test): deflake Will_not_stop_trying_on_rlpx_connection_failure

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -495,8 +495,10 @@ namespace Nethermind.Network.Test
             for (int i = 0; i < 10; i++)
             {
                 ctx.DiscoverNew(25);
-                await Task.Delay(_delay);
-                Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(25 * (i + 1)).After(_delayLonger, 10));
+                // The manager keeps retrying failed peers in the background, so the counter never
+                // settles — assert it reaches each cycle's threshold instead of an exact value.
+                await ctx.RlpxPeer.WaitForConnectCallsAsync(25 * (i + 1), TimeSpan.FromSeconds(30));
+                Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.AtLeast(25 * (i + 1)));
             }
         }
 


### PR DESCRIPTION
## Changes

- Fix flaky test `PeerManagerTests.Will_not_stop_trying_on_rlpx_connection_failure` (seen failing in the "Nethermind extra test variants" workflow, Network.Test [checked] job, e.g. [this run](https://github.com/NethermindEth/nethermind/actions/runs/28810480098/job/85436944238); cleared by a plain rerun).
- The test asserted `ConnectAsyncCallsCount == 25 * (i + 1)` with `Is.EqualTo(...).After(...)` while the `PeerManager` keeps retrying failed peers in the background. An exact-equality poll on a still-advancing counter is inherently racy: by the time the poll samples the counter, a background retry can have already bumped it (observed `Expected: 25 But was: 26`).
- The test's intent is that the peer manager *keeps trying* after RLPx connection failures — i.e. the counter keeps reaching new thresholds. The fix waits for each cycle's threshold with the file's existing event-driven helper `RlpxMock.WaitForConnectCallsAsync(...)` and asserts `Is.AtLeast(...)`, matching the tolerant pattern already used by neighbouring tests (`Will_fill_up_on_disconnects`, `Will_not_stop_trying_on_any_failure`). The unconditional `Task.Delay(_delay)` is no longer needed.

Test-only change; no production code touched.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Ran the test 12× in `release` and 12× with the [checked] CI variant's defines (`-p:DefineConstants=TRACE%3BDEBUG`, `--no-incremental`): 24/24 passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
