### PR TITLE
Skip idle data feed stats serialization

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/Monitoring/DataFeedTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Monitoring/DataFeedTests.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core.Specs;
+using Nethermind.Logging;
+using Nethermind.Runner.Monitoring;
+using Nethermind.Synchronization.Peers;
+using Nethermind.TxPool;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Runner.Test.Monitoring;
+
+public class DataFeedTests
+{
+    [Test]
+    public async Task Does_not_prepare_system_stats_without_subscribers()
+    {
+        using CancellationTokenSource lifetime = new();
+        lifetime.Cancel();
+
+        IMainProcessingContext mainProcessingContext = Substitute.For<IMainProcessingContext>();
+        mainProcessingContext.BlockchainProcessor.Returns(Substitute.For<IBlockchainProcessor>());
+
+        DataFeed dataFeed = new(
+            Substitute.For<ITxPool>(),
+            Substitute.For<ISpecProvider>(),
+            Substitute.For<IReceiptFinder>(),
+            Substitute.For<IBlockTree>(),
+            Substitute.For<ISyncPeerPool>(),
+            mainProcessingContext,
+            LimboLogs.Instance,
+            lifetime.Token);
+
+        byte[] data = await dataFeed.GetStatsTask(delayMs: 0);
+
+        Assert.That(data, Is.Null);
+    }
+}

--- a/src/Nethermind/Nethermind.Runner.Test/Monitoring/DataFeedTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Monitoring/DataFeedTests.cs
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+#nullable enable
+
+using System;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
@@ -12,12 +16,16 @@ using Nethermind.Runner.Monitoring;
 using Nethermind.Synchronization.Peers;
 using Nethermind.TxPool;
 using NSubstitute;
+using NSubstitute.Core;
 using NUnit.Framework;
 
 namespace Nethermind.Runner.Test.Monitoring;
 
 public class DataFeedTests
 {
+    [SetUp]
+    public void Setup() => SubstitutionContext.Current?.ThreadContext?.DequeueAllArgumentSpecifications();
+
     [Test]
     public async Task Does_not_prepare_system_stats_without_subscribers()
     {
@@ -25,7 +33,6 @@ public class DataFeedTests
         lifetime.Cancel();
 
         IMainProcessingContext mainProcessingContext = Substitute.For<IMainProcessingContext>();
-        mainProcessingContext.BlockchainProcessor.Returns(Substitute.For<IBlockchainProcessor>());
 
         DataFeed dataFeed = new(
             Substitute.For<ITxPool>(),
@@ -37,8 +44,26 @@ public class DataFeedTests
             LimboLogs.Instance,
             lifetime.Token);
 
-        byte[] data = await dataFeed.GetStatsTask(delayMs: 0);
+        byte[]? data = await dataFeed.GetStatsTask(delayMs: 0);
 
         Assert.That(data, Is.Null);
+    }
+
+    [Test]
+    public void Channel_subscription_stops_when_cancelled_before_data_arrives()
+    {
+        TaskCompletionSource<byte[]> source = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Channel<DataFeed.ChannelEntry> channel = Channel.CreateUnbounded<DataFeed.ChannelEntry>();
+        using CancellationTokenSource cancellation = new();
+
+        Task subscription = DataFeed.ChannelSubscribe(
+            DataFeed.EntryType.system,
+            () => source.Task,
+            channel,
+            cancellation.Token);
+
+        cancellation.Cancel();
+
+        Assert.That(async () => await subscription.WaitAsync(TimeSpan.FromSeconds(1)), Throws.Nothing);
     }
 }

--- a/src/Nethermind/Nethermind.Runner/Monitoring/DataFeed.cs
+++ b/src/Nethermind/Nethermind.Runner/Monitoring/DataFeed.cs
@@ -205,19 +205,28 @@ public class DataFeed
         _lastTimeStamp = Stopwatch.GetTimestamp();
         while (!_lifetime.IsCancellationRequested)
         {
-            byte[] data = await GetStatsTask(delayMs: 1000);
+            byte[]? data = await GetStatsTask(delayMs: 1000);
+            if (data is null) continue;
+
             DataCompletion systemStats = _systemStats;
             _systemStats = new(TaskCreationOptions.RunContinuationsAsynchronously);
             systemStats.TrySetResult(data);
         }
     }
 
-    private async Task<byte[]> GetStatsTask(int delayMs)
+    internal async Task<byte[]?> GetStatsTask(int delayMs)
     {
         await TaskExtensions.DelaySafe(delayMs, _lifetime);
 
         Environment.ProcessCpuUsage cpuUsage = Environment.CpuUsage;
         long timeStamp = Stopwatch.GetTimestamp();
+
+        if (!HaveSubscribers)
+        {
+            _lastCpuUsage = cpuUsage;
+            _lastTimeStamp = timeStamp;
+            return null;
+        }
 
         TimeSpan elapsed = Stopwatch.GetElapsedTime(_lastTimeStamp, timeStamp);
 

--- a/src/Nethermind/Nethermind.Runner/Monitoring/DataFeed.cs
+++ b/src/Nethermind/Nethermind.Runner/Monitoring/DataFeed.cs
@@ -135,7 +135,7 @@ public class DataFeed
         }
     }
 
-    private enum EntryType
+    internal enum EntryType
     {
         nodeData,
         txNodes,
@@ -147,20 +147,27 @@ public class DataFeed
         peers
     }
 
-    private class ChannelEntry
+    internal class ChannelEntry
     {
         public EntryType Type { get; set; }
         public byte[] Data { get; set; }
     }
-    private static async Task ChannelSubscribe(EntryType type, Func<Task<byte[]>> nextTask, Channel<ChannelEntry> channel, CancellationToken ct)
+    internal static async Task ChannelSubscribe(EntryType type, Func<Task<byte[]>> nextTask, Channel<ChannelEntry> channel, CancellationToken ct)
     {
         Task<byte[]> task = nextTask();
 
-        while (!ct.IsCancellationRequested)
+        try
         {
-            byte[] data = await task;
-            task = nextTask();
-            await channel.Writer.WriteAsync(new ChannelEntry { Type = type, Data = data }, ct);
+            while (!ct.IsCancellationRequested)
+            {
+                byte[] data = await task.WaitAsync(ct);
+                task = nextTask();
+                await channel.Writer.WriteAsync(new ChannelEntry { Type = type, Data = data }, ct);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Normal feed cancellation
         }
     }
 


### PR DESCRIPTION
## Changes

- `DataFeed.SystemStatsRefresh` was the only one of the six monitoring feed producers that did its work unconditionally: every second it read CPU usage, built a `SystemStats`, and JSON-serialized it even with zero dashboard subscribers. It now skips the stats construction and serialization when there are no subscribers, matching the `HaveSubscribers` gate the other five feeds (tx flow, peers, processing, forkchoice, log) already use.
- The idle path still refreshes the `_lastCpuUsage`/`_lastTimeStamp` baseline each tick, so the first sample after a subscriber connects measures CPU % over the last ~1s window rather than averaging over the entire idle period.
- The idle loop still ticks at 1Hz (the delay runs before the subscriber check), so there is no busy spin; a subscriber attaching mid-tick waits at most one extra second for its first `system` event, same as the other feeds.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New `DataFeedTests.Does_not_prepare_system_stats_without_subscribers` calls the (now internal) `GetStatsTask` directly with a cancelled lifetime, so the background refresh loops exit immediately and the no-subscriber path deterministically returns null.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
