### PR TITLE
Fix flat DB import skipped for a fresh DB during migration

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/ImportFlatDb.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/ImportFlatDb.cs
@@ -50,7 +50,7 @@ public class ImportFlatDb(
         using (IPersistence.IPersistenceReader reader = persistence.CreateReader())
         {
             if (_logger.IsWarn) _logger.Warn($"Current state is {reader.CurrentState}");
-            if (reader.CurrentState.BlockNumber > 0)
+            if (reader.CurrentState != StateId.PreGenesis)
             {
                 if (_logger.IsInfo) _logger.Info("Flat db already exist");
                 return;

--- a/src/Nethermind/Nethermind.Runner.Test/Init/ImportFlatDbTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Init/ImportFlatDbTests.cs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Init.Steps;
+using Nethermind.Logging;
+using Nethermind.State;
+using Nethermind.State.Flat;
+using Nethermind.State.Flat.Persistence;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Runner.Test.Init;
+
+[TestFixture]
+public class ImportFlatDbTests
+{
+    private MemDb _trieDb = null!;
+    private StateTree _stateTree = null!;
+    private NodeStorage _nodeStorage = null!;
+    private SnapshotableMemColumnsDb<FlatDbColumns> _columnsDb = null!;
+    private IPersistence _persistence = null!;
+    private Importer _importer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _trieDb = new MemDb();
+        _stateTree = new StateTree(new RawScopedTrieStore(_trieDb), LimboLogs.Instance);
+        for (int i = 0; i < 5; i++)
+        {
+            _stateTree.Set(TestItem.GetRandomAddress(), TestItem.GenerateIndexedAccount(i + 1));
+        }
+        _stateTree.Commit();
+
+        _nodeStorage = new NodeStorage(_trieDb);
+        _columnsDb = new SnapshotableMemColumnsDb<FlatDbColumns>();
+        _persistence = new RocksDbPersistence(_columnsDb, LimboLogs.Instance);
+        _importer = new Importer(_nodeStorage, _persistence, LimboLogs.Instance);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _trieDb.Dispose();
+        _columnsDb.Dispose();
+    }
+
+    private ImportFlatDb CreateStep(BlockHeader head)
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(Build.A.Block.WithHeader(head).TestObject);
+        return new ImportFlatDb(
+            blockTree,
+            _persistence,
+            _nodeStorage,
+            _importer,
+            Substitute.For<IProcessExitSource>(),
+            new FlatDbConfig(),
+            LimboLogs.Instance);
+    }
+
+    [Test]
+    public async Task Execute_WhenFlatDbIsFresh_ImportsHeadState()
+    {
+        using (IPersistence.IPersistenceReader reader = _persistence.CreateReader())
+        {
+            Assert.That(reader.CurrentState, Is.EqualTo(StateId.PreGenesis), "precondition: fresh flat db");
+        }
+
+        BlockHeader head = Build.A.BlockHeader.WithNumber(1).WithStateRoot(_stateTree.RootHash).TestObject;
+        await CreateStep(head).Execute(CancellationToken.None);
+
+        using IPersistence.IPersistenceReader after = _persistence.CreateReader();
+        Assert.That(after.CurrentState, Is.EqualTo(new StateId(head)), "import should have run on a fresh flat db");
+    }
+
+    [Test]
+    public async Task Execute_WhenFlatDbAlreadyPopulated_SkipsImport()
+    {
+        StateId existing = new(5, _stateTree.RootHash);
+        using (IPersistence.IWriteBatch seed = _persistence.CreateWriteBatch(StateId.PreGenesis, existing))
+        {
+        }
+        _persistence.Flush();
+
+        BlockHeader head = Build.A.BlockHeader.WithNumber(10).WithStateRoot(_stateTree.RootHash).TestObject;
+        await CreateStep(head).Execute(CancellationToken.None);
+
+        using IPersistence.IPersistenceReader after = _persistence.CreateReader();
+        Assert.That(after.CurrentState, Is.EqualTo(existing), "existing flat db state must not be overwritten");
+    }
+}


### PR DESCRIPTION
## Changes

- Fix `ImportFlatDb` skipping the import when migrating into a fresh flat DB. The guard used `CurrentState.BlockNumber > 0`, but a fresh flat DB reports `StateId.PreGenesis` (`BlockNumber == ulong.MaxValue`), so the import was always skipped and `TxPool` construction later crashed reading head state from the empty flat DB (`State ... no longer exists; concurrently removed`). Now gated on `CurrentState != StateId.PreGenesis`, matching `FlatStateActivationPolicy`.
- Add regression tests covering the fresh-DB (imports) and already-populated (skips) cases.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Verified end-to-end against a real HalfPath mainnet DB: migration now runs the import and exits cleanly instead of crashing.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)