### PR TITLE
Skip Rlp wrapper allocation in StorageTree

### DIFF
--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -80,15 +80,10 @@ namespace Nethermind.State
             }
             else
             {
-                Rlp rlpEncoded = Rlp.Encode(value);
-                if (rlpEncoded is null)
-                {
-                    encodedValue = [];
-                }
-                else
-                {
-                    encodedValue = rlpEncoded.Bytes;
-                }
+                // Encode straight into the leaf's persistent buffer, skipping the throwaway Rlp wrapper
+                // that Rlp.Encode(value) would allocate per changed slot on the block-commit flush path.
+                encodedValue = GC.AllocateUninitializedArray<byte>(Rlp.LengthOf(value));
+                Rlp.Encode(value, encodedValue);
             }
 
             return new BulkSetEntry(in key, encodedValue);

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -80,8 +80,6 @@ namespace Nethermind.State
             }
             else
             {
-                // Encode straight into the leaf's persistent buffer, skipping the throwaway Rlp wrapper
-                // that Rlp.Encode(value) would allocate per changed slot on the block-commit flush path.
                 encodedValue = GC.AllocateUninitializedArray<byte>(Rlp.LengthOf(value));
                 Rlp.Encode(value, encodedValue);
             }


### PR DESCRIPTION
## Changes

- Skip per-slot Rlp wrapper allocation on the hot block-commit flush path in StorageTree

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No