### PR TITLE
ci: build test binaries once per RID and share via artifact

### DIFF
--- a/.github/actions/download-test-artifacts/action.yaml
+++ b/.github/actions/download-test-artifacts/action.yaml
@@ -1,0 +1,49 @@
+name: Download test artifacts
+description: >-
+  Downloads and unpacks the prebuilt test binaries matching this runner's RID
+  (produced by build-test-artifacts.yml) and verifies the RID/variant marker.
+  Run after actions/checkout so the target tree exists.
+
+inputs:
+  variant:
+    description: Artifact variant tag to consume (release, checked).
+    default: release
+
+outputs:
+  rid:
+    description: The RID resolved for this runner.
+    value: ${{ steps.rid.outputs.rid }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve RID
+      id: rid
+      shell: bash
+      run: |
+        case "${{ runner.os }}-${{ runner.arch }}" in
+          Linux-X64)   rid=linux-x64 ;;
+          Linux-ARM64) rid=linux-arm64 ;;
+          Windows-X64) rid=win-x64 ;;
+          macOS-ARM64) rid=osx-arm64 ;;
+          *) echo "::error::no artifact RID mapping for runner ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
+        esac
+        echo "rid=$rid" >> "$GITHUB_OUTPUT"
+
+    - name: Download test binaries
+      uses: actions/download-artifact@v4
+      with:
+        name: test-bin-${{ inputs.variant }}-${{ steps.rid.outputs.rid }}
+
+    - name: Unpack and verify marker
+      shell: bash
+      run: |
+        set -euo pipefail
+        tar -xf test-bin.tar -C src/Nethermind
+        # Marker is two lines: rid then variant. (Line-by-line read avoids a set -e trip.)
+        { read -r got_rid; read -r got_var; } < src/Nethermind/artifacts/bin/.artifact-marker
+        if [ "$got_rid" != "${{ steps.rid.outputs.rid }}" ] || [ "$got_var" != "${{ inputs.variant }}" ]; then
+          echo "::error::test-binary artifact mismatch: got rid=$got_rid variant=$got_var, expected rid=${{ steps.rid.outputs.rid }} variant=${{ inputs.variant }}"
+          exit 1
+        fi
+        echo "Unpacked test binaries for $got_rid ($got_var)"

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -1,0 +1,94 @@
+name: Build test artifacts
+
+# Reusable per-RID producer: builds the test binaries once and uploads them so
+# consumers can `dotnet test --no-build`. See PR #12371 for the design rationale.
+
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        description: JSON strategy matrix; each include entry needs rid, os, variant, build_args.
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build ${{ matrix.variant }} (${{ matrix.rid }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.matrix) }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Fetch submodules
+        uses: ./.github/actions/fetch-submodules
+        with:
+          submodules: recursive
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Redirect build output to the large scratch disk (Linux)
+        # Build on the ~70 GB /mnt; the multi-RID output overflows the ~21 GB root disk.
+        if: runner.os == 'Linux'
+        run: |
+          sudo mkdir -p /mnt/nm-artifacts
+          sudo chown "$(id -u):$(id -g)" /mnt/nm-artifacts
+          ln -s /mnt/nm-artifacts src/Nethermind/artifacts
+
+      - name: Free up disk space (macOS)
+        # No /mnt on macOS; reclaim disk for the build (a framework-dependent build needs no Xcode).
+        if: runner.os == 'macOS'
+        run: |
+          sudo rm -rf /Applications/Xcode_*.app || true
+          sudo rm -rf "$HOME/Library/Developer/CoreSimulator" /Library/Developer/CoreSimulator || true
+
+      - name: Restore
+        run: |
+          dotnet restore src/Nethermind/Nethermind.slnx
+          dotnet restore src/Nethermind/EthereumTests.slnx
+
+      - name: Build
+        # Skip analyzers (run in code-lint); source generators still run, so binaries are identical.
+        run: |
+          dotnet build src/Nethermind/Nethermind.slnx -c release --no-restore -p:RunAnalyzersDuringBuild=false ${{ matrix.build_args }}
+          dotnet build src/Nethermind/EthereumTests.slnx -c release --no-restore -p:RunAnalyzersDuringBuild=false ${{ matrix.build_args }}
+
+      - name: Prune foreign-RID native assets
+        run: bash scripts/ci/prune-runtimes.sh "${{ matrix.rid }}"
+
+      - name: Deduplicate build output
+        # Hardlink duplicate files so tar stores each once. Best-effort.
+        if: runner.os == 'Linux'
+        run: |
+          if sudo apt-get install -y --no-install-recommends rdfind >/dev/null 2>&1; then
+            rdfind -makehardlinks true -makeresultsfile false src/Nethermind/artifacts/bin || true
+          else
+            echo "::warning::rdfind unavailable; artifact will not be deduplicated"
+          fi
+
+      - name: Stamp artifact marker
+        run: printf '%s\n%s\n' "${{ matrix.rid }}" "${{ matrix.variant }}" > src/Nethermind/artifacts/bin/.artifact-marker
+
+      - name: Package
+        # tar (not a raw upload) to preserve the apphost +x bit that upload-artifact's zip drops.
+        run: tar -C src/Nethermind -cf test-bin.tar artifacts/bin
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-bin-${{ matrix.variant }}-${{ matrix.rid }}
+          path: test-bin.tar
+          compression-level: 1
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -19,12 +19,20 @@ defaults:
     shell: bash
 
 jobs:
+  build:
+    uses: ./.github/workflows/build-test-artifacts.yml
+    with:
+      matrix: '{"include":[{"rid":"linux-x64","os":"ubuntu-latest","variant":"release","build_args":""},{"rid":"linux-x64","os":"ubuntu-latest","variant":"checked","build_args":"-p:DefineConstants=TRACE%3BDEBUG"}]}'
+
   tests:
     name: Run ${{ matrix.project }} [${{ matrix.variant.label }}]
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       DOTNET_GCConserveMemory: 9
+      # Only these fixture tests read the src/tests submodule at runtime.
+      FIXTURE_PROJECTS: '["Ethereum.Blockchain.Block.Test","Ethereum.Legacy.Blockchain.Block.Test","Ethereum.Legacy.Blockchain.Test","Ethereum.Legacy.Transition.Test","Ethereum.Legacy.VM.Test"]'
     strategy:
       fail-fast: false
       matrix:
@@ -32,10 +40,12 @@ jobs:
           - label: checked
             dotnet-args: -p:DefineConstants=TRACE%3BDEBUG
             hw-intrinsic: ''
+            artifact: checked
           - &no_intrinsics
             label: no-intrinsics
             dotnet-args: ''
             hw-intrinsic: 0
+            artifact: release
         project:
           - Ethereum.Abi.Test
           - Ethereum.Basic.Test
@@ -107,10 +117,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
-          submodules: ${{ startsWith(matrix.project, 'Ethereum.') && 'recursive' || 'false' }}
+          submodules: ${{ contains(fromJSON(env.FIXTURE_PROJECTS), matrix.project) && 'recursive' || 'false' }}
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download test binaries
+        uses: ./.github/actions/download-test-artifacts
+        with:
+          variant: ${{ matrix.variant.artifact }}
 
       - name: ${{ matrix.project }}
         id: test
@@ -118,14 +136,14 @@ jobs:
         env:
           DOTNET_EnableHWIntrinsic: ${{ matrix.variant.hw-intrinsic }}
         run: |
-          dotnet build ${{ matrix.project }}.csproj -c release ${{ matrix.variant.dotnet-args }}
-          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
+          dotnet restore ${{ matrix.project }}.csproj
           test_args=(--no-build --no-restore)
 
-          dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" ${{ matrix.variant.dotnet-args }}
+          dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}"
 
   tests-chunked:
     name: Run ${{ matrix.test.project }} (${{ matrix.test.chunk }}) [${{ matrix.variant.label }}]
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -137,9 +155,11 @@ jobs:
           - label: checked
             dotnet-args: -p:DefineConstants=TRACE%3BDEBUG
             hw-intrinsic: ''
+            artifact: checked
           - label: no-intrinsics
             dotnet-args: ''
             hw-intrinsic: 0
+            artifact: release
         test:
           - { project: Ethereum.Legacy.Blockchain.Test, chunk: 1of8 }
           - { project: Ethereum.Legacy.Blockchain.Test, chunk: 2of8 }
@@ -169,6 +189,14 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download test binaries
+        uses: ./.github/actions/download-test-artifacts
+        with:
+          variant: ${{ matrix.variant.artifact }}
 
       - name: ${{ matrix.test.project }} (${{ matrix.test.chunk }})
         id: test
@@ -178,11 +206,10 @@ jobs:
           TEST_CHUNK: ${{ matrix.test.chunk }}
           TEST_SKIP_HEAVY: 1
         run: |
-          dotnet build ${{ matrix.test.project }}.csproj -c release ${{ matrix.variant.dotnet-args }}
-          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
+          dotnet restore ${{ matrix.test.project }}.csproj
           test_args=(--no-build --no-restore)
 
-          dotnet test --project ${{ matrix.test.project }}.csproj -c release "${test_args[@]}" ${{ matrix.variant.dotnet-args }}
+          dotnet test --project ${{ matrix.test.project }}.csproj -c release "${test_args[@]}"
 
   tests-summary:
     name: Tests summary

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -16,12 +16,21 @@ env:
   TEST_USE_FLAT: 1
 
 jobs:
+  build:
+    uses: ./.github/workflows/build-test-artifacts.yml
+    with:
+      matrix: >-
+        {"include":[{"rid":"linux-x64","os":"ubuntu-latest","variant":"release","build_args":""}]}
+
   tests:
     name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       DOTNET_GCConserveMemory: 9
+      # Only these fixture tests read the src/tests submodule at runtime.
+      FIXTURE_PROJECTS: '["Ethereum.Blockchain.Block.Test","Ethereum.Legacy.Blockchain.Block.Test","Ethereum.Legacy.Blockchain.Test","Ethereum.Legacy.Transition.Test","Ethereum.Legacy.VM.Test"]'
     strategy:
       fail-fast: false
       matrix:
@@ -67,13 +76,23 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      # Submodule only for fixture tests; the checkout also serves other source files (e.g. Chains/*.json).
       - name: Fetch submodules
+        if: ${{ contains(fromJSON(env.FIXTURE_PROJECTS), matrix.project) }}
         uses: ./.github/actions/fetch-submodules
         with:
           submodules: recursive
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download test binaries
+        uses: ./.github/actions/download-test-artifacts
+        with:
+          variant: release
 
       - name: ${{ matrix.project }}
         id: test
@@ -81,8 +100,7 @@ jobs:
         env:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
-          dotnet build ${{ matrix.project }}.csproj -c release
-          dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
+          dotnet restore ${{ matrix.project }}.csproj
           dotnet test --project ${{ matrix.project }}.csproj -c release --no-build --no-restore
 
   # EEST fixtures under the flat state layout (formerly the Ethereum.Blockchain.Pyspec.Test

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -26,8 +26,16 @@ defaults:
     shell: bash
 
 jobs:
+  # Build the test binaries once per Linux RID and share as an artifact. Windows/macOS
+  # are excluded — their artifacts can't be deduped cheaply, so building in-job is faster.
+  build:
+    uses: ./.github/workflows/build-test-artifacts.yml
+    with:
+      matrix: '{"include":[{"rid":"linux-x64","os":"ubuntu-latest","variant":"release","build_args":""},{"rid":"linux-arm64","os":"ubuntu-24.04-arm","variant":"release","build_args":""}]}'
+
   tests:
     name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }} (${{ matrix.runner }})
+    needs: build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     outputs:
@@ -116,6 +124,15 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download test binaries
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/download-test-artifacts
+        with:
+          variant: release
 
       - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
         id: test
@@ -124,7 +141,11 @@ jobs:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
           flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
-          dotnet build ${{ matrix.project }}.csproj -c release
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            dotnet restore ${{ matrix.project }}.csproj          # binaries from the shared Linux artifact
+          else
+            dotnet build ${{ matrix.project }}.csproj -c release  # Windows/macOS: no artifact, build in-job
+          fi
           dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
@@ -151,8 +172,12 @@ jobs:
 
   tests-spec:
     name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }} (${{ matrix.runner }})
+    needs: build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
+    env:
+      # Only these EF fixture tests read the src/tests submodule at runtime.
+      FIXTURE_PROJECTS: '["Ethereum.Blockchain.Block.Test","Ethereum.Legacy.Blockchain.Block.Test","Ethereum.Legacy.Blockchain.Test","Ethereum.Legacy.Transition.Test","Ethereum.Legacy.VM.Test"]'
     strategy:
       fail-fast: false
       matrix:
@@ -193,12 +218,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Fetch submodules
+        if: ${{ contains(fromJSON(env.FIXTURE_PROJECTS), matrix.project) }}
         uses: ./.github/actions/fetch-submodules
         with:
           submodules: recursive
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download test binaries
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/download-test-artifacts
+        with:
+          variant: release
 
       - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
         id: test
@@ -207,7 +242,11 @@ jobs:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
           flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
-          dotnet build ${{ matrix.project }}.csproj -c release
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            dotnet restore ${{ matrix.project }}.csproj          # binaries from the shared Linux artifact
+          else
+            dotnet build ${{ matrix.project }}.csproj -c release  # Windows/macOS: no artifact, build in-job
+          fi
           dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 
@@ -234,6 +273,7 @@ jobs:
 
   tests-chunked:
     name: Run ${{ matrix.test.project }}${{ matrix.test.label && format(' [{0}]', matrix.test.label) || '' }} (${{ matrix.test.chunk }}) (${{ matrix.runner }})
+    needs: build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     strategy:
@@ -268,6 +308,15 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
+
+      - name: Download test binaries
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/download-test-artifacts
+        with:
+          variant: release
 
       - name: ${{ matrix.test.project }} (${{ matrix.test.chunk }})
         id: test
@@ -275,7 +324,11 @@ jobs:
         env:
           TEST_CHUNK: ${{ matrix.test.chunk }}
         run: |
-          dotnet build ${{ matrix.test.project }}.csproj -c release
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            dotnet restore ${{ matrix.test.project }}.csproj
+          else
+            dotnet build ${{ matrix.test.project }}.csproj -c release
+          fi
           dotnet build-server shutdown || true  # macOS VB/C# server sometimes fails to shut down; harmless
           test_args=(--no-build --no-restore)
 

--- a/scripts/ci/prune-runtimes.sh
+++ b/scripts/ci/prune-runtimes.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Drop foreign <os>-<arch> native RID folders from a build output tree so the per-RID
+# artifact is lean. Bare-OS parents (linux, unix, win, osx) are kept — they hold managed
+# fallback assemblies the target RID resolves via the RID-fallback graph.
+set -euo pipefail
+
+rid="${1:?usage: prune-runtimes.sh <target-rid> [bin-root]}"
+bin_root="${2:-src/Nethermind/artifacts/bin}"
+
+[ -d "$bin_root" ] || { echo "::error::bin root not found: $bin_root"; exit 1; }
+
+before=$(du -sm "$bin_root" 2>/dev/null | cut -f1 || echo '?')
+
+# Collect to a temp file (no `mapfile` — macOS ships bash 3.2), then delete, so find
+# isn't walking a directory being removed underneath it.
+list=$(mktemp)
+find "$bin_root" -type d -path '*/runtimes/*' \
+  | awk -F/ -v rid="$rid" '$(NF-1) == "runtimes" && $NF ~ /-/ && $NF != rid' \
+  | sort -u > "$list"
+
+removed=0
+while IFS= read -r d; do
+  [ -n "$d" ] || continue
+  rm -rf "$d" && removed=$((removed + 1))
+done < "$list"
+rm -f "$list"
+
+after=$(du -sm "$bin_root" 2>/dev/null | cut -f1 || echo '?')
+
+# Target RID should survive (unless there are no native deps) — else the rule/RID is wrong.
+if ! find "$bin_root" -type d -path "*/runtimes/$rid" -print -quit | grep -q .; then
+  echo "::warning::no runtimes/$rid folder present after prune for rid=$rid"
+fi
+
+echo "prune-runtimes[$rid]: ${before}MB -> ${after}MB (removed ${removed} foreign RID dirs)"


### PR DESCRIPTION
## Changes

Extract the redundant per-job build out of the unit-test workflows: build the test binaries **once per RID** and share them as an artifact, so the ~500 matrix jobs run `dotnet test --no-build` instead of each recompiling the whole shared graph (Core/Evm/State/Trie/…).

- **`.github/workflows/build-test-artifacts.yml`** — reusable per-RID producer (`workflow_call`): restores + builds `Nethermind.slnx` + `EthereumTests.slnx` once, prunes foreign-RID natives, hardlink-dedups (`rdfind`) to ~175 MB, tars (preserving `+x` on the MTP apphost/testhost), uploads. Skips diagnostic analyzers (`RunAnalyzersDuringBuild=false`; still validated in `code-lint.yml`, source generators unaffected) and builds on `/mnt` for disk headroom.
- **`.github/actions/download-test-artifacts/`** — resolves the runner's RID, downloads the matching artifact, unpacks it, verifies a RID/variant marker.
- **`scripts/ci/prune-runtimes.sh`** — drops foreign `<os>-<arch>` native folders, keeping the target RID + its bare-OS fallback parents. Portable (bash 3.2 / BSD / git-bash).
- **`nethermind-tests-flat` / `-checked` / `-tests`** — consumers download + `--no-build`. Submodules fetched only for the fixture tests that read `src/tests` at runtime. In `nethermind-tests.yml`, only the **Linux** legs use the artifact; **Windows/macOS build in-job** (their artifacts can't be deduped cheaply on those runners, so downloading the multi-GB tree is slower than building).

## Types of changes

- [x] Optimization
- [x] Build-related changes

## Testing

#### Requires testing
- [x] Yes

#### If yes, did you write tests?
- [x] No

#### Notes on testing

CI-infrastructure change — validated by dispatching all three workflows on the branch: same job and test counts, **all green, no hidden failures**.

Measured per single trigger (job-minutes = sum of job durations):
| Workflow | Old | New | Δ |
|---|---|---|---|
| flat | 406 job-min | 368 | −9% full run (−25% on the converted `tests` job; the rest is the already-optimized `nethtest`) |
| checked (variants) | 515 | 348 | **−32%** |
| tests | 924 | 721 | **−22%** (Linux legs) |

Trade-off: wall-time rises ~3 min/workflow — the producer is a serialization point (the same pattern `run-nethtest.yml` already uses).

## Documentation

#### Requires documentation update
- [x] No

#### Requires explanation in Release Notes
- [x] No

## Remarks

Scope note: `run-nethtest.yml` already build-once-shares; Hive/stateless are Docker/prebuilt; `build-solutions`/`code-lint` are single-purpose — so no other workflow has redundant builds to convert.

Follow-up ideas (not in this PR): a bigger runner for the ~6-min producer (halves the build), batching the ~65 overhead-dominated <60s jobs into ~30–40 groups, and a cross-platform dedup to bring Windows/macOS into the scheme.
