### PR TITLE
fix(test): disable mempool-driven prewarming in test environments

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/TestEnvironmentModule.cs
@@ -106,6 +106,7 @@ public class TestEnvironmentModule(PrivateKey nodeKey, string? networkGroup) : M
             .AddDecorator<IBlocksConfig>((_, blocksConfig) =>
             {
                 blocksConfig.PreWarmStateConcurrency = Math.Min(4, Environment.ProcessorCount);
+                blocksConfig.PreWarming = PreWarmMode.Block;
                 return blocksConfig;
             })
             .AddSingleton(new PreBlockCachesConfig { StorageCacheSetsBits = SeqlockCache<StorageCell, byte[]>.DefaultSetsBits })


### PR DESCRIPTION
## Changes

- Default `Blocks.PreWarming` to `Block` in `TestEnvironmentModule`, keeping reactive block prewarming covered while disabling the speculative mempool loop in test nodes.

Since #12344 every `TestNethermindModule`-based node runs `MempoolStatePrewarmer`. Test blocks use `ManualTimestamper` clocks consistent with their timestamps, so the stale-head guard never skips: each `NewHeadBlock` (hundreds per E2E sync test) clears `PreBlockCaches` and spins a speculative warming loop that is cancelled-and-joined at the next head — background contention that competes with the code under test on 4-core CI runners and amplifies timing flakes such as the `E2ESyncTests` BAL fast-sync timeout (`Nethermind.Synchronization.Test [checked]` exceeding its 15-minute job cap). This restores the pre-#12344 test surface.

Prewarmer coverage is unaffected: `MempoolStatePrewarmerTests` exercises static selection logic and `BlockCachePreWarmerTests` constructs the prewarmer with explicit config.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Verified locally: `Nethermind.Consensus.Test` 107/107 and `E2ESyncTests.FastSync_skips_pre_eip7928_block_access_lists_over_eth71` pass with the change.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)