### PR TITLE
fix(tracing): make custom JavaScript tracer caching concurrency-safe

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/Engine.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/Engine.cs
@@ -41,7 +41,7 @@ public class Engine : IDisposable
 
     private static readonly V8Runtime _runtime = new(new V8RuntimeConstraints { MaxOldSpaceSize = V8MaxOldSpaceMb });
     private static readonly ConcurrentDictionary<string, V8Script> _builtInScripts = new();
-    private static readonly LruCache<int, V8Script> _runtimeScripts = new(10, "runtime scripts");
+    private static readonly LruCache<string, V8Script> _runtimeScripts = new(10, "runtime scripts");
 
     public static Engine? CurrentEngine
     {
@@ -184,20 +184,10 @@ public class Engine : IDisposable
             }
             else if (tracer.StartsWith('{') && tracer.EndsWith('}'))
             {
-                int hashCode = tracer.GetHashCode();
-                if (_runtimeScripts.TryGet(hashCode, out V8Script script))
-                {
-                    return script;
-                }
-
-                script = _runtime.Compile(PackTracerCode(tracer));
-                if (_runtimeScripts.Set(hashCode, script))
-                {
-                    return script;
-                }
-
-                script.Dispose();
-                return _runtimeScripts.Get(hashCode);
+                return _runtimeScripts.SetOrGet(
+                    tracer,
+                    tracer,
+                    static (_, tracerCode) => _runtime.Compile(PackTracerCode(tracerCode)));
             }
             else
             {

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeJavaScriptTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeJavaScriptTracerTests.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core.Extensions;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using NUnit.Framework;
@@ -19,6 +21,43 @@ namespace Nethermind.Evm.Test.Tracing;
 
 public class GethLikeJavaScriptTracerTests : VirtualMachineTestsBase
 {
+    [Test]
+    public void Concurrent_custom_tracer_compilation_keeps_cached_script_alive()
+    {
+        const int concurrency = 16;
+        string marker = Guid.NewGuid().ToString("N");
+        string tracerCode = $$"""
+                              {
+                                  marker: "{{marker}}",
+                                  result: function() { return this.marker; }
+                              }
+                              """;
+        using CountdownEvent ready = new(concurrency);
+        using ManualResetEventSlim start = new();
+
+        Task[] tasks = Enumerable.Range(0, concurrency).Select(_ => Task.Factory.StartNew(
+            () =>
+            {
+                using Engine engine = new(Shanghai.Instance);
+                ready.Signal();
+                start.Wait();
+                dynamic tracer = engine.CreateTracer(tracerCode);
+                Assert.That((string)tracer.result(), Is.EqualTo(marker));
+            },
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default)).ToArray();
+
+        bool allReady = ready.Wait(TimeSpan.FromSeconds(30));
+        start.Set();
+        Assert.That(allReady, Is.True);
+        Task.WhenAll(tasks).GetAwaiter().GetResult();
+
+        using Engine sequentialEngine = new(Shanghai.Instance);
+        dynamic cachedTracer = sequentialEngine.CreateTracer(tracerCode);
+        Assert.That((string)cachedTracer.result(), Is.EqualTo(marker));
+    }
+
     [TestCase("{ result: function(ctx, db) { return null } }", TestName = "fault")]
     [TestCase("{ fault: function(log, db) { } }", TestName = "result")]
     [TestCase("{ fault: function(log, db) { }, result: function(ctx, db) { return null }, enter: function(frame) { } }", TestName = "exit")]


### PR DESCRIPTION
Fixes #12438


## Changes

- Make runtime JavaScript tracer compilation and cache insertion atomic by using `LruCache.SetOrGet`.
- Key cached runtime tracers by their complete normalized source instead of `string.GetHashCode()`, avoiding possible collisions between different tracer scripts.
- Add a regression test that loads the same custom tracer concurrently from 16 engines and verifies that the cached script remains usable by a subsequent sequential request.

Previously, two requests could miss the cache at the same time and compile the same tracer independently. The second cache insertion replaced the first entry and returned `false`, after which the newly cached script was disposed. The cache therefore retained a released `V8Script`, causing all later custom-tracer requests using that entry to fail until the process was restarted.

Using the cache's atomic factory ensures that only one script is compiled and stored for each source string, so concurrent requests cannot dispose the cached instance.




## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Added `Concurrent_custom_tracer_compilation_keeps_cached_script_alive`, covering concurrent first-time compilation and subsequent sequential cache reuse.
- `Nethermind.Evm.Test`: 4,940 passed, 8 pre-existing skips, 0 failed.


## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

_If yes, link the PR to the docs update or the issue with the details labeled `docs`. Remove if not applicable._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

_If yes, fill in the details here. Remove if not applicable._

## Remarks

_Optional. Remove if not applicable._
