### PR TITLE
fix(init): make step init logs identify the actually-running step

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
@@ -127,8 +127,6 @@ namespace Nethermind.Init.Steps
 
                 await stepWrapper.WaitForDependencies(dependencies, cancellationToken);
 
-                // Log once the dependencies are satisfied, so it names the step that is actually executing rather
-                // than one still queued waiting on its dependencies.
                 if (_logger.IsDebug) _logger.Debug($"Executing step: {stepWrapper.StepInfo}");
 
                 await stepWrapper.RunStep(cancellationToken);

--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
@@ -129,21 +129,21 @@ namespace Nethermind.Init.Steps
                 }
                 await stepWrapper.StartExecute(dependencies, cancellationToken);
 
-                if (_logger.IsDebug) _logger.Debug($"Step {stepWrapper.GetType().Name,-24} executed in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
+                if (_logger.IsDebug) _logger.Debug($"Step {stepWrapper.StepInfo.StepType.Name,-24} executed in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
             }
             catch (Exception exception) when (exception is not TaskCanceledException)
             {
                 if (stepWrapper.Step.MustInitialize)
                 {
-                    if (_logger.IsError) _logger.Error($"Step {stepWrapper.GetType().Name,-24} failed after {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms", exception);
+                    if (_logger.IsError) _logger.Error($"Step {stepWrapper.StepInfo.StepType.Name,-24} failed after {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms", exception);
                     throw;
                 }
 
-                if (_logger.IsWarn) _logger.Warn($"Step {stepWrapper.GetType().Name,-24} failed after {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms {exception}");
+                if (_logger.IsWarn) _logger.Warn($"Step {stepWrapper.StepInfo.StepType.Name,-24} failed after {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms {exception}");
             }
             finally
             {
-                if (_logger.IsDebug) _logger.Debug($"{stepWrapper.GetType().Name,-24} complete");
+                if (_logger.IsDebug) _logger.Debug($"{stepWrapper.StepInfo.StepType.Name,-24} complete");
             }
         }
 

--- a/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs
@@ -107,10 +107,7 @@ namespace Nethermind.Init.Steps
             List<Task> allRequiredSteps = [];
             foreach (StepWrapper stepWrapper in stepInfoMap.Values)
             {
-                StepInfo stepInfo = stepWrapper.StepInfo;
-                Task task = ExecuteStep(stepWrapper, stepInfoMap, cancellationToken);
-                if (_logger.IsDebug) _logger.Debug($"Executing step: {stepInfo}");
-                allRequiredSteps.Add(task);
+                allRequiredSteps.Add(ExecuteStep(stepWrapper, stepInfoMap, cancellationToken));
             }
             return allRequiredSteps;
         }
@@ -127,7 +124,14 @@ namespace Nethermind.Init.Steps
                         throw new StepDependencyException($"The dependent step {type.Name} for {stepWrapper.StepInfo.StepBaseType.Name} was not created.");
                     dependencies.AddRange(value);
                 }
-                await stepWrapper.StartExecute(dependencies, cancellationToken);
+
+                await stepWrapper.WaitForDependencies(dependencies, cancellationToken);
+
+                // Log once the dependencies are satisfied, so it names the step that is actually executing rather
+                // than one still queued waiting on its dependencies.
+                if (_logger.IsDebug) _logger.Debug($"Executing step: {stepWrapper.StepInfo}");
+
+                await stepWrapper.RunStep(cancellationToken);
 
                 if (_logger.IsDebug) _logger.Debug($"Step {stepWrapper.StepInfo.StepType.Name,-24} executed in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
             }
@@ -271,11 +275,15 @@ namespace Nethermind.Init.Steps
 
             private readonly TaskCompletionSource _taskCompletedSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            public async Task StartExecute(IEnumerable<StepWrapper> dependentSteps, CancellationToken cancellationToken)
+            public async Task WaitForDependencies(IEnumerable<StepWrapper> dependentSteps, CancellationToken cancellationToken)
             {
                 cancellationToken.Register(() => _taskCompletedSource.TrySetCanceled());
 
                 await Task.WhenAll(dependentSteps.Select(s => s.StepTask));
+            }
+
+            public async Task RunStep(CancellationToken cancellationToken)
+            {
                 try
                 {
                     await Step.Execute(cancellationToken);


### PR DESCRIPTION
## Changes

Two fixes to the `EthereumStepsManager` init-step logging so it's actually usable for diagnosing startup:

1. **Name the real step in timing/failure logs.** `ExecuteStep` logged `stepWrapper.GetType().Name`, which is always the private wrapper type — so every line read `Step StepWrapper executed in Xms` and never told you which step ran. Now uses the wrapped step's concrete type (`StepInfo.StepType.Name`).

2. **Log `Executing step: X` when the step actually starts.** It was logged up front in `CreateAndExecuteSteps` at task-creation time — before the step's dependencies were awaited — so every step logged immediately at startup regardless of whether it was running or still queued behind its dependencies. Moved into `ExecuteStep` after the dependency wait completes, so it names the step that's genuinely executing (useful for spotting which step a stalled startup is stuck on). `StepWrapper.StartExecute` was split into `WaitForDependencies` + `RunStep`; the wait stays inside the `try` and the `TaskCompletionSource` semantics are unchanged.

All log lines are `Debug`/`Warn`/`Error` level (unchanged).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Logging-only change. Existing `EthereumStepsManagerTests` (dependency ordering, failure propagation, cancellation, ambiguous steps) pass, confirming the `WaitForDependencies`/`RunStep` split preserves behavior.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)