### PR TITLE
fix(consensus): preserve chain-specific header type in mempool pre-warming

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/MempoolStatePrewarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/MempoolStatePrewarmerTests.cs
@@ -76,8 +76,6 @@ public class MempoolStatePrewarmerTests
     [Test]
     public async Task PreWarmFromMempool_PassesHeaderPreservingChainSpecificSubtypeToPreWarmer()
     {
-        // Regression: the header was previously built via `new BlockHeader(...)`, degrading chain-specific subtypes
-        // to a plain BlockHeader and throwing InvalidCastException in chain-specific processors (e.g. XDC).
         ChainSpecificHeader parentHeader = new(
             TestItem.KeccakA, Keccak.OfAnEmptySequenceRlp, TestItem.AddressA, UInt256.One, 10, 30_000_000, 100, [])
         {
@@ -85,6 +83,7 @@ public class MempoolStatePrewarmerTests
             MixHash = TestItem.KeccakC,
             ParentBeaconBlockRoot = TestItem.KeccakD,
             BaseFeePerGas = 7,
+            Author = TestItem.AddressD,
         };
         Block head = new(parentHeader);
 
@@ -117,11 +116,15 @@ public class MempoolStatePrewarmerTests
 
         BlockHeader deltaHeader = await preWarmer.CapturedHeader.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.That(deltaHeader, Is.InstanceOf<ChainSpecificHeader>(), "chain-specific header subtypes must survive so chain-specific processors don't hit an InvalidCastException");
-        Assert.That(deltaHeader.Number, Is.EqualTo(parentHeader.Number + 1), "the child is the parent's successor");
-        Assert.That(deltaHeader.MixHash, Is.EqualTo(parentHeader.MixHash), "MixHash is propagated from the parent");
-        Assert.That(deltaHeader.ParentBeaconBlockRoot, Is.EqualTo(parentHeader.ParentBeaconBlockRoot), "ParentBeaconBlockRoot is propagated from the parent");
-        Assert.That(deltaHeader.BaseFeePerGas, Is.EqualTo(BaseFeeCalculator.Calculate(parentHeader, London.Instance)), "BaseFeePerGas is recalculated for the child");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(deltaHeader, Is.InstanceOf<ChainSpecificHeader>(), "chain-specific header subtypes must survive so chain-specific processors don't hit an InvalidCastException");
+            Assert.That(deltaHeader.Number, Is.EqualTo(parentHeader.Number + 1), "the child is the parent's successor");
+            Assert.That(deltaHeader.MixHash, Is.EqualTo(parentHeader.MixHash), "MixHash is propagated from the parent");
+            Assert.That(deltaHeader.ParentBeaconBlockRoot, Is.EqualTo(parentHeader.ParentBeaconBlockRoot), "ParentBeaconBlockRoot is propagated from the parent");
+            Assert.That(deltaHeader.BaseFeePerGas, Is.EqualTo(BaseFeeCalculator.Calculate(parentHeader, London.Instance)), "BaseFeePerGas is recalculated for the child");
+            Assert.That(deltaHeader.GasBeneficiary, Is.EqualTo(parentHeader.GasBeneficiary), "Beneficiary resolves to the parent's actual coinbase (Author), not a diverging governance vote target");
+        }
     }
 
     // Stands in for a chain-specific header subtype (e.g. XdcBlockHeader) whose CreateSimulatedChild returns its own type.
@@ -138,9 +141,7 @@ public class MempoolStatePrewarmerTests
     }
 
     /// <summary>
-    /// Captures the header of the first delta block <see cref="MempoolStatePrewarmer"/> offers for warming, by
-    /// invoking <c>nextDelta</c> itself instead of only recording the call (as <see cref="StartSpeculativePreWarm"/>
-    /// would with a plain substitute).
+    /// Invokes <c>nextDelta</c> and captures the resulting header.
     /// </summary>
     private sealed class DeltaCapturingPreWarmer : IBlockCachePreWarmer
     {

--- a/src/Nethermind/Nethermind.Consensus.Test/MempoolStatePrewarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/MempoolStatePrewarmerTests.cs
@@ -5,8 +5,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
 using NUnit.Framework;
 
 namespace Nethermind.Consensus.Test;
@@ -57,6 +60,42 @@ public class MempoolStatePrewarmerTests
         Transaction[] secondPass = MempoolStatePrewarmer.SelectDelta(BuildSenderTxs(TestItem.PrivateKeyA, 4), warmedPerSender);
 
         Assert.That(secondPass.Length, Is.EqualTo(4), "when new transactions arrive the sender's full group is replayed so predecessors are present");
+    }
+
+    [Test]
+    public void BuildNextBlockHeader_PreservesChainSpecificHeaderSubtype()
+    {
+        // Regression: the header was previously built via `new BlockHeader(...)`, degrading chain-specific subtypes
+        // to a plain BlockHeader and throwing InvalidCastException in chain-specific processors (e.g. XDC).
+        ChainSpecificHeader parent = new(
+            TestItem.KeccakA, Keccak.OfAnEmptySequenceRlp, TestItem.AddressA, UInt256.One, 10, 30_000_000, 100, [])
+        {
+            Hash = TestItem.KeccakB,
+            MixHash = TestItem.KeccakC,
+            ParentBeaconBlockRoot = TestItem.KeccakD,
+            BaseFeePerGas = 7,
+        };
+
+        BlockHeader next = MempoolStatePrewarmer.BuildNextBlockHeader(parent, timestamp: 200, London.Instance);
+
+        Assert.That(next, Is.InstanceOf<ChainSpecificHeader>(), "chain-specific header subtypes must survive so chain-specific processors don't hit an InvalidCastException");
+        Assert.That(next.Number, Is.EqualTo(parent.Number + 1), "the child is the parent's successor");
+        Assert.That(next.MixHash, Is.EqualTo(parent.MixHash), "MixHash is propagated from the parent");
+        Assert.That(next.ParentBeaconBlockRoot, Is.EqualTo(parent.ParentBeaconBlockRoot), "ParentBeaconBlockRoot is propagated from the parent");
+        Assert.That(next.BaseFeePerGas, Is.EqualTo(BaseFeeCalculator.Calculate(parent, London.Instance)), "BaseFeePerGas is recalculated for the child");
+    }
+
+    // Stands in for a chain-specific header subtype (e.g. XdcBlockHeader) whose CreateSimulatedChild returns its own type.
+    private sealed class ChainSpecificHeader(
+        Hash256 parentHash, Hash256 unclesHash, Address beneficiary, in UInt256 difficulty,
+        ulong number, ulong gasLimit, ulong timestamp, byte[] extraData)
+        : BlockHeader(parentHash, unclesHash, beneficiary, difficulty, number, gasLimit, timestamp, extraData)
+    {
+        public override BlockHeader CreateSimulatedChild(ulong timestamp) =>
+            new ChainSpecificHeader(Hash!, Keccak.OfAnEmptySequenceRlp, Beneficiary!, UInt256.Zero, Number + 1, GasLimit, timestamp, [])
+            {
+                MixHash = Hash256.Zero,
+            };
     }
 
     private static Transaction[] BuildSenderTxs(PrivateKey sender, int count) =>

--- a/src/Nethermind/Nethermind.Consensus.Test/MempoolStatePrewarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/MempoolStatePrewarmerTests.cs
@@ -1,15 +1,26 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Config;
 using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Producers;
+using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
+using Nethermind.Evm.State;
 using Nethermind.Int256;
+using Nethermind.Logging;
 using Nethermind.Specs.Forks;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Consensus.Test;
@@ -63,11 +74,11 @@ public class MempoolStatePrewarmerTests
     }
 
     [Test]
-    public void BuildNextBlockHeader_PreservesChainSpecificHeaderSubtype()
+    public async Task PreWarmFromMempool_PassesHeaderPreservingChainSpecificSubtypeToPreWarmer()
     {
         // Regression: the header was previously built via `new BlockHeader(...)`, degrading chain-specific subtypes
         // to a plain BlockHeader and throwing InvalidCastException in chain-specific processors (e.g. XDC).
-        ChainSpecificHeader parent = new(
+        ChainSpecificHeader parentHeader = new(
             TestItem.KeccakA, Keccak.OfAnEmptySequenceRlp, TestItem.AddressA, UInt256.One, 10, 30_000_000, 100, [])
         {
             Hash = TestItem.KeccakB,
@@ -75,14 +86,42 @@ public class MempoolStatePrewarmerTests
             ParentBeaconBlockRoot = TestItem.KeccakD,
             BaseFeePerGas = 7,
         };
+        Block head = new(parentHeader);
 
-        BlockHeader next = MempoolStatePrewarmer.BuildNextBlockHeader(parent, timestamp: 200, London.Instance);
+        ITxSource txSource = Substitute.For<ITxSource>();
+        txSource.GetTransactions(Arg.Any<BlockHeader>(), Arg.Any<ulong>(), Arg.Any<PayloadAttributes>(), Arg.Any<bool>())
+            .Returns(BuildSenderTxs(TestItem.PrivateKeyA, 1));
+        IBlockProducerTxSourceFactory txSourceFactory = Substitute.For<IBlockProducerTxSourceFactory>();
+        txSourceFactory.Create().Returns(txSource);
 
-        Assert.That(next, Is.InstanceOf<ChainSpecificHeader>(), "chain-specific header subtypes must survive so chain-specific processors don't hit an InvalidCastException");
-        Assert.That(next.Number, Is.EqualTo(parent.Number + 1), "the child is the parent's successor");
-        Assert.That(next.MixHash, Is.EqualTo(parent.MixHash), "MixHash is propagated from the parent");
-        Assert.That(next.ParentBeaconBlockRoot, Is.EqualTo(parent.ParentBeaconBlockRoot), "ParentBeaconBlockRoot is propagated from the parent");
-        Assert.That(next.BaseFeePerGas, Is.EqualTo(BaseFeeCalculator.Calculate(parent, London.Instance)), "BaseFeePerGas is recalculated for the child");
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(London.Instance);
+
+        DateTime headTime = DateTimeOffset.FromUnixTimeSeconds((long)parentHeader.Timestamp).UtcDateTime;
+        ITimestamper timestamper = Substitute.For<ITimestamper>();
+        timestamper.UtcNow.Returns(headTime);
+        timestamper.UnixTime.Returns(new UnixTime(headTime));
+
+        IBlocksConfig blocksConfig = Substitute.For<IBlocksConfig>();
+        blocksConfig.PreWarming.Returns(PreWarmMode.BlockAndMempool);
+        blocksConfig.SecondsPerSlot.Returns(12ul);
+
+        DeltaCapturingPreWarmer preWarmer = new();
+
+        using MempoolStatePrewarmer _ = new(
+            preWarmer, txSourceFactory, blockTree, specProvider, timestamper, blocksConfig, LimboLogs.Instance);
+
+        blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(head));
+
+        BlockHeader deltaHeader = await preWarmer.CapturedHeader.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(deltaHeader, Is.InstanceOf<ChainSpecificHeader>(), "chain-specific header subtypes must survive so chain-specific processors don't hit an InvalidCastException");
+        Assert.That(deltaHeader.Number, Is.EqualTo(parentHeader.Number + 1), "the child is the parent's successor");
+        Assert.That(deltaHeader.MixHash, Is.EqualTo(parentHeader.MixHash), "MixHash is propagated from the parent");
+        Assert.That(deltaHeader.ParentBeaconBlockRoot, Is.EqualTo(parentHeader.ParentBeaconBlockRoot), "ParentBeaconBlockRoot is propagated from the parent");
+        Assert.That(deltaHeader.BaseFeePerGas, Is.EqualTo(BaseFeeCalculator.Calculate(parentHeader, London.Instance)), "BaseFeePerGas is recalculated for the child");
     }
 
     // Stands in for a chain-specific header subtype (e.g. XdcBlockHeader) whose CreateSimulatedChild returns its own type.
@@ -96,6 +135,28 @@ public class MempoolStatePrewarmerTests
             {
                 MixHash = Hash256.Zero,
             };
+    }
+
+    /// <summary>
+    /// Captures the header of the first delta block <see cref="MempoolStatePrewarmer"/> offers for warming, by
+    /// invoking <c>nextDelta</c> itself instead of only recording the call (as <see cref="StartSpeculativePreWarm"/>
+    /// would with a plain substitute).
+    /// </summary>
+    private sealed class DeltaCapturingPreWarmer : IBlockCachePreWarmer
+    {
+        public readonly TaskCompletionSource<BlockHeader> CapturedHeader = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task PreWarmCaches(Block suggestedBlock, BlockHeader parent, IReleaseSpec spec, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public CacheType ClearCaches() => default;
+        public bool IsBalReadWarmingEnabled(IReleaseSpec spec) => false;
+
+        public Task StartSpeculativePreWarm(BlockHeader head, IReleaseSpec spec, long generation, Func<CancellationToken, Block> nextDelta, int idlePassDelayMs, CancellationToken cancellationToken)
+        {
+            CapturedHeader.TrySetResult(nextDelta(CancellationToken.None)?.Header);
+            return Task.CompletedTask;
+        }
+
+        public void Dispose() { }
     }
 
     private static Transaction[] BuildSenderTxs(PrivateKey sender, int count) =>

--- a/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
@@ -10,9 +10,7 @@ using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
-using Nethermind.Int256;
 using Nethermind.Logging;
 
 namespace Nethermind.Consensus.Processing;
@@ -113,20 +111,12 @@ public sealed class MempoolStatePrewarmer : IDisposable
         ulong timestamp = Math.Max(parent.Timestamp + 1, _timestamper.UnixTime.Seconds);
         IReleaseSpec spec = _specProvider.GetSpec(new ForkActivation(number, timestamp));
 
-        BlockHeader header = new(
-            parent.Hash!,
-            Keccak.OfAnEmptySequenceRlp,
-            parent.GasBeneficiary ?? Address.Zero,
-            UInt256.Zero,
-            number,
-            parent.GasLimit,
-            timestamp,
-            [])
-        {
-            MixHash = parent.MixHash,
-            BaseFeePerGas = BaseFeeCalculator.Calculate(parent, spec),
-            ParentBeaconBlockRoot = parent.ParentBeaconBlockRoot,
-        };
+        // CreateSimulatedChild dispatches virtually, so chain-specific header subtypes (e.g. XdcBlockHeader)
+        // are preserved instead of degrading to a plain BlockHeader that chain-specific processors don't expect.
+        BlockHeader header = parent.CreateSimulatedChild(timestamp);
+        header.MixHash = parent.MixHash;
+        header.BaseFeePerGas = BaseFeeCalculator.Calculate(parent, spec);
+        header.ParentBeaconBlockRoot = parent.ParentBeaconBlockRoot;
 
         return new NextBlockContext(header, spec);
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
@@ -120,6 +120,8 @@ public sealed class MempoolStatePrewarmer : IDisposable
     private static BlockHeader BuildNextBlockHeader(BlockHeader parent, ulong timestamp, IReleaseSpec spec)
     {
         BlockHeader header = parent.CreateSimulatedChild(timestamp);
+        // Resolve the actual coinbase: on Clique, Beneficiary is a vote target, not the sealer.
+        header.Beneficiary = parent.GasBeneficiary ?? Address.Zero;
         header.MixHash = parent.MixHash;
         header.BaseFeePerGas = BaseFeeCalculator.Calculate(parent, spec);
         header.ParentBeaconBlockRoot = parent.ParentBeaconBlockRoot;

--- a/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
@@ -117,7 +117,7 @@ public sealed class MempoolStatePrewarmer : IDisposable
     /// <summary>
     /// Builds the synthetic "next block" header for warming.
     /// </summary>
-    internal static BlockHeader BuildNextBlockHeader(BlockHeader parent, ulong timestamp, IReleaseSpec spec)
+    private static BlockHeader BuildNextBlockHeader(BlockHeader parent, ulong timestamp, IReleaseSpec spec)
     {
         BlockHeader header = parent.CreateSimulatedChild(timestamp);
         header.MixHash = parent.MixHash;

--- a/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
@@ -111,14 +111,25 @@ public sealed class MempoolStatePrewarmer : IDisposable
         ulong timestamp = Math.Max(parent.Timestamp + 1, _timestamper.UnixTime.Seconds);
         IReleaseSpec spec = _specProvider.GetSpec(new ForkActivation(number, timestamp));
 
-        // CreateSimulatedChild dispatches virtually, so chain-specific header subtypes (e.g. XdcBlockHeader)
-        // are preserved instead of degrading to a plain BlockHeader that chain-specific processors don't expect.
+        return new NextBlockContext(BuildNextBlockHeader(parent, timestamp, spec), spec);
+    }
+
+    /// <summary>
+    /// Builds the synthetic "next block" header for speculative warming.
+    /// </summary>
+    /// <remarks>
+    /// Uses <see cref="BlockHeader.CreateSimulatedChild"/>, which dispatches virtually, so chain-specific header
+    /// subtypes (e.g. <c>XdcBlockHeader</c>) are preserved instead of degrading to a plain <see cref="BlockHeader"/>
+    /// that chain-specific processors don't expect (which would otherwise throw an <see cref="InvalidCastException"/>).
+    /// </remarks>
+    internal static BlockHeader BuildNextBlockHeader(BlockHeader parent, ulong timestamp, IReleaseSpec spec)
+    {
         BlockHeader header = parent.CreateSimulatedChild(timestamp);
         header.MixHash = parent.MixHash;
         header.BaseFeePerGas = BaseFeeCalculator.Calculate(parent, spec);
         header.ParentBeaconBlockRoot = parent.ParentBeaconBlockRoot;
 
-        return new NextBlockContext(header, spec);
+        return header;
     }
 
     private Block? BuildDeltaBlock(BlockHeader parent, NextBlockContext next, Dictionary<AddressAsKey, int> warmedPerSender)

--- a/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
@@ -115,13 +115,8 @@ public sealed class MempoolStatePrewarmer : IDisposable
     }
 
     /// <summary>
-    /// Builds the synthetic "next block" header for speculative warming.
+    /// Builds the synthetic "next block" header for warming.
     /// </summary>
-    /// <remarks>
-    /// Uses <see cref="BlockHeader.CreateSimulatedChild"/>, which dispatches virtually, so chain-specific header
-    /// subtypes (e.g. <c>XdcBlockHeader</c>) are preserved instead of degrading to a plain <see cref="BlockHeader"/>
-    /// that chain-specific processors don't expect (which would otherwise throw an <see cref="InvalidCastException"/>).
-    /// </remarks>
     internal static BlockHeader BuildNextBlockHeader(BlockHeader parent, ulong timestamp, IReleaseSpec spec)
     {
         BlockHeader header = parent.CreateSimulatedChild(timestamp);


### PR DESCRIPTION
## Summary
- `MempoolStatePrewarmer.PrepareNextBlockContext` built the synthetic "next block" header for speculative mempool pre-warming via `new BlockHeader(...)`, which always produces a plain `BlockHeader`, degrading any chain-specific header subtype.
- On XDC this surfaced as:
  ```
  DEBUG/ERROR: Error pre-warming cache 0x8afc...: System.InvalidCastException: Unable to cast object of type 'Nethermind.Core.BlockHeader' to type 'Nethermind.Xdc.XdcBlockHeader'.
     at Nethermind.Xdc.XdcTransactionProcessor.ValidateGas(...)
     at Nethermind.Consensus.Processing.BlockCachePreWarmer.WarmupSingleTransaction(...)
  ```
  The exception is already caught (logged as `DebugError`), so it wasn't crashing the node, but it silently defeated speculative mempool pre-warming for every transaction on XDC chains and spammed logs.
- Fix: use `BlockHeader.CreateSimulatedChild(timestamp)` instead of manually constructing a `BlockHeader`. It dispatches virtually and is already the established mechanism for building a simulated child header while preserving the parent's concrete subtype (used e.g. by `SimulateBridgeHelper` for `eth_simulateV1`, and already covered by existing `XdcBlockHeader`/`XdcSubnetBlockHeader` `CreateSimulatedChild` overrides and tests).
- No changes needed in `Nethermind.Xdc` — the fix is fully contained in the chain-agnostic `Nethermind.Consensus` prewarmer.

## Test plan
- [x] `dotnet build` for `Nethermind.Consensus`, `Nethermind.Consensus.Test`, `Nethermind.Xdc.Test` succeeds
- [x] `Nethermind.Consensus.Test` (`MempoolStatePrewarmerTests`, `BlockCachePreWarmerTests`) — 33/33 pass
- [x] `dotnet format whitespace` clean on the touched file