### PR TITLE
refactor: remove unused IFlatDbManager.ReorgBoundaryReached

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
@@ -1,11 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Threading;
 using Nethermind.Core.Crypto;
 using Nethermind.State.Flat;
-using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Core.Test.Modules;
 
@@ -37,10 +35,4 @@ internal class FlatDbManagerTestCompat(IFlatDbManager flatDbManager) : IFlatDbMa
     public void FlushCache(CancellationToken cancellationToken) => flatDbManager.FlushCache(cancellationToken);
 
     public void AddSnapshot(Snapshot snapshot, TransientResource transientResource) => flatDbManager.AddSnapshot(snapshot, transientResource);
-
-    public event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached
-    {
-        add => flatDbManager.ReorgBoundaryReached += value;
-        remove => flatDbManager.ReorgBoundaryReached -= value;
-    }
 }

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -10,7 +10,6 @@ using Nethermind.Logging;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.Core.Attributes;
 using Nethermind.State.Flat.PersistedSnapshots;
-using Nethermind.Trie.Pruning;
 
 namespace Nethermind.State.Flat;
 

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -57,8 +57,6 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     private int _isDisposed = 0;
     private readonly bool _enableDetailedMetrics;
 
-    public event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
-
     public FlatDbManager(
         IResourcePool resourcePool,
         IProcessExitSource processExitSource,
@@ -167,7 +165,6 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         if (currentPersistedStateId == StateId.PreGenesis) return;
 
         ClearReadOnlyBundleCache();
-        ReorgBoundaryReached?.Invoke(this, new ReorgBoundaryReached(currentPersistedStateId.BlockNumber));
     }
 
     private async Task RunTrieCachePopulator(CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
@@ -1,13 +1,10 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Trie.Pruning;
-
 namespace Nethermind.State.Flat;
 
 public interface IFlatDbManager : IFlatCommitTarget
 {
-    event EventHandler<ReorgBoundaryReached>? ReorgBoundaryReached;
     SnapshotBundle GatherSnapshotBundle(in StateId baseBlock, ResourcePool.Usage usage);
     ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock);
     void FlushCache(CancellationToken cancellationToken);


### PR DESCRIPTION
## Changes

- Remove `ReorgBoundaryReached` from `IFlatDbManager` and its implementation in `FlatDbManager` — the event was raised on every persist but had no subscribers anywhere in the tree.
- Remove the pass-through `add`/`remove` accessors in the test-only `FlatDbManagerTestCompat` decorator, which were the event's only other reference.

`BestPersistedState` is driven by `ITrieStore.ReorgBoundaryReached` (`WorldStateManager`), a separate event on a separate interface. That event and the `ReorgBoundaryReached` `EventArgs` type are untouched.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Dead-code removal with no behavior change — nothing subscribed to the event, so nothing observed it firing. `Nethermind.Core.Test` (transitively building `Nethermind.State.Flat`) compiles clean with `EnforceCodeStyleInBuild=true`: 0 warnings, 0 errors.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Worth noting separately: with this event gone it is explicit that nothing advances `BestPersistedState` on the flat path. If the flat DB is meant to drive that pointer, the wiring is missing — this PR does not address that, it just stops pretending the hook exists.
