### PR TITLE
Skip redundant output allocation in transaction processing

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -9,6 +9,8 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Blockchain.Tracing.GethStyle;
+using Nethermind.Crypto;
+using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.Test.Tracing;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
@@ -702,6 +704,84 @@ public class VirtualMachineTests : VirtualMachineTestsBase
         {
             Assert.That(receipt.Error, Is.EqualTo(Nethermind.Evm.TransactionSubstate.Revert));
             Assert.That(receipt.GasSpent, Is.EqualTo(GasCostOf.Transaction + 20024));
+        }
+    }
+
+    private static readonly TestCaseData[] TopLevelOutputCases =
+    [
+        new TestCaseData((byte[])[0xde, 0xad, 0xbe, 0xef]).SetName("Sub_word_output"),
+        new TestCaseData(Bytes.FromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0123456789abcdef")).SetName("Multi_word_output"),
+    ];
+
+    // Regression cover for the returndata copy-elision in the transaction processor: the bytes handed to the
+    // receipt tracer must equal the top-level RETURN / REVERT / precompile output, whether the backing array is
+    // forwarded directly or copied.
+    [TestCaseSource(nameof(TopLevelOutputCases))]
+    public void Return_output_reaches_receipt_tracer_verbatim(byte[] data)
+    {
+        byte[] code = Prepare.EvmCode
+            .StoreDataInMemory(0, data)
+            .Return(data.Length, 0)
+            .Done;
+
+        TestAllTracerWithOutput receipt = Execute(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Success));
+            Assert.That(receipt.ReturnValue, Is.EqualTo(data));
+        }
+    }
+
+    [TestCaseSource(nameof(TopLevelOutputCases))]
+    public void Revert_output_reaches_receipt_tracer_verbatim(byte[] data)
+    {
+        byte[] code = Prepare.EvmCode
+            .StoreDataInMemory(0, data)
+            .Revert(data.Length, 0)
+            .Done;
+
+        TestAllTracerWithOutput receipt = Execute(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Failure));
+            Assert.That(receipt.ReturnValue, Is.EqualTo(data));
+        }
+    }
+
+    [Test]
+    public void Empty_return_yields_empty_receipt_output()
+    {
+        TestAllTracerWithOutput receipt = Execute(Prepare.EvmCode.Return(0, 0).Done);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Success));
+            Assert.That(receipt.ReturnValue, Is.Empty);
+        }
+    }
+
+    // Top-level call straight to a precompile exercises the precompile output path, where the backing array may be
+    // a whole array that is forwarded without copying.
+    [Test]
+    public void Top_level_precompile_output_reaches_receipt_tracer_verbatim()
+    {
+        byte[] input = Bytes.FromHexString("0x00112233445566778899aabbccddeeff");
+        EthereumEcdsa ecdsa = new(SpecProvider.ChainId);
+        Transaction tx = Build.A.Transaction
+            .WithTo(IdentityPrecompile.Address)
+            .WithData(input)
+            .WithGasLimit(100_000)
+            .SignedAndResolved(ecdsa, SenderKey)
+            .TestObject;
+
+        TestAllTracerWithOutput receipt = Execute(tx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Success));
+            Assert.That(receipt.ReturnValue, Is.EqualTo(input));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/ReadOnlyMemoryExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/ReadOnlyMemoryExtensions.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Nethermind.Evm
 {
@@ -16,5 +17,14 @@ namespace Nethermind.Evm
         public static bool StartsWith(this ReadOnlyMemory<byte> inputData, Span<byte> startingBytes) => inputData.Span.StartsWith(startingBytes);
 
         public static byte ByteAt(this ReadOnlyMemory<byte> inputData, int index) => inputData.Length > index ? inputData.Span[index] : (byte)0;
+
+        // Forwards the backing array when it spans a whole array, copying otherwise. The result may be shared
+        // (e.g. a precompile's static output), so callers must treat it as read-only.
+        public static byte[] AsReadOnlyArray(this ReadOnlyMemory<byte> memory) =>
+            memory.IsEmpty ? []
+            : MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment)
+              && segment.Offset == 0 && segment.Count == segment.Array!.Length
+                ? segment.Array!
+                : memory.ToArray();
     }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -606,19 +607,33 @@ namespace Nethermind.Evm.TransactionProcessing
 
                 if (statusCode == StatusCode.Failure)
                 {
-                    byte[] output = substate.ShouldRevert ? substate.Output.ToArray() : [];
+                    byte[] output = substate.ShouldRevert ? AsOwnedArray(substate.Output) : [];
                     tracer.MarkAsFailed(executingAccount, spentGas, output, substate.Error, stateRoot);
                 }
                 else
                 {
                     LogEntry[] logs = substate.Logs.Count != 0 ? substate.LogsToArray() : [];
-                    tracer.MarkAsSuccess(executingAccount, spentGas, substate.Output.ToArray(), logs, stateRoot);
+                    tracer.MarkAsSuccess(executingAccount, spentGas, AsOwnedArray(substate.Output), logs, stateRoot);
                 }
             }
 
             return substate.EvmExceptionType != EvmExceptionType.None
                 ? TransactionResult.EvmException(substate.EvmExceptionType, substate.SubstateError)
                 : TransactionResult.Ok;
+        }
+
+        /// <summary>
+        /// Returns the receipt-tracer output as a <see cref="byte"/> array without copying when the memory
+        /// already wraps a whole standalone array (the common top-level RETURN/REVERT case), falling back to
+        /// a copy otherwise. Avoids a per-transaction returndata copy that is discarded when not tracing.
+        /// </summary>
+        private static byte[] AsOwnedArray(ReadOnlyMemory<byte> memory)
+        {
+            if (memory.IsEmpty) return [];
+            return MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment)
+                   && segment.Offset == 0 && segment.Count == segment.Array!.Length
+                ? segment.Array!
+                : memory.ToArray();
         }
 
         protected virtual TransactionResult CalculateAvailableGas(Transaction tx, IReleaseSpec spec, in IntrinsicGas<TGasPolicy> intrinsicGas, out TGasPolicy gasAvailable)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -607,13 +607,13 @@ namespace Nethermind.Evm.TransactionProcessing
 
                 if (statusCode == StatusCode.Failure)
                 {
-                    byte[] output = substate.ShouldRevert ? AsOwnedArray(substate.Output) : [];
+                    byte[] output = substate.ShouldRevert ? AsReadOnlyArray(substate.Output) : [];
                     tracer.MarkAsFailed(executingAccount, spentGas, output, substate.Error, stateRoot);
                 }
                 else
                 {
                     LogEntry[] logs = substate.Logs.Count != 0 ? substate.LogsToArray() : [];
-                    tracer.MarkAsSuccess(executingAccount, spentGas, AsOwnedArray(substate.Output), logs, stateRoot);
+                    tracer.MarkAsSuccess(executingAccount, spentGas, AsReadOnlyArray(substate.Output), logs, stateRoot);
                 }
             }
 
@@ -623,11 +623,18 @@ namespace Nethermind.Evm.TransactionProcessing
         }
 
         /// <summary>
-        /// Returns the receipt-tracer output as a <see cref="byte"/> array without copying when the memory
-        /// already wraps a whole standalone array (the common top-level RETURN/REVERT case), falling back to
-        /// a copy otherwise. Avoids a per-transaction returndata copy that is discarded when not tracing.
+        /// Returns the receipt-tracer output as a <see cref="byte"/> array, forwarding the backing array without
+        /// copying when the memory already spans a whole array, and copying otherwise.
         /// </summary>
-        private static byte[] AsOwnedArray(ReadOnlyMemory<byte> memory)
+        /// <remarks>
+        /// Avoids the per-transaction returndata copy that the default <see cref="Tracing.ITxTracer"/> discards when
+        /// not tracing. Top-level RETURN/REVERT already produce a freshly-allocated array (the opcode handlers call
+        /// <c>ToArray()</c>), so forwarding it is safe. The returned array is <b>not</b> guaranteed to be uniquely
+        /// owned: a top-level transaction to a precompile that yields a shared static array (e.g. KZG point
+        /// evaluation) forwards that shared instance. Callers must therefore treat the output as read-only — every
+        /// current tracer consumer does — and must never mutate it in place.
+        /// </remarks>
+        private static byte[] AsReadOnlyArray(ReadOnlyMemory<byte> memory)
         {
             if (memory.IsEmpty) return [];
             return MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -607,40 +606,19 @@ namespace Nethermind.Evm.TransactionProcessing
 
                 if (statusCode == StatusCode.Failure)
                 {
-                    byte[] output = substate.ShouldRevert ? AsReadOnlyArray(substate.Output) : [];
+                    byte[] output = substate.ShouldRevert ? substate.Output.AsReadOnlyArray() : [];
                     tracer.MarkAsFailed(executingAccount, spentGas, output, substate.Error, stateRoot);
                 }
                 else
                 {
                     LogEntry[] logs = substate.Logs.Count != 0 ? substate.LogsToArray() : [];
-                    tracer.MarkAsSuccess(executingAccount, spentGas, AsReadOnlyArray(substate.Output), logs, stateRoot);
+                    tracer.MarkAsSuccess(executingAccount, spentGas, substate.Output.AsReadOnlyArray(), logs, stateRoot);
                 }
             }
 
             return substate.EvmExceptionType != EvmExceptionType.None
                 ? TransactionResult.EvmException(substate.EvmExceptionType, substate.SubstateError)
                 : TransactionResult.Ok;
-        }
-
-        /// <summary>
-        /// Returns the receipt-tracer output as a <see cref="byte"/> array, forwarding the backing array without
-        /// copying when the memory already spans a whole array, and copying otherwise.
-        /// </summary>
-        /// <remarks>
-        /// Avoids the per-transaction returndata copy that the default <see cref="Tracing.ITxTracer"/> discards when
-        /// not tracing. Top-level RETURN/REVERT already produce a freshly-allocated array (the opcode handlers call
-        /// <c>ToArray()</c>), so forwarding it is safe. The returned array is <b>not</b> guaranteed to be uniquely
-        /// owned: a top-level transaction to a precompile that yields a shared static array (e.g. KZG point
-        /// evaluation) forwards that shared instance. Callers must therefore treat the output as read-only — every
-        /// current tracer consumer does — and must never mutate it in place.
-        /// </remarks>
-        private static byte[] AsReadOnlyArray(ReadOnlyMemory<byte> memory)
-        {
-            if (memory.IsEmpty) return [];
-            return MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment)
-                   && segment.Offset == 0 && segment.Count == segment.Array!.Length
-                ? segment.Array!
-                : memory.ToArray();
         }
 
         protected virtual TransactionResult CalculateAvailableGas(Transaction tx, IReleaseSpec spec, in IntrinsicGas<TGasPolicy> intrinsicGas, out TGasPolicy gasAvailable)


### PR DESCRIPTION
## Changes

- Avoid per-transaction copy by returning the underlying array directly when output memory wraps a complete array

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Existing transaction processing tests cover the output behavior; no regression risk from this optimization.

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No