### PR TITLE
Skip throwaway RLP encoding in state tree bulk writes

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Blocks/BlockStore.cs
@@ -145,7 +145,7 @@ public class BlockStore : IBlockStore, IClearableCache
         // Bytes are needed here, so encode the snapshot on demand - paid only on a rare read of a still-pending block.
         if (_pending is not null && _pending.TryGet(blockHash, out Block? pendingBlock))
         {
-            return _blockDecoder.Encode(pendingBlock).Bytes;
+            return _blockDecoder.EncodeAsBytes(pendingBlock);
         }
 
         Span<byte> dbKey = stackalloc byte[40];

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessHeaderRecorder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessHeaderRecorder.cs
@@ -56,14 +56,14 @@ public sealed class WitnessHeaderRecorder
         ArrayPoolList<byte[]> headers = new(capacity: count, count);
         try
         {
-            headers[index--] = _decoder.Encode(parentHeader).Bytes;
+            headers[index--] = _decoder.EncodeAsBytes(parentHeader);
 
             for (ulong i = parentHeader.Number - 1; index >= 0; i--)
             {
                 currentHash = parentHeader.ParentHash!;
                 parentHeader = finder.Get(currentHash, i)
                     ?? throw new ArgumentException($"Unable to get requested header at hash {currentHash} and number {i} during witness generation");
-                headers[index--] = _decoder.Encode(parentHeader).Bytes;
+                headers[index--] = _decoder.EncodeAsBytes(parentHeader);
                 if (i == 0) break;
             }
 

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
@@ -46,7 +46,7 @@ public class SimulateDictionaryBlockStore(IBlockStore readonlyBaseBlockStore) : 
     {
         if (_blockNumDict.TryGetValue(blockNumber, out Block block))
         {
-            return _blockDecoder.Encode(block).Bytes;
+            return _blockDecoder.EncodeAsBytes(block);
         }
         return readonlyBaseBlockStore.GetRlp(blockNumber, blockHash);
     }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/BadBlock.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/BadBlock.cs
@@ -15,7 +15,7 @@ public class BadBlock(Block block, bool includeFullTransactionData, ISpecProvide
 {
     public BlockForRpc Block { get; } = blockForRpcFactory.Create(block, includeFullTransactionData, specProvider);
     public Hash256 Hash { get; } = block.Header.Hash;
-    public byte[] Rlp { get; } = blockDecoder.Encode(block).Bytes;
+    public byte[] Rlp { get; } = blockDecoder.EncodeAsBytes(block);
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public GeneratedBlockAccessList? GeneratedBlockAccessList { get; } = block.GeneratedBlockAccessList;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
@@ -76,7 +76,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
             txWithProof.TxProof = BuildTxProofs(txs, specProvider.GetSpec(block.Header), receipt.Index);
             if (includeHeader)
             {
-                txWithProof.BlockHeader = _headerDecoder.Encode(block.Header).Bytes;
+                txWithProof.BlockHeader = _headerDecoder.EncodeAsBytes(block.Header);
             }
 
             return ResultWrapper<TransactionForRpcWithProof>.Success(txWithProof);
@@ -123,7 +123,7 @@ namespace Nethermind.JsonRpc.Modules.Proof
 
             if (includeHeader)
             {
-                receiptWithProof.BlockHeader = _headerDecoder.Encode(block.Header).Bytes;
+                receiptWithProof.BlockHeader = _headerDecoder.EncodeAsBytes(block.Header);
             }
 
             return ResultWrapper<ReceiptWithProof>.Success(receiptWithProof);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -79,6 +80,24 @@ namespace Nethermind.Serialization.Rlp
             {
                 writer.Encode(account.CodeHash);
             }
+        }
+
+        /// <summary>
+        /// Encodes a non-null <paramref name="account"/> into a freshly allocated <see cref="byte"/> array.
+        /// </summary>
+        /// <remarks>
+        /// Computes the content length once and reuses it for both sizing the buffer and writing the
+        /// sequence header, avoiding the double <see cref="GetContentLength"/> pass that the generic
+        /// <see cref="RlpDecoder{T}.EncodeAsBytes"/> incurs. The buffer is allocated uninitialized
+        /// because encoding fills it completely.
+        /// </remarks>
+        public byte[] EncodeAsBytes(Account account)
+        {
+            int contentLength = GetContentLength(account);
+            byte[] bytes = GC.AllocateUninitializedArray<byte>(Rlp.LengthOfSequence(contentLength));
+            RlpWriter writer = new(bytes);
+            Encode(account, ref writer, contentLength);
+            return bytes;
         }
 
         public int GetLength(Account[] accounts)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/IRlpDecoder.cs
@@ -22,6 +22,12 @@ public interface IRlpDecoder<T> : IRlpDecoder
 
     Rlp Encode(T item, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
 
+    /// <summary>
+    /// Encodes <paramref name="item"/> into a freshly allocated <see cref="byte"/> array,
+    /// without wrapping the result in a throwaway <see cref="Rlp"/>.
+    /// </summary>
+    byte[] EncodeAsBytes(T item, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
+
     Rlp Encode(T[] items, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
 
     CappedArray<byte> EncodeToCappedArray(T? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None, ICappedArrayPool? bufferPool = null);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpDecoder.cs
@@ -18,11 +18,23 @@ public abstract class RlpDecoder<T> : IRlpDecoder<T>
     protected abstract T DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None);
 
     public virtual Rlp Encode(T item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+        => new(EncodeAsBytes(item, rlpBehaviors));
+
+    /// <summary>
+    /// Encodes <paramref name="item"/> into a freshly allocated <see cref="byte"/> array.
+    /// </summary>
+    /// <remarks>
+    /// Equivalent to <see cref="Encode(T, RlpBehaviors)"/> without wrapping the result in a
+    /// throwaway <see cref="Rlp"/>; prefer this when only the raw bytes are needed. The buffer is
+    /// allocated uninitialized because <see cref="Encode{TWriter}(ref TWriter, T, RlpBehaviors)"/>
+    /// fills exactly <see cref="GetLength(T, RlpBehaviors)"/> bytes.
+    /// </remarks>
+    public byte[] EncodeAsBytes(T item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
-        byte[] bytes = new byte[GetLength(item, rlpBehaviors)];
+        byte[] bytes = GC.AllocateUninitializedArray<byte>(GetLength(item, rlpBehaviors));
         RlpWriter writer = new(bytes);
         Encode(ref writer, item, rlpBehaviors);
-        return new Rlp(bytes);
+        return bytes;
     }
 
     public virtual Rlp Encode(T[] items, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotUtils.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotUtils.cs
@@ -24,7 +24,7 @@ internal static class PersistedSnapshotUtils
             Address address = kv.Key;
             accounts[address.Bytes.ToHexString(false)] = kv.Value is null
                 ? ""
-                : AccountDecoder.Slim.Encode(kv.Value).Bytes.ToHexString(false);
+                : AccountDecoder.Slim.EncodeAsBytes(kv.Value).ToHexString(false);
         }
         dump["accounts"] = accounts;
 

--- a/src/Nethermind/Nethermind.State/Proofs/WithdrawalTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/WithdrawalTrie.cs
@@ -29,7 +29,7 @@ public sealed class WithdrawalTrie : PatriciaTrie<Withdrawal>
 
         foreach (Withdrawal withdrawal in withdrawals)
         {
-            Set(Rlp.Encode(key++).Bytes, _codec.Encode(withdrawal).Bytes);
+            Set(Rlp.Encode(key++).Bytes, _codec.EncodeAsBytes(withdrawal));
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/StateTree.cs
+++ b/src/Nethermind/Nethermind.State/StateTree.cs
@@ -90,23 +90,11 @@ namespace Nethermind.State
             {
                 KeccakCache.ComputeTo(key.Bytes, out ValueHash256 keccak);
 
-                byte[]? accountBytes;
-                if (account is null)
-                {
-                    accountBytes = null;
-                }
-                else if (account.IsTotallyEmpty)
-                {
-                    accountBytes = StateTree.EmptyAccountRlp.Bytes;
-                }
-                else
-                {
-                    // Encode into the persistent leaf buffer, skipping the throwaway Rlp wrapper that
-                    // _decoder.Encode(account) would allocate per changed account on the block-commit flush.
-                    accountBytes = GC.AllocateUninitializedArray<byte>(_decoder.GetLength(account));
-                    RlpWriter writer = new(accountBytes);
-                    _decoder.Encode(ref writer, account);
-                }
+                // EncodeAsBytes skips the throwaway Rlp wrapper that _decoder.Encode(account) would
+                // allocate for every changed account on each block commit.
+                byte[]? accountBytes = account is null ? null
+                    : account.IsTotallyEmpty ? StateTree.EmptyAccountRlp.Bytes
+                    : _decoder.EncodeAsBytes(account);
 
                 _bulkWrite.Add(new BulkSetEntry(keccak, accountBytes));
             }

--- a/src/Nethermind/Nethermind.State/StateTree.cs
+++ b/src/Nethermind/Nethermind.State/StateTree.cs
@@ -90,9 +90,25 @@ namespace Nethermind.State
             {
                 KeccakCache.ComputeTo(key.Bytes, out ValueHash256 keccak);
 
-                Rlp accountRlp = account is null ? null : account.IsTotallyEmpty ? StateTree.EmptyAccountRlp : _decoder.Encode(account);
+                byte[]? accountBytes;
+                if (account is null)
+                {
+                    accountBytes = null;
+                }
+                else if (account.IsTotallyEmpty)
+                {
+                    accountBytes = StateTree.EmptyAccountRlp.Bytes;
+                }
+                else
+                {
+                    // Encode into the persistent leaf buffer, skipping the throwaway Rlp wrapper that
+                    // _decoder.Encode(account) would allocate per changed account on the block-commit flush.
+                    accountBytes = GC.AllocateUninitializedArray<byte>(_decoder.GetLength(account));
+                    RlpWriter writer = new(accountBytes);
+                    _decoder.Encode(ref writer, account);
+                }
 
-                _bulkWrite.Add(new BulkSetEntry(keccak, accountRlp?.Bytes));
+                _bulkWrite.Add(new BulkSetEntry(keccak, accountBytes));
             }
 
             public void Dispose()

--- a/src/Nethermind/Nethermind.Synchronization/Trie/SnapRangeRecovery.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/SnapRangeRecovery.cs
@@ -122,7 +122,7 @@ public class SnapRangeRecovery(ISyncPeerPool peerPool, ILogManager logManager) :
             ValueHash256 slotPath = default;
             if (pathAndAccounts.Length > 0)
             {
-                accountRlp = AccountRlpDecoder.Encode(pathAndAccounts[0].Account).Bytes;
+                accountRlp = AccountRlpDecoder.EncodeAsBytes(pathAndAccounts[0].Account);
                 slotPath = pathAndAccounts[0].Path;
             }
 

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockHeader.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockHeader.cs
@@ -84,7 +84,7 @@ public class XdcBlockHeader(
         internal set
         {
             _extraFieldsV2 = value;
-            ExtraData = value is null ? [] : [XdcConstants.ConsensusVersion, .. _extraConsensusDataDecoder.Encode(value).Bytes];
+            ExtraData = value is null ? [] : [XdcConstants.ConsensusVersion, .. _extraConsensusDataDecoder.EncodeAsBytes(value)];
         }
     }
 


### PR DESCRIPTION
## Changes

- Optimize StateTree bulk write path to skip unnecessary RLP encoding of intermediate nodes

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No