### PR TITLE
perf(db): batched RocksDB MultiGet for flat BAL warmup — contiguous slices, no block-cache fill (bal-devnet-7)

### DIFF
--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -32,6 +32,17 @@ namespace Nethermind.Core
                 values[i] = Get(keys[i], flags);
         }
 
+        void MultiGet(ReadOnlySpan<byte> keys, int keyLength, Span<byte[]?> values, ReadFlags flags = ReadFlags.None)
+        {
+            if (keyLength <= 0)
+                throw new ArgumentOutOfRangeException(nameof(keyLength));
+            if (keys.Length != values.Length * keyLength)
+                throw new ArgumentException("The key buffer length must match the value count and fixed key length.", nameof(keys));
+
+            for (int i = 0; i < values.Length; i++)
+                values[i] = Get(keys.Slice(i * keyLength, keyLength), flags);
+        }
+
         /// <summary>
         /// Return span. Must call <see cref="DangerousReleaseMemory"/> after use to avoid memory leaks.
         /// Prefer using <see cref="GetOwnedMemory"/> which handles release automatically via disposal.

--- a/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Core/IKeyValueStore.cs
@@ -23,6 +23,15 @@ namespace Nethermind.Core
 
         byte[]? Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None);
 
+        void MultiGet(byte[][] keys, Span<byte[]?> values, ReadFlags flags = ReadFlags.None)
+        {
+            if (keys.Length != values.Length)
+                throw new ArgumentException("Keys and values must have the same length.", nameof(values));
+
+            for (int i = 0; i < keys.Length; i++)
+                values[i] = Get(keys[i], flags);
+        }
+
         /// <summary>
         /// Return span. Must call <see cref="DangerousReleaseMemory"/> after use to avoid memory leaks.
         /// Prefer using <see cref="GetOwnedMemory"/> which handles release automatically via disposal.

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -52,6 +52,9 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
     void IReadOnlyKeyValueStore.MultiGet(byte[][] keys, Span<byte[]?> values, ReadFlags flags) => _reader.MultiGet(keys, values, flags);
 
+    void IReadOnlyKeyValueStore.MultiGet(ReadOnlySpan<byte> keys, int keyLength, Span<byte[]?> values, ReadFlags flags) =>
+        _reader.MultiGet(keys, keyLength, values, flags);
+
     bool IReadOnlyKeyValueStore.KeyExists(ReadOnlySpan<byte> key) => _reader.KeyExists(key);
 
     void IReadOnlyKeyValueStore.DangerousReleaseMemory(in ReadOnlySpan<byte> key) => _reader.DangerousReleaseMemory(key);

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -50,6 +50,8 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
     int IReadOnlyKeyValueStore.Get(scoped ReadOnlySpan<byte> key, Span<byte> output, ReadFlags flags) => _reader.Get(key, output, flags);
 
+    void IReadOnlyKeyValueStore.MultiGet(byte[][] keys, Span<byte[]?> values, ReadFlags flags) => _reader.MultiGet(keys, values, flags);
+
     bool IReadOnlyKeyValueStore.KeyExists(ReadOnlySpan<byte> key) => _reader.KeyExists(key);
 
     void IReadOnlyKeyValueStore.DangerousReleaseMemory(in ReadOnlySpan<byte> key) => _reader.DangerousReleaseMemory(key);

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -911,28 +911,114 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
     }
 
-    internal KeyValuePair<byte[], byte[]?>[] MultiGet(byte[][] keys, ColumnFamilyHandle? cf, ReadOptions readOptions)
+    internal unsafe void MultiGet(byte[][] keys, Span<byte[]?> values, ColumnFamilyHandle? cf, ReadOptions readOptions)
     {
         ObjectDisposedException.ThrowIf(_isDisposing, this);
+
+        if (keys.Length != values.Length)
+            throw new ArgumentException("Keys and values must have the same length.", nameof(values));
+
+        if (keys.Length == 0) return;
 
         UpdateReadMetrics();
 
         try
         {
-            ColumnFamilyHandle[]? columnFamilies = null;
-            if (cf is not null)
+            if (cf is null)
             {
-                columnFamilies = new ColumnFamilyHandle[keys.Length];
-                Array.Fill(columnFamilies, cf);
+                KeyValuePair<byte[], byte[]?>[] results = _db.MultiGet(keys, null, readOptions);
+                for (int i = 0; i < results.Length; i++)
+                    values[i] = results[i].Value;
+                return;
             }
 
-            return _db.MultiGet(keys, columnFamilies, readOptions);
+            int keyBytesLength = 0;
+            for (int i = 0; i < keys.Length; i++)
+                keyBytesLength = checked(keyBytesLength + keys[i].Length);
+
+            byte[] keyBytes = new byte[keyBytesLength];
+            IntPtr[] keyPointers = new IntPtr[keys.Length];
+            UIntPtr[] keyLengths = new UIntPtr[keys.Length];
+            IntPtr[] valueHandles = new IntPtr[keys.Length];
+            IntPtr[] errors = new IntPtr[keys.Length];
+
+            fixed (byte* keyBytesPtr = keyBytes)
+            fixed (IntPtr* keyPointersPtr = keyPointers)
+            fixed (UIntPtr* keyLengthsPtr = keyLengths)
+            fixed (IntPtr* valueHandlesPtr = valueHandles)
+            {
+                int offset = 0;
+                for (int i = 0; i < keys.Length; i++)
+                {
+                    byte[] key = keys[i];
+                    key.CopyTo(keyBytes, offset);
+                    keyPointers[i] = (IntPtr)(keyBytesPtr + offset);
+                    keyLengths[i] = (UIntPtr)key.Length;
+                    offset += key.Length;
+                }
+
+                Native.Instance.rocksdb_batched_multi_get_cf(
+                    _db.Handle,
+                    readOptions.Handle,
+                    cf.Handle,
+                    (UIntPtr)keys.Length,
+                    (IntPtr)keyPointersPtr,
+                    (IntPtr)keyLengthsPtr,
+                    (IntPtr)valueHandlesPtr,
+                    errors,
+                    0);
+            }
+
+            IntPtr firstError = IntPtr.Zero;
+            for (int i = 0; i < errors.Length; i++)
+            {
+                IntPtr error = errors[i];
+                if (error == IntPtr.Zero) continue;
+
+                if (firstError == IntPtr.Zero)
+                    firstError = error;
+                else
+                    Native.Instance.rocksdb_free(error);
+
+                errors[i] = IntPtr.Zero;
+            }
+
+            try
+            {
+                if (firstError != IntPtr.Zero) ThrowRocksDbException(firstError);
+
+                for (int i = 0; i < valueHandles.Length; i++)
+                {
+                    IntPtr handle = valueHandles[i];
+                    if (handle == IntPtr.Zero)
+                    {
+                        values[i] = null;
+                        continue;
+                    }
+
+                    IntPtr valuePtr = Native.Instance.rocksdb_pinnableslice_value(handle, out UIntPtr valueLength);
+                    values[i] = valuePtr == IntPtr.Zero
+                        ? null
+                        : new ReadOnlySpan<byte>((void*)valuePtr, checked((int)valueLength)).ToArray();
+                }
+            }
+            finally
+            {
+                for (int i = 0; i < valueHandles.Length; i++)
+                {
+                    if (valueHandles[i] != IntPtr.Zero)
+                        Native.Instance.rocksdb_pinnableslice_destroy(valueHandles[i]);
+                }
+            }
         }
         catch (RocksDbSharpException e)
         {
             CreateMarkerIfCorrupt(e);
             throw;
         }
+
+        [DoesNotReturn, StackTraceHidden]
+        static void ThrowRocksDbException(nint errPtr) => throw new RocksDbException(errPtr);
     }
 
     internal Span<byte> GetSpanWithColumnFamily(scoped ReadOnlySpan<byte> key, ColumnFamilyHandle? cf, ReadOptions readOptions)

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -339,7 +339,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         _fileSystem.File.Delete(corruptMarker);
     }
 
-    protected internal void UpdateReadMetrics() => Interlocked.Increment(ref _totalReads);
+    protected internal void UpdateReadMetrics(int count = 1) => Interlocked.Add(ref _totalReads, count);
 
     protected internal void UpdateWriteMetrics() => Interlocked.Increment(ref _totalWrites);
 
@@ -899,6 +899,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     {
         get
         {
+            UpdateReadMetrics(keys.Length);
+
             try
             {
                 return _db.MultiGet(keys);
@@ -920,7 +922,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
         if (keys.Length == 0) return;
 
-        UpdateReadMetrics();
+        UpdateReadMetrics(keys.Length);
 
         try
         {
@@ -942,6 +944,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             IntPtr[] valueHandles = new IntPtr[keys.Length];
             IntPtr[] errors = new IntPtr[keys.Length];
 
+            // The pointer arrays only reference the pinned key buffer and remain valid for the native call.
             fixed (byte* keyBytesPtr = keyBytes)
             fixed (IntPtr* keyPointersPtr = keyPointers)
             fixed (UIntPtr* keyLengthsPtr = keyLengths)
@@ -969,56 +972,13 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                     0);
             }
 
-            IntPtr firstError = IntPtr.Zero;
-            for (int i = 0; i < errors.Length; i++)
-            {
-                IntPtr error = errors[i];
-                if (error == IntPtr.Zero) continue;
-
-                if (firstError == IntPtr.Zero)
-                    firstError = error;
-                else
-                    Native.Instance.rocksdb_free(error);
-
-                errors[i] = IntPtr.Zero;
-            }
-
-            try
-            {
-                if (firstError != IntPtr.Zero) ThrowRocksDbException(firstError);
-
-                for (int i = 0; i < valueHandles.Length; i++)
-                {
-                    IntPtr handle = valueHandles[i];
-                    if (handle == IntPtr.Zero)
-                    {
-                        values[i] = null;
-                        continue;
-                    }
-
-                    IntPtr valuePtr = Native.Instance.rocksdb_pinnableslice_value(handle, out UIntPtr valueLength);
-                    values[i] = valuePtr == IntPtr.Zero
-                        ? null
-                        : new ReadOnlySpan<byte>((void*)valuePtr, checked((int)valueLength)).ToArray();
-                }
-            }
-            finally
-            {
-                for (int i = 0; i < valueHandles.Length; i++)
-                {
-                    if (valueHandles[i] != IntPtr.Zero)
-                        Native.Instance.rocksdb_pinnableslice_destroy(valueHandles[i]);
-                }
-            }
+            CopyMultiGetResults(valueHandles, errors, values);
         }
         catch (RocksDbSharpException e)
         {
             CreateMarkerIfCorrupt(e);
             throw;
         }
-
-        [DoesNotReturn, StackTraceHidden]
-        static void ThrowRocksDbException(nint errPtr) => throw new RocksDbException(errPtr);
     }
 
     internal unsafe void MultiGet(
@@ -1043,7 +1003,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             return;
         }
 
-        UpdateReadMetrics();
+        UpdateReadMetrics(values.Length);
 
         const int StackAllocationLimit = 256;
         Span<RocksDbSlice> keySlices = values.Length <= StackAllocationLimit
@@ -1052,11 +1012,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         Span<IntPtr> valueHandles = values.Length <= StackAllocationLimit
             ? stackalloc IntPtr[values.Length]
             : new IntPtr[values.Length];
-        Span<IntPtr> errors = values.Length <= StackAllocationLimit
-            ? stackalloc IntPtr[values.Length]
-            : new IntPtr[values.Length];
+        IntPtr[] errors = new IntPtr[values.Length];
         valueHandles.Clear();
-        errors.Clear();
 
         try
         {
@@ -1064,36 +1021,58 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             fixed (byte* keysPtr = keys)
             fixed (RocksDbSlice* keySlicesPtr = keySlices)
             fixed (IntPtr* valueHandlesPtr = valueHandles)
-            fixed (IntPtr* errorsPtr = errors)
             {
                 for (int i = 0; i < keySlices.Length; i++)
                     keySlices[i] = new RocksDbSlice(keysPtr + (i * keyLength), keyLength);
 
-                RocksDbNativeMethods.BatchedMultiGetColumnFamilySlices(
+                Native.Instance.rocksdb_batched_multi_get_cf_slice(
                     _db.Handle,
                     readOptions.Handle,
                     cf.Handle,
                     (UIntPtr)values.Length,
-                    keySlicesPtr,
-                    valueHandlesPtr,
-                    errorsPtr,
+                    (IntPtr)keySlicesPtr,
+                    (IntPtr)valueHandlesPtr,
+                    errors,
                     0);
             }
 
-            IntPtr firstError = IntPtr.Zero;
-            for (int i = 0; i < errors.Length; i++)
-            {
-                IntPtr error = errors[i];
-                if (error == IntPtr.Zero) continue;
+            CopyMultiGetResults(valueHandles, errors, values);
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
+    }
 
-                if (firstError == IntPtr.Zero)
-                    firstError = error;
-                else
-                    Native.Instance.rocksdb_free(error);
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly unsafe struct RocksDbSlice(byte* data, int length)
+    {
+        public readonly byte* Data = data;
+        public readonly UIntPtr Length = (UIntPtr)length;
+    }
 
-                errors[i] = IntPtr.Zero;
-            }
+    private static unsafe void CopyMultiGetResults(
+        Span<IntPtr> valueHandles,
+        Span<IntPtr> errors,
+        Span<byte[]?> values)
+    {
+        IntPtr firstError = IntPtr.Zero;
+        for (int i = 0; i < errors.Length; i++)
+        {
+            IntPtr error = errors[i];
+            if (error == IntPtr.Zero) continue;
 
+            if (firstError == IntPtr.Zero)
+                firstError = error;
+            else
+                Native.Instance.rocksdb_free(error);
+
+            errors[i] = IntPtr.Zero;
+        }
+
+        try
+        {
             if (firstError != IntPtr.Zero) ThrowRocksDbException(firstError);
 
             for (int i = 0; i < valueHandles.Length; i++)
@@ -1106,15 +1085,11 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                 }
 
                 IntPtr valuePtr = Native.Instance.rocksdb_pinnableslice_value(handle, out UIntPtr valueLength);
+                // The PinnableSlice owns this buffer until its handle is destroyed below.
                 values[i] = valuePtr == IntPtr.Zero
                     ? null
                     : new ReadOnlySpan<byte>((void*)valuePtr, checked((int)valueLength)).ToArray();
             }
-        }
-        catch (RocksDbSharpException e)
-        {
-            CreateMarkerIfCorrupt(e);
-            throw;
         }
         finally
         {
@@ -1127,27 +1102,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
         [DoesNotReturn, StackTraceHidden]
         static void ThrowRocksDbException(nint errPtr) => throw new RocksDbException(errPtr);
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private readonly unsafe struct RocksDbSlice(byte* data, int length)
-    {
-        public readonly byte* Data = data;
-        public readonly UIntPtr Length = (UIntPtr)length;
-    }
-
-    private static unsafe class RocksDbNativeMethods
-    {
-        [DllImport("rocksdb", EntryPoint = "rocksdb_batched_multi_get_cf_slice", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void BatchedMultiGetColumnFamilySlices(
-            IntPtr db,
-            IntPtr readOptions,
-            IntPtr columnFamily,
-            UIntPtr keyCount,
-            RocksDbSlice* keys,
-            IntPtr* values,
-            IntPtr* errors,
-            byte sortedInput);
     }
 
     internal Span<byte> GetSpanWithColumnFamily(scoped ReadOnlySpan<byte> key, ColumnFamilyHandle? cf, ReadOptions readOptions)

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -911,6 +911,30 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
     }
 
+    internal KeyValuePair<byte[], byte[]?>[] MultiGet(byte[][] keys, ColumnFamilyHandle? cf, ReadOptions readOptions)
+    {
+        ObjectDisposedException.ThrowIf(_isDisposing, this);
+
+        UpdateReadMetrics();
+
+        try
+        {
+            ColumnFamilyHandle[]? columnFamilies = null;
+            if (cf is not null)
+            {
+                columnFamilies = new ColumnFamilyHandle[keys.Length];
+                Array.Fill(columnFamilies, cf);
+            }
+
+            return _db.MultiGet(keys, columnFamilies, readOptions);
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
+    }
+
     internal Span<byte> GetSpanWithColumnFamily(scoped ReadOnlySpan<byte> key, ColumnFamilyHandle? cf, ReadOptions readOptions)
     {
         ObjectDisposedException.ThrowIf(_isDisposing, this);

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1021,6 +1021,135 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         static void ThrowRocksDbException(nint errPtr) => throw new RocksDbException(errPtr);
     }
 
+    internal unsafe void MultiGet(
+        ReadOnlySpan<byte> keys,
+        int keyLength,
+        Span<byte[]?> values,
+        ColumnFamilyHandle? cf,
+        ReadOptions readOptions)
+    {
+        ObjectDisposedException.ThrowIf(_isDisposing, this);
+
+        if (keyLength <= 0)
+            throw new ArgumentOutOfRangeException(nameof(keyLength));
+        if (keys.Length != values.Length * keyLength)
+            throw new ArgumentException("The key buffer length must match the value count and fixed key length.", nameof(keys));
+        if (values.Length == 0) return;
+
+        if (cf is null)
+        {
+            for (int i = 0; i < values.Length; i++)
+                values[i] = Get(keys.Slice(i * keyLength, keyLength), null, readOptions);
+            return;
+        }
+
+        UpdateReadMetrics();
+
+        const int StackAllocationLimit = 256;
+        Span<RocksDbSlice> keySlices = values.Length <= StackAllocationLimit
+            ? stackalloc RocksDbSlice[values.Length]
+            : new RocksDbSlice[values.Length];
+        Span<IntPtr> valueHandles = values.Length <= StackAllocationLimit
+            ? stackalloc IntPtr[values.Length]
+            : new IntPtr[values.Length];
+        Span<IntPtr> errors = values.Length <= StackAllocationLimit
+            ? stackalloc IntPtr[values.Length]
+            : new IntPtr[values.Length];
+        valueHandles.Clear();
+        errors.Clear();
+
+        try
+        {
+            // All slices point into the pinned key span and remain valid for the duration of the native call.
+            fixed (byte* keysPtr = keys)
+            fixed (RocksDbSlice* keySlicesPtr = keySlices)
+            fixed (IntPtr* valueHandlesPtr = valueHandles)
+            fixed (IntPtr* errorsPtr = errors)
+            {
+                for (int i = 0; i < keySlices.Length; i++)
+                    keySlices[i] = new RocksDbSlice(keysPtr + (i * keyLength), keyLength);
+
+                RocksDbNativeMethods.BatchedMultiGetColumnFamilySlices(
+                    _db.Handle,
+                    readOptions.Handle,
+                    cf.Handle,
+                    (UIntPtr)values.Length,
+                    keySlicesPtr,
+                    valueHandlesPtr,
+                    errorsPtr,
+                    0);
+            }
+
+            IntPtr firstError = IntPtr.Zero;
+            for (int i = 0; i < errors.Length; i++)
+            {
+                IntPtr error = errors[i];
+                if (error == IntPtr.Zero) continue;
+
+                if (firstError == IntPtr.Zero)
+                    firstError = error;
+                else
+                    Native.Instance.rocksdb_free(error);
+
+                errors[i] = IntPtr.Zero;
+            }
+
+            if (firstError != IntPtr.Zero) ThrowRocksDbException(firstError);
+
+            for (int i = 0; i < valueHandles.Length; i++)
+            {
+                IntPtr handle = valueHandles[i];
+                if (handle == IntPtr.Zero)
+                {
+                    values[i] = null;
+                    continue;
+                }
+
+                IntPtr valuePtr = Native.Instance.rocksdb_pinnableslice_value(handle, out UIntPtr valueLength);
+                values[i] = valuePtr == IntPtr.Zero
+                    ? null
+                    : new ReadOnlySpan<byte>((void*)valuePtr, checked((int)valueLength)).ToArray();
+            }
+        }
+        catch (RocksDbSharpException e)
+        {
+            CreateMarkerIfCorrupt(e);
+            throw;
+        }
+        finally
+        {
+            for (int i = 0; i < valueHandles.Length; i++)
+            {
+                if (valueHandles[i] != IntPtr.Zero)
+                    Native.Instance.rocksdb_pinnableslice_destroy(valueHandles[i]);
+            }
+        }
+
+        [DoesNotReturn, StackTraceHidden]
+        static void ThrowRocksDbException(nint errPtr) => throw new RocksDbException(errPtr);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly unsafe struct RocksDbSlice(byte* data, int length)
+    {
+        public readonly byte* Data = data;
+        public readonly UIntPtr Length = (UIntPtr)length;
+    }
+
+    private static unsafe class RocksDbNativeMethods
+    {
+        [DllImport("rocksdb", EntryPoint = "rocksdb_batched_multi_get_cf_slice", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void BatchedMultiGetColumnFamilySlices(
+            IntPtr db,
+            IntPtr readOptions,
+            IntPtr columnFamily,
+            UIntPtr keyCount,
+            RocksDbSlice* keys,
+            IntPtr* values,
+            IntPtr* errors,
+            byte sortedInput);
+    }
+
     internal Span<byte> GetSpanWithColumnFamily(scoped ReadOnlySpan<byte> key, ColumnFamilyHandle? cf, ReadOptions readOptions)
     {
         ObjectDisposedException.ThrowIf(_isDisposing, this);

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;
@@ -88,6 +89,17 @@ public class RocksDbReader(DbOnTheRocks mainDb,
     {
         ReadOptions readOptions = ((flags & ReadFlags.HintCacheMiss) != 0 ? _hintCacheMissOptions : _options);
         return _mainDb.GetCStyleWithColumnFamily(key, output, _columnFamily, readOptions);
+    }
+
+    public void MultiGet(byte[][] keys, Span<byte[]?> values, ReadFlags flags = ReadFlags.None)
+    {
+        if (keys.Length != values.Length)
+            throw new ArgumentException("Keys and values must have the same length.", nameof(values));
+
+        ReadOptions readOptions = (flags & ReadFlags.HintCacheMiss) != 0 ? _hintCacheMissOptions : _options;
+        KeyValuePair<byte[], byte[]?>[] results = _mainDb.MultiGet(keys, _columnFamily, readOptions);
+        for (int i = 0; i < results.Length; i++)
+            values[i] = results[i].Value;
     }
 
     public Span<byte> GetSpan(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;
@@ -97,9 +96,7 @@ public class RocksDbReader(DbOnTheRocks mainDb,
             throw new ArgumentException("Keys and values must have the same length.", nameof(values));
 
         ReadOptions readOptions = (flags & ReadFlags.HintCacheMiss) != 0 ? _hintCacheMissOptions : _options;
-        KeyValuePair<byte[], byte[]?>[] results = _mainDb.MultiGet(keys, _columnFamily, readOptions);
-        for (int i = 0; i < results.Length; i++)
-            values[i] = results[i].Value;
+        _mainDb.MultiGet(keys, values, _columnFamily, readOptions);
     }
 
     public Span<byte> GetSpan(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
@@ -99,6 +99,17 @@ public class RocksDbReader(DbOnTheRocks mainDb,
         _mainDb.MultiGet(keys, values, _columnFamily, readOptions);
     }
 
+    public void MultiGet(ReadOnlySpan<byte> keys, int keyLength, Span<byte[]?> values, ReadFlags flags = ReadFlags.None)
+    {
+        if (keyLength <= 0)
+            throw new ArgumentOutOfRangeException(nameof(keyLength));
+        if (keys.Length != values.Length * keyLength)
+            throw new ArgumentException("The key buffer length must match the value count and fixed key length.", nameof(keys));
+
+        ReadOptions readOptions = (flags & ReadFlags.HintCacheMiss) != 0 ? _hintCacheMissOptions : _options;
+        _mainDb.MultiGet(keys, keyLength, values, _columnFamily, readOptions);
+    }
+
     public Span<byte> GetSpan(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None)
     {
         ReadOptions readOptions = ((flags & ReadFlags.HintCacheMiss) != 0 ? _hintCacheMissOptions : _options);

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -92,6 +92,20 @@ public class ColumnsDbTests
     }
 
     [Test]
+    public void FixedLengthMultiGet_PreservesInputOrderAndMissingValues()
+    {
+        IDb column = _db.GetColumnDb(ReceiptsColumns.Blocks);
+        column.Set([1, 2], [10]);
+        column.Set([3, 4], [30]);
+        byte[] keys = [3, 4, 5, 6, 1, 2];
+        byte[]?[] values = new byte[]?[3];
+
+        column.MultiGet(keys, 2, values);
+
+        Assert.That(values, Is.EqualTo(new byte[]?[] { [30], null, [10] }));
+    }
+
+    [Test]
     public void TestWriteBatch_WriteToAllColumn()
     {
         IColumnsWriteBatch<ReceiptsColumns> batch = _db.StartWriteBatch();

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -99,10 +99,15 @@ public class ColumnsDbTests
         column.Set([3, 4], [30]);
         byte[] keys = [3, 4, 5, 6, 1, 2];
         byte[]?[] values = new byte[]?[3];
+        long readsBefore = _db.GatherMetric().TotalReads;
 
         column.MultiGet(keys, 2, values);
 
-        Assert.That(values, Is.EqualTo(new byte[]?[] { [30], null, [10] }));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(values, Is.EqualTo(new byte[]?[] { [30], null, [10] }));
+            Assert.That(_db.GatherMetric().TotalReads - readsBefore, Is.EqualTo(3));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -436,6 +436,25 @@ namespace Nethermind.Db.Test
         }
 
         [Test]
+        public void Snapshot_multiget_uses_point_in_time_view()
+        {
+            IKeyValueStoreWithSnapshot withSnapshot = (IKeyValueStoreWithSnapshot)_db;
+            byte[][] keys = [[1], [2], [3]];
+            _db[keys[0]] = [10];
+            _db[keys[1]] = [20];
+
+            using IKeyValueStoreSnapshot snapshot = withSnapshot.CreateSnapshot();
+            _db[keys[0]] = [11];
+            _db[keys[1]] = null;
+            _db[keys[2]] = [30];
+            byte[]?[] values = new byte[]?[keys.Length];
+
+            snapshot.MultiGet(keys, values);
+
+            Assert.That(values, Is.EqualTo(new byte[]?[] { [10], [20], null }));
+        }
+
+        [Test]
         public void Snapshot_dispose_cleans_up_read_options()
         {
             IKeyValueStoreWithSnapshot withSnapshot = (IKeyValueStoreWithSnapshot)_db;

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -448,10 +448,15 @@ namespace Nethermind.Db.Test
             _db[keys[1]] = null;
             _db[keys[2]] = [30];
             byte[]?[] values = new byte[]?[keys.Length];
+            long readsBefore = _db.GatherMetric().TotalReads;
 
             snapshot.MultiGet(keys, values);
 
-            Assert.That(values, Is.EqualTo(new byte[]?[] { [10], [20], null }));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(values, Is.EqualTo(new byte[]?[] { [10], [20], null }));
+                Assert.That(_db.GatherMetric().TotalReads - readsBefore, Is.EqualTo(keys.Length));
+            }
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/CarryForwardCachingPersistenceTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/CarryForwardCachingPersistenceTests.cs
@@ -59,6 +59,27 @@ public class CarryForwardCachingPersistenceTests
         Assert.That(inner.AccountReads, Is.EqualTo(3), "second distinct address overflows capacity 1, clearing the first");
     }
 
+    [Test]
+    public void GetSlots_BatchesMissesAndServesSubsequentReadsFromCache()
+    {
+        FakePersistence inner = new();
+        CarryForwardCachingPersistence cache = new(inner);
+        StorageCell[] cells =
+        [
+            new(TestItem.AddressA, (UInt256)1),
+            new(TestItem.AddressB, (UInt256)2),
+        ];
+
+        ReadSlots(cache, cells);
+        ReadSlots(cache, cells);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(inner.SlotMultiGetCalls, Is.EqualTo(1));
+            Assert.That(inner.SlotReads, Is.EqualTo(2));
+        }
+    }
+
     private static IEnumerable<TestCaseData> SlotReadCases()
     {
         yield return new TestCaseData((Action<CarryForwardCachingPersistence, FakePersistence>)((_, _) => { }), 1)
@@ -116,11 +137,18 @@ public class CarryForwardCachingPersistenceTests
         reader.GetAccount(address);
     }
 
+    private static void ReadSlots(IPersistence persistence, StorageCell[] cells)
+    {
+        using IPersistence.IPersistenceReader reader = persistence.CreateReader();
+        reader.GetSlots(cells, new SlotValue[cells.Length], new bool[cells.Length]);
+    }
+
     public sealed class FakePersistence : IPersistence
     {
         public StateId ReaderState = Basis0;
         public int AccountReads;
         public int SlotReads;
+        public int SlotMultiGetCalls;
 
         public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None) => new Reader(this);
         public IPersistence.IWriteBatch CreateWriteBatch(in StateId from, in StateId to, WriteFlags flags = WriteFlags.None) => new FakeWriteBatch();
@@ -140,6 +168,13 @@ public class CarryForwardCachingPersistenceTests
                 parent.SlotReads++;
                 outValue = SlotValue.FromSpanWithoutLeadingZero([0x11]);
                 return true;
+            }
+
+            public void GetSlots(ReadOnlySpan<StorageCell> storageCells, Span<SlotValue> slots, Span<bool> found)
+            {
+                parent.SlotMultiGetCalls++;
+                for (int i = 0; i < storageCells.Length; i++)
+                    found[i] = TryGetSlot(storageCells[i].Address, storageCells[i].Index, ref slots[i]);
             }
 
             public StateId CurrentState => parent.ReaderState;

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
@@ -145,12 +145,15 @@ public class BaseFlatPersistenceReaderTests
         public byte[]? Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) =>
             throw new AssertionException("Point reads are not expected.");
 
-        public void MultiGet(byte[][] keys, Span<byte[]?> values, ReadFlags flags = ReadFlags.None)
+        public void MultiGet(ReadOnlySpan<byte> keys, int keyLength, Span<byte[]?> values, ReadFlags flags = ReadFlags.None)
         {
             MultiGetCalls++;
-            Keys = keys;
+            Keys = new byte[values.Length][];
             for (int i = 0; i < values.Length; i++)
+            {
+                Keys[i] = keys.Slice(i * keyLength, keyLength).ToArray();
                 values[i] = [(byte)(i + 1)];
+            }
         }
 
         public byte[]? FirstKey => null;

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
@@ -27,6 +27,7 @@ public class BaseFlatPersistenceReaderTests
         reader.GetAccounts([first, second], accounts);
 
         Assert.That(store.MultiGetCalls, Is.EqualTo(1));
+        Assert.That(store.LastFlags, Is.EqualTo(ReadFlags.HintCacheMiss));
         Assert.That(store.Keys, Has.Length.EqualTo(2));
         Assert.That(store.Keys![0], Is.EqualTo(first.Bytes[..20].ToArray()));
         Assert.That(store.Keys[1], Is.EqualTo(second.Bytes[..20].ToArray()));
@@ -61,6 +62,7 @@ public class BaseFlatPersistenceReaderTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(store.MultiGetCalls, Is.EqualTo(1));
+            Assert.That(store.LastFlags, Is.EqualTo(ReadFlags.HintCacheMiss));
             Assert.That(keys, Has.Length.EqualTo(2));
             Assert.That(keys[0], Is.EqualTo(firstExpectedKey));
             Assert.That(keys[1], Is.EqualTo(secondExpectedKey));
@@ -140,6 +142,7 @@ public class BaseFlatPersistenceReaderTests
     private sealed class TrackingMultiGetStore : ISortedKeyValueStore
     {
         public int MultiGetCalls { get; private set; }
+        public ReadFlags LastFlags { get; private set; }
         public byte[][]? Keys { get; private set; }
 
         public byte[]? Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) =>
@@ -148,6 +151,7 @@ public class BaseFlatPersistenceReaderTests
         public void MultiGet(ReadOnlySpan<byte> keys, int keyLength, Span<byte[]?> values, ReadFlags flags = ReadFlags.None)
         {
             MultiGetCalls++;
+            LastFlags = flags;
             Keys = new byte[values.Length][];
             for (int i = 0; i < values.Length; i++)
             {

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
@@ -33,6 +33,43 @@ public class BaseFlatPersistenceReaderTests
         Assert.That(accounts, Is.EqualTo(new byte[]?[] { [1], [2] }));
     }
 
+    [Test]
+    public void GetStorages_UsesSingleMultiGetWithEncodedKeys()
+    {
+        ValueHash256 firstAddress = new(Enumerable.Range(0, ValueHash256.MemorySize).Select(static i => (byte)i).ToArray());
+        ValueHash256 secondAddress = new(Enumerable.Range(0, ValueHash256.MemorySize).Select(static i => (byte)(255 - i)).ToArray());
+        ValueHash256 firstSlot = new(Enumerable.Repeat((byte)0x11, ValueHash256.MemorySize).ToArray());
+        ValueHash256 secondSlot = new(Enumerable.Repeat((byte)0x22, ValueHash256.MemorySize).ToArray());
+        TrackingMultiGetStore store = new();
+        BaseFlatPersistence.Reader reader = new(store, store);
+        SlotValue[] values = new SlotValue[2];
+        bool[] found = new bool[2];
+
+        reader.GetStorages([firstAddress, secondAddress], [firstSlot, secondSlot], values, found);
+
+        byte[] firstExpectedKey = new byte[52];
+        firstAddress.Bytes[..4].CopyTo(firstExpectedKey);
+        firstSlot.Bytes.CopyTo(firstExpectedKey.AsSpan(4));
+        firstAddress.Bytes[4..20].CopyTo(firstExpectedKey.AsSpan(36));
+        byte[] secondExpectedKey = new byte[52];
+        secondAddress.Bytes[..4].CopyTo(secondExpectedKey);
+        secondSlot.Bytes.CopyTo(secondExpectedKey.AsSpan(4));
+        secondAddress.Bytes[4..20].CopyTo(secondExpectedKey.AsSpan(36));
+
+        Assert.That(store.Keys, Is.Not.Null);
+        byte[][] keys = store.Keys!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(store.MultiGetCalls, Is.EqualTo(1));
+            Assert.That(keys, Has.Length.EqualTo(2));
+            Assert.That(keys[0], Is.EqualTo(firstExpectedKey));
+            Assert.That(keys[1], Is.EqualTo(secondExpectedKey));
+            Assert.That(found, Is.All.True);
+            Assert.That(values[0].AsReadOnlySpan[SlotValue.ByteCount - 1], Is.EqualTo(1));
+            Assert.That(values[1].AsReadOnlySpan[SlotValue.ByteCount - 1], Is.EqualTo(2));
+        }
+    }
+
     // Regression: a slot value longer than SlotValue.ByteCount must fail loudly instead of underflowing
     // the unchecked Unsafe.InitBlockUnaligned in TryGetStorage (which produced a wild memset / SIGSEGV).
     // Shorter values are right-aligned into the 32-byte slot with leading zeros.

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BaseFlatPersistenceReaderTests.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Linq;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State.Flat.Persistence;
@@ -13,6 +15,24 @@ namespace Nethermind.State.Flat.Test.Persistence;
 [TestFixture]
 public class BaseFlatPersistenceReaderTests
 {
+    [Test]
+    public void GetAccounts_UsesSingleMultiGetWithEncodedKeys()
+    {
+        ValueHash256 first = new(Enumerable.Range(0, ValueHash256.MemorySize).Select(static i => (byte)i).ToArray());
+        ValueHash256 second = new(Enumerable.Range(0, ValueHash256.MemorySize).Select(static i => (byte)(255 - i)).ToArray());
+        TrackingMultiGetStore store = new();
+        BaseFlatPersistence.Reader reader = new(store, store);
+        byte[]?[] accounts = new byte[]?[2];
+
+        reader.GetAccounts([first, second], accounts);
+
+        Assert.That(store.MultiGetCalls, Is.EqualTo(1));
+        Assert.That(store.Keys, Has.Length.EqualTo(2));
+        Assert.That(store.Keys![0], Is.EqualTo(first.Bytes[..20].ToArray()));
+        Assert.That(store.Keys[1], Is.EqualTo(second.Bytes[..20].ToArray()));
+        Assert.That(accounts, Is.EqualTo(new byte[]?[] { [1], [2] }));
+    }
+
     // Regression: a slot value longer than SlotValue.ByteCount must fail loudly instead of underflowing
     // the unchecked Unsafe.InitBlockUnaligned in TryGetStorage (which produced a wild memset / SIGSEGV).
     // Shorter values are right-aligned into the 32-byte slot with leading zeros.
@@ -74,6 +94,28 @@ public class BaseFlatPersistenceReaderTests
     private sealed class FixedValueStore(byte[] value) : ISortedKeyValueStore
     {
         public byte[]? Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) => value;
+        public byte[]? FirstKey => null;
+        public byte[]? LastKey => null;
+        public ISortedView GetViewBetween(ReadOnlySpan<byte> firstKeyInclusive, ReadOnlySpan<byte> lastKeyExclusive) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class TrackingMultiGetStore : ISortedKeyValueStore
+    {
+        public int MultiGetCalls { get; private set; }
+        public byte[][]? Keys { get; private set; }
+
+        public byte[]? Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) =>
+            throw new AssertionException("Point reads are not expected.");
+
+        public void MultiGet(byte[][] keys, Span<byte[]?> values, ReadFlags flags = ReadFlags.None)
+        {
+            MultiGetCalls++;
+            Keys = keys;
+            for (int i = 0; i < values.Length; i++)
+                values[i] = [(byte)(i + 1)];
+        }
+
         public byte[]? FirstKey => null;
         public byte[]? LastKey => null;
         public ISortedView GetViewBetween(ReadOnlySpan<byte> firstKeyInclusive, ReadOnlySpan<byte> lastKeyExclusive) =>

--- a/src/Nethermind/Nethermind.State.Flat.Test/ReadOnlySnapshotBundleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ReadOnlySnapshotBundleTests.cs
@@ -149,6 +149,37 @@ public class ReadOnlySnapshotBundleTests
     }
 
     [Test]
+    public void GetSlots_UsesSnapshotsAndBatchesOnlyPersistenceMisses()
+    {
+        StorageCell snapshotCell = new(TestItem.AddressA, (UInt256)1);
+        StorageCell persistenceCell = new(TestItem.AddressB, (UInt256)2);
+        StorageCell selfDestructedCell = new(TestItem.AddressC, (UInt256)3);
+        SlotValue snapshotValue = SlotValue.FromSpanWithoutLeadingZero([0x12, 0x34]);
+        SlotValue persistenceValue = SlotValue.FromSpanWithoutLeadingZero([0x56, 0x78]);
+        TrackingStoragePersistenceReader reader = new(persistenceCell, persistenceValue);
+
+        using ReadOnlySnapshotBundle bundle = Bundle(
+            FlatTestHelpers.SnapshotList(MakeSnapshot(c =>
+                c.Storages[new HashedKey<(Address, UInt256)>((snapshotCell.Address, snapshotCell.Index))] = snapshotValue)),
+            reader);
+        byte[]?[] slots = new byte[]?[3];
+
+        bundle.GetSlots(
+            [snapshotCell, persistenceCell, selfDestructedCell],
+            [-1, -1, 0],
+            slots);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(slots[0], Is.EqualTo(new byte[] { 0x12, 0x34 }));
+            Assert.That(slots[1], Is.EqualTo(new byte[] { 0x56, 0x78 }));
+            Assert.That(slots[2], Is.Null);
+            Assert.That(reader.MultiGetCalls, Is.EqualTo(1));
+            Assert.That(reader.RequestedCells, Is.EqualTo(new[] { persistenceCell }));
+        }
+    }
+
+    [Test]
     public void TryFindStateNodes_ReturnsTrueWhenPresentInSnapshot()
     {
         TreePath path = TreePath.FromHexString("12");
@@ -241,6 +272,40 @@ public class ReadOnlySnapshotBundleTests
         }
 
         public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue) => false;
+        public StateId CurrentState => default;
+        public byte[]? TryLoadStateRlp(in TreePath path, ReadFlags flags) => null;
+        public byte[]? TryLoadStorageRlp(Hash256 address, in TreePath path, ReadFlags flags) => null;
+        public byte[]? GetAccountRaw(in ValueHash256 addrHash) => null;
+        public bool TryGetStorageRaw(in ValueHash256 addrHash, in ValueHash256 slotHash, ref SlotValue value) => false;
+        public IPersistence.IFlatIterator CreateAccountIterator(in ValueHash256 startKey, in ValueHash256 endKey) => throw new NotSupportedException();
+        public IPersistence.IFlatIterator CreateStorageIterator(in ValueHash256 accountKey, in ValueHash256 startSlotKey, in ValueHash256 endSlotKey) => throw new NotSupportedException();
+        public bool IsPreimageMode => false;
+        public void Dispose() { }
+    }
+
+    private sealed class TrackingStoragePersistenceReader(StorageCell storageCell, SlotValue slotValue) : IPersistence.IPersistenceReader
+    {
+        public int MultiGetCalls { get; private set; }
+        public StorageCell[]? RequestedCells { get; private set; }
+
+        public Account? GetAccount(Address address) => null;
+
+        public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue)
+        {
+            StorageCell requestedCell = new(address, in slot);
+            if (!requestedCell.Equals(storageCell)) return false;
+            outValue = slotValue;
+            return true;
+        }
+
+        public void GetSlots(ReadOnlySpan<StorageCell> storageCells, Span<SlotValue> slots, Span<bool> found)
+        {
+            MultiGetCalls++;
+            RequestedCells = storageCells.ToArray();
+            for (int i = 0; i < storageCells.Length; i++)
+                found[i] = TryGetSlot(storageCells[i].Address, storageCells[i].Index, ref slots[i]);
+        }
+
         public StateId CurrentState => default;
         public byte[]? TryLoadStateRlp(in TreePath path, ReadFlags flags) => null;
         public byte[]? TryLoadStorageRlp(Hash256 address, in TreePath path, ReadFlags flags) => null;

--- a/src/Nethermind/Nethermind.State.Flat.Test/ReadOnlySnapshotBundleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ReadOnlySnapshotBundleTests.cs
@@ -74,6 +74,27 @@ public class ReadOnlySnapshotBundleTests
     }
 
     [Test]
+    public void GetAccounts_UsesSnapshotsAndBatchesOnlyPersistenceMisses()
+    {
+        Address snapshotAddress = TestItem.AddressA;
+        Address persistedAddress = TestItem.AddressB;
+        Account snapshotAccount = TestItem.GenerateIndexedAccount(1);
+        Account persistedAccount = TestItem.GenerateIndexedAccount(2);
+        TrackingPersistenceReader reader = new(persistedAddress, persistedAccount);
+
+        using ReadOnlySnapshotBundle bundle = Bundle(
+            FlatTestHelpers.SnapshotList(MakeSnapshot(c => c.Accounts[new HashedKey<Address>(snapshotAddress)] = snapshotAccount)),
+            reader);
+        Account?[] accounts = new Account?[2];
+
+        bundle.GetAccounts([snapshotAddress, persistedAddress], accounts);
+
+        Assert.That(accounts, Is.EqualTo(new[] { snapshotAccount, persistedAccount }));
+        Assert.That(reader.MultiGetCalls, Is.EqualTo(1));
+        Assert.That(reader.RequestedAddresses, Is.EqualTo(new[] { persistedAddress }));
+    }
+
+    [Test]
     public void DetermineSelfDestructSnapshotIdx_ReturnsHighestIndexWhenSelfDestructed()
     {
         Address address = TestItem.AddressA;
@@ -202,5 +223,32 @@ public class ReadOnlySnapshotBundleTests
         bundle.Dispose(); // tears down for real
 
         Assert.That(() => bundle.GetAccount(TestItem.AddressA), Throws.TypeOf<ObjectDisposedException>());
+    }
+
+    private sealed class TrackingPersistenceReader(Address address, Account account) : IPersistence.IPersistenceReader
+    {
+        public int MultiGetCalls { get; private set; }
+        public Address[]? RequestedAddresses { get; private set; }
+
+        public Account? GetAccount(Address requestedAddress) => requestedAddress == address ? account : null;
+
+        public void GetAccounts(ReadOnlySpan<Address> addresses, Span<Account?> accounts)
+        {
+            MultiGetCalls++;
+            RequestedAddresses = addresses.ToArray();
+            for (int i = 0; i < addresses.Length; i++)
+                accounts[i] = GetAccount(addresses[i]);
+        }
+
+        public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue) => false;
+        public StateId CurrentState => default;
+        public byte[]? TryLoadStateRlp(in TreePath path, ReadFlags flags) => null;
+        public byte[]? TryLoadStorageRlp(Hash256 address, in TreePath path, ReadFlags flags) => null;
+        public byte[]? GetAccountRaw(in ValueHash256 addrHash) => null;
+        public bool TryGetStorageRaw(in ValueHash256 addrHash, in ValueHash256 slotHash, ref SlotValue value) => false;
+        public IPersistence.IFlatIterator CreateAccountIterator(in ValueHash256 startKey, in ValueHash256 endKey) => throw new NotSupportedException();
+        public IPersistence.IFlatIterator CreateStorageIterator(in ValueHash256 accountKey, in ValueHash256 startSlotKey, in ValueHash256 endSlotKey) => throw new NotSupportedException();
+        public bool IsPreimageMode => false;
+        public void Dispose() { }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
@@ -116,7 +116,46 @@ public static class BaseFlatPersistence
             int resultSize = GetStorageBuffer(storageKey, buffer);
             if (resultSize == 0) return false;
 
-            ReadOnlySpan<byte> value = buffer[..resultSize];
+            DecodeStorageValue(buffer[..resultSize], ref outValue);
+            return true;
+        }
+
+        public void GetStorages(
+            ReadOnlySpan<ValueHash256> addresses,
+            ReadOnlySpan<ValueHash256> slots,
+            Span<SlotValue> values,
+            Span<bool> found)
+        {
+            if (addresses.Length != slots.Length || addresses.Length != values.Length || addresses.Length != found.Length)
+                throw new ArgumentException("Addresses, slots, values, and found flags must have the same length.", nameof(values));
+
+            byte[][] keys = new byte[addresses.Length][];
+            for (int i = 0; i < addresses.Length; i++)
+            {
+                byte[] key = new byte[StorageKeyLength];
+                EncodeStorageKeyHashedWithShortPrefix(key, addresses[i], slots[i]);
+                keys[i] = key;
+            }
+
+            byte[]?[] encodedValues = new byte[]?[addresses.Length];
+            storage.MultiGet(keys, encodedValues);
+            for (int i = 0; i < encodedValues.Length; i++)
+            {
+                byte[]? encodedValue = encodedValues[i];
+                if (encodedValue is null or { Length: 0 })
+                {
+                    found[i] = false;
+                    continue;
+                }
+
+                DecodeStorageValue(encodedValue, ref values[i]);
+                found[i] = true;
+            }
+        }
+
+        private void DecodeStorageValue(ReadOnlySpan<byte> encodedValue, ref SlotValue outValue)
+        {
+            ReadOnlySpan<byte> value = encodedValue;
             if (rlpWrapSlots)
             {
                 RlpReader ctx = new(value);
@@ -149,8 +188,6 @@ public static class BaseFlatPersistence
                     ref MemoryMarshal.GetReference(value),
                     (uint)len);
             }
-
-            return true;
         }
 
         private int GetStorageBuffer(ReadOnlySpan<byte> key, Span<byte> outBuffer) => storage.Get(key, outBuffer);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
@@ -100,7 +100,7 @@ public static class BaseFlatPersistence
             for (int i = 0; i < addresses.Length; i++)
                 EncodeAccountKeyHashed(keys.AsSpan(i * AccountKeyLength, AccountKeyLength), addresses[i]);
 
-            state.MultiGet(keys, AccountKeyLength, accounts);
+            state.MultiGet(keys, AccountKeyLength, accounts, ReadFlags.HintCacheMiss);
         }
 
         [SkipLocalsInit]
@@ -130,7 +130,7 @@ public static class BaseFlatPersistence
                 EncodeStorageKeyHashedWithShortPrefix(keys.AsSpan(i * StorageKeyLength, StorageKeyLength), addresses[i], slots[i]);
 
             byte[]?[] encodedValues = new byte[]?[addresses.Length];
-            storage.MultiGet(keys, StorageKeyLength, encodedValues);
+            storage.MultiGet(keys, StorageKeyLength, encodedValues, ReadFlags.HintCacheMiss);
             for (int i = 0; i < encodedValues.Length; i++)
             {
                 byte[]? encodedValue = encodedValues[i];

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
@@ -91,6 +91,22 @@ public static class BaseFlatPersistence
             return state.Get(key, outBuffer);
         }
 
+        public void GetAccounts(ReadOnlySpan<ValueHash256> addresses, Span<byte[]?> accounts)
+        {
+            if (addresses.Length != accounts.Length)
+                throw new ArgumentException("Addresses and accounts must have the same length.", nameof(accounts));
+
+            byte[][] keys = new byte[addresses.Length][];
+            for (int i = 0; i < addresses.Length; i++)
+            {
+                byte[] key = new byte[AccountKeyLength];
+                EncodeAccountKeyHashed(key, addresses[i]);
+                keys[i] = key;
+            }
+
+            state.MultiGet(keys, accounts);
+        }
+
         [SkipLocalsInit]
         public bool TryGetStorage(in ValueHash256 address, in ValueHash256 slot, ref SlotValue outValue)
         {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
@@ -96,15 +96,11 @@ public static class BaseFlatPersistence
             if (addresses.Length != accounts.Length)
                 throw new ArgumentException("Addresses and accounts must have the same length.", nameof(accounts));
 
-            byte[][] keys = new byte[addresses.Length][];
+            byte[] keys = new byte[addresses.Length * AccountKeyLength];
             for (int i = 0; i < addresses.Length; i++)
-            {
-                byte[] key = new byte[AccountKeyLength];
-                EncodeAccountKeyHashed(key, addresses[i]);
-                keys[i] = key;
-            }
+                EncodeAccountKeyHashed(keys.AsSpan(i * AccountKeyLength, AccountKeyLength), addresses[i]);
 
-            state.MultiGet(keys, accounts);
+            state.MultiGet(keys, AccountKeyLength, accounts);
         }
 
         [SkipLocalsInit]
@@ -129,16 +125,12 @@ public static class BaseFlatPersistence
             if (addresses.Length != slots.Length || addresses.Length != values.Length || addresses.Length != found.Length)
                 throw new ArgumentException("Addresses, slots, values, and found flags must have the same length.", nameof(values));
 
-            byte[][] keys = new byte[addresses.Length][];
+            byte[] keys = new byte[addresses.Length * StorageKeyLength];
             for (int i = 0; i < addresses.Length; i++)
-            {
-                byte[] key = new byte[StorageKeyLength];
-                EncodeStorageKeyHashedWithShortPrefix(key, addresses[i], slots[i]);
-                keys[i] = key;
-            }
+                EncodeStorageKeyHashedWithShortPrefix(keys.AsSpan(i * StorageKeyLength, StorageKeyLength), addresses[i], slots[i]);
 
             byte[]?[] encodedValues = new byte[]?[addresses.Length];
-            storage.MultiGet(keys, encodedValues);
+            storage.MultiGet(keys, StorageKeyLength, encodedValues);
             for (int i = 0; i < encodedValues.Length; i++)
             {
                 byte[]? encodedValue = encodedValues[i];

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -265,6 +265,7 @@ public static class BasePersistence
     public interface IHashedFlatReader
     {
         public int GetAccount(in ValueHash256 address, Span<byte> outBuffer);
+        public void GetAccounts(ReadOnlySpan<ValueHash256> addresses, Span<byte[]?> accounts);
         public bool TryGetStorage(in ValueHash256 address, in ValueHash256 slot, ref SlotValue outValue);
         public IPersistence.IFlatIterator CreateAccountIterator(in ValueHash256 startKey, in ValueHash256 endKey);
         public IPersistence.IFlatIterator CreateStorageIterator(in ValueHash256 accountKey, in ValueHash256 startSlotKey, in ValueHash256 endSlotKey);
@@ -292,6 +293,14 @@ public static class BasePersistence
     public interface IFlatReader
     {
         public Account? GetAccount(Address address);
+        public void GetAccounts(ReadOnlySpan<Address> addresses, Span<Account?> accounts)
+        {
+            if (addresses.Length != accounts.Length)
+                throw new ArgumentException("Addresses and accounts must have the same length.", nameof(accounts));
+
+            for (int i = 0; i < addresses.Length; i++)
+                accounts[i] = GetAccount(addresses[i]);
+        }
         public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue);
         public byte[]? GetAccountRaw(in ValueHash256 addrHash);
         public bool TryGetSlotRaw(in ValueHash256 address, in ValueHash256 slotHash, ref SlotValue outValue);
@@ -402,6 +411,32 @@ public static class BasePersistence
             return _accountDecoder.Decode(ref ctx);
         }
 
+        public void GetAccounts(ReadOnlySpan<Address> addresses, Span<Account?> accounts)
+        {
+            if (addresses.Length != accounts.Length)
+                throw new ArgumentException("Addresses and accounts must have the same length.", nameof(accounts));
+
+            ValueHash256[] addressHashes = new ValueHash256[addresses.Length];
+            byte[]?[] encodedAccounts = new byte[]?[addresses.Length];
+            for (int i = 0; i < addresses.Length; i++)
+                addressHashes[i] = addresses[i].ToAccountPath;
+
+            _flatReader.GetAccounts(addressHashes, encodedAccounts);
+
+            for (int i = 0; i < encodedAccounts.Length; i++)
+            {
+                byte[]? encodedAccount = encodedAccounts[i];
+                if (encodedAccount is null or { Length: 0 })
+                {
+                    accounts[i] = null;
+                    continue;
+                }
+
+                RlpReader ctx = new(encodedAccount);
+                accounts[i] = _accountDecoder.Decode(ref ctx);
+            }
+        }
+
         public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue)
         {
             ValueHash256 slotHash = ValueKeccak.Zero;
@@ -447,6 +482,9 @@ public static class BasePersistence
 
         public Account? GetAccount(Address address) =>
             _flatReader.GetAccount(address);
+
+        public void GetAccounts(ReadOnlySpan<Address> addresses, Span<Account?> accounts) =>
+            _flatReader.GetAccounts(addresses, accounts);
 
         public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue) =>
             _flatReader.TryGetSlot(address, in slot, ref outValue);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -267,6 +267,18 @@ public static class BasePersistence
         public int GetAccount(in ValueHash256 address, Span<byte> outBuffer);
         public void GetAccounts(ReadOnlySpan<ValueHash256> addresses, Span<byte[]?> accounts);
         public bool TryGetStorage(in ValueHash256 address, in ValueHash256 slot, ref SlotValue outValue);
+        public void GetStorages(
+            ReadOnlySpan<ValueHash256> addresses,
+            ReadOnlySpan<ValueHash256> slots,
+            Span<SlotValue> values,
+            Span<bool> found)
+        {
+            if (addresses.Length != slots.Length || addresses.Length != values.Length || addresses.Length != found.Length)
+                throw new ArgumentException("Addresses, slots, values, and found flags must have the same length.", nameof(values));
+
+            for (int i = 0; i < addresses.Length; i++)
+                found[i] = TryGetStorage(addresses[i], slots[i], ref values[i]);
+        }
         public IPersistence.IFlatIterator CreateAccountIterator(in ValueHash256 startKey, in ValueHash256 endKey);
         public IPersistence.IFlatIterator CreateStorageIterator(in ValueHash256 accountKey, in ValueHash256 startSlotKey, in ValueHash256 endSlotKey);
         public bool IsPreimageMode { get; }
@@ -302,6 +314,17 @@ public static class BasePersistence
                 accounts[i] = GetAccount(addresses[i]);
         }
         public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue);
+        public void GetSlots(ReadOnlySpan<StorageCell> storageCells, Span<SlotValue> slots, Span<bool> found)
+        {
+            if (storageCells.Length != slots.Length || storageCells.Length != found.Length)
+                throw new ArgumentException("Storage cells, slots, and found flags must have the same length.", nameof(slots));
+
+            for (int i = 0; i < storageCells.Length; i++)
+            {
+                StorageCell cell = storageCells[i];
+                found[i] = TryGetSlot(cell.Address, cell.Index, ref slots[i]);
+            }
+        }
         public byte[]? GetAccountRaw(in ValueHash256 addrHash);
         public bool TryGetSlotRaw(in ValueHash256 address, in ValueHash256 slotHash, ref SlotValue outValue);
         public IPersistence.IFlatIterator CreateAccountIterator(in ValueHash256 startKey, in ValueHash256 endKey);
@@ -445,6 +468,23 @@ public static class BasePersistence
             return TryGetSlotRaw(address.ToAccountPath, slotHash, ref outValue);
         }
 
+        public void GetSlots(ReadOnlySpan<StorageCell> storageCells, Span<SlotValue> slots, Span<bool> found)
+        {
+            if (storageCells.Length != slots.Length || storageCells.Length != found.Length)
+                throw new ArgumentException("Storage cells, slots, and found flags must have the same length.", nameof(slots));
+
+            ValueHash256[] addressHashes = new ValueHash256[storageCells.Length];
+            ValueHash256[] slotHashes = new ValueHash256[storageCells.Length];
+            for (int i = 0; i < storageCells.Length; i++)
+            {
+                StorageCell cell = storageCells[i];
+                addressHashes[i] = cell.Address.ToAccountPath;
+                StorageTree.ComputeKeyWithLookup(cell.Index, ref slotHashes[i]);
+            }
+
+            _flatReader.GetStorages(addressHashes, slotHashes, slots, found);
+        }
+
         public byte[]? GetAccountRaw(in ValueHash256 addrHash)
         {
             Span<byte> valueBuffer = stackalloc byte[_accountSpanBufferSize];
@@ -488,6 +528,9 @@ public static class BasePersistence
 
         public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue) =>
             _flatReader.TryGetSlot(address, in slot, ref outValue);
+
+        public void GetSlots(ReadOnlySpan<StorageCell> storageCells, Span<SlotValue> slots, Span<bool> found) =>
+            _flatReader.GetSlots(storageCells, slots, found);
 
         public byte[]? TryLoadStateRlp(in TreePath path, ReadFlags flags) =>
             _trieReader.TryLoadStateRlp(path, flags);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
@@ -217,6 +217,53 @@ public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposa
             return found;
         }
 
+        public void GetSlots(ReadOnlySpan<StorageCell> storageCells, Span<SlotValue> slots, Span<bool> found)
+        {
+            if (storageCells.Length != slots.Length || storageCells.Length != found.Length)
+                throw new ArgumentException("Storage cells, slots, and found flags must have the same length.", nameof(slots));
+
+            bool current = parent.IsCurrent(generation);
+            if (!current)
+            {
+                inner.GetSlots(storageCells, slots, found);
+                return;
+            }
+
+            StorageCell[] missingCells = new StorageCell[storageCells.Length];
+            int[] missingIndices = new int[storageCells.Length];
+            int missingCount = 0;
+            for (int i = 0; i < storageCells.Length; i++)
+            {
+                StorageCell cell = storageCells[i];
+                if (parent._slots.TryGetValue((cell.Address, cell.Index), out CachedSlot cached))
+                {
+                    found[i] = cached.Found;
+                    if (cached.Found) slots[i] = cached.Value;
+                    continue;
+                }
+
+                missingCells[missingCount] = cell;
+                missingIndices[missingCount] = i;
+                missingCount++;
+            }
+
+            if (missingCount == 0) return;
+
+            SlotValue[] missingSlots = new SlotValue[missingCount];
+            bool[] missingFound = new bool[missingCount];
+            inner.GetSlots(missingCells.AsSpan(0, missingCount), missingSlots, missingFound);
+            for (int i = 0; i < missingCount; i++)
+            {
+                StorageCell cell = missingCells[i];
+                SlotValue slot = missingSlots[i];
+                bool slotFound = missingFound[i];
+                int destinationIndex = missingIndices[i];
+                slots[destinationIndex] = slot;
+                found[destinationIndex] = slotFound;
+                parent.TryCacheSlot((cell.Address, cell.Index), new CachedSlot(slotFound, slotFound ? slot : default), generation);
+            }
+        }
+
         public StateId CurrentState => inner.CurrentState;
         public byte[]? TryLoadStateRlp(in TreePath path, ReadFlags flags) => inner.TryLoadStateRlp(path, flags);
         public byte[]? TryLoadStorageRlp(Hash256 address, in TreePath path, ReadFlags flags) => inner.TryLoadStorageRlp(address, path, flags);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
@@ -160,6 +160,48 @@ public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposa
             return account;
         }
 
+        public void GetAccounts(ReadOnlySpan<Address> addresses, Span<Account?> accounts)
+        {
+            if (addresses.Length != accounts.Length)
+                throw new ArgumentException("Addresses and accounts must have the same length.", nameof(accounts));
+
+            bool current = parent.IsCurrent(generation);
+            if (!current)
+            {
+                inner.GetAccounts(addresses, accounts);
+                return;
+            }
+
+            Address[] missingAddresses = new Address[addresses.Length];
+            int[] missingIndices = new int[addresses.Length];
+            int missingCount = 0;
+            for (int i = 0; i < addresses.Length; i++)
+            {
+                Address address = addresses[i];
+                if (parent._accounts.TryGetValue(address, out Account? cached))
+                {
+                    accounts[i] = cached;
+                    continue;
+                }
+
+                missingAddresses[missingCount] = address;
+                missingIndices[missingCount] = i;
+                missingCount++;
+            }
+
+            if (missingCount == 0) return;
+
+            Account?[] missingAccounts = new Account?[missingCount];
+            inner.GetAccounts(missingAddresses.AsSpan(0, missingCount), missingAccounts);
+            for (int i = 0; i < missingCount; i++)
+            {
+                Address address = missingAddresses[i];
+                Account? account = missingAccounts[i];
+                accounts[missingIndices[i]] = account;
+                parent.TryCacheAccount(address, account, generation);
+            }
+        }
+
         public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue)
         {
             (Address, UInt256) key = (address, slot);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -28,6 +28,15 @@ public interface IPersistence
     {
         Account? GetAccount(Address address);
 
+        void GetAccounts(ReadOnlySpan<Address> addresses, Span<Account?> accounts)
+        {
+            if (addresses.Length != accounts.Length)
+                throw new ArgumentException("Addresses and accounts must have the same length.", nameof(accounts));
+
+            for (int i = 0; i < addresses.Length; i++)
+                accounts[i] = GetAccount(addresses[i]);
+        }
+
         // Note: It can return true while setting outValue to zero. This is because there is a distinction between
         // zero and missing to conform to a potential verkle need.
         bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -40,6 +40,19 @@ public interface IPersistence
         // Note: It can return true while setting outValue to zero. This is because there is a distinction between
         // zero and missing to conform to a potential verkle need.
         bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue);
+
+        void GetSlots(ReadOnlySpan<StorageCell> storageCells, Span<SlotValue> slots, Span<bool> found)
+        {
+            if (storageCells.Length != slots.Length || storageCells.Length != found.Length)
+                throw new ArgumentException("Storage cells, slots, and found flags must have the same length.", nameof(slots));
+
+            for (int i = 0; i < storageCells.Length; i++)
+            {
+                StorageCell cell = storageCells[i];
+                found[i] = TryGetSlot(cell.Address, cell.Index, ref slots[i]);
+            }
+        }
+
         StateId CurrentState { get; }
         byte[]? TryLoadStateRlp(in TreePath path, ReadFlags flags);
         byte[]? TryLoadStorageRlp(Hash256 address, in TreePath path, ReadFlags flags);

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RefCountingPersistenceReader.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RefCountingPersistenceReader.cs
@@ -44,6 +44,9 @@ public class RefCountingPersistenceReader : RefCountingDisposable, IPersistence.
     public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue) =>
         _innerReader.TryGetSlot(address, in slot, ref outValue);
 
+    public void GetSlots(ReadOnlySpan<StorageCell> storageCells, Span<SlotValue> slots, Span<bool> found) =>
+        _innerReader.GetSlots(storageCells, slots, found);
+
     public StateId CurrentState => _innerReader.CurrentState;
 
     public byte[]? TryLoadStateRlp(in TreePath path, ReadFlags flags) =>

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RefCountingPersistenceReader.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RefCountingPersistenceReader.cs
@@ -38,6 +38,9 @@ public class RefCountingPersistenceReader : RefCountingDisposable, IPersistence.
     public Account? GetAccount(Address address) =>
         _innerReader.GetAccount(address);
 
+    public void GetAccounts(ReadOnlySpan<Address> addresses, Span<Account?> accounts) =>
+        _innerReader.GetAccounts(addresses, accounts);
+
     public bool TryGetSlot(Address address, in UInt256 slot, ref SlotValue outValue) =>
         _innerReader.TryGetSlot(address, in slot, ref outValue);
 

--- a/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
@@ -77,6 +77,53 @@ public sealed class ReadOnlySnapshotBundle(
         return account;
     }
 
+    public void GetAccounts(ReadOnlySpan<Address> addresses, Span<Account?> accounts)
+    {
+        GuardDispose();
+
+        if (addresses.Length != accounts.Length)
+            throw new ArgumentException("Addresses and accounts must have the same length.", nameof(accounts));
+
+        Address[] missingAddresses = new Address[addresses.Length];
+        int[] missingIndices = new int[addresses.Length];
+        int missingCount = 0;
+
+        for (int addressIndex = 0; addressIndex < addresses.Length; addressIndex++)
+        {
+            Address address = addresses[addressIndex];
+            HashedKey<Address> key = new(address);
+            bool found = false;
+
+            for (int snapshotIndex = snapshots.Count - 1; snapshotIndex >= 0; snapshotIndex--)
+            {
+                if (!snapshots[snapshotIndex].TryGetAccount(key, out Account? account)) continue;
+
+                accounts[addressIndex] = account;
+                found = true;
+                break;
+            }
+
+            if (found) continue;
+
+            if (_persistedSnapshotCount > 0 && persistedSnapshots.TryGetAccount(address, out Account? persistedAccount))
+            {
+                accounts[addressIndex] = persistedAccount;
+                continue;
+            }
+
+            missingAddresses[missingCount] = address;
+            missingIndices[missingCount] = addressIndex;
+            missingCount++;
+        }
+
+        if (missingCount == 0) return;
+
+        Account?[] missingAccounts = new Account?[missingCount];
+        persistenceReader.GetAccounts(missingAddresses.AsSpan(0, missingCount), missingAccounts);
+        for (int i = 0; i < missingCount; i++)
+            accounts[missingIndices[i]] = missingAccounts[i];
+    }
+
     public int DetermineSelfDestructSnapshotIdx(Address address)
     {
         HashedKey<Address> key = new(address);

--- a/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
@@ -139,6 +139,71 @@ public sealed class ReadOnlySnapshotBundle(
     public byte[]? GetSlot(Address address, in UInt256 index, int selfDestructStateIdx) =>
         GetSlot(selfDestructStateIdx, (address, index));
 
+    public void GetSlots(
+        ReadOnlySpan<StorageCell> storageCells,
+        ReadOnlySpan<int> selfDestructStateIdxs,
+        Span<byte[]?> slots)
+    {
+        GuardDispose();
+
+        if (storageCells.Length != selfDestructStateIdxs.Length || storageCells.Length != slots.Length)
+            throw new ArgumentException("Storage cells, self-destruct indices, and slots must have the same length.", nameof(slots));
+
+        StorageCell[] missingCells = new StorageCell[storageCells.Length];
+        int[] missingIndices = new int[storageCells.Length];
+        int missingCount = 0;
+
+        for (int cellIndex = 0; cellIndex < storageCells.Length; cellIndex++)
+        {
+            StorageCell cell = storageCells[cellIndex];
+            HashedKey<(Address, UInt256)> key = new((cell.Address, cell.Index));
+            int selfDestructStateIdx = selfDestructStateIdxs[cellIndex];
+            bool resolved = false;
+
+            for (int snapshotIndex = snapshots.Count - 1; snapshotIndex >= 0; snapshotIndex--)
+            {
+                if (snapshots[snapshotIndex].TryGetStorage(key, out SlotValue? slotValue))
+                {
+                    slots[cellIndex] = slotValue?.ToEvmBytes();
+                    resolved = true;
+                    break;
+                }
+
+                if (_persistedSnapshotCount + snapshotIndex <= selfDestructStateIdx)
+                {
+                    resolved = true;
+                    break;
+                }
+            }
+
+            if (resolved) continue;
+
+            long sw = recordDetailedMetrics ? Stopwatch.GetTimestamp() : 0;
+            if (_persistedSnapshotCount > 0 && persistedSnapshots.TryGetSlot(
+                cell.Address,
+                cell.Index,
+                selfDestructStateIdx,
+                sw,
+                out byte[]? persistedSlot))
+            {
+                slots[cellIndex] = persistedSlot;
+                continue;
+            }
+
+            missingCells[missingCount] = cell;
+            missingIndices[missingCount] = cellIndex;
+            missingCount++;
+        }
+
+        if (missingCount == 0) return;
+
+        SlotValue[] missingSlots = new SlotValue[missingCount];
+        bool[] missingFound = new bool[missingCount];
+        persistenceReader.GetSlots(missingCells.AsSpan(0, missingCount), missingSlots, missingFound);
+        for (int i = 0; i < missingCount; i++)
+            slots[missingIndices[i]] = missingSlots[i].ToEvmBytes();
+    }
+
     public byte[]? GetSlot(int selfDestructStateIdx, HashedKey<(Address, UInt256)> key)
     {
         GuardDispose();

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -21,6 +21,7 @@ namespace Nethermind.State.Flat.ScopeProvider;
 public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrieWarmer.IAddressWarmer
 {
     private const int AccountReadBatchSize = 256;
+    private const int StorageReadBatchSize = 256;
 
     private readonly SnapshotBundle _snapshotBundle;
     private readonly IFlatCommitTarget _commitTarget;
@@ -320,22 +321,46 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         // Lazy materialisation: this is the only call site that needs the pool, so chains/forks
         // that never see a BAL never allocate the dedicated reader threads.
         WarmReadPool pool = _warmReadPool.Value;
-        int workers = Math.Min(pool.MaxConcurrency, Math.Max(1, idx / 64));
+        int batchCount = (idx + StorageReadBatchSize - 1) / StorageReadBatchSize;
+        int workers = Math.Min(batchCount, Math.Min(pool.MaxConcurrency, Math.Max(1, idx / 64)));
 
-        pool.Run(idx, workers, j =>
+        pool.Run(batchCount, workers, batchIndex =>
         {
             if (_pausePrewarmer) return;
-            (Address address, int selfDestructIdx, UInt256 slot) = jobs[j];
-            ReadSlotToSink(sink, address, in slot, selfDestructIdx);
-        }, parallelOptions.CancellationToken);
-    }
 
-    private void ReadSlotToSink(IWorldStateScopeProvider.IAsyncBalReaderSink sink, Address address, in UInt256 slot, int selfDestructIdx)
-    {
-        StorageCell cell = new(address, in slot);
-        if (!sink.StillNeeded(in cell)) return;
-        byte[]? raw = _snapshotBundle.GetSlot(address, in slot, selfDestructIdx);
-        sink.OnStorageRead(in cell, raw is null || raw.Length == 0 ? StorageTree.ZeroBytes : raw);
+            int start = batchIndex * StorageReadBatchSize;
+            int end = Math.Min(start + StorageReadBatchSize, idx);
+            int rangeLength = end - start;
+            StorageCell[] storageCells = new StorageCell[rangeLength];
+            int[] selfDestructStateIdxs = new int[rangeLength];
+            int neededCount = 0;
+
+            for (int jobIndex = start; jobIndex < end; jobIndex++)
+            {
+                (Address address, int selfDestructIdx, UInt256 slot) = jobs[jobIndex];
+                StorageCell cell = new(address, in slot);
+                if (!sink.StillNeeded(in cell)) continue;
+
+                storageCells[neededCount] = cell;
+                selfDestructStateIdxs[neededCount] = selfDestructIdx;
+                neededCount++;
+            }
+
+            if (neededCount == 0) return;
+
+            byte[]?[] values = new byte[]?[neededCount];
+            _snapshotBundle.GetSlots(
+                storageCells.AsSpan(0, neededCount),
+                selfDestructStateIdxs.AsSpan(0, neededCount),
+                values);
+
+            for (int i = 0; i < neededCount; i++)
+            {
+                StorageCell cell = storageCells[i];
+                byte[]? value = values[i];
+                sink.OnStorageRead(in cell, value is null || value.Length == 0 ? StorageTree.ZeroBytes : value);
+            }
+        }, parallelOptions.CancellationToken);
     }
 
     public IWorldStateScopeProvider.ICodeDb CodeDb { get; }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -20,6 +20,8 @@ namespace Nethermind.State.Flat.ScopeProvider;
 
 public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrieWarmer.IAddressWarmer
 {
+    private const int AccountReadBatchSize = 256;
+
     private readonly SnapshotBundle _snapshotBundle;
     private readonly IFlatCommitTarget _commitTarget;
     private readonly IFlatDbConfig _configuration;
@@ -191,78 +193,83 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
 
             try
             {
-                Address[] addressesToRead = new Address[accountCount];
-                int[] addressIndices = new int[accountCount];
-                int addressCount = 0;
-                for (int i = 0; i < accountCount; i++)
-                {
-                    ReadOnlyAccountChanges accountChange = accountChanges[i];
-                    if (sink is null && accountChange.StorageChanges.Length == 0) continue;
-
-                    addressesToRead[addressCount] = accountChange.Address;
-                    addressIndices[addressCount] = i;
-                    addressCount++;
-                }
-
-                if (addressCount > 0)
-                {
-                    token.ThrowIfCancellationRequested();
-                    Account?[] batchAccounts = new Account?[addressCount];
-                    _snapshotBundle.GetAccounts(addressesToRead.AsSpan(0, addressCount), batchAccounts);
-                    for (int i = 0; i < addressCount; i++)
-                        loadedAccounts[addressIndices[i]] = batchAccounts[i];
-                }
-
-                // Phase 1: trie warmup + sink.OnAccountRead. Sink slot reads are
+                // Phase 1: account reads + trie warmup + sink.OnAccountRead. Sink slot reads are
                 // deferred to phase 2 so one huge account doesn't bottleneck a single worker.
-                Parallel.For(0, accountCount, parallelOptions, (i) =>
+                Parallel.ForEach(Partitioner.Create(0, accountCount, AccountReadBatchSize), parallelOptions, range =>
                 {
                     if (token.IsCancellationRequested || _hintSequenceId != snapshot || _pausePrewarmer) return;
 
-                    ReadOnlyAccountChanges ac = accountChanges[i];
-                    Address address = ac.Address;
-
-                    if (_snapshotBundle.ShouldQueuePrewarm(address)
-                        && _warmer.PushAddressJob(this, address, snapshot))
-                        Interlocked.Increment(ref _outstandingWarmups);
-
-                    ReadOnlySlotChanges[] storageChanges = ac.StorageChanges;
-                    int storageChangeCount = storageChanges.Length;
-
-                    Account? account = loadedAccounts[i];
-
-                    if (sink is not null && sink.StillNeeded(address, out _))
-                        sink.OnAccountRead(address, account);
-
-                    if (account is null) return;
-                    Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
-                    if (storageRoot == Keccak.EmptyTreeHash) return;
-
-                    if (storageChangeCount > 0)
+                    int rangeLength = range.Item2 - range.Item1;
+                    Address[] addressesToRead = new Address[rangeLength];
+                    int[] addressIndices = new int[rangeLength];
+                    int addressCount = 0;
+                    for (int i = range.Item1; i < range.Item2; i++)
                     {
-                        FlatStorageTree storageWarmer = new(
-                            this,
-                            _warmer,
-                            _snapshotBundle,
-                            _configuration,
-                            _concurrencyQuota,
-                            storageRoot,
-                            address,
-                            _logManager);
+                        ReadOnlyAccountChanges accountChange = accountChanges[i];
+                        if (sink is null && accountChange.StorageChanges.Length == 0) continue;
 
-                        foreach (ReadOnlySlotChanges slotChanges in storageChanges)
-                        {
-                            UInt256 key = slotChanges.Key;
-                            if (_snapshotBundle.ShouldQueuePrewarm(address, key)
-                                && _warmer.PushSlotJobMpmc(storageWarmer, key, snapshot))
-                                Interlocked.Increment(ref _outstandingWarmups);
-                        }
+                        addressesToRead[addressCount] = accountChange.Address;
+                        addressIndices[addressCount] = i;
+                        addressCount++;
                     }
 
-                    if (accounts is not null)
+                    if (addressCount > 0)
                     {
-                        accounts[i] = account;
-                        selfDestructIdxs![i] = _snapshotBundle.DetermineSelfDestructSnapshotIdx(address);
+                        Account?[] batchAccounts = new Account?[addressCount];
+                        _snapshotBundle.GetAccounts(addressesToRead.AsSpan(0, addressCount), batchAccounts);
+                        for (int i = 0; i < addressCount; i++)
+                            loadedAccounts[addressIndices[i]] = batchAccounts[i];
+                    }
+
+                    for (int i = range.Item1; i < range.Item2; i++)
+                    {
+                        if (token.IsCancellationRequested || _hintSequenceId != snapshot || _pausePrewarmer) return;
+
+                        ReadOnlyAccountChanges ac = accountChanges[i];
+                        Address address = ac.Address;
+
+                        if (_snapshotBundle.ShouldQueuePrewarm(address)
+                            && _warmer.PushAddressJob(this, address, snapshot))
+                            Interlocked.Increment(ref _outstandingWarmups);
+
+                        ReadOnlySlotChanges[] storageChanges = ac.StorageChanges;
+                        int storageChangeCount = storageChanges.Length;
+
+                        Account? account = loadedAccounts[i];
+
+                        if (sink is not null && sink.StillNeeded(address, out _))
+                            sink.OnAccountRead(address, account);
+
+                        if (account is null) continue;
+                        Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
+                        if (storageRoot == Keccak.EmptyTreeHash) continue;
+
+                        if (storageChangeCount > 0)
+                        {
+                            FlatStorageTree storageWarmer = new(
+                                this,
+                                _warmer,
+                                _snapshotBundle,
+                                _configuration,
+                                _concurrencyQuota,
+                                storageRoot,
+                                address,
+                                _logManager);
+
+                            foreach (ReadOnlySlotChanges slotChanges in storageChanges)
+                            {
+                                UInt256 key = slotChanges.Key;
+                                if (_snapshotBundle.ShouldQueuePrewarm(address, key)
+                                    && _warmer.PushSlotJobMpmc(storageWarmer, key, snapshot))
+                                    Interlocked.Increment(ref _outstandingWarmups);
+                            }
+                        }
+
+                        if (accounts is not null)
+                        {
+                            accounts[i] = account;
+                            selfDestructIdxs![i] = _snapshotBundle.DetermineSelfDestructSnapshotIdx(address);
+                        }
                     }
                 });
 

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/FlatWorldStateScope.cs
@@ -185,12 +185,35 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
         {
             ParallelOptions parallelOptions = new() { CancellationToken = token };
 
-            Account?[]? accounts = sink is null ? null : new Account?[accountCount];
+            Account?[] loadedAccounts = new Account?[accountCount];
+            Account?[]? accounts = sink is null ? null : loadedAccounts;
             int[]? selfDestructIdxs = sink is null ? null : new int[accountCount];
 
             try
             {
-                // Phase 1: trie warmup + GetAccount + sink.OnAccountRead. Sink slot reads are
+                Address[] addressesToRead = new Address[accountCount];
+                int[] addressIndices = new int[accountCount];
+                int addressCount = 0;
+                for (int i = 0; i < accountCount; i++)
+                {
+                    ReadOnlyAccountChanges accountChange = accountChanges[i];
+                    if (sink is null && accountChange.StorageChanges.Length == 0) continue;
+
+                    addressesToRead[addressCount] = accountChange.Address;
+                    addressIndices[addressCount] = i;
+                    addressCount++;
+                }
+
+                if (addressCount > 0)
+                {
+                    token.ThrowIfCancellationRequested();
+                    Account?[] batchAccounts = new Account?[addressCount];
+                    _snapshotBundle.GetAccounts(addressesToRead.AsSpan(0, addressCount), batchAccounts);
+                    for (int i = 0; i < addressCount; i++)
+                        loadedAccounts[addressIndices[i]] = batchAccounts[i];
+                }
+
+                // Phase 1: trie warmup + sink.OnAccountRead. Sink slot reads are
                 // deferred to phase 2 so one huge account doesn't bottleneck a single worker.
                 Parallel.For(0, accountCount, parallelOptions, (i) =>
                 {
@@ -206,9 +229,7 @@ public sealed class FlatWorldStateScope : IWorldStateScopeProvider.IScope, ITrie
                     ReadOnlySlotChanges[] storageChanges = ac.StorageChanges;
                     int storageChangeCount = storageChanges.Length;
 
-                    Account? account = sink is null && storageChangeCount == 0
-                        ? null
-                        : _snapshotBundle.GetAccount(address);
+                    Account? account = loadedAccounts[i];
 
                     if (sink is not null && sink.StillNeeded(address, out _))
                         sink.OnAccountRead(address, account);

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -188,6 +188,73 @@ public sealed class SnapshotBundle : IDisposable
         return _readOnlySnapshotBundle.GetSlot(selfDestructStateIdx, key);
     }
 
+    public void GetSlots(
+        ReadOnlySpan<StorageCell> storageCells,
+        ReadOnlySpan<int> selfDestructStateIdxs,
+        Span<byte[]?> slots)
+    {
+        GuardDispose();
+
+        if (storageCells.Length != selfDestructStateIdxs.Length || storageCells.Length != slots.Length)
+            throw new ArgumentException("Storage cells, self-destruct indices, and slots must have the same length.", nameof(slots));
+
+        StorageCell[] missingCells = new StorageCell[storageCells.Length];
+        int[] missingSelfDestructStateIdxs = new int[storageCells.Length];
+        int[] missingIndices = new int[storageCells.Length];
+        int missingCount = 0;
+
+        for (int cellIndex = 0; cellIndex < storageCells.Length; cellIndex++)
+        {
+            StorageCell cell = storageCells[cellIndex];
+            HashedKey<(Address, UInt256)> key = new((cell.Address, cell.Index));
+            int selfDestructStateIdx = selfDestructStateIdxs[cellIndex];
+
+            if (_changedSlots.TryGetValue(key, out SlotValue? slotValue))
+            {
+                slots[cellIndex] = slotValue?.ToEvmBytes();
+                continue;
+            }
+
+            if (selfDestructStateIdx == _snapshots.Count + _readOnlySnapshotBundle.SnapshotCount)
+                continue;
+
+            int currentBundleSelfDestructIdx = selfDestructStateIdx - _readOnlySnapshotBundle.SnapshotCount;
+            bool resolved = false;
+            for (int snapshotIndex = _snapshots.Count - 1; snapshotIndex >= 0; snapshotIndex--)
+            {
+                if (_snapshots[snapshotIndex].TryGetStorage(key, out slotValue))
+                {
+                    slots[cellIndex] = slotValue?.ToEvmBytes();
+                    resolved = true;
+                    break;
+                }
+
+                if (snapshotIndex <= currentBundleSelfDestructIdx)
+                {
+                    resolved = true;
+                    break;
+                }
+            }
+
+            if (resolved) continue;
+
+            missingCells[missingCount] = cell;
+            missingSelfDestructStateIdxs[missingCount] = selfDestructStateIdx;
+            missingIndices[missingCount] = cellIndex;
+            missingCount++;
+        }
+
+        if (missingCount == 0) return;
+
+        byte[]?[] missingSlots = new byte[]?[missingCount];
+        _readOnlySnapshotBundle.GetSlots(
+            missingCells.AsSpan(0, missingCount),
+            missingSelfDestructStateIdxs.AsSpan(0, missingCount),
+            missingSlots);
+        for (int i = 0; i < missingCount; i++)
+            slots[missingIndices[i]] = missingSlots[i];
+    }
+
     public TrieNode FindStateNodeOrUnknown(in TreePath path, Hash256 hash)
     {
         GuardDispose();

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -92,6 +92,53 @@ public sealed class SnapshotBundle : IDisposable
         return _readOnlySnapshotBundle.GetAccount(address, key);
     }
 
+    public void GetAccounts(ReadOnlySpan<Address> addresses, Span<Account?> accounts)
+    {
+        GuardDispose();
+
+        if (addresses.Length != accounts.Length)
+            throw new ArgumentException("Addresses and accounts must have the same length.", nameof(accounts));
+
+        Address[] missingAddresses = new Address[addresses.Length];
+        int[] missingIndices = new int[addresses.Length];
+        int missingCount = 0;
+
+        for (int addressIndex = 0; addressIndex < addresses.Length; addressIndex++)
+        {
+            Address address = addresses[addressIndex];
+            HashedKey<Address> key = new(address);
+
+            if (_changedAccounts.TryGetValue(key, out Account? account))
+            {
+                accounts[addressIndex] = account;
+                continue;
+            }
+
+            bool found = false;
+            for (int snapshotIndex = _snapshots.Count - 1; snapshotIndex >= 0; snapshotIndex--)
+            {
+                if (!_snapshots[snapshotIndex].TryGetAccount(key, out account)) continue;
+
+                accounts[addressIndex] = account;
+                found = true;
+                break;
+            }
+
+            if (found) continue;
+
+            missingAddresses[missingCount] = address;
+            missingIndices[missingCount] = addressIndex;
+            missingCount++;
+        }
+
+        if (missingCount == 0) return;
+
+        Account?[] missingAccounts = new Account?[missingCount];
+        _readOnlySnapshotBundle.GetAccounts(missingAddresses.AsSpan(0, missingCount), missingAccounts);
+        for (int i = 0; i < missingCount; i++)
+            accounts[missingIndices[i]] = missingAccounts[i];
+    }
+
     public int DetermineSelfDestructSnapshotIdx(Address address)
     {
         HashedKey<Address> key = new(address);


### PR DESCRIPTION
Port of #12467 to `bal-devnet-7`.

## Changes

- Add `MultiGet` batch-read overloads to `IReadOnlyKeyValueStore` — an array-of-keys form and a contiguous fixed-key-length buffer form — with loop-over-`Get` default implementations so only stores that benefit need a real override.
- Implement them in `DbOnTheRocks` on top of `rocksdb_batched_multi_get_cf_slice` (RocksDB 10.10). The contiguous-slice entry point removes one allocation per key, the separate pointer/length arrays, the second copy into a flattened native-call buffer, and RocksDB's internal conversion of pointer/length pairs into `Slice` objects.
- Add `GetAccounts`/`GetSlots` batch reads through the flat persistence stack (`IPersistence`, `BaseFlatPersistence`, `CarryForwardCachingPersistence`, `RefCountingPersistenceReader`, `SnapshotBundle`, `ReadOnlySnapshotBundle`).
- BAL hint warmup in `FlatWorldStateScope` now partitions account and storage reads into 256-entry batches served by a single `MultiGet` each, instead of one RocksDB `Get` per entry.
- BAL `MultiGet` reads pass `ReadFlags.HintCacheMiss` (`fill_cache=false`): the values are immediately inserted into Nethermind's managed pre-block caches, so also inserting them into the RocksDB block cache only perturbs its eviction order. RocksDB documents `fill_cache=false` as the intended mode for bulk reads.

### Merge with #12463 (WarmReadPool phase-1 dispatch)

The tip merge commit reconciles this stack with #12463, which rewrote the same phase-1 loop. The combined resolution keeps both changes:

- Accounts are read **unconditionally** (from #12463) so read-only touches reach the flat caches — the MultiGet batch no longer skips zero-storage-change accounts when no sink is attached.
- Phase 1 dispatches on the dedicated `WarmReadPool` when available (from #12463), with one pool job per 256-entry `MultiGet` batch; the `Parallel.ForEach` + `Partitioner` path remains the fallback.
- Worker count follows the existing `RunSinkSlotReads` heuristic: `min(batchCount, min(pool.MaxConcurrency, max(1, accountCount / 64)))`.

### Benchmarks

Focused BAL-warmup benchmark (measured on the master-based branch of #12467), incremental over the initial batched-`MultiGet` implementation:

| Variant | Accounts | Storage |
| --- | --- | --- |
| Batched MultiGet (pointer arrays) | 1.7317 s | 1.8282 s |
| + contiguous slice API | 1.6753 s (−3.26%) | 1.8067 s (−1.18%) |
| + `fill_cache=false` | 1.6133 s (−6.84%) | 1.7512 s (−4.20%) |

The storage cache-bypass result is noisier (three samples had a 9.1% range), but dotTrace supports the improvement:

- `DbOnTheRocks.MultiGet` own time: 94.1k → 74.8k (−20.5%)
- Warm-reader worker: 101.1k → 82.3k (−18.6%)
- BAL wait: 1.57k → 1.27k (−19.1%)
- Profiled block: 1.983 s → 1.677 s (−15.4%)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Real RocksDB column-family coverage for result order and not-found handling (`DbOnTheRocksTests`, `ColumnsDbTests`).
- Flat persistence reader tests assert key encoding, single-batch dispatch, and that BAL batch reads carry `ReadFlags.HintCacheMiss` (`BaseFlatPersistenceReaderTests`, `CarryForwardCachingPersistenceTests`, `ReadOnlySnapshotBundleTests`).
- Post-merge release build is clean; `Nethermind.State.Flat.Test` run on the merged branch matches the unmodified `bal-devnet-7` baseline (the only failures on Windows are pre-existing arena/persisted-snapshot teardown file-lock issues present on the base branch, unrelated to this change).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The `fill_cache=false` change is an isolated commit (as in #12467) so it can be evaluated or dropped independently of the contiguous-slice change.

Other RocksDB options considered and rejected (details in #12467): `sorted_input=true` (flat keys are hash-derived), async `MultiGet` (native library lacks folly/coroutine support), batch-size sweep (follow-up).
