### PR TITLE
Fall back to chain head when sync progress pointers are missing

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
@@ -6,6 +6,7 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
 using Nethermind.State;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
@@ -38,11 +39,56 @@ namespace Nethermind.Synchronization.Test
         }
 
         [Test]
+        public void Header_block_uses_head_when_no_header_was_suggested()
+        {
+            SyncProgressResolver syncProgressResolver = CreateProgressResolver(false, new SyncConfig { PivotNumber = 1 });
+            Block head = Build.A.Block.WithNumber(5).TestObject;
+            _blockTree.Head.Returns(head);
+            _blockTree.BestSuggestedHeader.ReturnsNull();
+
+            Assert.That(syncProgressResolver.FindBestHeader(), Is.EqualTo(head.Number));
+        }
+
+        [Test]
         public void Best_block_is_0_when_no_block_was_suggested()
         {
             SyncProgressResolver syncProgressResolver = CreateProgressResolver(false, new SyncConfig { PivotNumber = 1 });
             _blockTree.BestSuggestedBody.ReturnsNull();
             Assert.That(syncProgressResolver.FindBestFullBlock(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Best_block_uses_head_when_no_block_was_suggested()
+        {
+            SyncProgressResolver syncProgressResolver = CreateProgressResolver(false, new SyncConfig { PivotNumber = 1 });
+            Block head = Build.A.Block.WithNumber(5).TestObject;
+            _blockTree.Head.Returns(head);
+            _blockTree.BestSuggestedBody.ReturnsNull();
+
+            Assert.That(syncProgressResolver.FindBestFullBlock(), Is.EqualTo(head.Number));
+        }
+
+        [Test]
+        public void Chain_difficulty_uses_head_when_no_block_was_suggested()
+        {
+            SyncProgressResolver syncProgressResolver = CreateProgressResolver(false, new SyncConfig { PivotNumber = 1 });
+            Block head = Build.A.Block.WithNumber(5).WithTotalDifficulty((UInt256)10).TestObject;
+            _blockTree.Head.Returns(head);
+            _blockTree.BestSuggestedBody.ReturnsNull();
+
+            Assert.That(syncProgressResolver.ChainDifficulty, Is.EqualTo(head.TotalDifficulty));
+        }
+
+        [Test]
+        public void Chain_difficulty_uses_head_when_suggested_block_is_behind_head()
+        {
+            SyncProgressResolver syncProgressResolver = CreateProgressResolver(false, new SyncConfig { PivotNumber = 1 });
+            Block head = Build.A.Block.WithNumber(5).WithTotalDifficulty((UInt256)10).TestObject;
+            Block suggested = Build.A.Block.WithNumber(0).WithTotalDifficulty(UInt256.One).TestObject;
+            _blockTree.Head.Returns(head);
+            _blockTree.BestSuggestedBody.Returns(suggested);
+
+            Assert.That(syncProgressResolver.ChainDifficulty, Is.EqualTo(head.TotalDifficulty));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncProgressResolverTests.cs
@@ -80,15 +80,21 @@ namespace Nethermind.Synchronization.Test
         }
 
         [Test]
-        public void Chain_difficulty_uses_head_when_suggested_block_is_behind_head()
+        public void Suggested_pointers_behind_head_are_not_hidden()
         {
             SyncProgressResolver syncProgressResolver = CreateProgressResolver(false, new SyncConfig { PivotNumber = 1 });
             Block head = Build.A.Block.WithNumber(5).WithTotalDifficulty((UInt256)10).TestObject;
-            Block suggested = Build.A.Block.WithNumber(0).WithTotalDifficulty(UInt256.One).TestObject;
+            Block suggested = Build.A.Block.WithNumber(4).WithTotalDifficulty(UInt256.One).TestObject;
             _blockTree.Head.Returns(head);
+            _blockTree.BestSuggestedHeader.Returns(suggested.Header);
             _blockTree.BestSuggestedBody.Returns(suggested);
 
-            Assert.That(syncProgressResolver.ChainDifficulty, Is.EqualTo(head.TotalDifficulty));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(syncProgressResolver.FindBestHeader(), Is.EqualTo(suggested.Number));
+                Assert.That(syncProgressResolver.FindBestFullBlock(), Is.EqualTo(suggested.Number));
+                Assert.That(syncProgressResolver.ChainDifficulty, Is.EqualTo(suggested.TotalDifficulty));
+            }
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -27,25 +27,17 @@ namespace Nethermind.Synchronization.ParallelSync
         private readonly IFullStateFinder _fullStateFinder = fullStateFinder ?? throw new ArgumentNullException(nameof(fullStateFinder));
 
         public ulong FindBestFullState() => _fullStateFinder.FindBestFullState();
-        public ulong FindBestHeader() => Math.Max(
-            _blockTree.Head?.Number ?? 0UL,
-            _blockTree.BestSuggestedHeader?.Number ?? 0UL);
-        public ulong FindBestFullBlock() => Math.Max(
-            _blockTree.Head?.Number ?? 0UL,
-            Math.Min(
-                _blockTree.BestSuggestedHeader?.Number ?? 0UL,
-                _blockTree.BestSuggestedBody?.Number ?? 0UL)); // avoiding any potential concurrency issue
+        public ulong FindBestHeader() => _blockTree.BestSuggestedHeader?.Number ?? _blockTree.Head?.Number ?? 0UL;
+        public ulong FindBestFullBlock()
+        {
+            ulong headNumber = _blockTree.Head?.Number ?? 0UL;
+            return Math.Min(
+                _blockTree.BestSuggestedHeader?.Number ?? headNumber,
+                _blockTree.BestSuggestedBody?.Number ?? headNumber); // header and body suggestions advance independently
+        }
         public bool IsLoadingBlocksFromDb() => !_blockTree.CanAcceptNewBlocks;
         public ulong FindBestProcessedBlock() => _blockTree.Head?.Number ?? ulong.MaxValue;
-        public UInt256 ChainDifficulty
-        {
-            get
-            {
-                UInt256 headDifficulty = _blockTree.Head?.TotalDifficulty ?? UInt256.Zero;
-                UInt256 bestSuggestedBodyDifficulty = _blockTree.BestSuggestedBody?.TotalDifficulty ?? UInt256.Zero;
-                return headDifficulty.CompareTo(bestSuggestedBodyDifficulty) > 0 ? headDifficulty : bestSuggestedBodyDifficulty;
-            }
-        }
+        public UInt256 ChainDifficulty => _blockTree.BestSuggestedBody?.TotalDifficulty ?? _blockTree.Head?.TotalDifficulty ?? UInt256.Zero;
 
         public UInt256? GetTotalDifficulty(Hash256 blockHash)
         {

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncProgressResolver.cs
@@ -27,13 +27,25 @@ namespace Nethermind.Synchronization.ParallelSync
         private readonly IFullStateFinder _fullStateFinder = fullStateFinder ?? throw new ArgumentNullException(nameof(fullStateFinder));
 
         public ulong FindBestFullState() => _fullStateFinder.FindBestFullState();
-        public ulong FindBestHeader() => _blockTree.BestSuggestedHeader?.Number ?? 0UL;
-        public ulong FindBestFullBlock() => Math.Min(
-            _blockTree.BestSuggestedHeader?.Number ?? 0UL,
-            _blockTree.BestSuggestedBody?.Number ?? 0UL); // avoiding any potential concurrency issue
+        public ulong FindBestHeader() => Math.Max(
+            _blockTree.Head?.Number ?? 0UL,
+            _blockTree.BestSuggestedHeader?.Number ?? 0UL);
+        public ulong FindBestFullBlock() => Math.Max(
+            _blockTree.Head?.Number ?? 0UL,
+            Math.Min(
+                _blockTree.BestSuggestedHeader?.Number ?? 0UL,
+                _blockTree.BestSuggestedBody?.Number ?? 0UL)); // avoiding any potential concurrency issue
         public bool IsLoadingBlocksFromDb() => !_blockTree.CanAcceptNewBlocks;
         public ulong FindBestProcessedBlock() => _blockTree.Head?.Number ?? ulong.MaxValue;
-        public UInt256 ChainDifficulty => _blockTree.BestSuggestedBody?.TotalDifficulty ?? UInt256.Zero;
+        public UInt256 ChainDifficulty
+        {
+            get
+            {
+                UInt256 headDifficulty = _blockTree.Head?.TotalDifficulty ?? UInt256.Zero;
+                UInt256 bestSuggestedBodyDifficulty = _blockTree.BestSuggestedBody?.TotalDifficulty ?? UInt256.Zero;
+                return headDifficulty.CompareTo(bestSuggestedBodyDifficulty) > 0 ? headDifficulty : bestSuggestedBodyDifficulty;
+            }
+        }
 
         public UInt256? GetTotalDifficulty(Hash256 blockHash)
         {

--- a/src/Nethermind/Nethermind.Taiko/TaikoSyncProgressResolver.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoSyncProgressResolver.cs
@@ -16,9 +16,10 @@ namespace Nethermind.Taiko;
 /// drives the executor, advancing <c>Head</c> (and the state pointer) past
 /// <c>BestSuggestedHeader</c>.
 ///
-/// The default <see cref="SyncProgressResolver"/> reports <c>FindBestHeader</c> from
-/// <c>BestSuggestedHeader</c> only, so <see cref="MultiSyncModeSelector.IsSnapshotInvalid"/>
-/// fires <c>state &gt; header</c> and <c>processed &gt; block</c>, throws
+/// The default <see cref="SyncProgressResolver"/> uses <c>BestSuggestedHeader</c> whenever
+/// it is present and falls back to <c>Head</c> only when it is absent. On Taiko the stale
+/// non-null pointer makes <see cref="MultiSyncModeSelector.IsSnapshotInvalid"/> fire
+/// <c>state &gt; header</c> and <c>processed &gt; block</c>, which throws
 /// <see cref="System.ComponentModel.InvalidAsynchronousStateException"/>, and the recovery
 /// path (<c>BlockTree.LoadBestKnown</c>) cannot find non-beacon headers — so the sync
 /// loop wedges and the node stalls behind live tip.


### PR DESCRIPTION
## Changes

Fixed invalid snapshot progress by using the processed chain head only for missing suggested pointers, leaving stale pointers visible so the existing block-tree repair can still run.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

