### PR TITLE
fix(test): disable prewarming in state test runs

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/GeneralStateTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/GeneralStateTestBase.cs
@@ -79,6 +79,7 @@ namespace Ethereum.Test.Base
             // Patricia by default (the production default); opt into the flat state layout with
             // TEST_USE_FLAT=1, mirroring TestBlockchain.UseFlatDb.
             configProvider.GetConfig<IFlatDbConfig>().Enabled = Environment.GetEnvironmentVariable("TEST_USE_FLAT") == "1";
+            configProvider.GetConfig<IBlocksConfig>().PreWarming = PreWarmMode.None;
             using IContainer container = new ContainerBuilder()
                 .AddModule(new TestNethermindModule(configProvider))
                 .AddSingleton<IBlockhashProvider>(new TestBlockhashProvider())


### PR DESCRIPTION
## Changes

- Set `Blocks.PreWarming = None` in `GeneralStateTestBase.RunTest`, mirroring what `BlockchainTestBase` already does.

Since #12344 the default `BlockAndMempool` prewarming mode eagerly resolves `MempoolStatePrewarmer` — and with it a full `TxPool` — whenever `IBlockCachePreWarmer` is activated. `GeneralStateTestBase` builds a DI container per test, so every EEST state test constructed a `TxPool` (verified with ctor instrumentation). This pushed the `stateTest sequential 2of2` CI job past the 10-minute idle watchdog (nethtest emits no stderr progress, so the watchdog is effectively a runtime cap), failing every `Nethermind/Ethereum tests` run since the merge.

State tests execute a single transaction via `ITransactionProcessor` directly and never use the prewarmer, so disabling it also stops paying for the pre-existing per-test `BlockCachePreWarmer`/`PreBlockCaches` construction, making the job faster than it was before the regression.

Local measurement of the failing chunk (`tests-bal@v7.3.2` state_tests, CI env: `--workers 4 --chunk 2of2`, `DOTNET_gcServer=0`, `DOTNET_GCConserveMemory=9`; 34,033 tests green in all three runs):

| Build | Time |
|---|---|
| pre-#12344 (`1a616abd3c`) | 498 s |
| #12344 (`d278822b4a`) | 727 s (CI: watchdog kill) |
| #12344 + this fix | 237 s |

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Exercised by every EEST/Pyspec state test run; verified locally that all 34,033 tests of the affected chunk still pass with the fix.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)