### PR TITLE
fix(era): advance finality during replay

### DIFF
--- a/src/Nethermind/Nethermind.Era1.Test/EraImporterTest.cs
+++ b/src/Nethermind/Nethermind.Era1.Test/EraImporterTest.cs
@@ -173,7 +173,13 @@ public class EraImporterTest
         while (sut.CurrentPacer is null) await Task.Yield();
         await sut.CurrentPacer.WaitForPausedAsync(token);
 
-        Assert.That(maxSuggestedBlocks, Is.EqualTo(expectedStopBlock));
+        Block expectedFinalizedBlock = outputCtx.Resolve<IBlockTree>().FindBlock(expectedStopBlock)!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(maxSuggestedBlocks, Is.EqualTo(expectedStopBlock));
+            Assert.That(inTree.FinalizedHash, Is.EqualTo(expectedFinalizedBlock.Hash));
+            Assert.That(inTree.LastFinalizedBlockLevel, Is.EqualTo(expectedStopBlock));
+        }
         shouldAdvanceMainChain = true;
         inTree.TryUpdateMainChain(inTree.FindBlock(expectedStopBlock, BlockTreeLookupOptions.None)!.Header, true, preloadedBlocks: new[] { inTree.FindBlock(expectedStopBlock, BlockTreeLookupOptions.None)! });
 

--- a/src/Nethermind/Nethermind.Era1/EraImporter.cs
+++ b/src/Nethermind/Nethermind.Era1/EraImporter.cs
@@ -205,6 +205,7 @@ public class EraImporter(
             {
                 await pacer.WaitForQueue(block.Number, cancellation);
                 await SuggestAndProcessBlock(block);
+                blockTree.ForkChoiceUpdated(block.Hash, blockTree.SafeHash);
             }
             else
                 InsertBlockAndReceipts(block, receipt, to);

--- a/src/Nethermind/Nethermind.EraE.Test/Import/EraImporterTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/Import/EraImporterTests.cs
@@ -46,6 +46,13 @@ public class EraImporterTests
         {
             Assert.That(env.TargetTree.FindBlock(i, BlockTreeLookupOptions.None), Is.Not.Null, $"block {i} should have been imported");
         }
+
+        Block expectedFinalizedBlock = env.SourceCtx.Resolve<IBlockTree>().FindBlock((ulong)chainLength - 1)!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(env.TargetTree.FinalizedHash, Is.EqualTo(expectedFinalizedBlock.Hash));
+            Assert.That(env.TargetTree.LastFinalizedBlockLevel, Is.EqualTo((ulong)chainLength - 1));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.EraE/Import/EraImporter.cs
+++ b/src/Nethermind/Nethermind.EraE/Import/EraImporter.cs
@@ -165,6 +165,7 @@ public sealed class EraImporter(
             {
                 await pacer.WaitForQueue(block.Number, cancellation);
                 await SuggestAndProcessBlock(block);
+                blockTree.ForkChoiceUpdated(block.Hash, blockTree.SafeHash);
             }
             else
             {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1658,6 +1658,19 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Eth_get_block_by_number_returns_null_when_block_for_rpc_factory_returns_null()
+    {
+        IBlockForRpcFactory blockForRpcFactory = Substitute.For<IBlockForRpcFactory>();
+        blockForRpcFactory
+            .Create(Arg.Any<Block>(), Arg.Any<bool>(), Arg.Any<ISpecProvider>(), Arg.Any<bool>())
+            .Returns((BlockForRpc)null!);
+
+        using Context ctx = await Context.Create(configurer: builder => builder.AddSingleton(blockForRpcFactory));
+        string serialized = await ctx.Test.TestEthRpc("eth_getBlockByNumber", "latest", "true");
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":null,\"id\":67}"));
+    }
+
+    [Test]
     public async Task Eth_get_account_notfound()
     {
         using Context ctx = await Context.Create();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -635,7 +635,12 @@ public partial class EthRpcModule(
             return ResultWrapper<BlockForRpc?>.Success(null);
         }
 
-        BlockForRpc blockForRpc = _blockForRpcFactory.Create(block, returnFullTransactionObjects, _specProvider);
+        BlockForRpc? blockForRpc = _blockForRpcFactory.Create(block, returnFullTransactionObjects, _specProvider);
+        if (blockForRpc is null)
+        {
+            return ResultWrapper<BlockForRpc?>.Success(null);
+        }
+
         if (blockParameter.Type == BlockParameterType.Pending)
         {
             blockForRpc.Hash = null;


### PR DESCRIPTION
## Why

Era archives contain finalized history, but replay only suggested blocks for processing without publishing that finality to the block tree. FlatDB therefore treated finality as stalled and entered long-finality retention, which slows replay and substantially increases disk usage.

## Changes

- Advance block-tree finality as Era1 and EraE replay blocks are accepted for processing.
- Preserve the existing safe hash and avoid parallel historical-import finality races.
- Cover finality advancement during a paused Era1 replay and finalization of the EraE imported tip.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `Nethermind.Era1.Test`: 82 passed.
- `Nethermind.EraE.Test`: 170 passed, 3 network-dependent tests skipped.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No