### PR TITLE
feat(evm): EIP-8250 keyed-nonce state helper

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Extensions;
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// Represents the <see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see> (Keyed Nonces) parameters.
+/// </summary>
+public static class Eip8250Constants
+{
+    /// <summary>Maximum number of nonce keys a single frame transaction may declare.</summary>
+    public const int MaxNonceKeys = 16;
+
+    /// <summary>Upper bound a nonce sequence must stay strictly below (2^64 - 1).</summary>
+    public const ulong MaxNonceSeq = ulong.MaxValue;
+
+    /// <summary>Gas charged the first time a non-zero nonce key is used, per key.</summary>
+    public const long KeyedNonceFirstUseGas = 20_000;
+
+    /// <summary>The <c>NONCE_MANAGER</c> system-contract address.</summary>
+    /// <remarks>
+    /// The spec address is TBD; this provisional value mirrors the only existing implementation (ethrex)
+    /// pending ratification.
+    /// </remarks>
+    public static readonly Address NonceManagerAddress = new("0x0000000000000000000000000000000000008250");
+
+    /// <summary>The <c>NONCE_MANAGER</c> deployed bytecode.</summary>
+    /// <remarks>
+    /// Runtime is <c>revert(0, 0)</c>: the contract is a storage namespace only and is never callable.
+    /// </remarks>
+    public static readonly byte[] NonceManagerCode = Bytes.FromHexString("60006000fd");
+}

--- a/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Core.Extensions;
+using System;
 
 namespace Nethermind.Core;
 
@@ -26,9 +26,10 @@ public static class Eip8250Constants
     /// </remarks>
     public static readonly Address NonceManagerAddress = new("0x0000000000000000000000000000000000008250");
 
-    /// <summary>The <c>NONCE_MANAGER</c> deployed bytecode.</summary>
+    /// <summary>The <c>NONCE_MANAGER</c> deployed bytecode (<c>0x60006000fd</c>).</summary>
     /// <remarks>
     /// Runtime is <c>revert(0, 0)</c>: the contract is a storage namespace only and is never callable.
+    /// Exposed as a <see cref="ReadOnlySpan{T}"/> so the shared bytecode cannot be mutated by callers.
     /// </remarks>
-    public static readonly byte[] NonceManagerCode = Bytes.FromHexString("60006000fd");
+    public static ReadOnlySpan<byte> NonceManagerCode => [0x60, 0x00, 0x60, 0x00, 0xfd];
 }

--- a/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
@@ -5,31 +5,16 @@ using System;
 
 namespace Nethermind.Core;
 
-/// <summary>
-/// Represents the <see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see> (Keyed Nonces) parameters.
-/// </summary>
+/// <summary><see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see> (Keyed Nonces) parameters.</summary>
 public static class Eip8250Constants
 {
-    /// <summary>Maximum number of nonce keys a single frame transaction may declare.</summary>
     public const int MaxNonceKeys = 16;
-
-    /// <summary>Upper bound a nonce sequence must stay strictly below (2^64 - 1).</summary>
     public const ulong MaxNonceSeq = ulong.MaxValue;
-
-    /// <summary>Gas charged the first time a non-zero nonce key is used, per key.</summary>
     public const long KeyedNonceFirstUseGas = 20_000;
 
-    /// <summary>The <c>NONCE_MANAGER</c> system-contract address.</summary>
-    /// <remarks>
-    /// The spec address is TBD; this provisional value mirrors the only existing implementation (ethrex)
-    /// pending ratification.
-    /// </remarks>
+    // Provisional: spec address is TBD; mirrors the only existing implementation.
     public static readonly Address NonceManagerAddress = new("0x0000000000000000000000000000000000008250");
 
-    /// <summary>The <c>NONCE_MANAGER</c> deployed bytecode (<c>0x60006000fd</c>).</summary>
-    /// <remarks>
-    /// Runtime is <c>revert(0, 0)</c>: the contract is a storage namespace only and is never callable.
-    /// Exposed as a <see cref="ReadOnlySpan{T}"/> so the shared bytecode cannot be mutated by callers.
-    /// </remarks>
+    // Spec-pinned revert(0, 0): a storage namespace only, never callable.
     public static ReadOnlySpan<byte> NonceManagerCode => [0x60, 0x00, 0x60, 0x00, 0xfd];
 }

--- a/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
@@ -81,7 +81,7 @@ public class KeyedNonceManagerTests
     {
         _state.SetNonce(TestItem.AddressA, 3);
 
-        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [UInt256.Zero], nonceSeq: 99, Spec);
+        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [UInt256.Zero], nonceSeq: 99);
 
         Assert.That(_state.GetNonce(TestItem.AddressA), Is.EqualTo(4UL), "the account nonce must be incremented, not set to nonceSeq + 1");
     }
@@ -91,7 +91,7 @@ public class KeyedNonceManagerTests
     {
         _state.SetNonce(TestItem.AddressA, 3);
 
-        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [(UInt256)5, (UInt256)9], nonceSeq: 42, Spec);
+        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [(UInt256)5, (UInt256)9], nonceSeq: 42);
 
         Assert.That(KeyedNonceManager.CurrentNonceSeq(_state, TestItem.AddressA, (UInt256)5), Is.EqualTo(43UL));
         Assert.That(KeyedNonceManager.CurrentNonceSeq(_state, TestItem.AddressA, (UInt256)9), Is.EqualTo(43UL));
@@ -103,9 +103,13 @@ public class KeyedNonceManagerTests
     {
         Assert.That(KeyedNonceManager.IsFirstUse(_state, TestItem.AddressA, (UInt256)7), Is.True);
 
-        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [(UInt256)7], nonceSeq: 0, Spec);
+        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [(UInt256)7], nonceSeq: 0);
 
         Assert.That(KeyedNonceManager.IsFirstUse(_state, TestItem.AddressA, (UInt256)7), Is.False);
         Assert.That(KeyedNonceManager.CurrentNonceSeq(_state, TestItem.AddressA, (UInt256)7), Is.EqualTo(1UL));
     }
+
+    [Test]
+    public void IsFirstUse_for_key_zero_is_false() =>
+        Assert.That(KeyedNonceManager.IsFirstUse(_state, TestItem.AddressA, UInt256.Zero), Is.False);
 }

--- a/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+public class KeyedNonceManagerTests
+{
+    private static readonly IReleaseSpec Spec = Prague.Instance;
+    private IWorldState _state = null!;
+    private IDisposable _scope = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _state = TestWorldStateFactory.CreateForTest();
+        _scope = _state.BeginScope(IWorldState.PreGenesis);
+        _state.CreateAccount(TestItem.AddressA, 1.Ether);
+        _state.CreateAccount(Eip8250Constants.NonceManagerAddress, UInt256.Zero, 1);
+        _state.Commit(Spec);
+        _state.CommitTree(0);
+    }
+
+    [TearDown]
+    public void TearDown() => _scope.Dispose();
+
+    [Test]
+    public void StorageSlot_is_deterministic_and_distinct_per_sender_and_key()
+    {
+        StorageCell slotA1 = KeyedNonceManager.StorageSlot(TestItem.AddressA, (UInt256)1);
+        StorageCell slotA1Again = KeyedNonceManager.StorageSlot(TestItem.AddressA, (UInt256)1);
+        StorageCell slotA2 = KeyedNonceManager.StorageSlot(TestItem.AddressA, (UInt256)2);
+        StorageCell slotB1 = KeyedNonceManager.StorageSlot(TestItem.AddressB, (UInt256)1);
+
+        Assert.That(slotA1.Address, Is.EqualTo(Eip8250Constants.NonceManagerAddress));
+        Assert.That(slotA1Again.Index, Is.EqualTo(slotA1.Index), "same inputs must yield the same slot");
+        Assert.That(slotA2.Index, Is.Not.EqualTo(slotA1.Index), "distinct keys must yield distinct slots");
+        Assert.That(slotB1.Index, Is.Not.EqualTo(slotA1.Index), "distinct senders must yield distinct slots");
+    }
+
+    [Test]
+    public void CurrentNonceSeq_for_key_zero_returns_account_nonce()
+    {
+        _state.SetNonce(TestItem.AddressA, 7);
+
+        Assert.That(KeyedNonceManager.CurrentNonceSeq(_state, TestItem.AddressA, UInt256.Zero), Is.EqualTo(7UL));
+    }
+
+    [Test]
+    public void CurrentNonceSeq_for_absent_keyed_slot_is_zero() =>
+        Assert.That(KeyedNonceManager.CurrentNonceSeq(_state, TestItem.AddressA, (UInt256)5), Is.EqualTo(0UL));
+
+    [TestCaseSource(nameof(AboveUlongMaxValues))]
+    public void CurrentNonceSeq_clamps_slot_value_above_ulong_max(UInt256 storedValue)
+    {
+        StorageCell slot = KeyedNonceManager.StorageSlot(TestItem.AddressA, (UInt256)5);
+        _state.Set(slot, storedValue.ToBigEndian().WithoutLeadingZeros().ToArray());
+
+        Assert.That(KeyedNonceManager.CurrentNonceSeq(_state, TestItem.AddressA, (UInt256)5), Is.EqualTo(ulong.MaxValue));
+    }
+
+    private static UInt256[] AboveUlongMaxValues() =>
+    [
+        (UInt256)ulong.MaxValue + UInt256.One,
+        UInt256.MaxValue
+    ];
+
+    [Test]
+    public void ConsumeNonceSet_with_zero_key_increments_account_nonce()
+    {
+        _state.SetNonce(TestItem.AddressA, 3);
+
+        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [UInt256.Zero], nonceSeq: 99, Spec);
+
+        Assert.That(_state.GetNonce(TestItem.AddressA), Is.EqualTo(4UL), "the account nonce must be incremented, not set to nonceSeq + 1");
+    }
+
+    [Test]
+    public void ConsumeNonceSet_with_keyed_values_writes_next_seq()
+    {
+        _state.SetNonce(TestItem.AddressA, 3);
+
+        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [(UInt256)5, (UInt256)9], nonceSeq: 42, Spec);
+
+        Assert.That(KeyedNonceManager.CurrentNonceSeq(_state, TestItem.AddressA, (UInt256)5), Is.EqualTo(43UL));
+        Assert.That(KeyedNonceManager.CurrentNonceSeq(_state, TestItem.AddressA, (UInt256)9), Is.EqualTo(43UL));
+        Assert.That(_state.GetNonce(TestItem.AddressA), Is.EqualTo(3UL), "keyed consumption must not touch the account nonce");
+    }
+
+    [Test]
+    public void IsFirstUse_transitions_true_to_false_after_consume()
+    {
+        Assert.That(KeyedNonceManager.IsFirstUse(_state, TestItem.AddressA, (UInt256)7), Is.True);
+
+        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [(UInt256)7], nonceSeq: 0, Spec);
+
+        Assert.That(KeyedNonceManager.IsFirstUse(_state, TestItem.AddressA, (UInt256)7), Is.False);
+        Assert.That(KeyedNonceManager.CurrentNonceSeq(_state, TestItem.AddressA, (UInt256)7), Is.EqualTo(1UL));
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+
+namespace Nethermind.Evm.TransactionProcessing;
+
+/// <summary>
+/// State helper for <see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see> keyed nonces:
+/// derives <c>NONCE_MANAGER</c> storage slots and reads/consumes per-key nonce sequences.
+/// </summary>
+/// <remarks>
+/// A <c>nonce_keys</c> set of exactly <c>[0]</c> aliases the legacy account nonce; any non-zero key
+/// selects an independent nonce domain stored in the <c>NONCE_MANAGER</c> system contract. The
+/// protocol never writes 0 to a keyed slot, so a zero read means the key has never been used.
+/// </remarks>
+public static class KeyedNonceManager
+{
+    /// <summary>Length of the slot pre-image: 32-byte left-padded sender followed by the 32-byte key.</summary>
+    private const int SlotPreimageLength = 2 * 32;
+
+    /// <summary>
+    /// Derives the <c>NONCE_MANAGER</c> storage cell for the given <paramref name="sender"/> and
+    /// <paramref name="nonceKey"/>, i.e. <c>keccak256(left_pad_32(sender) ‖ uint256_to_bytes32(nonceKey))</c>.
+    /// </summary>
+    public static StorageCell StorageSlot(Address sender, in UInt256 nonceKey)
+    {
+        Span<byte> preimage = stackalloc byte[SlotPreimageLength];
+        preimage.Clear();
+        sender.Bytes.CopyTo(preimage.Slice(32 - Address.Size, Address.Size));
+        nonceKey.ToBigEndian(preimage.Slice(32));
+        UInt256 index = new(ValueKeccak.Compute(preimage).Bytes, isBigEndian: true);
+        return new StorageCell(Eip8250Constants.NonceManagerAddress, index);
+    }
+
+    /// <summary>
+    /// Returns the current nonce sequence for <paramref name="sender"/> under <paramref name="nonceKey"/>.
+    /// For key 0 this is the account nonce; otherwise it is the <c>NONCE_MANAGER</c> slot value, with an
+    /// absent slot reading as 0.
+    /// </summary>
+    /// <remarks>
+    /// A stored value exceeding <see cref="Eip8250Constants.MaxNonceSeq"/> is clamped to
+    /// <see cref="ulong.MaxValue"/> so a crafted high-bit slot cannot false-match a valid
+    /// <c>nonce_seq &lt; MAX_NONCE_SEQ</c>.
+    /// </remarks>
+    public static ulong CurrentNonceSeq(IWorldState state, Address sender, in UInt256 nonceKey)
+    {
+        if (nonceKey.IsZero)
+        {
+            return state.GetNonce(sender);
+        }
+
+        UInt256 stored = new(state.Get(StorageSlot(sender, nonceKey)), isBigEndian: true);
+        return stored > Eip8250Constants.MaxNonceSeq ? ulong.MaxValue : (ulong)stored;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the raw <c>NONCE_MANAGER</c> slot for
+    /// (<paramref name="sender"/>, <paramref name="nonceKey"/>) reads 0. Only meaningful for non-zero keys.
+    /// </summary>
+    public static bool IsFirstUse(IWorldState state, Address sender, in UInt256 nonceKey) =>
+        new UInt256(state.Get(StorageSlot(sender, nonceKey)), isBigEndian: true).IsZero;
+
+    /// <summary>
+    /// Consumes the nonce set for <paramref name="sender"/>: increments the account nonce when
+    /// <paramref name="nonceKeys"/> is exactly <c>[0]</c>, otherwise writes <c>nonceSeq + 1</c> to each
+    /// key's <c>NONCE_MANAGER</c> slot.
+    /// </summary>
+    public static void ConsumeNonceSet(IWorldState state, Address sender, ReadOnlySpan<UInt256> nonceKeys, ulong nonceSeq, IReleaseSpec spec)
+    {
+        if (nonceKeys.Length == 1 && nonceKeys[0].IsZero)
+        {
+            state.IncrementNonce(sender);
+            return;
+        }
+
+        byte[] nextSeq = ((UInt256)nonceSeq + UInt256.One).ToBigEndian().WithoutLeadingZeros().ToArray();
+        foreach (UInt256 nonceKey in nonceKeys)
+        {
+            state.Set(StorageSlot(sender, nonceKey), nextSeq);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
 
@@ -39,9 +39,9 @@ public static class KeyedNonceManager
     }
 
     public static bool IsFirstUse(IWorldState state, Address sender, in UInt256 nonceKey) =>
-        new UInt256(state.Get(StorageSlot(sender, nonceKey)), isBigEndian: true).IsZero;
+        !nonceKey.IsZero && CurrentNonceSeq(state, sender, nonceKey) == 0;
 
-    public static void ConsumeNonceSet(IWorldState state, Address sender, ReadOnlySpan<UInt256> nonceKeys, ulong nonceSeq, IReleaseSpec spec)
+    public static void ConsumeNonceSet(IWorldState state, Address sender, ReadOnlySpan<UInt256> nonceKeys, ulong nonceSeq)
     {
         if (nonceKeys.Length == 1 && nonceKeys[0].IsZero)
         {
@@ -49,9 +49,13 @@ public static class KeyedNonceManager
             return;
         }
 
-        byte[] nextSeq = ((UInt256)nonceSeq + UInt256.One).ToBigEndian().WithoutLeadingZeros().ToArray();
+        Span<byte> buffer = stackalloc byte[32];
+        ((UInt256)nonceSeq + UInt256.One).ToBigEndian(buffer);
+        byte[] nextSeq = buffer.WithoutLeadingZeros().ToArray();
         foreach (UInt256 nonceKey in nonceKeys)
         {
+            // EIP-8250 rejects key 0 in a non-[0] set; the decode-time validity check owns that, this guards the primitive.
+            Debug.Assert(!nonceKey.IsZero, "key 0 must not appear in a non-[0] nonce_keys set");
             state.Set(StorageSlot(sender, nonceKey), nextSeq);
         }
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
@@ -11,24 +11,11 @@ using Nethermind.Int256;
 
 namespace Nethermind.Evm.TransactionProcessing;
 
-/// <summary>
-/// State helper for <see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see> keyed nonces:
-/// derives <c>NONCE_MANAGER</c> storage slots and reads/consumes per-key nonce sequences.
-/// </summary>
-/// <remarks>
-/// A <c>nonce_keys</c> set of exactly <c>[0]</c> aliases the legacy account nonce; any non-zero key
-/// selects an independent nonce domain stored in the <c>NONCE_MANAGER</c> system contract. The
-/// protocol never writes 0 to a keyed slot, so a zero read means the key has never been used.
-/// </remarks>
+/// <summary>State helper for <see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see> keyed nonces: NONCE_MANAGER slot derivation and per-key nonce reads/consumption.</summary>
 public static class KeyedNonceManager
 {
-    /// <summary>Length of the slot pre-image: 32-byte left-padded sender followed by the 32-byte key.</summary>
     private const int SlotPreimageLength = 2 * 32;
 
-    /// <summary>
-    /// Derives the <c>NONCE_MANAGER</c> storage cell for the given <paramref name="sender"/> and
-    /// <paramref name="nonceKey"/>, i.e. <c>keccak256(left_pad_32(sender) ‖ uint256_to_bytes32(nonceKey))</c>.
-    /// </summary>
     public static StorageCell StorageSlot(Address sender, in UInt256 nonceKey)
     {
         Span<byte> preimage = stackalloc byte[SlotPreimageLength];
@@ -39,16 +26,6 @@ public static class KeyedNonceManager
         return new StorageCell(Eip8250Constants.NonceManagerAddress, index);
     }
 
-    /// <summary>
-    /// Returns the current nonce sequence for <paramref name="sender"/> under <paramref name="nonceKey"/>.
-    /// For key 0 this is the account nonce; otherwise it is the <c>NONCE_MANAGER</c> slot value, with an
-    /// absent slot reading as 0.
-    /// </summary>
-    /// <remarks>
-    /// A stored value exceeding <see cref="Eip8250Constants.MaxNonceSeq"/> is clamped to
-    /// <see cref="ulong.MaxValue"/> so a crafted high-bit slot cannot false-match a valid
-    /// <c>nonce_seq &lt; MAX_NONCE_SEQ</c>.
-    /// </remarks>
     public static ulong CurrentNonceSeq(IWorldState state, Address sender, in UInt256 nonceKey)
     {
         if (nonceKey.IsZero)
@@ -57,21 +34,13 @@ public static class KeyedNonceManager
         }
 
         UInt256 stored = new(state.Get(StorageSlot(sender, nonceKey)), isBigEndian: true);
+        // Clamp so a crafted high-bit slot cannot false-match a valid nonce_seq < MAX_NONCE_SEQ.
         return stored > Eip8250Constants.MaxNonceSeq ? ulong.MaxValue : (ulong)stored;
     }
 
-    /// <summary>
-    /// Returns <see langword="true"/> when the raw <c>NONCE_MANAGER</c> slot for
-    /// (<paramref name="sender"/>, <paramref name="nonceKey"/>) reads 0. Only meaningful for non-zero keys.
-    /// </summary>
     public static bool IsFirstUse(IWorldState state, Address sender, in UInt256 nonceKey) =>
         new UInt256(state.Get(StorageSlot(sender, nonceKey)), isBigEndian: true).IsZero;
 
-    /// <summary>
-    /// Consumes the nonce set for <paramref name="sender"/>: increments the account nonce when
-    /// <paramref name="nonceKeys"/> is exactly <c>[0]</c>, otherwise writes <c>nonceSeq + 1</c> to each
-    /// key's <c>NONCE_MANAGER</c> slot.
-    /// </summary>
     public static void ConsumeNonceSet(IWorldState state, Address sender, ReadOnlySpan<UInt256> nonceKeys, ulong nonceSeq, IReleaseSpec spec)
     {
         if (nonceKeys.Length == 1 && nonceKeys[0].IsZero)


### PR DESCRIPTION
Part of #12456, tracks #12454.

Adds the standalone state/crypto primitive for [EIP-8250](https://eips.ethereum.org/EIPS/eip-8250) (Keyed Nonces). This is an independent building block: it does not touch the frame-transaction processor, whose integration (payload decode, sig-hash, validity check, and wiring `ConsumeNonceSet` into the payment-APPROVE step) follows in a later PR.

## Changes

- `Eip8250Constants` — `MAX_NONCE_KEYS`, `MAX_NONCE_SEQ`, `KEYED_NONCE_FIRST_USE_GAS`, and the provisional `NONCE_MANAGER` address/code. The spec address is TBD; the provisional value mirrors the only existing implementation (ethrex) pending ratification. The code (`0x60006000fd`, runtime `revert(0, 0)`) is spec-pinned — the contract is a storage namespace only and is never callable.
- `KeyedNonceManager` — a static state helper:
  - `StorageSlot`: NONCE_MANAGER cell derivation, `keccak256(left_pad_32(sender) || uint256_to_bytes32(key))`.
  - `CurrentNonceSeq`: account nonce for key 0, otherwise the keyed slot value; an absent slot reads as 0, and a stored value above `ulong.MaxValue` is clamped so a crafted high-bit slot cannot false-match a valid `nonce_seq < MAX_NONCE_SEQ`.
  - `IsFirstUse`: true iff the raw keyed slot reads 0.
  - `ConsumeNonceSet`: increments the account nonce for exactly `[0]`, otherwise writes `nonce_seq + 1` to each key's slot.
- `KeyedNonceManagerTests` covering slot determinism/distinctness, key-0 aliasing, absent keyed slots, the u256->u64 clamp, `[0]` vs keyed consumption, and the first-use true->false transition.

TXPARAM indices and opcode numbers are intentionally omitted here — they are contested across the 8141/8250/8272 drafts and belong to the later integration PR.

## Types of changes

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`dotnet test src/Nethermind/Nethermind.Evm.Test -c release -- --filter FullyQualifiedName~KeyedNonceManager` — 8 passed.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
