### PR TITLE
perf(flat): fall back to the MPMC buffer when the trie warmer slot ring is full

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
@@ -41,7 +41,7 @@ public class FlatWorldStateScopeProviderTests
         public Snapshot? LastCommittedSnapshot { get; set; }
         public TransientResource? LastCreatedCachedResource { get; set; }
 
-        public TestContext(FlatDbConfig? config = null)
+        public TestContext(FlatDbConfig? config = null, ITrieWarmer? trieWarmer = null)
         {
             config ??= new FlatDbConfig();
 
@@ -79,6 +79,11 @@ public class FlatWorldStateScopeProviderTests
                     .AddSingleton<IFlatDbConfig>(config)
                     .AddSingleton<IWorldStateScopeProvider.ICodeDb>(_ => new TrieStoreScopeProvider.KeyValueWithBatchingBackedCodeDb(new TestMemDb()))
                 ;
+
+            if (trieWarmer is not null)
+            {
+                _containerBuilder.AddSingleton(trieWarmer);
+            }
 
             // Externally owned because snapshot bundle take ownership
             _containerBuilder.RegisterType<ReadOnlySnapshotBundle>()
@@ -887,6 +892,59 @@ public class FlatWorldStateScopeProviderTests
         reader.ResumeReads.Set();
 
         Assert.That(() => reader.IsDisposed, Is.True.After(5000, 50), "Reader should be disposed once the warmup job completes");
+    }
+
+    [TestCase(true, false, TestName = "StorageHintSet_SlotRingAccepts_DoesNotFallBack")]
+    [TestCase(false, true, TestName = "StorageHintSet_SlotRingFull_FallsBackToMpmcBuffer")]
+    [TestCase(false, false, TestName = "StorageHintSet_BothBuffersFull_DropsHint")]
+    public void StorageHintSet_FallsBackToMpmcBufferWhenSlotRingIsFull(bool slotRingAccepts, bool mpmcAccepts)
+    {
+        RecordingTrieWarmer warmer = new(slotRingAccepts, mpmcAccepts);
+        using TestContext ctx = new(trieWarmer: warmer);
+        FlatWorldStateScope scope = ctx.Scope;
+        IWorldStateScopeProvider.IStorageTree storageTree = scope.CreateStorageTree(TestItem.AddressA);
+
+        storageTree.HintSet((UInt256)1, [1]);
+
+        Assert.That(warmer.SlotJobPushes, Is.EqualTo(1));
+        Assert.That(warmer.MpmcSlotJobPushes, Is.EqualTo(slotRingAccepts ? 0 : 1));
+
+        // The dedupe bloom is already marked, so a repeated hint for the same slot must not push again.
+        storageTree.HintSet((UInt256)1, [1]);
+        Assert.That(warmer.SlotJobPushes, Is.EqualTo(1));
+        Assert.That(warmer.MpmcSlotJobPushes, Is.EqualTo(slotRingAccepts ? 0 : 1));
+
+        // An accepted push must have incremented the outstanding-warmup counter (and a dropped one must not):
+        // after balancing accepted pushes, Dispose should not enter the wait loop.
+        bool enteredWaitLoop = false;
+        scope.OnWaitingForWarmups = () => enteredWaitLoop = true;
+        if (slotRingAccepts || mpmcAccepts) scope.DecrementOutstandingWarmups();
+        scope.Dispose();
+        Assert.That(enteredWaitLoop, Is.False);
+    }
+
+    private sealed class RecordingTrieWarmer(bool acceptSlotJob, bool acceptMpmcSlotJob) : ITrieWarmer
+    {
+        public int SlotJobPushes { get; private set; }
+        public int MpmcSlotJobPushes { get; private set; }
+
+        public bool PushSlotJob(ITrieWarmer.IStorageWarmer storageTree, in UInt256 index, int sequenceId)
+        {
+            SlotJobPushes++;
+            return acceptSlotJob;
+        }
+
+        public bool PushSlotJobMpmc(ITrieWarmer.IStorageWarmer storageTree, in UInt256 index, int sequenceId)
+        {
+            MpmcSlotJobPushes++;
+            return acceptMpmcSlotJob;
+        }
+
+        public bool PushAddressJob(ITrieWarmer.IAddressWarmer scope, Address? path, int sequenceId) => false;
+
+        public void OnEnterScope() { }
+
+        public void OnExitScope() { }
     }
 
     private sealed class BlockingPersistenceReader : IPersistence.IPersistenceReader

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
@@ -95,7 +95,9 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
     {
         if (_bundle.ShouldQueuePrewarm(_address, index))
         {
-            if (_trieCacheWarmer.PushSlotJob(this, index, _scope.HintSequenceId))
+            // ShouldQueuePrewarm already marked the slot in the dedupe bloom, so a rejected push loses the hint for good.
+            if (_trieCacheWarmer.PushSlotJob(this, index, _scope.HintSequenceId)
+                || _trieCacheWarmer.PushSlotJobMpmc(this, index, _scope.HintSequenceId))
                 _scope.IncrementOutstandingWarmups();
         }
     }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
@@ -19,7 +19,7 @@ namespace Nethermind.State.Flat.ScopeProvider;
 public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
 {
     private const int BufferSize = 1024 * 16;
-    private const int SlotBufferSize = 1024;
+    private const int SlotBufferSize = 1024 * 8;
     private const int DisposeTimeoutMilliseconds = 1000;
 
     private readonly ILogger _logger;


### PR DESCRIPTION
## Changes

- `FlatStorageTree.WarmUpSlot`: when the single-producer slot ring rejects a warm-up hint (ring full), push the job to the 16K multi-producer buffer instead of silently dropping it. The dedupe bloom in `ShouldQueuePrewarm` is marked *before* the push, so a rejected push loses the hint permanently — later writes to that slot never re-hint it, and the un-warmed trie path surfaces as cold synchronous RocksDB node loads inside the storage-merkle commit phase.
- `TrieWarmer.SlotBufferSize`: 1024 → 8192. Dense SSTORE bursts overflow the 1024-entry ring exactly on the write-heavy blocks where the commit walk is deepest.
- Tests: `TestCase`-parameterized coverage of the fallback (ring accepts / ring full → MPMC / both full), including dedupe-bloom and outstanding-warmup-counter behavior, via an `ITrieWarmer` override seam in the scope-provider test context.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

EXPB flat realblocks (`amount=10000`, `--Blocks.SlowBlockThresholdMs=0` per-block phase timings, 16-core reproducible-benchmarks runner):

- Motivating measurement: paired halfpath-vs-flat 10k A/B shows flat `storage_merkle_ms` p90 at 8.4ms vs halfpath 4.6ms, with the gap scaling with write-set size (+40% at 2000–4000 writes/block, +66% above 4000) — hint loss on dense write bursts is one of the two coverage leaks.
- Combined with #12339 (which adds the early hint source that makes coverage matter most), confirmed 3×3 A/B vs master: SSE AVG 25.70 → 24.67 (−4.0%), MEDIAN 21.20 → 20.60 (−2.8%), non-overlapping ranges; `storage_merkle` p90 8.64 → 6.25, `state_hash` p90 10.25 → 7.99; `evm_ms` mean identical (19.78 both arms).
- Standalone 3× run of this branch alone (master base, without #12339) in flight: https://github.com/NethermindEth/nethermind/actions/runs/28978791122 — will post results as a comment.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Complements #12339 (early warm-up hints from the prewarmer): #12339 makes hints arrive ahead of execution; this PR makes sure none of them are lost under burst pressure. No code overlap — the two merge cleanly in either order. Not pursued (measured counterproductive): draining the leftover hint backlog into the commit window regressed storage_merkle p90 to 14.05ms — per-slot warming inside the commit phase loses to the bulk commit walk, so the discard-at-commit behavior is intentionally left unchanged.