### PR TITLE
ci: add concurrency guard to sync-master-validation and a timeout to hive tests

### DIFF
--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -91,6 +91,7 @@ jobs:
     name: Build and run tests (${{ matrix.name || matrix.suite }})
     needs: setup
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -35,7 +35,7 @@ env:
   TERM: xterm
 
 concurrency:
-  group: sync-master-validation
+  group: sync-master-validation-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -34,6 +34,10 @@ env:
   DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "1"
   TERM: xterm
 
+concurrency:
+  group: sync-master-validation
+  cancel-in-progress: true
+
 jobs:
   setup-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

- **`sync-master-validation.yml`**: add a `concurrency` group (`group: sync-master-validation`, `cancel-in-progress: true`). This workflow triggers on every completion of *Publish Docker image* on `master`, and always validates the current `master` image. Without a concurrency guard, several closely-spaced `master` merges queue overlapping, long-running validations on self-hosted capacity even though only the most recent image is meaningful. The guard supersedes an in-flight validation when a newer `master` image is published.
- **`hive-tests.yml`**: add `timeout-minutes: 60` to the `test` job. It previously had no explicit timeout and fell back to the GitHub default of 360 minutes, so a hung Docker build or Hive simulation could hold a runner for six hours. 60 minutes comfortably covers a normal run while bounding the failure case, matching the bounded timeouts used in the `nethermind-tests*` workflows.

## Types of changes

#### What types of changes does your code introduce?

- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Both changes are additive workflow metadata. The concurrency group only affects how overlapping `sync-master-validation` runs are scheduled; the timeout only caps a stuck `hive-tests` run. Neither alters job logic. Chosen the single concurrency group because the workflow always validates `master` (a per-ref group would be pointless here).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No