### PR TITLE
perf(evm): drop redundant gas re-check in UpdateGas

### DIFF
--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -100,6 +100,11 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
             : 0;
     }
 
+    /// <summary>Subtracts <paramref name="cost"/> from the regular gas budget with no affordability check.</summary>
+    /// <remarks>The caller must have already proven <c>gas.Value &gt;= cost</c>; otherwise the value underflows.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ConsumeRaw(ref EthereumGasPolicy gas, ulong cost) => gas.Value -= cost;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Consume(ref EthereumGasPolicy gas, ulong cost)
     {
@@ -110,21 +115,15 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         }
         else
         {
-            gas.Value -= cost;
+            ConsumeRaw(ref gas, cost);
         }
     }
-
-    /// <summary>Subtracts <paramref name="cost"/> from the regular gas budget with no affordability check.</summary>
-    /// <remarks>The caller must have already proven <c>gas.Value &gt;= cost</c>; otherwise the value underflows.</remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ConsumeRaw(ref EthereumGasPolicy gas, ulong cost) => gas.Value -= cost;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryConsume(ref EthereumGasPolicy gas, ulong cost)
     {
-        ulong v = gas.Value;
-        if (v < cost) return false;
-        gas.Value = v - cost;
+        if (gas.Value < cost) return false;
+        ConsumeRaw(ref gas, cost);
         return true;
     }
 

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -114,6 +114,11 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         }
     }
 
+    /// <summary>Subtracts <paramref name="cost"/> from the regular gas budget with no affordability check.</summary>
+    /// <remarks>The caller must have already proven <c>gas.Value &gt;= cost</c>; otherwise the value underflows.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ConsumeRaw(ref EthereumGasPolicy gas, ulong cost) => gas.Value -= cost;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryConsume(ref EthereumGasPolicy gas, ulong cost)
     {
@@ -318,7 +323,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
             return false;
         }
 
-        Consume(ref gas, gasCost);
+        ConsumeRaw(ref gas, gasCost);
         return true;
     }
 


### PR DESCRIPTION
## Changes

- `EthereumGasPolicy.UpdateGas` guards `gas.Value >= gasCost` and returns early on shortfall, then delegated to `Consume`, which re-tested the same `gas.Value < cost` condition. On the affordable path — the common case for every memory/access/storage charge — that's a dead compare + branch per call.
- Extract the unchecked subtraction into `ConsumeRaw` (aggressive-inlined, with an XML-documented `gas.Value >= cost` precondition) and call it from `UpdateGas`.

Behavior is identical; one branch removed from the hot gas-charge path.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

No functional change — the subtraction on the affordable path is identical to the previous `Consume` behavior. Covered by the existing `Nethermind.Evm.Test` suite (4885 passing, 0 failing).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No