### PR TITLE
test: key AddBlock head waits to the produced block

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchainUtil.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchainUtil.cs
@@ -12,7 +12,6 @@ using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Events;
-using Nethermind.Core.Test.Builders;
 using Nethermind.TxPool;
 using NUnit.Framework;
 

--- a/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchainUtil.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Blockchain/TestBlockchainUtil.cs
@@ -36,17 +36,6 @@ public class TestBlockchainUtil(
         AddBlock(blockTree.GetProducedBlockParent(null)!, flags, cancellationToken, transactions);
     public async Task<Block> AddBlock(BlockHeader parentToBuildOn, AddBlockFlags flags, CancellationToken cancellationToken, params Transaction[] transactions)
     {
-        Task waitforHead = flags.HasFlag(AddBlockFlags.DoNotWaitForHead)
-            ? Task.CompletedTask
-            : WaitAsync(blockTree.WaitForNewBlock(cancellationToken), "timeout waiting for new head");
-
-        Task txNewHead = flags.HasFlag(AddBlockFlags.DoNotWaitForHead)
-            ? Task.CompletedTask
-            : Wait.ForEventCondition<Block>(cancellationToken,
-                (h) => txPool.TxPoolHeadChanged += h,
-                (h) => txPool.TxPoolHeadChanged -= h,
-                b => true);
-
         Block? invalidBlock = null;
         void OnInvalidBlock(object? sender, IBlockchainProcessor.InvalidBlockEventArgs e) => invalidBlock = e.InvalidBlock;
 
@@ -101,6 +90,22 @@ public class TestBlockchainUtil(
             }
             iteration++;
         }
+        bool shouldWaitForHead = !flags.HasFlag(AddBlockFlags.DoNotWaitForHead);
+        // Keyed to the produced block and armed before Suggest: a stale event from an earlier block must not satisfy these waits.
+        Task waitforHead = shouldWaitForHead
+            ? WaitAsync(Wait.ForEventCondition<BlockReplacementEventArgs>(cancellationToken,
+                (h) => blockTree.BlockAddedToMain += h,
+                (h) => blockTree.BlockAddedToMain -= h,
+                e => e.Block.Hash == block!.Hash), "timeout waiting for new head")
+            : Task.CompletedTask;
+
+        Task txNewHead = shouldWaitForHead
+            ? Wait.ForEventCondition<Block>(cancellationToken,
+                (h) => txPool.TxPoolHeadChanged += h,
+                (h) => txPool.TxPoolHeadChanged -= h,
+                b => b.Hash == block!.Hash)
+            : Task.CompletedTask;
+
         Hash256? headBeforeSuggest = blockTree.Head?.Hash;
         Assert.That(blockTree.SuggestBlock(block!), Is.EqualTo(AddBlockResult.Added));
 


### PR DESCRIPTION
## Changes

- `TestBlockchainUtil.AddBlock` armed its two completion waits (`BlockAddedToMain`, `TxPoolHeadChanged`) at method entry with an any-event condition (`=> true`). A stale or duplicate event from an earlier block landing inside that window satisfied the wait, so `AddBlock` could return before its own block became head — subsequent RPC calls then observed a shorter chain than the test expected. This is the mechanism behind the `EthSimulateTestsHiveBase.TestSimulate_TimestampIsComputedCorrectly*` ParentHash mismatch seen on CI (`Expected: 0x65ab… But was: 0x2167…`), which does not reproduce locally (full suite + the fixture 20× at `DOTNET_PROCESSOR_COUNT=2`: 0 failures) because it needs an unluckily-timed event under runner load.
- The waits are now armed after the block is built and before `SuggestBlock` (its events cannot fire earlier), and keyed to the produced block's hash — a stale event can no longer complete them, and `AddBlock` returns only when *its* block became head and the tx pool observed it. `DoNotWaitForHead` paths are unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: test de-flaking

## Testing

Local (release, arm64): Nethermind.JsonRpc.Test 1920 total / 0 failed with the change.