### PR TITLE
perf(ci): build test solutions once and reuse across test jobs

### DIFF
--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -19,8 +19,51 @@ defaults:
     shell: bash
 
 jobs:
+  build:
+    name: Build [${{ matrix.variant.label }}]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - label: checked
+            dotnet-args: -p:DefineConstants=TRACE%3BDEBUG
+          - label: no-intrinsics
+            dotnet-args: ''
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Fetch submodules
+        uses: ./.github/actions/fetch-submodules
+        with:
+          submodules: recursive
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Build test solutions
+        run: |
+          dotnet restore src/Nethermind/Nethermind.slnx --locked-mode
+          dotnet build src/Nethermind/Nethermind.slnx -c release --no-restore ${{ matrix.variant.dotnet-args }}
+          dotnet restore src/Nethermind/EthereumTests.slnx --locked-mode
+          dotnet build src/Nethermind/EthereumTests.slnx -c release --no-restore ${{ matrix.variant.dotnet-args }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-${{ matrix.variant.label }}
+          path: src/Nethermind/artifacts
+          retention-days: 1
+          include-hidden-files: true
+
   tests:
     name: Run ${{ matrix.project }} [${{ matrix.variant.label }}]
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -102,6 +145,15 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-${{ matrix.variant.label }}
+          path: src/Nethermind/artifacts
 
       - name: ${{ matrix.project }}
         id: test
@@ -109,14 +161,13 @@ jobs:
         env:
           DOTNET_EnableHWIntrinsic: ${{ matrix.variant.hw-intrinsic }}
         run: |
-          dotnet build ${{ matrix.project }}.csproj -c release ${{ matrix.variant.dotnet-args }}
-          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
           dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" ${{ matrix.variant.dotnet-args }}
 
   tests-chunked:
     name: Run ${{ matrix.test.project }} (${{ matrix.test.chunk }}) [${{ matrix.variant.label }}]
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -160,6 +211,15 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-${{ matrix.variant.label }}
+          path: src/Nethermind/artifacts
 
       - name: ${{ matrix.test.project }} (${{ matrix.test.chunk }})
         id: test
@@ -169,21 +229,20 @@ jobs:
           TEST_CHUNK: ${{ matrix.test.chunk }}
           TEST_SKIP_HEAVY: 1
         run: |
-          dotnet build ${{ matrix.test.project }}.csproj -c release ${{ matrix.variant.dotnet-args }}
-          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
           dotnet test --project ${{ matrix.test.project }}.csproj -c release "${test_args[@]}" ${{ matrix.variant.dotnet-args }}
 
   tests-summary:
     name: Tests summary
-    needs: [tests, tests-chunked]
+    needs: [build, tests, tests-chunked]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check result
         run: |
           [[ \
+            "${{ needs.build.result }}" == "success" && \
             "${{ needs.tests.result }}" == "success" && \
             "${{ needs.tests-chunked.result }}" == "success" \
           ]]

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -16,8 +16,43 @@ env:
   TEST_USE_FLAT: 1
 
 jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Fetch submodules
+        uses: ./.github/actions/fetch-submodules
+        with:
+          submodules: recursive
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Build test solutions
+        run: |
+          dotnet restore src/Nethermind/Nethermind.slnx --locked-mode
+          dotnet build src/Nethermind/Nethermind.slnx -c release --no-restore
+          dotnet restore src/Nethermind/EthereumTests.slnx --locked-mode
+          dotnet build src/Nethermind/EthereumTests.slnx -c release --no-restore
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-ubuntu-latest
+          path: src/Nethermind/artifacts
+          retention-days: 1
+          include-hidden-files: true
+
   tests:
     name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -74,6 +109,15 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-ubuntu-latest
+          path: src/Nethermind/artifacts
 
       - name: ${{ matrix.project }}
         id: test
@@ -81,8 +125,6 @@ jobs:
         env:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
-          dotnet build ${{ matrix.project }}.csproj -c release
-          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           dotnet test --project ${{ matrix.project }}.csproj -c release --no-build --no-restore
 
   # EEST fixtures under the flat state layout (formerly the Ethereum.Blockchain.Pyspec.Test
@@ -100,13 +142,14 @@ jobs:
 
   tests-summary:
     name: Tests summary
-    needs: [tests, nethtest]
+    needs: [build, tests, nethtest]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check result
         run: |
           [[ \
+            "${{ needs.build.result }}" == "success" && \
             "${{ needs.tests.result }}" == "success" && \
             "${{ needs.nethtest.result }}" == "success" \
           ]]

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -26,8 +26,55 @@ defaults:
     shell: bash
 
 jobs:
+  build:
+    name: Build (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - windows-latest
+          - macos-latest
+    steps:
+      - name: Enable long paths (Windows)
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Fetch submodules
+        uses: ./.github/actions/fetch-submodules
+        with:
+          submodules: recursive
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Build test solutions
+        run: |
+          dotnet restore src/Nethermind/Nethermind.slnx --locked-mode
+          dotnet build src/Nethermind/Nethermind.slnx -c release --no-restore
+          dotnet restore src/Nethermind/EthereumTests.slnx --locked-mode
+          dotnet build src/Nethermind/EthereumTests.slnx -c release --no-restore
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-${{ matrix.runner }}
+          path: src/Nethermind/artifacts
+          retention-days: 1
+          include-hidden-files: true
+
   tests:
     name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }} (${{ matrix.runner }})
+    needs: build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     outputs:
@@ -116,6 +163,15 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-${{ matrix.runner }}
+          path: src/Nethermind/artifacts
 
       - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
         id: test
@@ -124,8 +180,6 @@ jobs:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
           flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
-          dotnet build ${{ matrix.project }}.csproj -c release
-          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
           set +e
@@ -151,6 +205,7 @@ jobs:
 
   tests-spec:
     name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }} (${{ matrix.runner }})
+    needs: build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     strategy:
@@ -199,6 +254,15 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-${{ matrix.runner }}
+          path: src/Nethermind/artifacts
 
       - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
         id: test
@@ -207,8 +271,6 @@ jobs:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
           flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
-          dotnet build ${{ matrix.project }}.csproj -c release
-          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
           set +e
@@ -234,6 +296,7 @@ jobs:
 
   tests-chunked:
     name: Run ${{ matrix.test.project }}${{ matrix.test.label && format(' [{0}]', matrix.test.label) || '' }} (${{ matrix.test.chunk }}) (${{ matrix.runner }})
+    needs: build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     strategy:
@@ -268,6 +331,15 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-${{ matrix.runner }}
+          path: src/Nethermind/artifacts
 
       - name: ${{ matrix.test.project }} (${{ matrix.test.chunk }})
         id: test
@@ -275,8 +347,6 @@ jobs:
         env:
           TEST_CHUNK: ${{ matrix.test.chunk }}
         run: |
-          dotnet build ${{ matrix.test.project }}.csproj -c release
-          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
           set +e
@@ -305,13 +375,14 @@ jobs:
 
   tests-summary:
     name: Tests summary
-    needs: [tests, tests-spec, tests-chunked, nethtest]
+    needs: [build, tests, tests-spec, tests-chunked, nethtest]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check result
         run: |
           [[ \
+            "${{ needs.build.result }}" == "success" && \
             "${{ needs.tests.result }}" == "success" && \
             "${{ needs.tests-spec.result }}" == "success" && \
             "${{ needs.tests-chunked.result }}" == "success" && \


### PR DESCRIPTION
## Changes

- Add a per-platform `build` job to `nethermind-tests.yml`, `nethermind-tests-flat.yml`, and `nethermind-tests-checked.yml` that builds the test solutions once and uploads `artifacts/` as a shared artifact.
- Test matrix jobs now `needs: build`, download the artifact, and run `dotnet test --no-build` instead of rebuilding per job — collapsing hundreds of redundant per-job builds into a handful per workflow.
- `tests-summary` gates include the `build` job.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Validated by CI running these workflows.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
