### PR TITLE
Fix flaky ERA importer, sync and JSON-RPC tests

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
@@ -35,27 +35,6 @@ public class BlockTreeSuggestPacerTests
     }
 
     [Test]
-    public async Task WaitForPausedAsync_WillCompleteWhenPacerStopsSuggesting()
-    {
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
-        using BlockTreeSuggestPacer pacer = new(blockTree, 10, 5);
-        using CancellationTokenSource waitCts = new(TimeSpan.FromSeconds(5));
-        using CancellationTokenSource queueCts = new();
-
-        Task pausedTask = pacer.WaitForPausedAsync();
-        Assert.That(pausedTask.IsCompleted, Is.False);
-
-        Task queueTask = pacer.WaitForQueue(11, queueCts.Token);
-
-        await pausedTask.WaitAsync(waitCts.Token);
-        Assert.That(queueTask.IsCompleted, Is.False);
-
-        queueCts.Cancel();
-        Assert.That(async () => await queueTask, Throws.InstanceOf<OperationCanceledException>());
-    }
-
-    [Test]
     public async Task WillNotMissHeadUpdateBeforeStartingBatch()
     {
         IBlockTree blockTree = Substitute.For<IBlockTree>();

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
@@ -56,61 +56,26 @@ public class BlockTreeSuggestPacerTests
     }
 
     [Test]
-    public async Task WillNotMissHeadUpdateWhenStartingBatch()
+    public void WillNotMissHeadUpdateBeforeStartingBatch()
     {
         IBlockTree blockTree = Substitute.For<IBlockTree>();
-        Block currentHead = Build.A.Block.WithNumber(0).TestObject;
-        TaskCompletionSource headRead = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        TaskCompletionSource releaseHeadRead = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        int firstHeadRead = 1;
+        Block initialHead = Build.A.Block.WithNumber(0).TestObject;
+        Block advancedHead = Build.A.Block.WithNumber(6).TestObject;
+        int headRead = 0;
         blockTree.Head.Returns(_ =>
         {
-            Block snapshot = Volatile.Read(ref currentHead);
-            if (Interlocked.Exchange(ref firstHeadRead, 0) != 0)
+            if (Interlocked.Increment(ref headRead) == 1)
             {
-                headRead.TrySetResult();
-                releaseHeadRead.Task.GetAwaiter().GetResult();
+                blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(advancedHead));
+                return initialHead;
             }
 
-            return snapshot;
+            return advancedHead;
         });
 
-        TaskCompletionSource headEventStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        TaskCompletionSource releaseHeadEvent = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        blockTree.NewHeadBlock += (_, _) =>
-        {
-            headEventStarted.TrySetResult();
-            releaseHeadEvent.Task.GetAwaiter().GetResult();
-        };
-
         using BlockTreeSuggestPacer pacer = new(blockTree, 10, 5);
-        TaskCompletionSource headEventHandled = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        blockTree.NewHeadBlock += (_, _) => headEventHandled.TrySetResult();
-        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
 
-        Task queueTask = Task.Run(() => pacer.WaitForQueue(11, cts.Token));
-        try
-        {
-            await headRead.Task.WaitAsync(cts.Token);
-            Volatile.Write(ref currentHead, Build.A.Block.WithNumber(6).TestObject);
-            Task headEventTask = Task.Run(() => blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(currentHead)));
-            await headEventStarted.Task.WaitAsync(cts.Token);
-
-            releaseHeadEvent.TrySetResult();
-            await Task.Delay(100, cts.Token);
-            Assert.That(headEventHandled.Task.IsCompleted, Is.False);
-
-            releaseHeadRead.TrySetResult();
-
-            await headEventTask.WaitAsync(cts.Token);
-            await queueTask.WaitAsync(cts.Token);
-        }
-        finally
-        {
-            releaseHeadEvent.TrySetResult();
-            releaseHeadRead.TrySetResult();
-            cts.Cancel();
-        }
+        Assert.That(pacer.WaitForQueue(11, default).IsCompleted, Is.True);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
@@ -56,28 +56,6 @@ public class BlockTreeSuggestPacerTests
     }
 
     [Test]
-    public async Task WaitForPausedAsync_WillWaitForNextPauseAfterResuming()
-    {
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
-        using BlockTreeSuggestPacer pacer = new(blockTree, 10, 5);
-        using CancellationTokenSource waitCts = new(TimeSpan.FromSeconds(5));
-
-        Task firstQueueTask = pacer.WaitForQueue(11, default);
-        blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(6).TestObject));
-        await firstQueueTask.WaitAsync(waitCts.Token);
-
-        Task pausedTask = pacer.WaitForPausedAsync();
-        Assert.That(pausedTask.IsCompleted, Is.False);
-
-        Task secondQueueTask = pacer.WaitForQueue(11, default);
-        await pausedTask.WaitAsync(waitCts.Token);
-
-        blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(6).TestObject));
-        await secondQueueTask.WaitAsync(waitCts.Token);
-    }
-
-    [Test]
     public void WillOnlyUnblockOnceHeadReachHighEnough()
     {
         IBlockTree blockTree = Substitute.For<IBlockTree>();

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
@@ -56,6 +56,64 @@ public class BlockTreeSuggestPacerTests
     }
 
     [Test]
+    public async Task WillNotMissHeadUpdateWhenStartingBatch()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        Block currentHead = Build.A.Block.WithNumber(0).TestObject;
+        TaskCompletionSource headRead = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseHeadRead = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int firstHeadRead = 1;
+        blockTree.Head.Returns(_ =>
+        {
+            Block snapshot = Volatile.Read(ref currentHead);
+            if (Interlocked.Exchange(ref firstHeadRead, 0) != 0)
+            {
+                headRead.TrySetResult();
+                releaseHeadRead.Task.GetAwaiter().GetResult();
+            }
+
+            return snapshot;
+        });
+
+        TaskCompletionSource headEventStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseHeadEvent = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        blockTree.NewHeadBlock += (_, _) =>
+        {
+            headEventStarted.TrySetResult();
+            releaseHeadEvent.Task.GetAwaiter().GetResult();
+        };
+
+        using BlockTreeSuggestPacer pacer = new(blockTree, 10, 5);
+        TaskCompletionSource headEventHandled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        blockTree.NewHeadBlock += (_, _) => headEventHandled.TrySetResult();
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+
+        Task queueTask = Task.Run(() => pacer.WaitForQueue(11, cts.Token));
+        try
+        {
+            await headRead.Task.WaitAsync(cts.Token);
+            Volatile.Write(ref currentHead, Build.A.Block.WithNumber(6).TestObject);
+            Task headEventTask = Task.Run(() => blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(currentHead)));
+            await headEventStarted.Task.WaitAsync(cts.Token);
+
+            releaseHeadEvent.TrySetResult();
+            await Task.Delay(100, cts.Token);
+            Assert.That(headEventHandled.Task.IsCompleted, Is.False);
+
+            releaseHeadRead.TrySetResult();
+
+            await headEventTask.WaitAsync(cts.Token);
+            await queueTask.WaitAsync(cts.Token);
+        }
+        finally
+        {
+            releaseHeadEvent.TrySetResult();
+            releaseHeadRead.TrySetResult();
+            cts.Cancel();
+        }
+    }
+
+    [Test]
     public void WillOnlyUnblockOnceHeadReachHighEnough()
     {
         IBlockTree blockTree = Substitute.For<IBlockTree>();

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
@@ -44,6 +44,8 @@ public class BlockTreeSuggestPacerTests
         using CancellationTokenSource queueCts = new();
 
         Task pausedTask = pacer.WaitForPausedAsync();
+        Assert.That(pausedTask.IsCompleted, Is.False);
+
         Task queueTask = pacer.WaitForQueue(11, queueCts.Token);
 
         await pausedTask.WaitAsync(waitCts.Token);
@@ -51,6 +53,28 @@ public class BlockTreeSuggestPacerTests
 
         queueCts.Cancel();
         Assert.That(async () => await queueTask, Throws.InstanceOf<OperationCanceledException>());
+    }
+
+    [Test]
+    public async Task WaitForPausedAsync_WillWaitForNextPauseAfterResuming()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
+        using BlockTreeSuggestPacer pacer = new(blockTree, 10, 5);
+        using CancellationTokenSource waitCts = new(TimeSpan.FromSeconds(5));
+
+        Task firstQueueTask = pacer.WaitForQueue(11, default);
+        blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(6).TestObject));
+        await firstQueueTask.WaitAsync(waitCts.Token);
+
+        Task pausedTask = pacer.WaitForPausedAsync();
+        Assert.That(pausedTask.IsCompleted, Is.False);
+
+        Task secondQueueTask = pacer.WaitForQueue(11, default);
+        await pausedTask.WaitAsync(waitCts.Token);
+
+        blockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(6).TestObject));
+        await secondQueueTask.WaitAsync(waitCts.Token);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
@@ -56,7 +56,7 @@ public class BlockTreeSuggestPacerTests
     }
 
     [Test]
-    public void WillNotMissHeadUpdateBeforeStartingBatch()
+    public async Task WillNotMissHeadUpdateBeforeStartingBatch()
     {
         IBlockTree blockTree = Substitute.For<IBlockTree>();
         Block initialHead = Build.A.Block.WithNumber(0).TestObject;
@@ -74,8 +74,24 @@ public class BlockTreeSuggestPacerTests
         });
 
         using BlockTreeSuggestPacer pacer = new(blockTree, 10, 5);
+        using CancellationTokenSource cts = new();
+        Task pausedTask = pacer.WaitForPausedAsync(cts.Token);
+        try
+        {
+            Task queueTask = pacer.WaitForQueue(11, default);
 
-        Assert.That(pacer.WaitForQueue(11, default).IsCompleted, Is.True);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(queueTask.IsCompleted, Is.True);
+                Assert.That(pausedTask.IsCompleted, Is.False);
+            }
+        }
+        finally
+        {
+            cts.Cancel();
+        }
+
+        Assert.That(async () => await pausedTask, Throws.InstanceOf<OperationCanceledException>());
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeSuggestPacerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
@@ -31,6 +32,25 @@ public class BlockTreeSuggestPacerTests
         using BlockTreeSuggestPacer pacer = new(blockTree, 10, 5);
 
         Assert.That(pacer.WaitForQueue(11, default).IsCompleted, Is.False);
+    }
+
+    [Test]
+    public async Task WaitForPausedAsync_WillCompleteWhenPacerStopsSuggesting()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
+        using BlockTreeSuggestPacer pacer = new(blockTree, 10, 5);
+        using CancellationTokenSource waitCts = new(TimeSpan.FromSeconds(5));
+        using CancellationTokenSource queueCts = new();
+
+        Task pausedTask = pacer.WaitForPausedAsync();
+        Task queueTask = pacer.WaitForQueue(11, queueCts.Token);
+
+        await pausedTask.WaitAsync(waitCts.Token);
+        Assert.That(queueTask.IsCompleted, Is.False);
+
+        queueCts.Cancel();
+        Assert.That(async () => await queueTask, Throws.InstanceOf<OperationCanceledException>());
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
@@ -13,6 +13,7 @@ namespace Nethermind.Blockchain;
 /// </summary>
 public class BlockTreeSuggestPacer : IDisposable
 {
+    private readonly Lock _lock = new();
     private TaskCompletionSource? _dbBatchProcessed;
     private TaskCompletionSource? _pausedSignal;
     private ulong _blockNumberReachedToUnlock = 0;
@@ -35,9 +36,13 @@ public class BlockTreeSuggestPacer : IDisposable
     /// </summary>
     public Task WaitForPausedAsync(CancellationToken token = default)
     {
-        if (_dbBatchProcessed is not null) return Task.CompletedTask;
-        TaskCompletionSource signal = LazyInitializer.EnsureInitialized(
-            ref _pausedSignal, () => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))!;
+        TaskCompletionSource signal;
+        lock (_lock)
+        {
+            if (_dbBatchProcessed is not null) return Task.CompletedTask;
+            signal = _pausedSignal ??= new(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
         return token.CanBeCanceled
             ? signal.Task.WaitAsync(token)
             : signal.Task;
@@ -45,33 +50,47 @@ public class BlockTreeSuggestPacer : IDisposable
 
     private void BlockTreeOnNewHeadBlock(object sender, BlockEventArgs e)
     {
-        TaskCompletionSource? completionSource = _dbBatchProcessed;
-        if (completionSource is null) return;
-        if (e.Block.Number < _blockNumberReachedToUnlock) return;
+        TaskCompletionSource? completionSource;
+        lock (_lock)
+        {
+            completionSource = _dbBatchProcessed;
+            if (completionSource is null || e.Block.Number < _blockNumberReachedToUnlock) return;
 
-        _dbBatchProcessed = null;
-        completionSource.SetResult();
+            _dbBatchProcessed = null;
+        }
+
+        completionSource.TrySetResult();
     }
 
     public async Task WaitForQueue(ulong currentBlockNumber, CancellationToken token)
     {
         ulong currentHeadNumber = _blockTree.Head?.Number ?? 0;
+        TaskCompletionSource? pauseSignal = null;
+        TaskCompletionSource? completionSource;
+
         // Head can transiently overtake the suggestion (parallel-import advance, post-FCU); wrap would pause indefinitely.
-        if (currentBlockNumber > currentHeadNumber
-            && currentBlockNumber - currentHeadNumber > _stopBatchSize
-            && _dbBatchProcessed is null)
+        lock (_lock)
         {
-            _blockNumberReachedToUnlock = currentBlockNumber - _stopBatchSize + _resumeBatchSize;
-            TaskCompletionSource completionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            _dbBatchProcessed = completionSource;
-            Interlocked.Exchange(ref _pausedSignal, null)?.TrySetResult();
+            if (currentBlockNumber > currentHeadNumber
+                && currentBlockNumber - currentHeadNumber > _stopBatchSize
+                && _dbBatchProcessed is null)
+            {
+                _blockNumberReachedToUnlock = currentBlockNumber - _stopBatchSize + _resumeBatchSize;
+                _dbBatchProcessed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                pauseSignal = _pausedSignal;
+                _pausedSignal = null;
+            }
+
+            completionSource = _dbBatchProcessed;
         }
 
-        if (_dbBatchProcessed is not null)
+        pauseSignal?.TrySetResult();
+
+        if (completionSource is not null)
         {
-            await using (token.Register(() => _dbBatchProcessed.TrySetCanceled()))
+            await using (token.Register(() => completionSource.TrySetCanceled()))
             {
-                await _dbBatchProcessed.Task;
+                await completionSource.Task;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
@@ -64,13 +64,14 @@ public class BlockTreeSuggestPacer : IDisposable
 
     public async Task WaitForQueue(ulong currentBlockNumber, CancellationToken token)
     {
-        ulong currentHeadNumber = _blockTree.Head?.Number ?? 0;
         TaskCompletionSource? pauseSignal = null;
         TaskCompletionSource? completionSource;
 
         // Head can transiently overtake the suggestion (parallel-import advance, post-FCU); wrap would pause indefinitely.
+        // Pair the head snapshot with the event callback so a new batch cannot miss an already-raised head update.
         lock (_lock)
         {
+            ulong currentHeadNumber = _blockTree.Head?.Number ?? 0;
             if (currentBlockNumber > currentHeadNumber
                 && currentBlockNumber - currentHeadNumber > _stopBatchSize
                 && _dbBatchProcessed is null)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
@@ -64,14 +64,14 @@ public class BlockTreeSuggestPacer : IDisposable
 
     public async Task WaitForQueue(ulong currentBlockNumber, CancellationToken token)
     {
+        ulong currentHeadNumber = _blockTree.Head?.Number ?? 0;
         TaskCompletionSource? pauseSignal = null;
         TaskCompletionSource? completionSource;
+        TaskCompletionSource? completedBatch = null;
 
         // Head can transiently overtake the suggestion (parallel-import advance, post-FCU); wrap would pause indefinitely.
-        // Pair the head snapshot with the event callback so a new batch cannot miss an already-raised head update.
         lock (_lock)
         {
-            ulong currentHeadNumber = _blockTree.Head?.Number ?? 0;
             if (currentBlockNumber > currentHeadNumber
                 && currentBlockNumber - currentHeadNumber > _stopBatchSize
                 && _dbBatchProcessed is null)
@@ -83,9 +83,17 @@ public class BlockTreeSuggestPacer : IDisposable
             }
 
             completionSource = _dbBatchProcessed;
+            // The head event may have run before it could observe the newly created batch.
+            if (completionSource is not null && (_blockTree.Head?.Number ?? 0) >= _blockNumberReachedToUnlock)
+            {
+                _dbBatchProcessed = null;
+                completedBatch = completionSource;
+                completionSource = null;
+            }
         }
 
         pauseSignal?.TrySetResult();
+        completedBatch?.TrySetResult();
 
         if (completionSource is not null)
         {

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
@@ -89,6 +89,9 @@ public class BlockTreeSuggestPacer : IDisposable
                 _dbBatchProcessed = null;
                 completedBatch = completionSource;
                 completionSource = null;
+                // The batch never blocked, so retain any observer for the next real pause.
+                _pausedSignal = pauseSignal;
+                pauseSignal = null;
             }
         }
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
@@ -13,13 +13,44 @@ namespace Nethermind.Blockchain;
 /// </summary>
 public class BlockTreeSuggestPacer : IDisposable
 {
-    private readonly Lock _lock = new();
-    private TaskCompletionSource? _dbBatchProcessed;
-    private TaskCompletionSource? _pausedSignal;
-    private ulong _blockNumberReachedToUnlock = 0;
+    private PacingState _pacingState = new();
     private readonly ulong _stopBatchSize;
     private readonly ulong _resumeBatchSize;
     private readonly IBlockTree _blockTree;
+
+    // An unpaused generation latches once it pauses so observers holding it cannot miss a rapid resume.
+    private sealed class PacingState(PacingBatch? pacingBatch = null)
+    {
+        private TaskCompletionSource? _pauseSignal;
+        private int _hasPaused;
+
+        public PacingBatch? PacingBatch { get; } = pacingBatch;
+
+        public Task WaitForPauseAsync(CancellationToken token)
+        {
+            if (Volatile.Read(ref _hasPaused) != 0) return Task.CompletedTask;
+
+            TaskCompletionSource signal = LazyInitializer.EnsureInitialized(
+                ref _pauseSignal, static () => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))!;
+            if (Volatile.Read(ref _hasPaused) != 0) signal.TrySetResult();
+
+            return token.CanBeCanceled
+                ? signal.Task.WaitAsync(token)
+                : signal.Task;
+        }
+
+        public void SignalPaused()
+        {
+            Volatile.Write(ref _hasPaused, 1);
+            Interlocked.Exchange(ref _pauseSignal, null)?.TrySetResult();
+        }
+    }
+
+    private sealed class PacingBatch(ulong unlockBlockNumber)
+    {
+        public ulong UnlockBlockNumber { get; } = unlockBlockNumber;
+        public TaskCompletionSource Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
 
     public BlockTreeSuggestPacer(IBlockTree blockTree, ulong stopBatchSize = 4096, ulong resumeBatchSize = 2048)
     {
@@ -36,61 +67,53 @@ public class BlockTreeSuggestPacer : IDisposable
     /// </summary>
     public Task WaitForPausedAsync(CancellationToken token = default)
     {
-        TaskCompletionSource signal;
-        lock (_lock)
-        {
-            if (_dbBatchProcessed is not null) return Task.CompletedTask;
-            signal = _pausedSignal ??= new(TaskCreationOptions.RunContinuationsAsynchronously);
-        }
-
-        return token.CanBeCanceled
-            ? signal.Task.WaitAsync(token)
-            : signal.Task;
+        PacingState state = Volatile.Read(ref _pacingState);
+        return state.PacingBatch is not null ? Task.CompletedTask : state.WaitForPauseAsync(token);
     }
 
     private void BlockTreeOnNewHeadBlock(object sender, BlockEventArgs e)
     {
-        TaskCompletionSource? completionSource;
-        lock (_lock)
-        {
-            completionSource = _dbBatchProcessed;
-            if (completionSource is null || e.Block.Number < _blockNumberReachedToUnlock) return;
+        PacingState state = Volatile.Read(ref _pacingState);
+        PacingBatch? pacingBatch = state.PacingBatch;
+        if (pacingBatch is null || e.Block.Number < pacingBatch.UnlockBlockNumber) return;
 
-            _dbBatchProcessed = null;
-        }
-
-        completionSource.TrySetResult();
+        if (Interlocked.CompareExchange(ref _pacingState, new PacingState(), state) == state)
+            pacingBatch.Completion.TrySetResult();
     }
 
     public async Task WaitForQueue(ulong currentBlockNumber, CancellationToken token)
     {
         ulong currentHeadNumber = _blockTree.Head?.Number ?? 0;
-        TaskCompletionSource? pauseSignal = null;
-        TaskCompletionSource? completionSource;
+        PacingState state = Volatile.Read(ref _pacingState);
+        PacingBatch? pacingBatch = state.PacingBatch;
 
         // Head can transiently overtake the suggestion (parallel-import advance, post-FCU); wrap would pause indefinitely.
-        lock (_lock)
+        if (currentBlockNumber > currentHeadNumber
+            && currentBlockNumber - currentHeadNumber > _stopBatchSize
+            && pacingBatch is null)
         {
-            if (currentBlockNumber > currentHeadNumber
-                && currentBlockNumber - currentHeadNumber > _stopBatchSize
-                && _dbBatchProcessed is null)
+            PacingBatch newPacingBatch = new(currentBlockNumber - _stopBatchSize + _resumeBatchSize);
+            PacingState pausedState = new(newPacingBatch);
+            while (pacingBatch is null)
             {
-                _blockNumberReachedToUnlock = currentBlockNumber - _stopBatchSize + _resumeBatchSize;
-                _dbBatchProcessed = new(TaskCreationOptions.RunContinuationsAsynchronously);
-                pauseSignal = _pausedSignal;
-                _pausedSignal = null;
-            }
+                if (Interlocked.CompareExchange(ref _pacingState, pausedState, state) == state)
+                {
+                    state.SignalPaused();
+                    pacingBatch = newPacingBatch;
+                    break;
+                }
 
-            completionSource = _dbBatchProcessed;
+                state = Volatile.Read(ref _pacingState);
+                pacingBatch = state.PacingBatch;
+            }
         }
 
-        pauseSignal?.TrySetResult();
-
-        if (completionSource is not null)
+        if (pacingBatch is not null)
         {
-            await using (token.Register(() => completionSource.TrySetCanceled()))
+            TaskCompletionSource completion = pacingBatch.Completion;
+            await using (token.Register(() => completion.TrySetCanceled()))
             {
-                await completionSource.Task;
+                await completion.Task;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeSuggestPacer.cs
@@ -13,44 +13,13 @@ namespace Nethermind.Blockchain;
 /// </summary>
 public class BlockTreeSuggestPacer : IDisposable
 {
-    private PacingState _pacingState = new();
+    private readonly Lock _lock = new();
+    private TaskCompletionSource? _dbBatchProcessed;
+    private TaskCompletionSource? _pausedSignal;
+    private ulong _blockNumberReachedToUnlock = 0;
     private readonly ulong _stopBatchSize;
     private readonly ulong _resumeBatchSize;
     private readonly IBlockTree _blockTree;
-
-    // An unpaused generation latches once it pauses so observers holding it cannot miss a rapid resume.
-    private sealed class PacingState(PacingBatch? pacingBatch = null)
-    {
-        private TaskCompletionSource? _pauseSignal;
-        private int _hasPaused;
-
-        public PacingBatch? PacingBatch { get; } = pacingBatch;
-
-        public Task WaitForPauseAsync(CancellationToken token)
-        {
-            if (Volatile.Read(ref _hasPaused) != 0) return Task.CompletedTask;
-
-            TaskCompletionSource signal = LazyInitializer.EnsureInitialized(
-                ref _pauseSignal, static () => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))!;
-            if (Volatile.Read(ref _hasPaused) != 0) signal.TrySetResult();
-
-            return token.CanBeCanceled
-                ? signal.Task.WaitAsync(token)
-                : signal.Task;
-        }
-
-        public void SignalPaused()
-        {
-            Volatile.Write(ref _hasPaused, 1);
-            Interlocked.Exchange(ref _pauseSignal, null)?.TrySetResult();
-        }
-    }
-
-    private sealed class PacingBatch(ulong unlockBlockNumber)
-    {
-        public ulong UnlockBlockNumber { get; } = unlockBlockNumber;
-        public TaskCompletionSource Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    }
 
     public BlockTreeSuggestPacer(IBlockTree blockTree, ulong stopBatchSize = 4096, ulong resumeBatchSize = 2048)
     {
@@ -67,53 +36,61 @@ public class BlockTreeSuggestPacer : IDisposable
     /// </summary>
     public Task WaitForPausedAsync(CancellationToken token = default)
     {
-        PacingState state = Volatile.Read(ref _pacingState);
-        return state.PacingBatch is not null ? Task.CompletedTask : state.WaitForPauseAsync(token);
+        TaskCompletionSource signal;
+        lock (_lock)
+        {
+            if (_dbBatchProcessed is not null) return Task.CompletedTask;
+            signal = _pausedSignal ??= new(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        return token.CanBeCanceled
+            ? signal.Task.WaitAsync(token)
+            : signal.Task;
     }
 
     private void BlockTreeOnNewHeadBlock(object sender, BlockEventArgs e)
     {
-        PacingState state = Volatile.Read(ref _pacingState);
-        PacingBatch? pacingBatch = state.PacingBatch;
-        if (pacingBatch is null || e.Block.Number < pacingBatch.UnlockBlockNumber) return;
+        TaskCompletionSource? completionSource;
+        lock (_lock)
+        {
+            completionSource = _dbBatchProcessed;
+            if (completionSource is null || e.Block.Number < _blockNumberReachedToUnlock) return;
 
-        if (Interlocked.CompareExchange(ref _pacingState, new PacingState(), state) == state)
-            pacingBatch.Completion.TrySetResult();
+            _dbBatchProcessed = null;
+        }
+
+        completionSource.TrySetResult();
     }
 
     public async Task WaitForQueue(ulong currentBlockNumber, CancellationToken token)
     {
         ulong currentHeadNumber = _blockTree.Head?.Number ?? 0;
-        PacingState state = Volatile.Read(ref _pacingState);
-        PacingBatch? pacingBatch = state.PacingBatch;
+        TaskCompletionSource? pauseSignal = null;
+        TaskCompletionSource? completionSource;
 
         // Head can transiently overtake the suggestion (parallel-import advance, post-FCU); wrap would pause indefinitely.
-        if (currentBlockNumber > currentHeadNumber
-            && currentBlockNumber - currentHeadNumber > _stopBatchSize
-            && pacingBatch is null)
+        lock (_lock)
         {
-            PacingBatch newPacingBatch = new(currentBlockNumber - _stopBatchSize + _resumeBatchSize);
-            PacingState pausedState = new(newPacingBatch);
-            while (pacingBatch is null)
+            if (currentBlockNumber > currentHeadNumber
+                && currentBlockNumber - currentHeadNumber > _stopBatchSize
+                && _dbBatchProcessed is null)
             {
-                if (Interlocked.CompareExchange(ref _pacingState, pausedState, state) == state)
-                {
-                    state.SignalPaused();
-                    pacingBatch = newPacingBatch;
-                    break;
-                }
-
-                state = Volatile.Read(ref _pacingState);
-                pacingBatch = state.PacingBatch;
+                _blockNumberReachedToUnlock = currentBlockNumber - _stopBatchSize + _resumeBatchSize;
+                _dbBatchProcessed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                pauseSignal = _pausedSignal;
+                _pausedSignal = null;
             }
+
+            completionSource = _dbBatchProcessed;
         }
 
-        if (pacingBatch is not null)
+        pauseSignal?.TrySetResult();
+
+        if (completionSource is not null)
         {
-            TaskCompletionSource completion = pacingBatch.Completion;
-            await using (token.Register(() => completion.TrySetCanceled()))
+            await using (token.Register(() => completionSource.TrySetCanceled()))
             {
-                await completion.Task;
+                await completionSource.Task;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Era1.Test/EraImporterTest.cs
+++ b/src/Nethermind/Nethermind.Era1.Test/EraImporterTest.cs
@@ -135,7 +135,7 @@ public class EraImporterTest
         Assert.That(importTask, Throws.TypeOf<EraVerificationException>());
     }
 
-    [CancelAfter(4000)]
+    [CancelAfter(30_000)]
     [Test]
     public async Task ImportAsArchiveSync_WillPaceSuggestBlock(CancellationToken token)
     {
@@ -169,9 +169,14 @@ public class EraImporterTest
         Task importTask = sut.Import(destinationPath, 0, ulong.MaxValue,
             Path.Join(destinationPath, EraExporter.AccumulatorFileName), token);
 
-        // Pacer is created when import starts; spin briefly until it's published.
-        while (sut.CurrentPacer is null) await Task.Yield();
-        await sut.CurrentPacer.WaitForPausedAsync(token);
+        BlockTreeSuggestPacer? pacer = null;
+        while (pacer is null)
+        {
+            token.ThrowIfCancellationRequested();
+            pacer = sut.CurrentPacer;
+            if (pacer is null) await Task.Yield();
+        }
+        await pacer.WaitForPausedAsync(token);
 
         Block expectedFinalizedBlock = outputCtx.Resolve<IBlockTree>().FindBlock(expectedStopBlock)!;
         using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Era1/EraImporter.cs
+++ b/src/Nethermind/Nethermind.Era1/EraImporter.cs
@@ -40,7 +40,7 @@ public class EraImporter(
     /// lets callers (notably tests) wait deterministically for the importer to back off when its suggest queue
     /// outruns the chain head, instead of relying on real-time delays.
     /// </summary>
-    public BlockTreeSuggestPacer? CurrentPacer => System.Threading.Volatile.Read(ref _currentPacer);
+    public BlockTreeSuggestPacer? CurrentPacer => Volatile.Read(ref _currentPacer);
 
     public async Task Import(string src, ulong from, ulong to, string? accumulatorFile, CancellationToken cancellation = default)
     {
@@ -117,7 +117,7 @@ public class EraImporter(
             ? eraConfig.ImportBlocksBufferSize - 1024UL
             : eraConfig.ImportBlocksBufferSize / 2;
         using BlockTreeSuggestPacer pacer = new(blockTree, eraConfig.ImportBlocksBufferSize, resumeBatchSize);
-        System.Threading.Volatile.Write(ref _currentPacer, pacer);
+        Volatile.Write(ref _currentPacer, pacer);
         ulong blockNumber = from;
 
         ulong suggestFromBlock = (blockTree.Head?.Number ?? 0UL) + 1UL;

--- a/src/Nethermind/Nethermind.Era1/EraImporter.cs
+++ b/src/Nethermind/Nethermind.Era1/EraImporter.cs
@@ -33,13 +33,14 @@ public class EraImporter(
 
     private readonly ILogger _logger = logManager.GetClassLogger<EraImporter>();
     private readonly ulong _maxEra1Size = eraConfig.MaxEra1Size;
+    private BlockTreeSuggestPacer? _currentPacer;
 
     /// <summary>
     /// Snapshot of the pacer used by the current import run. <see cref="BlockTreeSuggestPacer.WaitForPausedAsync"/>
     /// lets callers (notably tests) wait deterministically for the importer to back off when its suggest queue
     /// outruns the chain head, instead of relying on real-time delays.
     /// </summary>
-    public BlockTreeSuggestPacer? CurrentPacer { get; private set; }
+    public BlockTreeSuggestPacer? CurrentPacer => System.Threading.Volatile.Read(ref _currentPacer);
 
     public async Task Import(string src, ulong from, ulong to, string? accumulatorFile, CancellationToken cancellation = default)
     {
@@ -116,7 +117,7 @@ public class EraImporter(
             ? eraConfig.ImportBlocksBufferSize - 1024UL
             : eraConfig.ImportBlocksBufferSize / 2;
         using BlockTreeSuggestPacer pacer = new(blockTree, eraConfig.ImportBlocksBufferSize, resumeBatchSize);
-        CurrentPacer = pacer;
+        System.Threading.Volatile.Write(ref _currentPacer, pacer);
         ulong blockNumber = from;
 
         ulong suggestFromBlock = (blockTree.Head?.Number ?? 0UL) + 1UL;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsHiveBase.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsHiveBase.cs
@@ -80,7 +80,7 @@ new object[] {"multicall-transaction-too-low-nonce-38010", true, "{\"blockStateC
     {
         EthereumJsonSerializer serializer = new();
         SimulatePayload<TransactionForRpc>? payload = serializer.Deserialize<SimulatePayload<TransactionForRpc>>(data);
-        TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain(Osaka.Instance);
+        using TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain(Osaka.Instance);
         Console.WriteLine($"current test: {name}");
         ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
             chain.EthRpcModule.eth_simulateV1(payload!, BlockParameter.Latest);
@@ -130,7 +130,7 @@ new object[] {"multicall-transaction-too-low-nonce-38010", true, "{\"blockStateC
         EthereumJsonSerializer serializer = new();
         SimulatePayload<TransactionForRpc>? payload = serializer.Deserialize<SimulatePayload<TransactionForRpc>>(data);
 
-        TestRpcBlockchain chain = await TestRpcBlockchain
+        using TestRpcBlockchain chain = await TestRpcBlockchain
             .ForTest(new TestRpcBlockchain())
             .WithBlocksConfig(new BlocksConfig
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -762,14 +762,8 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
                 (e) => e.Block.Number == serverHead?.Number);
         }
 
-        public async Task WaitForSyncMode(Func<SyncMode, bool> modeCheck, CancellationToken cancellationToken)
-        {
-            if (modeCheck(syncModeSelector.Current)) return;
-            await Wait.ForEventCondition<SyncModeChangedEventArgs>(cancellationToken,
-                h => syncModeSelector.Changed += h,
-                h => syncModeSelector.Changed -= h,
-                (e) => modeCheck(e.Current));
-        }
+        public Task WaitForSyncMode(Func<SyncMode, bool> modeCheck, CancellationToken cancellationToken) =>
+            syncModeSelector.WaitUntilMode(modeCheck, cancellationToken);
     }
 
     private class PostMergeTestEnv(

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncedTxGossipPolicyTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Synchronization.ParallelSync;
 using Nethermind.TxPool;
@@ -69,9 +70,21 @@ public class SyncedTxGossipPolicyTests
         Assert.That(composite.ShouldListenToGossipedTransactions, Is.False);
     }
 
-    private class MutableSelector(SyncMode initial) : ISyncModeSelector
+    [Test]
+    public async Task WaitUntilMode_WillNotMissTransitionBeforeSubscription()
+    {
+        MutableSelector selector = new(SyncMode.FastSync, static selector => selector.Current = SyncMode.Full);
+        using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromSeconds(1));
+
+        await ((ISyncModeSelector)selector).WaitUntilMode(mode => mode == SyncMode.Full, cancellationTokenSource.Token);
+
+        Assert.That(selector.Current, Is.EqualTo(SyncMode.Full));
+    }
+
+    private class MutableSelector(SyncMode initial, Action<MutableSelector>? beforeChangedSubscription = null) : ISyncModeSelector
     {
         private SyncMode _current = initial;
+        private EventHandler<SyncModeChangedEventArgs>? _changed;
 
         public SyncMode Current
         {
@@ -80,13 +93,22 @@ public class SyncedTxGossipPolicyTests
             {
                 SyncMode previous = _current;
                 _current = value;
-                Changed?.Invoke(this, new SyncModeChangedEventArgs(previous, value));
+                _changed?.Invoke(this, new SyncModeChangedEventArgs(previous, value));
             }
         }
 
         public event EventHandler<SyncModeChangedEventArgs> Preparing { add { } remove { } }
         public event EventHandler<SyncModeChangedEventArgs> Changing { add { } remove { } }
-        public event EventHandler<SyncModeChangedEventArgs>? Changed;
+        public event EventHandler<SyncModeChangedEventArgs>? Changed
+        {
+            add
+            {
+                beforeChangedSubscription?.Invoke(this);
+                _changed += value;
+            }
+            remove => _changed -= value;
+        }
+
         public Task StopAsync() => Task.CompletedTask;
         public Task StartAsync() => Task.CompletedTask;
         public void Update() { }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/ISyncModeSelector.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Nethermind.Core.Events;
 using Nethermind.Core.ServiceStopper;
 
 namespace Nethermind.Synchronization.ParallelSync
@@ -25,13 +24,25 @@ namespace Nethermind.Synchronization.ParallelSync
 
         async Task WaitUntilMode(Func<SyncMode, bool> predicate, CancellationToken cancellationToken)
         {
-            if (predicate(Current)) return;
+            TaskCompletionSource completionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnChanged(object? _, SyncModeChangedEventArgs args)
+            {
+                if (predicate(args.Current))
+                {
+                    completionSource.TrySetResult();
+                }
+            }
 
-            await Wait.ForEventCondition<SyncModeChangedEventArgs>(
-                cancellationToken,
-                (e) => Changed += e,
-                (e) => Changed -= e,
-                (arg) => predicate(arg.Current));
+            Changed += OnChanged;
+            try
+            {
+                if (predicate(Current)) return;
+                await completionSource.Task.WaitAsync(cancellationToken);
+            }
+            finally
+            {
+                Changed -= OnChanged;
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -51,6 +51,10 @@ namespace Nethermind.Synchronization.ParallelSync
         private readonly IBetterPeerStrategy _betterPeerStrategy = betterPeerStrategy;
         private readonly bool _needToWaitForHeaders = syncConfig.NeedToWaitForHeader;
         private readonly ILogger _logger = logManager.GetClassLogger<MultiSyncModeSelector>();
+        private readonly Lock _modeLock = new();
+
+        private volatile SyncMode _current = SyncMode.Disconnected;
+        private EventHandler<SyncModeChangedEventArgs>? _changed;
 
         private bool FastSyncEnabled => _syncConfig.FastSync;
         private bool FastBodiesEnabled => FastSyncEnabled && _syncConfig.DownloadBodiesInFastSync;
@@ -67,9 +71,13 @@ namespace Nethermind.Synchronization.ParallelSync
 
         public event EventHandler<SyncModeChangedEventArgs>? Preparing;
         public event EventHandler<SyncModeChangedEventArgs>? Changing;
-        public event EventHandler<SyncModeChangedEventArgs>? Changed;
+        public event EventHandler<SyncModeChangedEventArgs>? Changed
+        {
+            add { lock (_modeLock) _changed += value; }
+            remove { lock (_modeLock) _changed -= value; }
+        }
 
-        public SyncMode Current { get; private set; } = SyncMode.Disconnected;
+        public SyncMode Current => _current;
 
         public async Task StartAsync()
         {
@@ -226,8 +234,14 @@ namespace Nethermind.Synchronization.ParallelSync
 
             Preparing?.Invoke(this, args);
             Changing?.Invoke(this, args);
-            Current = newModes;
-            Changed?.Invoke(this, args);
+            EventHandler<SyncModeChangedEventArgs>? changed;
+            lock (_modeLock)
+            {
+                _current = newModes;
+                changed = _changed;
+            }
+
+            changed?.Invoke(this, args);
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

- Protect the Pacer's batch and head-callback handshake with one short lock; no lock is held while awaiting the processor.
- Recheck the chain head immediately after recording a batch, so a `NewHeadBlock` event that ran just before the batch existed cannot leave the importer waiting indefinitely.
- Retain an existing pause observer when that recheck resolves a speculative batch without an actual pause.
- Keep one deterministic Pacer regression for the missed head-update ordering and observer-retention path; the ERA regression covers observing a real pause end-to-end.
- Safely publish the ERA importer's existing active-Pacer test hook and make its regression test wait for the real pause instead of a timing side effect.
- Dispose the per-case JSON-RPC simulation blockchains deterministically.
- Make sync-mode waits subscribe before their final state check, and publish the mode with its changed-handler snapshot under one short lock so a transition cannot be missed.
- Route the BAL E2E environment through the shared sync-mode wait and cover the transition-before-subscription ordering deterministically.

The ERA near-head import loop is sequential, but it asynchronously queues blocks for the blockchain processor, which advances the chain and raises `NewHeadBlock` independently. The small synchronization and head recheck therefore protect production back-pressure state, not a test-only concern.

The sync-mode selector likewise runs independently of receipt migration and state sync waiters. The selector’s lock covers only mode publication and handler snapshotting; callbacks and waits happen after it is released.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Focused release, code-lint-shaped analyzer, and full release solution builds completed with warnings treated as errors.
- `BlockTreeSuggestPacerTests`: 4/4 passed.
- `ImportAsArchiveSync_WillPaceSuggestBlock`: 5 fresh-process repetitions passed.
- `TestSimulate_TimestampIsComputedCorrectly_WhenNoTimestampOverride`: 5 fresh-process repetitions passed (8 cases each).
- The deterministic sync-mode regression and both affected BAL sync cases passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No