### PR TITLE
ci: unify Taiko and Surge integration workflows into a reusable workflow

### DIFF
--- a/.github/workflows/ci-l2-integration.yml
+++ b/.github/workflows/ci-l2-integration.yml
@@ -1,0 +1,186 @@
+name: L2 integration tests
+
+on:
+  workflow_call:
+    inputs:
+      mono-repo:
+        description: taiko-mono-style repository providing the taiko-client integration suite.
+        required: true
+        type: string
+      mono-dir:
+        description: Directory to check the mono repo out into.
+        required: true
+        type: string
+      main-ref:
+        description: Ref of the mono repo to check out.
+        required: true
+        type: string
+      pacaya-ref:
+        description: Ref of the Pacaya protocol fork.
+        required: true
+        type: string
+      shasta-ref:
+        description: Ref of the Shasta protocol fork.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  integration_tests:
+    if: >-
+      ${{ github.event.pull_request.draft == false
+      && !startsWith(github.head_ref, 'release-please') }}
+    name: Integration tests
+    runs-on: [ubuntu-latest]
+    timeout-minutes: 20
+    env:
+      MONO_DIR: ${{ inputs.mono-dir }}
+      PACAYA_FORK_TAIKO_MONO_DIR: pacaya-fork-taiko-mono
+      SHASTA_FORK_TAIKO_MONO_DIR: shasta-fork-taiko-mono
+
+    steps:
+      - name: Checkout Nethermind
+        uses: actions/checkout@v6
+
+      - name: Checkout mono repo
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.mono-repo }}
+          path: ${{ env.MONO_DIR }}
+          ref: ${{ inputs.main-ref }}
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: ${{ env.MONO_DIR }}/go.mod
+          cache: true
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: ${{ env.MONO_DIR }}/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: ${{ env.MONO_DIR }}
+        shell: bash
+        run: pnpm install
+
+      - name: Checkout Pacaya fork
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.mono-repo }}
+          path: >-
+            ${{ format('{0}/{1}', env.MONO_DIR,
+            env.PACAYA_FORK_TAIKO_MONO_DIR) }}
+          ref: ${{ inputs.pacaya-ref }}
+
+      - name: Checkout Shasta fork
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.mono-repo }}
+          path: >-
+            ${{ format('{0}/{1}', env.MONO_DIR,
+            env.SHASTA_FORK_TAIKO_MONO_DIR) }}
+          ref: ${{ inputs.shasta-ref }}
+
+      - name: Install pnpm dependencies for pacaya fork taiko-mono
+        working-directory: >-
+          ${{ format('{0}/{1}', env.MONO_DIR,
+          env.PACAYA_FORK_TAIKO_MONO_DIR) }}
+        run: cd ./packages/protocol && pnpm install
+
+      - name: Install pnpm dependencies for shasta fork taiko-mono
+        working-directory: >-
+          ${{ format('{0}/{1}', env.MONO_DIR,
+          env.SHASTA_FORK_TAIKO_MONO_DIR) }}
+        run: cd ./packages/protocol && pnpm install
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Docker Build Nethermind Client
+        run: |
+          image_name="nethermindeth/nethermind"
+          image_tag="${GITHUB_SHA:0:8}"
+          full_image="${image_name}:${image_tag}"
+
+          echo "Building Docker image: ${full_image}"
+
+          docker buildx build . \
+            --platform linux/amd64 \
+            -f Dockerfile \
+            -t "${full_image}" \
+            --load \
+            --build-arg BUILD_CONFIG=release \
+            --build-arg CI=true \
+            --build-arg COMMIT_HASH=${{ github.sha }} \
+            --build-arg SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+
+          echo "IMAGE_TAG=${full_image}" >> $GITHUB_ENV
+
+          echo "Verifying image exists locally:"
+          docker images | grep "${image_name}" | grep "${image_tag}" || (echo "Error: Image not found locally" && exit 1)
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Update taiko-client docker-compose.yml with new image
+        working-directory: >-
+          ${{ env.MONO_DIR }}/packages/taiko-client/internal/docker/nodes
+        run: |
+          docker_compose_file="docker-compose.yml"
+          if [ -f "$docker_compose_file" ]; then
+            echo "Current image in docker-compose.yml:"
+            yq eval '.services.l2_nmc.image' "$docker_compose_file"
+
+            echo "Updating docker-compose.yml with image: ${IMAGE_TAG}"
+            yq eval '.services.l2_nmc.image = "'"${IMAGE_TAG}"'"' -i "$docker_compose_file"
+
+            yq eval '.services.l2_nmc.pull_policy = "never"' -i "$docker_compose_file"
+
+            yq eval '.services.l2_nmc.command += ["--JsonRpc.StrictHexFormat", "false"]' -i "$docker_compose_file"
+
+            echo "Updated image in docker-compose.yml:"
+            yq eval '.services.l2_nmc.image' "$docker_compose_file"
+
+            echo "Pull policy set to:"
+            yq eval '.services.l2_nmc.pull_policy' "$docker_compose_file"
+          else
+            echo "Warning: docker-compose.yml not found at expected path"
+            exit 1
+          fi
+
+      - name: Run integration tests
+        timeout-minutes: 15
+        working-directory: >-
+          ${{ env.MONO_DIR }}/packages/taiko-client
+        env:
+          L2_NODE: l2_nmc
+        run: >-
+          SHASTA_FORK_TAIKO_MONO=${GITHUB_WORKSPACE}/${{ format('{0}/{1}', env.MONO_DIR, env.SHASTA_FORK_TAIKO_MONO_DIR) }}
+          PACAYA_FORK_TAIKO_MONO=${GITHUB_WORKSPACE}/${{ format('{0}/{1}', env.MONO_DIR, env.PACAYA_FORK_TAIKO_MONO_DIR) }}
+          make test
+
+      - name: Codecov.io
+        uses: codecov/codecov-action@v5
+        with:
+          files: ${{ env.MONO_DIR }}/packages/taiko-client/coverage.out
+          flags: taiko-client
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-surge.yml
+++ b/.github/workflows/ci-surge.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "src/Nethermind/Nethermind.Taiko/**"
       - ".github/workflows/ci-surge.yml"
+      - ".github/workflows/ci-l2-integration.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,158 +14,11 @@ concurrency:
 
 jobs:
   integration_tests:
-    if: >-
-      ${{ github.event.pull_request.draft == false
-      && !startsWith(github.head_ref, 'release-please') }}
-    name: Integration tests
-    runs-on: [ubuntu-latest]
-    timeout-minutes: 20
-    env:
-      SURGE_TAIKO_MONO_DIR: surge-taiko-mono
-      PACAYA_FORK_TAIKO_MONO_DIR: pacaya-fork-taiko-mono
-      SHASTA_FORK_TAIKO_MONO_DIR: shasta-fork-taiko-mono
-
-    steps:
-      - name: Checkout Nethermind
-        uses: actions/checkout@v6
-
-      - name: Checkout surge-taiko-mono
-        uses: actions/checkout@v6
-        with:
-          repository: NethermindEth/surge-taiko-mono
-          path: ${{ env.SURGE_TAIKO_MONO_DIR }}
-          ref: surge-shasta
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: ${{ env.SURGE_TAIKO_MONO_DIR }}/go.mod
-          cache: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: ${{ env.SURGE_TAIKO_MONO_DIR }}/pnpm-lock.yaml
-
-      - name: Install dependencies
-        working-directory: ${{ env.SURGE_TAIKO_MONO_DIR }}
-        shell: bash
-        run: pnpm install
-
-      - name: Checkout Pacaya fork
-        uses: actions/checkout@v6
-        with:
-          repository: NethermindEth/surge-taiko-mono
-          path: >-
-            ${{ format('{0}/{1}', env.SURGE_TAIKO_MONO_DIR,
-            env.PACAYA_FORK_TAIKO_MONO_DIR) }}
-          ref: jmadibekov/pacaya-dummy-verifiers-fix
-
-      - name: Checkout Shasta fork
-        uses: actions/checkout@v6
-        with:
-          repository: NethermindEth/surge-taiko-mono
-          path: >-
-            ${{ format('{0}/{1}', env.SURGE_TAIKO_MONO_DIR,
-            env.SHASTA_FORK_TAIKO_MONO_DIR) }}
-          ref: surge-alethia-protocol-v3.0.0
-
-      - name: Install pnpm dependencies for pacaya fork taiko-mono
-        working-directory: >-
-          ${{ format('{0}/{1}', env.SURGE_TAIKO_MONO_DIR,
-          env.PACAYA_FORK_TAIKO_MONO_DIR) }}
-        run: cd ./packages/protocol && pnpm install
-
-      - name: Install pnpm dependencies for shasta fork taiko-mono
-        working-directory: >-
-          ${{ format('{0}/{1}', env.SURGE_TAIKO_MONO_DIR,
-          env.SHASTA_FORK_TAIKO_MONO_DIR) }}
-        run: cd ./packages/protocol && pnpm install
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Docker Build Nethermind Client
-        run: |
-          image_name="nethermindeth/nethermind"
-          image_tag="${GITHUB_SHA:0:8}"
-          full_image="${image_name}:${image_tag}"
-
-          echo "Building Docker image: ${full_image}"
-
-          docker buildx build . \
-            --platform linux/amd64 \
-            -f Dockerfile \
-            -t "${full_image}" \
-            --load \
-            --build-arg BUILD_CONFIG=release \
-            --build-arg CI=true \
-            --build-arg COMMIT_HASH=${{ github.sha }} \
-            --build-arg SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
-
-          echo "IMAGE_TAG=${full_image}" >> $GITHUB_ENV
-
-          echo "Verifying image exists locally:"
-          docker images | grep "${image_name}" | grep "${image_tag}" || (echo "Error: Image not found locally" && exit 1)
-
-      - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
-          yq --version
-
-      - name: Update taiko-client docker-compose.yml with new image
-        working-directory: >-
-          ${{ env.SURGE_TAIKO_MONO_DIR }}/packages/taiko-client/internal/docker/nodes
-        run: |
-          docker_compose_file="docker-compose.yml"
-          if [ -f "$docker_compose_file" ]; then
-            echo "Current image in docker-compose.yml:"
-            yq eval '.services.l2_nmc.image' "$docker_compose_file"
-
-            echo "Updating docker-compose.yml with image: ${IMAGE_TAG}"
-            yq eval '.services.l2_nmc.image = "'"${IMAGE_TAG}"'"' -i "$docker_compose_file"
-
-            yq eval '.services.l2_nmc.pull_policy = "never"' -i "$docker_compose_file"
-
-            yq eval '.services.l2_nmc.command += ["--JsonRpc.StrictHexFormat", "false"]' -i "$docker_compose_file"
-
-            echo "Updated image in docker-compose.yml:"
-            yq eval '.services.l2_nmc.image' "$docker_compose_file"
-
-            echo "Pull policy set to:"
-            yq eval '.services.l2_nmc.pull_policy' "$docker_compose_file"
-          else
-            echo "Warning: docker-compose.yml not found at expected path"
-            exit 1
-          fi
-
-      - name: Run integration tests
-        timeout-minutes: 15
-        working-directory: >-
-          ${{ env.SURGE_TAIKO_MONO_DIR }}/packages/taiko-client
-        env:
-          L2_NODE: l2_nmc
-        run: >-
-          SHASTA_FORK_TAIKO_MONO=${GITHUB_WORKSPACE}/${{ format('{0}/{1}', env.SURGE_TAIKO_MONO_DIR, env.SHASTA_FORK_TAIKO_MONO_DIR) }}
-          PACAYA_FORK_TAIKO_MONO=${GITHUB_WORKSPACE}/${{ format('{0}/{1}', env.SURGE_TAIKO_MONO_DIR, env.PACAYA_FORK_TAIKO_MONO_DIR) }}
-          make test
-
-      - name: Codecov.io
-        uses: codecov/codecov-action@v5
-        with:
-          files: ${{ env.SURGE_TAIKO_MONO_DIR }}/packages/taiko-client/coverage.out
-          flags: taiko-client
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    uses: ./.github/workflows/ci-l2-integration.yml
+    secrets: inherit
+    with:
+      mono-repo: NethermindEth/surge-taiko-mono
+      mono-dir: surge-taiko-mono
+      main-ref: surge-shasta
+      pacaya-ref: jmadibekov/pacaya-dummy-verifiers-fix
+      shasta-ref: surge-alethia-protocol-v3.0.0

--- a/.github/workflows/ci-taiko.yml
+++ b/.github/workflows/ci-taiko.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "src/Nethermind/Nethermind.Taiko/**"
       - ".github/workflows/ci-taiko.yml"
+      - ".github/workflows/ci-l2-integration.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,158 +14,11 @@ concurrency:
 
 jobs:
   integration_tests:
-    if: >-
-      ${{ github.event.pull_request.draft == false
-      && !startsWith(github.head_ref, 'release-please') }}
-    name: Integration tests
-    runs-on: [ubuntu-latest]
-    timeout-minutes: 20
-    env:
-      TAIKO_MONO_DIR: taiko-mono
-      PACAYA_FORK_TAIKO_MONO_DIR: pacaya-fork-taiko-mono
-      SHASTA_FORK_TAIKO_MONO_DIR: shasta-fork-taiko-mono
-
-    steps:
-      - name: Checkout Nethermind
-        uses: actions/checkout@v6
-
-      - name: Checkout taiko-mono
-        uses: actions/checkout@v6
-        with:
-          repository: taikoxyz/taiko-mono
-          path: ${{ env.TAIKO_MONO_DIR }}
-          ref: main
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: ${{ env.TAIKO_MONO_DIR }}/go.mod
-          cache: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: ${{ env.TAIKO_MONO_DIR }}/pnpm-lock.yaml
-
-      - name: Install dependencies
-        working-directory: ${{ env.TAIKO_MONO_DIR }}
-        shell: bash
-        run: pnpm install
-
-      - name: Checkout Pacaya fork
-        uses: actions/checkout@v6
-        with:
-          repository: taikoxyz/taiko-mono
-          path: >-
-            ${{ format('{0}/{1}', env.TAIKO_MONO_DIR,
-            env.PACAYA_FORK_TAIKO_MONO_DIR) }}
-          ref: taiko-alethia-protocol-v2.3.0-devnet-shasta-test
-
-      - name: Checkout Shasta fork
-        uses: actions/checkout@v6
-        with:
-          repository: taikoxyz/taiko-mono
-          path: >-
-            ${{ format('{0}/{1}', env.TAIKO_MONO_DIR,
-            env.SHASTA_FORK_TAIKO_MONO_DIR) }}
-          ref: taiko-alethia-protocol-v3.0.0
-
-      - name: Install pnpm dependencies for pacaya fork taiko-mono
-        working-directory: >-
-          ${{ format('{0}/{1}', env.TAIKO_MONO_DIR,
-          env.PACAYA_FORK_TAIKO_MONO_DIR) }}
-        run: cd ./packages/protocol && pnpm install
-
-      - name: Install pnpm dependencies for shasta fork taiko-mono
-        working-directory: >-
-          ${{ format('{0}/{1}', env.TAIKO_MONO_DIR,
-          env.SHASTA_FORK_TAIKO_MONO_DIR) }}
-        run: cd ./packages/protocol && pnpm install
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Docker Build Nethermind Client
-        run: |
-          image_name="nethermindeth/nethermind"
-          image_tag="${GITHUB_SHA:0:8}"
-          full_image="${image_name}:${image_tag}"
-
-          echo "Building Docker image: ${full_image}"
-
-          docker buildx build . \
-            --platform linux/amd64 \
-            -f Dockerfile \
-            -t "${full_image}" \
-            --load \
-            --build-arg BUILD_CONFIG=release \
-            --build-arg CI=true \
-            --build-arg COMMIT_HASH=${{ github.sha }} \
-            --build-arg SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
-
-          echo "IMAGE_TAG=${full_image}" >> $GITHUB_ENV
-
-          echo "Verifying image exists locally:"
-          docker images | grep "${image_name}" | grep "${image_tag}" || (echo "Error: Image not found locally" && exit 1)
-
-      - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
-          yq --version
-
-      - name: Update taiko-client docker-compose.yml with new image
-        working-directory: >-
-          ${{ env.TAIKO_MONO_DIR }}/packages/taiko-client/internal/docker/nodes
-        run: |
-          docker_compose_file="docker-compose.yml"
-          if [ -f "$docker_compose_file" ]; then
-            echo "Current image in docker-compose.yml:"
-            yq eval '.services.l2_nmc.image' "$docker_compose_file"
-
-            echo "Updating docker-compose.yml with image: ${IMAGE_TAG}"
-            yq eval '.services.l2_nmc.image = "'"${IMAGE_TAG}"'"' -i "$docker_compose_file"
-
-            yq eval '.services.l2_nmc.pull_policy = "never"' -i "$docker_compose_file"
-
-            yq eval '.services.l2_nmc.command += ["--JsonRpc.StrictHexFormat", "false"]' -i "$docker_compose_file"
-
-            echo "Updated image in docker-compose.yml:"
-            yq eval '.services.l2_nmc.image' "$docker_compose_file"
-
-            echo "Pull policy set to:"
-            yq eval '.services.l2_nmc.pull_policy' "$docker_compose_file"
-          else
-            echo "Warning: docker-compose.yml not found at expected path"
-            exit 1
-          fi
-
-      - name: Run integration tests
-        timeout-minutes: 15
-        working-directory: >-
-          ${{ env.TAIKO_MONO_DIR }}/packages/taiko-client
-        env:
-          L2_NODE: l2_nmc
-        run: >-
-          SHASTA_FORK_TAIKO_MONO=${GITHUB_WORKSPACE}/${{ format('{0}/{1}', env.TAIKO_MONO_DIR, env.SHASTA_FORK_TAIKO_MONO_DIR) }}
-          PACAYA_FORK_TAIKO_MONO=${GITHUB_WORKSPACE}/${{ format('{0}/{1}', env.TAIKO_MONO_DIR, env.PACAYA_FORK_TAIKO_MONO_DIR) }}
-          make test
-
-      - name: Codecov.io
-        uses: codecov/codecov-action@v5
-        with:
-          files: ${{ env.TAIKO_MONO_DIR }}/packages/taiko-client/coverage.out
-          flags: taiko-client
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    uses: ./.github/workflows/ci-l2-integration.yml
+    secrets: inherit
+    with:
+      mono-repo: taikoxyz/taiko-mono
+      mono-dir: taiko-mono
+      main-ref: main
+      pacaya-ref: taiko-alethia-protocol-v2.3.0-devnet-shasta-test
+      shasta-ref: taiko-alethia-protocol-v3.0.0


### PR DESCRIPTION
## Changes

`ci-taiko.yml` and `ci-surge.yml` were ~170-line workflows that were identical except for five values. This extracts the shared body into a reusable workflow and reduces each caller to its distinguishing inputs.

- **New** `ci-l2-integration.yml` — a `workflow_call` reusable workflow containing the full integration-test job (checkout mono repo + Pacaya/Shasta forks, Foundry/Go/pnpm/Node setup, Docker build, `docker-compose` image swap, `make test`, Codecov). Parameterized by five inputs: `mono-repo`, `mono-dir`, `main-ref`, `pacaya-ref`, `shasta-ref`.
- **`ci-taiko.yml`** — now a thin caller passing the Taiko values (`taikoxyz/taiko-mono`, `taiko-mono`, `main`, `taiko-alethia-protocol-v2.3.0-devnet-shasta-test`, `taiko-alethia-protocol-v3.0.0`).
- **`ci-surge.yml`** — thin caller passing the Surge values (`NethermindEth/surge-taiko-mono`, `surge-taiko-mono`, `surge-shasta`, `jmadibekov/pacaya-dummy-verifiers-fix`, `surge-alethia-protocol-v3.0.0`).

Each caller keeps its own `pull_request` trigger, path filter, and `concurrency` group, so the two suites still run independently and cancel per ref. The path filter of each caller additionally watches `ci-l2-integration.yml`, so a change to the shared workflow re-runs both suites. Secrets reach the reusable workflow via `secrets: inherit` (only `CODECOV_TOKEN` is used).

Every value is preserved exactly, so behavior is unchanged for both suites. The internal env var was renamed `TAIKO_MONO_DIR`/`SURGE_TAIKO_MONO_DIR` → `MONO_DIR` (referenced only within the workflow). The two `shellcheck` findings actionlint reports in the `Docker Build` step are pre-existing on `master` and were copied verbatim (this PR does not change that step).

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

This PR modifies the workflow files that are in both callers' path filters, so opening it triggers both the Taiko and Surge integration suites against the reusable workflow — the change is self-exercising here. Reviewer to confirm both suites reach and complete `make test` as before. Diffing the rendered step sequence against `master`'s `ci-taiko.yml` shows the only step-name change is the generalized `Checkout taiko-mono` → `Checkout mono repo`; all other steps are identical.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No