### PR TITLE
fix(rpc): report missing state in eth_getStorageAt gracefully

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -508,18 +508,20 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
-    public async Task Eth_get_storage_at_missing_trie_node()
+    public async Task Eth_get_storage_at_no_state_reports_state_unavailable_like_sibling_methods()
     {
-        // Asserts the patricia "missing trie node" error, which has no equivalent in the flat backend.
+        // A block with no state must fail with -32002 "No state available", matching eth_getBalance/getCode/
+        // getTransactionCount/call — not surface a backend exception through the generic -32603 handler.
         using Context ctx = await Context.Create(useFlatDb: false);
         await Task.Delay(100); // Wait a bit for pruning
         ctx.Test.WorldStateManager.FlushCache(CancellationToken.None);
         ctx.Test.StateDb.Clear();
-        BlockParameter? blockParameter = null;
-        BlockHeader? header = ctx.Test.BlockFinder.FindHeader(blockParameter);
         string serialized = await ctx.Test.TestEthRpc("eth_getStorageAt", TestItem.AddressA.Bytes.ToHexString(true), "0x1");
-        string expected = $"{{\"jsonrpc\":\"2.0\",\"error\":{{\"code\":-32000,\"message\":\"missing trie node {header?.StateRoot} (path ) state {header?.StateRoot} is not available\"}},\"id\":67}}";
-        Assert.That(serialized, Is.EqualTo(expected));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(serialized, Does.Contain("\"code\":-32002"));
+            Assert.That(serialized, Does.Contain("No state available for block"));
+        }
     }
 
     private static IEnumerable<TestCaseData> EthGetStorageValuesCases()

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -206,6 +206,11 @@ public partial class EthRpcModule(
         }
 
         BlockHeader? header = searchResult.Object;
+        if (!_blockchainBridge.HasStateForBlock(header!))
+        {
+            return GetStateFailureResult<byte[]>(header!);
+        }
+
         try
         {
             ReadOnlySpan<byte> storage = _stateReader.GetStorage(header!, address, positionIndex);


### PR DESCRIPTION
## Changes

- `eth_getStorageAt` was the only state method without the `HasStateForBlock` guard, so querying a block with no state surfaced a backend exception instead of the `-32002` state-unavailable error every sibling returns: on the flat backend an `InvalidOperationException` escaped through the generic `-32603 Internal error` handler with a full server stack trace in `error.data`; on the trie backend a whole-state miss reported a raw missing-trie-node error.
- Add the same guard `eth_getBalance` / `eth_getCode` / `eth_getTransactionCount` / `eth_call` / `eth_getStorageValues` already use, so all state methods answer a stateless block identically with `-32002 "No state available for block ..."`.
- The `MissingTrieNodeException` catch is kept for partial state, where the root exists but a deeper node is missing.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

The no-state test (whole state db cleared) asserts `-32002` / "No state available" and fails without the guard; the remaining `eth_getStorageAt` tests (value reads at every block tag, leading-zero keys, storage-values batch) are unchanged and pass, covering the value path and the partial-state error path.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

`eth_getStorageAt` on a block with no available state now returns `-32002 "No state available for block ..."`, matching the other state methods, instead of a backend-specific error (previously `-32603 Internal error` on the flat backend, missing-trie-node on the trie backend).
