### PR TITLE
fix(blockstore): inject chain header decoder so AuRa blocks decode

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/Encoding/AuRaBlockStoreDecoderTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Encoding/AuRaBlockStoreDecoderTests.cs
@@ -11,14 +11,6 @@ using NUnit.Framework;
 
 namespace Nethermind.AuRa.Test.Encoding;
 
-/// <summary>
-/// Regression tests for a Gnosis/AuRa startup crash: <see cref="BlockStore"/> must decode blocks with the
-/// chain's <see cref="IHeaderDecoder"/> (the <see cref="AuRaHeaderDecoder"/>), not the base
-/// <see cref="HeaderDecoder"/>. The DI factory used to omit the decoder, so <see cref="BlockStore"/> fell back
-/// to the base decoder. On an AuRa header whose <c>step</c> is empty (e.g. the Gnosis genesis, step 0), the base
-/// decoder reads that empty item as a null mixHash and then reads the 65-byte AuRa signature as the 8-byte nonce
-/// via a 32-byte-limited <c>DecodeUInt256</c>, throwing <see cref="RlpLimitException"/> during block-tree init.
-/// </summary>
 public class AuRaBlockStoreDecoderTests
 {
     // Gnosis genesis shape: empty step + 65-byte (r|s|v) AuRa signature.

--- a/src/Nethermind/Nethermind.AuRa.Test/Encoding/AuRaBlockStoreDecoderTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Encoding/AuRaBlockStoreDecoderTests.cs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain.Blocks;
+using Nethermind.Consensus.AuRa;
+using Nethermind.Core;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Nethermind.AuRa.Test.Encoding;
+
+/// <summary>
+/// Regression tests for a Gnosis/AuRa startup crash: <see cref="BlockStore"/> must decode blocks with the
+/// chain's <see cref="IHeaderDecoder"/> (the <see cref="AuRaHeaderDecoder"/>), not the base
+/// <see cref="HeaderDecoder"/>. The DI factory used to omit the decoder, so <see cref="BlockStore"/> fell back
+/// to the base decoder. On an AuRa header whose <c>step</c> is empty (e.g. the Gnosis genesis, step 0), the base
+/// decoder reads that empty item as a null mixHash and then reads the 65-byte AuRa signature as the 8-byte nonce
+/// via a 32-byte-limited <c>DecodeUInt256</c>, throwing <see cref="RlpLimitException"/> during block-tree init.
+/// </summary>
+public class AuRaBlockStoreDecoderTests
+{
+    // Gnosis genesis shape: empty step + 65-byte (r|s|v) AuRa signature.
+    private static Block AuRaGenesisShapedBlock() =>
+        Build.A.Block.WithNumber(0).WithAura(0, new byte[65]).TestObject;
+
+    [Test]
+    public void Reads_back_aura_block_when_header_decoder_is_injected()
+    {
+        Block block = AuRaGenesisShapedBlock();
+
+        TestMemDb db = new();
+        BlockStore store = new(db, new AuRaHeaderDecoder());
+        store.Insert(block);
+
+        Block? retrieved = store.Get(block.Number, block.Hash!);
+
+        Assert.That(retrieved, Is.Not.Null);
+        Assert.That(retrieved!.Header, Is.InstanceOf<AuRaBlockHeader>());
+        Assert.That(((AuRaBlockHeader)retrieved.Header).AuRaSignature, Is.EqualTo(new byte[65]));
+    }
+
+    [Test]
+    public void Base_header_decoder_misreads_aura_signature_as_nonce()
+    {
+        Block block = AuRaGenesisShapedBlock();
+
+        TestMemDb db = new();
+        // Persist with the AuRa-aware decoder, as the node does.
+        new BlockStore(db, new AuRaHeaderDecoder()).Insert(block);
+
+        // The pre-fix wiring left BlockStore without a decoder, so it fell back to the base HeaderDecoder.
+        BlockStore baseStore = new(db);
+
+        Assert.That(() => baseStore.Get(block.Number, block.Hash!), Throws.InstanceOf<RlpLimitException>());
+    }
+}

--- a/src/Nethermind/Nethermind.AuRa.Test/Encoding/AuRaBlockStoreDecoderTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/Encoding/AuRaBlockStoreDecoderTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Linq;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Consensus.AuRa;
 using Nethermind.Core;
@@ -46,5 +47,21 @@ public class AuRaBlockStoreDecoderTests
         BlockStore baseStore = new(db);
 
         Assert.That(() => baseStore.Get(block.Number, block.Hash!), Throws.InstanceOf<RlpLimitException>());
+    }
+
+    [Test]
+    public void Bad_block_store_preserves_aura_header_when_decoder_is_injected()
+    {
+        Block block = AuRaGenesisShapedBlock();
+
+        TestMemDb db = new();
+        BadBlockStore store = new(db, maxSize: 100, headerDecoder: new AuRaHeaderDecoder());
+        store.Insert(block);
+
+        Block retrieved = store.GetAll().Single();
+
+        Assert.That(retrieved.Header, Is.InstanceOf<AuRaBlockHeader>());
+        Assert.That(((AuRaBlockHeader)retrieved.Header).AuRaSignature, Is.EqualTo(new byte[65]));
+        Assert.That(retrieved.Hash, Is.EqualTo(block.Hash));
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BadBlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BadBlockStore.cs
@@ -12,9 +12,9 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Blockchain.Blocks;
 
-public class BadBlockStore(IDb blockDb, long maxSize) : IBadBlockStore
+public class BadBlockStore(IDb blockDb, long maxSize, IHeaderDecoder? headerDecoder = null) : IBadBlockStore
 {
-    private readonly BlockDecoder _blockDecoder = new();
+    private readonly BlockDecoder _blockDecoder = new(headerDecoder ?? new HeaderDecoder());
 
     public void Insert(Block block, WriteFlags writeFlags = WriteFlags.None)
     {

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
@@ -80,7 +80,7 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
         SimulateDictionaryHeaderStore tmpHeaderStore,
         IBlockAccessListStore tmpBalStore)
     {
-        IBlockStore mainBlockStore = new BlockStore(editableDbProvider.BlocksDb);
+        IBlockStore mainBlockStore = new BlockStore(editableDbProvider.BlocksDb, (IHeaderDecoder)Rlp.GetDecoderOrThrow<BlockHeader>());
         const int badBlocksStored = 1;
 
         SimulateDictionaryBlockStore tmpBlockStore = new(mainBlockStore);

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
@@ -80,11 +80,12 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
         SimulateDictionaryHeaderStore tmpHeaderStore,
         IBlockAccessListStore tmpBalStore)
     {
-        IBlockStore mainBlockStore = new BlockStore(editableDbProvider.BlocksDb, (IHeaderDecoder)Rlp.GetDecoderOrThrow<BlockHeader>());
+        IHeaderDecoder headerDecoder = (IHeaderDecoder)Rlp.GetDecoderOrThrow<BlockHeader>();
+        IBlockStore mainBlockStore = new BlockStore(editableDbProvider.BlocksDb, headerDecoder);
         const int badBlocksStored = 1;
 
         SimulateDictionaryBlockStore tmpBlockStore = new(mainBlockStore);
-        IBadBlockStore badBlockStore = new BadBlockStore(editableDbProvider.BadBlocksDb, badBlocksStored);
+        IBadBlockStore badBlockStore = new BadBlockStore(editableDbProvider.BadBlocksDb, badBlocksStored, headerDecoder);
 
         return new(tmpBlockStore,
             tmpHeaderStore,

--- a/src/Nethermind/Nethermind.Init/Modules/BlockTreeModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockTreeModule.cs
@@ -18,6 +18,7 @@ using Nethermind.Db.LogIndex;
 using Nethermind.Facade.Find;
 using Nethermind.History;
 using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
 using Nethermind.State.Repositories;
 using Nethermind.TxPool;
 
@@ -30,7 +31,7 @@ public class BlockTreeModule(IReceiptConfig receiptConfig, ILogIndexConfig logIn
         builder
             .AddSingleton<IHeaderStore, HeaderStore>()
             .AddSingleton<IHeaderFinder>(c => c.Resolve<IHeaderStore>())
-            .AddSingleton<IBlockStore, IDb, IDeferredBlockDataWriter, IStatePersistenceBarrier>(CreateBlockStore)
+            .AddSingleton<IBlockStore, IDb, IHeaderDecoder, IDeferredBlockDataWriter, IStatePersistenceBarrier>(CreateBlockStore)
             .AddSingleton<IDeferredBlockDataWriter>(CreateDeferredWriter)
             .AddSingleton<IReceiptMigrationStore, PersistentReceiptStorage>()
             .Bind<IReceiptStorage, IReceiptMigrationStore>()
@@ -88,8 +89,8 @@ public class BlockTreeModule(IReceiptConfig receiptConfig, ILogIndexConfig logIn
         return new DeferredBlockDataWriter(receiptConfig.DeferredPersistence, receiptConfig.MaxDeferredWrites, ctx.Resolve<ILogManager>(), ctx.Resolve<IStatePersistenceBarrier>());
     }
 
-    private IBlockStore CreateBlockStore([KeyFilter(DbNames.Blocks)] IDb blocksDb, IDeferredBlockDataWriter deferredWriter, IStatePersistenceBarrier persistenceBarrier) =>
-        new BlockStore(blocksDb, deferredWriter: deferredWriter, persistenceBarrier: persistenceBarrier);
+    private IBlockStore CreateBlockStore([KeyFilter(DbNames.Blocks)] IDb blocksDb, IHeaderDecoder headerDecoder, IDeferredBlockDataWriter deferredWriter, IStatePersistenceBarrier persistenceBarrier) =>
+        new BlockStore(blocksDb, headerDecoder, deferredWriter: deferredWriter, persistenceBarrier: persistenceBarrier);
 
     private IBadBlockStore CreateBadBlockStore([KeyFilter(DbNames.BadBlocks)] IDb badBlockDb, IInitConfig initConfig) =>
         new BadBlockStore(badBlockDb, initConfig.BadBlocksStored ?? 100);

--- a/src/Nethermind/Nethermind.Init/Modules/BlockTreeModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockTreeModule.cs
@@ -35,7 +35,7 @@ public class BlockTreeModule(IReceiptConfig receiptConfig, ILogIndexConfig logIn
             .AddSingleton<IDeferredBlockDataWriter>(CreateDeferredWriter)
             .AddSingleton<IReceiptMigrationStore, PersistentReceiptStorage>()
             .Bind<IReceiptStorage, IReceiptMigrationStore>()
-            .AddSingleton<IBadBlockStore, IDb, IInitConfig>(CreateBadBlockStore)
+            .AddSingleton<IBadBlockStore, IDb, IInitConfig, IHeaderDecoder>(CreateBadBlockStore)
             .AddSingleton<IBlockAccessListStore, IDb, IDeferredBlockDataWriter, IStatePersistenceBarrier>(CreateBalStore)
             .AddSingleton<IChainLevelInfoRepository, ChainLevelInfoRepository>()
             .AddSingleton<IBlobTxStorage, BlobTxStorage>()
@@ -92,8 +92,8 @@ public class BlockTreeModule(IReceiptConfig receiptConfig, ILogIndexConfig logIn
     private IBlockStore CreateBlockStore([KeyFilter(DbNames.Blocks)] IDb blocksDb, IHeaderDecoder headerDecoder, IDeferredBlockDataWriter deferredWriter, IStatePersistenceBarrier persistenceBarrier) =>
         new BlockStore(blocksDb, headerDecoder, deferredWriter: deferredWriter, persistenceBarrier: persistenceBarrier);
 
-    private IBadBlockStore CreateBadBlockStore([KeyFilter(DbNames.BadBlocks)] IDb badBlockDb, IInitConfig initConfig) =>
-        new BadBlockStore(badBlockDb, initConfig.BadBlocksStored ?? 100);
+    private IBadBlockStore CreateBadBlockStore([KeyFilter(DbNames.BadBlocks)] IDb badBlockDb, IInitConfig initConfig, IHeaderDecoder headerDecoder) =>
+        new BadBlockStore(badBlockDb, initConfig.BadBlocksStored ?? 100, headerDecoder);
 
     private IBlockAccessListStore CreateBalStore([KeyFilter(DbNames.BlockAccessLists)] IDb balDb, IDeferredBlockDataWriter deferredWriter, IStatePersistenceBarrier persistenceBarrier) =>
         new BlockAccessListStore(balDb, deferredWriter: deferredWriter, persistenceBarrier: persistenceBarrier);


### PR DESCRIPTION
## Changes

`BlockStore` was constructed without an `IHeaderDecoder`, so it fell back to the base `HeaderDecoder` instead of the chain's `AuRaHeaderDecoder`. On an AuRa (Gnosis) header the seal is `[step, signature]`; when `step = 0` (RLP `0x80`), the base decoder's `DecodeSealAndCreateHeader` reads the empty step as a null `mixHash`, then decodes the 65-byte signature through `DecodeUInt256(NonceLength)` — a 32-byte limit — throwing `RlpLimitException: Collection count of 65 is over limit 32`. This crashed Gnosis nodes at block-tree init (`FindBlock` via `BlockStore`), while `HeaderStore` (which did receive the `AuRaHeaderDecoder`) worked.

Introduced by #11938, which moved header decoding behind a DI-injected `IHeaderDecoder` but never updated the `CreateBlockStore` factory. The recently tightened RLP array limits turned this latent wiring gap into a hard failure.

- `Nethermind.Init/Modules/BlockTreeModule.cs`: `CreateBlockStore` now receives and forwards `IHeaderDecoder`.
- `Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs`: same latent gap for `eth_simulate` on AuRa chains — pass the chain header decoder.

## Types of changes

- [x] Bug fix (a non-breaking change that fixes an issue)

## Testing

New regression tests in `Nethermind.AuRa.Test/Encoding/AuRaBlockStoreDecoderTests.cs`:
- round-trips a genesis-shaped AuRa block (step 0, 65-byte signature) through `BlockStore` with the injected `AuRaHeaderDecoder` — no throw, yields `AuRaBlockHeader`;
- reproduces the exact `RlpLimitException` when the decoder is omitted.

Both pass; existing `BlockStoreTests` (22/22) and `AuRaHeaderDecoderTests` (7/7) still pass. Reproduced against real Gnosis genesis RLP.

- [x] I have added tests that cover my changes