### PR TITLE
fix(test): migrate ScopeProviderTests to the PrewarmerState ctor

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -461,7 +461,7 @@ public class ScopeProviderTests(bool useFlat)
         // Populator probes must not move the pre-block counters: populators miss by design while
         // filling the cache, so counting them would skew the exported coverage ratio.
         LocalMetrics populatorMetrics = new();
-        PrewarmerScopeProvider populator = new(ctx.ScopeProvider, caches, LimboLogs.Instance, isPrewarmer: true);
+        PrewarmerScopeProvider populator = new(ctx.ScopeProvider, new PrewarmerState(caches, isPrewarmer: true), LimboLogs.Instance);
         using (IWorldStateScopeProvider.IScope scope = populator.BeginScope(baseBlock, populatorMetrics))
         {
             scope.Get(TestItem.AddressA);
@@ -473,7 +473,7 @@ public class ScopeProviderTests(bool useFlat)
 
         // Consumer probes count: AddressA / slot 1 were just populated (hits); AddressB / slot 2 are cold (misses).
         LocalMetrics consumerMetrics = new();
-        PrewarmerScopeProvider consumer = new(ctx.ScopeProvider, caches, LimboLogs.Instance, isPrewarmer: false);
+        PrewarmerScopeProvider consumer = new(ctx.ScopeProvider, new PrewarmerState(caches, isPrewarmer: false), LimboLogs.Instance);
         using (IWorldStateScopeProvider.IScope scope = consumer.BeginScope(baseBlock, consumerMetrics))
         {
             scope.Get(TestItem.AddressA);


### PR DESCRIPTION
## Changes

- Fixes the master build break introduced by the semantic conflict between #12385 (collapsed `PrewarmerScopeProvider(caches, ..., isPrewarmer)` into a single `IPrewarmerState` parameter) and #12372 (added two `ScopeProviderTests` constructor calls using the old signature). Each PR was green against its own base; combined, master fails `code-lint`/build with `CS1739` at `ScopeProviderTests.cs:464,476`.
- Migrates the two calls to `new PrewarmerState(caches, isPrewarmer: ...)` — the form every other call site in the file already uses.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Existing `ScopeProviderTests` now compile and pass (31/31, 1 skipped). No behavioral change — test-only signature migration.
