### PR TITLE
refactor(evm): make the code cache a DI-injected ICodeCache

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -197,7 +197,7 @@ namespace Nethermind.AuRa.Test
             IBlockTree blockTree = Build.A.BlockTree(GnosisSpecProvider.Instance).TestObject;
             ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
             IBlockhashProvider blockhashProvider = Substitute.For<IBlockhashProvider>();
-            BlockAccessListManager balManager = new(stateProvider, GnosisSpecProvider.Instance, blockhashProvider, LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), CodeInfoRepositoryFactories.Caching);
+            BlockAccessListManager balManager = new(stateProvider, GnosisSpecProvider.Instance, blockhashProvider, LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), static worldState => new EthereumCodeInfoRepository(worldState));
             ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
             IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.ParallelBlockValidationTransactionsExecutor(
                 new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider),

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
@@ -131,7 +131,7 @@ public class BlockAccessListSequentialValidationTests
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = false },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            CodeInfoRepositoryFactories.Caching);
+            static worldState => new EthereumCodeInfoRepository(worldState));
         return (stateProvider, balManager);
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BlockAccessListManagerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BlockAccessListManagerTests.cs
@@ -36,7 +36,7 @@ public class BlockAccessListManagerTests
             LimboLogs.Instance,
             new BlocksConfig(), // ParallelExecution / ParallelExecutionBatchRead default to true
             Substitute.For<IWithdrawalProcessorFactory>(),
-            CodeInfoRepositoryFactories.Caching,
+            static worldState => new EthereumCodeInfoRepository(worldState),
             // Enables parallel execution (and thus BAL read warmup), mirroring the production DI path.
             readOnlyTxProcessingEnvFactory: Substitute.For<IReadOnlyTxProcessingEnvFactory>());
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -126,7 +126,7 @@ public class BlockProcessorTests
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = true },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            CodeInfoRepositoryFactories.Caching,
+            static worldState => new EthereumCodeInfoRepository(worldState),
             readOnlyTxProcessingEnvFactory: parentReaderFactory);
 
         Transaction firstTx = Build.A.Transaction.WithNonce(0).TestObject;
@@ -197,7 +197,7 @@ public class BlockProcessorTests
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = true },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            CodeInfoRepositoryFactories.Caching,
+            static worldState => new EthereumCodeInfoRepository(worldState),
             readOnlyTxProcessingEnvFactory: parentReaderFactory);
 
         Transaction tx = Build.A.Transaction.WithNonce(0).TestObject;
@@ -256,7 +256,7 @@ public class BlockProcessorTests
     {
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
         ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
-        BlockAccessListManager balManager = new(stateProvider, HoodiSpecProvider.Instance, Substitute.For<IBlockhashProvider>(), LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), CodeInfoRepositoryFactories.Caching);
+        BlockAccessListManager balManager = new(stateProvider, HoodiSpecProvider.Instance, Substitute.For<IBlockhashProvider>(), LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), static worldState => new EthereumCodeInfoRepository(worldState));
         ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
         IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.ParallelBlockValidationTransactionsExecutor(
             new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider),
@@ -513,7 +513,7 @@ public class BlockProcessorTests
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = false },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            CodeInfoRepositoryFactories.Caching);
+            static worldState => new EthereumCodeInfoRepository(worldState));
 
         // Prepare with a block that has gasUsed = gasRemaining (sets _gasRemaining)
         ReadOnlyBlockAccessList suggestedBal = Build.A.BlockAccessList
@@ -557,7 +557,7 @@ public class BlockProcessorTests
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = false },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            CodeInfoRepositoryFactories.Caching);
+            static worldState => new EthereumCodeInfoRepository(worldState));
 
         Address lowAddress = TestItem.AddressA;
         Address highAddress = TestItem.AddressB;
@@ -1058,7 +1058,7 @@ public class BlockProcessorTests
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = true },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            CodeInfoRepositoryFactories.Caching,
+            static worldState => new EthereumCodeInfoRepository(worldState),
             readOnlyTxProcessingEnvFactory: Substitute.For<IReadOnlyTxProcessingEnvFactory>());
 
     private static void WithScopedAmsterdamBalManager(Action<BlockAccessListManager> action)

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockhashProviderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockhashProviderTests.cs
@@ -326,7 +326,7 @@ public class BlockhashProviderTests
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = false },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            CodeInfoRepositoryFactories.Caching);
+            static worldState => new EthereumCodeInfoRepository(worldState));
         balManager.PrepareForProcessing(current, spec, ProcessingOptions.None);
         balManager.SetBlockExecutionContext(new BlockExecutionContext(current.Header, spec));
         balManager.Setup(current);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Eip8037BlockGasIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Eip8037BlockGasIntegrationTests.cs
@@ -46,7 +46,7 @@ public class Eip8037BlockGasIntegrationTests
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = true },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            CodeInfoRepositoryFactories.Caching);
+            static worldState => new EthereumCodeInfoRepository(worldState));
     }
 
     private static (BlockAccessListManager, Block) BuildAmsterdamBlock(ulong blockGasLimit, params Transaction[] txs)
@@ -212,7 +212,7 @@ public class Eip8037BlockGasIntegrationTests
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = false },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            CodeInfoRepositoryFactories.Caching);
+            static worldState => new EthereumCodeInfoRepository(worldState));
 
         ulong blockGasLimit = Eip7825Constants.DefaultTxGasLimitCap + 100ul;
         Transaction tx = Build.A.Transaction.WithHash(TestItem.KeccakA)

--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
@@ -90,7 +90,7 @@ public class ReorgTests
             new EthereumCodeInfoRepository(stateProvider),
             LimboLogs.Instance);
 
-        BlockAccessListManager balManager = new(stateProvider, specProvider, blockhashProvider, LimboLogs.Instance, new BlocksConfig() { ParallelExecution = false }, new WithdrawalProcessorFactory(LimboLogs.Instance), CodeInfoRepositoryFactories.Caching);
+        BlockAccessListManager balManager = new(stateProvider, specProvider, blockhashProvider, LimboLogs.Instance, new BlocksConfig() { ParallelExecution = false }, new WithdrawalProcessorFactory(LimboLogs.Instance), static worldState => new EthereumCodeInfoRepository(worldState));
         BlockProcessor blockProcessor = new(
             MainnetSpecProvider.Instance,
             Always.Valid,

--- a/src/Nethermind/Nethermind.Blockchain/EthereumCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Blockchain/EthereumCodeInfoRepository.cs
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Evm;
 using Nethermind.Evm.State;
 
 namespace Nethermind.Blockchain;
 
 // Mainly used by tests
-public class EthereumCodeInfoRepository(IWorldState worldState) : Evm.CacheCodeInfoRepository(worldState, new EthereumPrecompileProvider())
+public class EthereumCodeInfoRepository(IWorldState worldState) : CacheCodeInfoRepository(worldState, new EthereumPrecompileProvider(), StaticCodeCache.Instance)
 {
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/StartBlockProducerAuRa.cs
@@ -164,7 +164,7 @@ public class StartBlockProducerAuRa(
         ContractRewriter? contractRewriter = rewriteBytecode?.Count > 0 || rewriteBytecodeTimestamp?.Length > 0 ? new(rewriteBytecode, rewriteBytecodeTimestamp) : null;
 
         BlockAccessListManager balManager = new(worldState, specProvider, blockhashProvider, logManager, blocksConfig, withdrawalProcessorFactory,
-            CodeInfoRepositoryFactories.Caching, transactionProcessorFactory: transactionProcessorFactory);
+            static worldState => new EthereumCodeInfoRepository(worldState), transactionProcessorFactory: transactionProcessorFactory);
 
         BlockProcessor.BlockProductionTransactionsExecutor transactionExecutor = new(
             new BuildUpTransactionProcessorAdapter(txProcessor),

--- a/src/Nethermind/Nethermind.Consensus/Processing/CodeInfoRepositoryFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/CodeInfoRepositoryFactory.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Blockchain;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 
@@ -9,15 +8,3 @@ namespace Nethermind.Consensus.Processing;
 
 /// <summary>Builds the <see cref="ICodeInfoRepository"/> a <see cref="BlockAccessListManager"/> tx-processor uses over its world state.</summary>
 public delegate ICodeInfoRepository CodeInfoRepositoryFactory(IWorldState worldState);
-
-/// <summary>Standard <see cref="CodeInfoRepositoryFactory"/> choices.</summary>
-public static class CodeInfoRepositoryFactories
-{
-    /// <summary>Caching repository for normal block processing; the DI default.</summary>
-    public static readonly CodeInfoRepositoryFactory Caching =
-        static worldState => new EthereumCodeInfoRepository(worldState);
-
-    /// <summary>Non-caching repository for witness/stateless execution: the caching repo serves code from a process-wide static cache without touching the world state, leaving those accesses out of the witness.</summary>
-    public static readonly CodeInfoRepositoryFactory Witness =
-        static worldState => new CodeInfoRepository(worldState, new EthereumPrecompileProvider());
-}

--- a/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
@@ -59,7 +59,7 @@ public class StatelessBlockProcessingEnv(
                 ParallelExecutionBatchRead = false
             },
             new WithdrawalProcessorFactory(logManager),
-            codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
+            codeInfoRepositoryFactory: static state => new CacheCodeInfoRepository(state, new EthereumPrecompileProvider(), NoopCodeCache.Instance),
             executionRequestsProcessorFactory: StatelessExecutionRequestsProcessorFactory.Instance
         );
         BlockProcessor.ParallelBlockValidationTransactionsExecutor txExecutor = new(
@@ -104,7 +104,7 @@ public class StatelessBlockProcessingEnv(
             specProvider,
             state,
             new EthereumVirtualMachine(blockhashProvider, specProvider, logManager),
-            new CacheCodeInfoRepository(state, new EthereumPrecompileProvider()),
+            new CacheCodeInfoRepository(state, new EthereumPrecompileProvider(), StaticCodeCache.Instance),
             logManager
         );
 }

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
@@ -84,7 +84,7 @@ public sealed class WitnessCapturingBlockProcessingEnv(
             .AddScoped<IWorldState>(recorder)
             .AddScoped<IHeaderFinder>(recordingFinder)
             .AddScoped<IBlockhashCache, BlockhashCache>()
-            .AddScoped<ICodeInfoRepository, CodeInfoRepository>()
+            .AddScoped<ICodeCache>(NoopCodeCache.Instance)
             .AddScoped<IBlockAccessListManager>(ctx => new BlockAccessListManager(
                 ctx.Resolve<IWorldState>(),
                 ctx.Resolve<ISpecProvider>(),
@@ -92,7 +92,7 @@ public sealed class WitnessCapturingBlockProcessingEnv(
                 ctx.Resolve<ILogManager>(),
                 ctx.Resolve<IBlocksConfig>(),
                 ctx.Resolve<IWithdrawalProcessorFactory>(),
-                codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
+                codeInfoRepositoryFactory: ctx.Resolve<CodeInfoRepositoryFactory>(),
                 transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
             // Validation tx executor; everything else is inherited from root and re-resolved against the overridden world state.
             .AddModule(validationModules));

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
@@ -91,7 +91,7 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
             .AddScoped<IHeaderFinder>(capturingHeaderFinder)
             .AddScoped<IBlockhashCache, BlockhashCache>()
             .AddScoped<IReceiptStorage>(NullReceiptStorage.Instance)
-            .AddScoped<ICodeInfoRepository, CodeInfoRepository>()
+            .AddScoped<ICodeCache>(NoopCodeCache.Instance)
             .AddScoped<IBlockAccessListManager>(ctx => new BlockAccessListManager(
                 ctx.Resolve<IWorldState>(),
                 ctx.Resolve<ISpecProvider>(),
@@ -99,7 +99,7 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
                 ctx.Resolve<ILogManager>(),
                 ctx.Resolve<IBlocksConfig>(),
                 ctx.Resolve<IWithdrawalProcessorFactory>(),
-                codeInfoRepositoryFactory: CodeInfoRepositoryFactories.Witness,
+                codeInfoRepositoryFactory: ctx.Resolve<CodeInfoRepositoryFactory>(),
                 transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
             .AddModule(validationModules)
             .AddScoped<IWitnessGeneratingBlockProcessingEnv, WitnessGeneratingBlockProcessingEnv>());

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
@@ -313,7 +313,8 @@ public unsafe class EvmOpcodesBenchmark
     public void CleanupStack()
     {
         _stateProvider.Reset(resetBlockChanges: true);
-        CacheCodeInfoRepository.Clear();
+        StaticCodeCache.Instance.Clear();
+        InstructionStreamCache.Clear();
     }
 
     [IterationSetup]

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
@@ -2087,7 +2087,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
     [Test]
     public void CacheCodeInfoRepository_reads_prior_code_change_from_bal_world_state()
     {
-        CacheCodeInfoRepository.Clear();
+        StaticCodeCache.Instance.Clear();
 
         byte[] priorCode = [(byte)Instruction.STOP];
         ReadOnlyAccountChanges priorChange = Build.An.AccountChanges
@@ -2103,7 +2103,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
         balWorldState.SetParentReader(TestState);
         balWorldState.Setup(Build.A.Block.WithBlockAccessList(suggestedBal).TestObject);
 
-        CacheCodeInfoRepository repo = new(balWorldState, new EthereumPrecompileProvider());
+        CacheCodeInfoRepository repo = new(balWorldState, new EthereumPrecompileProvider(), StaticCodeCache.Instance);
         CodeInfo result = repo.GetCachedCodeInfo(TestItem.AddressA, false, Amsterdam.Instance, out Address? delegationAddress);
 
         using (Assert.EnterMultipleScope())
@@ -2116,7 +2116,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
     [Test]
     public void CacheCodeInfoRepository_falls_back_to_parent_code_by_address_after_bal_hash_miss()
     {
-        CacheCodeInfoRepository.Clear();
+        StaticCodeCache.Instance.Clear();
 
         byte[] parentCode = [(byte)Instruction.STOP];
         TestState.CreateAccount(TestItem.AddressA, 0);
@@ -2135,7 +2135,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
         balWorldState.SetParentReader(TestState);
         balWorldState.Setup(Build.A.Block.WithBlockAccessList(suggestedBal).TestObject);
 
-        CacheCodeInfoRepository repo = new(balWorldState, new EthereumPrecompileProvider());
+        CacheCodeInfoRepository repo = new(balWorldState, new EthereumPrecompileProvider(), StaticCodeCache.Instance);
         CodeInfo result = repo.GetCachedCodeInfo(TestItem.AddressA, false, Amsterdam.Instance, out Address? delegationAddress);
 
         using (Assert.EnterMultipleScope())
@@ -2148,7 +2148,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
     [Test]
     public void CacheCodeInfoRepository_tracing_records_account_read_in_bal()
     {
-        CacheCodeInfoRepository.Clear();
+        StaticCodeCache.Instance.Clear();
 
         byte[] code = [(byte)Instruction.STOP];
 
@@ -2161,7 +2161,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
         TracedAccessWorldState tracedState = new(TestState, parallel: parallel);
         tracedState.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
 
-        CacheCodeInfoRepository repo = new(tracedState, new EthereumPrecompileProvider());
+        CacheCodeInfoRepository repo = new(tracedState, new EthereumPrecompileProvider(), StaticCodeCache.Instance);
         CodeInfo result = repo.GetCachedCodeInfo(TestItem.AddressB, false, Amsterdam.Instance, out Address? delegationAddress);
 
         using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
-using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
@@ -14,14 +12,14 @@ namespace Nethermind.Evm;
 
 public class CacheCodeInfoRepository : ICodeInfoRepository
 {
-    private static readonly CodeLruCache _codeCache = new();
-
     private readonly IWorldState _worldState;
+    private readonly ICodeCache _codeCache;
     private readonly CodeInfoRepository _inner;
 
-    public CacheCodeInfoRepository(IWorldState worldState, IPrecompileProvider precompileProvider)
+    public CacheCodeInfoRepository(IWorldState worldState, IPrecompileProvider precompileProvider, ICodeCache codeCache)
     {
         _worldState = worldState;
+        _codeCache = codeCache;
         _inner = new CodeInfoRepository(worldState, precompileProvider, GetOrCacheCodeInfo);
     }
 
@@ -67,32 +65,5 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
         {
             _codeCache.Set(in codeHash, new CodeInfo(authorizedBuffer));
         }
-    }
-
-    internal static void Clear()
-    {
-        _codeCache.Clear();
-        InstructionStreamCache.Clear();
-    }
-
-    private sealed class CodeLruCache
-    {
-        private readonly AssociativeCache<ValueHash256, CodeInfo> _cache = new(MemoryAllowance.CodeCacheSize);
-
-        public CodeInfo? Get(in ValueHash256 codeHash) => _cache.Get(in codeHash);
-
-        public void Set(in ValueHash256 codeHash, CodeInfo codeInfo)
-        {
-            codeInfo.CodeHash = codeHash;
-            _cache.Set(in codeHash, codeInfo);
-        }
-
-        public bool TryGet(in ValueHash256 codeHash, [NotNullWhen(true)] out CodeInfo? codeInfo)
-        {
-            codeInfo = Get(in codeHash);
-            return codeInfo is not null;
-        }
-
-        internal void Clear() => _cache.Clear();
     }
 }

--- a/src/Nethermind/Nethermind.Evm/ICodeCache.cs
+++ b/src/Nethermind/Nethermind.Evm/ICodeCache.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.CodeAnalysis;
+
+namespace Nethermind.Evm;
+
+/// <summary>Bytecode cache keyed by code hash, used by <see cref="CacheCodeInfoRepository"/> to avoid re-reading and re-parsing code from the world state.</summary>
+/// <remarks>
+/// The witness/stateless path injects <see cref="NoopCodeCache"/> so that every code lookup goes through the world state and
+/// is captured in the generated witness; a process-wide cache hit would otherwise serve code without a world-state read. See <see cref="CodeInfoRepository"/>.
+/// </remarks>
+public interface ICodeCache
+{
+    CodeInfo? Get(in ValueHash256 codeHash);
+    void Set(in ValueHash256 codeHash, CodeInfo codeInfo);
+    void Clear();
+}

--- a/src/Nethermind/Nethermind.Evm/NoopCodeCache.cs
+++ b/src/Nethermind/Nethermind.Evm/NoopCodeCache.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.CodeAnalysis;
+
+namespace Nethermind.Evm;
+
+/// <summary>An <see cref="ICodeCache"/> that stores nothing, forcing every code lookup through the world state.</summary>
+/// <remarks>Used by witness generation and stateless execution so touched bytecodes are recorded rather than served from a process-wide cache.</remarks>
+public sealed class NoopCodeCache : ICodeCache
+{
+    public static readonly NoopCodeCache Instance = new();
+
+    private NoopCodeCache() { }
+
+    public CodeInfo? Get(in ValueHash256 codeHash) => null;
+
+    public void Set(in ValueHash256 codeHash, CodeInfo codeInfo) { }
+
+    public void Clear() { }
+}

--- a/src/Nethermind/Nethermind.Evm/StaticCodeCache.cs
+++ b/src/Nethermind/Nethermind.Evm/StaticCodeCache.cs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Caching;
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.CodeAnalysis;
+
+namespace Nethermind.Evm;
+
+/// <summary>Process-wide LRU <see cref="ICodeCache"/> used for normal block processing; the DI default and the shared cache tests reset between runs.</summary>
+public sealed class StaticCodeCache : ICodeCache
+{
+    public static readonly StaticCodeCache Instance = new();
+
+    private readonly AssociativeCache<ValueHash256, CodeInfo> _cache = new(MemoryAllowance.CodeCacheSize);
+
+    public CodeInfo? Get(in ValueHash256 codeHash) => _cache.Get(in codeHash);
+
+    public void Set(in ValueHash256 codeHash, CodeInfo codeInfo)
+    {
+        codeInfo.CodeHash = codeHash;
+        _cache.Set(in codeHash, codeInfo);
+    }
+
+    public void Clear() => _cache.Clear();
+}

--- a/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
@@ -58,6 +58,7 @@ public class BlockProcessingModule(IInitConfig initConfig, IBlocksConfig blocksC
             .AddSingleton<ITransactionProcessorFactory, TransactionProcessorFactory<EthereumGasPolicy>>()
             .AddScoped<ICodeInfoRepository, CacheCodeInfoRepository>()
                 .AddSingleton<IPrecompileProvider, EthereumPrecompileProvider>()
+                .AddSingleton<ICodeCache>(StaticCodeCache.Instance)
             .AddScoped<IWorldState, WorldState>()
             .AddScoped<IVirtualMachine, EthereumVirtualMachine>()
             .AddScoped<IBlockhashProvider, BlockhashProvider>()
@@ -71,7 +72,8 @@ public class BlockProcessingModule(IInitConfig initConfig, IBlocksConfig blocksC
             .AddSingleton<IWithdrawalProcessorFactory, WithdrawalProcessorFactory>()
             .AddScoped<IExecutionRequestsProcessor, ExecutionRequestsProcessor>()
 
-            .AddSingleton<CodeInfoRepositoryFactory>(CodeInfoRepositoryFactories.Caching)
+            .AddScoped<CodeInfoRepositoryFactory, IPrecompileProvider, ICodeCache>((precompileProvider, codeCache) =>
+                worldState => new CacheCodeInfoRepository(worldState, precompileProvider, codeCache))
             .AddScoped<IBlockAccessListManager, BlockAccessListManager>()
 
             .AddScoped<IProcessingStats, ProcessingStats>()


### PR DESCRIPTION
## Changes

Separate the process-wide code cache out of `CacheCodeInfoRepository` into an `ICodeCache` interface, so the witness/stateless path selects a cache strategy instead of a different repository type.

- Add `ICodeCache` with two implementations: `StaticCodeCache` (the existing LRU, kept as a process-wide `Instance`) and `NoopCodeCache` (stores nothing).
- Register `ICodeCache` as the DI singleton `StaticCodeCache.Instance`; `CacheCodeInfoRepository` now takes it via its only constructor (the static field and the 2-arg convenience ctor are gone).
- Build `CodeInfoRepositoryFactory` from the **scoped** `ICodeCache`, and remove the `CodeInfoRepositoryFactories.Caching`/`Witness` selection.
- The witness scopes (`WitnessCapturingBlockProcessingEnv`, `WitnessGeneratingBlockProcessingEnvFactory`) now override `ICodeCache` with `NoopCodeCache` instead of overriding `ICodeInfoRepository`. This keeps every code lookup going through the world state so touched bytecode is captured in the witness, rather than being served from the shared cache without a read.
- **Fixes plugin compatibility for the witness path:** the witness scope previously re-registered `ICodeInfoRepository` with a hardcoded concrete type, silently discarding any plugin's custom `ICodeInfoRepository` registration during witness generation. It now overrides only `ICodeCache`, so a plugin's `ICodeInfoRepository` is preserved and simply picks up the no-op cache.
- `EthereumCodeInfoRepository` retargeted to the new ctor; `StatelessBlockProcessingEnv` and `StartBlockProducerAuRa` updated to the new construction; the removed static `Clear()` is replaced by callers invoking `ICodeCache.Clear()`.

Behavior is unchanged: normal block processing keeps the shared LRU; the witness/stateless path keeps its non-caching semantics.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Behavior-preserving refactor covered by existing tests. Verified `Nethermind.slnx` + `Nethermind.Evm.Benchmark` build clean and the affected suites pass: `CacheCodeInfoRepository` unit tests, `BlockAccessList*`, witness-capture engine tests (exercise the rewired witness DI), AuRa processor tests, and stateless/SSZ witness tests.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No