### PR TITLE
perf(flatdb): experimental flat node storage — shared slab arena on address-owned maps (default off)

### DIFF
--- a/src/Nethermind/Nethermind.Core/Collections/SafeArrayPool.std.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SafeArrayPool.std.cs
@@ -6,30 +6,10 @@ using System.Buffers;
 namespace Nethermind.Core.Collections;
 
 /// <summary>
-/// Shared array pool. Standard execution delegates small rents to <see cref="ArrayPool{T}.Shared"/>;
-/// rents above 1 MiB go to a dedicated non-trimming pool — the shared pool drops its retained
-/// arrays on gen2/high-memory-pressure callbacks, so at large state every whole-block-sized buffer
-/// (block RLP, JSON-RPC payload bodies) became a fresh large-object-heap allocation feeding
-/// blocking OutOfSpaceLOH collections. The zkVM build provides a single-threaded power-of-two
-/// bucket pool instead.
+/// Shared array pool. Standard execution delegates to <see cref="ArrayPool{T}.Shared"/>;
+/// the zkVM build provides a single-threaded power-of-two bucket pool instead.
 /// </summary>
 public static class SafeArrayPool<T>
 {
-    public static readonly ArrayPool<T> Shared = new TieredPool();
-
-    private sealed class TieredPool : ArrayPool<T>
-    {
-        private const int LargeThreshold = 1 << 20;
-
-        private readonly ArrayPool<T> _large = Create(1 << 27, 8);
-
-        public override T[] Rent(int minimumLength) =>
-            minimumLength <= LargeThreshold ? ArrayPool<T>.Shared.Rent(minimumLength) : _large.Rent(minimumLength);
-
-        public override void Return(T[] array, bool clearArray = false)
-        {
-            if (array.Length <= LargeThreshold) ArrayPool<T>.Shared.Return(array, clearArray);
-            else _large.Return(array, clearArray);
-        }
-    }
+    public static readonly ArrayPool<T> Shared = ArrayPool<T>.Shared;
 }

--- a/src/Nethermind/Nethermind.Core/Collections/SafeArrayPool.std.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/SafeArrayPool.std.cs
@@ -6,10 +6,30 @@ using System.Buffers;
 namespace Nethermind.Core.Collections;
 
 /// <summary>
-/// Shared array pool. Standard execution delegates to <see cref="ArrayPool{T}.Shared"/>;
-/// the zkVM build provides a single-threaded power-of-two bucket pool instead.
+/// Shared array pool. Standard execution delegates small rents to <see cref="ArrayPool{T}.Shared"/>;
+/// rents above 1 MiB go to a dedicated non-trimming pool — the shared pool drops its retained
+/// arrays on gen2/high-memory-pressure callbacks, so at large state every whole-block-sized buffer
+/// (block RLP, JSON-RPC payload bodies) became a fresh large-object-heap allocation feeding
+/// blocking OutOfSpaceLOH collections. The zkVM build provides a single-threaded power-of-two
+/// bucket pool instead.
 /// </summary>
 public static class SafeArrayPool<T>
 {
-    public static readonly ArrayPool<T> Shared = ArrayPool<T>.Shared;
+    public static readonly ArrayPool<T> Shared = new TieredPool();
+
+    private sealed class TieredPool : ArrayPool<T>
+    {
+        private const int LargeThreshold = 1 << 20;
+
+        private readonly ArrayPool<T> _large = Create(1 << 27, 8);
+
+        public override T[] Rent(int minimumLength) =>
+            minimumLength <= LargeThreshold ? ArrayPool<T>.Shared.Rent(minimumLength) : _large.Rent(minimumLength);
+
+        public override void Return(T[] array, bool clearArray = false)
+        {
+            if (array.Length <= LargeThreshold) ArrayPool<T>.Shared.Return(array, clearArray);
+            else _large.Return(array, clearArray);
+        }
+    }
 }

--- a/src/Nethermind/Nethermind.Core/Utils/RefCountingLease.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/RefCountingLease.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Core.Utils;
 /// (cache-line-padded vs. inline); the compare-and-swap logic operating on it is identical and lives
 /// here so it is not duplicated between them.
 /// </summary>
-internal static class RefCountingLease
+public static class RefCountingLease
 {
     public const int Single = 1;
     public const int NoAccessors = 0;

--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -9,6 +9,8 @@ public class FlatDbConfig : IFlatDbConfig
 {
     public bool Enabled { get; set; } = false;
     public bool EnablePreimageRecording { get; set; } = false;
+    public bool FlatNodeStorage { get; set; } = false;
+    public bool FlatNodeStorageDebugChecks { get; set; } = false;
     public bool ImportFromPruningTrieState { get; set; } = false;
     public bool InlineCompaction { get; set; } = false;
     public bool RegenerateCompactionOffset { get; set; } = false;

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -22,6 +22,12 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Enable recording of preimages (address/slot hash to original bytes)", DefaultValue = "false")]
     bool EnablePreimageRecording { get; set; }
 
+    [ConfigItem(Description = "Store snapshot storage-trie-node RLP in pooled pinned byte slabs referenced by blittable handles instead of TrieNode objects; reads decode transient nodes. Removes the storage-node object graphs from the in-memory write buffer, replacing them with packed bytes and exact byte accounting. State-trie nodes are unaffected. Experimental.", DefaultValue = "false")]
+    bool FlatNodeStorage { get; set; }
+
+    [ConfigItem(Description = "Slab-storage debug checks: poison-on-release and keccak-verify-on-decode. Test/soak only.", DefaultValue = "false")]
+    bool FlatNodeStorageDebugChecks { get; set; }
+
     [ConfigItem(Description = "Import from pruning trie state db", DefaultValue = "false")]
     bool ImportFromPruningTrieState { get; set; }
 

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers;
-using Nethermind.Core.Collections;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -642,11 +641,11 @@ public class Startup : IStartup
 
         private void RentCapacity(int newCapacity)
         {
-            byte[] newBuffer = SafeArrayPool<byte>.Shared.Rent(newCapacity);
+            byte[] newBuffer = ArrayPool<byte>.Shared.Rent(newCapacity);
             if (_buffer is not null)
             {
                 _buffer.AsSpan(0, BytesRead).CopyTo(newBuffer);
-                SafeArrayPool<byte>.Shared.Return(_buffer);
+                ArrayPool<byte>.Shared.Return(_buffer);
             }
 
             _buffer = newBuffer;
@@ -673,7 +672,7 @@ public class Startup : IStartup
                 return;
             }
 
-            SafeArrayPool<byte>.Shared.Return(_buffer);
+            ArrayPool<byte>.Shared.Return(_buffer);
             _buffer = null;
             BytesRead = 0;
         }

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using Nethermind.Core.Collections;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -641,11 +642,11 @@ public class Startup : IStartup
 
         private void RentCapacity(int newCapacity)
         {
-            byte[] newBuffer = ArrayPool<byte>.Shared.Rent(newCapacity);
+            byte[] newBuffer = SafeArrayPool<byte>.Shared.Rent(newCapacity);
             if (_buffer is not null)
             {
                 _buffer.AsSpan(0, BytesRead).CopyTo(newBuffer);
-                ArrayPool<byte>.Shared.Return(_buffer);
+                SafeArrayPool<byte>.Shared.Return(_buffer);
             }
 
             _buffer = newBuffer;
@@ -672,7 +673,7 @@ public class Startup : IStartup
                 return;
             }
 
-            ArrayPool<byte>.Shared.Return(_buffer);
+            SafeArrayPool<byte>.Shared.Return(_buffer);
             _buffer = null;
             BytesRead = 0;
         }

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatAddressStorageNodeDictionaryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatAddressStorageNodeDictionaryTests.cs
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Trie;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test;
+
+[TestFixture]
+public class FlatAddressStorageNodeDictionaryTests
+{
+    private static readonly Hash256 AddressA = TestItem.AddressA.ToAccountPath.ToCommitment();
+    private static readonly Hash256 AddressB = TestItem.AddressB.ToAccountPath.ToCommitment();
+
+    [Test]
+    public void Set_and_read_round_trips_rlp()
+    {
+        FlatAddressStorageNodeDictionary dict = new();
+        byte[] rlp = [0xC2, 0x01, 0x02];
+        dict[(AddressA, TreePath.FromHexString("12"))] = new TrieNode(NodeType.Leaf, rlp);
+
+        Assert.That(dict.TryGetValue(new((AddressA, TreePath.FromHexString("12"))), out TrieNode? node), Is.True);
+        Assert.That(node!.FullRlp.ToArray(), Is.EqualTo(rlp));
+    }
+
+    [Test]
+    public void Set_and_read_round_trips_keccak_only_as_unknown()
+    {
+        FlatAddressStorageNodeDictionary dict = new();
+        dict[(AddressA, TreePath.Empty)] = new TrieNode(NodeType.Unknown, TestItem.KeccakA);
+
+        Assert.That(dict.TryGetValue(new((AddressA, TreePath.Empty)), out TrieNode? node), Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(node!.NodeType, Is.EqualTo(NodeType.Unknown));
+            Assert.That(node.Keccak, Is.EqualTo(TestItem.KeccakA));
+        }
+    }
+
+    [Test]
+    public void Overwrite_returns_the_latest_record()
+    {
+        FlatAddressStorageNodeDictionary dict = new();
+        TreePath path = TreePath.FromHexString("34");
+        dict[(AddressA, path)] = new TrieNode(NodeType.Leaf, new byte[] { 0xC1, 0x01 });
+        dict[(AddressA, path)] = new TrieNode(NodeType.Leaf, new byte[] { 0xC1, 0x02 });
+
+        Assert.That(dict.TryGetValue(new((AddressA, path)), out TrieNode? node), Is.True);
+        Assert.That(node!.FullRlp.ToArray(), Is.EqualTo(new byte[] { 0xC1, 0x02 }));
+    }
+
+    [Test]
+    public void Count_sums_across_addresses()
+    {
+        FlatAddressStorageNodeDictionary dict = new();
+        dict[(AddressA, TreePath.FromHexString("12"))] = new TrieNode(NodeType.Leaf, new byte[] { 1 });
+        dict[(AddressA, TreePath.FromHexString("34"))] = new TrieNode(NodeType.Leaf, new byte[] { 2 });
+        dict[(AddressB, TreePath.FromHexString("56"))] = new TrieNode(NodeType.Leaf, new byte[] { 3 });
+
+        Assert.That(dict.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void RemoveAddress_drops_only_that_address()
+    {
+        FlatAddressStorageNodeDictionary dict = new();
+        dict[(AddressA, TreePath.FromHexString("12"))] = new TrieNode(NodeType.Leaf, new byte[] { 1 });
+        dict[(AddressB, TreePath.FromHexString("56"))] = new TrieNode(NodeType.Leaf, new byte[] { 2 });
+
+        Assert.That(dict.RemoveAddress(AddressA), Is.True);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(dict.Count, Is.EqualTo(1));
+            Assert.That(dict.TryGetValue(new((AddressA, TreePath.FromHexString("12"))), out _), Is.False);
+            Assert.That(dict.TryGetValue(new((AddressB, TreePath.FromHexString("56"))), out _), Is.True);
+        }
+    }
+
+    [Test]
+    public void Enumeration_yields_every_stored_key()
+    {
+        FlatAddressStorageNodeDictionary dict = new();
+        dict[(AddressA, TreePath.FromHexString("12"))] = new TrieNode(NodeType.Leaf, new byte[] { 1 });
+        dict[(AddressA, TreePath.FromHexString("34"))] = new TrieNode(NodeType.Leaf, new byte[] { 2 });
+        dict[(AddressB, TreePath.FromHexString("56"))] = new TrieNode(NodeType.Leaf, new byte[] { 3 });
+
+        HashSet<(Hash256, TreePath)> seen = [];
+        foreach (KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode> kvp in dict)
+        {
+            Assert.That(kvp.Value, Is.Not.Null);
+            seen.Add(kvp.Key.Key);
+        }
+
+        Assert.That(seen, Has.Count.EqualTo(3));
+        Assert.That(seen, Does.Contain((AddressA, TreePath.FromHexString("12"))));
+        Assert.That(seen, Does.Contain((AddressA, TreePath.FromHexString("34"))));
+        Assert.That(seen, Does.Contain((AddressB, TreePath.FromHexString("56"))));
+    }
+
+    [Test]
+    public void ForEachRlp_visits_raw_spans()
+    {
+        FlatAddressStorageNodeDictionary dict = new();
+        byte[] rlp = [0xC3, 0x0A, 0x0B, 0x0C];
+        dict[(AddressA, TreePath.FromHexString("12"))] = new TrieNode(NodeType.Leaf, rlp);
+
+        Dictionary<(Hash256, TreePath), byte[]> visited = [];
+        dict.ForEachRlp((in HashedKey<(Hash256, TreePath)> key, bool emptyUnknown, ReadOnlySpan<byte> span) =>
+        {
+            visited[key.Key] = span.ToArray();
+        });
+
+        Assert.That(visited, Has.Count.EqualTo(1));
+        Assert.That(visited[(AddressA, TreePath.FromHexString("12"))], Is.EqualTo(rlp));
+    }
+
+    [Test]
+    public void NoLockClear_empties_and_allows_reuse()
+    {
+        FlatAddressStorageNodeDictionary dict = new();
+        dict[(AddressA, TreePath.FromHexString("12"))] = new TrieNode(NodeType.Leaf, new byte[] { 1 });
+        Assert.That(dict.ArenaBytesReserved, Is.GreaterThan(0));
+
+        dict.NoLockClear();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(dict.Count, Is.Zero);
+            Assert.That(dict.ArenaBytesReserved, Is.Zero);
+        }
+
+        byte[] rlp = [0xC1, 0x2A];
+        dict[(AddressB, TreePath.FromHexString("56"))] = new TrieNode(NodeType.Leaf, rlp);
+        Assert.That(dict.TryGetValue(new((AddressB, TreePath.FromHexString("56"))), out TrieNode? node), Is.True);
+        Assert.That(node!.FullRlp.ToArray(), Is.EqualTo(rlp));
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -195,6 +195,7 @@ public class FlatDbManagerTests
         StateId snapshotTo = CreateStateId(11);
         Snapshot snapshot = realResourcePool.CreateSnapshot(snapshotFrom, snapshotTo, ResourcePool.Usage.MainBlockProcessing);
         TransientResource transientResource = realResourcePool.GetCachedResource(ResourcePool.Usage.MainBlockProcessing);
+        transientResource.OnRented(_resourcePool, ResourcePool.Usage.MainBlockProcessing);
 
         await using FlatDbManager manager = CreateManager();
         manager.AddSnapshot(snapshot, transientResource);

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
@@ -542,6 +542,75 @@ public class FlatWorldStateScopeProviderTests
     }
 
     [Test]
+    public void FlatStorage_StorageRootAfterSingleCommitMatchesRawTrie()
+    {
+        using TestContext ctx = new(new FlatDbConfig { FlatNodeStorage = true });
+        FlatWorldStateScope scope = ctx.Scope;
+
+        Address testAddress = TestItem.AddressA;
+        (UInt256 Slot, byte[] Value)[] slots =
+        [
+            (1, [0x01, 0x02]),
+            (2, [0xAA, 0xBB, 0xCC]),
+            (100, [0xFF]),
+        ];
+
+        ctx.PersistenceReader.GetAccount(testAddress).Returns(TestItem.GenerateRandomAccount());
+
+        using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(1))
+        {
+            using IWorldStateScopeProvider.IStorageWriteBatch storageBatch = writeBatch.CreateStorageWriteBatch(testAddress, slots.Length);
+            foreach ((UInt256 slot, byte[] value) in slots) storageBatch.Set(slot, value);
+        }
+
+        scope.Commit(1);
+
+        TestMemDb testDb = new();
+        RawScopedTrieStore trieStore = new(testDb);
+        StorageTree expectedTree = new(trieStore, LimboLogs.Instance);
+        foreach ((UInt256 slot, byte[] value) in slots) expectedTree.Set(slot, value);
+        expectedTree.UpdateRootHash();
+
+        Account? resultAccount = scope.Get(testAddress);
+        Assert.That(resultAccount!.StorageRoot, Is.EqualTo(expectedTree.RootHash));
+    }
+
+    [Test]
+    public void FlatStorage_StorageRootAfterParallelCommitMatchesRawTrie()
+    {
+        const int slotsPerCommit = 1024;
+        const int commitCount = 2;
+        using TestContext ctx = new(new FlatDbConfig { FlatNodeStorage = true });
+        FlatWorldStateScope scope = ctx.Scope;
+        Address address = TestItem.AddressA;
+
+        ctx.PersistenceReader.GetAccount(address).Returns(TestItem.GenerateRandomAccount());
+
+        for (int commit = 0; commit < commitCount; commit++)
+        {
+            using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(commit + 1))
+            {
+                using IWorldStateScopeProvider.IStorageWriteBatch storageBatch = writeBatch.CreateStorageWriteBatch(address, slotsPerCommit);
+                int firstSlot = commit * slotsPerCommit + 1;
+                int lastSlot = firstSlot + slotsPerCommit;
+                for (int i = firstSlot; i < lastSlot; i++) storageBatch.Set((UInt256)i, [(byte)i, (byte)(i >> 8)]);
+            }
+
+            scope.Commit((ulong)(commit + 1));
+        }
+
+        TestMemDb testDb = new();
+        RawScopedTrieStore trieStore = new(testDb);
+        StorageTree expectedTree = new(trieStore, LimboLogs.Instance);
+        for (int i = 1; i <= slotsPerCommit * commitCount; i++) expectedTree.Set((UInt256)i, [(byte)i, (byte)(i >> 8)]);
+        expectedTree.UpdateRootHash();
+
+        Account? account = scope.Get(address);
+        Assert.That(account, Is.Not.Null);
+        Assert.That(account!.StorageRoot, Is.EqualTo(expectedTree.RootHash));
+    }
+
+    [Test]
     public void TestStorageRootAfterMultipleCommits()
     {
         using TestContext ctx = new();

--- a/src/Nethermind/Nethermind.State.Flat.Test/SlabArenaTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SlabArenaTests.cs
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test;
+
+[TestFixture]
+public class SlabArenaTests
+{
+    [Test]
+    public void Append_and_read_round_trip_with_and_without_keccak()
+    {
+        SlabArena arena = new();
+        SlabArena.Cursor cursor = SlabArena.Cursor.Empty;
+        byte[] rlp = [1, 2, 3, 4, 5];
+
+        SlabHandle withKeccak = arena.Append(ref cursor, TestItem.KeccakA, rlp, SlabFlags.None);
+        SlabHandle withoutKeccak = arena.Append(ref cursor, null, rlp, SlabFlags.None);
+        SlabHandle emptyUnknown = arena.Append(ref cursor, TestItem.KeccakB, default, SlabFlags.EmptyUnknown);
+
+        int generation = arena.Generation;
+        Assert.That(arena.TryReadCopy(withKeccak, generation, out Hash256? k1, out byte[]? r1), Is.True);
+        Assert.That(k1, Is.EqualTo(TestItem.KeccakA));
+        Assert.That(r1, Is.EqualTo(rlp));
+
+        Assert.That(arena.TryReadCopy(withoutKeccak, generation, out Hash256? k2, out byte[]? r2), Is.True);
+        Assert.That(k2, Is.Null);
+        Assert.That(r2, Is.EqualTo(rlp));
+
+        Assert.That(arena.TryReadCopy(emptyUnknown, generation, out Hash256? k3, out byte[]? r3), Is.True);
+        Assert.That(k3, Is.EqualTo(TestItem.KeccakB));
+        Assert.That(r3, Is.Null);
+        Assert.That((emptyUnknown.Flags & SlabFlags.EmptyUnknown) != 0, Is.True);
+    }
+
+    [Test]
+    public void First_record_is_padded_so_none_handle_is_never_produced()
+    {
+        SlabArena arena = new();
+        SlabArena.Cursor cursor = SlabArena.Cursor.Empty;
+        SlabHandle first = arena.Append(ref cursor, null, new byte[] { 42 }, SlabFlags.None);
+        Assert.That(first.IsNone, Is.False);
+        Assert.That(first.Offset, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Rolls_to_a_new_slab_at_the_boundary()
+    {
+        SlabArena arena = new();
+        SlabArena.Cursor cursor = SlabArena.Cursor.Empty;
+        byte[] big = new byte[SlabHandle.MaxRlpLen];
+        int perSlab = SlabArena.SlabSize / (32 + big.Length);
+        SlabHandle last = default;
+        for (int i = 0; i < perSlab + 2; i++) last = arena.Append(ref cursor, TestItem.KeccakA, big, SlabFlags.None);
+        Assert.That(last.SlabIndex, Is.GreaterThanOrEqualTo(1));
+        Assert.That(arena.BytesReserved, Is.GreaterThanOrEqualTo(2 * SlabArena.SlabSize));
+
+        int generation = arena.Generation;
+        Assert.That(arena.TryReadCopy(last, generation, out _, out byte[]? rlp), Is.True);
+        Assert.That(rlp!.Length, Is.EqualTo(big.Length));
+    }
+
+    [Test]
+    public void Read_with_stale_generation_after_release_is_a_miss()
+    {
+        SlabArena arena = new();
+        SlabArena.Cursor cursor = SlabArena.Cursor.Empty;
+        SlabHandle handle = arena.Append(ref cursor, TestItem.KeccakA, new byte[] { 9, 9 }, SlabFlags.None);
+        int staleGeneration = arena.Generation;
+
+        arena.Release();
+
+        Assert.That(arena.TryReadCopy(handle, staleGeneration, out _, out _), Is.False);
+    }
+
+    [Test]
+    public void Oversize_rlp_throws()
+    {
+        SlabArena arena = new();
+        SlabArena.Cursor cursor = SlabArena.Cursor.Empty;
+        byte[] oversize = new byte[SlabHandle.MaxRlpLen + 1];
+        Assert.That(() => arena.Append(ref cursor, null, oversize, SlabFlags.None), Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public void Release_resets_counters_and_reuse_works()
+    {
+        SlabArena arena = new();
+        SlabArena.Cursor cursor = SlabArena.Cursor.Empty;
+        arena.Append(ref cursor, null, new byte[] { 1 }, SlabFlags.None);
+        Assert.That(arena.BytesAppended, Is.GreaterThan(0));
+
+        arena.Release();
+        Assert.That(arena.BytesAppended, Is.Zero);
+        Assert.That(arena.BytesReserved, Is.Zero);
+
+        cursor = SlabArena.Cursor.Empty;
+        SlabHandle again = arena.Append(ref cursor, null, new byte[] { 2 }, SlabFlags.None);
+        Assert.That(arena.TryReadCopy(again, arena.Generation, out _, out byte[]? rlp), Is.True);
+        Assert.That(rlp, Is.EqualTo(new byte[] { 2 }));
+    }
+
+    [Test]
+    public void AppendShared_round_trips_and_pads_first_record()
+    {
+        SlabArena arena = new();
+        long cursor = SlabArena.EmptySharedCursor;
+        byte[] rlp = [7, 7, 7];
+
+        SlabHandle first = arena.AppendShared(ref cursor, TestItem.KeccakA, rlp, SlabFlags.None);
+        Assert.That(first.IsNone, Is.False);
+        Assert.That(first.Offset, Is.EqualTo(1));
+
+        Assert.That(arena.TryReadCopy(first, arena.Generation, out Hash256? keccak, out byte[]? readRlp), Is.True);
+        Assert.That(keccak, Is.EqualTo(TestItem.KeccakA));
+        Assert.That(readRlp, Is.EqualTo(rlp));
+    }
+
+    [Test]
+    public void AppendShared_cursors_grab_distinct_slabs()
+    {
+        SlabArena arena = new();
+        long cursorA = SlabArena.EmptySharedCursor;
+        long cursorB = SlabArena.EmptySharedCursor;
+
+        SlabHandle a = arena.AppendShared(ref cursorA, null, new byte[] { 1 }, SlabFlags.None);
+        SlabHandle b = arena.AppendShared(ref cursorB, null, new byte[] { 2 }, SlabFlags.None);
+
+        Assert.That(a.SlabIndex, Is.Not.EqualTo(b.SlabIndex), "each shared cursor must own its slab exclusively");
+        Assert.That(arena.TryReadCopy(a, arena.Generation, out _, out byte[]? ra), Is.True);
+        Assert.That(arena.TryReadCopy(b, arena.Generation, out _, out byte[]? rb), Is.True);
+        Assert.That(ra, Is.EqualTo(new byte[] { 1 }));
+        Assert.That(rb, Is.EqualTo(new byte[] { 2 }));
+    }
+
+    [Test]
+    public void AppendShared_is_safe_under_concurrent_appends()
+    {
+        SlabArena arena = new();
+        const int shards = 8;
+        const int perShard = 2000;
+        long[] cursors = new long[shards];
+        for (int i = 0; i < shards; i++) cursors[i] = SlabArena.EmptySharedCursor;
+
+        ConcurrentBag<(SlabHandle Handle, byte Value)> handles = [];
+        Parallel.For(0, shards, s =>
+        {
+            for (int i = 0; i < perShard; i++)
+            {
+                byte value = (byte)((s * 31 + i) & 0xFF);
+                SlabHandle handle = arena.AppendShared(ref cursors[s], null, new[] { value }, SlabFlags.None);
+                handles.Add((handle, value));
+            }
+        });
+
+        int generation = arena.Generation;
+        foreach ((SlabHandle handle, byte value) in handles)
+        {
+            Assert.That(arena.TryReadCopy(handle, generation, out _, out byte[]? rlp), Is.True);
+            Assert.That(rlp, Is.EqualTo(new[] { value }));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleLeaseTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleLeaseTests.cs
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Int256;
+using Nethermind.State.Flat.PersistedSnapshots;
+using Nethermind.State.Flat.Persistence;
+using Nethermind.Trie;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test;
+
+[TestFixture]
+public class SnapshotBundleLeaseTests
+{
+    private static ReadOnlySnapshotBundle EmptyReadOnlyBundle() =>
+        new(new SnapshotPooledList(0), Substitute.For<IPersistence.IPersistenceReader>(),
+            recordDetailedMetrics: false, PersistedSnapshotStack.Empty());
+
+    private static SnapshotBundle NewBundle(IResourcePool pool) =>
+        new(EmptyReadOnlyBundle(), new NullTrieNodeCache(), pool, ResourcePool.Usage.MainBlockProcessing);
+
+    private sealed class NullTrieNodeCache : ITrieNodeCache
+    {
+        public bool TryGet(Hash256? address, in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node)
+        {
+            node = null;
+            return false;
+        }
+
+        public void Add(TransientResource transientResource) { }
+        public void Clear() { }
+    }
+
+    private sealed class CountingPool(IResourcePool inner) : IResourcePool
+    {
+        public int SnapshotContentReturns;
+        public int CachedResourceReturns;
+
+        public SnapshotContent GetSnapshotContent(ResourcePool.Usage usage) => inner.GetSnapshotContent(usage);
+
+        public void ReturnSnapshotContent(ResourcePool.Usage usage, SnapshotContent snapshotContent)
+        {
+            Interlocked.Increment(ref SnapshotContentReturns);
+            inner.ReturnSnapshotContent(usage, snapshotContent);
+        }
+
+        public SortedSnapshotContent GetSortedSnapshotContent(ResourcePool.Usage usage) => inner.GetSortedSnapshotContent(usage);
+
+        public void ReturnSortedSnapshotContent(ResourcePool.Usage usage, SortedSnapshotContent sortedContent) =>
+            inner.ReturnSortedSnapshotContent(usage, sortedContent);
+
+        public TransientResource GetCachedResource(ResourcePool.Usage usage) => inner.GetCachedResource(usage);
+
+        public void ReturnCachedResource(ResourcePool.Usage usage, TransientResource transientResource)
+        {
+            Interlocked.Increment(ref CachedResourceReturns);
+            inner.ReturnCachedResource(usage, transientResource);
+        }
+
+        public Snapshot CreateSnapshot(in StateId from, in StateId to, ResourcePool.Usage usage) =>
+            inner.CreateSnapshot(from, to, usage);
+    }
+
+    [Test]
+    public void TryLease_after_final_release_fails()
+    {
+        SnapshotBundle bundle = NewBundle(new ResourcePool(new FlatDbConfig { CompactSize = 2 }));
+
+        bundle.Dispose();
+
+        Assert.That(bundle.TryLease(), Is.False);
+    }
+
+    [Test]
+    public void Owner_dispose_defers_pool_returns_until_last_lease_and_runs_them_once()
+    {
+        CountingPool pool = new(new ResourcePool(new FlatDbConfig { CompactSize = 2 }));
+        SnapshotBundle bundle = NewBundle(pool);
+        bundle.SetAccount(TestItem.AddressA, new Account(42));
+
+        Assert.That(bundle.TryLease(), Is.True);
+
+        bundle.Dispose();
+        bundle.Dispose();
+
+        Assert.That(pool.SnapshotContentReturns, Is.Zero);
+        Assert.That(pool.CachedResourceReturns, Is.Zero);
+        Assert.That(bundle.GetAccount(TestItem.AddressA), Is.EqualTo(new Account(42)));
+
+        bundle.ReleaseLease();
+
+        Assert.That(pool.SnapshotContentReturns, Is.EqualTo(1));
+        Assert.That(pool.CachedResourceReturns, Is.EqualTo(1));
+        Assert.That(bundle.TryLease(), Is.False);
+    }
+
+    [Test]
+    public void Retired_transient_resource_returns_once_after_manager_and_warmer_release()
+    {
+        CountingPool pool = new(new ResourcePool(new FlatDbConfig { CompactSize = 2 }));
+        SnapshotBundle bundle = NewBundle(pool);
+
+        (Snapshot? snapshot, TransientResource? retired) =
+            bundle.CollectAndApplySnapshot(StateId.PreGenesis, new StateId(1, TestItem.KeccakA));
+
+        Assert.That(retired!.TryAcquireLease(), Is.True);
+
+        retired.ReleaseLease();
+        Assert.That(pool.CachedResourceReturns, Is.Zero);
+
+        retired.ReleaseLease();
+        Assert.That(pool.CachedResourceReturns, Is.EqualTo(1));
+        Assert.That(retired.TryAcquireLease(), Is.False);
+
+        snapshot!.Dispose();
+        bundle.Dispose();
+
+        Assert.That(pool.CachedResourceReturns, Is.EqualTo(2));
+        Assert.That(pool.SnapshotContentReturns, Is.EqualTo(2));
+    }
+
+    // Regression for the trie-warmer recycle-under-reader race: a warmer-shaped reader holding
+    // TryLease must never observe missing or foreign values while the owning scope disposes the
+    // bundle and the pool recycles its contents into subsequent bundles.
+    [Test]
+    public void Leased_warmer_reads_see_no_false_misses_or_foreign_values_under_pool_churn()
+    {
+        const int keyCount = 128;
+
+        ResourcePool pool = new(new FlatDbConfig { CompactSize = 2 });
+        Address[] addresses = TestItem.Addresses.AsSpan(0, keyCount).ToArray();
+        TreePath warmPath = TreePath.FromNibble([1, 2, 3]);
+
+        Published? published = null;
+        long anomalies = 0;
+        Exception? readerException = null;
+        bool stop = false;
+
+        Task[] readers = new Task[Math.Max(2, Environment.ProcessorCount - 2)];
+        for (int t = 0; t < readers.Length; t++)
+        {
+            readers[t] = Task.Run(() =>
+            {
+                try
+                {
+                    while (!Volatile.Read(ref stop))
+                    {
+                        Published? p = Volatile.Read(ref published);
+                        if (p is null || !p.Bundle.TryLease()) continue;
+                        try
+                        {
+                            foreach (Address address in addresses)
+                            {
+                                Account? account = p.Bundle.GetAccount(address);
+                                if (account is null || account.Balance != p.Epoch)
+                                {
+                                    Interlocked.Increment(ref anomalies);
+                                }
+                            }
+
+                            p.Bundle.FindStateNodeOrUnknownForTrieWarmer(warmPath, TestItem.KeccakB);
+                        }
+                        finally
+                        {
+                            p.Bundle.ReleaseLease();
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Interlocked.CompareExchange(ref readerException, e, null);
+                    Volatile.Write(ref stop, true);
+                }
+            });
+        }
+
+        Stopwatch sw = Stopwatch.StartNew();
+        int epochs = 0;
+        SnapshotBundle? previous = null;
+        for (ulong e = 1; sw.ElapsedMilliseconds < 3_000 && !Volatile.Read(ref stop); e++, epochs++)
+        {
+            SnapshotBundle bundle = NewBundle(pool);
+            foreach (Address address in addresses)
+            {
+                bundle.SetAccount(address, new Account((UInt256)e));
+            }
+
+            (Snapshot? snapshot, TransientResource? retired) =
+                bundle.CollectAndApplySnapshot(StateId.PreGenesis, new StateId(e, TestItem.KeccakA));
+            retired!.ReleaseLease();
+            snapshot!.Dispose();
+
+            Volatile.Write(ref published, new Published(bundle, (UInt256)e));
+            previous?.Dispose();
+            previous = bundle;
+        }
+
+        Volatile.Write(ref stop, true);
+        Task.WaitAll(readers);
+        previous?.Dispose();
+
+        TestContext.Out.WriteLine($"epochs={epochs} anomalies={Volatile.Read(ref anomalies)}");
+        Assert.That(readerException, Is.Null);
+        Assert.That(Volatile.Read(ref anomalies), Is.Zero);
+    }
+
+    private sealed record Published(SnapshotBundle Bundle, UInt256 Epoch);
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotContentFlatTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotContentFlatTests.cs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Trie;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test;
+
+[TestFixture]
+public class SnapshotContentFlatTests
+{
+    private static readonly Hash256 AddressA = TestItem.AddressA.ToAccountPath.ToCommitment();
+
+    [Test]
+    public void Default_config_keeps_storage_nodes_object_backed()
+    {
+        SnapshotContent content = new(flatNodeStorage: false);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content.StorageNodesAreFlat, Is.False);
+            Assert.That(content.FlatStorageNodes, Is.Null);
+            Assert.That(content.StorageNodes, Is.Not.Null);
+        }
+    }
+
+    [Test]
+    public void Flat_config_routes_storage_nodes_through_the_slab_tier()
+    {
+        SnapshotContent content = new(flatNodeStorage: true);
+        Assert.That(content.StorageNodesAreFlat, Is.True);
+        Assert.That(content.FlatStorageNodes, Is.Not.Null);
+
+        byte[] rlp = [0xC2, 0x01, 0x02];
+        content.FlatStorageNodes![(AddressA, TreePath.FromHexString("12"))] = new TrieNode(NodeType.Leaf, rlp);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content.StorageNodesCount, Is.EqualTo(1));
+            Assert.That(content.StorageNodes.Count, Is.Zero, "the object-backed tier stays empty when flat");
+            Assert.That(content.TryGetStorageNode(new((AddressA, TreePath.FromHexString("12"))), out TrieNode? node), Is.True);
+            Assert.That(node!.FullRlp.ToArray(), Is.EqualTo(rlp));
+        }
+
+        List<(Hash256, TreePath)> enumerated = [];
+        foreach (KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode> kvp in content.EnumerateStorageNodes())
+            enumerated.Add(kvp.Key.Key);
+
+        Assert.That(enumerated, Is.EqualTo(new[] { (AddressA, TreePath.FromHexString("12")) }));
+        Assert.That(content.StorageNodesForMerge, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Flat_pool_hands_out_flat_snapshots()
+    {
+        ResourcePool pool = new(new FlatDbConfig { FlatNodeStorage = true });
+        using Snapshot snapshot = pool.CreateSnapshot(StateId.PreGenesis, StateId.PreGenesis, ResourcePool.Usage.MainBlockProcessing);
+
+        Assert.That(snapshot.StorageNodesAreFlat, Is.True);
+        snapshot.Content.FlatStorageNodes![(AddressA, TreePath.Empty)] = new TrieNode(NodeType.Unknown, TestItem.KeccakA);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshot.StorageNodesCount, Is.EqualTo(1));
+            Assert.That(snapshot.TryGetStorageNode(new((AddressA, TreePath.Empty)), out TrieNode? node), Is.True);
+            Assert.That(node!.Keccak, Is.EqualTo(TestItem.KeccakA));
+        }
+    }
+
+    [Test]
+    public void Flat_reset_releases_the_arena_and_allows_reuse()
+    {
+        SnapshotContent content = new(flatNodeStorage: true);
+        content.FlatStorageNodes![(AddressA, TreePath.Empty)] = new TrieNode(NodeType.Leaf, new byte[] { 0xC1, 0x01 });
+        Assert.That(content.FlatStorageNodes.ArenaBytesReserved, Is.GreaterThan(0));
+
+        content.Reset();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content.StorageNodesCount, Is.Zero);
+            Assert.That(content.FlatStorageNodes.ArenaBytesReserved, Is.Zero);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/FlatAddressStorageNodeDictionary.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatAddressStorageNodeDictionary.cs
@@ -1,0 +1,346 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using Nethermind.Core.Buffers;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Trie;
+
+namespace Nethermind.State.Flat;
+
+/// <summary>
+/// Slab-backed counterpart of <see cref="AddressStorageNodeDictionary"/>: stores changed storage-trie
+/// nodes as packed <see cref="SlabHandle"/>s in address-owned handle dictionaries over one shared
+/// <see cref="SlabArena"/>. Reads decode transient <see cref="TrieNode"/>s from the arena bytes.
+/// </summary>
+/// <remarks>
+/// A storage-trie commit exclusively owns one address, so its handle dictionary has at most one writer,
+/// exactly as the object-backed variant. The append target is a single arena shared by all addresses —
+/// per-address arenas would round every address up to a whole 1MiB slab — so appends fan out over a
+/// small fixed set of lock-free cursors (each grabs slabs exclusively) that pack thousands of addresses
+/// into a handful of partial slabs. Reads must not overlap writes to the same address; enumeration and
+/// <see cref="Count"/> require all addresses to be quiescent.
+/// </remarks>
+public sealed class FlatAddressStorageNodeDictionary : IReadOnlyCollection<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>>
+{
+    private const int ShardCountLog2 = 4;
+    private const int ShardCount = 1 << ShardCountLog2;
+    private const int MaxPooledNodeDictionaries = 1_024;
+    private const int MaxPooledNodeCapacity = 4_096;
+
+    private readonly ConcurrentDictionary<Hash256AsKey, FlatAddressNodes> _byAddress = new();
+    private readonly SlabArena _arena = new();
+    private readonly long[] _shardCursors = new long[ShardCount];
+    private IEnumerator<KeyValuePair<Hash256AsKey, FlatAddressNodes>>? _cachedAddressEnumerator;
+
+    public FlatAddressStorageNodeDictionary() => ResetCursors();
+
+    private void ResetCursors()
+    {
+        for (int i = 0; i < ShardCount; i++) _shardCursors[i] = SlabArena.EmptySharedCursor;
+    }
+
+    private static int ShardOf(Hash256 address) => (int)((uint)address.GetHashCode() >> (32 - ShardCountLog2));
+
+    internal SlabArena Arena => _arena;
+    public long ArenaBytesReserved => _arena.BytesReserved;
+
+    public int Count
+    {
+        get
+        {
+            int count = 0;
+            IEnumerator<KeyValuePair<Hash256AsKey, FlatAddressNodes>> addresses = RentAddressEnumerator();
+            try
+            {
+                while (addresses.MoveNext()) count += addresses.Current.Value.Count;
+            }
+            finally
+            {
+                ReturnAddressEnumerator(addresses);
+            }
+            return count;
+        }
+    }
+
+    public TrieNode this[HashedKey<(Hash256, TreePath)> key]
+    {
+        set => GetOrAddAddress(key.Key.Item1).Set(key.Key.Item2, value);
+    }
+
+    internal FlatAddressNodes GetOrAddAddress(Hash256 address)
+    {
+        if (_byAddress.TryGetValue(address, out FlatAddressNodes? nodes)) return nodes;
+
+        FlatAddressNodes candidate = FlatAddressNodesPool.Rent();
+        candidate.Init(_arena, _shardCursors, ShardOf(address));
+        nodes = _byAddress.GetOrAdd(address, candidate);
+        if (!ReferenceEquals(nodes, candidate)) FlatAddressNodesPool.Return(candidate);
+        return nodes;
+    }
+
+    public bool TryGetValue(HashedKey<(Hash256, TreePath)> key, [NotNullWhen(true)] out TrieNode? node)
+    {
+        if (_byAddress.TryGetValue(key.Key.Item1, out FlatAddressNodes? nodes))
+        {
+            return nodes.TryGet(key.Key.Item2, out node);
+        }
+
+        node = null;
+        return false;
+    }
+
+    internal bool RemoveAddress(Hash256 address) => _byAddress.TryRemove(address, out _);
+
+    public void Clear()
+    {
+        _byAddress.Clear();
+        ResetCursors();
+        _arena.Release();
+    }
+
+    internal void NoLockClear()
+    {
+        IEnumerator<KeyValuePair<Hash256AsKey, FlatAddressNodes>> addresses = RentAddressEnumerator();
+        try
+        {
+            while (addresses.MoveNext()) FlatAddressNodesPool.Return(addresses.Current.Value);
+        }
+        finally
+        {
+            ReturnAddressEnumerator(addresses);
+        }
+
+        _byAddress.NoLockClear();
+        ResetCursors();
+        _arena.Release();
+    }
+
+    /// <summary>Releases the arena's slabs to the shared pool. Only valid at the content's quiescent
+    /// disposal boundary.</summary>
+    internal void ReleaseArena() => _arena.Release();
+
+    /// <summary>Raw-span visit of every stored record; caller must hold a lease for the full enumeration.</summary>
+    public void ForEachRlp(RlpVisitor<HashedKey<(Hash256, TreePath)>> visitor)
+    {
+        IEnumerator<KeyValuePair<Hash256AsKey, FlatAddressNodes>> addresses = RentAddressEnumerator();
+        try
+        {
+            while (addresses.MoveNext())
+            {
+                Hash256 address = addresses.Current.Key;
+                foreach (KeyValuePair<HashedKey<TreePath>, ulong> handle in addresses.Current.Value.Handles)
+                {
+                    SlabHandle slabHandle = new(handle.Value);
+                    _arena.ReadSpan(slabHandle, out _, out ReadOnlySpan<byte> rlp);
+                    HashedKey<(Hash256, TreePath)> key = new((address, handle.Key.Key));
+                    visitor(in key, (slabHandle.Flags & SlabFlags.EmptyUnknown) != 0, rlp);
+                }
+            }
+        }
+        finally
+        {
+            ReturnAddressEnumerator(addresses);
+        }
+    }
+
+    public Enumerator GetEnumerator() => new(this, RentAddressEnumerator(), _arena, _arena.Generation);
+
+    IEnumerator<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>> IEnumerable<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>>.GetEnumerator() =>
+        GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private IEnumerator<KeyValuePair<Hash256AsKey, FlatAddressNodes>> RentAddressEnumerator() =>
+        Interlocked.Exchange(ref _cachedAddressEnumerator, null) ?? _byAddress.GetEnumerator();
+
+    private void ReturnAddressEnumerator(IEnumerator<KeyValuePair<Hash256AsKey, FlatAddressNodes>> enumerator)
+    {
+        enumerator.Reset();
+        if (Interlocked.CompareExchange(ref _cachedAddressEnumerator, enumerator, null) is not null)
+        {
+            enumerator.Dispose();
+        }
+    }
+
+    internal static TrieNode Materialize(Hash256? keccak, byte[]? rlpCopy)
+    {
+        if (rlpCopy is null || rlpCopy.Length == 0)
+        {
+            return new TrieNode(NodeType.Unknown, keccak!);
+        }
+
+        if (SlabArena.DebugChecks && keccak is not null && ValueKeccak.Compute(rlpCopy) != keccak)
+        {
+            throw new InvalidOperationException("Slab record keccak mismatch — slab lifetime bug");
+        }
+
+        return keccak is not null
+            ? new TrieNode(NodeType.Unknown, keccak, new CappedArray<byte>(rlpCopy))
+            : new TrieNode(NodeType.Unknown, new CappedArray<byte>(rlpCopy));
+    }
+
+    internal sealed class FlatAddressNodes
+    {
+        internal Dictionary<HashedKey<TreePath>, ulong> Handles { get; } = [];
+        private SlabArena _arena = null!;
+        private long[] _cursors = null!;
+        private int _shard;
+
+        internal void Init(SlabArena arena, long[] cursors, int shard)
+        {
+            _arena = arena;
+            _cursors = cursors;
+            _shard = shard;
+        }
+
+        internal int Count => Handles.Count;
+
+        internal void EnsureAdditionalCapacity(int additionalCapacity) =>
+            Handles.EnsureCapacity(Handles.Count + additionalCapacity);
+
+        internal void Set(in TreePath path, TrieNode node)
+        {
+            SlabFlags flags = SlabFlags.None;
+            CappedArray<byte> fullRlp = node.FullRlp;
+            ReadOnlySpan<byte> rlp = fullRlp.IsNotNull ? fullRlp.AsSpan() : default;
+            if (rlp.Length == 0)
+            {
+                if (node.Keccak is null) throw new InvalidOperationException("Cannot publish a node with neither RLP nor keccak to flat node storage");
+                if (node.NodeType == NodeType.Unknown) flags |= SlabFlags.EmptyUnknown;
+            }
+
+            SlabHandle handle = _arena.AppendShared(ref _cursors[_shard], node.Keccak, rlp, flags);
+            Handles[path] = handle.Packed;
+        }
+
+        internal bool TryGet(in TreePath path, [NotNullWhen(true)] out TrieNode? node)
+        {
+            node = null;
+            int generation = _arena.Generation;
+            if (!Handles.TryGetValue(path, out ulong packed)) return false;
+
+            SlabHandle handle = new(packed);
+            if (handle.IsNone || !_arena.TryReadCopy(handle, generation, out Hash256? keccak, out byte[]? rlp)) return false;
+            node = Materialize(keccak, rlp);
+            return true;
+        }
+
+        internal void ClearForPool()
+        {
+            Handles.Clear();
+            _arena = null!;
+            _cursors = null!;
+        }
+    }
+
+    private static class FlatAddressNodesPool
+    {
+        private static readonly ConcurrentQueue<FlatAddressNodes> Pool = [];
+        private static int _count;
+
+        public static FlatAddressNodes Rent()
+        {
+            if (Volatile.Read(ref _count) > 0 && Pool.TryDequeue(out FlatAddressNodes? nodes))
+            {
+                Interlocked.Decrement(ref _count);
+                return nodes;
+            }
+
+            return new FlatAddressNodes();
+        }
+
+        public static void Return(FlatAddressNodes nodes)
+        {
+            if (nodes.Handles.Capacity > MaxPooledNodeCapacity) return;
+
+            if (Interlocked.Increment(ref _count) > MaxPooledNodeDictionaries)
+            {
+                Interlocked.Decrement(ref _count);
+                return;
+            }
+
+            nodes.ClearForPool();
+            Pool.Enqueue(nodes);
+        }
+    }
+
+    public struct Enumerator : IEnumerator<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>>
+    {
+        private FlatAddressStorageNodeDictionary? _owner;
+        private IEnumerator<KeyValuePair<Hash256AsKey, FlatAddressNodes>>? _addresses;
+        private Dictionary<HashedKey<TreePath>, ulong>.Enumerator _handles;
+        private readonly SlabArena _arena;
+        private readonly int _generation;
+        private Hash256 _address;
+        private HashedKey<(Hash256, TreePath)> _currentKey;
+        private TrieNode _currentNode;
+        private bool _hasNodes;
+
+        internal Enumerator(
+            FlatAddressStorageNodeDictionary owner,
+            IEnumerator<KeyValuePair<Hash256AsKey, FlatAddressNodes>> addresses,
+            SlabArena arena,
+            int generation)
+        {
+            _owner = owner;
+            _addresses = addresses;
+            _arena = arena;
+            _generation = generation;
+            _handles = default;
+            _address = null!;
+            _currentKey = default;
+            _currentNode = null!;
+            _hasNodes = false;
+        }
+
+        public readonly KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode> Current => new(_currentKey, _currentNode);
+
+        readonly object IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            while (true)
+            {
+                if (_hasNodes && _handles.MoveNext())
+                {
+                    KeyValuePair<HashedKey<TreePath>, ulong> entry = _handles.Current;
+                    SlabHandle handle = new(entry.Value);
+                    if (handle.IsNone || !_arena.TryReadCopy(handle, _generation, out Hash256? keccak, out byte[]? rlp))
+                    {
+                        // Miss can only happen if the arena was released concurrently; under a lease that
+                        // never happens, so skipping is a no-op on the leased persist/compaction paths.
+                        continue;
+                    }
+
+                    _currentKey = new HashedKey<(Hash256, TreePath)>((_address, entry.Key.Key));
+                    _currentNode = Materialize(keccak, rlp);
+                    return true;
+                }
+
+                if (!_addresses!.MoveNext()) return false;
+                KeyValuePair<Hash256AsKey, FlatAddressNodes> address = _addresses.Current;
+                _address = address.Key;
+                _handles = address.Value.Handles.GetEnumerator();
+                _hasNodes = true;
+            }
+        }
+
+        public void Reset() => throw new NotSupportedException();
+
+        public void Dispose()
+        {
+            IEnumerator<KeyValuePair<Hash256AsKey, FlatAddressNodes>>? addresses = _addresses;
+            if (addresses is null) return;
+
+            _addresses = null;
+            _handles.Dispose();
+            FlatAddressStorageNodeDictionary owner = _owner!;
+            _owner = null;
+            owner.ReturnAddressEnumerator(addresses);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/FlatAddressStorageNodeDictionary.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatAddressStorageNodeDictionary.cs
@@ -311,9 +311,13 @@ public sealed class FlatAddressStorageNodeDictionary : IReadOnlyCollection<KeyVa
                     SlabHandle handle = new(entry.Value);
                     if (handle.IsNone || !_arena.TryReadCopy(handle, _generation, out Hash256? keccak, out byte[]? rlp))
                     {
-                        // Miss can only happen if the arena was released concurrently; under a lease that
-                        // never happens, so skipping is a no-op on the leased persist/compaction paths.
-                        continue;
+                        // A handle present in the map but unreadable means the arena was released or its
+                        // generation rolled mid-enumeration. Every consumer of this enumerator (compaction
+                        // merge, EnumerateStorageNodes) runs under an arena lease, so this cannot happen by
+                        // design; silently skipping would drop a live storage node from the merged snapshot,
+                        // so fail loud rather than emit a torn result.
+                        throw new InvalidOperationException(
+                            $"Flat storage node {entry.Key.Key} for {_address} unreadable from the slab arena during a lease-covered enumeration (handle={entry.Value}, generation={_generation}); the arena lease is not held.");
                     }
 
                     _currentKey = new HashedKey<(Hash256, TreePath)>((_address, entry.Key.Key));

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -187,7 +187,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     private void PopulateTrieNodeCache(TransientResource transientResource)
     {
         _trieNodeCache.Add(transientResource);
-        _resourcePool.ReturnCachedResource(ResourcePool.Usage.MainBlockProcessing, transientResource);
+        transientResource.ReleaseLease();
     }
 
     private async Task NotifyWhenSlow(string name, Func<Task> closure)
@@ -353,7 +353,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         if (persistedStateId != StateId.PreGenesis && endBlock.BlockNumber <= persistedStateId.BlockNumber)
         {
             if (_logger.IsWarn) _logger.Warn($"Cannot register snapshot earlier than bigcache. Snapshot number {endBlock.BlockNumber}, bigcache number: {persistedStateId}");
-            _resourcePool.ReturnCachedResource(ResourcePool.Usage.MainBlockProcessing, transientResource);
+            transientResource.ReleaseLease();
             snapshot.Dispose();
             return;
         }
@@ -361,7 +361,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         if (!_snapshotRepository.TryAdd(snapshot, SnapshotTier.InMemoryBase))
         {
             if (_logger.IsWarn) _logger.Warn($"State {snapshot.To} already added");
-            _resourcePool.ReturnCachedResource(ResourcePool.Usage.MainBlockProcessing, transientResource);
+            transientResource.ReleaseLease();
             snapshot.Dispose();
             return;
         }
@@ -378,7 +378,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             if (!_populateTrieNodeCacheJobs.Writer.TryWrite(transientResource))
             {
                 // Queue full, return to pool instead of leaking
-                _resourcePool.ReturnCachedResource(ResourcePool.Usage.MainBlockProcessing, transientResource);
+                transientResource.ReleaseLease();
             }
 
             if (!_compactorJobs.Writer.TryWrite(endBlock))

--- a/src/Nethermind/Nethermind.State.Flat/Metrics.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Metrics.cs
@@ -16,6 +16,14 @@ public static class Metrics
     public static long SnapshotBundleSize { get; set; }
 
     [GaugeMetric]
+    [Description("Pinned 1MiB storage-node-RLP slabs currently cached in the shared slab pool")]
+    public static long SlabPoolCachedSlabs { get; set; }
+
+    [CounterMetric]
+    [Description("Flat storage-node reads that turned into tier misses because the arena was released concurrently")]
+    public static long SlabReadGenerationMisses { get; set; }
+
+    [GaugeMetric]
     [Description("Number of persisted snapshots in the most recently assembled snapshot bundle")]
     public static long SnapshotBundlePersistedSnapshotSize { get; set; }
 

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -524,25 +524,33 @@ public class PersistenceManager(
             }
 
             long storageNodesSize = 0;
-            foreach (KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode> kvp in snapshot.StorageNodes)
+            if (snapshot.StorageNodesAreFlat)
             {
-                (Hash256 address, TreePath path) = kvp.Key.Key;
-                TrieNode node = kvp.Value;
-
-                if (node.FullRlp.Length == 0)
+                // Flat storage nodes hold packed RLP; write the raw spans without decoding TrieNodes.
+                storageNodesSize = PersistFlatStorageNodes(snapshot, batch);
+            }
+            else
+            {
+                foreach (KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode> kvp in snapshot.StorageNodes)
                 {
-                    // TODO: Need to double check this case. Does it need a rewrite or not?
-                    if (node.NodeType == NodeType.Unknown)
-                    {
-                        continue;
-                    }
-                }
+                    (Hash256 address, TreePath path) = kvp.Key.Key;
+                    TrieNode node = kvp.Value;
 
-                storageNodesSize += node.FullRlp.Length;
-                // Note: Even if the node already marked as persisted, we still re-persist it
-                batch.SetStorageTrieNode(address, path, node.FullRlp.AsSpan());
-                node.IsPersisted = true;
-                node.PrunePersistedRecursively(1);
+                    if (node.FullRlp.Length == 0)
+                    {
+                        // TODO: Need to double check this case. Does it need a rewrite or not?
+                        if (node.NodeType == NodeType.Unknown)
+                        {
+                            continue;
+                        }
+                    }
+
+                    storageNodesSize += node.FullRlp.Length;
+                    // Note: Even if the node already marked as persisted, we still re-persist it
+                    batch.SetStorageTrieNode(address, path, node.FullRlp.AsSpan());
+                    node.IsPersisted = true;
+                    node.PrunePersistedRecursively(1);
+                }
             }
 
             Metrics.FlatPersistenceSnapshotSize.Observe(stateNodesSize, labels: new StringLabel("state_nodes"));
@@ -550,6 +558,20 @@ public class PersistenceManager(
         }
 
         Metrics.FlatPersistenceTime.Observe(Stopwatch.GetTimestamp() - sw);
+    }
+
+    private static long PersistFlatStorageNodes(Snapshot snapshot, IPersistence.IWriteBatch batch)
+    {
+        long storageNodesSize = 0;
+        snapshot.ForEachStorageNodeRlp((in HashedKey<(Hash256, TreePath)> key, bool emptyUnknown, ReadOnlySpan<byte> rlp) =>
+        {
+            // Mirror the object path: an empty-RLP Unknown node is not written.
+            if (rlp.Length == 0 && emptyUnknown) return;
+            (Hash256 address, TreePath path) = key.Key;
+            storageNodesSize += rlp.Length;
+            batch.SetStorageTrieNode(address, path, rlp);
+        });
+        return storageNodesSize;
     }
 
     internal void PersistPersistedSnapshot(PersistedSnapshot snapshot)

--- a/src/Nethermind/Nethermind.State.Flat/ResourcePool.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ResourcePool.cs
@@ -22,30 +22,33 @@ public class ResourcePool : IResourcePool
     {
         flatConfig.ValidateCompactSize();
 
+        bool flat = flatConfig.FlatNodeStorage;
+        SlabArena.DebugChecks = flatConfig.FlatNodeStorageDebugChecks;
+
         _categories = new()
         {
             // For main BlockProcessing once a compacted snapshot is persisted, all `flatConfig.CompactSize` snapshot content will be returned.
-            { Usage.MainBlockProcessing, new ResourcePoolCategory(Usage.MainBlockProcessing, (int)flatConfig.CompactSize + 8, 2) },
+            { Usage.MainBlockProcessing, new ResourcePoolCategory(Usage.MainBlockProcessing, (int)flatConfig.CompactSize + 8, 2, flat) },
 
             // PostMainBlockProcessing is a special usage right after the commit of `MainBlockProcessing` which only commit once and never modified.
-            { Usage.PostMainBlockProcessing, new ResourcePoolCategory(Usage.PostMainBlockProcessing, 1, 1) },
+            { Usage.PostMainBlockProcessing, new ResourcePoolCategory(Usage.PostMainBlockProcessing, 1, 1, flat) },
 
             // Note: prewarmer use readonly processing env
             // Note: readonly here means it's never committed to the flat repo, but within the worldscope itself it may be committed.
-            { Usage.ReadOnlyProcessingEnv, new ResourcePoolCategory(Usage.ReadOnlyProcessingEnv, Environment.ProcessorCount * 4, Environment.ProcessorCount * 4) },
+            { Usage.ReadOnlyProcessingEnv, new ResourcePoolCategory(Usage.ReadOnlyProcessingEnv, Environment.ProcessorCount * 4, Environment.ProcessorCount * 4, flat) },
 
             // Per-power-of-2 compact pools. Each level only has ~1 active snapshot at a time.
-            { Usage.Compact2, new ResourcePoolCategory(Usage.Compact2, 2, 1) },
-            { Usage.Compact4, new ResourcePoolCategory(Usage.Compact4, 2, 1) },
-            { Usage.Compact8, new ResourcePoolCategory(Usage.Compact8, 2, 1) },
-            { Usage.Compact16, new ResourcePoolCategory(Usage.Compact16, 2, 1) },
-            { Usage.Compact32, new ResourcePoolCategory(Usage.Compact32, 2, 1) },
-            { Usage.Compact64, new ResourcePoolCategory(Usage.Compact64, 2, 1) },
-            { Usage.Compact128, new ResourcePoolCategory(Usage.Compact128, 2, 1) },
-            { Usage.Compact256, new ResourcePoolCategory(Usage.Compact256, 2, 1) },
-            { Usage.Compact512, new ResourcePoolCategory(Usage.Compact512, 2, 1) },
-            { Usage.Compact1024, new ResourcePoolCategory(Usage.Compact1024, 2, 1) },
-            { Usage.Compact2048, new ResourcePoolCategory(Usage.Compact2048, 2, 1) },
+            { Usage.Compact2, new ResourcePoolCategory(Usage.Compact2, 2, 1, flat) },
+            { Usage.Compact4, new ResourcePoolCategory(Usage.Compact4, 2, 1, flat) },
+            { Usage.Compact8, new ResourcePoolCategory(Usage.Compact8, 2, 1, flat) },
+            { Usage.Compact16, new ResourcePoolCategory(Usage.Compact16, 2, 1, flat) },
+            { Usage.Compact32, new ResourcePoolCategory(Usage.Compact32, 2, 1, flat) },
+            { Usage.Compact64, new ResourcePoolCategory(Usage.Compact64, 2, 1, flat) },
+            { Usage.Compact128, new ResourcePoolCategory(Usage.Compact128, 2, 1, flat) },
+            { Usage.Compact256, new ResourcePoolCategory(Usage.Compact256, 2, 1, flat) },
+            { Usage.Compact512, new ResourcePoolCategory(Usage.Compact512, 2, 1, flat) },
+            { Usage.Compact1024, new ResourcePoolCategory(Usage.Compact1024, 2, 1, flat) },
+            { Usage.Compact2048, new ResourcePoolCategory(Usage.Compact2048, 2, 1, flat) },
         };
     }
 
@@ -125,7 +128,7 @@ public class ResourcePool : IResourcePool
 
     }
 
-    private class ResourcePoolCategory(Usage usage, int snapshotContentPoolSize, int cachedResourcePoolSize)
+    private class ResourcePoolCategory(Usage usage, int snapshotContentPoolSize, int cachedResourcePoolSize, bool flatNodeStorage = false)
     {
         private readonly ConcurrentStackPool<SnapshotContent> _snapshotPool = new(snapshotContentPoolSize);
         private readonly ConcurrentStackPool<SortedSnapshotContent> _sortedPool = new(snapshotContentPoolSize);
@@ -145,7 +148,7 @@ public class ResourcePool : IResourcePool
             }
 
             Metrics.CreatedPooledResource.AddBy(_snapshotLabel, 1);
-            return new SnapshotContent();
+            return new SnapshotContent(flatNodeStorage);
         }
 
         public void ReturnSnapshotContent(SnapshotContent snapshotContent)

--- a/src/Nethermind/Nethermind.State.Flat/RlpVisitor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/RlpVisitor.cs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.State.Flat;
+
+public delegate void RlpVisitor<TKey>(in TKey key, bool emptyUnknown, ReadOnlySpan<byte> rlp)
+    where TKey : struct, IEquatable<TKey>;

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatOverridableWorldScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatOverridableWorldScope.cs
@@ -75,7 +75,7 @@ public class FlatOverridableWorldScope : IOverridableWorldScope, IFlatCommitTarg
             snapshot.Dispose();
         }
 
-        _resourcePool.ReturnCachedResource(ResourcePool.Usage.ReadOnlyProcessingEnv, transientResource);
+        transientResource.ReleaseLease();
     }
 
     private SnapshotBundle GatherSnapshotBundle(BlockHeader? baseBlock)

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
@@ -112,7 +112,7 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
                 return false;
             }
 
-            if (!_bundle.TryLeaseReadOnlyBundle())
+            if (!_bundle.TryLease())
             {
                 return false;
             }
@@ -129,7 +129,7 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
             }
             finally
             {
-                _bundle.ReleaseReadOnlyBundleLease();
+                _bundle.ReleaseLease();
             }
         }
         finally

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatStorageTree.cs
@@ -119,6 +119,9 @@ public sealed class FlatStorageTree : IWorldStateScopeProvider.IStorageTree, ITr
 
             try
             {
+                // Pin the transient once for the whole traversal so the per-node warmer reads avoid lease atomics.
+                using SnapshotBundle.WarmerTransientLease _ = _bundle.EnterWarmerTransientScope();
+
                 // Note: storage tree root not changed after write batch. Also not cleared. So the result is not correct.
                 // this is just to warm up the nodes.
                 ValueHash256 key = ValueKeccak.Zero;

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -338,6 +338,9 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
             try
             {
+                // Pin the transient once for the whole traversal so the per-node warmer reads avoid lease atomics.
+                using SnapshotBundle.WarmerTransientLease _ = _snapshotBundle.EnterWarmerTransientScope();
+
                 // Note: tree root not changed after writing batch. Also, not cleared. So the result is not correct.
                 // this is just for warming up
                 _warmupStateTree.WarmUpPath(address.ToAccountPath.Bytes);

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -93,6 +93,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
     {
         if (Interlocked.CompareExchange(ref _isDisposed, true, false)) return;
         CancelHintBal();
+        Interlocked.Increment(ref _hintSequenceId); // Queued-not-started warmer jobs self-discard at entry.
         WaitForOutstandingWarmups();
         _snapshotBundle.Dispose();
         _warmer.OnExitScope();
@@ -333,7 +334,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         try
         {
             if (_hintSequenceId != sequenceId || _pausePrewarmer) return false;
-            if (!_snapshotBundle.TryLeaseReadOnlyBundle()) return false;
+            if (!_snapshotBundle.TryLease()) return false;
 
             try
             {
@@ -345,7 +346,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
             }
             finally
             {
-                _snapshotBundle.ReleaseReadOnlyBundleLease();
+                _snapshotBundle.ReleaseLease();
             }
         }
         finally
@@ -460,7 +461,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
             else
             {
                 newSnapshot?.Dispose();
-                cachedResource?.Dispose();
+                cachedResource?.ReleaseLease();
             }
         }
 

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/StateTrieStoreAdapter.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/StateTrieStoreAdapter.cs
@@ -84,13 +84,13 @@ internal sealed class StorageTrieStoreAdapter(
         Hash256AsKey addressHash,
         ConcurrencyController concurrencyQuota) : AbstractMinimalCommitter(concurrencyQuota)
     {
-        private readonly AddressStorageNodeDictionary.AddressNodes _nodes = bundle.GetStorageNodeDestination(addressHash);
+        private readonly SnapshotBundle.StorageNodeDestination _nodes = bundle.GetStorageNodeDestination(addressHash);
 
         protected override void WriteNode(in TreePath path, TrieNode node) =>
-            bundle.SetStorageNode(_nodes, addressHash, path, node);
+            bundle.SetStorageNode(in _nodes, addressHash, path, node);
 
         protected override void PublishNodes(IEnumerable<List<(TreePath Path, TrieNode Node)>> buffers) =>
-            bundle.PublishStorageNodes(_nodes, addressHash, buffers);
+            bundle.PublishStorageNodes(in _nodes, addressHash, buffers);
     }
 }
 

--- a/src/Nethermind/Nethermind.State.Flat/SlabArena.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SlabArena.cs
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Concurrent;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.State.Flat;
+
+/// <summary>
+/// Append-only pinned-slab byte arena for snapshot node records (keccak + RLP). Records are
+/// immutable once written; overwritten or tombstoned records leak their bytes until
+/// <see cref="Release"/>.
+/// </summary>
+/// <remarks>
+/// Two append protocols share one slab array: the single-threaded <see cref="Append"/> (owned
+/// <see cref="Cursor"/>) and the lock-free <see cref="AppendShared"/> (a caller-held packed
+/// <see cref="long"/> cursor). Address-owned flat node storage uses a small fixed set of shared
+/// cursors so thousands of addresses pack into a handful of partial slabs instead of one slab each.
+/// </remarks>
+public sealed class SlabArena
+{
+    public const int SlabSize = 1 << 20;
+    private const int MaxPooledSlabs = 8192;
+    private const int MinRetainedSlabs = 1024;
+    private const int TrimEpochReleases = 256;
+
+    /// <summary>Empty shared cursor: slab index -1 forces the first append to grow a slab.</summary>
+    public const long EmptySharedCursor = -1L << 32;
+
+    public static bool DebugChecks;
+
+    private static readonly ConcurrentStack<byte[]> s_slabPool = new();
+    private static int s_pooledCount;
+    private static int s_inUseCount;
+    private static int s_inUseHighWater;
+    private static int s_releasesSinceTrim;
+
+    private readonly object _growLock = new();
+    private byte[][] _slabs = [];
+    private int _slabCount;
+    private int _generation;
+    private long _bytesAppended;
+
+    public int Generation => Volatile.Read(ref _generation);
+    public long BytesAppended => Volatile.Read(ref _bytesAppended);
+    public long BytesReserved => (long)Volatile.Read(ref _slabCount) * SlabSize;
+
+    /// <summary>Append cursor; touched only under the owning shard's lock or by a single-threaded build.</summary>
+    public struct Cursor
+    {
+        internal int Slab;
+        internal int Offset;
+
+        public static Cursor Empty => new() { Slab = -1 };
+    }
+
+    public SlabHandle Append(ref Cursor cursor, Hash256? keccak, ReadOnlySpan<byte> rlp, SlabFlags flags)
+    {
+        if (keccak is not null) flags |= SlabFlags.HasKeccak;
+        int keccakLen = keccak is not null ? 32 : 0;
+        int recordLen = keccakLen + rlp.Length;
+        if (recordLen > SlabSize) throw new InvalidOperationException($"Node record of {recordLen} bytes exceeds the slab size");
+
+        if (cursor.Slab < 0 || cursor.Offset + recordLen > SlabSize)
+        {
+            (cursor.Slab, cursor.Offset) = AddSlab();
+        }
+
+        byte[] slab = Volatile.Read(ref _slabs)[cursor.Slab];
+        int offset = cursor.Offset;
+        if (keccakLen != 0) keccak!.Bytes.CopyTo(slab.AsSpan(offset, 32));
+        if (rlp.Length != 0) rlp.CopyTo(slab.AsSpan(offset + keccakLen, rlp.Length));
+
+        cursor.Offset = offset + recordLen;
+        Interlocked.Add(ref _bytesAppended, recordLen);
+        return SlabHandle.Create(cursor.Slab, offset, rlp.Length, flags);
+    }
+
+    /// <summary>
+    /// Lock-free append against a caller-held packed cursor (slabIndex:32 | offset:32). Each cursor
+    /// grabs slabs exclusively via CAS, so records reserved through the same cursor never overlap and
+    /// records reserved through different cursors land in different slabs. The record bytes are written
+    /// after the region is reserved; a reader must only look up a handle once it was published, which
+    /// happens-after the write.
+    /// </summary>
+    public SlabHandle AppendShared(ref long cursor, Hash256? keccak, ReadOnlySpan<byte> rlp, SlabFlags flags)
+    {
+        if (keccak is not null) flags |= SlabFlags.HasKeccak;
+        int keccakLen = keccak is not null ? 32 : 0;
+        int recordLen = keccakLen + rlp.Length;
+        if (recordLen > SlabSize) throw new InvalidOperationException($"Node record of {recordLen} bytes exceeds the slab size");
+
+        while (true)
+        {
+            long current = Volatile.Read(ref cursor);
+            int slabIndex = (int)(current >> 32);
+            int offset = (int)(uint)current;
+            if (slabIndex < 0 || offset + recordLen > SlabSize)
+            {
+                GrowSharedCursor(ref cursor, current);
+                continue;
+            }
+
+            long next = ((long)slabIndex << 32) | (uint)(offset + recordLen);
+            if (Interlocked.CompareExchange(ref cursor, next, current) != current) continue;
+
+            byte[] slab = Volatile.Read(ref _slabs)[slabIndex];
+            if (keccakLen != 0) keccak!.Bytes.CopyTo(slab.AsSpan(offset, 32));
+            if (rlp.Length != 0) rlp.CopyTo(slab.AsSpan(offset + keccakLen, rlp.Length));
+
+            Interlocked.Add(ref _bytesAppended, recordLen);
+            return SlabHandle.Create(slabIndex, offset, rlp.Length, flags);
+        }
+    }
+
+    private void GrowSharedCursor(ref long cursor, long observed)
+    {
+        lock (_growLock)
+        {
+            // Another appender already advanced this cursor to a fresh slab; retry against it.
+            if (Volatile.Read(ref cursor) != observed) return;
+
+            byte[] slab = RentSlab();
+            byte[][] slabs = _slabs;
+            if (_slabCount == slabs.Length)
+            {
+                byte[][] grown = new byte[Math.Max(4, slabs.Length * 2)][];
+                Array.Copy(slabs, grown, slabs.Length);
+                grown[_slabCount] = slab;
+                Volatile.Write(ref _slabs, grown);
+            }
+            else
+            {
+                slabs[_slabCount] = slab;
+            }
+
+            int index = _slabCount;
+            Volatile.Write(ref _slabCount, index + 1);
+            // No record may start at (slab 0, offset 0): SlabHandle.None must stay unambiguous.
+            int startOffset = index == 0 ? 1 : 0;
+            Volatile.Write(ref cursor, ((long)index << 32) | (uint)startOffset);
+        }
+    }
+
+    private (int Slab, int Offset) AddSlab()
+    {
+        lock (_growLock)
+        {
+            byte[] slab = RentSlab();
+            byte[][] slabs = _slabs;
+            if (_slabCount == slabs.Length)
+            {
+                byte[][] grown = new byte[Math.Max(4, slabs.Length * 2)][];
+                Array.Copy(slabs, grown, slabs.Length);
+                grown[_slabCount] = slab;
+                Volatile.Write(ref _slabs, grown);
+            }
+            else
+            {
+                slabs[_slabCount] = slab;
+            }
+
+            int index = _slabCount;
+            Volatile.Write(ref _slabCount, index + 1);
+            // No record may start at (slab 0, offset 0): SlabHandle.None must stay unambiguous.
+            return (index, index == 0 ? 1 : 0);
+        }
+    }
+
+    /// <summary>Copies the record out; <paramref name="generation"/> must have been sampled
+    /// BEFORE the handle was read. False = miss.</summary>
+    public bool TryReadCopy(SlabHandle handle, int generation, out Hash256? keccak, out byte[]? rlpCopy)
+    {
+        keccak = null;
+        rlpCopy = null;
+        if (handle.IsNone) return false;
+
+        byte[][] slabs = Volatile.Read(ref _slabs);
+        int slabIndex = handle.SlabIndex;
+        if ((uint)slabIndex >= (uint)Volatile.Read(ref _slabCount) || slabIndex >= slabs.Length) return false;
+
+        int keccakLen = (handle.Flags & SlabFlags.HasKeccak) != 0 ? 32 : 0;
+        int recordLen = keccakLen + handle.RlpLength;
+        if (handle.Offset + recordLen > SlabSize) return false;
+
+        byte[] slab = slabs[slabIndex];
+        Span<byte> keccakBytes = stackalloc byte[32];
+        if (keccakLen != 0) slab.AsSpan(handle.Offset, 32).CopyTo(keccakBytes);
+        byte[]? rlp = handle.RlpLength != 0 ? slab.AsSpan(handle.Offset + keccakLen, handle.RlpLength).ToArray() : null;
+
+        if (Volatile.Read(ref _generation) != generation)
+        {
+            Metrics.SlabReadGenerationMisses++;
+            return false;
+        }
+
+        if (keccakLen != 0) keccak = new Hash256(keccakBytes);
+        rlpCopy = rlp;
+        return true;
+    }
+
+    /// <summary>Raw span read; only valid while the caller holds a lease keeping the content quiescent.</summary>
+    internal void ReadSpan(SlabHandle handle, out ReadOnlySpan<byte> keccakOrEmpty, out ReadOnlySpan<byte> rlp)
+    {
+        byte[] slab = Volatile.Read(ref _slabs)[handle.SlabIndex];
+        int keccakLen = (handle.Flags & SlabFlags.HasKeccak) != 0 ? 32 : 0;
+        keccakOrEmpty = keccakLen != 0 ? slab.AsSpan(handle.Offset, 32) : default;
+        rlp = handle.RlpLength != 0 ? slab.AsSpan(handle.Offset + keccakLen, handle.RlpLength) : default;
+    }
+
+    /// <summary>Returns every slab to the pool. Only valid at the content's quiescent points (reset/dispose).</summary>
+    public void Release()
+    {
+        Interlocked.Increment(ref _generation);
+
+        byte[][] slabs;
+        int count;
+        lock (_growLock)
+        {
+            slabs = _slabs;
+            count = _slabCount;
+            Volatile.Write(ref _slabs, Array.Empty<byte[]>());
+            Volatile.Write(ref _slabCount, 0);
+            Interlocked.Exchange(ref _bytesAppended, 0);
+        }
+
+        for (int i = 0; i < count; i++)
+        {
+            byte[] slab = slabs[i];
+            if (DebugChecks) slab.AsSpan().Fill(0xDE);
+            ReturnSlab(slab);
+        }
+    }
+
+    private static byte[] RentSlab()
+    {
+        int inUse = Interlocked.Increment(ref s_inUseCount);
+        InterlockedMax(ref s_inUseHighWater, inUse);
+        if (s_slabPool.TryPop(out byte[]? pooled))
+        {
+            Interlocked.Decrement(ref s_pooledCount);
+            Metrics.SlabPoolCachedSlabs = s_pooledCount;
+            return pooled;
+        }
+
+        return GC.AllocateUninitializedArray<byte>(SlabSize, pinned: true);
+    }
+
+    private static void ReturnSlab(byte[] slab)
+    {
+        Interlocked.Decrement(ref s_inUseCount);
+        if (Volatile.Read(ref s_pooledCount) < MaxPooledSlabs)
+        {
+            s_slabPool.Push(slab);
+            Interlocked.Increment(ref s_pooledCount);
+        }
+
+        if (Interlocked.Increment(ref s_releasesSinceTrim) >= TrimEpochReleases)
+        {
+            Interlocked.Exchange(ref s_releasesSinceTrim, 0);
+            int keep = Math.Max(Interlocked.Exchange(ref s_inUseHighWater, Volatile.Read(ref s_inUseCount)), MinRetainedSlabs);
+            while (Volatile.Read(ref s_pooledCount) > keep && s_slabPool.TryPop(out _))
+            {
+                Interlocked.Decrement(ref s_pooledCount);
+            }
+        }
+
+        Metrics.SlabPoolCachedSlabs = s_pooledCount;
+    }
+
+    private static void InterlockedMax(ref int location, int value)
+    {
+        int current;
+        while ((current = Volatile.Read(ref location)) < value &&
+               Interlocked.CompareExchange(ref location, value, current) != current)
+        {
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/SlabHandle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SlabHandle.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.State.Flat;
+
+[Flags]
+public enum SlabFlags : byte
+{
+    None = 0,
+    HasKeccak = 1,
+    EmptyUnknown = 2,
+}
+
+/// <summary>
+/// Packed 64-bit handle into a <see cref="SlabArena"/>; layout (LSB first):
+/// rlpLen:12 | offset:20 | slabIndex:18 | flags:2. <see cref="None"/> (all-zero) never denotes
+/// a record: the arena pads slab 0 so no record starts at (slab 0, offset 0).
+/// </summary>
+public readonly struct SlabHandle(ulong packed) : IEquatable<SlabHandle>
+{
+    public const int MaxRlpLen = (1 << 12) - 1;
+    public const int MaxOffset = (1 << 20) - 1;
+    public const int MaxSlabIndex = (1 << 18) - 1;
+    public static readonly SlabHandle None = default;
+
+    public ulong Packed { get; } = packed;
+
+    public int RlpLength => (int)(Packed & 0xFFF);
+    public int Offset => (int)((Packed >> 12) & 0xFFFFF);
+    public int SlabIndex => (int)((Packed >> 32) & 0x3FFFF);
+    public SlabFlags Flags => (SlabFlags)((Packed >> 50) & 0x3);
+    public bool IsNone => Packed == 0;
+
+    public static SlabHandle Create(int slabIndex, int offset, int rlpLength, SlabFlags flags)
+    {
+        if ((uint)rlpLength > MaxRlpLen) throw new InvalidOperationException($"Node RLP length {rlpLength} exceeds the slab handle limit {MaxRlpLen}");
+        if ((uint)offset > MaxOffset) throw new InvalidOperationException($"Slab offset {offset} exceeds the handle limit");
+        if ((uint)slabIndex > MaxSlabIndex) throw new InvalidOperationException($"Slab index {slabIndex} exceeds the handle limit");
+        return new SlabHandle((ulong)(uint)rlpLength | ((ulong)(uint)offset << 12) | ((ulong)(uint)slabIndex << 32) | ((ulong)(byte)flags << 50));
+    }
+
+    public bool Equals(SlabHandle other) => Packed == other.Packed;
+    public override bool Equals(object? obj) => obj is SlabHandle other && Equals(other);
+    public override int GetHashCode() => Packed.GetHashCode();
+}

--- a/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
@@ -87,7 +87,7 @@ public class Snapshot : RefCountingDisposable
     public IEnumerable<KeyValuePair<HashedKey<Address>, Account?>> Accounts => _isSorted ? _sorted!.Accounts : _mutable!.Accounts;
     public IEnumerable<KeyValuePair<HashedKey<Address>, bool>> SelfDestructedStorageAddresses => _isSorted ? _sorted!.SelfDestructedStorageAddresses : _mutable!.SelfDestructedStorageAddresses;
     public IEnumerable<KeyValuePair<HashedKey<(Address, UInt256)>, SlotValue?>> Storages => _isSorted ? _sorted!.Storages : _mutable!.Storages;
-    public IEnumerable<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>> StorageNodes => _isSorted ? _sorted!.StorageNodes : _mutable!.StorageNodes;
+    public IEnumerable<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>> StorageNodes => _isSorted ? _sorted!.StorageNodes : _mutable!.EnumerateStorageNodes();
     public IEnumerable<KeyValuePair<HashedKey<TreePath>, TrieNode>> StateNodes => _isSorted ? _sorted!.StateNodes : _mutable!.StateNodes;
     public int AccountsCount => _isSorted ? _sorted!.AccountsCount : Counts.Accounts;
     public int StoragesCount => _isSorted ? _sorted!.StoragesCount : Counts.Storages;
@@ -112,7 +112,16 @@ public class Snapshot : RefCountingDisposable
         => _isSorted ? _sorted!.TryGetStateNode(key, out node) : _mutable!.StateNodes.TryGetValue(key, out node!);
 
     public bool TryGetStorageNode(HashedKey<(Hash256, TreePath)> key, [NotNullWhen(true)] out TrieNode? node)
-        => _isSorted ? _sorted!.TryGetStorageNode(key, out node) : _mutable!.StorageNodes.TryGetValue(key, out node!);
+        => _isSorted ? _sorted!.TryGetStorageNode(key, out node) : _mutable!.TryGetStorageNode(key, out node);
+
+    /// <summary>True when the mutable content stores storage-trie nodes as slab handles rather than
+    /// TrieNode objects. Always false for compacted (sorted) snapshots.</summary>
+    public bool StorageNodesAreFlat => !_isSorted && _mutable!.StorageNodesAreFlat;
+
+    /// <summary>Raw-span visit of flat storage-node records; caller must hold a lease for the full
+    /// enumeration. Only valid when <see cref="StorageNodesAreFlat"/> is true.</summary>
+    public void ForEachStorageNodeRlp(RlpVisitor<HashedKey<(Hash256, TreePath)>> visitor) =>
+        _mutable!.ForEachStorageNodeRlp(visitor);
 
     protected override void CleanUp()
     {
@@ -131,11 +140,44 @@ public sealed class SnapshotContent : IDisposable, IResettable
     public readonly ConcurrentDictionary<HashedKey<Address>, bool> SelfDestructedStorageAddresses = new();
 
     public readonly Dictionary<HashedKey<TreePath>, TrieNode> StateNodes = [];
+
+    // Object-backed storage-node tier (master default). When FlatDb.FlatNodeStorage is on, the
+    // slab-backed FlatStorageNodes tier is also constructed and used instead — StorageNodes then stays
+    // empty and every switch below routes through FlatStorageNodes. State nodes are always object-backed.
     public readonly AddressStorageNodeDictionary StorageNodes = new();
+    public readonly FlatAddressStorageNodeDictionary? FlatStorageNodes;
+
+    public SnapshotContent(bool flatNodeStorage)
+    {
+        if (flatNodeStorage) FlatStorageNodes = new FlatAddressStorageNodeDictionary();
+    }
+
+    public SnapshotContent() : this(false)
+    {
+    }
+
+    public bool StorageNodesAreFlat => FlatStorageNodes is not null;
+
+    public bool TryGetStorageNode(HashedKey<(Hash256, TreePath)> key, [NotNullWhen(true)] out TrieNode? node)
+        => FlatStorageNodes is null ? StorageNodes.TryGetValue(key, out node!) : FlatStorageNodes.TryGetValue(key, out node);
+
+    public int StorageNodesCount => FlatStorageNodes?.Count ?? StorageNodes.Count;
+
+    public IEnumerable<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>> EnumerateStorageNodes()
+        => FlatStorageNodes is null ? StorageNodes : FlatStorageNodes;
+
+    /// <summary>The storage-node tier as a read-only collection for compaction's merge; both tiers
+    /// yield decoded <see cref="TrieNode"/>s so the compacted tier is object-backed either way.</summary>
+    public IReadOnlyCollection<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>> StorageNodesForMerge
+        => FlatStorageNodes is null ? StorageNodes : FlatStorageNodes;
+
+    /// <summary>Raw-span visit of flat storage-node records; lease-covered consumers only.</summary>
+    public void ForEachStorageNodeRlp(RlpVisitor<HashedKey<(Hash256, TreePath)>> visitor) => FlatStorageNodes!.ForEachRlp(visitor);
 
     public void Reset()
     {
         foreach (KeyValuePair<HashedKey<TreePath>, TrieNode> kvp in StateNodes) kvp.Value.PrunePersistedRecursively(1);
+        // StorageNodes is empty when flat storage is on (nodes live in the arena, nothing to prune).
         foreach (KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode> kvp in StorageNodes) kvp.Value.PrunePersistedRecursively(1);
 
         // Reset runs at a quiescent pool-return boundary (final snapshot lease released, or the
@@ -146,10 +188,11 @@ public sealed class SnapshotContent : IDisposable, IResettable
         SelfDestructedStorageAddresses.NoLockClear();
         StateNodes.Clear();
         StorageNodes.NoLockClear();
+        FlatStorageNodes?.NoLockClear();
     }
 
     /// <summary>
-    /// Captures the five map counts in one pass. <see cref="ConcurrentDictionary{TKey,TValue}.Count"/>
+    /// Captures the map counts in one pass. <see cref="ConcurrentDictionary{TKey,TValue}.Count"/>
     /// acquires every stripe lock, so callers should capture once at a writer-quiescent boundary and
     /// reuse the result instead of re-reading live counts.
     /// </summary>
@@ -158,16 +201,15 @@ public sealed class SnapshotContent : IDisposable, IResettable
         Storages.Count,
         SelfDestructedStorageAddresses.Count,
         StateNodes.Count,
-        StorageNodes.Count);
+        StorageNodesCount,
+        FlatStorageNodes?.ArenaBytesReserved ?? -1);
 
     public long EstimateMemory() => CaptureCounts().EstimateMemory();
 
     /// <inheritdoc cref="SnapshotContentCounts.EstimateCompactedMemory"/>
     public long EstimateCompactedMemory() => CaptureCounts().EstimateCompactedMemory();
 
-    public void Dispose()
-    {
-    }
+    public void Dispose() => FlatStorageNodes?.ReleaseArena();
 }
 
 /// <summary>
@@ -179,9 +221,22 @@ internal readonly record struct SnapshotContentCounts(
     int Storages,
     int SelfDestructedStorageAddresses,
     int StateNodes,
-    int StorageNodes)
+    int StorageNodes,
+    long StorageNodeArenaBytes)
 {
     private const int NodeSizeEstimate = 650; // Counting the node size one by one has a notable overhead. So we use estimate.
+
+    // Flat storage nodes own their RLP bytes in the arena (exact) plus a blittable handle entry per node;
+    // object-backed nodes (StorageNodeArenaBytes < 0) fall back to the per-node estimate.
+    private long StorageNodeMemory =>
+        StorageNodeArenaBytes < 0
+            ? (long)StorageNodes * (NodeSizeEstimate + 84)  // Key (48B) + Value ref (8B) + dictionary overhead (28) + TrieNode
+            : (long)StorageNodes * 64 + StorageNodeArenaBytes;
+
+    private long StorageNodeCompactedMemory =>
+        StorageNodeArenaBytes < 0
+            ? (long)StorageNodes * 84
+            : (long)StorageNodes * 64 + StorageNodeArenaBytes;
 
     public long EstimateMemory() =>
         // Cast Count to long before multiplying to avoid int overflow for large snapshots
@@ -189,7 +244,7 @@ internal readonly record struct SnapshotContentCounts(
             (long)Storages * 136 +                         // Key (44B: addr ref 8B + UInt256 32B + hash 4B) + Value (40B SlotValue?) + CD overhead (48) + Value ref (4B)
             (long)SelfDestructedStorageAddresses * 64 +    // Key (12B: ref 8B + hash 4B) + Value (4B) + CD overhead (48)
             (long)StateNodes * (NodeSizeEstimate + 76) +   // Key (40B: TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28) + TrieNode
-            (long)StorageNodes * (NodeSizeEstimate + 84);  // Key (48B: Hash256 ref 8B + TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28) + TrieNode
+            StorageNodeMemory;
 
     /// <summary>
     /// Estimates memory for compacted snapshots, counting only dictionary overhead + keys + value-type values.
@@ -203,5 +258,5 @@ internal readonly record struct SnapshotContentCounts(
             (long)Storages * 136 +                         // Key (44B: addr ref 8B + UInt256 32B + hash 4B) + Value (40B SlotValue?) + CD overhead (48) + Value ref (4B)
             (long)SelfDestructedStorageAddresses * 64 +    // Key (12B: ref 8B + hash 4B) + Value (4B) + CD overhead (48)
             (long)StateNodes * 76 +                        // Key (40B: TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28)
-            (long)StorageNodes * 84;                       // Key (48B: Hash256 ref 8B + TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28)
+            StorageNodeCompactedMemory;
 }

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -7,6 +7,7 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Utils;
 using Nethermind.Int256;
 using Nethermind.Trie;
 
@@ -17,8 +18,15 @@ namespace Nethermind.State.Flat;
 /// </summary>
 public sealed class SnapshotBundle : IDisposable
 {
-    private readonly ReadOnlySnapshotBundle _readOnlySnapshotBundle;
+    private sealed class Lease(SnapshotBundle bundle) : RefCountingDisposable
+    {
+        public bool TryAcquire() => TryAcquireLease();
+        protected override void CleanUp() => bundle.CleanUp();
+    }
 
+    private readonly ReadOnlySnapshotBundle _readOnlySnapshotBundle;
+    private readonly Lease _lease;
+    private bool _ownerLeaseReleased;
 
     private SnapshotContent _currentPooledContent = null!;
     // These maps are direct reference from members in _currentPooledContent.
@@ -53,9 +61,11 @@ public sealed class SnapshotBundle : IDisposable
         _trieNodeCache = trieNodeCache;
         _resourcePool = resourcePool;
         _usage = usage;
+        _lease = new Lease(this);
 
         _currentPooledContent = resourcePool.GetSnapshotContent(usage);
         _transientResource = resourcePool.GetCachedResource(usage);
+        _transientResource.OnRented(resourcePool, usage);
 
         ExpandCurrentPooledContent();
 
@@ -180,19 +190,46 @@ public sealed class SnapshotBundle : IDisposable
         // TrieWarmer only touch `_transientResource`
         GuardDispose();
 
-        if (_transientResource.TryGetStateNode(path, hash, out TrieNode? node))
+        TransientResource transientResource = LeaseTransientResourceForWarmer();
+        try
         {
-            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
-        }
-        else
-        {
-            node = _transientResource.GetOrAddStateNode(path,
-                DoFindStateNodeExternal(path, hash, out node)
-                    ? node
-                    : new TrieNode(NodeType.Unknown, hash));
-        }
+            if (transientResource.TryGetStateNode(path, hash, out TrieNode? node))
+            {
+                Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
+            }
+            else
+            {
+                node = transientResource.GetOrAddStateNode(path,
+                    DoFindStateNodeExternal(path, hash, out node)
+                        ? node
+                        : new TrieNode(NodeType.Unknown, hash));
+            }
 
-        return node;
+            return node;
+        }
+        finally
+        {
+            transientResource.ReleaseLease();
+        }
+    }
+
+    // Terminates because the caller holds a bundle lease, which keeps the current resource's owner
+    // lease held. A stale read can acquire a retired resource that was already re-rented by another
+    // bundle, so the identity re-check below is required before trusting the acquire.
+    private TransientResource LeaseTransientResourceForWarmer()
+    {
+        SpinWait spinWait = default;
+        while (true)
+        {
+            TransientResource transientResource = Volatile.Read(ref _transientResource);
+            if (transientResource.TryAcquireLease())
+            {
+                if (ReferenceEquals(Volatile.Read(ref _transientResource), transientResource)) return transientResource;
+                transientResource.ReleaseLease();
+            }
+
+            spinWait.SpinOnce();
+        }
     }
 
     private bool DoFindStateNodeExternal(in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node)
@@ -246,19 +283,27 @@ public sealed class SnapshotBundle : IDisposable
     {
         GuardDispose();
 
-        if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out TrieNode? node))
+        TransientResource transientResource = LeaseTransientResourceForWarmer();
+        try
         {
-            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
-        }
-        else
-        {
-            node = _transientResource.GetOrAddStorageNode((Hash256AsKey)address, path,
-                DoTryFindStorageNodeExternal(address, path, hash, out node) && node is not null
-                    ? node
-                    : new TrieNode(NodeType.Unknown, hash));
-        }
+            if (transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out TrieNode? node))
+            {
+                Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
+            }
+            else
+            {
+                node = transientResource.GetOrAddStorageNode((Hash256AsKey)address, path,
+                    DoTryFindStorageNodeExternal(address, path, hash, out node) && node is not null
+                        ? node
+                        : new TrieNode(NodeType.Unknown, hash));
+            }
 
-        return node;
+            return node;
+        }
+        finally
+        {
+            transientResource.ReleaseLease();
+        }
     }
 
     // Note: No self-destruct boundary check needed for trie nodes. Trie iteration starts from the storage root hash,
@@ -428,14 +473,41 @@ public sealed class SnapshotBundle : IDisposable
     public bool ShouldQueuePrewarm(in ValueAddress address, UInt256? slot = null) => _transientResource.ShouldPrewarm(address, slot);
 
     /// <summary>
-    /// Takes a lease on the underlying <see cref="ReadOnlySnapshotBundle"/> for the duration of a trie warmer traversal.
+    /// Takes a lease on this bundle for the duration of a trie warmer traversal, covering the snapshot
+    /// contents, the pooled write buffer, the transient resource and the underlying
+    /// <see cref="ReadOnlySnapshotBundle"/>.
     /// </summary>
     /// <remarks>
-    /// Warmer jobs race scope disposal by design; the managed fallout is caught in the warmer, but a read that is
-    /// already inside the persistence reader when the last lease is released would touch a freed native RocksDB
-    /// snapshot and crash the process. Holding a lease per in-flight traversal defers that release until the job ends.
+    /// Warmer jobs race scope disposal by design; the managed fallout is caught in the warmer, but a read that
+    /// overlaps the teardown would observe pooled contents being reset or re-rented (lost writes read back as
+    /// zero), and a read already inside the persistence reader when the last lease is released would touch a
+    /// freed native RocksDB snapshot and crash the process. Holding a lease per in-flight traversal defers the
+    /// whole teardown until the job ends.
     /// </remarks>
     /// <returns><c>false</c> when the bundle is already fully disposed; the caller must skip the traversal.</returns>
+    internal bool TryLease()
+    {
+        if (!_lease.TryAcquire()) return false;
+        if (!_readOnlySnapshotBundle.TryLease())
+        {
+            _lease.Dispose();
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>Releases a lease taken with <see cref="TryLease"/>.</summary>
+    internal void ReleaseLease()
+    {
+        _readOnlySnapshotBundle.Dispose();
+        _lease.Dispose();
+    }
+
+    /// <summary>
+    /// Takes a lease on the underlying <see cref="ReadOnlySnapshotBundle"/> only, for callers that need
+    /// just the native persistence reader; warmer traversals must use <see cref="TryLease"/> instead.
+    /// </summary>
     internal bool TryLeaseReadOnlyBundle() => _readOnlySnapshotBundle.TryLease();
 
     /// <summary>Releases a lease taken with <see cref="TryLeaseReadOnlyBundle"/>.</summary>
@@ -467,7 +539,7 @@ public sealed class SnapshotBundle : IDisposable
                 _usage = ResourcePool.Usage.PostMainBlockProcessing;
             }
 
-            _transientResource = _resourcePool.GetCachedResource(_usage);
+            SwapTransientResource();
             _trieChanged = false;
 
             // Make and apply new snapshot content.
@@ -480,7 +552,9 @@ public sealed class SnapshotBundle : IDisposable
         {
             snapshot.Dispose(); // Revert the lease before
 
-            _transientResource.Reset();
+            TransientResource retired = _transientResource;
+            SwapTransientResource();
+            retired.ReleaseLease();
 
             _currentPooledContent = _resourcePool.GetSnapshotContent(_usage);
             ExpandCurrentPooledContent();
@@ -490,11 +564,25 @@ public sealed class SnapshotBundle : IDisposable
         }
     }
 
+    private void SwapTransientResource()
+    {
+        TransientResource fresh = _resourcePool.GetCachedResource(_usage);
+        fresh.OnRented(_resourcePool, _usage);
+        Volatile.Write(ref _transientResource, fresh);
+    }
+
     private void GuardDispose() => ObjectDisposedException.ThrowIf(_isDisposed, this);
 
     public void Dispose()
     {
-        if (Interlocked.Exchange(ref _isDisposed, true)) return;
+        if (Interlocked.Exchange(ref _ownerLeaseReleased, true)) return;
+
+        _lease.Dispose();
+    }
+
+    private void CleanUp()
+    {
+        _isDisposed = true;
 
         _snapshots.Dispose();
 
@@ -506,7 +594,7 @@ public sealed class SnapshotBundle : IDisposable
         _selfDestructedAccountAddresses = null!;
 
         _resourcePool.ReturnSnapshotContent(_usage, _currentPooledContent);
-        _resourcePool.ReturnCachedResource(_usage, _transientResource);
+        _transientResource.ReleaseLease();
         _readOnlySnapshotBundle.Dispose();
 
         Metrics.ActiveSnapshotBundle--;

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -42,6 +42,14 @@ public sealed class SnapshotBundle : IDisposable
     // Notably, it holds loaded caches from trie warmer.
     private TransientResource _transientResource = null!;
 
+    // Ambient per-job capture of the pinned transient resource. A warmer traversal runs synchronously
+    // on one thread and reads the transient once per node through a shared adapter that cannot carry a
+    // parameter. The owning job pins the transient once (see EnterWarmerTransientScope) and parks it here,
+    // so the per-node reads use the pinned reference directly with no per-node lease atomics. The owner
+    // reference gates the slot so a foreign bundle can never read another bundle's capture.
+    [ThreadStatic]
+    private static (SnapshotBundle Owner, TransientResource Resource) t_warmerJobCapture;
+
     internal SnapshotPooledList _snapshots;
     private readonly ITrieNodeCache _trieNodeCache;
     private bool _isDisposed;
@@ -190,27 +198,40 @@ public sealed class SnapshotBundle : IDisposable
         // TrieWarmer only touch `_transientResource`
         GuardDispose();
 
+        (SnapshotBundle owner, TransientResource resource) = t_warmerJobCapture;
+        if (ReferenceEquals(owner, this))
+        {
+            // The enclosing warmer job already pinned the transient for its whole traversal.
+            return WarmUpStateNode(resource, path, hash);
+        }
+
+        // Standalone caller (e.g. tests) with no per-job capture: pin per read.
         TransientResource transientResource = LeaseTransientResourceForWarmer();
         try
         {
-            if (transientResource.TryGetStateNode(path, hash, out TrieNode? node))
-            {
-                Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
-            }
-            else
-            {
-                node = transientResource.GetOrAddStateNode(path,
-                    DoFindStateNodeExternal(path, hash, out node)
-                        ? node
-                        : new TrieNode(NodeType.Unknown, hash));
-            }
-
-            return node;
+            return WarmUpStateNode(transientResource, path, hash);
         }
         finally
         {
             transientResource.ReleaseLease();
         }
+    }
+
+    private TrieNode WarmUpStateNode(TransientResource transientResource, in TreePath path, Hash256 hash)
+    {
+        if (transientResource.TryGetStateNode(path, hash, out TrieNode? node))
+        {
+            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
+        }
+        else
+        {
+            node = transientResource.GetOrAddStateNode(path,
+                DoFindStateNodeExternal(path, hash, out node)
+                    ? node
+                    : new TrieNode(NodeType.Unknown, hash));
+        }
+
+        return node;
     }
 
     // Terminates because the caller holds a bundle lease, which keeps the current resource's owner
@@ -229,6 +250,32 @@ public sealed class SnapshotBundle : IDisposable
             }
 
             spinWait.SpinOnce();
+        }
+    }
+
+    /// <summary>
+    /// Pins the transient resource once for the whole duration of a trie-warmer traversal and parks it in
+    /// <see cref="t_warmerJobCapture"/>, so the per-node warmer reads below skip the per-node lease atomics
+    /// and read the pinned resource directly. The single acquire keeps the ABA identity re-check; the reader
+    /// lease keeps the captured resource alive across a concurrent <see cref="SwapTransientResource"/> until
+    /// the returned handle is disposed. Callers must already hold the bundle lease (<see cref="TryLease"/>).
+    /// </summary>
+    internal WarmerTransientLease EnterWarmerTransientScope()
+    {
+        TransientResource captured = LeaseTransientResourceForWarmer();
+        (SnapshotBundle Owner, TransientResource Resource) previous = t_warmerJobCapture;
+        t_warmerJobCapture = (this, captured);
+        return new WarmerTransientLease(captured, previous);
+    }
+
+    internal readonly struct WarmerTransientLease(
+        TransientResource captured,
+        (SnapshotBundle Owner, TransientResource Resource) previous) : IDisposable
+    {
+        public void Dispose()
+        {
+            t_warmerJobCapture = previous;
+            captured.ReleaseLease();
         }
     }
 
@@ -283,27 +330,40 @@ public sealed class SnapshotBundle : IDisposable
     {
         GuardDispose();
 
+        (SnapshotBundle owner, TransientResource resource) = t_warmerJobCapture;
+        if (ReferenceEquals(owner, this))
+        {
+            // The enclosing warmer job already pinned the transient for its whole traversal.
+            return WarmUpStorageNode(resource, address, path, hash);
+        }
+
+        // Standalone caller (e.g. tests) with no per-job capture: pin per read.
         TransientResource transientResource = LeaseTransientResourceForWarmer();
         try
         {
-            if (transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out TrieNode? node))
-            {
-                Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
-            }
-            else
-            {
-                node = transientResource.GetOrAddStorageNode((Hash256AsKey)address, path,
-                    DoTryFindStorageNodeExternal(address, path, hash, out node) && node is not null
-                        ? node
-                        : new TrieNode(NodeType.Unknown, hash));
-            }
-
-            return node;
+            return WarmUpStorageNode(transientResource, address, path, hash);
         }
         finally
         {
             transientResource.ReleaseLease();
         }
+    }
+
+    private TrieNode WarmUpStorageNode(TransientResource transientResource, Hash256 address, in TreePath path, Hash256 hash)
+    {
+        if (transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out TrieNode? node))
+        {
+            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
+        }
+        else
+        {
+            node = transientResource.GetOrAddStorageNode((Hash256AsKey)address, path,
+                DoTryFindStorageNodeExternal(address, path, hash, out node) && node is not null
+                    ? node
+                    : new TrieNode(NodeType.Unknown, hash));
+        }
+
+        return node;
     }
 
     // Note: No self-destruct boundary check needed for trie nodes. Trie iteration starts from the storage root hash,

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -265,6 +265,10 @@ public sealed class SnapshotBundle : IDisposable
         TransientResource captured = LeaseTransientResourceForWarmer();
         (SnapshotBundle Owner, TransientResource Resource) previous = t_warmerJobCapture;
         t_warmerJobCapture = (this, captured);
+        // Invariant: the per-node warmer's in-place GetOrAdd into this captured resource may race a
+        // concurrent Commit->PopulateTrieNodeCache enumeration of the same shards. Tolerated by design --
+        // a torn tuple read yields at worst a misplaced/lost cache entry (Keccak-validated on read -> DB
+        // fallback), never a wrong node, and the lease pins the resource so the shards are not reallocated.
         return new WarmerTransientLease(captured, previous);
     }
 

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -33,7 +33,11 @@ public sealed class SnapshotBundle : IDisposable
     private ConcurrentDictionary<HashedKey<Address>, Account?> _changedAccounts = null!;
     private ConcurrentDictionary<HashedKey<(Address, UInt256)>, SlotValue?> _changedSlots = null!;
     private Dictionary<HashedKey<TreePath>, TrieNode> _changedStateNodes = null!;
+    // The object-backed tier is always present; when _flatNodeStorage is set the slab-backed tier is
+    // used instead and _changedStorageNodes stays an empty, unused reference.
     private AddressStorageNodeDictionary _changedStorageNodes = null!;
+    private FlatAddressStorageNodeDictionary? _changedFlatStorageNodes;
+    private bool _flatNodeStorage;
     private ConcurrentDictionary<HashedKey<Address>, bool> _selfDestructedAccountAddresses = null!;
 
     private bool _trieChanged = false;
@@ -85,6 +89,8 @@ public sealed class SnapshotBundle : IDisposable
         _changedAccounts = _currentPooledContent.Accounts;
         _changedSlots = _currentPooledContent.Storages;
         _changedStorageNodes = _currentPooledContent.StorageNodes;
+        _changedFlatStorageNodes = _currentPooledContent.FlatStorageNodes;
+        _flatNodeStorage = _currentPooledContent.StorageNodesAreFlat;
         _changedStateNodes = _currentPooledContent.StateNodes;
         _selfDestructedAccountAddresses = _currentPooledContent.SelfDestructedStorageAddresses;
     }
@@ -310,7 +316,7 @@ public sealed class SnapshotBundle : IDisposable
 
         HashedKey<(Hash256, TreePath)> key = new((address, path));
 
-        if (_trieChanged && _changedStorageNodes.TryGetValue(key, out TrieNode? node))
+        if (_trieChanged && TryGetChangedStorageNode(key, out TrieNode? node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
@@ -328,6 +334,11 @@ public sealed class SnapshotBundle : IDisposable
 
         return node;
     }
+
+    private bool TryGetChangedStorageNode(HashedKey<(Hash256, TreePath)> key, [NotNullWhen(true)] out TrieNode? node) =>
+        _flatNodeStorage
+            ? _changedFlatStorageNodes!.TryGetValue(key, out node)
+            : _changedStorageNodes.TryGetValue(key, out node);
 
 
     public TrieNode FindStorageNodeOrUnknownTrieWarmer(Hash256 address, in TreePath path, Hash256 hash)
@@ -430,8 +441,45 @@ public sealed class SnapshotBundle : IDisposable
         }
     }
 
-    internal AddressStorageNodeDictionary.AddressNodes GetStorageNodeDestination(Hash256 address) =>
-        _changedStorageNodes.GetOrAddAddress(address);
+    /// <summary>
+    /// A per-address storage-node write target captured once per storage-trie commit. Holds the
+    /// object-backed or slab-backed inner store, whichever is live, so the per-node write path stays a
+    /// direct concrete call rather than an interface dispatch on the default (object-backed) path.
+    /// </summary>
+    internal readonly struct StorageNodeDestination
+    {
+        private readonly AddressStorageNodeDictionary.AddressNodes? _nodes;
+        private readonly FlatAddressStorageNodeDictionary.FlatAddressNodes? _flat;
+
+        internal StorageNodeDestination(AddressStorageNodeDictionary.AddressNodes nodes)
+        {
+            _nodes = nodes;
+            _flat = null;
+        }
+
+        internal StorageNodeDestination(FlatAddressStorageNodeDictionary.FlatAddressNodes flat)
+        {
+            _flat = flat;
+            _nodes = null;
+        }
+
+        internal void Set(in TreePath path, TrieNode node)
+        {
+            if (_flat is not null) _flat.Set(path, node);
+            else _nodes!.Set(path, node);
+        }
+
+        internal void EnsureAdditionalCapacity(int additionalCapacity)
+        {
+            if (_flat is not null) _flat.EnsureAdditionalCapacity(additionalCapacity);
+            else _nodes!.EnsureAdditionalCapacity(additionalCapacity);
+        }
+    }
+
+    internal StorageNodeDestination GetStorageNodeDestination(Hash256 address) =>
+        _flatNodeStorage
+            ? new StorageNodeDestination(_changedFlatStorageNodes!.GetOrAddAddress(address))
+            : new StorageNodeDestination(_changedStorageNodes.GetOrAddAddress(address));
 
     // This is called only during trie commit
     public void SetStorageNode(Hash256 addr, in TreePath path, TrieNode newNode)
@@ -441,7 +489,7 @@ public sealed class SnapshotBundle : IDisposable
     }
 
     internal void SetStorageNode(
-        AddressStorageNodeDictionary.AddressNodes nodes,
+        in StorageNodeDestination nodes,
         Hash256 addr,
         in TreePath path,
         TrieNode newNode)
@@ -456,7 +504,7 @@ public sealed class SnapshotBundle : IDisposable
     }
 
     internal void PublishStorageNodes(
-        AddressStorageNodeDictionary.AddressNodes nodes,
+        in StorageNodeDestination nodes,
         Hash256 address,
         IEnumerable<List<(TreePath Path, TrieNode Node)>> buffers)
     {
@@ -511,7 +559,8 @@ public sealed class SnapshotBundle : IDisposable
 
         if (!isNewAccount)
         {
-            _changedStorageNodes.RemoveAddress(addressHash);
+            if (_flatNodeStorage) _changedFlatStorageNodes!.RemoveAddress(addressHash);
+            else _changedStorageNodes.RemoveAddress(addressHash);
 
             using ArrayPoolListRef<HashedKey<(Address, UInt256)>> slotKeysToRemove = new(16);
             foreach (KeyValuePair<HashedKey<(Address, UInt256)>, SlotValue?> kvp in _changedSlots)
@@ -655,6 +704,7 @@ public sealed class SnapshotBundle : IDisposable
         _changedSlots = null!;
         _changedAccounts = null!;
         _changedStorageNodes = null!;
+        _changedFlatStorageNodes = null;
         _selfDestructedAccountAddresses = null!;
 
         _resourcePool.ReturnSnapshotContent(_usage, _currentPooledContent);

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotCompactor.cs
@@ -160,7 +160,7 @@ public class SnapshotCompactor(
             compactTask.Add(Task.Run(() => MergeInto(
                 content.SortedStateNodes, snapshots, default(StateNodeKeyComparer), static m => m.SortedStateNodes, static c => c.StateNodes, null)));
             compactTask.Add(Task.Run(() => MergeInto(
-                content.SortedStorageNodes, snapshots, default(StorageNodeKeyComparer), static m => m.SortedStorageNodes, static c => c.StorageNodes, nodeKeep)));
+                content.SortedStorageNodes, snapshots, default(StorageNodeKeyComparer), static m => m.SortedStorageNodes, static c => c.StorageNodesForMerge, nodeKeep)));
 
             content.SortedSelfDestructs.BuildFromUnsorted(selfDestructMerged, default(AddressKeyComparer));
 

--- a/src/Nethermind/Nethermind.State.Flat/TransientResource.cs
+++ b/src/Nethermind/Nethermind.State.Flat/TransientResource.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Utils;
 using Nethermind.Int256;
 using Nethermind.State.Flat.Persistence.BloomFilter;
 using Nethermind.Trie;
@@ -24,8 +25,31 @@ public record TransientResource(TransientResource.Size size) : IDisposable, IRes
 {
     public record Size(long PrewarmedAddressSize, int NodesCacheSize);
 
+    // Invariant: the pool return runs exactly once, at refcount zero, so an in-flight trie-warmer
+    // lookup can never overlap Reset/re-rent of this resource.
+    private long _leases = RefCountingLease.Single;
+    private IResourcePool? _returnPool;
+    private ResourcePool.Usage _returnUsage;
+
     public BloomFilter PrewarmedAddresses = new(size.PrewarmedAddressSize, 14); // 14 is exactly 8 probes, which the SIMD instruction does.
     public TrieNodeCache.ChildCache Nodes = new(size.NodesCacheSize);
+
+    internal void OnRented(IResourcePool pool, ResourcePool.Usage usage)
+    {
+        _returnPool = pool;
+        _returnUsage = usage;
+        Volatile.Write(ref _leases, RefCountingLease.Single);
+    }
+
+    internal bool TryAcquireLease() => RefCountingLease.TryAcquire(ref _leases);
+
+    internal void ReleaseLease()
+    {
+        if (RefCountingLease.ReleaseOnce(ref _leases))
+        {
+            _returnPool?.ReturnCachedResource(_returnUsage, this);
+        }
+    }
 
     public Size GetSize() => new(PrewarmedAddresses.Capacity, Nodes.Capacity);
 


### PR DESCRIPTION
Stacked on #12402 — diff shows only the flat-storage commits.

## Changes

> **EXPERIMENTAL — default off.** Enable with `FlatDb.FlatNodeStorage`. Only the storage-node tier is flat; state nodes stay object-backed. A span-based trie walker and the transient-decode floor are scoped follow-ups.

Stores snapshot storage-trie-node bytes (keccak + RLP) in a shared pinned-slab arena referenced by packed blittable handles, instead of `TrieNode` object graphs, on master's address-owned storage-node model (#12421). The node data stops existing for the GC: the handle maps carry no object references, so inserts fire no write barriers, dirty no cards, and contribute nothing to ephemeral promotion; reads decode transient nodes (the exact posture of a DB load) that die young. Storage roots are bit-identical to the object path. The read p99 cost is the transient decode floor; the span-walker follow-up targets it.

Mechanisms:

- **`FlatAddressStorageNodeDictionary`** — the storage-node tier on master's address-owned model: a `ConcurrentDictionary<address, AddressNodes>` where each address owns a `Dictionary<TreePath, handle>`. Address ownership keeps writes single-writer per address (no stripe locks); the node bytes live in one arena shared across all addresses, so there is exactly one arena per dictionary rather than one per map.
- **`SlabArena`** — append-only arena of pinned-object-heap slabs shared by every address in the dictionary. Writes go through `AppendShared`, a lock-free bump append over 16 sharded cursors (address → shard), so concurrent per-address commits never contend on a single tail. Records are immutable once written; overwritten/tombstoned bytes leak until the whole arena is released wholesale at the content's quiescent point (the same refcount contract that drains the maps' retire lists). Lease-free reads follow a generation protocol: sample the generation, copy the record, re-check — any mismatch reports a tier miss (correct by the read path's stale-but-was-true fall-through).
- **`SlabHandle`** — packed 64-bit handle (offset / length / flags): a single word, so the map publishes and overwrites a value with one atomic store and keeps the parent map's publish-by-control-word contract with no seqlock. All-zero `None` never denotes a record (slab 0 is padded).
- **Compacted tier stays object-backed** — the compacted (`SortedSnapshotContent`) tier keeps master's decoded `TrieNode`s; compaction reads the flat tier decode-on-read, so the per-address merge assumption is unchanged and only the live (changed) tier is slab-backed.
- **Persist** — lease-covered raw-span visitor: no transient node materialization on the persist path, and an unreadable handle throws instead of silently skipping a record (fail-loud on the leased persist/merge paths).
- **Flat-mode read ordering** — the transient resource holds object nodes for the current block (every `Set` dual-writes it), so it is probed before the changed map: a transient hit is free while a changed-map hit costs a slab decode. Object mode keeps the original order.
- **`FlatDb.FlatNodeStorageDebugChecks`** — soak-only checks: poison-on-release, keccak-verify-on-decode.

Scoped follow-ups (not in this PR): flat state-node tier, span-based trie walker over slab records (removes the transient-decode floor behind the p99 gap), decode-floor profiling.

## Measured improvements

Re-measured on the current shared-arena base, baseline (`--FlatDb.FlatNodeStorage false`) vs slab on. Peak RSS is cgroup `anon` (page-cache-free). x1 = flat-imported mainnet (25570000); x10 = bloatnet (`neth-x10-24759769`, 2.2 TB). One run per arm, overlay-isolated, 192 GiB heap cap.

| Scale | Metric | Slabs off | Slabs on | Δ |
|---|---|---|---|---|
| x1 (mainnet) | peak RSS (anon) | 36.1 GiB | 30.9 GiB | −14% |
| x1 | newPayload p50 / p95 / p99 | 19.6 / 48.6 / 115.5 ms | 19.1 / 38.0 / 53.7 ms | tail −53% |
| x1 | getProof read p50 / p95 / p99 | 4.4 / 7.3 / 8.9 ms | 4.4 / 7.3 / 8.8 ms | flat |
| x10 (bloatnet) | peak RSS (anon) | 60.2 GiB | 62.6 GiB | +4% |
| x10 | newPayload mean / max | 191 / 364 ms | 160 / 252 ms | −16% / −31% |
| x10 | getProof read p50 / p95 / p99 | 5.5 / 12.4 / 20.5 ms | 5.8 / 12.7 / 20.8 ms | flat |

`--FlatDb.FlatNodeStorage` (experimental, default off), measured on top of the #12402 stack (pacer off). On the current base the slab is a memory win at mainnet (−14% peak RSS) and cuts the GC-driven newPayload tail, at a flat read-path cost; on the dense x10 state peak RSS is ~neutral (+4%) while the newPayload tail still improves. The in-memory binary-arena variant (variant 2, #12505) was benchmarked on top of this and only added RAM (+33% at mainnet), so it was dropped in favour of the slab.

> The earlier x5 figures (−33% RSS, +80% throughput) were an earlier per-map slab implementation and are superseded by the current-base measurement above.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: Description

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New `SlabArenaTests` and `FlatAddressStorageNodeDictionaryTests` (append/read round-trips, handle packing, generation-protocol race → miss, concurrent per-address writer/reader stress, fail-loud on an unreadable handle); the full `Nethermind.State.Flat.Test` suite runs with the flat tier wired through the pooled contents. x5 benchmark: 583k requests, 0 failures, per-block state roots validated.

## Documentation

#### Requires documentation update

- [x] No



## Confound-free x10 re-measurement (3× median, rebased onto master)

Rebased onto master - this PR now stands alone (the #12402 pacer stack it was measured on is closed and dropped). Within-image `--FlatDb.FlatNodeStorage` off vs on (same binary), immune to build/base-commit confounds. x10 bloatnet (`neth-x10-24759769`), 450 heavy blocks via `newPayloadV4` under a 30-thread read load, 18 GiB heap, peak RSS = cgroup anon.

| metric | flag off | on (slab) |
|---|---|---|
| getProof p99 | 19.7 ms | 20.2 ms |
| getProof p99.9 | 35.5 ms | 35.0 ms |
| peak RSS | 62.5 GiB | 62.5 GiB |
| longest persist stall | 38 s | 38 s |

Standalone on master the slab is x10-neutral: peak RSS flat (62.5 = 62.5, inside the ~2-4 GiB per-round noise), read latency flat, and it doesn't touch the persist stall (that's #12401's job). The earlier -2% x10 RSS wasn't robust once #12402's pool retune was dropped. The memory win is at mainnet (-14% RSS, single run). newPayload p99 at x10 is too noisy at n=3 to report as a delta. No regression.
