### PR TITLE
refactor(di): wire wallet, engine signer and keystore through DI

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithStores.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithStores.cs
@@ -4,8 +4,6 @@
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus;
-using Nethermind.Core;
-using Nethermind.Crypto;
 using Nethermind.TxPool;
 using Nethermind.Wallet;
 
@@ -15,11 +13,8 @@ namespace Nethermind.Api
     {
         IBlobTxStorage BlobTxStorage { get; }
         IBlockTree BlockTree { get; }
-        ISigner? EngineSigner { get; set; }
-        ISignerStore? EngineSignerStore { get; set; }
-        [SkipServiceCollection]
-        IProtectedPrivateKey? NodeKey { get; set; }
+        ISigner EngineSigner { get; }
         IReceiptFinder ReceiptFinder { get; }
-        IWallet? Wallet { get; set; }
+        IWallet Wallet { get; }
     }
 }

--- a/src/Nethermind/Nethermind.Api/IBasicApi.cs
+++ b/src/Nethermind/Nethermind.Api/IBasicApi.cs
@@ -11,7 +11,6 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Db;
-using Nethermind.KeyStore;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
 using Nethermind.Specs.ChainSpecStyle;
@@ -32,11 +31,8 @@ namespace Nethermind.Api
         [SkipServiceCollection]
         EthereumJsonSerializer EthereumJsonSerializer { get; }
         IFileSystem FileSystem { get; }
-        IKeyStore? KeyStore { get; set; }
         [SkipServiceCollection]
         ILogManager LogManager { get; }
-        [SkipServiceCollection]
-        IProtectedPrivateKey? OriginalSignerKey { get; set; }
         IReadOnlyList<INethermindPlugin> Plugins { get; }
         [SkipServiceCollection]
         string SealEngineType { get; }

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -20,7 +20,6 @@ using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.JsonRpc.Modules;
-using Nethermind.KeyStore;
 using Nethermind.Logging;
 using Nethermind.Network;
 using Nethermind.Serialization.Json;
@@ -56,8 +55,7 @@ namespace Nethermind.Api
         public IBlockTree BlockTree => Context.Resolve<IBlockTree>();
         public IConfigProvider ConfigProvider => _dependencies.ConfigProvider;
         public IDbProvider DbProvider => Context.Resolve<IDbProvider>();
-        public ISigner? EngineSigner { get; set; }
-        public ISignerStore? EngineSignerStore { get; set; }
+        public ISigner EngineSigner => Context.Resolve<ISigner>();
         public IEthereumEcdsa EthereumEcdsa => Context.Resolve<IEthereumEcdsa>();
         public IFileSystem FileSystem => Context.Resolve<IFileSystem>();
         public IEngineRequestsTracker EngineRequestsTracker => Context.Resolve<IEngineRequestsTracker>();
@@ -67,7 +65,6 @@ namespace Nethermind.Api
 
         public IIPResolver IpResolver => Context.Resolve<IIPResolver>();
         public EthereumJsonSerializer EthereumJsonSerializer => _dependencies.JsonSerializer;
-        public IKeyStore? KeyStore { get; set; }
         public ILogManager LogManager => _dependencies.LogManager;
         public IGossipPolicy GossipPolicy { get; set; } = Policy.FullGossip;
         public IProtocolsManager? ProtocolsManager => Context.Resolve<IProtocolsManager>();
@@ -90,15 +87,8 @@ namespace Nethermind.Api
 
         public IBackgroundTaskScheduler BackgroundTaskScheduler => Context.Resolve<IBackgroundTaskScheduler>();
         public ICensorshipDetector CensorshipDetector { get; set; } = new NoopCensorshipDetector();
-        public IWallet? Wallet { get; set; }
+        public IWallet Wallet => Context.Resolve<IWallet>();
         public ITransactionComparerProvider? TransactionComparerProvider { get; set; }
-
-        public IProtectedPrivateKey? NodeKey { get; set; }
-
-        /// <summary>
-        /// Key used for signing blocks. Original as its loaded on startup. This can later be changed via RPC in <see cref="Signer"/>.
-        /// </summary>
-        public IProtectedPrivateKey? OriginalSignerKey { get; set; }
 
         public ChainSpec ChainSpec => _dependencies.ChainSpec;
         public IDisposableStack DisposeStack => Context.Resolve<IDisposableStack>();

--- a/src/Nethermind/Nethermind.ExternalSigner.Plugin/ClefSignerModule.cs
+++ b/src/Nethermind/Nethermind.ExternalSigner.Plugin/ClefSignerModule.cs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Configuration;
+using Autofac;
+using Nethermind.Consensus;
+using Nethermind.Core;
+using Nethermind.JsonRpc.Client;
+using Nethermind.KeyStore.Config;
+using Nethermind.Logging;
+using Nethermind.Network;
+using Nethermind.Serialization.Json;
+using Nethermind.Wallet;
+
+namespace Nethermind.ExternalSigner.Plugin;
+
+/// <summary>
+/// Registers the remote Clef signer as the node's <see cref="IWallet"/> and, when mining, its block-author
+/// <see cref="ISigner"/>/<see cref="ISignerStore"/>, overriding the local defaults.
+/// </summary>
+/// <remarks>
+/// Only loaded when <c>Mining.Signer</c> is set (the plugin is otherwise disabled), so the wallet registration is
+/// unconditional here. The signer is registered only when mining is enabled, matching the previous behaviour where an
+/// external <c>EngineSigner</c> was wired up solely for block production.
+/// </remarks>
+public class ClefSignerModule(IMiningConfig miningConfig) : Module
+{
+    private const int RemoteSignerTimeoutSeconds = 10;
+
+    protected override void Load(ContainerBuilder builder)
+    {
+        base.Load(builder);
+
+        if (!Uri.TryCreate(miningConfig.Signer, UriKind.Absolute, out Uri? uri))
+        {
+            throw new ConfigurationErrorsException($"{miningConfig.Signer} must be a valid uri.");
+        }
+
+        builder
+            .AddSingleton<BasicJsonRpcClient, ILogManager>(logManager => CreateRpcClient(uri, logManager))
+            .AddSingleton<ClefWallet, BasicJsonRpcClient>(rpcClient => new ClefWallet(rpcClient))
+            .Bind<IWallet, ClefWallet>();
+
+        if (miningConfig.Enabled)
+        {
+            builder
+                .AddSingleton<ISigner, ClefWallet, IKeyStoreConfig>(CreateSigner)
+                .AddSingleton<ISignerStore>(static ctx => (ISignerStore)ctx.Resolve<ISigner>());
+        }
+    }
+
+    private static BasicJsonRpcClient CreateRpcClient(Uri uri, ILogManager logManager) =>
+        new(uri, new EthereumJsonSerializer([new ChecksumAddressConverter()]), logManager, TimeSpan.FromSeconds(RemoteSignerTimeoutSeconds));
+
+    private static ISigner CreateSigner(ClefWallet clefWallet, IKeyStoreConfig keyStoreConfig)
+    {
+        try
+        {
+            Address? blockAuthorAccount = string.IsNullOrEmpty(keyStoreConfig.BlockAuthorAccount) ? null : new Address(keyStoreConfig.BlockAuthorAccount);
+            return ClefSigner.Create(clefWallet, blockAuthorAccount);
+        }
+        catch (HttpRequestException e)
+        {
+            throw new NetworkingException("Remote signer did not respond during setup.", NetworkExceptionType.TargetUnreachable, e);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.ExternalSigner.Plugin/ClefSignerPlugin.cs
+++ b/src/Nethermind/Nethermind.ExternalSigner.Plugin/ClefSignerPlugin.cs
@@ -1,69 +1,21 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Api;
+using Autofac.Core;
 using Nethermind.Api.Extensions;
-using Nethermind.Core;
-using Nethermind.JsonRpc.Client;
-using Nethermind.Network;
 using Nethermind.Consensus;
-using Nethermind.KeyStore.Config;
-using System.Configuration;
-using Nethermind.Serialization.Json;
 
 namespace Nethermind.ExternalSigner.Plugin;
 
 public class ClefSignerPlugin(IMiningConfig miningConfig) : INethermindPlugin
 {
-    private INethermindApi? _nethermindApi;
-
     public string Name => "Clef signer";
 
     public string Description => "Enabled signing from a remote Clef instance over Json RPC.";
 
     public string Author => "Nethermind";
 
-    public bool MustInitialize => true;
     public bool Enabled => !string.IsNullOrEmpty(miningConfig.Signer);
 
-    public Task Init(INethermindApi nethermindApi)
-    {
-        _nethermindApi = nethermindApi ?? throw new ArgumentNullException(nameof(nethermindApi));
-        if (!string.IsNullOrEmpty(miningConfig.Signer))
-        {
-            if (!Uri.TryCreate(miningConfig.Signer, UriKind.Absolute, out Uri? uri))
-            {
-                throw new ConfigurationErrorsException($"{miningConfig.Signer} must be a valid uri.");
-            }
-
-            string blockAuthorAccount = _nethermindApi.Config<IKeyStoreConfig>().BlockAuthorAccount;
-
-            IJsonSerializer ethereumJsonSerializer = new EthereumJsonSerializer(new[] { new ChecksumAddressConverter() });
-
-            BasicJsonRpcClient rpcClient = new(uri, ethereumJsonSerializer, _nethermindApi.LogManager, TimeSpan.FromSeconds(10));
-            _nethermindApi.DisposeStack.Push(rpcClient);
-
-            ClefWallet clefWallet = new(rpcClient);
-            _nethermindApi.Wallet = clefWallet;
-
-            if (miningConfig.Enabled)
-                _nethermindApi.EngineSigner = SetupExternalSigner(clefWallet, blockAuthorAccount);
-
-        }
-        return Task.CompletedTask;
-    }
-
-    private ClefSigner SetupExternalSigner(ClefWallet clefWallet, string blockAuthorAccount)
-    {
-        try
-        {
-            Address? address = string.IsNullOrEmpty(blockAuthorAccount) ? null : new Address(blockAuthorAccount);
-
-            return ClefSigner.Create(clefWallet, address);
-        }
-        catch (HttpRequestException e)
-        {
-            throw new NetworkingException($"Remote signer did not respond during setup.", NetworkExceptionType.TargetUnreachable, e);
-        }
-    }
+    public IModule Module => new ClefSignerModule(miningConfig);
 }

--- a/src/Nethermind/Nethermind.Init/Modules/KeyStoreModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/KeyStoreModule.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Api;
+using Nethermind.Consensus;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Crypto;
+using Nethermind.KeyStore;
+using Nethermind.KeyStore.Config;
+using Nethermind.Logging;
+using Nethermind.Wallet;
+
+namespace Nethermind.Init.Modules;
+
+/// <summary>
+/// Registers the file-backed <see cref="IKeyStore"/>, the local <see cref="IWallet"/>, and the default block-author
+/// <see cref="ISigner"/>/<see cref="ISignerStore"/>.
+/// </summary>
+public class KeyStoreModule : Module
+{
+    protected override void Load(ContainerBuilder builder)
+    {
+        base.Load(builder);
+
+        builder
+            .AddSingleton<ISymmetricEncrypter, AesEncrypter>()
+            .AddSingleton<IKeyStoreIOSettingsProvider, PrivateKeyStoreIOSettingsProvider>()
+            .AddSingleton<IKeyStore, FileKeyStore>()
+            .AddKeyedSingleton<IPasswordProvider>(IPasswordProvider.ConfigOnly, static ctx => new KeyStorePasswordProvider(ctx.Resolve<IKeyStoreConfig>()))
+            .AddKeyedSingleton<IPasswordProvider>(IPasswordProvider.ConsoleFallback, static ctx =>
+            {
+                IKeyStoreConfig keyStoreConfig = ctx.Resolve<IKeyStoreConfig>();
+                return new KeyStorePasswordProvider(keyStoreConfig)
+                    .OrReadFromConsole($"Provide password for validator account {keyStoreConfig.BlockAuthorAccount}");
+            })
+            .AddSingleton<IWallet>(CreateWallet)
+            .AddSingleton<AccountUnlocker>()
+            .AddSingleton<INodeKeyManager, NodeKeyManager>()
+            .AddSingleton<ISigner>(CreateSigner)
+            .AddSingleton<ISignerStore>(static ctx => (ISignerStore)ctx.Resolve<ISigner>());
+    }
+
+    private static IWallet CreateWallet(IComponentContext ctx)
+    {
+        ILogManager logManager = ctx.Resolve<ILogManager>();
+        return ctx.Resolve<IInitConfig>() switch
+        {
+            { EnableUnsecuredDevWallet: true, KeepDevWalletInMemory: true } => new DevWallet(ctx.Resolve<IWalletConfig>(), logManager),
+            { EnableUnsecuredDevWallet: true, KeepDevWalletInMemory: false } => new DevKeyStoreWallet(ctx.Resolve<IKeyStore>(), logManager),
+            _ => CreateProtectedKeyStoreWallet(ctx, logManager),
+        };
+    }
+
+    private static IWallet CreateProtectedKeyStoreWallet(IComponentContext ctx, ILogManager logManager)
+    {
+        IKeyStoreConfig keyStoreConfig = ctx.Resolve<IKeyStoreConfig>();
+        ITimestamper timestamper = ctx.Resolve<ITimestamper>();
+        ProtectedPrivateKeyFactory keyFactory = new(ctx.Resolve<ICryptoRandom>(), timestamper, keyStoreConfig.KeyStoreDirectory);
+        return new ProtectedKeyStoreWallet(ctx.Resolve<IKeyStore>(), keyFactory, timestamper, logManager);
+    }
+
+    private static ISigner CreateSigner(IComponentContext ctx)
+    {
+        if (!ctx.Resolve<IMiningConfig>().Enabled) return NullSigner.Instance;
+
+        return new Signer(
+            ctx.Resolve<ISpecProvider>().ChainId,
+            ctx.Resolve<INodeKeyManager>().LoadSignerKey(),
+            ctx.Resolve<ILogManager>());
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/NethermindModule.cs
@@ -25,6 +25,7 @@ using Nethermind.Network.Config;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.State;
 using Nethermind.TxPool;
+using Nethermind.Wallet;
 using Testably.Abstractions;
 
 namespace Nethermind.Init.Modules;
@@ -63,10 +64,11 @@ public class NethermindModule(ChainSpec chainSpec, IConfigProvider configProvide
             .AddSource(new ConfigRegistrationSource())
             .AddModule(new BlockProcessingModule(configProvider.GetConfig<IInitConfig>(), configProvider.GetConfig<IBlocksConfig>()))
             .AddModule(new BlockTreeModule(configProvider.GetConfig<IReceiptConfig>(), configProvider.GetConfig<ILogIndexConfig>()))
+            .AddModule(new KeyStoreModule())
             .AddModule(new MonitoringModule(configProvider.GetConfig<IMetricsConfig>()))
             .AddSingleton<ISpecProvider, ChainSpecBasedSpecProvider>()
 
-            .AddKeyedSingleton<IProtectedPrivateKey>(IProtectedPrivateKey.NodeKey, (ctx) => ctx.Resolve<INethermindApi>().NodeKey!)
+            .AddKeyedSingleton<IProtectedPrivateKey>(IProtectedPrivateKey.NodeKey, (ctx) => ctx.Resolve<INodeKeyManager>().LoadNodeKey())
             .AddSingleton<IAbiEncoder>(AbiEncoder.Instance)
             .AddSingleton<IEciesCipher, EciesCipher>()
             .AddSingleton<ICryptoRandom, CryptoRandom>()

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockTree.cs
@@ -6,42 +6,23 @@ using System.Threading.Tasks;
 using Nethermind.Api;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain;
-using Nethermind.Consensus;
+using Nethermind.Config;
+using Nethermind.Logging;
 
 namespace Nethermind.Init.Steps
 {
     [RunnerStepDependencies(typeof(InitTxTypesAndRlp), typeof(SetupKeyStore))]
-    public class InitializeBlockTree : IStep
+    public class InitializeBlockTree(
+        IInitConfig initConfig,
+        IBlockTree blockTree,
+        IProcessExitSource processExitSource,
+        ILogManager logManager) : IStep
     {
-        private readonly IBasicApi _get;
-        private readonly IApiWithStores _set;
-        private readonly INethermindApi _api;
-
-        public InitializeBlockTree(INethermindApi api)
-        {
-            (_get, _set) = api.ForInit;
-            _api = api;
-        }
-
         public Task Execute(CancellationToken cancellationToken)
         {
-            IInitConfig initConfig = _get.Config<IInitConfig>();
-
-            ISigner signer = NullSigner.Instance;
-            ISignerStore signerStore = NullSigner.Instance;
-            if (_get.Config<IMiningConfig>().Enabled)
-            {
-                Signer signerAndStore = new(_get.SpecProvider!.ChainId, _get.OriginalSignerKey!, _get.LogManager);
-                signer = signerAndStore;
-                signerStore = signerAndStore;
-            }
-
-            _set.EngineSigner = signer;
-            _set.EngineSignerStore = signerStore;
-
             if (initConfig.ExitOnBlockNumber is not null)
             {
-                new ExitOnBlockNumberHandler(_api.BlockTree, _get.ProcessExit!, initConfig.ExitOnBlockNumber.Value, _get.LogManager);
+                new ExitOnBlockNumberHandler(blockTree, processExitSource, initConfig.ExitOnBlockNumber.Value, logManager);
             }
 
             return Task.CompletedTask;

--- a/src/Nethermind/Nethermind.Init/Steps/SetupKeyStore.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/SetupKeyStore.cs
@@ -1,65 +1,28 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Nethermind.Api;
+using Autofac.Features.AttributeFilters;
 using Nethermind.Api.Steps;
-using Nethermind.Consensus;
 using Nethermind.Crypto;
-using Nethermind.KeyStore;
-using Nethermind.KeyStore.Config;
 using Nethermind.Network.Config;
 using Nethermind.Wallet;
-using System.Linq;
 
 namespace Nethermind.Init.Steps
 {
     [RunnerStepDependencies]
-    public class SetupKeyStore(INethermindApi api, ICryptoRandom cryptoRandom) : IStep
+    public class SetupKeyStore(
+        INetworkConfig networkConfig,
+        AccountUnlocker accountUnlocker,
+        [KeyFilter(IProtectedPrivateKey.NodeKey)] IProtectedPrivateKey nodeKey) : IStep
     {
         public Task Execute(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            (IApiWithStores get, IApiWithBlockchain set) = api.ForInit;
-
-            IKeyStoreConfig keyStoreConfig = get.Config<IKeyStoreConfig>();
-            INetworkConfig networkConfig = get.Config<INetworkConfig>();
-
-            AesEncrypter encrypter = new(keyStoreConfig, get.LogManager);
-
-            IKeyStore? keyStore = set.KeyStore = new FileKeyStore(
-                keyStoreConfig,
-                get.EthereumJsonSerializer,
-                encrypter,
-                cryptoRandom,
-                get.LogManager,
-                new PrivateKeyStoreIOSettingsProvider(keyStoreConfig));
-
-            set.Wallet = get.Config<IInitConfig>() switch
-            {
-                { EnableUnsecuredDevWallet: true, KeepDevWalletInMemory: true } => new DevWallet(get.Config<IWalletConfig>(), get.LogManager),
-                { EnableUnsecuredDevWallet: true, KeepDevWalletInMemory: false } => new DevKeyStoreWallet(get.KeyStore, get.LogManager),
-                _ => new ProtectedKeyStoreWallet(keyStore, new ProtectedPrivateKeyFactory(cryptoRandom, get.Timestamper, keyStoreConfig.KeyStoreDirectory),
-                    get.Timestamper, get.LogManager),
-            };
-
-            new AccountUnlocker(keyStoreConfig, get.Wallet, get.LogManager, new KeyStorePasswordProvider(keyStoreConfig))
-                .UnlockAccounts();
-
-            BasePasswordProvider passwordProvider = new KeyStorePasswordProvider(keyStoreConfig)
-                .OrReadFromConsole($"Provide password for validator account {keyStoreConfig.BlockAuthorAccount}");
-
-            INodeKeyManager nodeKeyManager = new NodeKeyManager(cryptoRandom, get.KeyStore, keyStoreConfig, get.LogManager, passwordProvider, get.FileSystem);
-            IProtectedPrivateKey? nodeKey = set.NodeKey = nodeKeyManager.LoadNodeKey();
-
-            IMiningConfig miningConfig = get.Config<IMiningConfig>();
-            //Don't load the local key if an external signer is configured
-            if (string.IsNullOrEmpty(miningConfig.Signer))
-            {
-                set.OriginalSignerKey = nodeKeyManager.LoadSignerKey();
-            }
+            accountUnlocker.UnlockAccounts();
 
             networkConfig.Bootnodes = [.. networkConfig.Bootnodes.Where(bn => bn.NodeId != nodeKey.PublicKey)];
 

--- a/src/Nethermind/Nethermind.KeyStore/IPasswordProvider.cs
+++ b/src/Nethermind/Nethermind.KeyStore/IPasswordProvider.cs
@@ -8,6 +8,12 @@ namespace Nethermind.KeyStore
 {
     public interface IPasswordProvider
     {
+        /// <summary>Key for the keyed registration that resolves passwords from config only (no interactive fallback).</summary>
+        public const string ConfigOnly = "ConfigOnlyPasswordProvider";
+
+        /// <summary>Key for the keyed registration that falls back to a console prompt when the password is not in config.</summary>
+        public const string ConsoleFallback = "ConsoleFallbackPasswordProvider";
+
         SecureString GetPassword(Address address);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -173,11 +173,7 @@ public class AuRaMergeEngineModuleTests(bool parallel) : EngineModuleTests(paral
                 // as normally, test blockchain don't use INethermindApi at all.
                 .AddModule(new AuRaModule(ChainSpec))
 
-                .AddDecorator<AuRaNethermindApi>((_, api) =>
-                {
-                    api.EngineSigner = NullSigner.Instance;
-                    return api;
-                })
+                .AddSingleton<ISigner>(NullSigner.Instance)
                 .AddModule(new AuRaMergeModule())
                 .AddSingleton<NethermindApi.Dependencies>()
                 .AddSingleton<IReportingValidator>(NullReportingValidator.Instance)

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Build.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Build.cs
@@ -16,11 +16,9 @@ using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
-using Nethermind.KeyStore;
 using Nethermind.Serialization.Json;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.TxPool;
-using Nethermind.Wallet;
 using Nethermind.Specs;
 using NSubstitute;
 using Nethermind.Core;
@@ -88,12 +86,8 @@ namespace Nethermind.Runner.Test.Ethereum
         public static void MockOutNethermindApi(NethermindApi api)
         {
             api.TxPool = Substitute.For<ITxPool>();
-            api.Wallet = Substitute.For<IWallet>();
             api.BlockProducer = Substitute.For<IBlockProducer>();
-            api.EngineSigner = Substitute.For<ISigner>();
-            api.KeyStore = Substitute.For<IKeyStore>();
             api.TxSender = Substitute.For<ITxSender>();
-            api.EngineSignerStore = Substitute.For<ISignerStore>();
             api.TransactionComparerProvider = Substitute.For<ITransactionComparerProvider>();
         }
     }

--- a/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
@@ -207,7 +207,6 @@ public class EthereumRunnerTests
         api.Config<INetworkConfig>().ExternalIp = "127.0.0.1";
         _ = api.Config<IHealthChecksConfig>(); // Randomly fail type discovery if not resolved early.
 
-        api.NodeKey = new InsecureProtectedPrivateKey(TestItem.PrivateKeyA);
         api.BlockProducerRunner = Substitute.For<IBlockProducerRunner>();
 
         try
@@ -452,6 +451,8 @@ public class EthereumRunnerTests
                     // pass in runner test.
                     builder
                         .AddSingleton(Substitute.For<IReportingValidator>())
+                        // Pin a deterministic node key so resolving components does not load/generate a real key file.
+                        .AddKeyedSingleton<IProtectedPrivateKey>(IProtectedPrivateKey.NodeKey, new InsecureProtectedPrivateKey(TestItem.PrivateKeyA))
                         ;
                 }
 

--- a/src/Nethermind/Nethermind.Wallet/AccountUnlocker.cs
+++ b/src/Nethermind/Nethermind.Wallet/AccountUnlocker.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Autofac.Features.AttributeFilters;
 using Nethermind.Core;
 using Nethermind.Crypto;
 using Nethermind.KeyStore;
@@ -10,7 +11,7 @@ using Nethermind.Logging;
 
 namespace Nethermind.Wallet
 {
-    public class AccountUnlocker(IKeyStoreConfig config, IWallet wallet, ILogManager logManager, IPasswordProvider passwordProvider)
+    public class AccountUnlocker(IKeyStoreConfig config, IWallet wallet, ILogManager logManager, [KeyFilter(IPasswordProvider.ConfigOnly)] IPasswordProvider passwordProvider)
     {
         private readonly IKeyStoreConfig _config = config ?? throw new ArgumentNullException(nameof(config));
         private readonly IWallet _wallet = wallet ?? throw new ArgumentNullException(nameof(wallet));

--- a/src/Nethermind/Nethermind.Wallet/NodeKeyManager.cs
+++ b/src/Nethermind/Nethermind.Wallet/NodeKeyManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO.Abstractions;
 using System.Security;
+using Autofac.Features.AttributeFilters;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Extensions;
@@ -19,7 +20,7 @@ namespace Nethermind.Wallet
         IKeyStore keyStore,
         IKeyStoreConfig config,
         ILogManager logManager,
-        IPasswordProvider passwordProvider,
+        [KeyFilter(IPasswordProvider.ConsoleFallback)] IPasswordProvider passwordProvider,
         IFileSystem fileSystem) : INodeKeyManager
     {
         public const string UnsecuredNodeKeyFilePath = "node.key.plain";


### PR DESCRIPTION
## Changes

Moves the signer/wallet/keystore state off imperative `INethermindApi` property assignment and into container registration. The api properties that remain (`Wallet`, `EngineSigner`) become get-only, DI-backed forwarders (like `BlockTree`/`ReceiptFinder`); the ones with no remaining readers (`EngineSignerStore`, `KeyStore`, `OriginalSignerKey`, `NodeKey`) are removed entirely. Removing the setters also satisfies the `FallbackToFieldFromApi` guard, which throws when a service has both a container registration and a mutable api field.

- Add `KeyStoreModule` registering:
  - `IKeyStore` (`FileKeyStore` + `AesEncrypter` + `PrivateKeyStoreIOSettingsProvider`)
  - the config-based default `IWallet` (Dev / DevKeyStore / ProtectedKeyStore), ported from `SetupKeyStore`
  - the mining-based default `ISigner` (loads its key via `INodeKeyManager.LoadSignerKey()`); `ISignerStore` resolves the same instance
  - two keyed `IPasswordProvider`s — config-only (for `AccountUnlocker`) and console-fallback (for `NodeKeyManager`)
  - `AccountUnlocker` and `INodeKeyManager`, each keyed to its password provider via `[KeyFilter]`
- The keyed `NodeKey` registration now loads via `INodeKeyManager.LoadNodeKey()` instead of reading the api property.
- `SetupKeyStore` injects `AccountUnlocker`, the keyed node key (for bootnode filtering) and `INetworkConfig` directly — no more `INethermindApi` decomposition; `InitializeBlockTree` likewise takes its dependencies directly.
- `ClefSignerPlugin` drops its imperative `Init` in favour of an `IModule` (`ClefSignerModule`) that overrides the defaults via last-registration-wins — registering the remote wallet always and the Clef signer only when mining is enabled. That override is also what keeps the local signer key from loading when an external signer is configured.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Behaviour-preserving DI wiring, validated against the existing suites: `Runner.Test` (real-container DI graph, resolves every step + preloads RPC), `Wallet.Test`, `Network.Discovery.Test`, `JsonRpc.Test` (Parity), `Blockchain.Test` (`ClefSignerTests`), and `Merge.AuRa.Test`. Existing tests that set the removed api properties were updated to register via the container instead.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)