### PR TITLE
fix(build): unblock 1.39.0 Release packages build (NETSDK1047 in JsonRpc source generator)

### DIFF
--- a/src/Nethermind/Directory.Build.targets
+++ b/src/Nethermind/Directory.Build.targets
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GenerateRpcJsonContext)' == 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator\Nethermind.JsonRpc.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator.Build\Nethermind.JsonRpc.SourceGenerator.Build.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator\Nethermind.JsonRpc.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext;RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator.Build\Nethermind.JsonRpc.SourceGenerator.Build.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext;RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" />
   </ItemGroup>
 
   <Target Name="_GenerateRpcJsonSerializerContext"
@@ -42,6 +42,7 @@
     <MSBuild Projects="$(_RpcJsonContextGeneratorProject)"
       Targets="GetTargetPath"
       Properties="Configuration=$(_RpcJsonContextGeneratorConfiguration);GenerateRpcJsonContext=false"
+      RemoveProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract"
       BuildInParallel="false">
       <Output TaskParameter="TargetOutputs" PropertyName="_RpcJsonContextGeneratorPath" />
     </MSBuild>
@@ -49,6 +50,7 @@
     <MSBuild Projects="$(_RpcJsonContextGeneratorProject)"
       Targets="Build"
       Properties="Configuration=$(_RpcJsonContextGeneratorConfiguration);GenerateRpcJsonContext=false"
+      RemoveProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract"
       BuildInParallel="false"
       Condition="!Exists('$(_RpcJsonContextGeneratorPath)')" />
 


### PR DESCRIPTION
## Why
The 1.39.0 Release run [28952827201](https://github.com/NethermindEth/nethermind/actions/runs/28952827201) failed in **Build Nethermind packages**:

```
error NETSDK1047: Assets file '.../Nethermind.JsonRpc.SourceGenerator.Build/project.assets.json' doesn't have a target for 'net10.0/linux-x64'
```

`scripts/build/build.sh` publishes with `-r <rid> --sc`. Those CLI **global properties** (`RuntimeIdentifier`, `SelfContained`, `PublishSingleFile`, `IncludeAllContentForSelfExtract`) leak into the RID-less `Nethermind.JsonRpc.SourceGenerator[.Build]` tool builds (via the Exe ProjectReference RID flow and the raw `<MSBuild>` task in `Directory.Build.targets`), and the tool was never restored for a RID.

This is the **first Release packages build since #11697 introduced the generator** (1.38.1 predates it), which is why no release hit it before. The Docker image path is unaffected — it publishes framework-dependent without `-r`. Master has the identical latent bug (twin PR: see below).

## Fix
Strip those properties from the two generator ProjectReferences (`UndefineProperties` + `GlobalPropertiesToRemove`) and the two inner `<MSBuild>` invocations (`RemoveProperties`), so the tool always builds and runs as a portable framework-dependent app. That is also required for the cross-RID legs (win/osx), where the generator must **execute** on the Linux build host — pinning RIDs on the tool project instead would break `dotnet <tool.dll>` there.

## Verification (exact CI SDK container, `10.0.301-resolute`, same digest as `scripts/build/Dockerfile`)
- Pristine `release/1.39.0` tree: `dotnet publish -r linux-x64 --sc --no-restore` reproduces the exact NETSDK1047.
- Patched tree: **linux-x64 publishes successfully** and the produced single-file binary runs (`Version: 1.39.0+repr`).
- Patched tree: **win-x64 and osx-arm64 cross-publish successfully** (generator executed on the Linux host).

After merge: re-run the Release workflow on `release/1.39.0`.