### PR TITLE
Ignore sepolia-devnet-2 L1 in superchain chainspec generation

### DIFF
--- a/scripts/superchain.py
+++ b/scripts/superchain.py
@@ -17,7 +17,7 @@ from zipfile import ZipFile
 
 SUPERCHAIN_REPOSITORY = "https://github.com/ethereum-optimism/superchain-registry/archive/refs/heads/main.zip"
 IGNORED_CHAINS = ["arena-z-testnet", "creator-chain-testnet", "rehearsal-0-bn-0", "rehearsal-0-bn-1", "celo", "radius_testnet", "silent-data-mainnet"]
-IGNORED_L1S = ["sepolia-dev-0"]
+IGNORED_L1S = ["sepolia-dev-0", "sepolia-devnet-2"]
 
 
 def keccak(hex):


### PR DESCRIPTION
## Changes

- Add `sepolia-devnet-2` to `IGNORED_L1S` in `scripts/superchain.py`, alongside the already-ignored `sepolia-dev-0` devnet.

The superchain registry added a `sepolia-devnet-2/sepolia-devnet-2` devnet whose L1 is not in the script's constants table (`L1ChainId`, `L1BeaconGenesisSlotTime`, `DepositContractAddress`). The generated chainspec then enables EIP-6110 (Isthmus) without `depositContractAddress`, which fails chainspec validation and broke all `Nethermind.Runner.Test` smoke tests in #12395.

After this change, the "Update OP Superchain chains" workflow needs a re-run to regenerate #12395 without the devnet files.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Ran `scripts/superchain.py` locally: the devnet is now skipped (`Ignoring 'sepolia-devnet-2-sepolia-devnet-2'`) and the remaining 49 chain configs generate unchanged.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)