### PR TITLE
ci: pin linode-github-runner action to a commit SHA

### DIFF
--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -126,7 +126,7 @@ jobs:
           private-key: ${{ secrets.ADMIN_APP_PRIVATE_KEY }}
 
       - name: Create a Runner
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@beff87008ecb464ee3c142d1b59921abf51ab886
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ steps.gh-app.outputs.token }}"
@@ -347,7 +347,7 @@ jobs:
 
       - name: Destroy VM (make sure is removed)
         continue-on-error: true
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@beff87008ecb464ee3c142d1b59921abf51ab886
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ steps.gh-app.outputs.token }}"
@@ -359,7 +359,7 @@ jobs:
           repo_name: "nethermind"
 
       - name: Destroy Runner
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@beff87008ecb464ee3c142d1b59921abf51ab886
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ steps.gh-app.outputs.token }}"

--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Create a Runner
         id: run-linode-action
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@beff87008ecb464ee3c142d1b59921abf51ab886
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ steps.gh-app.outputs.token }}"
@@ -432,7 +432,7 @@ jobs:
       - name: Destroy VM
         if: always()
         id: run-linode-action
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@beff87008ecb464ee3c142d1b59921abf51ab886
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ secrets.REPOSITORY_DISPATCH_TOKEN }}"
@@ -460,7 +460,7 @@ jobs:
           private-key: ${{ secrets.ADMIN_APP_PRIVATE_KEY }}
 
       - name: Destroy VM (make sure is removed)
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@beff87008ecb464ee3c142d1b59921abf51ab886
         continue-on-error: true
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
@@ -473,7 +473,7 @@ jobs:
           repo_name: "nethermind"
 
       - name: Destroy Runner
-        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@main
+        uses: kamilchodola/linode-github-runner/.github/actions/linode-machine-manager@beff87008ecb464ee3c142d1b59921abf51ab886
         with:
           linode_token: ${{ secrets.LINODE_TOKEN }}
           github_token: "${{ steps.gh-app.outputs.token }}"


### PR DESCRIPTION
## Changes

- Pin every reference to the third-party composite action `kamilchodola/linode-github-runner/.github/actions/linode-machine-manager` from the mutable `@main` branch to the commit SHA `beff87008ecb464ee3c142d1b59921abf51ab886` (current `main`).
- Affected references: 3 in `.github/workflows/sync-master-validation.yml`, 4 in `.github/workflows/sync-supported-chains.yml` (7 total).

Why: `@main` is a moving target — any push to the upstream repository silently changes what runs in these workflows, so CI behavior is not reproducible and can break (or change) without any change on our side. Pinning to an immutable commit SHA makes these runs deterministic and upgrades explicit. This matches how the repository already pins some other third-party actions (e.g. Trivy, CodeQL upload) to SHAs.

No behavioral change: `beff8700` is the current tip of `main`, so this pins the exact revision running today. A future bump is a one-line SHA change.

## Types of changes

#### What types of changes does your code introduce?

- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Pure `uses:` ref change; no workflow logic altered. The pinned SHA is the current `main` tip, so the resolved action is byte-identical to what runs today.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No