### PR TITLE
perf(flat): serve snap responses as pre-serialized RLP

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapServerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapServerTests.cs
@@ -113,6 +113,17 @@ public class FlatSnapServerTests
         Assert.That(result.Count, Is.LessThan(RequestCount));
     }
 
+    [Test]
+    public void GetTrieNodes_EmptyPathGroup_ReturnsNull()
+    {
+        // A path group with no paths is a malformed request; the whole response must be null.
+        using RlpPathGroupList pathSet = PathGroup.EncodeToRlpPathGroupList([new PathGroup { Group = [] }]);
+
+        IByteArrayList? result = _server.GetTrieNodes(pathSet, _rootHash, CancellationToken.None);
+
+        Assert.That(result, Is.Null);
+    }
+
     private static byte[] BuildRootRlp(out Hash256 rootHash)
     {
         using MemDb trieDb = new();

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotCompactor.cs
@@ -67,11 +67,10 @@ public class SnapshotCompactor(
         if (!isFullCompaction)
         {
             // Save memory by removing the compacted state from previous compaction
-            foreach (StateId id in _snapshotRepository.GetStatesAtBlockNumber(blockNumber - _compactSize))
+            using ArrayPoolList<StateId> previousStates = _snapshotRepository.GetStatesAtBlockNumber(blockNumber - _compactSize);
+            foreach (StateId id in previousStates)
             {
-                if (_snapshotRepository.RemoveAndReleaseInMemoryKnownState(id, SnapshotTier.InMemoryCompacted))
-                {
-                }
+                _snapshotRepository.RemoveAndReleaseInMemoryKnownState(id, SnapshotTier.InMemoryCompacted);
             }
         }
 

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
@@ -25,9 +25,6 @@ public class FlatSnapServer(
     private readonly ILogger _logger = logManager.GetClassLogger<FlatSnapServer>();
     private readonly SnapCodeServer _codeServer = new(codeDb);
 
-    private const long HardResponseByteLimit = 2000000;
-    private const int HardResponseNodeLimit = 100000;
-
     // Flat state uses HintCacheMiss since it has different I/O patterns than Patricia
     private readonly ReadFlags _optimizedReadFlags = ReadFlags.HintCacheMiss;
 
@@ -55,7 +52,7 @@ public class FlatSnapServer(
         {
             if (_logger.IsDebug) _logger.Debug($"Get trie nodes {pathSet.Count}");
 
-            byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
+            byteLimit = Math.Max(Math.Min(byteLimit, ISnapServer.HardResponseByteLimit), 1);
             int pathLength = pathSet.Count;
             using DeferredRlpItemList.Builder builder = new(pathLength);
             DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer();
@@ -132,7 +129,7 @@ public class FlatSnapServer(
 
         using (bundle)
         {
-            byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
+            byteLimit = Math.Max(Math.Min(byteLimit, ISnapServer.HardResponseByteLimit), 1);
 
             AccountCollector accounts = new();
             (long _, IByteArrayList proofs, _) = GetNodesFromTrieVisitor(
@@ -164,7 +161,7 @@ public class FlatSnapServer(
 
         using (bundle)
         {
-            byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
+            byteLimit = Math.Max(Math.Min(byteLimit, ISnapServer.HardResponseByteLimit), 1);
 
             ValueHash256 startingHash1 = startingHash ?? ValueKeccak.Zero;
             ValueHash256 limitHash1 = limitHash ?? ValueKeccak.MaxValue;
@@ -245,7 +242,7 @@ public class FlatSnapServer(
     {
         ReadOnlyStateTrieStoreAdapter trieStore = new(bundle);
         PatriciaTree tree = new(trieStore, logManager);
-        using RangeQueryVisitor visitor = new(startingHash, limitHash, valueCollector, byteLimit, HardResponseNodeLimit, readFlags: _optimizedReadFlags, cancellationToken);
+        using RangeQueryVisitor visitor = new(startingHash, limitHash, valueCollector, byteLimit, ISnapServer.HardResponseNodeLimit, readFlags: _optimizedReadFlags, cancellationToken);
         VisitingOptions opt = new();
         tree.Accept(visitor, rootHash.ToCommitment(), opt, storageAddr: storage?.ToCommitment(), storageRoot: storageRoot?.ToCommitment());
 

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapServer.cs
@@ -23,6 +23,7 @@ public class FlatSnapServer(
     public bool CanServe => true;
 
     private readonly ILogger _logger = logManager.GetClassLogger<FlatSnapServer>();
+    private readonly SnapCodeServer _codeServer = new(codeDb);
 
     private const long HardResponseByteLimit = 2000000;
     private const int HardResponseNodeLimit = 100000;
@@ -56,7 +57,8 @@ public class FlatSnapServer(
 
             byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
             int pathLength = pathSet.Count;
-            ArrayPoolList<byte[]> response = new(pathLength);
+            using DeferredRlpItemList.Builder builder = new(pathLength);
+            DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer();
             ReadOnlyStateTrieStoreAdapter trieStore = new(bundle);
             StateTree tree = new(trieStore, logManager);
             bool abort = false;
@@ -68,13 +70,12 @@ public class FlatSnapServer(
                 switch (requestedPath.Length)
                 {
                     case 0:
-                        response.Dispose();
                         return null;
                     case 1:
                         try
                         {
                             byte[]? rlp = tree.GetNodeByPath(Nibbles.CompactToHexEncode(requestedPath[0]), stateId.StateRoot.ToCommitment());
-                            response.Add(rlp ?? []);
+                            writer.WriteValue(rlp);
                             responseSize += rlp?.Length ?? 0;
                         }
                         catch (MissingTrieNodeException)
@@ -98,7 +99,7 @@ public class FlatSnapServer(
                                 for (int reqStorage = 1; reqStorage < requestedPath.Length && responseSize < byteLimit && !cancellationToken.IsCancellationRequested; reqStorage++)
                                 {
                                     byte[]? sRlp = sTree.GetNodeByPath(Nibbles.CompactToHexEncode(requestedPath[reqStorage]));
-                                    response.Add(sRlp ?? []);
+                                    writer.WriteValue(sRlp);
                                     responseSize += sRlp?.Length ?? 0;
                                 }
                             }
@@ -111,44 +112,13 @@ public class FlatSnapServer(
                 }
             }
 
-            return response.Count == 0 ? EmptyByteArrayList.Instance : new ByteArrayListAdapter(response);
+            writer.Dispose();
+            return new RlpByteArrayList(builder.ToRlpItemList());
         }
     }
 
-    public IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken)
-    {
-        long currentByteCount = 0;
-        ArrayPoolList<byte[]> response = new(requestedHashes.Count);
-
-        if (byteLimit > HardResponseByteLimit)
-        {
-            byteLimit = HardResponseByteLimit;
-        }
-
-        foreach (ValueHash256 codeHash in requestedHashes)
-        {
-            if (currentByteCount > byteLimit || cancellationToken.IsCancellationRequested)
-            {
-                break;
-            }
-
-            if (codeHash.Bytes.SequenceEqual(Keccak.OfAnEmptyString.Bytes))
-            {
-                response.Add([]);
-                currentByteCount += 1;
-                continue;
-            }
-
-            byte[]? code = codeDb[codeHash.Bytes];
-            if (code is not null)
-            {
-                response.Add(code);
-                currentByteCount += code.Length;
-            }
-        }
-
-        return new ByteArrayListAdapter(response);
-    }
+    public IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken) =>
+        _codeServer.GetByteCodes(requestedHashes, byteLimit, cancellationToken);
 
     public (IOwnedReadOnlyList<PathWithAccount>, IByteArrayList) GetAccountRanges(
         Hash256 rootHash,

--- a/src/Nethermind/Nethermind.State/SnapServer/ISnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/ISnapServer.cs
@@ -25,6 +25,9 @@ namespace Nethermind.State.SnapServer;
 
 public interface ISnapServer
 {
+    const long HardResponseByteLimit = 2000000;
+    const int HardResponseNodeLimit = 100000;
+
     bool CanServe { get; }
     IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken) =>
         GetTrieNodes(pathSet, rootHash, long.MaxValue, cancellationToken);

--- a/src/Nethermind/Nethermind.State/SnapServer/SnapCodeServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapCodeServer.cs
@@ -13,12 +13,10 @@ namespace Nethermind.State.SnapServer;
 
 public sealed class SnapCodeServer(IReadOnlyKeyValueStore codeDb)
 {
-    private const long HardResponseByteLimit = 2000000;
-
     public IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken)
     {
-        if (byteLimit > HardResponseByteLimit)
-            byteLimit = HardResponseByteLimit;
+        if (byteLimit > ISnapServer.HardResponseByteLimit)
+            byteLimit = ISnapServer.HardResponseByteLimit;
 
         long currentByteCount = 0;
         using DeferredRlpItemList.Builder builder = new(requestedHashes.Count);

--- a/src/Nethermind/Nethermind.State/SnapServer/SnapCodeServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapCodeServer.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.State.SnapServer;
+
+public sealed class SnapCodeServer(IReadOnlyKeyValueStore codeDb)
+{
+    private const long HardResponseByteLimit = 2000000;
+
+    public IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken)
+    {
+        if (byteLimit > HardResponseByteLimit)
+            byteLimit = HardResponseByteLimit;
+
+        long currentByteCount = 0;
+        using DeferredRlpItemList.Builder builder = new(requestedHashes.Count);
+        DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer();
+
+        foreach (ValueHash256 codeHash in requestedHashes)
+        {
+            if (currentByteCount > byteLimit || cancellationToken.IsCancellationRequested) break;
+
+            if (codeHash.Bytes.SequenceEqual(Keccak.OfAnEmptyString.Bytes))
+            {
+                writer.WriteValue([]);
+                currentByteCount += 1;
+                continue;
+            }
+
+            byte[]? code = codeDb[codeHash.Bytes];
+            if (code is not null)
+            {
+                writer.WriteValue(code);
+                currentByteCount += code.Length;
+            }
+        }
+
+        writer.Dispose();
+        return new RlpByteArrayList(builder.ToRlpItemList());
+    }
+}

--- a/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
@@ -48,9 +48,6 @@ public class SnapServer : ISnapServer
     private readonly ILastNStateRootTracker? _lastNStateRootTracker;
     private readonly SnapCodeServer _codeServer;
 
-    private const long HardResponseByteLimit = 2000000;
-    private const int HardResponseNodeLimit = 100000;
-
     public SnapServer(IReadOnlyTrieStore trieStore, IReadOnlyKeyValueStore codeDb, ILogManager logManager, ILastNStateRootTracker? lastNStateRootTracker = null)
     {
         _store = trieStore ?? throw new ArgumentNullException(nameof(trieStore));
@@ -74,7 +71,7 @@ public class SnapServer : ISnapServer
 
         if (_logger.IsDebug) _logger.Debug($"Get trie nodes {pathSet.Count}");
         // TODO: use cache to reduce node retrieval from disk
-        byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
+        byteLimit = Math.Max(Math.Min(byteLimit, ISnapServer.HardResponseByteLimit), 1);
         int pathLength = pathSet.Count;
         using DeferredRlpItemList.Builder builder = new(pathLength);
         DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer();
@@ -147,7 +144,7 @@ public class SnapServer : ISnapServer
         CancellationToken cancellationToken)
     {
         if (IsRootMissing(rootHash)) return (ArrayPoolList<PathWithAccount>.Empty(), EmptyByteArrayList.Instance);
-        byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
+        byteLimit = Math.Max(Math.Min(byteLimit, ISnapServer.HardResponseByteLimit), 1);
 
         AccountCollector accounts = new();
         (long _, IOwnedReadOnlyList<byte[]> proofs, _) = GetNodesFromTrieVisitor(
@@ -173,7 +170,7 @@ public class SnapServer : ISnapServer
         CancellationToken cancellationToken)
     {
         if (IsRootMissing(rootHash)) return (ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(), EmptyByteArrayList.Instance);
-        byteLimit = Math.Max(Math.Min(byteLimit, HardResponseByteLimit), 1);
+        byteLimit = Math.Max(Math.Min(byteLimit, ISnapServer.HardResponseByteLimit), 1);
 
         ValueHash256 startingHash1 = startingHash ?? ValueKeccak.Zero;
         ValueHash256 limitHash1 = limitHash ?? ValueKeccak.MaxValue;
@@ -249,7 +246,7 @@ public class SnapServer : ISnapServer
         CancellationToken cancellationToken)
     {
         PatriciaTree tree = new(_store, _logManager);
-        using RangeQueryVisitor visitor = new(startingHash, limitHash, valueCollector, byteLimit, HardResponseNodeLimit, readFlags: _optimizedReadFlags, cancellationToken);
+        using RangeQueryVisitor visitor = new(startingHash, limitHash, valueCollector, byteLimit, ISnapServer.HardResponseNodeLimit, readFlags: _optimizedReadFlags, cancellationToken);
         VisitingOptions opt = new();
         tree.Accept(visitor, rootHash.ToCommitment(), opt, storageAddr: storage?.ToCommitment(), storageRoot: storageRoot?.ToCommitment());
 

--- a/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapServer.cs
@@ -36,7 +36,6 @@ public class SnapServer : ISnapServer
 
     private readonly IReadOnlyTrieStore _store;
     private readonly TrieStoreWithReadFlags _storeWithReadFlag;
-    private readonly IReadOnlyKeyValueStore _codeDb;
     private readonly ILogManager _logManager;
     private readonly ILogger _logger;
 
@@ -47,6 +46,7 @@ public class SnapServer : ISnapServer
 
     private readonly AccountDecoder _decoder = new();
     private readonly ILastNStateRootTracker? _lastNStateRootTracker;
+    private readonly SnapCodeServer _codeServer;
 
     private const long HardResponseByteLimit = 2000000;
     private const int HardResponseNodeLimit = 100000;
@@ -54,7 +54,7 @@ public class SnapServer : ISnapServer
     public SnapServer(IReadOnlyTrieStore trieStore, IReadOnlyKeyValueStore codeDb, ILogManager logManager, ILastNStateRootTracker? lastNStateRootTracker = null)
     {
         _store = trieStore ?? throw new ArgumentNullException(nameof(trieStore));
-        _codeDb = codeDb ?? throw new ArgumentNullException(nameof(codeDb));
+        _codeServer = new SnapCodeServer(codeDb ?? throw new ArgumentNullException(nameof(codeDb)));
         _lastNStateRootTracker = lastNStateRootTracker;
         _logManager = logManager ?? throw new ArgumentNullException(nameof(logManager));
         _logger = logManager.GetClassLogger<SnapServer>();
@@ -136,41 +136,8 @@ public class SnapServer : ISnapServer
         return new RlpByteArrayList(builder.ToRlpItemList());
     }
 
-    public IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken)
-    {
-        long currentByteCount = 0;
-        if (byteLimit > HardResponseByteLimit)
-        {
-            byteLimit = HardResponseByteLimit;
-        }
-
-        using DeferredRlpItemList.Builder builder = new(requestedHashes.Count);
-        DeferredRlpItemList.Builder.Writer writer = builder.BeginRootContainer();
-
-        foreach (ValueHash256 codeHash in requestedHashes)
-        {
-            // break when the response size exceeds the byteLimit - it is a soft limit
-            // so not a big issue if we so over slightly.
-            if (currentByteCount > byteLimit || cancellationToken.IsCancellationRequested) break;
-
-            if (codeHash.Bytes.SequenceEqual(Keccak.OfAnEmptyString.Bytes))
-            {
-                writer.WriteValue([]);
-                currentByteCount += 1;
-                continue;
-            }
-
-            byte[]? code = _codeDb[codeHash.Bytes];
-            if (code is not null)
-            {
-                writer.WriteValue(code);
-                currentByteCount += code.Length;
-            }
-        }
-
-        writer.Dispose();
-        return new RlpByteArrayList(builder.ToRlpItemList());
-    }
+    public IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken) =>
+        _codeServer.GetByteCodes(requestedHashes, byteLimit, cancellationToken);
 
     public (IOwnedReadOnlyList<PathWithAccount>, IByteArrayList) GetAccountRanges(
         Hash256 rootHash,


### PR DESCRIPTION
## Changes

- Make `FlatSnapServer` work the same way as `SnapServer`: use the ready-made RLP
  path (`DeferredRlpItemList.Builder` → `RlpByteArrayList`) in `GetTrieNodes` and
  `GetByteCodes`. `SnapServer` already did this, but `FlatSnapServer` never did.
  Now the serializer just copies the already-encoded bytes instead of encoding
  the list a second time.
- Move the shared `GetByteCodes` logic (which doesn't depend on the state model)
  into a new `SnapCodeServer`. Both servers now call it, so the code isn't
  duplicated.
- Bonus: the `using` builder fixes two `ArrayPool` leaks in the old
  `FlatSnapServer.GetTrieNodes`. Before, an empty response or any error other
  than `MissingTrieNodeException` left the rented array undisposed.
- Small fix: dispose the `ArrayPoolList` returned by `GetStatesAtBlockNumber` in
  `SnapshotCompactor`.
- Move the shared limits (`HardResponseByteLimit`, `HardResponseNodeLimit`) onto
  `ISnapServer` so they live in one place instead of being copied in
  `SnapServer`, `FlatSnapServer`, and `SnapCodeServer`.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Optimization
- [x] Refactoring

#### Notes on testing

Added `FlatSnapServerTests.GetTrieNodes_EmptyPathGroup_ReturnsNull` to cover the
empty-path-group (`case 0`) return, which had no test before