### PR TITLE
feat(zkevm): align stateless inputs with tests-zkevm@v0.6.2

### DIFF
--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -30,7 +30,7 @@ on:
       zkevm_version:
         description: zkEVM fixtures release tag (zkevmTest only), or latest / latest-<keyword>
         required: false
-        default: tests-zkevm@v0.6.0
+        default: tests-zkevm@v0.6.2
         type: string
       filter:
         description: Regex filter for test names
@@ -76,7 +76,7 @@ on:
       zkevm_version:
         description: zkEVM fixtures release tag (zkevmTest only), or latest / latest-<keyword>
         required: false
-        default: tests-zkevm@v0.6.0
+        default: tests-zkevm@v0.6.2
         type: string
       filter:
         description: Regex filter for test names (optional)
@@ -106,9 +106,9 @@ env:
   EEST_VERSION: ${{ inputs.eest_version || 'tests-glamsterdam-devnet@v7.2.0' }}
   EEST_ARCHIVE: fixtures_glamsterdam-devnet.tar.gz
   # zkEVM stateless-preview fixtures ship in their own release line of the same repo;
-  # zkevmTest jobs resolve this instead of EEST_VERSION. Pinned to v0.6.0, which this
+  # zkevmTest jobs resolve this instead of EEST_VERSION. Pinned to v0.6.2, which this
   # branch's witness roots match (dispatch with zkevm_version to test other releases).
-  ZKEVM_VERSION: ${{ inputs.zkevm_version || 'tests-zkevm@v0.6.0' }}
+  ZKEVM_VERSION: ${{ inputs.zkevm_version || 'tests-zkevm@v0.6.2' }}
   # ubuntu-latest runners have 16 GB of RAM. The runner ships with server GC
   # (throughput-oriented, collects lazily), which previously ballooned past the
   # runner limit on the full fixture set. Workstation GC keeps the heap tight,

--- a/.github/workflows/stateless-tests.yml
+++ b/.github/workflows/stateless-tests.yml
@@ -4,7 +4,6 @@ on:
   merge_group:
     types: [checks_requested]
   pull_request:
-    branches: [master]
   push:
     branches: [master]
   workflow_dispatch:
@@ -44,26 +43,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - input: 25252737.ssz
-            hash: c92d57065d7f4a65ab83b4bd602a91a0e5240a19225f19f6d7e089adef006f0a
-          - input: 25252778.ssz
-            hash: 3688e4fd880e78d3000865896c5fe4d3337e560c955293a477e721898af040cc
-          - input: 25252780.ssz
-            hash: 6dee87ba2b6a9274c5bfa96614fddedc821213cf6566c351c43114247c836391
-          - input: 25252794.ssz
-            hash: fd6be1fcb42c2ce0ed7d65b2283bf7ee6c87e667869ac83363ab734d9a298892
-          - input: 25252835.ssz
-            hash: 8c79b8a6106cc3dd60a9073a23ad0569bfd4d2b5173b5f722b9dd349342158ba
-          - input: 25273697.ssz
-            hash: 6a34aa473484709d08b6416a4f8a266025696c288dcc767331de8d13b9b9f6fe
-          - input: 25274052.ssz
-            hash: 9ed88ee7fd20a1e04e3b2ae1f00c51803266c02d0475909782a715c16b8afbfe
-          - input: 25301641.ssz
-            hash: fb9cba9d13201b31f2788663212836c92b36e8905283dfc1558886dede4722d1
-          - input: 25302208.ssz
-            hash: 404eb7dc779682304b37dec2df8cccc33f5ea6ff5b28505d0138b4dc391b4920
-          - input: 25303404.ssz
-            hash: aba20005ff85b27a3bc3b4a9967d9730b44512cd5dad01fb30cfbc8967311af2
+          - input: 25526356.ssz
+            hash: 5822695902784ea16c68f3becbf1fc53650cd2289a28d6da0e60a8ebddeba05e
+          - input: 25532382.ssz
+            hash: b16c95ce92f518bbdbc62f331457d936f46442befd6aececc8cbe726e52b5935
+          - input: 25532386.ssz
+            hash: f3f98230b82da1fdf57f4ccdac8dbaf9e672bcc20ab4925efc228426b727bbd0
+          - input: 25532442.ssz
+            hash: 26896435247a3e69c5917ea623aa8908951922e7acfb54b1e13f6628adcadc8b
+          - input: 25532454.ssz
+            hash: f5012e7e8324709b4c415f78bcc2542cca6db045f1b9a7856c59a8cd4c422c43
+          - input: 25532471.ssz
+            hash: a0225bbbdb2a7b12e68ac1d1e8bcaabce297c13ac0237fd8d67b69678bc3bff3
+          - input: 25532480.ssz
+            hash: ec1c24bdb687c95b5e4c53ca064995ee8be22467f59fe36d2dea052dd6412d57
+          - input: 25532553.ssz
+            hash: 4fc6a2e66562523bb3b757d5d0691cafabd1b24d237a51b78988bb63c507f223
+          - input: 25532642.ssz
+            hash: c4255a01122dd7ff5d4bcb3d466d4bf3b714088483505ed8e2390797e17ee62e
+          - input: 25532711.ssz
+            hash: 1bb5815b03b8d2b47dc4081a8c11fdf763c4ae6414f91c19f7a52d7eb0bf0f8f
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -77,7 +76,7 @@ jobs:
       - name: Download input
         working-directory: src/Nethermind/Nethermind.Stateless.ZiskGuest/bin
         run: |
-          curl -sSL "https://us-southeast-1.linodeobjects.com/zktests/20260612/${{ matrix.input }}" \
+          curl -sSL "https://us-southeast-1.linodeobjects.com/zktests/20260714/${{ matrix.input }}" \
             -o "${{ matrix.input }}"
           echo "${{ matrix.hash }}  ${{ matrix.input }}" | sha256sum --status -c - || \
             { echo "Checksum failed"; exit 1; }

--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Ethereum.Blockchain.Pyspec.Test.csproj
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Ethereum.Blockchain.Pyspec.Test.csproj
@@ -4,6 +4,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\Ethereum.Test.Base\Ethereum.Test.Base.csproj" />
-    <ProjectReference Include="..\Nethermind.Stateless.Executor\Nethermind.Stateless.Executor.csproj" />
+    <ProjectReference Include="..\Nethermind.Stateless.Executor\Nethermind.Stateless.Executor.csproj" Aliases="global,stateless" />
   </ItemGroup>
 </Project>

--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/ZkEvmFixtures/Constants.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/ZkEvmFixtures/Constants.cs
@@ -7,6 +7,6 @@ namespace Ethereum.Blockchain.Pyspec.Test.ZkEvmFixtures;
 // ARCHIVE_URL_TEMPLATE already points there, so only the version/name need overriding.
 public static class Constants
 {
-    public const string ArchiveVersion = "tests-zkevm@v0.6.0";
+    public const string ArchiveVersion = "tests-zkevm@v0.6.2";
     public const string ArchiveName = "fixtures_zkevm.tar.gz";
 }

--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/ZkEvmFixtures/ZkEvmBlockchainTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/ZkEvmFixtures/ZkEvmBlockchainTests.cs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+extern alias stateless;
+
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,12 +15,16 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
+using Nethermind.Serialization.Ssz;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.GnosisForks;
 using Nethermind.Stateless.Execution;
 using Nethermind.Stateless.Execution.IO;
 using NUnit.Framework;
+using StatelessExecutionPayloadV1 = stateless::Nethermind.Merge.Plugin.SszRest.SszExecutionPayloadV1;
+using StatelessExecutionPayloadV3 = stateless::Nethermind.Merge.Plugin.SszRest.SszExecutionPayloadV3;
+using StatelessExecutionPayloadV4 = stateless::Nethermind.Merge.Plugin.SszRest.SszExecutionPayloadV4;
 
 namespace Ethereum.Blockchain.Pyspec.Test.ZkEvmFixtures;
 
@@ -81,6 +88,52 @@ public abstract class ZkEvmBlockchainTestFixture : PyspecLinuxX64BlockchainFixtu
 [TestFixture]
 public class StatelessSchemaTests
 {
+    [TestCase(ProtocolFork.Cancun)]
+    [TestCase(ProtocolFork.Prague)]
+    [TestCase(ProtocolFork.Osaka)]
+    [TestCase(ProtocolFork.BPO1)]
+    [TestCase(ProtocolFork.BPO2)]
+    [TestCase(ProtocolFork.Amsterdam)]
+    public void Revision_1_schema_roundtrips(ProtocolFork fork)
+    {
+        byte[] encoded = fork == ProtocolFork.Amsterdam
+            ? EncodeInput<StatelessExecutionPayloadV4>(fork)
+            : EncodeInput<StatelessExecutionPayloadV3>(fork);
+
+        StatelessPayload payload = InputDecoder.Decode(encoded);
+        bool foundByName = ProtocolForkExtensions.TryGetByName(fork.GetName(), out ProtocolFork forkByName);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(payload.ProtocolFork, Is.EqualTo(fork));
+            Assert.That(payload.ChainConfig.ChainId, Is.EqualTo(1));
+            Assert.That(foundByName, Is.True);
+            Assert.That(forkByName, Is.EqualTo(fork));
+        }
+    }
+
+    [TestCase(0)]
+    [TestCase(1)]
+    public void Schema_prefix_must_be_two_bytes(int length)
+    {
+        byte[] encoded = new byte[length];
+
+        Assert.That(() => InputDecoder.Decode(encoded), Throws.TypeOf<ArgumentOutOfRangeException>());
+    }
+
+    [TestCase(0x0f01)]
+    [TestCase(0x1002)]
+    [TestCase(0x1601)]
+    public void Unsupported_schema_id_is_rejected(int schemaId)
+    {
+        byte[] encoded = new byte[sizeof(ushort)];
+        BinaryPrimitives.WriteUInt16BigEndian(encoded, (ushort)schemaId);
+
+        Assert.That(
+            () => InputDecoder.Decode(encoded),
+            Throws.TypeOf<ArgumentException>().With.Message.Contains($"0x{schemaId:x4}"));
+    }
+
     [TestCase(10UL, 20UL, true)]
     [TestCase(9UL, 20UL, false)]
     [TestCase(10UL, 19UL, false)]
@@ -125,6 +178,56 @@ public class StatelessSchemaTests
             Assert.That(spec.Name, Is.EqualTo(Amsterdam.Instance.Name));
             Assert.That(spec, usesGnosisRules ? Is.SameAs(AmsterdamGnosis.Instance) : Is.SameAs(Amsterdam.Instance));
         }
+    }
+
+    private static byte[] EncodeInput<TExecutionPayload>(ProtocolFork fork)
+        where TExecutionPayload : StatelessExecutionPayloadV1,
+        stateless::Nethermind.Merge.Plugin.SszRest.ISszExecutionPayloadFactory<TExecutionPayload>,
+        ISszCodec<TExecutionPayload>, new()
+    {
+        StatelessInput<TExecutionPayload> input = new()
+        {
+            NewPayloadRequest = new()
+            {
+                ExecutionPayload = new TExecutionPayload(),
+                VersionedHashes = [],
+                ParentBeaconBlockRoot = Hash256.Zero,
+                ExecutionRequests = new()
+                {
+                    Deposits = [],
+                    Withdrawals = [],
+                    Consolidations = [],
+                    BuilderDeposits = [],
+                    BuilderExits = []
+                }
+            },
+            Witness = new()
+            {
+                State = [],
+                Codes = [],
+                Headers = []
+            },
+            ChainConfig = new()
+            {
+                ChainId = 1,
+                ActiveFork = new()
+                {
+                    Activation = new()
+                    {
+                        BlockNumber = [0],
+                        Timestamp = []
+                    }
+                }
+            },
+            PublicKeys = []
+        };
+        byte[] payload = StatelessInput<TExecutionPayload>.Encode(input);
+        byte[] encoded = new byte[sizeof(ushort) + payload.Length];
+
+        BinaryPrimitives.WriteUInt16BigEndian(encoded, fork.ToRevision1SchemaId());
+        payload.AsSpan().CopyTo(encoded.AsSpan(sizeof(ushort)));
+
+        return encoded;
     }
 
     private static BlockHeader CreateHeader(ulong blockNumber, ulong timestamp) => new(

--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/ZkEvmFixtures/ZkEvmBlockchainTests.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/ZkEvmFixtures/ZkEvmBlockchainTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Ethereum.Test.Base;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.ExecutionRequest;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
@@ -102,6 +103,7 @@ public class StatelessSchemaTests
 
         StatelessPayload payload = InputDecoder.Decode(encoded);
         bool foundByName = ProtocolForkExtensions.TryGetByName(fork.GetName(), out ProtocolFork forkByName);
+        Hash256 expectedRequestsHash = fork >= ProtocolFork.Prague ? ExecutionRequestExtensions.EmptyRequestsHash : null;
 
         using (Assert.EnterMultipleScope())
         {
@@ -109,6 +111,37 @@ public class StatelessSchemaTests
             Assert.That(payload.ChainConfig.ChainId, Is.EqualTo(1));
             Assert.That(foundByName, Is.True);
             Assert.That(forkByName, Is.EqualTo(fork));
+            Assert.That(payload.Block.Header.RequestsHash, Is.EqualTo(expectedRequestsHash));
+        }
+    }
+
+    [TestCase((byte)ExecutionRequestType.Deposit, ExecutionRequestExtensions.DepositRequestsBytesSize)]
+    [TestCase((byte)ExecutionRequestType.WithdrawalRequest, ExecutionRequestExtensions.WithdrawalRequestsBytesSize)]
+    [TestCase((byte)ExecutionRequestType.ConsolidationRequest, ExecutionRequestExtensions.ConsolidationRequestsBytesSize)]
+    [TestCase((byte)ExecutionRequestType.BuilderDepositRequest, ExecutionRequestExtensions.BuilderDepositRequestsBytesSize)]
+    [TestCase((byte)ExecutionRequestType.BuilderExitRequest, ExecutionRequestExtensions.BuilderExitRequestsBytesSize)]
+    public void Request_struct_conversion_roundtrips(byte requestType, int size)
+    {
+        byte[] data = new byte[size];
+
+        for (int i = 0; i < data.Length; i++)
+            data[i] = (byte)i;
+
+        ExecutionRequest request = new() { RequestType = requestType, RequestData = data };
+        ExecutionRequest roundTripped = (ExecutionRequestType)requestType switch
+        {
+            ExecutionRequestType.Deposit => DepositRequest.From(request).ToExecutionRequest(),
+            ExecutionRequestType.WithdrawalRequest => WithdrawalRequest.From(request).ToExecutionRequest(),
+            ExecutionRequestType.ConsolidationRequest => ConsolidationRequest.From(request).ToExecutionRequest(),
+            ExecutionRequestType.BuilderDepositRequest => BuilderDepositRequest.From(request).ToExecutionRequest(),
+            ExecutionRequestType.BuilderExitRequest => BuilderExitRequest.From(request).ToExecutionRequest(),
+            _ => throw new AssertionException($"Unsupported request type: {requestType}")
+        };
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roundTripped.RequestType, Is.EqualTo(requestType));
+            Assert.That(roundTripped.RequestData, Is.EqualTo(data));
         }
     }
 

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TestItem.cs
@@ -120,6 +120,10 @@ namespace Nethermind.Core.Test.Builders
         public static TestExecutionRequest ExecutionRequestG = new() { RequestType = 2, RequestDataParts = [AddressA.Bytes.ToArray(), PublicKeyA.Bytes.Slice(0, 48), PublicKeyB.Bytes.Slice(0, 48)] };
         public static TestExecutionRequest ExecutionRequestH = new() { RequestType = 2, RequestDataParts = [AddressB.Bytes.ToArray(), PublicKeyB.Bytes.Slice(0, 48), PublicKeyC.Bytes.Slice(0, 48)] };
         public static TestExecutionRequest ExecutionRequestI = new() { RequestType = 2, RequestDataParts = [AddressC.Bytes.ToArray(), PublicKeyC.Bytes.Slice(0, 48), PublicKeyA.Bytes.Slice(0, 48)] };
+        public static TestExecutionRequest ExecutionRequestJ = new() { RequestType = 3, RequestDataParts = [PublicKeyA.Bytes.Slice(0, 48), KeccakA.Bytes.ToArray(), BitConverter.GetBytes((ulong)1_000_000_000), SignatureBytes] };
+        public static TestExecutionRequest ExecutionRequestK = new() { RequestType = 3, RequestDataParts = [PublicKeyB.Bytes.Slice(0, 48), KeccakB.Bytes.ToArray(), BitConverter.GetBytes((ulong)2_000_000_000), SignatureBytes] };
+        public static TestExecutionRequest ExecutionRequestL = new() { RequestType = 4, RequestDataParts = [AddressA.Bytes.ToArray(), PublicKeyA.Bytes.Slice(0, 48)] };
+        public static TestExecutionRequest ExecutionRequestM = new() { RequestType = 4, RequestDataParts = [AddressB.Bytes.ToArray(), PublicKeyB.Bytes.Slice(0, 48)] };
 
         public static IPEndPoint IPEndPointA = IPEndPoint.Parse("10.0.0.1");
         public static IPEndPoint IPEndPointB = IPEndPoint.Parse("10.0.0.2");

--- a/src/Nethermind/Nethermind.Core.Test/ExecutionRequests/ExecutionRequestExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/ExecutionRequests/ExecutionRequestExtensionsTests.cs
@@ -15,9 +15,29 @@ public class ExecutionRequestExtensionsTests
     private static readonly TestExecutionRequest[] DepositRequests = [TestItem.ExecutionRequestA, TestItem.ExecutionRequestB, TestItem.ExecutionRequestC];
     private static readonly TestExecutionRequest[] WithdrawalRequests = [TestItem.ExecutionRequestD, TestItem.ExecutionRequestE, TestItem.ExecutionRequestF];
     private static readonly TestExecutionRequest[] ConsolidationRequests = [TestItem.ExecutionRequestG, TestItem.ExecutionRequestH, TestItem.ExecutionRequestI];
+    private static readonly TestExecutionRequest[] BuilderDepositRequests = [TestItem.ExecutionRequestJ, TestItem.ExecutionRequestK];
+    private static readonly TestExecutionRequest[] BuilderExitRequests = [TestItem.ExecutionRequestL, TestItem.ExecutionRequestM];
 
     [Test]
     public void GetFlatEncodedRequests_encodes_request_groups()
+    {
+        using ArrayPoolList<byte[]> flatEncodedRequests = ExecutionRequestExtensions.GetFlatEncodedRequests(
+            DepositRequests,
+            WithdrawalRequests,
+            ConsolidationRequests,
+            BuilderDepositRequests,
+            BuilderExitRequests);
+
+        Assert.That(flatEncodedRequests, Has.Count.EqualTo(ExecutionRequestExtensions.MaxRequestsCount));
+        AssertFlatEncodedRequests(flatEncodedRequests[0], ExecutionRequestType.Deposit, DepositRequests, ExecutionRequestExtensions.DepositRequestsBytesSize);
+        AssertFlatEncodedRequests(flatEncodedRequests[1], ExecutionRequestType.WithdrawalRequest, WithdrawalRequests, ExecutionRequestExtensions.WithdrawalRequestsBytesSize);
+        AssertFlatEncodedRequests(flatEncodedRequests[2], ExecutionRequestType.ConsolidationRequest, ConsolidationRequests, ExecutionRequestExtensions.ConsolidationRequestsBytesSize);
+        AssertFlatEncodedRequests(flatEncodedRequests[3], ExecutionRequestType.BuilderDepositRequest, BuilderDepositRequests, ExecutionRequestExtensions.BuilderDepositRequestsBytesSize);
+        AssertFlatEncodedRequests(flatEncodedRequests[4], ExecutionRequestType.BuilderExitRequest, BuilderExitRequests, ExecutionRequestExtensions.BuilderExitRequestsBytesSize);
+    }
+
+    [Test]
+    public void GetFlatEncodedRequests_preserves_legacy_overload()
     {
         using ArrayPoolList<byte[]> flatEncodedRequests = ExecutionRequestExtensions.GetFlatEncodedRequests(
             DepositRequests,
@@ -38,6 +58,8 @@ public class ExecutionRequestExtensionsTests
         using ArrayPoolList<byte[]> flatEncodedRequests = ExecutionRequestExtensions.GetFlatEncodedRequests(
             [],
             withdrawalRequests,
+            [],
+            [],
             []);
 
         Assert.That(flatEncodedRequests, Has.Count.EqualTo(1));
@@ -45,7 +67,30 @@ public class ExecutionRequestExtensionsTests
     }
 
     [Test]
-    public void GetFlatDecodedRequests_decodes_flat_encoded_requests()
+    public void GetAllFlatDecodedRequests_decodes_flat_encoded_requests()
+    {
+        using ArrayPoolList<byte[]> flatEncodedRequests = ExecutionRequestExtensions.GetFlatEncodedRequests(
+            DepositRequests,
+            WithdrawalRequests,
+            ConsolidationRequests,
+            BuilderDepositRequests,
+            BuilderExitRequests);
+        (CoreExecutionRequest[] decodedDepositRequests,
+            CoreExecutionRequest[] decodedWithdrawalRequests,
+            CoreExecutionRequest[] decodedConsolidationRequests,
+            CoreExecutionRequest[] decodedBuilderDepositRequests,
+            CoreExecutionRequest[] decodedBuilderExitRequests) =
+            ExecutionRequestExtensions.GetAllFlatDecodedRequests([.. flatEncodedRequests]);
+
+        AssertRequests(DepositRequests, decodedDepositRequests);
+        AssertRequests(WithdrawalRequests, decodedWithdrawalRequests);
+        AssertRequests(ConsolidationRequests, decodedConsolidationRequests);
+        AssertRequests(BuilderDepositRequests, decodedBuilderDepositRequests);
+        AssertRequests(BuilderExitRequests, decodedBuilderExitRequests);
+    }
+
+    [Test]
+    public void GetFlatDecodedRequests_preserves_legacy_contract()
     {
         using ArrayPoolList<byte[]> flatEncodedRequests = ExecutionRequestExtensions.GetFlatEncodedRequests(
             DepositRequests,
@@ -62,55 +107,76 @@ public class ExecutionRequestExtensionsTests
     }
 
     [Test]
-    public void GetFlatDecodedRequests_allows_empty_request_groups()
+    public void GetFlatDecodedRequests_rejects_builder_requests()
+    {
+        using ArrayPoolList<byte[]> flatEncodedRequests = ExecutionRequestExtensions.GetFlatEncodedRequests(
+            [],
+            [],
+            [],
+            BuilderDepositRequests,
+            []);
+
+        Assert.That(
+            () => ExecutionRequestExtensions.GetFlatDecodedRequests([.. flatEncodedRequests]),
+            Throws.TypeOf<NotSupportedException>());
+    }
+
+    [Test]
+    public void GetAllFlatDecodedRequests_allows_empty_request_groups()
     {
         (CoreExecutionRequest[] depositRequests,
             CoreExecutionRequest[] withdrawalRequests,
-            CoreExecutionRequest[] consolidationRequests) =
-            ExecutionRequestExtensions.GetFlatDecodedRequests([[(byte)ExecutionRequestType.Deposit]]);
+            CoreExecutionRequest[] consolidationRequests,
+            CoreExecutionRequest[] builderDepositRequests,
+            CoreExecutionRequest[] builderExitRequests) =
+            ExecutionRequestExtensions.GetAllFlatDecodedRequests([[(byte)ExecutionRequestType.Deposit]]);
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(depositRequests, Is.Empty);
             Assert.That(withdrawalRequests, Is.Empty);
             Assert.That(consolidationRequests, Is.Empty);
+            Assert.That(builderDepositRequests, Is.Empty);
+            Assert.That(builderExitRequests, Is.Empty);
         }
     }
 
     [Test]
-    public void GetFlatDecodedRequests_rejects_empty_request_blob() =>
-        Assert.Throws<ArgumentException>(() => ExecutionRequestExtensions.GetFlatDecodedRequests([[]]));
+    public void GetAllFlatDecodedRequests_rejects_empty_request_blob() =>
+        Assert.Throws<ArgumentException>(() => ExecutionRequestExtensions.GetAllFlatDecodedRequests([[]]));
 
     [TestCase((byte)ExecutionRequestType.Deposit, ExecutionRequestExtensions.DepositRequestsBytesSize)]
     [TestCase((byte)ExecutionRequestType.WithdrawalRequest, ExecutionRequestExtensions.WithdrawalRequestsBytesSize)]
     [TestCase((byte)ExecutionRequestType.ConsolidationRequest, ExecutionRequestExtensions.ConsolidationRequestsBytesSize)]
-    public void GetFlatDecodedRequests_rejects_partial_request_data(byte type, int requestDataSize)
+    [TestCase((byte)ExecutionRequestType.BuilderDepositRequest, ExecutionRequestExtensions.BuilderDepositRequestsBytesSize)]
+    [TestCase((byte)ExecutionRequestType.BuilderExitRequest, ExecutionRequestExtensions.BuilderExitRequestsBytesSize)]
+    public void GetAllFlatDecodedRequests_rejects_partial_request_data(byte type, int requestDataSize)
     {
         byte[] encodedRequests = new byte[requestDataSize];
         encodedRequests[0] = type;
 
         Assert.Throws<ArgumentException>(() =>
         {
-            ExecutionRequestExtensions.GetFlatDecodedRequests([encodedRequests]);
+            ExecutionRequestExtensions.GetAllFlatDecodedRequests([encodedRequests]);
         });
     }
 
     [Test]
-    public void GetFlatDecodedRequests_rejects_unknown_request_type() =>
-        Assert.Throws<ArgumentOutOfRangeException>(() => ExecutionRequestExtensions.GetFlatDecodedRequests([[byte.MaxValue, 0]]));
+    public void GetAllFlatDecodedRequests_rejects_unknown_request_type() =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => ExecutionRequestExtensions.GetAllFlatDecodedRequests([[byte.MaxValue, 0]]));
 
     [Test]
-    public void GetFlatDecodedRequests_rejects_duplicate_request_type() =>
+    public void GetAllFlatDecodedRequests_rejects_duplicate_request_type() =>
         Assert.Throws<ArgumentException>(() =>
-            ExecutionRequestExtensions.GetFlatDecodedRequests([
+            ExecutionRequestExtensions.GetAllFlatDecodedRequests([
                 [(byte)ExecutionRequestType.Deposit],
                 [(byte)ExecutionRequestType.Deposit]
             ]));
 
     [Test]
-    public void GetFlatDecodedRequests_rejects_descending_request_type() =>
+    public void GetAllFlatDecodedRequests_rejects_descending_request_type() =>
         Assert.Throws<ArgumentException>(() =>
-            ExecutionRequestExtensions.GetFlatDecodedRequests([
+            ExecutionRequestExtensions.GetAllFlatDecodedRequests([
                 [(byte)ExecutionRequestType.WithdrawalRequest],
                 [(byte)ExecutionRequestType.Deposit]
             ]));

--- a/src/Nethermind/Nethermind.Core/ExecutionRequest/ExecutionRequestExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/ExecutionRequest/ExecutionRequestExtensions.cs
@@ -26,10 +26,11 @@ public static class ExecutionRequestExtensions
 
     public const int WithdrawalRequestsBytesSize = Address.Size + PublicKeySize /*validator_pubkey: Bytes48*/ + sizeof(ulong) /*amount: uint64*/;
     public const int ConsolidationRequestsBytesSize = Address.Size + PublicKeySize /*source_pubkey: Bytes48*/ + PublicKeySize /*target_pubkey: Bytes48*/;
+    public const int BuilderDepositRequestsBytesSize = PublicKeySize + WithdrawalCredentialsSize + AmountSize + SignatureSize;
+    public const int BuilderExitRequestsBytesSize = Address.Size + PublicKeySize;
     public const int MaxRequestsCount = 5;
     /// <summary>
-    /// Number of request types representable in the flat-encoded stateless input format
-    /// (deposit, withdrawal, consolidation).
+    /// Number of request types representable before EIP-8282 (deposit, withdrawal, consolidation).
     /// </summary>
     public const int StatelessRequestTypesCount = 3;
 
@@ -53,14 +54,23 @@ public static class ExecutionRequestExtensions
     }
 
 
-    // the following functions are only used in tests
+    /// <summary>Flat-encodes the pre-EIP-8282 execution request groups.</summary>
     public static ArrayPoolList<byte[]> GetFlatEncodedRequests(
         ExecutionRequest[] depositRequests,
         ExecutionRequest[] withdrawalRequests,
-        ExecutionRequest[] consolidationRequests
+        ExecutionRequest[] consolidationRequests) =>
+        GetFlatEncodedRequests(depositRequests, withdrawalRequests, consolidationRequests, [], []);
+
+    /// <summary>Flat-encodes all execution request groups.</summary>
+    public static ArrayPoolList<byte[]> GetFlatEncodedRequests(
+        ExecutionRequest[] depositRequests,
+        ExecutionRequest[] withdrawalRequests,
+        ExecutionRequest[] consolidationRequests,
+        ExecutionRequest[] builderDepositRequests,
+        ExecutionRequest[] builderExitRequests
     )
     {
-        ArrayPoolList<byte[]> result = new(StatelessRequestTypesCount);
+        ArrayPoolList<byte[]> result = new(MaxRequestsCount);
 
         if (depositRequests.Length > 0)
         {
@@ -75,6 +85,16 @@ public static class ExecutionRequestExtensions
         if (consolidationRequests.Length > 0)
         {
             result.Add(FlatEncodeRequests(consolidationRequests, consolidationRequests.Length * ConsolidationRequestsBytesSize, (byte)ExecutionRequestType.ConsolidationRequest));
+        }
+
+        if (builderDepositRequests.Length > 0)
+        {
+            result.Add(FlatEncodeRequests(builderDepositRequests, builderDepositRequests.Length * BuilderDepositRequestsBytesSize, (byte)ExecutionRequestType.BuilderDepositRequest));
+        }
+
+        if (builderExitRequests.Length > 0)
+        {
+            result.Add(FlatEncodeRequests(builderExitRequests, builderExitRequests.Length * BuilderExitRequestsBytesSize, (byte)ExecutionRequestType.BuilderExitRequest));
         }
 
         return result;
@@ -97,14 +117,49 @@ public static class ExecutionRequestExtensions
     /// </summary>
     /// <param name="requests">Flat encoded request groups, each prefixed by an execution request type byte.</param>
     /// <returns>The decoded request groups.</returns>
-    public static (ExecutionRequest[] DepositRequests, ExecutionRequest[] WithdrawalRequests, ExecutionRequest[] ConsolidationRequests)
+    public static (
+        ExecutionRequest[] DepositRequests,
+        ExecutionRequest[] WithdrawalRequests,
+        ExecutionRequest[] ConsolidationRequests)
         GetFlatDecodedRequests(byte[][] requests)
+    {
+        (ExecutionRequest[] depositRequests,
+            ExecutionRequest[] withdrawalRequests,
+            ExecutionRequest[] consolidationRequests,
+            _, _) = DecodeFlatRequests(requests, includeBuilderRequests: false);
+
+        return (depositRequests, withdrawalRequests, consolidationRequests);
+    }
+
+    /// <summary>
+    /// Decodes flat encoded execution request groups into deposit, withdrawal, consolidation,
+    /// builder deposit, and builder exit requests.
+    /// </summary>
+    /// <param name="requests">Flat encoded request groups, each prefixed by an execution request type byte.</param>
+    /// <returns>The decoded request groups.</returns>
+    public static (
+        ExecutionRequest[] DepositRequests,
+        ExecutionRequest[] WithdrawalRequests,
+        ExecutionRequest[] ConsolidationRequests,
+        ExecutionRequest[] BuilderDepositRequests,
+        ExecutionRequest[] BuilderExitRequests)
+        GetAllFlatDecodedRequests(byte[][] requests) => DecodeFlatRequests(requests, includeBuilderRequests: true);
+
+    private static (
+        ExecutionRequest[] DepositRequests,
+        ExecutionRequest[] WithdrawalRequests,
+        ExecutionRequest[] ConsolidationRequests,
+        ExecutionRequest[] BuilderDepositRequests,
+        ExecutionRequest[] BuilderExitRequests)
+        DecodeFlatRequests(byte[][] requests, bool includeBuilderRequests)
     {
         ArgumentNullException.ThrowIfNull(requests);
 
         ExecutionRequest[] depositRequests = [];
         ExecutionRequest[] withdrawalRequests = [];
         ExecutionRequest[] consolidationRequests = [];
+        ExecutionRequest[] builderDepositRequests = [];
+        ExecutionRequest[] builderExitRequests = [];
         int lastType = -1;
 
         for (int i = 0; i < requests.Length; i++)
@@ -133,15 +188,23 @@ public static class ExecutionRequestExtensions
                     consolidationRequests = DecodeRequests(encoded, ConsolidationRequestsBytesSize, type, nameof(ExecutionRequestType.ConsolidationRequest), nameof(requests));
                     break;
                 case ExecutionRequestType.BuilderDepositRequest:
+                    if (!includeBuilderRequests)
+                        throw new NotSupportedException($"EIP-8282 builder requests (type {type}) are not supported by this overload.");
+
+                    builderDepositRequests = DecodeRequests(encoded, BuilderDepositRequestsBytesSize, type, nameof(ExecutionRequestType.BuilderDepositRequest), nameof(requests));
+                    break;
                 case ExecutionRequestType.BuilderExitRequest:
-                    throw new NotSupportedException(
-                        $"EIP-8282 builder requests (type {type}) are not representable in the stateless input format.");
+                    if (!includeBuilderRequests)
+                        throw new NotSupportedException($"EIP-8282 builder requests (type {type}) are not supported by this overload.");
+
+                    builderExitRequests = DecodeRequests(encoded, BuilderExitRequestsBytesSize, type, nameof(ExecutionRequestType.BuilderExitRequest), nameof(requests));
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(requests), type, "Unknown execution request type.");
             }
         }
 
-        return (depositRequests, withdrawalRequests, consolidationRequests);
+        return (depositRequests, withdrawalRequests, consolidationRequests, builderDepositRequests, builderExitRequests);
 
         static ExecutionRequest[] DecodeRequests(byte[] encodedRequests, int requestDataSize, byte type, string typeName, string parameterName)
         {

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/BuilderDepositRequest.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/BuilderDepositRequest.cs
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.ExecutionRequest;
+using Nethermind.Core.Crypto;
+using Nethermind.Serialization.Ssz;
+using System.Buffers.Binary;
+
+namespace Nethermind.Stateless.Execution.IO;
+
+[SszContainer]
+public partial struct BuilderDepositRequest
+{
+    [SszVector(48)]
+    public ReadOnlyMemory<byte> PublicKey { get; set; }
+
+    public ValueHash256 WithdrawalCredentials { get; set; }
+
+    public ulong Amount { get; set; }
+
+    [SszVector(96)]
+    public ReadOnlyMemory<byte> Signature { get; set; }
+
+    public static BuilderDepositRequest From(ExecutionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request, nameof(request));
+        ArgumentOutOfRangeException.ThrowIfNotEqual(
+            request.RequestType, (byte)ExecutionRequestType.BuilderDepositRequest, nameof(request.RequestType));
+        ArgumentOutOfRangeException.ThrowIfNotEqual(
+            request.RequestData?.Length ?? 0, ExecutionRequestExtensions.BuilderDepositRequestsBytesSize, nameof(request.RequestData));
+
+        ReadOnlyMemory<byte> buffer = request.RequestData;
+        ReadOnlySpan<byte> span = buffer.Span;
+
+        return new()
+        {
+            PublicKey = buffer[0..48],
+            WithdrawalCredentials = new ValueHash256(span[48..80]),
+            Amount = BinaryPrimitives.ReadUInt64LittleEndian(span[80..88]),
+            Signature = buffer[88..184]
+        };
+    }
+
+    public readonly ExecutionRequest ToExecutionRequest()
+    {
+        byte[] result = new byte[ExecutionRequestExtensions.BuilderDepositRequestsBytesSize];
+        Span<byte> buffer = result;
+
+        PublicKey.Span.CopyTo(buffer); // offset = 0
+        WithdrawalCredentials.Bytes.CopyTo(buffer[48..]); // offset = 48
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer[80..], Amount); // offset = 48 + 32
+        Signature.Span.CopyTo(buffer[88..]); // offset = 48 + 32 + 8
+
+        return new()
+        {
+            RequestType = (byte)ExecutionRequestType.BuilderDepositRequest,
+            RequestData = result
+        };
+    }
+}

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/BuilderExitRequest.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/BuilderExitRequest.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.ExecutionRequest;
+using Nethermind.Serialization.Ssz;
+
+namespace Nethermind.Stateless.Execution.IO;
+
+[SszContainer]
+public partial struct BuilderExitRequest
+{
+    public Address SourceAddress { get; set; }
+
+    [SszVector(48)]
+    public ReadOnlyMemory<byte> PublicKey { get; set; }
+
+    public static BuilderExitRequest From(ExecutionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request, nameof(request));
+        ArgumentOutOfRangeException.ThrowIfNotEqual(
+            request.RequestType, (byte)ExecutionRequestType.BuilderExitRequest, nameof(request.RequestType));
+        ArgumentOutOfRangeException.ThrowIfNotEqual(
+            request.RequestData?.Length ?? 0, ExecutionRequestExtensions.BuilderExitRequestsBytesSize, nameof(request.RequestData));
+
+        ReadOnlyMemory<byte> buffer = request.RequestData;
+
+        return new()
+        {
+            SourceAddress = new(buffer.Span[0..20]),
+            PublicKey = buffer[20..68]
+        };
+    }
+
+    public readonly ExecutionRequest ToExecutionRequest()
+    {
+        byte[] result = new byte[ExecutionRequestExtensions.BuilderExitRequestsBytesSize];
+        Span<byte> buffer = result;
+
+        SourceAddress.Bytes.CopyTo(buffer); // offset = 0
+        PublicKey.Span.CopyTo(buffer[20..]); // offset = 20
+
+        return new()
+        {
+            RequestType = (byte)ExecutionRequestType.BuilderExitRequest,
+            RequestData = result
+        };
+    }
+}

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/InputDecoder.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/InputDecoder.cs
@@ -36,7 +36,7 @@ internal static class InputDecoder
         NewPayloadRequest<TExecutionPayload>.Merkleize(input.NewPayloadRequest, out UInt256 root);
 
         return new(
-            Block: input.NewPayloadRequest.ToBlock()!,
+            Block: input.NewPayloadRequest.ToBlock(requestsEnabled: protocolFork >= ProtocolFork.Prague)!,
             Witness: input.Witness,
             ChainConfig: input.ChainConfig,
             PublicKeys: input.PublicKeys,

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/InputDecoder.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/InputDecoder.cs
@@ -11,17 +11,20 @@ namespace Nethermind.Stateless.Execution.IO;
 
 internal static class InputDecoder
 {
-    private const ushort AmsterdamRevision1SchemaId = ((ushort)ProtocolFork.Amsterdam << 8) | 0x01;
+    /// <summary>The schema revision selecting the SSZ <c>StatelessInput</c> payload encoding.</summary>
+    internal const byte Revision1 = 0x01;
 
     internal static StatelessPayload Decode(ReadOnlySpan<byte> data)
     {
         ushort schemaId = BinaryPrimitives.ReadUInt16BigEndian(data);
+        ProtocolFork fork = (ProtocolFork)(schemaId >> 8);
+        byte revision = (byte)schemaId;
+        ReadOnlySpan<byte> payload = data[sizeof(ushort)..];
 
-        return schemaId switch
+        return (fork, revision) switch
         {
-            AmsterdamRevision1SchemaId => DecodeRevision1<SszExecutionPayloadV4>(
-                data[sizeof(ushort)..],
-                ProtocolFork.Amsterdam),
+            (ProtocolFork.Amsterdam, Revision1) => DecodeRevision1<SszExecutionPayloadV4>(payload, fork),
+            ( >= ProtocolFork.Cancun and < ProtocolFork.Amsterdam, Revision1) => DecodeRevision1<SszExecutionPayloadV3>(payload, fork),
             _ => throw new ArgumentException($"Unsupported schema id: 0x{schemaId:x4}", nameof(data))
         };
     }

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/NewPayloadRequest.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/NewPayloadRequest.cs
@@ -102,7 +102,7 @@ public partial class NewPayloadRequest<TExecutionPayload>
         return request;
     }
 
-    public Block? ToBlock()
+    public Block? ToBlock(bool requestsEnabled)
     {
         if (ExecutionPayload is null)
             return null;
@@ -110,6 +110,16 @@ public partial class NewPayloadRequest<TExecutionPayload>
         ExecutionPayload payload = ExecutionPayload.AsExecutionPayload();
         payload.ParentBeaconBlockRoot = ParentBeaconBlockRoot;
 
+        if (requestsEnabled)
+            payload.ExecutionRequests = GetFlatEncodedRequests();
+
+        Result<Block> result = payload.TryGetBlock();
+
+        return result.Data ?? throw new InvalidOperationException(result.Error);
+    }
+
+    private byte[][] GetFlatEncodedRequests()
+    {
         ExecutionRequest[] deposits = new ExecutionRequest[ExecutionRequests.Deposits.Length];
 
         for (int i = 0; i < deposits.Length; i++)
@@ -138,10 +148,6 @@ public partial class NewPayloadRequest<TExecutionPayload>
         using ArrayPoolList<byte[]> pool = ExecutionRequestExtensions.GetFlatEncodedRequests(
             deposits, withdrawals, consolidations, builderDeposits, builderExits);
 
-        payload.ExecutionRequests = [.. pool];
-
-        Result<Block> result = payload.TryGetBlock();
-
-        return result.Data ?? throw new InvalidOperationException(result.Error);
+        return [.. pool];
     }
 }

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/NewPayloadRequest.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/NewPayloadRequest.cs
@@ -57,17 +57,22 @@ public partial class NewPayloadRequest<TExecutionPayload>
             {
                 Deposits = [],
                 Withdrawals = [],
-                Consolidations = []
+                Consolidations = [],
+                BuilderDeposits = [],
+                BuilderExits = []
             };
         }
         else
         {
-            (ExecutionRequest[] deposits, ExecutionRequest[] withdrawals, ExecutionRequest[] consolidations)
-                = ExecutionRequestExtensions.GetFlatDecodedRequests(block.ExecutionRequests);
+            (ExecutionRequest[] deposits, ExecutionRequest[] withdrawals, ExecutionRequest[] consolidations,
+                ExecutionRequest[] builderDeposits, ExecutionRequest[] builderExits)
+                = ExecutionRequestExtensions.GetAllFlatDecodedRequests(block.ExecutionRequests);
 
             DepositRequest[] depositRequests = new DepositRequest[deposits.Length];
             WithdrawalRequest[] withdrawalRequests = new WithdrawalRequest[withdrawals.Length];
             ConsolidationRequest[] consolidationRequests = new ConsolidationRequest[consolidations.Length];
+            BuilderDepositRequest[] builderDepositRequests = new BuilderDepositRequest[builderDeposits.Length];
+            BuilderExitRequest[] builderExitRequests = new BuilderExitRequest[builderExits.Length];
 
             for (int i = 0; i < deposits.Length; i++)
                 depositRequests[i] = DepositRequest.From(deposits[i]);
@@ -78,11 +83,19 @@ public partial class NewPayloadRequest<TExecutionPayload>
             for (int i = 0; i < consolidations.Length; i++)
                 consolidationRequests[i] = ConsolidationRequest.From(consolidations[i]);
 
+            for (int i = 0; i < builderDeposits.Length; i++)
+                builderDepositRequests[i] = BuilderDepositRequest.From(builderDeposits[i]);
+
+            for (int i = 0; i < builderExits.Length; i++)
+                builderExitRequests[i] = BuilderExitRequest.From(builderExits[i]);
+
             request.ExecutionRequests = new()
             {
                 Deposits = depositRequests,
                 Withdrawals = withdrawalRequests,
-                Consolidations = consolidationRequests
+                Consolidations = consolidationRequests,
+                BuilderDeposits = builderDepositRequests,
+                BuilderExits = builderExitRequests
             };
         }
 
@@ -112,8 +125,18 @@ public partial class NewPayloadRequest<TExecutionPayload>
         for (int i = 0; i < consolidations.Length; i++)
             consolidations[i] = ExecutionRequests.Consolidations[i].ToExecutionRequest();
 
+        ExecutionRequest[] builderDeposits = new ExecutionRequest[ExecutionRequests.BuilderDeposits.Length];
+
+        for (int i = 0; i < builderDeposits.Length; i++)
+            builderDeposits[i] = ExecutionRequests.BuilderDeposits[i].ToExecutionRequest();
+
+        ExecutionRequest[] builderExits = new ExecutionRequest[ExecutionRequests.BuilderExits.Length];
+
+        for (int i = 0; i < builderExits.Length; i++)
+            builderExits[i] = ExecutionRequests.BuilderExits[i].ToExecutionRequest();
+
         using ArrayPoolList<byte[]> pool = ExecutionRequestExtensions.GetFlatEncodedRequests(
-            deposits, withdrawals, consolidations);
+            deposits, withdrawals, consolidations, builderDeposits, builderExits);
 
         payload.ExecutionRequests = [.. pool];
 

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/ProtocolFork.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/ProtocolFork.cs
@@ -1,9 +1,54 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Specs.Forks;
+
 namespace Nethermind.Stateless.Execution.IO;
 
-internal enum ProtocolFork : byte
+/// <summary>
+/// Stable execution-layer fork identifiers used as the first byte of the stateless input schema id,
+/// as defined by the execution specs <c>ProtocolFork</c> enum.
+/// </summary>
+/// <remarks>
+/// Only forks whose payloads are representable by the stateless input schemas are listed:
+/// Cancun through BPO2 use the pre-BAL payload, Amsterdam adds the EIP-7928/EIP-7843 fields.
+/// </remarks>
+public enum ProtocolFork : byte
 {
+    Cancun = 0x10,
+    Prague = 0x11,
+    Osaka = 0x12,
+    BPO1 = 0x13,
+    BPO2 = 0x14,
     Amsterdam = 0x15
+}
+
+public static class ProtocolForkExtensions
+{
+    private static readonly Dictionary<string, ProtocolFork> _forksByName = new(StringComparer.Ordinal)
+    {
+        [Cancun.Instance.Name] = ProtocolFork.Cancun,
+        [Prague.Instance.Name] = ProtocolFork.Prague,
+        [Osaka.Instance.Name] = ProtocolFork.Osaka,
+        [BPO1.Instance.Name] = ProtocolFork.BPO1,
+        [BPO2.Instance.Name] = ProtocolFork.BPO2,
+        [Amsterdam.Instance.Name] = ProtocolFork.Amsterdam
+    };
+
+    public static bool TryGetByName(string name, out ProtocolFork fork) => _forksByName.TryGetValue(name, out fork);
+
+    public static string GetName(this ProtocolFork fork) => fork switch
+    {
+        ProtocolFork.Cancun => Cancun.Instance.Name,
+        ProtocolFork.Prague => Prague.Instance.Name,
+        ProtocolFork.Osaka => Osaka.Instance.Name,
+        ProtocolFork.BPO1 => BPO1.Instance.Name,
+        ProtocolFork.BPO2 => BPO2.Instance.Name,
+        ProtocolFork.Amsterdam => Amsterdam.Instance.Name,
+        _ => throw new ArgumentOutOfRangeException(nameof(fork), fork, "Unknown protocol fork")
+    };
+
+    /// <summary>Composes the schema id selecting the SSZ <c>StatelessInput</c> encoding (revision 1) for the fork.</summary>
+    public static ushort ToRevision1SchemaId(this ProtocolFork fork) =>
+        (ushort)(((ushort)fork << 8) | InputDecoder.Revision1);
 }

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/SszExecutionRequests.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/SszExecutionRequests.cs
@@ -16,4 +16,10 @@ public partial struct SszExecutionRequests
 
     [SszList(0x2)]
     public ConsolidationRequest[] Consolidations { get; set; }
+
+    [SszList(0x40)]
+    public BuilderDepositRequest[] BuilderDeposits { get; set; }
+
+    [SszList(0x10)]
+    public BuilderExitRequest[] BuilderExits { get; set; }
 }

--- a/src/Nethermind/Nethermind.Stateless.Executor/StatelessSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/StatelessSpecProvider.cs
@@ -4,7 +4,6 @@
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
-using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.GnosisForks;
 using Nethermind.Stateless.Execution.IO;
@@ -59,11 +58,7 @@ internal sealed class StatelessSpecProvider(
         ForkConfig forkConfig,
         ProtocolFork protocolFork)
     {
-        string forkName = protocolFork switch
-        {
-            ProtocolFork.Amsterdam => Amsterdam.Instance.Name,
-            _ => throw new ArgumentOutOfRangeException(nameof(protocolFork), protocolFork, "Unknown protocol fork")
-        };
+        string forkName = protocolFork.GetName();
 
         IReleaseSpec spec;
         if (!baseProvider.TryGetForkSpec(forkName, out IReleaseSpec? configuredSpec) || configuredSpec is null)

--- a/tools/StatelessInputGen/InputGenerator.cs
+++ b/tools/StatelessInputGen/InputGenerator.cs
@@ -13,6 +13,7 @@ using Nethermind.Logging;
 using Nethermind.Merge.Plugin.SszRest;
 using Nethermind.Serialization.Json;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Serialization.Ssz;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Stateless.Execution.IO;
 using Spectre.Console;
@@ -36,22 +37,22 @@ internal static class InputGenerator
             if (block is null || witness is null || chainId is null)
                 return 1;
 
-            StatelessInput<SszExecutionPayloadV3> input = new()
-            {
-                NewPayloadRequest = NewPayloadRequest<SszExecutionPayloadV3>.From(block),
-                Witness = ExecutionWitness.From(witness),
-                ChainConfig = new()
-                {
-                    ChainId = chainId.Value,
-                    ActiveFork = ForkConfig.From(block.Header, GetSpecProvider(chainId.Value))
-                },
-                PublicKeys = RecoverPublicKeys(block.Transactions, chainId.Value)
-            };
+            ISpecProvider specProvider = GetSpecProvider(chainId.Value);
+            IReleaseSpec spec = specProvider.GetSpec(block.Header);
 
-            byte[] encoded = StatelessInput<SszExecutionPayloadV3>.Encode(input);
+            if (!ProtocolForkExtensions.TryGetByName(spec.Name, out ProtocolFork fork))
+            {
+                AnsiConsole.MarkupLine($"[red]Unsupported fork {spec.Name}: the stateless input schema requires a Cancun or later block[/]");
+                return 1;
+            }
+
+            byte[] encoded = fork == ProtocolFork.Amsterdam
+                ? EncodeInput<SszExecutionPayloadV4>(block, witness, chainId.Value, specProvider)
+                : EncodeInput<SszExecutionPayloadV3>(block, witness, chainId.Value, specProvider);
+
             data = new byte[encoded.Length + sizeof(ushort)];
 
-            BinaryPrimitives.WriteUInt16BigEndian(data, 0);
+            BinaryPrimitives.WriteUInt16BigEndian(data, fork.ToRevision1SchemaId());
 
             Buffer.BlockCopy(encoded, 0, data, sizeof(ushort), encoded.Length);
         }
@@ -69,6 +70,24 @@ internal static class InputGenerator
         AnsiConsole.MarkupLine($"[green]✓[/] Saved to [dim]{Path.GetDirectoryName(path)}{Path.DirectorySeparatorChar}[/]{fileName}");
 
         return 0;
+    }
+
+    private static byte[] EncodeInput<TExecutionPayload>(Block block, Witness witness, ulong chainId, ISpecProvider specProvider)
+        where TExecutionPayload : SszExecutionPayloadV1, ISszExecutionPayloadFactory<TExecutionPayload>, ISszCodec<TExecutionPayload>, new()
+    {
+        StatelessInput<TExecutionPayload> input = new()
+        {
+            NewPayloadRequest = NewPayloadRequest<TExecutionPayload>.From(block),
+            Witness = ExecutionWitness.From(witness),
+            ChainConfig = new()
+            {
+                ChainId = chainId,
+                ActiveFork = ForkConfig.From(block.Header, specProvider)
+            },
+            PublicKeys = RecoverPublicKeys(block.Transactions, chainId)
+        };
+
+        return StatelessInput<TExecutionPayload>.Encode(input);
     }
 
     private static async Task<(Block?, Witness?, ulong? chainId)> FetchData(string blockParam, Uri host, CancellationToken cancellationToken)


### PR DESCRIPTION
## Changes

- Add EIP-8282 builder deposit and builder exit requests to the
  stateless input SSZ schema and the flat-encoded request codec
  (execution-specs #3157)
- Restore pre-Amsterdam inputs: accept revision-1 schema ids for
  Cancun through BPO2 with the pre-BAL payload, and extend
  ProtocolFork accordingly
- Fix StatelessInputGen to emit the fork-prefixed schema id (it still
  wrote the legacy 0x0000 prefix rejected by the decoder) and select
  the payload version by fork
- Expose ProtocolFork and schema id composition as public API instead
  of InternalsVisibleTo for the tool
- Pin zkEVM fixtures to tests-zkevm@v0.6.2

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No
