### PR TITLE
perf(flat): devirtualize snapshot key comparer dispatch

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat/Collections/SnapshotKeyComparers.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Collections/SnapshotKeyComparers.cs
@@ -9,39 +9,34 @@ using Nethermind.Trie;
 
 namespace Nethermind.State.Flat.Collections;
 
-/// <summary>Key comparers for snapshot content; trie-node order matches the persistence layer's sort.</summary>
-internal static class SnapshotKeyComparers
+// Key comparers for snapshot content; trie-node order matches the persistence layer's sort. They are stateless
+// structs passed as value-type generic arguments (see SortedMergeDictionary.BuildFromMerge), so every Compare
+// call is devirtualized and inlined instead of interface-dispatched.
+
+internal readonly struct AddressKeyComparer : IComparer<HashedKey<Address>>
 {
-    public static readonly IComparer<HashedKey<Address>> Address = new AddressComparer();
-    public static readonly IComparer<HashedKey<(Address, UInt256)>> Storage = new StorageComparer();
-    public static readonly IComparer<HashedKey<TreePath>> StateNode = new StateNodeComparer();
-    public static readonly IComparer<HashedKey<(Hash256, TreePath)>> StorageNode = new StorageNodeComparer();
+    public int Compare(HashedKey<Address> x, HashedKey<Address> y) => x.Key.CompareTo(y.Key);
+}
 
-    private sealed class AddressComparer : IComparer<HashedKey<Address>>
+internal readonly struct StorageKeyComparer : IComparer<HashedKey<(Address, UInt256)>>
+{
+    public int Compare(HashedKey<(Address, UInt256)> x, HashedKey<(Address, UInt256)> y)
     {
-        public int Compare(HashedKey<Address> x, HashedKey<Address> y) => x.Key.CompareTo(y.Key);
+        int c = x.Key.Item1.CompareTo(y.Key.Item1);
+        return c != 0 ? c : x.Key.Item2.CompareTo(y.Key.Item2);
     }
+}
 
-    private sealed class StorageComparer : IComparer<HashedKey<(Address, UInt256)>>
-    {
-        public int Compare(HashedKey<(Address, UInt256)> x, HashedKey<(Address, UInt256)> y)
-        {
-            int c = x.Key.Item1.CompareTo(y.Key.Item1);
-            return c != 0 ? c : x.Key.Item2.CompareTo(y.Key.Item2);
-        }
-    }
+internal readonly struct StateNodeKeyComparer : IComparer<HashedKey<TreePath>>
+{
+    public int Compare(HashedKey<TreePath> x, HashedKey<TreePath> y) => x.Key.CompareTo(y.Key);
+}
 
-    private sealed class StateNodeComparer : IComparer<HashedKey<TreePath>>
+internal readonly struct StorageNodeKeyComparer : IComparer<HashedKey<(Hash256, TreePath)>>
+{
+    public int Compare(HashedKey<(Hash256, TreePath)> x, HashedKey<(Hash256, TreePath)> y)
     {
-        public int Compare(HashedKey<TreePath> x, HashedKey<TreePath> y) => x.Key.CompareTo(y.Key);
-    }
-
-    private sealed class StorageNodeComparer : IComparer<HashedKey<(Hash256, TreePath)>>
-    {
-        public int Compare(HashedKey<(Hash256, TreePath)> x, HashedKey<(Hash256, TreePath)> y)
-        {
-            int c = x.Key.Item1.CompareTo(y.Key.Item1);
-            return c != 0 ? c : x.Key.Item2.CompareTo(y.Key.Item2);
-        }
+        int c = x.Key.Item1.CompareTo(y.Key.Item1);
+        return c != 0 ? c : x.Key.Item2.CompareTo(y.Key.Item2);
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/Collections/SortedMergeDictionary.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Collections/SortedMergeDictionary.cs
@@ -54,7 +54,8 @@ internal sealed class SortedMergeDictionary<TKey, TValue> : IEnumerable<KeyValue
         return false;
     }
 
-    public void BuildFromUnsorted(IReadOnlyCollection<KeyValuePair<TKey, TValue>> source, IComparer<TKey> keyComparer)
+    public void BuildFromUnsorted<TComparer>(IReadOnlyCollection<KeyValuePair<TKey, TValue>> source, TComparer keyComparer)
+        where TComparer : IComparer<TKey>
     {
         int count = source.Count;
         EnsureEntryCapacity(count);
@@ -64,7 +65,7 @@ internal sealed class SortedMergeDictionary<TKey, TValue> : IEnumerable<KeyValue
             _entries[i++] = new Entry { HashCode = (uint)kv.Key.GetHashCode(), Key = kv.Key, Value = kv.Value };
         }
 
-        Array.Sort(_entries, 0, count, new EntryKeyComparer(keyComparer));
+        _entries.AsSpan(0, count).Sort(new EntryKeyComparer<TComparer>(keyComparer));
         _count = count;
         BuildBuckets();
     }
@@ -73,10 +74,15 @@ internal sealed class SortedMergeDictionary<TKey, TValue> : IEnumerable<KeyValue
     /// Merges already-sorted inputs (ascending priority; the highest-index source wins on equal keys). When
     /// <paramref name="keep"/> is supplied, entries it rejects are dropped and keys with no survivor are omitted.
     /// </summary>
-    public void BuildFromMerge(
+    /// <remarks>
+    /// <typeparamref name="TComparer"/> is a type parameter rather than an <see cref="IComparer{T}"/> parameter so
+    /// that struct comparers are monomorphized: their Compare calls are devirtualized and inlined at every JIT tier.
+    /// </remarks>
+    public void BuildFromMerge<TComparer>(
         ReadOnlySpan<SortedMergeDictionary<TKey, TValue>> sources,
-        IComparer<TKey> keyComparer,
+        TComparer keyComparer,
         Func<int, TKey, bool>? keep = null)
+        where TComparer : IComparer<TKey>
     {
         if (sources.Length == 0)
         {
@@ -89,7 +95,7 @@ internal sealed class SortedMergeDictionary<TKey, TValue> : IEnumerable<KeyValue
         foreach (SortedMergeDictionary<TKey, TValue> source in sources) total += source._count;
         EnsureEntryCapacity(total);
 
-        LoserTree tree = new(sources, keyComparer);
+        LoserTree<TComparer> tree = new(sources, keyComparer);
         int count = 0;
         while (tree.TryNext(keep, out Entry chosen))
         {
@@ -158,18 +164,20 @@ internal sealed class SortedMergeDictionary<TKey, TValue> : IEnumerable<KeyValue
         }
     }
 
-    public static SortedMergeDictionary<TKey, TValue> FromUnsorted(
-        IReadOnlyCollection<KeyValuePair<TKey, TValue>> source, IComparer<TKey> keyComparer)
+    public static SortedMergeDictionary<TKey, TValue> FromUnsorted<TComparer>(
+        IReadOnlyCollection<KeyValuePair<TKey, TValue>> source, TComparer keyComparer)
+        where TComparer : IComparer<TKey>
     {
         SortedMergeDictionary<TKey, TValue> dictionary = new();
         dictionary.BuildFromUnsorted(source, keyComparer);
         return dictionary;
     }
 
-    public static SortedMergeDictionary<TKey, TValue> Merge(
+    public static SortedMergeDictionary<TKey, TValue> Merge<TComparer>(
         ReadOnlySpan<SortedMergeDictionary<TKey, TValue>> sources,
-        IComparer<TKey> keyComparer,
+        TComparer keyComparer,
         Func<int, TKey, bool>? keep = null)
+        where TComparer : IComparer<TKey>
     {
         SortedMergeDictionary<TKey, TValue> dictionary = new();
         dictionary.BuildFromMerge(sources, keyComparer, keep);
@@ -207,7 +215,8 @@ internal sealed class SortedMergeDictionary<TKey, TValue> : IEnumerable<KeyValue
         public readonly void Dispose() { }
     }
 
-    private sealed class EntryKeyComparer(IComparer<TKey> keyComparer) : IComparer<Entry>
+    private readonly struct EntryKeyComparer<TComparer>(TComparer keyComparer) : IComparer<Entry>
+        where TComparer : IComparer<TKey>
     {
         public int Compare(Entry x, Entry y) => keyComparer.Compare(x.Key, y.Key);
     }
@@ -219,15 +228,15 @@ internal sealed class SortedMergeDictionary<TKey, TValue> : IEnumerable<KeyValue
     /// than O(k). Leaf index <c>_k</c> is a sentinel: it seeds the tree (smaller than any real head) and marks
     /// exhausted runs (larger than any real head).
     /// </summary>
-    private ref struct LoserTree
+    private ref struct LoserTree<TComparer> where TComparer : IComparer<TKey>
     {
         private readonly ReadOnlySpan<SortedMergeDictionary<TKey, TValue>> _sources;
-        private readonly IComparer<TKey> _keyComparer;
+        private readonly TComparer _keyComparer;
         private readonly int _k;
         private readonly int[] _tree;
         private readonly int[] _position;
 
-        public LoserTree(ReadOnlySpan<SortedMergeDictionary<TKey, TValue>> sources, IComparer<TKey> keyComparer)
+        public LoserTree(ReadOnlySpan<SortedMergeDictionary<TKey, TValue>> sources, TComparer keyComparer)
         {
             _sources = sources;
             _keyComparer = keyComparer;

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotCompactor.cs
@@ -154,15 +154,15 @@ public class SnapshotCompactor(
         {
             using ArrayPoolListRef<Task> compactTask = new(4);
             compactTask.Add(Task.Run(() => MergeInto(
-                content.SortedAccounts, snapshots, SnapshotKeyComparers.Address, static m => m.SortedAccounts, static c => c.Accounts, null)));
+                content.SortedAccounts, snapshots, default(AddressKeyComparer), static m => m.SortedAccounts, static c => c.Accounts, null)));
             compactTask.Add(Task.Run(() => MergeInto(
-                content.SortedStorages, snapshots, SnapshotKeyComparers.Storage, static m => m.SortedStorages, static c => c.Storages, slotKeep)));
+                content.SortedStorages, snapshots, default(StorageKeyComparer), static m => m.SortedStorages, static c => c.Storages, slotKeep)));
             compactTask.Add(Task.Run(() => MergeInto(
-                content.SortedStateNodes, snapshots, SnapshotKeyComparers.StateNode, static m => m.SortedStateNodes, static c => c.StateNodes, null)));
+                content.SortedStateNodes, snapshots, default(StateNodeKeyComparer), static m => m.SortedStateNodes, static c => c.StateNodes, null)));
             compactTask.Add(Task.Run(() => MergeInto(
-                content.SortedStorageNodes, snapshots, SnapshotKeyComparers.StorageNode, static m => m.SortedStorageNodes, static c => c.StorageNodes, nodeKeep)));
+                content.SortedStorageNodes, snapshots, default(StorageNodeKeyComparer), static m => m.SortedStorageNodes, static c => c.StorageNodes, nodeKeep)));
 
-            content.SortedSelfDestructs.BuildFromUnsorted(selfDestructMerged, SnapshotKeyComparers.Address);
+            content.SortedSelfDestructs.BuildFromUnsorted(selfDestructMerged, default(AddressKeyComparer));
 
             Task.WaitAll(compactTask.AsSpan());
         }
@@ -175,13 +175,15 @@ public class SnapshotCompactor(
         return new Snapshot(from, to, content, _resourcePool, usage);
     }
 
-    private static void MergeInto<TKey, TValue>(
+    private static void MergeInto<TKey, TValue, TComparer>(
         SortedMergeDictionary<TKey, TValue> target,
         SnapshotPooledList snapshots,
-        IComparer<TKey> comparer,
+        TComparer comparer,
         Func<SortedSnapshotContent, SortedMergeDictionary<TKey, TValue>> fromSorted,
         Func<SnapshotContent, IReadOnlyCollection<KeyValuePair<TKey, TValue>>> fromMutable,
-        Func<int, TKey, bool>? keep) where TKey : IEquatable<TKey>
+        Func<int, TKey, bool>? keep)
+        where TKey : IEquatable<TKey>
+        where TComparer : IComparer<TKey>
     {
         int count = snapshots.Count;
         SortedMergeDictionary<TKey, TValue>[] sources = new SortedMergeDictionary<TKey, TValue>[count];


### PR DESCRIPTION
## Changes

Follow-up to the `SortedMergeDictionary` comparers discussed in the #12353 review: passes the key comparers as value-type generic arguments (`TComparer : IComparer<TKey>`) instead of `IComparer<TKey>` parameters, and converts the comparer classes to stateless `readonly struct`s.

- With an `IComparer<TKey>`-typed parameter, every `Compare` in the loser-tree merge is an interface call that only gets devirtualized probabilistically (dynamic PGO guarded devirtualization after tier-up). With a value-type `TComparer`, the instantiation is monomorphized and every `Compare` is a direct, inlinable call at every JIT tier — including tier-0/OSR during the first compactions.
- `BuildFromUnsorted` now sorts through the generic `Span.Sort<T, TComparer>` overload, which devirtualizes the sort's compares as well and removes the per-build `EntryKeyComparer` wrapper allocation.
- The `SnapshotKeyComparers` holder class is gone; call sites pass `default(AddressKeyComparer)` etc., and generic inference does the rest — no call-site signature changes beyond that.

The comparer bodies and ordering semantics are unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

Covered by the existing `Nethermind.State.Flat` suite (570 passed, 4 skipped locally); no behavior change to test.

`SnapshotCompactionBenchmark` (default job, `SelfDestructsPerSnapshot = 0`), base = #12353 head `14329bdf`:

| Snapshots | Inputs | Base | This PR | Δ |
|---:|:--|---:|---:|---:|
| 8  | sorted  | 68.7 ± 1.1 ms | 60.6 ± 1.4 ms | **−12%** |
| 32 | sorted  | 440.3 ± 15.0 ms | 367.9 ± 13.1 ms | **−16%** |
| 8  | mutable | 311.7 ± 12.5 ms | 297.0 ± 7.6 ms | −5% (≈noise) |
| 32 | mutable | 1,235 ± 45 ms | 1,335 ± 51 ms | +8% (≈noise) |

The already-sorted rows — the dominant production shape — improve consistently and outside the error bars; the loser tree makes several comparer calls per emitted element, so the dispatch saving compounds. The mutable rows move in opposite directions within ~2σ on a noisy desktop, so I read them as unchanged. Allocations are unchanged (sorted rows stay ~KB-level pooled).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
