### PR TITLE
test: add E2E coverage for bootnodes with TCP port 0 (discport-only enodes)

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/E2EDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/E2EDiscoveryTests.cs
@@ -30,7 +30,7 @@ public class E2EDiscoveryTests(DiscoveryVersion discoveryVersion)
     private static readonly TimeSpan PeerDiscoveryTimeout = TimeSpan.FromSeconds(45);
     private static readonly TimeSpan PeerDiscoveryPollInterval = TimeSpan.FromMilliseconds(100);
 
-    private IContainer CreateNode(PrivateKey nodeKey, IEnode? bootEnode = null)
+    private IContainer CreateNode(PrivateKey nodeKey, IEnode? bootEnode = null, bool bootnodeTcpPortZero = false)
     {
         ConfigProvider configProvider = new();
         ChainSpecFileLoader loader = new(new EthereumJsonSerializer(), LimboLogs.Instance);
@@ -39,7 +39,9 @@ public class E2EDiscoveryTests(DiscoveryVersion discoveryVersion)
 
         if (bootEnode is not null)
         {
-            spec.Bootnodes = [new(bootEnode.PublicKey, bootEnode.HostIp.ToString(), bootEnode.Port)];
+            spec.Bootnodes = bootnodeTcpPortZero
+                ? [new(new Enode(bootEnode.PublicKey, bootEnode.HostIp, port: 0, discoveryPort: bootEnode.Port))]
+                : [new(bootEnode.PublicKey, bootEnode.HostIp.ToString(), bootEnode.Port)];
         }
 
         INetworkConfig networkConfig = configProvider.GetConfig<INetworkConfig>();
@@ -68,19 +70,20 @@ public class E2EDiscoveryTests(DiscoveryVersion discoveryVersion)
     int _ip = 1;
     private int AssignIp() => Interlocked.Increment(ref _ip);
 
-    [Test]
+    [TestCase(false)]
+    [TestCase(true)]
     [Category("Flaky"), Retry(3)]
     [Parallelizable(ParallelScope.None)]
-    public async Task TestDiscovery()
+    public async Task TestDiscovery(bool bootnodeTcpPortZero)
     {
         using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
 
         await using IContainer boot = CreateNode(TestItem.PrivateKeys[0]);
         IEnode bootEnode = boot.Resolve<IEnode>();
-        await using IContainer node1 = CreateNode(TestItem.PrivateKeys[1], bootEnode);
-        await using IContainer node2 = CreateNode(TestItem.PrivateKeys[2], bootEnode);
-        await using IContainer node3 = CreateNode(TestItem.PrivateKeys[3], bootEnode);
-        await using IContainer node4 = CreateNode(TestItem.PrivateKeys[4], bootEnode);
+        await using IContainer node1 = CreateNode(TestItem.PrivateKeys[1], bootEnode, bootnodeTcpPortZero);
+        await using IContainer node2 = CreateNode(TestItem.PrivateKeys[2], bootEnode, bootnodeTcpPortZero);
+        await using IContainer node3 = CreateNode(TestItem.PrivateKeys[3], bootEnode, bootnodeTcpPortZero);
+        await using IContainer node4 = CreateNode(TestItem.PrivateKeys[4], bootEnode, bootnodeTcpPortZero);
 
         IContainer[] nodes = [boot, node1, node2, node3, node4];
 


### PR DESCRIPTION
## Changes

- Parameterize `E2EDiscoveryTests.TestDiscovery` with a `bootnodeTcpPortZero` case where the bootnode is configured as `enode://<id>@<ip>:0?discport=<udp>` — the standard form for a dedicated bootnode that only participates in discovery and has no RLPx listener.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: Test-only change (adds regression coverage, no product code touched)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

All four cases (V4/V5 fixtures × normal/TCP-0 bootnode) pass locally in ~8s total.

`Should_use_discovery_port_from_configured_enode_bootnode` already unit-tests the port mapping in `CreateBootNodes`, but a mapping test alone cannot catch a downstream rejection of TCP-port-0 nodes. That failure mode is not hypothetical: in all releases through 1.39.1, discv4 built the bootnode `Node` from the enode's TCP port, so a `:0?discport=<udp>` bootnode was silently dropped ("Bootnode ignored (self or invalid)") and never pinged — nodes on devnets using dedicated bootnodes found no peers. Current master fixed this via the discovery rework (`Node.DiscoveryPort` / `DiscoveryAddress`), but only incidentally; this E2E case exercises the full path (enode parsing → bootstrap → UDP ping → neighbors → peer pool) so the regression cannot ship again unnoticed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No