### PR TITLE
perf: seal WorldState and CodeInfo

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -446,13 +446,11 @@ namespace Nethermind.Blockchain.Test
     }
 
     public class WorldStateStab()
-        : WorldState(Substitute.For<IWorldStateScopeProvider>(), LimboLogs.Instance), IWorldState
+        : WorldStateDecorator(Substitute.For<IWorldState>())
     {
-        public new UInt256 GetBalance(Address address) => UInt256.MaxValue;
-
         public static IReadOnlyStateProvider GetUntrackedReader() => TestReadOnlyStateProvider.Instance;
 
-        public new bool TryGetAccount(Address address, out AccountStruct account)
+        public override bool TryGetAccount(Address address, out AccountStruct account)
         {
             account = new(0ul, ulong.MaxValue);
             return true;

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -9,7 +9,7 @@ using Nethermind.Evm.Precompiles;
 
 namespace Nethermind.Evm.CodeAnalysis;
 
-public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
+public sealed class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
 {
     public static CodeInfo Empty { get; }
     // Empty code sentinel
@@ -49,14 +49,6 @@ public class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
     public CodeInfo(IPrecompile? precompile)
     {
         Precompile = precompile;
-        _analyzer = null;
-        _streamBuildState = StreamBuildUnavailable;
-    }
-
-    protected CodeInfo(IPrecompile precompile, ReadOnlyMemory<byte> code)
-    {
-        Precompile = precompile;
-        Code = code;
         _analyzer = null;
         _streamBuildState = StreamBuildUnavailable;
     }

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -28,7 +28,7 @@ using Nethermind.Logging;
 
 namespace Nethermind.State
 {
-    public class WorldState : IWorldState
+    public sealed class WorldState : IWorldState
     {
         internal readonly StateProvider _stateProvider;
         internal readonly PersistentStorageProvider _persistentStorageProvider;


### PR DESCRIPTION
## Changes

- Seal `WorldState`. It has no virtual members, and the only subclass in the solution was the test stub `WorldStateStab`, whose `new`-hiding was partly dead code (its `GetBalance` never took the interface slot because the interface member returns `ref readonly`); the stub now derives from `WorldStateDecorator` - the intended extension point - with a proper `override`.
- Seal `CodeInfo` and remove its `protected CodeInfo(IPrecompile, ReadOnlyMemory<byte>)` constructor, which had no callers and no derived types anywhere in the solution.

Sealing lets the JIT devirtualize interface calls on exact-typed references and removes an unused extension surface. External plugins that subclass either type would break; wrapping (`WorldStateDecorator`, `ICodeInfoRepository` decoration) is the supported pattern in-tree.

## Types of changes

#### What types of changes does your code introduce?

- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Full `Nethermind.slnx` compiles with no errors or new warnings (all projects, including the Optimism/Taiko/Xdc/Flashbots plugins - none subclass either type). `Nethermind.State.Test` (1,157), `Nethermind.Evm.Test` (4,948), and the two fixtures using `WorldStateStab` (`TransactionsExecutorTests`, `BlockProcessorTests`, 57) all pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No