### PR TITLE
ci: set explicit read-only token permissions on build and test workflows

### DIFF
--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -18,6 +18,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Run ${{ matrix.project }} [${{ matrix.variant.label }}]

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -15,6 +15,9 @@ env:
   TERM: xterm
   TEST_USE_FLAT: 1
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -25,6 +25,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }} (${{ matrix.runner }})

--- a/.github/workflows/stateless-tests.yml
+++ b/.github/workflows/stateless-tests.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
## Changes

Add an explicit top-level `permissions:` block scoping the `GITHUB_TOKEN` to `contents: read` on the workflows that only check out, build, and test the repository:

- `nethermind-tests.yml`
- `nethermind-tests-flat.yml`
- `nethermind-tests-checked.yml`
- `build-solutions.yml`
- `build-tools.yml`
- `stateless-tests.yml`

Why: when a workflow declares no `permissions:` block, the `GITHUB_TOKEN` inherits the repository/organization default scope, which is decided outside the file and is broader than these jobs need. Declaring the scope explicitly makes each workflow self-describing (the token it gets is visible in the file, not inferred from a global setting) and is the GitHub Actions recommended default. It follows the pattern already used elsewhere in the repo (e.g. `sync-pr-gate.yml` uses `permissions: contents: read`, and `code-lint.yml`/`spellcheck.yml`/`code-formatting.yml` scope per job).

Scope: limited to workflows verified to perform no write operations (no `git push`, no `gh pr`/`gh release`, no PR comments, no package publishing). The coverage upload in `nethermind-tests.yml` uses `CODECOV_TOKEN` (a repo secret), not the `GITHUB_TOKEN`, so `contents: read` is sufficient. Workflows that genuinely need write scopes are intentionally left untouched.

## Types of changes

#### What types of changes does your code introduce?

- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Additive change. `contents: read` grants exactly what `actions/checkout` needs; the only observable failure mode would be a job that actually required a write scope, which was ruled out per the scope note above. Confirmed by a green run of each workflow on this PR.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No