### PR TITLE
test: carry storage slot values as EvmWord end-to-end

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -434,7 +434,7 @@ public class BlockCachePreWarmerTests
         Assert.That(preBlockCaches.StorageCache.TryGetValue(in warmedCell, out _), Is.True);
 
         preBlockCaches.StateCache.Set(in warmedAddress, new Account(777UL));
-        preBlockCaches.StorageCache.Set(in warmedCell, [0x24]);
+        preBlockCaches.StorageCache.Set(in warmedCell, StorageWord.FromStorageBytes([0x24]));
 
         AddressAsKey missedAddress = TestItem.AddressB;
         StorageCell missedCell = new(TestItem.AddressB, 10);
@@ -457,8 +457,8 @@ public class BlockCachePreWarmerTests
 
         Assert.That(preBlockCaches.StateCache.TryGetValue(in missedAddress, out Account? populatedAccount), Is.True);
         Assert.That(populatedAccount!.Balance, Is.EqualTo(1_000_000.Ether));
-        Assert.That(preBlockCaches.StorageCache.TryGetValue(in missedCell, out byte[]? populatedStorage), Is.True);
-        Assert.That(new UInt256(populatedStorage, isBigEndian: true), Is.EqualTo((UInt256)0x99));
+        Assert.That(preBlockCaches.StorageCache.TryGetValue(in missedCell, out EvmWord populatedStorage), Is.True);
+        Assert.That(new UInt256(StorageWord.AsSpan(in populatedStorage), isBigEndian: true), Is.EqualTo((UInt256)0x99));
     }
 
     [TestCase(false, true, false, TestName = "PreWarmCaches_NoSpeculativePass_Clears")]

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingWorldState.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingWorldState.cs
@@ -248,6 +248,12 @@ public class WitnessGeneratingWorldState(
         base.Set(in storageCell, newValue);
     }
 
+    public override SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+    {
+        RecordSlot(storageCell);
+        return base.SStore(in storageCell, in newValue);
+    }
+
     public override void ClearStorage(Address address)
     {
         RecordEmptySlots(address);

--- a/src/Nethermind/Nethermind.Core.Test/Collections/SeqlockCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Collections/SeqlockCacheTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core.Collections;
@@ -73,6 +74,29 @@ public class SeqlockCacheTests
         {
             Assert.That(found, Is.True);
             Assert.That(value, Is.SameAs(expected));
+        }
+    }
+
+    // A 32-byte struct value is the seqlock's raison d'être: it is copied inline (no heap box) and read under
+    // the version guard. This exercises the value-type path enabled by relaxing the class constraint.
+    [Test]
+    public void Struct_value_stored_inline_round_trips_and_overwrites()
+    {
+        SeqlockCache<StorageCell, Vector256<byte>> cache = new();
+        StorageCell key = CreateKey(1);
+        Vector256<byte> first = Vector256.Create(CreateValue(1));
+        Vector256<byte> second = Vector256.Create(CreateValue(2));
+
+        Assert.That(cache.TryGetValue(in key, out Vector256<byte> _), Is.False);
+
+        cache.Set(in key, first);
+        cache.Set(in key, second);
+        bool found = cache.TryGetValue(in key, out Vector256<byte> value);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(found, Is.True);
+            Assert.That(value, Is.EqualTo(second));
         }
     }
 

--- a/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SeqlockCache.cs
@@ -40,8 +40,9 @@ namespace Nethermind.Core.Collections;
 /// <typeparam name="TValue">The value type (reference type, nullable allowed)</typeparam>
 public sealed class SeqlockCache<TKey, TValue>
     where TKey : struct, IHash64bit<TKey>
-    where TValue : class?
 {
+    // The seqlock read protocol copies the whole value between two version reads and retries on a torn read,
+    // so a multi-word struct value (e.g. a 32-byte EvmWord) is stored safely inline without a heap box.
     /// <summary>
     /// Default number of set-index bits: 16384 sets × 2 ways = 32768 total entries.
     /// </summary>
@@ -327,7 +328,8 @@ public sealed class SeqlockCache<TKey, TValue>
             long h0_2 = Volatile.Read(ref e0.HashEpochSeqLock);
             if (h0 == h0_2 && k0.Equals(in key))
             {
-                if (ReferenceEquals(v0, value)) return; // fast-path: same key+value, no-op
+                // Reference-identity no-op fast path; only meaningful for reference values, JIT-folded away for structs.
+                if (default(TValue) is null && ReferenceEquals(v0, value)) return;
                 WriteEntry(ref e0, h0_2, in key, value, tagToStore);
                 return;
             }
@@ -347,7 +349,8 @@ public sealed class SeqlockCache<TKey, TValue>
             long h1_2 = Volatile.Read(ref e1.HashEpochSeqLock);
             if (h1 == h1_2 && k1.Equals(in key))
             {
-                if (ReferenceEquals(v1, value)) return; // fast-path: same key+value, no-op
+                // Reference-identity no-op fast path; only meaningful for reference values, JIT-folded away for structs.
+                if (default(TValue) is null && ReferenceEquals(v1, value)) return;
                 WriteEntry(ref e1, h1_2, in key, value, tagToStore);
                 return;
             }

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -2143,6 +2143,24 @@ public ref struct EvmStack
         return true;
     }
 
+    /// <summary>Pops the top of the stack as a big-endian 32-byte word, copied out of the stack slot.</summary>
+    /// <remarks>
+    /// Unlike <see cref="PopWord256"/> the result does not alias the stack, so it stays valid across pushes.
+    /// No byte swap is performed: both the stack slot and <c>EvmWord</c> are big-endian.
+    /// </remarks>
+    public bool PopEvmWord(out EvmWord word)
+    {
+        int head = Head - 1;
+        if (head < 0)
+        {
+            word = default;
+            return false;
+        }
+        Head = head;
+        word = Unsafe.ReadUnaligned<EvmWord>(ref Unsafe.Add(ref _stack, (nint)((uint)head * WordSize)));
+        return true;
+    }
+
     public int PopByte()
     {
         int head = Head;

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -122,6 +122,22 @@ public ref struct EvmStack
         return EvmExceptionType.None;
     }
 
+    /// <summary>Pushes a full 32-byte big-endian word, without the length dispatch <see cref="PushBytes{TTracingInst}(ReadOnlySpan{byte})"/> performs.</summary>
+    /// <remarks>
+    /// Does not report the push to the tracer: callers on an instruction-tracing path must use
+    /// <see cref="PushBytes{TTracingInst}(ReadOnlySpan{byte})"/>, whose span is recorded verbatim.
+    /// </remarks>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public EvmExceptionType PushEvmWord(in EvmWord value)
+    {
+        ref byte dst = ref PushBytesRef();
+        if (Unsafe.IsNullRef(ref dst)) return EvmExceptionType.StackOverflow;
+
+        Unsafe.WriteUnaligned(ref dst, value);
+        return EvmExceptionType.None;
+    }
+
     [SkipLocalsInit]
     private static void PushBytesPartial(ref byte dst, ref byte src, nuint length)
     {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -651,16 +651,23 @@ public static partial class EvmInstructions
             goto OutOfGas;
 
         // Retrieve the persistent storage value and push it onto the stack.
-        ReadOnlySpan<byte> value = vm.WorldState.Get(in storageCell);
-        EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(value);
+        EvmWord value = vm.WorldState.SLoad(in storageCell);
 
-        // Log the storage load operation if tracing is enabled.
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        // Tracers record the value in its minimal-length storage encoding, so keep them on the span-based push.
+        if (TTracingInst.IsActive || vm.TxTracer.IsTracingOpLevelStorage)
         {
-            vm.TxTracer.LoadOperationStorage(executingAccount, result, value);
+            ReadOnlySpan<byte> bytes = StorageWord.ToStorageBytes(in value, out _);
+            EvmExceptionType tracedPushResult = stack.PushBytes<TTracingInst>(bytes);
+
+            if (vm.TxTracer.IsTracingOpLevelStorage)
+            {
+                vm.TxTracer.LoadOperationStorage(executingAccount, result, bytes);
+            }
+
+            return tracedPushResult;
         }
 
-        return pushResult;
+        return stack.PushEvmWord(in value);
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -8,6 +8,7 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.GasPolicy;
+using Nethermind.Evm.State;
 using static Nethermind.Evm.VirtualMachineStatics;
 
 namespace Nethermind.Evm;
@@ -475,12 +476,9 @@ public static partial class EvmInstructions
 
         // Pop the key and then the new value for storage; signal underflow if unavailable.
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
-        if (!stack.PopWord256(out Span<byte> bytesSpan)) goto StackUnderflow;
-        ReadOnlySpan<byte> bytes = bytesSpan;
+        if (!stack.PopEvmWord(out EvmWord newValue)) goto StackUnderflow;
 
-        // Determine if the new value is effectively zero and normalize non-zero values by stripping leading zeros.
-        bool newIsZero = bytes.IsZero();
-        bytes = !newIsZero ? bytes.WithoutLeadingZeros() : BytesZero;
+        bool newIsZero = newValue == default;
 
         // Construct the storage cell for the executing account.
         StorageCell storageCell = new(vmState.Env.ExecutingAccount, in result);
@@ -489,12 +487,17 @@ public static partial class EvmInstructions
         if (!TGasPolicy.ConsumeStorageAccessGas(ref gas, in vmState.AccessTracker, vm.TxTracer.IsTracingAccess, in storageCell, StorageAccessType.SSTORE, spec))
             goto OutOfGas;
 
-        // Retrieve the current value from persistent storage.
-        ReadOnlySpan<byte> currentValue = vm.WorldState.Get(in storageCell);
-        bool currentIsZero = currentValue.IsZero();
+        // SStore performs the write, and Get's span dies on the next IWorldState call, so the tracer's
+        // pre-write value has to be copied out first.
+        byte[]? tracedCurrentValue = vm.TxTracer.IsTracingOpLevelStorage
+            ? vm.WorldState.Get(in storageCell).ToArray()
+            : null;
 
-        // Determine whether the new value is identical to the current stored value.
-        bool newSameAsCurrent = (newIsZero && currentIsZero) || Bytes.AreEqual(currentValue, bytes);
+        // Apply the store and learn how the new value relates to the current and original ones.
+        SStoreState storeState = vm.WorldState.SStore(in storageCell, in newValue);
+
+        bool newSameAsCurrent = storeState.HasFlag(SStoreState.NewSameAsCurrent);
+        bool currentIsZero = storeState.HasFlag(SStoreState.CurrentIsZero);
 
         // Retrieve the refund value associated with clearing storage.
         long sClearRefunds = (long)gasCosts.SClearRefund;
@@ -506,10 +509,8 @@ public static partial class EvmInstructions
         }
         else
         {
-            // Retrieve the original storage value to determine if this is a reversal.
-            ReadOnlySpan<byte> originalValue = vm.WorldState.GetOriginal(in storageCell);
-            bool originalIsZero = originalValue.IsZero();
-            bool currentSameAsOriginal = Bytes.AreEqual(originalValue, currentValue);
+            bool originalIsZero = storeState.HasFlag(SStoreState.OriginalIsZero);
+            bool currentSameAsOriginal = storeState.HasFlag(SStoreState.CurrentSameAsOriginal);
 
             if (currentSameAsOriginal)
             {
@@ -555,7 +556,7 @@ public static partial class EvmInstructions
                 }
 
                 // If the new value reverts to the original, grant a reversal refund.
-                bool newSameAsOriginal = Bytes.AreEqual(originalValue, bytes);
+                bool newSameAsOriginal = storeState.HasFlag(SStoreState.NewSameAsOriginal);
                 if (newSameAsOriginal)
                 {
                     long refundFromReversal = (long)gasCosts.RefundFromReversal(originalIsZero);
@@ -573,25 +574,25 @@ public static partial class EvmInstructions
             }
         }
 
-        // Only update storage if the new value differs from the current value.
-        if (!newSameAsCurrent)
+        if (!newSameAsCurrent && newIsZero)
         {
-            vm.WorldState.Set(in storageCell, newIsZero ? BytesZero : bytes.ToArray());
-            if (newIsZero)
+            vm.MetricsCounters.IncrementStorageDeleted();
+        }
+
+        // Only the tracers want the value in its minimal-length storage encoding; SStore took the raw word.
+        if (TTracingInst.IsActive || vm.TxTracer.IsTracingOpLevelStorage)
+        {
+            ReadOnlySpan<byte> bytes = StorageWord.ToStorageBytes(in newValue, out _);
+
+            if (TTracingInst.IsActive)
             {
-                vm.MetricsCounters.IncrementStorageDeleted();
+                TraceSstore(vm, newIsZero, in storageCell, bytes);
             }
-        }
 
-        // Report storage changes for tracing if enabled.
-        if (TTracingInst.IsActive)
-        {
-            TraceSstore(vm, newIsZero, in storageCell, bytes);
-        }
-
-        if (vm.TxTracer.IsTracingOpLevelStorage)
-        {
-            vm.TxTracer.SetOperationStorage(storageCell.Address, result, bytes, currentValue);
+            if (vm.TxTracer.IsTracingOpLevelStorage)
+            {
+                vm.TxTracer.SetOperationStorage(storageCell.Address, result, bytes, tracedCurrentValue);
+            }
         }
 
         return EvmExceptionType.None;

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -49,6 +49,18 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     ReadOnlySpan<byte> Get(in StorageCell storageCell);
 
     /// <summary>
+    /// Reads the persistent storage value at <paramref name="storageCell"/> as a full 32-byte big-endian word.
+    /// </summary>
+    /// <remarks>
+    /// The SLOAD counterpart to <see cref="SStore"/>: it returns the value in the form the EVM stack holds it,
+    /// so neither side handles the minimal-length encoding <see cref="Get"/> exposes. Unlike <see cref="Get"/>
+    /// the result does not alias backend storage, so it stays valid across later calls.
+    /// </remarks>
+    /// <param name="storageCell">Storage location.</param>
+    /// <returns>Value at cell, zero-padded to 32 bytes.</returns>
+    EvmWord SLoad(in StorageCell storageCell);
+
+    /// <summary>
     /// Set the provided value to persistent storage at the specified storage cell
     /// </summary>
     /// <param name="storageCell">Storage location</param>

--- a/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldState.cs
@@ -56,6 +56,31 @@ public interface IWorldState : IJournal<Snapshot>, IReadOnlyStateProvider
     void Set(in StorageCell storageCell, byte[] newValue);
 
     /// <summary>
+    /// Applies an SSTORE to <paramref name="storageCell"/> and reports the comparisons that net gas
+    /// metering needs, without exposing the stored values.
+    /// </summary>
+    /// <remarks>
+    /// The cell is written only when <paramref name="newValue"/> differs from the current value (EIP-2200).
+    /// The write precedes the caller's gas accounting, so an out-of-gas SSTORE mutates state before failing;
+    /// this is safe because the write is journaled and the frame's snapshot restore undoes it, along with the
+    /// block-access-list entry it produces.
+    /// <para>
+    /// The original value is read only when the store is not a no-op, so that witness and access-list tracing
+    /// observe the same accesses as a hand-rolled Get/GetOriginal/Set sequence.
+    /// </para>
+    /// <para>
+    /// <see cref="WorldStateExtensions.ApplySStore"/> is the reference implementation, expressed in terms of
+    /// <see cref="Get"/>, <see cref="GetOriginal"/> and <see cref="Set"/>. Backends that store slots as
+    /// fixed-width words may instead compare without materializing the minimal-length encoding those
+    /// primitives require.
+    /// </para>
+    /// </remarks>
+    /// <param name="storageCell">Storage location.</param>
+    /// <param name="newValue">The 32-byte big-endian word to store.</param>
+    /// <returns>The comparisons between the original, current and new values.</returns>
+    SStoreState SStore(in StorageCell storageCell, in EvmWord newValue);
+
+    /// <summary>
     /// Get the transient storage value at the specified storage cell
     /// </summary>
     /// <param name="storageCell">Storage location</param>

--- a/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IWorldStateScopeProvider.cs
@@ -115,8 +115,8 @@ public interface IWorldStateScopeProvider
         /// Called when a storage slot has been read for the given cell.
         /// </summary>
         /// <param name="storageCell">The storage cell (address + slot index).</param>
-        /// <param name="value">The storage value bytes.</param>
-        void OnStorageRead(in StorageCell storageCell, byte[] value);
+        /// <param name="value">The storage value as a full 32-byte word.</param>
+        void OnStorageRead(in StorageCell storageCell, in EvmWord value);
 
         /// <summary>
         /// Returns whether the BAL reader should still fetch the given account.
@@ -167,13 +167,13 @@ public interface IWorldStateScopeProvider
     {
         Hash256 RootHash { get; }
 
-        byte[] Get(in UInt256 index);
+        EvmWord Get(in UInt256 index);
 
         /// <summary>
         /// Hint that a slot is being written. Backends may use this to start asynchronous
         /// trie warm-up for the slot path.
         /// </summary>
-        void HintSet(in UInt256 index, byte[]? value);
+        void HintSet(in UInt256 index, in EvmWord value);
     }
 
     public interface IWorldStateWriteBatch : IDisposable
@@ -200,7 +200,7 @@ public interface IWorldStateScopeProvider
 
     public interface IStorageWriteBatch : IDisposable
     {
-        void Set(in UInt256 index, byte[] value);
+        void Set(in UInt256 index, in EvmWord value);
 
         /// <summary>
         /// Self-destruct. Maybe costly. Must be called first.

--- a/src/Nethermind/Nethermind.Evm/State/PreBlockCaches.cs
+++ b/src/Nethermind/Nethermind.Evm/State/PreBlockCaches.cs
@@ -19,7 +19,7 @@ public class PreBlockCaches
 
     private readonly Func<CacheType>[] _clearCaches;
 
-    private readonly SeqlockCache<StorageCell, byte[]> _storageCache;
+    private readonly SeqlockCache<StorageCell, EvmWord> _storageCache;
     private readonly SeqlockCache<AddressAsKey, Account> _stateCache = new();
     private readonly ConcurrentDictionary<PrecompileCacheKey, Result<byte[]>> _precompileCache = new(LockPartitions, InitialCapacity);
     private volatile IWorldStateScopeProvider.IScope? _mainScope;
@@ -28,7 +28,7 @@ public class PreBlockCaches
 
     public PreBlockCaches(PreBlockCachesConfig config)
     {
-        _storageCache = new SeqlockCache<StorageCell, byte[]>(config.StorageCacheSetsBits);
+        _storageCache = new SeqlockCache<StorageCell, EvmWord>(config.StorageCacheSetsBits);
         _clearCaches =
         [
             () => { _storageCache.Clear(); return CacheType.None; },
@@ -37,7 +37,7 @@ public class PreBlockCaches
         ];
     }
 
-    public SeqlockCache<StorageCell, byte[]> StorageCache => _storageCache;
+    public SeqlockCache<StorageCell, EvmWord> StorageCache => _storageCache;
     public SeqlockCache<AddressAsKey, Account> StateCache => _stateCache;
     public ConcurrentDictionary<PrecompileCacheKey, Result<byte[]>> PrecompileCache => _precompileCache;
 

--- a/src/Nethermind/Nethermind.Evm/State/SStoreState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/SStoreState.cs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Evm.State;
+
+/// <summary>
+/// Converts the fixed-width word an SSTORE pops off the stack into the minimal-length big-endian encoding
+/// that <see cref="IWorldState.Get"/>, <see cref="IWorldState.GetOriginal"/> and <see cref="IWorldState.Set"/> use.
+/// </summary>
+public static class StorageWord
+{
+    /// <summary>Returns the storage encoding of <paramref name="word"/>: leading zeros stripped, or <c>[0]</c> when zero.</summary>
+    /// <remarks>The returned span aliases <paramref name="word"/> unless it is zero.</remarks>
+    public static ReadOnlySpan<byte> ToStorageBytes(in EvmWord word, out bool isZero)
+    {
+        ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in word), 1));
+        isZero = bytes.IsZero();
+        return isZero ? VirtualMachineStatics.BytesZero : bytes.WithoutLeadingZeros();
+    }
+}
+
+/// <summary>
+/// The comparisons that SSTORE net gas metering needs from a storage write, as reported by
+/// <see cref="IWorldState.SStore"/>.
+/// </summary>
+/// <remarks>
+/// SSTORE never reads the stored digits: EIP-2200 and EIP-3529 are defined purely in terms of whether the
+/// original, current and new values are zero and whether they are equal. Reporting the answers rather than
+/// the bytes keeps the value encoding private to the backend.
+/// <para>
+/// <see cref="CurrentSameAsOriginal"/>, <see cref="OriginalIsZero"/> and <see cref="NewSameAsOriginal"/> are
+/// only meaningful when <see cref="NewSameAsCurrent"/> is unset. A store that changes nothing must not read
+/// the original value, because witness and access-list tracing observe that read.
+/// </para>
+/// </remarks>
+[Flags]
+public enum SStoreState : byte
+{
+    None = 0,
+
+    /// <summary>The new value equals the value already stored, so no write was performed.</summary>
+    NewSameAsCurrent = 1 << 0,
+
+    /// <summary>The value stored before this write is zero.</summary>
+    CurrentIsZero = 1 << 1,
+
+    /// <summary>The value stored before this write is the value the cell held at the start of the transaction.</summary>
+    CurrentSameAsOriginal = 1 << 2,
+
+    /// <summary>The value the cell held at the start of the transaction is zero.</summary>
+    OriginalIsZero = 1 << 3,
+
+    /// <summary>The new value restores the cell to the value it held at the start of the transaction.</summary>
+    NewSameAsOriginal = 1 << 4,
+}

--- a/src/Nethermind/Nethermind.Evm/State/SStoreState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/SStoreState.cs
@@ -9,16 +9,21 @@ using Nethermind.Core.Extensions;
 namespace Nethermind.Evm.State;
 
 /// <summary>
-/// Converts the fixed-width word an SSTORE pops off the stack into the minimal-length big-endian encoding
-/// that <see cref="IWorldState.Get"/>, <see cref="IWorldState.GetOriginal"/> and <see cref="IWorldState.Set"/> use.
+/// Conversions between the fixed-width <c>EvmWord</c> that carries storage values in memory and the
+/// minimal-length big-endian encoding used at the trie/RLP boundary and on the legacy
+/// <see cref="IWorldState.Get"/>/<see cref="IWorldState.Set"/> surface.
 /// </summary>
 public static class StorageWord
 {
+    /// <summary>Returns the full 32-byte big-endian view of <paramref name="word"/>. The span aliases <paramref name="word"/>.</summary>
+    public static ReadOnlySpan<byte> AsSpan(in EvmWord word) =>
+        MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in word), 1));
+
     /// <summary>Returns the storage encoding of <paramref name="word"/>: leading zeros stripped, or <c>[0]</c> when zero.</summary>
     /// <remarks>The returned span aliases <paramref name="word"/> unless it is zero.</remarks>
     public static ReadOnlySpan<byte> ToStorageBytes(in EvmWord word, out bool isZero)
     {
-        ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in word), 1));
+        ReadOnlySpan<byte> bytes = AsSpan(in word);
         isZero = bytes.IsZero();
         return isZero ? VirtualMachineStatics.BytesZero : bytes.WithoutLeadingZeros();
     }

--- a/src/Nethermind/Nethermind.Evm/State/SStoreState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/SStoreState.cs
@@ -22,6 +22,22 @@ public static class StorageWord
         isZero = bytes.IsZero();
         return isZero ? VirtualMachineStatics.BytesZero : bytes.WithoutLeadingZeros();
     }
+
+    /// <summary>Widens a minimal-length big-endian storage value back into a full word, padding leading zeros.</summary>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="bytes"/> exceeds 32 bytes.</exception>
+    public static EvmWord FromStorageBytes(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length > EvmWordSize) ThrowValueTooLong(bytes.Length);
+
+        EvmWord word = default;
+        bytes.CopyTo(MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref word, 1))[(EvmWordSize - bytes.Length)..]);
+        return word;
+    }
+
+    private const int EvmWordSize = 32;
+
+    private static void ThrowValueTooLong(int length) =>
+        throw new ArgumentException($"Storage value cannot exceed {EvmWordSize} bytes, was {length}", "bytes");
 }
 
 /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
@@ -180,7 +180,7 @@ public class FlatWorldStateScopeProviderTests
 
         // Verify slot shadowed by Layer 2 snapshot (newerSlotValue)
         IWorldStateScopeProvider.IStorageTree storageTree = ctx.Scope.CreateStorageTree(testAddress);
-        Assert.That(storageTree.Get(slotIndex), Is.EqualTo(newerSlotValue));
+        Assert.That(storageTree.Get(slotIndex).ToStorageBytes(), Is.EqualTo(newerSlotValue));
     }
 
     [Test]
@@ -207,7 +207,7 @@ public class FlatWorldStateScopeProviderTests
         Assert.That(ctx.Scope.Get(testAddress), Is.EqualTo(persistedAccount));
 
         IWorldStateScopeProvider.IStorageTree storageTree = ctx.Scope.CreateStorageTree(testAddress);
-        Assert.That(storageTree.Get(slotIndex), Is.EqualTo(persistedSlotValue));
+        Assert.That(storageTree.Get(slotIndex).ToStorageBytes(), Is.EqualTo(persistedSlotValue));
     }
 
     [Test]
@@ -242,7 +242,7 @@ public class FlatWorldStateScopeProviderTests
         Assert.That(resultAccount!.Nonce, Is.EqualTo(testAccount.Nonce));
 
         IWorldStateScopeProvider.IStorageTree storageTree = scope.CreateStorageTree(testAddress);
-        Assert.That(storageTree.Get(slotIndex), Is.EqualTo(writtenSlotValue));
+        Assert.That(storageTree.Get(slotIndex).ToStorageBytes(), Is.EqualTo(writtenSlotValue));
     }
 
     [Test]
@@ -309,7 +309,7 @@ public class FlatWorldStateScopeProviderTests
 
         // Slot should be blocked by selfdestruct
         IWorldStateScopeProvider.IStorageTree storageTree = scope.CreateStorageTree(testAddress);
-        Assert.That(storageTree.Get(slotIndex), Is.EqualTo(StorageTree.ZeroBytes));
+        Assert.That(storageTree.Get(slotIndex).ToStorageBytes(), Is.EqualTo(StorageTree.ZeroBytes));
     }
 
     [Test]
@@ -336,10 +336,10 @@ public class FlatWorldStateScopeProviderTests
         IWorldStateScopeProvider.IStorageTree storageTree = scope.CreateStorageTree(testAddress);
 
         // slot1 should return zero (blocked by selfdestruct)
-        Assert.That(storageTree.Get(slot1), Is.EqualTo(StorageTree.ZeroBytes));
+        Assert.That(storageTree.Get(slot1).ToStorageBytes(), Is.EqualTo(StorageTree.ZeroBytes));
 
         // slot2 should return the value (written after selfdestruct)
-        Assert.That(storageTree.Get(slot2), Is.EqualTo(slot2AfterValue));
+        Assert.That(storageTree.Get(slot2).ToStorageBytes(), Is.EqualTo(slot2AfterValue));
     }
 
     #endregion
@@ -648,7 +648,7 @@ public class FlatWorldStateScopeProviderTests
 
         // Verify both are blocked
         IWorldStateScopeProvider.IStorageTree storageTree = scope.CreateStorageTree(addr);
-        Assert.That(storageTree.Get(slot), Is.EqualTo(StorageTree.ZeroBytes));
+        Assert.That(storageTree.Get(slot).ToStorageBytes(), Is.EqualTo(StorageTree.ZeroBytes));
     }
 
     [Test]
@@ -693,7 +693,7 @@ public class FlatWorldStateScopeProviderTests
         // Before the fix: would fail because DoTryFindStorageNodeExternal exited early
         // After the fix: properly falls through and finds storage in ReadOnlySnapshots
         IWorldStateScopeProvider.IStorageTree storageTree = scope.CreateStorageTree(addr1);
-        Assert.That(storageTree.Get(slot1), Is.EqualTo(value1));
+        Assert.That(storageTree.Get(slot1).ToStorageBytes(), Is.EqualTo(value1));
     }
 
     [Test]
@@ -752,9 +752,9 @@ public class FlatWorldStateScopeProviderTests
         // - slotAtSelfDestruct should be found (set in same commit as self-destruct)
         // - slotAfter should be found (added after self-destruct)
         IWorldStateScopeProvider.IStorageTree storageTree = scope.CreateStorageTree(addr);
-        Assert.That(storageTree.Get(slotBefore), Is.EqualTo(StorageTree.ZeroBytes), "Slot before self-destruct should be zero");
-        Assert.That(storageTree.Get(slotAtSelfDestruct), Is.EqualTo(valueAtSelfDestruct), "Slot at self-destruct should be found");
-        Assert.That(storageTree.Get(slotAfter), Is.EqualTo(valueAfter), "Slot after self-destruct should be found");
+        Assert.That(storageTree.Get(slotBefore).ToStorageBytes(), Is.EqualTo(StorageTree.ZeroBytes), "Slot before self-destruct should be zero");
+        Assert.That(storageTree.Get(slotAtSelfDestruct).ToStorageBytes(), Is.EqualTo(valueAtSelfDestruct), "Slot at self-destruct should be found");
+        Assert.That(storageTree.Get(slotAfter).ToStorageBytes(), Is.EqualTo(valueAfter), "Slot after self-destruct should be found");
     }
 
     [Test]
@@ -807,11 +807,11 @@ public class FlatWorldStateScopeProviderTests
         IWorldStateScopeProvider.IStorageTree storageTree = scope.CreateStorageTree(addr);
 
         // Slots written after self-destruct in local snapshots should be visible
-        Assert.That(storageTree.Get(slotAfter1), Is.EqualTo(valueAfter1), "Slot in local snapshot after read-only self-destruct should be visible");
-        Assert.That(storageTree.Get(slotAfter2), Is.EqualTo(valueAfter2), "Slot in local snapshot after read-only self-destruct should be visible");
+        Assert.That(storageTree.Get(slotAfter1).ToStorageBytes(), Is.EqualTo(valueAfter1), "Slot in local snapshot after read-only self-destruct should be visible");
+        Assert.That(storageTree.Get(slotAfter2).ToStorageBytes(), Is.EqualTo(valueAfter2), "Slot in local snapshot after read-only self-destruct should be visible");
 
         // Slot from before self-destruct (in read-only snapshot) should be blocked
-        Assert.That(storageTree.Get(slotBefore), Is.EqualTo(StorageTree.ZeroBytes), "Slot before self-destruct should be zero");
+        Assert.That(storageTree.Get(slotBefore).ToStorageBytes(), Is.EqualTo(StorageTree.ZeroBytes), "Slot before self-destruct should be zero");
     }
 
     #endregion
@@ -904,13 +904,13 @@ public class FlatWorldStateScopeProviderTests
         FlatWorldStateScope scope = ctx.Scope;
         IWorldStateScopeProvider.IStorageTree storageTree = scope.CreateStorageTree(TestItem.AddressA);
 
-        storageTree.HintSet((UInt256)1, [1]);
+        storageTree.HintSet((UInt256)1, default);
 
         Assert.That(warmer.SlotJobPushes, Is.EqualTo(1));
         Assert.That(warmer.MpmcSlotJobPushes, Is.EqualTo(slotRingAccepts ? 0 : 1));
 
         // The dedupe bloom is already marked, so a repeated hint for the same slot must not push again.
-        storageTree.HintSet((UInt256)1, [1]);
+        storageTree.HintSet((UInt256)1, default);
         Assert.That(warmer.SlotJobPushes, Is.EqualTo(1));
         Assert.That(warmer.MpmcSlotJobPushes, Is.EqualTo(slotRingAccepts ? 0 : 1));
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/SlotValueTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SlotValueTests.cs
@@ -19,27 +19,6 @@ public class SlotValueTests
         return data;
     }
 
-    [TestCase(0)]
-    [TestCase(1)]
-    [TestCase(16)]
-    [TestCase(31)]
-    [TestCase(32)]
-    public void Test_Ctor_AcceptsLengthsUpTo32(int length)
-    {
-        byte[] data = IncrementingBytes(length);
-
-        SlotValue value = new(data);
-        ReadOnlySpan<byte> bytes = value.AsReadOnlySpan;
-
-        Assert.That(bytes.Length, Is.EqualTo(32));
-        for (int i = 0; i < length; i++) Assert.That(bytes[i], Is.EqualTo(data[i]));
-        for (int i = length; i < 32; i++) Assert.That(bytes[i], Is.EqualTo(0));
-    }
-
-    [Test]
-    public void Test_Ctor_ThrowsOnOversizedInput() =>
-        Assert.That(() => new SlotValue(new byte[33]), Throws.ArgumentException);
-
     [TestCase(33)]
     [TestCase(64)]
     public void Test_FromSpanWithoutLeadingZero_ThrowsOnOversizedInput(int length) =>
@@ -69,22 +48,9 @@ public class SlotValueTests
     }
 
     [Test]
-    public void Test_FromBytes_ReturnsNullForNull() =>
-        Assert.That(SlotValue.FromBytes(null), Is.Null);
-
-    [Test]
-    public void Test_FromBytes_WrapsNonNull()
-    {
-        byte[] data = Bytes.FromHexString(FullSlotHex);
-        SlotValue? value = SlotValue.FromBytes(data);
-        Assert.That(value, Is.Not.Null);
-        Assert.That(value!.Value.AsReadOnlySpan.ToArray(), Is.EqualTo(data));
-    }
-
-    [Test]
     public void Test_ToEvmBytes_ReturnsCanonicalZeroForZeroValue()
     {
-        SlotValue zero = new(ReadOnlySpan<byte>.Empty);
+        SlotValue zero = SlotValue.FromSpanWithoutLeadingZero(ReadOnlySpan<byte>.Empty);
         Assert.That(zero.ToEvmBytes(), Is.EqualTo(new byte[] { 0 }));
     }
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotCompactorTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotCompactorTests.cs
@@ -103,8 +103,8 @@ public class SnapshotCompactorTests
         TreePath storageNodePath2 = TreePath.FromHexString("5678");
         Hash256 storageNodeHash1 = Keccak.Zero;
         Hash256 storageNodeHash2 = Keccak.Zero;
-        SlotValue slotValue1 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100 });
-        SlotValue slotValue2 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 200 });
+        SlotValue slotValue1 = SlotValue.FromSpanWithoutLeadingZero([100]);
+        SlotValue slotValue2 = SlotValue.FromSpanWithoutLeadingZero([200]);
 
         // Add accounts
         snapshot.Content.Accounts[address1] = new Account(1, 100);
@@ -158,8 +158,8 @@ public class SnapshotCompactorTests
         TreePath statePath2 = TreePath.FromHexString("ef01");
         TreePath storageNodePath1 = TreePath.FromHexString("1234");
         TreePath storageNodePath2 = TreePath.FromHexString("5678");
-        SlotValue slotValue1 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100 });
-        SlotValue slotValue2 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 200 });
+        SlotValue slotValue1 = SlotValue.FromSpanWithoutLeadingZero([100]);
+        SlotValue slotValue2 = SlotValue.FromSpanWithoutLeadingZero([200]);
 
         // First snapshot
         StateId from0 = new(0, Keccak.Zero);
@@ -203,8 +203,8 @@ public class SnapshotCompactorTests
         UInt256 storageIndex = new(1);
         TreePath statePath = TreePath.FromHexString("abcd");
         TreePath storageNodePath = TreePath.FromHexString("1234");
-        SlotValue slotValue1 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100 });
-        SlotValue slotValue2 = new(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 200 });
+        SlotValue slotValue1 = SlotValue.FromSpanWithoutLeadingZero([100]);
+        SlotValue slotValue2 = SlotValue.FromSpanWithoutLeadingZero([200]);
 
         // First snapshot with initial values
         StateId from0 = new(0, Keccak.Zero);
@@ -251,7 +251,7 @@ public class SnapshotCompactorTests
         UInt256 storageIndex = new(1);
         TreePath storagePath = TreePath.FromHexString("1234");
         Hash256 storageHash = Keccak.Zero;
-        SlotValue slotValue = new(new byte[32]);
+        SlotValue slotValue = SlotValue.FromSpanWithoutLeadingZero(new byte[32]);
 
         StateId from0 = new(0, Keccak.Zero);
         StateId to0 = new(1, Keccak.Zero);

--- a/src/Nethermind/Nethermind.State.Flat.Test/StorageWordTestExtensions.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/StorageWordTestExtensions.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+
+namespace Nethermind.State.Flat.Test;
+
+/// <summary>
+/// Test conveniences bridging the minimal-length <c>byte[]</c> the tests express storage values in and the
+/// fixed-width <c>EvmWord</c> the storage seam now carries.
+/// </summary>
+internal static class StorageWordTestExtensions
+{
+    public static EvmWord ToWord(this byte[] bytes) => StorageWord.FromStorageBytes(bytes);
+
+    public static byte[] ToStorageBytes(this EvmWord word) => StorageWord.ToStorageBytes(in word, out _).ToArray();
+
+    public static void Set(this IWorldStateScopeProvider.IStorageWriteBatch batch, in UInt256 index, byte[] value)
+        => batch.Set(in index, StorageWord.FromStorageBytes(value));
+}

--- a/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
@@ -83,9 +83,12 @@ public sealed class ReadOnlySnapshotBundle(
     }
 
     public byte[]? GetSlot(Address address, in UInt256 index, int selfDestructStateIdx) =>
-        GetSlot(selfDestructStateIdx, (address, index));
+        GetSlotValue(selfDestructStateIdx, (address, index))?.ToEvmBytes();
 
-    public byte[]? GetSlot(int selfDestructStateIdx, HashedKey<(Address, UInt256)> key)
+    public byte[]? GetSlot(int selfDestructStateIdx, HashedKey<(Address, UInt256)> key) =>
+        GetSlotValue(selfDestructStateIdx, key)?.ToEvmBytes();
+
+    public SlotValue? GetSlotValue(int selfDestructStateIdx, HashedKey<(Address, UInt256)> key)
     {
         GuardDispose();
 
@@ -94,9 +97,8 @@ public sealed class ReadOnlySnapshotBundle(
         {
             if (snapshots[i].TryGetStorage(key, out SlotValue? slotValue))
             {
-                byte[]? res = slotValue?.ToEvmBytes();
                 if (recordDetailedMetrics) Metrics.ReadOnlySnapshotBundleTimes.Observe(Stopwatch.GetTimestamp() - sw, _readStorageSnapshotLabel);
-                return res;
+                return slotValue;
             }
 
             if (i <= selfDestructStateIdx)
@@ -108,12 +110,11 @@ public sealed class ReadOnlySnapshotBundle(
         SlotValue outSlotValue = new();
 
         sw = recordDetailedMetrics ? Stopwatch.GetTimestamp() : 0;
-        persistenceReader.TryGetSlot(key.Key.Item1, key.Key.Item2, ref outSlotValue);
-        byte[]? value = outSlotValue.ToEvmBytes();
+        bool found = persistenceReader.TryGetSlot(key.Key.Item1, key.Key.Item2, ref outSlotValue);
 
         if (recordDetailedMetrics)
         {
-            if (value is null || value.IsZero())
+            if (!found || outSlotValue.IsZero)
             {
                 Metrics.ReadOnlySnapshotBundleTimes.Observe(Stopwatch.GetTimestamp() - sw, _readStoragePersistenceNullLabel);
             }
@@ -123,7 +124,9 @@ public sealed class ReadOnlySnapshotBundle(
             }
         }
 
-        return value;
+        // Persistence reaching this point means the slot is not shadowed/self-destructed: a miss is a real
+        // zero (outSlotValue stays default), distinct from the null the self-destruct branches above return.
+        return outSlotValue;
     }
 
     public bool TryFindStateNodes(in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node) =>

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
@@ -65,31 +65,28 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
 
     internal bool IsDisposed => _scope.IsDisposed;
 
-    public byte[] Get(in UInt256 index)
+    public EvmWord Get(in UInt256 index)
     {
-        byte[]? value = _bundle.GetSlot(_address, index, _selfDestructKnownStateIdx);
-        if (value is null || value.Length == 0)
-        {
-            value = StorageTree.ZeroBytes;
-        }
+        SlotValue? value = _bundle.GetSlotValue(_address, index, _selfDestructKnownStateIdx);
+        EvmWord word = value?.AsWord ?? default;
 
         if (_config.VerifyWithTrie)
         {
-            byte[] treeValue = _tree.Get(index);
-            if (!Bytes.AreEqual(treeValue, value))
+            EvmWord treeValue = _tree.GetWord(index);
+            if (treeValue != word)
             {
-                throw new TrieException($"Get slot got wrong value. Address {_address}, {_tree.RootHash}, {index}. Tree: {treeValue?.ToHexString()} vs Flat: {value?.ToHexString()}. Self destruct it {_selfDestructKnownStateIdx}");
+                throw new TrieException($"Get slot got wrong value. Address {_address}, {_tree.RootHash}, {index}. Tree: {StorageWord.ToStorageBytes(in treeValue, out _).ToHexString()} vs Flat: {StorageWord.ToStorageBytes(in word, out _).ToHexString()}. Self destruct it {_selfDestructKnownStateIdx}");
             }
         }
 
-        return value!;
+        return word;
     }
 
     // Reads do not warm the trie: most reads come through the prewarmer, and read-only slots
     // (~30-40% of accesses per @weiihann's analysis) never need their trie path warmed because
     // they don't trigger commit-time tree updates. Warm-up is driven from HintSet on the write
     // path instead.
-    public void HintSet(in UInt256 index, byte[]? value) => WarmUpSlot(index);
+    public void HintSet(in UInt256 index, in EvmWord value) => WarmUpSlot(index);
 
     private void WarmUpSlot(UInt256 index)
     {
@@ -138,7 +135,7 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
         }
     }
 
-    private void Set(UInt256 slot, byte[] value) => _bundle.SetChangedSlot(_address, slot, value);
+    private void Set(in UInt256 slot, in EvmWord value) => _bundle.SetChangedSlot(_address, slot, in value);
 
     public void SelfDestruct()
     {
@@ -168,10 +165,10 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
         TrieStoreScopeProvider.StorageTreeBulkWriteBatch storageTreeBulkWriteBatch,
         FlatStorageTree storageTree) : IWorldStateScopeProvider.IStorageWriteBatch
     {
-        public void Set(in UInt256 index, byte[] value)
+        public void Set(in UInt256 index, in EvmWord value)
         {
-            storageTreeBulkWriteBatch.Set(in index, value);
-            storageTree.Set(index, value);
+            storageTreeBulkWriteBatch.Set(in index, in value);
+            storageTree.Set(index, in value);
         }
 
         public void Clear()

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -306,8 +306,8 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     {
         StorageCell cell = new(address, in slot);
         if (!sink.StillNeeded(in cell)) return;
-        byte[]? raw = _snapshotBundle.GetSlot(address, in slot, selfDestructIdx);
-        sink.OnStorageRead(in cell, raw is null || raw.Length == 0 ? StorageTree.ZeroBytes : raw);
+        SlotValue? raw = _snapshotBundle.GetSlotValue(address, in slot, selfDestructIdx);
+        sink.OnStorageRead(in cell, raw?.AsWord ?? default);
     }
 
     public IWorldStateScopeProvider.ICodeDb CodeDb { get; }

--- a/src/Nethermind/Nethermind.State.Flat/SlotValue.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SlotValue.cs
@@ -19,28 +19,17 @@ public readonly struct SlotValue
     public ReadOnlySpan<byte> AsReadOnlySpan => MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _bytes), 1));
     public const int ByteCount = 32;
 
-    public SlotValue(ReadOnlySpan<byte> data)
-    {
-        if (data.Length > 32)
-        {
-            ThrowInvalidLength();
-        }
-
-        if (data.Length == 32)
-        {
-            _bytes = Unsafe.ReadUnaligned<Vector256<byte>>(ref MemoryMarshal.GetReference(data));
-        }
-        else
-        {
-            _bytes = Vector256<byte>.Zero;
-            data.CopyTo(MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref _bytes, 1)));
-        }
-    }
-
     private static void ThrowInvalidLength() => throw new ArgumentException("Slot value cannot exceed 32 bytes", "data");
 
-    public static SlotValue? FromBytes(byte[]? data) => data == null ? null : new SlotValue(data);
-
+    /// <summary>
+    /// Builds a slot value from big-endian bytes, right-aligning shorter input by padding leading zeros.
+    /// </summary>
+    /// <remarks>
+    /// The only way to construct a non-zero value: slot values are big-endian 32-byte words, so a shorter
+    /// buffer must be padded at the front. A left-aligning overload would silently scale the value by a
+    /// power of 256.
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="data"/> exceeds 32 bytes.</exception>
     public static SlotValue FromSpanWithoutLeadingZero(ReadOnlySpan<byte> data)
     {
         switch (data.Length)

--- a/src/Nethermind/Nethermind.State.Flat/SlotValue.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SlotValue.cs
@@ -11,13 +11,20 @@ namespace Nethermind.State.Flat;
 /// <summary>
 /// Make storing slot value smaller than a byte[].
 /// </summary>
+/// <remarks>Wraps a full 32-byte word verbatim (both are big-endian <c>Vector256&lt;byte&gt;</c>).</remarks>
 [StructLayout(LayoutKind.Sequential, Pack = 32, Size = 32)]
-public readonly struct SlotValue
+public readonly struct SlotValue(in EvmWord word)
 {
-    public readonly Vector256<byte> _bytes; // Use Vector256 as the internal storage field
+    public readonly Vector256<byte> _bytes = word; // Use Vector256 as the internal storage field
     public Span<byte> AsSpan => MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in _bytes), 1));
     public ReadOnlySpan<byte> AsReadOnlySpan => MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _bytes), 1));
     public const int ByteCount = 32;
+
+    /// <summary>The value as the <c>EvmWord</c> the storage layer carries. Zero-cost — same underlying representation.</summary>
+    public EvmWord AsWord => _bytes;
+
+    /// <summary>True when the slot holds zero.</summary>
+    public bool IsZero => _bytes == default;
 
     private static void ThrowInvalidLength() => throw new ArgumentException("Slot value cannot exceed 32 bytes", "data");
 

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -106,7 +106,10 @@ public sealed class SnapshotBundle : IDisposable
         return _readOnlySnapshotBundle.DetermineSelfDestructSnapshotIdx(address);
     }
 
-    public byte[]? GetSlot(Address address, in UInt256 index, int selfDestructStateIdx)
+    public byte[]? GetSlot(Address address, in UInt256 index, int selfDestructStateIdx) =>
+        GetSlotValue(address, index, selfDestructStateIdx)?.ToEvmBytes();
+
+    public SlotValue? GetSlotValue(Address address, in UInt256 index, int selfDestructStateIdx)
     {
         GuardDispose();
 
@@ -114,7 +117,7 @@ public sealed class SnapshotBundle : IDisposable
 
         if (_changedSlots.TryGetValue(key, out SlotValue? slotValue))
         {
-            return slotValue?.ToEvmBytes();
+            return slotValue;
         }
 
         // Self-destructed at the point of the latest change
@@ -128,7 +131,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             if (_snapshots[i].TryGetStorage(key, out slotValue))
             {
-                return slotValue?.ToEvmBytes();
+                return slotValue;
             }
 
             if (i <= currentBundleSelfDestructIdx)
@@ -138,7 +141,7 @@ public sealed class SnapshotBundle : IDisposable
             }
         }
 
-        return _readOnlySnapshotBundle.GetSlot(selfDestructStateIdx, key);
+        return _readOnlySnapshotBundle.GetSlotValue(selfDestructStateIdx, key);
     }
 
     public TrieNode FindStateNodeOrUnknown(in TreePath path, Hash256 hash)
@@ -321,20 +324,12 @@ public sealed class SnapshotBundle : IDisposable
     public void SetAccount(Address address, Account? account) =>
         _changedAccounts[address] = account;
 
-    public void SetChangedSlot(Address address, in UInt256 index, byte[] value)
+    public void SetChangedSlot(Address address, in UInt256 index, in EvmWord value)
     {
-        // So right now, if the value is zero, then it is a deletion. This is not the case with verkle where you
-        // can set a value to be zero. Because of this distinction, the zerobytes logic is handled here instead of
-        // lower down.
+        // A zero value is a deletion (this is not the case with verkle, where a slot can be explicitly set to zero;
+        // that distinction is handled here rather than lower down).
         HashedKey<(Address, UInt256)> key = new((address, index));
-        if (value is null || Bytes.AreEqual(value, StorageTree.ZeroBytes))
-        {
-            _changedSlots[key] = null;
-        }
-        else
-        {
-            _changedSlots[key] = SlotValue.FromSpanWithoutLeadingZero(value);
-        }
+        _changedSlots[key] = value == default ? null : new SlotValue(in value);
     }
 
     // Also called SelfDestruct

--- a/src/Nethermind/Nethermind.State.Test/SStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SStoreTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.State;
@@ -70,6 +71,65 @@ public class SStoreTests
 
             byte[] expectedStored = newValue == 0 ? [0] : [newValue];
             Assert.That(state.Get(in Cell).ToArray(), Is.EqualTo(expectedStored));
+        }
+    }
+
+    /// <summary>SLoad must widen the stored minimal-length value back to the word the EVM stack holds.</summary>
+    [TestCase("", TestName = "SLoad_of_unset_slot_is_zero")]
+    [TestCase("01", TestName = "SLoad_pads_single_byte")]
+    [TestCase("0102", TestName = "SLoad_pads_two_bytes")]
+    [TestCase("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", TestName = "SLoad_full_width")]
+    public void SLoad_returns_zero_padded_word(string storedHex)
+    {
+        byte[] stored = Bytes.FromHexString(storedHex);
+
+        IWorldState state = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = state.BeginScope(IWorldState.PreGenesis);
+        state.CreateAccount(Address, 1);
+        if (stored.Length != 0) state.Set(in Cell, stored);
+        state.Commit(Frontier.Instance);
+
+        byte[] expected = new byte[32];
+        stored.CopyTo(expected.AsSpan(32 - stored.Length));
+
+        EvmWord loaded = state.SLoad(in Cell);
+        Assert.That(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref loaded, 1)).ToArray(), Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// SLoad reads the backing store directly rather than through Get, but must still capture the original
+    /// value: a later SStore reads it (EIP-2200), and would otherwise throw or misreport the reversal.
+    /// </summary>
+    [Test]
+    public void SLoad_captures_original_for_a_later_SStore()
+    {
+        IWorldState state = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = state.BeginScope(IWorldState.PreGenesis);
+        state.CreateAccount(Address, 1);
+        state.Set(in Cell, [5]);
+        state.Commit(Frontier.Instance);
+        state.TakeSnapshot(newTransactionStart: true);
+
+        // The only read of the slot this transaction, so SStore's GetOriginal depends on it.
+        Assert.That(state.SLoad(in Cell), Is.EqualTo(Word(5)));
+
+        // 5 -> 9 is the first write: current still equals the captured original.
+        Assert.That(state.SStore(in Cell, Word(9)), Is.EqualTo(SStoreState.CurrentSameAsOriginal));
+        // 9 -> 5 reverts to the original SLoad observed.
+        Assert.That(state.SStore(in Cell, Word(5)), Is.EqualTo(SStoreState.NewSameAsOriginal));
+    }
+
+    /// <summary>SStore then SLoad must observe the value just written, through the same word representation.</summary>
+    [TestCase(0, TestName = "SLoad_after_SStore_zero")]
+    [TestCase(1, TestName = "SLoad_after_SStore_one")]
+    [TestCase(255, TestName = "SLoad_after_SStore_max_byte")]
+    public void SLoad_observes_preceding_SStore(byte newValue)
+    {
+        (IWorldState state, IDisposable scope) = StateWith(original: 3, current: 3);
+        using (scope)
+        {
+            state.SStore(in Cell, Word(newValue));
+            Assert.That(state.SLoad(in Cell), Is.EqualTo(Word(newValue)));
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Test/SStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/SStoreTests.cs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+using NUnit.Framework;
+
+namespace Nethermind.Store.Test;
+
+[Parallelizable(ParallelScope.All)]
+public class SStoreTests
+{
+    private static readonly Address Address = TestItem.AddressA;
+    private static readonly StorageCell Cell = new(Address, UInt256.One);
+
+    /// <summary>Builds the 32-byte big-endian word an SSTORE would pop off the stack.</summary>
+    private static EvmWord Word(byte value)
+    {
+        Span<byte> word = stackalloc byte[32];
+        word[31] = value;
+        return Unsafe.ReadUnaligned<EvmWord>(ref MemoryMarshal.GetReference(word));
+    }
+
+    /// <summary>
+    /// Opens a scope where <paramref name="original"/> is the value the cell held at the start of the
+    /// transaction, then drives the cell to <paramref name="current"/> with a preceding SStore.
+    /// </summary>
+    private static (IWorldState state, IDisposable scope) StateWith(byte original, byte current)
+    {
+        IWorldState state = TestWorldStateFactory.CreateForTest();
+        IDisposable scope = state.BeginScope(IWorldState.PreGenesis);
+
+        state.CreateAccount(Address, 1);
+        if (original != 0) state.Set(in Cell, [original]);
+        state.Commit(Frontier.Instance);
+
+        // Everything after this snapshot is a new transaction, so `original` is what GetOriginal reports.
+        state.TakeSnapshot(newTransactionStart: true);
+
+        if (current != original) state.SStore(in Cell, Word(current));
+        return (state, scope);
+    }
+
+    // (original, current, new) -> the comparisons EIP-2200 metering reads.
+    [TestCase(0, 0, 0, SStoreState.NewSameAsCurrent | SStoreState.CurrentIsZero, TestName = "Noop_on_zero")]
+    [TestCase(1, 1, 1, SStoreState.NewSameAsCurrent, TestName = "Noop_on_nonzero")]
+    [TestCase(0, 0, 1, SStoreState.CurrentIsZero | SStoreState.CurrentSameAsOriginal | SStoreState.OriginalIsZero, TestName = "Fresh_set")]
+    [TestCase(1, 1, 0, SStoreState.CurrentSameAsOriginal, TestName = "Fresh_clear")]
+    [TestCase(1, 1, 2, SStoreState.CurrentSameAsOriginal, TestName = "Fresh_overwrite")]
+    [TestCase(0, 1, 0, SStoreState.OriginalIsZero | SStoreState.NewSameAsOriginal, TestName = "Dirty_reverted_to_zero_original")]
+    [TestCase(1, 2, 1, SStoreState.NewSameAsOriginal, TestName = "Dirty_reverted_to_nonzero_original")]
+    [TestCase(1, 2, 3, SStoreState.None, TestName = "Dirty_overwrite")]
+    [TestCase(1, 0, 1, SStoreState.CurrentIsZero | SStoreState.NewSameAsOriginal, TestName = "Dirty_cleared_then_restored")]
+    public void SStore_reports_comparisons_and_writes(byte original, byte current, byte newValue, SStoreState expected)
+    {
+        (IWorldState state, IDisposable scope) = StateWith(original, current);
+        using (scope)
+        {
+            Assert.That(state.SStore(in Cell, Word(newValue)), Is.EqualTo(expected));
+
+            byte[] expectedStored = newValue == 0 ? [0] : [newValue];
+            Assert.That(state.Get(in Cell).ToArray(), Is.EqualTo(expectedStored));
+        }
+    }
+
+    /// <summary>
+    /// The wrapped state performs the write, so <see cref="TracedAccessWorldState.Set"/> never sees it. The
+    /// decorator's own SStore must record the block-access-list change instead — and only when it writes.
+    /// </summary>
+    [TestCase(7, 7, 0, TestName = "Noop_records_no_storage_change")]
+    [TestCase(7, 8, 1, TestName = "Write_records_storage_change")]
+    public void SStore_records_block_access_list_change_only_when_it_writes(byte original, byte newValue, int expectedChanges)
+    {
+        IWorldState inner = TestWorldStateFactory.CreateForTest();
+        Hash256 stateRoot;
+        using (inner.BeginScope(IWorldState.PreGenesis))
+        {
+            inner.CreateAccount(Address, 1);
+            inner.Set(in Cell, [original]);
+            inner.Commit(Amsterdam.Instance, isGenesis: true);
+            inner.CommitTree(0);
+            stateRoot = inner.StateRoot;
+        }
+
+        BlockHeader baseBlock = Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(0).TestObject;
+        TracedAccessWorldState tracing = new(inner, parallel: false);
+        tracing.SetGeneratingBlockAccessList(new());
+        using IDisposable scope = tracing.BeginScope(baseBlock);
+        tracing.SetIndex(0);
+
+        tracing.SStore(in Cell, Word(newValue));
+
+        AccountChangesAtIndex changes = tracing.GetGeneratingBlockAccessList()!.GetAccountChanges(Address)!;
+        Assert.That(changes.StorageChangeCount, Is.EqualTo(expectedChanges));
+    }
+}

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -97,7 +97,7 @@ public class ScopeProviderTests(bool useFlat)
                 writeBatch.Set(TestItem.AddressA, new Account(100, 100));
 
                 using IWorldStateScopeProvider.IStorageWriteBatch storageSet = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1);
-                storageSet.Set(1, [1, 2, 3]);
+                storageSet.Set(1, new byte[] { 1, 2, 3 });
             }
 
             scope.Commit(1);
@@ -110,7 +110,7 @@ public class ScopeProviderTests(bool useFlat)
         using (IWorldStateScopeProvider.IScope scope = ctx.ScopeProvider.BeginScope(Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(1).TestObject))
         {
             IWorldStateScopeProvider.IStorageTree storage = scope.CreateStorageTree(TestItem.AddressA);
-            Assert.That(storage.Get(1), Is.EqualTo([1, 2, 3]));
+            Assert.That(storage.Get(1).ToStorageBytes(), Is.EqualTo([1, 2, 3]));
         }
     }
 
@@ -148,7 +148,7 @@ public class ScopeProviderTests(bool useFlat)
         using IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(1);
         using (IWorldStateScopeProvider.IStorageWriteBatch storageSet = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1))
         {
-            storageSet.Set(1, [1, 2, 3]);
+            storageSet.Set(1, new byte[] { 1, 2, 3 });
         }
 
         writeBatch.Set(TestItem.AddressA, null);
@@ -170,12 +170,12 @@ public class ScopeProviderTests(bool useFlat)
 
                 using (IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 2))
                 {
-                    storageA.Set(1, [10, 20]);
-                    storageA.Set(2, [30, 40]);
+                    storageA.Set(1, new byte[] { 10, 20 });
+                    storageA.Set(2, new byte[] { 30, 40 });
                 }
 
                 using IWorldStateScopeProvider.IStorageWriteBatch storageB = writeBatch.CreateStorageWriteBatch(TestItem.AddressB, 1);
-                storageB.Set(5, [50, 60]);
+                storageB.Set(5, new byte[] { 50, 60 });
             }
 
             scope.Commit(1);
@@ -214,13 +214,13 @@ public class ScopeProviderTests(bool useFlat)
                 StorageCell cellB5 = new(TestItem.AddressB, 5);
 
                 Assert.That(sink.Storage.ContainsKey(cellA1), Is.True);
-                Assert.That(sink.Storage[cellA1], Is.EqualTo(storageTreeA.Get(1)));
+                Assert.That(sink.Storage[cellA1], Is.EqualTo(storageTreeA.Get(1).ToStorageBytes()));
 
                 Assert.That(sink.Storage.ContainsKey(cellA2), Is.True);
-                Assert.That(sink.Storage[cellA2], Is.EqualTo(storageTreeA.Get(2)));
+                Assert.That(sink.Storage[cellA2], Is.EqualTo(storageTreeA.Get(2).ToStorageBytes()));
 
                 Assert.That(sink.Storage.ContainsKey(cellB5), Is.True);
-                Assert.That(sink.Storage[cellB5], Is.EqualTo(storageTreeB.Get(5)));
+                Assert.That(sink.Storage[cellB5], Is.EqualTo(storageTreeB.Get(5).ToStorageBytes()));
             }
         }
     }
@@ -241,7 +241,7 @@ public class ScopeProviderTests(bool useFlat)
                 using IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, slotCount);
                 for (int i = 1; i <= slotCount; i++)
                 {
-                    storageA.Set((UInt256)i, [(byte)i, (byte)(i >> 8)]);
+                    storageA.Set((UInt256)i, new byte[] { (byte)i, (byte)(i >> 8) });
                 }
             }
 
@@ -266,7 +266,7 @@ public class ScopeProviderTests(bool useFlat)
             for (int i = 1; i <= slotCount; i++)
             {
                 StorageCell cell = new(TestItem.AddressA, (UInt256)i);
-                Assert.That(sink.Storage[cell], Is.EqualTo(storageTreeA.Get((UInt256)i)), $"slot {i}");
+                Assert.That(sink.Storage[cell], Is.EqualTo(storageTreeA.Get((UInt256)i).ToStorageBytes()), $"slot {i}");
             }
         }
     }
@@ -285,7 +285,7 @@ public class ScopeProviderTests(bool useFlat)
                 writeBatch.Set(TestItem.AddressB, new Account(200, 200));
 
                 using IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1);
-                storageA.Set(1, [10, 20]);
+                storageA.Set(1, new byte[] { 10, 20 });
             }
 
             scope.Commit(1);
@@ -317,7 +317,7 @@ public class ScopeProviderTests(bool useFlat)
             {
                 writeBatch.Set(TestItem.AddressA, new Account(100, 100));
                 using IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1);
-                storageA.Set(1, [10, 20]);
+                storageA.Set(1, new byte[] { 10, 20 });
             }
 
             scope.Commit(1);
@@ -451,7 +451,7 @@ public class ScopeProviderTests(bool useFlat)
                 writeBatch.Set(TestItem.AddressA, new Account(100, 100));
                 writeBatch.Set(TestItem.AddressB, new Account(200, 200));
                 using IWorldStateScopeProvider.IStorageWriteBatch storageA = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1);
-                storageA.Set(1, [10, 20]);
+                storageA.Set(1, new byte[] { 10, 20 });
             }
 
             scope.Commit(1);
@@ -494,8 +494,8 @@ public class ScopeProviderTests(bool useFlat)
                 Accounts[address] = account;
         }
 
-        public void OnStorageRead(in StorageCell storageCell, byte[] value)
-            => Storage[storageCell] = value;
+        public void OnStorageRead(in StorageCell storageCell, in EvmWord value)
+            => Storage[storageCell] = StorageWord.ToStorageBytes(in value, out _).ToArray();
     }
 #nullable disable
 }

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -480,7 +480,7 @@ public class StorageProviderTests(bool useFlat)
         WorldState provider = BuildStorageProvider(ctx);
         StorageCell accessedStorageCell = new(TestItem.AddressA, 1);
         StorageCell nonAccessedStorageCell = new(TestItem.AddressA, 2);
-        preBlockCaches.StorageCache.Set(accessedStorageCell, [1, 2, 3]);
+        preBlockCaches.StorageCache.Set(accessedStorageCell, StorageWord.FromStorageBytes([1, 2, 3]));
         provider.Get(accessedStorageCell);
         provider.Commit(Paris.Instance);
         provider.ClearStorage(TestItem.AddressA);
@@ -783,7 +783,7 @@ public class StorageProviderTests(bool useFlat)
         PreBlockCaches preBlockCaches = new();
         using Context ctx = new(useFlat, preBlockCaches: preBlockCaches);
         StorageCell accessedStorageCell = new(TestItem.AddressA, 1);
-        preBlockCaches.StorageCache.Set(accessedStorageCell, [1, 2, 3]);
+        preBlockCaches.StorageCache.Set(accessedStorageCell, StorageWord.FromStorageBytes([1, 2, 3]));
 
         WorldState provider = BuildStorageProvider(ctx);
         Assert.That(provider.Get(accessedStorageCell).ToArray(), Is.EqualTo([1, 2, 3]));
@@ -1076,10 +1076,10 @@ public class StorageProviderTests(bool useFlat)
         {
             public void Dispose() => baseStorageBatch?.Dispose();
 
-            public void Set(in UInt256 index, byte[] value)
+            public void Set(in UInt256 index, in EvmWord value)
             {
-                baseStorageBatch.Set(in index, value);
-                writtenData.Slots[new StorageCell(address, index)] = value;
+                baseStorageBatch.Set(in index, in value);
+                writtenData.Slots[new StorageCell(address, index)] = StorageWord.ToStorageBytes(in value, out _).ToArray();
             }
 
             public void Clear()

--- a/src/Nethermind/Nethermind.State.Test/StorageWordTestExtensions.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageWordTestExtensions.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+
+namespace Nethermind.Store.Test;
+
+/// <summary>
+/// Test conveniences bridging the minimal-length <c>byte[]</c> the tests express storage values in and the
+/// fixed-width <c>EvmWord</c> the storage seam now carries.
+/// </summary>
+internal static class StorageWordTestExtensions
+{
+    public static EvmWord ToWord(this byte[] bytes) => StorageWord.FromStorageBytes(bytes);
+
+    public static byte[] ToStorageBytes(this EvmWord word) => StorageWord.ToStorageBytes(in word, out _).ToArray();
+
+    public static void Set(this IWorldStateScopeProvider.IStorageWriteBatch batch, in UInt256 index, byte[] value)
+        => batch.Set(in index, StorageWord.FromStorageBytes(value));
+}

--- a/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
+++ b/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
@@ -32,6 +32,7 @@ public class BlockAccessListBasedWorldState(IWorldState state, ILogManager logMa
     private uint _blockAccessIndex = 0;
     private EvmWord _readScratch;
     private EvmWord _originalScratch;
+    private EvmWord _transientScratch;
     private UInt256 _scratchBalance;
     private ValueHash256 _scratchCodeHash;
     private readonly TransientStorageProvider _transientStorageProvider = new(logManager);
@@ -318,10 +319,13 @@ public class BlockAccessListBasedWorldState(IWorldState state, ILogManager logMa
     }
 
     public override ReadOnlySpan<byte> GetTransientState(in StorageCell storageCell)
-        => _transientStorageProvider.Get(in storageCell);
+    {
+        _transientScratch = _transientStorageProvider.Get(in storageCell);
+        return StorageWord.ToStorageBytes(in _transientScratch, out _);
+    }
 
     public override void SetTransientState(in StorageCell storageCell, byte[] newValue)
-        => _transientStorageProvider.Set(in storageCell, newValue);
+        => _transientStorageProvider.Set(in storageCell, StorageWord.FromStorageBytes(newValue));
 
     public override void ResetTransient()
         => _transientStorageProvider.Reset();

--- a/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
+++ b/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
@@ -126,6 +126,29 @@ public class BlockAccessListBasedWorldState(IWorldState state, ILogManager logMa
 
     public override void Set(in StorageCell storageCell, byte[] newValue) { }
 
+    /// <inheritdoc cref="IWorldState.SStore"/>
+    /// <remarks>
+    /// Reports the comparisons without writing: this state replays a block access list, so <see cref="Set"/> is
+    /// a no-op and delegating to the wrapped state would mutate it.
+    /// </remarks>
+    public override SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+    {
+        ReadOnlySpan<byte> newBytes = StorageWord.ToStorageBytes(in newValue, out bool newIsZero);
+        ReadOnlySpan<byte> currentValue = Get(in storageCell);
+        bool currentIsZero = currentValue.IsZero();
+        bool newSameAsCurrent = (newIsZero && currentIsZero) || Bytes.AreEqual(currentValue, newBytes);
+
+        SStoreState state = currentIsZero ? SStoreState.CurrentIsZero : SStoreState.None;
+        if (newSameAsCurrent) return state | SStoreState.NewSameAsCurrent;
+
+        ReadOnlySpan<byte> originalValue = GetOriginal(in storageCell);
+        if (originalValue.IsZero()) state |= SStoreState.OriginalIsZero;
+        if (Bytes.AreEqual(originalValue, currentValue)) state |= SStoreState.CurrentSameAsOriginal;
+        if (Bytes.AreEqual(originalValue, newBytes)) state |= SStoreState.NewSameAsOriginal;
+
+        return state;
+    }
+
     public override ref readonly UInt256 GetBalance(Address address)
     {
         (IWorldState parentReader, ReadOnlyAccountChanges accountChanges) = ResolveContext(address);

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -27,18 +27,18 @@ namespace Nethermind.State
         protected readonly Stack<int> _transactionChangesSnapshots = new();
 
         /// <summary>
-        /// Get the storage value at the specified storage cell
+        /// Get the storage value at the specified storage cell as a full 32-byte word.
         /// </summary>
         /// <param name="storageCell">Storage location</param>
-        /// <returns>Value at cell</returns>
-        public ReadOnlySpan<byte> Get(in StorageCell storageCell) => GetCurrentValue(in storageCell);
+        /// <returns>Value at cell, zero-padded to 32 bytes.</returns>
+        public EvmWord Get(in StorageCell storageCell) => GetCurrentValue(in storageCell);
 
         /// <summary>
-        /// Set the provided value to storage at the specified storage cell
+        /// Set the provided value to storage at the specified storage cell.
         /// </summary>
         /// <param name="storageCell">Storage location</param>
-        /// <param name="newValue">Value to store</param>
-        public virtual void Set(in StorageCell storageCell, byte[] newValue) => PushUpdate(in storageCell, newValue);
+        /// <param name="newValue">Value to store as a full 32-byte word.</param>
+        public virtual void Set(in StorageCell storageCell, in EvmWord newValue) => PushUpdate(in storageCell, in newValue);
 
         /// <summary>
         /// Creates a restartable snapshot.
@@ -173,7 +173,7 @@ namespace Nethermind.State
         /// <param name="storageCell">Storage location</param>
         /// <param name="bytes">Resulting value</param>
         /// <returns>True if value has been set</returns>
-        protected bool TryGetCachedValue(in StorageCell storageCell, out byte[]? bytes)
+        protected bool TryGetCachedValue(in StorageCell storageCell, out EvmWord value)
         {
             // If the cache is completely empty (no writes or reads yet this transaction),
             // skip hashing the 52-byte cell — TryGetValue would miss anyway.
@@ -181,12 +181,12 @@ namespace Nethermind.State
             {
                 int lastChangeIndex = stack.Peek();
                 {
-                    bytes = _changes[lastChangeIndex].Value;
+                    value = _changes[lastChangeIndex].Value;
                     return true;
                 }
             }
 
-            bytes = null;
+            value = default;
             return false;
         }
 
@@ -194,19 +194,19 @@ namespace Nethermind.State
         /// Get the current value at the specified location
         /// </summary>
         /// <param name="storageCell">Storage location</param>
-        /// <returns>Value at location</returns>
-        protected abstract ReadOnlySpan<byte> GetCurrentValue(in StorageCell storageCell);
+        /// <returns>Value at location, zero-padded to 32 bytes.</returns>
+        protected abstract EvmWord GetCurrentValue(in StorageCell storageCell);
 
         /// <summary>
         /// Update the storage cell with provided value
         /// </summary>
         /// <param name="cell">Storage location</param>
         /// <param name="value">Value to set</param>
-        private void PushUpdate(in StorageCell cell, byte[] value)
+        private void PushUpdate(in StorageCell cell, in EvmWord value)
         {
             StackList<int> stack = SetupRegistry(cell);
             stack.Push(_changes.Count);
-            _changes.Add(new Change(in cell, value, ChangeType.Update));
+            _changes.Add(new Change(in cell, in value, ChangeType.Update));
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace Nethermind.State
             {
                 if (cellByAddress.Key.Address == address)
                 {
-                    Set(cellByAddress.Key, StorageTree.ZeroBytes);
+                    Set(cellByAddress.Key, default);
                 }
             }
         }
@@ -244,10 +244,10 @@ namespace Nethermind.State
         /// <summary>
         /// Used for tracking each change to storage
         /// </summary>
-        protected readonly struct Change(in StorageCell storageCell, byte[] value, ChangeType changeType)
+        protected readonly struct Change(in StorageCell storageCell, in EvmWord value, ChangeType changeType)
         {
             public readonly StorageCell StorageCell = storageCell;
-            public readonly byte[] Value = value;
+            public readonly EvmWord Value = value;
             public readonly ChangeType ChangeType = changeType;
 
             public bool IsNull => ChangeType == ChangeType.Null;

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -15,6 +15,7 @@ using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Resettables;
+using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing.State;
 using Nethermind.Int256;
@@ -77,6 +78,26 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// <returns>Value at location</returns>
     protected override ReadOnlySpan<byte> GetCurrentValue(in StorageCell storageCell) =>
         TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes! : LoadFromTree(storageCell);
+
+    /// <inheritdoc cref="IWorldState.SStore"/>
+    public SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+    {
+        ReadOnlySpan<byte> newBytes = StorageWord.ToStorageBytes(in newValue, out bool newIsZero);
+        ReadOnlySpan<byte> currentValue = Get(in storageCell);
+        bool currentIsZero = currentValue.IsZero();
+        bool newSameAsCurrent = (newIsZero && currentIsZero) || Bytes.AreEqual(currentValue, newBytes);
+
+        SStoreState state = currentIsZero ? SStoreState.CurrentIsZero : SStoreState.None;
+        if (newSameAsCurrent) return state | SStoreState.NewSameAsCurrent;
+
+        ReadOnlySpan<byte> originalValue = GetOriginal(in storageCell);
+        if (originalValue.IsZero()) state |= SStoreState.OriginalIsZero;
+        if (Bytes.AreEqual(originalValue, currentValue)) state |= SStoreState.CurrentSameAsOriginal;
+        if (Bytes.AreEqual(originalValue, newBytes)) state |= SStoreState.NewSameAsOriginal;
+
+        Set(in storageCell, newIsZero ? VirtualMachineStatics.BytesZero : newBytes.ToArray());
+        return state;
+    }
 
     /// <summary>
     /// Return the original persistent storage value from the storage cell

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -79,6 +79,15 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     protected override ReadOnlySpan<byte> GetCurrentValue(in StorageCell storageCell) =>
         TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes! : LoadFromTree(storageCell);
 
+    /// <inheritdoc cref="IWorldState.SLoad"/>
+    /// <remarks>
+    /// Reads the backing store directly instead of going through <see cref="PartialStorageProviderBase.Get"/>, so
+    /// that widening is the only step between the stored value and the caller. A backend holding fixed-width words
+    /// can drop that step too.
+    /// </remarks>
+    public EvmWord SLoad(in StorageCell storageCell) =>
+        StorageWord.FromStorageBytes(TryGetCachedValue(storageCell, out byte[]? cached) ? cached! : LoadFromTree(storageCell));
+
     /// <inheritdoc cref="IWorldState.SStore"/>
     public SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
     {

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -39,7 +39,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// <summary>
     /// <see href="https://eips.ethereum.org/EIPS/eip-1283"/>
     /// </summary>
-    private readonly Dictionary<StorageCell, byte[]> _originalValues = [];
+    private readonly Dictionary<StorageCell, EvmWord> _originalValues = [];
     private readonly HashSet<AddressAsKey> _destroyedThisRound = [];
     private readonly HashSet<StorageCell> _committedThisRound = [];
 
@@ -62,10 +62,10 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
     public void SetBackendScope(IWorldStateScopeProvider.IScope scope) => _currentScope = scope;
 
-    public override void Set(in StorageCell storageCell, byte[] newValue)
+    public override void Set(in StorageCell storageCell, in EvmWord newValue)
     {
         _metrics.IncrementStorageWrites();
-        base.Set(in storageCell, newValue);
+        base.Set(in storageCell, in newValue);
         // Write-time warm-up hint: the commit-time HintSet fires too late for speculative
         // (populator) executions, which never commit. No-op for backends without trie warm-up.
         _currentScope.HintWarmSlot(new ValueAddress(storageCell.Address.Bytes), storageCell.Index);
@@ -75,47 +75,38 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// Get the current value at the specified location
     /// </summary>
     /// <param name="storageCell">Storage location</param>
-    /// <returns>Value at location</returns>
-    protected override ReadOnlySpan<byte> GetCurrentValue(in StorageCell storageCell) =>
-        TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes! : LoadFromTree(storageCell);
+    /// <returns>Value at location, zero-padded to 32 bytes.</returns>
+    protected override EvmWord GetCurrentValue(in StorageCell storageCell) =>
+        TryGetCachedValue(storageCell, out EvmWord value) ? value : LoadFromTree(storageCell);
 
     /// <inheritdoc cref="IWorldState.SLoad"/>
-    /// <remarks>
-    /// Reads the backing store directly instead of going through <see cref="PartialStorageProviderBase.Get"/>, so
-    /// that widening is the only step between the stored value and the caller. A backend holding fixed-width words
-    /// can drop that step too.
-    /// </remarks>
-    public EvmWord SLoad(in StorageCell storageCell) =>
-        StorageWord.FromStorageBytes(TryGetCachedValue(storageCell, out byte[]? cached) ? cached! : LoadFromTree(storageCell));
+    public EvmWord SLoad(in StorageCell storageCell) => GetCurrentValue(in storageCell);
 
     /// <inheritdoc cref="IWorldState.SStore"/>
     public SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
     {
-        ReadOnlySpan<byte> newBytes = StorageWord.ToStorageBytes(in newValue, out bool newIsZero);
-        ReadOnlySpan<byte> currentValue = Get(in storageCell);
-        bool currentIsZero = currentValue.IsZero();
-        bool newSameAsCurrent = (newIsZero && currentIsZero) || Bytes.AreEqual(currentValue, newBytes);
+        EvmWord currentValue = GetCurrentValue(in storageCell);
+        bool currentIsZero = currentValue == default;
+        bool newSameAsCurrent = newValue == currentValue;
 
         SStoreState state = currentIsZero ? SStoreState.CurrentIsZero : SStoreState.None;
         if (newSameAsCurrent) return state | SStoreState.NewSameAsCurrent;
 
-        ReadOnlySpan<byte> originalValue = GetOriginal(in storageCell);
-        if (originalValue.IsZero()) state |= SStoreState.OriginalIsZero;
-        if (Bytes.AreEqual(originalValue, currentValue)) state |= SStoreState.CurrentSameAsOriginal;
-        if (Bytes.AreEqual(originalValue, newBytes)) state |= SStoreState.NewSameAsOriginal;
+        EvmWord originalValue = GetOriginalWord(in storageCell);
+        if (originalValue == default) state |= SStoreState.OriginalIsZero;
+        if (originalValue == currentValue) state |= SStoreState.CurrentSameAsOriginal;
+        if (originalValue == newValue) state |= SStoreState.NewSameAsOriginal;
 
-        Set(in storageCell, newIsZero ? VirtualMachineStatics.BytesZero : newBytes.ToArray());
+        Set(in storageCell, in newValue);
         return state;
     }
 
     /// <summary>
-    /// Return the original persistent storage value from the storage cell
+    /// Return the original persistent storage value from the storage cell as a full 32-byte word.
     /// </summary>
-    /// <param name="storageCell"></param>
-    /// <returns></returns>
-    public ReadOnlySpan<byte> GetOriginal(in StorageCell storageCell)
+    public EvmWord GetOriginalWord(in StorageCell storageCell)
     {
-        if (!_originalValues.TryGetValue(storageCell, out byte[] value))
+        if (!_originalValues.TryGetValue(storageCell, out EvmWord value))
         {
             throw new InvalidOperationException("Get original should only be called after get within the same caching round");
         }
@@ -191,7 +182,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 {
                     if (isTracing)
                     {
-                        trace![change.StorageCell] = new StorageChangeTrace(StorageTree.ZeroBytes);
+                        trace![change.StorageCell] = new StorageChangeTrace(default);
                     }
 
                     continue;
@@ -199,11 +190,11 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
                 if (_logger.IsTrace)
                 {
-                    _logger.Trace($"  Update {change.StorageCell.Address}_{change.StorageCell.Index} V = {change.Value.ToHexString(true)}");
+                    _logger.Trace($"  Update {change.StorageCell.Address}_{change.StorageCell.Index} V = {StorageWord.ToStorageBytes(in change.Value, out _).ToHexString(true)}");
                 }
 
-                if (_originalValues.TryGetValue(change.StorageCell, out byte[] initialValue) &&
-                    initialValue.AsSpan().SequenceEqual(change.Value))
+                if (_originalValues.TryGetValue(change.StorageCell, out EvmWord initialValue) &&
+                    initialValue == change.Value)
                 {
                     // no need to update the tree if the value is the same
                 }
@@ -246,7 +237,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         if (isTracing)
         {
-            foreach ((StorageCell cell, byte[] originalValue) in _originalValues)
+            foreach ((StorageCell cell, EvmWord originalValue) in _originalValues)
             {
                 if (trace!.TryGetValue(cell, out StorageChangeTrace changeTrace))
                 {
@@ -350,18 +341,18 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
     }
 
-    private ReadOnlySpan<byte> LoadFromTree(in StorageCell storageCell) =>
+    private EvmWord LoadFromTree(in StorageCell storageCell) =>
         GetOrCreateStorage(storageCell.Address).LoadFromTree(storageCell);
 
     /// <summary>
     /// Reads skip the registry/change journal that writes use: repeat reads are served by
     /// <see cref="PerContractState.BlockChange"/>, which is inherently revert-safe (reads have
     /// no side effects). Only the first-loaded value is captured here, backing
-    /// <see cref="GetOriginal"/> and commit-time <see cref="IStorageTracer.ReportStorageRead"/>.
+    /// <see cref="GetOriginalWord"/> and commit-time <see cref="IStorageTracer.ReportStorageRead"/>.
     /// </summary>
-    private void CaptureOriginalValue(in StorageCell cell, byte[] value)
+    private void CaptureOriginalValue(in StorageCell cell, in EvmWord value)
     {
-        ref byte[]? slot = ref CollectionsMarshal.GetValueRefOrAddDefault(_originalValues, cell, out bool exists);
+        ref EvmWord slot = ref CollectionsMarshal.GetValueRefOrAddDefault(_originalValues, cell, out bool exists);
         if (!exists)
         {
             slot = value;
@@ -372,12 +363,9 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     {
         foreach ((StorageCell address, StorageChangeTrace change) in trace)
         {
-            byte[] before = change.Before;
-            byte[] after = change.After;
-
-            if (!Bytes.AreEqual(before, after))
+            if (change.Before != change.After)
             {
-                tracer.ReportStorageChange(address, before, after);
+                tracer.ReportStorageChange(address, StorageWord.ToStorageBytes(in change.Before, out _).ToArray(), StorageWord.ToStorageBytes(in change.After, out _).ToArray());
             }
         }
     }
@@ -425,11 +413,11 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
     public override void ClearStorage(Address address)
     {
-        foreach (KeyValuePair<StorageCell, byte[]> readCell in _originalValues)
+        foreach (KeyValuePair<StorageCell, EvmWord> readCell in _originalValues)
         {
             if (readCell.Key.Address == address)
             {
-                Set(readCell.Key, StorageTree.ZeroBytes);
+                Set(readCell.Key, default);
             }
         }
 
@@ -573,7 +561,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             Pool.Return(this);
         }
 
-        public void SaveChange(StorageCell storageCell, byte[] value)
+        public void SaveChange(StorageCell storageCell, in EvmWord value)
         {
             _wasWritten = true;
             ref StorageChangeTrace valueChanges = ref BlockChange.GetValueRefOrAddDefault(storageCell.Index, out bool exists);
@@ -587,15 +575,15 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             }
 
             EnsureStorageTree();
-            _backend.HintSet(storageCell.Index, value);
+            _backend.HintSet(storageCell.Index, in value);
         }
 
-        public ReadOnlySpan<byte> LoadFromTree(in StorageCell storageCell)
+        public EvmWord LoadFromTree(in StorageCell storageCell)
         {
             ref StorageChangeTrace valueChange = ref BlockChange.GetValueRefOrAddDefault(storageCell.Index, out bool exists);
             if (!exists)
             {
-                byte[] value = LoadFromTreeStorage(storageCell);
+                EvmWord value = LoadFromTreeStorage(storageCell);
 
                 valueChange = new(value, value);
             }
@@ -608,7 +596,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             return valueChange.After;
         }
 
-        private byte[] LoadFromTreeStorage(StorageCell storageCell)
+        private EvmWord LoadFromTreeStorage(StorageCell storageCell)
         {
             _provider._metrics.IncrementStorageTreeReads();
 
@@ -641,10 +629,10 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
             foreach (KeyValuePair<UInt256, StorageChangeTrace> kvp in BlockChange)
             {
-                byte[] after = kvp.Value.After;
-                if (!Bytes.AreEqual(kvp.Value.Before, after) || kvp.Value.IsInitialValue)
+                EvmWord after = kvp.Value.After;
+                if (kvp.Value.Before != after || kvp.Value.IsInitialValue)
                 {
-                    if (after.IsZero())
+                    if (after == default)
                     {
                         deferredDeletes.Add(kvp);
                     }
@@ -652,7 +640,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                     {
                         // Safe while enumerating: this only overwrites the existing key, never adds or removes.
                         BlockChange[kvp.Key] = new(after, after);
-                        storageWriteBatch.Set(kvp.Key, after);
+                        storageWriteBatch.Set(kvp.Key, in after);
 
                         writes++;
                     }
@@ -665,9 +653,9 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
             foreach (KeyValuePair<UInt256, StorageChangeTrace> kvp in deferredDeletes.AsSpan())
             {
-                byte[] after = kvp.Value.After;
+                EvmWord after = kvp.Value.After;
                 BlockChange[kvp.Key] = new(after, after);
-                storageWriteBatch.Set(kvp.Key, after);
+                storageWriteBatch.Set(kvp.Key, in after);
 
                 writes++;
             }
@@ -720,24 +708,24 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
     private readonly struct StorageChangeTrace
     {
-        public static readonly StorageChangeTrace _zeroBytes = new(StorageTree.ZeroBytes, StorageTree.ZeroBytes);
+        public static readonly StorageChangeTrace _zeroBytes = default;
         public static ref readonly StorageChangeTrace ZeroBytes => ref _zeroBytes;
 
-        public StorageChangeTrace(byte[]? before, byte[]? after)
+        public StorageChangeTrace(in EvmWord before, in EvmWord after)
         {
-            After = after ?? StorageTree.ZeroBytes;
-            Before = before ?? StorageTree.ZeroBytes;
+            After = after;
+            Before = before;
         }
 
-        public StorageChangeTrace(byte[]? after)
+        public StorageChangeTrace(in EvmWord after)
         {
-            After = after ?? StorageTree.ZeroBytes;
-            Before = StorageTree.ZeroBytes;
+            After = after;
+            Before = default;
             IsInitialValue = true;
         }
 
-        public readonly byte[] Before;
-        public readonly byte[] After;
+        public readonly EvmWord Before;
+        public readonly EvmWord After;
         public readonly bool IsInitialValue;
     }
 }

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -65,7 +65,7 @@ public class PrewarmerScopeProvider(
         private readonly IWorldStateScopeProvider.IScope baseScope = baseScope;
         private readonly PreBlockCaches preBlockCaches = preBlockCaches;
         private readonly SeqlockCache<AddressAsKey, Account> preBlockCache = preBlockCaches.StateCache;
-        private readonly SeqlockCache<StorageCell, byte[]> storageCache = preBlockCaches.StorageCache;
+        private readonly SeqlockCache<StorageCell, EvmWord> storageCache = preBlockCaches.StorageCache;
         private readonly bool isPrewarmer = isPrewarmer;
         private readonly IWorldStateScopeProvider.IScope? mainScope = isPrewarmer ? preBlockCaches.MainScope : null;
         private readonly LocalMetrics _metrics = metrics;
@@ -179,7 +179,7 @@ public class PrewarmerScopeProvider(
 
         private sealed class CacheSink(
             SeqlockCache<AddressAsKey, Account> stateCache,
-            SeqlockCache<StorageCell, byte[]> storageCache
+            SeqlockCache<StorageCell, EvmWord> storageCache
         ) : IWorldStateScopeProvider.IAsyncBalReaderSink
         {
             public void OnAccountRead(Address address, Account? account)
@@ -188,7 +188,7 @@ public class PrewarmerScopeProvider(
                 stateCache.Set(in key, account);
             }
 
-            public void OnStorageRead(in StorageCell storageCell, byte[] value)
+            public void OnStorageRead(in StorageCell storageCell, in EvmWord value)
                 => storageCache.Set(in storageCell, value);
 
             public bool StillNeeded(Address address, out Account? account)
@@ -206,13 +206,13 @@ public class PrewarmerScopeProvider(
 
     private sealed class StorageTreeWrapper(
         IWorldStateScopeProvider.IStorageTree baseStorageTree,
-        SeqlockCache<StorageCell, byte[]> preBlockCache,
+        SeqlockCache<StorageCell, EvmWord> preBlockCache,
         Address address,
         bool isPrewarmer,
         LocalMetrics metrics) : IWorldStateScopeProvider.IStorageTree
     {
         private readonly IWorldStateScopeProvider.IStorageTree baseStorageTree = baseStorageTree;
-        private readonly SeqlockCache<StorageCell, byte[]> preBlockCache = preBlockCache;
+        private readonly SeqlockCache<StorageCell, EvmWord> preBlockCache = preBlockCache;
         private readonly Address address = address;
         private readonly bool isPrewarmer = isPrewarmer;
         private readonly LocalMetrics _metrics = metrics;
@@ -222,11 +222,11 @@ public class PrewarmerScopeProvider(
 
         public Hash256 RootHash => baseStorageTree.RootHash;
 
-        public byte[] Get(in UInt256 index)
+        public EvmWord Get(in UInt256 index)
         {
             StorageCell storageCell = new(address, in index); // TODO: Make the dictionary use UInt256 directly
             long sw = _measureMetric ? Stopwatch.GetTimestamp() : 0;
-            if (preBlockCache.TryGetValue(in storageCell, out byte[] value))
+            if (preBlockCache.TryGetValue(in storageCell, out EvmWord value))
             {
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
                 _metrics.IncrementStorageTreeCache();
@@ -241,9 +241,9 @@ public class PrewarmerScopeProvider(
             return value;
         }
 
-        public void HintSet(in UInt256 index, byte[]? value) => baseStorageTree.HintSet(in index, value);
+        public void HintSet(in UInt256 index, in EvmWord value) => baseStorageTree.HintSet(in index, in value);
 
-        private byte[] LoadFromTreeStorage(in StorageCell storageCell)
+        private EvmWord LoadFromTreeStorage(in StorageCell storageCell)
         {
             _metrics.IncrementStorageTreeReads();
 

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -94,6 +94,13 @@ namespace Nethermind.State
             return new BulkSetEntry(in key, encodedValue);
         }
 
+        public static BulkSetEntry CreateBulkSetEntry(in ValueHash256 key, in EvmWord value)
+        {
+            ReadOnlySpan<byte> stripped = StorageWord.ToStorageBytes(in value, out bool isZero);
+            byte[] encodedValue = isZero ? [] : Rlp.Encode(stripped).Bytes;
+            return new BulkSetEntry(in key, encodedValue);
+        }
+
         [SkipLocalsInit]
         public byte[] Get(in UInt256 index, Hash256? storageRoot = null)
         {
@@ -138,7 +145,33 @@ namespace Nethermind.State
 
         public byte[] Get(in UInt256 index) => Get(index, null);
 
-        public void HintSet(in UInt256 index, byte[]? value)
+        /// <summary>Reads a slot as a full 32-byte word, widening the minimal-length RLP leaf. Empty leaf → zero.</summary>
+        [SkipLocalsInit]
+        public EvmWord GetWord(in UInt256 index, Hash256? storageRoot = null)
+        {
+            ValueHash256[] lookup = Lookup;
+            ulong u0 = index.u0;
+            if (index.IsUint64 && u0 < (uint)lookup.Length)
+            {
+                return GetWordByKey(in Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(lookup), (nuint)u0), storageRoot);
+            }
+
+            ComputeKey(index, out ValueHash256 key);
+            return GetWordByKey(in key, storageRoot);
+        }
+
+        private EvmWord GetWordByKey(in ValueHash256 key, Hash256? rootHash)
+        {
+            ReadOnlySpan<byte> value = Get(key.Bytes, rootHash);
+            if (value.IsEmpty) return default;
+
+            RlpReader rlp = new(value);
+            return StorageWord.FromStorageBytes(rlp.DecodeByteArraySpan());
+        }
+
+        EvmWord IWorldStateScopeProvider.IStorageTree.Get(in UInt256 index) => GetWord(in index);
+
+        void IWorldStateScopeProvider.IStorageTree.HintSet(in UInt256 index, in EvmWord value)
         {
         }
 
@@ -165,6 +198,37 @@ namespace Nethermind.State
         }
 
         public void Set(in ValueHash256 key, byte[] value, bool rlpEncode = true) => SetInternal(in key, value, rlpEncode);
+
+        /// <summary>Writes a slot from a full 32-byte word, storing the minimal-length RLP leaf. Zero → empty leaf (deletion).</summary>
+        [SkipLocalsInit]
+        public void SetWord(in UInt256 index, in EvmWord value)
+        {
+            ValueHash256[] lookup = Lookup;
+            ulong u0 = index.u0;
+            if (index.IsUint64 && u0 < (uint)lookup.Length)
+            {
+                SetWordInternal(in Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(lookup), (nuint)u0), in value);
+            }
+            else
+            {
+                ComputeKey(index, out ValueHash256 key);
+                SetWordInternal(in key, in value);
+            }
+        }
+
+        private void SetWordInternal(in ValueHash256 hash, in EvmWord value)
+        {
+            ReadOnlySpan<byte> rawKey = hash.Bytes;
+            ReadOnlySpan<byte> stripped = StorageWord.ToStorageBytes(in value, out bool isZero);
+            if (isZero)
+            {
+                Set(rawKey, []);
+            }
+            else
+            {
+                Set(rawKey, Rlp.Encode(stripped));
+            }
+        }
 
         private void SetInternal(in ValueHash256 hash, byte[] value, bool rlpEncode = true)
         {

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -117,6 +117,27 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
         base.Set(storageCell, newValue);
     }
 
+    /// <inheritdoc cref="IWorldState.SStore"/>
+    /// <remarks>
+    /// The wrapped state performs the read and the write, so the read-recording and the change-recording that
+    /// <see cref="Get"/> and <see cref="Set"/> normally contribute are done here instead.
+    /// </remarks>
+    public override SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+    {
+        // Records the read; copied because the span dies on the next call into the wrapped state.
+        byte[] oldValue = Get(in storageCell).ToArray();
+
+        SStoreState state = base.SStore(in storageCell, in newValue);
+
+        if (!state.HasFlag(SStoreState.NewSameAsCurrent))
+        {
+            ReadOnlySpan<byte> newBytes = StorageWord.ToStorageBytes(in newValue, out _);
+            _generatingBlockAccessList.AddStorageChange(storageCell, new(oldValue, true), new(newBytes, true));
+        }
+
+        return state;
+    }
+
     public override ref readonly UInt256 GetBalance(Address address)
     {
         AccountChangesAtIndex? accountChanges = RecordReadAndGetChanges(address);

--- a/src/Nethermind/Nethermind.State/TransientStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/TransientStorageProvider.cs
@@ -18,8 +18,8 @@ namespace Nethermind.State
         /// Get the storage value at the specified storage cell
         /// </summary>
         /// <param name="storageCell">Storage location</param>
-        /// <returns>Value at cell</returns>
-        protected override ReadOnlySpan<byte> GetCurrentValue(in StorageCell storageCell) =>
-            TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes! : StorageTree.ZeroBytes;
+        /// <returns>Value at cell, zero-padded to 32 bytes.</returns>
+        protected override EvmWord GetCurrentValue(in StorageCell storageCell) =>
+            TryGetCachedValue(storageCell, out EvmWord value) ? value : default;
     }
 }

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -183,7 +183,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                                 }
                                 StorageCell cell = new(address, in slot);
                                 if (!sink.StillNeeded(in cell)) continue;
-                                sink.OnStorageRead(in cell, storageTree.Get(in slot));
+                                sink.OnStorageRead(in cell, storageTree.GetWord(in slot));
                             }
                         }
                         catch (MissingTrieNodeException) { }
@@ -332,17 +332,17 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
 
         private ValueHash256 _keyBuff = new();
 
-        public void Set(in UInt256 index, byte[] value)
+        public void Set(in UInt256 index, in EvmWord value)
         {
             _wasSetCalled = true;
             if (_bulkWrite is null)
             {
-                storageTree.Set(index, value);
+                storageTree.SetWord(index, in value);
             }
             else
             {
                 StorageTree.ComputeKeyWithLookup(index, ref _keyBuff);
-                _bulkWrite.Add(StorageTree.CreateBulkSetEntry(_keyBuff, value));
+                _bulkWrite.Add(StorageTree.CreateBulkSetEntry(_keyBuff, in value));
             }
         }
 

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -111,6 +111,13 @@ namespace Nethermind.State
             return _persistentStorageProvider.Get(storageCell);
         }
 
+        /// <inheritdoc cref="IWorldState.SLoad"/>
+        public EvmWord SLoad(in StorageCell storageCell)
+        {
+            DebugGuardInScope();
+            return _persistentStorageProvider.SLoad(in storageCell);
+        }
+
         /// <inheritdoc cref="IWorldState.SStore"/>
         public SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
         {

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -110,6 +110,13 @@ namespace Nethermind.State
             DebugGuardInScope();
             return _persistentStorageProvider.Get(storageCell);
         }
+
+        /// <inheritdoc cref="IWorldState.SStore"/>
+        public SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+        {
+            DebugGuardInScope();
+            return _persistentStorageProvider.SStore(in storageCell, in newValue);
+        }
         public void Set(in StorageCell storageCell, byte[] newValue)
         {
             DebugGuardInScope();

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -33,6 +33,13 @@ namespace Nethermind.State
         internal readonly StateProvider _stateProvider;
         internal readonly PersistentStorageProvider _persistentStorageProvider;
         private readonly TransientStorageProvider _transientStorageProvider;
+        // Backing storage for the minimal-length spans returned by the legacy Get/GetOriginal/GetTransientState
+        // surface: they narrow the word-native providers, and the returned span aliases these fields, so each
+        // stays valid only until the next call on this instance (the documented contract). Separate fields let a
+        // Get and a GetOriginal span be live at once.
+        private EvmWord _getScratch;
+        private EvmWord _originalScratch;
+        private EvmWord _transientScratch;
         // Per-scope counter accumulator shared with the providers and scope; folded into the global
         // Metrics in Commit/EndScope to avoid per-increment cross-thread contention.
         private readonly LocalMetrics _localMetrics = new();
@@ -103,12 +110,14 @@ namespace Nethermind.State
         public ReadOnlySpan<byte> GetOriginal(in StorageCell storageCell)
         {
             DebugGuardInScope();
-            return _persistentStorageProvider.GetOriginal(storageCell);
+            _originalScratch = _persistentStorageProvider.GetOriginalWord(in storageCell);
+            return StorageWord.ToStorageBytes(in _originalScratch, out _);
         }
         public ReadOnlySpan<byte> Get(in StorageCell storageCell)
         {
             DebugGuardInScope();
-            return _persistentStorageProvider.Get(storageCell);
+            _getScratch = _persistentStorageProvider.Get(in storageCell);
+            return StorageWord.ToStorageBytes(in _getScratch, out _);
         }
 
         /// <inheritdoc cref="IWorldState.SLoad"/>
@@ -127,17 +136,18 @@ namespace Nethermind.State
         public void Set(in StorageCell storageCell, byte[] newValue)
         {
             DebugGuardInScope();
-            _persistentStorageProvider.Set(storageCell, newValue);
+            _persistentStorageProvider.Set(in storageCell, StorageWord.FromStorageBytes(newValue));
         }
         public ReadOnlySpan<byte> GetTransientState(in StorageCell storageCell)
         {
             DebugGuardInScope();
-            return _transientStorageProvider.Get(storageCell);
+            _transientScratch = _transientStorageProvider.Get(in storageCell);
+            return StorageWord.ToStorageBytes(in _transientScratch, out _);
         }
         public void SetTransientState(in StorageCell storageCell, byte[] newValue)
         {
             DebugGuardInScope();
-            _transientStorageProvider.Set(storageCell, newValue);
+            _transientStorageProvider.Set(in storageCell, StorageWord.FromStorageBytes(newValue));
         }
         public void Reset(bool resetBlockChanges = true)
         {

--- a/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
@@ -72,6 +72,15 @@ public abstract class WorldStateDecorator(IWorldState state) : IWorldState
     public virtual void Set(in StorageCell storageCell, byte[] newValue)
         => State.Set(in storageCell, newValue);
 
+    /// <inheritdoc cref="IWorldState.SStore"/>
+    /// <remarks>
+    /// The store runs entirely inside <see cref="State"/>, so a derived class that hooks <see cref="Get"/>,
+    /// <see cref="GetOriginal"/> or <see cref="Set"/> to record accesses must override this too — those hooks
+    /// are not reached from here.
+    /// </remarks>
+    public virtual SStoreState SStore(in StorageCell storageCell, in EvmWord newValue)
+        => State.SStore(in storageCell, in newValue);
+
     public virtual ReadOnlySpan<byte> GetTransientState(in StorageCell storageCell)
         => State.GetTransientState(in storageCell);
 

--- a/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
@@ -69,6 +69,15 @@ public abstract class WorldStateDecorator(IWorldState state) : IWorldState
     public virtual ReadOnlySpan<byte> Get(in StorageCell storageCell)
         => State.Get(in storageCell);
 
+    /// <inheritdoc cref="IWorldState.SLoad"/>
+    /// <remarks>
+    /// Reads through this decorator's <see cref="Get"/> rather than forwarding to <see cref="State"/>: a derived
+    /// class may serve the value from elsewhere or record the access, and forwarding would bypass both. There is
+    /// nothing else for a decorator to hook here, so overriding this is normally unnecessary.
+    /// </remarks>
+    public virtual EvmWord SLoad(in StorageCell storageCell)
+        => StorageWord.FromStorageBytes(Get(in storageCell));
+
     public virtual void Set(in StorageCell storageCell, byte[] newValue)
         => State.Set(in storageCell, newValue);
 

--- a/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
@@ -75,14 +75,14 @@ public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopePr
     {
         public Hash256 RootHash => storageTree.RootHash;
 
-        public byte[] Get(in UInt256 index)
+        public EvmWord Get(in UInt256 index)
         {
-            byte[]? bytes = storageTree.Get(in index);
-            logger.Trace($"{scopeId}: S:{address} Get slot {index}, got {bytes?.ToHexString()}");
-            return bytes;
+            EvmWord value = storageTree.Get(in index);
+            logger.Trace($"{scopeId}: S:{address} Get slot {index}, got {StorageWord.ToStorageBytes(in value, out _).ToHexString()}");
+            return value;
         }
 
-        public void HintSet(in UInt256 index, byte[]? value) => storageTree.HintSet(in index, value);
+        public void HintSet(in UInt256 index, in EvmWord value) => storageTree.HintSet(in index, in value);
     }
 
     private class WriteBatchWrapper : IWorldStateScopeProvider.IWorldStateWriteBatch
@@ -137,10 +137,10 @@ public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopePr
             logger.Trace($"{scopeId}: {address}, Storage write batch disposed");
         }
 
-        public void Set(in UInt256 index, byte[] value)
+        public void Set(in UInt256 index, in EvmWord value)
         {
-            writeBatch.Set(in index, value);
-            logger.Trace($"{scopeId}: {address}, Set {index} to {value?.ToHexString()}");
+            writeBatch.Set(in index, in value);
+            logger.Trace($"{scopeId}: {address}, Set {index} to {StorageWord.ToStorageBytes(in value, out _).ToHexString()}");
         }
 
         public void Clear()


### PR DESCRIPTION
## Changes

Makes `EvmWord` (a 32-byte `Vector256<byte>`) the in-memory representation of storage slot values everywhere between the EVM boundary and the trie encode step, removing the per-read/per-write `byte[]` allocation the old minimal-length representation forced. Builds on the SLOAD/SSTORE word API from #12362 (included in this branch).

- **Seam** (`IWorldStateScopeProvider`): `IStorageTree.Get`, `IStorageWriteBatch.Set`, `HintSet`, `IAsyncBalReaderSink.OnStorageRead` carry `EvmWord`.
- **Provider internals**: the change journal (`Change.Value`), `_originalValues`, `StorageChangeTrace`, and the committed `BlockChange` dictionary hold `EvmWord`; comparisons are `Vector256 ==`, zero is `default`. `SLoad`/`SStore` are allocation-free.
- **Flat backend**: `GetSlotValue`/`SetChangedSlot` carry `SlotValue`/`EvmWord` natively (the persistence layer below was already `SlotValue`-native), dropping `ToEvmBytes`/`FromSpanWithoutLeadingZero` on the hot path. `SlotValue` ↔ `EvmWord` is a zero-cost reinterpret.
- **Trie backend**: `StorageTree.GetWord`/`SetWord` widen/strip via `StorageWord` at the RLP boundary; the leaf stays `RLP(minimal-big-endian)`, so **storage roots are unchanged**.
- **Prewarm cache** (`PreBlockCaches.StorageCache`) stores `EvmWord`. Required relaxing `SeqlockCache`'s `where TValue : class?` constraint — a seqlock's version-guarded copy-on-read is exactly what makes an inline 32-byte struct value safe (added a struct-value regression test).
- **External `byte[]` surface preserved**: `IWorldState.Get`/`Set`/`GetOriginal` and `IStateReader.GetStorage` keep their signatures via per-instance scratch words, so RPC, XDC contracts, genesis, tracers and the ~40 other callers are untouched.

> **Draft — `test:` prefixed to trigger the reproducible/expb benchmark on this branch.** The point of this PR is the benchmark signal on the storage hot path (per-SLOAD/SSTORE allocation removal on the flat backend); not yet up for review.

## Types of changes

- [x] Optimization
- [x] Refactoring
- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Passing locally: `Nethermind.State.Test` (1174), `Nethermind.State.Flat.Test` (558), `Nethermind.Evm.Test` (4828), `Nethermind.Consensus.Test` (107), `Nethermind.Blockchain.Test` (1500 — full block processing, would fail on any storage-root drift), `Nethermind.Core.Test` SeqlockCache incl. the new struct-value case. Solution builds with 0 warnings. **Not run locally:** the Ethereum Foundation spec suite (`EthereumTests.slnx`) — the definitive storage-root check; relying on CI.

## Documentation

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
