### PR TITLE
fix(flat): keep writer-held shared arenas alive until the write finishes

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/StorageLayerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/StorageLayerTests.cs
@@ -216,6 +216,77 @@ public class StorageLayerTests
         Assert.That(loc.Offset, Is.EqualTo(PageLayout.RoundUpToOsPage(baselineLoc.Offset + baselineLoc.Size)));
     }
 
+    // Regression test: all previously-live bytes dying while a writer holds a shared arena must
+    // not tear the file down mid-write (the completed reservation would point at a deleted file)
+    // nor re-add the dead arena's id to the mutable pool on the writer's Complete/Cancel (the
+    // next pool scan then threw KeyNotFoundException, wedging the persisted compactor).
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ArenaManager_ArenaFullyDeadWhileWriterActive_SurvivesUntilWriterFinishes(bool completeSecondWrite)
+    {
+        string arenaDir = Path.Combine(_testDir, "arenas");
+        using ArenaManager manager = new(arenaDir, new FlatDbConfig
+        {
+            PersistedSnapshotArenaPageCacheBytes = 0,
+            ArenaFileSizeBytes = 64 * 1024,
+        }, LimboLogs.Instance);
+        manager.Initialize([]);
+
+        byte[] baseline = [1, 2, 3];
+        SnapshotLocation baselineLoc;
+        ArenaReservation baselineReservation;
+        using (ArenaWriter bw = manager.CreateWriter(baseline.Length))
+        {
+            baseline.CopyTo(bw.GetWriter().GetSpan(baseline.Length));
+            bw.GetWriter().Advance(baseline.Length);
+            (baselineLoc, baselineReservation) = bw.Complete();
+        }
+
+        byte[] data = [4, 5, 6, 7];
+        ArenaReservation? reservation = null;
+        using (ArenaWriter w = manager.CreateWriter(data.Length))
+        {
+            // The only live reservation dies while the writer holds the arena.
+            baselineReservation.Dispose();
+
+            if (completeSecondWrite)
+            {
+                data.CopyTo(w.GetWriter().GetSpan(data.Length));
+                w.GetWriter().Advance(data.Length);
+                (SnapshotLocation loc, reservation) = w.Complete();
+                Assert.That(loc.ArenaId, Is.EqualTo(baselineLoc.ArenaId));
+                using WholeReadSession session = reservation.BeginWholeReadSession();
+                Assert.That(TestFixtureHelpers.ReadAll(session), Is.EqualTo(data));
+            }
+            // else: Dispose cancels the write; with no live bytes left the arena must be
+            // dropped rather than returned to the pool.
+        }
+
+        byte[] next = [8, 9];
+        SnapshotLocation nextLoc;
+        using (ArenaWriter nw = manager.CreateWriter(next.Length))
+        {
+            next.CopyTo(nw.GetWriter().GetSpan(next.Length));
+            nw.GetWriter().Advance(next.Length);
+            (nextLoc, _) = nw.Complete();
+        }
+
+        if (completeSecondWrite)
+        {
+            // The arena stayed live (its second reservation is still alive), so the next write
+            // packs into it at the page-aligned frontier.
+            Assert.That(nextLoc.ArenaId, Is.EqualTo(baselineLoc.ArenaId));
+            reservation!.Dispose();
+        }
+        else
+        {
+            // The fully-dead arena was dropped on cancel — its file is gone and the next write
+            // gets a fresh arena instead of the poisoned id.
+            Assert.That(nextLoc.ArenaId, Is.Not.EqualTo(baselineLoc.ArenaId));
+            Assert.That(Directory.GetFiles(arenaDir, "arena_*.bin"), Has.Length.EqualTo(1));
+        }
+    }
+
     [Test]
     public void ArenaManager_CreateWriter_NextReservationIsPageAligned()
     {

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaFile.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaFile.cs
@@ -76,6 +76,14 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     internal long DeadBytes { get; set; }
 
     /// <summary>
+    /// True while an <see cref="ArenaWriter"/> holds this shared arena. Guarded by the manager's
+    /// lock. Keeps <see cref="ArenaManager.MarkDead"/> from treating the arena as fully dead (and
+    /// deleting the file) while a write with bytes not yet published to <see cref="Frontier"/> is
+    /// in flight.
+    /// </summary>
+    internal bool WriterActive { get; set; }
+
+    /// <summary>
     /// Last value of <see cref="Frontier"/> reported to <c>Metrics.ArenaAllocatedBytes</c>.
     /// Lets <see cref="ArenaManager"/> push frontier deltas on writer.Complete without
     /// keeping a parallel dict and without re-counting bytes it already reported.

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
@@ -160,7 +160,13 @@ public sealed class ArenaManager : IArenaManager
         // file. OnWriteCompleted / OnWriteCancelledShared re-adds the id if room remains.
         // Dedicated files never enter the mutable pool. Route off file.Small (not the small
         // arg) so the remove always targets the same pool the file was scanned from.
-        if (!dedicated) PoolFor(file).Remove(file.Id);
+        // WriterActive keeps MarkDead from tearing the file down if every previously-live
+        // byte dies while this write is in flight.
+        if (!dedicated)
+        {
+            PoolFor(file).Remove(file.Id);
+            file.WriterActive = true;
+        }
         FileStream stream = file.CreateWriteStream(offset);
         return new ArenaWriter(this, file, dedicated, offset, stream);
     }
@@ -180,6 +186,7 @@ public sealed class ArenaManager : IArenaManager
     internal void OnWriteCompleted(ArenaFile file, long newFrontier, bool hasHeadroom)
     {
         using Lock.Scope scope = _lock.EnterScope();
+        file.WriterActive = false;
         file.Frontier = newFrontier;
         if (hasHeadroom) PoolFor(file).Add(file.Id);
         // Ratchet ArenaAllocatedBytes up to file.Frontier (post-write high-water): push the
@@ -195,11 +202,19 @@ public sealed class ArenaManager : IArenaManager
     /// <summary>
     /// Bookkeeping after a cancelled write on a shared (non-dedicated) arena: return the id
     /// to the mutable pool (the writer didn't advance the frontier, so by construction it
-    /// still has the same headroom it had when picked).
+    /// still has the same headroom it had when picked), unless every previously-live byte
+    /// died mid-write — then finish the removal <see cref="MarkDead(ArenaFile, long)"/>
+    /// deferred while the writer held the file.
     /// </summary>
     internal void OnWriteCancelledShared(ArenaFile file)
     {
         using Lock.Scope scope = _lock.EnterScope();
+        file.WriterActive = false;
+        if (!_disposed && file.Frontier > 0 && file.DeadBytes >= file.Frontier)
+        {
+            RemoveFullyDeadArena(file);
+            return;
+        }
         PoolFor(file).Add(file.Id);
     }
 
@@ -255,7 +270,21 @@ public sealed class ArenaManager : IArenaManager
         // Sole caller is ArenaReservation.CleanUp, so one call == one reservation released.
         if (_logger.IsDebug) _logger.Debug($"Released arena reservation on arena {file.Id} ({deadSize} bytes)");
         file.DeadBytes += deadSize;
-        if (file.DeadBytes < file.Frontier) return true;
+        // An active writer has in-flight bytes not yet published to Frontier, so "all bytes
+        // dead" cannot be concluded here — tearing the file down would delete it mid-write and
+        // re-adding its id to the pool on write completion would poison the pool scan.
+        // OnWriteCompleted publishes the new frontier (making the arena legitimately live
+        // again); OnWriteCancelledShared re-runs the fully-dead check.
+        if (file.DeadBytes < file.Frontier || file.WriterActive) return true;
+        RemoveFullyDeadArena(file);
+        return false;
+    }
+
+    // Drop a shared arena whose bytes are all dead: pool + dict removal, metric update, and the
+    // manager's lease release (the file self-deletes once the last outstanding lease is gone).
+    // Caller must hold _lock.
+    private void RemoveFullyDeadArena(ArenaFile file)
+    {
         PoolFor(file).Remove(file.Id);
         if (_arenas.TryRemove(file.Id, out _))
         {
@@ -263,7 +292,6 @@ public sealed class ArenaManager : IArenaManager
             file.ReportRemoved();
             file.Dispose();
         }
-        return false;
     }
 
     /// <inheritdoc/>

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
@@ -160,8 +160,6 @@ public sealed class ArenaManager : IArenaManager
         // file. OnWriteCompleted / OnWriteCancelledShared re-adds the id if room remains.
         // Dedicated files never enter the mutable pool. Route off file.Small (not the small
         // arg) so the remove always targets the same pool the file was scanned from.
-        // WriterActive keeps MarkDead from tearing the file down if every previously-live
-        // byte dies while this write is in flight.
         if (!dedicated)
         {
             PoolFor(file).Remove(file.Id);
@@ -202,9 +200,7 @@ public sealed class ArenaManager : IArenaManager
     /// <summary>
     /// Bookkeeping after a cancelled write on a shared (non-dedicated) arena: return the id
     /// to the mutable pool (the writer didn't advance the frontier, so by construction it
-    /// still has the same headroom it had when picked), unless every previously-live byte
-    /// died mid-write — then finish the removal <see cref="MarkDead(ArenaFile, long)"/>
-    /// deferred while the writer held the file.
+    /// still has the same headroom it had when picked).
     /// </summary>
     internal void OnWriteCancelledShared(ArenaFile file)
     {
@@ -270,19 +266,11 @@ public sealed class ArenaManager : IArenaManager
         // Sole caller is ArenaReservation.CleanUp, so one call == one reservation released.
         if (_logger.IsDebug) _logger.Debug($"Released arena reservation on arena {file.Id} ({deadSize} bytes)");
         file.DeadBytes += deadSize;
-        // An active writer has in-flight bytes not yet published to Frontier, so "all bytes
-        // dead" cannot be concluded here — tearing the file down would delete it mid-write and
-        // re-adding its id to the pool on write completion would poison the pool scan.
-        // OnWriteCompleted publishes the new frontier (making the arena legitimately live
-        // again); OnWriteCancelledShared re-runs the fully-dead check.
         if (file.DeadBytes < file.Frontier || file.WriterActive) return true;
         RemoveFullyDeadArena(file);
         return false;
     }
 
-    // Drop a shared arena whose bytes are all dead: pool + dict removal, metric update, and the
-    // manager's lease release (the file self-deletes once the last outstanding lease is gone).
-    // Caller must hold _lock.
     private void RemoveFullyDeadArena(ArenaFile file)
     {
         PoolFor(file).Remove(file.Id);


### PR DESCRIPTION
## Changes

- Fix a race in `ArenaManager` where a shared arena could be declared fully dead and torn down while an `ArenaWriter` was still writing to it. The writer's in-flight bytes are not published to `Frontier` until `Complete`, so releasing the last prior reservation mid-write deleted the arena file under the writer, and the writer's `Complete`/`Cancel` then re-added the dead arena id to the mutable pool. Every subsequent `GetOrCreateArena` pool scan threw `KeyNotFoundException` (observed during era import as repeated `Error compacting persisted snapshot batch. System.Collections.Generic.KeyNotFoundException: The given key '25' was not present in the dictionary.`), permanently wedging the persisted-snapshot compactor for the rest of the run.
- Track the writer's hold with a `WriterActive` flag on `ArenaFile` (guarded by the manager lock): `MarkDead` defers the fully-dead removal while the flag is set, `OnWriteCompleted` clears it as the new frontier is published, and `OnWriteCancelledShared` clears it and finishes the deferred removal instead of returning a fully-dead arena to the pool.
- Add regression test `ArenaManager_ArenaFullyDeadWhileWriterActive_SurvivesUntilWriterFinishes` covering both writer-exit paths (complete and cancel); both cases fail without the fix.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.State.Flat.Test` passes in full (828 passed, 4 pre-existing skips). The new regression test was verified to fail on both parameter cases with the fix reverted.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)