### PR TITLE
fix(build): keep RPC JSON source generator portable in self-contained RID publish

### DIFF
--- a/src/Nethermind/Directory.Build.targets
+++ b/src/Nethermind/Directory.Build.targets
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GenerateRpcJsonContext)' == 'true'">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator\Nethermind.JsonRpc.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator.Build\Nethermind.JsonRpc.SourceGenerator.Build.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator\Nethermind.JsonRpc.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext;RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator.Build\Nethermind.JsonRpc.SourceGenerator.Build.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext;RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" />
   </ItemGroup>
 
   <Target Name="_GenerateRpcJsonSerializerContext"
@@ -47,6 +47,7 @@
     <MSBuild Projects="$(_RpcJsonContextGeneratorProject)"
       Targets="GetTargetPath"
       Properties="Configuration=$(_RpcJsonContextGeneratorConfiguration);GenerateRpcJsonContext=false"
+      RemoveProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract"
       BuildInParallel="false">
       <Output TaskParameter="TargetOutputs" PropertyName="_RpcJsonContextGeneratorPath" />
     </MSBuild>
@@ -54,6 +55,7 @@
     <MSBuild Projects="$(_RpcJsonContextGeneratorProject)"
       Targets="Build"
       Properties="Configuration=$(_RpcJsonContextGeneratorConfiguration);GenerateRpcJsonContext=false"
+      RemoveProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract"
       BuildInParallel="false"
       Condition="!Exists('$(_RpcJsonContextGeneratorPath)')" />
 


### PR DESCRIPTION
Twin of #12341 (release/1.39.0) — master has the identical latent bug.

The Release packages build (`scripts/build/build.sh`) publishes with `-r <rid> --sc`; those CLI global properties (`RuntimeIdentifier`, `SelfContained`, `PublishSingleFile`, `IncludeAllContentForSelfExtract`) leak into the RID-less `Nethermind.JsonRpc.SourceGenerator[.Build]` tool builds, which fail with **NETSDK1047** (no `net10.0/<rid>` target in assets). This broke the 1.39.0 Release run ([28952827201](https://github.com/NethermindEth/nethermind/actions/runs/28952827201)) — the first packages build since #11697 introduced the generator. Without this, the 1.40 release will fail the same way.

Fix: strip the properties from the generator ProjectReferences (`UndefineProperties` + `GlobalPropertiesToRemove`) and the inner `<MSBuild>` invocations (`RemoveProperties`) so the tool always builds and runs as a portable framework-dependent app — required anyway for cross-RID legs (win/osx) where the generator must execute on the Linux build host.

Verified in the CI SDK container (`10.0.301-resolute`) on the 1.39.0 tree: pristine reproduces NETSDK1047 on `publish -r linux-x64 --sc`; patched publishes linux-x64/win-x64/osx-arm64 successfully and the linux binary runs.