### PR TITLE
perf: uncontend hot-path metric counters

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -91,14 +91,10 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     private readonly List<IDisposable> _metricsUpdaters = [];
 
-    // Bumped on every Get/Set by the block-processing thread, prewarm/warm-read workers, and sync
-    // concurrently (all columns share this instance) - main/other split on padded slots keeps the
-    // block thread's line private and the counters from false-sharing with each other.
+    // Padded: bumped on every Get/Set from all threads across all column families.
     internal CacheLinePaddedLong _allocatedSpan;
-    private CacheLinePaddedLong _mainTotalReads;
-    private CacheLinePaddedLong _otherTotalReads;
-    private CacheLinePaddedLong _mainTotalWrites;
-    private CacheLinePaddedLong _otherTotalWrites;
+    private CacheLinePaddedLong _totalReads;
+    private CacheLinePaddedLong _totalWrites;
 
     private readonly IteratorManager _iteratorManager;
     private ulong _writeBufferSize;
@@ -345,11 +341,9 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         _fileSystem.File.Delete(corruptMarker);
     }
 
-    protected internal void UpdateReadMetrics() =>
-        Interlocked.Increment(ref ProcessingThread.IsBlockProcessingThread ? ref _mainTotalReads.Value : ref _otherTotalReads.Value);
+    protected internal void UpdateReadMetrics() => Interlocked.Increment(ref _totalReads.Value);
 
-    protected internal void UpdateWriteMetrics() =>
-        Interlocked.Increment(ref ProcessingThread.IsBlockProcessingThread ? ref _mainTotalWrites.Value : ref _otherTotalWrites.Value);
+    protected internal void UpdateWriteMetrics() => Interlocked.Increment(ref _totalWrites.Value);
 
     protected virtual long FetchTotalPropertyValue(string propertyName) =>
         long.TryParse(_db.GetProperty(propertyName), out long parsedValue)
@@ -366,8 +360,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                 CacheSize = 0,
                 IndexSize = 0,
                 MemtableSize = 0,
-                TotalReads = _mainTotalReads.Value + _otherTotalReads.Value,
-                TotalWrites = _mainTotalWrites.Value + _otherTotalWrites.Value,
+                TotalReads = _totalReads.Value,
+                TotalWrites = _totalWrites.Value,
             };
         }
         return new IDbMeta.DbMetric()
@@ -376,8 +370,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             CacheSize = GetCacheSize(),
             IndexSize = GetIndexSize(),
             MemtableSize = GetMemtableSize(),
-            TotalReads = _mainTotalReads.Value + _otherTotalReads.Value,
-            TotalWrites = _mainTotalWrites.Value + _otherTotalWrites.Value,
+            TotalReads = _totalReads.Value,
+            TotalWrites = _totalWrites.Value,
         };
     }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -24,6 +24,7 @@ using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Threading;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Db.Rocks.Statistics;
 using Nethermind.Logging;
@@ -90,9 +91,14 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     private readonly List<IDisposable> _metricsUpdaters = [];
 
-    internal long _allocatedSpan = 0;
-    private long _totalReads;
-    private long _totalWrites;
+    // Bumped on every Get/Set by the block-processing thread, prewarm/warm-read workers, and sync
+    // concurrently (all columns share this instance) - main/other split on padded slots keeps the
+    // block thread's line private and the counters from false-sharing with each other.
+    internal CacheLinePaddedLong _allocatedSpan;
+    private CacheLinePaddedLong _mainTotalReads;
+    private CacheLinePaddedLong _otherTotalReads;
+    private CacheLinePaddedLong _mainTotalWrites;
+    private CacheLinePaddedLong _otherTotalWrites;
 
     private readonly IteratorManager _iteratorManager;
     private ulong _writeBufferSize;
@@ -339,9 +345,11 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         _fileSystem.File.Delete(corruptMarker);
     }
 
-    protected internal void UpdateReadMetrics() => Interlocked.Increment(ref _totalReads);
+    protected internal void UpdateReadMetrics() =>
+        Interlocked.Increment(ref ProcessingThread.IsBlockProcessingThread ? ref _mainTotalReads.Value : ref _otherTotalReads.Value);
 
-    protected internal void UpdateWriteMetrics() => Interlocked.Increment(ref _totalWrites);
+    protected internal void UpdateWriteMetrics() =>
+        Interlocked.Increment(ref ProcessingThread.IsBlockProcessingThread ? ref _mainTotalWrites.Value : ref _otherTotalWrites.Value);
 
     protected virtual long FetchTotalPropertyValue(string propertyName) =>
         long.TryParse(_db.GetProperty(propertyName), out long parsedValue)
@@ -358,8 +366,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                 CacheSize = 0,
                 IndexSize = 0,
                 MemtableSize = 0,
-                TotalReads = _totalReads,
-                TotalWrites = _totalWrites,
+                TotalReads = _mainTotalReads.Value + _otherTotalReads.Value,
+                TotalWrites = _mainTotalWrites.Value + _otherTotalWrites.Value,
             };
         }
         return new IDbMeta.DbMetric()
@@ -368,8 +376,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             CacheSize = GetCacheSize(),
             IndexSize = GetIndexSize(),
             MemtableSize = GetMemtableSize(),
-            TotalReads = _totalReads,
-            TotalWrites = _totalWrites,
+            TotalReads = _mainTotalReads.Value + _otherTotalReads.Value,
+            TotalWrites = _mainTotalWrites.Value + _otherTotalWrites.Value,
         };
     }
 
@@ -923,7 +931,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
             if (!span.IsNullOrEmpty())
             {
-                Interlocked.Increment(ref _allocatedSpan);
+                Interlocked.Increment(ref _allocatedSpan.Value);
                 GC.AddMemoryPressure(span.Length);
             }
             return span;
@@ -1023,7 +1031,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     {
         if (!span.IsNullOrEmpty())
         {
-            Interlocked.Decrement(ref _allocatedSpan);
+            Interlocked.Decrement(ref _allocatedSpan.Value);
             GC.RemoveMemoryPressure(span.Length);
         }
         _db.DangerousReleaseMemory(span);

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -91,7 +91,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     private readonly List<IDisposable> _metricsUpdaters = [];
 
-    // Padded: bumped on every Get/Set from all threads across all column families.
     internal CacheLinePaddedLong _allocatedSpan;
     private CacheLinePaddedLong _totalReads;
     private CacheLinePaddedLong _totalWrites;

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -390,10 +390,10 @@ namespace Nethermind.Db.Test
             {
                 if (_db is ColumnDb columnDb)
                 {
-                    return columnDb._mainDb._allocatedSpan;
+                    return columnDb._mainDb._allocatedSpan.Value;
                 }
 
-                return (_db as DbOnTheRocks)._allocatedSpan;
+                return (_db as DbOnTheRocks)._allocatedSpan.Value;
             }
         }
 

--- a/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
@@ -149,7 +149,7 @@ public sealed class ReadOnlySnapshotBundle(
         {
             if (snapshots[i].TryGetStateNode(key, out node))
             {
-                Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+                Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
                 if (recordDetailedMetrics) Metrics.ReadOnlySnapshotBundleTimes.Observe(Stopwatch.GetTimestamp() - sw, _readStateNodeSnapshotLabel);
                 return true;
             }
@@ -173,7 +173,7 @@ public sealed class ReadOnlySnapshotBundle(
         {
             if (snapshots[i].TryGetStorageNode(key, out node))
             {
-                Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+                Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
                 if (recordDetailedMetrics) Metrics.ReadOnlySnapshotBundleTimes.Observe(Stopwatch.GetTimestamp() - sw, _readStorageNodeSnapshotLabel);
                 return true;
             }
@@ -190,7 +190,7 @@ public sealed class ReadOnlySnapshotBundle(
         if (_persistedSnapshotCount > 0 && persistedSnapshots.TryLoadStateRlp(in path, out byte[]? persistedRlp))
             return persistedRlp;
 
-        Nethermind.Trie.Pruning.Metrics.LoadedFromDbNodesCount++;
+        Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromDbNodesCount();
         long sw = recordDetailedMetrics ? Stopwatch.GetTimestamp() : 0;
         byte[]? value = persistenceReader.TryLoadStateRlp(path, flags);
         if (recordDetailedMetrics) Metrics.ReadOnlySnapshotBundleTimes.Observe(Stopwatch.GetTimestamp() - sw, _readStateRlpLabel);
@@ -205,7 +205,7 @@ public sealed class ReadOnlySnapshotBundle(
         if (_persistedSnapshotCount > 0 && persistedSnapshots.TryLoadStorageRlp(address, in path, out byte[]? persistedRlp))
             return persistedRlp;
 
-        Nethermind.Trie.Pruning.Metrics.LoadedFromDbNodesCount++;
+        Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromDbNodesCount();
         long sw = recordDetailedMetrics ? Stopwatch.GetTimestamp() : 0;
         byte[]? value = persistenceReader.TryLoadStorageRlp(address, path, flags);
         if (recordDetailedMetrics) Metrics.ReadOnlySnapshotBundleTimes.Observe(Stopwatch.GetTimestamp() - sw, _readStorageRlpLabel);

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -149,11 +149,11 @@ public sealed class SnapshotBundle : IDisposable
 
         if (_trieChanged && _changedStateNodes.TryGetValue(key, out TrieNode? node))
         {
-            Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
         else if (_transientResource.TryGetStateNode(path, hash, out node))
         {
-            Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
         else if (DoFindStateNodeExternal(path, hash, out node))
         {
@@ -173,7 +173,7 @@ public sealed class SnapshotBundle : IDisposable
 
         if (_transientResource.TryGetStateNode(path, hash, out TrieNode? node))
         {
-            Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
         else
         {
@@ -190,7 +190,7 @@ public sealed class SnapshotBundle : IDisposable
     {
         if (_trieNodeCache.TryGet(null, path, hash, out node))
         {
-            Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
             return true;
         }
 
@@ -199,7 +199,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             if (_snapshots[i].TryGetStateNode(key, out node))
             {
-                Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+                Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
                 return true;
             }
         }
@@ -215,11 +215,11 @@ public sealed class SnapshotBundle : IDisposable
 
         if (_trieChanged && _changedStorageNodes.TryGetValue(key, out TrieNode? node))
         {
-            Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
         else if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out node))
         {
-            Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
         else if (DoTryFindStorageNodeExternal(address, path, hash, out node) && node is not null)
         {
@@ -239,7 +239,7 @@ public sealed class SnapshotBundle : IDisposable
 
         if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out TrieNode? node))
         {
-            Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
         else
         {
@@ -259,7 +259,7 @@ public sealed class SnapshotBundle : IDisposable
     {
         if (_trieNodeCache.TryGet(address, path, hash, out node))
         {
-            Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+            Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
             return true;
         }
 
@@ -268,7 +268,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             if (_snapshots[i].TryGetStorageNode(key, out node))
             {
-                Nethermind.Trie.Pruning.Metrics.LoadedFromCacheNodesCount++;
+                Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
                 return true;
             }
         }

--- a/src/Nethermind/Nethermind.State.Test/StateTreeTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateTreeTests.cs
@@ -20,12 +20,16 @@ public class StateTreeTests
     private readonly Account _account2 = Build.An.Account.WithBalance(2).TestObject;
     private readonly Account _account3 = Build.An.Account.WithBalance(3).TestObject;
 
+    private long _hashesBaseline;
+    private long _decodingsBaseline;
+    private long _encodingsBaseline;
+
     [SetUp]
     public void Setup()
     {
-        Trie.Metrics.TreeNodeHashCalculations = 0;
-        Trie.Metrics.TreeNodeRlpDecodings = 0;
-        Trie.Metrics.TreeNodeRlpEncodings = 0;
+        _hashesBaseline = Trie.Metrics.TreeNodeHashCalculations;
+        _decodingsBaseline = Trie.Metrics.TreeNodeRlpDecodings;
+        _encodingsBaseline = Trie.Metrics.TreeNodeRlpEncodings;
     }
 
     private static (MemDb db, StateTree tree) CreateTree()
@@ -69,9 +73,9 @@ public class StateTreeTests
 
         long actual = metric switch
         {
-            "hashes" => Trie.Metrics.TreeNodeHashCalculations,
-            "encodings" => Trie.Metrics.TreeNodeRlpEncodings,
-            "decodings" => Trie.Metrics.TreeNodeRlpDecodings,
+            "hashes" => Trie.Metrics.TreeNodeHashCalculations - _hashesBaseline,
+            "encodings" => Trie.Metrics.TreeNodeRlpEncodings - _encodingsBaseline,
+            "decodings" => Trie.Metrics.TreeNodeRlpDecodings - _decodingsBaseline,
             _ => throw new System.ArgumentOutOfRangeException(nameof(metric))
         };
 
@@ -98,8 +102,8 @@ public class StateTreeTests
 
         tree.Commit();
         Assert.That(db.WritesCount, Is.EqualTo(expectedWrites), "writes");
-        Assert.That(Trie.Metrics.TreeNodeHashCalculations, Is.EqualTo(expectedHashes), "hashes");
-        Assert.That(Trie.Metrics.TreeNodeRlpEncodings, Is.EqualTo(expectedEncodings), "encodings");
+        Assert.That(Trie.Metrics.TreeNodeHashCalculations - _hashesBaseline, Is.EqualTo(expectedHashes), "hashes");
+        Assert.That(Trie.Metrics.TreeNodeRlpEncodings - _encodingsBaseline, Is.EqualTo(expectedEncodings), "encodings");
     }
 
     private void AssertRootHashAfterUpdateAndCommit(StateTree tree, string expectedRootHash)

--- a/src/Nethermind/Nethermind.Trie/Metrics.cs
+++ b/src/Nethermind/Nethermind.Trie/Metrics.cs
@@ -2,22 +2,46 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Nethermind.Core.Attributes;
+using Nethermind.Core.Threading;
 
 namespace Nethermind.Trie
 {
+    // Per-node counters are incremented from the parallel commit/resolve paths (trie commit tasks,
+    // ParallelUnbalancedWork encode workers, prewarm scopes) as well as the block-processing thread,
+    // so they use the main/other split on cache-line-padded slots: the block thread updates a line
+    // no other thread touches, and the counters do not false-share with each other.
     public static class Metrics
     {
+        private static bool IsBlockProcessingThread => ProcessingThread.IsBlockProcessingThread;
+
         [CounterMetric]
         [Description("Number of trie node hash calculations.")]
-        public static long TreeNodeHashCalculations { get; set; }
+        public static long TreeNodeHashCalculations => _mainTreeNodeHashCalculations.Value + _otherTreeNodeHashCalculations.Value;
+        private static CacheLinePaddedLong _mainTreeNodeHashCalculations;
+        private static CacheLinePaddedLong _otherTreeNodeHashCalculations;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void IncrementTreeNodeHashCalculations() =>
+            Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainTreeNodeHashCalculations.Value : ref _otherTreeNodeHashCalculations.Value);
 
         [CounterMetric]
         [Description("Number of trie node RLP encodings.")]
-        public static long TreeNodeRlpEncodings { get; set; }
+        public static long TreeNodeRlpEncodings => _mainTreeNodeRlpEncodings.Value + _otherTreeNodeRlpEncodings.Value;
+        private static CacheLinePaddedLong _mainTreeNodeRlpEncodings;
+        private static CacheLinePaddedLong _otherTreeNodeRlpEncodings;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void IncrementTreeNodeRlpEncodings() =>
+            Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainTreeNodeRlpEncodings.Value : ref _otherTreeNodeRlpEncodings.Value);
 
         [CounterMetric]
         [Description("Number of trie node RLP decodings.")]
-        public static long TreeNodeRlpDecodings { get; set; }
+        public static long TreeNodeRlpDecodings => _mainTreeNodeRlpDecodings.Value + _otherTreeNodeRlpDecodings.Value;
+        private static CacheLinePaddedLong _mainTreeNodeRlpDecodings;
+        private static CacheLinePaddedLong _otherTreeNodeRlpDecodings;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void IncrementTreeNodeRlpDecodings() =>
+            Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainTreeNodeRlpDecodings.Value : ref _otherTreeNodeRlpDecodings.Value);
     }
 }

--- a/src/Nethermind/Nethermind.Trie/Metrics.cs
+++ b/src/Nethermind/Nethermind.Trie/Metrics.cs
@@ -9,10 +9,6 @@ using Nethermind.Core.Threading;
 
 namespace Nethermind.Trie
 {
-    // Per-node counters are incremented from the parallel commit/resolve paths (trie commit tasks,
-    // ParallelUnbalancedWork encode workers, prewarm scopes) as well as the block-processing thread,
-    // so they use the main/other split on cache-line-padded slots: the block thread updates a line
-    // no other thread touches, and the counters do not false-share with each other.
     public static class Metrics
     {
         private static bool IsBlockProcessingThread => ProcessingThread.IsBlockProcessingThread;

--- a/src/Nethermind/Nethermind.Trie/Pruning/Metrics.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/Metrics.cs
@@ -45,11 +45,10 @@ namespace Nethermind.Trie.Pruning
         [Description("Nodes that have been removed from the cache during pruning because they were no longer needed.")]
         public static long PrunedTransientNodesCount { get; set; }
 
-        // Incremented once per resolved node on the flat/pruning read paths, concurrently from the
-        // block-processing thread, prewarm workers, the trie warmer, and parallel commit tasks - the
-        // main/other split on padded slots keeps the block thread's line private and the counters
-        // from false-sharing with their neighbours.
-
+        // The two Loaded* counters below are incremented once per resolved node on the flat/pruning
+        // read paths, concurrently from the block-processing thread, prewarm workers, the trie
+        // warmer, and parallel commit tasks - the main/other split on padded slots keeps the block
+        // thread's line private and the counters from false-sharing with their neighbours.
         [CounterMetric]
         [Description("Number of DB reads.")]
         public static long LoadedFromDbNodesCount => _mainLoadedFromDbNodesCount.Value + _otherLoadedFromDbNodesCount.Value;

--- a/src/Nethermind/Nethermind.Trie/Pruning/Metrics.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/Metrics.cs
@@ -45,10 +45,6 @@ namespace Nethermind.Trie.Pruning
         [Description("Nodes that have been removed from the cache during pruning because they were no longer needed.")]
         public static long PrunedTransientNodesCount { get; set; }
 
-        // The two Loaded* counters below are incremented once per resolved node on the flat/pruning
-        // read paths, concurrently from the block-processing thread, prewarm workers, the trie
-        // warmer, and parallel commit tasks - the main/other split on padded slots keeps the block
-        // thread's line private and the counters from false-sharing with their neighbours.
         [CounterMetric]
         [Description("Number of DB reads.")]
         public static long LoadedFromDbNodesCount => _mainLoadedFromDbNodesCount.Value + _otherLoadedFromDbNodesCount.Value;

--- a/src/Nethermind/Nethermind.Trie/Pruning/Metrics.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/Metrics.cs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Nethermind.Core.Attributes;
+using Nethermind.Core.Threading;
 
 namespace Nethermind.Trie.Pruning
 {
     public static class Metrics
     {
+        private static bool IsBlockProcessingThread => ProcessingThread.IsBlockProcessingThread;
+
         [GaugeMetric]
         [Description("Nodes that are currently kept in cache (either persisted or not)")]
         public static long DirtyNodesCount { get; set; }
@@ -40,13 +45,28 @@ namespace Nethermind.Trie.Pruning
         [Description("Nodes that have been removed from the cache during pruning because they were no longer needed.")]
         public static long PrunedTransientNodesCount { get; set; }
 
+        // Incremented once per resolved node on the flat/pruning read paths, concurrently from the
+        // block-processing thread, prewarm workers, the trie warmer, and parallel commit tasks - the
+        // main/other split on padded slots keeps the block thread's line private and the counters
+        // from false-sharing with their neighbours.
+
         [CounterMetric]
         [Description("Number of DB reads.")]
-        public static long LoadedFromDbNodesCount { get; set; }
+        public static long LoadedFromDbNodesCount => _mainLoadedFromDbNodesCount.Value + _otherLoadedFromDbNodesCount.Value;
+        private static CacheLinePaddedLong _mainLoadedFromDbNodesCount;
+        private static CacheLinePaddedLong _otherLoadedFromDbNodesCount;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void IncrementLoadedFromDbNodesCount() =>
+            Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainLoadedFromDbNodesCount.Value : ref _otherLoadedFromDbNodesCount.Value);
 
         [CounterMetric]
         [Description("Number of reads from the node cache.")]
-        public static long LoadedFromCacheNodesCount { get; set; }
+        public static long LoadedFromCacheNodesCount => _mainLoadedFromCacheNodesCount.Value + _otherLoadedFromCacheNodesCount.Value;
+        private static CacheLinePaddedLong _mainLoadedFromCacheNodesCount;
+        private static CacheLinePaddedLong _otherLoadedFromCacheNodesCount;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void IncrementLoadedFromCacheNodesCount() =>
+            Interlocked.Increment(ref IsBlockProcessingThread ? ref _mainLoadedFromCacheNodesCount.Value : ref _otherLoadedFromCacheNodesCount.Value);
 
         [CounterMetric]
         [Description("Number of reads from the RLP cache.")]

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -500,7 +500,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         if (rlp is not null)
         {
-            Metrics.LoadedFromDbNodesCount++;
+            Metrics.IncrementLoadedFromDbNodesCount();
         }
 
         return rlp;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -81,7 +81,7 @@ internal class TrieStoreDirtyNodesCache
         NodeRecord nodeRecord = GetOrAdd(in key, this);
         if (nodeRecord.Node.NodeType != NodeType.Unknown)
         {
-            Metrics.LoadedFromCacheNodesCount++;
+            Metrics.IncrementLoadedFromCacheNodesCount();
         }
         else
         {
@@ -101,7 +101,7 @@ internal class TrieStoreDirtyNodesCache
         {
             trieNode = _trieStore.CloneForReadOnly(key, trieNode);
 
-            Metrics.LoadedFromCacheNodesCount++;
+            Metrics.IncrementLoadedFromCacheNodesCount();
         }
         else
         {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -30,7 +30,7 @@ namespace Nethermind.Trie
             [SkipLocalsInit]
             public static CappedArray<byte> EncodeExtension(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
-                Metrics.TreeNodeRlpEncodings++;
+                Metrics.IncrementTreeNodeRlpEncodings();
 
                 Debug.Assert(item.NodeType == NodeType.Extension,
                     $"Node passed to {nameof(EncodeExtension)} is {item.NodeType}");
@@ -98,7 +98,7 @@ namespace Nethermind.Trie
             [SkipLocalsInit]
             public static CappedArray<byte> EncodeLeaf(TrieNode node, ICappedArrayPool? pool)
             {
-                Metrics.TreeNodeRlpEncodings++;
+                Metrics.IncrementTreeNodeRlpEncodings();
 
                 if (node.Key is null)
                 {
@@ -139,7 +139,7 @@ namespace Nethermind.Trie
 
             public static CappedArray<byte> RlpEncodeBranch(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? pool, bool canBeParallel)
             {
-                Metrics.TreeNodeRlpEncodings++;
+                Metrics.IncrementTreeNodeRlpEncodings();
 
                 const int valueRlpLength = 1;
                 int contentLength = valueRlpLength + (UseParallel(canBeParallel, item) ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel) : GetChildrenRlpLengthForBranch(tree, ref path, item, pool, canBeParallel));

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -483,7 +483,7 @@ namespace Nethermind.Trie
 
         private bool DecodeRlp(RlpReader rlpReader, ICappedArrayPool bufferPool, out int itemsCount)
         {
-            Metrics.TreeNodeRlpDecodings++;
+            Metrics.IncrementTreeNodeRlpDecodings();
 
             rlpReader.ReadSequenceLength();
 
@@ -558,7 +558,7 @@ namespace Nethermind.Trie
              * */
             if (rlp.Length >= 32 || isRoot)
             {
-                Metrics.TreeNodeHashCalculations++;
+                Metrics.IncrementTreeNodeHashCalculations();
                 return Nethermind.Core.Crypto.Keccak.Compute(rlp.AsSpan());
             }
 


### PR DESCRIPTION
## Changes

- `Nethermind.Trie.Metrics` (`TreeNodeHashCalculations`/`TreeNodeRlpEncodings`/`TreeNodeRlpDecodings`) and `Nethermind.Trie.Pruning.Metrics` (`LoadedFromCacheNodesCount`/`LoadedFromDbNodesCount`) were plain `++` on adjacent static auto-properties, but they are incremented concurrently: from the block-processing thread, prewarm workers, the trie warmer, and parallel commit tasks (`ResolveKey` runs inside `ParallelUnbalancedWork` bodies, and the `SnapshotBundle` resolvers bump `LoadedFromCacheNodesCount` on every node-cache hit). The increments were silently lossy (non-atomic RMW) and produced a per-node dirty-cache-line ping between all of those threads on the flat read path's hottest statement.
- Applied the main/other split on `CacheLinePaddedLong` already established for `Nethermind.Evm.Metrics` (#11005, #12071): the block-processing thread increments a padded slot no other thread touches, other threads share a second padded slot, each counter lives on its own cache line, and increments are atomic. The exported value is the sum, so scraping is unchanged.
- `DbOnTheRocks._totalReads`/`_totalWrites`/`_allocatedSpan` were three adjacent instance longs updated with `Interlocked` on every Get/Set from all threads across all column families (all columns share one instance) — same treatment: reads/writes split main/other, `_allocatedSpan` padded.
- `StateTreeTests` reset the counters to zero and asserted absolute values; the counters are now get-only computed sums, so the tests assert deltas against a baseline captured in `Setup`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

Local (release, arm64): Nethermind.Trie.Test 477 total / 0 failed, Nethermind.State.Test 1157 / 0, Nethermind.Db.Test 1089 / 0.