### PR TITLE
Extract censorship detector into plugin

### DIFF
--- a/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
+++ b/src/Nethermind/Nethermind.Api/IApiWithBlockchain.cs
@@ -4,7 +4,6 @@
 using Nethermind.Consensus;
 using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Processing;
-using Nethermind.Consensus.Processing.CensorshipDetector;
 using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Consensus.Validators;
@@ -36,6 +35,5 @@ namespace Nethermind.Api
         ITxValidator? HeadTxValidator { get; }
 
         IBackgroundTaskScheduler BackgroundTaskScheduler { get; }
-        ICensorshipDetector CensorshipDetector { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.Api/NethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/NethermindApi.cs
@@ -28,7 +28,6 @@ using Nethermind.Synchronization.ParallelSync;
 using Nethermind.Synchronization.Peers;
 using Nethermind.TxPool;
 using Nethermind.Wallet;
-using Nethermind.Consensus.Processing.CensorshipDetector;
 
 namespace Nethermind.Api
 {
@@ -85,7 +84,6 @@ namespace Nethermind.Api
         public ITxValidator? HeadTxValidator => Context.ResolveOptionalKeyed<ITxValidator>(ITxValidator.HeadTxValidatorKey);
 
         public IBackgroundTaskScheduler BackgroundTaskScheduler => Context.Resolve<IBackgroundTaskScheduler>();
-        public ICensorshipDetector CensorshipDetector { get; set; } = new NoopCensorshipDetector();
         public IWallet Wallet => Context.Resolve<IWallet>();
         public ITransactionComparerProvider? TransactionComparerProvider { get; set; }
 

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin.Test/CensorshipDetectorPluginTests.cs
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin.Test/CensorshipDetectorPluginTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
-using System.Collections.Generic;
 using Autofac;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain;

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin.Test/CensorshipDetectorPluginTests.cs
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin.Test/CensorshipDetectorPluginTests.cs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Autofac;
+using Nethermind.Api.Steps;
+using Nethermind.Blockchain;
+using Nethermind.Consensus.Comparers;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Init.Steps;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin.Handlers;
+using Nethermind.TxPool;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.CensorshipDetector.Plugin.Test;
+
+public class CensorshipDetectorPluginTests
+{
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Plugin_enabled_follows_config(bool enabled)
+    {
+        CensorshipDetectorPlugin plugin = new(new CensorshipDetectorConfig { Enabled = enabled });
+
+        Assert.That(plugin.Enabled, Is.EqualTo(enabled));
+    }
+
+    [Test]
+    public void Module_registers_one_detector_and_orders_initialization()
+    {
+        IBranchProcessor branchProcessor = Substitute.For<IBranchProcessor>();
+        IMainProcessingContext mainProcessingContext = Substitute.For<IMainProcessingContext>();
+        mainProcessingContext.BranchProcessor.Returns(branchProcessor);
+        ITransactionComparerProvider comparerProvider = Substitute.For<ITransactionComparerProvider>();
+        comparerProvider.GetDefaultComparer().Returns(Substitute.For<IComparer<Transaction>>());
+
+        IContainer container = new ContainerBuilder()
+            .AddModule(new CensorshipDetectorModule())
+            .AddSingleton(Substitute.For<IBlockTree>())
+            .AddSingleton(Substitute.For<ITxPool>())
+            .AddSingleton(comparerProvider)
+            .AddSingleton(mainProcessingContext)
+            .AddSingleton<ILogManager>(LimboLogs.Instance)
+            .AddSingleton<ICensorshipDetectorConfig>(new CensorshipDetectorConfig())
+            .Build();
+
+        CensorshipDetector detector = container.Resolve<CensorshipDetector>();
+        IBuilderOverridePolicy policy = container.Resolve<IBuilderOverridePolicy>();
+        StepInfo step = new(typeof(InitializeCensorshipDetector));
+        branchProcessor.Received(1).BlockProcessing += Arg.Any<EventHandler<BlockEventArgs>>();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(policy, Is.SameAs(detector));
+            Assert.That(step.Dependencies, Is.EqualTo(new[] { typeof(InitializeBlockchain) }));
+            Assert.That(step.Dependents, Is.EqualTo(new[] { typeof(StartBlockProcessor) }));
+        }
+
+        container.Dispose();
+        branchProcessor.Received(1).BlockProcessing -= Arg.Any<EventHandler<BlockEventArgs>>();
+    }
+}

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin.Test/CensorshipDetectorTests.cs
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin.Test/CensorshipDetectorTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Spec;
 using Nethermind.Consensus.Comparers;

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin.Test/CensorshipDetectorTests.cs
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin.Test/CensorshipDetectorTests.cs
@@ -7,7 +7,6 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Spec;
 using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Processing;
-using Nethermind.Consensus.Processing.CensorshipDetector;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -22,7 +21,7 @@ using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
 
-namespace Nethermind.Consensus.Test;
+namespace Nethermind.CensorshipDetector.Plugin.Test;
 
 [TestFixture]
 public class CensorshipDetectorTests
@@ -34,6 +33,8 @@ public class CensorshipDetectorTests
     private ISpecProvider _specProvider;
     private IEthereumEcdsa _ethereumEcdsa;
     private IComparer<Transaction> _comparer;
+    private ITransactionComparerProvider _transactionComparerProvider;
+    private IMainProcessingContext _mainProcessingContext;
     private TxPool.TxPool _txPool;
     private CensorshipDetector _censorshipDetector;
 
@@ -43,6 +44,8 @@ public class CensorshipDetectorTests
         _logManager = LimboLogs.Instance;
         _stateProvider = new TestReadOnlyStateProvider();
         _branchProcessor = Substitute.For<IBranchProcessor>();
+        _mainProcessingContext = Substitute.For<IMainProcessingContext>();
+        _mainProcessingContext.BranchProcessor.Returns(_branchProcessor);
     }
 
     [TearDown]
@@ -57,7 +60,7 @@ public class CensorshipDetectorTests
     public async Task Censorship_when_address_censorship_is_false_and_high_paying_tx_censorship_is_true_for_all_blocks_in_main_cache()
     {
         _txPool = CreatePool();
-        _censorshipDetector = new(_blockTree, _txPool, _comparer, _branchProcessor, _logManager, new CensorshipDetectorConfig() { });
+        _censorshipDetector = new(_blockTree, _txPool, _transactionComparerProvider, _mainProcessingContext, _logManager, new CensorshipDetectorConfig() { });
 
         Transaction tx1 = SubmitTxToPool(1, TestItem.PrivateKeyA, TestItem.AddressA);
         Transaction tx2 = SubmitTxToPool(2, TestItem.PrivateKeyB, TestItem.AddressA);
@@ -88,7 +91,7 @@ public class CensorshipDetectorTests
     public async Task No_censorship_when_address_censorship_is_false_and_high_paying_tx_censorship_is_false_for_some_blocks_in_main_cache()
     {
         _txPool = CreatePool();
-        _censorshipDetector = new(_blockTree, _txPool, _comparer, _branchProcessor, _logManager, new CensorshipDetectorConfig() { });
+        _censorshipDetector = new(_blockTree, _txPool, _transactionComparerProvider, _mainProcessingContext, _logManager, new CensorshipDetectorConfig() { });
 
         Transaction tx1 = SubmitTxToPool(1, TestItem.PrivateKeyA, TestItem.AddressA);
         Transaction tx2 = SubmitTxToPool(2, TestItem.PrivateKeyB, TestItem.AddressA);
@@ -126,8 +129,8 @@ public class CensorshipDetectorTests
         _censorshipDetector = new(
             _blockTree,
             _txPool,
-            _comparer,
-            _branchProcessor,
+            _transactionComparerProvider,
+            _mainProcessingContext,
             _logManager,
             new CensorshipDetectorConfig()
             {
@@ -182,8 +185,8 @@ public class CensorshipDetectorTests
         _censorshipDetector = new(
             _blockTree,
             _txPool,
-            _comparer,
-            _branchProcessor,
+            _transactionComparerProvider,
+            _mainProcessingContext,
             _logManager,
             new CensorshipDetectorConfig()
             {
@@ -246,7 +249,8 @@ public class CensorshipDetectorTests
         _blockTree.FindBestSuggestedHeader().Returns(Build.A.BlockHeader.WithNumber(1_000_000).TestObject);
         _blockTree.Head.Returns(Build.A.Block.WithNumber(1_000_000).TestObject);
         _ethereumEcdsa = new EthereumEcdsa(_specProvider.ChainId);
-        _comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+        _transactionComparerProvider = new TransactionComparerProvider(_specProvider, _blockTree);
+        _comparer = _transactionComparerProvider.GetDefaultComparer();
 
         return new(
             _ethereumEcdsa,

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin.Test/Nethermind.CensorshipDetector.Plugin.Test.csproj
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin.Test/Nethermind.CensorshipDetector.Plugin.Test.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../tests.props" />
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NSubstitute" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Nethermind.CensorshipDetector.Plugin\Nethermind.CensorshipDetector.Plugin.csproj" />
+    <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
+    <ProjectReference Include="..\Nethermind.Specs\Nethermind.Specs.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin/CensorshipDetector.cs
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin/CensorshipDetector.cs
@@ -7,30 +7,20 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
+using Nethermind.Consensus.Comparers;
+using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.TxPool;
 
-namespace Nethermind.Consensus.Processing.CensorshipDetector;
+namespace Nethermind.CensorshipDetector.Plugin;
 
-public interface ICensorshipDetector
-{
-    IEnumerable<BlockNumberHash> GetCensoredBlocks();
-    bool BlockPotentiallyCensored(ulong blockNumber, ValueHash256 blockHash);
-}
-
-public class NoopCensorshipDetector : ICensorshipDetector
-{
-    public IEnumerable<BlockNumberHash> GetCensoredBlocks() => [];
-
-    public bool BlockPotentiallyCensored(ulong blockNumber, ValueHash256 blockHash) => false;
-}
-
-public class CensorshipDetector : IDisposable, ICensorshipDetector
+public class CensorshipDetector : IDisposable, IBuilderOverridePolicy
 {
     private readonly IBlockTree _blockTree;
     private readonly ITxPool _txPool;
@@ -47,15 +37,15 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
     public CensorshipDetector(
         IBlockTree blockTree,
         ITxPool txPool,
-        IComparer<Transaction> betterTxComparer,
-        IBranchProcessor blockProcessor,
+        ITransactionComparerProvider transactionComparerProvider,
+        IMainProcessingContext mainProcessingContext,
         ILogManager logManager,
         ICensorshipDetectorConfig censorshipDetectorConfig)
     {
         _blockTree = blockTree;
         _txPool = txPool;
-        _betterTxComparer = betterTxComparer;
-        _blockProcessor = blockProcessor;
+        _betterTxComparer = transactionComparerProvider.GetDefaultComparer();
+        _blockProcessor = mainProcessingContext.BranchProcessor;
         _blockCensorshipThreshold = censorshipDetectorConfig.BlockCensorshipThreshold;
         _cacheSize = (int)(4 * _blockCensorshipThreshold);
         _logger = logManager?.GetClassLogger<CensorshipDetector>() ?? throw new ArgumentNullException(nameof(logManager));
@@ -64,7 +54,7 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
         {
             foreach (string hexString in censorshipDetectorConfig.AddressesForCensorshipDetection)
             {
-                if (Address.TryParse(hexString, out Address address))
+                if (Address.TryParse(hexString, out Address? address))
                 {
                     _bestTxPerObservedAddresses ??= [];
                     _bestTxPerObservedAddresses[address!] = null;
@@ -93,8 +83,7 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
         // skip censorship detection if node is not synced yet
         if (IsSyncing()) return;
 
-        bool tracksPerAddressCensorship = _bestTxPerObservedAddresses is not null;
-        if (tracksPerAddressCensorship)
+        if (_bestTxPerObservedAddresses is { } observedAddresses)
         {
             UInt256 baseFee = e.Block.BaseFeePerGas;
             IEnumerable<Transaction> poolBestTransactions = _txPool.GetBestTxOfEachSender();
@@ -103,10 +92,10 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
                 // checking tx.GasBottleneck > baseFee ensures only ready transactions are considered.
                 if (tx.To is not null
                     && tx.GasBottleneck > baseFee
-                    && _bestTxPerObservedAddresses.TryGetValue(tx.To, out Transaction? bestTx)
+                    && observedAddresses.TryGetValue(tx.To, out Transaction? bestTx)
                     && (bestTx is null || _betterTxComparer.Compare(bestTx, tx) > 0))
                 {
-                    _bestTxPerObservedAddresses[tx.To] = tx;
+                    observedAddresses[tx.To] = tx;
                 }
             }
         }
@@ -129,7 +118,7 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
 
     private void Cache(Block block)
     {
-        bool tracksPerAddressCensorship = _bestTxPerObservedAddresses is not null;
+        Dictionary<AddressAsKey, Transaction?>? observedAddresses = _bestTxPerObservedAddresses;
 
         try
         {
@@ -162,7 +151,7 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
                             bestTxInBlock = tx;
                         }
 
-                        if (tracksPerAddressCensorship)
+                        if (observedAddresses is not null)
                         {
                             // Finds worst tx in pool to compare with pool transactions of tracked addresses
                             if (_betterTxComparer.Compare(worstTxInBlock, tx) < 0)
@@ -170,7 +159,7 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
                                 worstTxInBlock = tx;
                             }
 
-                            bool trackAddress = _bestTxPerObservedAddresses.ContainsKey(tx.To!);
+                            bool trackAddress = observedAddresses.ContainsKey(tx.To!);
                             if (trackAddress && trackedAddressesInBlock.Add(tx.To!))
                             {
                                 blockTxsOfTrackedAddresses++;
@@ -179,9 +168,9 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
                     }
                 }
 
-                if (tracksPerAddressCensorship)
+                if (observedAddresses is not null)
                 {
-                    foreach (Transaction? bestTx in _bestTxPerObservedAddresses.Values)
+                    foreach (Transaction? bestTx in observedAddresses.Values)
                     {
                         // if there is no transaction in block or the best tx in the pool is better than the worst tx in the block
                         if (bestTx is null || _betterTxComparer.Compare(bestTx, worstTxInBlock) < 0)
@@ -212,11 +201,11 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
         }
         finally
         {
-            if (tracksPerAddressCensorship)
+            if (observedAddresses is not null)
             {
-                foreach (AddressAsKey key in _bestTxPerObservedAddresses.Keys)
+                foreach (AddressAsKey key in observedAddresses.Keys)
                 {
-                    _bestTxPerObservedAddresses[key] = null;
+                    observedAddresses[key] = null;
                 }
             }
         }
@@ -262,6 +251,8 @@ public class CensorshipDetector : IDisposable, ICensorshipDetector
     public IEnumerable<BlockNumberHash> GetCensoredBlocks() => _censoredBlocks;
 
     public bool BlockPotentiallyCensored(ulong blockNumber, ValueHash256 blockHash) => _potentiallyCensoredBlocks.Contains(new BlockNumberHash(blockNumber, blockHash));
+
+    public bool ShouldOverrideBuilder(Block block) => _censoredBlocks.Contains(new BlockNumberHash(block));
 
     public void Dispose() => _blockProcessor.BlockProcessing -= OnBlockProcessing;
 }

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin/CensorshipDetector.cs
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin/CensorshipDetector.cs
@@ -1,11 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Processing;

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin/CensorshipDetectorConfig.cs
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin/CensorshipDetectorConfig.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-namespace Nethermind.Consensus.Processing.CensorshipDetector;
+namespace Nethermind.CensorshipDetector.Plugin;
 
 public class CensorshipDetectorConfig : ICensorshipDetectorConfig
 {

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin/CensorshipDetectorPlugin.cs
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin/CensorshipDetectorPlugin.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Autofac.Core;
+using Nethermind.Api.Extensions;
+using Nethermind.Api.Steps;
+using Nethermind.Core;
+using Nethermind.Init.Steps;
+using Nethermind.Merge.Plugin.Handlers;
+
+namespace Nethermind.CensorshipDetector.Plugin;
+
+public class CensorshipDetectorPlugin(ICensorshipDetectorConfig config) : INethermindPlugin
+{
+    public string Name => "CensorshipDetector";
+    public string Description => "Detects transaction censorship in processed blocks.";
+    public string Author => "Nethermind";
+    public bool Enabled => config.Enabled;
+    public IModule Module => new CensorshipDetectorModule();
+}
+
+public class CensorshipDetectorModule : Module
+{
+    protected override void Load(ContainerBuilder builder) => builder
+        .AddSingleton<CensorshipDetector>()
+        .Bind<IBuilderOverridePolicy, CensorshipDetector>()
+        .AddStep(typeof(InitializeCensorshipDetector));
+}
+
+[RunnerStepDependencies(
+    dependencies: [typeof(InitializeBlockchain)],
+    dependents: [typeof(StartBlockProcessor)])]
+public class InitializeCensorshipDetector(CensorshipDetector censorshipDetector) : IStep
+{
+    public Task Execute(CancellationToken cancellationToken)
+    {
+        _ = censorshipDetector;
+        return Task.CompletedTask;
+    }
+}

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin/ICensorshipDetectorConfig.cs
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin/ICensorshipDetectorConfig.cs
@@ -3,7 +3,7 @@
 
 using Nethermind.Config;
 
-namespace Nethermind.Consensus.Processing.CensorshipDetector;
+namespace Nethermind.CensorshipDetector.Plugin;
 
 public interface ICensorshipDetectorConfig : IConfig
 {

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin/Metrics.cs
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin/Metrics.cs
@@ -4,7 +4,7 @@
 using System.ComponentModel;
 using Nethermind.Core.Attributes;
 
-namespace Nethermind.Consensus.Processing.CensorshipDetector;
+namespace Nethermind.CensorshipDetector.Plugin;
 
 public static class Metrics
 {

--- a/src/Nethermind/Nethermind.CensorshipDetector.Plugin/Nethermind.CensorshipDetector.Plugin.csproj
+++ b/src/Nethermind/Nethermind.CensorshipDetector.Plugin/Nethermind.CensorshipDetector.Plugin.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Nethermind.Api\Nethermind.Api.csproj" />
+    <ProjectReference Include="..\Nethermind.Blockchain\Nethermind.Blockchain.csproj" />
+    <ProjectReference Include="..\Nethermind.Config\Nethermind.Config.csproj" />
+    <ProjectReference Include="..\Nethermind.Consensus\Nethermind.Consensus.csproj" />
+    <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
+    <ProjectReference Include="..\Nethermind.Crypto\Nethermind.Crypto.csproj" />
+    <ProjectReference Include="..\Nethermind.Init\Nethermind.Init.csproj" />
+    <ProjectReference Include="..\Nethermind.Logging\Nethermind.Logging.csproj" />
+    <ProjectReference Include="..\Nethermind.Merge.Plugin\Nethermind.Merge.Plugin.csproj" />
+    <ProjectReference Include="..\Nethermind.TxPool\Nethermind.TxPool.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/InitializeBlockchain.cs
@@ -10,8 +10,6 @@ using Nethermind.Api.Steps;
 using Nethermind.Blockchain;
 using Nethermind.Config;
 using Nethermind.Consensus.Comparers;
-using Nethermind.Consensus.Processing;
-using Nethermind.Consensus.Processing.CensorshipDetector;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.TxPool;
@@ -51,23 +49,6 @@ namespace Nethermind.Init.Steps
             TxSealer nonceReservingTxSealer =
                 new(txSigner, getApi.Timestamper);
             setApi.TxSender = new TxPoolSender(txPool, nonceReservingTxSealer, _api.NonceManager!, getApi.EthereumEcdsa!);
-
-            IBranchProcessor mainBranchProcessor = setApi.MainProcessingContext.BranchProcessor;
-
-            ICensorshipDetectorConfig censorshipDetectorConfig = _api.Config<ICensorshipDetectorConfig>();
-            if (censorshipDetectorConfig.Enabled)
-            {
-                CensorshipDetector censorshipDetector = new(
-                    _api.BlockTree!,
-                    txPool,
-                    CreateTxPoolTxComparer(),
-                    mainBranchProcessor,
-                    _api.LogManager,
-                    censorshipDetectorConfig
-                );
-                setApi.CensorshipDetector = censorshipDetector;
-                _api.DisposeStack.Push(censorshipDetector);
-            }
 
             return Task.CompletedTask;
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BuilderOverridePolicyTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BuilderOverridePolicyTests.cs
@@ -1,13 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Generic;
-using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Logging;
-using Nethermind.Merge.Plugin.BlockProduction;
-using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 using NUnit.Framework;
 
@@ -16,25 +11,16 @@ namespace Nethermind.Merge.Plugin.Test;
 public class BuilderOverridePolicyTests
 {
     [Test]
-    public void Should_override_when_any_policy_requests_it()
+    public void Composite_should_override_when_any_policy_requests_it()
     {
         Block block = Build.A.Block.TestObject;
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(new TestGetPayloadHandler([]).ShouldOverride(block), Is.False);
-            Assert.That(new TestGetPayloadHandler([new TestPolicy(false), new TestPolicy(true)]).ShouldOverride(block), Is.True);
-            Assert.That(new TestGetPayloadHandler([new TestPolicy(false)]).ShouldOverride(block), Is.False);
+            Assert.That(new CompositeBuilderOverridePolicy().ShouldOverrideBuilder(block), Is.False);
+            Assert.That(new CompositeBuilderOverridePolicy(new TestPolicy(false), new TestPolicy(true)).ShouldOverrideBuilder(block), Is.True);
+            Assert.That(new CompositeBuilderOverridePolicy(new TestPolicy(false)).ShouldOverrideBuilder(block), Is.False);
         }
-    }
-
-    private sealed class TestGetPayloadHandler(IEnumerable<IBuilderOverridePolicy> policies)
-        : GetPayloadHandlerBase<GetPayloadV2Result>(1, null!, null!, LimboLogs.Instance, policies)
-    {
-        public bool ShouldOverride(Block block) => ShouldOverrideBuilder(block);
-
-        protected override GetPayloadV2Result GetPayloadResultFromBlock(IBlockProductionContext blockProductionContext) =>
-            throw new System.NotSupportedException();
     }
 
     private sealed class TestPolicy(bool result) : IBuilderOverridePolicy

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BuilderOverridePolicyTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BuilderOverridePolicyTests.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin.BlockProduction;
+using Nethermind.Merge.Plugin.Data;
+using Nethermind.Merge.Plugin.Handlers;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+public class BuilderOverridePolicyTests
+{
+    [Test]
+    public void Should_override_when_any_policy_requests_it()
+    {
+        Block block = Build.A.Block.TestObject;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(new TestGetPayloadHandler([]).ShouldOverride(block), Is.False);
+            Assert.That(new TestGetPayloadHandler([new TestPolicy(false), new TestPolicy(true)]).ShouldOverride(block), Is.True);
+            Assert.That(new TestGetPayloadHandler([new TestPolicy(false)]).ShouldOverride(block), Is.False);
+        }
+    }
+
+    private sealed class TestGetPayloadHandler(IEnumerable<IBuilderOverridePolicy> policies)
+        : GetPayloadHandlerBase<GetPayloadV2Result>(1, null!, null!, LimboLogs.Instance, policies)
+    {
+        public bool ShouldOverride(Block block) => ShouldOverrideBuilder(block);
+
+        protected override GetPayloadV2Result GetPayloadResultFromBlock(IBlockProductionContext blockProductionContext) =>
+            throw new System.NotSupportedException();
+    }
+
+    private sealed class TestPolicy(bool result) : IBuilderOverridePolicy
+    {
+        public bool ShouldOverrideBuilder(Block block) => result;
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadHandlerBase.cs
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Consensus.Processing.CensorshipDetector;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
@@ -9,8 +10,6 @@ using Nethermind.Core.Specs;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Nethermind.Merge.Plugin.Handlers;
 
@@ -19,7 +18,7 @@ public abstract class GetPayloadHandlerBase<TGetPayloadResult>(
     IPayloadPreparationService payloadPreparationService,
     ISpecProvider specProvider,
     ILogManager logManager,
-    ICensorshipDetector? censorshipDetector = null)
+    IEnumerable<IBuilderOverridePolicy>? builderOverridePolicies = null)
     : IAsyncHandler<byte[], TGetPayloadResult?>
     where TGetPayloadResult : IForkValidator
 {
@@ -57,7 +56,17 @@ public abstract class GetPayloadHandlerBase<TGetPayloadResult>(
     }
 
     protected bool ShouldOverrideBuilder(Block block)
-         => censorshipDetector?.GetCensoredBlocks().Contains(new BlockNumberHash(block)) ?? false;
+    {
+        if (builderOverridePolicies is not null)
+        {
+            foreach (IBuilderOverridePolicy policy in builderOverridePolicies)
+            {
+                if (policy.ShouldOverrideBuilder(block)) return true;
+            }
+        }
+
+        return false;
+    }
 
     protected abstract TGetPayloadResult GetPayloadResultFromBlock(IBlockProductionContext blockProductionContext);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadHandlerBase.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
@@ -18,7 +17,7 @@ public abstract class GetPayloadHandlerBase<TGetPayloadResult>(
     IPayloadPreparationService payloadPreparationService,
     ISpecProvider specProvider,
     ILogManager logManager,
-    IEnumerable<IBuilderOverridePolicy>? builderOverridePolicies = null)
+    IBuilderOverridePolicy? builderOverridePolicy = null)
     : IAsyncHandler<byte[], TGetPayloadResult?>
     where TGetPayloadResult : IForkValidator
 {
@@ -55,18 +54,10 @@ public abstract class GetPayloadHandlerBase<TGetPayloadResult>(
         return ResultWrapper<TGetPayloadResult?>.Success(getPayloadResult);
     }
 
-    protected bool ShouldOverrideBuilder(Block block)
-    {
-        if (builderOverridePolicies is not null)
-        {
-            foreach (IBuilderOverridePolicy policy in builderOverridePolicies)
-            {
-                if (policy.ShouldOverrideBuilder(block)) return true;
-            }
-        }
-
-        return false;
-    }
+    /// <summary>
+    /// Evaluates policies used by Engine API getPayload V3 and later to populate the <c>shouldOverrideBuilder</c> field.
+    /// </summary>
+    protected bool ShouldOverrideBuilder(Block block) => builderOverridePolicy?.ShouldOverrideBuilder(block) ?? false;
 
     protected abstract TGetPayloadResult GetPayloadResultFromBlock(IBlockProductionContext blockProductionContext);
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV3Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV3Handler.cs
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
-using Nethermind.Consensus.Processing.CensorshipDetector;
 
 namespace Nethermind.Merge.Plugin.Handlers;
 
@@ -19,8 +19,8 @@ public class GetPayloadV3Handler(
     IPayloadPreparationService payloadPreparationService,
     ISpecProvider specProvider,
     ILogManager logManager,
-    ICensorshipDetector? censorshipDetector = null)
-    : GetPayloadHandlerBase<GetPayloadV3Result>(EngineApiVersions.GetPayload.V3, payloadPreparationService, specProvider, logManager, censorshipDetector)
+    IEnumerable<IBuilderOverridePolicy>? builderOverridePolicies = null)
+    : GetPayloadHandlerBase<GetPayloadV3Result>(EngineApiVersions.GetPayload.V3, payloadPreparationService, specProvider, logManager, builderOverridePolicies)
 {
     protected override GetPayloadV3Result GetPayloadResultFromBlock(IBlockProductionContext context) => new(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV1(context.CurrentBestBlock!), ShouldOverrideBuilder(context.CurrentBestBlock!));
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV3Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV3Handler.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core.Specs;
@@ -19,8 +18,8 @@ public class GetPayloadV3Handler(
     IPayloadPreparationService payloadPreparationService,
     ISpecProvider specProvider,
     ILogManager logManager,
-    IEnumerable<IBuilderOverridePolicy>? builderOverridePolicies = null)
-    : GetPayloadHandlerBase<GetPayloadV3Result>(EngineApiVersions.GetPayload.V3, payloadPreparationService, specProvider, logManager, builderOverridePolicies)
+    IBuilderOverridePolicy builderOverridePolicy)
+    : GetPayloadHandlerBase<GetPayloadV3Result>(EngineApiVersions.GetPayload.V3, payloadPreparationService, specProvider, logManager, builderOverridePolicy)
 {
     protected override GetPayloadV3Result GetPayloadResultFromBlock(IBlockProductionContext context) => new(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV1(context.CurrentBestBlock!), ShouldOverrideBuilder(context.CurrentBestBlock!));
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV4Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV4Handler.cs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
-using Nethermind.Consensus.Processing.CensorshipDetector;
 using Nethermind.Consensus.Producers;
 
 namespace Nethermind.Merge.Plugin.Handlers;
@@ -19,8 +19,8 @@ public class GetPayloadV4Handler(
     IPayloadPreparationService payloadPreparationService,
     ISpecProvider specProvider,
     ILogManager logManager,
-    ICensorshipDetector? censorshipDetector = null)
-    : GetPayloadHandlerBase<GetPayloadV4Result>(EngineApiVersions.GetPayload.V4, payloadPreparationService, specProvider, logManager, censorshipDetector)
+    IEnumerable<IBuilderOverridePolicy>? builderOverridePolicies = null)
+    : GetPayloadHandlerBase<GetPayloadV4Result>(EngineApiVersions.GetPayload.V4, payloadPreparationService, specProvider, logManager, builderOverridePolicies)
 {
     protected override GetPayloadV4Result GetPayloadResultFromBlock(IBlockProductionContext context) => new(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV1(context.CurrentBestBlock!), context.CurrentBestBlock!.ExecutionRequests!, ShouldOverrideBuilder(context.CurrentBestBlock!));
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV4Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV4Handler.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
@@ -19,8 +18,8 @@ public class GetPayloadV4Handler(
     IPayloadPreparationService payloadPreparationService,
     ISpecProvider specProvider,
     ILogManager logManager,
-    IEnumerable<IBuilderOverridePolicy>? builderOverridePolicies = null)
-    : GetPayloadHandlerBase<GetPayloadV4Result>(EngineApiVersions.GetPayload.V4, payloadPreparationService, specProvider, logManager, builderOverridePolicies)
+    IBuilderOverridePolicy builderOverridePolicy)
+    : GetPayloadHandlerBase<GetPayloadV4Result>(EngineApiVersions.GetPayload.V4, payloadPreparationService, specProvider, logManager, builderOverridePolicy)
 {
     protected override GetPayloadV4Result GetPayloadResultFromBlock(IBlockProductionContext context) => new(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV1(context.CurrentBestBlock!), context.CurrentBestBlock!.ExecutionRequests!, ShouldOverrideBuilder(context.CurrentBestBlock!));
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV5Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV5Handler.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
@@ -19,8 +18,8 @@ public class GetPayloadV5Handler(
     IPayloadPreparationService payloadPreparationService,
     ISpecProvider specProvider,
     ILogManager logManager,
-    IEnumerable<IBuilderOverridePolicy>? builderOverridePolicies = null)
-    : GetPayloadHandlerBase<GetPayloadV5Result>(EngineApiVersions.GetPayload.V5, payloadPreparationService, specProvider, logManager, builderOverridePolicies)
+    IBuilderOverridePolicy builderOverridePolicy)
+    : GetPayloadHandlerBase<GetPayloadV5Result>(EngineApiVersions.GetPayload.V5, payloadPreparationService, specProvider, logManager, builderOverridePolicy)
 {
     protected override GetPayloadV5Result GetPayloadResultFromBlock(IBlockProductionContext context) => new GetPayloadV5DirectResponse(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV2(context.CurrentBestBlock!), context.CurrentBestBlock!.ExecutionRequests!, ShouldOverrideBuilder(context.CurrentBestBlock!));
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV5Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV5Handler.cs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
-using Nethermind.Consensus.Processing.CensorshipDetector;
 using Nethermind.Consensus.Producers;
 
 namespace Nethermind.Merge.Plugin.Handlers;
@@ -19,8 +19,8 @@ public class GetPayloadV5Handler(
     IPayloadPreparationService payloadPreparationService,
     ISpecProvider specProvider,
     ILogManager logManager,
-    ICensorshipDetector? censorshipDetector = null)
-    : GetPayloadHandlerBase<GetPayloadV5Result>(EngineApiVersions.GetPayload.V5, payloadPreparationService, specProvider, logManager, censorshipDetector)
+    IEnumerable<IBuilderOverridePolicy>? builderOverridePolicies = null)
+    : GetPayloadHandlerBase<GetPayloadV5Result>(EngineApiVersions.GetPayload.V5, payloadPreparationService, specProvider, logManager, builderOverridePolicies)
 {
     protected override GetPayloadV5Result GetPayloadResultFromBlock(IBlockProductionContext context) => new GetPayloadV5DirectResponse(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV2(context.CurrentBestBlock!), context.CurrentBestBlock!.ExecutionRequests!, ShouldOverrideBuilder(context.CurrentBestBlock!));
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV6Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV6Handler.cs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
-using Nethermind.Consensus.Processing.CensorshipDetector;
 using Nethermind.Consensus.Producers;
 
 namespace Nethermind.Merge.Plugin.Handlers;
@@ -19,8 +19,8 @@ public class GetPayloadV6Handler(
     IPayloadPreparationService payloadPreparationService,
     ISpecProvider specProvider,
     ILogManager logManager,
-    ICensorshipDetector? censorshipDetector = null)
-    : GetPayloadHandlerBase<GetPayloadV6Result>(EngineApiVersions.GetPayload.V6, payloadPreparationService, specProvider, logManager, censorshipDetector)
+    IEnumerable<IBuilderOverridePolicy>? builderOverridePolicies = null)
+    : GetPayloadHandlerBase<GetPayloadV6Result>(EngineApiVersions.GetPayload.V6, payloadPreparationService, specProvider, logManager, builderOverridePolicies)
 {
     protected override GetPayloadV6Result GetPayloadResultFromBlock(IBlockProductionContext context) => new GetPayloadV6DirectResponse(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV2(context.CurrentBestBlock!), context.CurrentBestBlock!.ExecutionRequests!, ShouldOverrideBuilder(context.CurrentBestBlock!));
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV6Handler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetPayloadV6Handler.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
@@ -19,8 +18,8 @@ public class GetPayloadV6Handler(
     IPayloadPreparationService payloadPreparationService,
     ISpecProvider specProvider,
     ILogManager logManager,
-    IEnumerable<IBuilderOverridePolicy>? builderOverridePolicies = null)
-    : GetPayloadHandlerBase<GetPayloadV6Result>(EngineApiVersions.GetPayload.V6, payloadPreparationService, specProvider, logManager, builderOverridePolicies)
+    IBuilderOverridePolicy builderOverridePolicy)
+    : GetPayloadHandlerBase<GetPayloadV6Result>(EngineApiVersions.GetPayload.V6, payloadPreparationService, specProvider, logManager, builderOverridePolicy)
 {
     protected override GetPayloadV6Result GetPayloadResultFromBlock(IBlockProductionContext context) => new GetPayloadV6DirectResponse(context.CurrentBestBlock!, context.BlockFees, new BlobsBundleV2(context.CurrentBestBlock!), context.CurrentBestBlock!.ExecutionRequests!, ShouldOverrideBuilder(context.CurrentBestBlock!));
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/IBuilderOverridePolicy.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/IBuilderOverridePolicy.cs
@@ -12,3 +12,20 @@ public interface IBuilderOverridePolicy
 {
     bool ShouldOverrideBuilder(Block block);
 }
+
+/// <summary>
+/// Requests a builder override when any registered policy requests one.
+/// </summary>
+public class CompositeBuilderOverridePolicy(params IBuilderOverridePolicy[] policies) : IBuilderOverridePolicy
+{
+    /// <inheritdoc />
+    public bool ShouldOverrideBuilder(Block block)
+    {
+        foreach (IBuilderOverridePolicy policy in policies)
+        {
+            if (policy.ShouldOverrideBuilder(block)) return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/IBuilderOverridePolicy.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/IBuilderOverridePolicy.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+
+namespace Nethermind.Merge.Plugin.Handlers;
+
+/// <summary>
+/// Determines whether the consensus layer should override its selected builder payload.
+/// </summary>
+public interface IBuilderOverridePolicy
+{
+    bool ShouldOverrideBuilder(Block block);
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergePlugin.cs
@@ -168,6 +168,7 @@ public class BaseMergePluginModule : Module
             .AddKeyedSingleton<ITxValidator>(ITxValidator.HeadTxValidatorKey, new HeadTxValidator())
 
             // Engine rpc related
+            .AddComposite<IBuilderOverridePolicy, CompositeBuilderOverridePolicy>()
             .RegisterSingletonJsonRpcModule<IEngineRpcModule, EngineRpcModule>()
                 .AddSingleton<IPayloadPreparationService, PayloadPreparationService>()
                     .AddSingleton<IBlockImprovementContextFactory>(CreateBlockImprovementContextFactory)

--- a/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/EthereumRunnerTests.cs
@@ -19,6 +19,7 @@ using Nethermind.Api;
 using Nethermind.Api.Extensions;
 using Nethermind.Api.Steps;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.CensorshipDetector.Plugin;
 using Nethermind.Config;
 using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa.Validators;
@@ -116,6 +117,15 @@ public class EthereumRunnerTests
             configProvider.Initialize();
             configProvider.GetConfig<IFlashbotsConfig>().Enabled = true;
             result.Add(("flashbots", configProvider));
+        }
+
+        {
+            // Censorship detector
+            ConfigProvider configProvider = new();
+            configProvider.AddSource(new JsonConfigSource("configs/mainnet.json"));
+            configProvider.Initialize();
+            configProvider.GetConfig<ICensorshipDetectorConfig>().Enabled = true;
+            result.Add(("censorship-detector", configProvider));
         }
 
         return result;

--- a/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
+++ b/src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Api\Nethermind.Api.csproj" />
     <ProjectReference Include="..\Nethermind.BalRecorder\Nethermind.BalRecorder.csproj" />
+    <ProjectReference Include="..\Nethermind.CensorshipDetector.Plugin\Nethermind.CensorshipDetector.Plugin.csproj" />
     <ProjectReference Include="..\Nethermind.Flashbots\Nethermind.Flashbots.csproj" />
     <ProjectReference Include="..\Nethermind.Consensus.AuRa\Nethermind.Consensus.AuRa.csproj" />
     <ProjectReference Include="..\Nethermind.Consensus.Clique\Nethermind.Consensus.Clique.csproj" />
@@ -114,8 +115,8 @@
 
   <Target Name="CollectPlugins" AfterTargets="AfterBuild;AfterPublish">
     <ItemGroup>
-      <PluginsForBuild Include="$(OutputPath)\Nethermind.Merge.AuRa.*;$(OutputPath)\Nethermind.Shutter.*;$(OutputPath)\Nethermind.Merge.Plugin.*;$(OutputPath)\Nethermind.Consensus.AuRa.*;$(OutputPath)\Nethermind.Init.*;$(OutputPath)\Nethermind.HealthChecks.*;$(OutputPath)\Nethermind.Api.*;$(OutputPath)\Nethermind.EthStats.*;$(OutputPath)\Nethermind.JsonRpc.TraceStore.*;$(OutputPath)\Nethermind.Init.Snapshot.*;$(OutputPath)\Nethermind.Optimism.*;$(OutputPath)\Nethermind.ExternalSigner.Plugin.*;$(OutputPath)\Nethermind.Taiko.*;$(OutputPath)\Nethermind.Flashbots.*;$(OutputPath)\Nethermind.StateDiff.Core.*;$(OutputPath)\Nethermind.StateDiffsWriter.*;$(OutputPath)\Nethermind.OpcodeTracing.Plugin.*" />
-      <PluginsForPublish Include="$(OutputPath)\Nethermind.Merge.AuRa.dll;$(OutputPath)\Nethermind.Shutter.dll;$(OutputPath)\Nethermind.Merge.Plugin.dll;$(OutputPath)\Nethermind.Consensus.AuRa.dll;$(OutputPath)\Nethermind.Init.dll;$(OutputPath)\Nethermind.HealthChecks.dll;$(OutputPath)\Nethermind.Api.dll;$(OutputPath)\Nethermind.EthStats.dll;$(OutputPath)\Nethermind.JsonRpc.TraceStore.dll;$(OutputPath)\Nethermind.Init.Snapshot.dll;$(OutputPath)\Nethermind.Optimism.dll;$(OutputPath)\Nethermind.ExternalSigner.Plugin.dll;$(OutputPath)\Nethermind.Taiko.dll;$(OutputPath)\Nethermind.Flashbots.dll;$(OutputPath)\Nethermind.StateDiff.Core.dll;$(OutputPath)\Nethermind.StateDiffsWriter.dll;$(OutputPath)\Nethermind.OpcodeTracing.Plugin.dll" />
+      <PluginsForBuild Include="$(OutputPath)\Nethermind.Merge.AuRa.*;$(OutputPath)\Nethermind.Shutter.*;$(OutputPath)\Nethermind.Merge.Plugin.*;$(OutputPath)\Nethermind.Consensus.AuRa.*;$(OutputPath)\Nethermind.Init.*;$(OutputPath)\Nethermind.HealthChecks.*;$(OutputPath)\Nethermind.Api.*;$(OutputPath)\Nethermind.EthStats.*;$(OutputPath)\Nethermind.JsonRpc.TraceStore.*;$(OutputPath)\Nethermind.Init.Snapshot.*;$(OutputPath)\Nethermind.Optimism.*;$(OutputPath)\Nethermind.ExternalSigner.Plugin.*;$(OutputPath)\Nethermind.Taiko.*;$(OutputPath)\Nethermind.Flashbots.*;$(OutputPath)\Nethermind.StateDiff.Core.*;$(OutputPath)\Nethermind.StateDiffsWriter.*;$(OutputPath)\Nethermind.OpcodeTracing.Plugin.*;$(OutputPath)\Nethermind.CensorshipDetector.Plugin.*" />
+      <PluginsForPublish Include="$(OutputPath)\Nethermind.Merge.AuRa.dll;$(OutputPath)\Nethermind.Shutter.dll;$(OutputPath)\Nethermind.Merge.Plugin.dll;$(OutputPath)\Nethermind.Consensus.AuRa.dll;$(OutputPath)\Nethermind.Init.dll;$(OutputPath)\Nethermind.HealthChecks.dll;$(OutputPath)\Nethermind.Api.dll;$(OutputPath)\Nethermind.EthStats.dll;$(OutputPath)\Nethermind.JsonRpc.TraceStore.dll;$(OutputPath)\Nethermind.Init.Snapshot.dll;$(OutputPath)\Nethermind.Optimism.dll;$(OutputPath)\Nethermind.ExternalSigner.Plugin.dll;$(OutputPath)\Nethermind.Taiko.dll;$(OutputPath)\Nethermind.Flashbots.dll;$(OutputPath)\Nethermind.StateDiff.Core.dll;$(OutputPath)\Nethermind.StateDiffsWriter.dll;$(OutputPath)\Nethermind.OpcodeTracing.Plugin.dll;$(OutputPath)\Nethermind.CensorshipDetector.Plugin.dll" />
     </ItemGroup>
   </Target>
 

--- a/src/Nethermind/Nethermind.Runner/NethermindPlugins.cs
+++ b/src/Nethermind/Nethermind.Runner/NethermindPlugins.cs
@@ -11,6 +11,7 @@ public static class NethermindPlugins
     public static readonly IReadOnlyList<Type> EmbeddedPlugins =
     [
         typeof(Nethermind.BalRecorder.BalRecorderPlugin),
+        typeof(Nethermind.CensorshipDetector.Plugin.CensorshipDetectorPlugin),
         typeof(Nethermind.Consensus.AuRa.AuRaPlugin),
         typeof(Nethermind.Consensus.Clique.CliquePlugin),
         typeof(Nethermind.Consensus.Ethash.EthashPlugin),

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -617,6 +617,21 @@
           "Polly": "[8.6.6, )"
         }
       },
+      "nethermind.censorshipdetector.plugin": {
+        "type": "Project",
+        "dependencies": {
+          "Nethermind.Api": "[1.40.0-unstable, )",
+          "Nethermind.Blockchain": "[1.40.0-unstable, )",
+          "Nethermind.Config": "[1.40.0-unstable, )",
+          "Nethermind.Consensus": "[1.40.0-unstable, )",
+          "Nethermind.Core": "[1.40.0-unstable, )",
+          "Nethermind.Crypto": "[1.40.0-unstable, )",
+          "Nethermind.Init": "[1.40.0-unstable, )",
+          "Nethermind.Logging": "[1.40.0-unstable, )",
+          "Nethermind.Merge.Plugin": "[1.40.0-unstable, )",
+          "Nethermind.TxPool": "[1.40.0-unstable, )"
+        }
+      },
       "nethermind.config": {
         "type": "Project",
         "dependencies": {

--- a/src/Nethermind/Nethermind.slnx
+++ b/src/Nethermind/Nethermind.slnx
@@ -11,6 +11,10 @@
     <Project Path="Nethermind.Flashbots.Test/Nethermind.Flashbots.Test.csproj" />
     <Project Path="Nethermind.Flashbots/Nethermind.Flashbots.csproj" />
   </Folder>
+  <Folder Name="/Plugins/CensorshipDetector/">
+    <Project Path="Nethermind.CensorshipDetector.Plugin.Test/Nethermind.CensorshipDetector.Plugin.Test.csproj" />
+    <Project Path="Nethermind.CensorshipDetector.Plugin/Nethermind.CensorshipDetector.Plugin.csproj" />
+  </Folder>
   <Folder Name="/Plugins/OpcodeTracing/">
     <Project Path="Nethermind.OpcodeTracing.Plugin/Nethermind.OpcodeTracing.Plugin.csproj" />
   </Folder>

--- a/tools/DocGen/DocGen.slnx
+++ b/tools/DocGen/DocGen.slnx
@@ -47,6 +47,7 @@
     <Project Path="../../src/Nethermind/Nethermind.Network.Enr/Nethermind.Network.Enr.csproj" />
     <Project Path="../../src/Nethermind/Nethermind.Network.Stats/Nethermind.Network.Stats.csproj" />
     <Project Path="../../src/Nethermind/Nethermind.Network/Nethermind.Network.csproj" />
+    <Project Path="../../src/Nethermind/Nethermind.CensorshipDetector.Plugin/Nethermind.CensorshipDetector.Plugin.csproj" />
     <Project Path="../../src/Nethermind/Nethermind.OpcodeTracing.Plugin/Nethermind.OpcodeTracing.Plugin.csproj" />
     <Project Path="../../src/Nethermind/Nethermind.Optimism/Nethermind.Optimism.csproj" />
     <Project Path="../../src/Nethermind/Nethermind.Runner/Nethermind.Runner.csproj" />

--- a/tools/SchemaGenerator/SchemaGenerator.csproj
+++ b/tools/SchemaGenerator/SchemaGenerator.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Nethermind\Nethermind.BalRecorder\Nethermind.BalRecorder.csproj" />
+    <ProjectReference Include="..\..\src\Nethermind\Nethermind.CensorshipDetector.Plugin\Nethermind.CensorshipDetector.Plugin.csproj" />
     <ProjectReference Include="..\..\src\Nethermind\Nethermind.Flashbots\Nethermind.Flashbots.csproj" />
     <ProjectReference Include="..\..\src\Nethermind\Nethermind.Hive\Nethermind.Hive.csproj" />
     <ProjectReference Include="..\..\src\Nethermind\Nethermind.Api\Nethermind.Api.csproj" />

--- a/tools/SchemaGenerator/SchemaGenerator.slnx
+++ b/tools/SchemaGenerator/SchemaGenerator.slnx
@@ -38,6 +38,7 @@
   <Project Path="../../src/Nethermind/Nethermind.Network.Enr/Nethermind.Network.Enr.csproj" />
   <Project Path="../../src/Nethermind/Nethermind.Network.Stats/Nethermind.Network.Stats.csproj" />
   <Project Path="../../src/Nethermind/Nethermind.Network/Nethermind.Network.csproj" />
+  <Project Path="../../src/Nethermind/Nethermind.CensorshipDetector.Plugin/Nethermind.CensorshipDetector.Plugin.csproj" />
   <Project Path="../../src/Nethermind/Nethermind.OpcodeTracing.Plugin/Nethermind.OpcodeTracing.Plugin.csproj" />
   <Project Path="../../src/Nethermind/Nethermind.Optimism/Nethermind.Optimism.csproj" />
   <Project Path="../../src/Nethermind/Nethermind.Seq/Nethermind.Seq.csproj" />


### PR DESCRIPTION
## Changes

- Extract the censorship detector, configuration, metrics, and tests into a built-in optional plugin.
- Remove censorship-specific API and blockchain initialization wiring from core projects.
- Add a composite `IBuilderOverridePolicy` extension point for Engine API `getPayloadV3` and later.
- Initialize the detector after blockchain initialization and before block processing starts.
- Include the plugin in runner packaging, solution, DocGen, and SchemaGenerator metadata.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet build -c release Nethermind.slnx`
- Censorship detector plugin tests: 7 passed
- Merge plugin tests: 1,624 passed, 2 environment-dependent tests skipped
- Runner/container tests: 271 passed, 2 environment-dependent tests skipped
- Config tests: 52 passed

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

- Existing `CensorshipDetector.*` configuration keys are preserved.
- The plugin remains disabled by default and core behavior is unchanged when it is absent.
- PR prepared by the OpenCode agent using `openai/gpt-5.6-sol`.