### PR TITLE
perf: add SmallRefCountingDisposable with an inline lease counter

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Utils/RefCountingTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Utils/RefCountingTests.cs
@@ -31,8 +31,8 @@ public class RefCountingTests
         }
     }
 
-    // Duplicated for SmallRefCountingDisposable, which intentionally copies the RefCountingDisposable
-    // lease algorithm with an inline (non-cache-line-padded) counter.
+    // SmallRefCountingDisposable is a separate public type (inline counter, shared lease algorithm),
+    // so it is exercised through its own harness alongside the padded RefCountingDisposable above.
     private class TestSmallRefCounting : SmallRefCountingDisposable
     {
         private const int Used = 0;

--- a/src/Nethermind/Nethermind.Core.Test/Utils/RefCountingTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Utils/RefCountingTests.cs
@@ -31,12 +31,76 @@ public class RefCountingTests
         }
     }
 
+    // Duplicated for SmallRefCountingDisposable, which intentionally copies the RefCountingDisposable
+    // lease algorithm with an inline (non-cache-line-padded) counter.
+    private class TestSmallRefCounting : SmallRefCountingDisposable
+    {
+        private const int Used = 0;
+        private const int Cleaned = 1;
+
+        private int _cleaned = Used;
+        private int _tryCount;
+
+        public long TryCount => _tryCount;
+
+        public bool Try()
+        {
+            Interlocked.Increment(ref _tryCount);
+            return TryAcquireLease();
+        }
+
+        protected override void CleanUp()
+        {
+            int existing = Interlocked.Exchange(ref _cleaned, Cleaned);
+
+            // should be called only once and set it to used
+            Assert.That(existing, Is.EqualTo(Used));
+        }
+    }
+
     [Test]
     public void Two_threads()
     {
         const int sleepInMs = 100;
 
         TestRefCounting counter = new();
+
+        Thread thread1 = new(LeaseRelease);
+        Thread thread2 = new(LeaseRelease);
+
+        thread1.Start();
+        thread2.Start();
+
+        Thread.Sleep(sleepInMs);
+
+        // dispose once
+        counter.Dispose();
+
+        thread1.Join();
+        thread2.Join();
+
+        const int minLeasesPerSecond = 1_000_000;
+        const int msInSec = 1000;
+        const int minLeaseCount = minLeasesPerSecond * sleepInMs / msInSec;
+
+        Assert.That(counter.TryCount, Is.GreaterThan(minLeaseCount), $"On modern CPUs the speed of lease should be bigger than {minLeasesPerSecond} / s");
+
+        void LeaseRelease()
+        {
+            while (counter.Try())
+            {
+                // after lease, dispose
+                counter.Dispose();
+            }
+        }
+    }
+
+    [Test]
+    public void Two_threads_small()
+    {
+        const int sleepInMs = 100;
+
+        TestSmallRefCounting counter = new();
 
         Thread thread1 = new(LeaseRelease);
         Thread thread2 = new(LeaseRelease);

--- a/src/Nethermind/Nethermind.Core/Utils/RefCountingDisposable.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/RefCountingDisposable.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -9,15 +12,17 @@ namespace Nethermind.Core.Utils;
 /// <summary>
 /// Provides a component that can be disposed multiple times and runs <see cref="CleanUp"/> only on the last dispose.
 /// </summary>
+/// <remarks>
+/// The lease counter lives in a <see cref="CacheLinePaddedLong"/> so concurrent atomic updates do not
+/// suffer false sharing with neighbouring fields. See <see cref="SmallRefCountingDisposable"/> for a
+/// variant that stores the counter inline for types that exist in large numbers. The lease algorithm
+/// itself is shared through <see cref="RefCountingLease"/>.
+/// </remarks>
 public abstract class RefCountingDisposable : IDisposable
 {
-    private const int Single = 1;
-    private const int NoAccessors = 0;
-    private const int Disposing = -1;
-
     protected CacheLinePaddedLong _leases;
 
-    protected RefCountingDisposable(int initialCount = Single) => _leases.Value = initialCount;
+    protected RefCountingDisposable(int initialCount = RefCountingLease.Single) => _leases.Value = initialCount;
 
     public void AcquireLease()
     {
@@ -31,93 +36,20 @@ public abstract class RefCountingDisposable : IDisposable
         static void ThrowCouldNotAcquire() => throw new InvalidOperationException("The lease cannot be acquired");
     }
 
-    protected bool TryAcquireLease()
-    {
-        // Volatile read for starting value
-        long current = Volatile.Read(ref _leases.Value);
-        if (current == Disposing)
-        {
-            // Already disposed
-            return false;
-        }
-
-        while (true)
-        {
-            long prev = Interlocked.CompareExchange(ref _leases.Value, current + Single, current);
-            if (prev == current)
-            {
-                // Successfully acquired
-                return true;
-            }
-            if (prev == Disposing)
-            {
-                // Already disposed
-                return false;
-            }
-
-            // Try again with new starting value
-            current = prev;
-            // Add PAUSE instruction to reduce shared core contention
-            Thread.SpinWait(1);
-        }
-    }
+    protected bool TryAcquireLease() => RefCountingLease.TryAcquire(ref _leases.Value);
 
     /// <summary>
     /// Disposes it once, decreasing the lease count by 1.
     /// </summary>
-    public void Dispose() => ReleaseLeaseOnce();
-
-    private void ReleaseLeaseOnce()
+    public void Dispose()
     {
-        // Volatile read for starting value
-        long current = Volatile.Read(ref _leases.Value);
-        if (current <= NoAccessors)
+        if (RefCountingLease.ReleaseOnce(ref _leases.Value))
         {
-            // Mismatched Acquire/Release
-            ThrowOverDisposed();
-        }
-
-        while (true)
-        {
-            long prev = Interlocked.CompareExchange(ref _leases.Value, current - Single, current);
-            if (prev != current)
-            {
-                current = prev;
-                // Add PAUSE instruction to reduce shared core contention
-                Thread.SpinWait(1);
-                continue;
-            }
-            if (prev == Single)
-            {
-                // Last use, try to dispose underlying
-                break;
-            }
-            if (prev <= NoAccessors)
-            {
-                // Mismatched Acquire/Release
-                ThrowOverDisposed();
-            }
-
-            // Successfully released
-            return;
-        }
-
-        if (Interlocked.CompareExchange(ref _leases.Value, Disposing, NoAccessors) == NoAccessors)
-        {
-            // set to disposed by this Release
             CleanUp();
         }
-
-        [DoesNotReturn]
-        [StackTraceHidden]
-        static void ThrowOverDisposed() => throw new ObjectDisposedException("The lease has already been disposed");
     }
 
     protected abstract void CleanUp();
 
-    public override string ToString()
-    {
-        long leases = Volatile.Read(ref _leases.Value);
-        return leases == Disposing ? "Disposed" : $"Leases: {leases}";
-    }
+    public override string ToString() => RefCountingLease.Describe(Volatile.Read(ref _leases.Value));
 }

--- a/src/Nethermind/Nethermind.Core/Utils/RefCountingLease.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/RefCountingLease.cs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Nethermind.Core.Utils;
+
+/// <summary>
+/// The lock-free lease-counter algorithm shared by <see cref="RefCountingDisposable"/> and
+/// <see cref="SmallRefCountingDisposable"/>. The two types differ only in how they store the counter
+/// (cache-line-padded vs. inline); the compare-and-swap logic operating on it is identical and lives
+/// here so it is not duplicated between them.
+/// </summary>
+internal static class RefCountingLease
+{
+    public const int Single = 1;
+    public const int NoAccessors = 0;
+    public const int Disposing = -1;
+
+    /// <summary>
+    /// Attempts to increment the lease count, returning <c>false</c> once the object is being torn down.
+    /// </summary>
+    public static bool TryAcquire(ref long leases)
+    {
+        // Volatile read for starting value
+        long current = Volatile.Read(ref leases);
+
+        while (true)
+        {
+            // Reject once the count has reached zero (NoAccessors) or gone to Disposing: the object is
+            // being torn down. Acquiring at NoAccessors would resurrect an object whose owner has
+            // already observed the zero count and begun teardown — the release path moves the count
+            // 1 → 0 and only then CASes 0 → Disposing, so a concurrent acquirer can briefly see 0.
+            // Checking inside the loop (not just on the initial read) also closes the window where a
+            // failed CAS hands back a now-zero count.
+            if (current <= NoAccessors)
+            {
+                return false;
+            }
+
+            long prev = Interlocked.CompareExchange(ref leases, current + Single, current);
+            if (prev == current)
+            {
+                // Successfully acquired
+                return true;
+            }
+
+            // Try again with the observed value
+            current = prev;
+            // Add PAUSE instruction to reduce shared core contention
+            Thread.SpinWait(1);
+        }
+    }
+
+    /// <summary>
+    /// Decrements the lease count by one, returning <c>true</c> when the caller performed the exclusive
+    /// last release and must therefore run cleanup exactly once.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">The lease has already been fully released.</exception>
+    public static bool ReleaseOnce(ref long leases)
+    {
+        // Volatile read for starting value
+        long current = Volatile.Read(ref leases);
+
+        while (true)
+        {
+            // Re-validate on every iteration (the initial read and each failed-CAS retry). A failed CAS
+            // hands back the observed value, which a concurrent release can have already driven to
+            // NoAccessors — or to Disposing — inside the teardown window. Decrementing from there would
+            // write Disposing(-1) via the subtract below, spuriously and bypassing the dedicated
+            // NoAccessors -> Disposing CAS, leaving the genuine last-releaser's CleanUp unrun.
+            if (current <= NoAccessors)
+            {
+                // Mismatched Acquire/Release
+                ThrowOverDisposed();
+            }
+
+            long prev = Interlocked.CompareExchange(ref leases, current - Single, current);
+            if (prev != current)
+            {
+                current = prev;
+                // Add PAUSE instruction to reduce shared core contention
+                Thread.SpinWait(1);
+                continue;
+            }
+            if (prev == Single)
+            {
+                // Last use, try to dispose underlying
+                break;
+            }
+
+            // Successfully released (prev > Single here, guaranteed > NoAccessors by the check above)
+            return false;
+        }
+
+        // Only the thread that won the exclusive 1 -> 0 decrement above reaches here, and nothing can move
+        // the count off 0 afterwards (a concurrent acquire refuses at 0, a concurrent release throws
+        // over-disposed), so this CAS always succeeds and the caller runs cleanup exactly once.
+        return Interlocked.CompareExchange(ref leases, Disposing, NoAccessors) == NoAccessors;
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowOverDisposed() => throw new ObjectDisposedException("The lease has already been disposed");
+    }
+
+    /// <summary>
+    /// Renders the counter for diagnostics: <c>"Disposed"</c> once torn down, otherwise the live count.
+    /// </summary>
+    public static string Describe(long leases) => leases == Disposing ? "Disposed" : $"Leases: {leases}";
+}

--- a/src/Nethermind/Nethermind.Core/Utils/SmallRefCountingDisposable.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/SmallRefCountingDisposable.cs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Nethermind.Core.Utils;
+
+/// <summary>
+/// Variant of <see cref="RefCountingDisposable"/> that stores its lease counter inline as a single
+/// <see cref="long"/> instead of a cache-line-padded one, trading false-sharing protection for a much
+/// smaller per-instance footprint. Prefer it for types that exist in large numbers and whose lease
+/// counts are rarely contended across cores.
+/// </summary>
+public abstract class SmallRefCountingDisposable(int initialCount = 1) : IDisposable
+{
+    private const int Single = 1;
+    private const int NoAccessors = 0;
+    private const int Disposing = -1;
+
+    private long _leases = initialCount;
+
+    public void AcquireLease()
+    {
+        if (!TryAcquireLease())
+        {
+            ThrowCouldNotAcquire();
+        }
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowCouldNotAcquire() => throw new InvalidOperationException("The lease cannot be acquired");
+    }
+
+    protected bool TryAcquireLease()
+    {
+        // Volatile read for starting value
+        long current = Volatile.Read(ref _leases);
+
+        while (true)
+        {
+            // Reject once the count has reached zero (NoAccessors) or gone to Disposing: the object is
+            // being torn down. Acquiring at NoAccessors would resurrect an object whose owner has
+            // already observed the zero count and begun teardown — the release path moves the count
+            // 1 → 0 and only then CASes 0 → Disposing, so a concurrent acquirer can briefly see 0.
+            // Checking inside the loop (not just on the initial read) also closes the window where a
+            // failed CAS hands back a now-zero count.
+            if (current <= NoAccessors)
+            {
+                return false;
+            }
+
+            long prev = Interlocked.CompareExchange(ref _leases, current + Single, current);
+            if (prev == current)
+            {
+                // Successfully acquired
+                return true;
+            }
+
+            // Try again with the observed value
+            current = prev;
+            // Add PAUSE instruction to reduce shared core contention
+            Thread.SpinWait(1);
+        }
+    }
+
+    /// <summary>
+    /// Disposes it once, decreasing the lease count by 1.
+    /// </summary>
+    public void Dispose() => ReleaseLeaseOnce();
+
+    private void ReleaseLeaseOnce()
+    {
+        // Volatile read for starting value
+        long current = Volatile.Read(ref _leases);
+
+        while (true)
+        {
+            // Re-validate on every iteration (the initial read and each failed-CAS retry). A failed CAS
+            // hands back the observed value, which a concurrent release can have already driven to
+            // NoAccessors — or to Disposing — inside the teardown window. Decrementing from there would
+            // write Disposing(-1) via the subtract below, spuriously and bypassing the dedicated
+            // NoAccessors -> Disposing CAS, leaving the genuine last-releaser's CleanUp unrun. Mirrors
+            // the guard in TryAcquireLease.
+            if (current <= NoAccessors)
+            {
+                // Mismatched Acquire/Release
+                ThrowOverDisposed();
+            }
+
+            long prev = Interlocked.CompareExchange(ref _leases, current - Single, current);
+            if (prev != current)
+            {
+                current = prev;
+                // Add PAUSE instruction to reduce shared core contention
+                Thread.SpinWait(1);
+                continue;
+            }
+            if (prev == Single)
+            {
+                // Last use, try to dispose underlying
+                break;
+            }
+
+            // Successfully released (prev > Single here, guaranteed > NoAccessors by the check above)
+            return;
+        }
+
+        // Only the thread that won the exclusive 1 -> 0 decrement above reaches here, and nothing can move
+        // _leases off 0 afterwards (a concurrent acquire refuses at 0, a concurrent release throws
+        // over-disposed), so this CAS always succeeds and CleanUp runs exactly once — no double dispose.
+        if (Interlocked.CompareExchange(ref _leases, Disposing, NoAccessors) == NoAccessors)
+        {
+            CleanUp();
+        }
+
+        [DoesNotReturn]
+        [StackTraceHidden]
+        static void ThrowOverDisposed() => throw new ObjectDisposedException("The lease has already been disposed");
+    }
+
+    protected abstract void CleanUp();
+
+    public override string ToString()
+    {
+        long leases = Volatile.Read(ref _leases);
+        return leases == Disposing ? "Disposed" : $"Leases: {leases}";
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Utils/SmallRefCountingDisposable.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/SmallRefCountingDisposable.cs
@@ -14,12 +14,12 @@ namespace Nethermind.Core.Utils;
 /// smaller per-instance footprint. Prefer it for types that exist in large numbers and whose lease
 /// counts are rarely contended across cores.
 /// </summary>
-public abstract class SmallRefCountingDisposable(int initialCount = 1) : IDisposable
+/// <remarks>
+/// Only the counter storage differs from <see cref="RefCountingDisposable"/>; the lease algorithm is
+/// shared through <see cref="RefCountingLease"/>.
+/// </remarks>
+public abstract class SmallRefCountingDisposable(int initialCount = RefCountingLease.Single) : IDisposable
 {
-    private const int Single = 1;
-    private const int NoAccessors = 0;
-    private const int Disposing = -1;
-
     private long _leases = initialCount;
 
     public void AcquireLease()
@@ -34,98 +34,20 @@ public abstract class SmallRefCountingDisposable(int initialCount = 1) : IDispos
         static void ThrowCouldNotAcquire() => throw new InvalidOperationException("The lease cannot be acquired");
     }
 
-    protected bool TryAcquireLease()
-    {
-        // Volatile read for starting value
-        long current = Volatile.Read(ref _leases);
-
-        while (true)
-        {
-            // Reject once the count has reached zero (NoAccessors) or gone to Disposing: the object is
-            // being torn down. Acquiring at NoAccessors would resurrect an object whose owner has
-            // already observed the zero count and begun teardown — the release path moves the count
-            // 1 → 0 and only then CASes 0 → Disposing, so a concurrent acquirer can briefly see 0.
-            // Checking inside the loop (not just on the initial read) also closes the window where a
-            // failed CAS hands back a now-zero count.
-            if (current <= NoAccessors)
-            {
-                return false;
-            }
-
-            long prev = Interlocked.CompareExchange(ref _leases, current + Single, current);
-            if (prev == current)
-            {
-                // Successfully acquired
-                return true;
-            }
-
-            // Try again with the observed value
-            current = prev;
-            // Add PAUSE instruction to reduce shared core contention
-            Thread.SpinWait(1);
-        }
-    }
+    protected bool TryAcquireLease() => RefCountingLease.TryAcquire(ref _leases);
 
     /// <summary>
     /// Disposes it once, decreasing the lease count by 1.
     /// </summary>
-    public void Dispose() => ReleaseLeaseOnce();
-
-    private void ReleaseLeaseOnce()
+    public void Dispose()
     {
-        // Volatile read for starting value
-        long current = Volatile.Read(ref _leases);
-
-        while (true)
-        {
-            // Re-validate on every iteration (the initial read and each failed-CAS retry). A failed CAS
-            // hands back the observed value, which a concurrent release can have already driven to
-            // NoAccessors — or to Disposing — inside the teardown window. Decrementing from there would
-            // write Disposing(-1) via the subtract below, spuriously and bypassing the dedicated
-            // NoAccessors -> Disposing CAS, leaving the genuine last-releaser's CleanUp unrun. Mirrors
-            // the guard in TryAcquireLease.
-            if (current <= NoAccessors)
-            {
-                // Mismatched Acquire/Release
-                ThrowOverDisposed();
-            }
-
-            long prev = Interlocked.CompareExchange(ref _leases, current - Single, current);
-            if (prev != current)
-            {
-                current = prev;
-                // Add PAUSE instruction to reduce shared core contention
-                Thread.SpinWait(1);
-                continue;
-            }
-            if (prev == Single)
-            {
-                // Last use, try to dispose underlying
-                break;
-            }
-
-            // Successfully released (prev > Single here, guaranteed > NoAccessors by the check above)
-            return;
-        }
-
-        // Only the thread that won the exclusive 1 -> 0 decrement above reaches here, and nothing can move
-        // _leases off 0 afterwards (a concurrent acquire refuses at 0, a concurrent release throws
-        // over-disposed), so this CAS always succeeds and CleanUp runs exactly once — no double dispose.
-        if (Interlocked.CompareExchange(ref _leases, Disposing, NoAccessors) == NoAccessors)
+        if (RefCountingLease.ReleaseOnce(ref _leases))
         {
             CleanUp();
         }
-
-        [DoesNotReturn]
-        [StackTraceHidden]
-        static void ThrowOverDisposed() => throw new ObjectDisposedException("The lease has already been disposed");
     }
 
     protected abstract void CleanUp();
 
-    public override string ToString()
-    {
-        long leases = Volatile.Read(ref _leases);
-        return leases == Disposing ? "Disposed" : $"Leases: {leases}";
-    }
+    public override string ToString() => RefCountingLease.Describe(Volatile.Read(ref _leases));
 }


### PR DESCRIPTION
## Changes

Adds `SmallRefCountingDisposable` — a variant of `RefCountingDisposable` that stores its lease counter inline as a single `long` (8 bytes) instead of a 128-byte cache-line-padded `CacheLinePaddedLong`. This trades false-sharing protection for a much smaller per-instance footprint, which is worthwhile for types that exist in large numbers and rarely contend their lease count across cores. Extracted from the `flat/simpler-long-finality` line, where high-count types (`PersistedSnapshot`, `ArenaReservation`) switch onto it.

Rather than duplicating the lease algorithm between the two disposables, the compare-and-swap acquire/release logic is factored into a `RefCountingLease` static helper that operates on a `ref long`; both types delegate to it and differ only in how they store the counter.

This unification also lands the **hardened** form of the algorithm for both types (reject acquire at `NoAccessors`, re-validate release on every iteration), closing two latent races that `RefCountingDisposable` still had:
- a concurrent acquire observing the transient `1 → 0` window could resurrect a tearing-down object;
- a racy release retry could write `Disposing` via the decrement and skip the genuine last releaser's `CleanUp`.

## Types of changes

- [x] Performance optimization
- [x] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`RefCountingTests` exercises both public types (`Two_threads`, `Two_threads_small`):

```
dotnet test --project Nethermind.Core.Test/Nethermind.Core.Test.csproj -c release \
  --filter FullyQualifiedName~RefCountingTests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)