### PR TITLE
perf(evm): skip recipient delegation lookup when EIP-8037 is not active

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -307,7 +307,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             // EIP-8037 top-frame charges. At most one applies: a delegated recipient has code and is
             // therefore never a dead account, hence the if/else-if.
-            bool recipientIsDelegated = spec.IsEip7702Enabled && tx.To is not null
+            bool recipientIsDelegated = spec.IsEip8037Enabled && spec.IsEip7702Enabled && tx.To is not null
                 && _codeInfoRepository.TryGetDelegation(tx.To, spec, out _);
 
             // The flag defers the halt to ExecuteEvmCall so the value transfer rolls back and the


### PR DESCRIPTION
## Changes

- Skip the recipient delegation lookup in `TransactionProcessor` when EIP-8037 is not active. `recipientIsDelegated` is only consumed by the EIP-8037 top-frame delegation charge, so pre-8037 (mainnet today) the `TryGetDelegation` call ran for every transaction with a recipient and its result was discarded - a redundant `HasCode`/`GetCodeHash`/code fetch plus an `Address` allocation per transaction, duplicating reads `BuildExecutionEnvironment` had already performed. With EIP-8037 active the evaluation is unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Covered by the existing suites: full `Nethermind.Evm.Test` passes (4,948 tests), including the TransactionProcessor, EIP-7702, EIP-8037, and SetCode suites. With EIP-8037 enabled the expression is evaluated identically; without it the branch that consumes the value is unreachable, so no observable behavior changes.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No