### PR TITLE
ci: free root-disk space in the test-binary producer

### DIFF
--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -46,6 +46,15 @@ jobs:
           sudo chown "$(id -u):$(id -g)" /mnt/nm-artifacts
           ln -s /mnt/nm-artifacts src/Nethermind/artifacts
 
+      - name: Free up disk space (Linux)
+        # Checkout + submodules + SDK + NuGet cache still land on the root disk and can
+        # exhaust its remaining free space; the runner worker then dies on ENOSPC mid-build,
+        # leaving a red job with no logs. Drop the unused preinstalled toolchains for headroom.
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          df -h / | tail -1
+
       - name: Free up disk space (macOS)
         # No /mnt on macOS; reclaim disk for the build (a framework-dependent build needs no Xcode).
         if: runner.os == 'macOS'


### PR DESCRIPTION
## Changes

- Free ~14 GB on the root disk in the `build-test-artifacts` producer (Linux) by removing the unused preinstalled Android SDK and CodeQL bundle before restore, and print the remaining root-disk headroom for future diagnosis.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

CI on this PR exercises the changed producer directly; the `df` line in the new step shows the reclaimed headroom.

## Remarks

Since #12371, the `build / Build release (linux-x64)` producer job sometimes dies mid-build with **no logs**: the job turns red, the Build step stays `in_progress` forever, and the log blob is never uploaded. Reported by @svlachakis on #12441, but it also hit `master` (run [29430544597](https://github.com/NethermindEth/nethermind/actions/runs/29430544597)) and PR runs (e.g. [29459615024](https://github.com/NethermindEth/nethermind/actions/runs/29459615024)).

The check-run annotation on the dead jobs shows the actual cause — the runner worker itself crashes on ENOSPC while writing its own diag log:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/2.335.1/_diag/Worker_...log'
   at GitHub.Runner.Worker.Worker.RunAsync(...)
```

#12371 already redirects `artifacts/` (bin+obj) to the ~70 GB `/mnt`, but checkout + submodules + SDK + NuGet cache still land on the root disk, which has only ~21 GB free — less on some image revisions, which is why the failure is intermittent. Deleting the Android SDK + CodeQL is the standard low-risk way to reclaim space; the producer job runs once per RID per workflow, so the ~1 min `rm` cost is not multiplied across the test matrix.