### PR TITLE
Demote per-block tx selection logs from Debug to Trace

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -57,7 +57,7 @@ namespace Nethermind.Consensus.Producers
             ulong maxBlobCount = spec.MaxProductionBlobCount(blocksConfig.BlockProductionBlobLimit);
             IEnumerable<Transaction> transactions = GetOrderedTransactions(pendingTransactions, comparer, filter, gasLimit);
             IEnumerable<(Transaction tx, ulong blobChain)> blobTransactions = GetOrderedBlobTransactions(pendingBlobTransactionsEquivalences, comparer, filter, maxBlobCount);
-            if (_logger.IsDebug) _logger.Debug($"Collecting pending transactions at block gas limit {gasLimit}.");
+            if (_logger.IsTrace) _logger.Trace($"Collecting pending transactions at block gas limit {gasLimit}.");
 
             int checkedTransactions = 0;
             int selectedTransactions = 0;
@@ -102,7 +102,7 @@ namespace Nethermind.Consensus.Producers
                 }
             }
 
-            if (_logger.IsDebug) _logger.Debug($"Potentially selected {selectedTransactions} out of {checkedTransactions} pending transactions checked.");
+            if (_logger.IsTrace) _logger.Trace($"Potentially selected {selectedTransactions} out of {checkedTransactions} pending transactions checked.");
 
             bool ResolveBlob(Transaction blobTx, out Transaction fullBlobTx)
             {


### PR DESCRIPTION
## Changes

- Demoted two log messages in `TxPoolTxSource.GetTransactions` from `Debug` to `Trace`: "Collecting pending transactions at block gas limit ..." and "Potentially selected N out of M pending transactions checked."

These fire on every block-production attempt so at Debug level they flood the log with noise. 

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)