### PR TITLE
test: IWorldState.SStore/SLoad word-based storage surface

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingWorldState.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingWorldState.cs
@@ -248,6 +248,12 @@ public class WitnessGeneratingWorldState(
         base.Set(in storageCell, newValue);
     }
 
+    public override SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+    {
+        RecordSlot(storageCell);
+        return base.SStore(in storageCell, in newValue);
+    }
+
     public override void ClearStorage(Address address)
     {
         RecordEmptySlots(address);

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -2143,6 +2143,24 @@ public ref struct EvmStack
         return true;
     }
 
+    /// <summary>Pops the top of the stack as a big-endian 32-byte word, copied out of the stack slot.</summary>
+    /// <remarks>
+    /// Unlike <see cref="PopWord256"/> the result does not alias the stack, so it stays valid across pushes.
+    /// No byte swap is performed: both the stack slot and <c>EvmWord</c> are big-endian.
+    /// </remarks>
+    public bool PopEvmWord(out EvmWord word)
+    {
+        int head = Head - 1;
+        if (head < 0)
+        {
+            word = default;
+            return false;
+        }
+        Head = head;
+        word = Unsafe.ReadUnaligned<EvmWord>(ref Unsafe.Add(ref _stack, (nint)((uint)head * WordSize)));
+        return true;
+    }
+
     public int PopByte()
     {
         int head = Head;

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -122,6 +122,22 @@ public ref struct EvmStack
         return EvmExceptionType.None;
     }
 
+    /// <summary>Pushes a full 32-byte big-endian word, without the length dispatch <see cref="PushBytes{TTracingInst}(ReadOnlySpan{byte})"/> performs.</summary>
+    /// <remarks>
+    /// Does not report the push to the tracer: callers on an instruction-tracing path must use
+    /// <see cref="PushBytes{TTracingInst}(ReadOnlySpan{byte})"/>, whose span is recorded verbatim.
+    /// </remarks>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public EvmExceptionType PushEvmWord(in EvmWord value)
+    {
+        ref byte dst = ref PushBytesRef();
+        if (Unsafe.IsNullRef(ref dst)) return EvmExceptionType.StackOverflow;
+
+        Unsafe.WriteUnaligned(ref dst, value);
+        return EvmExceptionType.None;
+    }
+
     [SkipLocalsInit]
     private static void PushBytesPartial(ref byte dst, ref byte src, nuint length)
     {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -651,16 +651,23 @@ public static partial class EvmInstructions
             goto OutOfGas;
 
         // Retrieve the persistent storage value and push it onto the stack.
-        ReadOnlySpan<byte> value = vm.WorldState.Get(in storageCell);
-        EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(value);
+        EvmWord value = vm.WorldState.SLoad(in storageCell);
 
-        // Log the storage load operation if tracing is enabled.
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        // Tracers record the value in its minimal-length storage encoding, so keep them on the span-based push.
+        if (TTracingInst.IsActive || vm.TxTracer.IsTracingOpLevelStorage)
         {
-            vm.TxTracer.LoadOperationStorage(executingAccount, result, value);
+            ReadOnlySpan<byte> bytes = StorageWord.ToStorageBytes(in value, out _);
+            EvmExceptionType tracedPushResult = stack.PushBytes<TTracingInst>(bytes);
+
+            if (vm.TxTracer.IsTracingOpLevelStorage)
+            {
+                vm.TxTracer.LoadOperationStorage(executingAccount, result, bytes);
+            }
+
+            return tracedPushResult;
         }
 
-        return pushResult;
+        return stack.PushEvmWord(in value);
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -8,6 +8,7 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.GasPolicy;
+using Nethermind.Evm.State;
 using static Nethermind.Evm.VirtualMachineStatics;
 
 namespace Nethermind.Evm;
@@ -475,12 +476,9 @@ public static partial class EvmInstructions
 
         // Pop the key and then the new value for storage; signal underflow if unavailable.
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
-        if (!stack.PopWord256(out Span<byte> bytesSpan)) goto StackUnderflow;
-        ReadOnlySpan<byte> bytes = bytesSpan;
+        if (!stack.PopEvmWord(out EvmWord newValue)) goto StackUnderflow;
 
-        // Determine if the new value is effectively zero and normalize non-zero values by stripping leading zeros.
-        bool newIsZero = bytes.IsZero();
-        bytes = !newIsZero ? bytes.WithoutLeadingZeros() : BytesZero;
+        bool newIsZero = newValue == default;
 
         // Construct the storage cell for the executing account.
         StorageCell storageCell = new(vmState.Env.ExecutingAccount, in result);
@@ -489,12 +487,17 @@ public static partial class EvmInstructions
         if (!TGasPolicy.ConsumeStorageAccessGas(ref gas, in vmState.AccessTracker, vm.TxTracer.IsTracingAccess, in storageCell, StorageAccessType.SSTORE, spec))
             goto OutOfGas;
 
-        // Retrieve the current value from persistent storage.
-        ReadOnlySpan<byte> currentValue = vm.WorldState.Get(in storageCell);
-        bool currentIsZero = currentValue.IsZero();
+        // SStore performs the write, and Get's span dies on the next IWorldState call, so the tracer's
+        // pre-write value has to be copied out first.
+        byte[]? tracedCurrentValue = vm.TxTracer.IsTracingOpLevelStorage
+            ? vm.WorldState.Get(in storageCell).ToArray()
+            : null;
 
-        // Determine whether the new value is identical to the current stored value.
-        bool newSameAsCurrent = (newIsZero && currentIsZero) || Bytes.AreEqual(currentValue, bytes);
+        // Apply the store and learn how the new value relates to the current and original ones.
+        SStoreState storeState = vm.WorldState.SStore(in storageCell, in newValue);
+
+        bool newSameAsCurrent = storeState.HasFlag(SStoreState.NewSameAsCurrent);
+        bool currentIsZero = storeState.HasFlag(SStoreState.CurrentIsZero);
 
         // Retrieve the refund value associated with clearing storage.
         long sClearRefunds = (long)gasCosts.SClearRefund;
@@ -506,10 +509,8 @@ public static partial class EvmInstructions
         }
         else
         {
-            // Retrieve the original storage value to determine if this is a reversal.
-            ReadOnlySpan<byte> originalValue = vm.WorldState.GetOriginal(in storageCell);
-            bool originalIsZero = originalValue.IsZero();
-            bool currentSameAsOriginal = Bytes.AreEqual(originalValue, currentValue);
+            bool originalIsZero = storeState.HasFlag(SStoreState.OriginalIsZero);
+            bool currentSameAsOriginal = storeState.HasFlag(SStoreState.CurrentSameAsOriginal);
 
             if (currentSameAsOriginal)
             {
@@ -555,7 +556,7 @@ public static partial class EvmInstructions
                 }
 
                 // If the new value reverts to the original, grant a reversal refund.
-                bool newSameAsOriginal = Bytes.AreEqual(originalValue, bytes);
+                bool newSameAsOriginal = storeState.HasFlag(SStoreState.NewSameAsOriginal);
                 if (newSameAsOriginal)
                 {
                     long refundFromReversal = (long)gasCosts.RefundFromReversal(originalIsZero);
@@ -573,25 +574,25 @@ public static partial class EvmInstructions
             }
         }
 
-        // Only update storage if the new value differs from the current value.
-        if (!newSameAsCurrent)
+        if (!newSameAsCurrent && newIsZero)
         {
-            vm.WorldState.Set(in storageCell, newIsZero ? BytesZero : bytes.ToArray());
-            if (newIsZero)
+            vm.MetricsCounters.IncrementStorageDeleted();
+        }
+
+        // Only the tracers want the value in its minimal-length storage encoding; SStore took the raw word.
+        if (TTracingInst.IsActive || vm.TxTracer.IsTracingOpLevelStorage)
+        {
+            ReadOnlySpan<byte> bytes = StorageWord.ToStorageBytes(in newValue, out _);
+
+            if (TTracingInst.IsActive)
             {
-                vm.MetricsCounters.IncrementStorageDeleted();
+                TraceSstore(vm, newIsZero, in storageCell, bytes);
             }
-        }
 
-        // Report storage changes for tracing if enabled.
-        if (TTracingInst.IsActive)
-        {
-            TraceSstore(vm, newIsZero, in storageCell, bytes);
-        }
-
-        if (vm.TxTracer.IsTracingOpLevelStorage)
-        {
-            vm.TxTracer.SetOperationStorage(storageCell.Address, result, bytes, currentValue);
+            if (vm.TxTracer.IsTracingOpLevelStorage)
+            {
+                vm.TxTracer.SetOperationStorage(storageCell.Address, result, bytes, tracedCurrentValue);
+            }
         }
 
         return EvmExceptionType.None;

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -49,6 +49,18 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     ReadOnlySpan<byte> Get(in StorageCell storageCell);
 
     /// <summary>
+    /// Reads the persistent storage value at <paramref name="storageCell"/> as a full 32-byte big-endian word.
+    /// </summary>
+    /// <remarks>
+    /// The SLOAD counterpart to <see cref="SStore"/>: it returns the value in the form the EVM stack holds it,
+    /// so neither side handles the minimal-length encoding <see cref="Get"/> exposes. Unlike <see cref="Get"/>
+    /// the result does not alias backend storage, so it stays valid across later calls.
+    /// </remarks>
+    /// <param name="storageCell">Storage location.</param>
+    /// <returns>Value at cell, zero-padded to 32 bytes.</returns>
+    EvmWord SLoad(in StorageCell storageCell);
+
+    /// <summary>
     /// Set the provided value to persistent storage at the specified storage cell
     /// </summary>
     /// <param name="storageCell">Storage location</param>

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -56,6 +56,31 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     void Set(in StorageCell storageCell, byte[] newValue);
 
     /// <summary>
+    /// Applies an SSTORE to <paramref name="storageCell"/> and reports the comparisons that net gas
+    /// metering needs, without exposing the stored values.
+    /// </summary>
+    /// <remarks>
+    /// The cell is written only when <paramref name="newValue"/> differs from the current value (EIP-2200).
+    /// The write precedes the caller's gas accounting, so an out-of-gas SSTORE mutates state before failing;
+    /// this is safe because the write is journaled and the frame's snapshot restore undoes it, along with the
+    /// block-access-list entry it produces.
+    /// <para>
+    /// The original value is read only when the store is not a no-op, so that witness and access-list tracing
+    /// observe the same accesses as a hand-rolled Get/GetOriginal/Set sequence.
+    /// </para>
+    /// <para>
+    /// <see cref="WorldStateExtensions.ApplySStore"/> is the reference implementation, expressed in terms of
+    /// <see cref="Get"/>, <see cref="GetOriginal"/> and <see cref="Set"/>. Backends that store slots as
+    /// fixed-width words may instead compare without materializing the minimal-length encoding those
+    /// primitives require.
+    /// </para>
+    /// </remarks>
+    /// <param name="storageCell">Storage location.</param>
+    /// <param name="newValue">The 32-byte big-endian word to store.</param>
+    /// <returns>The comparisons between the original, current and new values.</returns>
+    SStoreState SStore(in StorageCell storageCell, in EvmWord newValue);
+
+    /// <summary>
     /// Get the transient storage value at the specified storage cell
     /// </summary>
     /// <param name="storageCell">Storage location</param>

--- a/src/Nethermind/Nethermind.Evm/State/SStoreState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/SStoreState.cs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Evm.State;
+
+/// <summary>
+/// Converts the fixed-width word an SSTORE pops off the stack into the minimal-length big-endian encoding
+/// that <see cref="IWorldState.Get"/>, <see cref="IWorldState.GetOriginal"/> and <see cref="IWorldState.Set"/> use.
+/// </summary>
+public static class StorageWord
+{
+    /// <summary>Returns the storage encoding of <paramref name="word"/>: leading zeros stripped, or <c>[0]</c> when zero.</summary>
+    /// <remarks>The returned span aliases <paramref name="word"/> unless it is zero.</remarks>
+    public static ReadOnlySpan<byte> ToStorageBytes(in EvmWord word, out bool isZero)
+    {
+        ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in word), 1));
+        isZero = bytes.IsZero();
+        return isZero ? VirtualMachineStatics.BytesZero : bytes.WithoutLeadingZeros();
+    }
+}
+
+/// <summary>
+/// The comparisons that SSTORE net gas metering needs from a storage write, as reported by
+/// <see cref="IWorldState.SStore"/>.
+/// </summary>
+/// <remarks>
+/// SSTORE never reads the stored digits: EIP-2200 and EIP-3529 are defined purely in terms of whether the
+/// original, current and new values are zero and whether they are equal. Reporting the answers rather than
+/// the bytes keeps the value encoding private to the backend.
+/// <para>
+/// <see cref="CurrentSameAsOriginal"/>, <see cref="OriginalIsZero"/> and <see cref="NewSameAsOriginal"/> are
+/// only meaningful when <see cref="NewSameAsCurrent"/> is unset. A store that changes nothing must not read
+/// the original value, because witness and access-list tracing observe that read.
+/// </para>
+/// </remarks>
+[Flags]
+public enum SStoreState : byte
+{
+    None = 0,
+
+    /// <summary>The new value equals the value already stored, so no write was performed.</summary>
+    NewSameAsCurrent = 1 << 0,
+
+    /// <summary>The value stored before this write is zero.</summary>
+    CurrentIsZero = 1 << 1,
+
+    /// <summary>The value stored before this write is the value the cell held at the start of the transaction.</summary>
+    CurrentSameAsOriginal = 1 << 2,
+
+    /// <summary>The value the cell held at the start of the transaction is zero.</summary>
+    OriginalIsZero = 1 << 3,
+
+    /// <summary>The new value restores the cell to the value it held at the start of the transaction.</summary>
+    NewSameAsOriginal = 1 << 4,
+}

--- a/src/Nethermind/Nethermind.Evm/State/SStoreState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/SStoreState.cs
@@ -22,6 +22,22 @@ public static class StorageWord
         isZero = bytes.IsZero();
         return isZero ? VirtualMachineStatics.BytesZero : bytes.WithoutLeadingZeros();
     }
+
+    /// <summary>Widens a minimal-length big-endian storage value back into a full word, padding leading zeros.</summary>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="bytes"/> exceeds 32 bytes.</exception>
+    public static EvmWord FromStorageBytes(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length > EvmWordSize) ThrowValueTooLong(bytes.Length);
+
+        EvmWord word = default;
+        bytes.CopyTo(MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref word, 1))[(EvmWordSize - bytes.Length)..]);
+        return word;
+    }
+
+    private const int EvmWordSize = 32;
+
+    private static void ThrowValueTooLong(int length) =>
+        throw new ArgumentException($"Storage value cannot exceed {EvmWordSize} bytes, was {length}", "bytes");
 }
 
 /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat.Test/SlotValueTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SlotValueTests.cs
@@ -19,27 +19,6 @@ public class SlotValueTests
         return data;
     }
 
-    [TestCase(0)]
-    [TestCase(1)]
-    [TestCase(16)]
-    [TestCase(31)]
-    [TestCase(32)]
-    public void Test_Ctor_AcceptsLengthsUpTo32(int length)
-    {
-        byte[] data = IncrementingBytes(length);
-
-        SlotValue value = new(data);
-        ReadOnlySpan<byte> bytes = value.AsReadOnlySpan;
-
-        Assert.That(bytes.Length, Is.EqualTo(32));
-        for (int i = 0; i < length; i++) Assert.That(bytes[i], Is.EqualTo(data[i]));
-        for (int i = length; i < 32; i++) Assert.That(bytes[i], Is.EqualTo(0));
-    }
-
-    [Test]
-    public void Test_Ctor_ThrowsOnOversizedInput() =>
-        Assert.That(() => new SlotValue(new byte[33]), Throws.ArgumentException);
-
     [TestCase(33)]
     [TestCase(64)]
     public void Test_FromSpanWithoutLeadingZero_ThrowsOnOversizedInput(int length) =>
@@ -69,22 +48,9 @@ public class SlotValueTests
     }
 
     [Test]
-    public void Test_FromBytes_ReturnsNullForNull() =>
-        Assert.That(SlotValue.FromBytes(null), Is.Null);
-
-    [Test]
-    public void Test_FromBytes_WrapsNonNull()
-    {
-        byte[] data = Bytes.FromHexString(FullSlotHex);
-        SlotValue? value = SlotValue.FromBytes(data);
-        Assert.That(value, Is.Not.Null);
-        Assert.That(value!.Value.AsReadOnlySpan.ToArray(), Is.EqualTo(data));
-    }
-
-    [Test]
     public void Test_ToEvmBytes_ReturnsCanonicalZeroForZeroValue()
     {
-        SlotValue zero = new(ReadOnlySpan<byte>.Empty);
+        SlotValue zero = SlotValue.FromSpanWithoutLeadingZero(ReadOnlySpan<byte>.Empty);
         Assert.That(zero.ToEvmBytes(), Is.EqualTo(new byte[] { 0 }));
     }
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotCompactorTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotCompactorTests.cs
@@ -103,8 +103,8 @@ public class SnapshotCompactorTests
         TreePath storageNodePath2 = TreePath.FromHexString("5678");
         Hash256 storageNodeHash1 = Keccak.Zero;
         Hash256 storageNodeHash2 = Keccak.Zero;
-        SlotValue slotValue1 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100 });
-        SlotValue slotValue2 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 200 });
+        SlotValue slotValue1 = SlotValue.FromSpanWithoutLeadingZero([100]);
+        SlotValue slotValue2 = SlotValue.FromSpanWithoutLeadingZero([200]);
 
         // Add accounts
         snapshot.Content.Accounts[address1] = new Account(1, 100);
@@ -158,8 +158,8 @@ public class SnapshotCompactorTests
         TreePath statePath2 = TreePath.FromHexString("ef01");
         TreePath storageNodePath1 = TreePath.FromHexString("1234");
         TreePath storageNodePath2 = TreePath.FromHexString("5678");
-        SlotValue slotValue1 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100 });
-        SlotValue slotValue2 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 200 });
+        SlotValue slotValue1 = SlotValue.FromSpanWithoutLeadingZero([100]);
+        SlotValue slotValue2 = SlotValue.FromSpanWithoutLeadingZero([200]);
 
         // First snapshot
         StateId from0 = new(0, Keccak.Zero);
@@ -203,8 +203,8 @@ public class SnapshotCompactorTests
         UInt256 storageIndex = new(1);
         TreePath statePath = TreePath.FromHexString("abcd");
         TreePath storageNodePath = TreePath.FromHexString("1234");
-        SlotValue slotValue1 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100 });
-        SlotValue slotValue2 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 200 });
+        SlotValue slotValue1 = SlotValue.FromSpanWithoutLeadingZero([100]);
+        SlotValue slotValue2 = SlotValue.FromSpanWithoutLeadingZero([200]);
 
         // First snapshot with initial values
         StateId from0 = new(0, Keccak.Zero);
@@ -251,7 +251,7 @@ public class SnapshotCompactorTests
         UInt256 storageIndex = new(1);
         TreePath storagePath = TreePath.FromHexString("1234");
         Hash256 storageHash = Keccak.Zero;
-        SlotValue slotValue = new(new byte[32]);
+        SlotValue slotValue = SlotValue.FromSpanWithoutLeadingZero(new byte[32]);
 
         StateId from0 = new(0, Keccak.Zero);
         StateId to0 = new(1, Keccak.Zero);

--- a/src/Nethermind/Nethermind.State.Flat/SlotValue.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SlotValue.cs
@@ -19,28 +19,17 @@ public readonly struct SlotValue
     public ReadOnlySpan<byte> AsReadOnlySpan => MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _bytes), 1));
     public const int ByteCount = 32;
 
-    public SlotValue(ReadOnlySpan<byte> data)
-    {
-        if (data.Length > 32)
-        {
-            ThrowInvalidLength();
-        }
-
-        if (data.Length == 32)
-        {
-            _bytes = Unsafe.ReadUnaligned<Vector256<byte>>(ref MemoryMarshal.GetReference(data));
-        }
-        else
-        {
-            _bytes = Vector256<byte>.Zero;
-            data.CopyTo(MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref _bytes, 1)));
-        }
-    }
-
     private static void ThrowInvalidLength() => throw new ArgumentException("Slot value cannot exceed 32 bytes", "data");
 
-    public static SlotValue? FromBytes(byte[]? data) => data == null ? null : new SlotValue(data);
-
+    /// <summary>
+    /// Builds a slot value from big-endian bytes, right-aligning shorter input by padding leading zeros.
+    /// </summary>
+    /// <remarks>
+    /// The only way to construct a non-zero value: slot values are big-endian 32-byte words, so a shorter
+    /// buffer must be padded at the front. A left-aligning overload would silently scale the value by a
+    /// power of 256.
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="data"/> exceeds 32 bytes.</exception>
     public static SlotValue FromSpanWithoutLeadingZero(ReadOnlySpan<byte> data)
     {
         switch (data.Length)

--- a/src/Nethermind/Nethermind.State.Test/SStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SStoreTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.State;
@@ -70,6 +71,65 @@ public class SStoreTests
 
             byte[] expectedStored = newValue == 0 ? [0] : [newValue];
             Assert.That(state.Get(in Cell).ToArray(), Is.EqualTo(expectedStored));
+        }
+    }
+
+    /// <summary>SLoad must widen the stored minimal-length value back to the word the EVM stack holds.</summary>
+    [TestCase("", TestName = "SLoad_of_unset_slot_is_zero")]
+    [TestCase("01", TestName = "SLoad_pads_single_byte")]
+    [TestCase("0102", TestName = "SLoad_pads_two_bytes")]
+    [TestCase("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", TestName = "SLoad_full_width")]
+    public void SLoad_returns_zero_padded_word(string storedHex)
+    {
+        byte[] stored = Bytes.FromHexString(storedHex);
+
+        IWorldState state = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = state.BeginScope(IWorldState.PreGenesis);
+        state.CreateAccount(Address, 1);
+        if (stored.Length != 0) state.Set(in Cell, stored);
+        state.Commit(Frontier.Instance);
+
+        byte[] expected = new byte[32];
+        stored.CopyTo(expected.AsSpan(32 - stored.Length));
+
+        EvmWord loaded = state.SLoad(in Cell);
+        Assert.That(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref loaded, 1)).ToArray(), Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// SLoad reads the backing store directly rather than through Get, but must still capture the original
+    /// value: a later SStore reads it (EIP-2200), and would otherwise throw or misreport the reversal.
+    /// </summary>
+    [Test]
+    public void SLoad_captures_original_for_a_later_SStore()
+    {
+        IWorldState state = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = state.BeginScope(IWorldState.PreGenesis);
+        state.CreateAccount(Address, 1);
+        state.Set(in Cell, [5]);
+        state.Commit(Frontier.Instance);
+        state.TakeSnapshot(newTransactionStart: true);
+
+        // The only read of the slot this transaction, so SStore's GetOriginal depends on it.
+        Assert.That(state.SLoad(in Cell), Is.EqualTo(Word(5)));
+
+        // 5 -> 9 is the first write: current still equals the captured original.
+        Assert.That(state.SStore(in Cell, Word(9)), Is.EqualTo(SStoreState.CurrentSameAsOriginal));
+        // 9 -> 5 reverts to the original SLoad observed.
+        Assert.That(state.SStore(in Cell, Word(5)), Is.EqualTo(SStoreState.NewSameAsOriginal));
+    }
+
+    /// <summary>SStore then SLoad must observe the value just written, through the same word representation.</summary>
+    [TestCase(0, TestName = "SLoad_after_SStore_zero")]
+    [TestCase(1, TestName = "SLoad_after_SStore_one")]
+    [TestCase(255, TestName = "SLoad_after_SStore_max_byte")]
+    public void SLoad_observes_preceding_SStore(byte newValue)
+    {
+        (IWorldState state, IDisposable scope) = StateWith(original: 3, current: 3);
+        using (scope)
+        {
+            state.SStore(in Cell, Word(newValue));
+            Assert.That(state.SLoad(in Cell), Is.EqualTo(Word(newValue)));
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Test/SStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SStoreTests.cs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+using NUnit.Framework;
+
+namespace Nethermind.Store.Test;
+
+[Parallelizable(ParallelScope.All)]
+public class SStoreTests
+{
+    private static readonly Address Address = TestItem.AddressA;
+    private static readonly StorageCell Cell = new(Address, UInt256.One);
+
+    /// <summary>Builds the 32-byte big-endian word an SSTORE would pop off the stack.</summary>
+    private static EvmWord Word(byte value)
+    {
+        Span<byte> word = stackalloc byte[32];
+        word[31] = value;
+        return Unsafe.ReadUnaligned<EvmWord>(ref MemoryMarshal.GetReference(word));
+    }
+
+    /// <summary>
+    /// Opens a scope where <paramref name="original"/> is the value the cell held at the start of the
+    /// transaction, then drives the cell to <paramref name="current"/> with a preceding SStore.
+    /// </summary>
+    private static (IWorldState state, IDisposable scope) StateWith(byte original, byte current)
+    {
+        IWorldState state = TestWorldStateFactory.CreateForTest();
+        IDisposable scope = state.BeginScope(IWorldState.PreGenesis);
+
+        state.CreateAccount(Address, 1);
+        if (original != 0) state.Set(in Cell, [original]);
+        state.Commit(Frontier.Instance);
+
+        // Everything after this snapshot is a new transaction, so `original` is what GetOriginal reports.
+        state.TakeSnapshot(newTransactionStart: true);
+
+        if (current != original) state.SStore(in Cell, Word(current));
+        return (state, scope);
+    }
+
+    // (original, current, new) -> the comparisons EIP-2200 metering reads.
+    [TestCase(0, 0, 0, SStoreState.NewSameAsCurrent | SStoreState.CurrentIsZero, TestName = "Noop_on_zero")]
+    [TestCase(1, 1, 1, SStoreState.NewSameAsCurrent, TestName = "Noop_on_nonzero")]
+    [TestCase(0, 0, 1, SStoreState.CurrentIsZero | SStoreState.CurrentSameAsOriginal | SStoreState.OriginalIsZero, TestName = "Fresh_set")]
+    [TestCase(1, 1, 0, SStoreState.CurrentSameAsOriginal, TestName = "Fresh_clear")]
+    [TestCase(1, 1, 2, SStoreState.CurrentSameAsOriginal, TestName = "Fresh_overwrite")]
+    [TestCase(0, 1, 0, SStoreState.OriginalIsZero | SStoreState.NewSameAsOriginal, TestName = "Dirty_reverted_to_zero_original")]
+    [TestCase(1, 2, 1, SStoreState.NewSameAsOriginal, TestName = "Dirty_reverted_to_nonzero_original")]
+    [TestCase(1, 2, 3, SStoreState.None, TestName = "Dirty_overwrite")]
+    [TestCase(1, 0, 1, SStoreState.CurrentIsZero | SStoreState.NewSameAsOriginal, TestName = "Dirty_cleared_then_restored")]
+    public void SStore_reports_comparisons_and_writes(byte original, byte current, byte newValue, SStoreState expected)
+    {
+        (IWorldState state, IDisposable scope) = StateWith(original, current);
+        using (scope)
+        {
+            Assert.That(state.SStore(in Cell, Word(newValue)), Is.EqualTo(expected));
+
+            byte[] expectedStored = newValue == 0 ? [0] : [newValue];
+            Assert.That(state.Get(in Cell).ToArray(), Is.EqualTo(expectedStored));
+        }
+    }
+
+    /// <summary>
+    /// The wrapped state performs the write, so <see cref="TracedAccessWorldState.Set"/> never sees it. The
+    /// decorator's own SStore must record the block-access-list change instead — and only when it writes.
+    /// </summary>
+    [TestCase(7, 7, 0, TestName = "Noop_records_no_storage_change")]
+    [TestCase(7, 8, 1, TestName = "Write_records_storage_change")]
+    public void SStore_records_block_access_list_change_only_when_it_writes(byte original, byte newValue, int expectedChanges)
+    {
+        IWorldState inner = TestWorldStateFactory.CreateForTest();
+        Hash256 stateRoot;
+        using (inner.BeginScope(IWorldState.PreGenesis))
+        {
+            inner.CreateAccount(Address, 1);
+            inner.Set(in Cell, [original]);
+            inner.Commit(Amsterdam.Instance, isGenesis: true);
+            inner.CommitTree(0);
+            stateRoot = inner.StateRoot;
+        }
+
+        BlockHeader baseBlock = Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(0).TestObject;
+        TracedAccessWorldState tracing = new(inner, parallel: false);
+        tracing.SetGeneratingBlockAccessList(new());
+        using IDisposable scope = tracing.BeginScope(baseBlock);
+        tracing.SetIndex(0);
+
+        tracing.SStore(in Cell, Word(newValue));
+
+        AccountChangesAtIndex changes = tracing.GetGeneratingBlockAccessList()!.GetAccountChanges(Address)!;
+        Assert.That(changes.StorageChangeCount, Is.EqualTo(expectedChanges));
+    }
+}

--- a/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
+++ b/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
@@ -126,6 +126,29 @@ public class BlockAccessListBasedWorldState(IWorldState state, ILogManager logMa
 
     public override void Set(in StorageCell storageCell, byte[] newValue) { }
 
+    /// <inheritdoc cref="IWorldState.SStore"/>
+    /// <remarks>
+    /// Reports the comparisons without writing: this state replays a block access list, so <see cref="Set"/> is
+    /// a no-op and delegating to the wrapped state would mutate it.
+    /// </remarks>
+    public override SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+    {
+        ReadOnlySpan<byte> newBytes = StorageWord.ToStorageBytes(in newValue, out bool newIsZero);
+        ReadOnlySpan<byte> currentValue = Get(in storageCell);
+        bool currentIsZero = currentValue.IsZero();
+        bool newSameAsCurrent = (newIsZero && currentIsZero) || Bytes.AreEqual(currentValue, newBytes);
+
+        SStoreState state = currentIsZero ? SStoreState.CurrentIsZero : SStoreState.None;
+        if (newSameAsCurrent) return state | SStoreState.NewSameAsCurrent;
+
+        ReadOnlySpan<byte> originalValue = GetOriginal(in storageCell);
+        if (originalValue.IsZero()) state |= SStoreState.OriginalIsZero;
+        if (Bytes.AreEqual(originalValue, currentValue)) state |= SStoreState.CurrentSameAsOriginal;
+        if (Bytes.AreEqual(originalValue, newBytes)) state |= SStoreState.NewSameAsOriginal;
+
+        return state;
+    }
+
     public override ref readonly UInt256 GetBalance(Address address)
     {
         (IWorldState parentReader, ReadOnlyAccountChanges accountChanges) = ResolveContext(address);

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -15,6 +15,7 @@ using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Resettables;
+using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing.State;
 using Nethermind.Int256;
@@ -77,6 +78,26 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// <returns>Value at location</returns>
     protected override ReadOnlySpan<byte> GetCurrentValue(in StorageCell storageCell) =>
         TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes! : LoadFromTree(storageCell);
+
+    /// <inheritdoc cref="IWorldState.SStore"/>
+    public SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+    {
+        ReadOnlySpan<byte> newBytes = StorageWord.ToStorageBytes(in newValue, out bool newIsZero);
+        ReadOnlySpan<byte> currentValue = Get(in storageCell);
+        bool currentIsZero = currentValue.IsZero();
+        bool newSameAsCurrent = (newIsZero && currentIsZero) || Bytes.AreEqual(currentValue, newBytes);
+
+        SStoreState state = currentIsZero ? SStoreState.CurrentIsZero : SStoreState.None;
+        if (newSameAsCurrent) return state | SStoreState.NewSameAsCurrent;
+
+        ReadOnlySpan<byte> originalValue = GetOriginal(in storageCell);
+        if (originalValue.IsZero()) state |= SStoreState.OriginalIsZero;
+        if (Bytes.AreEqual(originalValue, currentValue)) state |= SStoreState.CurrentSameAsOriginal;
+        if (Bytes.AreEqual(originalValue, newBytes)) state |= SStoreState.NewSameAsOriginal;
+
+        Set(in storageCell, newIsZero ? VirtualMachineStatics.BytesZero : newBytes.ToArray());
+        return state;
+    }
 
     /// <summary>
     /// Return the original persistent storage value from the storage cell

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -79,6 +79,15 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     protected override ReadOnlySpan<byte> GetCurrentValue(in StorageCell storageCell) =>
         TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes! : LoadFromTree(storageCell);
 
+    /// <inheritdoc cref="IWorldState.SLoad"/>
+    /// <remarks>
+    /// Reads the backing store directly instead of going through <see cref="PartialStorageProviderBase.Get"/>, so
+    /// that widening is the only step between the stored value and the caller. A backend holding fixed-width words
+    /// can drop that step too.
+    /// </remarks>
+    public EvmWord SLoad(in StorageCell storageCell) =>
+        StorageWord.FromStorageBytes(TryGetCachedValue(storageCell, out byte[]? cached) ? cached! : LoadFromTree(storageCell));
+
     /// <inheritdoc cref="IWorldState.SStore"/>
     public SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
     {

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -117,6 +117,27 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
         base.Set(storageCell, newValue);
     }
 
+    /// <inheritdoc cref="IWorldState.SStore"/>
+    /// <remarks>
+    /// The wrapped state performs the read and the write, so the read-recording and the change-recording that
+    /// <see cref="Get"/> and <see cref="Set"/> normally contribute are done here instead.
+    /// </remarks>
+    public override SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+    {
+        // Records the read; copied because the span dies on the next call into the wrapped state.
+        byte[] oldValue = Get(in storageCell).ToArray();
+
+        SStoreState state = base.SStore(in storageCell, in newValue);
+
+        if (!state.HasFlag(SStoreState.NewSameAsCurrent))
+        {
+            ReadOnlySpan<byte> newBytes = StorageWord.ToStorageBytes(in newValue, out _);
+            _generatingBlockAccessList.AddStorageChange(storageCell, new(oldValue, true), new(newBytes, true));
+        }
+
+        return state;
+    }
+
     public override ref readonly UInt256 GetBalance(Address address)
     {
         AccountChangesAtIndex? accountChanges = RecordReadAndGetChanges(address);

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -111,6 +111,13 @@ namespace Nethermind.State
             return _persistentStorageProvider.Get(storageCell);
         }
 
+        /// <inheritdoc cref="IWorldState.SLoad"/>
+        public EvmWord SLoad(in StorageCell storageCell)
+        {
+            DebugGuardInScope();
+            return _persistentStorageProvider.SLoad(in storageCell);
+        }
+
         /// <inheritdoc cref="IWorldState.SStore"/>
         public SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
         {

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -110,6 +110,13 @@ namespace Nethermind.State
             DebugGuardInScope();
             return _persistentStorageProvider.Get(storageCell);
         }
+
+        /// <inheritdoc cref="IWorldState.SStore"/>
+        public SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+        {
+            DebugGuardInScope();
+            return _persistentStorageProvider.SStore(in storageCell, in newValue);
+        }
         public void Set(in StorageCell storageCell, byte[] newValue)
         {
             DebugGuardInScope();

--- a/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
@@ -72,6 +72,15 @@ public abstract class WorldStateDecorator(IWorldState state) : IWorldState
     public virtual void Set(in StorageCell storageCell, byte[] newValue)
         => State.Set(in storageCell, newValue);
 
+    /// <inheritdoc cref="IWorldState.SStore"/>
+    /// <remarks>
+    /// The store runs entirely inside <see cref="State"/>, so a derived class that hooks <see cref="Get"/>,
+    /// <see cref="GetOriginal"/> or <see cref="Set"/> to record accesses must override this too — those hooks
+    /// are not reached from here.
+    /// </remarks>
+    public virtual SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+        => State.SStore(in storageCell, in newValue);
+
     public virtual ReadOnlySpan<byte> GetTransientState(in StorageCell storageCell)
         => State.GetTransientState(in storageCell);
 

--- a/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
@@ -69,6 +69,15 @@ public abstract class WorldStateDecorator(IWorldState state) : IWorldState
     public virtual ReadOnlySpan<byte> Get(in StorageCell storageCell)
         => State.Get(in storageCell);
 
+    /// <inheritdoc cref="IWorldState.SLoad"/>
+    /// <remarks>
+    /// Reads through this decorator's <see cref="Get"/> rather than forwarding to <see cref="State"/>: a derived
+    /// class may serve the value from elsewhere or record the access, and forwarding would bypass both. There is
+    /// nothing else for a decorator to hook here, so overriding this is normally unnecessary.
+    /// </remarks>
+    public virtual EvmWord SLoad(in StorageCell storageCell)
+        => StorageWord.FromStorageBytes(Get(in storageCell));
+
     public virtual void Set(in StorageCell storageCell, byte[] newValue)
         => State.Set(in storageCell, newValue);
 


### PR DESCRIPTION
## Changes

Narrows the storage surface the EVM uses so SLOAD/SSTORE no longer handle the minimal-length value encoding — that stays private to the storage backend.

- `IWorldState.SStore(in StorageCell, in EvmWord)` — takes the raw 32-byte stack word, performs the write, and returns an `SStoreState` flags value with the comparisons EIP-2200/EIP-3529 metering needs (`NewSameAsCurrent`, `CurrentIsZero`, `CurrentSameAsOriginal`, `OriginalIsZero`, `NewSameAsOriginal`). The opcode no longer reads or compares stored bytes itself.
- `IWorldState.SLoad(in StorageCell) → EvmWord` — the counterpart read, returning the value in the word form the stack holds, so neither side re-pads.
- Canonical logic lives in `PersistentStorageProvider`; `WorldState` proxies. Decorators (`TracedAccessWorldState`, `BlockAccessListBasedWorldState`, `WitnessGeneratingWorldState`) carry their own recording/replay logic where forwarding would bypass it.
- `EvmStack.PopEvmWord` / `PushEvmWord` (no byte swap — stack slot and `EvmWord` are both big-endian); `StorageWord.To/FromStorageBytes` for the encoding boundary.
- Removes the left-aligning `SlotValue` constructor and `FromBytes` (dead, and silently scaled short input by a power of 256).

The EVM now hands over a raw word and only computes the minimal-length encoding for the tracers. The payoff lands fully once the backend stores fixed-width words: the flat path's `SlotValue → ToEvmBytes → WithoutLeadingZeros → ToArray` per-read allocation disappears.

> **Draft — `test:` prefixed to trigger the EVM/payload benchmark on this branch.** Opened for the benchmark signal on the SSTORE write-ordering and SLOAD read-path changes, not yet for review.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring
- [x] Optimization
- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New `SStoreTests` cover the `SStore` comparison flags across the EIP-2200 state matrix, the no-op-doesn't-read-original invariant (via BAL recording), `SLoad` zero-padding, and `SLoad`-captures-original-for-a-later-`SStore`. `Nethermind.Evm.Test` (4828), `Nethermind.State.Test`, and `Nethermind.Consensus.Test` (107) pass locally. **Not yet run locally:** `Ethereum.Blockchain.Test` (EF spec suite) and `dotnet format` — relying on CI for those, since the SSTORE write now precedes gas accounting (rolled back via the frame snapshot on out-of-gas).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
