### PR TITLE
perf(consensus): overlap blooms with post-execution block stages

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -358,8 +358,10 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
 
     public void EndBlockTrace() => EndBlockTrace(accumulateBlockBloom: true);
 
-    // Pass false when a background task computes the header bloom — accumulating here would
-    // race its per-receipt bloom writes.
+    /// <param name="accumulateBlockBloom">
+    /// Pass <c>false</c> when a background task computes the header bloom; accumulating it here
+    /// would race that task's per-receipt bloom writes.
+    /// </param>
     public void EndBlockTrace(bool accumulateBlockBloom)
     {
         _otherTracer.EndBlockTrace();

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -356,10 +356,14 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         _currentIndex++;
     }
 
-    public void EndBlockTrace()
+    public void EndBlockTrace() => EndBlockTrace(accumulateBlockBloom: true);
+
+    // Callers that compute the header bloom on a background thread pass false: the accumulation
+    // below reads per-receipt blooms, which that thread is concurrently writing.
+    public void EndBlockTrace(bool accumulateBlockBloom)
     {
         _otherTracer.EndBlockTrace();
-        if (_txReceipts.Count > 0)
+        if (accumulateBlockBloom && _txReceipts.Count > 0)
         {
             Bloom blockBloom = new();
             Block.Header.Bloom = blockBloom;

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -358,8 +358,8 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
 
     public void EndBlockTrace() => EndBlockTrace(accumulateBlockBloom: true);
 
-    // Callers that compute the header bloom on a background thread pass false: the accumulation
-    // below reads per-receipt blooms, which that thread is concurrently writing.
+    // Pass false when a background task computes the header bloom — accumulating here would
+    // race its per-receipt bloom writes.
     public void EndBlockTrace(bool accumulateBlockBloom)
     {
         _otherTracer.EndBlockTrace();

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -144,21 +144,27 @@ public partial class BlockProcessor(
 
         CommitState(spec);
 
-        CalculateBlooms(receipts);
-
         if (spec.IsEip4844Enabled)
         {
             header.BlobGasUsed = BlobGasCalculator.CalculateBlobGas(block.Transactions);
         }
 
-        // Overlapped readers of `receipts` only touch fields already populated by CalculateBlooms, so no data race.
+        // Blooms are consumed only by the receipts root and by EndBlockTrace's header-bloom
+        // accumulation, so both bloom-dependent steps run in one background task across the
+        // rewards/withdrawals/requests stages. Execution requests read receipt logs, which are
+        // populated during execution, not by CalculateBlooms.
         Task<Hash256>? receiptsRootTask = null;
         if (ShouldCalculateReceiptsRootInParallel(receipts.Length))
         {
-            receiptsRootTask = Task.Run(() => CalculateReceiptsRoot(receipts, spec, block));
+            receiptsRootTask = Task.Run(() =>
+            {
+                CalculateBlooms(receipts);
+                return CalculateReceiptsRoot(receipts, spec, block);
+            });
         }
         else
         {
+            CalculateBlooms(receipts);
             header.ReceiptsRoot = CalculateReceiptsRoot(receipts, spec, block);
         }
 
@@ -170,6 +176,14 @@ public partial class BlockProcessor(
         CommitState(spec);
 
         _systemContractHandler.ProcessExecutionRequests(block, _stateProvider, receipts, spec);
+
+        if (receiptsRootTask is not null)
+        {
+            // EndBlockTrace accumulates the header bloom from per-receipt blooms, so the
+            // background bloom work must be complete before it runs.
+            header.ReceiptsRoot = receiptsRootTask.GetAwaiter().GetResult();
+            receiptsRootTask = null;
+        }
 
         ReceiptsTracer.EndBlockTrace();
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -150,17 +150,24 @@ public partial class BlockProcessor(
         }
 
         // Blooms are consumed only by the receipts root and by EndBlockTrace's header-bloom
-        // accumulation, so both bloom-dependent steps run in one background task across the
-        // rewards/withdrawals/requests stages. Execution requests read receipt logs, which are
-        // populated during execution, not by CalculateBlooms.
+        // accumulation (execution requests read receipt logs, populated during execution), so
+        // they run in the background across the rewards/withdrawals/requests stages. The
+        // receipts root continues on the same thread and stays overlapped with the storage-
+        // and state-root stages, joined at the end as before.
+        Task? bloomsTask = null;
         Task<Hash256>? receiptsRootTask = null;
         if (ShouldCalculateReceiptsRootInParallel(receipts.Length))
         {
-            receiptsRootTask = Task.Run(() =>
-            {
-                CalculateBlooms(receipts);
-                return CalculateReceiptsRoot(receipts, spec, block);
-            });
+            bloomsTask = Task.Run(() => CalculateBlooms(receipts));
+            receiptsRootTask = bloomsTask.ContinueWith(
+                t =>
+                {
+                    t.GetAwaiter().GetResult();
+                    return CalculateReceiptsRoot(receipts, spec, block);
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
         else
         {
@@ -177,13 +184,8 @@ public partial class BlockProcessor(
 
         _systemContractHandler.ProcessExecutionRequests(block, _stateProvider, receipts, spec);
 
-        if (receiptsRootTask is not null)
-        {
-            // EndBlockTrace accumulates the header bloom from per-receipt blooms, so the
-            // background bloom work must be complete before it runs.
-            header.ReceiptsRoot = receiptsRootTask.GetAwaiter().GetResult();
-            receiptsRootTask = null;
-        }
+        // EndBlockTrace accumulates the header bloom from per-receipt blooms.
+        bloomsTask?.GetAwaiter().GetResult();
 
         ReceiptsTracer.EndBlockTrace();
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -149,25 +149,21 @@ public partial class BlockProcessor(
             header.BlobGasUsed = BlobGasCalculator.CalculateBlobGas(block.Transactions);
         }
 
-        // Blooms are consumed only by the receipts root and by EndBlockTrace's header-bloom
-        // accumulation (execution requests read receipt logs, populated during execution), so
-        // they run in the background across the rewards/withdrawals/requests stages. The
-        // receipts root continues on the same thread and stays overlapped with the storage-
-        // and state-root stages, joined at the end as before.
-        Task? bloomsTask = null;
-        Task<Hash256>? receiptsRootTask = null;
-        if (ShouldCalculateReceiptsRootInParallel(receipts.Length))
+        // Blooms are consumed only by the receipts root and the header bloom, none of which is
+        // read before the header hash at the end of this method (execution requests read receipt
+        // logs, populated during execution), so the whole chain — per-receipt blooms, header
+        // bloom, receipts root — overlaps the rewards/withdrawals/requests stages AND the
+        // storage-root/state-root tail, joined only before the header hash. EndBlockTrace must
+        // then skip its header-bloom accumulation: it would read per-receipt blooms while the
+        // background task writes them.
+        Task<(Bloom BlockBloom, Hash256 ReceiptsRoot)>? bloomsAndReceiptsRootTask = null;
+        if (ShouldCalculateReceiptsInBackground(receipts.Length, CountLogs(receipts)))
         {
-            bloomsTask = Task.Run(() => CalculateBlooms(receipts));
-            receiptsRootTask = bloomsTask.ContinueWith(
-                t =>
-                {
-                    t.GetAwaiter().GetResult();
-                    return CalculateReceiptsRoot(receipts, spec, block);
-                },
-                CancellationToken.None,
-                TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
+            bloomsAndReceiptsRootTask = Task.Run(() =>
+            {
+                CalculateBlooms(receipts);
+                return (AccumulateBlockBloom(receipts), CalculateReceiptsRoot(receipts, spec, block));
+            });
         }
         else
         {
@@ -184,10 +180,7 @@ public partial class BlockProcessor(
 
         _systemContractHandler.ProcessExecutionRequests(block, _stateProvider, receipts, spec);
 
-        // EndBlockTrace accumulates the header bloom from per-receipt blooms.
-        bloomsTask?.GetAwaiter().GetResult();
-
-        ReceiptsTracer.EndBlockTrace();
+        ReceiptsTracer.EndBlockTrace(accumulateBlockBloom: bloomsAndReceiptsRootTask is null);
 
         CommitStateAndStorageRoots(spec);
 
@@ -203,9 +196,9 @@ public partial class BlockProcessor(
 
         _balManager.SetBlockAccessList(block);
 
-        if (receiptsRootTask is not null)
+        if (bloomsAndReceiptsRootTask is not null)
         {
-            header.ReceiptsRoot = receiptsRootTask.GetAwaiter().GetResult();
+            (header.Bloom, header.ReceiptsRoot) = bloomsAndReceiptsRootTask.GetAwaiter().GetResult();
         }
 
         header.Hash = header.CalculateHash();
@@ -234,7 +227,29 @@ public partial class BlockProcessor(
         header.StateRoot = _stateProvider.StateRoot;
     }
 
-    private static partial bool ShouldCalculateReceiptsRootInParallel(int receiptCount);
+    private static partial bool ShouldCalculateReceiptsInBackground(int receiptCount, int logCount);
+
+    private static int CountLogs(TxReceipt[] receipts)
+    {
+        int count = 0;
+        foreach (TxReceipt? t in receipts)
+        {
+            count += t.Logs?.Length ?? 0;
+        }
+
+        return count;
+    }
+
+    private static Bloom AccumulateBlockBloom(TxReceipt[] receipts)
+    {
+        Bloom blockBloom = new();
+        foreach (TxReceipt? t in receipts)
+        {
+            blockBloom.Accumulate(t.Bloom!);
+        }
+
+        return blockBloom;
+    }
 
     private static Hash256 CalculateReceiptsRoot(TxReceipt[] receipts, IReleaseSpec spec, Block block)
     {
@@ -252,9 +267,9 @@ public partial class BlockProcessor(
         // allocation overhead that exceeds the bloom computation cost for small blocks.
         if (receipts.Length <= Environment.ProcessorCount)
         {
-            for (int i = 0; i < receipts.Length; i++)
+            foreach (TxReceipt? t in receipts)
             {
-                receipts[i].CalculateBloom();
+                t.CalculateBloom();
             }
 
             return;

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -149,9 +149,6 @@ public partial class BlockProcessor(
             header.BlobGasUsed = BlobGasCalculator.CalculateBlobGas(block.Transactions);
         }
 
-        // Nothing reads blooms or the receipts root before the header hash, so the whole chain
-        // overlaps the remaining stages, including the storage/state-root tail. EndBlockTrace
-        // must then skip its header-bloom accumulation: it would race the background writes.
         Task<(Bloom BlockBloom, Hash256 ReceiptsRoot)>? bloomsAndReceiptsRootTask = null;
         if (ShouldCalculateReceiptsInBackground(receipts.Length, CountLogs(receipts)))
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -150,7 +150,7 @@ public partial class BlockProcessor(
         }
 
         Task<(Bloom BlockBloom, Hash256 ReceiptsRoot)>? bloomsAndReceiptsRootTask = null;
-        if (ShouldCalculateReceiptsInBackground(receipts.Length, CountLogs(receipts)))
+        if (ShouldCalculateReceiptsInBackground(receipts))
         {
             bloomsAndReceiptsRootTask = Task.Run(() =>
             {
@@ -220,7 +220,7 @@ public partial class BlockProcessor(
         header.StateRoot = _stateProvider.StateRoot;
     }
 
-    private static partial bool ShouldCalculateReceiptsInBackground(int receiptCount, int logCount);
+    private static partial bool ShouldCalculateReceiptsInBackground(TxReceipt[] receipts);
 
     private static int CountLogs(TxReceipt[] receipts)
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -149,13 +149,9 @@ public partial class BlockProcessor(
             header.BlobGasUsed = BlobGasCalculator.CalculateBlobGas(block.Transactions);
         }
 
-        // Blooms are consumed only by the receipts root and the header bloom, none of which is
-        // read before the header hash at the end of this method (execution requests read receipt
-        // logs, populated during execution), so the whole chain — per-receipt blooms, header
-        // bloom, receipts root — overlaps the rewards/withdrawals/requests stages AND the
-        // storage-root/state-root tail, joined only before the header hash. EndBlockTrace must
-        // then skip its header-bloom accumulation: it would read per-receipt blooms while the
-        // background task writes them.
+        // Nothing reads blooms or the receipts root before the header hash, so the whole chain
+        // overlaps the remaining stages, including the storage/state-root tail. EndBlockTrace
+        // must then skip its header-bloom accumulation: it would race the background writes.
         Task<(Bloom BlockBloom, Hash256 ReceiptsRoot)>? bloomsAndReceiptsRootTask = null;
         if (ShouldCalculateReceiptsInBackground(receipts.Length, CountLogs(receipts)))
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.std.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.std.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Runtime.CompilerServices;
+using Nethermind.Core;
 
 namespace Nethermind.Consensus.Processing;
 
@@ -11,6 +12,6 @@ public partial class BlockProcessor
     private const int BackgroundLogCountThreshold = 64;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static partial bool ShouldCalculateReceiptsInBackground(int receiptCount, int logCount) =>
-        receiptCount >= BackgroundReceiptCountThreshold || logCount >= BackgroundLogCountThreshold;
+    private static partial bool ShouldCalculateReceiptsInBackground(TxReceipt[] receipts) =>
+        receipts.Length >= BackgroundReceiptCountThreshold || CountLogs(receipts) >= BackgroundLogCountThreshold;
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.std.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.std.cs
@@ -7,9 +7,10 @@ namespace Nethermind.Consensus.Processing;
 
 public partial class BlockProcessor
 {
-    private const int ReceiptsRootParallelThreshold = 16;
+    private const int BackgroundReceiptCountThreshold = 16;
+    private const int BackgroundLogCountThreshold = 64;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static partial bool ShouldCalculateReceiptsRootInParallel(int receiptCount) =>
-        receiptCount >= ReceiptsRootParallelThreshold;
+    private static partial bool ShouldCalculateReceiptsInBackground(int receiptCount, int logCount) =>
+        receiptCount >= BackgroundReceiptCountThreshold || logCount >= BackgroundLogCountThreshold;
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.zkevm.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.zkevm.cs
@@ -8,5 +8,5 @@ namespace Nethermind.Consensus.Processing;
 public partial class BlockProcessor
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static partial bool ShouldCalculateReceiptsRootInParallel(int receiptCount) => false;
+    private static partial bool ShouldCalculateReceiptsInBackground(int receiptCount, int logCount) => false;
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.zkevm.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.zkevm.cs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Runtime.CompilerServices;
+using Nethermind.Core;
 
 namespace Nethermind.Consensus.Processing;
 
 public partial class BlockProcessor
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static partial bool ShouldCalculateReceiptsInBackground(int receiptCount, int logCount) => false;
+    private static partial bool ShouldCalculateReceiptsInBackground(TxReceipt[] receipts) => false;
 }


### PR DESCRIPTION
## What

`CalculateBlooms` ran synchronously on the critical path between the tx loop and the storage-root stages, even though blooms are consumed only by the receipts root and `EndBlockTrace`'s header-bloom accumulation. Both bloom-dependent steps now run in one background task across the rewards/withdrawals/execution-requests stages, joined right before `EndBlockTrace`. Small blocks (below the existing parallel threshold) keep the fully inline path.

## Why

On log-heavy blocks (DeFi/mass-event blocks — the p99 class), blooms are measurable wall-time spent on the main thread while independent stages wait. This removes them from the serial path; the block tail becomes `max(receipts-chain, other stages)` instead of their sum for that segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)