### PR TITLE
test(merge): drop NewPayloadBlockProcessingTimeout in engine tests

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -576,10 +576,7 @@ public partial class EngineModuleTests
         const int BlockCount = 10;
         const int SyncingBlockNumber = 5;
 
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         for (int i = 1; i < BlockCount; i++)
@@ -599,10 +596,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task ForkChoiceUpdatedV3_should_allow_lower_finalized_than_previous_when_building_payload()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
+        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         ExecutionPayloadV3 block1 = await AddNewBlockV3(rpcModule, chain);
@@ -634,10 +628,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task GetBlobsV1_should_throw_if_more_than_128_requested_blobs([Values(128, 129)] int requestSize)
     {
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         List<byte[]> request = new(requestSize);
@@ -663,10 +654,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task GetBlobsV1_should_handle_empty_request()
     {
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         ResultWrapper<IReadOnlyList<BlobAndProofV1?>> result = await rpcModule.engine_getBlobsV1([]);
@@ -678,10 +666,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task GetBlobsV1_should_return_requested_blobs([Values(1, 2, 3, 4, 5, 6)] int numberOfBlobs)
     {
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         Transaction blobTx = Build.A.Transaction
@@ -703,10 +688,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task GetBlobsV1_should_return_nulls_when_blobs_not_found([Values(1, 2, 3, 4, 5, 6)] int numberOfRequestedBlobs)
     {
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         // we are not adding this tx
@@ -729,10 +711,7 @@ public partial class EngineModuleTests
     {
         int requestSize = 10 * numberOfBlobs;
 
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         Transaction blobTx = Build.A.Transaction
@@ -829,26 +808,17 @@ public partial class EngineModuleTests
     public async Task Sync_proper_chain_when_header_fork_came_from_fcu_and_beacon_sync()
     {
         // fork A
-        MergeTestBlockchain chainA = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
+        MergeTestBlockchain chainA = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModuleA = chainA.EngineRpcModule;
         await rpcModuleA.engine_forkchoiceUpdatedV3(new(chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!), null);
 
         // main fork B
-        MergeTestBlockchain chainB = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
+        MergeTestBlockchain chainB = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModuleB = chainB.EngineRpcModule;
         await rpcModuleB.engine_forkchoiceUpdatedV3(new(chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!), null);
 
         // syncing chain
-        MergeTestBlockchain chainC = await CreateBlockchain(releaseSpec: Cancun.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
+        MergeTestBlockchain chainC = await CreateBlockchain(releaseSpec: Cancun.Instance);
         IEngineRpcModule rpcModuleC = chainC.EngineRpcModule;
         await rpcModuleC.engine_forkchoiceUpdatedV3(new(chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!, chainA.BlockTree.Head!.Hash!), null);
 
@@ -1077,10 +1047,7 @@ public partial class EngineModuleTests
     private async Task<(IEngineRpcModule, string?, Transaction[], MergeTestBlockchain chain)> BuildAndGetPayloadV3Result(
         IReleaseSpec spec, int transactionCount = 0, bool oneBlobPerTx = true)
     {
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: spec, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000,
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: spec);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
         Transaction[] txs = [];
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V5.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V5.cs
@@ -120,10 +120,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task GetBlobsV2_should_throw_if_more_than_128_requested_blobs([Values(128, 129)] int requestSize)
     {
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = (int)TimeSpan.FromDays(1).TotalMilliseconds
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         List<byte[]> request = new(requestSize);
@@ -149,10 +146,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task GetBlobsV2_should_handle_empty_request()
     {
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = (int)TimeSpan.FromDays(1).TotalMilliseconds
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         ResultWrapper<IReadOnlyList<BlobAndProofV2?>?> result = await rpcModule.engine_getBlobsV2([]);
@@ -164,10 +158,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task GetBlobsV2_should_return_requested_blobs([Values(1, 2, 3, 4, 5, 6)] int numberOfBlobs)
     {
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = (int)TimeSpan.FromDays(1).TotalMilliseconds
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         Transaction blobTx = Build.A.Transaction
@@ -195,10 +186,7 @@ public partial class EngineModuleTests
     [Test]
     public async Task GetBlobsV2_should_return_empty_array_when_blobs_not_found([Values(1, 2, 3, 4, 5, 6)] int numberOfRequestedBlobs)
     {
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = (int)TimeSpan.FromDays(1).TotalMilliseconds
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         // we are not adding this tx
@@ -221,10 +209,7 @@ public partial class EngineModuleTests
     {
         int requestSize = multiplier * numberOfBlobs;
 
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = (int)TimeSpan.FromDays(1).TotalMilliseconds
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         Transaction blobTx = Build.A.Transaction
@@ -270,10 +255,7 @@ public partial class EngineModuleTests
     {
         int requestSize = multiplier * numberOfBlobs;
 
-        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance, mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = (int)TimeSpan.FromDays(1).TotalMilliseconds
-        });
+        MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Osaka.Instance);
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
 
         Transaction blobTx = Build.A.Transaction

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
@@ -46,10 +46,7 @@ public class NewPayloadHandlerRaceConditionTests : BaseEngineModuleTests
         // Multiple threads trying to complete the same TaskCompletionSource
         // and unsubscribe the same event handler multiple times
 
-        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 5000 // Long timeout to allow race condition to occur
-        });
+        using MergeTestBlockchain chain = await CreateBlockchain();
 
         // Create a block to process that will trigger the event handling mechanism
         Block block = Build.A.Block


### PR DESCRIPTION
## Changes

When block validation takes longer than `NewPayloadBlockProcessingTimeout`, `NewPayloadHandler` returns `SYNCING`. #11381 raised the default for non-timeout tests to 60 s to avoid this. But some tests that don't test the timeout still set their own value that is lower than the default, so they still flake on slow [CI](https://github.com/NethermindEth/nethermind/actions/runs/29572432634/job/87860337539):

Fix: remove the custom timeout from these tests so they use the 60 s default.

**Race-condition test:** `NewPayloadV1_RaceCondition_EventHandling` runs 10 calls at once and checks they all return the same status, so it needs the timeout to not fire. Removed its `5000` so it uses 60 s.

**Not changed:** tests that really check the timeout keep their short values.