### PR TITLE
perf(prewarm): warm the block beneficiary

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -562,22 +562,28 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
             ObjectPool<IReadOnlyTxProcessorSource> envPool = PreWarmer._envPool;
             try
             {
-                if (SystemTxAccessLists is not null)
+                Address? beneficiary = block.Header.GasBeneficiary;
+                if (SystemTxAccessLists is not null || beneficiary is not null)
                 {
                     IReadOnlyTxProcessorSource env = envPool.Get();
                     try
                     {
                         using IReadOnlyTxProcessingScope scope = env.Build(parent);
 
-                        foreach (AccessList list in SystemTxAccessLists.AsSpan())
+                        WarmupSender(beneficiary, null, scope.WorldState);
+
+                        if (SystemTxAccessLists is not null)
                         {
-                            scope.WorldState.WarmUp(list);
+                            foreach (AccessList list in SystemTxAccessLists.AsSpan())
+                            {
+                                scope.WorldState.WarmUp(list);
+                            }
                         }
                     }
                     finally
                     {
                         envPool.Return(env);
-                        SystemTxAccessLists.Dispose();
+                        SystemTxAccessLists?.Dispose();
                     }
                 }
 


### PR DESCRIPTION
## Changes

`AddressWarmer` warms only tx senders/targets, but the beneficiary receives a fee write at the head of the serial transaction loop every block — always a cold read on the critical path. Warm it alongside the system access lists in the same pooled scope (the guard widens so the scope is also built when only the beneficiary needs warming; a read-warm of a missing account is harmless and `MissingTrieNodeException` is already swallowed).

Split out of #12410 per review.

## Testing

- `Nethermind.Consensus.Test` green (incl. prewarmer suite); full build 0 errors.

## Types of changes

- [x] Optimization