### PR TITLE
chore(ci): Disable stateless devnet tests scheduled run

### DIFF
--- a/.github/workflows/stateless-glamsterdam-devnet-tests.yml
+++ b/.github/workflows/stateless-glamsterdam-devnet-tests.yml
@@ -1,8 +1,6 @@
 name: Stateless glamsterdam-devnet tests
 
 on:
-  schedule:
-    - cron: '12 */12 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Changes

Disabled the scheduled run of stateless glamsterdam devnet 5 tests as obsolete

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: CI

## Testing

#### Requires testing

- [ ] Yes
- [x] No
