### PR TITLE
test: deterministic prewarmer env-pool eviction test

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -80,22 +80,28 @@ public class BlockCachePreWarmerTests
     }
 
     /// <summary>
-    /// Verifies that envs evicted from the pool during real block processing are disposed
-    /// immediately. With pool capacity 1 and two parallel sender groups, the second worker
-    /// to return its env triggers eviction — that env must be disposed on the spot.
+    /// Verifies that an env returned to a full pool is disposed immediately.
     /// </summary>
     [Test]
-    public async Task PreWarmCaches_WhenPoolEvicts_EvictedEnvsAreDisposed()
+    public void EnvPool_ReturnedBeyondCapacity_IsDisposedImmediately()
     {
         (BlockCachePreWarmer preWarmer, ConcurrentBag<IReadOnlyTxProcessorSource> created,
             ConcurrentBag<IReadOnlyTxProcessorSource> disposed) = CreatePreWarmer(maxPoolSize: 1);
 
-        await RunPreWarmCaches(preWarmer, BuildTwoSenderBlock(), BuildParentHeader(), Osaka.Instance);
+        IReadOnlyTxProcessorSource first = preWarmer._envPool.Get();
+        IReadOnlyTxProcessorSource second = preWarmer._envPool.Get();
+        Assert.That(created.Count, Is.EqualTo(2), "precondition: an empty pool must create one env per overlapping rental");
 
-        // With pool capacity 1 and two parallel workers, at least one eviction must occur.
-        Assert.That(created.Count, Is.GreaterThanOrEqualTo(2), "two distinct senders must have exercised two concurrent workers");
-        int evictedCount = created.Count - 1; // at most 1 retained in pool
-        Assert.That(disposed.Count, Is.GreaterThanOrEqualTo(evictedCount), "all envs evicted from the pool must have Dispose() called immediately");
+        preWarmer._envPool.Return(first);
+        preWarmer._envPool.Return(second);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(disposed.Count, Is.EqualTo(1), "the env returned beyond pool capacity must be disposed on the spot");
+            Assert.That(disposed, Does.Contain(second), "the first return fills the capacity-1 pool, so the second is the evicted one");
+        }
+
+        preWarmer.Dispose();
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -85,15 +85,21 @@ public class BlockCachePreWarmerTests
     [Test]
     public void EnvPool_ReturnedBeyondCapacity_IsDisposedImmediately()
     {
-        (BlockCachePreWarmer preWarmer, ConcurrentBag<IReadOnlyTxProcessorSource> created,
-            ConcurrentBag<IReadOnlyTxProcessorSource> disposed) = CreatePreWarmer(maxPoolSize: 1);
+        PrewarmerEnvFactory envFactory = _processingScope.Resolve<PrewarmerEnvFactory>();
+        PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
 
-        IReadOnlyTxProcessorSource first = preWarmer._envPool.Get();
-        IReadOnlyTxProcessorSource second = preWarmer._envPool.Get();
+        ConcurrentBag<IReadOnlyTxProcessorSource> created = [];
+        ConcurrentBag<IReadOnlyTxProcessorSource> disposed = [];
+        DisposalTrackingPolicy trackingPolicy = new(envFactory, preBlockCaches, created, disposed);
+
+        ObjectPool<IReadOnlyTxProcessorSource> envPool = new DefaultObjectPoolProvider { MaximumRetained = 1 }.Create(trackingPolicy);
+
+        IReadOnlyTxProcessorSource first = envPool.Get();
+        IReadOnlyTxProcessorSource second = envPool.Get();
         Assert.That(created.Count, Is.EqualTo(2), "precondition: an empty pool must create one env per overlapping rental");
 
-        preWarmer._envPool.Return(first);
-        preWarmer._envPool.Return(second);
+        envPool.Return(first);
+        envPool.Return(second);
 
         using (Assert.EnterMultipleScope())
         {
@@ -101,7 +107,7 @@ public class BlockCachePreWarmerTests
             Assert.That(disposed, Does.Contain(second), "the first return fills the capacity-1 pool, so the second is the evicted one");
         }
 
-        preWarmer.Dispose();
+        (envPool as IDisposable)?.Dispose();
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -34,7 +34,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
     // Speculative warming runs in the idle gap alongside RPC, so it is capped below the reactive level to leave cores free.
     private readonly int _speculativeConcurrencyLevel;
     private readonly bool _parallelExecutionBatchRead;
-    private readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool;
+    internal readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool;
     private readonly ILogger _logger;
     private readonly PreBlockCaches _preBlockCaches;
     private readonly NodeStorageCache _nodeStorageCache;

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -34,7 +34,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
     // Speculative warming runs in the idle gap alongside RPC, so it is capped below the reactive level to leave cores free.
     private readonly int _speculativeConcurrencyLevel;
     private readonly bool _parallelExecutionBatchRead;
-    internal readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool;
+    private readonly ObjectPool<IReadOnlyTxProcessorSource> _envPool;
     private readonly ILogger _logger;
     private readonly PreBlockCaches _preBlockCaches;
     private readonly NodeStorageCache _nodeStorageCache;


### PR DESCRIPTION
## Changes

- `PreWarmCaches_WhenPoolEvicts_EvictedEnvsAreDisposed` asserted `created.Count >= 2`, which requires the two sender-group warmup iterations to run on two workers *concurrently*. That is scheduler-dependent: on a constrained runner one worker can warm both groups before the second pool thread wakes, so only one env is created and the test fails (seen on CI: `Expected: greater than or equal to 2 / But was: 1`).
- The eviction-disposal contract ("an env returned to a full pool is disposed immediately") is now exercised deterministically by `EnvPool_ReturnedBeyondCapacity_IsDisposedImmediately`: it builds a capacity-1 `DisposableObjectPool` from the same framework provider and env policy, then does two overlapping rentals and two returns single-threaded — no scheduling dependence.
- **Production code is unchanged** (`BlockCachePreWarmer` is byte-identical to master; no internals exposed for tests). That the real prewarmer wires up a disposing pool is already covered through the public `Dispose()` API by `Dispose_WhenCalled_DisposesRetainedEnvsInPool`, so there is no coverage gap.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: test de-flaking
