### PR TITLE
fix(tracing): restore log.contract when inner call frame exits

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/GethLikeJavaScriptTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/JavaScript/GethLikeJavaScriptTxTracer.cs
@@ -98,19 +98,25 @@ public sealed class GethLikeJavaScriptTxTracer : GethLikeTxTracer
             _ctx.Input = input;
             _ctx.Value = value;
         }
-        else if (_functions.HasFlag(TracerFunctions.enter))
+        else
         {
+            // Always track the parent frame contract so it can be restored on frame exit,
+            // even when the tracer defines no enter/exit callbacks.
             _contracts ??= new Stack<Log.Contract>();
             _contracts.Push(_log.contract);
-            _frame.From = from;
-            _frame.To = to;
-            _frame.Input = input;
-            _frame.Value = callType == ExecutionType.STATICCALL ? null : value;
-            _frame.Gas = gas;
-            _frame.Type = callType.FastToString();
-            _tracer.enter(_frame);
-            _frameGas ??= new Stack<ulong>();
-            _frameGas.Push(gas);
+
+            if (_functions.HasFlag(TracerFunctions.enter))
+            {
+                _frame.From = from;
+                _frame.To = to;
+                _frame.Input = input;
+                _frame.Value = callType == ExecutionType.STATICCALL ? null : value;
+                _frame.Gas = gas;
+                _frame.Type = callType.FastToString();
+                _tracer.enter(_frame);
+                _frameGas ??= new Stack<ulong>();
+                _frameGas.Push(gas);
+            }
         }
 
         _log.contract = callType == ExecutionType.DELEGATECALL

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeJavaScriptTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeJavaScriptTracerTests.cs
@@ -129,6 +129,36 @@ public class GethLikeJavaScriptTracerTests : VirtualMachineTestsBase
     }
 
     [Test]
+    public void log_contract_is_restored_after_inner_call_returns()
+    {
+        string userTracer = @"{
+                    retVal: [],
+                    step: function(log, db) {
+                        var entry = log.getDepth() + ':' + toHex(log.contract.getAddress());
+                        if (this.retVal.length == 0 || this.retVal[this.retVal.length - 1] != entry) {
+                            this.retVal.push(entry);
+                        }
+                    },
+                    fault: function(log, db) { },
+                    result: function(ctx, db) { return this.retVal }
+                }";
+        TestState.CreateAccount(TestItem.AddressC, 1.Ether);
+        TestState.InsertCode(TestItem.AddressC, Prepare.EvmCode.Op(Instruction.STOP).Done, Spec);
+        byte[] code = Prepare.EvmCode
+            .Call(TestItem.AddressC, 50000)
+            .Op(Instruction.STOP)
+            .Done;
+        using GethLikeBlockJavaScriptTracer tracer = ExecuteBlock(
+                GetTracer(userTracer),
+                code,
+                MainnetSpecProvider.CancunActivation);
+        using GethLikeTxTrace traces = tracer.BuildResult().First();
+        string caller = "1:942921b14f1b1c385cd7e0cc2ef7abe5598c8358";
+        string callee = "2:76e68a8696537e4141926f3e528733af9e237d69";
+        Assert.That(traces.CustomTracerResult?.Value, Is.EqualTo(new[] { caller, callee, caller }));
+    }
+
+    [Test]
     public void Js_traces_simple_filter()
     {
         string userTracer = @"{


### PR DESCRIPTION
Fixes #12439

## Changes

- Restore `log.contract` to the parent frame's contract when an inner call frame exits, regardless of whether the JS tracer defines `enter`/`exit` callbacks. Previously the parent contract was pushed onto the restore stack only when `enter`/`exit` were defined, so for step-only tracers `log.contract` kept pointing at the inner contract after the first inner call returned, while `pc`/`op` correctly tracked the resumed outer frame. Step callbacks then attributed opcodes to the wrong contract's bytecode — e.g. a PC landing inside another contract's PUSH data, or a PC past the end of a short contract (both cases reported in #12439).
- Add a regression test asserting that a step-only tracer observes the caller's contract address again after an inner call returns.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New regression test `log_contract_is_restored_after_inner_call_returns` fails on master and passes with the fix. Full `Nethermind.Evm.Test.Tracing` suite passes (418 passed, 1 skipped).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
