### PR TITLE
perf(evm): decouple and bound the instruction-stream cache memory

### DIFF
--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -67,7 +67,6 @@ public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
     public IPrecompile? Precompile { get; }
 
     private readonly JumpDestinationAnalyzer? _analyzer;
-    private InstructionStream? _stream;
     private int _streamHits;
 
     private const int StreamBuildIdle = 0;
@@ -80,25 +79,19 @@ public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
     public ValueHash256 CodeHash { get; set; }
 
     /// <summary>
-    /// Returns the built stream, or <c>null</c> until ready: past <see cref="StreamInterpreter.BuildThreshold"/>
-    /// the build is scheduled once on the thread pool and callers keep getting <c>null</c> until it publishes,
-    /// so no call blocks. Lock-free via two CASes (schedule, publish).
+    /// Returns the built stream from the shared cache, or <c>null</c> until ready: past
+    /// <see cref="StreamInterpreter.BuildThreshold"/> the build is scheduled once on the thread pool and callers keep
+    /// getting <c>null</c> until it publishes, so no call blocks. The stream is held only by the shared cache (not on
+    /// this instance), so retained stream memory is bounded by that cache alone, not by the CodeInfo cache size.
     /// </summary>
     internal InstructionStream? GetOrBuildStream()
     {
-        InstructionStream? stream = Volatile.Read(ref _stream);
-        if (stream is not null)
-            return stream;
         if (Volatile.Read(ref _streamBuildState) == StreamBuildUnavailable)
             return null;
+        if (CodeHash != default && InstructionStreamCache.TryGet(CodeHash, out InstructionStream? cached))
+            return cached;
         if (Interlocked.Increment(ref _streamHits) < StreamInterpreter.BuildThreshold)
             return null;
-
-        if (CodeHash != default && InstructionStreamCache.TryGet(CodeHash, out InstructionStream? cached))
-        {
-            Volatile.Write(ref _stream, cached);
-            return cached;
-        }
 
         if (Interlocked.CompareExchange(ref _streamBuildState, StreamBuildScheduled, StreamBuildIdle) == StreamBuildIdle)
             ThreadPool.UnsafeQueueUserWorkItem(new StreamBuilder(this), preferLocal: false);
@@ -109,11 +102,9 @@ public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
     private void BuildStream()
     {
         InstructionStream? stream = InstructionStream.TryBuild(CodeSpan);
-        if (stream is not null && stream.RetainedBytes <= StreamInterpreter.MaxStreamRetainedBytes)
+        if (stream is not null && CodeHash != default && stream.RetainedBytes <= StreamInterpreter.MaxStreamRetainedBytes)
         {
-            if (CodeHash != default)
-                InstructionStreamCache.Set(CodeHash, stream);
-            Interlocked.CompareExchange(ref _stream, stream, null);
+            InstructionStreamCache.Set(CodeHash, stream);
         }
         else
         {

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -79,10 +79,8 @@ public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
     public ValueHash256 CodeHash { get; set; }
 
     /// <summary>
-    /// Returns the built stream from the shared cache, or <c>null</c> until ready: past
-    /// <see cref="StreamInterpreter.BuildThreshold"/> the build is scheduled once on the thread pool and callers keep
-    /// getting <c>null</c> until it publishes, so no call blocks. The stream is held only by the shared cache (not on
-    /// this instance), so retained stream memory is bounded by that cache alone, not by the CodeInfo cache size.
+    /// Built stream from the shared cache, or <c>null</c> until built (scheduled once past
+    /// <see cref="StreamInterpreter.BuildThreshold"/>, never blocks). Held only by the shared cache, not this instance.
     /// </summary>
     internal InstructionStream? GetOrBuildStream()
     {

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -109,7 +109,7 @@ public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
     private void BuildStream()
     {
         InstructionStream? stream = InstructionStream.TryBuild(CodeSpan);
-        if (stream is not null)
+        if (stream is not null && stream.RetainedBytes <= StreamInterpreter.MaxStreamRetainedBytes)
         {
             if (CodeHash != default)
                 InstructionStreamCache.Set(CodeHash, stream);

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Int256;
 
@@ -123,6 +124,14 @@ internal sealed class InstructionStream
     /// <summary>Entry index for every entry-start pc; <see cref="InvalidEntry"/> for immediate
     /// bytes and fused-pair interiors; index one past the last op at pc == code length.</summary>
     public readonly ushort[] PcToEntry;
+
+    public int RetainedBytes =>
+        Ops.Length * Unsafe.SizeOf<StreamOp>()
+        + BlockGas.Length * sizeof(ulong)
+        + Constants.Length * Unsafe.SizeOf<UInt256>()
+        + ConstantBytes.Length
+        + PcToEntry.Length * sizeof(ushort);
+
     private InstructionStream(StreamOp[] ops, ulong[] blockGas, UInt256[] constants, ushort[] pcToEntry, bool buildConstantBytes)
     {
         Ops = ops;

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStreamCache.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStreamCache.cs
@@ -11,13 +11,13 @@ namespace Nethermind.Evm.CodeAnalysis;
 /// survives CodeInfo eviction. Keyed by code hash alone is safe: the precharged op set is fork-invariant,
 /// so a stream is valid for any fork &gt;= Shanghai (the only context it runs in). Cleared with the code
 /// cache on a fork/state change.
-/// Memory: holds up to <see cref="MemoryAllowance.CodeCacheSize"/> streams, each retaining
-/// Ops/BlockGas/Constants/ConstantBytes/PcToEntry. Under heavy RPC this can retain a full code-cache
-/// worth of stream arrays in addition to the CodeInfo cache — revisit the bound if footprint matters.
+/// Memory: holds up to <see cref="MemoryAllowance.InstructionStreamCacheSize"/> streams, each retaining
+/// Ops/BlockGas/Constants/ConstantBytes/PcToEntry. Per-entry footprint is far larger than a CodeInfo entry, so
+/// this cache is bounded separately (and smaller) than the CodeInfo cache.
 /// </summary>
 internal static class InstructionStreamCache
 {
-    private static readonly AssociativeCache<ValueHash256, InstructionStream> _cache = new(MemoryAllowance.CodeCacheSize);
+    private static readonly AssociativeCache<ValueHash256, InstructionStream> _cache = new(MemoryAllowance.InstructionStreamCacheSize);
 
     public static bool TryGet(in ValueHash256 codeHash, out InstructionStream? stream) => _cache.TryGet(in codeHash, out stream);
 

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStreamCache.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStreamCache.cs
@@ -10,10 +10,8 @@ namespace Nethermind.Evm.CodeAnalysis;
 /// Caches built <see cref="InstructionStream"/>s separately from the CodeInfo cache, so a stream
 /// survives CodeInfo eviction. Keyed by code hash alone is safe: the precharged op set is fork-invariant,
 /// so a stream is valid for any fork &gt;= Shanghai (the only context it runs in). Cleared with the code
-/// cache on a fork/state change.
-/// Memory: holds up to <see cref="MemoryAllowance.InstructionStreamCacheSize"/> streams, each retaining
-/// Ops/BlockGas/Constants/ConstantBytes/PcToEntry. Per-entry footprint is far larger than a CodeInfo entry, so
-/// this cache is bounded separately (and smaller) than the CodeInfo cache.
+/// cache on a fork/state change. Bounded to <see cref="MemoryAllowance.InstructionStreamCacheSize"/> entries,
+/// separately from the CodeInfo cache (per-entry footprint is far larger).
 /// </summary>
 internal static class InstructionStreamCache
 {

--- a/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
@@ -5,7 +5,7 @@ namespace Nethermind.Evm
 {
     public static class MemoryAllowance
     {
-        public static int CodeCacheSize { get; } = 16_384;
+        public static int CodeCacheSize { get; } = 4_096 + 1_024;
         public static int InstructionStreamCacheSize { get; } = 2_048;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
@@ -5,6 +5,6 @@ namespace Nethermind.Evm
 {
     public static class MemoryAllowance
     {
-        public static int CodeCacheSize { get; } = 4_096 + 1_024;
+        public static int CodeCacheSize { get; } = 32_768;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
@@ -6,6 +6,6 @@ namespace Nethermind.Evm
     public static class MemoryAllowance
     {
         public static int CodeCacheSize { get; } = 16_384;
-        public static int InstructionStreamCacheSize { get; } = 4_096 + 1_024;
+        public static int InstructionStreamCacheSize { get; } = 2_048;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
@@ -5,6 +5,7 @@ namespace Nethermind.Evm
 {
     public static class MemoryAllowance
     {
-        public static int CodeCacheSize { get; } = 32_768;
+        public static int CodeCacheSize { get; } = 16_384;
+        public static int InstructionStreamCacheSize { get; } = 4_096 + 1_024;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -25,8 +25,7 @@ internal static class StreamInterpreter
     // Executions before a CodeInfo's stream is built; keeps the one-time build off cold code. Minimum 1.
     public static int BuildThreshold = 4;
 
-    // Streams whose retained arrays exceed this are not kept (the frame falls back to the metered loop), bounding
-    // per-entry memory. 256 KiB covers the analyzed stream of any EIP-170 contract, so normal contracts keep streaming.
+    // Streams over this size aren't retained (fall back to the metered loop); 256 KiB covers any EIP-170 contract.
     public const int MaxStreamRetainedBytes = 256 * 1024;
 
     // Per-thread diagnostic counter of stream frames executed, read by differential tests to assert the

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -25,6 +25,10 @@ internal static class StreamInterpreter
     // Executions before a CodeInfo's stream is built; keeps the one-time build off cold code. Minimum 1.
     public static int BuildThreshold = 4;
 
+    // Streams whose retained arrays exceed this are not kept (the frame falls back to the metered loop), bounding
+    // per-entry memory so decode-hostile contracts can't amplify a cached stream to many times the code size.
+    public const int MaxStreamRetainedBytes = 64 * 1024;
+
     // Per-thread diagnostic counter of stream frames executed, read by differential tests to assert the
     // stream engaged. [ThreadStatic] so each thread bumps its own slot with a plain write: no atomic and
     // no cross-core cache-line bouncing on the hot RunStream entry. Tests run single-threaded, so they

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -26,8 +26,8 @@ internal static class StreamInterpreter
     public static int BuildThreshold = 4;
 
     // Streams whose retained arrays exceed this are not kept (the frame falls back to the metered loop), bounding
-    // per-entry memory so decode-hostile contracts can't amplify a cached stream to many times the code size.
-    public const int MaxStreamRetainedBytes = 64 * 1024;
+    // per-entry memory. 256 KiB covers the analyzed stream of any EIP-170 contract, so normal contracts keep streaming.
+    public const int MaxStreamRetainedBytes = 256 * 1024;
 
     // Per-thread diagnostic counter of stream frames executed, read by differential tests to assert the
     // stream engaged. [ThreadStatic] so each thread bumps its own slot with a plain write: no atomic and


### PR DESCRIPTION
## Changes

Bound the instruction-stream cache and decouple it from the CodeInfo cache. `MemoryAllowance.CodeCacheSize` previously sized **both** the CodeInfo cache and `InstructionStreamCache`, and built streams were additionally pinned on each `CodeInfo` (`_stream`). This PR:

- Retains built `InstructionStream`s **only** in the shared `InstructionStreamCache` (no longer also pinned on `CodeInfo`), so retained stream memory no longer scales with the CodeInfo cache count.
- Gives `InstructionStreamCache` its **own** bound (2,048 entries), independent of `CodeCacheSize`.
- **Caps per-stream retained bytes at 256 KiB**: larger streams fall back to the metered loop and aren't kept, so per-entry size can't grow unbounded with a contract's decode structure.

The CodeInfo cache size is **unchanged**.

## Why

A retained `InstructionStream` holds roughly an order of magnitude more than the contract's code bytes (the analyzed `Ops`/`BlockGas`/`Constants`/`PcToEntry` arrays), and more for decode-dense code. Because one constant sized both caches and streams were also pinned per-`CodeInfo`, the retained stream footprint scaled with the CodeInfo cache count and had no per-entry ceiling, so worst case reached several GiB on long-running RPC nodes.

The stream cache is only populated for cancelable frames (`eth_call`/`estimateGas`/`simulate`); block processing does not stream, so this does not affect validation.

## Memory — both caches, worst case

| Scenario | Before | After |
|---|---|---|
| Min — empty (arrays only) | ~0.9 MiB | ~0.9 MiB |
| Average — ~8 KiB hot contracts | ~0.7 GiB | ~0.3 GiB |
| Max — all 24 KiB (EIP-170) | ~2.1 GiB | ~0.9 GiB |
| Max — adversarial (decode-dense streams) | ~6.8 GiB | **~0.5 GiB** (capped) |

The instruction-stream term drops from unbounded-per-entry × ~8k retained to a hard **2,048 × 256 KiB = 0.5 GiB** ceiling, independent of the CodeInfo cache size or contract structure.

## Trade-off

The dedicated stream cache holds fewer distinct contracts than the previous CodeInfo-pinned retention, so `eth_call` on a very cold contract may rebuild its stream. A byte-budgeted stream cache would restore coverage at the same memory ceiling and could be a follow-up if the reduced count proves limiting.

## Types of changes

- [x] Optimization

## Testing

- Builds clean.
