### PR TITLE
fix(state): drop stale StorageCell.IsHash guard breaking the master build

### DIFF
--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -67,10 +67,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         base.Set(in storageCell, newValue);
         // Write-time warm-up hint: the commit-time HintSet fires too late for speculative
         // (populator) executions, which never commit. No-op for backends without trie warm-up.
-        if (!storageCell.IsHash)
-        {
-            _currentScope.HintWarmSlot(new ValueAddress(storageCell.Address.Bytes), storageCell.Index);
-        }
+        _currentScope.HintWarmSlot(new ValueAddress(storageCell.Address.Bytes), storageCell.Index);
     }
 
     /// <summary>


### PR DESCRIPTION
## Changes

- Remove the `if (!storageCell.IsHash)` guard around the write-time trie warm-up hint in `PersistentStorageProvider.Set`. Master fails to compile ([docker publish run](https://github.com/NethermindEth/nethermind/actions/runs/29016021702)): #12351 removed `StorageCell.IsHash` one commit before #12339 merged this (guarded) call site — a textually clean, semantically fatal cross-merge. All storage cells are index-based since #12351, so the hint fires unconditionally, matching what #12351 did to every other former `IsHash` call site.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Compile fix; `Nethermind.State` builds again and the storage/scope provider suites pass (131 green), including `Set_pushes_slot_trie_warm_hint_only_from_populator` which covers the hint call site.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No