### PR TITLE
feat(analyzers): add NETH007 — prefer PutSpan over Set with a span-copied array

### DIFF
--- a/src/Nethermind/Nethermind.Analyzers.Test/KeyValueStoreSetToArrayAnalyzerTests.cs
+++ b/src/Nethermind/Nethermind.Analyzers.Test/KeyValueStoreSetToArrayAnalyzerTests.cs
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Nethermind.Analyzers.Test;
+
+public class KeyValueStoreSetToArrayAnalyzerTests
+{
+    // Minimal stand-ins for the real types so the analyzer resolves them by metadata name.
+    private const string StoreStub = """
+        namespace Nethermind.Core
+        {
+            using System;
+            public enum WriteFlags { None = 0 }
+            public interface IWriteOnlyKeyValueStore
+            {
+                void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None);
+                bool PreferWriteByArray => false;
+                void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None)
+                    => Set(key, value.ToArray(), flags);
+            }
+            public class MemDb : IWriteOnlyKeyValueStore
+            {
+                public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) { }
+            }
+            public sealed class Hash256
+            {
+                private readonly byte[] _bytes = new byte[32];
+                public ReadOnlySpan<byte> Bytes => _bytes;
+                public byte[] BytesToArray() => (byte[])_bytes.Clone();
+            }
+        }
+        """;
+
+    [Test]
+    public async Task Set_with_span_toarray_reports([Values("Span", "ReadOnlySpan")] string spanKind)
+    {
+        string source = $$"""
+            using System;
+            using Nethermind.Core;
+            class C
+            {
+                static void Use(IWriteOnlyKeyValueStore db, {{spanKind}}<byte> key, {{spanKind}}<byte> value)
+                    => db.Set(key, {|#0:value.ToArray()|});
+            }
+            """;
+        await Verify(source, Diagnostic().WithLocation(0).WithArguments($"{spanKind}<byte>.ToArray()", "the span"));
+    }
+
+    [Test]
+    public async Task Set_with_bytes_to_array_reports()
+    {
+        string source = """
+            using System;
+            using Nethermind.Core;
+            class C
+            {
+                static void Use(IWriteOnlyKeyValueStore db, ReadOnlySpan<byte> key, Hash256 hash)
+                    => db.Set(key, {|#0:hash.BytesToArray()|});
+            }
+            """;
+        await Verify(source, Diagnostic().WithLocation(0).WithArguments("BytesToArray()", "its .Bytes span"));
+    }
+
+    [Test]
+    public async Task Set_with_bytes_to_array_on_type_without_bytes_span_no_diagnostic()
+    {
+        // BytesToArray() exists but the type has no `Bytes` span property, so `.Bytes` is not a valid replacement.
+        string source = """
+            using System;
+            using Nethermind.Core;
+            class NoBytesSpan { public byte[] BytesToArray() => new byte[1]; }
+            class C
+            {
+                static void Use(IWriteOnlyKeyValueStore db, ReadOnlySpan<byte> key, NoBytesSpan x)
+                    => db.Set(key, x.BytesToArray());
+            }
+            """;
+        await Verify(source);
+    }
+
+    [Test]
+    public async Task Set_through_interface_with_flags_reports()
+    {
+        string source = """
+            using System;
+            using Nethermind.Core;
+            class C
+            {
+                static void Use(IWriteOnlyKeyValueStore db, ReadOnlySpan<byte> key, Span<byte> value)
+                    => db.Set(key, {|#0:value.ToArray()|}, WriteFlags.None);
+            }
+            """;
+        await Verify(source, Diagnostic().WithLocation(0).WithArguments("Span<byte>.ToArray()", "the span"));
+    }
+
+    [Test]
+    public async Task Set_on_concrete_store_no_diagnostic()
+    {
+        // Bound to MemDb.Set (a concrete override), not the interface member — low-level plumbing where
+        // a PreferWriteByArray store deliberately takes an owned array. Not flagged.
+        string source = """
+            using System;
+            using Nethermind.Core;
+            class C
+            {
+                static void Use(MemDb db, ReadOnlySpan<byte> key, Span<byte> value)
+                    => db.Set(key, value.ToArray(), WriteFlags.None);
+            }
+            """;
+        await Verify(source);
+    }
+
+    [Test]
+    public async Task Set_with_plain_array_value_no_diagnostic()
+    {
+        // Value is already a byte[]; no span.ToArray() to eliminate.
+        string source = """
+            using System;
+            using Nethermind.Core;
+            class C
+            {
+                static void Use(IWriteOnlyKeyValueStore db, ReadOnlySpan<byte> key, byte[] value)
+                    => db.Set(key, value);
+            }
+            """;
+        await Verify(source);
+    }
+
+    [Test]
+    public async Task Set_with_list_toarray_value_no_diagnostic()
+    {
+        // ToArray on List<byte> cannot be replaced by a span; PutSpan would not help.
+        string source = """
+            using System;
+            using System.Collections.Generic;
+            using Nethermind.Core;
+            class C
+            {
+                static void Use(IWriteOnlyKeyValueStore db, ReadOnlySpan<byte> key, List<byte> value)
+                    => db.Set(key, value.ToArray());
+            }
+            """;
+        await Verify(source);
+    }
+
+    [Test]
+    public async Task PutSpan_default_impl_delegating_to_this_Set_no_diagnostic()
+    {
+        // Rewriting this.Set -> this.PutSpan inside PutSpan would self-recurse.
+        string source = """
+            using System;
+            using Nethermind.Core;
+            class MyStore : IWriteOnlyKeyValueStore
+            {
+                public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) { }
+                public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None)
+                    => Set(key, value.ToArray(), flags);
+            }
+            """;
+        await Verify(source);
+    }
+
+    [Test]
+    public async Task PutSpan_delegating_to_another_interface_typed_store_reports()
+    {
+        // The Set target is a different, interface-typed store — no self-recursion, so flag it.
+        string source = """
+            using System;
+            using Nethermind.Core;
+            class Wrapper : IWriteOnlyKeyValueStore
+            {
+                private readonly IWriteOnlyKeyValueStore _inner;
+                public Wrapper(IWriteOnlyKeyValueStore inner) => _inner = inner;
+                public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) { }
+                public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None)
+                    => _inner.Set(key, {|#0:value.ToArray()|}, flags);
+            }
+            """;
+        await Verify(source, Diagnostic().WithLocation(0).WithArguments("ReadOnlySpan<byte>.ToArray()", "the span"));
+    }
+
+    [Test]
+    public async Task Unrelated_Set_method_no_diagnostic()
+    {
+        // A Set method not implementing IWriteOnlyKeyValueStore must not be flagged.
+        string source = """
+            using System;
+            using Nethermind.Core;
+            class NotAStore
+            {
+                public void Set(ReadOnlySpan<byte> key, byte[]? value) { }
+                static void Use(NotAStore x, ReadOnlySpan<byte> key, Span<byte> value)
+                    => x.Set(key, value.ToArray());
+            }
+            """;
+        await Verify(source);
+    }
+
+    private static DiagnosticResult Diagnostic() =>
+        CSharpAnalyzerVerifier<KeyValueStoreSetToArrayAnalyzer, DefaultVerifier>.Diagnostic(KeyValueStoreSetToArrayAnalyzer.DiagnosticId);
+
+    private static async Task Verify(string source, params DiagnosticResult[] expected)
+    {
+        CSharpAnalyzerTest<KeyValueStoreSetToArrayAnalyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source + "\n" + StoreStub,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync();
+    }
+}

--- a/src/Nethermind/Nethermind.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Nethermind/Nethermind.Analyzers/AnalyzerReleases.Unshipped.md
@@ -11,3 +11,4 @@ NETH003 | Naming | Warning | File name does not match the single contained top-l
 NETH004 | Performance | Warning | ConcurrentDictionary&lt;TKey,TValue&gt;.Keys / .Values allocate a snapshot list. Enumerate the dictionary directly with foreach, or use AcquireLock for a deliberate snapshot.
 NETH005 | Performance | Warning | Span<T>.ToArray() / ReadOnlySpan<T>.ToArray() passed to a method that has a Span<T>/ReadOnlySpan<T> overload at the same position. Pass the span directly.
 NETH006 | Reliability | Warning | TaskCompletionSource constructed without TaskCreationOptions.RunContinuationsAsynchronously can run continuations synchronously and deadlock.
+NETH007 | Performance | Warning | IWriteOnlyKeyValueStore.Set called with a value copied from a byte span (Span&lt;byte&gt;/ReadOnlySpan&lt;byte&gt;.ToArray(), or x.BytesToArray() on a type with a Bytes span). Call PutSpan with the span directly instead of allocating an array.

--- a/src/Nethermind/Nethermind.Analyzers/KeyValueStoreSetToArrayAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Analyzers/KeyValueStoreSetToArrayAnalyzer.cs
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Nethermind.Analyzers;
+
+/// <summary>
+/// Reports calls to <c>IWriteOnlyKeyValueStore.Set(key, value)</c> whose <c>value</c> argument is a
+/// freshly materialized <c>byte[]</c> that already exists as a <c>byte</c>-span. Two shapes are flagged:
+/// <list type="bullet">
+/// <item><c>span.ToArray()</c> where <c>span</c> is <see cref="System.Span{T}"/>/<see cref="System.ReadOnlySpan{T}"/>
+/// of <c>byte</c> — pass the span itself.</item>
+/// <item><c>x.BytesToArray()</c> where <c>x</c>'s type exposes a <c>Bytes</c> property of
+/// <c>Span&lt;byte&gt;</c>/<c>ReadOnlySpan&lt;byte&gt;</c> (e.g. <c>Hash256</c>/<c>ValueHash256</c>) — pass
+/// <c>x.Bytes</c>.</item>
+/// </list>
+/// The copy is often unnecessary — call <c>PutSpan(key, span)</c> instead and let the store decide
+/// whether it needs to copy (see <c>IWriteOnlyKeyValueStore.PreferWriteByArray</c>).
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class KeyValueStoreSetToArrayAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "NETH007";
+
+    private static readonly LocalizableString Title =
+        "Avoid Set with a byte[] copied from a span when PutSpan is available";
+
+    private static readonly LocalizableString MessageFormat =
+        "Value passed to IWriteOnlyKeyValueStore.Set is copied to an array via {0}; call PutSpan with {1} instead";
+
+    private static readonly LocalizableString Description =
+        "IWriteOnlyKeyValueStore.Set takes a byte[]. Materializing a span into an array (span.ToArray() or " +
+        "x.BytesToArray()) to satisfy it always allocates a heap copy. PutSpan accepts a ReadOnlySpan<byte> " +
+        "and lets the store decide whether a copy is needed (governed by PreferWriteByArray). Replace " +
+        "Set(key, span.ToArray(), flags) with PutSpan(key, span, flags).";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(static startContext =>
+        {
+            INamedTypeSymbol? store = startContext.Compilation.GetTypeByMetadataName("Nethermind.Core.IWriteOnlyKeyValueStore");
+            INamedTypeSymbol? spanType = startContext.Compilation.GetTypeByMetadataName("System.Span`1");
+            INamedTypeSymbol? readOnlySpanType = startContext.Compilation.GetTypeByMetadataName("System.ReadOnlySpan`1");
+            if (store is null || spanType is null || readOnlySpanType is null)
+                return;
+
+            IMethodSymbol? setMethod = FindByteArraySet(store);
+            if (setMethod is null)
+                return;
+
+            StoreTypes types = new(setMethod, spanType, readOnlySpanType,
+                startContext.Compilation.GetSpecialType(SpecialType.System_Byte));
+
+            startContext.RegisterOperationAction(c => Analyze(c, types), OperationKind.Invocation);
+        });
+    }
+
+    /// <summary>Locates the <c>Set(ReadOnlySpan&lt;byte&gt; key, byte[]? value, WriteFlags flags)</c> member.</summary>
+    private static IMethodSymbol? FindByteArraySet(INamedTypeSymbol store)
+    {
+        foreach (ISymbol member in store.GetMembers("Set"))
+        {
+            if (member is IMethodSymbol { Parameters.Length: >= 2 } method
+                && method.Parameters[1].Type is IArrayTypeSymbol { ElementType.SpecialType: SpecialType.System_Byte })
+            {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    private readonly struct StoreTypes(
+        IMethodSymbol setMethod,
+        INamedTypeSymbol span,
+        INamedTypeSymbol readOnlySpan,
+        INamedTypeSymbol byteType)
+    {
+        public IMethodSymbol SetMethod { get; } = setMethod;
+        public INamedTypeSymbol Span { get; } = span;
+        public INamedTypeSymbol ReadOnlySpan { get; } = readOnlySpan;
+        public INamedTypeSymbol Byte { get; } = byteType;
+    }
+
+    private static void Analyze(OperationAnalysisContext context, StoreTypes types)
+    {
+        IInvocationOperation invocation = (IInvocationOperation)context.Operation;
+        if (!IsStoreSet(invocation.TargetMethod, types))
+            return;
+
+        // Skip the store's own PutSpan default/override delegating to this.Set — rewriting it to
+        // this.PutSpan would self-recurse.
+        if (invocation.Instance is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance }
+            && context.ContainingSymbol is IMethodSymbol { Name: "PutSpan" })
+            return;
+
+        foreach (IArgumentOperation argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Ordinal != 1)
+                continue;
+
+            IOperation value = argument.Value;
+            while (value is IConversionOperation conv)
+                value = conv.Operand;
+
+            if (value is IInvocationOperation { TargetMethod: { IsStatic: false, Parameters.Length: 0 } } call
+                && TryClassifyCopy(call, types, out string copyDescription, out string replacement))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Rule, value.Syntax.GetLocation(), copyDescription, replacement));
+            }
+            return;
+        }
+    }
+
+    /// <summary>
+    /// Recognizes the two span-to-array copy shapes and yields how to describe the copy and what to pass
+    /// to <c>PutSpan</c> instead.
+    /// </summary>
+    private static bool TryClassifyCopy(IInvocationOperation call, StoreTypes types, out string copyDescription, out string replacement)
+    {
+        copyDescription = replacement = string.Empty;
+        IMethodSymbol method = call.TargetMethod;
+
+        // Span<byte>.ToArray() / ReadOnlySpan<byte>.ToArray() -> pass the span.
+        if (method.Name == "ToArray"
+            && method.ContainingType is INamedTypeSymbol { TypeArguments.Length: 1 } span
+            && SymbolEqualityComparer.Default.Equals(span.TypeArguments[0], types.Byte))
+        {
+            INamedTypeSymbol original = span.OriginalDefinition;
+            bool isSpan = SymbolEqualityComparer.Default.Equals(original, types.Span);
+            if (!isSpan && !SymbolEqualityComparer.Default.Equals(original, types.ReadOnlySpan))
+                return false;
+
+            copyDescription = $"{(isSpan ? "Span" : "ReadOnlySpan")}<byte>.ToArray()";
+            replacement = "the span";
+            return true;
+        }
+
+        // x.BytesToArray() where x's type exposes a byte-span `Bytes` property -> pass x.Bytes.
+        if (method.Name == "BytesToArray"
+            && method.ReturnType is IArrayTypeSymbol { ElementType.SpecialType: SpecialType.System_Byte }
+            && call.Instance?.Type is ITypeSymbol receiverType
+            && HasByteSpanBytesProperty(receiverType, types))
+        {
+            copyDescription = "BytesToArray()";
+            replacement = "its .Bytes span";
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>True when <paramref name="type"/> (or a base type) exposes an instance <c>Bytes</c> property of type <c>Span&lt;byte&gt;</c> or <c>ReadOnlySpan&lt;byte&gt;</c>.</summary>
+    private static bool HasByteSpanBytesProperty(ITypeSymbol type, StoreTypes types)
+    {
+        for (ITypeSymbol? current = type; current is not null; current = current.BaseType)
+        {
+            foreach (ISymbol member in current.GetMembers("Bytes"))
+            {
+                if (member is IPropertySymbol { IsStatic: false, Type: INamedTypeSymbol { TypeArguments.Length: 1 } propertyType }
+                    && (SymbolEqualityComparer.Default.Equals(propertyType.OriginalDefinition, types.Span)
+                        || SymbolEqualityComparer.Default.Equals(propertyType.OriginalDefinition, types.ReadOnlySpan))
+                    && SymbolEqualityComparer.Default.Equals(propertyType.TypeArguments[0], types.Byte))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// True when the call is dispatched through <see cref="StoreTypes.SetMethod"/> — i.e. the receiver is
+    /// typed as <c>IWriteOnlyKeyValueStore</c> or a derived interface. Calls that bind to a concrete store's
+    /// override are ignored: those are low-level plumbing where <c>PreferWriteByArray</c> stores deliberately
+    /// take an owned array, and <c>PutSpan</c> is only reachable there via an interface cast.
+    /// </summary>
+    private static bool IsStoreSet(IMethodSymbol method, StoreTypes types) =>
+        method.Name == "Set" && SymbolEqualityComparer.Default.Equals(method.OriginalDefinition, types.SetMethod);
+}

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -98,8 +98,8 @@ public class ColumnsDbTests
         IWriteBatch colA = batch.GetColumnBatch(ReceiptsColumns.Blocks);
         IWriteBatch colB = batch.GetColumnBatch(ReceiptsColumns.Transactions);
 
-        colA.Set(TestItem.KeccakA.Bytes, TestItem.KeccakA.BytesToArray());
-        colB.Set(TestItem.KeccakA.Bytes, TestItem.KeccakB.BytesToArray());
+        colA.PutSpan(TestItem.KeccakA.Bytes, TestItem.KeccakA.Bytes);
+        colB.PutSpan(TestItem.KeccakA.Bytes, TestItem.KeccakB.Bytes);
 
         batch.Dispose();
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -107,7 +107,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         slotHash.Bytes.CopyTo(storageKey.AsSpan()[4..36]);
         addrHash.Bytes[4..20].CopyTo(storageKey.AsSpan()[36..52]);
 
-        storageDb.Set(storageKey, ((ReadOnlySpan<byte>)value).WithoutLeadingZeros().ToArray());
+        storageDb.PutSpan(storageKey, ((ReadOnlySpan<byte>)value).WithoutLeadingZeros());
     }
 
     private void CorruptAccountInFlat(Address address, Account corruptedAccount)
@@ -118,7 +118,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
             : ValueKeccak.Compute(address.Bytes);
 
         using ArrayPoolSpan<byte> stream = SlimAccountDecoder.EncodeToArrayPoolSpan(corruptedAccount);
-        accountDb.Set(addrKey.BytesAsSpan[..20], ((ReadOnlySpan<byte>)stream).ToArray());
+        accountDb.PutSpan(addrKey.BytesAsSpan[..20], (ReadOnlySpan<byte>)stream);
     }
 
     private static ValueHash256 CreatePreimageAddressKey(Address address)

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
@@ -49,7 +49,7 @@ public class FlatTreeSyncStoreTests
         slotHash.Bytes.CopyTo(storageKey.AsSpan()[4..36]);
         addrHash.Bytes[4..20].CopyTo(storageKey.AsSpan()[36..52]);
 
-        storageDb.Set(storageKey, ((ReadOnlySpan<byte>)value).WithoutLeadingZeros().ToArray());
+        storageDb.PutSpan(storageKey, ((ReadOnlySpan<byte>)value).WithoutLeadingZeros());
     }
 
     private bool HasStorageEntries(Address address)

--- a/src/Nethermind/Nethermind.StateDiffsWriter/Storage/BlockDiffsStore.cs
+++ b/src/Nethermind/Nethermind.StateDiffsWriter/Storage/BlockDiffsStore.cs
@@ -106,7 +106,7 @@ public sealed class BlockDiffsStore(IColumnsDb<BlockDiffsColumns> db)
         }
         Span<byte> value = stackalloc byte[SlotCountValueLength];
         BinaryPrimitives.WriteUInt64BigEndian(value, count);
-        _slotCounts.Set(key, value.ToArray());
+        _slotCounts.PutSpan(key, value);
     }
 
     /// <summary>


### PR DESCRIPTION
## Changes

- Add Roslyn analyzer **NETH007** (`KeyValueStoreSetToArrayAnalyzer`) that flags calls to `IWriteOnlyKeyValueStore.Set(key, value)` whose `value` is a `byte[]` freshly copied from a byte span, and suggests `PutSpan` instead:
  - `span.ToArray()` where `span` is `Span<byte>`/`ReadOnlySpan<byte>` → pass the span.
  - `x.BytesToArray()` where `x`'s type exposes a `Bytes` property of `Span<byte>`/`ReadOnlySpan<byte>` (e.g. `Hash256`, `ValueHash256`) → pass `x.Bytes`.
- `Set` takes a `byte[]`, so these always allocate a heap copy; `PutSpan` takes a `ReadOnlySpan<byte>` and lets the store decide whether a copy is needed (governed by `PreferWriteByArray`).
- **Scope:** fires only on interface-dispatched `Set`. Calls binding to a concrete store's override (`MemDb`, `ReadOnlyDb`, in-memory write batches) are low-level plumbing that deliberately take an owned array (those stores set `PreferWriteByArray => true`), so they're left alone — and `PutSpan` there is only reachable via an interface cast for no benefit.
- **Safety:** `ToByteArray()` is intentionally **not** matched — on types like `UInt256` it reorders to big-endian and is not equivalent to the memory-order `.Bytes` span.
- Convert the existing violations surfaced by the analyzer to `PutSpan` (`BlockDiffsStore`, `ColumnsDbTests`, `FlatTrieVerifierTests`, `FlatTreeSyncStoreTests`). Since the repo builds with `TreatWarningsAsErrors=true`, these had to be fixed for the build to stay green.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`KeyValueStoreSetToArrayAnalyzerTests` (11 cases) covers both copy shapes, interface-vs-concrete dispatch, the `Bytes`-span requirement, list/plain-array negatives, and the `PutSpan`-self-recursion guard. Full `Nethermind.slnx` builds clean with warnings-as-errors; touched test projects pass (`ColumnsDbTests`, `BlockDiffsStoreTests`, `FlatTrieVerifierTests`, `FlatTreeSyncStoreTests`).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
