### PR TITLE
fix(xdc): accept all peer fork IDs at discovery to restore Hello exchange

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/P2P/XdcForkInfo.cs
+++ b/src/Nethermind/Nethermind.Xdc/P2P/XdcForkInfo.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Network;
+
+namespace Nethermind.Xdc.P2P;
+
+/// <summary>
+/// Delegates all fork ID operations to the inner <see cref="IForkInfo"/> but accepts every peer fork ID
+/// as compatible, consistent with <see cref="XdcProtocolValidator.MustValidateForkId"/>.
+/// </summary>
+/// <remarks>
+/// XDC runs a private fork schedule that does not match Ethereum mainnet. Peer fork IDs are already
+/// validated (and intentionally skipped) at the ETH handshake layer via <see cref="XdcProtocolValidator"/>.
+/// Filtering peers at the discovery layer based on fork ID would silently drop all XDC peers before Hello
+/// is even exchanged, so the check is bypassed here as well.
+/// </remarks>
+internal sealed class XdcForkInfo(IForkInfo inner) : IForkInfo
+{
+    public ForkId GetForkId(ulong headNumber, ulong headTimestamp) =>
+        inner.GetForkId(headNumber, headTimestamp);
+
+    public Network.ValidationResult ValidateForkId(ForkId peerId, BlockHeader? head) =>
+        inner.ValidateForkId(peerId, head);
+
+    public ForkActivationsSummary GetForkActivationsSummary(BlockHeader? head) =>
+        inner.GetForkActivationsSummary(head);
+
+    /// <inheritdoc/>
+    /// <remarks>Always returns <see langword="true"/>; see class remarks.</remarks>
+    public bool IsForkIdCompatible(ForkId peerId) => true;
+}

--- a/src/Nethermind/Nethermind.Xdc/XdcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcModule.cs
@@ -118,6 +118,7 @@ public class XdcModule : Module
 
 
             //Network
+            .AddDecorator<IForkInfo, XdcForkInfo>()
             .AddSingleton<IProtocolValidator, XdcProtocolValidator>()
             .AddSingleton<IHeaderDecoder, XdcHeaderDecoder>()
             .AddSingleton(new BlockDecoder(new XdcHeaderDecoder()))


### PR DESCRIPTION
## Changes

- Add `XdcForkInfo`, an `IForkInfo` decorator that delegates all operations to the default `ForkInfo` except `IsForkIdCompatible`, which always returns `true`
- Register it in `XdcModule` via `AddDecorator<IForkInfo, XdcForkInfo>()`

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

The root cause is a regression from commit 3b6cbe0c95 ("Don't feed p2p with external networks peers"), which added `IsForkIdCompatible` filtering to `NodeSource.IsExcluded` in both discv4 and discv5. XDC runs a private fork schedule whose CRC fork hashes differ from Ethereum mainnet, so all XDC peer ENRs fail the compatibility check and are silently dropped before Hello can be exchanged.

`XdcForkInfo` bypasses this filter, consistent with `XdcProtocolValidator.MustValidateForkId = false`, which was already in place at the ETH handshake layer for the same reason. Fork ID enforcement at the discovery layer is unnecessary since XDC controls which bootnodes peers connect through.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No