### PR TITLE
Fix slow-block cache hit stats: report first-touch pre-block coverage instead of a layer blend

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/Processing/SlowBlockIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Processing/SlowBlockIntegrationTests.cs
@@ -9,6 +9,7 @@ using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Threading;
 using Nethermind.Crypto;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
@@ -18,6 +19,7 @@ using Nethermind.Specs.Forks;
 using Nethermind.State;
 using NSubstitute;
 using NUnit.Framework;
+using DbMetrics = Nethermind.Db.Metrics;
 
 #nullable enable
 
@@ -123,6 +125,75 @@ public class SlowBlockIntegrationTests
         Assert.That(log.StateWrites.StorageSlots, Is.GreaterThan(0));
         Assert.That(log.StateWrites.StorageSlotsDeleted, Is.GreaterThanOrEqualTo(1));
         Assert.That(log.Evm.Sstore, Is.GreaterThanOrEqualTo(2));
+    }
+
+    [Test]
+    public void Cache_stats_report_first_touch_hit_rate_when_preblock_counters_present()
+    {
+        PrivateKey sender = TestItem.PrivateKeyA;
+        _harness.WorldState.CreateAccount(sender.Address, 10.Ether);
+
+        Transaction tx = Build.A.Transaction.WithTo(TestItem.AddressB).WithValue(1.Ether)
+            .WithGasLimit(21_000).SignedAndResolved(_harness.Ecdsa, sender, true).TestObject;
+        Block block = _harness.CreateBlock(tx);
+
+        _stats.Start();
+        _stats.CaptureStartStats();
+
+        // Simulate the pre-block wrapper's first-touch probes (the harness world state has no
+        // prewarmer scope, so these are the only pre-block increments in the delta window) plus
+        // legacy blended hits, on the block-processing thread so they land in the main bucket.
+        bool wasProcessingThread = ProcessingThread.IsBlockProcessingThread;
+        ProcessingThread.IsBlockProcessingThread = true;
+        try
+        {
+            DbMetrics.AddPreBlockAccountHits(90);
+            DbMetrics.AddPreBlockAccountMisses(10);
+            DbMetrics.AddPreBlockStorageHits(80);
+            DbMetrics.AddPreBlockStorageMisses(20);
+            // Legacy counters blend change-dict repeats with pre-block hits: 60 repeats + the 90/80 above.
+            DbMetrics.AddStateTreeCacheHits(150);
+            DbMetrics.AddStorageTreeCache(140);
+
+            _harness.ExecuteTx(tx, block);
+        }
+        finally
+        {
+            ProcessingThread.IsBlockProcessingThread = wasProcessingThread;
+        }
+
+        _stats.UpdateStats(new[] { block }, Build.A.BlockHeader.TestObject, blockProcessingTimeInMicros: 100_000);
+        _slowBlockLogger.WaitForEntry(TimeSpan.FromSeconds(5));
+        SlowBlockLogEntry log = JsonSerializer.Deserialize<SlowBlockLogEntry>(_slowBlockLogger.LogList.Last())!;
+
+        // hits/misses/hit_rate must be the first-touch pre-block numbers, NOT the legacy blend
+        // (which would fold the 150/140 repeat-layer hits into hits and inflate misses).
+        Assert.That(log.Cache.Account.Hits, Is.EqualTo(90));
+        Assert.That(log.Cache.Account.Misses, Is.EqualTo(10));
+        Assert.That(log.Cache.Account.HitRate, Is.EqualTo(90.0));
+        Assert.That(log.Cache.Storage.Hits, Is.EqualTo(80));
+        Assert.That(log.Cache.Storage.Misses, Is.EqualTo(20));
+        Assert.That(log.Cache.Storage.HitRate, Is.EqualTo(80.0));
+        // repeat_hits = legacy hits minus pre-block hits; the real tx adds its own dict hits on top.
+        Assert.That(log.Cache.Account.RepeatHits, Is.Not.Null);
+        Assert.That(log.Cache.Account.RepeatHits, Is.GreaterThanOrEqualTo(60));
+        Assert.That(log.Cache.Storage.RepeatHits, Is.GreaterThanOrEqualTo(60));
+    }
+
+    [Test]
+    public void Cache_stats_fall_back_to_legacy_when_prewarmer_scope_absent()
+    {
+        PrivateKey sender = TestItem.PrivateKeyA;
+        _harness.WorldState.CreateAccount(sender.Address, 10.Ether);
+
+        Transaction tx = Build.A.Transaction.WithTo(TestItem.AddressB).WithValue(1.Ether)
+            .WithGasLimit(21_000).SignedAndResolved(_harness.Ecdsa, sender, true).TestObject;
+
+        SlowBlockLogEntry log = Execute(tx, _harness.CreateBlock(tx));
+
+        // No pre-block counters moved: legacy semantics, and no repeat_hits field emitted.
+        Assert.That(log.Cache.Account.RepeatHits, Is.Null);
+        Assert.That(log.Cache.Storage.RepeatHits, Is.Null);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Consensus.Test/Processing/SlowBlockLogEntry.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Processing/SlowBlockLogEntry.cs
@@ -79,6 +79,7 @@ public record SlowBlockLogEntry
         [JsonPropertyName("hits")] public long Hits { get; init; }
         [JsonPropertyName("misses")] public long Misses { get; init; }
         [JsonPropertyName("hit_rate")] public double HitRate { get; init; }
+        [JsonPropertyName("repeat_hits")] public long? RepeatHits { get; init; }
     }
 
     public record EvmInfo

--- a/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ProcessingStats.cs
@@ -92,6 +92,10 @@ namespace Nethermind.Consensus.Processing
         private long _startAccountCacheMisses;
         private long _startStorageCacheHits;
         private long _startStorageCacheMisses;
+        private long _startPreBlockAccountHits;
+        private long _startPreBlockAccountMisses;
+        private long _startPreBlockStorageHits;
+        private long _startPreBlockStorageMisses;
         private long _startCodeCacheHits;
         private long _startCodeCacheMisses;
         private long _startEip7702DelegationsSet;
@@ -199,6 +203,10 @@ namespace Nethermind.Consensus.Processing
             _startAccountCacheMisses = DbMetrics.MainThreadStateTreeReads;
             _startStorageCacheHits = DbMetrics.MainThreadStorageTreeCache;
             _startStorageCacheMisses = DbMetrics.MainThreadStorageTreeReads;
+            _startPreBlockAccountHits = DbMetrics.MainThreadPreBlockAccountHits;
+            _startPreBlockAccountMisses = DbMetrics.MainThreadPreBlockAccountMisses;
+            _startPreBlockStorageHits = DbMetrics.MainThreadPreBlockStorageHits;
+            _startPreBlockStorageMisses = DbMetrics.MainThreadPreBlockStorageMisses;
             _startCodeCacheHits = Evm.Metrics.MainThreadCodeDbCache;
             _startCodeCacheMisses = Evm.Metrics.MainThreadCodeReads;
             _startEip7702DelegationsSet = Evm.Metrics.MainThreadEip7702DelegationsSet;
@@ -275,6 +283,10 @@ namespace Nethermind.Consensus.Processing
                 blockData.DeltaAccountCacheMisses = DbMetrics.MainThreadStateTreeReads - _startAccountCacheMisses;
                 blockData.DeltaStorageCacheHits = DbMetrics.MainThreadStorageTreeCache - _startStorageCacheHits;
                 blockData.DeltaStorageCacheMisses = DbMetrics.MainThreadStorageTreeReads - _startStorageCacheMisses;
+                blockData.DeltaPreBlockAccountHits = DbMetrics.MainThreadPreBlockAccountHits - _startPreBlockAccountHits;
+                blockData.DeltaPreBlockAccountMisses = DbMetrics.MainThreadPreBlockAccountMisses - _startPreBlockAccountMisses;
+                blockData.DeltaPreBlockStorageHits = DbMetrics.MainThreadPreBlockStorageHits - _startPreBlockStorageHits;
+                blockData.DeltaPreBlockStorageMisses = DbMetrics.MainThreadPreBlockStorageMisses - _startPreBlockStorageMisses;
                 blockData.DeltaCodeCacheHits = Evm.Metrics.MainThreadCodeDbCache - _startCodeCacheHits;
                 blockData.DeltaCodeCacheMisses = Evm.Metrics.MainThreadCodeReads - _startCodeCacheMisses;
                 blockData.DeltaAccountReads = blockData.DeltaAccountCacheMisses;
@@ -660,8 +672,18 @@ namespace Nethermind.Consensus.Processing
                     evmMs = executionMs;
                 }
 
-                double accountHitRate = CalculateHitRate(data.DeltaAccountCacheHits, data.DeltaAccountCacheMisses);
-                double storageHitRate = CalculateHitRate(data.DeltaStorageCacheHits, data.DeltaStorageCacheMisses);
+                // Pre-block counters cover first-in-block touches only, so their rate = prewarm coverage.
+                // The legacy counters blend the per-block change-dict layer (repeat reads) into hits — kept
+                // as repeat_hits so the aggregate stays derivable. Fall back to legacy when the prewarmer
+                // scope is absent (counters zero, e.g. PreWarmStateOnBlockProcessing=false).
+                bool hasPreBlockStats = data.DeltaPreBlockAccountHits + data.DeltaPreBlockAccountMisses
+                    + data.DeltaPreBlockStorageHits + data.DeltaPreBlockStorageMisses > 0;
+                double accountHitRate = hasPreBlockStats
+                    ? CalculateHitRate(data.DeltaPreBlockAccountHits, data.DeltaPreBlockAccountMisses)
+                    : CalculateHitRate(data.DeltaAccountCacheHits, data.DeltaAccountCacheMisses);
+                double storageHitRate = hasPreBlockStats
+                    ? CalculateHitRate(data.DeltaPreBlockStorageHits, data.DeltaPreBlockStorageMisses)
+                    : CalculateHitRate(data.DeltaStorageCacheHits, data.DeltaStorageCacheMisses);
                 double codeHitRate = CalculateHitRate(data.DeltaCodeCacheHits, data.DeltaCodeCacheMisses);
 
                 // Blob count was already summed in UpdateStats on the block-processing thread
@@ -722,8 +744,19 @@ namespace Nethermind.Consensus.Processing
                     writer.WriteEndObject();
 
                     writer.WriteStartObject("cache");
-                    WriteCacheEntry(writer, "account", data.DeltaAccountCacheHits, data.DeltaAccountCacheMisses, accountHitRate);
-                    WriteCacheEntry(writer, "storage", data.DeltaStorageCacheHits, data.DeltaStorageCacheMisses, storageHitRate);
+                    if (hasPreBlockStats)
+                    {
+                        WriteCacheEntry(writer, "account", data.DeltaPreBlockAccountHits, data.DeltaPreBlockAccountMisses, accountHitRate,
+                            repeatHits: data.DeltaAccountCacheHits - data.DeltaPreBlockAccountHits);
+                        WriteCacheEntry(writer, "storage", data.DeltaPreBlockStorageHits, data.DeltaPreBlockStorageMisses, storageHitRate,
+                            repeatHits: data.DeltaStorageCacheHits - data.DeltaPreBlockStorageHits);
+                    }
+                    else
+                    {
+                        WriteCacheEntry(writer, "account", data.DeltaAccountCacheHits, data.DeltaAccountCacheMisses, accountHitRate);
+                        WriteCacheEntry(writer, "storage", data.DeltaStorageCacheHits, data.DeltaStorageCacheMisses, storageHitRate);
+                    }
+
                     WriteCacheEntry(writer, "code", data.DeltaCodeCacheHits, data.DeltaCodeCacheMisses, codeHitRate);
                     writer.WriteEndObject();
 
@@ -782,12 +815,13 @@ namespace Nethermind.Consensus.Processing
                 if (_logger.IsError) _logger.Error($"Error logging slow block {block.Number}", ex);
             }
 
-            static void WriteCacheEntry(Utf8JsonWriter writer, string name, long hits, long misses, double hitRate)
+            static void WriteCacheEntry(Utf8JsonWriter writer, string name, long hits, long misses, double hitRate, long? repeatHits = null)
             {
                 writer.WriteStartObject(name);
                 writer.WriteNumber("hits", hits);
                 writer.WriteNumber("misses", misses);
                 writer.WriteNumber("hit_rate", hitRate);
+                if (repeatHits is not null) writer.WriteNumber("repeat_hits", repeatHits.Value);
                 writer.WriteEndObject();
             }
         }
@@ -853,6 +887,10 @@ namespace Nethermind.Consensus.Processing
                 data.DeltaAccountCacheMisses = 0;
                 data.DeltaStorageCacheHits = 0;
                 data.DeltaStorageCacheMisses = 0;
+                data.DeltaPreBlockAccountHits = 0;
+                data.DeltaPreBlockAccountMisses = 0;
+                data.DeltaPreBlockStorageHits = 0;
+                data.DeltaPreBlockStorageMisses = 0;
                 data.DeltaCodeCacheHits = 0;
                 data.DeltaCodeCacheMisses = 0;
                 data.DeltaEip7702DelegationsSet = 0;
@@ -913,6 +951,10 @@ namespace Nethermind.Consensus.Processing
             public long DeltaAccountCacheMisses;
             public long DeltaStorageCacheHits;
             public long DeltaStorageCacheMisses;
+            public long DeltaPreBlockAccountHits;
+            public long DeltaPreBlockAccountMisses;
+            public long DeltaPreBlockStorageHits;
+            public long DeltaPreBlockStorageMisses;
             public long DeltaCodeCacheHits;
             public long DeltaCodeCacheMisses;
             public long DeltaEip7702DelegationsSet;

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -86,7 +86,7 @@ namespace Nethermind.Db
         internal static void AddStorageTreeReads(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStorageTreeReads.Value : ref _otherStorageTreeReads.Value, count);
 
         [CounterMetric]
-        [Description("Number of pre-block (prewarmer-shared) cache hits for accounts; first-in-block touches only, so hits/(hits+misses) = prewarm coverage.")]
+        [Description("Number of pre-block (prewarmer-shared) cache hits for accounts, counted on the consumer scope only (populator probes excluded); first-in-block touches, so hits/(hits+misses) = prewarm coverage.")]
         public static long PreBlockCacheAccountHits => _mainPreBlockAccountHits.Value + _otherPreBlockAccountHits.Value;
         private static CacheLinePaddedLong _mainPreBlockAccountHits;
         private static CacheLinePaddedLong _otherPreBlockAccountHits;
@@ -94,7 +94,7 @@ namespace Nethermind.Db
         internal static void AddPreBlockAccountHits(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainPreBlockAccountHits.Value : ref _otherPreBlockAccountHits.Value, count);
 
         [CounterMetric]
-        [Description("Number of pre-block (prewarmer-shared) cache misses for accounts.")]
+        [Description("Number of pre-block (prewarmer-shared) cache misses for accounts, counted on the consumer scope only (populator probes excluded).")]
         public static long PreBlockCacheAccountMisses => _mainPreBlockAccountMisses.Value + _otherPreBlockAccountMisses.Value;
         private static CacheLinePaddedLong _mainPreBlockAccountMisses;
         private static CacheLinePaddedLong _otherPreBlockAccountMisses;
@@ -102,7 +102,7 @@ namespace Nethermind.Db
         internal static void AddPreBlockAccountMisses(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainPreBlockAccountMisses.Value : ref _otherPreBlockAccountMisses.Value, count);
 
         [CounterMetric]
-        [Description("Number of pre-block (prewarmer-shared) cache hits for storage slots; first-in-block touches only, so hits/(hits+misses) = prewarm coverage.")]
+        [Description("Number of pre-block (prewarmer-shared) cache hits for storage slots, counted on the consumer scope only (populator probes excluded); first-in-block touches, so hits/(hits+misses) = prewarm coverage.")]
         public static long PreBlockCacheStorageHits => _mainPreBlockStorageHits.Value + _otherPreBlockStorageHits.Value;
         private static CacheLinePaddedLong _mainPreBlockStorageHits;
         private static CacheLinePaddedLong _otherPreBlockStorageHits;
@@ -110,7 +110,7 @@ namespace Nethermind.Db
         internal static void AddPreBlockStorageHits(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainPreBlockStorageHits.Value : ref _otherPreBlockStorageHits.Value, count);
 
         [CounterMetric]
-        [Description("Number of pre-block (prewarmer-shared) cache misses for storage slots.")]
+        [Description("Number of pre-block (prewarmer-shared) cache misses for storage slots, counted on the consumer scope only (populator probes excluded).")]
         public static long PreBlockCacheStorageMisses => _mainPreBlockStorageMisses.Value + _otherPreBlockStorageMisses.Value;
         private static CacheLinePaddedLong _mainPreBlockStorageMisses;
         private static CacheLinePaddedLong _otherPreBlockStorageMisses;

--- a/src/Nethermind/Nethermind.Db/Metrics.cs
+++ b/src/Nethermind/Nethermind.Db/Metrics.cs
@@ -86,6 +86,38 @@ namespace Nethermind.Db
         internal static void AddStorageTreeReads(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainStorageTreeReads.Value : ref _otherStorageTreeReads.Value, count);
 
         [CounterMetric]
+        [Description("Number of pre-block (prewarmer-shared) cache hits for accounts; first-in-block touches only, so hits/(hits+misses) = prewarm coverage.")]
+        public static long PreBlockCacheAccountHits => _mainPreBlockAccountHits.Value + _otherPreBlockAccountHits.Value;
+        private static CacheLinePaddedLong _mainPreBlockAccountHits;
+        private static CacheLinePaddedLong _otherPreBlockAccountHits;
+        internal static long MainThreadPreBlockAccountHits => _mainPreBlockAccountHits.Value;
+        internal static void AddPreBlockAccountHits(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainPreBlockAccountHits.Value : ref _otherPreBlockAccountHits.Value, count);
+
+        [CounterMetric]
+        [Description("Number of pre-block (prewarmer-shared) cache misses for accounts.")]
+        public static long PreBlockCacheAccountMisses => _mainPreBlockAccountMisses.Value + _otherPreBlockAccountMisses.Value;
+        private static CacheLinePaddedLong _mainPreBlockAccountMisses;
+        private static CacheLinePaddedLong _otherPreBlockAccountMisses;
+        internal static long MainThreadPreBlockAccountMisses => _mainPreBlockAccountMisses.Value;
+        internal static void AddPreBlockAccountMisses(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainPreBlockAccountMisses.Value : ref _otherPreBlockAccountMisses.Value, count);
+
+        [CounterMetric]
+        [Description("Number of pre-block (prewarmer-shared) cache hits for storage slots; first-in-block touches only, so hits/(hits+misses) = prewarm coverage.")]
+        public static long PreBlockCacheStorageHits => _mainPreBlockStorageHits.Value + _otherPreBlockStorageHits.Value;
+        private static CacheLinePaddedLong _mainPreBlockStorageHits;
+        private static CacheLinePaddedLong _otherPreBlockStorageHits;
+        internal static long MainThreadPreBlockStorageHits => _mainPreBlockStorageHits.Value;
+        internal static void AddPreBlockStorageHits(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainPreBlockStorageHits.Value : ref _otherPreBlockStorageHits.Value, count);
+
+        [CounterMetric]
+        [Description("Number of pre-block (prewarmer-shared) cache misses for storage slots.")]
+        public static long PreBlockCacheStorageMisses => _mainPreBlockStorageMisses.Value + _otherPreBlockStorageMisses.Value;
+        private static CacheLinePaddedLong _mainPreBlockStorageMisses;
+        private static CacheLinePaddedLong _otherPreBlockStorageMisses;
+        internal static long MainThreadPreBlockStorageMisses => _mainPreBlockStorageMisses.Value;
+        internal static void AddPreBlockStorageMisses(long count) => Interlocked.Add(ref IsBlockProcessingThread ? ref _mainPreBlockStorageMisses.Value : ref _otherPreBlockStorageMisses.Value, count);
+
+        [CounterMetric]
         [Description("Number of storage reader reads.")]
         public static long StorageReaderReads => _storageReaderReads.Value;
         private static CacheLinePaddedLong _storageReaderReads;

--- a/src/Nethermind/Nethermind.Evm/State/LocalMetrics.cs
+++ b/src/Nethermind/Nethermind.Evm/State/LocalMetrics.cs
@@ -23,6 +23,12 @@ public sealed class LocalMetrics
     public long StateSkippedWrites;
     public long StorageTreeCache;
     public long StorageTreeReads;
+    // Pre-block (prewarmer-shared) cache probes, split from the per-block change-dict layer above:
+    // hits+misses = first-in-block touches only, so hit rate here = prewarm coverage.
+    public long PreBlockAccountHits;
+    public long PreBlockAccountMisses;
+    public long PreBlockStorageHits;
+    public long PreBlockStorageMisses;
     // Storage write/skipped counters are deliberately absent: reported from parallel worker finalizers,
     // so they go straight to the atomic global Db.Metrics (see PersistentStorageProvider.ReportMetrics).
 
@@ -45,6 +51,14 @@ public sealed class LocalMetrics
     public void IncrementStorageTreeCache() => StorageTreeCache++;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void IncrementStorageTreeReads() => StorageTreeReads++;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementPreBlockAccountHits() => PreBlockAccountHits++;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementPreBlockAccountMisses() => PreBlockAccountMisses++;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementPreBlockStorageHits() => PreBlockStorageHits++;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void IncrementPreBlockStorageMisses() => PreBlockStorageMisses++;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void IncrementStorageWrites()
@@ -84,6 +98,10 @@ public sealed class LocalMetrics
         StateSkippedWrites = 0;
         StorageTreeCache = 0;
         StorageTreeReads = 0;
+        PreBlockAccountHits = 0;
+        PreBlockAccountMisses = 0;
+        PreBlockStorageHits = 0;
+        PreBlockStorageMisses = 0;
         AccountWrites = 0;
         AccountDeleted = 0;
         StorageWrites = 0;

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -437,6 +437,59 @@ public class ScopeProviderTests(bool useFlat)
     }
 
     [Test]
+    public void Test_PreBlockCacheCounters_CountConsumerProbesOnly()
+    {
+        using Context ctx = new(useFlat);
+
+        Hash256 stateRoot;
+        using (IWorldStateScopeProvider.IScope scope = ctx.ScopeProvider.BeginScope(null))
+        {
+            using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(1))
+            {
+                writeBatch.Set(TestItem.AddressA, new Account(100, 100));
+                using IWorldStateScopeProvider.IStorageWriteBatch storage = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1);
+                storage.Set(1, [1, 2, 3]);
+            }
+
+            scope.Commit(1);
+            stateRoot = scope.RootHash;
+        }
+
+        PreBlockCaches caches = new();
+        BlockHeader baseBlock = Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(1).TestObject;
+
+        // Populator probes must not move the pre-block counters: populators miss by design while
+        // filling the cache, so counting them would skew the exported coverage ratio.
+        LocalMetrics populatorMetrics = new();
+        PrewarmerScopeProvider populator = new(ctx.ScopeProvider, caches, LimboLogs.Instance, isPrewarmer: true);
+        using (IWorldStateScopeProvider.IScope scope = populator.BeginScope(baseBlock, populatorMetrics))
+        {
+            scope.Get(TestItem.AddressA);
+            scope.CreateStorageTree(TestItem.AddressA).Get(1);
+        }
+
+        Assert.That(populatorMetrics.PreBlockAccountHits + populatorMetrics.PreBlockAccountMisses, Is.Zero);
+        Assert.That(populatorMetrics.PreBlockStorageHits + populatorMetrics.PreBlockStorageMisses, Is.Zero);
+
+        // Consumer probes count: AddressA / slot 1 were just populated (hits); AddressB / slot 2 are cold (misses).
+        LocalMetrics consumerMetrics = new();
+        PrewarmerScopeProvider consumer = new(ctx.ScopeProvider, caches, LimboLogs.Instance, isPrewarmer: false);
+        using (IWorldStateScopeProvider.IScope scope = consumer.BeginScope(baseBlock, consumerMetrics))
+        {
+            scope.Get(TestItem.AddressA);
+            scope.Get(TestItem.AddressB);
+            IWorldStateScopeProvider.IStorageTree storage = scope.CreateStorageTree(TestItem.AddressA);
+            storage.Get(1);
+            storage.Get(2);
+        }
+
+        Assert.That(consumerMetrics.PreBlockAccountHits, Is.EqualTo(1));
+        Assert.That(consumerMetrics.PreBlockAccountMisses, Is.EqualTo(1));
+        Assert.That(consumerMetrics.PreBlockStorageHits, Is.EqualTo(1));
+        Assert.That(consumerMetrics.PreBlockStorageMisses, Is.EqualTo(1));
+    }
+
+    [Test]
     public void Test_FlatScope_TrieWarmHints_Smoke()
     {
         Assume.That(useFlat, Is.True);

--- a/src/Nethermind/Nethermind.State/LocalMetricsFlush.std.cs
+++ b/src/Nethermind/Nethermind.State/LocalMetricsFlush.std.cs
@@ -28,6 +28,10 @@ internal static class LocalMetricsFlush
         if (m.StateSkippedWrites != 0) DbMetrics.IncrementStateSkippedWrites(m.StateSkippedWrites);
         if (m.StorageTreeCache != 0) DbMetrics.AddStorageTreeCache(m.StorageTreeCache);
         if (m.StorageTreeReads != 0) DbMetrics.AddStorageTreeReads(m.StorageTreeReads);
+        if (m.PreBlockAccountHits != 0) DbMetrics.AddPreBlockAccountHits(m.PreBlockAccountHits);
+        if (m.PreBlockAccountMisses != 0) DbMetrics.AddPreBlockAccountMisses(m.PreBlockAccountMisses);
+        if (m.PreBlockStorageHits != 0) DbMetrics.AddPreBlockStorageHits(m.PreBlockStorageHits);
+        if (m.PreBlockStorageMisses != 0) DbMetrics.AddPreBlockStorageMisses(m.PreBlockStorageMisses);
 
         if (m.AccountWrites != 0) EvmMetrics.AddAccountWrites(m.AccountWrites);
         if (m.AccountDeleted != 0) EvmMetrics.AddAccountDeleted(m.AccountDeleted);

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -149,6 +149,7 @@ public class PrewarmerScopeProvider(
                 // Consumers seed the scope-local cache on a hit for their later commit; populators don't.
                 if (!isPrewarmer) baseScope.HintGet(address, account);
                 _metrics.IncrementStateTreeCacheHits();
+                _metrics.IncrementPreBlockAccountHits();
             }
             else
             {
@@ -156,6 +157,7 @@ public class PrewarmerScopeProvider(
                 // Backfill so other readers reuse this resolve; SeqlockCache.Set is safe under concurrent writers.
                 preBlockCache.Set(in addressAsKey, account);
                 mainScope?.HintWarmAccount(new ValueAddress(address.Bytes));
+                _metrics.IncrementPreBlockAccountMisses();
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
             }
             return account;
@@ -230,6 +232,7 @@ public class PrewarmerScopeProvider(
             {
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
                 _metrics.IncrementStorageTreeCache();
+                _metrics.IncrementPreBlockStorageHits();
             }
             else
             {
@@ -245,7 +248,9 @@ public class PrewarmerScopeProvider(
 
         private byte[] LoadFromTreeStorage(in StorageCell storageCell)
         {
-            _metrics.IncrementStorageTreeReads();
+            // PreBlock misses only: StorageTreeReads is already counted once per first-in-block touch by
+            // PersistentStorageProvider; counting it here again double-counted fully-cold reads.
+            _metrics.IncrementPreBlockStorageMisses();
 
             return baseStorageTree.Get(storageCell.Index);
         }

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -147,9 +147,15 @@ public class PrewarmerScopeProvider(
             {
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressHit);
                 // Consumers seed the scope-local cache on a hit for their later commit; populators don't.
-                if (!isPrewarmer) baseScope.HintGet(address, account);
+                // Pre-block counters are consumer-only: populators miss by design while filling the cache,
+                // so counting their probes would drag the exported coverage ratio below the true value.
+                if (!isPrewarmer)
+                {
+                    baseScope.HintGet(address, account);
+                    _metrics.IncrementPreBlockAccountHits();
+                }
+
                 _metrics.IncrementStateTreeCacheHits();
-                _metrics.IncrementPreBlockAccountHits();
             }
             else
             {
@@ -157,7 +163,7 @@ public class PrewarmerScopeProvider(
                 // Backfill so other readers reuse this resolve; SeqlockCache.Set is safe under concurrent writers.
                 preBlockCache.Set(in addressAsKey, account);
                 mainScope?.HintWarmAccount(new ValueAddress(address.Bytes));
-                _metrics.IncrementPreBlockAccountMisses();
+                if (!isPrewarmer) _metrics.IncrementPreBlockAccountMisses();
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.AddressMiss);
             }
             return account;
@@ -232,7 +238,7 @@ public class PrewarmerScopeProvider(
             {
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
                 _metrics.IncrementStorageTreeCache();
-                _metrics.IncrementPreBlockStorageHits();
+                if (!isPrewarmer) _metrics.IncrementPreBlockStorageHits();
             }
             else
             {
@@ -248,9 +254,10 @@ public class PrewarmerScopeProvider(
 
         private byte[] LoadFromTreeStorage(in StorageCell storageCell)
         {
-            // PreBlock misses only: StorageTreeReads is already counted once per first-in-block touch by
-            // PersistentStorageProvider; counting it here again double-counted fully-cold reads.
-            _metrics.IncrementPreBlockStorageMisses();
+            // PreBlock misses only (consumer scope): StorageTreeReads is already counted once per
+            // first-in-block touch by PersistentStorageProvider; counting it here again double-counted
+            // fully-cold reads. Populator probes are excluded — they miss by design while filling.
+            if (!isPrewarmer) _metrics.IncrementPreBlockStorageMisses();
 
             return baseStorageTree.Get(storageCell.Index);
         }


### PR DESCRIPTION
## Changes

The slow-block JSON `"cache"` hit rates were a blend of two unrelated cache layers, which made them systematically misleading about prewarmer effectiveness:

- `hits` summed **per-block change-dict hits** (intra-block repeat reads — nearly free, always hit, independent of any warming) together with **pre-block (prewarmer-shared) cache hits**;
- `misses` counted **every first-in-block touch**, including the ones the pre-block cache actually served;
- fully-cold storage reads were **double-counted** in `StorageTreeReads` — once at the change-dict layer (`PersistentStorageProvider`), once at the pre-block wrapper (`PrewarmerScopeProvider`).

The result: the JSON reported ~68% "hit rate" while the actual pre-block cache coverage of first-touch reads is ~95% for accounts / ~89% for storage (see proof below). Every historical "~50-68% cache hit rate" reading from these logs was this blend, not prewarmer coverage.

This PR:

- Adds dedicated `PreBlockCacheAccountHits/Misses` and `PreBlockCacheStorageHits/Misses` counters, incremented at the pre-block wrapper probe. They are batched through the existing `LocalMetrics` per-scope accumulator (no new hot-path contention) with the standard main/other thread split, and exported as Prometheus counters — giving live nodes a true prewarm-coverage metric for the first time.
- Changes the slow-block JSON `cache.account`/`cache.storage` sections to report `hits`/`misses`/`hit_rate` from these first-touch-only counters (identical semantics to the `PrewarmerGetTime` detailed-metric histogram), and adds a `repeat_hits` field carrying the change-dict layer so the old aggregate stays derivable. When the prewarmer scope is absent (`PreWarmStateOnBlockProcessing=false`), the previous behavior is kept unchanged.
- Removes the wrapper's duplicate `StorageTreeReads` increment. Note for dashboard users: the public `StorageTreeReads` counter drops by the previously double-counted fraction (~10% on flat mainnet nodes) — this is the artifact disappearing, not a workload change.

## Proof

Validated against an independent per-read tracing instrument (a diagnostic branch that records every main-thread state ask with the exact cache layer that served it) on the **same benchmark execution** — one EXPB flat/realblocks run (`amount=100`, 229 blocks processed) with both the tracer and `--Blocks.SlowBlockThresholdMs=0` enabled, then a per-block join of the JSON against the trace:

| JSON field | agreement with per-read trace |
| --- | --- |
| `account.hits` | exact on 229/229 blocks |
| `storage.hits` | exact on 229/229 blocks |
| `storage.misses` | exact on 229/229 blocks |
| `account.repeat_hits`, `storage.repeat_hits` | exact on 229/229 blocks |
| `account.misses` | constant +1/block (bracketing: the stats window includes the post-execution commit phase, where one account read per block passes the wrapper outside the tracer's window) |

Aggregates over the same 229 blocks — old formula vs fixed, identical execution:

| | old (blended) | fixed (first-touch) |
| --- | --- | --- |
| account hit rate | 68.1% | **95.3%** (97,568 hits / 4,772 misses; 121,279 repeat_hits) |
| storage hit rate | 70.4% | **88.9%** (265,776 hits / 33,324 misses; 446,852 repeat_hits) |

Verification run: https://github.com/NethermindEth/nethermind/actions/runs/29094441536 (branch `diag/readtrace`, which is this change plus the tracing instrument).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`SlowBlockIntegrationTests`: two new tests cover the layered path (first-touch-only `hits`/`misses`/`hit_rate` with `repeat_hits` present and exact) and the fallback path (prewarmer scope absent → legacy semantics, no `repeat_hits`). All existing SlowBlock and ProcessingStats tests pass. Beyond unit tests, the change was cross-validated per block against an independent per-read trace on a full EXPB run (see Proof).

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [x] Yes

`StorageTreeReads` no longer double-counts fully-cold storage reads on nodes with state prewarming enabled; the counter drops by the previously double-counted fraction (~10% on flat-layout mainnet), and the slow-block JSON field `state_reads.storage_slots` drops by the same amount for the same reason. New counters `PreBlockCacheAccountHits/Misses`, `PreBlockCacheStorageHits/Misses` report pre-block (prewarmer-shared) cache coverage of first-in-block state reads (consumer scope only; populator probes excluded).
