### PR TITLE
Split and prioritize heavy same-sender groups in block prewarmer

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -603,7 +603,7 @@ public class BlockCachePreWarmerTests
     }
 
     [Test]
-    public void GroupTransactionsBySender_OrdersGroupsHeaviestFirst()
+    public void GroupTransactionsBySender_HoistsHeavyGroupsAndKeepsRestInBlockOrder()
     {
         Block block = Build.A.Block.WithTransactions(
             GroupingTx(TestItem.PrivateKeyB, nonce: 0, gasLimit: 100_000),
@@ -615,9 +615,9 @@ public class BlockCachePreWarmerTests
         try
         {
             Assert.That(groups.Count, Is.EqualTo(3));
-            Assert.That(groups[0][0].Tx.SenderAddress, Is.EqualTo(TestItem.AddressA));
-            Assert.That(groups[1][0].Tx.SenderAddress, Is.EqualTo(TestItem.AddressC));
-            Assert.That(groups[2][0].Tx.SenderAddress, Is.EqualTo(TestItem.AddressB));
+            Assert.That(groups[0][0].Tx.SenderAddress, Is.EqualTo(TestItem.AddressA), "heavy group is hoisted to the front");
+            Assert.That(groups[1][0].Tx.SenderAddress, Is.EqualTo(TestItem.AddressB), "light groups keep block order");
+            Assert.That(groups[2][0].Tx.SenderAddress, Is.EqualTo(TestItem.AddressC));
         }
         finally
         {

--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -14,11 +14,13 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Container;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
 using Nethermind.Core.Test.Modules;
 using Nethermind.Core.Threading;
 using Nethermind.Evm;
@@ -553,6 +555,97 @@ public class BlockCachePreWarmerTests
 
         Assert.That(speculativeWarmups, Is.GreaterThan(0), "precondition: the speculative pass warmed the transactions");
         Assert.That(Volatile.Read(ref warmups), Is.EqualTo(0), "the reactive pass must skip senders already fully warmed speculatively");
+    }
+
+    [Test]
+    public void GroupTransactionsBySender_SameSenderStaysGroupedInOrder()
+    {
+        Block block = Build.A.Block.WithTransactions(
+            GroupingTx(TestItem.PrivateKeyA, nonce: 0, gasLimit: 100_000),
+            GroupingTx(TestItem.PrivateKeyB, nonce: 0, gasLimit: 100_000),
+            GroupingTx(TestItem.PrivateKeyA, nonce: 1, gasLimit: 100_000)).TestObject;
+
+        ArrayPoolList<ArrayPoolList<(int Index, Transaction Tx)>> groups = BlockCachePreWarmer.GroupTransactionsBySender(block);
+        try
+        {
+            Assert.That(groups.Count, Is.EqualTo(2));
+            ArrayPoolList<(int Index, Transaction Tx)> senderA = FindGroup(groups, TestItem.AddressA);
+            Assert.That(senderA.Count, Is.EqualTo(2));
+            Assert.That(senderA[0].Index, Is.EqualTo(0));
+            Assert.That(senderA[1].Index, Is.EqualTo(2));
+        }
+        finally
+        {
+            DisposeGroups(groups);
+        }
+    }
+
+    [Test]
+    public void GroupTransactionsBySender_SplitsHeavySameSenderGroup()
+    {
+        Block block = Build.A.Block.WithTransactions(
+            GroupingTx(TestItem.PrivateKeyA, nonce: 0, gasLimit: 3_000_000),
+            GroupingTx(TestItem.PrivateKeyA, nonce: 1, gasLimit: 3_000_000)).TestObject;
+
+        ArrayPoolList<ArrayPoolList<(int Index, Transaction Tx)>> groups = BlockCachePreWarmer.GroupTransactionsBySender(block);
+        try
+        {
+            Assert.That(groups.Count, Is.EqualTo(2), "a same-sender group above the split threshold must warm per-tx");
+            foreach (ArrayPoolList<(int Index, Transaction Tx)> group in groups.AsSpan())
+            {
+                Assert.That(group.Count, Is.EqualTo(1));
+            }
+        }
+        finally
+        {
+            DisposeGroups(groups);
+        }
+    }
+
+    [Test]
+    public void GroupTransactionsBySender_OrdersGroupsHeaviestFirst()
+    {
+        Block block = Build.A.Block.WithTransactions(
+            GroupingTx(TestItem.PrivateKeyB, nonce: 0, gasLimit: 100_000),
+            GroupingTx(TestItem.PrivateKeyB, nonce: 1, gasLimit: 100_000),
+            GroupingTx(TestItem.PrivateKeyC, nonce: 0, gasLimit: 1_000_000),
+            GroupingTx(TestItem.PrivateKeyA, nonce: 0, gasLimit: 5_000_000)).TestObject;
+
+        ArrayPoolList<ArrayPoolList<(int Index, Transaction Tx)>> groups = BlockCachePreWarmer.GroupTransactionsBySender(block);
+        try
+        {
+            Assert.That(groups.Count, Is.EqualTo(3));
+            Assert.That(groups[0][0].Tx.SenderAddress, Is.EqualTo(TestItem.AddressA));
+            Assert.That(groups[1][0].Tx.SenderAddress, Is.EqualTo(TestItem.AddressC));
+            Assert.That(groups[2][0].Tx.SenderAddress, Is.EqualTo(TestItem.AddressB));
+        }
+        finally
+        {
+            DisposeGroups(groups);
+        }
+    }
+
+    private static Transaction GroupingTx(PrivateKey sender, uint nonce, ulong gasLimit) =>
+        Build.A.Transaction.WithNonce(nonce).WithGasLimit(gasLimit).WithTo(TestItem.AddressD).SignedAndResolved(sender).TestObject;
+
+    private static ArrayPoolList<(int Index, Transaction Tx)> FindGroup(
+        ArrayPoolList<ArrayPoolList<(int Index, Transaction Tx)>> groups, Address sender)
+    {
+        foreach (ArrayPoolList<(int Index, Transaction Tx)> group in groups.AsSpan())
+        {
+            if (group[0].Tx.SenderAddress == sender) return group;
+        }
+
+        throw new InvalidOperationException($"No group for {sender}");
+    }
+
+    private static void DisposeGroups(ArrayPoolList<ArrayPoolList<(int Index, Transaction Tx)>> groups)
+    {
+        foreach (ArrayPoolList<(int Index, Transaction Tx)> group in groups.AsSpan())
+        {
+            group.Dispose();
+        }
+        groups.Dispose();
     }
 
     private Block BuildChildBlock(BlockHeader head) =>

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -470,8 +470,18 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
             }
         }
 
-        // Heaviest groups first: they take the longest to warm and gain the most from lead time.
-        result.AsSpan().Sort(static (a, b) => TotalGasLimit(b).CompareTo(TotalGasLimit(a)));
+        // Hoist heavy groups to the front (heaviest first): they take the longest to warm and gain
+        // the most from lead time. The rest keep block order, which streams just ahead of the main
+        // thread on transaction-dense blocks.
+        result.AsSpan().Sort(static (a, b) =>
+        {
+            ulong aGas = TotalGasLimit(a);
+            ulong bGas = TotalGasLimit(b);
+            bool aHeavy = aGas > SplitSenderGroupGasThreshold;
+            bool bHeavy = bGas > SplitSenderGroupGasThreshold;
+            if (aHeavy != bHeavy) return aHeavy ? -1 : 1;
+            return aHeavy ? bGas.CompareTo(aGas) : a[0].Index.CompareTo(b[0].Index);
+        });
 
         return result;
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -22,7 +22,6 @@ using Nethermind.Evm.State;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Collections;
-using Nethermind.Core.Extensions;
 using Nethermind.Trie;
 using PrewarmMetrics = Nethermind.Consensus.Processing.Prewarming.Metrics;
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -368,19 +368,16 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
 
             // Group transactions by sender to process same-sender transactions sequentially
             // This ensures state changes (balance, storage) from tx[N] are visible to tx[N+1]
-            Dictionary<AddressAsKey, ArrayPoolList<(int Index, Transaction Tx)>>? senderGroups = GroupTransactionsBySender(block);
+            using ArrayPoolList<ArrayPoolList<(int Index, Transaction Tx)>> senderGroups = GroupTransactionsBySender(block);
 
             try
             {
-                // Convert to array for parallel iteration
-                using ArrayPoolList<ArrayPoolList<(int Index, Transaction Tx)>> groupArray = senderGroups.Values.ToPooledList();
-
                 // Parallel across different senders, sequential within the same sender
                 ParallelUnbalancedWork.For(
                     0,
-                    groupArray.Count,
+                    senderGroups.Count,
                     parallelOptions,
-                    (blockState, groupArray, parallelOptions.CancellationToken),
+                    (blockState, senderGroups, parallelOptions.CancellationToken),
                     static (groupIndex, tupleState) =>
                     {
                         (BlockState? blockState, ArrayPoolList<ArrayPoolList<(int Index, Transaction Tx)>> groups, CancellationToken token) = tupleState;
@@ -421,8 +418,8 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
             }
             finally
             {
-                foreach (KeyValuePair<AddressAsKey, ArrayPoolList<(int Index, Transaction Tx)>> kvp in senderGroups)
-                    kvp.Value.Dispose();
+                foreach (ArrayPoolList<(int Index, Transaction Tx)> group in senderGroups.AsSpan())
+                    group.Dispose();
             }
         }
         catch (OperationCanceledException)
@@ -435,7 +432,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         }
     }
 
-    private static Dictionary<AddressAsKey, ArrayPoolList<(int Index, Transaction Tx)>> GroupTransactionsBySender(Block block)
+    internal static ArrayPoolList<ArrayPoolList<(int Index, Transaction Tx)>> GroupTransactionsBySender(Block block)
     {
         Dictionary<AddressAsKey, ArrayPoolList<(int, Transaction)>> groups = [];
 
@@ -456,8 +453,46 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
             list.Add((i, tx));
         }
 
-        return groups;
+        ArrayPoolList<ArrayPoolList<(int Index, Transaction Tx)>> result = new(groups.Count);
+        foreach (ArrayPoolList<(int Index, Transaction Tx)> group in groups.Values)
+        {
+            if (ShouldSplitGroup(group))
+            {
+                // A heavy chain warms slower than the main loop executes it; warm each tx in parallel from parent state instead.
+                foreach ((int Index, Transaction Tx) item in group.AsSpan())
+                {
+                    result.Add(new ArrayPoolList<(int, Transaction)>(1) { item });
+                }
+                group.Dispose();
+            }
+            else
+            {
+                result.Add(group);
+            }
+        }
+
+        // Heaviest groups first: they take the longest to warm and gain the most from lead time.
+        result.AsSpan().Sort(static (a, b) => TotalGasLimit(b).CompareTo(TotalGasLimit(a)));
+
+        return result;
     }
+
+    /// <summary>Total gas limit above which a multi-tx sender group is warmed per-tx in parallel instead of sequentially.</summary>
+    private const ulong SplitSenderGroupGasThreshold = 4_000_000;
+
+    private static ulong TotalGasLimit(ArrayPoolList<(int Index, Transaction Tx)> group)
+    {
+        ulong totalGasLimit = 0;
+        foreach ((int _, Transaction tx) in group.AsSpan())
+        {
+            totalGasLimit += tx.GasLimit;
+        }
+
+        return totalGasLimit;
+    }
+
+    private static bool ShouldSplitGroup(ArrayPoolList<(int Index, Transaction Tx)> group) =>
+        group.Count >= 2 && TotalGasLimit(group) > SplitSenderGroupGasThreshold;
 
     private static bool AllSpeculativelyWarmed(ArrayPoolList<(int Index, Transaction Tx)> group, ISet<Hash256> warmed)
     {


### PR DESCRIPTION
## Changes

- Split same-sender transaction groups whose combined gas limit exceeds 4M into per-tx groups, so heavy chains warm in parallel from parent state. Previously such chains warmed sequentially on one worker, the main thread overtook the warmer, and the `MainThreadTxIndex` guard skipped the tail txs entirely — leaving their reads fully cold on the main thread.
- Order sender groups heaviest-first before the warm fan-out: the slowest-to-warm groups get the most lead time, while small groups the main thread reaches immediately are skipped cheaply by the existing guard.

Measured on the fusaka payload set (real post-Fusaka mainnet blocks, EXPB reproducible benchmarks, flat layout):

| metric (1k blocks) | before (10-run band) | after (n=3) |
|---|---|---|
| P99 | 119.8–126.5 ms | 113.7 / 114.9 / 114.0 ms (−6%) |
| block 25,490,611 (5-tx XEN `bulkClaimMintReward` chain, 55.4M gas) | 512.8–531.7 ms | 183.3–194.7 ms (−63%) |
| block 25,490,229 (9-tx XEN chain) | 242.7–246.1 ms | 72.4–77.9 ms (−69%) |
| AVG / MED | 32.7–34.9 / 29.1–31.0 ms | neutral |

The split alone was isolated at −61% on block 25,490,611 (run 29250678741); heaviest-first ordering adds the P99 win by halving late-completing warm-ups (−47% gas-weighted). Paired per-block comparison across 6 runs (999 blocks) shows zero blocks systematically slower.

Runs: baseline 29241604030 / 29251828634, isolation 29250678741, ordering 29257453683 + 29258512948, final 29259599877.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Unit tests cover the grouping invariants (same-sender order preserved below the threshold, per-tx split above it, heaviest-first ordering). Correctness risk is limited: the prewarmer already executes speculatively from parent state concurrently with the main loop; this change only alters which txs get that treatment and in what order.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Improves worst-case block processing latency on blocks with heavy same-sender transaction chains (e.g. XEN batch claims): P99 −6% on recent mainnet blocks, with the worst offenders improving up to 60–70%.