### PR TITLE
perf(flat): sealed snapshot counts, HintGet promotion skip, prewarm-filter hash

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatWorldStateScopeProviderTests.cs
@@ -38,6 +38,7 @@ public class FlatWorldStateScopeProviderTests
         private IContainer Container => _container ??= _containerBuilder.Build();
 
         public ResourcePool ResourcePool => field ??= Container.Resolve<ResourcePool>();
+        public SnapshotBundle SnapshotBundle => Container.Resolve<SnapshotBundle>();
         public SnapshotPooledList ReadOnlySnapshots = new(0);
         public IPersistence.IPersistenceReader PersistenceReader => field ??= Container.Resolve<IPersistence.IPersistenceReader>();
         public Snapshot? LastCommittedSnapshot { get; set; }
@@ -247,6 +248,79 @@ public class FlatWorldStateScopeProviderTests
 
         IWorldStateScopeProvider.IStorageTree storageTree = scope.CreateStorageTree(testAddress);
         Assert.That(storageTree.Get(slotIndex), Is.EqualTo(writtenSlotValue));
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void GetAccount_ReportsWhetherAccountIsInCurrentSnapshot(bool isNull)
+    {
+        using TestContext ctx = new();
+        Address address = TestItem.AddressA;
+        Account? account = isNull ? null : TestItem.GenerateRandomAccount();
+
+        ctx.SnapshotBundle.SetAccount(address, account);
+
+        Account? result = ctx.SnapshotBundle.GetAccount(address, out bool isInCurrentSnapshot);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(account));
+            Assert.That(isInCurrentSnapshot, Is.True);
+        }
+    }
+
+    [Test]
+    public void GetAccount_ReportsAccountFromPersistenceIsNotInCurrentSnapshot()
+    {
+        using TestContext ctx = new();
+        Address address = TestItem.AddressA;
+        Account account = TestItem.GenerateRandomAccount();
+        ctx.PersistenceReader.GetAccount(address).Returns(account);
+
+        Account? result = ctx.SnapshotBundle.GetAccount(address, out bool isInCurrentSnapshot);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(account));
+            Assert.That(isInCurrentSnapshot, Is.False);
+        }
+    }
+
+    [Test]
+    public void Get_PromotesAccountFromPersistenceIntoCurrentSnapshot()
+    {
+        using TestContext ctx = new();
+        Address address = TestItem.AddressA;
+        Account account = TestItem.GenerateRandomAccount();
+        ctx.PersistenceReader.GetAccount(address).Returns(account);
+
+        Assert.That(ctx.Scope.Get(address), Is.EqualTo(account));
+
+        Account? promoted = ctx.SnapshotBundle.GetAccount(address, out bool isInCurrentSnapshot);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(promoted, Is.EqualTo(account));
+            Assert.That(isInCurrentSnapshot, Is.True);
+        }
+    }
+
+    [Test]
+    public void HintGet_DoesNotOverwriteDirtyAccount()
+    {
+        using TestContext ctx = new();
+        FlatWorldStateScope scope = ctx.Scope;
+        Address address = TestItem.AddressA;
+        Account dirtyAccount = TestItem.GenerateIndexedAccount(1);
+        Account staleAccount = TestItem.GenerateIndexedAccount(0);
+
+        using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(1))
+        {
+            writeBatch.Set(address, dirtyAccount);
+        }
+
+        scope.HintGet(address, staleAccount);
+
+        Assert.That(scope.Get(address), Is.EqualTo(dirtyAccount));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/ResourcePoolTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ResourcePoolTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Db;
+using Nethermind.Int256;
 using NUnit.Framework;
 
 namespace Nethermind.State.Flat.Test;
@@ -87,6 +88,19 @@ public class ResourcePoolTests
         Assert.That(resource, Is.Not.Null);
         Assert.That(resource.size.PrewarmedAddressSize, Is.EqualTo(1024));
         Assert.That(resource.size.NodesCacheSize, Is.EqualTo(1024));
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void ShouldPrewarm_AddressOverloadsUseSameHash(bool includeSlot)
+    {
+        using TransientResource resource = new(new TransientResource.Size(1024, 1));
+        Address address = new("0x1234567890123456789012345678901234567890");
+        ValueAddress valueAddress = new(address.Bytes);
+        UInt256? slot = includeSlot ? (UInt256)1 : null;
+
+        Assert.That(resource.ShouldPrewarm(address, slot), Is.True);
+        Assert.That(resource.ShouldPrewarm(in valueAddress, slot), Is.False);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotTests.cs
@@ -3,21 +3,38 @@
 
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.State.Flat.PersistedSnapshots;
 using NUnit.Framework;
 
 namespace Nethermind.State.Flat.Test;
 
 public class SnapshotTests
 {
+    private ResourcePool _pool = null!;
+
+    [SetUp]
+    public void SetUp() => _pool = new ResourcePool(new FlatDbConfig());
+
     [Test]
-    public void MutableSnapshotCountsAndEstimatesAreSealedAtConstruction()
+    public void CountsSealOnFirstObservationNotBefore()
+    {
+        // ResourcePool.CreateSnapshot hands out an EMPTY snapshot that callers populate through
+        // Content afterwards, so counts must not be frozen at construction.
+        using Snapshot snapshot = _pool.CreateSnapshot(StateId.PreGenesis, StateId.PreGenesis, ResourcePool.Usage.MainBlockProcessing);
+        snapshot.Content.Accounts[new(TestItem.AddressA)] = new(1, 100);
+
+        Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
+        Assert.That(snapshot.EstimateMemory(), Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void CountsAndEstimatesAreSealedByFirstObservation()
     {
         // The repository adds EstimateMemory() to its memory ledger when a snapshot is published and
         // subtracts a later call on removal: both sides must see the same value even if a straggling
-        // writer (e.g. a trie-warmer job) mutates the content after publication, and serving sealed
-        // counts avoids the all-stripe-locks ConcurrentDictionary.Count on live maps.
-        ResourcePool pool = new(new FlatDbConfig());
-        Snapshot snapshot = FlatTestHelpers.MakeSnapshot(pool, content =>
+        // writer (e.g. a trie-warmer job) mutates the content in between, and serving sealed counts
+        // avoids the all-stripe-locks ConcurrentDictionary.Count on live maps.
+        using Snapshot snapshot = FlatTestHelpers.MakeSnapshot(_pool, content =>
         {
             content.Accounts[new(TestItem.AddressA)] = new(1, 100);
             content.Storages[new((TestItem.AddressA, 1))] = new SlotValue(TestItem.KeccakA.Bytes);
@@ -28,21 +45,18 @@ public class SnapshotTests
         Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
         Assert.That(snapshot.StoragesCount, Is.EqualTo(1));
 
-        // A write landing after publication must not move the sealed values.
+        // A write landing after the first observation must not move the sealed values.
         snapshot.Content.Accounts[new(TestItem.AddressB)] = new(2, 200);
 
         Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
         Assert.That(snapshot.EstimateMemory(), Is.EqualTo(estimate));
         Assert.That(snapshot.EstimateCompactedMemory(), Is.EqualTo(compactedEstimate));
-
-        snapshot.Dispose();
     }
 
     [Test]
     public void SealedEstimatesMatchLiveContentEstimates()
     {
-        ResourcePool pool = new(new FlatDbConfig());
-        Snapshot snapshot = FlatTestHelpers.MakeSnapshot(pool, content =>
+        using Snapshot snapshot = FlatTestHelpers.MakeSnapshot(_pool, content =>
         {
             content.Accounts[new(TestItem.AddressA)] = new(1, 100);
             content.SelfDestructedStorageAddresses[new(TestItem.AddressB)] = true;
@@ -50,7 +64,21 @@ public class SnapshotTests
 
         Assert.That(snapshot.EstimateMemory(), Is.EqualTo(snapshot.Content.EstimateMemory()));
         Assert.That(snapshot.EstimateCompactedMemory(), Is.EqualTo(snapshot.Content.EstimateCompactedMemory()));
+    }
 
-        snapshot.Dispose();
+    [Test]
+    public void ArenaSizingUsesLiveCountsNotSealedCounts()
+    {
+        // The arena writer throws if the persisted write overruns the extent sized from EstimateSize,
+        // so persist-time sizing must reflect content written after the counts were sealed.
+        using Snapshot snapshot = FlatTestHelpers.MakeSnapshot(_pool, content =>
+            content.Accounts[new(TestItem.AddressA)] = new(1, 100));
+
+        long sealedEstimate = snapshot.EstimateMemory();
+        snapshot.Content.Accounts[new(TestItem.AddressB)] = new(2, 200);
+
+        Assert.That(snapshot.EstimateMemory(), Is.EqualTo(sealedEstimate), "ledger value must stay sealed");
+        Assert.That(PersistedSnapshotBuilder.EstimateSize(snapshot), Is.GreaterThan(sealedEstimate),
+            "arena sizing must see the post-seal write");
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotTests.cs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test;
+
+public class SnapshotTests
+{
+    [Test]
+    public void MutableSnapshotCountsAndEstimatesAreSealedAtConstruction()
+    {
+        // The repository adds EstimateMemory() to its memory ledger when a snapshot is published and
+        // subtracts a later call on removal: both sides must see the same value even if a straggling
+        // writer (e.g. a trie-warmer job) mutates the content after publication, and serving sealed
+        // counts avoids the all-stripe-locks ConcurrentDictionary.Count on live maps.
+        ResourcePool pool = new(new FlatDbConfig());
+        Snapshot snapshot = FlatTestHelpers.MakeSnapshot(pool, content =>
+        {
+            content.Accounts[new(TestItem.AddressA)] = new(1, 100);
+            content.Storages[new((TestItem.AddressA, 1))] = new SlotValue(TestItem.KeccakA.Bytes);
+        });
+
+        long estimate = snapshot.EstimateMemory();
+        long compactedEstimate = snapshot.EstimateCompactedMemory();
+        Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
+        Assert.That(snapshot.StoragesCount, Is.EqualTo(1));
+
+        // A write landing after publication must not move the sealed values.
+        snapshot.Content.Accounts[new(TestItem.AddressB)] = new(2, 200);
+
+        Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
+        Assert.That(snapshot.EstimateMemory(), Is.EqualTo(estimate));
+        Assert.That(snapshot.EstimateCompactedMemory(), Is.EqualTo(compactedEstimate));
+
+        snapshot.Dispose();
+    }
+
+    [Test]
+    public void SealedEstimatesMatchLiveContentEstimates()
+    {
+        ResourcePool pool = new(new FlatDbConfig());
+        Snapshot snapshot = FlatTestHelpers.MakeSnapshot(pool, content =>
+        {
+            content.Accounts[new(TestItem.AddressA)] = new(1, 100);
+            content.SelfDestructedStorageAddresses[new(TestItem.AddressB)] = true;
+        });
+
+        Assert.That(snapshot.EstimateMemory(), Is.EqualTo(snapshot.Content.EstimateMemory()));
+        Assert.That(snapshot.EstimateCompactedMemory(), Is.EqualTo(snapshot.Content.EstimateCompactedMemory()));
+
+        snapshot.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotTests.cs
@@ -23,8 +23,11 @@ public class SnapshotTests
         using Snapshot snapshot = _pool.CreateSnapshot(StateId.PreGenesis, StateId.PreGenesis, ResourcePool.Usage.MainBlockProcessing);
         snapshot.Content.Accounts[new(TestItem.AddressA)] = new(1, 100);
 
-        Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
-        Assert.That(snapshot.EstimateMemory(), Is.GreaterThan(0));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
+            Assert.That(snapshot.EstimateMemory(), Is.GreaterThan(0));
+        }
     }
 
     [Test]
@@ -42,15 +45,21 @@ public class SnapshotTests
 
         long estimate = snapshot.EstimateMemory();
         long compactedEstimate = snapshot.EstimateCompactedMemory();
-        Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
-        Assert.That(snapshot.StoragesCount, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
+            Assert.That(snapshot.StoragesCount, Is.EqualTo(1));
+        }
 
         // A write landing after the first observation must not move the sealed values.
         snapshot.Content.Accounts[new(TestItem.AddressB)] = new(2, 200);
 
-        Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
-        Assert.That(snapshot.EstimateMemory(), Is.EqualTo(estimate));
-        Assert.That(snapshot.EstimateCompactedMemory(), Is.EqualTo(compactedEstimate));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshot.AccountsCount, Is.EqualTo(1));
+            Assert.That(snapshot.EstimateMemory(), Is.EqualTo(estimate));
+            Assert.That(snapshot.EstimateCompactedMemory(), Is.EqualTo(compactedEstimate));
+        }
     }
 
     [Test]
@@ -62,8 +71,11 @@ public class SnapshotTests
             content.SelfDestructedStorageAddresses[new(TestItem.AddressB)] = true;
         });
 
-        Assert.That(snapshot.EstimateMemory(), Is.EqualTo(snapshot.Content.EstimateMemory()));
-        Assert.That(snapshot.EstimateCompactedMemory(), Is.EqualTo(snapshot.Content.EstimateCompactedMemory()));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshot.EstimateMemory(), Is.EqualTo(snapshot.Content.EstimateMemory()));
+            Assert.That(snapshot.EstimateCompactedMemory(), Is.EqualTo(snapshot.Content.EstimateCompactedMemory()));
+        }
     }
 
     [Test]
@@ -74,11 +86,15 @@ public class SnapshotTests
         using Snapshot snapshot = FlatTestHelpers.MakeSnapshot(_pool, content =>
             content.Accounts[new(TestItem.AddressA)] = new(1, 100));
 
-        long sealedEstimate = snapshot.EstimateMemory();
+        long sealedEstimate = snapshot.EstimateMemory(); // seals the ledger value
+        long sizeBeforeMutation = PersistedSnapshotBuilder.EstimateSize(snapshot);
         snapshot.Content.Accounts[new(TestItem.AddressB)] = new(2, 200);
 
-        Assert.That(snapshot.EstimateMemory(), Is.EqualTo(sealedEstimate), "ledger value must stay sealed");
-        Assert.That(PersistedSnapshotBuilder.EstimateSize(snapshot), Is.GreaterThan(sealedEstimate),
-            "arena sizing must see the post-seal write");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshot.EstimateMemory(), Is.EqualTo(sealedEstimate), "ledger value must stay sealed");
+            Assert.That(PersistedSnapshotBuilder.EstimateSize(snapshot), Is.GreaterThan(sizeBeforeMutation),
+                "arena sizing must see the post-seal write");
+        }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotBuilder.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotBuilder.cs
@@ -190,7 +190,11 @@ public static class PersistedSnapshotBuilder
     /// <see cref="Sorted.SortedTableBuilder{TWriter}"/> builds tables past 2 GiB and the arena is
     /// long-addressed.
     /// </summary>
-    public static long EstimateSize(Snapshot snapshot) => snapshot.EstimateMemory() + 1.KiB;
+    public static long EstimateSize(Snapshot snapshot) =>
+        // The arena writer throws if the write overruns the extent sized from this estimate, so a mutable
+        // snapshot must be measured live at persist time: Snapshot.EstimateMemory serves counts sealed at
+        // first observation (for repository-ledger consistency), which may predate late content writes.
+        (snapshot.IsSorted ? snapshot.EstimateMemory() : snapshot.Content.EstimateMemory()) + 1.KiB;
 
     private static void WritePerAddress<TWriter>(
         ref SortedTableBuilder<TWriter> table, Snapshot snapshot,

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -141,9 +141,9 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
     public Account? Get(Address address)
     {
-        Account? account = _snapshotBundle.GetAccount(address);
+        Account? account = _snapshotBundle.GetAccount(address, out bool isInCurrentSnapshot);
 
-        HintGet(address, account);
+        HintGet(address, account, promote: !isInCurrentSnapshot);
 
         if (_configuration.VerifyWithTrie)
         {
@@ -157,9 +157,11 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         return account;
     }
 
-    public void HintGet(Address address, Account? account)
+    public void HintGet(Address address, Account? account) => HintGet(address, account, promote: true);
+
+    private void HintGet(Address address, Account? account, bool promote)
     {
-        _snapshotBundle.SetAccount(address, account);
+        if (promote) _snapshotBundle.PromoteAccount(address, account);
         if (_snapshotBundle.ShouldQueuePrewarm(address))
         {
             if (_warmer.PushAddressJob(this, address, _hintSequenceId))

--- a/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
@@ -26,6 +26,10 @@ public class Snapshot : RefCountingDisposable
     private readonly SnapshotContent? _mutable;
     private readonly SortedSnapshotContent? _sorted;
     private readonly bool _isSorted;
+    // Sealed at construction (the publication boundary, after commit writers join): ConcurrentDictionary.Count
+    // acquires every stripe lock, so live counts would stall concurrent writers on each estimate, and the
+    // repository's add/remove memory ledger needs the same value on both sides even if stragglers still write.
+    private readonly SnapshotContentCounts _counts;
 
     public Snapshot(in StateId from, in StateId to, SnapshotContent content, IResourcePool resourcePool, ResourcePool.Usage usage)
     {
@@ -35,6 +39,7 @@ public class Snapshot : RefCountingDisposable
         _resourcePool = resourcePool;
         _usage = usage;
         _isSorted = false;
+        _counts = content.CaptureCounts();
     }
 
     public Snapshot(in StateId from, in StateId to, SortedSnapshotContent content, IResourcePool resourcePool, ResourcePool.Usage usage)
@@ -47,8 +52,8 @@ public class Snapshot : RefCountingDisposable
         _isSorted = true;
     }
 
-    public long EstimateMemory() => _isSorted ? _sorted!.EstimateMemory() : _mutable!.EstimateMemory();
-    public long EstimateCompactedMemory() => _isSorted ? _sorted!.EstimateCompactedMemory() : _mutable!.EstimateCompactedMemory();
+    public long EstimateMemory() => _isSorted ? _sorted!.EstimateMemory() : _counts.EstimateMemory();
+    public long EstimateCompactedMemory() => _isSorted ? _sorted!.EstimateCompactedMemory() : _counts.EstimateCompactedMemory();
     // Test-only observability (SnapshotCompactorTests); not consumed by production.
     internal ResourcePool.Usage Usage => _usage;
 
@@ -61,10 +66,10 @@ public class Snapshot : RefCountingDisposable
     public IEnumerable<KeyValuePair<HashedKey<(Address, UInt256)>, SlotValue?>> Storages => _isSorted ? _sorted!.Storages : _mutable!.Storages;
     public IEnumerable<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>> StorageNodes => _isSorted ? _sorted!.StorageNodes : _mutable!.StorageNodes;
     public IEnumerable<KeyValuePair<HashedKey<TreePath>, TrieNode>> StateNodes => _isSorted ? _sorted!.StateNodes : _mutable!.StateNodes;
-    public int AccountsCount => _isSorted ? _sorted!.AccountsCount : _mutable!.Accounts.Count;
-    public int StoragesCount => _isSorted ? _sorted!.StoragesCount : _mutable!.Storages.Count;
-    public int StateNodesCount => _isSorted ? _sorted!.StateNodesCount : _mutable!.StateNodes.Count;
-    public int StorageNodesCount => _isSorted ? _sorted!.StorageNodesCount : _mutable!.StorageNodes.Count;
+    public int AccountsCount => _isSorted ? _sorted!.AccountsCount : _counts.Accounts;
+    public int StoragesCount => _isSorted ? _sorted!.StoragesCount : _counts.Storages;
+    public int StateNodesCount => _isSorted ? _sorted!.StateNodesCount : _counts.StateNodes;
+    public int StorageNodesCount => _isSorted ? _sorted!.StorageNodesCount : _counts.StorageNodes;
 
     /// <summary>The mutable content; only valid for snapshots created for commit (not compacted ones).</summary>
     public SnapshotContent Content => _mutable!;
@@ -97,8 +102,6 @@ public class Snapshot : RefCountingDisposable
 
 public sealed class SnapshotContent : IDisposable, IResettable
 {
-    private const int NodeSizeEstimate = 650; // Counting the node size one by one has a notable overhead. So we use estimate.
-
     // ConcurrentDictionary: lock-free reads, best read latency for accounts/slots
     public readonly ConcurrentDictionary<HashedKey<Address>, Account?> Accounts = new();
     public readonly ConcurrentDictionary<HashedKey<(Address, UInt256)>, SlotValue?> Storages = new();
@@ -119,13 +122,48 @@ public sealed class SnapshotContent : IDisposable, IResettable
         StorageNodes.NoResizeClear();
     }
 
+    /// <summary>
+    /// Captures the five map counts in one pass. <see cref="ConcurrentDictionary{TKey,TValue}.Count"/>
+    /// acquires every stripe lock, so callers should capture once at a writer-quiescent boundary and
+    /// reuse the result instead of re-reading live counts.
+    /// </summary>
+    public SnapshotContentCounts CaptureCounts() => new(
+        Accounts.Count,
+        Storages.Count,
+        SelfDestructedStorageAddresses.Count,
+        StateNodes.Count,
+        StorageNodes.Count);
+
+    public long EstimateMemory() => CaptureCounts().EstimateMemory();
+
+    /// <inheritdoc cref="SnapshotContentCounts.EstimateCompactedMemory"/>
+    public long EstimateCompactedMemory() => CaptureCounts().EstimateCompactedMemory();
+
+    public void Dispose()
+    {
+    }
+}
+
+/// <summary>
+/// Entry counts of a <see cref="SnapshotContent"/>, captured once so memory estimates are pure
+/// functions of a single consistent capture.
+/// </summary>
+public readonly record struct SnapshotContentCounts(
+    int Accounts,
+    int Storages,
+    int SelfDestructedStorageAddresses,
+    int StateNodes,
+    int StorageNodes)
+{
+    private const int NodeSizeEstimate = 650; // Counting the node size one by one has a notable overhead. So we use estimate.
+
     public long EstimateMemory() =>
         // Cast Count to long before multiplying to avoid int overflow for large snapshots
-        (long)Accounts.Count * 172 +                         // Key (12B: ref 8B + hash 4B) + Value ref (8B) + CD overhead (48) + Account object (~104B)
-            (long)Storages.Count * 136 +                         // Key (44B: addr ref 8B + UInt256 32B + hash 4B) + Value (40B SlotValue?) + CD overhead (48) + Value ref (4B)
-            (long)SelfDestructedStorageAddresses.Count * 64 +    // Key (12B: ref 8B + hash 4B) + Value (4B) + CD overhead (48)
-            (long)StateNodes.Count * (NodeSizeEstimate + 76) +   // Key (40B: TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28) + TrieNode
-            (long)StorageNodes.Count * (NodeSizeEstimate + 84);  // Key (48B: Hash256 ref 8B + TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28) + TrieNode
+        (long)Accounts * 172 +                         // Key (12B: ref 8B + hash 4B) + Value ref (8B) + CD overhead (48) + Account object (~104B)
+            (long)Storages * 136 +                         // Key (44B: addr ref 8B + UInt256 32B + hash 4B) + Value (40B SlotValue?) + CD overhead (48) + Value ref (4B)
+            (long)SelfDestructedStorageAddresses * 64 +    // Key (12B: ref 8B + hash 4B) + Value (4B) + CD overhead (48)
+            (long)StateNodes * (NodeSizeEstimate + 76) +   // Key (40B: TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28) + TrieNode
+            (long)StorageNodes * (NodeSizeEstimate + 84);  // Key (48B: Hash256 ref 8B + TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28) + TrieNode
 
     /// <summary>
     /// Estimates memory for compacted snapshots, counting only dictionary overhead + keys + value-type values.
@@ -135,13 +173,9 @@ public sealed class SnapshotContent : IDisposable, IResettable
     public long EstimateCompactedMemory() =>
         // ConcurrentDictionary entry overhead ~48 bytes
         // Reference type values (Account, TrieNode) not counted - already accounted by non-compacted snapshot
-        Accounts.Count * 68 +                          // Key (12B: ref 8B + hash 4B) + Value ref (8B) + CD overhead (48)
-            Storages.Count * 136 +                         // Key (44B: addr ref 8B + UInt256 32B + hash 4B) + Value (40B SlotValue?) + CD overhead (48) + Value ref (4B)
-            SelfDestructedStorageAddresses.Count * 64 +    // Key (12B: ref 8B + hash 4B) + Value (4B) + CD overhead (48)
-            StateNodes.Count * 76 +                        // Key (40B: TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28)
-            StorageNodes.Count * 84;                       // Key (48B: Hash256 ref 8B + TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28)
-
-    public void Dispose()
-    {
-    }
+        (long)Accounts * 68 +                          // Key (12B: ref 8B + hash 4B) + Value ref (8B) + CD overhead (48)
+            (long)Storages * 136 +                         // Key (44B: addr ref 8B + UInt256 32B + hash 4B) + Value (40B SlotValue?) + CD overhead (48) + Value ref (4B)
+            (long)SelfDestructedStorageAddresses * 64 +    // Key (12B: ref 8B + hash 4B) + Value (4B) + CD overhead (48)
+            (long)StateNodes * 76 +                        // Key (40B: TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28)
+            (long)StorageNodes * 84;                       // Key (48B: Hash256 ref 8B + TreePath 36B + hash 4B) + Value ref (8B) + dictionary overhead (28)
 }

--- a/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -27,12 +28,13 @@ public class Snapshot : RefCountingDisposable
     private readonly SnapshotContent? _mutable;
     private readonly SortedSnapshotContent? _sorted;
     private readonly bool _isSorted;
-    // Boxed SnapshotContentCounts, sealed on first observation: ConcurrentDictionary.Count acquires every
-    // stripe lock, so serving live counts would stall concurrent writers on each estimate, and the
-    // repository's add/remove memory ledger needs the same value on both sides even if stragglers still
-    // write. Sealing lazily (not in the constructor) keeps ResourcePool.CreateSnapshot's
+    // Counts sealed on first observation: ConcurrentDictionary.Count acquires every stripe lock, so
+    // serving live counts would stall concurrent writers on each estimate, and the repository's
+    // add/remove memory ledger needs the same value on both sides even if stragglers still write.
+    // Sealing lazily (not in the constructor) keeps ResourcePool.CreateSnapshot's
     // construct-then-populate contract working: population always precedes the first count observation.
-    private object? _sealedCounts;
+    // Boxed so publication is a single reference CAS.
+    private StrongBox<SnapshotContentCounts>? _sealedCounts;
 
     public Snapshot(in StateId from, in StateId to, SnapshotContent content, IResourcePool resourcePool, ResourcePool.Usage usage)
     {
@@ -66,14 +68,14 @@ public class Snapshot : RefCountingDisposable
     {
         get
         {
-            object? sealedCounts = Volatile.Read(ref _sealedCounts);
+            StrongBox<SnapshotContentCounts>? sealedCounts = Volatile.Read(ref _sealedCounts);
             if (sealedCounts is null)
             {
-                object candidate = _mutable!.CaptureCounts();
+                StrongBox<SnapshotContentCounts> candidate = new(_mutable!.CaptureCounts());
                 sealedCounts = Interlocked.CompareExchange(ref _sealedCounts, candidate, null) ?? candidate;
             }
 
-            return (SnapshotContentCounts)sealedCounts;
+            return sealedCounts.Value;
         }
     }
     // Test-only observability (SnapshotCompactorTests); not consumed by production.

--- a/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
@@ -4,7 +4,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -151,7 +150,7 @@ public sealed class SnapshotContent : IDisposable, IResettable
     /// acquires every stripe lock, so callers should capture once at a writer-quiescent boundary and
     /// reuse the result instead of re-reading live counts.
     /// </summary>
-    public SnapshotContentCounts CaptureCounts() => new(
+    internal SnapshotContentCounts CaptureCounts() => new(
         Accounts.Count,
         Storages.Count,
         SelfDestructedStorageAddresses.Count,
@@ -172,7 +171,7 @@ public sealed class SnapshotContent : IDisposable, IResettable
 /// Entry counts of a <see cref="SnapshotContent"/>, captured once so memory estimates are pure
 /// functions of a single consistent capture.
 /// </summary>
-public readonly record struct SnapshotContentCounts(
+internal readonly record struct SnapshotContentCounts(
     int Accounts,
     int Storages,
     int SelfDestructedStorageAddresses,

--- a/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -26,10 +27,12 @@ public class Snapshot : RefCountingDisposable
     private readonly SnapshotContent? _mutable;
     private readonly SortedSnapshotContent? _sorted;
     private readonly bool _isSorted;
-    // Sealed at construction (the publication boundary, after commit writers join): ConcurrentDictionary.Count
-    // acquires every stripe lock, so live counts would stall concurrent writers on each estimate, and the
-    // repository's add/remove memory ledger needs the same value on both sides even if stragglers still write.
-    private readonly SnapshotContentCounts _counts;
+    // Boxed SnapshotContentCounts, sealed on first observation: ConcurrentDictionary.Count acquires every
+    // stripe lock, so serving live counts would stall concurrent writers on each estimate, and the
+    // repository's add/remove memory ledger needs the same value on both sides even if stragglers still
+    // write. Sealing lazily (not in the constructor) keeps ResourcePool.CreateSnapshot's
+    // construct-then-populate contract working: population always precedes the first count observation.
+    private object? _sealedCounts;
 
     public Snapshot(in StateId from, in StateId to, SnapshotContent content, IResourcePool resourcePool, ResourcePool.Usage usage)
     {
@@ -39,7 +42,6 @@ public class Snapshot : RefCountingDisposable
         _resourcePool = resourcePool;
         _usage = usage;
         _isSorted = false;
-        _counts = content.CaptureCounts();
     }
 
     public Snapshot(in StateId from, in StateId to, SortedSnapshotContent content, IResourcePool resourcePool, ResourcePool.Usage usage)
@@ -52,8 +54,28 @@ public class Snapshot : RefCountingDisposable
         _isSorted = true;
     }
 
-    public long EstimateMemory() => _isSorted ? _sorted!.EstimateMemory() : _counts.EstimateMemory();
-    public long EstimateCompactedMemory() => _isSorted ? _sorted!.EstimateCompactedMemory() : _counts.EstimateCompactedMemory();
+    public long EstimateMemory() => _isSorted ? _sorted!.EstimateMemory() : Counts.EstimateMemory();
+    public long EstimateCompactedMemory() => _isSorted ? _sorted!.EstimateCompactedMemory() : Counts.EstimateCompactedMemory();
+
+    /// <summary>
+    /// The mutable content's counts, captured once on first access and immutable afterwards. Racing
+    /// first observers may compute different candidates, but CompareExchange publishes exactly one,
+    /// so every reader (including the repository's add and remove ledger sides) sees the same value.
+    /// </summary>
+    private SnapshotContentCounts Counts
+    {
+        get
+        {
+            object? sealedCounts = Volatile.Read(ref _sealedCounts);
+            if (sealedCounts is null)
+            {
+                object candidate = _mutable!.CaptureCounts();
+                sealedCounts = Interlocked.CompareExchange(ref _sealedCounts, candidate, null) ?? candidate;
+            }
+
+            return (SnapshotContentCounts)sealedCounts;
+        }
+    }
     // Test-only observability (SnapshotCompactorTests); not consumed by production.
     internal ResourcePool.Usage Usage => _usage;
 
@@ -66,10 +88,10 @@ public class Snapshot : RefCountingDisposable
     public IEnumerable<KeyValuePair<HashedKey<(Address, UInt256)>, SlotValue?>> Storages => _isSorted ? _sorted!.Storages : _mutable!.Storages;
     public IEnumerable<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>> StorageNodes => _isSorted ? _sorted!.StorageNodes : _mutable!.StorageNodes;
     public IEnumerable<KeyValuePair<HashedKey<TreePath>, TrieNode>> StateNodes => _isSorted ? _sorted!.StateNodes : _mutable!.StateNodes;
-    public int AccountsCount => _isSorted ? _sorted!.AccountsCount : _counts.Accounts;
-    public int StoragesCount => _isSorted ? _sorted!.StoragesCount : _counts.Storages;
-    public int StateNodesCount => _isSorted ? _sorted!.StateNodesCount : _counts.StateNodes;
-    public int StorageNodesCount => _isSorted ? _sorted!.StorageNodesCount : _counts.StorageNodes;
+    public int AccountsCount => _isSorted ? _sorted!.AccountsCount : Counts.Accounts;
+    public int StoragesCount => _isSorted ? _sorted!.StoragesCount : Counts.Storages;
+    public int StateNodesCount => _isSorted ? _sorted!.StateNodesCount : Counts.StateNodes;
+    public int StorageNodesCount => _isSorted ? _sorted!.StorageNodesCount : Counts.StorageNodes;
 
     /// <summary>The mutable content; only valid for snapshots created for commit (not compacted ones).</summary>
     public SnapshotContent Content => _mutable!;

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -71,15 +71,24 @@ public sealed class SnapshotBundle : IDisposable
         _selfDestructedAccountAddresses = _currentPooledContent.SelfDestructedStorageAddresses;
     }
 
-    public Account? GetAccount(Address address) => DoGetAccount(address, false);
+    public Account? GetAccount(Address address) => DoGetAccount(address, excludeChanged: false, out _);
 
-    private Account? DoGetAccount(Address address, bool excludeChanged)
+    internal Account? GetAccount(Address address, out bool isInCurrentSnapshot) =>
+        DoGetAccount(address, excludeChanged: false, out isInCurrentSnapshot);
+
+    private Account? DoGetAccount(Address address, bool excludeChanged, out bool isInCurrentSnapshot)
     {
         GuardDispose();
 
         HashedKey<Address> key = new(address);
 
-        if (!excludeChanged && _changedAccounts.TryGetValue(key, out Account? acc)) return acc;
+        if (!excludeChanged && _changedAccounts.TryGetValue(key, out Account? acc))
+        {
+            isInCurrentSnapshot = true;
+            return acc;
+        }
+
+        isInCurrentSnapshot = false;
 
         for (int i = _snapshots.Count - 1; i >= 0; i--)
         {
@@ -321,6 +330,9 @@ public sealed class SnapshotBundle : IDisposable
     public void SetAccount(Address address, Account? account) =>
         _changedAccounts[address] = account;
 
+    internal void PromoteAccount(Address address, Account? account) =>
+        _changedAccounts.TryAdd(address, account);
+
     public void SetChangedSlot(Address address, in UInt256 index, byte[] value)
     {
         // So right now, if the value is zero, then it is a deletion. This is not the case with verkle where you
@@ -342,7 +354,7 @@ public sealed class SnapshotBundle : IDisposable
     {
         GuardDispose();
 
-        Account? account = DoGetAccount(address, excludeChanged: true);
+        Account? account = DoGetAccount(address, excludeChanged: true, out _);
         // So... a clear is always sent even on a new account. This makes is a minor optimization as
         // it skips persistence, but probably need to make sure it does not send it at all in the first place.
         bool isNewAccount = account == null || account.StorageRoot == Keccak.EmptyTreeHash;

--- a/src/Nethermind/Nethermind.State.Flat/TransientResource.cs
+++ b/src/Nethermind/Nethermind.State.Flat/TransientResource.cs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Diagnostics.CodeAnalysis;
-using System.IO.Hashing;
 using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 using Nethermind.State.Flat.Persistence.BloomFilter;
 using Nethermind.Trie;
@@ -55,21 +57,18 @@ public record TransientResource(TransientResource.Size size) : IDisposable, IRes
 
     private bool ShouldPrewarm(ReadOnlySpan<byte> addressBytes, UInt256? slot)
     {
-        ulong hash;
-        if (slot is null)
+        long hash = SpanExtensions.FastHash64For20Bytes(ref MemoryMarshal.GetReference(addressBytes));
+        if (slot is not null)
         {
-            hash = XxHash64.HashToUInt64(addressBytes);
-        }
-        else
-        {
-            Span<byte> buffer = stackalloc byte[20 + 32];
-            addressBytes.CopyTo(buffer);
-            slot.Value.ToBigEndian(buffer[20..]);
-            hash = XxHash64.HashToUInt64(buffer);
+            // Safe reinterpret: the ref targets a 32-byte stack local, so the read is exactly sized and
+            // cannot outlive or move. Hashes the native representation; the filter is process-transient.
+            UInt256 slotValue = slot.Value;
+            hash ^= SpanExtensions.FastHash64For32Bytes(ref Unsafe.As<UInt256, byte>(ref slotValue));
         }
 
-        if (PrewarmedAddresses.MightContain(hash)) return false;
-        PrewarmedAddresses.Add(hash);
+        ulong bloomKey = (ulong)hash;
+        if (PrewarmedAddresses.MightContain(bloomKey)) return false;
+        PrewarmedAddresses.Add(bloomKey);
         return true;
     }
 

--- a/src/Nethermind/Nethermind.State.Flat/TransientResource.cs
+++ b/src/Nethermind/Nethermind.State.Flat/TransientResource.cs
@@ -60,8 +60,6 @@ public record TransientResource(TransientResource.Size size) : IDisposable, IRes
         long hash = SpanExtensions.FastHash64For20Bytes(ref MemoryMarshal.GetReference(addressBytes));
         if (slot is not null)
         {
-            // Safe reinterpret: the ref targets a 32-byte stack local, so the read is exactly sized and
-            // cannot outlive or move. Hashes the native representation; the filter is process-transient.
             UInt256 slotValue = slot.Value;
             hash ^= SpanExtensions.FastHash64For32Bytes(ref Unsafe.As<UInt256, byte>(ref slotValue));
         }


### PR DESCRIPTION
## Changes

Split from #12396 (measurements there). Three independent small contention/allocation fixes in the flat state layer, kept as their original commits:

- **Sealed snapshot counts**: the repository memory ledger repeatedly called `ConcurrentDictionary.Count` on snapshot content for its estimates - `Count` acquires EVERY stripe lock, stalling concurrent writers, and the ledger's add and remove sides could observe different live values if stragglers wrote in between. Counts now seal on first observation (a `StrongBox` published by one reference CAS, lazily so `ResourcePool.CreateSnapshot`'s construct-then-populate contract keeps working), both ledger sides see the same value, and persist-arena sizing still measures live content because the arena writer throws on overrunning its extent.
- **HintGet promotion**: execution-read hints promoted every observed account into the current per-block snapshot map, taking the dictionary update lock even when the value (including a null miss) was already in the current mutable map. The redundant re-promotion is skipped, and external promotions use `TryAdd` so a stale cache hint can never overwrite a dirty account.
- **Prewarm dedup filter**: the per-access bloom-filter key dropped `XxHash64` + stackalloc for direct `FastHash64` over the address/slot bytes.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Sealed-counts lifecycle tests: construct-then-populate, seal-on-first-observation, sealed-equals-live, and a discriminating live-arena-sizing test (fails if persist sizing served sealed counts). Affected flat suites green (218 tests across snapshot/pool/repository/compactor/scope-provider).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
