### PR TITLE
ci: skip the no-intrinsics variant for plumbing test projects

### DIFF
--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -32,7 +32,8 @@ jobs:
           - label: checked
             dotnet-args: -p:DefineConstants=TRACE%3BDEBUG
             hw-intrinsic: ''
-          - label: no-intrinsics
+          - &no_intrinsics
+            label: no-intrinsics
             dotnet-args: ''
             hw-intrinsic: 0
         project:
@@ -95,30 +96,19 @@ jobs:
           - Nethermind.Wallet.Test
           - Nethermind.Xdc.Test
         # The no-intrinsics variant exercises the scalar fallback of SIMD/intrinsic-accelerated
-        # code. Skip it for plumbing/config/orchestration projects that do not exercise any
-        # intrinsic-sensitive path (hashing, big-integer, serialization, EVM/state). Extend this
-        # list only after confirming a project has no divergent scalar path.
+        # code. Skip it for pure plumbing/config/orchestration projects that do not exercise any
+        # intrinsic-sensitive path (hashing, big-integer, serialization, EVM/state). Kept
+        # conservative: projects that can transitively touch crypto/state (Wallet, Hive, Runner)
+        # still run it. The *no_intrinsics alias must resolve to the matrix variant object above
+        # for the exclude to match. Extend only after confirming a project has no divergent path.
         exclude:
-          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
-            project: Nethermind.Api.Test
-          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
-            project: Nethermind.Config.Test
-          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
-            project: Nethermind.EthStats.Test
-          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
-            project: Nethermind.HealthChecks.Test
-          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
-            project: Nethermind.Logging.NLog.Test
-          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
-            project: Nethermind.Monitoring.Test
-          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
-            project: Nethermind.Sockets.Test
-          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
-            project: Nethermind.Wallet.Test
-          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
-            project: Nethermind.Hive.Test
-          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
-            project: Nethermind.Runner.Test
+          - { variant: *no_intrinsics, project: Nethermind.Api.Test }
+          - { variant: *no_intrinsics, project: Nethermind.Config.Test }
+          - { variant: *no_intrinsics, project: Nethermind.EthStats.Test }
+          - { variant: *no_intrinsics, project: Nethermind.HealthChecks.Test }
+          - { variant: *no_intrinsics, project: Nethermind.Logging.NLog.Test }
+          - { variant: *no_intrinsics, project: Nethermind.Monitoring.Test }
+          - { variant: *no_intrinsics, project: Nethermind.Sockets.Test }
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -95,12 +95,6 @@ jobs:
           - Nethermind.TxPool.Test
           - Nethermind.Wallet.Test
           - Nethermind.Xdc.Test
-        # The no-intrinsics variant exercises the scalar fallback of SIMD/intrinsic-accelerated
-        # code. Skip it for pure plumbing/config/orchestration projects that do not exercise any
-        # intrinsic-sensitive path (hashing, big-integer, serialization, EVM/state). Kept
-        # conservative: projects that can transitively touch crypto/state (Wallet, Hive, Runner)
-        # still run it. The *no_intrinsics alias must resolve to the matrix variant object above
-        # for the exclude to match. Extend only after confirming a project has no divergent path.
         exclude:
           - { variant: *no_intrinsics, project: Nethermind.Api.Test }
           - { variant: *no_intrinsics, project: Nethermind.Config.Test }

--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -94,6 +94,31 @@ jobs:
           - Nethermind.TxPool.Test
           - Nethermind.Wallet.Test
           - Nethermind.Xdc.Test
+        # The no-intrinsics variant exercises the scalar fallback of SIMD/intrinsic-accelerated
+        # code. Skip it for plumbing/config/orchestration projects that do not exercise any
+        # intrinsic-sensitive path (hashing, big-integer, serialization, EVM/state). Extend this
+        # list only after confirming a project has no divergent scalar path.
+        exclude:
+          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
+            project: Nethermind.Api.Test
+          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
+            project: Nethermind.Config.Test
+          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
+            project: Nethermind.EthStats.Test
+          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
+            project: Nethermind.HealthChecks.Test
+          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
+            project: Nethermind.Logging.NLog.Test
+          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
+            project: Nethermind.Monitoring.Test
+          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
+            project: Nethermind.Sockets.Test
+          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
+            project: Nethermind.Wallet.Test
+          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
+            project: Nethermind.Hive.Test
+          - variant: { label: no-intrinsics, dotnet-args: '', hw-intrinsic: 0 }
+            project: Nethermind.Runner.Test
     steps:
       - name: Check out repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Changes

In `nethermind-tests-checked.yml`, exclude the `no-intrinsics` variant (`DOTNET_EnableHWIntrinsic=0`) for 7 pure plumbing/config/orchestration test projects that do not exercise any SIMD/intrinsic-accelerated code path (hashing, big-integer, serialization, EVM/state):

`Api.Test`, `Config.Test`, `EthStats.Test`, `HealthChecks.Test`, `Logging.NLog.Test`, `Monitoring.Test`, `Sockets.Test`.

The exclude references the matrix variant via a YAML anchor (`*no_intrinsics`) so it cannot silently drift from the definition. `Wallet.Test`, `Hive.Test` and `Runner.Test` were intentionally **kept** on `no-intrinsics` — they can transitively touch crypto/state.

The `no-intrinsics` variant exists to catch divergence between the SIMD and scalar code paths; a test can only catch such a divergence if it *exercises* the accelerated path, so running it for these projects is wasted work. The `checked` (DEBUG-assert) variant still runs the full project list, and `no-intrinsics` still runs for every numeric/crypto/serialization/EVM/state project.

## Coverage-policy decision

This narrows a deliberate safety-net (the full-suite no-intrinsics run). The excluded list is intentionally **conservative** — only obvious plumbing. It can be widened (Abi, Clique, AuRa, Mining, Optimism, Taiko, Xdc, Db, Era1, History, Shutter, KeyStore, …) if the team judges those exercise no divergent scalar path, or narrowed further. Same class of tradeoff as the Windows OS-sensitive subset (#12379).

## Types of changes

- [x] Optimization
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### Notes on testing

Matrix-only change — the `checked` variant coverage is unchanged; only `no-intrinsics` is skipped for the listed projects. This PR's own `nethermind-tests-checked` run measures the effect: main `tests` legs drop from ~116 to ~106 (workflow total ~141 → ~131). No test logic altered.

## Documentation

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No


---

## Results (measured on this PR's CI run)

Verified on run `29155678520` (`Nethermind extra test variants`) vs the `master` baseline:

| Metric | master | This PR | Δ |
|--------|-------:|--------:|---|
| total jobs | 141 | **134** | −7 |
| `no-intrinsics` legs | 70 | **63** | −7 |
| `checked` legs | 70 | 70 | 0 (full coverage kept) |

The `checked` (DEBUG-assert) variant still runs the full project list; only the 7 plumbing projects drop their `no-intrinsics` leg. Removed legs are ~3–4 min each (build + test), so ~25–30 runner-min off the workflow per PR.
