### PR TITLE
refactor: remove no-op precalculated intrinsic gas plumbing

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -12,7 +12,6 @@ using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Threading;
 using Nethermind.Evm;
-using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
@@ -84,13 +83,12 @@ public partial class BlockProcessor
             for (uint i = 0; i < block.Transactions.Length; i++)
             {
                 Transaction currentTx = block.Transactions[i];
-                IntrinsicGas<EthereumGasPolicy> intrinsicGas = EthereumGasPolicy.CalculateIntrinsicGas(currentTx, spec, block.Header.GasLimit);
                 if (shouldValidate)
                 {
                     BlockAccessListManager.CheckPerTxInclusion(block, (int)i, currentTx, spec, totalRegularGas, totalStateGas);
                 }
 
-                ProcessTransaction(balManager.GetTxProcessor(i + 1), stateProvider, block, currentTx, (int)i, receiptsTracer, processingOptions, inner, in intrinsicGas);
+                ProcessTransaction(balManager.GetTxProcessor(i + 1), stateProvider, block, currentTx, (int)i, receiptsTracer, processingOptions, inner);
                 totalRegularGas = receiptsTracer.CumulativeRegularGasUsed;
                 totalStateGas = receiptsTracer.BlockStateGasUsed;
 
@@ -165,8 +163,6 @@ public partial class BlockProcessor
                                 Transaction tx = state.txs[txIndex];
                                 try
                                 {
-                                    IntrinsicGas<EthereumGasPolicy> intrinsicGas = EthereumGasPolicy.CalculateIntrinsicGas(tx, state.specProvider.GetSpec(state.block.Header), state.block.Header.GasLimit);
-
                                     // The using block detaches the worker's BAL into _perTxBal[txIndex + 1] and
                                     // recycles the pool slot via Dispose BEFORE we signal the gas result,
                                     // so the validator finds the canonical BAL slot populated when it awaits
@@ -181,8 +177,7 @@ public partial class BlockProcessor
                                             txIndex,
                                             state.receiptsTracers[txIndex],
                                             state.processingOptions,
-                                            state.inner,
-                                            in intrinsicGas);
+                                            state.inner);
                                     }
                                     state.gasResults[txIndex].TrySetResult(new GasValidationResult(tx.BlockGasUsed, state.receiptsTracers[txIndex].BlockStateGasUsed, null));
                                 }
@@ -375,14 +370,13 @@ public partial class BlockProcessor
             int index,
             BlockReceiptsTracer receiptsTracer,
             ProcessingOptions processingOptions,
-            IBlockProcessor.IBlockTransactionsExecutor inner,
-            in IntrinsicGas<EthereumGasPolicy> intrinsicGas)
+            IBlockProcessor.IBlockTransactionsExecutor inner)
         {
             long txStart = inner.StartTxTimer();
             TransactionResult result;
             try
             {
-                result = transactionProcessor.ProcessTransaction(currentTx, receiptsTracer, processingOptions, stateProvider, in intrinsicGas);
+                result = transactionProcessor.ProcessTransaction(currentTx, receiptsTracer, processingOptions, stateProvider);
             }
             finally
             {

--- a/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerTxAdapter.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PrewarmerTxAdapter.cs
@@ -3,7 +3,6 @@
 
 using Nethermind.Core;
 using Nethermind.Evm;
-using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
@@ -20,13 +19,6 @@ public class PrewarmerTxAdapter(ITransactionProcessorAdapter baseAdapter, BlockC
     {
         ReportProgress();
         return baseAdapter.Execute(transaction, txTracer);
-    }
-
-    public TransactionResult Execute<TGasPolicy>(Transaction transaction, ITxTracer txTracer, in IntrinsicGas<TGasPolicy> intrinsicGas)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-    {
-        ReportProgress();
-        return baseAdapter.Execute(transaction, txTracer, in intrinsicGas);
     }
 
     private void ReportProgress()

--- a/src/Nethermind/Nethermind.Consensus/Processing/TransactionProcessorAdapterExtensions.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/TransactionProcessorAdapterExtensions.cs
@@ -3,7 +3,6 @@
 
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
-using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
@@ -25,25 +24,6 @@ internal static class TransactionProcessorAdapterExtensions
 
         using ITxTracer tracer = receiptsTracer.StartNewTxTrace(currentTx);
         TransactionResult result = transactionProcessor.Execute(currentTx, receiptsTracer);
-        receiptsTracer.EndTxTrace();
-        return result;
-    }
-
-    public static TransactionResult ProcessTransaction<TGasPolicy>(this ITransactionProcessorAdapter transactionProcessor,
-        Transaction currentTx,
-        BlockReceiptsTracer receiptsTracer,
-        ProcessingOptions processingOptions,
-        IWorldState stateProvider,
-        in IntrinsicGas<TGasPolicy> intrinsicGas)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-    {
-        if (processingOptions.ContainsFlag(ProcessingOptions.LoadNonceFromState) && currentTx.SenderAddress != Address.SystemUser)
-        {
-            currentTx.Nonce = stateProvider.GetNonce(currentTx.SenderAddress!);
-        }
-
-        using ITxTracer tracer = receiptsTracer.StartNewTxTrace(currentTx);
-        TransactionResult result = transactionProcessor.Execute(currentTx, receiptsTracer, in intrinsicGas);
         receiptsTracer.EndTxTrace();
         return result;
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecuteTransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecuteTransactionProcessorAdapter.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
-using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Evm.TransactionProcessing
@@ -12,12 +11,6 @@ namespace Nethermind.Evm.TransactionProcessing
     {
         public TransactionResult Execute(Transaction transaction, ITxTracer txTracer) =>
             transactionProcessor.Execute(transaction, txTracer);
-
-        public TransactionResult Execute<TGasPolicy>(Transaction transaction, ITxTracer txTracer, in IntrinsicGas<TGasPolicy> intrinsicGas)
-            where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-            => transactionProcessor is TransactionProcessor<TGasPolicy> processor
-                ? processor.Process(transaction, txTracer, ExecutionOptions.Commit, in intrinsicGas)
-                : Execute(transaction, txTracer);
 
         public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
             => transactionProcessor.SetBlockExecutionContext(in blockExecutionContext);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessorAdapter.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
-using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Evm.TransactionProcessing
@@ -10,9 +9,6 @@ namespace Nethermind.Evm.TransactionProcessing
     public interface ITransactionProcessorAdapter
     {
         TransactionResult Execute(Transaction transaction, ITxTracer txTracer);
-        TransactionResult Execute<TGasPolicy>(Transaction transaction, ITxTracer txTracer, in IntrinsicGas<TGasPolicy> intrinsicGas)
-            where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-            => Execute(transaction, txTracer);
 
         void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext);
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -37,8 +37,6 @@ namespace Nethermind.Evm.TransactionProcessing
         : TransactionProcessorBase<TGasPolicy>(blobBaseFeeCalculator, specProvider, worldState, virtualMachine, codeInfoRepository, logManager, parallel)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
-        public TransactionResult Process(Transaction transaction, ITxTracer txTracer, ExecutionOptions options, in IntrinsicGas<TGasPolicy> intrinsicGas)
-            => ExecuteCore(transaction, txTracer, options, in intrinsicGas);
     }
 
     /// <summary>
@@ -176,31 +174,11 @@ namespace Nethermind.Evm.TransactionProcessing
             return result;
         }
 
-        protected TransactionResult ExecuteCore(Transaction tx, ITxTracer tracer, ExecutionOptions opts, in IntrinsicGas<TGasPolicy> intrinsicGas)
-        {
-            if (Logger.IsTrace) Logger.Trace($"Executing tx {tx.Hash}");
-            if (tx.IsSystem() || (opts & ~ExecutionOptions.Warmup) == ExecutionOptions.SkipValidation)
-            {
-                return GetOrCreateSystemTransactionProcessor().Execute(tx, tracer, opts);
-            }
-
-            TransactionResult result = Execute(tx, tracer, opts, in intrinsicGas);
-            if (Logger.IsTrace) Logger.Trace($"Tx {tx.Hash} was executed, {result}");
-            return result;
-        }
-
         protected virtual TransactionResult Execute(Transaction tx, ITxTracer tracer, ExecutionOptions opts)
         {
             BlockHeader header = VirtualMachine.BlockExecutionContext.Header;
             IReleaseSpec spec = GetSpec(header);
             IntrinsicGas<TGasPolicy> intrinsicGas = CalculateIntrinsicGas(tx, spec, header.GasLimit);
-            return Execute(tx, tracer, opts, header, spec, in intrinsicGas);
-        }
-
-        protected TransactionResult Execute(Transaction tx, ITxTracer tracer, ExecutionOptions opts, in IntrinsicGas<TGasPolicy> intrinsicGas)
-        {
-            BlockHeader header = VirtualMachine.BlockExecutionContext.Header;
-            IReleaseSpec spec = GetSpec(header);
             return Execute(tx, tracer, opts, header, spec, in intrinsicGas);
         }
 


### PR DESCRIPTION
## Changes

Removes the precalculated-intrinsic-gas mechanism and the runtime `is TransactionProcessor<TGasPolicy>` downcast it fed.

The BAL parallel executor precomputed `IntrinsicGas<EthereumGasPolicy>` and threaded it into the transaction processor through a generic `Execute<TGasPolicy>` adapter overload, dispatched via a runtime downcast in `ExecuteTransactionProcessorAdapter`. This provided **no speedup**: intrinsic gas is computed exactly once whether the executor precomputes it or the processor computes it in `CalculateIntrinsicGas`, and nothing outside the processor ever consumed the executor's value (the executor only forwarded it, the BAL manager never referenced it, and the concurrent gas validator uses `tx.GasLimit`). The mechanism merely relocated one computation into the executor and threaded it through three layers to a fragile cast that silently missed every non-sealed processor subclass anyway.

Deleted (a closed set — the BAL executor was the only entry point):

- `ExecuteTransactionProcessorAdapter.Execute<TGasPolicy>(…, in IntrinsicGas)` — **the cast**
- `ITransactionProcessorAdapter.Execute<TGasPolicy>` interface method + default impl
- `PrewarmerTxAdapter.Execute<TGasPolicy>` forward
- `TransactionProcessorAdapterExtensions.ProcessTransaction<TGasPolicy>` extension (the non-generic `ProcessTransaction`, incl. its `LoadNonceFromState` handling, is kept)
- the executor's `CalculateIntrinsicGas` calls + `in intrinsicGas` threading
- the sealed `TransactionProcessor<TGasPolicy>.Process(…, in IntrinsicGas)` (empty sealed class kept — the factory instantiates it)
- the dead 4-arg `ExecuteCore`/`Execute(…, in IntrinsicGas)` base overloads

The processor now always computes intrinsic gas itself, exactly as the classic/non-BAL executor path already relied on. Behavior-identical; net **+4 / −71** across 6 files.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

Behavior is identical (pure removal of a no-op optimization), so it is covered by existing suites. Full solution builds clean (warnings-as-errors), and the relevant suites pass:

- `Nethermind.Blockchain.Test` (TransactionProcessor + BlockProcessor): 209/209
- `Nethermind.Consensus.Test` (BAL/parallel executor + prewarmer): 110/110
- `Nethermind.Evm.Test` (tx processing, EIP-7623/7778): 52/52
- `Nethermind.Xdc.Test` (most-affected plugin — overrides `Execute`/`ValidateGas`/`CalculateIntrinsicGas`): 489/489

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
