### PR TITLE
fix(evm): address devnet-6 state-gas review findings

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
@@ -213,8 +213,46 @@ public class Eip8037Tests : VirtualMachineTestsBase
 
         bool consumed = EthereumGasPolicy.ConsumeStateGas(ref gas, 70);
 
-        Assert.That((consumed, gas.Value, gas.StateReservoir, gas.StateGasUsed, gas.StateGasSpill),
-            Is.EqualTo((false, 10L, 50L, 0L, 0L)));
+        Assert.That((consumed, gas.Value, gas.StateReservoir, gas.StateGasUsed, gas.StateGasSpill, EthereumGasPolicy.IsOutOfGas(in gas)),
+            Is.EqualTo((false, 10UL, 50L, 0L, 0L, true)));
+    }
+
+    [Test]
+    public void Revoking_advanced_refund_restores_net_spill_reservoir_and_spill_tracking()
+    {
+        // A net-spill (negative) reservoir, as left by RestoreChildStateGas after nested spills.
+        EthereumGasPolicy gas = new() { Value = 400, StateReservoir = -300, StateGasUsed = 0, StateGasSpill = 300, StateGasSpillRefunded = 0 };
+
+        long tracked = EthereumGasPolicy.AddStateGasRefundToReservoir(ref gas, 200, trackSpillRefund: true);
+        Assert.That((tracked, gas.StateReservoir, gas.StateGasSpillRefunded), Is.EqualTo((200L, -100L, 200L)));
+
+        EthereumGasPolicy.RemoveStateGasRefundFromReservoir(ref gas, 200, tracked);
+
+        Assert.That((gas.StateReservoir, gas.StateGasUsed, gas.StateGasSpillRefunded), Is.EqualTo((-300L, 0L, 0L)));
+    }
+
+    [Test]
+    public void Revoking_consumed_advanced_refund_deducts_usage_without_fabricating_spill_debt()
+    {
+        EthereumGasPolicy gas = new() { Value = 400, StateReservoir = 0, StateGasUsed = 100 };
+
+        long tracked = EthereumGasPolicy.AddStateGasRefundToReservoir(ref gas, 200, trackSpillRefund: true);
+        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref gas, 200), Is.True);
+
+        EthereumGasPolicy.RemoveStateGasRefundFromReservoir(ref gas, 200, tracked);
+
+        Assert.That((gas.StateReservoir, gas.StateGasUsed), Is.EqualTo((0L, 100L)));
+    }
+
+    [Test]
+    public void Intrinsic_regular_gas_above_the_tx_cap_saturates_into_the_reservoir()
+    {
+        EthereumGasPolicy intrinsic = new() { Value = Eip7825Constants.DefaultTxGasLimitCap + 1, StateReservoir = 0 };
+
+        EthereumGasPolicy gas = EthereumGasPolicy.CreateAvailableFromIntrinsic(
+            Eip7825Constants.DefaultTxGasLimitCap + 2, in intrinsic, Amsterdam.Instance);
+
+        Assert.That((gas.Value, gas.StateReservoir), Is.EqualTo((0UL, 1L)));
     }
 
     [Test]
@@ -332,7 +370,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
 
         Machine.ExecuteTransaction<OffFlag>(vmState, TestState, NullTxTracer.Instance);
 
-        Assert.That((vmState.Gas.StateGasUsed, vmState.Gas.StateReservoir, vmState.StateGasRefundPending),
+        Assert.That((vmState.Gas.StateGasUsed, vmState.Gas.StateReservoir, vmState.StateGasRefundAdvanced),
             Is.EqualTo((0L, GasCostOf.CreateState, 0L)));
     }
 

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -137,6 +137,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         ulong spillAmount = CalculateStateGasSpill(in gas, stateGasCost);
         if (!TryConsume(ref gas, spillAmount))
         {
+            gas.OutOfGas = true;
             return false;
         }
 
@@ -385,34 +386,38 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void AddStateGasRefundToReservoir(ref EthereumGasPolicy gas, long amount, bool trackSpillRefund)
+    public static long AddStateGasRefundToReservoir(ref EthereumGasPolicy gas, long amount, bool trackSpillRefund)
     {
-        if (trackSpillRefund)
-        {
-            TrackStateGasSpillRefund(ref gas, amount);
-        }
-
+        long trackedSpillRefund = trackSpillRefund ? TrackStateGasSpillRefund(ref gas, amount) : 0;
         gas.StateReservoir += amount;
+        return trackedSpillRefund;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void RemoveStateGasRefundFromReservoir(ref EthereumGasPolicy gas, long amount)
+    public static void RemoveStateGasRefundFromReservoir(ref EthereumGasPolicy gas, long amount, long trackedSpillRefund)
     {
-        long fromReservoir = Math.Min(amount, gas.StateReservoir);
+        gas.StateGasSpillRefunded -= Math.Min(trackedSpillRefund, gas.StateGasSpillRefunded);
+
+        // Revoke what is still parked in the reservoir (never fabricating spill debt), then what
+        // the credit funded from usage; any remainder refilled a net-spill hole, so restore the debt.
+        long fromReservoir = Math.Clamp(gas.StateReservoir, 0, amount);
         gas.StateReservoir -= fromReservoir;
         amount -= fromReservoir;
 
         if (amount > 0)
         {
-            gas.StateGasUsed -= Math.Min(amount, gas.StateGasUsed);
+            long fromUsed = Math.Min(amount, gas.StateGasUsed);
+            gas.StateGasUsed -= fromUsed;
+            gas.StateReservoir -= amount - fromUsed;
         }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void TrackStateGasSpillRefund(ref EthereumGasPolicy gas, long amount)
+    private static long TrackStateGasSpillRefund(ref EthereumGasPolicy gas, long amount)
     {
-        long unrefundedSpill = GetUnrefundedStateGasSpill(in gas);
-        gas.StateGasSpillRefunded += Math.Min(amount, unrefundedSpill);
+        long tracked = Math.Min(amount, GetUnrefundedStateGasSpill(in gas));
+        gas.StateGasSpillRefunded += tracked;
+        return tracked;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -538,16 +543,13 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         // before calling; if they don't, the subtraction wraps silently.
         Debug.Assert(gasLimit >= intrinsicGas.Value + (ulong)intrinsicGas.StateReservoir,
             $"gasLimit ({gasLimit}) < intrinsicRegular ({intrinsicGas.Value}) + intrinsicState ({intrinsicGas.StateReservoir})");
-        Debug.Assert(!spec.IsEip8037Enabled || Eip7825Constants.DefaultTxGasLimitCap >= intrinsicGas.Value,
-            "Eip8037 enabled but intrinsicRegular exceeds tx gas cap.");
-
         ulong executionGas = gasLimit - intrinsicGas.Value - (ulong)intrinsicGas.StateReservoir;
         ulong reservoir = 0;
 
         if (spec.IsEip8037Enabled)
         {
             // EIP-8037: cap gas_left at TX_MAX_GAS_LIMIT - intrinsic_regular, overflow goes to reservoir
-            ulong maxGasLeft = Eip7825Constants.DefaultTxGasLimitCap - intrinsicGas.Value;
+            ulong maxGasLeft = Eip7825Constants.DefaultTxGasLimitCap.SaturatingSub(intrinsicGas.Value);
             reservoir = executionGas.SaturatingSub(maxGasLeft);
             executionGas -= reservoir;
         }

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -228,12 +228,20 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual long DiscardStateGas(ref TSelf gas, long amount, long stateGasFloor, bool trackSpillRefund) => amount;
 
+    /// <summary>Credits a speculative state-gas refund to the frame's reservoir.</summary>
+    /// <returns>The spill-refund amount marked, to be passed back verbatim as
+    /// <c>trackedSpillRefund</c> when the advance is revoked.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void AddStateGasRefundToReservoir(ref TSelf gas, long amount, bool trackSpillRefund) =>
+    static virtual long AddStateGasRefundToReservoir(ref TSelf gas, long amount, bool trackSpillRefund)
+    {
         TSelf.UpdateGasUp(ref gas, (ulong)amount);
+        return 0;
+    }
 
+    /// <summary>Revokes a speculative refund credited by <see cref="AddStateGasRefundToReservoir"/>.</summary>
+    /// <param name="trackedSpillRefund">The value returned by the matching add; unmarks the spill refund exactly.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void RemoveStateGasRefundFromReservoir(ref TSelf gas, long amount) { }
+    static virtual void RemoveStateGasRefundFromReservoir(ref TSelf gas, long amount, long trackedSpillRefund) { }
 
     // EIP-8037 top-level halt: snap state-gas back to (R0, intrinsicStateUsed, 0); the
     // post-reset StateGasUsed feeds SpentGas so the user doesn't pay for uncommitted state.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -73,6 +73,22 @@ namespace Nethermind.Evm.TransactionProcessing
     public abstract class TransactionProcessorBase
     {
         internal static bool ForceSimpleTransferDisabled;
+
+        private protected static void DestroyAccount(IWorldState worldState, Address toBeDestroyed, in UInt256 balance, bool commit, bool removeSelfdestructBurn)
+        {
+            // Build-up rounds (!commit) span the whole block: later txs may redeploy this address,
+            // so the order-preserving journaled clear is required; the O(1) mark needs a commit after.
+            if (commit) worldState.MarkStorageDestroyed(toBeDestroyed);
+            else worldState.ClearStorage(toBeDestroyed);
+            worldState.DeleteAccount(toBeDestroyed);
+
+            // EIP-8246: preserve any remaining balance as a fresh nonce-0, code-less account;
+            // an empty account stays deleted via EIP-161.
+            if (removeSelfdestructBurn && !balance.IsZero)
+            {
+                worldState.CreateAccount(toBeDestroyed, balance);
+            }
+        }
     }
 
     public abstract class TransactionProcessorBase<TGasPolicy> : TransactionProcessorBase, ITransactionProcessor
@@ -380,16 +396,7 @@ namespace Nethermind.Evm.TransactionProcessing
                         substate.Logs.Add(TransferLog.CreateBurn(toBeDestroyed, balance));
                     }
 
-                    if (commit) worldState.MarkStorageDestroyed(toBeDestroyed);
-                    else worldState.ClearStorage(toBeDestroyed);
-                    worldState.DeleteAccount(toBeDestroyed);
-
-                    // EIP-8246: preserve any remaining balance as a fresh nonce-0,
-                    // code-less account; an empty account stays deleted via EIP-161.
-                    if (removeSelfdestructBurn && !balance.IsZero)
-                    {
-                        worldState.CreateAccount(toBeDestroyed, balance);
-                    }
+                    DestroyAccount(worldState, toBeDestroyed, in balance, commit, removeSelfdestructBurn);
                 }
             }
 
@@ -1386,19 +1393,7 @@ namespace Nethermind.Evm.TransactionProcessing
                                 substate.Logs.Add(TransferLog.CreateSelfDestruct(toBeDestroyed, balance));
                             }
 
-                            // Build-up rounds (!commit) span the whole block: later txs may
-                            // redeploy this address, so the order-preserving journaled clear
-                            // is required; the O(1) mark is only valid when a commit follows.
-                            if (commit) WorldState.MarkStorageDestroyed(toBeDestroyed);
-                            else WorldState.ClearStorage(toBeDestroyed);
-                            WorldState.DeleteAccount(toBeDestroyed);
-
-                            // EIP-8246: preserve any remaining balance as a fresh nonce-0,
-                            // code-less account; an empty account stays deleted via EIP-161.
-                            if (removeSelfdestructBurn && !balance.IsZero)
-                            {
-                                WorldState.CreateAccount(toBeDestroyed, balance);
-                            }
+                            DestroyAccount(WorldState, toBeDestroyed, in balance, commit, removeSelfdestructBurn);
 
                             if (tracingRefunds)
                             {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Config;
 using Nethermind.Core;
@@ -687,18 +688,18 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
         {
             // Restored state gas paid by an ancestor frame stays spendable here; the
             // state-gas-used reduction must propagate upward separately.
-            TGasPolicy.AddStateGasRefundToReservoir(ref gas, pendingRefund, trackSpillRefund);
-            vmState.StateGasRefundPending += pendingRefund;
+            long trackedSpillRefund = TGasPolicy.AddStateGasRefundToReservoir(ref gas, pendingRefund, trackSpillRefund);
             vmState.StateGasRefundAdvanced += pendingRefund;
+            vmState.StateGasSpillRefundAdvanced += trackedSpillRefund;
         }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void IncorporateChildStateGasRefunds(VmState<TGasPolicy> childState)
     {
-        if (childState.StateGasRefundPending > 0)
+        if (childState.StateGasRefundAdvanced > 0)
         {
-            long pendingRefund = childState.StateGasRefundPending;
+            long pendingRefund = childState.StateGasRefundAdvanced;
             long unappliedRefund = TGasPolicy.DiscardStateGas(
                 ref _currentState.Gas,
                 pendingRefund,
@@ -707,25 +708,28 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
 
             if (unappliedRefund > 0)
             {
-                _currentState.StateGasRefundPending += unappliedRefund;
                 _currentState.StateGasRefundAdvanced += unappliedRefund;
+                // Conservative bound: the child's spill-marks attributable to the still-revocable
+                // (unapplied) portion cannot be attributed exactly without the reference model.
+                _currentState.StateGasSpillRefundAdvanced += Math.Min(childState.StateGasSpillRefundAdvanced, unappliedRefund);
             }
 
-            childState.StateGasRefundPending = 0;
             childState.StateGasRefundAdvanced = 0;
+            childState.StateGasSpillRefundAdvanced = 0;
         }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void RemoveAdvancedStateGasRefund(VmState<TGasPolicy> vmState, ref TGasPolicy gas)
     {
+        Debug.Assert(vmState.StateGasSpillRefundAdvanced <= vmState.StateGasRefundAdvanced,
+            "Spill-marked portion of an advanced refund exceeds the advance.");
         if (vmState.StateGasRefundAdvanced > 0)
         {
-            TGasPolicy.RemoveStateGasRefundFromReservoir(ref gas, vmState.StateGasRefundAdvanced);
+            TGasPolicy.RemoveStateGasRefundFromReservoir(ref gas, vmState.StateGasRefundAdvanced, vmState.StateGasSpillRefundAdvanced);
             vmState.StateGasRefundAdvanced = 0;
+            vmState.StateGasSpillRefundAdvanced = 0;
         }
-
-        vmState.StateGasRefundPending = 0;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -33,10 +33,12 @@ public class VmState<TGasPolicy> : IDisposable
     public byte[]? DataStack;
     public TGasPolicy Gas;
     public long InitialStateGasUsed;
-    public long StateGasRefundPending;
     // State-gas refund already made spendable in this frame while its accounting correction
     // still has to reach the ancestor frame that originally paid the state gas.
     public long StateGasRefundAdvanced;
+    // Portion of StateGasRefundAdvanced counted into StateGasSpillRefunded; un-marked exactly
+    // on revocation (invariant: <= StateGasRefundAdvanced).
+    public long StateGasSpillRefundAdvanced;
     internal long OutputDestination { get; private set; } // TODO: move to CallEnv
     internal long OutputLength { get; private set; } // TODO: move to CallEnv
     public long Refund { get; set; }
@@ -154,12 +156,12 @@ public class VmState<TGasPolicy> : IDisposable
             _accessTracker.WasCreated(env.ExecutingAccount);
         }
         _accessTracker.TakeSnapshot();
-        Debug.Assert(StateGasRefundPending == 0, "Pooled VmState returned with uncleared StateGasRefundPending.");
         Debug.Assert(StateGasRefundAdvanced == 0, "Pooled VmState returned with uncleared StateGasRefundAdvanced.");
+        Debug.Assert(StateGasSpillRefundAdvanced == 0, "Pooled VmState returned with uncleared StateGasSpillRefundAdvanced.");
         Gas = gas;
         InitialStateGasUsed = TGasPolicy.GetStateGasUsed(in gas);
-        StateGasRefundPending = 0;
         StateGasRefundAdvanced = 0;
+        StateGasSpillRefundAdvanced = 0;
         OutputDestination = outputDestination;
         OutputLength = outputLength;
         Refund = 0;
@@ -228,8 +230,8 @@ public class VmState<TGasPolicy> : IDisposable
         if (!IsTopLevel) _env?.Dispose();
         _env = null;
         _snapshot = default;
-        StateGasRefundPending = 0;
         StateGasRefundAdvanced = 0;
+        StateGasSpillRefundAdvanced = 0;
 
         _statePool.Enqueue(this);
 


### PR DESCRIPTION
## Changes

Addresses the [review findings on #12117](https://github.com/NethermindEth/nethermind/pull/12117#issuecomment-4927083033):

- **Medium — asymmetric clamp in `RemoveStateGasRefundFromReservoir`**: with a net-spill (negative) reservoir, revoking an advanced state-gas refund reclaimed spilled gas and over-deducted `StateGasUsed`. Now clamped to zero (matching `DiscardStateGas`), with a regression test.
- **Low — `ConsumeStateGas`** now sets the `OutOfGas` flag when the spill-path consume fails.
- **Low — `CreateAvailableFromIntrinsic`** saturates the EIP-7825 cap subtraction instead of wrapping.
- **Low — duplicated destroy-finalization blocks** in `TransactionProcessor` extracted into a shared `DestroyAccount` helper.
- **Low — SELFDESTRUCT/EIP-2780 divergence**: confirmed intentional (EIP-2780 reprices CALL value costs only); no change needed.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Regression test for the negative-reservoir refund removal; Evm.Test and Blockchain.Test suites pass; devnet-6 consensus behavior covered by the EEST v6.1.1 fixtures in CI.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
