### PR TITLE
perf(evm): clear large pooled EVM memory buffers non-temporally

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -7,6 +7,8 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Evm.Tracing;
@@ -479,7 +481,7 @@ public struct EvmPooledMemory
         if (minLength > MaxCachedArrayLength)
         {
             byte[] pooled = RentLarge(minLength);
-            Array.Clear(pooled);
+            ClearBuffer(pooled, pooled.Length);
             return pooled;
         }
 
@@ -497,9 +499,47 @@ public struct EvmPooledMemory
         byte[]?[] cache = _cleanArrays ??= new byte[CleanCacheSlots][];
         if (_cleanArrayCount < CleanCacheSlots)
         {
-            Array.Clear(array, 0, dirtyLength);
+            ClearBuffer(array, dirtyLength);
             cache[_cleanArrayCount++] = array;
         }
+    }
+
+    // Above this the buffer is comparable to L1, so zeroing it evicts the block's warm working set
+    // (bytecode, state, trie nodes). Non-temporal stores bypass cache and avoid that collateral eviction.
+    private const int NonTemporalClearThreshold = 32 * 1024;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ClearBuffer(byte[] array, int length)
+    {
+        if (length >= NonTemporalClearThreshold && Avx.IsSupported)
+        {
+            ClearNonTemporal(array, length);
+        }
+        else
+        {
+            Array.Clear(array, 0, length);
+        }
+    }
+
+    // Zeroes [0, length) with non-temporal (cache-bypassing) AVX stores. length >= 32 is guaranteed by
+    // the caller's threshold. Unaligned head/tail stores cover the ends; the fence orders the weakly
+    // ordered non-temporal writes before the buffer is handed out and read again.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static unsafe void ClearNonTemporal(byte[] array, int length)
+    {
+        fixed (byte* p = array)
+        {
+            Vector256<byte> zero = default;
+            Avx.Store(p, zero);
+            byte* cur = (byte*)(((nuint)p + 31) & ~(nuint)31);
+            byte* tail = p + length - Vector256<byte>.Count;
+            for (; cur <= tail; cur += Vector256<byte>.Count)
+            {
+                Avx.StoreAlignedNonTemporal(cur, zero);
+            }
+            Avx.Store(tail, zero);
+        }
+        Sse.StoreFence();
     }
 
 #if ZK_EVM


### PR DESCRIPTION
## Changes

Idea 1 from the memory-clear investigation. Keeps master's clear-on-return model unchanged (no per-access tracking — that's what regressed in #12382/#12387); only swaps **how** large buffers are zeroed.

- Buffers `>= 32 KB` (comparable to L1) are cleared with **non-temporal (cache-bypassing) AVX stores** instead of `Array.Clear`. Zeroing a large buffer with a normal memset evicts the block's warm working set (bytecode, state, trie nodes) from cache; non-temporal stores write straight to memory and leave the cache intact.
- Smaller buffers keep `Array.Clear` (they fit in cache, and memset is optimal there). Non-AVX hardware (incl. ARM64) also falls back to `Array.Clear`.

### Why this and not a smarter clear

The microbenchmark ceiling showed the clear's *own* cost is a weak lever for real blocks (~5% of small-frame ops; the big BulkCopy savings are already unreachable without per-access tracking, which regressed). The one factor the microbenchmark **cannot** measure is the clear's *collateral* cache eviction of surrounding block work — which is plausibly what the tip-following profile attributed ~10% to. This PR targets exactly that, with zero per-access overhead, so **EXPB is the arbiter**: if the non-temporal clear doesn't move superblocks/realblocks, the dispose-clear is conclusively not a throughput lever and this line of work can close.

## Types of changes

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No (behaviour-preserving; existing memory tests cover the zeroing, incl. the 2 MB reuse path that exercises the non-temporal clear)

#### Notes on testing

- Full `Nethermind.Evm.Test` passes (4885), EF legacy VM fixtures pass locally.
- Draft pending EXPB superblocks/realblocks — the decisive signal.

## Documentation

- [x] No