### PR TITLE
Eliminate JUMPDEST dispatch after valid taken non-traced jumps

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -6,9 +6,11 @@ using System.Numerics;
 using System.Text.Json;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Evm.Test.Tracing;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.Serialization.Json;
 using NUnit.Framework;
@@ -19,11 +21,84 @@ namespace Nethermind.Evm.Test;
 [Parallelizable(ParallelScope.Self)]
 public class VirtualMachineTests : VirtualMachineTestsBase
 {
+    private static readonly TestCaseData[] JumpCompletionCases =
+    [
+        new TestCaseData("600456005b00", 21012UL, 4).SetName("Jump_taken"),
+        new TestCaseData("6001600657005b00", 21017UL, 5).SetName("JumpI_taken"),
+        new TestCaseData("6000600657005b00", 21016UL, 4).SetName("JumpI_not_taken"),
+        new TestCaseData("6003565b00", 21012UL, 4).SetName("Jump_to_next_instruction"),
+        new TestCaseData("600456fe5b5b00", 21013UL, 5).SetName("Jump_to_consecutive_markers"),
+        new TestCaseData("6003565b", 21012UL, 3).SetName("Jump_to_final_byte"),
+    ];
+
+    private static readonly TestCaseData[] JumpFailureCases =
+    [
+        new TestCaseData("56", 100000UL, 1).SetName("Jump_stack_underflow"),
+        new TestCaseData("600056", 100000UL, 2).SetName("Jump_invalid_destination"),
+        new TestCaseData("6003565b", 21010UL, 2).SetName("Jump_charge_out_of_gas"),
+        new TestCaseData("6003565b", 21011UL, 3).SetName("JumpDest_charge_out_of_gas_after_Jump"),
+        new TestCaseData("60016005575b", 21015UL, 3).SetName("JumpI_charge_out_of_gas"),
+        new TestCaseData("60016005575b", 21016UL, 4).SetName("JumpDest_charge_out_of_gas_after_JumpI"),
+    ];
+
+    private sealed class NoInstructionTracer : TestAllTracerWithOutput
+    {
+        public override bool IsTracingInstructions => false;
+    }
+
     [Test]
     public void Stop()
     {
         TestAllTracerWithOutput receipt = Execute((byte)Instruction.STOP);
         Assert.That(receipt.GasSpent, Is.EqualTo(GasCostOf.Transaction));
+    }
+
+    [TestCaseSource(nameof(JumpCompletionCases))]
+    public void Untraced_jump_completion_preserves_semantics(string bytecode, ulong expectedGas, int expectedOpCodeCount)
+    {
+        TestAllTracerWithOutput receipt = ExecuteUntraced(100000UL, Bytes.FromHexString(bytecode));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Success), "status");
+            Assert.That(receipt.GasSpent, Is.EqualTo(expectedGas), "gas");
+            Assert.That(Machine.OpCodeCount, Is.EqualTo(expectedOpCodeCount), "opcode count");
+        }
+    }
+
+    [TestCaseSource(nameof(JumpFailureCases))]
+    public void Untraced_jump_completion_preserves_failure_ordering(string bytecode, ulong gasLimit, int expectedOpCodeCount)
+    {
+        TestAllTracerWithOutput receipt = ExecuteUntraced(gasLimit, Bytes.FromHexString(bytecode));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Failure), "status");
+            Assert.That(receipt.GasSpent, Is.EqualTo(gasLimit), "gas");
+            Assert.That(Machine.OpCodeCount, Is.EqualTo(expectedOpCodeCount), "opcode count");
+        }
+    }
+
+    [TestCase(Instruction.JUMP, "600456005b00", 4)]
+    [TestCase(Instruction.JUMPI, "6001600657005b00", 6)]
+    public void Traced_taken_jump_keeps_jumpdest_visible(Instruction instruction, string bytecode, int target)
+    {
+        GethLikeTxTrace trace = ExecuteAndTrace(Bytes.FromHexString(bytecode));
+        GethTxTraceEntry jumpDest = trace.Entries.Single(static entry => entry.Opcode == nameof(Instruction.JUMPDEST));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(jumpDest.ProgramCounter, Is.EqualTo(target), $"{instruction} target");
+            Assert.That(jumpDest.GasCost, Is.EqualTo(GasCostOf.JumpDest), $"{instruction} gas");
+        }
+    }
+
+    private TestAllTracerWithOutput ExecuteUntraced(ulong gasLimit, byte[] code)
+    {
+        (Block block, Transaction transaction) = PrepareTx(Activation, gasLimit, code);
+        NoInstructionTracer tracer = new();
+        _processor.Execute(transaction, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+        return tracer;
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -99,13 +99,7 @@ public static partial class EvmInstructions
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
         // Validate the jump destination and update the program counter if valid.
         if (!Jump(result, ref programCounter, vm.VmState.Env)) goto InvalidJumpDestination;
-        if (TSkipJumpDest.IsActive && !TGasPolicy.IsOutOfGas(in gas))
-        {
-            // Count before charging so an out-of-gas JUMPDEST matches the dispatch loop's ordering.
-            vm.OpCodeCount++;
-            TGasPolicy.Consume<JumpDestGasCost>(ref gas);
-            programCounter++;
-        }
+        SkipJumpDest<TGasPolicy, TSkipJumpDest>(vm, ref gas, ref programCounter);
         // Prefetch the cache line at the jump destination since hardware prefetcher can't predict jumps.
         PrefetchCodeAtDestination(ref stack, programCounter);
 
@@ -163,13 +157,7 @@ public static partial class EvmInstructions
         if (shouldJump)
         {
             if (!Jump(result, ref programCounter, vm.VmState.Env)) goto InvalidJumpDestination;
-            if (TSkipJumpDest.IsActive && !TGasPolicy.IsOutOfGas(in gas))
-            {
-                // Count before charging so an out-of-gas JUMPDEST matches the dispatch loop's ordering.
-                vm.OpCodeCount++;
-                TGasPolicy.Consume<JumpDestGasCost>(ref gas);
-                programCounter++;
-            }
+            SkipJumpDest<TGasPolicy, TSkipJumpDest>(vm, ref gas, ref programCounter);
             // Prefetch the cache line at the jump destination since hardware prefetcher can't predict jumps.
             PrefetchCodeAtDestination(ref stack, programCounter);
         }
@@ -180,6 +168,20 @@ public static partial class EvmInstructions
         return EvmExceptionType.StackUnderflow;
     InvalidJumpDestination:
         return EvmExceptionType.InvalidJumpDestination;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SkipJumpDest<TGasPolicy, TSkipJumpDest>(VirtualMachine<TGasPolicy> vm, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        where TSkipJumpDest : struct, IFlag
+    {
+        if (TSkipJumpDest.IsActive && !TGasPolicy.IsOutOfGas(in gas))
+        {
+            // Count before charging so an out-of-gas JUMPDEST matches the dispatch loop's ordering.
+            vm.OpCodeCount++;
+            TGasPolicy.Consume<JumpDestGasCost>(ref gas);
+            programCounter++;
+        }
     }
 
     [SkipLocalsInit]
@@ -414,12 +416,6 @@ public static partial class EvmInstructions
                     // Best-effort hint: PREFETCHT0 never faults. A GC relocation just
                     // makes the hint useless, not unsafe.
                     Sse.Prefetch0(Unsafe.AsPointer(ref Unsafe.Add(ref code, dest)));
-                    // Prefetch next cache line too (64 bytes ahead)
-                    nuint nextLine = (dest + 64) & ~(nuint)63;
-                    if (nextLine < codeLength)
-                    {
-                        Sse.Prefetch0(Unsafe.AsPointer(ref Unsafe.Add(ref code, nextLine)));
-                    }
                 }
             }
         }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -75,6 +75,23 @@ public static partial class EvmInstructions
     [SkipLocalsInit]
     public static EvmExceptionType InstructionJump<TGasPolicy>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        => InstructionJump<TGasPolicy, OffFlag>(vm, ref stack, ref gas, ref programCounter);
+
+    /// <summary>
+    /// <see cref="InstructionJump{TGasPolicy}"/> for non-traced tables: a valid taken jump also
+    /// counts and charges the target <c>JUMPDEST</c> and leaves PC on the instruction after it,
+    /// eliminating the marker's dispatch.
+    /// </summary>
+    [SkipLocalsInit]
+    internal static EvmExceptionType InstructionJumpAndSkipJumpDest<TGasPolicy>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        => InstructionJump<TGasPolicy, OnFlag>(vm, ref stack, ref gas, ref programCounter);
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static EvmExceptionType InstructionJump<TGasPolicy, TSkipJumpDest>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        where TSkipJumpDest : struct, IFlag
     {
         // Deduct the gas cost for performing a jump.
         TGasPolicy.Consume<JumpGasCost>(ref gas);
@@ -82,6 +99,13 @@ public static partial class EvmInstructions
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
         // Validate the jump destination and update the program counter if valid.
         if (!Jump(result, ref programCounter, vm.VmState.Env)) goto InvalidJumpDestination;
+        if (TSkipJumpDest.IsActive && !TGasPolicy.IsOutOfGas(in gas))
+        {
+            // Count before charging so an out-of-gas JUMPDEST matches the dispatch loop's ordering.
+            vm.OpCodeCount++;
+            TGasPolicy.Consume<JumpDestGasCost>(ref gas);
+            programCounter++;
+        }
         // Prefetch the cache line at the jump destination since hardware prefetcher can't predict jumps.
         PrefetchCodeAtDestination(ref stack, programCounter);
 
@@ -110,6 +134,24 @@ public static partial class EvmInstructions
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static EvmExceptionType InstructionJumpIf<TGasPolicy>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        => InstructionJumpIf<TGasPolicy, OffFlag>(vm, ref stack, ref gas, ref programCounter);
+
+    /// <summary>
+    /// <see cref="InstructionJumpIf{TGasPolicy}"/> for non-traced tables: a valid taken jump also
+    /// counts and charges the target <c>JUMPDEST</c> and leaves PC on the instruction after it,
+    /// eliminating the marker's dispatch. Untaken jumps are unchanged.
+    /// </summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    internal static EvmExceptionType InstructionJumpIfAndSkipJumpDest<TGasPolicy>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        => InstructionJumpIf<TGasPolicy, OnFlag>(vm, ref stack, ref gas, ref programCounter);
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static EvmExceptionType InstructionJumpIf<TGasPolicy, TSkipJumpDest>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        where TSkipJumpDest : struct, IFlag
     {
         // Deduct the high gas cost for a conditional jump.
         TGasPolicy.Consume<JumpIGasCost>(ref gas);
@@ -121,6 +163,13 @@ public static partial class EvmInstructions
         if (shouldJump)
         {
             if (!Jump(result, ref programCounter, vm.VmState.Env)) goto InvalidJumpDestination;
+            if (TSkipJumpDest.IsActive && !TGasPolicy.IsOutOfGas(in gas))
+            {
+                // Count before charging so an out-of-gas JUMPDEST matches the dispatch loop's ordering.
+                vm.OpCodeCount++;
+                TGasPolicy.Consume<JumpDestGasCost>(ref gas);
+                programCounter++;
+            }
             // Prefetch the cache line at the jump destination since hardware prefetcher can't predict jumps.
             PrefetchCodeAtDestination(ref stack, programCounter);
         }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -157,8 +157,8 @@ public static unsafe partial class EvmInstructions
             &InstructionSStoreUnmetered<TGasPolicy, TTracingInst>;
 
         // Jump instructions.
-        lookup[(int)Instruction.JUMP] = &InstructionJump;
-        lookup[(int)Instruction.JUMPI] = &InstructionJumpIf;
+        lookup[(int)Instruction.JUMP] = TTracingInst.IsActive ? &InstructionJump : &InstructionJumpAndSkipJumpDest;
+        lookup[(int)Instruction.JUMPI] = TTracingInst.IsActive ? &InstructionJumpIf : &InstructionJumpIfAndSkipJumpDest;
         lookup[(int)Instruction.PC] = &InstructionProgramCounter<TGasPolicy, TTracingInst>;
         lookup[(int)Instruction.MSIZE] = &InstructionEnvUInt64<TGasPolicy, OpMSize<TGasPolicy>, TTracingInst>;
         lookup[(int)Instruction.GAS] = &InstructionGas<TGasPolicy, TTracingInst>;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.DispatchSpecialized.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.DispatchSpecialized.cs
@@ -144,10 +144,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                             exceptionType = EvmInstructions.InstructionSLoad<TGasPolicy, TTracingInst>(this, ref stack, ref gas, ref pc);
                             break;
                         case Instruction.JUMP:
-                            exceptionType = EvmInstructions.InstructionJump(this, ref stack, ref gas, ref pc);
+                            exceptionType = TTracingInst.IsActive
+                                ? EvmInstructions.InstructionJump(this, ref stack, ref gas, ref pc)
+                                : EvmInstructions.InstructionJumpAndSkipJumpDest(this, ref stack, ref gas, ref pc);
                             break;
                         case Instruction.JUMPI:
-                            exceptionType = EvmInstructions.InstructionJumpIf(this, ref stack, ref gas, ref pc);
+                            exceptionType = TTracingInst.IsActive
+                                ? EvmInstructions.InstructionJumpIf(this, ref stack, ref gas, ref pc)
+                                : EvmInstructions.InstructionJumpIfAndSkipJumpDest(this, ref stack, ref gas, ref pc);
                             break;
                         case Instruction.JUMPDEST:
                             exceptionType = EvmInstructions.InstructionJumpDest(this, ref stack, ref gas, ref pc);


### PR DESCRIPTION
## Changes

Removes one interpreter dispatch per valid taken, non-traced `JUMP`/`JUMPI`: the jump handler validates the target as before, then counts and charges the target `JUMPDEST` itself and continues at `target + 1`, so the marker is never dispatched. In the profiled workload `JUMPDEST` is 7.3% of all opcodes run (89,398 executions, alongside 56,485 `JUMP` and 54,405 `JUMPI`), making the marker one of the most frequently dispatched no-op bodies.

- The public `InstructionJump`/`InstructionJumpIf` contracts are unchanged (PC lands on the target marker); internal `...AndSkipJumpDest` variants share the same bodies through a struct `IFlag` specialization, so the JIT drops the inactive completion branch from each. No tracer property is read in the handlers.
- The non-traced opcode table and the direct-dispatch switch bind the skipping variants only when `TTracingInst.IsActive` is false (compile-time fold). Instruction tracing and debugger stepping still execute and report `JUMPDEST` as a distinct step at the target PC.
- Failure ordering is preserved exactly: an untaken `JUMPI`, an invalid target, or stack underflow never synthesizes the marker; a jump charge that exhausts gas suppresses it (`Consume` saturates and sets the out-of-gas flag, which the handler checks); if only the 1-gas marker charge fails, the marker is counted first, matching the dispatch loop's count-before-charge ordering.
- The logical opcode count remains a count of original EVM instructions: the handler adds the synthetic marker directly to `OpCodeCount`, the same split the existing `PUSH2 + JUMP/JUMPI` peephole already uses.
- Stream boundary and metered jumps inherit the new handler through the no-trace table with no stream-specific code: `JUMPDEST` is one byte and a solo block in the stream, so the `target + 1` landing is always a valid entry (or code end) and the skipped entry's solo block charge equals exactly the gas the handler paid.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New parameterized `VirtualMachineTests` pin the observable contract on the untraced path (status, exact gas, logical opcode count) for: taken `JUMP`, taken/untaken `JUMPI`, jump to the immediately following marker, consecutive markers (only the target is skipped), and a target at the final code byte. Failure-ordering cases prove the synthetic marker appears only after a valid, affordable taken jump, including the two exact boundaries: gas leaving 0 after the jump charge (marker counted, then fails its own 1-gas charge) and gas one short of the jump charge (no marker). A traced test asserts the Geth-style trace still contains the distinct `JUMPDEST` entry with its original PC and 1-gas cost, guarding against a future table-selection change silently enabling the skip under tracing.

`VirtualMachineTests` (49) and the stream/fusion suites (`StreamInterpreterDifferentialTests`, `Push2JumpFusionTests`, `InstructionStreamTests` - 113) pass; the differential `JumpLoop` case exercises the inherited handler through the stream boundary path. The reproducible payload benchmark comparison runs on this PR.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
