### PR TITLE
Fix eth/70 receipt validation for EIP-2780

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandlerTests.cs
@@ -243,9 +243,9 @@ public class Eth70ProtocolHandlerTests
 
         TxReceipt[] receipts =
         [
-            new() { GasUsedTotal = GasCostOf.TransactionEip2780, Logs = [] },
-            new() { GasUsedTotal = GasCostOf.TransactionEip2780 * 2, Logs = [] },
-            new() { GasUsedTotal = GasCostOf.TransactionEip2780 * 3, Logs = [] }
+            new() { GasUsedTotal = GasCostOf.Transaction / 2, Logs = [] },
+            new() { GasUsedTotal = GasCostOf.Transaction, Logs = [] },
+            new() { GasUsedTotal = GasCostOf.Transaction * 3 / 2, Logs = [] }
         ];
 
         _session.When(s => s.DeliverMessage(Arg.Any<GetReceiptsMessage70>())).Do(call =>
@@ -485,7 +485,7 @@ public class Eth70ProtocolHandlerTests
     {
         TxReceipt[] receipts =
         [
-            new() { GasUsedTotal = GasCostOf.TransactionEip2780 - 1, Logs = [] }
+            new() { GasUsedTotal = GasCostOf.Transaction / 2 - 1, Logs = [] }
         ];
 
         _session.When(s => s.DeliverMessage(Arg.Any<GetReceiptsMessage70>())).Do(call =>

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandlerTests.cs
@@ -236,23 +236,17 @@ public class Eth70ProtocolHandlerTests
             Arg.Is<string>(s => s.Contains("Invalid firstBlockReceiptIndex")));
     }
 
-    [TestCase(false, GasCostOf.Transaction)]
-    [TestCase(true, GasCostOf.TransactionEip2780)]
-    public async Task Should_request_additional_pages_until_complete(bool isEip2780Enabled, ulong transactionGas)
+    [Test]
+    public async Task Should_request_additional_pages_until_complete()
     {
         SyncPeerProtocolHandlerBase.SoftOutgoingMessageSizeLimit = 75;
 
         TxReceipt[] receipts =
         [
-            new() { GasUsedTotal = transactionGas, Logs = [] },
-            new() { GasUsedTotal = transactionGas * 2, Logs = [] },
-            new() { GasUsedTotal = transactionGas * 3, Logs = [] }
+            new() { GasUsedTotal = GasCostOf.TransactionEip2780, Logs = [] },
+            new() { GasUsedTotal = GasCostOf.TransactionEip2780 * 2, Logs = [] },
+            new() { GasUsedTotal = GasCostOf.TransactionEip2780 * 3, Logs = [] }
         ];
-        SetupBlockMetadata(Keccak.Zero, 1_000_000, transactionGas * 3, 100_000, 100_000, 100_000);
-
-        IReleaseSpec spec = ReleaseSpecSubstitute.Create();
-        spec.IsEip2780Enabled.Returns(isEip2780Enabled);
-        _specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
 
         _session.When(s => s.DeliverMessage(Arg.Any<GetReceiptsMessage70>())).Do(call =>
         {
@@ -486,60 +480,26 @@ public class Eth70ProtocolHandlerTests
         Assert.That(exception?.Message, Does.StartWith("Received partial receipts response below minimum size"));
     }
 
-    [TestCase(false, GasCostOf.Transaction - 1, "Intrinsic gas lower bound exceeds block gas used",
-        TestName = "Rejects_receipt_below_legacy_intrinsic_gas_floor")]
-    [TestCase(true, GasCostOf.TransactionEip2780 - 1, "Intrinsic gas lower bound exceeds block gas used",
-        TestName = "Rejects_receipt_below_Eip2780_intrinsic_gas_floor")]
-    [TestCase(true, GasCostOf.TransactionEip2780, null,
-        TestName = "Accepts_receipt_at_Eip2780_intrinsic_gas_floor")]
-    [TestCase(null, GasCostOf.TransactionEip2780, null,
-        TestName = "Accepts_Eip2780_receipt_when_header_is_unavailable")]
-    public async Task Should_validate_receipt_gas_floor_by_spec(
-        bool? isEip2780Enabled,
-        ulong receiptGasUsed,
-        string? expectedException)
+    [Test]
+    public void Should_reject_when_receipt_gas_is_below_minimum_supported_transaction_gas()
     {
-        Hash256 blockHash = TestItem.KeccakA;
         TxReceipt[] receipts =
         [
-            new() { GasUsedTotal = receiptGasUsed, Logs = [] }
+            new() { GasUsedTotal = GasCostOf.TransactionEip2780 - 1, Logs = [] }
         ];
-        if (isEip2780Enabled is bool enabled)
-        {
-            SetupBlockMetadata(blockHash, 1_000_000, receiptGasUsed, 100_000);
-
-            IReleaseSpec spec = ReleaseSpecSubstitute.Create();
-            spec.IsEip2780Enabled.Returns(enabled);
-            _specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
-        }
-        else
-        {
-            _syncManager.FindHeader(blockHash).Returns((BlockHeader?)null);
-        }
 
         _session.When(s => s.DeliverMessage(Arg.Any<GetReceiptsMessage70>())).Do(call =>
         {
             GetReceiptsMessage70 sent = (GetReceiptsMessage70)call[0];
-            using ReceiptsMessage70 response = new(sent.RequestId, new[] { receipts }.ToPooledList(), false);
+            ReceiptsMessage70 response = new(sent.RequestId, new[] { receipts }.ToPooledList(), false);
             HandleZeroMessage(response, Eth70MessageCode.Receipts);
         });
 
         HandleIncomingStatusMessage();
-        async Task Act()
-        {
-            using IOwnedReadOnlyList<TxReceipt[]> result = await _handler.GetReceipts(new[] { blockHash }, CancellationToken.None);
-            Assert.That(result, Has.Count.EqualTo(1));
-        }
+        Func<Task> act = async () => await _handler.GetReceipts(new[] { Keccak.Zero }, CancellationToken.None);
 
-        if (expectedException is null)
-        {
-            await Act();
-        }
-        else
-        {
-            SubprotocolException? exception = Assert.ThrowsAsync<SubprotocolException>(async () => await Act());
-            Assert.That(exception?.Message, Is.EqualTo(expectedException));
-        }
+        SubprotocolException? exception = Assert.ThrowsAsync<SubprotocolException>(async () => await act());
+        Assert.That(exception?.Message, Is.EqualTo("Intrinsic gas lower bound exceeds block gas used"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandlerTests.cs
@@ -236,17 +236,23 @@ public class Eth70ProtocolHandlerTests
             Arg.Is<string>(s => s.Contains("Invalid firstBlockReceiptIndex")));
     }
 
-    [Test]
-    public async Task Should_request_additional_pages_until_complete()
+    [TestCase(false, GasCostOf.Transaction)]
+    [TestCase(true, GasCostOf.TransactionEip2780)]
+    public async Task Should_request_additional_pages_until_complete(bool isEip2780Enabled, ulong transactionGas)
     {
         SyncPeerProtocolHandlerBase.SoftOutgoingMessageSizeLimit = 75;
 
         TxReceipt[] receipts =
         [
-            new() { GasUsedTotal = GasCostOf.Transaction, Logs = [] },
-            new() { GasUsedTotal = GasCostOf.Transaction * 2, Logs = [] },
-            new() { GasUsedTotal = GasCostOf.Transaction * 3, Logs = [] }
+            new() { GasUsedTotal = transactionGas, Logs = [] },
+            new() { GasUsedTotal = transactionGas * 2, Logs = [] },
+            new() { GasUsedTotal = transactionGas * 3, Logs = [] }
         ];
+        SetupBlockMetadata(Keccak.Zero, 1_000_000, transactionGas * 3, 100_000, 100_000, 100_000);
+
+        IReleaseSpec spec = ReleaseSpecSubstitute.Create();
+        spec.IsEip2780Enabled.Returns(isEip2780Enabled);
+        _specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
 
         _session.When(s => s.DeliverMessage(Arg.Any<GetReceiptsMessage70>())).Do(call =>
         {
@@ -480,26 +486,60 @@ public class Eth70ProtocolHandlerTests
         Assert.That(exception?.Message, Does.StartWith("Received partial receipts response below minimum size"));
     }
 
-    [Test]
-    public void Should_reject_when_intrinsic_exceeds_block_gas()
+    [TestCase(false, GasCostOf.Transaction - 1, "Intrinsic gas lower bound exceeds block gas used",
+        TestName = "Rejects_receipt_below_legacy_intrinsic_gas_floor")]
+    [TestCase(true, GasCostOf.TransactionEip2780 - 1, "Intrinsic gas lower bound exceeds block gas used",
+        TestName = "Rejects_receipt_below_Eip2780_intrinsic_gas_floor")]
+    [TestCase(true, GasCostOf.TransactionEip2780, null,
+        TestName = "Accepts_receipt_at_Eip2780_intrinsic_gas_floor")]
+    [TestCase(null, GasCostOf.TransactionEip2780, null,
+        TestName = "Accepts_Eip2780_receipt_when_header_is_unavailable")]
+    public async Task Should_validate_receipt_gas_floor_by_spec(
+        bool? isEip2780Enabled,
+        ulong receiptGasUsed,
+        string? expectedException)
     {
+        Hash256 blockHash = TestItem.KeccakA;
         TxReceipt[] receipts =
         [
-            new() { GasUsedTotal = GasCostOf.Transaction / 2, Logs = [] },
-            new() { GasUsedTotal = GasCostOf.Transaction, Logs = [] }
+            new() { GasUsedTotal = receiptGasUsed, Logs = [] }
         ];
+        if (isEip2780Enabled is bool enabled)
+        {
+            SetupBlockMetadata(blockHash, 1_000_000, receiptGasUsed, 100_000);
+
+            IReleaseSpec spec = ReleaseSpecSubstitute.Create();
+            spec.IsEip2780Enabled.Returns(enabled);
+            _specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
+        }
+        else
+        {
+            _syncManager.FindHeader(blockHash).Returns((BlockHeader?)null);
+        }
 
         _session.When(s => s.DeliverMessage(Arg.Any<GetReceiptsMessage70>())).Do(call =>
         {
             GetReceiptsMessage70 sent = (GetReceiptsMessage70)call[0];
-            ReceiptsMessage70 response = new(sent.RequestId, new[] { receipts }.ToPooledList(), true);
+            using ReceiptsMessage70 response = new(sent.RequestId, new[] { receipts }.ToPooledList(), false);
             HandleZeroMessage(response, Eth70MessageCode.Receipts);
         });
 
         HandleIncomingStatusMessage();
-        Func<Task> act = async () => await _handler.GetReceipts(new[] { Keccak.Zero }, CancellationToken.None);
+        async Task Act()
+        {
+            using IOwnedReadOnlyList<TxReceipt[]> result = await _handler.GetReceipts(new[] { blockHash }, CancellationToken.None);
+            Assert.That(result, Has.Count.EqualTo(1));
+        }
 
-        Assert.ThrowsAsync<SubprotocolException>(async () => await act());
+        if (expectedException is null)
+        {
+            await Act();
+        }
+        else
+        {
+            SubprotocolException? exception = Assert.ThrowsAsync<SubprotocolException>(async () => await Act());
+            Assert.That(exception?.Message, Is.EqualTo(expectedException));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -256,6 +256,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
 
         using ArrayPoolList<ulong> expectedGasUsed = new(blockHashes.Count);
         using ArrayPoolList<ulong> blockGasLimits = new(blockHashes.Count);
+        using ArrayPoolList<ulong> minimumTransactionGas = new(blockHashes.Count);
         using ArrayPoolList<Transaction[]?> blockTransactions = new(blockHashes.Count);
         using ArrayPoolList<RlpBehaviors> receiptRlpBehaviors = new(blockHashes.Count);
         using ArrayPoolList<bool> validateReceiptGasUpperBoundAgainstHeader = new(blockHashes.Count);
@@ -271,6 +272,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                 {
                     expectedGasUsed.Add(0);
                     blockGasLimits.Add(0);
+                    minimumTransactionGas.Add(0);
                     blockTransactions.Add(null);
                     receiptRlpBehaviors.Add(RlpBehaviors.None);
                     validateReceiptGasUpperBoundAgainstHeader.Add(false);
@@ -282,6 +284,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                 Block? block = SyncServer.Find(blockHash);
                 expectedGasUsed.Add(header.GasUsed);
                 blockGasLimits.Add(header.GasLimit);
+                minimumTransactionGas.Add(spec.IsEip2780Enabled ? GasCostOf.TransactionEip2780 : GasCostOf.Transaction);
                 blockTransactions.Add(GetTransactionsForReceiptValidation(block));
                 receiptRlpBehaviors.Add(spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts : RlpBehaviors.None);
                 validateReceiptGasUpperBoundAgainstHeader.Add(!spec.IsEip8037Enabled);
@@ -334,6 +337,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                         TxReceipt[] blockReceipts = txReceipts[i] ?? throw new SubprotocolException("Unexpected null receipt block payload");
                         ulong blockExpectedGasUsed = expectedGasUsed[blockIndex];
                         ulong blockGasLimit = blockGasLimits[blockIndex];
+                        ulong blockMinimumTransactionGas = minimumTransactionGas[blockIndex];
                         Transaction[]? transactions = blockTransactions[blockIndex];
                         RlpBehaviors receiptBehaviors = receiptRlpBehaviors[blockIndex];
                         bool validateGasUpperBound = validateReceiptGasUpperBoundAgainstHeader[blockIndex];
@@ -349,9 +353,9 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                             partialReceiptsGas = partialReceipts[^1].GasUsedTotal;
                             partialReceipts.AddRange(blockReceipts);
                             ReceiptsValidationResult validationResult = ValidateBlockReceipts(blockReceipts, blockExpectedGasUsed,
-                                blockGasLimit, transactions, receiptBehaviors, validateGasUpperBound, validateGasEqual, firstBlockReceiptIndex,
-                                !response.LastBlockIncomplete || !isLast, partialReceiptsGas, partialReceiptsLogsGas,
-                                partialReceiptsContentSize);
+                                blockGasLimit, blockMinimumTransactionGas, transactions, receiptBehaviors, validateGasUpperBound,
+                                validateGasEqual, firstBlockReceiptIndex, !response.LastBlockIncomplete || !isLast, partialReceiptsGas,
+                                partialReceiptsLogsGas, partialReceiptsContentSize);
                             partialReceiptsLogsGas = validationResult.LogsGas;
                             partialReceiptsContentSize = validationResult.ReceiptsContentSize;
 
@@ -388,8 +392,9 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                             }
 
                             ReceiptsValidationResult validationResult = ValidateBlockReceipts(blockReceipts, blockExpectedGasUsed,
-                                blockGasLimit, transactions, receiptBehaviors, validateGasUpperBound, validateGasEqual, firstBlockReceiptIndex,
-                                false, partialReceiptsGas, partialReceiptsLogsGas, partialReceiptsContentSize);
+                                blockGasLimit, blockMinimumTransactionGas, transactions, receiptBehaviors, validateGasUpperBound,
+                                validateGasEqual, firstBlockReceiptIndex, false, partialReceiptsGas, partialReceiptsLogsGas,
+                                partialReceiptsContentSize);
                             partialReceipts = new ArrayPoolList<TxReceipt>(blockReceipts.Length + firstBlockReceiptIndex);
                             partialReceipts.AddRange(blockReceipts);
                             firstBlockReceiptIndex = partialReceipts.Count;
@@ -401,9 +406,9 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                             continue;
                         }
 
-                        ValidateBlockReceipts(blockReceipts, blockExpectedGasUsed, blockGasLimit, transactions,
-                            receiptBehaviors, validateGasUpperBound, validateGasEqual, firstBlockReceiptIndex, true, partialReceiptsGas,
-                            partialReceiptsLogsGas, partialReceiptsContentSize);
+                        ValidateBlockReceipts(blockReceipts, blockExpectedGasUsed, blockGasLimit, blockMinimumTransactionGas,
+                            transactions, receiptBehaviors, validateGasUpperBound, validateGasEqual, firstBlockReceiptIndex,
+                            true, partialReceiptsGas, partialReceiptsLogsGas, partialReceiptsContentSize);
                         aggregated.Add(blockReceipts);
                         blockIndex++;
                         firstBlockReceiptIndex = 0;
@@ -516,6 +521,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
         TxReceipt[] blockReceipts,
         ulong expectedGasUsed,
         ulong blockGasLimit,
+        ulong minimumTransactionGas,
         Transaction[]? transactions,
         RlpBehaviors receiptBehaviors,
         bool validateReceiptGasUpperBoundAgainstHeader,
@@ -536,7 +542,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
             return new ReceiptsValidationResult(previousGasUsed, previousLogsGas, previousReceiptsContentSize);
         }
 
-        previousGasUsed = GetPreviousGasUsedForSegment(firstReceiptIndex, previousGasUsed);
+        previousGasUsed = GetPreviousGasUsedForSegment(firstReceiptIndex, previousGasUsed, minimumTransactionGas);
         ulong logsGas = previousLogsGas;
         ulong receiptsContentSize = previousReceiptsContentSize;
 
@@ -548,7 +554,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
             ValidateReceiptSizeAgainstTransactionGasLimit(receiptSize, transactions, receiptIndex);
             receiptsContentSize = checked(receiptsContentSize + receiptSize);
             ValidateTotalReceiptsSizeAgainstBlockGasLimit(receiptsContentSize, blockGasLimit);
-            previousGasUsed = ValidateReceiptGas(receipt, previousGasUsed);
+            previousGasUsed = ValidateReceiptGas(receipt, previousGasUsed, minimumTransactionGas);
             logsGas = AddReceiptLogsGas(logsGas, receipt);
         }
 
@@ -567,9 +573,9 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
         }
     }
 
-    private static ulong GetPreviousGasUsedForSegment(int firstReceiptIndex, ulong previousGasUsed)
+    private static ulong GetPreviousGasUsedForSegment(int firstReceiptIndex, ulong previousGasUsed, ulong minimumTransactionGas)
     {
-        ulong minimalPreviousGasUsed = checked((ulong)firstReceiptIndex * GasCostOf.Transaction);
+        ulong minimalPreviousGasUsed = checked((ulong)firstReceiptIndex * minimumTransactionGas);
         return Math.Max(previousGasUsed, minimalPreviousGasUsed);
     }
 
@@ -579,10 +585,10 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
     private static ulong GetReceiptSize(TxReceipt receipt, RlpBehaviors behaviors) =>
         (ulong)ReceiptMessageDecoder.GetLength(receipt, behaviors);
 
-    private static ulong ValidateReceiptGas(TxReceipt receipt, ulong previousGasUsed)
+    private static ulong ValidateReceiptGas(TxReceipt receipt, ulong previousGasUsed, ulong minimumTransactionGas)
     {
         ulong receiptGasUsed = GetReceiptGasUsed(receipt, previousGasUsed);
-        ValidateReceiptGasCoversIntrinsicCost(receiptGasUsed);
+        ValidateReceiptGasCoversIntrinsicCost(receiptGasUsed, minimumTransactionGas);
         return receipt.GasUsedTotal;
     }
 
@@ -596,9 +602,9 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
         return receipt.GasUsedTotal - previousGasUsed;
     }
 
-    private static void ValidateReceiptGasCoversIntrinsicCost(ulong receiptGasUsed)
+    private static void ValidateReceiptGasCoversIntrinsicCost(ulong receiptGasUsed, ulong minimumTransactionGas)
     {
-        if (GasCostOf.Transaction > receiptGasUsed)
+        if (minimumTransactionGas > receiptGasUsed)
         {
             throw new SubprotocolException("Intrinsic gas lower bound exceeds block gas used");
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -35,6 +35,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
 
     /// <summary>Sentinel for <c>lastBlockNumber</c> meaning no receipt block has been seen yet.</summary>
     private const ulong NoBlockSeen = ulong.MaxValue;
+    private const ulong MinimumSupportedTransactionGas = GasCostOf.TransactionEip2780;
 
     private readonly MessageDictionary<GetReceiptsMessage70, ReceiptsMessage70> _receiptsRequests70;
     private readonly ISpecProvider _specProvider;
@@ -256,7 +257,6 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
 
         using ArrayPoolList<ulong> expectedGasUsed = new(blockHashes.Count);
         using ArrayPoolList<ulong> blockGasLimits = new(blockHashes.Count);
-        using ArrayPoolList<ulong> minimumTransactionGas = new(blockHashes.Count);
         using ArrayPoolList<Transaction[]?> blockTransactions = new(blockHashes.Count);
         using ArrayPoolList<RlpBehaviors> receiptRlpBehaviors = new(blockHashes.Count);
         using ArrayPoolList<bool> validateReceiptGasUpperBoundAgainstHeader = new(blockHashes.Count);
@@ -272,7 +272,6 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                 {
                     expectedGasUsed.Add(0);
                     blockGasLimits.Add(0);
-                    minimumTransactionGas.Add(0);
                     blockTransactions.Add(null);
                     receiptRlpBehaviors.Add(RlpBehaviors.None);
                     validateReceiptGasUpperBoundAgainstHeader.Add(false);
@@ -284,7 +283,6 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                 Block? block = SyncServer.Find(blockHash);
                 expectedGasUsed.Add(header.GasUsed);
                 blockGasLimits.Add(header.GasLimit);
-                minimumTransactionGas.Add(spec.IsEip2780Enabled ? GasCostOf.TransactionEip2780 : GasCostOf.Transaction);
                 blockTransactions.Add(GetTransactionsForReceiptValidation(block));
                 receiptRlpBehaviors.Add(spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts : RlpBehaviors.None);
                 validateReceiptGasUpperBoundAgainstHeader.Add(!spec.IsEip8037Enabled);
@@ -337,7 +335,6 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                         TxReceipt[] blockReceipts = txReceipts[i] ?? throw new SubprotocolException("Unexpected null receipt block payload");
                         ulong blockExpectedGasUsed = expectedGasUsed[blockIndex];
                         ulong blockGasLimit = blockGasLimits[blockIndex];
-                        ulong blockMinimumTransactionGas = minimumTransactionGas[blockIndex];
                         Transaction[]? transactions = blockTransactions[blockIndex];
                         RlpBehaviors receiptBehaviors = receiptRlpBehaviors[blockIndex];
                         bool validateGasUpperBound = validateReceiptGasUpperBoundAgainstHeader[blockIndex];
@@ -353,9 +350,9 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                             partialReceiptsGas = partialReceipts[^1].GasUsedTotal;
                             partialReceipts.AddRange(blockReceipts);
                             ReceiptsValidationResult validationResult = ValidateBlockReceipts(blockReceipts, blockExpectedGasUsed,
-                                blockGasLimit, blockMinimumTransactionGas, transactions, receiptBehaviors, validateGasUpperBound,
-                                validateGasEqual, firstBlockReceiptIndex, !response.LastBlockIncomplete || !isLast, partialReceiptsGas,
-                                partialReceiptsLogsGas, partialReceiptsContentSize);
+                                blockGasLimit, transactions, receiptBehaviors, validateGasUpperBound, validateGasEqual, firstBlockReceiptIndex,
+                                !response.LastBlockIncomplete || !isLast, partialReceiptsGas, partialReceiptsLogsGas,
+                                partialReceiptsContentSize);
                             partialReceiptsLogsGas = validationResult.LogsGas;
                             partialReceiptsContentSize = validationResult.ReceiptsContentSize;
 
@@ -392,9 +389,8 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                             }
 
                             ReceiptsValidationResult validationResult = ValidateBlockReceipts(blockReceipts, blockExpectedGasUsed,
-                                blockGasLimit, blockMinimumTransactionGas, transactions, receiptBehaviors, validateGasUpperBound,
-                                validateGasEqual, firstBlockReceiptIndex, false, partialReceiptsGas, partialReceiptsLogsGas,
-                                partialReceiptsContentSize);
+                                blockGasLimit, transactions, receiptBehaviors, validateGasUpperBound, validateGasEqual, firstBlockReceiptIndex,
+                                false, partialReceiptsGas, partialReceiptsLogsGas, partialReceiptsContentSize);
                             partialReceipts = new ArrayPoolList<TxReceipt>(blockReceipts.Length + firstBlockReceiptIndex);
                             partialReceipts.AddRange(blockReceipts);
                             firstBlockReceiptIndex = partialReceipts.Count;
@@ -406,9 +402,9 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
                             continue;
                         }
 
-                        ValidateBlockReceipts(blockReceipts, blockExpectedGasUsed, blockGasLimit, blockMinimumTransactionGas,
-                            transactions, receiptBehaviors, validateGasUpperBound, validateGasEqual, firstBlockReceiptIndex,
-                            true, partialReceiptsGas, partialReceiptsLogsGas, partialReceiptsContentSize);
+                        ValidateBlockReceipts(blockReceipts, blockExpectedGasUsed, blockGasLimit, transactions,
+                            receiptBehaviors, validateGasUpperBound, validateGasEqual, firstBlockReceiptIndex, true, partialReceiptsGas,
+                            partialReceiptsLogsGas, partialReceiptsContentSize);
                         aggregated.Add(blockReceipts);
                         blockIndex++;
                         firstBlockReceiptIndex = 0;
@@ -521,7 +517,6 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
         TxReceipt[] blockReceipts,
         ulong expectedGasUsed,
         ulong blockGasLimit,
-        ulong minimumTransactionGas,
         Transaction[]? transactions,
         RlpBehaviors receiptBehaviors,
         bool validateReceiptGasUpperBoundAgainstHeader,
@@ -542,7 +537,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
             return new ReceiptsValidationResult(previousGasUsed, previousLogsGas, previousReceiptsContentSize);
         }
 
-        previousGasUsed = GetPreviousGasUsedForSegment(firstReceiptIndex, previousGasUsed, minimumTransactionGas);
+        previousGasUsed = GetPreviousGasUsedForSegment(firstReceiptIndex, previousGasUsed);
         ulong logsGas = previousLogsGas;
         ulong receiptsContentSize = previousReceiptsContentSize;
 
@@ -554,7 +549,7 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
             ValidateReceiptSizeAgainstTransactionGasLimit(receiptSize, transactions, receiptIndex);
             receiptsContentSize = checked(receiptsContentSize + receiptSize);
             ValidateTotalReceiptsSizeAgainstBlockGasLimit(receiptsContentSize, blockGasLimit);
-            previousGasUsed = ValidateReceiptGas(receipt, previousGasUsed, minimumTransactionGas);
+            previousGasUsed = ValidateReceiptGas(receipt, previousGasUsed);
             logsGas = AddReceiptLogsGas(logsGas, receipt);
         }
 
@@ -573,9 +568,9 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
         }
     }
 
-    private static ulong GetPreviousGasUsedForSegment(int firstReceiptIndex, ulong previousGasUsed, ulong minimumTransactionGas)
+    private static ulong GetPreviousGasUsedForSegment(int firstReceiptIndex, ulong previousGasUsed)
     {
-        ulong minimalPreviousGasUsed = checked((ulong)firstReceiptIndex * minimumTransactionGas);
+        ulong minimalPreviousGasUsed = checked((ulong)firstReceiptIndex * MinimumSupportedTransactionGas);
         return Math.Max(previousGasUsed, minimalPreviousGasUsed);
     }
 
@@ -585,10 +580,10 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
     private static ulong GetReceiptSize(TxReceipt receipt, RlpBehaviors behaviors) =>
         (ulong)ReceiptMessageDecoder.GetLength(receipt, behaviors);
 
-    private static ulong ValidateReceiptGas(TxReceipt receipt, ulong previousGasUsed, ulong minimumTransactionGas)
+    private static ulong ValidateReceiptGas(TxReceipt receipt, ulong previousGasUsed)
     {
         ulong receiptGasUsed = GetReceiptGasUsed(receipt, previousGasUsed);
-        ValidateReceiptGasCoversIntrinsicCost(receiptGasUsed, minimumTransactionGas);
+        ValidateReceiptGasCoversIntrinsicCost(receiptGasUsed);
         return receipt.GasUsedTotal;
     }
 
@@ -602,9 +597,9 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
         return receipt.GasUsedTotal - previousGasUsed;
     }
 
-    private static void ValidateReceiptGasCoversIntrinsicCost(ulong receiptGasUsed, ulong minimumTransactionGas)
+    private static void ValidateReceiptGasCoversIntrinsicCost(ulong receiptGasUsed)
     {
-        if (minimumTransactionGas > receiptGasUsed)
+        if (MinimumSupportedTransactionGas > receiptGasUsed)
         {
             throw new SubprotocolException("Intrinsic gas lower bound exceeds block gas used");
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V70/Eth70ProtocolHandler.cs
@@ -35,7 +35,8 @@ public class Eth70ProtocolHandler : Eth69ProtocolHandler, IStaticProtocolInfo
 
     /// <summary>Sentinel for <c>lastBlockNumber</c> meaning no receipt block has been seen yet.</summary>
     private const ulong NoBlockSeen = ulong.MaxValue;
-    private const ulong MinimumSupportedTransactionGas = GasCostOf.TransactionEip2780;
+    // Before EIP-3529, refunds could reduce gas used by at most half.
+    private const ulong MinimumSupportedTransactionGas = GasCostOf.Transaction / 2;
 
     private readonly MessageDictionary<GetReceiptsMessage70, ReceiptsMessage70> _receiptsRequests70;
     private readonly ISpecProvider _specProvider;


### PR DESCRIPTION
Fixes #12461

## Changes

- Use a 10,500 gas receipt sanity floor, expressed as the legacy 21,000 intrinsic transaction gas divided by the pre-EIP-3529 maximum refund quotient of 2.
- Apply the same conservative floor to complete and paginated receipt responses, including when local header metadata is unavailable.
- Add regression coverage proving that paginated receipts at the 10,500 gas boundary are accepted and receipts below it are rejected.

The eth/70 receipt validator previously hard-coded the legacy 21,000 gas transaction minimum. That rejected valid EIP-2780 receipts, including 12,000 gas self-transfers, and could pin receipt backfill/full sync.

Using 12,000 as the universal floor would still reject canonical historical receipts. Before [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529), refunds were capped at half of gas spent, and before [EIP-150](https://eips.ethereum.org/EIPS/eip-150) `SELFDESTRUCT` had no execution cost while granting a refund. Mainnet includes such receipts below 12,000 gas; for example, [this transaction in block 73,765](https://etherscan.io/tx/0x35e5b3cd04821404bb70716b23be4df58efcb2c45bb8d7371536785c9f59ae1a) used 10,649 gas.

This check is an early sanity bound for untrusted peer data rather than fork-exact consensus validation. Completed receipt lists are still verified against the block's receipts root by the synchronization layer.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- All 50 eth/70 protocol handler tests pass.
- The main client and benchmark solutions build with warnings treated as errors and no diagnostics.
- The Ethereum test solution could not complete because the external `src/tests` fixture files are absent from this checkout.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No