### PR TITLE
perf(xdc): forward the blockhash prewarm hint through the decorator

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcBlockhashStoreTests.cs
@@ -5,10 +5,12 @@ using System;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Eip2930;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.State;
 using Nethermind.Specs;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Xdc.Test;
@@ -22,6 +24,34 @@ internal class XdcBlockhashStoreTests
         IsEip2935Enabled = true,
         Eip2935RingBufferSize = Eip2935Constants.RingBufferSize,
     };
+
+    // Dropping IHasAccessList from the decorator silently disables the inner store's prewarm hint.
+    [TestCase(true, TestName = "GetAccessList_WithHintCapableInner_ForwardsTheInnerHint")]
+    [TestCase(false, TestName = "GetAccessList_WithHintlessInner_IsNull")]
+    public void GetAccessList_AtGivenInnerCapability_ForwardsExactly(bool innerHintCapable)
+    {
+        IWorldState worldState = TestWorldStateFactory.CreateForTest();
+        using IDisposable _ = worldState.BeginScope(IWorldState.PreGenesis);
+        ReleaseSpec spec = Eip2935Spec;
+        Block block = Build.A.Block.WithNumber(42).WithParentHash(TestItem.KeccakA).TestObject;
+        IBlockhashStore inner = innerHintCapable ? new BlockhashStore(worldState) : Substitute.For<IBlockhashStore>();
+        XdcBlockhashStore store = new(inner, worldState);
+        store.ApplyBlockhashStateChanges(block.Header, spec);
+
+        AccessList? hint = store.GetAccessList(block, spec);
+
+        if (!innerHintCapable)
+        {
+            Assert.That(hint, Is.Null);
+            return;
+        }
+
+        Assert.That(hint, Is.Not.Null, "the decorator must forward the inner store's hint");
+        foreach ((Address address, AccessList.StorageKeysEnumerable _) in hint!)
+        {
+            Assert.That(address, Is.EqualTo(Eip2935Account));
+        }
+    }
 
     [Test]
     public void Deploys_history_contract_when_missing()

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
@@ -4,8 +4,8 @@
 using System;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Core;
-using Nethermind.Core.Eip2930;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
 

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockhashStore.cs
@@ -4,13 +4,14 @@
 using System;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Core;
+using Nethermind.Core.Eip2930;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
 
 namespace Nethermind.Xdc;
 
-public class XdcBlockhashStore(IBlockhashStore inner, IWorldState worldState) : IBlockhashStore
+public class XdcBlockhashStore(IBlockhashStore inner, IWorldState worldState) : IBlockhashStore, IHasAccessList
 {
     private static readonly ValueHash256 CodeHash =
         ValueKeccak.Compute(Eip2935Constants.Code);
@@ -38,4 +39,8 @@ public class XdcBlockhashStore(IBlockhashStore inner, IWorldState worldState) : 
 
     public Hash256? GetBlockHashFromState(BlockHeader currentBlockHeader, ulong requiredBlockNumber, IReleaseSpec spec) =>
         inner.GetBlockHashFromState(currentBlockHeader, requiredBlockNumber, spec);
+
+    // The parent-hash write is delegated to the inner store, so its prewarm hint is exact here.
+    public AccessList? GetAccessList(Block block, IReleaseSpec spec) =>
+        (inner as IHasAccessList)?.GetAccessList(block, spec);
 }


### PR DESCRIPTION
## Changes

`XdcBlockhashStore` delegates the parent-hash write to the inner store, so the inner's EIP-2935 prewarm hint (#12410) is exact for Xdc as well — but the decorator didn't implement `IHasAccessList`, silently dropping it (the prewarmer's registration falls back to a no-hint provider for hint-less stores). Forward it: `GetAccessList` delegates to the inner store when it is hint-capable.

Follow-up to the Xdc break discussion on #12410.

## Types of changes

- [x] Optimization