### PR TITLE
fix(persistence): delete flat trie nodes by subtree containment

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTestHelpers.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTestHelpers.cs
@@ -53,8 +53,8 @@ internal sealed class FakeWriteBatch : IPersistence.IWriteBatch
     public List<(ValueHash256 AddrHash, Account Account)> SetAccountRawCalls { get; } = [];
     public List<(ValueHash256 FromPath, ValueHash256 ToPath)> DeleteAccountRangeCalls { get; } = [];
     public List<(ValueHash256 AddressHash, ValueHash256 FromPath, ValueHash256 ToPath)> DeleteStorageRangeCalls { get; } = [];
-    public List<(TreePath FromPath, TreePath ToPath)> DeleteStateTrieNodeRangeCalls { get; } = [];
-    public List<(ValueHash256 AddressHash, TreePath FromPath, TreePath ToPath)> DeleteStorageTrieNodeRangeCalls { get; } = [];
+    public List<(ValueHash256 From, ValueHash256 To)> DeleteStateTrieNodeRangeCalls { get; } = [];
+    public List<(ValueHash256 AddressHash, ValueHash256 From, ValueHash256 To)> DeleteStorageTrieNodeRangeCalls { get; } = [];
     public int DisposeCount { get; private set; }
 
     public void SelfDestruct(Address addr) => SelfDestructCalls.Add(addr);
@@ -78,11 +78,11 @@ internal sealed class FakeWriteBatch : IPersistence.IWriteBatch
     public void DeleteStorageRange(in ValueHash256 addressHash, in ValueHash256 fromPath, in ValueHash256 toPath) =>
         DeleteStorageRangeCalls.Add((addressHash, fromPath, toPath));
 
-    public void DeleteStateTrieNodeRange(in TreePath fromPath, in TreePath toPath) =>
-        DeleteStateTrieNodeRangeCalls.Add((fromPath, toPath));
+    public void DeleteStateTrieNodeRange(in ValueHash256 from, in ValueHash256 to) =>
+        DeleteStateTrieNodeRangeCalls.Add((from, to));
 
-    public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in TreePath fromPath, in TreePath toPath) =>
-        DeleteStorageTrieNodeRangeCalls.Add((addressHash, fromPath, toPath));
+    public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in ValueHash256 from, in ValueHash256 to) =>
+        DeleteStorageTrieNodeRangeCalls.Add((addressHash, from, to));
 
     public void Dispose() => DisposeCount++;
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
@@ -736,37 +736,65 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
         }
     }
 
-    // Nodes across all columns (lengths 4/10/32/64), in-range pairs under "ab" and
-    // out-of-range neighbours (aa/ac), to verify the range bounds delete only in-range nodes.
-    private static readonly (string Path, bool Deleted)[] RangeDeleteNodes =
-    [
-        ("ab00",                true),  ("abffff",               true),
-        ("ab00000000",          true),  ("abffffffffffff",        true),
-        ("ab".PadRight(32,'0'), true),  ("ab".PadRight(32, 'f'), true),
-        ("ab".PadRight(64,'0'), true),  ("ab".PadRight(64, 'f'), true),
-        ("aa00",                false), ("ac00",                  false),
-        ("aa00000000",          false), ("ac00000000",            false),
-        ("aa".PadRight(32,'0'), false), ("ac".PadRight(32, '0'), false),
-        ("aa".PadRight(64,'0'), false), ("ac".PadRight(64, '0'), false),
-    ];
-    private static readonly TreePath RangeDeleteFrom = TreePath.FromHexString("ab".PadRight(64, '0'));
-    private static readonly TreePath RangeDeleteTo = TreePath.FromHexString("ab".PadRight(64, 'f'));
+    // Each case: the value range [from, to] (the subtree of some root path) and nodes spread across all columns
+    // (top 0-5 / shortened 6-15 / fallback 16+), tagged with whether their whole subtree is contained in the range.
+    private static IEnumerable<TestCaseData> SubtreeDeleteCases()
+    {
+        // Shallow "ab" subtree: everything under ab is fully contained; aa/ac neighbours are not.
+        yield return Case("ab", new (string, bool)[]
+        {
+            ("ab00", true), ("abffff", true), ("ab00000000", true), ("abffffffffffff", true),
+            ("ab".PadRight(32, '0'), true), ("ab".PadRight(32, 'f'), true),
+            ("ab".PadRight(64, '0'), true), ("ab".PadRight(64, 'f'), true),
+            ("aa00", false), ("ac00", false), ("aa".PadRight(64, '0'), false), ("ac".PadRight(64, '0'), false),
+        });
 
-    [Test]
-    public void TestDeleteStateTrieNodeRange()
+        // Deep subtree (depth 20): ancestors on the zero tail (depths 2/10/16/18) only partially overlap the range
+        // (their subtree overflows `to`), so they are preserved; the root (depth 20) and its descendants are removed.
+        yield return Case("ab".PadRight(20, '0'), new (string, bool)[]
+        {
+            ("ab", false), ("ab".PadRight(10, '0'), false), ("ab".PadRight(16, '0'), false), ("ab".PadRight(18, '0'), false),
+            ("ab".PadRight(20, '0'), true), ("ab".PadRight(20, '0') + "cccc", true), ("ab".PadRight(32, '0'), true), ("ab".PadRight(64, '0'), true),
+            ("aa".PadRight(20, '0'), false), ("ac".PadRight(20, '0'), false), ("aa".PadRight(64, '0'), false), ("ac".PadRight(64, '0'), false),
+        });
+
+        // Shortened-depth subtree (depth 10): top ancestor (depth 2) and shortened ancestors (depths 6/8) preserved;
+        // root (depth 10) and descendants removed.
+        yield return Case("ab".PadRight(10, '0'), new (string, bool)[]
+        {
+            ("ab", false), ("ab".PadRight(6, '0'), false), ("ab".PadRight(8, '0'), false),
+            ("ab".PadRight(10, '0'), true), ("ab".PadRight(12, '0'), true), ("ab".PadRight(32, '0'), true), ("ab".PadRight(64, '0'), true),
+            ("aa".PadRight(64, '0'), false), ("ac".PadRight(64, '0'), false),
+        });
+
+        // Whole trie: [Zero, MaxValue] contains every node.
+        yield return new TestCaseData(ValueKeccak.Zero, ValueKeccak.MaxValue, new (string, bool)[]
+        {
+            ("ab", true), ("ab".PadRight(10, '0'), true), ("ab".PadRight(64, '0'), true), ("cd".PadRight(64, 'f'), true),
+        }).SetName("Whole trie");
+
+        static TestCaseData Case(string rootHex, (string, bool)[] nodes)
+        {
+            TreePath root = TreePath.FromHexString(rootHex);
+            return new TestCaseData(root.ToLowerBoundPath(), root.ToUpperBoundPath(), nodes).SetName($"Subtree depth {rootHex.Length}");
+        }
+    }
+
+    [TestCaseSource(nameof(SubtreeDeleteCases))]
+    public void TestDeleteStateTrieNodeRange(ValueHash256 from, ValueHash256 to, (string Path, bool Deleted)[] nodes)
     {
         byte[] rlp = [0xc1, 0x11];
 
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis))
-            foreach ((string p, _) in RangeDeleteNodes) writer.SetStateTrieNode(TreePath.FromHexString(p), rlp);
+            foreach ((string p, _) in nodes) writer.SetStateTrieNode(TreePath.FromHexString(p), rlp);
 
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis))
-            writer.DeleteStateTrieNodeRange(RangeDeleteFrom, RangeDeleteTo);
+            writer.DeleteStateTrieNodeRange(from, to);
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         using (Assert.EnterMultipleScope())
         {
-            foreach ((string p, bool del) in RangeDeleteNodes)
+            foreach ((string p, bool del) in nodes)
             {
                 byte[]? node = reader.TryLoadStateRlp(TreePath.FromHexString(p), ReadFlags.None);
                 Assert.That(node, del ? Is.Null : Is.EqualTo(rlp), p);
@@ -774,22 +802,22 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
         }
     }
 
-    [Test]
-    public void TestDeleteStorageTrieNodeRange()
+    [TestCaseSource(nameof(SubtreeDeleteCases))]
+    public void TestDeleteStorageTrieNodeRange(ValueHash256 from, ValueHash256 to, (string Path, bool Deleted)[] nodes)
     {
         Hash256 account = TestItem.KeccakA;
         byte[] rlp = [0xc1, 0x11];
 
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis))
-            foreach ((string p, _) in RangeDeleteNodes) writer.SetStorageTrieNode(account, TreePath.FromHexString(p), rlp);
+            foreach ((string p, _) in nodes) writer.SetStorageTrieNode(account, TreePath.FromHexString(p), rlp);
 
         using (IPersistence.IWriteBatch writer = _persistence.CreateWriteBatch(StateId.PreGenesis, StateId.PreGenesis))
-            writer.DeleteStorageTrieNodeRange(new ValueHash256(account.Bytes), RangeDeleteFrom, RangeDeleteTo);
+            writer.DeleteStorageTrieNodeRange(new ValueHash256(account.Bytes), from, to);
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         using (Assert.EnterMultipleScope())
         {
-            foreach ((string p, bool del) in RangeDeleteNodes)
+            foreach ((string p, bool del) in nodes)
             {
                 byte[]? node = reader.TryLoadStorageRlp(account, TreePath.FromHexString(p), ReadFlags.None);
                 Assert.That(node, del ? Is.Null : Is.EqualTo(rlp), p);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -329,8 +329,8 @@ public static class BasePersistence
         public void SelfDestruct(in ValueHash256 address);
         public void SetStateTrieNode(in TreePath path, scoped ReadOnlySpan<byte> rlp);
         public void SetStorageTrieNode(Hash256 address, in TreePath path, scoped ReadOnlySpan<byte> rlp);
-        public void DeleteStateTrieNodeRange(in TreePath fromPath, in TreePath toPath);
-        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in TreePath fromPath, in TreePath toPath);
+        public void DeleteStateTrieNodeRange(in ValueHash256 from, in ValueHash256 to);
+        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in ValueHash256 from, in ValueHash256 to);
     }
 
     public struct ToHashedWriteBatch<TWriteBatch>(
@@ -515,10 +515,10 @@ public static class BasePersistence
         public void DeleteStorageRange(in ValueHash256 addressHash, in ValueHash256 fromPath, in ValueHash256 toPath) =>
             _flatWriter.DeleteStorageRange(addressHash, fromPath, toPath);
 
-        public void DeleteStateTrieNodeRange(in TreePath fromPath, in TreePath toPath) =>
-            _trieWriteBatch.DeleteStateTrieNodeRange(fromPath, toPath);
+        public void DeleteStateTrieNodeRange(in ValueHash256 from, in ValueHash256 to) =>
+            _trieWriteBatch.DeleteStateTrieNodeRange(from, to);
 
-        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in TreePath fromPath, in TreePath toPath) =>
-            _trieWriteBatch.DeleteStorageTrieNodeRange(addressHash, fromPath, toPath);
+        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in ValueHash256 from, in ValueHash256 to) =>
+            _trieWriteBatch.DeleteStorageTrieNodeRange(addressHash, from, to);
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseTriePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseTriePersistence.cs
@@ -193,75 +193,118 @@ public static class BaseTriePersistence
             }
         }
 
+        /// <inheritdoc cref="IPersistence.IWriteBatch.DeleteStateTrieNodeRange"/>
         [SkipLocalsInit]
-        public void DeleteStateTrieNodeRange(in TreePath fromPath, in TreePath toPath)
+        public void DeleteStateTrieNodeRange(in ValueHash256 from, in ValueHash256 to)
         {
             // State trie nodes are stored across 3 columns based on path length:
             // - StateNodesTop: path length 0-5 (3 byte keys)
             // - StateNodes: path length 6-15 (8 byte keys)
             // - FallbackNodes: path length 16+ (34 byte keys with 0x00 prefix)
+            // Each column is scanned over the [from, to] value range and a node is removed only when its whole
+            // subtree [ToLowerBoundPath, ToUpperBoundPath] is contained in [from, to] (see IsFullyContained).
 
             Span<byte> firstKeyBuf = stackalloc byte[FullStateNodesKeyLength];
             Span<byte> lastKeyBuf = stackalloc byte[FullStateNodesKeyLength + 1];
 
-            // Delete from StateNodesTop (path length 0-5)
-            // Truncate toPath to max length for this column to ensure all keys in range are included
-            EncodeStateTopNodeKey(firstKeyBuf[..StateNodesTopPathLength], fromPath);
-            EncodeStateTopNodeKey(lastKeyBuf[..StateNodesTopPathLength], toPath.Truncate(StateNodesTopThreshold));
+            EncodeStateTopNodeKey(firstKeyBuf[..StateNodesTopPathLength], new TreePath(from, 0));
+            EncodeStateTopNodeKey(lastKeyBuf[..StateNodesTopPathLength], new TreePath(to, StateNodesTopThreshold));
             lastKeyBuf[StateNodesTopPathLength] = 0;
-            BasePersistence.DeleteMatchingKeys(stateTopNodesSnap, stateTopNodes,
+            DeleteContainedKeys(stateTopNodesSnap, stateTopNodes,
                 firstKeyBuf[..StateNodesTopPathLength], lastKeyBuf[..(StateNodesTopPathLength + 1)],
-                StateNodesTopPathLength);
+                StateNodesTopPathLength, pathOffset: 0, pathBytes: StateNodesTopPathLength, packedLength: true, from, to);
 
-            // Delete from StateNodes (path length 6-15)
-            // Truncate toPath to max length for this column to ensure all keys in range are included
-            EncodeShortenedStateNodeKey(firstKeyBuf[..ShortenedPathLength], fromPath);
-            EncodeShortenedStateNodeKey(lastKeyBuf[..ShortenedPathLength], toPath.Truncate(ShortenedPathThreshold));
+            EncodeShortenedStateNodeKey(firstKeyBuf[..ShortenedPathLength], new TreePath(from, 0));
+            EncodeShortenedStateNodeKey(lastKeyBuf[..ShortenedPathLength], new TreePath(to, ShortenedPathThreshold));
             lastKeyBuf[ShortenedPathLength] = 0;
-            BasePersistence.DeleteMatchingKeys(stateNodesSnap, stateNodes,
+            DeleteContainedKeys(stateNodesSnap, stateNodes,
                 firstKeyBuf[..ShortenedPathLength], lastKeyBuf[..(ShortenedPathLength + 1)],
-                ShortenedPathLength);
+                ShortenedPathLength, pathOffset: 0, pathBytes: ShortenedPathLength, packedLength: true, from, to);
 
-            // Delete from FallbackNodes (path length 16+, prefix 0x00)
-            EncodeFullStateNodeKey(firstKeyBuf, fromPath);
-            firstKeyBuf[1 + FullPathLength] = 0;
-            EncodeFullStateNodeKey(lastKeyBuf[..FullStateNodesKeyLength], toPath);
+            EncodeFullStateNodeKey(firstKeyBuf, new TreePath(from, 0));
+            EncodeFullStateNodeKey(lastKeyBuf[..FullStateNodesKeyLength], new TreePath(to, 2 * FullPathLength));
             lastKeyBuf[FullStateNodesKeyLength] = 0;
-            BasePersistence.DeleteMatchingKeys(fallbackNodesSnap, fallbackNodes,
-                firstKeyBuf, lastKeyBuf[..(FullStateNodesKeyLength + 1)], FullStateNodesKeyLength);
+            DeleteContainedKeys(fallbackNodesSnap, fallbackNodes,
+                firstKeyBuf, lastKeyBuf[..(FullStateNodesKeyLength + 1)],
+                FullStateNodesKeyLength, pathOffset: 1, pathBytes: FullPathLength, packedLength: false, from, to);
         }
 
+        /// <inheritdoc cref="IPersistence.IWriteBatch.DeleteStorageTrieNodeRange"/>
         [SkipLocalsInit]
-        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in TreePath fromPath, in TreePath toPath)
+        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in ValueHash256 from, in ValueHash256 to)
         {
             // Storage trie nodes are stored across 2 columns based on path length:
             // - StorageNodes: path length 0-15 (28 byte keys)
             // - FallbackNodes: path length 16+ (54 byte keys with 0x01 prefix)
-
             Hash256 address = new(addressHash);
             ReadOnlySpan<byte> addressSuffix = addressHash.Bytes[StoragePrefixPortion..StorageHashPrefixLength];
 
             Span<byte> firstKeyBuf = stackalloc byte[FullStorageNodesKeyLength];
             Span<byte> lastKeyBuf = stackalloc byte[FullStorageNodesKeyLength + 1];
 
-            // Delete from StorageNodes (path length 0-15)
-            // Truncate toPath to max length for this column to ensure all keys in range are included
-            EncodeShortenedStorageNodeKey(firstKeyBuf[..ShortenedStorageNodesKeyLength], address, fromPath);
-            EncodeShortenedStorageNodeKey(lastKeyBuf[..ShortenedStorageNodesKeyLength], address, toPath.Truncate(ShortenedPathThreshold));
+            EncodeShortenedStorageNodeKey(firstKeyBuf[..ShortenedStorageNodesKeyLength], address, new TreePath(from, 0));
+            EncodeShortenedStorageNodeKey(lastKeyBuf[..ShortenedStorageNodesKeyLength], address, new TreePath(to, ShortenedPathThreshold));
             lastKeyBuf[ShortenedStorageNodesKeyLength] = 0;
-            BasePersistence.DeleteMatchingKeys(storageNodesSnap, storageNodes,
+            DeleteContainedKeys(storageNodesSnap, storageNodes,
                 firstKeyBuf[..ShortenedStorageNodesKeyLength], lastKeyBuf[..(ShortenedStorageNodesKeyLength + 1)],
-                StoragePrefixPortion + ShortenedPathLength, addressSuffix);
+                ShortenedStorageNodesKeyLength, pathOffset: StoragePrefixPortion, pathBytes: ShortenedPathLength, packedLength: true,
+                from, to, suffixOffset: StoragePrefixPortion + ShortenedPathLength, addressSuffix);
 
-            // Delete from FallbackNodes (path length 16+, prefix 0x01)
-            EncodeFullStorageNodeKey(firstKeyBuf, address, fromPath);
-            firstKeyBuf[1 + StoragePrefixPortion + FullPathLength] = 0;
-            EncodeFullStorageNodeKey(lastKeyBuf[..FullStorageNodesKeyLength], address, toPath);
+            EncodeFullStorageNodeKey(firstKeyBuf, address, new TreePath(from, 0));
+            EncodeFullStorageNodeKey(lastKeyBuf[..FullStorageNodesKeyLength], address, new TreePath(to, 2 * FullPathLength));
             lastKeyBuf[FullStorageNodesKeyLength] = 0;
-            BasePersistence.DeleteMatchingKeys(fallbackNodesSnap, fallbackNodes,
+            DeleteContainedKeys(fallbackNodesSnap, fallbackNodes,
                 firstKeyBuf, lastKeyBuf[..(FullStorageNodesKeyLength + 1)],
-                1 + StoragePrefixPortion + FullPathLength + PathLengthLength, addressSuffix);
+                FullStorageNodesKeyLength, pathOffset: 1 + StoragePrefixPortion, pathBytes: FullPathLength, packedLength: false,
+                from, to, suffixOffset: 1 + StoragePrefixPortion + FullPathLength + PathLengthLength, addressSuffix);
         }
+    }
+
+    /// <summary>
+    /// Scans <c>[firstKey, lastKey)</c> and removes every key whose node is entirely contained in <c>[from, to]</c>.
+    /// The node's path value and length are decoded from the key (<paramref name="pathOffset"/>/<paramref name="pathBytes"/>,
+    /// with the length packed in the low nibble of the last path byte when <paramref name="packedLength"/>, else the byte
+    /// after the path); for storage columns an optional <paramref name="addressSuffix"/> must match at
+    /// <paramref name="suffixOffset"/>.
+    /// </summary>
+    [SkipLocalsInit]
+    private static void DeleteContainedKeys(
+        ISortedKeyValueStore snap, IWriteBatch batch,
+        scoped ReadOnlySpan<byte> firstKey, scoped ReadOnlySpan<byte> lastKey,
+        int keyLength, int pathOffset, int pathBytes, bool packedLength,
+        in ValueHash256 from, in ValueHash256 to,
+        int suffixOffset = -1, scoped ReadOnlySpan<byte> addressSuffix = default)
+    {
+        using ISortedView view = snap.GetViewBetween(firstKey, lastKey);
+        Span<byte> value = stackalloc byte[FullPathLength];
+        while (view.MoveNext())
+        {
+            ReadOnlySpan<byte> key = view.CurrentKey;
+            if (key.Length != keyLength) continue;
+            if (suffixOffset >= 0 && !key[suffixOffset..].SequenceEqual(addressSuffix)) continue;
+
+            value.Clear();
+            key.Slice(pathOffset, pathBytes).CopyTo(value);
+            int length;
+            if (packedLength)
+            {
+                length = value[pathBytes - 1] & 0x0f;
+                value[pathBytes - 1] &= 0xf0; // the low nibble held the length, not path data
+            }
+            else
+            {
+                length = key[pathOffset + pathBytes];
+            }
+
+            if (IsFullyContained(value, length, from, to)) batch.Remove(key);
+        }
+    }
+
+    /// <summary>Whether the subtree of the node at (<paramref name="value"/>, <paramref name="length"/>) is within <c>[from, to]</c>.</summary>
+    private static bool IsFullyContained(scoped ReadOnlySpan<byte> value, int length, in ValueHash256 from, in ValueHash256 to)
+    {
+        TreePath path = new(new ValueHash256(value), length);
+        return from.CompareTo(path.ToLowerBoundPath()) <= 0 && path.ToUpperBoundPath().CompareTo(to) <= 0;
     }
 
     public readonly struct Reader(

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CachedReaderPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CachedReaderPersistence.cs
@@ -133,8 +133,8 @@ public class CachedReaderPersistence : IPersistence, IAsyncDisposable
         public void SetAccountRaw(in ValueHash256 addrHash, Account account) => inner.SetAccountRaw(addrHash, account);
         public void DeleteAccountRange(in ValueHash256 fromPath, in ValueHash256 toPath) => inner.DeleteAccountRange(fromPath, toPath);
         public void DeleteStorageRange(in ValueHash256 addressHash, in ValueHash256 fromPath, in ValueHash256 toPath) => inner.DeleteStorageRange(addressHash, fromPath, toPath);
-        public void DeleteStateTrieNodeRange(in TreePath fromPath, in TreePath toPath) => inner.DeleteStateTrieNodeRange(fromPath, toPath);
-        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in TreePath fromPath, in TreePath toPath) => inner.DeleteStorageTrieNodeRange(addressHash, fromPath, toPath);
+        public void DeleteStateTrieNodeRange(in ValueHash256 from, in ValueHash256 to) => inner.DeleteStateTrieNodeRange(from, to);
+        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in ValueHash256 from, in ValueHash256 to) => inner.DeleteStorageTrieNodeRange(addressHash, from, to);
 
         public void Dispose()
         {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
@@ -237,8 +237,8 @@ public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposa
 
         public void SetStateTrieNode(in TreePath path, scoped ReadOnlySpan<byte> rlp) => inner.SetStateTrieNode(path, rlp);
         public void SetStorageTrieNode(Hash256 address, in TreePath path, scoped ReadOnlySpan<byte> rlp) => inner.SetStorageTrieNode(address, path, rlp);
-        public void DeleteStateTrieNodeRange(in TreePath fromPath, in TreePath toPath) => inner.DeleteStateTrieNodeRange(fromPath, toPath);
-        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in TreePath fromPath, in TreePath toPath) => inner.DeleteStorageTrieNodeRange(addressHash, fromPath, toPath);
+        public void DeleteStateTrieNodeRange(in ValueHash256 from, in ValueHash256 to) => inner.DeleteStateTrieNodeRange(from, to);
+        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in ValueHash256 from, in ValueHash256 to) => inner.DeleteStorageTrieNodeRange(addressHash, from, to);
 
         public void Dispose()
         {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -64,8 +64,18 @@ public interface IPersistence
 
         void DeleteAccountRange(in ValueHash256 fromPath, in ValueHash256 toPath);
         void DeleteStorageRange(in ValueHash256 addressHash, in ValueHash256 fromPath, in ValueHash256 toPath);
-        void DeleteStateTrieNodeRange(in TreePath fromPath, in TreePath toPath);
-        void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in TreePath fromPath, in TreePath toPath);
+
+        /// <summary>
+        /// Deletes every state trie node whose node and subtree are entirely contained within the value range
+        /// <c>[<paramref name="from"/>, <paramref name="to"/>]</c> — i.e. every node at path P for which
+        /// <c><paramref name="from"/> &lt;= P.ToLowerBoundPath()</c> and <c>P.ToUpperBoundPath() &lt;= <paramref name="to"/></c>.
+        /// A node whose subtree only partially overlaps the range (an ancestor of the range) is left intact.
+        /// </summary>
+        void DeleteStateTrieNodeRange(in ValueHash256 from, in ValueHash256 to);
+
+        /// <inheritdoc cref="DeleteStateTrieNodeRange"/>
+        /// <remarks>Restricted to the storage trie of the account identified by <paramref name="addressHash"/>.</remarks>
+        void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in ValueHash256 from, in ValueHash256 to);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRecordingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRecordingPersistence.cs
@@ -116,10 +116,10 @@ public class PreimageRecordingPersistence(IPersistence inner, IDb preimageDb) : 
         public void DeleteStorageRange(in ValueHash256 addressHash, in ValueHash256 fromPath, in ValueHash256 toPath) =>
             inner.DeleteStorageRange(addressHash, fromPath, toPath);
 
-        public void DeleteStateTrieNodeRange(in TreePath fromPath, in TreePath toPath) =>
-            inner.DeleteStateTrieNodeRange(fromPath, toPath);
+        public void DeleteStateTrieNodeRange(in ValueHash256 from, in ValueHash256 to) =>
+            inner.DeleteStateTrieNodeRange(from, to);
 
-        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in TreePath fromPath, in TreePath toPath) =>
-            inner.DeleteStorageTrieNodeRange(addressHash, fromPath, toPath);
+        public void DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in ValueHash256 from, in ValueHash256 to) =>
+            inner.DeleteStorageTrieNodeRange(addressHash, from, to);
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/FlatTreeSyncStore.cs
@@ -83,7 +83,7 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
         foreach (DeletionRange range in ranges.AsSpan())
         {
             writeBatch.DeleteAccountRange(range.From, range.To);
-            writeBatch.DeleteStateTrieNodeRange(new TreePath(range.From, 64), new TreePath(range.To, 64));
+            writeBatch.DeleteStateTrieNodeRange(range.From, range.To);
         }
     }
 
@@ -95,7 +95,7 @@ public class FlatTreeSyncStore(IPersistence persistence, IPersistenceManager per
         foreach (DeletionRange range in ranges.AsSpan())
         {
             writeBatch.DeleteStorageRange(addressHash, range.From, range.To);
-            writeBatch.DeleteStorageTrieNodeRange(addressHash, new TreePath(range.From, 64), new TreePath(range.To, 64));
+            writeBatch.DeleteStorageTrieNodeRange(addressHash, range.From, range.To);
         }
     }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/FlatLocalDbContext.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/FlatLocalDbContext.cs
@@ -83,7 +83,8 @@ public class FlatLocalDbContext(IPersistence persistence, ILogManager logManager
     {
         using IPersistence.IPersistenceReader reader = persistence.CreateReader();
         using IPersistence.IWriteBatch writeBatch = persistence.CreateWriteBatch(reader.CurrentState, reader.CurrentState);
-        writeBatch.DeleteStateTrieNodeRange(TreePath.Empty, TreePath.Empty);
+        // The whole state trie is under the empty-path root, so [Zero, MaxValue] removes every node (heal re-fetches).
+        writeBatch.DeleteStateTrieNodeRange(ValueKeccak.Zero, ValueKeccak.MaxValue);
     }
 
     /// <summary>


### PR DESCRIPTION
## Changes

Follow-up to #12238. That PR fixed an under-deletion but its fix (force the fallback lower-bound length byte to `0`) **over**-deletes: it removes ancestor nodes that share the range's lower-bound value.

Root cause: `DeleteState/StorageTrieNodeRange` took `TreePath` bounds, and the only caller (`FlatTreeSyncStore`) always wrapped the range as `new TreePath(range.From, 64)` / `…, 64)`. The real subtree-root depth was never conveyed — only a fabricated `64` — so no length floor can be both correct at the boundary and safe (`64` under-deletes, `0` over-deletes).

- **Signature → `ValueHash256`**: `DeleteStateTrieNodeRange(in ValueHash256 from, in ValueHash256 to)` and `DeleteStorageTrieNodeRange(in ValueHash256 addressHash, in ValueHash256 from, in ValueHash256 to)`. The caller passes `range.From` / `range.To` directly.
- **Interface contract**: delete a node **iff its whole subtree `[P.ToLowerBoundPath(), P.ToUpperBoundPath()]` is contained in `[from, to]`.** A node whose subtree only partially overlaps the range (an ancestor of the range) is left intact.
- **Implementation**: each column is scanned over the `[from, to]` value range; for every key the node's `(value, length)` is decoded and the node is removed only when `from ≤ lower && upper ≤ to`. No depth is needed — a straddling ancestor's `upper` overflows `to`, so it's naturally preserved.

This also makes the caller trivial and drops the `TreePath` fabrication, and the extension "gap" ranges are handled directly (a contained node in the gap is deleted; the gap needs no subtree decomposition).

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

Requires testing: **Yes** — did you write tests: **Yes**.

- `PersistenceScenario` delete tests rewritten as parameterized containment cases (state + storage, all three flat layouts): shallow subtree, **deep subtree with zero-tail ancestors preserved** (the #12238 over-deletion regression), shortened-depth subtree, and whole-trie.
- `DeletionRangeCalculationTests` is unchanged — `ComputeDeletionRanges` (the `From`/`To` values) is untouched.
- `Nethermind.State.Flat.Test` (561 tests) and `Nethermind.Synchronization.Test` `StateSyncFeedTests` (836) build clean (0 warnings) and pass locally.

## Documentation

Requires documentation update: No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
