### PR TITLE
ci: build the PR sync image once and share it across sync-pr-gate legs

### DIFF
--- a/.github/workflows/sync-pr-gate.yml
+++ b/.github/workflows/sync-pr-gate.yml
@@ -16,8 +16,40 @@ permissions:
   contents: read
 
 jobs:
+  build-image:
+    name: Build PR image
+    if: github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-arm64-8-core
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Build Docker image
+        run: |
+          docker build -t nethermind:pr-local \
+            --build-arg BUILD_CONFIG=release \
+            --build-arg CI=true \
+            --build-arg COMMIT_HASH=${{ github.event.pull_request.head.sha }} \
+            .
+
+      - name: Save image
+        run: docker save nethermind:pr-local | gzip > /tmp/nethermind-pr-local.tar.gz
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nethermind-pr-local-image
+          path: /tmp/nethermind-pr-local.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
   sync-hoodi:
     name: "Sync hoodi (${{ matrix.mode }})"
+    needs: build-image
     if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-arm64-8-core
     timeout-minutes: 180
@@ -87,13 +119,14 @@ jobs:
           cd sedge
           make compile
 
-      - name: Build Docker image locally
-        run: |
-          docker build -t nethermind:pr-local \
-            --build-arg BUILD_CONFIG=release \
-            --build-arg CI=true \
-            --build-arg COMMIT_HASH=${{ github.event.pull_request.head.sha }} \
-            .
+      - name: Download PR image
+        uses: actions/download-artifact@v4
+        with:
+          name: nethermind-pr-local-image
+          path: /tmp
+
+      - name: Load PR image
+        run: docker load < /tmp/nethermind-pr-local.tar.gz
 
       - name: Generate and run Sedge
         working-directory: sedge


### PR DESCRIPTION
## Changes

`sync-pr-gate.yml` fans out `sync-hoodi` over `matrix.mode: [HalfPath, Flat]`, and each leg ran its own `docker build -t nethermind:pr-local .` — but the two legs differ only in a **runtime** flag (`--el-extra-flag FlatDb.Enabled=$FLATDB`), so the image bits are identical. The full from-source client image was therefore built **twice per PR** on a `ubuntu-arm64-8-core` self-hosted runner.

This adds a `build-image` job that builds the image once (native ARM, same runner class), `docker save | gzip`s it, and uploads it as an artifact; both `sync-hoodi` legs now `needs: build-image`, download it, and `docker load` instead of rebuilding.

The fork guard (`head.repo.fork == false`) is applied to the new job too, and the `COMMIT_HASH` build-arg (`head.sha`) is identical to what each leg passed, so the shared image is byte-for-byte what the legs built before.

## Types of changes

- [x] Optimization
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### Notes on testing

Runs on this PR (sync-pr-gate is `pull_request`-triggered). The measurable signal is structural: one `build-image` job instead of a `docker build` step inside each of the two `sync-hoodi` legs — i.e. one full ARM client build per PR instead of two. Both legs must still reach `sedge generate`/`docker compose up` with the loaded `nethermind:pr-local` tag. Net win holds as long as the artifact up/download (~1 image, gzipped) is cheaper than a second full build, which on the 8-core ARM runner it is.

## Documentation

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

---

## Results (measured on this PR's CI run)

Verified on run `29155086836`:

- **`Build PR image` runs once** (~1 min on the warm self-hosted 8-core ARM layer cache) and uploads the image artifact.
- Both `sync-hoodi` legs now `docker load` that artifact instead of building — `Sync hoodi (HalfPath)` completed at ~21 min consuming the shared image (no in-leg `docker build`), and the `Flat` leg does the same.

Net: **one full from-source client build per PR instead of two**. Peak concurrent runners is unchanged (build-image runs alone, then the two legs in parallel). The eliminated second build is a full `dotnet publish` of the client on a heavy ARM runner.
