### PR TITLE
ci: run the full unit suite on Linux only; Windows to the OS-sensitive subset

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -40,7 +40,6 @@ jobs:
         runner:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - windows-latest
         project:
           - Nethermind.Abi.Test
           - Nethermind.Api.Test
@@ -92,7 +91,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             project: Nethermind.Synchronization.Test
             chunk: ''
-        include: # macOS only for OS-sensitive tests (I/O, networking, sockets)
+        include: # macOS and windows-latest run only the OS-sensitive subset (I/O, networking, sockets); the full suite runs on Linux (x64 + arm64)
           - { runner: macos-latest, project: Nethermind.Db.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.JsonRpc.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.KeyStore.Test, chunk: '' }
@@ -110,6 +109,19 @@ jobs:
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 2of4 }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 3of4 }
           - { runner: ubuntu-24.04-arm, project: Nethermind.Synchronization.Test, chunk: 4of4 }
+          - { runner: windows-latest, project: Nethermind.Db.Test, chunk: '' }
+          - { runner: windows-latest, project: Nethermind.JsonRpc.Test, chunk: '' }
+          - { runner: windows-latest, project: Nethermind.KeyStore.Test, chunk: '' }
+          - { runner: windows-latest, project: Nethermind.Network.Discovery.Test, chunk: '' }
+          - { runner: windows-latest, project: Nethermind.Network.Dns.Test, chunk: '' }
+          - { runner: windows-latest, project: Nethermind.Network.Enr.Test, chunk: '' }
+          - { runner: windows-latest, project: Nethermind.Network.Test, chunk: '' }
+          - { runner: windows-latest, project: Nethermind.Runner.Test, chunk: '' }
+          - { runner: windows-latest, project: Nethermind.Sockets.Test, chunk: '' }
+          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 1of4 }
+          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
+          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
+          - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -91,7 +91,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             project: Nethermind.Synchronization.Test
             chunk: ''
-        include: # macOS and windows-latest run only the OS-sensitive subset (I/O, networking, sockets); the full suite runs on Linux (x64 + arm64)
+        include: # macOS only for OS-sensitive tests (I/O, networking, sockets)
           - { runner: macos-latest, project: Nethermind.Db.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.JsonRpc.Test, chunk: '' }
           - { runner: macos-latest, project: Nethermind.KeyStore.Test, chunk: '' }


### PR DESCRIPTION
## Changes

Restrict `windows-latest` in the `tests` job to the same OS-sensitive project subset that `macos-latest` already uses, instead of running the full 44-project unit matrix on Windows. `windows-latest` becomes include-only (the existing macOS pattern); the exhaustive unit suite continues to run on Linux (ubuntu-latest x64 + ubuntu-24.04-arm).

Windows now runs: `Db`, `JsonRpc`, `KeyStore`, `Network.Discovery`, `Network.Dns`, `Network.Enr`, `Network`, `Runner`, `Sockets`, and `Synchronization` (4-way chunked) — the same set macOS runs.

**Based on `master`, independent of #12378** — both can merge in either order. The only overlap is the `nethermind-tests.yml` matrix `include` list; a merge keeps both PRs' entries (trivial "keep-both", not a real conflict). This PR owns all Windows handling, including Windows's `Synchronization` chunking; #12378 owns the Linux `Synchronization` and `engineTest` chunking.

Measured motivation (real `nethermind-tests.yml` run): 244 jobs, ~12 of the ~21-min wall-clock is runner-pool queue wait. Windows ran all 44 projects (~44 legs, each a ~7-min build-bound leg — measured 433s dominated by `dotnet build`). Trimming to ~13 Windows legs removes ~30 build-bound legs, cutting runner-minute demand on the shared pool — the term that drives the queue wait under load.

Most of the 44 unit-test projects are OS-independent logic (Abi, Evm, Core, Blockchain, RLP, …); the OS-sensitive ones (I/O, filesystem, sockets, networking) are what the team already curated into the macOS `include`. This PR applies that same judgment to Windows. If Windows coverage is wanted for more projects (e.g. `Config`, `Era1`, `Trie` for file/path handling), add them to the Windows `include` — this list is deliberately matched to macOS as a starting point.

Out of scope: the `tests-spec` and `tests-chunked` jobs (EF fixture tests) still run their Windows legs unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Matrix-only change — no test logic altered, same tests run (fewer on Windows). Coverage impact is a policy decision (see above), not a correctness one.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No


---

## Results (measured on this PR's CI run)

Verified on run `29111553873` (master-based) vs the `master` baseline:

| Metric | master | This PR | Δ |
|--------|-------:|--------:|---|
| total jobs (`nethermind-tests.yml`) | ~244 | **212** | −32 |
| `windows-latest` legs (whole workflow) | ~53 | **21** | −32 |
| `windows-latest` unit legs (`tests` job) | ~44 | **13** (9 OS-sensitive + 4 `Synchronization` chunks) | −31 |

The 32 removed legs are each a ~7-min build-bound Windows leg — a direct cut to runner-minute demand, which is what drives queue wait when the pool is contended. Wall-clock on an uncontended run is unchanged (it's already at the per-leg floor); the win shows up as queue relief under load. The remaining Windows legs (`Ethereum.Legacy.Blockchain.Test` chunks) belong to the `tests-chunked` job, intentionally out of scope here.
