### PR TITLE
XDC Blockhash Store

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockhashStore.cs
@@ -18,7 +18,7 @@ public class BlockhashStore(IWorldState worldState) : IBlockhashStore
 {
     private static readonly byte[] EmptyBytes = [0];
 
-    public virtual void ApplyBlockhashStateChanges(BlockHeader blockHeader, IReleaseSpec spec)
+    public void ApplyBlockhashStateChanges(BlockHeader blockHeader, IReleaseSpec spec)
     {
         if (!spec.IsEip2935Enabled || blockHeader.IsGenesis || blockHeader.ParentHash is null) return;
 

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockhashStore.cs
@@ -18,7 +18,7 @@ public class BlockhashStore(IWorldState worldState) : IBlockhashStore
 {
     private static readonly byte[] EmptyBytes = [0];
 
-    virtual public void ApplyBlockhashStateChanges(BlockHeader blockHeader, IReleaseSpec spec)
+    public virtual void ApplyBlockhashStateChanges(BlockHeader blockHeader, IReleaseSpec spec)
     {
         if (!spec.IsEip2935Enabled || blockHeader.IsGenesis || blockHeader.ParentHash is null) return;
 

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockhashStore.cs
@@ -18,7 +18,7 @@ public class BlockhashStore(IWorldState worldState) : IBlockhashStore
 {
     private static readonly byte[] EmptyBytes = [0];
 
-    public void ApplyBlockhashStateChanges(BlockHeader blockHeader, IReleaseSpec spec)
+    virtual public void ApplyBlockhashStateChanges(BlockHeader blockHeader, IReleaseSpec spec)
     {
         if (!spec.IsEip2935Enabled || blockHeader.IsGenesis || blockHeader.ParentHash is null) return;
 

--- a/src/Nethermind/Nethermind.Core/Eip2935Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip2935Constants.cs
@@ -23,7 +23,7 @@ public static class Eip2935Constants
     public static readonly ulong RingBufferSize = 8191;
 
     /// <summary>
-    /// The bytecode of history contract.
-    /// /// </summary>
+    /// The deployed bytecode of the EIP-2935 history-storage contract.
+    /// </summary>
     public static readonly byte[] Code = Bytes.FromHexString("3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
 }

--- a/src/Nethermind/Nethermind.Core/Eip2935Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip2935Constants.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core.Extensions;
+
 namespace Nethermind.Core;
 
 /// <summary>
@@ -19,4 +21,9 @@ public static class Eip2935Constants
     /// The <c>HISTORY_SERVE_WINDOW</c> parameter.
     /// </summary>
     public static readonly ulong RingBufferSize = 8191;
+
+    /// <summary>
+    /// The bytecode of history contract.
+    /// /// </summary>
+    public static readonly byte[] Code = Bytes.FromHexString("3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500");
 }

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
@@ -1,15 +1,143 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Specs;
 using NUnit.Framework;
 
 namespace Nethermind.Xdc.Test;
 
 internal class XdcBlockhashStoreTests
 {
-    [Test]
-    public void XdcBlockhashStore_ShouldCreate()
+    private static readonly Address Eip2935Account = Eip2935Constants.BlockHashHistoryAddress;
+
+    private static ReleaseSpec Eip2935Spec => new()
     {
-        
+        IsEip2935Enabled = true,
+        Eip2935RingBufferSize = Eip2935Constants.RingBufferSize,
+    };
+
+    [Test]
+    public void Deploys_history_contract_when_missing()
+    {
+        IWorldState worldState = TestWorldStateFactory.CreateForTest();
+        using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
+        ReleaseSpec spec = Eip2935Spec;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;;
+
+        XdcBlockhashStore store = new(worldState);
+        store.ApplyBlockhashStateChanges(header, spec);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(worldState.IsContract(Eip2935Account), Is.True);
+            Assert.That(worldState.GetCode(Eip2935Account), Is.EqualTo(Eip2935Constants.Code));
+            Assert.That(worldState.GetNonce(Eip2935Account), Is.EqualTo(1UL));
+        });
+    }
+
+    [Test]
+    public void Stores_parent_hash_after_deploying_contract()
+    {
+        IWorldState worldState = TestWorldStateFactory.CreateForTest();
+        using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
+        ReleaseSpec spec = Eip2935Spec;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;;
+
+        XdcBlockhashStore store = new(worldState);
+        store.ApplyBlockhashStateChanges(header, spec);
+
+        Hash256? stored = store.GetBlockHashFromState(header, header.Number - 1, spec);
+        Assert.That(stored, Is.EqualTo(header.ParentHash));
+    }
+
+    [Test]
+    public void Does_not_redeploy_when_history_contract_already_present()
+    {
+        IWorldState worldState = TestWorldStateFactory.CreateForTest();
+        using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
+        ReleaseSpec spec = Eip2935Spec;
+
+        const ulong existingNonce = 7;
+        worldState.CreateAccount(Eip2935Account, 0, existingNonce);
+        worldState.InsertCode(Eip2935Account, ValueKeccak.Compute(Eip2935Constants.Code), Eip2935Constants.Code, spec);
+        worldState.Commit(spec);
+
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;;
+        XdcBlockhashStore store = new(worldState);
+        store.ApplyBlockhashStateChanges(header, spec);
+
+        Assert.Multiple(() =>
+        {
+            // Nonce is left untouched — the contract is not redeployed.
+            Assert.That(worldState.GetNonce(Eip2935Account), Is.EqualTo(existingNonce));
+            Assert.That(store.GetBlockHashFromState(header, header.Number - 1, spec), Is.EqualTo(header.ParentHash));
+        });
+    }
+
+    [Test]
+    public void Throws_when_history_contract_code_mismatches()
+    {
+        IWorldState worldState = TestWorldStateFactory.CreateForTest();
+        using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
+        ReleaseSpec spec = Eip2935Spec;
+
+        byte[] wrongCode = [1, 2, 3];
+        worldState.CreateAccount(Eip2935Account, 0, 1);
+        worldState.InsertCode(Eip2935Account, ValueKeccak.Compute(wrongCode), wrongCode, spec);
+        worldState.Commit(spec);
+
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;;
+        XdcBlockhashStore store = new(worldState);
+
+        Assert.Throws<InvalidOperationException>(() => store.ApplyBlockhashStateChanges(header, spec));
+    }
+
+    [Test]
+    public void Does_nothing_for_genesis_block()
+    {
+        IWorldState worldState = TestWorldStateFactory.CreateForTest();
+        using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
+        ReleaseSpec spec = Eip2935Spec;
+        BlockHeader genesis = Build.A.BlockHeader.WithNumber(0).TestObject;
+
+        XdcBlockhashStore store = new(worldState);
+        store.ApplyBlockhashStateChanges(genesis, spec);
+
+        Assert.That(worldState.AccountExists(Eip2935Account), Is.False);
+    }
+
+    [Test]
+    public void Does_nothing_when_eip2935_disabled()
+    {
+        IWorldState worldState = TestWorldStateFactory.CreateForTest();
+        using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
+        ReleaseSpec spec = new() { IsEip2935Enabled = false };
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;;
+
+        XdcBlockhashStore store = new(worldState);
+        store.ApplyBlockhashStateChanges(header, spec);
+
+        Assert.That(worldState.AccountExists(Eip2935Account), Is.False);
+    }
+
+    [Test]
+    public void Does_nothing_when_parent_hash_missing()
+    {
+        IWorldState worldState = TestWorldStateFactory.CreateForTest();
+        using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
+        ReleaseSpec spec = Eip2935Spec;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).TestObject;
+        header.ParentHash = null;
+
+        XdcBlockhashStore store = new(worldState);
+        store.ApplyBlockhashStateChanges(header, spec);
+
+        Assert.That(worldState.AccountExists(Eip2935Account), Is.False);
     }
 }

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test;
+
+internal class XdcBlockhashStoreTests
+{
+    [Test]
+    public void XdcBlockhashStore_ShouldCreate()
+    {
+        
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
@@ -28,7 +28,7 @@ internal class XdcBlockhashStoreTests
         IWorldState worldState = TestWorldStateFactory.CreateForTest();
         using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
         ReleaseSpec spec = Eip2935Spec;
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject; ;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
 
         XdcBlockhashStore store = new(worldState);
         store.ApplyBlockhashStateChanges(header, spec);
@@ -47,7 +47,7 @@ internal class XdcBlockhashStoreTests
         IWorldState worldState = TestWorldStateFactory.CreateForTest();
         using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
         ReleaseSpec spec = Eip2935Spec;
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject; ;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
 
         XdcBlockhashStore store = new(worldState);
         store.ApplyBlockhashStateChanges(header, spec);
@@ -68,7 +68,7 @@ internal class XdcBlockhashStoreTests
         worldState.InsertCode(Eip2935Account, ValueKeccak.Compute(Eip2935Constants.Code), Eip2935Constants.Code, spec);
         worldState.Commit(spec);
 
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject; ;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
         XdcBlockhashStore store = new(worldState);
         store.ApplyBlockhashStateChanges(header, spec);
 
@@ -92,7 +92,7 @@ internal class XdcBlockhashStoreTests
         worldState.InsertCode(Eip2935Account, ValueKeccak.Compute(wrongCode), wrongCode, spec);
         worldState.Commit(spec);
 
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject; ;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
         XdcBlockhashStore store = new(worldState);
 
         Assert.Throws<InvalidOperationException>(() => store.ApplyBlockhashStateChanges(header, spec));
@@ -118,7 +118,7 @@ internal class XdcBlockhashStoreTests
         IWorldState worldState = TestWorldStateFactory.CreateForTest();
         using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
         ReleaseSpec spec = new() { IsEip2935Enabled = false };
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject; ;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
 
         XdcBlockhashStore store = new(worldState);
         store.ApplyBlockhashStateChanges(header, spec);

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
@@ -28,7 +28,7 @@ internal class XdcBlockhashStoreTests
         IWorldState worldState = TestWorldStateFactory.CreateForTest();
         using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
         ReleaseSpec spec = Eip2935Spec;
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject; ;
 
         XdcBlockhashStore store = new(worldState);
         store.ApplyBlockhashStateChanges(header, spec);
@@ -47,7 +47,7 @@ internal class XdcBlockhashStoreTests
         IWorldState worldState = TestWorldStateFactory.CreateForTest();
         using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
         ReleaseSpec spec = Eip2935Spec;
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject; ;
 
         XdcBlockhashStore store = new(worldState);
         store.ApplyBlockhashStateChanges(header, spec);
@@ -68,7 +68,7 @@ internal class XdcBlockhashStoreTests
         worldState.InsertCode(Eip2935Account, ValueKeccak.Compute(Eip2935Constants.Code), Eip2935Constants.Code, spec);
         worldState.Commit(spec);
 
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject; ;
         XdcBlockhashStore store = new(worldState);
         store.ApplyBlockhashStateChanges(header, spec);
 
@@ -92,7 +92,7 @@ internal class XdcBlockhashStoreTests
         worldState.InsertCode(Eip2935Account, ValueKeccak.Compute(wrongCode), wrongCode, spec);
         worldState.Commit(spec);
 
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject; ;
         XdcBlockhashStore store = new(worldState);
 
         Assert.Throws<InvalidOperationException>(() => store.ApplyBlockhashStateChanges(header, spec));
@@ -118,7 +118,7 @@ internal class XdcBlockhashStoreTests
         IWorldState worldState = TestWorldStateFactory.CreateForTest();
         using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
         ReleaseSpec spec = new() { IsEip2935Enabled = false };
-        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject; ;
 
         XdcBlockhashStore store = new(worldState);
         store.ApplyBlockhashStateChanges(header, spec);

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
@@ -30,7 +31,7 @@ internal class XdcBlockhashStoreTests
         ReleaseSpec spec = Eip2935Spec;
         BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
 
-        XdcBlockhashStore store = new(worldState);
+        XdcBlockhashStore store = new(new BlockhashStore(worldState), worldState);
         store.ApplyBlockhashStateChanges(header, spec);
 
         Assert.Multiple(() =>
@@ -49,7 +50,7 @@ internal class XdcBlockhashStoreTests
         ReleaseSpec spec = Eip2935Spec;
         BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
 
-        XdcBlockhashStore store = new(worldState);
+        XdcBlockhashStore store = new(new BlockhashStore(worldState), worldState);
         store.ApplyBlockhashStateChanges(header, spec);
 
         Hash256? stored = store.GetBlockHashFromState(header, header.Number - 1, spec);
@@ -69,7 +70,7 @@ internal class XdcBlockhashStoreTests
         worldState.Commit(spec);
 
         BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
-        XdcBlockhashStore store = new(worldState);
+        XdcBlockhashStore store = new(new BlockhashStore(worldState), worldState);
         store.ApplyBlockhashStateChanges(header, spec);
 
         Assert.Multiple(() =>
@@ -93,7 +94,7 @@ internal class XdcBlockhashStoreTests
         worldState.Commit(spec);
 
         BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
-        XdcBlockhashStore store = new(worldState);
+        XdcBlockhashStore store = new(new BlockhashStore(worldState), worldState);
 
         Assert.Throws<InvalidOperationException>(() => store.ApplyBlockhashStateChanges(header, spec));
     }
@@ -106,7 +107,7 @@ internal class XdcBlockhashStoreTests
         ReleaseSpec spec = Eip2935Spec;
         BlockHeader genesis = Build.A.BlockHeader.WithNumber(0).TestObject;
 
-        XdcBlockhashStore store = new(worldState);
+        XdcBlockhashStore store = new(new BlockhashStore(worldState), worldState);
         store.ApplyBlockhashStateChanges(genesis, spec);
 
         Assert.That(worldState.AccountExists(Eip2935Account), Is.False);
@@ -120,7 +121,7 @@ internal class XdcBlockhashStoreTests
         ReleaseSpec spec = new() { IsEip2935Enabled = false };
         BlockHeader header = Build.A.BlockHeader.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
 
-        XdcBlockhashStore store = new(worldState);
+        XdcBlockhashStore store = new(new BlockhashStore(worldState), worldState);
         store.ApplyBlockhashStateChanges(header, spec);
 
         Assert.That(worldState.AccountExists(Eip2935Account), Is.False);
@@ -135,7 +136,7 @@ internal class XdcBlockhashStoreTests
         BlockHeader header = Build.A.BlockHeader.WithNumber(42).TestObject;
         header.ParentHash = null;
 
-        XdcBlockhashStore store = new(worldState);
+        XdcBlockhashStore store = new(new BlockhashStore(worldState), worldState);
         store.ApplyBlockhashStateChanges(header, spec);
 
         Assert.That(worldState.AccountExists(Eip2935Account), Is.False);

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText:2023 Demerzel Solutions Limited
-// SPDX-License-Identifier:LGPL-3.0-only
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
 using Nethermind.Blockchain.Blocks;
@@ -34,5 +34,4 @@ public class XdcBlockhashStore(IWorldState worldState) : BlockhashStore(worldSta
 
         base.ApplyBlockhashStateChanges(blockHeader, spec);
     }
-
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
@@ -10,30 +10,36 @@ using Nethermind.Evm.State;
 
 namespace Nethermind.Xdc;
 
-public class XdcBlockhashStore(IWorldState worldState) : BlockhashStore(worldState)
+public class XdcBlockhashStore(IBlockhashStore inner, IWorldState worldState) : IBlockhashStore
 {
-    private static readonly ValueHash256 CodeHash = ValueKeccak.Compute(Eip2935Constants.Code);
+    private static readonly ValueHash256 CodeHash =
+        ValueKeccak.Compute(Eip2935Constants.Code);
 
-    private readonly IWorldState _worldState = worldState;
-
-    public override void ApplyBlockhashStateChanges(BlockHeader blockHeader, IReleaseSpec spec)
+    public void ApplyBlockhashStateChanges(BlockHeader blockHeader, IReleaseSpec spec)
     {
         if (!spec.IsEip2935Enabled || blockHeader.IsGenesis || blockHeader.ParentHash is null) return;
 
         Address eip2935Account = spec.Eip2935ContractAddress ?? Eip2935Constants.BlockHashHistoryAddress;
 
-        ValueHash256 actualCodeHash = _worldState.GetCodeHash(eip2935Account);
+        ValueHash256 actualCodeHash = worldState.GetCodeHash(eip2935Account);
         bool hasCode = actualCodeHash != Keccak.OfAnEmptyString.ValueHash256;
         if (hasCode && actualCodeHash != CodeHash)
             throw new InvalidOperationException($"EIP-2935 contract code mismatch at {eip2935Account}.");
 
         if (!hasCode)
         {
-            _worldState.CreateAccountIfNotExists(eip2935Account, 0);
-            _worldState.SetNonce(eip2935Account, 1);
-            _worldState.InsertCode(eip2935Account, CodeHash, Eip2935Constants.Code, spec);
+            worldState.CreateAccountIfNotExists(eip2935Account, 0);
+            worldState.SetNonce(eip2935Account, 1);
+            worldState.InsertCode(eip2935Account, CodeHash, Eip2935Constants.Code, spec);
         }
+        
+        inner.ApplyBlockhashStateChanges(blockHeader, spec);
+    }
 
-        base.ApplyBlockhashStateChanges(blockHeader, spec);
+    public Hash256? GetBlockHashFromState(BlockHeader currentBlockHeader, ulong requiredBlockNumber, IReleaseSpec spec) => 
+        inner.GetBlockHashFromState(currentBlockHeader, requiredBlockNumber, spec);
+
+    protected virtual void EnsureContract(BlockHeader blockHeader, IReleaseSpec spec)
+    {
     }
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
@@ -5,7 +5,6 @@ using System;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
 
@@ -13,23 +12,26 @@ namespace Nethermind.Xdc;
 
 public class XdcBlockhashStore(IWorldState worldState) : BlockhashStore(worldState)
 {
+    private static readonly ValueHash256 CodeHash = ValueKeccak.Compute(Eip2935Constants.Code);
+
     private readonly IWorldState _worldState = worldState;
 
     public override void ApplyBlockhashStateChanges(BlockHeader blockHeader, IReleaseSpec spec)
     {
         if (!spec.IsEip2935Enabled || blockHeader.IsGenesis || blockHeader.ParentHash is null) return;
 
-        Address? eip2935Account = spec.Eip2935ContractAddress ?? Eip2935Constants.BlockHashHistoryAddress;
+        Address eip2935Account = spec.Eip2935ContractAddress ?? Eip2935Constants.BlockHashHistoryAddress;
 
-        byte[] code = _worldState.GetCode(eip2935Account) ?? [];
-        if (code.Length > 0 && !code.SequenceEqual(Eip2935Constants.Code))
-            throw new InvalidOperationException($"EIP-2935 contract code mismatch at {eip2935Account}. Expected: {Eip2935Constants.Code.ToHexString()}, Actual: {code.ToHexString()}");
+        ValueHash256 actualCodeHash = _worldState.GetCodeHash(eip2935Account);
+        bool hasCode = actualCodeHash != Keccak.OfAnEmptyString.ValueHash256;
+        if (hasCode && actualCodeHash != CodeHash)
+            throw new InvalidOperationException($"EIP-2935 contract code mismatch at {eip2935Account}.");
 
-        if (code.Length == 0)
+        if (!hasCode)
         {
             _worldState.CreateAccountIfNotExists(eip2935Account, 0);
             _worldState.SetNonce(eip2935Account, 1);
-            _worldState.InsertCode(eip2935Account, ValueKeccak.Compute(Eip2935Constants.Code), Eip2935Constants.Code, spec);
+            _worldState.InsertCode(eip2935Account, CodeHash, Eip2935Constants.Code, spec);
         }
 
         base.ApplyBlockhashStateChanges(blockHeader, spec);

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
@@ -22,17 +22,17 @@ public class XdcBlockhashStore(IWorldState worldState) : BlockhashStore(worldSta
         Address? eip2935Account = spec.Eip2935ContractAddress ?? Eip2935Constants.BlockHashHistoryAddress;
 
         byte[] code = _worldState.GetCode(eip2935Account) ?? [];
-        if(code.Length > 0 && !code.SequenceEqual(Eip2935Constants.Code))
+        if (code.Length > 0 && !code.SequenceEqual(Eip2935Constants.Code))
             throw new InvalidOperationException($"EIP-2935 contract code mismatch at {eip2935Account}. Expected: {Eip2935Constants.Code.ToHexString()}, Actual: {code.ToHexString()}");
-        
-        if(code.Length == 0)
+
+        if (code.Length == 0)
         {
             _worldState.CreateAccountIfNotExists(eip2935Account, 0);
             _worldState.SetNonce(eip2935Account, 1);
             _worldState.InsertCode(eip2935Account, ValueKeccak.Compute(Eip2935Constants.Code), Eip2935Constants.Code, spec);
         }
-        base.ApplyBlockhashStateChanges(blockHeader, spec);
 
+        base.ApplyBlockhashStateChanges(blockHeader, spec);
     }
 
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText:2023 Demerzel Solutions Limited
+// SPDX-License-Identifier:LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain.Blocks;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
+
+namespace Nethermind.Xdc;
+
+public class XdcBlockhashStore(IWorldState worldState) : BlockhashStore(worldState)
+{
+    private readonly IWorldState _worldState = worldState;
+
+    public override void ApplyBlockhashStateChanges(BlockHeader blockHeader, IReleaseSpec spec)
+    {
+        if (!spec.IsEip2935Enabled || blockHeader.IsGenesis || blockHeader.ParentHash is null) return;
+
+        Address? eip2935Account = spec.Eip2935ContractAddress ?? Eip2935Constants.BlockHashHistoryAddress;
+
+        byte[] code = _worldState.GetCode(eip2935Account) ?? [];
+        if(code.Length > 0 && !code.SequenceEqual(Eip2935Constants.Code))
+            throw new InvalidOperationException($"EIP-2935 contract code mismatch at {eip2935Account}. Expected: {Eip2935Constants.Code.ToHexString()}, Actual: {code.ToHexString()}");
+        
+        if(code.Length == 0)
+        {
+            _worldState.CreateAccountIfNotExists(eip2935Account, 0);
+            _worldState.SetNonce(eip2935Account, 1);
+            _worldState.InsertCode(eip2935Account, ValueKeccak.Compute(Eip2935Constants.Code), Eip2935Constants.Code, spec);
+        }
+        base.ApplyBlockhashStateChanges(blockHeader, spec);
+
+    }
+
+}

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
@@ -32,14 +32,10 @@ public class XdcBlockhashStore(IBlockhashStore inner, IWorldState worldState) : 
             worldState.SetNonce(eip2935Account, 1);
             worldState.InsertCode(eip2935Account, CodeHash, Eip2935Constants.Code, spec);
         }
-        
+
         inner.ApplyBlockhashStateChanges(blockHeader, spec);
     }
 
-    public Hash256? GetBlockHashFromState(BlockHeader currentBlockHeader, ulong requiredBlockNumber, IReleaseSpec spec) => 
+    public Hash256? GetBlockHashFromState(BlockHeader currentBlockHeader, ulong requiredBlockNumber, IReleaseSpec spec) =>
         inner.GetBlockHashFromState(currentBlockHeader, requiredBlockNumber, spec);
-
-    protected virtual void EnsureContract(BlockHeader blockHeader, IReleaseSpec spec)
-    {
-    }
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcModule.cs
@@ -68,6 +68,7 @@ public class XdcModule : Module
             .AddSingleton<IXdcHeaderStore, XdcHeaderStore>()
             .AddSingleton<IBlockStore, XdcBlockStore>()
             .AddSingleton<IBlockTree, XdcBlockTree>()
+            .AddSingleton<IBlockhashStore, XdcBlockhashStore>()
 
             // Sys contracts
             //TODO this might not be wired correctly

--- a/src/Nethermind/Nethermind.Xdc/XdcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcModule.cs
@@ -68,7 +68,7 @@ public class XdcModule : Module
             .AddSingleton<IXdcHeaderStore, XdcHeaderStore>()
             .AddSingleton<IBlockStore, XdcBlockStore>()
             .AddSingleton<IBlockTree, XdcBlockTree>()
-            .AddSingleton<IBlockhashStore, XdcBlockhashStore>()
+            .AddScoped<IBlockhashStore, XdcBlockhashStore>()
 
             // Sys contracts
             //TODO this might not be wired correctly

--- a/src/Nethermind/Nethermind.Xdc/XdcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcModule.cs
@@ -68,7 +68,7 @@ public class XdcModule : Module
             .AddSingleton<IXdcHeaderStore, XdcHeaderStore>()
             .AddSingleton<IBlockStore, XdcBlockStore>()
             .AddSingleton<IBlockTree, XdcBlockTree>()
-            .AddScoped<IBlockhashStore, XdcBlockhashStore>()
+            .AddDecorator<IBlockhashStore, XdcBlockhashStore>()
 
             // Sys contracts
             //TODO this might not be wired correctly


### PR DESCRIPTION
Changes

- Add `XdcBlockhashStore` (`IBlockhashStore` for XDC) that deploys the EIP-2935 history contract on demand when it's missing, then records the parent block hash.
- Expose the history-contract bytecode as `Eip2935Constants.Code`.
- Make `BlockhashStore.ApplyBlockhashStateChanges` virtual so XDC can override it.
- Register `XdcBlockhashStore` in `XdcModule`; add tests.

Why

On Ethereum the EIP-2935 contract is deployed via a normal tx just before the fork, so the stock store assumes it already exists. XDC skips that step, so `XdcBlockhashStore` deploys it lazily (nonce=1) when the account has no code — reusing existing code if present, throwing on a code mismatch.

Types of changes

- [x] New feature

Testing

- [x] Yes / wrote tests — deploy, no-redeploy, code mismatch, genesis, EIP disabled, missing parent.