### PR TITLE
perf(blockchain): presize BlockReceiptsTracer lists and span the bloom loop

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -321,8 +321,11 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         _currentIndex = 0;
         CurrentTx = null;
         _currentTxTracer = NullTxTracer.Instance;
+        int txCount = block.Transactions.Length;
         _txReceipts.Clear();
+        _txReceipts.EnsureCapacity(txCount);
         _cumulativeBlockGasPerTx.Clear();
+        _cumulativeBlockGasPerTx.EnsureCapacity(txCount);
         _cumulativeReceiptGas = 0;
 
         _otherTracer.StartNewBlockTrace(block);
@@ -369,9 +372,8 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         {
             Bloom blockBloom = new();
             Block.Header.Bloom = blockBloom;
-            for (int index = 0; index < _txReceipts.Count; index++)
+            foreach (TxReceipt? receipt in CollectionsMarshal.AsSpan(_txReceipts))
             {
-                TxReceipt? receipt = _txReceipts[index];
                 if (receipt is not null)
                 {
                     blockBloom.Accumulate(receipt.Bloom!);


### PR DESCRIPTION
## Changes

- Presize `BlockReceiptsTracer`'s receipt and cumulative-gas lists to the block's transaction count in `StartNewBlockTrace`, avoiding repeated list growth while receipts accumulate. The tracer instance is reused across blocks, so this only costs anything when a block exceeds the previously reached capacity.
- Iterate the final block-bloom accumulation in `EndBlockTrace` over `CollectionsMarshal.AsSpan` instead of indexing the list; the null check for diagnostic `SetReceipt` gaps is preserved.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Behavior-identical change covered by the existing suite: full `Nethermind.Blockchain.Test` passes (1,557 tests).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No