### PR TITLE
Size ParallelUnbalancedWork to the range; skip init/finally on idle workers

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -260,9 +260,7 @@ public partial class BlockProcessor(
     {
         using MetricsTimer<BloomsTimeSink> _ = new();
 
-        // Avoid parallel scheduling overhead for small receipt counts: ParallelUnbalancedWork queues
-        // ProcessorCount-1 ThreadPool items regardless of work size, which adds scheduling jitter and
-        // allocation overhead that exceeds the bloom computation cost for small blocks.
+        // Parallel scheduling overhead exceeds the bloom computation cost for small blocks.
         if (receipts.Length <= Environment.ProcessorCount)
         {
             foreach (TxReceipt? t in receipts)

--- a/src/Nethermind/Nethermind.Core.Test/Threading/ParallelUnbalancedWorkTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Threading/ParallelUnbalancedWorkTests.cs
@@ -158,6 +158,49 @@ public class ParallelUnbalancedWorkTests
     }
 
     [Test]
+    public void For_WithEmptyRange_DoesNotRunActionOrInitializeThreadLocalState()
+    {
+        int actionCalls = 0;
+        int initCalls = 0;
+        int finallyCalls = 0;
+
+        ParallelUnbalancedWork.For<int>(
+            1, 1, FourThreads,
+            init: () => Interlocked.Increment(ref initCalls),
+            action: (_, local) => { Interlocked.Increment(ref actionCalls); return local; },
+            @finally: _ => Interlocked.Increment(ref finallyCalls));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(actionCalls, Is.EqualTo(0));
+            Assert.That(initCalls, Is.EqualTo(0));
+            Assert.That(finallyCalls, Is.EqualTo(0));
+        }
+    }
+
+    [Test]
+    public void For_WithThreadLocal_DoesNotInitializeWorkersWithoutWork()
+    {
+        int initCalls = 0;
+        int emptyLocals = 0;
+
+        ParallelUnbalancedWork.For<int>(
+            0, 2, FourThreads,
+            init: () => { Interlocked.Increment(ref initCalls); return 0; },
+            action: (_, local) => local + 1,
+            @finally: local =>
+            {
+                if (local == 0) Interlocked.Increment(ref emptyLocals);
+            });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(initCalls, Is.InRange(1, 2));
+            Assert.That(emptyLocals, Is.EqualTo(0));
+        }
+    }
+
+    [Test]
     public void For_DoesNotLeakWorkerExceptionToThreadPool()
     {
         // If a worker exception escaped onto a thread-pool thread it would surface via

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -34,7 +34,8 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
     /// <param name="action">The delegate that is invoked once per iteration.</param>
     public static void For(int fromInclusive, int toExclusive, ParallelOptions parallelOptions, Action<int> action)
     {
-        int threads = parallelOptions.MaxDegreeOfParallelism > 0 ? parallelOptions.MaxDegreeOfParallelism : Environment.ProcessorCount;
+        int threads = GetWorkerCount(fromInclusive, toExclusive, parallelOptions);
+        if (threads == 0) return;
 
         Data data = new(threads, fromInclusive, toExclusive, action, parallelOptions.CancellationToken);
 
@@ -122,6 +123,20 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         TLocal state,
         Func<int, TLocal, TLocal> action)
         => InitProcessor<TLocal>.For(fromInclusive, toExclusive, parallelOptions, null, state, action);
+
+    private static int GetWorkerCount(int fromInclusive, int toExclusive, ParallelOptions parallelOptions)
+    {
+        parallelOptions.CancellationToken.ThrowIfCancellationRequested();
+
+        long rangeLength = (long)toExclusive - fromInclusive;
+        if (rangeLength <= 0) return 0;
+
+        int maxWorkers = parallelOptions.MaxDegreeOfParallelism > 0
+            ? parallelOptions.MaxDegreeOfParallelism
+            : Environment.ProcessorCount;
+
+        return (int)Math.Min(rangeLength, maxWorkers);
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ParallelUnbalancedWork"/> class.
@@ -280,10 +295,8 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
             Func<int, TLocal, TLocal> action,
             Action<TLocal>? @finally = null)
         {
-            // Determine the number of threads to use
-            int threads = parallelOptions.MaxDegreeOfParallelism > 0
-                ? parallelOptions.MaxDegreeOfParallelism
-                : Environment.ProcessorCount;
+            int threads = GetWorkerCount(fromInclusive, toExclusive, parallelOptions);
+            if (threads == 0) return;
 
             // Create shared data with thread-local initializers and finalizers
             Data<TLocal> data = new(threads, fromInclusive, toExclusive, action, init, initValue, @finally, parallelOptions.CancellationToken);
@@ -326,9 +339,14 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
             bool initSucceeded = false;
             try
             {
+                int i = _data.Index.GetNext();
+                if (i >= _data.ToExclusive || _data.CancellationToken.IsCancellationRequested || _data.IsFaulted)
+                {
+                    return;
+                }
+
                 value = _data.Init();
                 initSucceeded = true;
-                int i = _data.Index.GetNext();
                 while (i < _data.ToExclusive)
                 {
                     // Stop pulling work once cancelled or another worker has faulted.


### PR DESCRIPTION
## Changes

- `ParallelUnbalancedWork.For` now sizes its worker count to `min(rangeLength, MaxDegreeOfParallelism)` instead of always spawning `MaxDegreeOfParallelism` workers. Small ranges no longer queue `ProcessorCount - 1` thread-pool items that each grab one out-of-range index and exit; an empty range returns without queuing anything.
- In the thread-local (`TLocal`) path, a worker now reserves an index before running `init`. Workers that never receive work skip both `init` and `finally`, so e.g. `BlockCachePreWarmer` idle workers no longer rent an env, build a read-only scope, and immediately return it. The `init`/`finally` pairing is unchanged: `finally` runs exactly when `init` ran, matching BCL `Parallel.For<TLocal>` semantics.
- A pre-cancelled `CancellationToken` now throws `OperationCanceledException` before any workers are queued (previously it was thrown after the no-op workers joined) - same exception surface as BCL `Parallel.For`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Two new tests in `ParallelUnbalancedWorkTests`: an empty range invokes neither `action`, `init`, nor `finally`; and with more workers than work, only workers that actually receive an index run `init` (and every `finally` observes a local that performed work). All 13 `ParallelUnbalancedWorkTests` pass.

All production `init`/`finally` call sites were audited for the skip-on-idle change: `BlockCachePreWarmer` (env rent/return - the motivating case) and `PersistentStorageProvider` (`ReportMetrics(0, 0)` on idle workers, a no-op) are the only `finally` users; the remaining call sites use the state-passthrough overloads with no `finally`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
