### PR TITLE
feat(flatdb): persist via SST ingestion (opt-in)

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -128,14 +128,42 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             underlyingWriteBatch.Merge(key, value, columnDb._columnFamily, flags);
     }
 
-    public IWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
+    public ISstIngestWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
 
-    private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
+    public string IngestStagingDir => Path.Combine(_mainDb.FullPath, "sst_ingest");
+
+    private const int MaxL0FilesBeforeThrottle = 20;
+    private const int L0DrainMaxPolls = 1500;
+    private const int L0DrainPollMs = 20;
+
+    private readonly IngestExternalFileOptions _ingestOptions = new IngestExternalFileOptions()
+        .SetMoveFiles(true)
+        .SetAllowGlobalSeqno(true)
+        .SetAllowBlockingFlush(true);
+
+    public void IngestStagedFiles(IReadOnlyList<string> files)
+    {
+        if (files.Count == 0) return;
+        _testIngestFailureHook?.Invoke();
+        _rocksDb.IngestExternalFiles([.. files], _ingestOptions, _columnFamily);
+    }
+
+    public void WaitForIngestCompactionHeadroom()
+    {
+        for (int i = 0; i < L0DrainMaxPolls; i++)
+        {
+            string? v = _rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnFamily);
+            if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
+            Thread.Sleep(L0DrainPollMs);
+        }
+
+        ILogger logger = _mainDb.Logger;
+        if (logger.IsWarn) logger.Warn($"L0 of {_mainDb.Name} column {Name} did not drain below {MaxL0FilesBeforeThrottle} files within {L0DrainMaxPolls * L0DrainPollMs / 1000}s; continuing SST ingestion without compaction headroom");
+    }
+
+    private sealed class SstIngestWriteBatch(ColumnDb columnDb) : ISstIngestWriteBatch
     {
         private const long MaxBufferedBytes = 128L * 1024 * 1024;
-        private const int MaxL0FilesBeforeThrottle = 20;
-        private const int L0DrainMaxPolls = 1500;
-        private const int L0DrainPollMs = 20;
         private const int SlabSize = 1 << 20;
 
         // Worst-case permanent retention: slabs <= 1024 x 1 MiB = 1 GiB; entries <= 6 arrays/bucket over 2^16..2^22 x 32 B ~= 1.5 GiB.
@@ -146,15 +174,12 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
         private readonly ColumnDb _columnDb = columnDb;
         private readonly List<byte[]> _slabs = [];
+        private readonly List<string> _stagedFiles = [];
         private Entry[] _index = s_entryPool.Rent(1 << 16);
         private int _count;
         private int _slabIndex = -1;
         private int _slabOffset;
         private long _bufferedBytes;
-        private readonly IngestExternalFileOptions _options = new IngestExternalFileOptions()
-            .SetMoveFiles(true)
-            .SetAllowGlobalSeqno(true)
-            .SetAllowBlockingFlush(true);
 
         private struct Entry
         {
@@ -281,9 +306,8 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
             Array.Sort(_index, 0, _count, new EntryComparer(this));
 
-            string dir = Path.Combine(_columnDb._mainDb.FullPath, "sst_ingest");
-            Directory.CreateDirectory(dir);
-            string file = Path.Combine(dir, $"{_columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
+            Directory.CreateDirectory(_columnDb.IngestStagingDir);
+            string file = Path.Combine(_columnDb.IngestStagingDir, $"{_columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
 
             try
             {
@@ -311,9 +335,6 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                 {
                     Native.Instance.rocksdb_sstfilewriter_destroy(writer);
                 }
-
-                _columnDb._testIngestFailureHook?.Invoke();
-                _columnDb._rocksDb.IngestExternalFiles([file], _options, _columnDb._columnFamily);
             }
             catch
             {
@@ -321,26 +342,33 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                 throw;
             }
 
+            _stagedFiles.Add(file);
             Clear();
-            WaitForCompactionHeadroom();
         }
 
-        private void WaitForCompactionHeadroom()
+        public IReadOnlyList<string> SealToStagedFiles()
         {
-            for (int i = 0; i < L0DrainMaxPolls; i++)
-            {
-                string? v = _columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnDb._columnFamily);
-                if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
-                Thread.Sleep(L0DrainPollMs);
-            }
+            FlushChunk();
+            return _stagedFiles;
+        }
 
-            ILogger logger = _columnDb._mainDb.Logger;
-            if (logger.IsWarn) logger.Warn($"L0 of {_columnDb._mainDb.Name} column {_columnDb.Name} did not drain below {MaxL0FilesBeforeThrottle} files within {L0DrainMaxPolls * L0DrainPollMs / 1000}s; continuing SST ingestion without compaction headroom");
+        public void IngestStagedFiles()
+        {
+            _columnDb.IngestStagedFiles(_stagedFiles);
+            _stagedFiles.Clear();
+        }
+
+        public void DeleteStagedFiles()
+        {
+            foreach (string file in _stagedFiles)
+            {
+                try { if (File.Exists(file)) File.Delete(file); } catch { }
+            }
+            _stagedFiles.Clear();
         }
 
         public void Dispose()
         {
-            FlushChunk();
             foreach (byte[] slab in _slabs)
             {
                 if (slab.Length == SlabSize) s_slabPool.Return(slab);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -12,6 +12,7 @@ using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Logging;
 using RocksDbSharp;
 using IWriteBatch = Nethermind.Core.IWriteBatch;
 
@@ -131,6 +132,8 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
     {
         private const long MaxBufferedBytes = 128L * 1024 * 1024;
         private const int MaxL0FilesBeforeThrottle = 20;
+        private const int L0DrainMaxPolls = 1500;
+        private const int L0DrainPollMs = 20;
         private const int SlabSize = 1 << 20;
 
         private static readonly ArrayPool<byte> s_slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
@@ -318,12 +321,15 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
         private void WaitForCompactionHeadroom()
         {
-            for (int i = 0; i < 1500; i++)
+            for (int i = 0; i < L0DrainMaxPolls; i++)
             {
                 string? v = _columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnDb._columnFamily);
                 if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
-                Thread.Sleep(20);
+                Thread.Sleep(L0DrainPollMs);
             }
+
+            ILogger logger = _columnDb._mainDb.Logger;
+            if (logger.IsWarn) logger.Warn($"L0 of {_columnDb._mainDb.Name} column {_columnDb.Name} did not drain below {MaxL0FilesBeforeThrottle} files within {L0DrainMaxPolls * L0DrainPollMs / 1000}s; continuing SST ingestion without compaction headroom");
         }
 
         public void Dispose()

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.IO;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
@@ -13,8 +15,10 @@ using IWriteBatch = Nethermind.Core.IWriteBatch;
 
 namespace Nethermind.Db.Rocks;
 
-public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKeyValueStoreWithSnapshot
+public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKeyValueStoreWithSnapshot, ISstIngestible
 {
+    private static long _sstIngestSeq;
+
     private readonly RocksDb _rocksDb;
     internal readonly DbOnTheRocks _mainDb;
     internal readonly ColumnFamilyHandle _columnFamily;
@@ -117,6 +121,54 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
         public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
             underlyingWriteBatch.Merge(key, value, columnDb._columnFamily, flags);
+    }
+
+    public IWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
+
+    // Buffers point puts/deletes for one persisted snapshot, then on Dispose writes a single sorted SST and
+    // ingests it into this column — bypassing the memtable -> flush -> L0-compaction burst of a large WriteBatch.
+    private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
+    {
+        // Last write wins: a SelfDestruct (delete) followed by re-creation (put) can target the same key in one
+        // snapshot, and an SST forbids duplicate keys, so collapse to the final value before writing.
+        private readonly Dictionary<byte[], byte[]?> _entries = new(Bytes.EqualityComparer);
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) =>
+            _entries[key.ToArray()] = value;
+
+        public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
+            throw new NotSupportedException("SST ingestion does not support merge writes");
+
+        public void Clear() => _entries.Clear();
+
+        public void Dispose()
+        {
+            if (_entries.Count == 0) return;
+
+            List<KeyValuePair<byte[], byte[]?>> items = [.. _entries];
+            items.Sort(static (a, b) => a.Key.AsSpan().SequenceCompareTo(b.Key));
+
+            string dir = Path.Combine(columnDb._mainDb.FullPath, "sst_ingest");
+            Directory.CreateDirectory(dir);
+            string file = Path.Combine(dir, $"{columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
+
+            using (SstFileWriter writer = new(new EnvOptions(), new ColumnFamilyOptions()))
+            {
+                writer.Open(file);
+                foreach ((byte[] key, byte[]? value) in items)
+                {
+                    if (value is null) writer.Delete(key);
+                    else writer.Put(key, value);
+                }
+                writer.Finish();
+            }
+
+            IngestExternalFileOptions options = new IngestExternalFileOptions()
+                .SetMoveFiles(true)
+                .SetAllowGlobalSeqno(true)
+                .SetAllowBlockingFlush(true);
+            columnDb._rocksDb.IngestExternalFiles([file], options, columnDb._columnFamily);
+        }
     }
 
     public void Remove(ReadOnlySpan<byte> key) => Set(key, null);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -150,10 +150,11 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         _rocksDb.IngestExternalFiles([.. files], _ingestOptions, _columnFamily);
     }
 
-    public void WaitForIngestCompactionHeadroom()
+    public void WaitForIngestCompactionHeadroom(CancellationToken cancellationToken)
     {
         for (int i = 0; i < L0DrainMaxPolls; i++)
         {
+            if (cancellationToken.IsCancellationRequested) return;
             string? v = _rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnFamily);
             if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
             Thread.Sleep(L0DrainPollMs);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -7,6 +7,7 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
@@ -294,8 +295,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                         ref Entry e = ref _index[i];
                         // Equal keys sort by ascending Seq; only the last of each run (the latest write) is emitted.
                         if (i + 1 < _count && IsSameKey(in e, in _index[i + 1])) continue;
-                        fixed (byte* data = &_slabs[e.Slab][e.Offset])
+                        fixed (byte* slabPtr = &MemoryMarshal.GetArrayDataReference(_slabs[e.Slab]))
                         {
+                            byte* data = slabPtr + e.Offset;
                             if (e.ValLen < 0) Native.Instance.rocksdb_sstfilewriter_delete(writer, data, (UIntPtr)e.KeyLen);
                             else Native.Instance.rocksdb_sstfilewriter_put(writer, data, (UIntPtr)e.KeyLen, data + e.KeyLen, (UIntPtr)e.ValLen);
                         }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -26,6 +26,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
     private readonly RocksDb _rocksDb;
     internal readonly DbOnTheRocks _mainDb;
     internal readonly ColumnFamilyHandle _columnFamily;
+    internal Action? _testIngestFailureHook;
 
     private readonly DbOnTheRocks.IteratorManager _iteratorManager;
     private readonly RocksDbReader _reader;
@@ -311,6 +312,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                     Native.Instance.rocksdb_sstfilewriter_destroy(writer);
                 }
 
+                _columnDb._testIngestFailureHook?.Invoke();
                 _columnDb._rocksDb.IngestExternalFiles([file], _options, _columnDb._columnFamily);
             }
             catch

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
@@ -162,25 +163,32 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         if (logger.IsWarn) logger.Warn($"L0 of {_mainDb.Name} column {Name} did not drain below {MaxL0FilesBeforeThrottle} files within {L0DrainMaxPolls * L0DrainPollMs / 1000}s; continuing SST ingestion without compaction headroom");
     }
 
-    private sealed class SstIngestWriteBatch(ColumnDb columnDb) : ISstIngestWriteBatch
+    private sealed class SstIngestWriteBatch : ISstIngestWriteBatch
     {
         private const long MaxBufferedBytes = 128L * 1024 * 1024;
         private const int SlabSize = 1 << 20;
 
         // Worst-case permanent retention: slabs <= 1024 x 1 MiB = 1 GiB; entries <= 6 arrays/bucket over 2^16..2^22 x 32 B ~= 1.5 GiB.
         // 6 covers peak concurrency: six column batches alive per persist, one persist in flight.
-        private static readonly ArrayPool<byte> s_slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
-        private static readonly ArrayPool<Entry> s_entryPool = ArrayPool<Entry>.Create(1 << 22, 6);
-        private static readonly EnvOptions s_envOptions = new();
+        private static readonly ArrayPool<byte> _slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
+        private static readonly ArrayPool<Entry> _entryPool = ArrayPool<Entry>.Create(1 << 22, 6);
+        private static readonly EnvOptions _envOptions = new();
 
-        private readonly ColumnDb _columnDb = columnDb;
+        private readonly ColumnDb _columnDb;
+        private readonly EntryComparer _comparer;
         private readonly List<byte[]> _slabs = [];
-        private readonly List<string> _stagedFiles = [];
-        private Entry[] _index = s_entryPool.Rent(1 << 16);
+        private readonly ArrayPoolList<string> _stagedFiles = new(4);
+        private Entry[] _index = _entryPool.Rent(1 << 16);
         private int _count;
         private int _slabIndex = -1;
         private int _slabOffset;
         private long _bufferedBytes;
+
+        public SstIngestWriteBatch(ColumnDb columnDb)
+        {
+            _columnDb = columnDb;
+            _comparer = new EntryComparer(this);
+        }
 
         private struct Entry
         {
@@ -255,7 +263,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                 }
                 while (_slabIndex < _slabs.Count && _slabs[_slabIndex].Length != SlabSize);
 
-                if (_slabIndex == _slabs.Count) _slabs.Add(s_slabPool.Rent(SlabSize));
+                if (_slabIndex == _slabs.Count) _slabs.Add(_slabPool.Rent(SlabSize));
                 _slabOffset = 0;
             }
 
@@ -267,9 +275,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
         private void GrowIndex()
         {
-            Entry[] grown = s_entryPool.Rent(_index.Length * 2);
+            Entry[] grown = _entryPool.Rent(_index.Length * 2);
             Array.Copy(_index, grown, _count);
-            s_entryPool.Return(_index);
+            _entryPool.Return(_index);
             _index = grown;
         }
 
@@ -305,7 +313,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         {
             if (_count == 0) return;
 
-            Array.Sort(_index, 0, _count, new EntryComparer(this));
+            Array.Sort(_index, 0, _count, _comparer);
 
             Directory.CreateDirectory(_columnDb.IngestStagingDir);
             string file = Path.Combine(_columnDb.IngestStagingDir, $"{_columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
@@ -314,7 +322,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             {
                 ColumnFamilyOptions writerOptions = _columnDb._mainDb.GetColumnFamilyOptions(_columnDb.Name)
                     ?? throw new InvalidOperationException($"No column family options registered for column {_columnDb.Name} of {_columnDb._mainDb.Name}");
-                IntPtr writer = Native.Instance.rocksdb_sstfilewriter_create(s_envOptions.Handle, writerOptions.Handle);
+                IntPtr writer = Native.Instance.rocksdb_sstfilewriter_create(_envOptions.Handle, writerOptions.Handle);
                 try
                 {
                     Native.Instance.rocksdb_sstfilewriter_open(writer, file);
@@ -323,6 +331,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                         ref Entry e = ref _index[i];
                         // Equal keys sort by ascending Seq; only the last of each run (the latest write) is emitted.
                         if (i + 1 < _count && IsSameKey(in e, in _index[i + 1])) continue;
+                        // Safety: Reserve wrote KeyLen (+ ValLen for puts) contiguous bytes at [Offset, Offset + length)
+                        // inside _slabs[Slab], so data, data + KeyLen and data + KeyLen + ValLen all stay within the pinned
+                        // slab; the native put/delete therefore cannot read or write past the slab's bounds.
                         fixed (byte* slabPtr = &MemoryMarshal.GetArrayDataReference(_slabs[e.Slab]))
                         {
                             byte* data = slabPtr + e.Offset;
@@ -339,7 +350,14 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             }
             catch
             {
-                try { if (File.Exists(file)) File.Delete(file); } catch { }
+                try
+                {
+                    if (File.Exists(file)) File.Delete(file);
+                }
+                catch (Exception cleanupError)
+                {
+                    if (_columnDb._mainDb.Logger.IsDebug) _columnDb._mainDb.Logger.Debug($"Failed to delete partial SST file '{file}' after a writer error; it will be swept on next startup. {cleanupError}");
+                }
                 throw;
             }
 
@@ -363,7 +381,14 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         {
             foreach (string file in _stagedFiles)
             {
-                try { if (File.Exists(file)) File.Delete(file); } catch { }
+                try
+                {
+                    if (File.Exists(file)) File.Delete(file);
+                }
+                catch (Exception e)
+                {
+                    if (_columnDb._mainDb.Logger.IsDebug) _columnDb._mainDb.Logger.Debug($"Failed to delete staged SST file '{file}' during cleanup; it will be swept on next startup. {e}");
+                }
             }
             _stagedFiles.Clear();
         }
@@ -372,11 +397,12 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         {
             foreach (byte[] slab in _slabs)
             {
-                if (slab.Length == SlabSize) s_slabPool.Return(slab);
+                if (slab.Length == SlabSize) _slabPool.Return(slab);
             }
             _slabs.Clear();
-            s_entryPool.Return(_index);
+            _entryPool.Return(_index);
             _index = [];
+            _stagedFiles.Dispose();
         }
     }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -127,20 +127,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
     public IWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
 
-    // Buffers key/value bytes in pooled slabs indexed by unmanaged entry structs instead of a
-    // Dictionary<byte[], byte[]?>: the dictionary buffered 2-3M small arrays per 128 MB chunk plus
-    // multi-MB bucket/entry/List-copy arrays — ~1.5-2.5 GB of promoted + LOH garbage per persist
-    // that fed blocking gen2 GC pauses (measured 1.3-2.1 s read stalls). Dedup is deferred to the
-    // flush-time sort (stable by append order, keep-last), which is semantics-preserving: duplicate
-    // keys across chunk files are already resolved by ingest order via AllowGlobalSeqno.
     private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
     {
-        // Byte cap on the in-memory buffer. At the cap we flush+ingest one SST and free the buffer, so a large
-        // persist (e.g. 10x state) never holds the whole batch in managed memory — that transient spike, on top
-        // of the working set, OOM-kills the node. Overlapping chunks are fine: each ingest gets a higher global
-        // seqno, so the later (final) value wins, which also preserves last-write-wins across chunk boundaries.
         private const long MaxBufferedBytes = 128L * 1024 * 1024;
-        // Throttle the persist thread when L0 files pile up, bounding the native compaction working set.
         private const int MaxL0FilesBeforeThrottle = 20;
         private const int SlabSize = 1 << 20;
 
@@ -218,7 +207,6 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         {
             if (length > SlabSize)
             {
-                // Oversized entries get a dedicated exact-size array; dropped (not pooled) at reset.
                 byte[] dedicated = new byte[length];
                 _slabs.Add(dedicated);
                 slab = _slabs.Count - 1;
@@ -315,13 +303,11 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                     Native.Instance.rocksdb_sstfilewriter_destroy(writer);
                 }
 
-                // SetMoveFiles(true): on success RocksDB moves (consumes) the file. Only a Finish/ingest failure
-                // leaves it staged, so delete it on failure to stop sst_ingest/ accumulating orphaned files.
                 _columnDb._rocksDb.IngestExternalFiles([file], _options, _columnDb._columnFamily);
             }
             catch
             {
-                try { if (File.Exists(file)) File.Delete(file); } catch { /* best effort */ }
+                try { if (File.Exists(file)) File.Delete(file); } catch { }
                 throw;
             }
 
@@ -329,12 +315,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             WaitForCompactionHeadroom();
         }
 
-        // Ingestion bypasses RocksDB's memtable write-stall, so back-to-back ingests pile up L0 files and the
-        // compaction working set grows without bound (native memory OOM at large state). Replicate the missing
-        // flow control: throttle the persist thread until L0 drains — exactly what the memtable write path does.
         private void WaitForCompactionHeadroom()
         {
-            for (int i = 0; i < 1500; i++) // ~30s safety cap
+            for (int i = 0; i < 1500; i++)
             {
                 string? v = _columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnDb._columnFamily);
                 if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -125,8 +125,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
     public IWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
 
-    // Buffers point puts/deletes for one persisted snapshot, then on Dispose writes a single sorted SST and
-    // ingests it into this column — bypassing the memtable -> flush -> L0-compaction burst of a large WriteBatch.
+    // Buffers point puts/deletes in a byte-capped managed buffer; at the cap (and on Dispose) it flushes the buffer
+    // as a sorted SST and ingests it into this column — bypassing the memtable -> flush -> L0-compaction burst of a
+    // large WriteBatch. Buffering is on the managed heap, hence the byte cap to bound peak persist memory.
     private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
     {
         // Byte cap on the in-memory buffer. At the cap we flush+ingest one SST and free the buffer, so a large
@@ -176,18 +177,29 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             Directory.CreateDirectory(dir);
             string file = Path.Combine(dir, $"{columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
 
-            using (SstFileWriter writer = new(new EnvOptions(), new ColumnFamilyOptions()))
+            try
             {
-                writer.Open(file);
-                foreach ((byte[] key, byte[]? value) in items)
+                using (SstFileWriter writer = new(new EnvOptions(), new ColumnFamilyOptions()))
                 {
-                    if (value is null) writer.Delete(key);
-                    else writer.Put(key, value);
+                    writer.Open(file);
+                    foreach ((byte[] key, byte[]? value) in items)
+                    {
+                        if (value is null) writer.Delete(key);
+                        else writer.Put(key, value);
+                    }
+                    writer.Finish();
                 }
-                writer.Finish();
+
+                // SetMoveFiles(true): on success RocksDB moves (consumes) the file. Only a Finish/ingest failure
+                // leaves it staged, so delete it on failure to stop sst_ingest/ accumulating orphaned files.
+                columnDb._rocksDb.IngestExternalFiles([file], _options, columnDb._columnFamily);
+            }
+            catch
+            {
+                try { if (File.Exists(file)) File.Delete(file); } catch { /* best effort */ }
+                throw;
             }
 
-            columnDb._rocksDb.IngestExternalFiles([file], _options, columnDb._columnFamily);
             Clear();
             WaitForCompactionHeadroom();
         }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -173,11 +173,14 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         // 6 covers peak concurrency: six column batches alive per persist, one persist in flight.
         private static readonly ArrayPool<byte> _slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
         private static readonly ArrayPool<Entry> _entryPool = ArrayPool<Entry>.Create(1 << 22, 6);
+        // Dedicated pool for the slab-reference list backing so the per-persist list allocation stays off the shared
+        // pool; sized to the worst-case 1024 slabs over the six concurrent column batches of a single in-flight persist.
+        private static readonly ArrayPool<byte[]> _slabListPool = ArrayPool<byte[]>.Create(1024, 6);
         private static readonly EnvOptions _envOptions = new();
 
         private readonly ColumnDb _columnDb;
         private readonly EntryComparer _comparer;
-        private readonly List<byte[]> _slabs = [];
+        private readonly ArrayPoolList<byte[]> _slabs = new(_slabListPool, 16);
         private readonly ArrayPoolList<string> _stagedFiles = new(4);
         private Entry[] _index = _entryPool.Rent(1 << 16);
         private int _count;
@@ -400,7 +403,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             {
                 if (slab.Length == SlabSize) _slabPool.Return(slab);
             }
-            _slabs.Clear();
+            _slabs.Dispose();
             _entryPool.Return(_index);
             _index = [];
             _stagedFiles.Dispose();

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -137,8 +137,10 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         private const int L0DrainPollMs = 20;
         private const int SlabSize = 1 << 20;
 
+        // Worst-case permanent retention: slabs <= 1024 x 1 MiB = 1 GiB; entries <= 6 arrays/bucket over 2^16..2^22 x 32 B ~= 1.5 GiB.
+        // 6 covers peak concurrency: six column batches alive per persist, one persist in flight.
         private static readonly ArrayPool<byte> s_slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
-        private static readonly ArrayPool<Entry> s_entryPool = ArrayPool<Entry>.Create(1 << 22, 8);
+        private static readonly ArrayPool<Entry> s_entryPool = ArrayPool<Entry>.Create(1 << 22, 6);
         private static readonly EnvOptions s_envOptions = new();
 
         private readonly ColumnDb _columnDb = columnDb;

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -129,19 +129,43 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
     // ingests it into this column — bypassing the memtable -> flush -> L0-compaction burst of a large WriteBatch.
     private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
     {
-        // Last write wins: a SelfDestruct (delete) followed by re-creation (put) can target the same key in one
-        // snapshot, and an SST forbids duplicate keys, so collapse to the final value before writing.
-        private readonly Dictionary<byte[], byte[]?> _entries = new(Bytes.EqualityComparer);
+        // Byte cap on the in-memory buffer. At the cap we flush+ingest one SST and free the buffer, so a large
+        // persist (e.g. 10x state) never holds the whole batch in managed memory — that transient spike, on top
+        // of the working set, OOM-kills the node. Overlapping chunks are fine: each ingest gets a higher global
+        // seqno, so the later (final) value wins, which also preserves last-write-wins across chunk boundaries.
+        private const long MaxBufferedBytes = 128L * 1024 * 1024;
+        // Throttle the persist thread when L0 files pile up, bounding the native compaction working set.
+        private const int MaxL0FilesBeforeThrottle = 20;
 
-        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) =>
-            _entries[key.ToArray()] = value;
+        // Last write wins within a chunk: a SelfDestruct (delete) followed by re-creation (put) can target the
+        // same key, and an SST forbids duplicate keys, so collapse to the final value before writing.
+        private readonly Dictionary<byte[], byte[]?> _entries = new(Bytes.EqualityComparer);
+        private long _bufferedBytes;
+        private readonly IngestExternalFileOptions _options = new IngestExternalFileOptions()
+            .SetMoveFiles(true)
+            .SetAllowGlobalSeqno(true)
+            .SetAllowBlockingFlush(true);
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            byte[] k = key.ToArray();
+            if (_entries.TryGetValue(k, out byte[]? existing)) _bufferedBytes -= existing?.Length ?? 0;
+            else _bufferedBytes += k.Length;
+            _entries[k] = value;
+            _bufferedBytes += value?.Length ?? 0;
+            if (_bufferedBytes >= MaxBufferedBytes) FlushChunk();
+        }
 
         public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
             throw new NotSupportedException("SST ingestion does not support merge writes");
 
-        public void Clear() => _entries.Clear();
+        public void Clear()
+        {
+            _entries.Clear();
+            _bufferedBytes = 0;
+        }
 
-        public void Dispose()
+        private void FlushChunk()
         {
             if (_entries.Count == 0) return;
 
@@ -163,12 +187,25 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                 writer.Finish();
             }
 
-            IngestExternalFileOptions options = new IngestExternalFileOptions()
-                .SetMoveFiles(true)
-                .SetAllowGlobalSeqno(true)
-                .SetAllowBlockingFlush(true);
-            columnDb._rocksDb.IngestExternalFiles([file], options, columnDb._columnFamily);
+            columnDb._rocksDb.IngestExternalFiles([file], _options, columnDb._columnFamily);
+            Clear();
+            WaitForCompactionHeadroom();
         }
+
+        // Ingestion bypasses RocksDB's memtable write-stall, so back-to-back ingests pile up L0 files and the
+        // compaction working set grows without bound (native memory OOM at large state). Replicate the missing
+        // flow control: throttle the persist thread until L0 drains — exactly what the memtable write path does.
+        private void WaitForCompactionHeadroom()
+        {
+            for (int i = 0; i < 1500; i++) // ~30s safety cap
+            {
+                string? v = columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", columnDb._columnFamily);
+                if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
+                Thread.Sleep(20);
+            }
+        }
+
+        public void Dispose() => FlushChunk();
     }
 
     public void Remove(ReadOnlySpan<byte> key) => Set(key, null);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -26,6 +26,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
     private readonly RocksDb _rocksDb;
     internal readonly DbOnTheRocks _mainDb;
     internal readonly ColumnFamilyHandle _columnFamily;
+    // Test-only injection point: invoked before the native ingest so tests can simulate a mid-commit failure.
     internal Action? _testIngestFailureHook;
 
     private readonly DbOnTheRocks.IteratorManager _iteratorManager;

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
@@ -125,9 +127,12 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
     public IWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
 
-    // Buffers point puts/deletes in a byte-capped managed buffer; at the cap (and on Dispose) it flushes the buffer
-    // as a sorted SST and ingests it into this column — bypassing the memtable -> flush -> L0-compaction burst of a
-    // large WriteBatch. Buffering is on the managed heap, hence the byte cap to bound peak persist memory.
+    // Buffers key/value bytes in pooled slabs indexed by unmanaged entry structs instead of a
+    // Dictionary<byte[], byte[]?>: the dictionary buffered 2-3M small arrays per 128 MB chunk plus
+    // multi-MB bucket/entry/List-copy arrays — ~1.5-2.5 GB of promoted + LOH garbage per persist
+    // that fed blocking gen2 GC pauses (measured 1.3-2.1 s read stalls). Dedup is deferred to the
+    // flush-time sort (stable by append order, keep-last), which is semantics-preserving: duplicate
+    // keys across chunk files are already resolved by ingest order via AllowGlobalSeqno.
     private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
     {
         // Byte cap on the in-memory buffer. At the cap we flush+ingest one SST and free the buffer, so a large
@@ -137,63 +142,182 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         private const long MaxBufferedBytes = 128L * 1024 * 1024;
         // Throttle the persist thread when L0 files pile up, bounding the native compaction working set.
         private const int MaxL0FilesBeforeThrottle = 20;
+        private const int SlabSize = 1 << 20;
 
-        // Last write wins within a chunk: a SelfDestruct (delete) followed by re-creation (put) can target the
-        // same key, and an SST forbids duplicate keys, so collapse to the final value before writing.
-        private readonly Dictionary<byte[], byte[]?> _entries = new(Bytes.EqualityComparer);
+        private static readonly ArrayPool<byte> s_slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
+        private static readonly ArrayPool<Entry> s_entryPool = ArrayPool<Entry>.Create(1 << 22, 8);
+        private static readonly EnvOptions s_envOptions = new();
+
+        private readonly ColumnDb _columnDb = columnDb;
+        private readonly List<byte[]> _slabs = [];
+        private Entry[] _index = s_entryPool.Rent(1 << 16);
+        private int _count;
+        private int _slabIndex = -1;
+        private int _slabOffset;
         private long _bufferedBytes;
         private readonly IngestExternalFileOptions _options = new IngestExternalFileOptions()
             .SetMoveFiles(true)
             .SetAllowGlobalSeqno(true)
             .SetAllowBlockingFlush(true);
 
+        private struct Entry
+        {
+            public ulong KeyPrefix;
+            public int Slab;
+            public int Offset;
+            public int KeyLen;
+            public int ValLen; // -1 encodes delete
+            public int Seq;
+        }
+
         public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
         {
-            byte[] k = key.ToArray();
-            if (_entries.TryGetValue(k, out byte[]? existing)) _bufferedBytes -= existing?.Length ?? 0;
-            else _bufferedBytes += k.Length;
-            _entries[k] = value;
-            _bufferedBytes += value?.Length ?? 0;
-            if (_bufferedBytes >= MaxBufferedBytes) FlushChunk();
+            if (value is null) Append(key, default, isDelete: true);
+            else Append(key, value, isDelete: false);
         }
+
+        public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
+            Append(key, value, isDelete: false);
 
         public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
             throw new NotSupportedException("SST ingestion does not support merge writes");
 
+        private void Append(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, bool isDelete)
+        {
+            int length = key.Length + (isDelete ? 0 : value.Length);
+            Span<byte> destination = Reserve(length, out int slab, out int offset);
+            key.CopyTo(destination);
+            if (!isDelete) value.CopyTo(destination[key.Length..]);
+
+            if (_count == _index.Length) GrowIndex();
+            _index[_count] = new Entry
+            {
+                KeyPrefix = ReadPrefix(key),
+                Slab = slab,
+                Offset = offset,
+                KeyLen = key.Length,
+                ValLen = isDelete ? -1 : value.Length,
+                Seq = _count,
+            };
+            _count++;
+
+            _bufferedBytes += length + Unsafe.SizeOf<Entry>();
+            if (_bufferedBytes >= MaxBufferedBytes) FlushChunk();
+        }
+
+        private static ulong ReadPrefix(ReadOnlySpan<byte> key)
+        {
+            if (key.Length >= sizeof(ulong)) return BinaryPrimitives.ReadUInt64BigEndian(key);
+            Span<byte> padded = stackalloc byte[sizeof(ulong)];
+            padded.Clear();
+            key.CopyTo(padded);
+            return BinaryPrimitives.ReadUInt64BigEndian(padded);
+        }
+
+        private Span<byte> Reserve(int length, out int slab, out int offset)
+        {
+            if (length > SlabSize)
+            {
+                // Oversized entries get a dedicated exact-size array; dropped (not pooled) at reset.
+                byte[] dedicated = new byte[length];
+                _slabs.Add(dedicated);
+                slab = _slabs.Count - 1;
+                offset = 0;
+                return dedicated;
+            }
+
+            if (_slabIndex < 0 || _slabOffset + length > SlabSize)
+            {
+                do
+                {
+                    _slabIndex++;
+                }
+                while (_slabIndex < _slabs.Count && _slabs[_slabIndex].Length != SlabSize);
+
+                if (_slabIndex == _slabs.Count) _slabs.Add(s_slabPool.Rent(SlabSize));
+                _slabOffset = 0;
+            }
+
+            slab = _slabIndex;
+            offset = _slabOffset;
+            _slabOffset += length;
+            return _slabs[slab].AsSpan(offset, length);
+        }
+
+        private void GrowIndex()
+        {
+            Entry[] grown = s_entryPool.Rent(_index.Length * 2);
+            Array.Copy(_index, grown, _count);
+            s_entryPool.Return(_index);
+            _index = grown;
+        }
+
         public void Clear()
         {
-            _entries.Clear();
+            for (int i = _slabs.Count - 1; i >= 0; i--)
+            {
+                if (_slabs[i].Length != SlabSize) _slabs.RemoveAt(i);
+            }
+            _count = 0;
+            _slabIndex = _slabs.Count > 0 ? 0 : -1;
+            _slabOffset = 0;
             _bufferedBytes = 0;
         }
 
-        private void FlushChunk()
+        private ReadOnlySpan<byte> KeySpan(in Entry e) => _slabs[e.Slab].AsSpan(e.Offset, e.KeyLen);
+
+        private bool IsSameKey(in Entry x, in Entry y) =>
+            x.KeyPrefix == y.KeyPrefix && x.KeyLen == y.KeyLen && KeySpan(in x).SequenceEqual(KeySpan(in y));
+
+        private sealed class EntryComparer(SstIngestWriteBatch batch) : IComparer<Entry>
         {
-            if (_entries.Count == 0) return;
+            public int Compare(Entry x, Entry y)
+            {
+                int c = x.KeyPrefix.CompareTo(y.KeyPrefix);
+                if (c != 0) return c;
+                c = batch.KeySpan(in x).SequenceCompareTo(batch.KeySpan(in y));
+                return c != 0 ? c : x.Seq.CompareTo(y.Seq);
+            }
+        }
 
-            List<KeyValuePair<byte[], byte[]?>> items = [.. _entries];
-            items.Sort(static (a, b) => a.Key.AsSpan().SequenceCompareTo(b.Key));
+        private unsafe void FlushChunk()
+        {
+            if (_count == 0) return;
 
-            string dir = Path.Combine(columnDb._mainDb.FullPath, "sst_ingest");
+            Array.Sort(_index, 0, _count, new EntryComparer(this));
+
+            string dir = Path.Combine(_columnDb._mainDb.FullPath, "sst_ingest");
             Directory.CreateDirectory(dir);
-            string file = Path.Combine(dir, $"{columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
+            string file = Path.Combine(dir, $"{_columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
 
             try
             {
-                ColumnFamilyOptions writerOptions = columnDb._mainDb.GetColumnFamilyOptions(columnDb.Name) ?? new ColumnFamilyOptions();
-                using (SstFileWriter writer = new(new EnvOptions(), writerOptions))
+                ColumnFamilyOptions writerOptions = _columnDb._mainDb.GetColumnFamilyOptions(_columnDb.Name) ?? new ColumnFamilyOptions();
+                IntPtr writer = Native.Instance.rocksdb_sstfilewriter_create(s_envOptions.Handle, writerOptions.Handle);
+                try
                 {
-                    writer.Open(file);
-                    foreach ((byte[] key, byte[]? value) in items)
+                    Native.Instance.rocksdb_sstfilewriter_open(writer, file);
+                    for (int i = 0; i < _count; i++)
                     {
-                        if (value is null) writer.Delete(key);
-                        else writer.Put(key, value);
+                        ref Entry e = ref _index[i];
+                        // Equal keys sort by ascending Seq; only the last of each run (the latest write) is emitted.
+                        if (i + 1 < _count && IsSameKey(in e, in _index[i + 1])) continue;
+                        fixed (byte* data = &_slabs[e.Slab][e.Offset])
+                        {
+                            if (e.ValLen < 0) Native.Instance.rocksdb_sstfilewriter_delete(writer, data, (UIntPtr)e.KeyLen);
+                            else Native.Instance.rocksdb_sstfilewriter_put(writer, data, (UIntPtr)e.KeyLen, data + e.KeyLen, (UIntPtr)e.ValLen);
+                        }
                     }
-                    writer.Finish();
+                    Native.Instance.rocksdb_sstfilewriter_finish(writer);
+                }
+                finally
+                {
+                    Native.Instance.rocksdb_sstfilewriter_destroy(writer);
                 }
 
                 // SetMoveFiles(true): on success RocksDB moves (consumes) the file. Only a Finish/ingest failure
                 // leaves it staged, so delete it on failure to stop sst_ingest/ accumulating orphaned files.
-                columnDb._rocksDb.IngestExternalFiles([file], _options, columnDb._columnFamily);
+                _columnDb._rocksDb.IngestExternalFiles([file], _options, _columnDb._columnFamily);
             }
             catch
             {
@@ -212,13 +336,23 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         {
             for (int i = 0; i < 1500; i++) // ~30s safety cap
             {
-                string? v = columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", columnDb._columnFamily);
+                string? v = _columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnDb._columnFamily);
                 if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
                 Thread.Sleep(20);
             }
         }
 
-        public void Dispose() => FlushChunk();
+        public void Dispose()
+        {
+            FlushChunk();
+            foreach (byte[] slab in _slabs)
+            {
+                if (slab.Length == SlabSize) s_slabPool.Return(slab);
+            }
+            _slabs.Clear();
+            s_entryPool.Return(_index);
+            _index = [];
+        }
     }
 
     public void Remove(ReadOnlySpan<byte> key) => Set(key, null);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -179,7 +179,8 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
             try
             {
-                using (SstFileWriter writer = new(new EnvOptions(), new ColumnFamilyOptions()))
+                ColumnFamilyOptions writerOptions = columnDb._mainDb.GetColumnFamilyOptions(columnDb.Name) ?? new ColumnFamilyOptions();
+                using (SstFileWriter writer = new(new EnvOptions(), writerOptions))
                 {
                     writer.Open(file);
                     foreach ((byte[] key, byte[]? value) in items)

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -280,7 +280,8 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
             try
             {
-                ColumnFamilyOptions writerOptions = _columnDb._mainDb.GetColumnFamilyOptions(_columnDb.Name) ?? new ColumnFamilyOptions();
+                ColumnFamilyOptions writerOptions = _columnDb._mainDb.GetColumnFamilyOptions(_columnDb.Name)
+                    ?? throw new InvalidOperationException($"No column family options registered for column {_columnDb.Name} of {_columnDb._mainDb.Name}");
                 IntPtr writer = Native.Instance.rocksdb_sstfilewriter_create(s_envOptions.Handle, writerOptions.Handle);
                 try
                 {

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -147,19 +147,43 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
     // ingests it into this column — bypassing the memtable -> flush -> L0-compaction burst of a large WriteBatch.
     private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
     {
-        // Last write wins: a SelfDestruct (delete) followed by re-creation (put) can target the same key in one
-        // snapshot, and an SST forbids duplicate keys, so collapse to the final value before writing.
-        private readonly Dictionary<byte[], byte[]?> _entries = new(Bytes.EqualityComparer);
+        // Byte cap on the in-memory buffer. At the cap we flush+ingest one SST and free the buffer, so a large
+        // persist (e.g. 10x state) never holds the whole batch in managed memory — that transient spike, on top
+        // of the working set, OOM-kills the node. Overlapping chunks are fine: each ingest gets a higher global
+        // seqno, so the later (final) value wins, which also preserves last-write-wins across chunk boundaries.
+        private const long MaxBufferedBytes = 128L * 1024 * 1024;
+        // Throttle the persist thread when L0 files pile up, bounding the native compaction working set.
+        private const int MaxL0FilesBeforeThrottle = 20;
 
-        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) =>
-            _entries[key.ToArray()] = value;
+        // Last write wins within a chunk: a SelfDestruct (delete) followed by re-creation (put) can target the
+        // same key, and an SST forbids duplicate keys, so collapse to the final value before writing.
+        private readonly Dictionary<byte[], byte[]?> _entries = new(Bytes.EqualityComparer);
+        private long _bufferedBytes;
+        private readonly IngestExternalFileOptions _options = new IngestExternalFileOptions()
+            .SetMoveFiles(true)
+            .SetAllowGlobalSeqno(true)
+            .SetAllowBlockingFlush(true);
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
+        {
+            byte[] k = key.ToArray();
+            if (_entries.TryGetValue(k, out byte[]? existing)) _bufferedBytes -= existing?.Length ?? 0;
+            else _bufferedBytes += k.Length;
+            _entries[k] = value;
+            _bufferedBytes += value?.Length ?? 0;
+            if (_bufferedBytes >= MaxBufferedBytes) FlushChunk();
+        }
 
         public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
             throw new NotSupportedException("SST ingestion does not support merge writes");
 
-        public void Clear() => _entries.Clear();
+        public void Clear()
+        {
+            _entries.Clear();
+            _bufferedBytes = 0;
+        }
 
-        public void Dispose()
+        private void FlushChunk()
         {
             if (_entries.Count == 0) return;
 
@@ -181,12 +205,25 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                 writer.Finish();
             }
 
-            IngestExternalFileOptions options = new IngestExternalFileOptions()
-                .SetMoveFiles(true)
-                .SetAllowGlobalSeqno(true)
-                .SetAllowBlockingFlush(true);
-            columnDb._rocksDb.IngestExternalFiles([file], options, columnDb._columnFamily);
+            columnDb._rocksDb.IngestExternalFiles([file], _options, columnDb._columnFamily);
+            Clear();
+            WaitForCompactionHeadroom();
         }
+
+        // Ingestion bypasses RocksDB's memtable write-stall, so back-to-back ingests pile up L0 files and the
+        // compaction working set grows without bound (native memory OOM at large state). Replicate the missing
+        // flow control: throttle the persist thread until L0 drains — exactly what the memtable write path does.
+        private void WaitForCompactionHeadroom()
+        {
+            for (int i = 0; i < 1500; i++) // ~30s safety cap
+            {
+                string? v = columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", columnDb._columnFamily);
+                if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
+                Thread.Sleep(20);
+            }
+        }
+
+        public void Dispose() => FlushChunk();
     }
 
     public void Remove(ReadOnlySpan<byte> key) => Set(key, null);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -166,7 +166,15 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
     {
         if (files.Count == 0) return;
         _testIngestFailureHook?.Invoke();
-        _rocksDb.IngestExternalFiles([.. files], _ingestOptions, _columnFamily);
+        try
+        {
+            _rocksDb.IngestExternalFiles([.. files], _ingestOptions, _columnFamily);
+        }
+        catch (RocksDbSharpException x)
+        {
+            _mainDb.HandleFatalDbError(x);
+            throw;
+        }
     }
 
     public void WaitForIngestCompactionHeadroom(CancellationToken cancellationToken)
@@ -371,8 +379,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                     Native.Instance.rocksdb_sstfilewriter_destroy(writer);
                 }
             }
-            catch
+            catch (Exception writerError)
             {
+                if (writerError is RocksDbSharpException dbEx) _columnDb._mainDb.HandleFatalDbError(dbEx);
                 try
                 {
                     if (File.Exists(file)) File.Delete(file);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -16,6 +16,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.RocksDbBindings;
+using Nethermind.RocksDbBindings.Native;
 using IWriteBatch = Nethermind.Core.IWriteBatch;
 
 namespace Nethermind.Db.Rocks;
@@ -170,7 +171,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             _testIngestFailureHook?.Invoke();
             _rocksDb.IngestExternalFiles([.. files], _ingestOptions, _columnFamily);
         }
-        catch (RocksDbSharpException x)
+        catch (RocksDbException x)
         {
             _mainDb.HandleFatalDbError(x, scheduleRepairMarker: false);
             throw;
@@ -353,35 +354,31 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             {
                 ColumnFamilyOptions writerOptions = _columnDb._mainDb.GetColumnFamilyOptions(_columnDb.Name)
                     ?? throw new InvalidOperationException($"No column family options registered for column {_columnDb.Name} of {_columnDb._mainDb.Name}");
-                IntPtr writer = Native.Instance.rocksdb_sstfilewriter_create(_envOptions.Handle, writerOptions.Handle);
-                try
+                using SstFileWriter writer = new(_envOptions, writerOptions);
+                rocksdb_sstfilewriter_t* writerHandle = (rocksdb_sstfilewriter_t*)writer.Handle;
+                writer.Open(file);
+                for (int i = 0; i < _count; i++)
                 {
-                    Native.Instance.rocksdb_sstfilewriter_open(writer, file);
-                    for (int i = 0; i < _count; i++)
+                    ref Entry e = ref _index[i];
+                    // Equal keys sort by ascending Seq; only the last of each run (the latest write) is emitted.
+                    if (i + 1 < _count && IsSameKey(in e, in _index[i + 1])) continue;
+                    // Safety: Reserve wrote KeyLen (+ ValLen for puts) contiguous bytes at [Offset, Offset + length)
+                    // inside _slabs[Slab], so data, data + KeyLen and data + KeyLen + ValLen all stay within the pinned
+                    // slab; the native put/delete therefore cannot read or write past the slab's bounds.
+                    fixed (byte* slabPtr = &MemoryMarshal.GetArrayDataReference(_slabs[e.Slab]))
                     {
-                        ref Entry e = ref _index[i];
-                        // Equal keys sort by ascending Seq; only the last of each run (the latest write) is emitted.
-                        if (i + 1 < _count && IsSameKey(in e, in _index[i + 1])) continue;
-                        // Safety: Reserve wrote KeyLen (+ ValLen for puts) contiguous bytes at [Offset, Offset + length)
-                        // inside _slabs[Slab], so data, data + KeyLen and data + KeyLen + ValLen all stay within the pinned
-                        // slab; the native put/delete therefore cannot read or write past the slab's bounds.
-                        fixed (byte* slabPtr = &MemoryMarshal.GetArrayDataReference(_slabs[e.Slab]))
-                        {
-                            byte* data = slabPtr + e.Offset;
-                            if (e.ValLen < 0) Native.Instance.rocksdb_sstfilewriter_delete(writer, data, (UIntPtr)e.KeyLen);
-                            else Native.Instance.rocksdb_sstfilewriter_put(writer, data, (UIntPtr)e.KeyLen, data + e.KeyLen, (UIntPtr)e.ValLen);
-                        }
+                        byte* data = slabPtr + e.Offset;
+                        sbyte* err = null;
+                        if (e.ValLen < 0) RocksDbNative.rocksdb_sstfilewriter_delete(writerHandle, (sbyte*)data, (UIntPtr)e.KeyLen, &err);
+                        else RocksDbNative.rocksdb_sstfilewriter_put(writerHandle, (sbyte*)data, (UIntPtr)e.KeyLen, (sbyte*)(data + e.KeyLen), (UIntPtr)e.ValLen, &err);
+                        if (err is not null) throw new RocksDbNativeException((IntPtr)err);
                     }
-                    Native.Instance.rocksdb_sstfilewriter_finish(writer);
                 }
-                finally
-                {
-                    Native.Instance.rocksdb_sstfilewriter_destroy(writer);
-                }
+                writer.Finish();
             }
             catch (Exception writerError)
             {
-                if (writerError is RocksDbSharpException dbEx) _columnDb._mainDb.HandleFatalDbError(dbEx, scheduleRepairMarker: false);
+                if (writerError is RocksDbException dbEx) _columnDb._mainDb.HandleFatalDbError(dbEx, scheduleRepairMarker: false);
                 try
                 {
                     if (File.Exists(file)) File.Delete(file);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -11,6 +11,8 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.RocksDbBindings;
@@ -180,25 +182,32 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         if (logger.IsWarn) logger.Warn($"L0 of {_mainDb.Name} column {Name} did not drain below {MaxL0FilesBeforeThrottle} files within {L0DrainMaxPolls * L0DrainPollMs / 1000}s; continuing SST ingestion without compaction headroom");
     }
 
-    private sealed class SstIngestWriteBatch(ColumnDb columnDb) : ISstIngestWriteBatch
+    private sealed class SstIngestWriteBatch : ISstIngestWriteBatch
     {
         private const long MaxBufferedBytes = 128L * 1024 * 1024;
         private const int SlabSize = 1 << 20;
 
         // Worst-case permanent retention: slabs <= 1024 x 1 MiB = 1 GiB; entries <= 6 arrays/bucket over 2^16..2^22 x 32 B ~= 1.5 GiB.
         // 6 covers peak concurrency: six column batches alive per persist, one persist in flight.
-        private static readonly ArrayPool<byte> s_slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
-        private static readonly ArrayPool<Entry> s_entryPool = ArrayPool<Entry>.Create(1 << 22, 6);
-        private static readonly EnvOptions s_envOptions = new();
+        private static readonly ArrayPool<byte> _slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
+        private static readonly ArrayPool<Entry> _entryPool = ArrayPool<Entry>.Create(1 << 22, 6);
+        private static readonly EnvOptions _envOptions = new();
 
-        private readonly ColumnDb _columnDb = columnDb;
+        private readonly ColumnDb _columnDb;
+        private readonly EntryComparer _comparer;
         private readonly List<byte[]> _slabs = [];
-        private readonly List<string> _stagedFiles = [];
-        private Entry[] _index = s_entryPool.Rent(1 << 16);
+        private readonly ArrayPoolList<string> _stagedFiles = new(4);
+        private Entry[] _index = _entryPool.Rent(1 << 16);
         private int _count;
         private int _slabIndex = -1;
         private int _slabOffset;
         private long _bufferedBytes;
+
+        public SstIngestWriteBatch(ColumnDb columnDb)
+        {
+            _columnDb = columnDb;
+            _comparer = new EntryComparer(this);
+        }
 
         private struct Entry
         {
@@ -273,7 +282,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                 }
                 while (_slabIndex < _slabs.Count && _slabs[_slabIndex].Length != SlabSize);
 
-                if (_slabIndex == _slabs.Count) _slabs.Add(s_slabPool.Rent(SlabSize));
+                if (_slabIndex == _slabs.Count) _slabs.Add(_slabPool.Rent(SlabSize));
                 _slabOffset = 0;
             }
 
@@ -285,9 +294,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
         private void GrowIndex()
         {
-            Entry[] grown = s_entryPool.Rent(_index.Length * 2);
+            Entry[] grown = _entryPool.Rent(_index.Length * 2);
             Array.Copy(_index, grown, _count);
-            s_entryPool.Return(_index);
+            _entryPool.Return(_index);
             _index = grown;
         }
 
@@ -323,7 +332,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         {
             if (_count == 0) return;
 
-            Array.Sort(_index, 0, _count, new EntryComparer(this));
+            Array.Sort(_index, 0, _count, _comparer);
 
             Directory.CreateDirectory(_columnDb.IngestStagingDir);
             string file = Path.Combine(_columnDb.IngestStagingDir, $"{_columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
@@ -332,7 +341,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             {
                 ColumnFamilyOptions writerOptions = _columnDb._mainDb.GetColumnFamilyOptions(_columnDb.Name)
                     ?? throw new InvalidOperationException($"No column family options registered for column {_columnDb.Name} of {_columnDb._mainDb.Name}");
-                IntPtr writer = Native.Instance.rocksdb_sstfilewriter_create(s_envOptions.Handle, writerOptions.Handle);
+                IntPtr writer = Native.Instance.rocksdb_sstfilewriter_create(_envOptions.Handle, writerOptions.Handle);
                 try
                 {
                     Native.Instance.rocksdb_sstfilewriter_open(writer, file);
@@ -341,6 +350,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                         ref Entry e = ref _index[i];
                         // Equal keys sort by ascending Seq; only the last of each run (the latest write) is emitted.
                         if (i + 1 < _count && IsSameKey(in e, in _index[i + 1])) continue;
+                        // Safety: Reserve wrote KeyLen (+ ValLen for puts) contiguous bytes at [Offset, Offset + length)
+                        // inside _slabs[Slab], so data, data + KeyLen and data + KeyLen + ValLen all stay within the pinned
+                        // slab; the native put/delete therefore cannot read or write past the slab's bounds.
                         fixed (byte* slabPtr = &MemoryMarshal.GetArrayDataReference(_slabs[e.Slab]))
                         {
                             byte* data = slabPtr + e.Offset;
@@ -357,7 +369,14 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             }
             catch
             {
-                try { if (File.Exists(file)) File.Delete(file); } catch { }
+                try
+                {
+                    if (File.Exists(file)) File.Delete(file);
+                }
+                catch (Exception cleanupError)
+                {
+                    if (_columnDb._mainDb.Logger.IsDebug) _columnDb._mainDb.Logger.Debug($"Failed to delete partial SST file '{file}' after a writer error; it will be swept on next startup. {cleanupError}");
+                }
                 throw;
             }
 
@@ -381,7 +400,14 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         {
             foreach (string file in _stagedFiles)
             {
-                try { if (File.Exists(file)) File.Delete(file); } catch { }
+                try
+                {
+                    if (File.Exists(file)) File.Delete(file);
+                }
+                catch (Exception e)
+                {
+                    if (_columnDb._mainDb.Logger.IsDebug) _columnDb._mainDb.Logger.Debug($"Failed to delete staged SST file '{file}' during cleanup; it will be swept on next startup. {e}");
+                }
             }
             _stagedFiles.Clear();
         }
@@ -390,11 +416,12 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         {
             foreach (byte[] slab in _slabs)
             {
-                if (slab.Length == SlabSize) s_slabPool.Return(slab);
+                if (slab.Length == SlabSize) _slabPool.Return(slab);
             }
             _slabs.Clear();
-            s_entryPool.Return(_index);
+            _entryPool.Return(_index);
             _index = [];
+            _stagedFiles.Dispose();
         }
     }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.IO;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Extensions;
@@ -12,8 +14,10 @@ using IWriteBatch = Nethermind.Core.IWriteBatch;
 
 namespace Nethermind.Db.Rocks;
 
-public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKeyValueStoreWithSnapshot, IRangeRemovableKeyValueStore
+public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKeyValueStoreWithSnapshot, IRangeRemovableKeyValueStore, ISstIngestible
 {
+    private static long _sstIngestSeq;
+
     private readonly RocksDb _rocksDb;
     internal readonly DbOnTheRocks _mainDb;
     internal readonly IColumnFamilyHandle _columnFamily;
@@ -135,6 +139,54 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
         public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
             underlyingWriteBatch.Merge(key, value, columnDb._columnFamily, flags);
+    }
+
+    public IWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
+
+    // Buffers point puts/deletes for one persisted snapshot, then on Dispose writes a single sorted SST and
+    // ingests it into this column — bypassing the memtable -> flush -> L0-compaction burst of a large WriteBatch.
+    private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
+    {
+        // Last write wins: a SelfDestruct (delete) followed by re-creation (put) can target the same key in one
+        // snapshot, and an SST forbids duplicate keys, so collapse to the final value before writing.
+        private readonly Dictionary<byte[], byte[]?> _entries = new(Bytes.EqualityComparer);
+
+        public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) =>
+            _entries[key.ToArray()] = value;
+
+        public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
+            throw new NotSupportedException("SST ingestion does not support merge writes");
+
+        public void Clear() => _entries.Clear();
+
+        public void Dispose()
+        {
+            if (_entries.Count == 0) return;
+
+            List<KeyValuePair<byte[], byte[]?>> items = [.. _entries];
+            items.Sort(static (a, b) => a.Key.AsSpan().SequenceCompareTo(b.Key));
+
+            string dir = Path.Combine(columnDb._mainDb.FullPath, "sst_ingest");
+            Directory.CreateDirectory(dir);
+            string file = Path.Combine(dir, $"{columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
+
+            using (SstFileWriter writer = new(new EnvOptions(), new ColumnFamilyOptions()))
+            {
+                writer.Open(file);
+                foreach ((byte[] key, byte[]? value) in items)
+                {
+                    if (value is null) writer.Delete(key);
+                    else writer.Put(key, value);
+                }
+                writer.Finish();
+            }
+
+            IngestExternalFileOptions options = new IngestExternalFileOptions()
+                .SetMoveFiles(true)
+                .SetAllowGlobalSeqno(true)
+                .SetAllowBlockingFlush(true);
+            columnDb._rocksDb.IngestExternalFiles([file], options, columnDb._columnFamily);
+        }
     }
 
     public void Remove(ReadOnlySpan<byte> key) => Set(key, null);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -298,7 +298,8 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
             try
             {
-                ColumnFamilyOptions writerOptions = _columnDb._mainDb.GetColumnFamilyOptions(_columnDb.Name) ?? new ColumnFamilyOptions();
+                ColumnFamilyOptions writerOptions = _columnDb._mainDb.GetColumnFamilyOptions(_columnDb.Name)
+                    ?? throw new InvalidOperationException($"No column family options registered for column {_columnDb.Name} of {_columnDb._mainDb.Name}");
                 IntPtr writer = Native.Instance.rocksdb_sstfilewriter_create(s_envOptions.Handle, writerOptions.Handle);
                 try
                 {

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -172,7 +172,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         }
         catch (RocksDbSharpException x)
         {
-            _mainDb.HandleFatalDbError(x);
+            _mainDb.HandleFatalDbError(x, scheduleRepairMarker: false);
             throw;
         }
     }
@@ -381,7 +381,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             }
             catch (Exception writerError)
             {
-                if (writerError is RocksDbSharpException dbEx) _columnDb._mainDb.HandleFatalDbError(dbEx);
+                if (writerError is RocksDbSharpException dbEx) _columnDb._mainDb.HandleFatalDbError(dbEx, scheduleRepairMarker: false);
                 try
                 {
                     if (File.Exists(file)) File.Delete(file);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -7,6 +7,7 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
@@ -312,8 +313,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                         ref Entry e = ref _index[i];
                         // Equal keys sort by ascending Seq; only the last of each run (the latest write) is emitted.
                         if (i + 1 < _count && IsSameKey(in e, in _index[i + 1])) continue;
-                        fixed (byte* data = &_slabs[e.Slab][e.Offset])
+                        fixed (byte* slabPtr = &MemoryMarshal.GetArrayDataReference(_slabs[e.Slab]))
                         {
+                            byte* data = slabPtr + e.Offset;
                             if (e.ValLen < 0) Native.Instance.rocksdb_sstfilewriter_delete(writer, data, (UIntPtr)e.KeyLen);
                             else Native.Instance.rocksdb_sstfilewriter_put(writer, data, (UIntPtr)e.KeyLen, data + e.KeyLen, (UIntPtr)e.ValLen);
                         }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -169,10 +169,11 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         _rocksDb.IngestExternalFiles([.. files], _ingestOptions, _columnFamily);
     }
 
-    public void WaitForIngestCompactionHeadroom()
+    public void WaitForIngestCompactionHeadroom(CancellationToken cancellationToken)
     {
         for (int i = 0; i < L0DrainMaxPolls; i++)
         {
+            if (cancellationToken.IsCancellationRequested) return;
             string? v = _rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnFamily);
             if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
             Thread.Sleep(L0DrainPollMs);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -155,8 +155,10 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         private const int L0DrainPollMs = 20;
         private const int SlabSize = 1 << 20;
 
+        // Worst-case permanent retention: slabs <= 1024 x 1 MiB = 1 GiB; entries <= 6 arrays/bucket over 2^16..2^22 x 32 B ~= 1.5 GiB.
+        // 6 covers peak concurrency: six column batches alive per persist, one persist in flight.
         private static readonly ArrayPool<byte> s_slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
-        private static readonly ArrayPool<Entry> s_entryPool = ArrayPool<Entry>.Create(1 << 22, 8);
+        private static readonly ArrayPool<Entry> s_entryPool = ArrayPool<Entry>.Create(1 << 22, 6);
         private static readonly EnvOptions s_envOptions = new();
 
         private readonly ColumnDb _columnDb = columnDb;

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
@@ -143,9 +145,12 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
     public IWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
 
-    // Buffers point puts/deletes in a byte-capped managed buffer; at the cap (and on Dispose) it flushes the buffer
-    // as a sorted SST and ingests it into this column — bypassing the memtable -> flush -> L0-compaction burst of a
-    // large WriteBatch. Buffering is on the managed heap, hence the byte cap to bound peak persist memory.
+    // Buffers key/value bytes in pooled slabs indexed by unmanaged entry structs instead of a
+    // Dictionary<byte[], byte[]?>: the dictionary buffered 2-3M small arrays per 128 MB chunk plus
+    // multi-MB bucket/entry/List-copy arrays — ~1.5-2.5 GB of promoted + LOH garbage per persist
+    // that fed blocking gen2 GC pauses (measured 1.3-2.1 s read stalls). Dedup is deferred to the
+    // flush-time sort (stable by append order, keep-last), which is semantics-preserving: duplicate
+    // keys across chunk files are already resolved by ingest order via AllowGlobalSeqno.
     private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
     {
         // Byte cap on the in-memory buffer. At the cap we flush+ingest one SST and free the buffer, so a large
@@ -155,63 +160,182 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         private const long MaxBufferedBytes = 128L * 1024 * 1024;
         // Throttle the persist thread when L0 files pile up, bounding the native compaction working set.
         private const int MaxL0FilesBeforeThrottle = 20;
+        private const int SlabSize = 1 << 20;
 
-        // Last write wins within a chunk: a SelfDestruct (delete) followed by re-creation (put) can target the
-        // same key, and an SST forbids duplicate keys, so collapse to the final value before writing.
-        private readonly Dictionary<byte[], byte[]?> _entries = new(Bytes.EqualityComparer);
+        private static readonly ArrayPool<byte> s_slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
+        private static readonly ArrayPool<Entry> s_entryPool = ArrayPool<Entry>.Create(1 << 22, 8);
+        private static readonly EnvOptions s_envOptions = new();
+
+        private readonly ColumnDb _columnDb = columnDb;
+        private readonly List<byte[]> _slabs = [];
+        private Entry[] _index = s_entryPool.Rent(1 << 16);
+        private int _count;
+        private int _slabIndex = -1;
+        private int _slabOffset;
         private long _bufferedBytes;
         private readonly IngestExternalFileOptions _options = new IngestExternalFileOptions()
             .SetMoveFiles(true)
             .SetAllowGlobalSeqno(true)
             .SetAllowBlockingFlush(true);
 
+        private struct Entry
+        {
+            public ulong KeyPrefix;
+            public int Slab;
+            public int Offset;
+            public int KeyLen;
+            public int ValLen; // -1 encodes delete
+            public int Seq;
+        }
+
         public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None)
         {
-            byte[] k = key.ToArray();
-            if (_entries.TryGetValue(k, out byte[]? existing)) _bufferedBytes -= existing?.Length ?? 0;
-            else _bufferedBytes += k.Length;
-            _entries[k] = value;
-            _bufferedBytes += value?.Length ?? 0;
-            if (_bufferedBytes >= MaxBufferedBytes) FlushChunk();
+            if (value is null) Append(key, default, isDelete: true);
+            else Append(key, value, isDelete: false);
         }
+
+        public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
+            Append(key, value, isDelete: false);
 
         public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
             throw new NotSupportedException("SST ingestion does not support merge writes");
 
+        private void Append(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, bool isDelete)
+        {
+            int length = key.Length + (isDelete ? 0 : value.Length);
+            Span<byte> destination = Reserve(length, out int slab, out int offset);
+            key.CopyTo(destination);
+            if (!isDelete) value.CopyTo(destination[key.Length..]);
+
+            if (_count == _index.Length) GrowIndex();
+            _index[_count] = new Entry
+            {
+                KeyPrefix = ReadPrefix(key),
+                Slab = slab,
+                Offset = offset,
+                KeyLen = key.Length,
+                ValLen = isDelete ? -1 : value.Length,
+                Seq = _count,
+            };
+            _count++;
+
+            _bufferedBytes += length + Unsafe.SizeOf<Entry>();
+            if (_bufferedBytes >= MaxBufferedBytes) FlushChunk();
+        }
+
+        private static ulong ReadPrefix(ReadOnlySpan<byte> key)
+        {
+            if (key.Length >= sizeof(ulong)) return BinaryPrimitives.ReadUInt64BigEndian(key);
+            Span<byte> padded = stackalloc byte[sizeof(ulong)];
+            padded.Clear();
+            key.CopyTo(padded);
+            return BinaryPrimitives.ReadUInt64BigEndian(padded);
+        }
+
+        private Span<byte> Reserve(int length, out int slab, out int offset)
+        {
+            if (length > SlabSize)
+            {
+                // Oversized entries get a dedicated exact-size array; dropped (not pooled) at reset.
+                byte[] dedicated = new byte[length];
+                _slabs.Add(dedicated);
+                slab = _slabs.Count - 1;
+                offset = 0;
+                return dedicated;
+            }
+
+            if (_slabIndex < 0 || _slabOffset + length > SlabSize)
+            {
+                do
+                {
+                    _slabIndex++;
+                }
+                while (_slabIndex < _slabs.Count && _slabs[_slabIndex].Length != SlabSize);
+
+                if (_slabIndex == _slabs.Count) _slabs.Add(s_slabPool.Rent(SlabSize));
+                _slabOffset = 0;
+            }
+
+            slab = _slabIndex;
+            offset = _slabOffset;
+            _slabOffset += length;
+            return _slabs[slab].AsSpan(offset, length);
+        }
+
+        private void GrowIndex()
+        {
+            Entry[] grown = s_entryPool.Rent(_index.Length * 2);
+            Array.Copy(_index, grown, _count);
+            s_entryPool.Return(_index);
+            _index = grown;
+        }
+
         public void Clear()
         {
-            _entries.Clear();
+            for (int i = _slabs.Count - 1; i >= 0; i--)
+            {
+                if (_slabs[i].Length != SlabSize) _slabs.RemoveAt(i);
+            }
+            _count = 0;
+            _slabIndex = _slabs.Count > 0 ? 0 : -1;
+            _slabOffset = 0;
             _bufferedBytes = 0;
         }
 
-        private void FlushChunk()
+        private ReadOnlySpan<byte> KeySpan(in Entry e) => _slabs[e.Slab].AsSpan(e.Offset, e.KeyLen);
+
+        private bool IsSameKey(in Entry x, in Entry y) =>
+            x.KeyPrefix == y.KeyPrefix && x.KeyLen == y.KeyLen && KeySpan(in x).SequenceEqual(KeySpan(in y));
+
+        private sealed class EntryComparer(SstIngestWriteBatch batch) : IComparer<Entry>
         {
-            if (_entries.Count == 0) return;
+            public int Compare(Entry x, Entry y)
+            {
+                int c = x.KeyPrefix.CompareTo(y.KeyPrefix);
+                if (c != 0) return c;
+                c = batch.KeySpan(in x).SequenceCompareTo(batch.KeySpan(in y));
+                return c != 0 ? c : x.Seq.CompareTo(y.Seq);
+            }
+        }
 
-            List<KeyValuePair<byte[], byte[]?>> items = [.. _entries];
-            items.Sort(static (a, b) => a.Key.AsSpan().SequenceCompareTo(b.Key));
+        private unsafe void FlushChunk()
+        {
+            if (_count == 0) return;
 
-            string dir = Path.Combine(columnDb._mainDb.FullPath, "sst_ingest");
+            Array.Sort(_index, 0, _count, new EntryComparer(this));
+
+            string dir = Path.Combine(_columnDb._mainDb.FullPath, "sst_ingest");
             Directory.CreateDirectory(dir);
-            string file = Path.Combine(dir, $"{columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
+            string file = Path.Combine(dir, $"{_columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
 
             try
             {
-                ColumnFamilyOptions writerOptions = columnDb._mainDb.GetColumnFamilyOptions(columnDb.Name) ?? new ColumnFamilyOptions();
-                using (SstFileWriter writer = new(new EnvOptions(), writerOptions))
+                ColumnFamilyOptions writerOptions = _columnDb._mainDb.GetColumnFamilyOptions(_columnDb.Name) ?? new ColumnFamilyOptions();
+                IntPtr writer = Native.Instance.rocksdb_sstfilewriter_create(s_envOptions.Handle, writerOptions.Handle);
+                try
                 {
-                    writer.Open(file);
-                    foreach ((byte[] key, byte[]? value) in items)
+                    Native.Instance.rocksdb_sstfilewriter_open(writer, file);
+                    for (int i = 0; i < _count; i++)
                     {
-                        if (value is null) writer.Delete(key);
-                        else writer.Put(key, value);
+                        ref Entry e = ref _index[i];
+                        // Equal keys sort by ascending Seq; only the last of each run (the latest write) is emitted.
+                        if (i + 1 < _count && IsSameKey(in e, in _index[i + 1])) continue;
+                        fixed (byte* data = &_slabs[e.Slab][e.Offset])
+                        {
+                            if (e.ValLen < 0) Native.Instance.rocksdb_sstfilewriter_delete(writer, data, (UIntPtr)e.KeyLen);
+                            else Native.Instance.rocksdb_sstfilewriter_put(writer, data, (UIntPtr)e.KeyLen, data + e.KeyLen, (UIntPtr)e.ValLen);
+                        }
                     }
-                    writer.Finish();
+                    Native.Instance.rocksdb_sstfilewriter_finish(writer);
+                }
+                finally
+                {
+                    Native.Instance.rocksdb_sstfilewriter_destroy(writer);
                 }
 
                 // SetMoveFiles(true): on success RocksDB moves (consumes) the file. Only a Finish/ingest failure
                 // leaves it staged, so delete it on failure to stop sst_ingest/ accumulating orphaned files.
-                columnDb._rocksDb.IngestExternalFiles([file], _options, columnDb._columnFamily);
+                _columnDb._rocksDb.IngestExternalFiles([file], _options, _columnDb._columnFamily);
             }
             catch
             {
@@ -230,13 +354,23 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         {
             for (int i = 0; i < 1500; i++) // ~30s safety cap
             {
-                string? v = columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", columnDb._columnFamily);
+                string? v = _columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnDb._columnFamily);
                 if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
                 Thread.Sleep(20);
             }
         }
 
-        public void Dispose() => FlushChunk();
+        public void Dispose()
+        {
+            FlushChunk();
+            foreach (byte[] slab in _slabs)
+            {
+                if (slab.Length == SlabSize) s_slabPool.Return(slab);
+            }
+            _slabs.Clear();
+            s_entryPool.Return(_index);
+            _index = [];
+        }
     }
 
     public void Remove(ReadOnlySpan<byte> key) => Set(key, null);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Extensions;
+using Nethermind.Logging;
 using Nethermind.RocksDbBindings;
 using IWriteBatch = Nethermind.Core.IWriteBatch;
 
@@ -149,6 +150,8 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
     {
         private const long MaxBufferedBytes = 128L * 1024 * 1024;
         private const int MaxL0FilesBeforeThrottle = 20;
+        private const int L0DrainMaxPolls = 1500;
+        private const int L0DrainPollMs = 20;
         private const int SlabSize = 1 << 20;
 
         private static readonly ArrayPool<byte> s_slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
@@ -336,12 +339,15 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
         private void WaitForCompactionHeadroom()
         {
-            for (int i = 0; i < 1500; i++)
+            for (int i = 0; i < L0DrainMaxPolls; i++)
             {
                 string? v = _columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnDb._columnFamily);
                 if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
-                Thread.Sleep(20);
+                Thread.Sleep(L0DrainPollMs);
             }
+
+            ILogger logger = _columnDb._mainDb.Logger;
+            if (logger.IsWarn) logger.Warn($"L0 of {_columnDb._mainDb.Name} column {_columnDb.Name} did not drain below {MaxL0FilesBeforeThrottle} files within {L0DrainMaxPolls * L0DrainPollMs / 1000}s; continuing SST ingestion without compaction headroom");
         }
 
         public void Dispose()

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -143,8 +143,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
     public IWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
 
-    // Buffers point puts/deletes for one persisted snapshot, then on Dispose writes a single sorted SST and
-    // ingests it into this column — bypassing the memtable -> flush -> L0-compaction burst of a large WriteBatch.
+    // Buffers point puts/deletes in a byte-capped managed buffer; at the cap (and on Dispose) it flushes the buffer
+    // as a sorted SST and ingests it into this column — bypassing the memtable -> flush -> L0-compaction burst of a
+    // large WriteBatch. Buffering is on the managed heap, hence the byte cap to bound peak persist memory.
     private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
     {
         // Byte cap on the in-memory buffer. At the cap we flush+ingest one SST and free the buffer, so a large
@@ -194,18 +195,29 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             Directory.CreateDirectory(dir);
             string file = Path.Combine(dir, $"{columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
 
-            using (SstFileWriter writer = new(new EnvOptions(), new ColumnFamilyOptions()))
+            try
             {
-                writer.Open(file);
-                foreach ((byte[] key, byte[]? value) in items)
+                using (SstFileWriter writer = new(new EnvOptions(), new ColumnFamilyOptions()))
                 {
-                    if (value is null) writer.Delete(key);
-                    else writer.Put(key, value);
+                    writer.Open(file);
+                    foreach ((byte[] key, byte[]? value) in items)
+                    {
+                        if (value is null) writer.Delete(key);
+                        else writer.Put(key, value);
+                    }
+                    writer.Finish();
                 }
-                writer.Finish();
+
+                // SetMoveFiles(true): on success RocksDB moves (consumes) the file. Only a Finish/ingest failure
+                // leaves it staged, so delete it on failure to stop sst_ingest/ accumulating orphaned files.
+                columnDb._rocksDb.IngestExternalFiles([file], _options, columnDb._columnFamily);
+            }
+            catch
+            {
+                try { if (File.Exists(file)) File.Delete(file); } catch { /* best effort */ }
+                throw;
             }
 
-            columnDb._rocksDb.IngestExternalFiles([file], _options, columnDb._columnFamily);
             Clear();
             WaitForCompactionHeadroom();
         }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -25,6 +25,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
     private readonly RocksDb _rocksDb;
     internal readonly DbOnTheRocks _mainDb;
     internal readonly IColumnFamilyHandle _columnFamily;
+    // Test-only injection point: invoked before the native ingest so tests can simulate a mid-commit failure.
     internal Action? _testIngestFailureHook;
 
     private readonly DisposableLazy<DbOnTheRocks.IteratorManager>? _iteratorManager;

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -146,14 +146,42 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             underlyingWriteBatch.Merge(key, value, columnDb._columnFamily, flags);
     }
 
-    public IWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
+    public ISstIngestWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
 
-    private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
+    public string IngestStagingDir => Path.Combine(_mainDb.FullPath, "sst_ingest");
+
+    private const int MaxL0FilesBeforeThrottle = 20;
+    private const int L0DrainMaxPolls = 1500;
+    private const int L0DrainPollMs = 20;
+
+    private readonly IngestExternalFileOptions _ingestOptions = new IngestExternalFileOptions()
+        .SetMoveFiles(true)
+        .SetAllowGlobalSeqno(true)
+        .SetAllowBlockingFlush(true);
+
+    public void IngestStagedFiles(IReadOnlyList<string> files)
+    {
+        if (files.Count == 0) return;
+        _testIngestFailureHook?.Invoke();
+        _rocksDb.IngestExternalFiles([.. files], _ingestOptions, _columnFamily);
+    }
+
+    public void WaitForIngestCompactionHeadroom()
+    {
+        for (int i = 0; i < L0DrainMaxPolls; i++)
+        {
+            string? v = _rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnFamily);
+            if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
+            Thread.Sleep(L0DrainPollMs);
+        }
+
+        ILogger logger = _mainDb.Logger;
+        if (logger.IsWarn) logger.Warn($"L0 of {_mainDb.Name} column {Name} did not drain below {MaxL0FilesBeforeThrottle} files within {L0DrainMaxPolls * L0DrainPollMs / 1000}s; continuing SST ingestion without compaction headroom");
+    }
+
+    private sealed class SstIngestWriteBatch(ColumnDb columnDb) : ISstIngestWriteBatch
     {
         private const long MaxBufferedBytes = 128L * 1024 * 1024;
-        private const int MaxL0FilesBeforeThrottle = 20;
-        private const int L0DrainMaxPolls = 1500;
-        private const int L0DrainPollMs = 20;
         private const int SlabSize = 1 << 20;
 
         // Worst-case permanent retention: slabs <= 1024 x 1 MiB = 1 GiB; entries <= 6 arrays/bucket over 2^16..2^22 x 32 B ~= 1.5 GiB.
@@ -164,15 +192,12 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
         private readonly ColumnDb _columnDb = columnDb;
         private readonly List<byte[]> _slabs = [];
+        private readonly List<string> _stagedFiles = [];
         private Entry[] _index = s_entryPool.Rent(1 << 16);
         private int _count;
         private int _slabIndex = -1;
         private int _slabOffset;
         private long _bufferedBytes;
-        private readonly IngestExternalFileOptions _options = new IngestExternalFileOptions()
-            .SetMoveFiles(true)
-            .SetAllowGlobalSeqno(true)
-            .SetAllowBlockingFlush(true);
 
         private struct Entry
         {
@@ -299,9 +324,8 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
             Array.Sort(_index, 0, _count, new EntryComparer(this));
 
-            string dir = Path.Combine(_columnDb._mainDb.FullPath, "sst_ingest");
-            Directory.CreateDirectory(dir);
-            string file = Path.Combine(dir, $"{_columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
+            Directory.CreateDirectory(_columnDb.IngestStagingDir);
+            string file = Path.Combine(_columnDb.IngestStagingDir, $"{_columnDb.Name}_{Interlocked.Increment(ref _sstIngestSeq)}.sst");
 
             try
             {
@@ -329,9 +353,6 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                 {
                     Native.Instance.rocksdb_sstfilewriter_destroy(writer);
                 }
-
-                _columnDb._testIngestFailureHook?.Invoke();
-                _columnDb._rocksDb.IngestExternalFiles([file], _options, _columnDb._columnFamily);
             }
             catch
             {
@@ -339,26 +360,33 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                 throw;
             }
 
+            _stagedFiles.Add(file);
             Clear();
-            WaitForCompactionHeadroom();
         }
 
-        private void WaitForCompactionHeadroom()
+        public IReadOnlyList<string> SealToStagedFiles()
         {
-            for (int i = 0; i < L0DrainMaxPolls; i++)
-            {
-                string? v = _columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnDb._columnFamily);
-                if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;
-                Thread.Sleep(L0DrainPollMs);
-            }
+            FlushChunk();
+            return _stagedFiles;
+        }
 
-            ILogger logger = _columnDb._mainDb.Logger;
-            if (logger.IsWarn) logger.Warn($"L0 of {_columnDb._mainDb.Name} column {_columnDb.Name} did not drain below {MaxL0FilesBeforeThrottle} files within {L0DrainMaxPolls * L0DrainPollMs / 1000}s; continuing SST ingestion without compaction headroom");
+        public void IngestStagedFiles()
+        {
+            _columnDb.IngestStagedFiles(_stagedFiles);
+            _stagedFiles.Clear();
+        }
+
+        public void DeleteStagedFiles()
+        {
+            foreach (string file in _stagedFiles)
+            {
+                try { if (File.Exists(file)) File.Delete(file); } catch { }
+            }
+            _stagedFiles.Clear();
         }
 
         public void Dispose()
         {
-            FlushChunk();
             foreach (byte[] slab in _slabs)
             {
                 if (slab.Length == SlabSize) s_slabPool.Return(slab);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -192,11 +192,14 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         // 6 covers peak concurrency: six column batches alive per persist, one persist in flight.
         private static readonly ArrayPool<byte> _slabPool = ArrayPool<byte>.Create(SlabSize, 1024);
         private static readonly ArrayPool<Entry> _entryPool = ArrayPool<Entry>.Create(1 << 22, 6);
+        // Dedicated pool for the slab-reference list backing so the per-persist list allocation stays off the shared
+        // pool; sized to the worst-case 1024 slabs over the six concurrent column batches of a single in-flight persist.
+        private static readonly ArrayPool<byte[]> _slabListPool = ArrayPool<byte[]>.Create(1024, 6);
         private static readonly EnvOptions _envOptions = new();
 
         private readonly ColumnDb _columnDb;
         private readonly EntryComparer _comparer;
-        private readonly List<byte[]> _slabs = [];
+        private readonly ArrayPoolList<byte[]> _slabs = new(_slabListPool, 16);
         private readonly ArrayPoolList<string> _stagedFiles = new(4);
         private Entry[] _index = _entryPool.Rent(1 << 16);
         private int _count;
@@ -419,7 +422,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             {
                 if (slab.Length == SlabSize) _slabPool.Return(slab);
             }
-            _slabs.Clear();
+            _slabs.Dispose();
             _entryPool.Return(_index);
             _index = [];
             _stagedFiles.Dispose();

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -165,9 +165,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
     public void IngestStagedFiles(IReadOnlyList<string> files)
     {
         if (files.Count == 0) return;
-        _testIngestFailureHook?.Invoke();
         try
         {
+            _testIngestFailureHook?.Invoke();
             _rocksDb.IngestExternalFiles([.. files], _ingestOptions, _columnFamily);
         }
         catch (RocksDbSharpException x)

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -197,7 +197,8 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
             try
             {
-                using (SstFileWriter writer = new(new EnvOptions(), new ColumnFamilyOptions()))
+                ColumnFamilyOptions writerOptions = columnDb._mainDb.GetColumnFamilyOptions(columnDb.Name) ?? new ColumnFamilyOptions();
+                using (SstFileWriter writer = new(new EnvOptions(), writerOptions))
                 {
                     writer.Open(file);
                     foreach ((byte[] key, byte[]? value) in items)

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -145,20 +145,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
     public IWriteBatch StartSstIngestBatch() => new SstIngestWriteBatch(this);
 
-    // Buffers key/value bytes in pooled slabs indexed by unmanaged entry structs instead of a
-    // Dictionary<byte[], byte[]?>: the dictionary buffered 2-3M small arrays per 128 MB chunk plus
-    // multi-MB bucket/entry/List-copy arrays — ~1.5-2.5 GB of promoted + LOH garbage per persist
-    // that fed blocking gen2 GC pauses (measured 1.3-2.1 s read stalls). Dedup is deferred to the
-    // flush-time sort (stable by append order, keep-last), which is semantics-preserving: duplicate
-    // keys across chunk files are already resolved by ingest order via AllowGlobalSeqno.
     private sealed class SstIngestWriteBatch(ColumnDb columnDb) : IWriteBatch
     {
-        // Byte cap on the in-memory buffer. At the cap we flush+ingest one SST and free the buffer, so a large
-        // persist (e.g. 10x state) never holds the whole batch in managed memory — that transient spike, on top
-        // of the working set, OOM-kills the node. Overlapping chunks are fine: each ingest gets a higher global
-        // seqno, so the later (final) value wins, which also preserves last-write-wins across chunk boundaries.
         private const long MaxBufferedBytes = 128L * 1024 * 1024;
-        // Throttle the persist thread when L0 files pile up, bounding the native compaction working set.
         private const int MaxL0FilesBeforeThrottle = 20;
         private const int SlabSize = 1 << 20;
 
@@ -236,7 +225,6 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         {
             if (length > SlabSize)
             {
-                // Oversized entries get a dedicated exact-size array; dropped (not pooled) at reset.
                 byte[] dedicated = new byte[length];
                 _slabs.Add(dedicated);
                 slab = _slabs.Count - 1;
@@ -333,13 +321,11 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                     Native.Instance.rocksdb_sstfilewriter_destroy(writer);
                 }
 
-                // SetMoveFiles(true): on success RocksDB moves (consumes) the file. Only a Finish/ingest failure
-                // leaves it staged, so delete it on failure to stop sst_ingest/ accumulating orphaned files.
                 _columnDb._rocksDb.IngestExternalFiles([file], _options, _columnDb._columnFamily);
             }
             catch
             {
-                try { if (File.Exists(file)) File.Delete(file); } catch { /* best effort */ }
+                try { if (File.Exists(file)) File.Delete(file); } catch { }
                 throw;
             }
 
@@ -347,12 +333,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
             WaitForCompactionHeadroom();
         }
 
-        // Ingestion bypasses RocksDB's memtable write-stall, so back-to-back ingests pile up L0 files and the
-        // compaction working set grows without bound (native memory OOM at large state). Replicate the missing
-        // flow control: throttle the persist thread until L0 drains — exactly what the memtable write path does.
         private void WaitForCompactionHeadroom()
         {
-            for (int i = 0; i < 1500; i++) // ~30s safety cap
+            for (int i = 0; i < 1500; i++)
             {
                 string? v = _columnDb._rocksDb.GetProperty("rocksdb.num-files-at-level0", _columnDb._columnFamily);
                 if (!int.TryParse(v, out int l0Files) || l0Files < MaxL0FilesBeforeThrottle) return;

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -25,6 +25,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
     private readonly RocksDb _rocksDb;
     internal readonly DbOnTheRocks _mainDb;
     internal readonly IColumnFamilyHandle _columnFamily;
+    internal Action? _testIngestFailureHook;
 
     private readonly DisposableLazy<DbOnTheRocks.IteratorManager>? _iteratorManager;
     private readonly DisposableLazy<DbOnTheRocks.IteratorManager> _seekIteratorManager;
@@ -329,6 +330,7 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
                     Native.Instance.rocksdb_sstfilewriter_destroy(writer);
                 }
 
+                _columnDb._testIngestFailureHook?.Invoke();
                 _columnDb._rocksDb.IngestExternalFiles([file], _options, _columnDb._columnFamily);
             }
             catch

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -172,7 +172,20 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         }
         catch (RocksDbException x)
         {
-            _mainDb.HandleFatalDbError(x, scheduleRepairMarker: false);
+            // Ingestion also flushes this column's memtable and reads live SST metadata to pick a target level, so
+            // corruption reported here is only the staged file's when the message names one; otherwise it is the
+            // live DB's and must still schedule the repair marker.
+            bool stagedFileCorruption = false;
+            foreach (string file in files)
+            {
+                if (x.Message.Contains(Path.GetFileName(file), StringComparison.Ordinal))
+                {
+                    stagedFileCorruption = true;
+                    break;
+                }
+            }
+
+            _mainDb.HandleFatalDbError(x, scheduleRepairMarker: !stagedFileCorruption);
             throw;
         }
     }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Collections;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.RocksDbBindings;

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -38,6 +38,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 {
     protected ILogger _logger;
 
+    internal ILogger Logger => _logger;
+
     private string? _fullPath;
 
     internal string FullPath => _fullPath ?? throw new InvalidOperationException("DB path not initialized");

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -94,6 +94,14 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     private readonly List<IDisposable> _metricsUpdaters = [];
 
+    // Rooted for the DB lifetime so SST-ingest writers can produce files with the column's real
+    // table format (filter policy, block size, compression) instead of RocksDB defaults — a
+    // default-format ingested file has no filter, so every point read probes its data blocks.
+    private readonly Dictionary<string, ColumnFamilyOptions> _columnFamilyOptionsByName = [];
+
+    internal ColumnFamilyOptions? GetColumnFamilyOptions(string columnFamilyName) =>
+        _columnFamilyOptionsByName.GetValueOrDefault(columnFamilyName);
+
     internal CacheLinePaddedLong _allocatedSpan;
     private CacheLinePaddedLong _totalReads;
     private CacheLinePaddedLong _totalWrites;
@@ -180,6 +188,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                     // "default" is a special column name with rocksdb, which is what previously not specifying column goes to
                     if (columnFamily == "Default") columnFamily = "default";
                     columnFamilies.Add(columnFamily, options);
+                    _columnFamilyOptionsByName[columnFamily] = options;
                 }
             }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -40,7 +40,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     private string? _fullPath;
 
-    /// <summary>On-disk directory of this DB. Used to stage SST files for ingestion on the same filesystem.</summary>
     internal string FullPath => _fullPath ?? throw new InvalidOperationException("DB path not initialized");
 
     private static readonly ConcurrentDictionary<string, RocksDb> _dbsByPath = new();
@@ -94,9 +93,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     private readonly List<IDisposable> _metricsUpdaters = [];
 
-    // Rooted for the DB lifetime so SST-ingest writers can produce files with the column's real
-    // table format (filter policy, block size, compression) instead of RocksDB defaults — a
-    // default-format ingested file has no filter, so every point read probes its data blocks.
     private readonly Dictionary<string, ColumnFamilyOptions> _columnFamilyOptionsByName = [];
 
     internal ColumnFamilyOptions? GetColumnFamilyOptions(string columnFamilyName) =>

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -40,6 +40,9 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     private string? _fullPath;
 
+    /// <summary>On-disk directory of this DB. Used to stage SST files for ingestion on the same filesystem.</summary>
+    internal string FullPath => _fullPath ?? throw new InvalidOperationException("DB path not initialized");
+
     private static readonly ConcurrentDictionary<string, RocksDb> _dbsByPath = new();
 
     private bool _isDisposing;

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -36,6 +36,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 {
     protected ILogger _logger;
 
+    internal ILogger Logger => _logger;
+
     private string? _fullPath;
 
     internal string FullPath => _fullPath ?? throw new InvalidOperationException("DB path not initialized");

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -38,6 +38,9 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     private string? _fullPath;
 
+    /// <summary>On-disk directory of this DB. Used to stage SST files for ingestion on the same filesystem.</summary>
+    internal string FullPath => _fullPath ?? throw new InvalidOperationException("DB path not initialized");
+
     private static readonly ConcurrentDictionary<string, RocksDb> _dbsByPath = new();
 
     private static readonly FlushOptions _defaultFlushOptions = new();

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -330,7 +330,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
     }
 
-    internal void HandleFatalDbError(RocksDbException rocksDbException)
+    internal void HandleFatalDbError(RocksDbException rocksDbException, bool scheduleRepairMarker = true)
     {
         bool corruption = rocksDbException.Message.Contains("Corruption:", StringComparison.Ordinal);
         bool ioError = rocksDbException.Message.Contains("IO error", StringComparison.Ordinal);
@@ -346,10 +346,14 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         // never write the marker for it. Either way we fast-shutdown, because continuing past a
         // failed write would apply later writes as if it had succeeded and corrupt state at the
         // application layer even when the DB files themselves are intact.
-        if (corruption)
+        if (corruption && scheduleRepairMarker)
         {
             if (_logger.IsWarn) _logger.Warn($"Corrupted DB detected on path {_fullPath}. Please restart Nethermind to attempt repair.");
             _fileSystem.File.WriteAllText(CorruptMarkerPath, "marker");
+        }
+        else if (corruption)
+        {
+            if (_logger.IsWarn) _logger.Warn($"Corruption reported by an SST ingest on path {_fullPath}; shutting down without scheduling a repair of the live DB.");
         }
         else if (_logger.IsWarn)
         {

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -330,6 +330,11 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
     }
 
+    /// <param name="scheduleRepairMarker">
+    /// When <c>false</c>, a reported <c>Corruption:</c> is treated as originating from an external artifact
+    /// (an SST staged for ingestion) rather than the live DB files, so the fast-shutdown still happens but no
+    /// repair marker is written and no lossy repair of a healthy DB is scheduled.
+    /// </param>
     internal void HandleFatalDbError(RocksDbException rocksDbException, bool scheduleRepairMarker = true)
     {
         bool corruption = rocksDbException.Message.Contains("Corruption:", StringComparison.Ordinal);

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -38,7 +38,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     private string? _fullPath;
 
-    /// <summary>On-disk directory of this DB. Used to stage SST files for ingestion on the same filesystem.</summary>
     internal string FullPath => _fullPath ?? throw new InvalidOperationException("DB path not initialized");
 
     private static readonly ConcurrentDictionary<string, RocksDb> _dbsByPath = new();
@@ -102,9 +101,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     internal readonly StripedLong _allocatedSpan = new();
     private readonly StripedLong _totalReads = new();
 
-    // Rooted for the DB lifetime so SST-ingest writers can produce files with the column's real
-    // table format (filter policy, block size, compression) instead of RocksDB defaults — a
-    // default-format ingested file has no filter, so every point read probes its data blocks.
     private readonly Dictionary<string, ColumnFamilyOptions> _columnFamilyOptionsByName = [];
 
     internal ColumnFamilyOptions? GetColumnFamilyOptions(string columnFamilyName) =>

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -101,6 +101,14 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     // a single shared word per DB serializes them under load.
     internal readonly StripedLong _allocatedSpan = new();
     private readonly StripedLong _totalReads = new();
+
+    // Rooted for the DB lifetime so SST-ingest writers can produce files with the column's real
+    // table format (filter policy, block size, compression) instead of RocksDB defaults — a
+    // default-format ingested file has no filter, so every point read probes its data blocks.
+    private readonly Dictionary<string, ColumnFamilyOptions> _columnFamilyOptionsByName = [];
+
+    internal ColumnFamilyOptions? GetColumnFamilyOptions(string columnFamilyName) =>
+        _columnFamilyOptionsByName.GetValueOrDefault(columnFamilyName);
     private CacheLinePaddedLong _totalWrites;
 
     private readonly DisposableLazy<IteratorManager>? _iteratorManager;
@@ -185,6 +193,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                     // "default" is a special column name with rocksdb, which is what previously not specifying column goes to
                     if (columnFamily == "Default") columnFamily = "default";
                     columnFamilies.Add(columnFamily, options);
+                    _columnFamilyOptionsByName[columnFamily] = options;
                 }
             }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/Nethermind.Db.Rocks.csproj
+++ b/src/Nethermind/Nethermind.Db.Rocks/Nethermind.Db.Rocks.csproj
@@ -12,6 +12,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Nethermind.Db.Test</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Nethermind.State.Flat.Test</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -19,6 +19,7 @@ public class FlatDbConfig : IFlatDbConfig
     public ulong MaxReorgDepth { get; set; } = 256;
     public ulong MinReorgDepth { get; set; } = 128;
     public long PersistenceWriteBufferFloor { get; set; } = 16.MiB;
+    public bool PersistViaSstIngestion { get; set; } = false;
     public int TrieWarmerWorkerCount { get; set; } = -1;
     public int WarmReadConcurrency { get; set; } = -1;
     public ulong BlockCacheSizeBudget { get; set; } = 1UL.GiB;

--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -29,6 +29,7 @@ public class FlatDbConfig : IFlatDbConfig
     public ulong MaxReorgDepth { get; set; } = 256;
     public ulong MinReorgDepth { get; set; } = 128;
     public long PersistenceWriteBufferFloor { get; set; } = 16.MiB;
+    public bool PersistViaSstIngestion { get; set; } = false;
     public int TrieWarmerWorkerCount { get; set; } = -1;
     public int WarmReadConcurrency { get; set; } = -1;
     public ulong BlockCacheSizeBudget { get; set; } = 1UL.GiB;

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -43,7 +43,7 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Lower bound, in bytes, for the RocksDB write buffer (memtable) size of the flat-state columns. The per-batch adjuster never shrinks a column's memtable below this value. Raising it lets frequent small persistence batches (small CompactSize) coalesce and deduplicate in the memtable instead of churning L0, decoupling write amplification from CompactSize.", DefaultValue = "16777216")]
     long PersistenceWriteBufferFloor { get; set; }
 
-    [ConfigItem(Description = "Persist compacted snapshots by building sorted SST files (from a byte-capped in-memory buffer) and ingesting them (bypassing the memtable → flush → L0-compaction burst) instead of committing one large WriteBatch. Removes the multi-second persist stalls that block reads at large state sizes, at the cost of higher peak persist memory. Default off.", DefaultValue = "false")]
+    [ConfigItem(Description = "Persist compacted snapshots by ingesting sorted SST files instead of one large WriteBatch, avoiding the memtable-flush burst that stalls reads at large state. Default off.", DefaultValue = "false")]
     bool PersistViaSstIngestion { get; set; }
 
     [ConfigItem(Description = "Regenerate the per-instance compaction offset on startup instead of loading from metadata DB. Use when restoring one backup to multiple instances. Flag is sticky across restarts — toggle off after first restart.", DefaultValue = "false")]

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -43,7 +43,7 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Lower bound, in bytes, for the RocksDB write buffer (memtable) size of the flat-state columns. The per-batch adjuster never shrinks a column's memtable below this value. Raising it lets frequent small persistence batches (small CompactSize) coalesce and deduplicate in the memtable instead of churning L0, decoupling write amplification from CompactSize.", DefaultValue = "16777216")]
     long PersistenceWriteBufferFloor { get; set; }
 
-    [ConfigItem(Description = "Persist compacted snapshots by building sorted SST files off-heap and ingesting them (bypassing the memtable → flush → L0-compaction burst) instead of committing one large WriteBatch. Removes the multi-second persist stalls that block reads at large state sizes.", DefaultValue = "false")]
+    [ConfigItem(Description = "Persist compacted snapshots by building sorted SST files (from a byte-capped in-memory buffer) and ingesting them (bypassing the memtable → flush → L0-compaction burst) instead of committing one large WriteBatch. Removes the multi-second persist stalls that block reads at large state sizes, at the cost of higher peak persist memory. Default off.", DefaultValue = "false")]
     bool PersistViaSstIngestion { get; set; }
 
     [ConfigItem(Description = "Regenerate the per-instance compaction offset on startup instead of loading from metadata DB. Use when restoring one backup to multiple instances. Flag is sticky across restarts — toggle off after first restart.", DefaultValue = "false")]

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -43,6 +43,9 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Lower bound, in bytes, for the RocksDB write buffer (memtable) size of the flat-state columns. The per-batch adjuster never shrinks a column's memtable below this value. Raising it lets frequent small persistence batches (small CompactSize) coalesce and deduplicate in the memtable instead of churning L0, decoupling write amplification from CompactSize.", DefaultValue = "16777216")]
     long PersistenceWriteBufferFloor { get; set; }
 
+    [ConfigItem(Description = "Persist compacted snapshots by building sorted SST files off-heap and ingesting them (bypassing the memtable → flush → L0-compaction burst) instead of committing one large WriteBatch. Removes the multi-second persist stalls that block reads at large state sizes.", DefaultValue = "false")]
+    bool PersistViaSstIngestion { get; set; }
+
     [ConfigItem(Description = "Regenerate the per-instance compaction offset on startup instead of loading from metadata DB. Use when restoring one backup to multiple instances. Flag is sticky across restarts — toggle off after first restart.", DefaultValue = "false")]
     bool RegenerateCompactionOffset { get; set; }
 

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -73,7 +73,7 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Lower bound, in bytes, for the RocksDB write buffer (memtable) size of the flat-state columns. The per-batch adjuster never shrinks a column's memtable below this value. Raising it lets frequent small persistence batches (small CompactSize) coalesce and deduplicate in the memtable instead of churning L0, decoupling write amplification from CompactSize.", DefaultValue = "16777216")]
     long PersistenceWriteBufferFloor { get; set; }
 
-    [ConfigItem(Description = "Persist compacted snapshots by building sorted SST files (from a byte-capped in-memory buffer) and ingesting them (bypassing the memtable → flush → L0-compaction burst) instead of committing one large WriteBatch. Removes the multi-second persist stalls that block reads at large state sizes, at the cost of higher peak persist memory. Default off.", DefaultValue = "false")]
+    [ConfigItem(Description = "Persist compacted snapshots by ingesting sorted SST files instead of one large WriteBatch, avoiding the memtable-flush burst that stalls reads at large state. Default off.", DefaultValue = "false")]
     bool PersistViaSstIngestion { get; set; }
 
     [ConfigItem(Description = "Regenerate the per-instance compaction offset on startup instead of loading from metadata DB. Use when restoring one backup to multiple instances. Flag is sticky across restarts — toggle off after first restart.", DefaultValue = "false")]

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -73,6 +73,9 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Lower bound, in bytes, for the RocksDB write buffer (memtable) size of the flat-state columns. The per-batch adjuster never shrinks a column's memtable below this value. Raising it lets frequent small persistence batches (small CompactSize) coalesce and deduplicate in the memtable instead of churning L0, decoupling write amplification from CompactSize.", DefaultValue = "16777216")]
     long PersistenceWriteBufferFloor { get; set; }
 
+    [ConfigItem(Description = "Persist compacted snapshots by building sorted SST files off-heap and ingesting them (bypassing the memtable → flush → L0-compaction burst) instead of committing one large WriteBatch. Removes the multi-second persist stalls that block reads at large state sizes.", DefaultValue = "false")]
+    bool PersistViaSstIngestion { get; set; }
+
     [ConfigItem(Description = "Regenerate the per-instance compaction offset on startup instead of loading from metadata DB. Use when restoring one backup to multiple instances. Flag is sticky across restarts — toggle off after first restart.", DefaultValue = "false")]
     bool RegenerateCompactionOffset { get; set; }
 

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -73,7 +73,7 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Lower bound, in bytes, for the RocksDB write buffer (memtable) size of the flat-state columns. The per-batch adjuster never shrinks a column's memtable below this value. Raising it lets frequent small persistence batches (small CompactSize) coalesce and deduplicate in the memtable instead of churning L0, decoupling write amplification from CompactSize.", DefaultValue = "16777216")]
     long PersistenceWriteBufferFloor { get; set; }
 
-    [ConfigItem(Description = "Persist compacted snapshots by building sorted SST files off-heap and ingesting them (bypassing the memtable → flush → L0-compaction burst) instead of committing one large WriteBatch. Removes the multi-second persist stalls that block reads at large state sizes.", DefaultValue = "false")]
+    [ConfigItem(Description = "Persist compacted snapshots by building sorted SST files (from a byte-capped in-memory buffer) and ingesting them (bypassing the memtable → flush → L0-compaction burst) instead of committing one large WriteBatch. Removes the multi-second persist stalls that block reads at large state sizes, at the cost of higher peak persist memory. Default off.", DefaultValue = "false")]
     bool PersistViaSstIngestion { get; set; }
 
     [ConfigItem(Description = "Regenerate the per-instance compaction offset on startup instead of loading from metadata DB. Use when restoring one backup to multiple instances. Flag is sticky across restarts — toggle off after first restart.", DefaultValue = "false")]

--- a/src/Nethermind/Nethermind.Db/ISstIngestible.cs
+++ b/src/Nethermind/Nethermind.Db/ISstIngestible.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+
+namespace Nethermind.Db;
+
+/// <summary>
+/// A column store that can persist a batch of writes by building a sorted SST file off-heap and
+/// ingesting it as a metadata-only add, bypassing the memtable → flush → L0-compaction burst that a
+/// single large WriteBatch triggers. The returned batch buffers point puts/deletes (last write wins);
+/// on <see cref="System.IDisposable.Dispose"/> it sorts them, writes one SST, and ingests it into this column.
+/// </summary>
+public interface ISstIngestible
+{
+    IWriteBatch StartSstIngestBatch();
+}

--- a/src/Nethermind/Nethermind.Db/ISstIngestible.cs
+++ b/src/Nethermind/Nethermind.Db/ISstIngestible.cs
@@ -1,12 +1,37 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using Nethermind.Core;
 
 namespace Nethermind.Db;
 
-/// <summary>Column store that persists a write batch by ingesting a sorted SST file.</summary>
+/// <summary>Column store that persists a write batch by staging sorted SST files and ingesting them at commit.</summary>
 public interface ISstIngestible
 {
-    IWriteBatch StartSstIngestBatch();
+    ISstIngestWriteBatch StartSstIngestBatch();
+
+    /// <summary>Ingests previously staged SST files into the column family in a single native call.</summary>
+    void IngestStagedFiles(IReadOnlyList<string> files);
+
+    /// <summary>Bounded wait until the column's L0 drains below the ingest throttle threshold.</summary>
+    void WaitForIngestCompactionHeadroom();
+
+    string IngestStagingDir { get; }
+}
+
+/// <summary>
+/// Write batch that buffers into staged SST files; nothing becomes visible until <see cref="IngestStagedFiles"/>.
+/// Dispose releases buffers only — staged files that were neither ingested nor deleted stay on disk.
+/// </summary>
+public interface ISstIngestWriteBatch : IWriteBatch
+{
+    /// <summary>Flushes remaining buffered writes to staged SST files and returns every staged file path.</summary>
+    IReadOnlyList<string> SealToStagedFiles();
+
+    /// <summary>Ingests all staged files into the column family.</summary>
+    void IngestStagedFiles();
+
+    /// <summary>Deletes staged files that were never ingested (failure cleanup).</summary>
+    void DeleteStagedFiles();
 }

--- a/src/Nethermind/Nethermind.Db/ISstIngestible.cs
+++ b/src/Nethermind/Nethermind.Db/ISstIngestible.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Threading;
 using Nethermind.Core;
 
 namespace Nethermind.Db;
@@ -14,8 +15,8 @@ public interface ISstIngestible
     /// <summary>Ingests previously staged SST files into the column family in a single native call.</summary>
     void IngestStagedFiles(IReadOnlyList<string> files);
 
-    /// <summary>Bounded wait until the column's L0 drains below the ingest throttle threshold.</summary>
-    void WaitForIngestCompactionHeadroom();
+    /// <summary>Bounded wait until the column's L0 drains below the ingest throttle threshold, or the token trips.</summary>
+    void WaitForIngestCompactionHeadroom(CancellationToken cancellationToken);
 
     string IngestStagingDir { get; }
 }

--- a/src/Nethermind/Nethermind.Db/ISstIngestible.cs
+++ b/src/Nethermind/Nethermind.Db/ISstIngestible.cs
@@ -5,12 +5,7 @@ using Nethermind.Core;
 
 namespace Nethermind.Db;
 
-/// <summary>
-/// A column store that can persist a batch of writes by building a sorted SST file off-heap and
-/// ingesting it as a metadata-only add, bypassing the memtable → flush → L0-compaction burst that a
-/// single large WriteBatch triggers. The returned batch buffers point puts/deletes (last write wins);
-/// on <see cref="System.IDisposable.Dispose"/> it sorts them, writes one SST, and ingests it into this column.
-/// </summary>
+/// <summary>Column store that persists a write batch by ingesting a sorted SST file.</summary>
 public interface ISstIngestible
 {
     IWriteBatch StartSstIngestBatch();

--- a/src/Nethermind/Nethermind.Runner.Test/Init/ImportFlatDbTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Init/ImportFlatDbTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #nullable enable
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -51,6 +52,7 @@ public class ImportFlatDbTests
     [TearDown]
     public void TearDown()
     {
+        (_persistence as IDisposable)?.Dispose();
         _trieDb.Dispose();
         _columnsDb.Dispose();
     }

--- a/src/Nethermind/Nethermind.State.Flat.Test/ImporterTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ImporterTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
@@ -38,6 +39,7 @@ public class ImporterTests
     [TearDown]
     public void TearDown()
     {
+        (_persistence as IDisposable)?.Dispose();
         _trieDb.Dispose();
         _columnsDb.Dispose();
     }

--- a/src/Nethermind/Nethermind.State.Flat.Test/Nethermind.State.Flat.Test.csproj
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Nethermind.State.Flat.Test.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
+    <ProjectReference Include="..\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj" />
     <ProjectReference Include="..\Nethermind.State.Flat\Nethermind.State.Flat.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Nethermind/Nethermind.State.Flat.Test/Nethermind.State.Flat.Test.csproj
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Nethermind.State.Flat.Test.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
+    <ProjectReference Include="..\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj" />
     <ProjectReference Include="..\Nethermind.State.Flat\Nethermind.State.Flat.csproj" />
     <ProjectReference Include="..\Nethermind.State.Flat.History\Nethermind.State.Flat.History.csproj" />
   </ItemGroup>

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -17,10 +17,6 @@ using NUnit.Framework;
 
 namespace Nethermind.State.Flat.Test;
 
-// Exercises the --FlatDb.PersistViaSstIngestion path end-to-end on a real RocksDB. The MemDb-backed tests only
-// cover the default WriteBatch path (MemDb is not ISstIngestible and falls back), so without this the ingest code
-// is untested. Covers: ingest round-trip, the SelfDestruct+recreate last-write-wins dedup (which an SST forbids as
-// a duplicate key), delete tombstones, the currentState pointer advance, and the MemDb fallback.
 [TestFixture]
 public class SstIngestionTests
 {
@@ -50,7 +46,7 @@ public class SstIngestionTests
     public void TearDown()
     {
         _db.Dispose();
-        try { Directory.Delete(_dbPath, true); } catch { /* best effort */ }
+        try { Directory.Delete(_dbPath, true); } catch { }
     }
 
     private static SlotValue Slot(byte v) => SlotValue.FromSpanWithoutLeadingZero(new byte[] { v });
@@ -84,8 +80,6 @@ public class SstIngestionTests
             batch.Set(dedupedKey, [0x0a]);
             batch.Set(dedupedKey, [0x0b]);
 
-            // Push past the chunk threshold so a mid-batch flush ingests the writes above,
-            // then write conflicting values that land in the next chunk's file.
             byte[] filler = new byte[64 * 1024];
             Span<byte> key = stackalloc byte[32];
             for (int i = 0; i < 2100; i++)
@@ -138,9 +132,6 @@ public class SstIngestionTests
             batch.SetStorage(Addr, Slot2, v2);
         }
 
-        // SelfDestruct clears all existing storage (delete tombstones for slot1 + slot2), then slot1 is recreated
-        // and slot3 added. The ingested SST must collapse slot1's delete+put to the put (last write wins, no
-        // duplicate key) and keep slot2 tombstoned.
         using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None))
         {
             batch.SelfDestruct(Addr);
@@ -149,16 +140,15 @@ public class SstIngestionTests
         }
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
-        AssertSlot(reader, Slot1, v1b);  // recreated — last write wins
-        AssertSlot(reader, Slot3, v3);   // added
-        AssertSlotAbsent(reader, Slot2); // tombstoned by self-destruct
+        AssertSlot(reader, Slot1, v1b);
+        AssertSlot(reader, Slot3, v3);
+        AssertSlotAbsent(reader, Slot2);
         Assert.That(reader.CurrentState, Is.EqualTo(s2));
     }
 
     [Test]
     public void PersistViaSstIngestion_on_MemDb_falls_back_and_round_trips()
     {
-        // MemDb is not ISstIngestible, so the flag falls back to the WriteBatch path — must still round-trip.
         using SnapshotableMemColumnsDb<FlatDbColumns> memDb = new();
         RocksDbPersistence persistence = new(memDb, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
         StateId s1 = State(1, 1);

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.IO;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Db.Rocks;
+using Nethermind.Db.Rocks.Config;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.State.Flat.Persistence;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test;
+
+// Exercises the --FlatDb.PersistViaSstIngestion path end-to-end on a real RocksDB. The MemDb-backed tests only
+// cover the default WriteBatch path (MemDb is not ISstIngestible and falls back), so without this the ingest code
+// is untested. Covers: ingest round-trip, the SelfDestruct+recreate last-write-wins dedup (which an SST forbids as
+// a duplicate key), delete tombstones, the currentState pointer advance, and the MemDb fallback.
+[TestFixture]
+public class SstIngestionTests
+{
+    private static readonly Address Addr = TestItem.AddressA;
+    private static readonly UInt256 Slot1 = 1, Slot2 = 2, Slot3 = 3;
+
+    private string _dbPath = null!;
+    private ColumnsDb<FlatDbColumns> _db = null!;
+    private RocksDbPersistence _persistence = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), "flat-sst-ingest-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dbPath);
+        _db = new ColumnsDb<FlatDbColumns>(
+            _dbPath,
+            new DbSettings("State", _dbPath) { DeleteOnStart = true },
+            new DbConfig(),
+            new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(), LimboLogs.Instance, validateConfig: false),
+            LimboLogs.Instance,
+            Enum.GetValues<FlatDbColumns>());
+        _persistence = new RocksDbPersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _db.Dispose();
+        try { Directory.Delete(_dbPath, true); } catch { /* best effort */ }
+    }
+
+    private static SlotValue Slot(byte v) => SlotValue.FromSpanWithoutLeadingZero(new byte[] { v });
+    private static StateId State(ulong number, byte seed) => new(number, ValueKeccak.Compute(new byte[] { seed }));
+
+    private static void AssertSlot(IPersistence.IPersistenceReader reader, in UInt256 slot, SlotValue expected)
+    {
+        SlotValue read = default;
+        Assert.That(reader.TryGetSlot(Addr, slot, ref read), Is.True);
+        Assert.That(read.AsReadOnlySpan.ToArray(), Is.EqualTo(expected.AsReadOnlySpan.ToArray()));
+    }
+
+    private static void AssertSlotAbsent(IPersistence.IPersistenceReader reader, in UInt256 slot)
+    {
+        SlotValue read = default;
+        Assert.That(reader.TryGetSlot(Addr, slot, ref read), Is.False);
+    }
+
+    [Test]
+    public void Ingest_round_trips_and_advances_pointer()
+    {
+        StateId s1 = State(1, 1);
+        SlotValue v1 = Slot(0x11), v2 = Slot(0x22);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+            batch.SetStorage(Addr, Slot1, v1);
+            batch.SetStorage(Addr, Slot2, v2);
+        }
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        AssertSlot(reader, Slot1, v1);
+        AssertSlot(reader, Slot2, v2);
+        Assert.That(reader.GetAccount(Addr), Is.Not.Null);
+        Assert.That(reader.CurrentState, Is.EqualTo(s1));
+    }
+
+    [Test]
+    public void Ingest_self_destruct_then_recreate_keeps_last_write_and_tombstones_the_rest()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        SlotValue v1 = Slot(0x11), v2 = Slot(0x22), v1b = Slot(0x1b), v3 = Slot(0x33);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+            batch.SetStorage(Addr, Slot1, v1);
+            batch.SetStorage(Addr, Slot2, v2);
+        }
+
+        // SelfDestruct clears all existing storage (delete tombstones for slot1 + slot2), then slot1 is recreated
+        // and slot3 added. The ingested SST must collapse slot1's delete+put to the put (last write wins, no
+        // duplicate key) and keep slot2 tombstoned.
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None))
+        {
+            batch.SelfDestruct(Addr);
+            batch.SetStorage(Addr, Slot1, v1b);
+            batch.SetStorage(Addr, Slot3, v3);
+        }
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        AssertSlot(reader, Slot1, v1b);  // recreated — last write wins
+        AssertSlot(reader, Slot3, v3);   // added
+        AssertSlotAbsent(reader, Slot2); // tombstoned by self-destruct
+        Assert.That(reader.CurrentState, Is.EqualTo(s2));
+    }
+
+    [Test]
+    public void PersistViaSstIngestion_on_MemDb_falls_back_and_round_trips()
+    {
+        // MemDb is not ISstIngestible, so the flag falls back to the WriteBatch path — must still round-trip.
+        using SnapshotableMemColumnsDb<FlatDbColumns> memDb = new();
+        RocksDbPersistence persistence = new(memDb, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
+        StateId s1 = State(1, 1);
+        SlotValue v1 = Slot(0x11);
+
+        using (IPersistence.IWriteBatch batch = persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetStorage(Addr, Slot1, v1);
+        }
+
+        using IPersistence.IPersistenceReader reader = persistence.CreateReader();
+        AssertSlot(reader, Slot1, v1);
+        Assert.That(reader.CurrentState, Is.EqualTo(s1));
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -293,6 +293,60 @@ public class SstIngestionTests
     }
 
     [Test]
+    public void Failed_ingest_after_first_column_completes_inline_when_the_retry_succeeds()
+    {
+        // Torn-live-state fix: when a later column ingest fails after an earlier one already went live, the commit
+        // is completed inline (still under the write lock) so no reader ever observes a torn base. A transient
+        // failure (one-shot here) is rolled forward inline - the pointer advances to `to` with no reopen and no
+        // leftover marker, and the batch dispose does not surface an error.
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        TreePath topPath = new(Keccak.Compute("top"), 4);
+        TreePath deepPath = new(Keccak.Compute("deep"), 10);
+        TreePath fallbackPath = new(Keccak.Compute("fallback"), 20);
+        Hash256 storageAccount = TestItem.KeccakA;
+        TreePath storagePath = new(Keccak.Compute("storage"), 8);
+        byte[] payload = [0x02, 0x02];
+        SlotValue v2 = Slot(0x22);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        ColumnDb storageColumn = (ColumnDb)_db.GetColumnDb(FlatDbColumns.Storage);
+        // Fail the storage ingest once, then clear the hook so the inline roll-forward's retry succeeds.
+        storageColumn._testIngestFailureHook = () =>
+        {
+            storageColumn._testIngestFailureHook = null;
+            throw new IOException("injected transient SST ingest failure");
+        };
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(200));
+            batch.SetStorage(Addr, Slot2, v2);
+            batch.SetStateTrieNode(topPath, payload);
+            batch.SetStateTrieNode(deepPath, payload);
+            batch.SetStateTrieNode(fallbackPath, payload);
+            batch.SetStorageTrieNode(storageAccount, storagePath, payload);
+        }
+
+        Assert.That(storageColumn._testIngestFailureHook, Is.Null, "the injected failure should have fired exactly once");
+        Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null, "the marker is cleared by the inline completion");
+        Assert.That(StagedSstFiles(), Is.Empty);
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        Assert.That(reader.CurrentState, Is.EqualTo(s2));
+        Assert.That(reader.GetAccount(Addr)!.Balance, Is.EqualTo((UInt256)200));
+        AssertSlot(reader, Slot2, v2);
+        Assert.That(reader.TryLoadStateRlp(topPath, ReadFlags.None), Is.EqualTo(payload));
+        Assert.That(reader.TryLoadStateRlp(deepPath, ReadFlags.None), Is.EqualTo(payload));
+        Assert.That(reader.TryLoadStateRlp(fallbackPath, ReadFlags.None), Is.EqualTo(payload));
+        Assert.That(reader.TryLoadStorageRlp(storageAccount, storagePath, ReadFlags.None), Is.EqualTo(payload));
+    }
+
+    [Test]
     public void Crash_between_column_ingests_rolls_forward_on_reopen()
     {
         StateId s1 = State(1, 1);

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -176,6 +176,41 @@ public class SstIngestionTests
     }
 
     [Test]
+    public void Failed_ingest_leaves_pointer_and_staging_dir_untouched()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        SlotValue v1 = Slot(0x11), v2 = Slot(0x22);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+            batch.SetStorage(Addr, Slot1, v1);
+        }
+
+        ColumnDb accountColumn = (ColumnDb)_db.GetColumnDb(FlatDbColumns.Account);
+        accountColumn._testIngestFailureHook = () => throw new IOException("injected SST ingest failure");
+
+        Assert.That(() =>
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None);
+            batch.SetAccount(Addr, new Account(200));
+            batch.SetStorage(Addr, Slot2, v2);
+        }, Throws.InstanceOf<IOException>());
+
+        accountColumn._testIngestFailureHook = null;
+
+        using (IPersistence.IPersistenceReader reader = _persistence.CreateReader())
+        {
+            Assert.That(reader.CurrentState, Is.EqualTo(s1));
+        }
+
+        string stagingDir = Path.Combine(_dbPath, "sst_ingest");
+        string[] leftover = Directory.Exists(stagingDir) ? Directory.GetFiles(stagingDir, "*.sst") : [];
+        Assert.That(leftover, Is.Empty);
+    }
+
+    [Test]
     public void PersistViaSstIngestion_on_MemDb_falls_back_and_round_trips()
     {
         using SnapshotableMemColumnsDb<FlatDbColumns> memDb = new();

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -240,6 +240,59 @@ public class SstIngestionTests
     }
 
     [Test]
+    public void Failed_ingest_after_first_column_keeps_marker_and_rolls_forward_on_reopen()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        TreePath topPath = new(Keccak.Compute("top"), 4);
+        TreePath deepPath = new(Keccak.Compute("deep"), 10);
+        TreePath fallbackPath = new(Keccak.Compute("fallback"), 20);
+        Hash256 storageAccount = TestItem.KeccakA;
+        TreePath storagePath = new(Keccak.Compute("storage"), 8);
+        byte[] payload = [0x02, 0x02];
+        SlotValue v2 = Slot(0x22);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        ColumnDb storageColumn = (ColumnDb)_db.GetColumnDb(FlatDbColumns.Storage);
+        storageColumn._testIngestFailureHook = () => throw new IOException("injected SST ingest failure");
+
+        Assert.That(() =>
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None);
+            batch.SetAccount(Addr, new Account(200));
+            batch.SetStorage(Addr, Slot2, v2);
+            batch.SetStateTrieNode(topPath, payload);
+            batch.SetStateTrieNode(deepPath, payload);
+            batch.SetStateTrieNode(fallbackPath, payload);
+            batch.SetStorageTrieNode(storageAccount, storagePath, payload);
+        }, Throws.InstanceOf<IOException>());
+
+        storageColumn._testIngestFailureHook = null;
+
+        (StateId To, string[] Files)? marker = BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata));
+        Assert.That(marker, Is.Not.Null);
+        Assert.That(marker!.Value.To, Is.EqualTo(s2));
+        Assert.That(StagedSstFiles(), Is.Not.Empty);
+
+        Reopen();
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        Assert.That(reader.CurrentState, Is.EqualTo(s2));
+        Assert.That(reader.GetAccount(Addr)!.Balance, Is.EqualTo((UInt256)200));
+        AssertSlot(reader, Slot2, v2);
+        Assert.That(reader.TryLoadStateRlp(topPath, ReadFlags.None), Is.EqualTo(payload));
+        Assert.That(reader.TryLoadStateRlp(deepPath, ReadFlags.None), Is.EqualTo(payload));
+        Assert.That(reader.TryLoadStateRlp(fallbackPath, ReadFlags.None), Is.EqualTo(payload));
+        Assert.That(reader.TryLoadStorageRlp(storageAccount, storagePath, ReadFlags.None), Is.EqualTo(payload));
+        Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
+        Assert.That(StagedSstFiles(), Is.Empty);
+    }
+
+    [Test]
     public void Crash_between_column_ingests_rolls_forward_on_reopen()
     {
         StateId s1 = State(1, 1);

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
@@ -13,6 +17,7 @@ using Nethermind.Db.Rocks.Config;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State.Flat.Persistence;
+using Nethermind.Trie;
 using NUnit.Framework;
 
 namespace Nethermind.State.Flat.Test;
@@ -52,6 +57,25 @@ public class SstIngestionTests
     private static SlotValue Slot(byte v) => SlotValue.FromSpanWithoutLeadingZero(new byte[] { v });
     private static StateId State(ulong number, byte seed) => new(number, ValueKeccak.Compute(new byte[] { seed }));
 
+    private void Reopen()
+    {
+        _db.Dispose();
+        _db = new ColumnsDb<FlatDbColumns>(
+            _dbPath,
+            new DbSettings("State", _dbPath),
+            new DbConfig(),
+            new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(), LimboLogs.Instance, validateConfig: false),
+            LimboLogs.Instance,
+            Enum.GetValues<FlatDbColumns>());
+        _persistence = new RocksDbPersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
+    }
+
+    private string[] StagedSstFiles()
+    {
+        string stagingDir = Path.Combine(_dbPath, "sst_ingest");
+        return Directory.Exists(stagingDir) ? Directory.GetFiles(stagingDir, "*.sst") : [];
+    }
+
     private static void AssertSlot(IPersistence.IPersistenceReader reader, in UInt256 slot, SlotValue expected)
     {
         SlotValue read = default;
@@ -73,7 +97,7 @@ public class SstIngestionTests
         byte[] deletedKey = ValueKeccak.Compute("deleted"u8).ToByteArray();
         byte[] dedupedKey = ValueKeccak.Compute("deduped"u8).ToByteArray();
 
-        using (IWriteBatch batch = ((ISstIngestible)accountDb).StartSstIngestBatch())
+        using (ISstIngestWriteBatch batch = ((ISstIngestible)accountDb).StartSstIngestBatch())
         {
             batch.Set(overwrittenKey, [0x01]);
             batch.Set(deletedKey, [0x0d]);
@@ -91,6 +115,9 @@ public class SstIngestionTests
 
             batch.Set(overwrittenKey, [0x02]);
             batch.Set(deletedKey, null);
+
+            batch.SealToStagedFiles();
+            batch.IngestStagedFiles();
         }
 
         Assert.That(accountDb.Get(overwrittenKey), Is.EqualTo(new byte[] { 0x02 }));
@@ -109,7 +136,7 @@ public class SstIngestionTests
         byte[] probeValue = new byte[entrySize - keySize];
         probeValue[0] = 0x42;
 
-        using (IWriteBatch batch = ((ISstIngestible)accountDb).StartSstIngestBatch())
+        using (ISstIngestWriteBatch batch = ((ISstIngestible)accountDb).StartSstIngestBatch())
         {
             byte[] filler = new byte[entrySize - keySize];
             Span<byte> key = stackalloc byte[keySize];
@@ -122,6 +149,9 @@ public class SstIngestionTests
 
             batch.Set(probeKey, probeValue);
             batch.PutSpan(default, default);
+
+            batch.SealToStagedFiles();
+            batch.IngestStagedFiles();
         }
 
         Assert.That(accountDb.Get(probeKey), Is.EqualTo(probeValue));
@@ -205,9 +235,175 @@ public class SstIngestionTests
             Assert.That(reader.CurrentState, Is.EqualTo(s1));
         }
 
+        Assert.That(StagedSstFiles(), Is.Empty);
+        Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
+    }
+
+    [Test]
+    public void Crash_between_column_ingests_rolls_forward_on_reopen()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        byte[] accountKey = ValueKeccak.Compute("crash-account"u8).ToByteArray();
+        byte[] storageKey = ValueKeccak.Compute("crash-storage"u8).ToByteArray();
+
+        ISstIngestWriteBatch accountBatch = ((ISstIngestible)_db.GetColumnDb(FlatDbColumns.Account)).StartSstIngestBatch();
+        ISstIngestWriteBatch storageBatch = ((ISstIngestible)_db.GetColumnDb(FlatDbColumns.Storage)).StartSstIngestBatch();
+        try
+        {
+            accountBatch.Set(accountKey, [0xa2]);
+            storageBatch.Set(storageKey, [0xb2]);
+            List<string> stagedFiles = [.. accountBatch.SealToStagedFiles(), .. storageBatch.SealToStagedFiles()];
+
+            using (IColumnsWriteBatch<FlatDbColumns> markerBatch = _db.StartWriteBatch())
+                BasePersistence.SetIngestMarker(markerBatch.GetColumnBatch(FlatDbColumns.Metadata), s2, stagedFiles);
+            _db.Flush(onlyWal: true);
+
+            // The "crash": Account already ingested, Storage still staged, pointer never advanced.
+            accountBatch.IngestStagedFiles();
+        }
+        finally
+        {
+            accountBatch.Dispose();
+            storageBatch.Dispose();
+        }
+
+        Reopen();
+
+        Assert.That(_db.GetColumnDb(FlatDbColumns.Account).Get(accountKey), Is.EqualTo(new byte[] { 0xa2 }));
+        Assert.That(_db.GetColumnDb(FlatDbColumns.Storage).Get(storageKey), Is.EqualTo(new byte[] { 0xb2 }));
+        using (IPersistence.IPersistenceReader reader = _persistence.CreateReader())
+        {
+            Assert.That(reader.CurrentState, Is.EqualTo(s2));
+        }
+        Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
+        Assert.That(StagedSstFiles(), Is.Empty);
+    }
+
+    [Test]
+    public void Crash_after_all_ingests_completes_pointer_on_reopen()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        byte[] accountKey = ValueKeccak.Compute("crash-account"u8).ToByteArray();
+
+        ISstIngestWriteBatch accountBatch = ((ISstIngestible)_db.GetColumnDb(FlatDbColumns.Account)).StartSstIngestBatch();
+        try
+        {
+            accountBatch.Set(accountKey, [0xa3]);
+            List<string> stagedFiles = [.. accountBatch.SealToStagedFiles()];
+
+            using (IColumnsWriteBatch<FlatDbColumns> markerBatch = _db.StartWriteBatch())
+                BasePersistence.SetIngestMarker(markerBatch.GetColumnBatch(FlatDbColumns.Metadata), s2, stagedFiles);
+            _db.Flush(onlyWal: true);
+
+            // The "crash": everything ingested, only the pointer advance is missing.
+            accountBatch.IngestStagedFiles();
+        }
+        finally
+        {
+            accountBatch.Dispose();
+        }
+
+        Reopen();
+
+        Assert.That(_db.GetColumnDb(FlatDbColumns.Account).Get(accountKey), Is.EqualTo(new byte[] { 0xa3 }));
+        using (IPersistence.IPersistenceReader reader = _persistence.CreateReader())
+        {
+            Assert.That(reader.CurrentState, Is.EqualTo(s2));
+        }
+        Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
+        Assert.That(StagedSstFiles(), Is.Empty);
+    }
+
+    [Test]
+    public void Startup_sweep_deletes_orphaned_staged_files_without_marker()
+    {
+        StateId s1 = State(1, 1);
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
         string stagingDir = Path.Combine(_dbPath, "sst_ingest");
-        string[] leftover = Directory.Exists(stagingDir) ? Directory.GetFiles(stagingDir, "*.sst") : [];
-        Assert.That(leftover, Is.Empty);
+        Directory.CreateDirectory(stagingDir);
+        File.WriteAllBytes(Path.Combine(stagingDir, "Account_9999.sst"), [1, 2, 3]);
+        File.WriteAllBytes(Path.Combine(stagingDir, "StorageNodes_10000.sst"), [4, 5, 6]);
+
+        Reopen();
+
+        Assert.That(StagedSstFiles(), Is.Empty);
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        Assert.That(reader.CurrentState, Is.EqualTo(s1));
+        Assert.That(reader.GetAccount(Addr), Is.Not.Null);
+    }
+
+    [Test]
+    public void Concurrent_readers_never_observe_torn_cross_column_state()
+    {
+        const int PersistCount = 25;
+        TreePath topPath = new(Keccak.Compute("top"), 4);
+        TreePath deepPath = new(Keccak.Compute("deep"), 10);
+        TreePath fallbackPath = new(Keccak.Compute("fallback"), 20);
+        Hash256 storageAccount = TestItem.KeccakA;
+        TreePath storagePath = new(Keccak.Compute("storage"), 8);
+
+        StateId[] states = new StateId[PersistCount + 1];
+        for (int i = 1; i <= PersistCount; i++) states[i] = State((ulong)i, (byte)i);
+
+        void Persist(int i)
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(
+                i == 1 ? StateId.PreGenesis : states[i - 1], states[i], WriteFlags.None);
+            byte[] payload = [0x01, (byte)i];
+            batch.SetAccount(Addr, new Account((ulong)i, (UInt256)i));
+            batch.SetStorage(Addr, Slot1, Slot((byte)i));
+            batch.SetStateTrieNode(topPath, payload);
+            batch.SetStateTrieNode(deepPath, payload);
+            batch.SetStateTrieNode(fallbackPath, payload);
+            batch.SetStorageTrieNode(storageAccount, storagePath, payload);
+        }
+
+        Persist(1);
+
+        using CancellationTokenSource done = new();
+        Task[] readers = [.. Enumerable.Range(0, 2).Select(_ => Task.Run(() =>
+        {
+            while (!done.IsCancellationRequested)
+            {
+                using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+                ulong n = reader.CurrentState.BlockNumber;
+                Assert.That(n, Is.InRange(1UL, (ulong)PersistCount));
+                byte[] expected = [0x01, (byte)n];
+
+                Account? account = reader.GetAccount(Addr);
+                Assert.That(account, Is.Not.Null);
+                Assert.That(account!.Nonce, Is.EqualTo(n), "Account column is torn relative to the pointer");
+
+                SlotValue slotValue = default;
+                Assert.That(reader.TryGetSlot(Addr, Slot1, ref slotValue), Is.True);
+                Assert.That(slotValue.AsReadOnlySpan.ToArray(), Is.EqualTo(Slot((byte)n).AsReadOnlySpan.ToArray()), "Storage column is torn relative to the pointer");
+
+                Assert.That(reader.TryLoadStateRlp(topPath, ReadFlags.None), Is.EqualTo(expected), "StateTopNodes column is torn relative to the pointer");
+                Assert.That(reader.TryLoadStateRlp(deepPath, ReadFlags.None), Is.EqualTo(expected), "StateNodes column is torn relative to the pointer");
+                Assert.That(reader.TryLoadStateRlp(fallbackPath, ReadFlags.None), Is.EqualTo(expected), "FallbackNodes column is torn relative to the pointer");
+                Assert.That(reader.TryLoadStorageRlp(storageAccount, storagePath, ReadFlags.None), Is.EqualTo(expected), "StorageNodes column is torn relative to the pointer");
+            }
+        }))];
+
+        for (int i = 2; i <= PersistCount; i++) Persist(i);
+        done.Cancel();
+        Task.WaitAll(readers);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -70,6 +70,41 @@ public class SstIngestionTests
     }
 
     [Test]
+    public void Ingest_duplicate_and_delete_across_chunk_boundary_last_write_wins()
+    {
+        IDb accountDb = _db.GetColumnDb(FlatDbColumns.Account);
+        byte[] overwrittenKey = ValueKeccak.Compute("overwritten"u8).ToByteArray();
+        byte[] deletedKey = ValueKeccak.Compute("deleted"u8).ToByteArray();
+        byte[] dedupedKey = ValueKeccak.Compute("deduped"u8).ToByteArray();
+
+        using (IWriteBatch batch = ((ISstIngestible)accountDb).StartSstIngestBatch())
+        {
+            batch.Set(overwrittenKey, [0x01]);
+            batch.Set(deletedKey, [0x0d]);
+            batch.Set(dedupedKey, [0x0a]);
+            batch.Set(dedupedKey, [0x0b]);
+
+            // Push past the chunk threshold so a mid-batch flush ingests the writes above,
+            // then write conflicting values that land in the next chunk's file.
+            byte[] filler = new byte[64 * 1024];
+            Span<byte> key = stackalloc byte[32];
+            for (int i = 0; i < 2100; i++)
+            {
+                BitConverter.TryWriteBytes(key, i);
+                key[8] = 0xff;
+                batch.Set(key, filler);
+            }
+
+            batch.Set(overwrittenKey, [0x02]);
+            batch.Set(deletedKey, null);
+        }
+
+        Assert.That(accountDb.Get(overwrittenKey), Is.EqualTo(new byte[] { 0x02 }));
+        Assert.That(accountDb.Get(deletedKey), Is.Null);
+        Assert.That(accountDb.Get(dedupedKey), Is.EqualTo(new byte[] { 0x0b }));
+    }
+
+    [Test]
     public void Ingest_round_trips_and_advances_pointer()
     {
         StateId s1 = State(1, 1);

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -99,6 +99,35 @@ public class SstIngestionTests
     }
 
     [Test]
+    public void Ingest_zero_length_write_at_exact_slab_boundary_round_trips()
+    {
+        const int slabSize = 1 << 20;
+        const int entrySize = 1024;
+        const int keySize = 32;
+        IDb accountDb = _db.GetColumnDb(FlatDbColumns.Account);
+        byte[] probeKey = ValueKeccak.Compute("probe"u8).ToByteArray();
+        byte[] probeValue = new byte[entrySize - keySize];
+        probeValue[0] = 0x42;
+
+        using (IWriteBatch batch = ((ISstIngestible)accountDb).StartSstIngestBatch())
+        {
+            byte[] filler = new byte[entrySize - keySize];
+            Span<byte> key = stackalloc byte[keySize];
+            for (int i = 0; i < slabSize / entrySize - 1; i++)
+            {
+                BitConverter.TryWriteBytes(key, i);
+                key[8] = 0xee;
+                batch.Set(key, filler);
+            }
+
+            batch.Set(probeKey, probeValue);
+            batch.PutSpan(default, default);
+        }
+
+        Assert.That(accountDb.Get(probeKey), Is.EqualTo(probeValue));
+    }
+
+    [Test]
     public void Ingest_round_trips_and_advances_pointer()
     {
         StateId s1 = State(1, 1);

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -19,6 +19,7 @@ using Nethermind.Logging;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.Trie;
 using NUnit.Framework;
+using RocksDbSharp;
 
 namespace Nethermind.State.Flat.Test;
 
@@ -57,7 +58,7 @@ public class SstIngestionTests
     private static SlotValue Slot(byte v) => SlotValue.FromSpanWithoutLeadingZero(new byte[] { v });
     private static StateId State(ulong number, byte seed) => new(number, ValueKeccak.Compute(new byte[] { seed }));
 
-    private void Reopen()
+    private void Reopen(bool persistViaSstIngestion = true)
     {
         _db.Dispose();
         _db = new ColumnsDb<FlatDbColumns>(
@@ -67,7 +68,7 @@ public class SstIngestionTests
             new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(), LimboLogs.Instance, validateConfig: false),
             LimboLogs.Instance,
             Enum.GetValues<FlatDbColumns>());
-        _persistence = new RocksDbPersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
+        _persistence = new RocksDbPersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = persistViaSstIngestion });
     }
 
     private string[] StagedSstFiles()
@@ -529,5 +530,125 @@ public class SstIngestionTests
         using IPersistence.IPersistenceReader reader = persistence.CreateReader();
         AssertSlot(reader, Slot1, v1);
         Assert.That(reader.CurrentState, Is.EqualTo(s1));
+    }
+
+    [Test]
+    public void Same_state_and_disable_wal_batches_bypass_the_ingest_path()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s1, WriteFlags.None))
+        {
+            batch.SetStorage(Addr, Slot1, Slot(0x11));
+        }
+        Assert.That(StagedSstFiles(), Is.Empty);
+        Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.DisableWAL))
+        {
+            batch.SetStorage(Addr, Slot2, Slot(0x22));
+        }
+        Assert.That(StagedSstFiles(), Is.Empty);
+        Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
+    }
+
+    [Test]
+    public void Interrupted_ingest_rolls_forward_on_reopen_even_with_sst_ingestion_disabled()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        byte[] accountKey = ValueKeccak.Compute("flagoff-account"u8).ToByteArray();
+        byte[] storageKey = ValueKeccak.Compute("flagoff-storage"u8).ToByteArray();
+
+        ISstIngestWriteBatch accountBatch = ((ISstIngestible)_db.GetColumnDb(FlatDbColumns.Account)).StartSstIngestBatch();
+        ISstIngestWriteBatch storageBatch = ((ISstIngestible)_db.GetColumnDb(FlatDbColumns.Storage)).StartSstIngestBatch();
+        try
+        {
+            accountBatch.Set(accountKey, [0xa2]);
+            storageBatch.Set(storageKey, [0xb2]);
+            List<string> stagedFiles = [.. accountBatch.SealToStagedFiles(), .. storageBatch.SealToStagedFiles()];
+
+            using (IColumnsWriteBatch<FlatDbColumns> markerBatch = _db.StartWriteBatch())
+                BasePersistence.SetIngestMarker(markerBatch.GetColumnBatch(FlatDbColumns.Metadata), s2, stagedFiles);
+            _db.Flush(onlyWal: true);
+
+            accountBatch.IngestStagedFiles();
+        }
+        finally
+        {
+            accountBatch.Dispose();
+            storageBatch.Dispose();
+        }
+
+        Reopen(persistViaSstIngestion: false);
+
+        Assert.That(_db.GetColumnDb(FlatDbColumns.Account).Get(accountKey), Is.EqualTo(new byte[] { 0xa2 }));
+        Assert.That(_db.GetColumnDb(FlatDbColumns.Storage).Get(storageKey), Is.EqualTo(new byte[] { 0xb2 }));
+        using (IPersistence.IPersistenceReader reader = _persistence.CreateReader())
+        {
+            Assert.That(reader.CurrentState, Is.EqualTo(s2));
+        }
+        Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
+        Assert.That(StagedSstFiles(), Is.Empty);
+    }
+
+    [Test]
+    public void Ingest_corruption_fast_shuts_down_without_scheduling_a_repair_of_the_live_db()
+    {
+        _db.Dispose();
+        ObservableColumnsDb observable = new(
+            _dbPath,
+            new DbSettings("State", _dbPath) { DeleteOnStart = true },
+            new DbConfig(),
+            new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(), LimboLogs.Instance, validateConfig: false),
+            LimboLogs.Instance,
+            Enum.GetValues<FlatDbColumns>());
+        _db = observable;
+        _persistence = new RocksDbPersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
+
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        ColumnDb accountColumn = (ColumnDb)_db.GetColumnDb(FlatDbColumns.Account);
+        accountColumn._testIngestFailureHook = () => throw new RocksDbSharpException("Corruption: injected external SST corruption");
+
+        Assert.That(() =>
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None);
+            batch.SetAccount(Addr, new Account(200));
+            batch.SetStorage(Addr, Slot1, Slot(0x11));
+        }, Throws.InstanceOf<RocksDbSharpException>());
+
+        accountColumn._testIngestFailureHook = null;
+        Assert.That(observable.FatalShutdownCount, Is.EqualTo(1));
+        Assert.That(Directory.GetFiles(_dbPath, "corrupt.marker", SearchOption.AllDirectories), Is.Empty);
+    }
+
+    private sealed class ObservableColumnsDb(
+        string basePath,
+        DbSettings settings,
+        IDbConfig dbConfig,
+        IRocksDbConfigFactory rocksDbConfigFactory,
+        ILogManager logManager,
+        IReadOnlyList<FlatDbColumns> keys)
+        : ColumnsDb<FlatDbColumns>(basePath, settings, dbConfig, rocksDbConfigFactory, logManager, keys)
+    {
+        public int FatalShutdownCount { get; private set; }
+
+        protected override void FatalShutdown() => FatalShutdownCount++;
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -57,7 +57,7 @@ public class SstIngestionTests
     private static SlotValue Slot(byte v) => SlotValue.FromSpanWithoutLeadingZero(new byte[] { v });
     private static StateId State(ulong number, byte seed) => new(number, ValueKeccak.Compute(new byte[] { seed }));
 
-    private void Reopen()
+    private void Reopen(bool persistViaSstIngestion = true)
     {
         _db.Dispose();
         _db = new ColumnsDb<FlatDbColumns>(
@@ -67,7 +67,7 @@ public class SstIngestionTests
             new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(), LimboLogs.Instance, validateConfig: false),
             LimboLogs.Instance,
             Enum.GetValues<FlatDbColumns>());
-        _persistence = new RocksDbPersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
+        _persistence = new RocksDbPersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = persistViaSstIngestion });
     }
 
     private string[] StagedSstFiles()
@@ -346,8 +346,9 @@ public class SstIngestionTests
         Assert.That(reader.TryLoadStorageRlp(storageAccount, storagePath, ReadFlags.None), Is.EqualTo(payload));
     }
 
-    [Test]
-    public void Crash_between_column_ingests_rolls_forward_on_reopen()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Crash_between_column_ingests_rolls_forward_on_reopen(bool reopenWithIngestionEnabled)
     {
         StateId s1 = State(1, 1);
         StateId s2 = State(2, 2);
@@ -380,7 +381,7 @@ public class SstIngestionTests
             storageBatch.Dispose();
         }
 
-        Reopen();
+        Reopen(reopenWithIngestionEnabled);
 
         Assert.That(_db.GetColumnDb(FlatDbColumns.Account).Get(accountKey), Is.EqualTo(new byte[] { 0xa2 }));
         Assert.That(_db.GetColumnDb(FlatDbColumns.Storage).Get(storageKey), Is.EqualTo(new byte[] { 0xb2 }));

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -14,12 +14,12 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Db.Rocks;
 using Nethermind.Db.Rocks.Config;
+using Nethermind.RocksDbBindings;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.Trie;
 using NUnit.Framework;
-using RocksDbSharp;
 
 namespace Nethermind.State.Flat.Test;
 
@@ -624,14 +624,14 @@ public class SstIngestionTests
         }
 
         ColumnDb accountColumn = (ColumnDb)_db.GetColumnDb(FlatDbColumns.Account);
-        accountColumn._testIngestFailureHook = () => throw new RocksDbSharpException("Corruption: injected external SST corruption");
+        accountColumn._testIngestFailureHook = () => throw new RocksDbException("Corruption: injected external SST corruption");
 
         Assert.That(() =>
         {
             using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None);
             batch.SetAccount(Addr, new Account(200));
             batch.SetStorage(Addr, Slot1, Slot(0x11));
-        }, Throws.InstanceOf<RocksDbSharpException>());
+        }, Throws.InstanceOf<RocksDbException>());
 
         accountColumn._testIngestFailureHook = null;
         Assert.That(observable.FatalShutdownCount, Is.EqualTo(1));

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -182,6 +182,120 @@ public class SstIngestionTests
         Assert.That(reader.CurrentState, Is.EqualTo(s2));
     }
 
+    [Test]
+    public void Marker_committed_by_a_failing_batch_is_cleared_with_its_staged_files()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        // The marker batch commits on Dispose and only then reports a failure, so the marker is durable even
+        // though the persist threw: the rollback must clear it, not delete the files it still references.
+        WrapWithWriteBatchFaults().FailWriteBatchAfter(0, commitBeforeFailing: true);
+
+        Assert.That(() =>
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None);
+            batch.SetAccount(Addr, new Account(200));
+        }, Throws.InstanceOf<IOException>());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
+            Assert.That(StagedSstFiles(), Is.Empty);
+        }
+
+        Reopen();
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        using (Assert.EnterMultipleScope())
+        {
+            // A marker outliving its deleted files would advance the pointer here over data never ingested.
+            Assert.That(reader.CurrentState, Is.EqualTo(s1));
+            Assert.That(reader.GetAccount(Addr)!.Balance, Is.EqualTo((UInt256)100));
+        }
+    }
+
+    [Test]
+    public void Failed_pointer_advance_after_every_ingest_is_completed_inline()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        // Every column goes live at s2 and only the pointer write fails. Releasing the gate there would publish a
+        // base ahead of its pointer, so the commit must be rolled forward inline instead.
+        WrapWithWriteBatchFaults().FailWriteBatchAfter(1);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(200));
+            batch.SetStorage(Addr, Slot1, Slot(0x11));
+        }
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_persistence.FatalShutdownCount, Is.Zero);
+            Assert.That(reader.CurrentState, Is.EqualTo(s2));
+            Assert.That(reader.GetAccount(Addr)!.Balance, Is.EqualTo((UInt256)200));
+            AssertSlot(reader, Slot1, Slot(0x11));
+            Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
+            Assert.That(StagedSstFiles(), Is.Empty);
+        }
+    }
+
+    [Test]
+    public void Unclearable_marker_after_a_failed_persist_is_fatal_and_rolls_forward()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        ColumnDb accountColumn = (ColumnDb)_db.GetColumnDb(FlatDbColumns.Account);
+        accountColumn._testIngestFailureHook = () => throw new IOException("injected SST ingest failure");
+
+        // Nothing is ingested, so the rollback owns the marker - but its clearing batch fails too. The marker then
+        // outlives the persist and every later one refuses to start, so the node must stop instead of stalling.
+        WrapWithWriteBatchFaults().FailWriteBatchAfter(1);
+
+        Assert.That(() =>
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None);
+            batch.SetAccount(Addr, new Account(200));
+        }, Throws.InstanceOf<IOException>());
+
+        accountColumn._testIngestFailureHook = null;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_persistence.FatalShutdownCount, Is.EqualTo(1));
+            Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata))?.To, Is.EqualTo(s2));
+            Assert.That(StagedSstFiles(), Is.Not.Empty);
+        }
+
+        Reopen();
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reader.CurrentState, Is.EqualTo(s2));
+            Assert.That(reader.GetAccount(Addr)!.Balance, Is.EqualTo((UInt256)200));
+        }
+    }
+
     /// <summary>Observes the fatal-exit decision instead of taking it, which a test process cannot survive.</summary>
     private sealed class ObservablePersistence(IColumnsDb<FlatDbColumns> db, ILogManager logManager, IFlatDbConfig config)
         : RocksDbPersistence(db, logManager, config)
@@ -189,6 +303,67 @@ public class SstIngestionTests
         public int FatalShutdownCount { get; private set; }
 
         protected override void FatalShutdown() => FatalShutdownCount++;
+    }
+
+    /// <summary>Re-points <see cref="_persistence"/> at the same DB through a write-batch fault injector.</summary>
+    private WriteBatchFaultingColumnsDb WrapWithWriteBatchFaults()
+    {
+        WriteBatchFaultingColumnsDb faulting = new(_db);
+        _persistence = new ObservablePersistence(faulting, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
+        return faulting;
+    }
+
+    /// <summary>Fails one chosen write batch of the real DB, optionally after it has already committed.</summary>
+    /// <remarks>Forwards only what the SST-ingest persist path uses.</remarks>
+    private sealed class WriteBatchFaultingColumnsDb(IColumnsDb<FlatDbColumns> inner) : IColumnsDb<FlatDbColumns>
+    {
+        private int _skipBatches = -1;
+        private bool _commitBeforeFailing;
+
+        /// <summary>Fails the write batch started after <paramref name="skip"/> further ones, once.</summary>
+        /// <param name="commitBeforeFailing">Whether the failing batch commits before throwing, the shape a
+        /// throw from <c>Dispose</c> leaves behind.</param>
+        public void FailWriteBatchAfter(int skip, bool commitBeforeFailing = false)
+        {
+            _skipBatches = skip;
+            _commitBeforeFailing = commitBeforeFailing;
+        }
+
+        public IColumnsWriteBatch<FlatDbColumns> StartWriteBatch()
+        {
+            IColumnsWriteBatch<FlatDbColumns> batch = inner.StartWriteBatch();
+            if (_skipBatches < 0) return batch;
+            if (_skipBatches > 0)
+            {
+                _skipBatches--;
+                return batch;
+            }
+
+            _skipBatches = -1;
+            return new FaultingWriteBatch(batch, _commitBeforeFailing);
+        }
+
+        public IDb GetColumnDb(FlatDbColumns key) => inner.GetColumnDb(key);
+        public IEnumerable<FlatDbColumns> ColumnKeys => inner.ColumnKeys;
+        public IColumnDbSnapshot<FlatDbColumns> CreateSnapshot() => inner.CreateSnapshot();
+        public void Flush(bool onlyWal = false) => inner.Flush(onlyWal);
+        public void SyncWal() => inner.SyncWal();
+        public void Dispose() => inner.Dispose();
+
+        private sealed class FaultingWriteBatch(IColumnsWriteBatch<FlatDbColumns> inner, bool commitBeforeFailing)
+            : IColumnsWriteBatch<FlatDbColumns>
+        {
+            public IWriteBatch GetColumnBatch(FlatDbColumns key) => inner.GetColumnBatch(key);
+            public void Clear() => inner.Clear();
+
+            public void Dispose()
+            {
+                // Disposing the batch is what commits it, so dropping the writes means clearing them first.
+                if (!commitBeforeFailing) inner.Clear();
+                inner.Dispose();
+                throw new IOException("injected write batch failure");
+            }
+        }
     }
 
     private static SlotValue Slot(byte v) => SlotValue.FromSpanWithoutLeadingZero(new byte[] { v });

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -31,7 +31,7 @@ public class SstIngestionTests
 
     private string _dbPath = null!;
     private ColumnsDb<FlatDbColumns> _db = null!;
-    private RocksDbPersistence _persistence = null!;
+    private ObservablePersistence _persistence = null!;
 
     [SetUp]
     public void SetUp()
@@ -45,7 +45,7 @@ public class SstIngestionTests
             new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(), LimboLogs.Instance, validateConfig: false),
             LimboLogs.Instance,
             Enum.GetValues<FlatDbColumns>());
-        _persistence = new RocksDbPersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
+        _persistence = new ObservablePersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
     }
 
     [TearDown]
@@ -53,6 +53,142 @@ public class SstIngestionTests
     {
         _db.Dispose();
         try { Directory.Delete(_dbPath, true); } catch { }
+    }
+
+    [Test]
+    public void Unrepairable_torn_base_is_fatal_and_keeps_the_marker_for_roll_forward()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        ColumnDb storageColumn = (ColumnDb)_db.GetColumnDb(FlatDbColumns.Storage);
+        storageColumn._testIngestFailureHook = () => throw new IOException("injected SST ingest failure");
+
+        Assert.That(() =>
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None);
+            batch.SetAccount(Addr, new Account(200));
+            batch.SetStorage(Addr, Slot2, Slot(0x22));
+        }, Throws.InstanceOf<IOException>());
+
+        storageColumn._testIngestFailureHook = null;
+
+        using (Assert.EnterMultipleScope())
+        {
+            // The account column went live at s2 while the pointer stayed at s1: releasing the gate would publish
+            // that torn base to every later reader snapshot, so the commit must stop the node instead.
+            Assert.That(_persistence.FatalShutdownCount, Is.EqualTo(1));
+            Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata))?.To, Is.EqualTo(s2));
+            Assert.That(StagedSstFiles(), Is.Not.Empty);
+        }
+    }
+
+    [Test]
+    public void Pending_marker_is_not_overwritten_by_the_next_persist()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        StateId s3 = State(3, 3);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        ColumnDb storageColumn = (ColumnDb)_db.GetColumnDb(FlatDbColumns.Storage);
+        storageColumn._testIngestFailureHook = () => throw new IOException("injected SST ingest failure");
+
+        Assert.That(() =>
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None);
+            batch.SetAccount(Addr, new Account(200));
+            batch.SetStorage(Addr, Slot2, Slot(0x22));
+        }, Throws.InstanceOf<IOException>());
+
+        storageColumn._testIngestFailureHook = null;
+
+        (StateId To, string[] Files)? pending = BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata));
+        Assert.That(pending, Is.Not.Null);
+        string[] pendingFiles = StagedSstFiles();
+
+        // The marker is a single slot. Taking it here would orphan the files above and strand the account column
+        // ahead of the pointer with nothing left to roll it forward.
+        Assert.That(() =>
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s3, WriteFlags.None);
+            batch.SetAccount(Addr, new Account(300));
+        }, Throws.InstanceOf<InvalidOperationException>());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata))?.To, Is.EqualTo(pending!.Value.To));
+            Assert.That(StagedSstFiles(), Is.SupersetOf(pendingFiles));
+        }
+
+        Reopen();
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        using (Assert.EnterMultipleScope())
+        {
+            // Roll forward completes the interrupted commit, not the one that was refused.
+            Assert.That(reader.CurrentState, Is.EqualTo(s2));
+            Assert.That(reader.GetAccount(Addr)!.Balance, Is.EqualTo((UInt256)200));
+            Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
+        }
+    }
+
+    [Test]
+    public void Empty_pointer_bump_does_not_clobber_a_pending_marker()
+    {
+        StateId s1 = State(1, 1);
+        StateId s2 = State(2, 2);
+        StateId s3 = State(3, 3);
+
+        using (IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(StateId.PreGenesis, s1, WriteFlags.None))
+        {
+            batch.SetAccount(Addr, new Account(100));
+        }
+
+        ColumnDb storageColumn = (ColumnDb)_db.GetColumnDb(FlatDbColumns.Storage);
+        storageColumn._testIngestFailureHook = () => throw new IOException("injected SST ingest failure");
+
+        Assert.That(() =>
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s2, WriteFlags.None);
+            batch.SetAccount(Addr, new Account(200));
+            batch.SetStorage(Addr, Slot2, Slot(0x22));
+        }, Throws.InstanceOf<IOException>());
+
+        storageColumn._testIngestFailureHook = null;
+
+        // The shape Importer and FlatTreeSyncStore use: a write-free batch purely to advance the pointer. Without
+        // the pending-marker check it would clear the marker and advance having written nothing, stranding the
+        // already-live account column at s2 forever.
+        Assert.That(() =>
+        {
+            using IPersistence.IWriteBatch batch = _persistence.CreateWriteBatch(s1, s3, WriteFlags.None);
+        }, Throws.InstanceOf<InvalidOperationException>());
+
+        Assert.That(BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata))?.To, Is.EqualTo(s2));
+
+        Reopen();
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        Assert.That(reader.CurrentState, Is.EqualTo(s2));
+    }
+
+    /// <summary>Observes the fatal-exit decision instead of taking it, which a test process cannot survive.</summary>
+    private sealed class ObservablePersistence(IColumnsDb<FlatDbColumns> db, ILogManager logManager, IFlatDbConfig config)
+        : RocksDbPersistence(db, logManager, config)
+    {
+        public int FatalShutdownCount { get; private set; }
+
+        protected override void FatalShutdown() => FatalShutdownCount++;
     }
 
     private static SlotValue Slot(byte v) => SlotValue.FromSpanWithoutLeadingZero(new byte[] { v });
@@ -68,7 +204,7 @@ public class SstIngestionTests
             new RocksDbConfigFactory(new DbConfig(), new PruningConfig(), new TestHardwareInfo(), LimboLogs.Instance, validateConfig: false),
             LimboLogs.Instance,
             Enum.GetValues<FlatDbColumns>());
-        _persistence = new RocksDbPersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = persistViaSstIngestion });
+        _persistence = new ObservablePersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = persistViaSstIngestion });
     }
 
     private string[] StagedSstFiles()
@@ -278,6 +414,8 @@ public class SstIngestionTests
         Assert.That(marker, Is.Not.Null);
         Assert.That(marker!.Value.To, Is.EqualTo(s2));
         Assert.That(StagedSstFiles(), Is.Not.Empty);
+        Assert.That(_persistence.FatalShutdownCount, Is.EqualTo(1),
+            "an unrepairable torn base must stop the node rather than serve it to readers");
 
         Reopen();
 
@@ -614,7 +752,7 @@ public class SstIngestionTests
             LimboLogs.Instance,
             Enum.GetValues<FlatDbColumns>());
         _db = observable;
-        _persistence = new RocksDbPersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
+        _persistence = new ObservablePersistence(_db, LimboLogs.Instance, new FlatDbConfig { PersistViaSstIngestion = true });
 
         StateId s1 = State(1, 1);
         StateId s2 = State(2, 2);

--- a/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SstIngestionTests.cs
@@ -51,8 +51,10 @@ public class SstIngestionTests
     [TearDown]
     public void TearDown()
     {
+        _persistence.Dispose();
         _db.Dispose();
-        try { Directory.Delete(_dbPath, true); } catch { }
+        try { Directory.Delete(_dbPath, true); }
+        catch (Exception e) { TestContext.Out.WriteLine($"Failed to delete {_dbPath}: {e}"); }
     }
 
     [Test]
@@ -371,6 +373,7 @@ public class SstIngestionTests
 
     private void Reopen(bool persistViaSstIngestion = true)
     {
+        _persistence.Dispose();
         _db.Dispose();
         _db = new ColumnsDb<FlatDbColumns>(
             _dbPath,
@@ -916,7 +919,8 @@ public class SstIngestionTests
     }
 
     [Test]
-    public void Ingest_corruption_fast_shuts_down_without_scheduling_a_repair_of_the_live_db()
+    public void Ingest_corruption_fast_shuts_down_and_schedules_a_repair_only_for_the_live_db(
+        [Values] bool corruptionNamesStagedFile)
     {
         _db.Dispose();
         ObservableColumnsDb observable = new(
@@ -937,7 +941,10 @@ public class SstIngestionTests
         }
 
         ColumnDb accountColumn = (ColumnDb)_db.GetColumnDb(FlatDbColumns.Account);
-        accountColumn._testIngestFailureHook = () => throw new RocksDbException("Corruption: injected external SST corruption");
+        accountColumn._testIngestFailureHook = () => throw new RocksDbException(
+            corruptionNamesStagedFile
+                ? $"Corruption: injected external SST corruption in {StagedFileName(FlatDbColumns.Account)}"
+                : "Corruption: injected corruption of the live DB");
 
         Assert.That(() =>
         {
@@ -947,8 +954,27 @@ public class SstIngestionTests
         }, Throws.InstanceOf<RocksDbException>());
 
         accountColumn._testIngestFailureHook = null;
-        Assert.That(observable.FatalShutdownCount, Is.EqualTo(1));
-        Assert.That(Directory.GetFiles(_dbPath, "corrupt.marker", SearchOption.AllDirectories), Is.Empty);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(observable.FatalShutdownCount, Is.EqualTo(1));
+            // Ingestion also flushes the memtable and reads live SST metadata, so corruption raised there is the
+            // live DB's unless the message names a staged file - and only the live DB's is worth repairing.
+            Assert.That(
+                Directory.GetFiles(_dbPath, "corrupt.marker", SearchOption.AllDirectories),
+                corruptionNamesStagedFile ? Is.Empty : Is.Not.Empty);
+        }
+    }
+
+    private string StagedFileName(FlatDbColumns column)
+    {
+        foreach (string path in StagedSstFiles())
+        {
+            string name = Path.GetFileName(path);
+            if (name.StartsWith($"{column}_", StringComparison.Ordinal)) return name;
+        }
+
+        throw new InvalidOperationException($"No staged SST file for column {column}");
     }
 
     private sealed class ObservableColumnsDb(

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatBalHealingTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatBalHealingTests.cs
@@ -53,6 +53,7 @@ public class FlatBalHealingTests
     [TearDown]
     public void TearDown()
     {
+        (_persistence as IDisposable)?.Dispose();
         _columnsDb.Dispose();
         _codeDb.Dispose();
         _balDb.Dispose();

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/FlatTreeSyncStoreTests.cs
@@ -34,7 +34,11 @@ public class FlatTreeSyncStoreTests
     }
 
     [TearDown]
-    public void TearDown() => _columnsDb.Dispose();
+    public void TearDown()
+    {
+        (_persistence as IDisposable)?.Dispose();
+        _columnsDb.Dispose();
+    }
 
     private void WriteStorageDirectToDb(Address address, UInt256 slot, byte[] value)
     {

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/SnapFlatStateServerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/SnapFlatStateServerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -61,7 +62,11 @@ public class SnapFlatStateServerTests
     }
 
     [TearDown]
-    public void TearDown() => _columnsDb.Dispose();
+    public void TearDown()
+    {
+        (_persistence as IDisposable)?.Dispose();
+        _columnsDb.Dispose();
+    }
 
     [Test]
     public void GetTrieNodes_RespectsHardResponseByteLimit()

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/TrieReassemblerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/TrieReassemblerTests.cs
@@ -37,7 +37,11 @@ public class TrieReassemblerTests
     }
 
     [TearDown]
-    public void TearDown() => _columnsDb.Dispose();
+    public void TearDown()
+    {
+        (_persistence as IDisposable)?.Dispose();
+        _columnsDb.Dispose();
+    }
 
     [Test]
     public void Reassembles_state_root_from_single_account()

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -35,6 +36,7 @@ public static class BasePersistence
     private static readonly byte[] CurrentStateKey = Keccak.Compute("CurrentState").BytesToArray();
     private static readonly byte[] LayoutKey = Keccak.Compute("Layout").BytesToArray();
     private static readonly byte[] SlotEncodingKey = Keccak.Compute("SlotEncoding").BytesToArray();
+    private static readonly byte[] IngestMarkerKey = Keccak.Compute("SstIngestMarker").BytesToArray();
 
     /// <summary>Raw storage slot encoding: the stripped value bytes are stored verbatim. Legacy, deprecated.</summary>
     internal const byte SlotEncodingRaw = 0;
@@ -60,6 +62,52 @@ public static class BasePersistence
         stateId.StateRoot.BytesAsSpan.CopyTo(bytes[8..]);
         kv.PutSpan(CurrentStateKey, bytes);
     }
+
+    /// <summary>
+    /// Durable redo marker for an SST-ingest persist: target state plus the staged file names. Written (WAL-synced)
+    /// before the first ingest; cleared atomically with the <see cref="CurrentStateKey"/> advance. A marker found at
+    /// startup means the process died mid-commit and the persist must be rolled forward.
+    /// </summary>
+    internal static void SetIngestMarker(IWriteOnlyKeyValueStore kv, in StateId to, IReadOnlyList<string> files)
+    {
+        int size = 8 + 32;
+        foreach (string file in files) size += 2 + Encoding.UTF8.GetByteCount(Path.GetFileName(file));
+
+        Span<byte> bytes = size <= 4096 ? stackalloc byte[size] : new byte[size];
+        BinaryPrimitives.WriteUInt64BigEndian(bytes[..8], to.BlockNumber);
+        to.StateRoot.BytesAsSpan.CopyTo(bytes[8..]);
+        int offset = 8 + 32;
+        foreach (string file in files)
+        {
+            int written = Encoding.UTF8.GetBytes(Path.GetFileName(file), bytes[(offset + 2)..]);
+            BinaryPrimitives.WriteUInt16BigEndian(bytes[offset..], (ushort)written);
+            offset += 2 + written;
+        }
+
+        kv.PutSpan(IngestMarkerKey, bytes);
+    }
+
+    internal static (StateId To, string[] Files)? ReadIngestMarker(IReadOnlyKeyValueStore kv)
+    {
+        byte[]? bytes = kv.Get(IngestMarkerKey);
+        if (bytes is null || bytes.Length < 8 + 32) return null;
+
+        StateId to = new(BinaryPrimitives.ReadUInt64BigEndian(bytes), new ValueHash256(bytes.AsSpan(8, 32)));
+        List<string> files = [];
+        int offset = 8 + 32;
+        while (offset + 2 <= bytes.Length)
+        {
+            int length = BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(offset));
+            offset += 2;
+            if (offset + length > bytes.Length) throw new InvalidDataException("Flat DB SST ingest marker is truncated");
+            files.Add(Encoding.UTF8.GetString(bytes, offset, length));
+            offset += length;
+        }
+
+        return (to, files.ToArray());
+    }
+
+    internal static void ClearIngestMarker(IWriteOnlyKeyValueStore kv) => kv.Remove(IngestMarkerKey);
 
     internal static FlatLayout? ReadLayout(IReadOnlyKeyValueStore kv)
     {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -73,18 +74,26 @@ public static class BasePersistence
         int size = 8 + 32;
         foreach (string file in files) size += 2 + Encoding.UTF8.GetByteCount(Path.GetFileName(file));
 
-        Span<byte> bytes = size <= 4096 ? stackalloc byte[size] : new byte[size];
-        BinaryPrimitives.WriteUInt64BigEndian(bytes[..8], to.BlockNumber);
-        to.StateRoot.BytesAsSpan.CopyTo(bytes[8..]);
-        int offset = 8 + 32;
-        foreach (string file in files)
+        byte[]? rented = size <= 4096 ? null : ArrayPool<byte>.Shared.Rent(size);
+        Span<byte> bytes = rented is null ? stackalloc byte[size] : rented.AsSpan(0, size);
+        try
         {
-            int written = Encoding.UTF8.GetBytes(Path.GetFileName(file), bytes[(offset + 2)..]);
-            BinaryPrimitives.WriteUInt16BigEndian(bytes[offset..], (ushort)written);
-            offset += 2 + written;
-        }
+            BinaryPrimitives.WriteUInt64BigEndian(bytes[..8], to.BlockNumber);
+            to.StateRoot.BytesAsSpan.CopyTo(bytes[8..]);
+            int offset = 8 + 32;
+            foreach (string file in files)
+            {
+                int written = Encoding.UTF8.GetBytes(Path.GetFileName(file), bytes[(offset + 2)..]);
+                BinaryPrimitives.WriteUInt16BigEndian(bytes[offset..], (ushort)written);
+                offset += 2 + written;
+            }
 
-        kv.PutSpan(IngestMarkerKey, bytes);
+            kv.PutSpan(IngestMarkerKey, bytes);
+        }
+        finally
+        {
+            if (rented is not null) ArrayPool<byte>.Shared.Return(rented);
+        }
     }
 
     internal static (StateId To, string[] Files)? ReadIngestMarker(IReadOnlyKeyValueStore kv)

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -248,6 +248,7 @@ public static class BasePersistence
                 {
                     // Preserve the format markers; wiping them makes a re-synced RLP DB read back as raw. #11996
                     batch.GetColumnBatch(column).Remove(CurrentStateKey);
+                    batch.GetColumnBatch(column).Remove(IngestMarkerKey);
                     continue;
                 }
 

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/DirectorySync.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/DirectorySync.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.InteropServices;
+
+namespace Nethermind.State.Flat.Persistence;
+
+/// <summary>Forces a directory's entries to durable storage.</summary>
+/// <remarks>
+/// Syncing a file does not sync the directory entry naming it, so a file created and fsynced can still be absent
+/// after a power loss. Callers that later look the file up by name - the SST ingest redo marker lists its staged
+/// files by path - need the directory synced too.
+/// </remarks>
+internal static class DirectorySync
+{
+    private const int O_RDONLY = 0;
+
+    [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+    private static extern int Open(string path, int flags);
+
+    [DllImport("libc", EntryPoint = "fsync", SetLastError = true)]
+    private static extern int Fsync(int fd);
+
+    [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+    private static extern int Close(int fd);
+
+    /// <summary>
+    /// <c>fsync(2)</c> on <paramref name="path"/> itself. No-op off Linux, matching the rest of the flat DB's
+    /// durability syscalls - the production target is Linux, and elsewhere this only weakens a crash window.
+    /// </summary>
+    /// <exception cref="IOException">The directory could not be opened or synced.</exception>
+    internal static void Fsync(string path)
+    {
+        if (!OperatingSystem.IsLinux()) return;
+
+        int fd = Open(path, O_RDONLY);
+        if (fd < 0) throw new IOException($"open of directory '{path}' failed: errno {Marshal.GetLastPInvokeError()}");
+
+        try
+        {
+            if (Fsync(fd) != 0)
+                throw new IOException($"fsync of directory '{path}' failed: errno {Marshal.GetLastPInvokeError()}");
+        }
+        finally
+        {
+            Close(fd);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -12,6 +12,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
     private readonly WriteBufferAdjuster _adjuster = new(db, config?.PersistenceWriteBufferFloor ?? WriteBufferAdjuster.DefaultWriteBufferFloor);
     private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.Flat);
     private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.Storage), logManager.GetClassLogger<RocksDbPersistence>());
+    private readonly bool _useSstIngestion = config?.PersistViaSstIngestion ?? false;
 
     public void Flush() => db.Flush();
 
@@ -55,6 +56,71 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
         }
     }
 
+    // Persist by building one sorted SST per column off-heap and ingesting it (metadata-only add) instead of a
+    // single large WriteBatch. This bypasses the memtable, so persisting a compacted snapshot no longer triggers
+    // the flush -> L0 pile-up -> compaction burst that saturates I/O and stalls concurrent reads for seconds.
+    private IPersistence.IWriteBatch CreateIngestWriteBatch(IColumnDbSnapshot<FlatDbColumns> dbSnap, StateId to)
+    {
+        IWriteBatch Ingest(FlatDbColumns column) => ((ISstIngestible)db.GetColumnDb(column)).StartSstIngestBatch();
+
+        IWriteBatch accountBatch = Ingest(FlatDbColumns.Account);
+        IWriteBatch storageBatch = Ingest(FlatDbColumns.Storage);
+        IWriteBatch stateTopNodesBatch = Ingest(FlatDbColumns.StateTopNodes);
+        IWriteBatch stateNodesBatch = Ingest(FlatDbColumns.StateNodes);
+        IWriteBatch storageNodesBatch = Ingest(FlatDbColumns.StorageNodes);
+        IWriteBatch fallbackNodesBatch = Ingest(FlatDbColumns.FallbackNodes);
+
+        BaseTriePersistence.WriteBatch trieWriteBatch = new(
+            (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.StateTopNodes),
+            (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.StateNodes),
+            (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.StorageNodes),
+            (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.FallbackNodes),
+            stateTopNodesBatch,
+            stateNodesBatch,
+            storageNodesBatch,
+            fallbackNodesBatch,
+            WriteFlags.None);
+
+        StateId toCopy = to;
+
+        return new BasePersistence.WriteBatch<BasePersistence.ToHashedWriteBatch<BaseFlatPersistence.WriteBatch>, BaseTriePersistence.WriteBatch>(
+            new BasePersistence.ToHashedWriteBatch<BaseFlatPersistence.WriteBatch>(
+                new BaseFlatPersistence.WriteBatch(
+                    (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.Account),
+                    (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.Storage),
+                    accountBatch,
+                    storageBatch,
+                    WriteFlags.None,
+                    rlpWrapSlots: _rlpWrapSlots
+                )
+            ),
+            trieWriteBatch,
+            new Reactive.AnonymousDisposable(() =>
+            {
+                // Each Dispose builds one sorted SST and ingests it (metadata-only add, bypassing the memtable),
+                // then the pointer advances. NOTE: per-CF ingest is not yet crash-atomic with the pointer write; a
+                // crash in between leaves the pointer behind the ingested data and recovery re-executes/overwrites
+                // it. Full atomicity needs the multi-CF rocksdb_ingest_external_files (follow-up).
+                accountBatch.Dispose();
+                storageBatch.Dispose();
+                stateTopNodesBatch.Dispose();
+                stateNodesBatch.Dispose();
+                storageNodesBatch.Dispose();
+                fallbackNodesBatch.Dispose();
+
+                using (IColumnsWriteBatch<FlatDbColumns> metaBatch = db.StartWriteBatch())
+                {
+                    BasePersistence.SetCurrentState(metaBatch.GetColumnBatch(FlatDbColumns.Metadata), toCopy);
+                    if (_rlpWrapSlots)
+                        BasePersistence.RecordLayoutOnFirstBatch(metaBatch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.Flat);
+                }
+
+                db.Flush(onlyWal: true);
+                dbSnap.Dispose();
+            })
+        );
+    }
+
     public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags)
     {
         IColumnDbSnapshot<FlatDbColumns> dbSnap = db.CreateSnapshot();
@@ -63,6 +129,12 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
         {
             dbSnap.Dispose();
             throw new InvalidOperationException($"Attempted to apply snapshot on top of wrong state. Snapshot from: {from}, Db state: {currentState}");
+        }
+
+        if (_useSstIngestion && from != StateId.Sync && to != StateId.Sync
+            && db.GetColumnDb(FlatDbColumns.Account) is ISstIngestible)
+        {
+            return CreateIngestWriteBatch(dbSnap, to);
         }
 
         IColumnsWriteBatch<FlatDbColumns> batch = db.StartWriteBatch();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -140,6 +140,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
 
     private void CommitIngest(ISstIngestWriteBatch[] batches, in StateId to)
     {
+        int columnsIngested = 0;
         try
         {
             List<string> stagedFiles = [];
@@ -161,7 +162,10 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
             try
             {
                 foreach (ISstIngestWriteBatch batch in batches)
+                {
                     batch.IngestStagedFiles();
+                    columnsIngested++;
+                }
 
                 using (IColumnsWriteBatch<FlatDbColumns> pointerBatch = db.StartWriteBatch())
                 {
@@ -176,9 +180,19 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
                 _ingestGate.ExitWriteLock();
             }
         }
-        catch
+        catch (Exception e)
         {
-            RollbackFailedIngest(batches);
+            // Rollback is only safe while no column has been ingested; after that the already-live columns
+            // cannot be un-ingested, so the marker and remaining staged files must survive for a retried
+            // persist or startup recovery to roll the commit forward.
+            if (columnsIngested == 0)
+            {
+                RollbackFailedIngest(batches);
+            }
+            else if (_logger.IsError)
+            {
+                _logger.Error($"Persist to {to} failed after {columnsIngested} of {batches.Length} column ingests; keeping the redo marker and staged files for roll-forward", e);
+            }
             throw;
         }
 

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Runtime.ExceptionServices;
 using Nethermind.Core;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -10,10 +9,25 @@ namespace Nethermind.State.Flat.Persistence;
 
 public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logManager, IFlatDbConfig? config = null) : IPersistence
 {
+    private static readonly FlatDbColumns[] IngestColumns =
+    [
+        FlatDbColumns.Account,
+        FlatDbColumns.Storage,
+        FlatDbColumns.StateTopNodes,
+        FlatDbColumns.StateNodes,
+        FlatDbColumns.StorageNodes,
+        FlatDbColumns.FallbackNodes,
+    ];
+
+    private readonly bool _storeSupportsIngest = RecoverInterruptedIngest(db, logManager);
     private readonly WriteBufferAdjuster _adjuster = new(db, config?.PersistenceWriteBufferFloor ?? WriteBufferAdjuster.DefaultWriteBufferFloor);
     private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.Flat);
     private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.Storage), logManager.GetClassLogger<RocksDbPersistence>());
     private readonly bool _useSstIngestion = config?.PersistViaSstIngestion ?? false;
+    private readonly ILogger _logger = logManager.GetClassLogger<RocksDbPersistence>();
+    // Gates new reader snapshots out of the ingest commit window (per-CF ingests + pointer write), which is
+    // not a single RocksDB sequence number the way a normal WriteBatch commit is.
+    private readonly ReaderWriterLockSlim _ingestGate = new();
 
     public void Flush() => db.Flush();
 
@@ -21,7 +35,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
-        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot();
+        IColumnDbSnapshot<FlatDbColumns> snapshot = CreateGatedSnapshot();
         try
         {
             BaseTriePersistence.Reader trieReader = new(
@@ -57,16 +71,31 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
         }
     }
 
+    private IColumnDbSnapshot<FlatDbColumns> CreateGatedSnapshot()
+    {
+        if (!_useSstIngestion) return db.CreateSnapshot();
+
+        _ingestGate.EnterReadLock();
+        try
+        {
+            return db.CreateSnapshot();
+        }
+        finally
+        {
+            _ingestGate.ExitReadLock();
+        }
+    }
+
     private IPersistence.IWriteBatch CreateIngestWriteBatch(IColumnDbSnapshot<FlatDbColumns> dbSnap, StateId to)
     {
-        IWriteBatch Ingest(FlatDbColumns column) => ((ISstIngestible)db.GetColumnDb(column)).StartSstIngestBatch();
+        ISstIngestWriteBatch Ingest(FlatDbColumns column) => ((ISstIngestible)db.GetColumnDb(column)).StartSstIngestBatch();
 
-        IWriteBatch accountBatch = Ingest(FlatDbColumns.Account);
-        IWriteBatch storageBatch = Ingest(FlatDbColumns.Storage);
-        IWriteBatch stateTopNodesBatch = Ingest(FlatDbColumns.StateTopNodes);
-        IWriteBatch stateNodesBatch = Ingest(FlatDbColumns.StateNodes);
-        IWriteBatch storageNodesBatch = Ingest(FlatDbColumns.StorageNodes);
-        IWriteBatch fallbackNodesBatch = Ingest(FlatDbColumns.FallbackNodes);
+        ISstIngestWriteBatch accountBatch = Ingest(FlatDbColumns.Account);
+        ISstIngestWriteBatch storageBatch = Ingest(FlatDbColumns.Storage);
+        ISstIngestWriteBatch stateTopNodesBatch = Ingest(FlatDbColumns.StateTopNodes);
+        ISstIngestWriteBatch stateNodesBatch = Ingest(FlatDbColumns.StateNodes);
+        ISstIngestWriteBatch storageNodesBatch = Ingest(FlatDbColumns.StorageNodes);
+        ISstIngestWriteBatch fallbackNodesBatch = Ingest(FlatDbColumns.FallbackNodes);
 
         BaseTriePersistence.WriteBatch trieWriteBatch = new(
             (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.StateTopNodes),
@@ -95,32 +124,150 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
             trieWriteBatch,
             new Reactive.AnonymousDisposable(() =>
             {
+                ISstIngestWriteBatch[] batches = [accountBatch, storageBatch, stateTopNodesBatch, stateNodesBatch, storageNodesBatch, fallbackNodesBatch];
                 try
                 {
-                    IWriteBatch[] batches = [accountBatch, storageBatch, stateTopNodesBatch, stateNodesBatch, storageNodesBatch, fallbackNodesBatch];
-                    ExceptionDispatchInfo? firstFailure = null;
-                    foreach (IWriteBatch batch in batches)
-                    {
-                        try { batch.Dispose(); }
-                        catch (Exception e) { firstFailure ??= ExceptionDispatchInfo.Capture(e); }
-                    }
-                    firstFailure?.Throw();
-
-                    using (IColumnsWriteBatch<FlatDbColumns> metaBatch = db.StartWriteBatch())
-                    {
-                        BasePersistence.SetCurrentState(metaBatch.GetColumnBatch(FlatDbColumns.Metadata), toCopy);
-                        if (_rlpWrapSlots)
-                            BasePersistence.RecordLayoutOnFirstBatch(metaBatch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.Flat);
-                    }
-
-                    db.Flush(onlyWal: true);
+                    CommitIngest(batches, toCopy);
                 }
                 finally
                 {
+                    foreach (ISstIngestWriteBatch batch in batches) batch.Dispose();
                     dbSnap.Dispose();
                 }
             })
         );
+    }
+
+    private void CommitIngest(ISstIngestWriteBatch[] batches, in StateId to)
+    {
+        try
+        {
+            List<string> stagedFiles = [];
+            foreach (ISstIngestWriteBatch batch in batches)
+                stagedFiles.AddRange(batch.SealToStagedFiles());
+
+            // Redo marker: durable before the first ingest so a crash anywhere below rolls forward to `to`
+            // on reopen; the pointer therefore never claims a state some column lacks.
+            using (IColumnsWriteBatch<FlatDbColumns> markerBatch = db.StartWriteBatch())
+            {
+                IWriteBatch metadata = markerBatch.GetColumnBatch(FlatDbColumns.Metadata);
+                BasePersistence.SetIngestMarker(metadata, to, stagedFiles);
+                if (_rlpWrapSlots)
+                    BasePersistence.RecordLayoutOnFirstBatch(metadata, ref _layoutPersisted, FlatLayout.Flat);
+            }
+            db.Flush(onlyWal: true);
+
+            _ingestGate.EnterWriteLock();
+            try
+            {
+                foreach (ISstIngestWriteBatch batch in batches)
+                    batch.IngestStagedFiles();
+
+                using (IColumnsWriteBatch<FlatDbColumns> pointerBatch = db.StartWriteBatch())
+                {
+                    IWriteBatch metadata = pointerBatch.GetColumnBatch(FlatDbColumns.Metadata);
+                    BasePersistence.SetCurrentState(metadata, to);
+                    BasePersistence.ClearIngestMarker(metadata);
+                }
+                db.Flush(onlyWal: true);
+            }
+            finally
+            {
+                _ingestGate.ExitWriteLock();
+            }
+        }
+        catch
+        {
+            RollbackFailedIngest(batches);
+            throw;
+        }
+
+        // The L0 throttle stays outside the gate so reader snapshot creation is not stalled behind compaction.
+        foreach (FlatDbColumns column in IngestColumns)
+            ((ISstIngestible)db.GetColumnDb(column)).WaitForIngestCompactionHeadroom();
+    }
+
+    private void RollbackFailedIngest(ISstIngestWriteBatch[] batches)
+    {
+        try
+        {
+            // The marker must be gone before staged files are deleted: a marker surviving its files would
+            // roll the pointer forward past missing data on the next open.
+            using (IColumnsWriteBatch<FlatDbColumns> batch = db.StartWriteBatch())
+                BasePersistence.ClearIngestMarker(batch.GetColumnBatch(FlatDbColumns.Metadata));
+            db.Flush(onlyWal: true);
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsError) _logger.Error("Failed to clear the SST ingest marker after a failed persist; keeping staged files for startup roll-forward", e);
+            return;
+        }
+
+        foreach (ISstIngestWriteBatch batch in batches)
+            batch.DeleteStagedFiles();
+    }
+
+    /// <summary>
+    /// Startup recovery for the SST-ingest persist path. A pending marker means the process died between the
+    /// first ingest and the pointer advance: re-ingest the staged files that remain (move-ingest consumed the
+    /// rest) and complete the pointer write. Without a marker, leftover staged files are orphans and are removed.
+    /// Returns whether the store supports SST ingestion at all.
+    /// </summary>
+    private static bool RecoverInterruptedIngest(IColumnsDb<FlatDbColumns> db, ILogManager logManager)
+    {
+        if (db.GetColumnDb(FlatDbColumns.Account) is not ISstIngestible ingestible) return false;
+
+        ILogger logger = logManager.GetClassLogger<RocksDbPersistence>();
+        string stagingDir = ingestible.IngestStagingDir;
+
+        if (BasePersistence.ReadIngestMarker(db.GetColumnDb(FlatDbColumns.Metadata)) is { } pending)
+            RollForwardPendingIngest(db, stagingDir, pending, logger);
+
+        if (Directory.Exists(stagingDir))
+        {
+            string[] orphans = Directory.GetFiles(stagingDir);
+            foreach (string orphan in orphans) File.Delete(orphan);
+            if (orphans.Length > 0 && logger.IsInfo)
+                logger.Info($"Deleted {orphans.Length} orphaned SST staging file(s) from {stagingDir}");
+        }
+
+        return true;
+    }
+
+    private static void RollForwardPendingIngest(IColumnsDb<FlatDbColumns> db, string stagingDir, (StateId To, string[] Files) pending, ILogger logger)
+    {
+        Dictionary<FlatDbColumns, List<string>> byColumn = [];
+        foreach (string name in pending.Files)
+        {
+            int cut = name.LastIndexOf('_');
+            if (cut <= 0 || !Enum.TryParse(name.AsSpan(0, cut), out FlatDbColumns column) || !Enum.IsDefined(column) || column == FlatDbColumns.Metadata)
+                throw new InvalidOperationException($"Flat DB SST ingest marker references unrecognized staged file '{name}'");
+
+            string path = Path.Combine(stagingDir, name);
+            // A missing file was already ingested: move-ingest deletes its source on success.
+            if (!File.Exists(path)) continue;
+
+            if (!byColumn.TryGetValue(column, out List<string>? files)) byColumn[column] = files = [];
+            files.Add(path);
+        }
+
+        int reingested = 0;
+        foreach ((FlatDbColumns column, List<string> files) in byColumn)
+        {
+            ((ISstIngestible)db.GetColumnDb(column)).IngestStagedFiles(files);
+            reingested += files.Count;
+        }
+
+        using (IColumnsWriteBatch<FlatDbColumns> batch = db.StartWriteBatch())
+        {
+            IWriteBatch metadata = batch.GetColumnBatch(FlatDbColumns.Metadata);
+            BasePersistence.SetCurrentState(metadata, pending.To);
+            BasePersistence.ClearIngestMarker(metadata);
+        }
+        db.Flush(onlyWal: true);
+
+        if (logger.IsInfo)
+            logger.Info($"Rolled interrupted flat DB persist forward to {pending.To}: re-ingested {reingested} of {pending.Files.Length} staged SST file(s)");
     }
 
     public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags)
@@ -133,8 +280,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
             throw new InvalidOperationException($"Attempted to apply snapshot on top of wrong state. Snapshot from: {from}, Db state: {currentState}");
         }
 
-        if (_useSstIngestion && from != StateId.Sync && to != StateId.Sync
-            && db.GetColumnDb(FlatDbColumns.Account) is ISstIngestible)
+        if (_useSstIngestion && _storeSupportsIngest && from != StateId.Sync && to != StateId.Sync)
         {
             return CreateIngestWriteBatch(dbSnap, to);
         }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Runtime.ExceptionServices;
 using Nethermind.Core;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -56,9 +57,11 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
         }
     }
 
-    // Persist by building one sorted SST per column off-heap and ingesting it (metadata-only add) instead of a
-    // single large WriteBatch. This bypasses the memtable, so persisting a compacted snapshot no longer triggers
-    // the flush -> L0 pile-up -> compaction burst that saturates I/O and stalls concurrent reads for seconds.
+    // Persist by building sorted SST file(s) per column (from a byte-capped in-memory buffer) and ingesting them
+    // as a metadata-only add, instead of a single large WriteBatch. This bypasses the memtable, so persisting a
+    // compacted snapshot no longer triggers the flush -> L0 pile-up -> compaction burst that saturates I/O and
+    // stalls concurrent reads for seconds. Peak persist memory is higher than the streaming WriteBatch (the buffer
+    // holds up to the byte cap per column on the managed heap), which is why it is capped and default-off.
     private IPersistence.IWriteBatch CreateIngestWriteBatch(IColumnDbSnapshot<FlatDbColumns> dbSnap, StateId to)
     {
         IWriteBatch Ingest(FlatDbColumns column) => ((ISstIngestible)db.GetColumnDb(column)).StartSstIngestBatch();
@@ -97,26 +100,36 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
             trieWriteBatch,
             new Reactive.AnonymousDisposable(() =>
             {
-                // Each Dispose builds one sorted SST and ingests it (metadata-only add, bypassing the memtable),
-                // then the pointer advances. NOTE: per-CF ingest is not yet crash-atomic with the pointer write; a
-                // crash in between leaves the pointer behind the ingested data and recovery re-executes/overwrites
-                // it. Full atomicity needs the multi-CF rocksdb_ingest_external_files (follow-up).
-                accountBatch.Dispose();
-                storageBatch.Dispose();
-                stateTopNodesBatch.Dispose();
-                stateNodesBatch.Dispose();
-                storageNodesBatch.Dispose();
-                fallbackNodesBatch.Dispose();
-
-                using (IColumnsWriteBatch<FlatDbColumns> metaBatch = db.StartWriteBatch())
+                // Each batch Dispose builds sorted SST file(s) from its buffer and ingests them (metadata-only add,
+                // bypassing the memtable), then the pointer advances. Every batch Dispose does disk I/O and can
+                // throw; dispose all of them and the snapshot regardless of failure so nothing leaks, and surface
+                // the first failure so the currentState pointer is NOT advanced past a partial persist (recovery
+                // then re-executes from the previous pointer). NOTE: per-CF ingest is not yet crash-atomic with the
+                // pointer write; full atomicity needs the multi-CF rocksdb_ingest_external_files (follow-up).
+                try
                 {
-                    BasePersistence.SetCurrentState(metaBatch.GetColumnBatch(FlatDbColumns.Metadata), toCopy);
-                    if (_rlpWrapSlots)
-                        BasePersistence.RecordLayoutOnFirstBatch(metaBatch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.Flat);
-                }
+                    IWriteBatch[] batches = [accountBatch, storageBatch, stateTopNodesBatch, stateNodesBatch, storageNodesBatch, fallbackNodesBatch];
+                    ExceptionDispatchInfo? firstFailure = null;
+                    foreach (IWriteBatch batch in batches)
+                    {
+                        try { batch.Dispose(); }
+                        catch (Exception e) { firstFailure ??= ExceptionDispatchInfo.Capture(e); }
+                    }
+                    firstFailure?.Throw();
 
-                db.Flush(onlyWal: true);
-                dbSnap.Dispose();
+                    using (IColumnsWriteBatch<FlatDbColumns> metaBatch = db.StartWriteBatch())
+                    {
+                        BasePersistence.SetCurrentState(metaBatch.GetColumnBatch(FlatDbColumns.Metadata), toCopy);
+                        if (_rlpWrapSlots)
+                            BasePersistence.RecordLayoutOnFirstBatch(metaBatch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.Flat);
+                    }
+
+                    db.Flush(onlyWal: true);
+                }
+                finally
+                {
+                    dbSnap.Dispose();
+                }
             })
         );
     }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -57,11 +57,6 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
         }
     }
 
-    // Persist by building sorted SST file(s) per column (from a byte-capped in-memory buffer) and ingesting them
-    // as a metadata-only add, instead of a single large WriteBatch. This bypasses the memtable, so persisting a
-    // compacted snapshot no longer triggers the flush -> L0 pile-up -> compaction burst that saturates I/O and
-    // stalls concurrent reads for seconds. Peak persist memory is higher than the streaming WriteBatch (the buffer
-    // holds up to the byte cap per column on the managed heap), which is why it is capped and default-off.
     private IPersistence.IWriteBatch CreateIngestWriteBatch(IColumnDbSnapshot<FlatDbColumns> dbSnap, StateId to)
     {
         IWriteBatch Ingest(FlatDbColumns column) => ((ISstIngestible)db.GetColumnDb(column)).StartSstIngestBatch();
@@ -100,12 +95,6 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
             trieWriteBatch,
             new Reactive.AnonymousDisposable(() =>
             {
-                // Each batch Dispose builds sorted SST file(s) from its buffer and ingests them (metadata-only add,
-                // bypassing the memtable), then the pointer advances. Every batch Dispose does disk I/O and can
-                // throw; dispose all of them and the snapshot regardless of failure so nothing leaks, and surface
-                // the first failure so the currentState pointer is NOT advanced past a partial persist (recovery
-                // then re-executes from the previous pointer). NOTE: per-CF ingest is not yet crash-atomic with the
-                // pointer write; full atomicity needs the multi-CF rocksdb_ingest_external_files (follow-up).
                 try
                 {
                     IWriteBatch[] batches = [accountBatch, storageBatch, stateTopNodesBatch, stateNodesBatch, storageNodesBatch, fallbackNodesBatch];

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -179,18 +179,21 @@ public class RocksDbPersistence : IPersistence
                     columnsIngested++;
                 }
 
-                using (IColumnsWriteBatch<FlatDbColumns> pointerBatch = _db.StartWriteBatch())
-                {
-                    IWriteBatch metadata = pointerBatch.GetColumnBatch(FlatDbColumns.Metadata);
-                    BasePersistence.SetCurrentState(metadata, to);
-                    BasePersistence.ClearIngestMarker(metadata);
-                }
-                _db.Flush(onlyWal: true);
+                using IColumnsWriteBatch<FlatDbColumns> pointerBatch = _db.StartWriteBatch();
+                IWriteBatch metadata = pointerBatch.GetColumnBatch(FlatDbColumns.Metadata);
+                BasePersistence.SetCurrentState(metadata, to);
+                BasePersistence.ClearIngestMarker(metadata);
             }
             finally
             {
                 _ingestGate.ExitWriteLock();
             }
+
+            // The committed pointer/marker WriteBatch is already visible to new snapshots; fsyncing the WAL only
+            // adds durability, so it runs after releasing the gate to keep reader snapshot creation off the
+            // exclusive section. A crash before this fsync leaves the redo marker on disk (its clear was not yet
+            // durable) and reopen rolls the commit forward to the same `to`.
+            _db.Flush(onlyWal: true);
         }
         catch (Exception e)
         {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -29,6 +29,11 @@ public class RocksDbPersistence : IPersistence
     // Gates new reader snapshots out of the ingest commit window (per-CF ingests + pointer write), which is
     // not a single RocksDB sequence number the way a normal WriteBatch commit is.
     private readonly ReaderWriterLockSlim _ingestGate = new();
+    private readonly string? _stagingDir;
+
+    // Total budget for post-commit L0 backpressure across all ingest columns, so a graceful shutdown is not held
+    // for minutes when compaction is behind.
+    private static readonly TimeSpan IngestBackpressureBudget = TimeSpan.FromSeconds(30);
 
     public RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logManager, IFlatDbConfig? config = null)
     {
@@ -39,10 +44,15 @@ public class RocksDbPersistence : IPersistence
         _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.Storage), _logger);
         _useSstIngestion = config?.PersistViaSstIngestion ?? false;
 
-        // Startup recovery is an explicit step gated on the flag: with SST ingestion disabled a node must neither
-        // roll a stale marker forward nor dir-scan the staging directory, so the short-circuit skips it entirely.
-        // When enabled, RecoverInterruptedIngest also reports whether the store supports ingestion at all.
-        _storeSupportsIngest = _useSstIngestion && RecoverInterruptedIngest(db, logManager);
+        // A pending ingest marker means a previous run crashed between the first ingest and the pointer advance;
+        // it must be rolled forward (and any orphaned staging files swept) whenever the store supports ingestion,
+        // regardless of whether SST ingestion is enabled *now* - otherwise a restart with the flag back off leaves
+        // the ingested columns live while the pointer stays behind, i.e. a torn flat base. Recovery therefore runs
+        // unconditionally; the flag only gates whether new persists take the ingest write path.
+        _storeSupportsIngest = RecoverInterruptedIngest(db, logManager);
+        _stagingDir = _storeSupportsIngest
+            ? ((ISstIngestible)db.GetColumnDb(FlatDbColumns.Account)).IngestStagingDir
+            : null;
     }
 
     public void Flush() => _db.Flush();
@@ -173,16 +183,36 @@ public class RocksDbPersistence : IPersistence
             _ingestGate.EnterWriteLock();
             try
             {
-                foreach (ISstIngestWriteBatch batch in batches)
+                bool completedInline = false;
+                try
                 {
-                    batch.IngestStagedFiles();
-                    columnsIngested++;
+                    foreach (ISstIngestWriteBatch batch in batches)
+                    {
+                        batch.IngestStagedFiles();
+                        columnsIngested++;
+                    }
+                }
+                catch when (columnsIngested > 0)
+                {
+                    // A later column ingest threw after an earlier one already went live: the flat base is now torn
+                    // (some columns at `to`, the pointer and the rest at `from`). Complete the commit inline, still
+                    // holding the write lock, so no snapshot ever observes that torn base - roll the durable marker
+                    // forward exactly as startup recovery does (re-ingest the staged files the failed and remaining
+                    // columns still have, then advance the pointer). If this itself throws, the outer catch keeps the
+                    // marker and files for the next persist or startup to finish; the pointer just never advances over
+                    // a torn base for live reads.
+                    if (BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is not { } pending) throw;
+                    RollForwardPendingIngest(_db, _stagingDir!, pending, _logger);
+                    completedInline = true;
                 }
 
-                using IColumnsWriteBatch<FlatDbColumns> pointerBatch = _db.StartWriteBatch();
-                IWriteBatch metadata = pointerBatch.GetColumnBatch(FlatDbColumns.Metadata);
-                BasePersistence.SetCurrentState(metadata, to);
-                BasePersistence.ClearIngestMarker(metadata);
+                if (!completedInline)
+                {
+                    using IColumnsWriteBatch<FlatDbColumns> pointerBatch = _db.StartWriteBatch();
+                    IWriteBatch metadata = pointerBatch.GetColumnBatch(FlatDbColumns.Metadata);
+                    BasePersistence.SetCurrentState(metadata, to);
+                    BasePersistence.ClearIngestMarker(metadata);
+                }
             }
             finally
             {
@@ -216,8 +246,12 @@ public class RocksDbPersistence : IPersistence
         // best-effort: a throw must not surface a committed persist as a failure to the caller.
         try
         {
+            // Best-effort L0 backpressure, bounded as a whole: without a single deadline six columns each polling
+            // up to the per-column cap could hold a graceful shutdown for minutes. The state is already durable, so
+            // a shared budget just trades a little compaction headroom for a bounded stop.
+            using CancellationTokenSource backpressure = new(IngestBackpressureBudget);
             foreach (FlatDbColumns column in IngestColumns)
-                ((ISstIngestible)_db.GetColumnDb(column)).WaitForIngestCompactionHeadroom();
+                ((ISstIngestible)_db.GetColumnDb(column)).WaitForIngestCompactionHeadroom(backpressure.Token);
         }
         catch (Exception e)
         {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -7,7 +7,7 @@ using Nethermind.Logging;
 
 namespace Nethermind.State.Flat.Persistence;
 
-public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logManager, IFlatDbConfig? config = null) : IPersistence
+public class RocksDbPersistence : IPersistence
 {
     private static readonly FlatDbColumns[] IngestColumns =
     [
@@ -19,19 +19,35 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
         FlatDbColumns.FallbackNodes,
     ];
 
-    private readonly bool _storeSupportsIngest = RecoverInterruptedIngest(db, logManager);
-    private readonly WriteBufferAdjuster _adjuster = new(db, config?.PersistenceWriteBufferFloor ?? WriteBufferAdjuster.DefaultWriteBufferFloor);
-    private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.Flat);
-    private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.Storage), logManager.GetClassLogger<RocksDbPersistence>());
-    private readonly bool _useSstIngestion = config?.PersistViaSstIngestion ?? false;
-    private readonly ILogger _logger = logManager.GetClassLogger<RocksDbPersistence>();
+    private readonly IColumnsDb<FlatDbColumns> _db;
+    private readonly bool _storeSupportsIngest;
+    private readonly WriteBufferAdjuster _adjuster;
+    private int _layoutPersisted;
+    private readonly bool _rlpWrapSlots;
+    private readonly bool _useSstIngestion;
+    private readonly ILogger _logger;
     // Gates new reader snapshots out of the ingest commit window (per-CF ingests + pointer write), which is
     // not a single RocksDB sequence number the way a normal WriteBatch commit is.
     private readonly ReaderWriterLockSlim _ingestGate = new();
 
-    public void Flush() => db.Flush();
+    public RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logManager, IFlatDbConfig? config = null)
+    {
+        _db = db;
+        _logger = logManager.GetClassLogger<RocksDbPersistence>();
+        _adjuster = new(db, config?.PersistenceWriteBufferFloor ?? WriteBufferAdjuster.DefaultWriteBufferFloor);
+        _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.Flat);
+        _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.Storage), _logger);
+        _useSstIngestion = config?.PersistViaSstIngestion ?? false;
 
-    public void Clear() => BasePersistence.ClearAllColumns(db);
+        // Startup recovery is an explicit step gated on the flag: with SST ingestion disabled a node must neither
+        // roll a stale marker forward nor dir-scan the staging directory, so the short-circuit skips it entirely.
+        // When enabled, RecoverInterruptedIngest also reports whether the store supports ingestion at all.
+        _storeSupportsIngest = _useSstIngestion && RecoverInterruptedIngest(db, logManager);
+    }
+
+    public void Flush() => _db.Flush();
+
+    public void Clear() => BasePersistence.ClearAllColumns(_db);
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
@@ -73,12 +89,12 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
 
     private IColumnDbSnapshot<FlatDbColumns> CreateGatedSnapshot()
     {
-        if (!_useSstIngestion) return db.CreateSnapshot();
+        if (!_useSstIngestion) return _db.CreateSnapshot();
 
         _ingestGate.EnterReadLock();
         try
         {
-            return db.CreateSnapshot();
+            return _db.CreateSnapshot();
         }
         finally
         {
@@ -88,24 +104,21 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
 
     private IPersistence.IWriteBatch CreateIngestWriteBatch(IColumnDbSnapshot<FlatDbColumns> dbSnap, StateId to)
     {
-        ISstIngestWriteBatch Ingest(FlatDbColumns column) => ((ISstIngestible)db.GetColumnDb(column)).StartSstIngestBatch();
+        ISstIngestWriteBatch[] batches = new ISstIngestWriteBatch[IngestColumns.Length];
+        for (int i = 0; i < IngestColumns.Length; i++)
+            batches[i] = ((ISstIngestible)_db.GetColumnDb(IngestColumns[i])).StartSstIngestBatch();
 
-        ISstIngestWriteBatch accountBatch = Ingest(FlatDbColumns.Account);
-        ISstIngestWriteBatch storageBatch = Ingest(FlatDbColumns.Storage);
-        ISstIngestWriteBatch stateTopNodesBatch = Ingest(FlatDbColumns.StateTopNodes);
-        ISstIngestWriteBatch stateNodesBatch = Ingest(FlatDbColumns.StateNodes);
-        ISstIngestWriteBatch storageNodesBatch = Ingest(FlatDbColumns.StorageNodes);
-        ISstIngestWriteBatch fallbackNodesBatch = Ingest(FlatDbColumns.FallbackNodes);
+        ISstIngestWriteBatch BatchFor(FlatDbColumns column) => batches[Array.IndexOf(IngestColumns, column)];
 
         BaseTriePersistence.WriteBatch trieWriteBatch = new(
             (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.StateTopNodes),
             (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.StateNodes),
             (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.StorageNodes),
             (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.FallbackNodes),
-            stateTopNodesBatch,
-            stateNodesBatch,
-            storageNodesBatch,
-            fallbackNodesBatch,
+            BatchFor(FlatDbColumns.StateTopNodes),
+            BatchFor(FlatDbColumns.StateNodes),
+            BatchFor(FlatDbColumns.StorageNodes),
+            BatchFor(FlatDbColumns.FallbackNodes),
             WriteFlags.None);
 
         StateId toCopy = to;
@@ -115,8 +128,8 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
                 new BaseFlatPersistence.WriteBatch(
                     (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.Account),
                     (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.Storage),
-                    accountBatch,
-                    storageBatch,
+                    BatchFor(FlatDbColumns.Account),
+                    BatchFor(FlatDbColumns.Storage),
                     WriteFlags.None,
                     rlpWrapSlots: _rlpWrapSlots
                 )
@@ -124,7 +137,6 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
             trieWriteBatch,
             new Reactive.AnonymousDisposable(() =>
             {
-                ISstIngestWriteBatch[] batches = [accountBatch, storageBatch, stateTopNodesBatch, stateNodesBatch, storageNodesBatch, fallbackNodesBatch];
                 try
                 {
                     CommitIngest(batches, toCopy);
@@ -149,14 +161,14 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
 
             // Redo marker: durable before the first ingest so a crash anywhere below rolls forward to `to`
             // on reopen; the pointer therefore never claims a state some column lacks.
-            using (IColumnsWriteBatch<FlatDbColumns> markerBatch = db.StartWriteBatch())
+            using (IColumnsWriteBatch<FlatDbColumns> markerBatch = _db.StartWriteBatch())
             {
                 IWriteBatch metadata = markerBatch.GetColumnBatch(FlatDbColumns.Metadata);
                 BasePersistence.SetIngestMarker(metadata, to, stagedFiles);
                 if (_rlpWrapSlots)
                     BasePersistence.RecordLayoutOnFirstBatch(metadata, ref _layoutPersisted, FlatLayout.Flat);
             }
-            db.Flush(onlyWal: true);
+            _db.Flush(onlyWal: true);
 
             _ingestGate.EnterWriteLock();
             try
@@ -167,13 +179,13 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
                     columnsIngested++;
                 }
 
-                using (IColumnsWriteBatch<FlatDbColumns> pointerBatch = db.StartWriteBatch())
+                using (IColumnsWriteBatch<FlatDbColumns> pointerBatch = _db.StartWriteBatch())
                 {
                     IWriteBatch metadata = pointerBatch.GetColumnBatch(FlatDbColumns.Metadata);
                     BasePersistence.SetCurrentState(metadata, to);
                     BasePersistence.ClearIngestMarker(metadata);
                 }
-                db.Flush(onlyWal: true);
+                _db.Flush(onlyWal: true);
             }
             finally
             {
@@ -202,7 +214,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
         try
         {
             foreach (FlatDbColumns column in IngestColumns)
-                ((ISstIngestible)db.GetColumnDb(column)).WaitForIngestCompactionHeadroom();
+                ((ISstIngestible)_db.GetColumnDb(column)).WaitForIngestCompactionHeadroom();
         }
         catch (Exception e)
         {
@@ -216,9 +228,9 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
         {
             // The marker must be gone before staged files are deleted: a marker surviving its files would
             // roll the pointer forward past missing data on the next open.
-            using (IColumnsWriteBatch<FlatDbColumns> batch = db.StartWriteBatch())
+            using (IColumnsWriteBatch<FlatDbColumns> batch = _db.StartWriteBatch())
                 BasePersistence.ClearIngestMarker(batch.GetColumnBatch(FlatDbColumns.Metadata));
-            db.Flush(onlyWal: true);
+            _db.Flush(onlyWal: true);
         }
         catch (Exception e)
         {
@@ -295,7 +307,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
 
     public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags)
     {
-        IColumnDbSnapshot<FlatDbColumns> dbSnap = db.CreateSnapshot();
+        IColumnDbSnapshot<FlatDbColumns> dbSnap = _db.CreateSnapshot();
         StateId currentState = BasePersistence.ReadCurrentState(dbSnap.GetColumn(FlatDbColumns.Metadata));
         if (from != StateId.Sync && to != StateId.Sync && currentState != from)
         {
@@ -308,7 +320,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
             return CreateIngestWriteBatch(dbSnap, to);
         }
 
-        IColumnsWriteBatch<FlatDbColumns> batch = db.StartWriteBatch();
+        IColumnsWriteBatch<FlatDbColumns> batch = _db.StartWriteBatch();
 
         IWriteBatch accountBatch = _adjuster.Wrap(batch, FlatDbColumns.Account, flags);
         IWriteBatch storageBatch = _adjuster.Wrap(batch, FlatDbColumns.Storage, flags);
@@ -354,7 +366,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
                 _adjuster.OnBatchDisposed();
                 if (!flags.HasFlag(WriteFlags.DisableWAL))
                 {
-                    db.Flush(onlyWal: true);
+                    _db.Flush(onlyWal: true);
                 }
             })
         );

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -264,9 +264,21 @@ public class RocksDbPersistence : IPersistence
         if (Directory.Exists(stagingDir))
         {
             string[] orphans = Directory.GetFiles(stagingDir);
-            foreach (string orphan in orphans) File.Delete(orphan);
-            if (orphans.Length > 0 && logger.IsInfo)
-                logger.Info($"Deleted {orphans.Length} orphaned SST staging file(s) from {stagingDir}");
+            int deleted = 0;
+            foreach (string orphan in orphans)
+            {
+                try
+                {
+                    File.Delete(orphan);
+                    deleted++;
+                }
+                catch (Exception e)
+                {
+                    if (logger.IsDebug) logger.Debug($"Failed to delete orphaned SST staging file '{orphan}'; it will be retried on the next startup sweep. {e}");
+                }
+            }
+            if (deleted > 0 && logger.IsInfo)
+                logger.Info($"Deleted {deleted} orphaned SST staging file(s) from {stagingDir}");
         }
 
         return true;

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -197,8 +197,17 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
         }
 
         // The L0 throttle stays outside the gate so reader snapshot creation is not stalled behind compaction.
-        foreach (FlatDbColumns column in IngestColumns)
-            ((ISstIngestible)db.GetColumnDb(column)).WaitForIngestCompactionHeadroom();
+        // The persist is already durable here (pointer advanced, marker cleared), so this backpressure is
+        // best-effort: a throw must not surface a committed persist as a failure to the caller.
+        try
+        {
+            foreach (FlatDbColumns column in IngestColumns)
+                ((ISstIngestible)db.GetColumnDb(column)).WaitForIngestCompactionHeadroom();
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsWarn) _logger.Warn($"Ingest compaction backpressure after persisting {to} failed; the state is already durable, continuing. {e}");
+        }
     }
 
     private void RollbackFailedIngest(ISstIngestWriteBatch[] batches)

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -192,7 +192,7 @@ public class RocksDbPersistence : IPersistence
                 if (_rlpWrapSlots)
                     BasePersistence.RecordLayoutOnFirstBatch(metadata, ref _layoutPersisted, FlatLayout.Flat);
             }
-            _db.Flush(onlyWal: true);
+            _db.SyncWal();
 
             _ingestGate.EnterWriteLock();
             try
@@ -275,22 +275,21 @@ public class RocksDbPersistence : IPersistence
 
     private void RollbackFailedIngest(ISstIngestWriteBatch[] batches, in StateId to)
     {
-        bool markerIsOurs = BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is not { } marker || marker.To == to;
-        if (markerIsOurs)
+        try
         {
-            try
+            // The marker must be gone before staged files are deleted: a marker surviving its files would
+            // roll the pointer forward past missing data on the next open.
+            if (BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is not { } marker || marker.To == to)
             {
-                // The marker must be gone before staged files are deleted: a marker surviving its files would
-                // roll the pointer forward past missing data on the next open.
                 using (IColumnsWriteBatch<FlatDbColumns> batch = _db.StartWriteBatch())
                     BasePersistence.ClearIngestMarker(batch.GetColumnBatch(FlatDbColumns.Metadata));
-                _db.Flush(onlyWal: true);
+                _db.SyncWal();
             }
-            catch (Exception e)
-            {
-                if (_logger.IsError) _logger.Error("Failed to clear the SST ingest marker after a failed persist; keeping staged files for startup roll-forward", e);
-                return;
-            }
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsError) _logger.Error("Failed to clear the SST ingest marker after a failed persist; keeping staged files for startup roll-forward", e);
+            return;
         }
 
         foreach (ISstIngestWriteBatch batch in batches)
@@ -366,7 +365,7 @@ public class RocksDbPersistence : IPersistence
             BasePersistence.SetCurrentState(metadata, pending.To);
             BasePersistence.ClearIngestMarker(metadata);
         }
-        db.Flush(onlyWal: true);
+        db.SyncWal();
 
         if (logger.IsInfo)
             logger.Info($"Rolled interrupted flat DB persist forward to {pending.To}: re-ingested {reingested} of {pending.Files.Length} staged SST file(s)");

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -275,22 +275,22 @@ public class RocksDbPersistence : IPersistence
 
     private void RollbackFailedIngest(ISstIngestWriteBatch[] batches, in StateId to)
     {
-        if (BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is { } marker && marker.To != to)
+        bool markerIsOurs = BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is not { } marker || marker.To == to;
+        if (markerIsOurs)
         {
-            return;
-        }
-        try
-        {
-            // The marker must be gone before staged files are deleted: a marker surviving its files would
-            // roll the pointer forward past missing data on the next open.
-            using (IColumnsWriteBatch<FlatDbColumns> batch = _db.StartWriteBatch())
-                BasePersistence.ClearIngestMarker(batch.GetColumnBatch(FlatDbColumns.Metadata));
-            _db.Flush(onlyWal: true);
-        }
-        catch (Exception e)
-        {
-            if (_logger.IsError) _logger.Error("Failed to clear the SST ingest marker after a failed persist; keeping staged files for startup roll-forward", e);
-            return;
+            try
+            {
+                // The marker must be gone before staged files are deleted: a marker surviving its files would
+                // roll the pointer forward past missing data on the next open.
+                using (IColumnsWriteBatch<FlatDbColumns> batch = _db.StartWriteBatch())
+                    BasePersistence.ClearIngestMarker(batch.GetColumnBatch(FlatDbColumns.Metadata));
+                _db.Flush(onlyWal: true);
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsError) _logger.Error("Failed to clear the SST ingest marker after a failed persist; keeping staged files for startup roll-forward", e);
+                return;
+            }
         }
 
         foreach (ISstIngestWriteBatch batch in batches)

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -57,7 +57,21 @@ public class RocksDbPersistence : IPersistence
 
     public void Flush() => _db.Flush();
 
-    public void Clear() => BasePersistence.ClearAllColumns(_db);
+    public void Clear()
+    {
+        BasePersistence.ClearAllColumns(_db);
+        if (_stagingDir is not null && Directory.Exists(_stagingDir))
+        {
+            try
+            {
+                Directory.Delete(_stagingDir, recursive: true);
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Failed to delete SST ingest staging directory '{_stagingDir}' during Clear. {e}");
+            }
+        }
+    }
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
@@ -232,7 +246,7 @@ public class RocksDbPersistence : IPersistence
             // persist or startup recovery to roll the commit forward.
             if (columnsIngested == 0)
             {
-                RollbackFailedIngest(batches);
+                RollbackFailedIngest(batches, to);
             }
             else if (_logger.IsError)
             {
@@ -259,8 +273,12 @@ public class RocksDbPersistence : IPersistence
         }
     }
 
-    private void RollbackFailedIngest(ISstIngestWriteBatch[] batches)
+    private void RollbackFailedIngest(ISstIngestWriteBatch[] batches, in StateId to)
     {
+        if (BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is { } marker && marker.To != to)
+        {
+            return;
+        }
         try
         {
             // The marker must be gone before staged files are deleted: a marker surviving its files would
@@ -364,7 +382,7 @@ public class RocksDbPersistence : IPersistence
             throw new InvalidOperationException($"Attempted to apply snapshot on top of wrong state. Snapshot from: {from}, Db state: {currentState}");
         }
 
-        if (_useSstIngestion && _storeSupportsIngest && from != StateId.Sync && to != StateId.Sync)
+        if (_useSstIngestion && _storeSupportsIngest && from != StateId.Sync && to != StateId.Sync && from != to && !flags.HasFlag(WriteFlags.DisableWAL))
         {
             return CreateIngestWriteBatch(dbSnap, to);
         }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Runtime.ExceptionServices;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Db;
@@ -8,7 +9,7 @@ using Nethermind.Logging;
 
 namespace Nethermind.State.Flat.Persistence;
 
-public class RocksDbPersistence : IPersistence
+public class RocksDbPersistence : IPersistence, IDisposable
 {
     private static readonly FlatDbColumns[] IngestColumns =
     [
@@ -31,14 +32,16 @@ public class RocksDbPersistence : IPersistence
     // not a single RocksDB sequence number the way a normal WriteBatch commit is.
     private readonly ReaderWriterLockSlim _ingestGate = new();
     private readonly string? _stagingDir;
+    private readonly CancellationToken _exitToken;
 
     // Total budget for post-commit L0 backpressure across all ingest columns, so a graceful shutdown is not held
     // for minutes when compaction is behind.
     private static readonly TimeSpan IngestBackpressureBudget = TimeSpan.FromSeconds(30);
 
-    public RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logManager, IFlatDbConfig? config = null)
+    public RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logManager, IFlatDbConfig? config = null, IProcessExitSource? exitSource = null)
     {
         _db = db;
+        _exitToken = exitSource?.Token ?? CancellationToken.None;
         _logger = logManager.GetClassLogger<RocksDbPersistence>();
         _adjuster = new(db, config?.PersistenceWriteBufferFloor ?? WriteBufferAdjuster.DefaultWriteBufferFloor);
         _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.Flat);
@@ -127,7 +130,7 @@ public class RocksDbPersistence : IPersistence
         }
     }
 
-    private IPersistence.IWriteBatch CreateIngestWriteBatch(IColumnDbSnapshot<FlatDbColumns> dbSnap, StateId to)
+    private IPersistence.IWriteBatch CreateIngestWriteBatch(IColumnDbSnapshot<FlatDbColumns> dbSnap, StateId to, WriteFlags flags)
     {
         ISstIngestWriteBatch[] batches = new ISstIngestWriteBatch[IngestColumns.Length];
         for (int i = 0; i < IngestColumns.Length; i++)
@@ -144,7 +147,7 @@ public class RocksDbPersistence : IPersistence
             BatchFor(FlatDbColumns.StateNodes),
             BatchFor(FlatDbColumns.StorageNodes),
             BatchFor(FlatDbColumns.FallbackNodes),
-            WriteFlags.None);
+            flags);
 
         StateId toCopy = to;
 
@@ -155,7 +158,7 @@ public class RocksDbPersistence : IPersistence
                     (ISortedKeyValueStore)dbSnap.GetColumn(FlatDbColumns.Storage),
                     BatchFor(FlatDbColumns.Account),
                     BatchFor(FlatDbColumns.Storage),
-                    WriteFlags.None,
+                    flags,
                     rlpWrapSlots: _rlpWrapSlots
                 )
             ),
@@ -194,6 +197,12 @@ public class RocksDbPersistence : IPersistence
             List<string> stagedFiles = [];
             foreach (ISstIngestWriteBatch batch in batches)
                 stagedFiles.AddRange(batch.SealToStagedFiles());
+
+            // The staged files are the marker's redo log, and roll-forward reads a missing one as move-ingested.
+            // Their contents are already synced by SstFileWriter.Finish, but the directory entries naming them are
+            // not: without this a power loss could drop a file the marker lists, and the reopen would advance the
+            // pointer over rows nothing ever wrote.
+            if (stagedFiles.Count > 0) DirectorySync.Fsync(_stagingDir!);
 
             // Redo marker: durable before the first ingest so a crash anywhere below rolls forward to `to`
             // on reopen; the pointer therefore never claims a state some column lacks.
@@ -249,7 +258,9 @@ public class RocksDbPersistence : IPersistence
                         }
 
                         FatalShutdown();
-                        throw;
+
+                        // Surface what tore the base rather than what failed to repair it; the log above carries both.
+                        ExceptionDispatchInfo.Capture(commitFailure).Throw();
                     }
                 }
             }
@@ -287,8 +298,10 @@ public class RocksDbPersistence : IPersistence
         {
             // Best-effort L0 backpressure, bounded as a whole: without a single deadline six columns each polling
             // up to the per-column cap could hold a graceful shutdown for minutes. The state is already durable, so
-            // a shared budget just trades a little compaction headroom for a bounded stop.
-            using CancellationTokenSource backpressure = new(IngestBackpressureBudget);
+            // a shared budget just trades a little compaction headroom for a bounded stop, and a shutdown request
+            // drops the remaining headroom wait immediately rather than after the budget.
+            using CancellationTokenSource backpressure = CancellationTokenSource.CreateLinkedTokenSource(_exitToken);
+            backpressure.CancelAfter(IngestBackpressureBudget);
             foreach (FlatDbColumns column in IngestColumns)
                 ((ISstIngestible)_db.GetColumnDb(column)).WaitForIngestCompactionHeadroom(backpressure.Token);
         }
@@ -297,6 +310,8 @@ public class RocksDbPersistence : IPersistence
             if (_logger.IsWarn) _logger.Warn($"Ingest compaction backpressure after persisting {to} failed; the state is already durable, continuing. {e}");
         }
     }
+
+    public void Dispose() => _ingestGate.Dispose();
 
     /// <summary>Finishes a commit that tore the flat base, the way startup recovery would.</summary>
     /// <remarks>
@@ -404,7 +419,8 @@ public class RocksDbPersistence : IPersistence
                 throw new InvalidOperationException($"Flat DB SST ingest marker references unrecognized staged file '{name}'");
 
             string path = Path.Combine(stagingDir, name);
-            // A missing file was already ingested: move-ingest deletes its source on success.
+            // A missing file was already ingested: move-ingest deletes its source on success, and the staging
+            // directory is fsynced before the marker, so a listed file cannot be absent for any other reason.
             if (!File.Exists(path)) continue;
 
             if (!byColumn.TryGetValue(column, out List<string>? files)) byColumn[column] = files = [];
@@ -432,7 +448,9 @@ public class RocksDbPersistence : IPersistence
 
     public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags)
     {
-        IColumnDbSnapshot<FlatDbColumns> dbSnap = _db.CreateSnapshot();
+        // Gated like a reader's: the batch decides its tombstones by scanning this snapshot, so one taken inside
+        // an ingest window would delete against a base whose columns are at different states.
+        IColumnDbSnapshot<FlatDbColumns> dbSnap = CreateGatedSnapshot();
         StateId currentState = BasePersistence.ReadCurrentState(dbSnap.GetColumn(FlatDbColumns.Metadata));
         if (from != StateId.Sync && to != StateId.Sync && currentState != from)
         {
@@ -442,7 +460,7 @@ public class RocksDbPersistence : IPersistence
 
         if (_useSstIngestion && _storeSupportsIngest && from != StateId.Sync && to != StateId.Sync && from != to && !flags.HasFlag(WriteFlags.DisableWAL))
         {
-            return CreateIngestWriteBatch(dbSnap, to);
+            return CreateIngestWriteBatch(dbSnap, to, flags);
         }
 
         IColumnsWriteBatch<FlatDbColumns> batch = _db.StartWriteBatch();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -197,6 +197,9 @@ public class RocksDbPersistence : IPersistence
 
             // Redo marker: durable before the first ingest so a crash anywhere below rolls forward to `to`
             // on reopen; the pointer therefore never claims a state some column lacks.
+            // Claimed before the batch commits: a throw inside the block below can still leave the marker durable,
+            // and deleting staged files a durable marker references strands the pointer past missing data.
+            markerWritten = true;
             using (IColumnsWriteBatch<FlatDbColumns> markerBatch = _db.StartWriteBatch())
             {
                 IWriteBatch metadata = markerBatch.GetColumnBatch(FlatDbColumns.Metadata);
@@ -204,13 +207,11 @@ public class RocksDbPersistence : IPersistence
                 if (_rlpWrapSlots)
                     BasePersistence.RecordLayoutOnFirstBatch(metadata, ref _layoutPersisted, FlatLayout.Flat);
             }
-            markerWritten = true;
             _db.SyncWal();
 
             _ingestGate.EnterWriteLock();
             try
             {
-                bool completedInline = false;
                 try
                 {
                     foreach (ISstIngestWriteBatch batch in batches)
@@ -218,24 +219,21 @@ public class RocksDbPersistence : IPersistence
                         batch.IngestStagedFiles();
                         columnsIngested++;
                     }
+
+                    using IColumnsWriteBatch<FlatDbColumns> pointerBatch = _db.StartWriteBatch();
+                    IWriteBatch metadata = pointerBatch.GetColumnBatch(FlatDbColumns.Metadata);
+                    BasePersistence.SetCurrentState(metadata, to);
+                    BasePersistence.ClearIngestMarker(metadata);
                 }
-                catch (Exception ingestFailure) when (columnsIngested > 0)
+                catch (Exception commitFailure) when (columnsIngested > 0)
                 {
-                    // A later column ingest threw after an earlier one already went live: the flat base is now torn
-                    // (some columns at `to`, the pointer and the rest at `from`). Complete the commit inline, still
-                    // holding the write lock, so no snapshot ever observes that torn base - roll the durable marker
-                    // forward exactly as startup recovery does (re-ingest the staged files the failed and remaining
-                    // columns still have, then advance the pointer).
+                    // A later column ingest, or the pointer advance itself, threw after an earlier ingest already
+                    // went live: the flat base is now torn (some columns at `to`, the pointer and the rest at
+                    // `from`). Complete the commit inline, still holding the write lock, so no snapshot ever
+                    // observes that torn base.
                     try
                     {
-                        if (BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is not { } pending)
-                        {
-                            throw new InvalidOperationException(
-                                $"The flat DB SST ingest marker for {to} is gone after {columnsIngested} column ingest(s)");
-                        }
-
-                        RollForwardPendingIngest(_db, _stagingDir!, pending, _logger);
-                        completedInline = true;
+                        CompleteTornCommit(to, columnsIngested);
                     }
                     catch (Exception repairFailure)
                     {
@@ -247,20 +245,12 @@ public class RocksDbPersistence : IPersistence
                         {
                             _logger.Error(
                                 $"Flat DB persist to {to} tore the base after {columnsIngested} of {batches.Length} column ingests and could not be completed in place. Shutting down; the pending ingest marker rolls forward on restart.",
-                                new AggregateException(ingestFailure, repairFailure));
+                                new AggregateException(commitFailure, repairFailure));
                         }
 
                         FatalShutdown();
                         throw;
                     }
-                }
-
-                if (!completedInline)
-                {
-                    using IColumnsWriteBatch<FlatDbColumns> pointerBatch = _db.StartWriteBatch();
-                    IWriteBatch metadata = pointerBatch.GetColumnBatch(FlatDbColumns.Metadata);
-                    BasePersistence.SetCurrentState(metadata, to);
-                    BasePersistence.ClearIngestMarker(metadata);
                 }
             }
             finally
@@ -308,6 +298,29 @@ public class RocksDbPersistence : IPersistence
         }
     }
 
+    /// <summary>Finishes a commit that tore the flat base, the way startup recovery would.</summary>
+    /// <remarks>
+    /// Re-ingests the staged files the failed and remaining columns still have (move-ingest consumed the rest) and
+    /// advances the pointer. Called while the reader gate is held, so the torn base is never observable.
+    /// </remarks>
+    private void CompleteTornCommit(in StateId to, int columnsIngested)
+    {
+        IDb metadata = _db.GetColumnDb(FlatDbColumns.Metadata);
+        if (BasePersistence.ReadIngestMarker(metadata) is { } pending)
+        {
+            RollForwardPendingIngest(_db, _stagingDir!, pending, _logger);
+        }
+        else if (BasePersistence.ReadCurrentState(metadata) != to)
+        {
+            // Neither a marker to roll forward nor a pointer at `to`: nothing is left to carry the live columns
+            // forward, so the base cannot be made whole here.
+            throw new InvalidOperationException(
+                $"The flat DB SST ingest marker for {to} is gone after {columnsIngested} column ingest(s)");
+        }
+
+        // Marker cleared and pointer already at `to`: the commit did complete and only reporting it failed.
+    }
+
     /// <summary>Stops the process when the flat base is torn and cannot be repaired in place.</summary>
     /// <remarks>
     /// Mirrors <c>DbOnTheRocks.FatalShutdown</c>: the torn columns are already visible to reader snapshots and only a
@@ -331,7 +344,10 @@ public class RocksDbPersistence : IPersistence
         }
         catch (Exception e)
         {
-            if (_logger.IsError) _logger.Error("Failed to clear the SST ingest marker after a failed persist; keeping staged files for startup roll-forward", e);
+            // The marker outlives this persist and `CommitIngest` refuses to start while one is pending, so the node
+            // would keep processing blocks it can never persist. The staged files stay, so a restart loses nothing.
+            if (_logger.IsError) _logger.Error("Failed to clear the SST ingest marker after a failed persist; shutting down, the staged files roll forward on restart", e);
+            FatalShutdown();
             return;
         }
 

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -177,8 +178,19 @@ public class RocksDbPersistence : IPersistence
     private void CommitIngest(ISstIngestWriteBatch[] batches, in StateId to)
     {
         int columnsIngested = 0;
+        bool markerWritten = false;
         try
         {
+            // The marker is a single-slot redo record owned by one commit at a time. A marker left by an earlier
+            // persist may already have columns live at its own target; overwriting it orphans that commit's staged
+            // files and strands those columns ahead of the pointer with nothing left to roll them forward. Refuse
+            // rather than replace - the marker and its files stay durable, so a restart completes that commit intact.
+            if (BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is { } pendingMarker)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot persist {to}: the flat DB SST ingest to {pendingMarker.To} is still pending. Restart to roll it forward.");
+            }
+
             List<string> stagedFiles = [];
             foreach (ISstIngestWriteBatch batch in batches)
                 stagedFiles.AddRange(batch.SealToStagedFiles());
@@ -192,6 +204,7 @@ public class RocksDbPersistence : IPersistence
                 if (_rlpWrapSlots)
                     BasePersistence.RecordLayoutOnFirstBatch(metadata, ref _layoutPersisted, FlatLayout.Flat);
             }
+            markerWritten = true;
             _db.SyncWal();
 
             _ingestGate.EnterWriteLock();
@@ -206,18 +219,40 @@ public class RocksDbPersistence : IPersistence
                         columnsIngested++;
                     }
                 }
-                catch when (columnsIngested > 0)
+                catch (Exception ingestFailure) when (columnsIngested > 0)
                 {
                     // A later column ingest threw after an earlier one already went live: the flat base is now torn
                     // (some columns at `to`, the pointer and the rest at `from`). Complete the commit inline, still
                     // holding the write lock, so no snapshot ever observes that torn base - roll the durable marker
                     // forward exactly as startup recovery does (re-ingest the staged files the failed and remaining
-                    // columns still have, then advance the pointer). If this itself throws, the outer catch keeps the
-                    // marker and files for the next persist or startup to finish; the pointer just never advances over
-                    // a torn base for live reads.
-                    if (BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is not { } pending) throw;
-                    RollForwardPendingIngest(_db, _stagingDir!, pending, _logger);
-                    completedInline = true;
+                    // columns still have, then advance the pointer).
+                    try
+                    {
+                        if (BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is not { } pending)
+                        {
+                            throw new InvalidOperationException(
+                                $"The flat DB SST ingest marker for {to} is gone after {columnsIngested} column ingest(s)");
+                        }
+
+                        RollForwardPendingIngest(_db, _stagingDir!, pending, _logger);
+                        completedInline = true;
+                    }
+                    catch (Exception repairFailure)
+                    {
+                        // The torn base cannot be repaired in place, and releasing the gate would publish it to every
+                        // later reader snapshot - a running node serving torn state is worse than a stopped one. The
+                        // marker and the remaining staged files are durable, so a restart rolls this commit forward
+                        // and loses nothing.
+                        if (_logger.IsError)
+                        {
+                            _logger.Error(
+                                $"Flat DB persist to {to} tore the base after {columnsIngested} of {batches.Length} column ingests and could not be completed in place. Shutting down; the pending ingest marker rolls forward on restart.",
+                                new AggregateException(ingestFailure, repairFailure));
+                        }
+
+                        FatalShutdown();
+                        throw;
+                    }
                 }
 
                 if (!completedInline)
@@ -246,7 +281,7 @@ public class RocksDbPersistence : IPersistence
             // persist or startup recovery to roll the commit forward.
             if (columnsIngested == 0)
             {
-                RollbackFailedIngest(batches, to);
+                RollbackFailedIngest(batches, markerWritten);
             }
             else if (_logger.IsError)
             {
@@ -273,13 +308,21 @@ public class RocksDbPersistence : IPersistence
         }
     }
 
-    private void RollbackFailedIngest(ISstIngestWriteBatch[] batches, in StateId to)
+    /// <summary>Stops the process when the flat base is torn and cannot be repaired in place.</summary>
+    /// <remarks>
+    /// Mirrors <c>DbOnTheRocks.FatalShutdown</c>: the torn columns are already visible to reader snapshots and only a
+    /// reopen, which rolls the pending ingest marker forward, can make the base whole again. Overridden in tests,
+    /// which cannot survive a process exit.
+    /// </remarks>
+    protected virtual void FatalShutdown() => Environment.Exit(ExitCodes.DbCorruption);
+
+    private void RollbackFailedIngest(ISstIngestWriteBatch[] batches, bool markerWritten)
     {
         try
         {
-            // The marker must be gone before staged files are deleted: a marker surviving its files would
-            // roll the pointer forward past missing data on the next open.
-            if (BasePersistence.ReadIngestMarker(_db.GetColumnDb(FlatDbColumns.Metadata)) is not { } marker || marker.To == to)
+            // Only this commit's own marker may be cleared, and it must be gone before its staged files are deleted:
+            // a marker surviving its files would roll the pointer forward past missing data on the next open.
+            if (markerWritten)
             {
                 using (IColumnsWriteBatch<FlatDbColumns> batch = _db.StartWriteBatch())
                     BasePersistence.ClearIngestMarker(batch.GetColumnBatch(FlatDbColumns.Metadata));


### PR DESCRIPTION
## Issue
At x10 (~2.2 TB) the flat-DB checkpoint commits a full compacted snapshot (~32 blocks) as one RocksDB WriteBatch per column. That overflows the memtable, forces a flush, and the L0 pileup + compaction burst stalls concurrent reads for tens of seconds.

## Fix
Persist via SST ingestion instead of the memtable path: build the SST files off the reader gate and ingest them (crash-atomic with a redo marker + startup sweep). Opt-in via `--FlatDb.PersistViaSstIngestion` (default off).

## Benchmark — x10, confound-free 3× median (flag off vs on)
| metric | off | on |
|---|---|---|
| **longest persist stall** | **40 s** | **3 s** |
| slow-task count | 50 | 12 |
| peak RSS | 61.8 GiB | 58.2 GiB |
| getProof p99 / p99.9 | 19.8 / 33.9 ms | 18.8 / 31.0 ms |

The stall is real on master (44 s, 54 slow tasks/run); SST cuts it to **3 s (−93%)**, every round, at **RSS −6%** and read latency flat-to-better. x1 mainnet (single run): RSS 45.7 → 40.4 GiB, getProof flat.
