### PR TITLE
fix(sync): bound beacon header reconciliation to the beacon segment

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -3073,6 +3073,56 @@ public class BlockTreeTests
         Assert.That(tree.LowestInsertedBeaconHeader?.Number, Is.EqualTo(7UL));
     }
 
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void RecalculateTreeLevels_WhenBestSuggestedHeaderUnresolvableInPoS_StopsAtBeaconJunction()
+    {
+        // Post-merge repro of the O(n) startup walk (#12273): on a node whose best-suggested
+        // header sits ahead of the processed main-chain head, FindHeader(number, None) returns
+        // null (GetBlockHashOnMainOrBestDifficultyHash bails post-merge), so BestSuggestedHeader
+        // is null and the old stop bound collapsed to 1. The reconciliation must still stop at the
+        // beacon/non-beacon junction rather than walking every already-synced header to genesis.
+        CustomSpecProvider specProvider = new(((ForkActivation)0, London.Instance))
+        {
+            TerminalTotalDifficulty = UInt256.Zero
+        };
+
+        _blocksDb = new TestMemDb();
+        _headersDb = new TestMemDb();
+        _blocksInfosDb = new TestMemDb();
+        BlockTree tree = Build.A.BlockTree(specProvider)
+            .WithBlocksDb(_blocksDb)
+            .WithHeadersDb(_headersDb)
+            .WithBlockInfoDb(_blocksInfosDb)
+            .WithoutSettingHead
+            .TestObject;
+
+        // Already-synced, processed main chain 0..4 (non-beacon, canonical).
+        Block previous = Build.A.Block.WithNumber(0).WithDifficulty(0).TestObject;
+        tree.SuggestBlock(previous);
+        tree.TryUpdateMainChain(previous.Header, true, preloadedBlocks: new[] { previous });
+        for (int i = 1; i <= 4; i++)
+        {
+            Block block = Build.A.Block.WithNumber((ulong)i).WithDifficulty(0).WithParent(previous).TestObject;
+            tree.SuggestBlock(block);
+            tree.TryUpdateMainChain(block.Header, true, preloadedBlocks: new[] { block });
+            previous = block;
+        }
+
+        // A non-beacon header suggested ahead of the processed head: the best-suggested number
+        // resolves to a level with no main-chain block, so BestSuggestedHeader is null post-merge.
+        Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
+        tree.SuggestBlock(block5);
+
+        // Beacon header backfilled on top; pointer parked one above the junction.
+        BlockHeader header6 = Build.A.BlockHeader.WithNumber(6).WithParent(block5.Header).TestObject;
+        tree.Insert(header6, BlockTreeInsertHeaderOptions.BeaconHeaderInsert | BlockTreeInsertHeaderOptions.TotalDifficultyNotNeeded);
+
+        tree.RecalculateTreeLevels();
+
+        // Must stay at the lowest beacon header, not descend into the synced chain (was 1 before the fix).
+        Assert.That(tree.LowestInsertedBeaconHeader?.Number, Is.EqualTo(6UL));
+    }
+
     private static void AssertSuggestNotifications(AddBlockResult result, bool hasNotified, bool hasNotifiedNewSuggested)
     {
         using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -28,17 +28,23 @@ public partial class BlockTree
     private void FixLowestInsertedBeaconHeader()
     {
         BlockHeader? lowest = _lowestInsertedBeaconHeader;
-        ulong stopAt = (BestSuggestedHeader?.Number ?? 0) + 1;
-        if (lowest is null || lowest.Number <= stopAt)
+        if (lowest is null)
         {
             return;
         }
 
+        // An unclean shutdown between a beacon header write and its pointer update can leave
+        // LowestInsertedBeaconHeader parked above headers the backfill had already inserted.
+        // Walk down through the contiguous beacon segment and stop at the merge junction — the
+        // first already-synced non-beacon block. Anchoring on IsKnownBlock (rather than the
+        // BestSuggestedHeader number) keeps the walk bounded to the beacon segment: post-merge
+        // BestSuggestedHeader can be null when headers sit ahead of the processed head, which
+        // used to collapse the stop bound and drag the walk down the whole canonical chain.
         BlockHeader current = lowest;
-        while (current.Number > stopAt)
+        while (current.ParentHash is not null)
         {
-            BlockHeader? parent = FindHeader(current.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-            if (parent is null)
+            BlockHeader? parent = FindHeader(current.ParentHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+            if (parent?.Hash is null || IsKnownBlock(parent.Number, parent.Hash))
             {
                 break;
             }
@@ -48,7 +54,7 @@ public partial class BlockTree
 
         if (!ReferenceEquals(current, lowest))
         {
-            if (Logger.IsInfo) Logger.Info($"Lowest inserted beacon header moved from {lowest.Number} down to {current.Number} through already known headers");
+            if (Logger.IsInfo) Logger.Info($"Lowest inserted beacon header moved from {lowest.Number} down to {current.Number} through already inserted beacon headers");
             LowestInsertedBeaconHeader = current;
         }
     }


### PR DESCRIPTION
## Changes

`FixLowestInsertedBeaconHeader` (added in #12273) reconciles a `LowestInsertedBeaconHeader` pointer that an interrupted backfill may have left *above* headers it had already inserted. It walked down parent-by-parent until reaching `BestSuggestedHeader.Number + 1`.

On a **post-merge** node whose best-suggested header sits ahead of the processed main-chain head (headers inserted ahead of processing — normal while syncing), `FindHeader(number, None)` returns `null`: `GetBlockHashOnMainOrBestDifficultyHash` bails out post-merge because total difficulty can no longer distinguish canonical from orphaned. So `BestSuggestedHeader` is `null`, `stopAt` collapses to `1`, and the walk crosses the beacon/non-beacon junction and traverses the **entire already-synced canonical chain down to genesis** — millions of sequential header reads.

Observed in the wild: `InitializeBlockTree` took **473 s** on startup, the whole gap spent in this walk:

```
20:45:43 | Loading fork choice info
20:53:30 | Lowest inserted beacon header moved from 23448480 down to 1 through already known headers
20:53:30 | Step InitializeBlockTree      executed in 473,350ms
```

This PR anchors the walk's terminal condition on `IsKnownBlock` instead of the `BestSuggestedHeader` number: it stops at the first already-synced **non-beacon** block (the merge junction) — the same signal `BeaconHeadersSyncFeed` uses to mark the chain merged. That keeps the walk bounded to the beacon segment regardless of whether `BestSuggestedHeader` resolves, while preserving the interrupted-backfill reconciliation the original PR targeted.

A regression test reproduces the post-merge null-`BestSuggestedHeader` topology: the pointer walks to genesis (→ 1) before the fix and stops at the junction after. The two existing `RecalculateTreeLevels_*` tests from #12273 still pass unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added `RecalculateTreeLevels_WhenBestSuggestedHeaderUnresolvableInPoS_StopsAtBeaconJunction`, verified failing on the pre-fix method (pointer → 1) and passing after. Full `BlockTreeTests` class (257 tests) green.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Regression from #12273. cc reviewers of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)