### PR TITLE
ci: chunk the wall-clock-critical test legs

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -102,6 +102,9 @@ jobs:
           - runner: ubuntu-24.04-arm
             project: Nethermind.Synchronization.Test
             chunk: ''
+          - runner: ubuntu-latest
+            project: Nethermind.Synchronization.Test
+            chunk: ''
         include: # macOS only for OS-sensitive tests (I/O, networking, sockets)
           - { runner: macos-latest, project: Nethermind.Db.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.JsonRpc.Test, chunk: '' }
@@ -120,6 +123,10 @@ jobs:
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 2of4 }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 3of4 }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 4of4 }
+          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 1of4 }
+          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
+          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
+          - { runner: ubuntu-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
           - { runner: windows-latest, project: Nethermind.Db.Test, chunk: '' }
           - { runner: windows-latest, project: Nethermind.JsonRpc.Test, chunk: '' }
           - { runner: windows-latest, project: Nethermind.KeyStore.Test, chunk: '' }

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -98,7 +98,7 @@ jobs:
           - Nethermind.Wallet.Test
           - Nethermind.Xdc.Test
         chunk: ['']
-        exclude: # Synchronization.Test on ARM/macOS is chunked (see include block) — its unchunked variant hits the 15-min wall.
+        exclude: # Synchronization.Test is chunked on every runner (see include block) — its unchunked variant hits the 15-min wall.
           - runner: ubuntu-24.04-arm
             project: Nethermind.Synchronization.Test
             chunk: ''

--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -218,10 +218,10 @@ jobs:
                   # Chunk counts are sized to keep every job under ~8 min wall (measured):
                   # engineTest fixtures run ~2x slower than blockTest, so engine gets more.
                   if [ "$type" = "engineTest" ]; then
-                    emit "$type" sequential   full      '' false false 4 5
-                    emit "$type" parallel     amsterdam '' true  false 1 2
+                    emit "$type" sequential   full      '' false false 4 7
+                    emit "$type" parallel     amsterdam '' true  false 1 4
                     emit "$type" batchread    amsterdam '' false true  4 2
-                    emit "$type" parallelfull amsterdam '' true  true  1 2
+                    emit "$type" parallelfull amsterdam '' true  true  1 4
                   else
                     emit "$type" sequential   full      '' false false 4 4
                     emit "$type" parallel     amsterdam '' true  false 1 1


### PR DESCRIPTION
## Changes

Chunk the two execution-bound test legs that set the wall-clock floor on the PR test critical path. Measured on a real `nethermind-tests.yml` run: total wall-clock ~21 min, slowest single leg ~9 min, so shortening the slowest legs lowers the achievable floor.

- **`nethermind-tests.yml` — chunk `Nethermind.Synchronization.Test` on `ubuntu-latest` (x64).** It ran unchunked on x64 (the file comment notes the unchunked variant "hits the 15-min wall"); `ubuntu-24.04-arm` and `macos-latest` were already 4-way chunked. This adds the same `1of4..4of4` split on x64. (Windows's `Synchronization` chunking is handled in the separate Windows-subset PR #12379, so this PR touches only Linux runners.)
- **`run-nethtest.yml` — rebalance the `engineTest` (non-flat `sequential` group) chunk counts.** `parallel`/`parallelfull` were the measured ~9-min slowest legs at 2 chunks each → raised to 4; `sequential` 5 → 7. These variants run at 1 worker (`parallel`/`parallelfull`), so more chunks means fewer fixtures per chunk with no extra memory pressure. The memory-tuned `flat_*` group (used by `nethermind-tests-flat.yml`) is unchanged.

Pure test-distribution change — the same tests run, split across more jobs so the longest job is shorter.

Rebased onto current `master` (post #12371 build-once restructure and #12379, which is now merged and already covers the Windows `Synchronization` chunking) — this PR carries only the remaining delta: the x64 `Synchronization` chunks and the `engineTest` rebalance.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

This PR triggers `nethermind-tests.yml` / `run-nethtest.yml`, so its own CI run exercises the new chunking. Same fixtures/tests run — only the chunk boundaries move (chunking already proven for these projects on ARM/macOS).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

---

## Results (measured on this PR's CI run)

Targeted execution-bound legs, before vs after:

| Leg | Before | After |
|-----|--------|-------|
| `Synchronization.Test` (ubuntu-latest x64) | unchunked, near the 15-min wall | ~3 min (4-way) |
| `engineTest parallel` / `parallelfull` | ~9 min (`1of2`) | ~5–6 min (`1of4`) |
| `engineTest sequential` | ~6–7 min (5 chunks) | ~5 min (7 chunks) |

The ~9-min floor legs are eliminated; the workflow's new slowest legs (~7 min) are build-bound (`TxPool.Test` on Windows, `blockTest 1of1`) and are addressed by other changes (Windows subset / build-once), not chunking. Total wall-clock also depends on runner-pool queueing (varies with concurrent load), so the reliable signal is the per-leg drop above.

