### PR TITLE
Raise default TrieWarmer worker count from 1/2 to 3/4 of cores

### DIFF
--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -49,7 +49,7 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Trie cache memory target", DefaultValue = "536870912")]
     ulong TrieCacheMemoryBudget { get; set; }
 
-    [ConfigItem(Description = "Trie warmer worker count (-1 for 3/4 of processor count capped at 16, 0 to disable)", DefaultValue = "-1")]
+    [ConfigItem(Description = "Trie warmer worker count (-1 for 3/4 of processor count, 0 to disable)", DefaultValue = "-1")]
     int TrieWarmerWorkerCount { get; set; }
 
     [ConfigItem(Description = "Verify with trie", DefaultValue = "false")]

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -49,7 +49,7 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Trie cache memory target", DefaultValue = "536870912")]
     ulong TrieCacheMemoryBudget { get; set; }
 
-    [ConfigItem(Description = "Trie warmer worker count (-1 for processor count - 1, 0 to disable)", DefaultValue = "-1")]
+    [ConfigItem(Description = "Trie warmer worker count (-1 for 3/4 of processor count capped at 16, 0 to disable)", DefaultValue = "-1")]
     int TrieWarmerWorkerCount { get; set; }
 
     [ConfigItem(Description = "Verify with trie", DefaultValue = "false")]

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
@@ -54,8 +54,10 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
         _logger = logManager.GetClassLogger<TrieWarmer>();
 
         int configuredWorkerCount = flatDbConfig.TrieWarmerWorkerCount;
+        // 3/4 of logical cores is the measured optimum (16T EXPB sweep: 8/10/12/14 workers → 12 best,
+        // realblocks P90 −11%; beyond it warm workers start starving execution). Capped at 16 pending >16T data.
         int workerCount = configuredWorkerCount == -1
-            ? Math.Max(Environment.ProcessorCount / 2, 1)
+            ? Math.Min(Environment.ProcessorCount * 3 / 4, 16)
             : configuredWorkerCount;
         workerCount = Math.Max(workerCount, 2); // Min worker count is 2
 

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
@@ -54,8 +54,6 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
         _logger = logManager.GetClassLogger<TrieWarmer>();
 
         int configuredWorkerCount = flatDbConfig.TrieWarmerWorkerCount;
-        // 3/4 of logical cores is the measured optimum (16T EXPB sweep: 8/10/12/14 workers → 12 best,
-        // realblocks P90 −11%; beyond it warm workers start starving execution). Capped at 16 pending >16T data.
         int workerCount = configuredWorkerCount == -1
             ? Math.Min(Environment.ProcessorCount * 3 / 4, 16)
             : configuredWorkerCount;

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/TrieWarmer.cs
@@ -55,7 +55,7 @@ public sealed class TrieWarmer : ITrieWarmer, IAsyncDisposable
 
         int configuredWorkerCount = flatDbConfig.TrieWarmerWorkerCount;
         int workerCount = configuredWorkerCount == -1
-            ? Math.Min(Environment.ProcessorCount * 3 / 4, 16)
+            ? Math.Max(Environment.ProcessorCount * 3 / 4, 1)
             : configuredWorkerCount;
         workerCount = Math.Max(workerCount, 2); // Min worker count is 2
 


### PR DESCRIPTION
## Changes

- Default `FlatDb.TrieWarmerWorkerCount` (`-1`) now resolves to `ProcessorCount * 3/4` instead of `ProcessorCount / 2` (8T→6, 12T→9, 16T→12, 32T→24; existing floor of 2 unchanged).
- Fixed the stale `ConfigItem` description (claimed `processor count - 1`; the code used `processor count / 2`).

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Validated with a 72-run EXPB reproducible-benchmark dose-response study: 4 worker counts × 3 payload sets × 2 pacing modes × 3 runs each.

**Methodology**

- Runner: dedicated `reproducible-benchmarks` host, AMD EPYC 4344P (8C/16T), NVMe, snapshot restored per run; flat layout; `PersistenceWriteBufferFloor=64MiB` (workflow default) in all runs.
- Payload sets: `realblocks` (1000 mainnet payloads), `superblocks` (100 synthetic ~100M-gas payloads), `fusaka` (1000 heavy mainnet payloads incl. XEN storms); each at `delay=0` (back-to-back) and `delay=1` (1s gap — closer to production cadence; mainnet 12s / Gnosis 5s slots have even more between-block headroom).
- Worker counts: **W8** = stock `PC/2` default (master @ `80f8306e84`), **W10/W12** = `--FlatDb.TrieWarmerWorkerCount` override on the *identical* W8 image (no rebuild — binary-identical, flag application verified in client logs: `FlatDb.TrieWarmerWorkerCount = 10`), **W14** = `PC−2` experiment branch. The W14 branch also raised two unrelated 16→20 parallelism caps, but on a 16T runner those are arithmetic no-ops (`min(16,20)`), so all four points isolate worker count as the only variable.
- Metric: per-block `processing_ms` from the SSE client-metric feed (Nethermind-internal processing time, not TTFB), first 3 blocks skipped; n=999 samples/run (realblocks, fusaka), n=99 (superblocks). Every run clean: 0 failed payloads, no exceptions, clean shutdown.

**Results — mean of 3 runs, ms**

realblocks, delay=1:

| Workers | AVG | Median | P90 | P95 | P99 |
|---|---|---|---|---|---|
| 8 | 21.48 | 18.47 | 36.03 | 42.83 | 84.90 |
| 10 | 20.77 | 18.00 | 32.70 | 38.17 | 83.67 |
| **12** | 20.79 | 18.23 | **32.03 (−11.1%)** | **38.00 (−11.3%)** | 83.47 |
| 14 | 20.88 | 18.03 | 34.30 | 40.00 | 83.47 |

realblocks, delay=0:

| Workers | AVG | Median | P90 | P95 | P99 |
|---|---|---|---|---|---|
| 8 | 25.65 | 21.50 | 43.37 | 53.47 | 96.70 |
| 10 | 25.54 | 21.63 | 41.43 | 52.00 | 97.30 |
| **12** | 25.51 | 21.57 | 41.73 (−3.8%) | 53.77 | 98.20 |
| 14 | 25.42 | 21.43 | 41.83 | 52.10 | 96.67 |

fusaka (heavy real blocks), delay=1:

| Workers | AVG | Median | P90 | P95 | P99 |
|---|---|---|---|---|---|
| 8 | 30.82 | 27.50 | 47.63 | 58.43 | 112.10 |
| 10 | 30.82 | 27.83 | 47.47 | 56.30 | 113.30 |
| **12** | 30.82 | 27.87 | 47.37 | 55.53 | 114.80 |
| 14 | 30.57 | 27.40 | 47.07 | 56.97 | 112.67 |

fusaka (heavy real blocks), delay=0:

| Workers | AVG | Median | P90 | P95 | P99 |
|---|---|---|---|---|---|
| 8 | 32.48 | 28.97 | 50.70 | 61.27 | 116.23 |
| 10 | 32.42 | 29.30 | 50.43 | 60.07 | 116.83 |
| **12** | 32.66 | 29.30 | 50.60 | 59.93 | 117.80 |
| 14 | 32.26 | 28.80 | 50.17 | 59.80 | 116.33 |

superblocks (synthetic ~100M-gas saturation), delay=1 — P99 not interpretable at n=99, see caveats:

| Workers | AVG | Median | P90 | P95 | P99 |
|---|---|---|---|---|---|
| 8 | 999.6 | 922.8 | 1188.1 | 1255.9 | 2746.1 |
| 10 | 1042.3 | 970.0 | 1218.4 | 1290.3 | 3012.0 |
| **12** | 1060.5 | 994.8 | 1234.4 | 1301.5 | 2072.3 |
| 14 | 1025.6 | 949.4 | 1186.7 | 1267.1 | 3031.2 |

superblocks (synthetic ~100M-gas saturation), delay=0 — P99 not interpretable at n=99, see caveats:

| Workers | AVG | Median | P90 | P95 | P99 |
|---|---|---|---|---|---|
| 8 | 1002.6 | 926.0 | 1191.0 | 1246.1 | 3073.6 |
| 10 | 1061.0 | 983.5 | 1216.3 | 1339.9 | 3359.9 |
| **12** | 1070.1 | 1001.6 | 1240.4 | 1352.2 | 2559.3 |
| 14 | 1022.3 | 967.6 | 1172.0 | 1236.0 | 2489.8 |

**Reading the data**

- The win is **mid-tail compression**: P90/P95 improve up to −11%, while P99 (−1.7%) and MAX (~0) barely move. P90-class blocks are storage-merkle-bound — exactly what more warm-queue drain bandwidth helps; P99+ blocks are cold-read-bound and no warm worker count fixes them.
- The curve **peaks at 10–12 and declines at 14** (PC−2): past ~3/4 of cores, warm workers start starving execution. That is why the new default is a fraction stopping at 3/4, not "leave N cores free".
- **Superblocks penalize any raise** (+2–7% AVG): a fully saturated box has no idle headroom for extra warm workers. This is the synthetic worst case (100M-gas); fusaka — the heaviest *real* blocks — shows no penalty. This is the second reason the default stays at 3/4 rather than higher, and the argument for a future demand-gated worker count as gas limits grow.
- Bigger win at delay=1 than delay=0: the gap lets deferred background work (compaction, gen2 GC, pruning) drain *between* blocks instead of bleeding into the next block's processing window — production cadence (12s/5s slots) is at least as favorable as the delay=1 column.

**Confidence / caveats**

- Run-to-run variance is sub-percent on realblocks/fusaka (e.g. W10 realblocks-d1 P90 samples: 32.7 / 32.7 / 32.7; AVG samples: 20.76 / 20.80 / 20.76), so the realblocks deltas are far outside noise.
- Superblocks caveats: only 99 samples/run (P99 there spans 1.85–3.96s between runs — not interpretable); W10/W12 ran ~5h after W8/W14 on the shared runner and superblocks is the most disk-state-sensitive set, so its cross-batch *magnitudes* carry uncertainty (realblocks/fusaka show zero cross-batch drift). The *direction* — no benefit from raising workers on saturated blocks — is consistent across both pacing modes.
- Measured on 16T only; larger machines extrapolate the 3/4 fraction (e.g. 64T→48 workers). The exposure is bounded because workers are demand-scheduled `IThreadPoolWorkItem`s — only `min(pending, workerCount)` are woken, so extra workers engage only when a heavy block queues that much warm work, and on big machines idle cores are available for them. Worth re-benchmarking on >16T hardware; per-machine tuning remains available via `--FlatDb.TrieWarmerWorkerCount`.

<details>
<summary>Benchmark run links (24 dispatches × run_count=3 = 72 runs)</summary>

| Set | Delay | W8 (baseline) | W10 | W12 | W14 (PC−2) |
|---|---|---|---|---|---|
| realblocks | 0 | [29505675469](https://github.com/NethermindEth/nethermind/actions/runs/29505675469) | [29528372255](https://github.com/NethermindEth/nethermind/actions/runs/29528372255) | [29528378006](https://github.com/NethermindEth/nethermind/actions/runs/29528378006) | [29505668926](https://github.com/NethermindEth/nethermind/actions/runs/29505668926) |
| realblocks | 1 | [29505688956](https://github.com/NethermindEth/nethermind/actions/runs/29505688956) | [29528383397](https://github.com/NethermindEth/nethermind/actions/runs/29528383397) | [29528389068](https://github.com/NethermindEth/nethermind/actions/runs/29528389068) | [29505682441](https://github.com/NethermindEth/nethermind/actions/runs/29505682441) |
| superblocks | 0 | [29505701848](https://github.com/NethermindEth/nethermind/actions/runs/29505701848) | [29528394988](https://github.com/NethermindEth/nethermind/actions/runs/29528394988) | [29528400684](https://github.com/NethermindEth/nethermind/actions/runs/29528400684) | [29505695337](https://github.com/NethermindEth/nethermind/actions/runs/29505695337) |
| superblocks | 1 | [29505714438](https://github.com/NethermindEth/nethermind/actions/runs/29505714438) | [29528406381](https://github.com/NethermindEth/nethermind/actions/runs/29528406381) | [29528412038](https://github.com/NethermindEth/nethermind/actions/runs/29528412038) | [29505707978](https://github.com/NethermindEth/nethermind/actions/runs/29505707978) |
| fusaka | 0 | [29505726877](https://github.com/NethermindEth/nethermind/actions/runs/29505726877) | [29528418053](https://github.com/NethermindEth/nethermind/actions/runs/29528418053) | [29528423855](https://github.com/NethermindEth/nethermind/actions/runs/29528423855) | [29505720685](https://github.com/NethermindEth/nethermind/actions/runs/29505720685) |
| fusaka | 1 | [29505741693](https://github.com/NethermindEth/nethermind/actions/runs/29505741693) | [29528429463](https://github.com/NethermindEth/nethermind/actions/runs/29528429463) | [29528434875](https://github.com/NethermindEth/nethermind/actions/runs/29528434875) | [29505734227](https://github.com/NethermindEth/nethermind/actions/runs/29505734227) |

W14 branch: `perf/parallelism-caps-20` @ `84f24d39cf`; W8/W10/W12 image: `perf/parallelism-caps-20-base` @ master merge-base `80f8306e84`.
</details>

## Remarks

History of this default: the original FlatDB implementation (#9854) shipped with `ProcessorCount − 1` dedicated worker threads — which is what the `ConfigItem` description still describes. The TrieWarmer rework (#11848) replaced dedicated threads with ThreadPool-scheduled processors and, as an unheadlined part of that change, halved the default to `ProcessorCount / 2`. This PR re-tunes the value on the current ThreadPool architecture: the sweep shows the optimum at 3/4 (12 on 16T) — between the original 15 and the post-rework 8 — while the original PC−1-class value (14 in the sweep) is measurably past the peak under the new model.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Flat-layout block processing: the trie warmer now uses 3/4 of logical cores by default (was 1/2), cutting realblocks P90 processing time by ~11% at realistic block pacing on 16-thread hardware.
