### PR TITLE
ci: rebalance blockTest chunk counts to cut wall-clock

### DIFF
--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -182,8 +182,9 @@ jobs:
                   # unfiltered, so the Amsterdam parallel/batch-read variant classes also
                   # ran under the default (patricia) layout — including parallel-full,
                   # which is the production configuration. Mirror that coverage here.
-                  # Chunk counts are sized to keep every job under ~8 min wall (measured):
-                  # engineTest fixtures run ~2x slower than blockTest, so engine gets more.
+                  # Chunk counts are sized per variant by measured wall-clock: the full-scope
+                  # sequential set is the largest so it gets the most chunks, and engineTest
+                  # fixtures run ~2x slower per test than blockTest.
                   if [ "$type" = "engineTest" ]; then
                     emit "$type" sequential   full      '' false false 4 5
                     emit "$type" parallel     amsterdam '' true  false 1 2

--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -190,10 +190,10 @@ jobs:
                     emit "$type" batchread    amsterdam '' false true  4 2
                     emit "$type" parallelfull amsterdam '' true  true  1 2
                   else
-                    emit "$type" sequential   full      '' false false 4 4
-                    emit "$type" parallel     amsterdam '' true  false 1 1
-                    emit "$type" batchread    amsterdam '' false true  4 1
-                    emit "$type" parallelfull amsterdam '' true  true  1 1
+                    emit "$type" sequential   full      '' false false 4 6
+                    emit "$type" parallel     amsterdam '' true  false 1 2
+                    emit "$type" batchread    amsterdam '' false true  4 2
+                    emit "$type" parallelfull amsterdam '' true  true  1 2
                   fi
                 fi
                 if run_flat; then

--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -182,9 +182,8 @@ jobs:
                   # unfiltered, so the Amsterdam parallel/batch-read variant classes also
                   # ran under the default (patricia) layout — including parallel-full,
                   # which is the production configuration. Mirror that coverage here.
-                  # Chunk counts are sized per variant by measured wall-clock: the full-scope
-                  # sequential set is the largest so it gets the most chunks, and engineTest
-                  # fixtures run ~2x slower per test than blockTest.
+                  # Chunk counts are sized to keep every job under ~8 min wall (measured):
+                  # engineTest fixtures run ~2x slower than blockTest, so engine gets more.
                   if [ "$type" = "engineTest" ]; then
                     emit "$type" sequential   full      '' false false 4 5
                     emit "$type" parallel     amsterdam '' true  false 1 2


### PR DESCRIPTION
## Changes

Increase the chunk counts of the `blockTest` (non-flat `sequential` group) variants in `run-nethtest.yml` — the workflow's slowest legs after the `engineTest` rebalance (#12378). Three ran as a single chunk (`1of1`); `sequential` was already `4of4` and is the largest fixture set, so it gets a smaller bump:

- `parallel` 1 → 2 chunks
- `parallelfull` 1 → 2 chunks
- `batchread` 1 → 2 chunks
- `sequential` 4 → 6 chunks

Measured on a recent run (post-#12378): `blockTest parallel 1of1` was ~8 min and `parallelfull`/`batchread 1of1` ~7 min — the new wall-clock floor once `engineTest` was chunked. Splitting them halves the fixtures per chunk. The `parallel`/`parallelfull` variants run at 1 worker (no extra memory pressure from more chunks); the memory-tuned `flat_*` group is left unchanged.

Same pattern as #12378's `engineTest` change, on the sibling `else` branch of the same `case`, so the two merge cleanly. Independent and based on `master`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Triggers `nethermind-tests.yml` (which runs `blockTest` via `run-nethtest.yml`), so its own CI run exercises the new chunking. Same fixtures run — only the chunk boundaries move. Expected: the `blockTest parallel/parallelfull/batchread` legs drop from ~7–8 min to ~4 min. Results will be posted here after the run.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

---

## Results (measured on this PR's CI run)

Verified on run `29111908546` (success, 249 jobs). The `blockTest` legs that were single-chunk on `master` dropped as intended:

| `blockTest` leg | Before (`master`) | After |
|-----------------|------------------:|------:|
| `parallel` | ~8 min (`1of1`) | ~4 min (`1of2`), ~3 min (`2of2`) |
| `parallelfull` | ~7 min (`1of1`) | ~4 min (`1of2`), ~3 min (`2of2`) |
| `batchread` | ~7 min (`1of1`) | ~4 min (`1of2`), ~3 min (`2of2`) |
| `sequential` | ~7 min (4 chunks) | ~5 min (6 chunks) |

The `blockTest` floor drops from ~8 min to ~5 min. Note this PR is based on `master`, so `engineTest` here is still at its `master` chunk counts (~9 min) — that leg is chunked by the separate #12378. With both #12378 and #12380 merged, the whole `nethtest` group's slowest leg drops to ~5–6 min. As before, total wall-clock also depends on runner-pool queueing; the reliable signal is the per-leg drop above.

