### PR TITLE
perf(crypto): back the sender cache with AssociativeCache instead of ClockCache

### DIFF
--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
@@ -22,11 +22,8 @@ public static class EthereumEcdsaExtensions
     /// content or signature after the hash is set.
     /// </remarks>
     private const int SenderCacheCapacity = 1 << 15;
-    // AssociativeCache over ClockCache: block recovery inserts a NEW key per transaction from every
-    // parallel worker, and ClockCache serializes every insert (plus its clock-sweep eviction) on one
-    // writer lock. The 8-way set-associative cache takes a per-set gate (4096 sets at this capacity),
-    // so uniformly-hashed tx keys make insert collisions negligible, and set-local 3-random eviction
-    // is equivalent to global sampling for uniform keys.
+    // Block recovery inserts a new key per tx from every parallel worker; the per-set gates avoid
+    // ClockCache's single writer lock, which serialized every insert plus its in-lock eviction sweep.
     private static readonly AssociativeCache<ValueHash256, Address> _senderCache = new(SenderCacheCapacity);
 
     /// <summary>Clears the process-wide sender cache. Intended for test isolation only.</summary>

--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
@@ -22,8 +22,6 @@ public static class EthereumEcdsaExtensions
     /// content or signature after the hash is set.
     /// </remarks>
     private const int SenderCacheCapacity = 1 << 15;
-    // Block recovery inserts a new key per tx from every parallel worker; the per-set gates avoid
-    // ClockCache's single writer lock, which serialized every insert plus its in-lock eviction sweep.
     private static readonly AssociativeCache<ValueHash256, Address> _senderCache = new(SenderCacheCapacity);
 
     /// <summary>Clears the process-wide sender cache. Intended for test isolation only.</summary>

--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
@@ -22,7 +22,12 @@ public static class EthereumEcdsaExtensions
     /// content or signature after the hash is set.
     /// </remarks>
     private const int SenderCacheCapacity = 1 << 15;
-    private static readonly ClockCache<ValueHash256, Address> _senderCache = new(SenderCacheCapacity);
+    // AssociativeCache over ClockCache: block recovery inserts a NEW key per transaction from every
+    // parallel worker, and ClockCache serializes every insert (plus its clock-sweep eviction) on one
+    // writer lock. The 8-way set-associative cache takes a per-set gate (4096 sets at this capacity),
+    // so uniformly-hashed tx keys make insert collisions negligible, and set-local 3-random eviction
+    // is equivalent to global sampling for uniform keys.
+    private static readonly AssociativeCache<ValueHash256, Address> _senderCache = new(SenderCacheCapacity);
 
     /// <summary>Clears the process-wide sender cache. Intended for test isolation only.</summary>
     internal static void ClearSenderCache() => _senderCache.Clear();


### PR DESCRIPTION
## Changes

Split from #12396 (measurements there).

`RecoverAddress` caches recovered senders keyed by transaction hash so a mempool-recovered transaction becomes a lookup on block arrival. The cache was a `ClockCache`, whose single writer lock serializes every insert and runs its clock-sweep eviction while holding the lock - block recovery inserts a NEW key per transaction from every parallel worker, so the profile shows 21k units of wait on `ClockCache.Set` for superblocks with the eviction sweep as serial holder-side work on top.

Replaced with the 8-way set-associative `AssociativeCache` at the same capacity (1 << 15 = 4096 sets x 8 ways exactly): per-set gates make insert collisions negligible for uniformly-hashed tx keys, reads are lock-free (seqlock), and set-local 3-random eviction is statistically equivalent to global sampling for uniform keys. After the swap the cache write disappears from the wait profile (~11 units), and both benchmark scenarios recorded their then-best wall times (realblocks AVG -4.8%, P95 -8.7% versus the prior run).

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Behavioral surface is unchanged (same keying, same legacy-transaction exclusion, same capacity); existing `EcdsaTests`/`EthereumEcdsaTests` cover recovery correctness and pass. `AssociativeCache` has its own pre-existing test suite.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
