### PR TITLE
Warm read-only accounts in HintBal phase 1 on the dedicated WarmReadPool

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
@@ -17,7 +17,7 @@ namespace Nethermind.State.Flat.Persistence;
 /// </summary>
 public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposable
 {
-    private const int DefaultMaxEntriesPerKind = 131072;
+    private const int DefaultMaxEntriesPerKind = 262144;
 
     private readonly IPersistence _inner;
     private readonly int _maxEntriesPerKind;

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -192,7 +192,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
             {
                 // Phase 1: trie warmup + GetAccount + sink.OnAccountRead. Sink slot reads are
                 // deferred to phase 2 so one huge account doesn't bottleneck a single worker.
-                Parallel.For(0, accountCount, parallelOptions, (i) =>
+                void WarmAccount(int i)
                 {
                     if (token.IsCancellationRequested || _hintSequenceId != snapshot || _pausePrewarmer) return;
 
@@ -206,9 +206,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
                     ReadOnlySlotChanges[] storageChanges = ac.StorageChanges;
                     int storageChangeCount = storageChanges.Length;
 
-                    Account? account = sink is null && storageChangeCount == 0
-                        ? null
-                        : _snapshotBundle.GetAccount(address);
+                    Account? account = _snapshotBundle.GetAccount(address);
 
                     if (sink is not null && sink.StillNeeded(address, out _))
                         sink.OnAccountRead(address, account);
@@ -243,7 +241,21 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
                         accounts[i] = account;
                         selfDestructIdxs![i] = _snapshotBundle.DetermineSelfDestructSnapshotIdx(address);
                     }
-                });
+                }
+
+                // The shared ThreadPool is saturated by the parallel EVM executor
+                // during newPayload, so Parallel.For here gets starved exactly when
+                // warmup matters. The dedicated reader pool is idle at that point.
+                if (_warmReadPool is not null)
+                {
+                    WarmReadPool pool = _warmReadPool.Value;
+                    int workers = Math.Min(pool.MaxConcurrency, Math.Max(1, accountCount / 64));
+                    pool.Run(accountCount, workers, WarmAccount, token);
+                }
+                else
+                {
+                    Parallel.For(0, accountCount, parallelOptions, WarmAccount);
+                }
 
                 if (sink is not null) RunSinkSlotReads(accountChanges, accounts!, selfDestructIdxs!, sink, parallelOptions);
             }


### PR DESCRIPTION
## Problem

On BAL blocks, phase 1 of `FlatWorldStateScope.HintBal` is supposed to warm every account the block touches, but it had two gaps that leave **read-only account accesses cold** during execution:

1. **Read-only accounts were never fetched.** `GetAccount` was gated on `sink is null && storageChangeCount == 0` → skip. An account that the block merely *reads* (the `BALANCE`/`EXTCODE*` pattern) never reached the CarryForward/flat caches, so the EVM paid the full cold flat-reader-stack walk per access inside the newPayload window.
2. **Phase 1 ran on the shared ThreadPool** (`Parallel.For`), which the parallel EVM executor saturates during newPayload — the warmup gets starved exactly when it matters. The dedicated `WarmReadPool` (already wired for writable scopes in `FlatScopeProvider`) is idle at that point.

## Changes

- Fetch the account unconditionally in phase 1.
- Extract the phase-1 lambda into a local function and dispatch it on `WarmReadPool` when available (worker count `min(MaxConcurrency, accountCount/64)` so small BALs don't spin up the full pool); fall back to `Parallel.For` for scopes without a pool.
- Double `CarryForwardCachingPersistence.DefaultMaxEntriesPerKind` (131072 → 262144) so the extra warmed entries are not evicted before execution reads them. Worst-case extra memory is a few tens of MB per kind.

## Benchmarks

gas-benchmarks stateful suite (jochemnet, `amsterdam-repricings-v5.2.0`), family `test_account_access[...opcode_BALANCE...EXISTING_CONTRACT...NO_CACHE]`, 11 gas sizes 100M–300M, one podman/CRIU memory-checkpoint restore per test (cold state, warm process, via benchmarkoor `container-checkpoint-restore`), AMD EPYC 4344P, image built from `bal-devnet-7` + this patch.

Baseline was run twice to establish noise: **4.1% spread on suite totals** (±20–40% on individual gas sizes — per-size deltas are not meaningful).

| arm | suite total | vs baseline mean |
|---|---|---|
| baseline run 1 | 15.22 s | — |
| baseline run 2 | 14.60 s | — |
| **this patch, run 1** | **12.98 s** | **−12.9%** |
| **this patch, run 2** | **12.59 s** | **−15.6%** |

Supporting evidence that the gain is the intended mechanism and not noise:

- Slow-block telemetry over the same ~3.2G gas of slow blocks: EVM execution 16,693 ms → 14,647 ms, while merkle/state-hash components are unchanged — the signature of cold reads turning into cache hits.
- TrieWarmer hint-drop rate is unchanged (~77–79% in both arms), i.e. the win does not come through the warmer ring but through the direct `GetAccount` warmup.

On this family the gap to reth (same suite, warm-process methodology) tightens from ~1.7–1.8× to ~1.5×.

Also benchmarked and rejected: raising `--FlatDb.BlockCacheSizeBudget` to 24 GiB on top of this patch does **not** compose (−9.5% vs −14% for the patch alone).

## Notes

- `restore_in_place`d checkpoint benchmarking resets client state per test, so these numbers measure genuinely cold account reads; a mainnet-following node should see the same effect on BAL blocks with many read-only touches.
- The `accountCount/64` worker heuristic is a first cut — happy to adjust if there's a preferred sizing convention for `WarmReadPool`.
