### PR TITLE
fix(trie): run background pruning off the thread pool to avoid pool starvation

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -1536,13 +1536,14 @@ namespace Nethermind.Trie.Test.Pruning
             writeBlocker.Reset();
             writeReached.Reset();
 
-            // Background pruning
-            Task persistTask = Task.Run(() =>
+            // Background pruning on a dedicated thread, not a pool worker: SyncPruneQueue blocks on
+            // parallel-persist pool tasks, so backgrounding it on the pool can starve and deadlock it.
+            Task persistTask = Task.Factory.StartNew(() =>
             {
                 testPruningStrategy.ShouldPruneEnabled = true;
                 fullTrieStore.SyncPruneQueue();
                 testPruningStrategy.ShouldPruneEnabled = false;
-            });
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             Assert.That(writeReached.Wait(1000), Is.True, "Pruning task did not reach database write");
 
             // Bring block 5's node to block 12

--- a/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/PruningScenariosTests.cs
@@ -426,7 +426,10 @@ namespace Nethermind.Trie.Test
                 return this;
             }
 
-            public Task StartSyncPruneInBackground() => Task.Run(() => _trieStore.SyncPruneQueue());
+            // Dedicated thread, not a pool worker: SyncPruneQueue blocks on parallel-persist pool
+            // tasks, so backgrounding it on the pool can starve and deadlock the pool.
+            public Task StartSyncPruneInBackground() =>
+                Task.Factory.StartNew(() => _trieStore.SyncPruneQueue(), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
             public PruningContext DisposeAndRecreate()
             {
@@ -1373,14 +1376,15 @@ namespace Nethermind.Trie.Test
             ctx.TurnOnPrune();
 
             TimeSpan syncPruneCheckTime = TimeSpan.Zero;
-            Task pruneTime = Task.Run(() =>
+            // Dedicated thread, not a pool worker: SyncPruneCheck blocks on parallel-persist pool tasks.
+            Task pruneTime = Task.Factory.StartNew(() =>
             {
                 long sw = Stopwatch.GetTimestamp();
                 ctx.SyncPruneCheck();
                 ctx.TurnOffPrune();
                 ctx.AssertThatCachedPersistedNodeCountIs(21747L);
                 syncPruneCheckTime = Stopwatch.GetElapsedTime(sw);
-            });
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
             long sw = Stopwatch.GetTimestamp();
             for (int i = 0; i < 1000; i++)

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -578,6 +578,17 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             if (!await Nethermind.Core.Extensions.TaskExtensions.DelaySafe(pruneDelayMs, _pruningTaskCancellationTokenSource.Token)) return;
         }
 
+        // Run off the thread pool: the prune blocks on parallel-persist pool tasks, so joining on
+        // a pool thread can starve and deadlock the pool when many stores prune on a small pool.
+        await Task.Factory.StartNew(
+            RunSyncPrune,
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+    }
+
+    private void RunSyncPrune()
+    {
         using (_pruningLock.EnterScope())
         {
             // Skip triggering GC while pruning so they don't fight each other causing pruning to take longer


### PR DESCRIPTION
## Changes

Fixes the intermittent hang of `Nethermind.Trie.Test` under the `[no-intrinsics]` CI variant (e.g. [run 29043453962](https://github.com/NethermindEth/nethermind/actions/runs/29043453962/job/86206160542)), where the job streamed test events for ~2m40s and then produced zero output until the 15-minute job timeout cancelled it.

**Root cause — thread-pool starvation deadlock.** `TrieStore.TrySyncPrune` runs its background prune on a thread-pool worker (its continuation after the initial `await`). That prune synchronously joins on the parallel-persist work in `ParallelPersistBlockCommitSet` via `Task.WaitAll` over a set of `Task.Run` children (plus a bounded-channel producer/consumer). When many trie stores prune concurrently, the blocked joiners occupy every pool worker while the child persist tasks they are waiting on are still queued — so the child tasks can never be scheduled and the pool deadlocks.

This is latent in production (a single store prunes at a time on a healthy pool), but the trie test suite runs many `TrieStore` instances in parallel (`[Parallelizable(ParallelScope.All)]`), each firing background pruning + parallel persistence. The `[no-intrinsics]` variant is what tips it over: on the 4-core CI runner, with `DOTNET_GCConserveMemory=9` and all hardware intrinsics disabled (slow scalar fallbacks that hold threads/locks far longer), the pool starts small and its blocking-adjusted growth cannot outrun the pile-up of blocked joiners before the job times out.

A thread-stack dump of a reproduced hang shows every worker blocked in `TrieStore.ParallelPersistBlockCommitSet → Task.WaitAll` / `WaitForPruning → _pruningTask.Wait()`, with **zero** CPU activity across snapshots 40s apart — a true stall, not slowness.

The fix keeps the blocking prune off the pool:

- `Nethermind.Trie/Pruning/TrieStore.cs` — run `TrySyncPrune`'s prune body on a dedicated (`LongRunning`) thread instead of a pool worker, so joining on the parallel-persist tasks no longer consumes a pool thread. Pruning is a throttled background operation (`PruneDelayMilliseconds` default 75 ms), so this does not affect the hot path.
- `Nethermind.Trie.Test/PruningScenariosTests.cs`, `Nethermind.Trie.Test/Pruning/TreeStoreTests.cs` — the test helpers that background `SyncPruneQueue`/`SyncPruneCheck` (which internally block on the same parallel-persist tasks) now use dedicated threads instead of `Task.Run`, for the same reason.

No behavioural/consensus change: identical work under the same lock and ordering, only the executing thread changes.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The race is not deterministically reproducible on fast/many-core hardware because the pool grows fast enough. It was reproduced deterministically by forcing a small pool (`DOTNET_ThreadPool_ForceMaxWorkerThreads=4`) together with the CI env (`DOTNET_EnableHWIntrinsic=0 DOTNET_GCConserveMemory=9`): without the fix the suite deadlocks indefinitely; with the fix it completes cleanly. Verified locally:

- Pruning fixtures (`PruningScenariosTests` + `TreeStoreTests`) under the deadlock condition (no-intrinsics + capped pool): **22/22 consecutive runs pass** (~2m each; deadlocked indefinitely before the fix).
- Full `Nethermind.Trie.Test` suite, plain env: 2/2 runs pass (464 tests, 0 failed).
- Full `Nethermind.Trie.Test` suite under the deadlock condition (no-intrinsics + capped pool): 2/2 runs pass (464 tests, 0 failed).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Depends on nothing else; `Nethermind.Trie.Test` builds and passes against current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
