### PR TITLE
fix(rpc): align eth_getBlockAccessList and engine payload bodies V2 with execution-apis spec

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockFinderExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockFinderExtensionsTests.cs
@@ -70,6 +70,6 @@ public class BlockFinderExtensionsTests
         Assert.That(result.IsError, Is.True);
         Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.PrunedHistoryUnavailable));
         Assert.That(result.Error, Does.Contain("50"));
-        Assert.That(result.Error, Does.Contain("pruned history unavailable"));
+        Assert.That(result.Error, Does.Contain("Pruned history unavailable"));
     }
 }

--- a/src/Nethermind/Nethermind.Facade/Eth/BlockForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/BlockForRpc.cs
@@ -13,7 +13,6 @@ using Nethermind.Serialization.Rlp;
 using System.Text.Json.Serialization;
 using System.Runtime.CompilerServices;
 using Nethermind.Facade.Eth.RpcTransaction;
-using Nethermind.Core.BlockAccessLists;
 
 namespace Nethermind.Facade.Eth;
 
@@ -106,7 +105,6 @@ public class BlockForRpc
         WithdrawalsRoot = block.Header.WithdrawalsRoot;
         RequestsHash = block.Header.RequestsHash;
         BlockAccessListHash = block.Header.BlockAccessListHash;
-        BlockAccessList = block.BlockAccessList;
     }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -169,9 +167,6 @@ public class BlockForRpc
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Hash256? BlockAccessListHash { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public ReadOnlyBlockAccessList? BlockAccessList { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ulong? SlotNumber { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/AccountAccessForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/AccountAccessForRpcTests.cs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.JsonRpc.Data;
+using Nethermind.Serialization.Json;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test.Data;
+
+[Parallelizable(ParallelScope.All)]
+[TestFixture]
+public class AccountAccessForRpcTests
+{
+    [Test]
+    public void Serializes_to_execution_apis_account_access_schema()
+    {
+        ReadOnlyAccountChanges accountChanges = new(
+            TestItem.AddressA,
+            storageChanges: [new ReadOnlySlotChanges(new UInt256(2), [new StorageChange(3, new UInt256(0x100))])],
+            storageReads: [new UInt256(1)],
+            balanceChanges: [new BalanceChange(1, new UInt256(0xa410))],
+            nonceChanges: [new NonceChange(2, 5)],
+            codeChanges: [new CodeChange(4, [0xde, 0xad, 0xbe, 0xef])]);
+        ReadOnlyBlockAccessList blockAccessList = new([accountChanges], itemCount: 5);
+
+        string json = new EthereumJsonSerializer().Serialize(AccountAccessForRpc.FromBlockAccessList(blockAccessList));
+
+        // Bare array; 32-byte zero-padded storage keys/values/reads; hex-quantity indices and
+        // balance/nonce values; code changes carry only index and code.
+        Assert.That(json, Is.EqualTo(
+            "[{\"address\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\"," +
+            "\"storageChanges\":[{\"key\":\"0x0000000000000000000000000000000000000000000000000000000000000002\"," +
+            "\"changes\":[{\"index\":\"0x3\",\"value\":\"0x0000000000000000000000000000000000000000000000000000000000000100\"}]}]," +
+            "\"storageReads\":[\"0x0000000000000000000000000000000000000000000000000000000000000001\"]," +
+            "\"balanceChanges\":[{\"index\":\"0x1\",\"value\":\"0xa410\"}]," +
+            "\"nonceChanges\":[{\"index\":\"0x2\",\"value\":\"0x5\"}]," +
+            "\"codeChanges\":[{\"index\":\"0x4\",\"code\":\"0xdeadbeef\"}]}]"));
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1325,7 +1325,7 @@ public partial class EthRpcModuleTests
         Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32016,\"message\":\"eth_getLogs request was canceled due to enabled timeout.\"},\"id\":67}"));
     }
 
-    [TestCase("{\"fromBlock\":\"earliest\",\"toBlock\":\"latest\"}", "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":4444,\"message\":\"pruned history unavailable\"},\"id\":67}")]
+    [TestCase("{\"fromBlock\":\"earliest\",\"toBlock\":\"latest\"}", "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":4444,\"message\":\"Pruned history unavailable\"},\"id\":67}")]
     public async Task Eth_get_logs_with_resourceNotFound(string parameter, string expected)
     {
         using Context ctx = await Context.Create();
@@ -1355,7 +1355,7 @@ public partial class EthRpcModuleTests
         ctx.Test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev).WithBlockchainBridge(bridge).Build();
         string serialized = await ctx.Test.TestEthRpc("eth_getFilterLogs", "0x1");
 
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":4444,\"message\":\"pruned history unavailable\"},\"id\":67}"));
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":4444,\"message\":\"Pruned history unavailable\"},\"id\":67}"));
 
         static IEnumerable<FilterLog> ThrowsOnIteration()
         {
@@ -2651,29 +2651,43 @@ public partial class EthRpcModuleTests
         Assert.That(recovered, Is.EqualTo(new Address(keyAddress)));
     }
 
+    // Head block (number 3) access list in the execution-apis wire format: a bare array of
+    // account accesses with 32-byte zero-padded storage keys/values/reads and hex-quantity indices.
+    private const string ExpectedHeadBlockAccessList = "[{\"address\":\"0x00000961ef480eb55e80d19ad83579a64c007002\",\"storageChanges\":[],\"storageReads\":[\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x0000000000000000000000000000000000000000000000000000000000000001\",\"0x0000000000000000000000000000000000000000000000000000000000000002\",\"0x0000000000000000000000000000000000000000000000000000000000000003\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x000014574a74c805590aff9499fc7a690f008282\",\"storageChanges\":[],\"storageReads\":[\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x0000000000000000000000000000000000000000000000000000000000000001\",\"0x0000000000000000000000000000000000000000000000000000000000000002\",\"0x0000000000000000000000000000000000000000000000000000000000000003\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000884d2aa32eaa155f59a2f24efa73d9008282\",\"storageChanges\":[],\"storageReads\":[\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x0000000000000000000000000000000000000000000000000000000000000001\",\"0x0000000000000000000000000000000000000000000000000000000000000002\",\"0x0000000000000000000000000000000000000000000000000000000000000003\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000bbddc7ce488642fb579f8b00f3a590007251\",\"storageChanges\":[],\"storageReads\":[\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x0000000000000000000000000000000000000000000000000000000000000001\",\"0x0000000000000000000000000000000000000000000000000000000000000002\",\"0x0000000000000000000000000000000000000000000000000000000000000003\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000f90827f1c53a10cb7a02335b175320002935\",\"storageChanges\":[{\"key\":\"0x0000000000000000000000000000000000000000000000000000000000000002\",\"changes\":[{\"index\":\"0x0\",\"value\":\"0xd633c9913b3f8e1881b3aaf31be29395b9701a40d973685bbb77d5d8af4e399e\"}]}],\"storageReads\":[],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x475674cb523a0a2736b7f7534390288fce16982c\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":\"0x1\",\"value\":\"0xa410\"},{\"index\":\"0x2\",\"value\":\"0xf618\"}],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":\"0x1\",\"value\":\"0x3635c9adc5dea00002\"},{\"index\":\"0x2\",\"value\":\"0x3635c9adc5dea00003\"}],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":\"0x1\",\"value\":\"0x3635c9adc5de9f5bee\"},{\"index\":\"0x2\",\"value\":\"0x3635c9adc5de9f09e5\"}],\"nonceChanges\":[{\"index\":\"0x1\",\"value\":\"0x2\"},{\"index\":\"0x2\",\"value\":\"0x3\"}],\"codeChanges\":[]}]";
+
     [Test]
     public async Task Eth_get_block_access_list_by_hash()
     {
         using Context ctx = await Context.CreateWithAmsterdamEnabled();
         Hash256 blockHash = ctx.Test.BlockTree.Head!.Hash!;
-        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessListByHash", blockHash);
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":{\"accountChanges\":[{\"address\":\"0x00000961ef480eb55e80d19ad83579a64c007002\",\"storageChanges\":[],\"storageReads\":[\"0x0\",\"0x1\",\"0x2\",\"0x3\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x000014574a74c805590aff9499fc7a690f008282\",\"storageChanges\":[],\"storageReads\":[\"0x0\",\"0x1\",\"0x2\",\"0x3\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000884d2aa32eaa155f59a2f24efa73d9008282\",\"storageChanges\":[],\"storageReads\":[\"0x0\",\"0x1\",\"0x2\",\"0x3\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000bbddc7ce488642fb579f8b00f3a590007251\",\"storageChanges\":[],\"storageReads\":[\"0x0\",\"0x1\",\"0x2\",\"0x3\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000f90827f1c53a10cb7a02335b175320002935\",\"storageChanges\":[{\"key\":\"0x2\",\"changes\":{\"0\":{\"index\":0,\"value\":\"0xd633c9913b3f8e1881b3aaf31be29395b9701a40d973685bbb77d5d8af4e399e\"}}}],\"storageReads\":[],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x475674cb523a0a2736b7f7534390288fce16982c\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":1,\"value\":\"0xa410\"},{\"index\":2,\"value\":\"0xf618\"}],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":1,\"value\":\"0x3635c9adc5dea00002\"},{\"index\":2,\"value\":\"0x3635c9adc5dea00003\"}],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":1,\"value\":\"0x3635c9adc5de9f5bee\"},{\"index\":2,\"value\":\"0x3635c9adc5de9f09e5\"}],\"nonceChanges\":[{\"index\":1,\"value\":\"0x2\"},{\"index\":2,\"value\":\"0x3\"}],\"codeChanges\":[]}]},\"id\":67}"));
+        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessList", blockHash);
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":" + ExpectedHeadBlockAccessList + ",\"id\":67}"));
     }
 
-    [Test]
-    public async Task Eth_get_block_access_list_by_hash_not_found()
+    [TestCase("0x3")]
+    [TestCase("latest")]
+    public async Task Eth_get_block_access_list_by_number_or_tag(string blockParameter)
     {
         using Context ctx = await Context.CreateWithAmsterdamEnabled();
-        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessListByHash", Hash256.Zero);
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32001,\"message\":\"Resource not found\"},\"id\":67}"));
+        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessList", blockParameter);
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":" + ExpectedHeadBlockAccessList + ",\"id\":67}"));
+    }
+
+    [TestCase("0x64")]
+    [TestCase("0x0000000000000000000000000000000000000000000000000000000000000000")]
+    [TestCase("pending")]
+    public async Task Eth_get_block_access_list_unknown_block_returns_null(string blockParameter)
+    {
+        using Context ctx = await Context.CreateWithAmsterdamEnabled();
+        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessList", blockParameter);
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":null,\"id\":67}"));
     }
 
     [Test]
-    public async Task Eth_get_block_access_list_by_hash_unavailable_before_fork()
+    public async Task Eth_get_block_access_list_unavailable_before_fork()
     {
         using Context ctx = await Context.Create(); // Amsterdam disabled
-        Hash256 blockHash = ctx.Test.BlockTree.Head!.Hash!;
-        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessListByHash", blockHash);
+        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessList", "0x3");
         Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32001,\"message\":\"Resource not found\"},\"id\":67}"));
     }
 
@@ -2683,32 +2697,8 @@ public partial class EthRpcModuleTests
         using Context ctx = await Context.CreateWithAmsterdamEnabled();
         Block head = ctx.Test.BlockTree.Head!;
         ctx.Test.Bridge.DeleteBlockAccessList(head.Number, head.Hash!);
-        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessListByHash", head.Hash!);
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":4444,\"message\":\"pruned history unavailable\"},\"id\":67}"));
-    }
-
-    [Test]
-    public async Task Eth_get_block_access_list_by_number()
-    {
-        using Context ctx = await Context.CreateWithAmsterdamEnabled();
-        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessListByNumber", "0x3");
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":{\"accountChanges\":[{\"address\":\"0x00000961ef480eb55e80d19ad83579a64c007002\",\"storageChanges\":[],\"storageReads\":[\"0x0\",\"0x1\",\"0x2\",\"0x3\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x000014574a74c805590aff9499fc7a690f008282\",\"storageChanges\":[],\"storageReads\":[\"0x0\",\"0x1\",\"0x2\",\"0x3\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000884d2aa32eaa155f59a2f24efa73d9008282\",\"storageChanges\":[],\"storageReads\":[\"0x0\",\"0x1\",\"0x2\",\"0x3\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000bbddc7ce488642fb579f8b00f3a590007251\",\"storageChanges\":[],\"storageReads\":[\"0x0\",\"0x1\",\"0x2\",\"0x3\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000f90827f1c53a10cb7a02335b175320002935\",\"storageChanges\":[{\"key\":\"0x2\",\"changes\":{\"0\":{\"index\":0,\"value\":\"0xd633c9913b3f8e1881b3aaf31be29395b9701a40d973685bbb77d5d8af4e399e\"}}}],\"storageReads\":[],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x475674cb523a0a2736b7f7534390288fce16982c\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":1,\"value\":\"0xa410\"},{\"index\":2,\"value\":\"0xf618\"}],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":1,\"value\":\"0x3635c9adc5dea00002\"},{\"index\":2,\"value\":\"0x3635c9adc5dea00003\"}],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":1,\"value\":\"0x3635c9adc5de9f5bee\"},{\"index\":2,\"value\":\"0x3635c9adc5de9f09e5\"}],\"nonceChanges\":[{\"index\":1,\"value\":\"0x2\"},{\"index\":2,\"value\":\"0x3\"}],\"codeChanges\":[]}]},\"id\":67}"));
-    }
-
-    [Test]
-    public async Task Eth_get_block_access_list_by_number_not_found()
-    {
-        using Context ctx = await Context.CreateWithAmsterdamEnabled();
-        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessListByNumber", "0x64");
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32001,\"message\":\"Resource not found\"},\"id\":67}"));
-    }
-
-    [Test]
-    public async Task Eth_get_block_access_list_by_number_unavailable_before_fork()
-    {
-        using Context ctx = await Context.Create(); // Amsterdam disabled
-        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessListByNumber", "0x3");
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32001,\"message\":\"Resource not found\"},\"id\":67}"));
+        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessList", head.Hash!);
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":4444,\"message\":\"Pruned history unavailable\"},\"id\":67}"));
     }
 
     [Test]
@@ -2718,8 +2708,8 @@ public partial class EthRpcModuleTests
         using Context ctx = await Context.CreateWithAmsterdamEnabled();
         Hash256 blockHash = ctx.Test.BlockTree.FindLevel(number)!.BlockInfos[0].BlockHash;
         ctx.Test.Bridge.DeleteBlockAccessList(number, blockHash);
-        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessListByNumber", number);
-        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":4444,\"message\":\"pruned history unavailable\"},\"id\":67}"));
+        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessList", "0x3");
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":4444,\"message\":\"Pruned history unavailable\"},\"id\":67}"));
     }
 
     public class AllowNullAuthorizationTuple : AuthorizationTuple

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -2684,6 +2684,14 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Eth_get_block_access_list_ancient_block_pruned()
+    {
+        using Context ctx = await Context.CreateWithAncientBarriers(10000);
+        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessList", "0x100");
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":4444,\"message\":\"Pruned history unavailable for block 256\"},\"id\":67}"));
+    }
+
+    [Test]
     public async Task Eth_get_block_access_list_unavailable_before_fork()
     {
         using Context ctx = await Context.Create(); // Amsterdam disabled

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -2651,8 +2651,7 @@ public partial class EthRpcModuleTests
         Assert.That(recovered, Is.EqualTo(new Address(keyAddress)));
     }
 
-    // Head block (number 3) access list in the execution-apis wire format: a bare array of
-    // account accesses with 32-byte zero-padded storage keys/values/reads and hex-quantity indices.
+    // Head block (number 3) access list in the execution-apis wire format.
     private const string ExpectedHeadBlockAccessList = "[{\"address\":\"0x00000961ef480eb55e80d19ad83579a64c007002\",\"storageChanges\":[],\"storageReads\":[\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x0000000000000000000000000000000000000000000000000000000000000001\",\"0x0000000000000000000000000000000000000000000000000000000000000002\",\"0x0000000000000000000000000000000000000000000000000000000000000003\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x000014574a74c805590aff9499fc7a690f008282\",\"storageChanges\":[],\"storageReads\":[\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x0000000000000000000000000000000000000000000000000000000000000001\",\"0x0000000000000000000000000000000000000000000000000000000000000002\",\"0x0000000000000000000000000000000000000000000000000000000000000003\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000884d2aa32eaa155f59a2f24efa73d9008282\",\"storageChanges\":[],\"storageReads\":[\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x0000000000000000000000000000000000000000000000000000000000000001\",\"0x0000000000000000000000000000000000000000000000000000000000000002\",\"0x0000000000000000000000000000000000000000000000000000000000000003\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000bbddc7ce488642fb579f8b00f3a590007251\",\"storageChanges\":[],\"storageReads\":[\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x0000000000000000000000000000000000000000000000000000000000000001\",\"0x0000000000000000000000000000000000000000000000000000000000000002\",\"0x0000000000000000000000000000000000000000000000000000000000000003\"],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x0000f90827f1c53a10cb7a02335b175320002935\",\"storageChanges\":[{\"key\":\"0x0000000000000000000000000000000000000000000000000000000000000002\",\"changes\":[{\"index\":\"0x0\",\"value\":\"0xd633c9913b3f8e1881b3aaf31be29395b9701a40d973685bbb77d5d8af4e399e\"}]}],\"storageReads\":[],\"balanceChanges\":[],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x475674cb523a0a2736b7f7534390288fce16982c\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":\"0x1\",\"value\":\"0xa410\"},{\"index\":\"0x2\",\"value\":\"0xf618\"}],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0x942921b14f1b1c385cd7e0cc2ef7abe5598c8358\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":\"0x1\",\"value\":\"0x3635c9adc5dea00002\"},{\"index\":\"0x2\",\"value\":\"0x3635c9adc5dea00003\"}],\"nonceChanges\":[],\"codeChanges\":[]},{\"address\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\",\"storageChanges\":[],\"storageReads\":[],\"balanceChanges\":[{\"index\":\"0x1\",\"value\":\"0x3635c9adc5de9f5bee\"},{\"index\":\"0x2\",\"value\":\"0x3635c9adc5de9f09e5\"}],\"nonceChanges\":[{\"index\":\"0x1\",\"value\":\"0x2\"},{\"index\":\"0x2\",\"value\":\"0x3\"}],\"codeChanges\":[]}]";
 
     [Test]
@@ -2681,6 +2680,17 @@ public partial class EthRpcModuleTests
         using Context ctx = await Context.CreateWithAmsterdamEnabled();
         string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessList", blockParameter);
         Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":null,\"id\":67}"));
+    }
+
+    [Test]
+    public async Task Eth_get_block_access_list_non_canonical_require_canonical_hash()
+    {
+        using Context ctx = await Context.CreateWithAmsterdamEnabled();
+        Block parent = ctx.Test.BlockTree.FindBlock(ctx.Test.BlockTree.Head!.Header.ParentHash!)!;
+        Block nonCanonical = Build.A.Block.WithParent(parent).WithExtraData([1]).TestObject;
+        ctx.Test.BlockTree.SuggestBlock(nonCanonical, BlockTreeSuggestOptions.ForceDontSetAsMain);
+        string serialized = await ctx.Test.TestEthRpc("eth_getBlockAccessList", new BlockParameter(nonCanonical.Hash!, true));
+        Assert.That(serialized, Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"error\":{{\"code\":-32000,\"message\":\"{nonCanonical.Hash} block is not canonical\"}},\"id\":67}}"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/Data/AccountAccessForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/AccountAccessForRpc.cs
@@ -36,58 +36,33 @@ public class AccountAccessForRpc
         return result;
     }
 
-    private static AccountAccessForRpc FromAccountChanges(ReadOnlyAccountChanges account)
-    {
-        SlotChangesForRpc[] storageChanges = new SlotChangesForRpc[account.StorageChanges.Length];
-        for (int i = 0; i < storageChanges.Length; i++)
-        {
-            ReadOnlySlotChanges slotChanges = account.StorageChanges[i];
-            StorageChangeForRpc[] changes = new StorageChangeForRpc[slotChanges.Changes.Length];
-            for (int j = 0; j < changes.Length; j++)
-            {
-                StorageChange change = slotChanges.Changes[j];
-                changes[j] = new StorageChangeForRpc { Index = change.Index, Value = ToValueHash(change.Value) };
-            }
-
-            storageChanges[i] = new SlotChangesForRpc { Key = slotChanges.Key.ToValueHash(), Changes = changes };
-        }
-
-        ValueHash256[] storageReads = new ValueHash256[account.StorageReads.Length];
-        for (int i = 0; i < storageReads.Length; i++)
-        {
-            storageReads[i] = account.StorageReads[i].ToValueHash();
-        }
-
-        BalanceChangeForRpc[] balanceChanges = new BalanceChangeForRpc[account.BalanceChanges.Length];
-        for (int i = 0; i < balanceChanges.Length; i++)
-        {
-            BalanceChange change = account.BalanceChanges[i];
-            balanceChanges[i] = new BalanceChangeForRpc { Index = change.Index, Value = change.Value };
-        }
-
-        NonceChangeForRpc[] nonceChanges = new NonceChangeForRpc[account.NonceChanges.Length];
-        for (int i = 0; i < nonceChanges.Length; i++)
-        {
-            NonceChange change = account.NonceChanges[i];
-            nonceChanges[i] = new NonceChangeForRpc { Index = change.Index, Value = change.Value };
-        }
-
-        CodeChangeForRpc[] codeChanges = new CodeChangeForRpc[account.CodeChanges.Length];
-        for (int i = 0; i < codeChanges.Length; i++)
-        {
-            CodeChange change = account.CodeChanges[i];
-            codeChanges[i] = new CodeChangeForRpc { Index = change.Index, Code = change.Code };
-        }
-
-        return new AccountAccessForRpc
+    private static AccountAccessForRpc FromAccountChanges(ReadOnlyAccountChanges account) =>
+        new()
         {
             Address = account.Address,
-            StorageChanges = storageChanges,
-            StorageReads = storageReads,
-            BalanceChanges = balanceChanges,
-            NonceChanges = nonceChanges,
-            CodeChanges = codeChanges,
+            StorageChanges = Map(account.StorageChanges, static sc => new SlotChangesForRpc
+            {
+                Key = sc.Key.ToValueHash(),
+                Changes = Map(sc.Changes, static c => new StorageChangeForRpc { Index = c.Index, Value = ToValueHash(c.Value) }),
+            }),
+            StorageReads = Map(account.StorageReads, static r => r.ToValueHash()),
+            BalanceChanges = Map(account.BalanceChanges, static c => new BalanceChangeForRpc { Index = c.Index, Value = c.Value }),
+            NonceChanges = Map(account.NonceChanges, static c => new NonceChangeForRpc { Index = c.Index, Value = c.Value }),
+            CodeChanges = Map(account.CodeChanges, static c => new CodeChangeForRpc { Index = c.Index, Code = c.Code }),
         };
+
+    /// <summary>Projects each element of <paramref name="source"/>, reusing a shared empty array when empty.</summary>
+    private static TResult[] Map<TSource, TResult>(TSource[] source, Func<TSource, TResult> selector)
+    {
+        if (source.Length == 0) return [];
+
+        TResult[] result = new TResult[source.Length];
+        for (int i = 0; i < source.Length; i++)
+        {
+            result[i] = selector(source[i]);
+        }
+
+        return result;
     }
 
     // EvmWord already holds the 32 big-endian bytes.

--- a/src/Nethermind/Nethermind.JsonRpc/Data/AccountAccessForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/AccountAccessForRpc.cs
@@ -12,14 +12,9 @@ using Nethermind.Int256;
 namespace Nethermind.JsonRpc.Data;
 
 /// <summary>
-/// Single account entry of an EIP-7928 block access list as returned by
-/// <c>eth_getBlockAccessList</c>.
+/// Account entry of an EIP-7928 block access list as returned by <c>eth_getBlockAccessList</c>,
+/// matching the execution-apis <c>AccountAccess</c> schema.
 /// </summary>
-/// <remarks>
-/// Mirrors the execution-apis <c>AccountAccess</c> schema: storage keys, values, and reads are
-/// 32-byte zero-padded hex, indices and balance/nonce values are hex quantities, and the result
-/// is a bare array of these entries.
-/// </remarks>
 public class AccountAccessForRpc
 {
     public required Address Address { get; init; }
@@ -95,7 +90,7 @@ public class AccountAccessForRpc
         };
     }
 
-    // EvmWord already holds the 32 big-endian bytes, so this is a pure reinterpretation.
+    // EvmWord already holds the 32 big-endian bytes.
     private static ValueHash256 ToValueHash(in EvmWord word) => Unsafe.BitCast<EvmWord, ValueHash256>(word);
 }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Data/AccountAccessForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/AccountAccessForRpc.cs
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Int256;
+
+namespace Nethermind.JsonRpc.Data;
+
+/// <summary>
+/// Single account entry of an EIP-7928 block access list as returned by
+/// <c>eth_getBlockAccessList</c>.
+/// </summary>
+/// <remarks>
+/// Mirrors the execution-apis <c>AccountAccess</c> schema: storage keys, values, and reads are
+/// 32-byte zero-padded hex, indices and balance/nonce values are hex quantities, and the result
+/// is a bare array of these entries.
+/// </remarks>
+public class AccountAccessForRpc
+{
+    public required Address Address { get; init; }
+    public required SlotChangesForRpc[] StorageChanges { get; init; }
+    public required ValueHash256[] StorageReads { get; init; }
+    public required BalanceChangeForRpc[] BalanceChanges { get; init; }
+    public required NonceChangeForRpc[] NonceChanges { get; init; }
+    public required CodeChangeForRpc[] CodeChanges { get; init; }
+
+    public static AccountAccessForRpc[] FromBlockAccessList(ReadOnlyBlockAccessList blockAccessList)
+    {
+        ReadOnlySpan<ReadOnlyAccountChanges> accounts = blockAccessList.AccountChanges.AsSpan();
+        AccountAccessForRpc[] result = new AccountAccessForRpc[accounts.Length];
+        for (int i = 0; i < accounts.Length; i++)
+        {
+            result[i] = FromAccountChanges(accounts[i]);
+        }
+
+        return result;
+    }
+
+    private static AccountAccessForRpc FromAccountChanges(ReadOnlyAccountChanges account)
+    {
+        SlotChangesForRpc[] storageChanges = new SlotChangesForRpc[account.StorageChanges.Length];
+        for (int i = 0; i < storageChanges.Length; i++)
+        {
+            ReadOnlySlotChanges slotChanges = account.StorageChanges[i];
+            StorageChangeForRpc[] changes = new StorageChangeForRpc[slotChanges.Changes.Length];
+            for (int j = 0; j < changes.Length; j++)
+            {
+                StorageChange change = slotChanges.Changes[j];
+                changes[j] = new StorageChangeForRpc { Index = change.Index, Value = ToValueHash(change.Value) };
+            }
+
+            storageChanges[i] = new SlotChangesForRpc { Key = slotChanges.Key.ToValueHash(), Changes = changes };
+        }
+
+        ValueHash256[] storageReads = new ValueHash256[account.StorageReads.Length];
+        for (int i = 0; i < storageReads.Length; i++)
+        {
+            storageReads[i] = account.StorageReads[i].ToValueHash();
+        }
+
+        BalanceChangeForRpc[] balanceChanges = new BalanceChangeForRpc[account.BalanceChanges.Length];
+        for (int i = 0; i < balanceChanges.Length; i++)
+        {
+            BalanceChange change = account.BalanceChanges[i];
+            balanceChanges[i] = new BalanceChangeForRpc { Index = change.Index, Value = change.Value };
+        }
+
+        NonceChangeForRpc[] nonceChanges = new NonceChangeForRpc[account.NonceChanges.Length];
+        for (int i = 0; i < nonceChanges.Length; i++)
+        {
+            NonceChange change = account.NonceChanges[i];
+            nonceChanges[i] = new NonceChangeForRpc { Index = change.Index, Value = change.Value };
+        }
+
+        CodeChangeForRpc[] codeChanges = new CodeChangeForRpc[account.CodeChanges.Length];
+        for (int i = 0; i < codeChanges.Length; i++)
+        {
+            CodeChange change = account.CodeChanges[i];
+            codeChanges[i] = new CodeChangeForRpc { Index = change.Index, Code = change.Code };
+        }
+
+        return new AccountAccessForRpc
+        {
+            Address = account.Address,
+            StorageChanges = storageChanges,
+            StorageReads = storageReads,
+            BalanceChanges = balanceChanges,
+            NonceChanges = nonceChanges,
+            CodeChanges = codeChanges,
+        };
+    }
+
+    // EvmWord already holds the 32 big-endian bytes, so this is a pure reinterpretation.
+    private static ValueHash256 ToValueHash(in EvmWord word) => Unsafe.BitCast<EvmWord, ValueHash256>(word);
+}
+
+public readonly struct SlotChangesForRpc
+{
+    public required ValueHash256 Key { get; init; }
+    public required StorageChangeForRpc[] Changes { get; init; }
+}
+
+public readonly struct StorageChangeForRpc
+{
+    public required ulong Index { get; init; }
+    public required ValueHash256 Value { get; init; }
+}
+
+public readonly struct BalanceChangeForRpc
+{
+    public required ulong Index { get; init; }
+    public required UInt256 Value { get; init; }
+}
+
+public readonly struct NonceChangeForRpc
+{
+    public required ulong Index { get; init; }
+    public required ulong Value { get; init; }
+}
+
+public readonly struct CodeChangeForRpc
+{
+    public required ulong Index { get; init; }
+    public required byte[] Code { get; init; }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/ErrorMessages.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ErrorMessages.cs
@@ -8,7 +8,7 @@ public static class ErrorMessages
     /// <summary>
     /// EIP-4444 message for <see cref="ErrorCodes.PrunedHistoryUnavailable"/>
     /// </summary>
-    public const string PrunedHistoryUnavailable = "pruned history unavailable";
+    public const string PrunedHistoryUnavailable = "Pruned history unavailable";
 
     public static string MethodNotFound(string methodName) => $"the method {methodName} does not exist/is not available";
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -1213,28 +1213,32 @@ public partial class EthRpcModule(
         }
     }
 
-    public ResultWrapper<ReadOnlyBlockAccessList?> eth_getBlockAccessListByHash(Hash256 blockHash)
-        => GetBlockAccessList(blockHash, null);
-
-    public ResultWrapper<ReadOnlyBlockAccessList?> eth_getBlockAccessListByNumber(ulong blockNumber)
-        => GetBlockAccessList(null, blockNumber);
-    private ResultWrapper<ReadOnlyBlockAccessList?> GetBlockAccessList(Hash256? blockHash, ulong? blockNumber)
+    public ResultWrapper<AccountAccessForRpc[]?> eth_getBlockAccessList(BlockParameter blockParameter)
     {
-        Block block = blockHash is null ? _blockFinder.FindBlock(blockNumber!.Value) : _blockFinder.FindBlock(blockHash);
-        if (block is null)
+        // A pending block has no committed access list yet.
+        if (blockParameter.Type == BlockParameterType.Pending)
         {
-            return ResultWrapper<ReadOnlyBlockAccessList?>.Fail("Resource not found", ErrorCodes.BlockAccessListResourceNotFound);
-        }
-        else if (block.BlockAccessListHash is null)
-        {
-            return ResultWrapper<ReadOnlyBlockAccessList?>.Fail("Resource not found", ErrorCodes.BlockAccessListResourceNotFound);
+            return ResultWrapper<AccountAccessForRpc[]?>.Success(null);
         }
 
-        ReadOnlyBlockAccessList? bal = blockchainBridge.GetBlockAccessList(block.Number, block.Hash);
+        SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
+        if (searchResult.IsError)
+        {
+            return ResultWrapper<AccountAccessForRpc[]?>.Success(null);
+        }
+
+        Block block = searchResult.Object!;
+        if (block.BlockAccessListHash is null)
+        {
+            // Pre-EIP-7928 block: the access list resource does not exist.
+            return ResultWrapper<AccountAccessForRpc[]?>.Fail("Resource not found", ErrorCodes.BlockAccessListResourceNotFound);
+        }
+
+        ReadOnlyBlockAccessList? bal = blockchainBridge.GetBlockAccessList(block.Number, block.Hash!);
 
         return bal is null ?
-            ResultWrapper<ReadOnlyBlockAccessList?>.Fail(ErrorMessages.PrunedHistoryUnavailable, ErrorCodes.PrunedHistoryUnavailable)
-            : ResultWrapper<ReadOnlyBlockAccessList?>.Success(bal);
+            ResultWrapper<AccountAccessForRpc[]?>.Fail(ErrorMessages.PrunedHistoryUnavailable, ErrorCodes.PrunedHistoryUnavailable)
+            : ResultWrapper<AccountAccessForRpc[]?>.Success(AccountAccessForRpc.FromBlockAccessList(bal));
     }
 
     public ResultWrapper<EthCapabilities> eth_capabilities() =>

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -1224,7 +1224,11 @@ public partial class EthRpcModule(
         SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
         if (searchResult.IsError)
         {
-            return ResultWrapper<AccountAccessForRpc[]?>.Success(null);
+            // Unknown blocks yield a null result per execution-apis; other search failures
+            // (pruned history, non-canonical requireCanonical hash) keep their error.
+            return searchResult.ErrorCode == ErrorCodes.ResourceNotFound
+                ? ResultWrapper<AccountAccessForRpc[]?>.Success(null)
+                : ResultWrapper<AccountAccessForRpc[]?>.Fail(searchResult);
         }
 
         Block block = searchResult.Object!;

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -1224,9 +1224,8 @@ public partial class EthRpcModule(
         SearchResult<Block> searchResult = _blockFinder.SearchForBlock(blockParameter);
         if (searchResult.IsError)
         {
-            // Unknown blocks yield a null result per execution-apis; other search failures
-            // (pruned history, non-canonical requireCanonical hash) keep their error.
-            return searchResult.ErrorCode == ErrorCodes.ResourceNotFound
+            // Unknown blocks yield null per execution-apis; pruned/non-canonical failures keep their error.
+            return searchResult.Error == BlockFinderExtensions.HeaderNotFound
                 ? ResultWrapper<AccountAccessForRpc[]?>.Success(null)
                 : ResultWrapper<AccountAccessForRpc[]?>.Fail(searchResult);
         }
@@ -1234,7 +1233,7 @@ public partial class EthRpcModule(
         Block block = searchResult.Object!;
         if (block.BlockAccessListHash is null)
         {
-            // Pre-EIP-7928 block: the access list resource does not exist.
+            // Pre-EIP-7928 block: the resource does not exist.
             return ResultWrapper<AccountAccessForRpc[]?>.Fail("Resource not found", ErrorCodes.BlockAccessListResourceNotFound);
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/IEthRpcModule.cs
@@ -6,7 +6,6 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Find;
 using Nethermind.Core;
-using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Evm;
@@ -367,10 +366,9 @@ namespace Nethermind.JsonRpc.Modules.Eth
             ExampleResponse = "{\"head\":{\"number\":\"0x1\",\"hash\":\"0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3\"},\"state\":{\"disabled\":false,\"oldestBlock\":\"0x0\"},\"tx\":{\"disabled\":false,\"oldestBlock\":\"0x0\"},\"logs\":{\"disabled\":false,\"oldestBlock\":\"0x0\"},\"receipts\":{\"disabled\":false,\"oldestBlock\":\"0x0\"},\"blocks\":{\"disabled\":false,\"oldestBlock\":\"0x0\"},\"stateproofs\":{\"disabled\":false,\"oldestBlock\":\"0x0\"}}")]
         ResultWrapper<EthCapabilities> eth_capabilities();
 
-        [JsonRpcMethod(Description = "Retrieves block access list for a block by hash.")]
-        ResultWrapper<ReadOnlyBlockAccessList?> eth_getBlockAccessListByHash(Hash256 blockHash);
-
-        [JsonRpcMethod(Description = "Retrieves block access list for a block by number.")]
-        ResultWrapper<ReadOnlyBlockAccessList?> eth_getBlockAccessListByNumber(ulong number);
+        [JsonRpcMethod(IsImplemented = true,
+            Description = "Returns the block access list for a given block.",
+            IsSharable = true)]
+        ResultWrapper<AccountAccessForRpc[]?> eth_getBlockAccessList([JsonRpcParameter(ExampleValue = "[\"latest\"]")] BlockParameter blockParameter);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V2.cs
@@ -558,7 +558,10 @@ public partial class EngineModuleTests
             new ExecutionPayloadBodyV1Result([], null)
         ]);
 
-        await AssertStreamedJsonMatchesSerializer(response);
+        string streamedJson = await AssertStreamedJsonMatchesSerializer(response);
+
+        // V1 bodies predate EIP-7928 and must not carry the blockAccessList key.
+        Assert.That(streamedJson, Does.Not.Contain("blockAccessList"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -487,7 +487,11 @@ public partial class EngineModuleTests
 
         using PayloadBodiesV2DirectResponse response = new(items);
 
-        await AssertStreamedJsonMatchesSerializer(response);
+        string streamedJson = await AssertStreamedJsonMatchesSerializer(response);
+
+        // V2 bodies must always carry the key, with a literal null when the block has no access list.
+        Assert.That(streamedJson, Does.Contain("\"blockAccessList\":\"0x010203\""));
+        Assert.That(streamedJson, Does.Contain("\"blockAccessList\":null"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadBodyV2Result.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadBodyV2Result.cs
@@ -38,5 +38,7 @@ public class ExecutionPayloadBodyV2Result
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public Withdrawal[]? Withdrawals { get; set; }
 
+    // Engine API: the key must be present with a literal null when the block has no access list.
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public byte[]? BlockAccessList { get; set; }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadBodyV2Result.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayloadBodyV2Result.cs
@@ -38,7 +38,7 @@ public class ExecutionPayloadBodyV2Result
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public Withdrawal[]? Withdrawals { get; set; }
 
-    // Engine API: the key must be present with a literal null when the block has no access list.
+    // Engine API: key must be present, literal null when absent.
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public byte[]? BlockAccessList { get; set; }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/PayloadBodiesV1DirectResponse.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/PayloadBodiesV1DirectResponse.cs
@@ -188,11 +188,7 @@ internal static class PayloadBodiesDirectResponseWriter
         writer.Write("}"u8);
     }
 
-    /// <summary>
-    /// Writes the <c>blockAccessList</c> field for V2 payload bodies. The engine API requires
-    /// the key to be present with a literal <c>null</c> when the block has no access list;
-    /// V1 payload bodies must omit the key entirely.
-    /// </summary>
+    /// <summary>V2 bodies always carry the key (literal <c>null</c> when absent); V1 bodies omit it.</summary>
     private static void WriteBlockAccessList(
         IBufferWriter<byte> writer,
         MemoryManager<byte>? blockAccessList,

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/PayloadBodiesV1DirectResponse.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/PayloadBodiesV1DirectResponse.cs
@@ -134,28 +134,31 @@ internal static class PayloadBodiesDirectResponseWriter
         IBufferWriter<byte> writer,
         byte[][] transactions,
         Withdrawal[]? withdrawals,
-        MemoryManager<byte>? blockAccessList = null)
+        MemoryManager<byte>? blockAccessList = null,
+        bool includeBlockAccessList = false)
     {
         writer.Write("{\"transactions\":"u8);
         WriteTransactions(writer, transactions);
-        WritePayloadBodySuffix(writer, withdrawals, blockAccessList);
+        WritePayloadBodySuffix(writer, withdrawals, blockAccessList, includeBlockAccessList);
     }
 
     public static void WritePayloadBody(
         IBufferWriter<byte> writer,
         Transaction[] transactions,
         Withdrawal[]? withdrawals,
-        MemoryManager<byte>? blockAccessList = null)
+        MemoryManager<byte>? blockAccessList = null,
+        bool includeBlockAccessList = false)
     {
         writer.Write("{\"transactions\":"u8);
         WriteTransactions(writer, transactions);
-        WritePayloadBodySuffix(writer, withdrawals, blockAccessList);
+        WritePayloadBodySuffix(writer, withdrawals, blockAccessList, includeBlockAccessList);
     }
 
     public static void WritePayloadBody(
         IBufferWriter<byte> writer,
         byte[] blockRlp,
-        MemoryManager<byte>? blockAccessList = null)
+        MemoryManager<byte>? blockAccessList = null,
+        bool includeBlockAccessList = false)
     {
         RlpReader ctx = new(blockRlp);
         int blockEnd = ctx.ReadSequenceLength() + ctx.Position;
@@ -169,29 +172,46 @@ internal static class PayloadBodiesDirectResponseWriter
         writer.Write(",\"withdrawals\":"u8);
         WriteWithdrawalsFromBlockRlp(writer, ref ctx, blockEnd);
 
-        if (blockAccessList is not null)
-        {
-            writer.Write(",\"blockAccessList\":"u8);
-            HexWriter.WriteHexString(writer, blockAccessList.Memory.Span, chunked: true);
-        }
-
+        WriteBlockAccessList(writer, blockAccessList, includeBlockAccessList);
         writer.Write("}"u8);
     }
 
     private static void WritePayloadBodySuffix(
         IBufferWriter<byte> writer,
         Withdrawal[]? withdrawals,
-        MemoryManager<byte>? blockAccessList)
+        MemoryManager<byte>? blockAccessList,
+        bool includeBlockAccessList)
     {
         writer.Write(",\"withdrawals\":"u8);
         WriteWithdrawals(writer, withdrawals);
-        if (blockAccessList is not null)
+        WriteBlockAccessList(writer, blockAccessList, includeBlockAccessList);
+        writer.Write("}"u8);
+    }
+
+    /// <summary>
+    /// Writes the <c>blockAccessList</c> field for V2 payload bodies. The engine API requires
+    /// the key to be present with a literal <c>null</c> when the block has no access list;
+    /// V1 payload bodies must omit the key entirely.
+    /// </summary>
+    private static void WriteBlockAccessList(
+        IBufferWriter<byte> writer,
+        MemoryManager<byte>? blockAccessList,
+        bool includeBlockAccessList)
+    {
+        if (!includeBlockAccessList)
         {
-            writer.Write(",\"blockAccessList\":"u8);
-            HexWriter.WriteHexString(writer, blockAccessList.Memory.Span, chunked: true);
+            return;
         }
 
-        writer.Write("}"u8);
+        writer.Write(",\"blockAccessList\":"u8);
+        if (blockAccessList is null)
+        {
+            writer.Write("null"u8);
+        }
+        else
+        {
+            HexWriter.WriteHexString(writer, blockAccessList.Memory.Span, chunked: true);
+        }
     }
 
     public static void WriteTransactions(IBufferWriter<byte> writer, byte[][] transactions)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/PayloadBodiesV2DirectResponse.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/PayloadBodiesV2DirectResponse.cs
@@ -138,11 +138,11 @@ public sealed class PayloadBodiesV2DirectResponse : IStreamableResult, IReadOnly
         {
             if (_blockRlp is { } blockRlp)
             {
-                PayloadBodiesDirectResponseWriter.WritePayloadBody(writer, blockRlp, _blockAccessList);
+                PayloadBodiesDirectResponseWriter.WritePayloadBody(writer, blockRlp, _blockAccessList, includeBlockAccessList: true);
             }
             else
             {
-                PayloadBodiesDirectResponseWriter.WritePayloadBody(writer, _transactions!, _withdrawals, _blockAccessList);
+                PayloadBodiesDirectResponseWriter.WritePayloadBody(writer, _transactions!, _withdrawals, _blockAccessList, includeBlockAccessList: true);
             }
         }
 


### PR DESCRIPTION
Addresses the Nethermind findings from the cross-client Block Access List API compliance review: https://hackmd.io/@Nerolation/Hk1WTpuVze

## Changes

- Replaced `eth_getBlockAccessListByHash(hash)` / `eth_getBlockAccessListByNumber(number)` with a single `eth_getBlockAccessList` accepting a block number, tag, or hash in one parameter (per the execution-apis `BlockNumberOrTagOrHash` schema)
- The result is now a bare JSON array of account accesses instead of being wrapped in `{"accountChanges": [...]}`, via new `AccountAccessForRpc` DTOs mirroring the execution-apis `AccountAccess` schema
- Per-slot storage `changes` are serialized as an array of `{index, value}` objects instead of a decimal-keyed object map
- `index` fields are hex quantity strings instead of raw JSON numbers
- Storage keys, storage change values, and `storageReads` are 32-byte zero-padded hex instead of minimal-hex quantities
- `codeChanges` entries no longer leak the extra `codeHash` field — only `{index, code}`
- Unknown blocks (and `pending`) return a `null` result instead of a `-32001` error; `-32001 Resource not found` is still returned for pre-fork blocks and `4444 Pruned history unavailable` for pruned ones
- `eth_getBlockByNumber`/`eth_getBlockByHash` responses no longer embed the non-spec full `blockAccessList` object (`blockAccessListHash` stays)
- `engine_getPayloadBodiesByHashV2`/`ByRangeV2` always emit the `blockAccessList` key, writing a literal `null` when the block has no access list (V1 bodies keep omitting the key); fixed in both the streaming writer and the `ExecutionPayloadBodyV2Result` serialization
- Capitalized the `Pruned history unavailable` error message to match execution-apis casing

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Rewrote the `eth_getBlockAccessList` E2E RPC tests for the unified method: by hash, by number, by `latest` tag, unknown block/hash/`pending` → `null`, pre-fork → `-32001`, pruned → `4444`
- Added `AccountAccessForRpcTests` asserting the exact execution-apis wire format including `codeChanges` shape
- Extended the payload bodies direct-response tests to assert V2 emits `"blockAccessList":null` and V1 omits the key
- Ran `Nethermind.JsonRpc.Test` (EthRpcModuleTests), Merge.Plugin payload bodies tests, Facade, Optimism block tests — all green

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

`eth_getBlockAccessListByHash`/`ByNumber` are replaced by the spec's `eth_getBlockAccessList`, and its response format changed to the execution-apis wire format; `engine_getPayloadBodiesBy*V2` now always includes the `blockAccessList` key.

## Remarks

The response shape follows the execution-apis schema in `src/eth/block.yaml` / `src/schemas/block-access-list.yaml` (`SlotChanges` uses `key` + `changes[{index, value}]`; indices are hex `uint32` quantities; storage keys/values/reads are `hash32`).