### PR TITLE
fix(evm): use fixed EIP-7623 token cost for the calldata floor

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/IntrinsicGasCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/IntrinsicGasCalculatorTests.cs
@@ -280,7 +280,6 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Calculate_Eip7623FloorWithoutEip2028_UsesFixedTokenCost()
         {
-            // EIP-7623 floor uses the fixed post-EIP-2028 weight (4) even on a chain without EIP-2028 (multiplier 17).
             ReleaseSpec spec = new()
             {
                 IsEip2Enabled = true,

--- a/src/Nethermind/Nethermind.Evm.Test/IntrinsicGasCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/IntrinsicGasCalculatorTests.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Int256;
+using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using NUnit.Framework;
 
@@ -274,6 +275,33 @@ namespace Nethermind.Evm.Test
 
             ulong regularPlusState = GasCostOf.Transaction + GasCostOf.CreateRegular + GasCostOf.CreateState;
             Assert.That(gas.MinimalGas, Is.GreaterThanOrEqualTo(regularPlusState));
+        }
+
+        [Test]
+        public void Calculate_Eip7623FloorWithoutEip2028_UsesFixedTokenCost()
+        {
+            // EIP-7623 floor uses the fixed post-EIP-2028 weight (4) even on a chain without EIP-2028 (multiplier 17).
+            ReleaseSpec spec = new()
+            {
+                IsEip2Enabled = true,
+                IsEip7623Enabled = true,
+                IsEip2028Enabled = false,
+            };
+
+            byte[] data = new byte[30];
+            for (int i = 0; i < 10; i++) data[i] = 0x01; // 10 non-zero, 20 zero bytes
+            Transaction tx = Build.A.Transaction.SignedAndResolved().WithData(data).TestObject;
+
+            EthereumIntrinsicGas gas = IntrinsicGasCalculator.Calculate(tx, spec);
+
+            const ulong zeros = 20, nonZeros = 10;
+            ulong expectedFloor = GasCostOf.Transaction
+                + GasCostOf.TotalCostFloorPerTokenEip7623 * (zeros + nonZeros * GasCostOf.TxDataNonZeroMultiplierEip2028);
+            ulong expectedStandard = GasCostOf.Transaction
+                + (zeros + nonZeros * spec.GasCosts.TxDataNonZeroMultiplier) * GasCostOf.TxDataZero;
+
+            Assert.That(gas.FloorGas, Is.EqualTo(expectedFloor));   // 21600
+            Assert.That(gas.Standard, Is.EqualTo(expectedStandard)); // 21760, still 68/non-zero byte
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
@@ -104,12 +104,6 @@ public static class IntrinsicGasCalculator
     private static ulong CalculateFloorTokensInCallData(Transaction transaction, IReleaseSpec spec) =>
         (ulong)transaction.Data.Length * spec.GasCosts.TxDataNonZeroMultiplier;
 
-    /// <summary>
-    /// We should use the post-EIP-2028 non-zero calldata multiplier for the EIP-7623 floor cost,
-    /// even when EIP-2028 itself is disabled and the regular intrinsic calldata cost still uses
-    /// the pre-EIP-2028 pricing.
-    /// Matches Geth behavior.
-    /// </summary>
     private static ulong CalculateEip7623FloorTokensInCallData(Transaction transaction, IReleaseSpec spec, ulong tokensInCallData)
     {
         if (spec.IsEip2028Enabled) return tokensInCallData;

--- a/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/IntrinsicGasCalculator.cs
@@ -104,10 +104,25 @@ public static class IntrinsicGasCalculator
     private static ulong CalculateFloorTokensInCallData(Transaction transaction, IReleaseSpec spec) =>
         (ulong)transaction.Data.Length * spec.GasCosts.TxDataNonZeroMultiplier;
 
+    /// <summary>
+    /// We should use the post-EIP-2028 non-zero calldata multiplier for the EIP-7623 floor cost,
+    /// even when EIP-2028 itself is disabled and the regular intrinsic calldata cost still uses
+    /// the pre-EIP-2028 pricing.
+    /// Matches Geth behavior.
+    /// </summary>
+    private static ulong CalculateEip7623FloorTokensInCallData(Transaction transaction, IReleaseSpec spec, ulong tokensInCallData)
+    {
+        if (spec.IsEip2028Enabled) return tokensInCallData;
+
+        ReadOnlySpan<byte> data = transaction.Data.Span;
+        ulong totalZeros = (ulong)data.CountZeros();
+        return totalZeros + ((ulong)data.Length - totalZeros) * GasCostOf.TxDataNonZeroMultiplierEip2028;
+    }
+
     internal static ulong CalculateFloorCost(Transaction transaction, IReleaseSpec spec, ulong tokensInCallData, ulong floorTokensInAccessList) => spec switch
     {
         { IsEip7976Enabled: true } => GasCostOf.Transaction + (CalculateFloorTokensInCallData(transaction, spec) + floorTokensInAccessList) * spec.GasCosts.TotalCostFloorPerToken,
-        { IsEip7623Enabled: true } => GasCostOf.Transaction + tokensInCallData * spec.GasCosts.TotalCostFloorPerToken,
+        { IsEip7623Enabled: true } => GasCostOf.Transaction + CalculateEip7623FloorTokensInCallData(transaction, spec, tokensInCallData) * spec.GasCosts.TotalCostFloorPerToken,
         _ => 0
     };
 }


### PR DESCRIPTION
## Summary

EIP-7623 floor calldata cost should use the post-EIP-2028 non-zero byte weight, which is a fixed constant `4`.

This applies even when EIP-2028 is disabled and regular intrinsic gas still uses pre-EIP-2028 calldata pricing.

This does not affect normal chains where EIP-7623 is enabled together with EIP-2028, but fixes custom configs such as XDC where EIP-7623 is enabled without EIP-2028.

I tried to fix this in XDC plugin only, but it does not seem worth it, and anyway this matches go-ethereum behavior.

## Testing

Added a regression test for an EIP-7623-without-EIP-2028 spec.