### PR TITLE
fix(nethtest): report zkEVM progress in test cases instead of fixture files

### DIFF
--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -471,11 +471,57 @@ internal class Program
     {
         Regex? filterRegex = filter is not null ? new Regex($"^({filter})", RegexOptions.Compiled) : null;
 
-        int completedFiles = 0;
+        // Witness fixtures are large, so files are parsed one at a time and released instead of
+        // materializing the whole set up front. The test-case total for progress reporting
+        // therefore comes from a count-only pre-pass over the same files.
+        int CountFile(int index)
+        {
+            try
+            {
+                int count = 0;
+                TestsSourceLoader source = new(new LoadBlockchainTestFileStrategy(), files[index]);
+                foreach (BlockchainTest test in source.LoadTests<BlockchainTest>())
+                {
+                    if (filterRegex is not null && test.Name is not null && !filterRegex.IsMatch(test.Name))
+                        continue;
+
+                    count += ZkEvmTestsRunner.CountCases(test);
+                }
+
+                return count;
+            }
+            catch (Exception)
+            {
+                // The execution pass reports the failure and yields exactly one EXCEPTION result.
+                return 1;
+            }
+        }
+
+        int[] casesPerFile = new int[files.Count];
+        if (workers <= 1)
+        {
+            for (int i = 0; i < files.Count; i++)
+            {
+                casesPerFile[i] = CountFile(i);
+            }
+        }
+        else
+        {
+            Parallel.For(0, files.Count, new ParallelOptions { MaxDegreeOfParallelism = workers }, i =>
+            {
+                casesPerFile[i] = CountFile(i);
+            });
+        }
+
+        int totalCases = 0;
+        foreach (int cases in casesPerFile)
+        {
+            totalCases += cases;
+        }
+
+        int completedCases = 0;
         List<EthereumTestResult>[] resultsByFile = new List<EthereumTestResult>[files.Count];
 
-        // Witness fixtures are large, so each file is parsed, executed, and released before
-        // the next one instead of materializing the whole set up front.
         void ProcessFile(int index)
         {
             List<EthereumTestResult> fileResults = [];
@@ -500,19 +546,23 @@ internal class Program
 
             resultsByFile[index] = fileResults;
 
-            int done = Interlocked.Increment(ref completedFiles);
+            if (fileResults.Count == 0)
+                return;
+
+            int done = Interlocked.Add(ref completedCases, fileResults.Count);
             foreach (EthereumTestResult result in fileResults)
             {
                 if (!result.Pass)
                 {
-                    Console.Error.WriteLine($"\x1b[31mFAIL\x1b[0m [{done}/{files.Count}] {result.Name} - {result.Error}");
+                    Console.Error.WriteLine($"\x1b[31mFAIL\x1b[0m [{done}/{totalCases}] {result.Name} - {result.Error}");
                     Console.Error.Flush();
                 }
             }
 
-            if (done % 10 == 0 || done == files.Count)
+            int previousDone = done - fileResults.Count;
+            if (done == totalCases || done / ProgressReportTestInterval != previousDone / ProgressReportTestInterval)
             {
-                Console.Error.WriteLine($"PROGRESS [{done}/{files.Count}]");
+                Console.Error.WriteLine($"PROGRESS [{done}/{totalCases}]");
                 Console.Error.Flush();
             }
         }

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -471,9 +471,6 @@ internal class Program
     {
         Regex? filterRegex = filter is not null ? new Regex($"^({filter})", RegexOptions.Compiled) : null;
 
-        // Witness fixtures are large, so files are parsed one at a time and released instead of
-        // materializing the whole set up front. The test-case total for progress reporting
-        // therefore comes from a count-only pre-pass over the same files.
         int CountFile(int index)
         {
             try
@@ -492,7 +489,6 @@ internal class Program
             }
             catch (Exception)
             {
-                // The execution pass reports the failure and yields exactly one EXCEPTION result.
                 return 1;
             }
         }
@@ -522,6 +518,8 @@ internal class Program
         int completedCases = 0;
         List<EthereumTestResult>[] resultsByFile = new List<EthereumTestResult>[files.Count];
 
+        // Witness fixtures are large, so each file is parsed, executed, and released before
+        // the next one instead of materializing the whole set up front.
         void ProcessFile(int index)
         {
             List<EthereumTestResult> fileResults = [];

--- a/src/Nethermind/Nethermind.Test.Runner/ZkEvmTestsRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/ZkEvmTestsRunner.cs
@@ -39,6 +39,24 @@ public static class ZkEvmTestsRunner
         return results;
     }
 
+    /// <summary>
+    /// Counts the test cases <see cref="RunTest"/> would produce for a fixture, without executing them.
+    /// </summary>
+    public static int CountCases(BlockchainTest test)
+    {
+        if (test.Blocks is not { Length: > 0 } blocks)
+            return 0;
+
+        int count = 0;
+        foreach (TestBlockJson block in blocks)
+        {
+            if (block.StatelessInputBytes is not null || block.StatelessOutputBytes is not null)
+                count++;
+        }
+
+        return count;
+    }
+
     private static string? ExecuteCase(TestBlockJson block)
     {
         string? inputBytes = block.StatelessInputBytes;

--- a/src/Nethermind/Nethermind.Test.Runner/ZkEvmTestsRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/ZkEvmTestsRunner.cs
@@ -39,9 +39,6 @@ public static class ZkEvmTestsRunner
         return results;
     }
 
-    /// <summary>
-    /// Counts the test cases <see cref="RunTest"/> would produce for a fixture, without executing them.
-    /// </summary>
     public static int CountCases(BlockchainTest test)
     {
         if (test.Blocks is not { Length: > 0 } blocks)


### PR DESCRIPTION
## Changes

- `RunZkEvmTestFiles` now reports `FAIL`/`PROGRESS` lines in test-case units (`PROGRESS [done/total]` every 100 cases, reusing `ProgressReportTestInterval`) instead of every 10 fixture files, so the final progress line matches the summary's `Total` (previously e.g. `PROGRESS [3029/3029]` files vs `Total: 25477` cases).
- The exact case total comes from a new count-only pre-pass over the fixture files (`ZkEvmTestsRunner.CountCases`). Files are still parsed and released one at a time, so peak memory is unchanged; the extra parse is a few seconds against ~30 s of execution (no measurable step slowdown on CI).
- Side effect: the `run-nethtest.yml` no-JSON fallback summary previously mixed units for zkEVM runs (`PASSED = files done − tests failed`); with test-unit progress lines its arithmetic is now consistent.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

- Verified locally with synthetic fixtures: sequential and `--workers 4` paths, `--filter`, the 100-case interval crossing, and skipping of blocks without stateless data — progress totals matched `--jsonout` result counts in all cases.
- Verified on CI ([run 29311261537](https://github.com/NethermindEth/nethermind/actions/runs/29311261537), `zkevmTest sequential`): progress ends at `PROGRESS [25477/25477]` and the summary reports `Total: 25477 | Passed: 25477 | Failed: 0`; step duration 30 s vs 38 s on the master reference run.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No