### PR TITLE
feat(flatdb): RAM-backed arena for persisted-snapshot tier (variant 2, draft)

### DIFF
--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -11,6 +11,7 @@ public class FlatDbConfig : IFlatDbConfig
     public bool EnablePreimageRecording { get; set; } = false;
     public bool FlatNodeStorage { get; set; } = false;
     public bool FlatNodeStorageDebugChecks { get; set; } = false;
+    public bool FlatNodeStorageInMemoryArena { get; set; } = false;
     public bool ImportFromPruningTrieState { get; set; } = false;
     public bool InlineCompaction { get; set; } = false;
     public bool RegenerateCompactionOffset { get; set; } = false;

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -28,6 +28,9 @@ public interface IFlatDbConfig : IConfig
     [ConfigItem(Description = "Slab-storage debug checks: poison-on-release and keccak-verify-on-decode. Test/soak only.", DefaultValue = "false")]
     bool FlatNodeStorageDebugChecks { get; set; }
 
+    [ConfigItem(Description = "Demote aged base persisted snapshots into a RAM-backed arena instead of on-disk arena files. Trades disk for memory on the persisted-snapshot metadata + blob tiers; the tier becomes session-ephemeral (not rehydrated across restarts). Experimental.", DefaultValue = "false")]
+    bool FlatNodeStorageInMemoryArena { get; set; }
+
     [ConfigItem(Description = "Import from pruning trie state db", DefaultValue = "false")]
     bool ImportFromPruningTrieState { get; set; }
 

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -72,6 +72,9 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                     Path.Combine(basePath, "blob"),
                     cfg.ArenaFileSizeBytes);
             })
+            // Consumers depend on IBlobArenaManager; by default it resolves the on-disk BlobArenaManager
+            // above. The FlatNodeStorageInMemoryArena block below overrides this with the RAM impl.
+            .AddSingleton<IBlobArenaManager>(ctx => ctx.Resolve<BlobArenaManager>())
             .AddSingleton<IPersistedSnapshotCompactor, PersistedSnapshotCompactor>()
             .AddSingleton<ISnapshotRepository, SnapshotRepository>()
             .AddSingleton<IPersistedSnapshotLoader, PersistedSnapshotLoader>()
@@ -132,6 +135,16 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                 .AddSingleton<ISnapshotCatalog>(NullSnapshotCatalog.Instance)
                 .AddSingleton<IPersistedSnapshotLoader>(NullPersistedSnapshotLoader.Instance)
                 .AddSingleton<IPersistedSnapshotCompactor>(NullPersistedSnapshotCompactor.Instance);
+        }
+
+        if (flatDbConfig.FlatNodeStorageInMemoryArena)
+        {
+            // RAM-backed persisted-snapshot arenas (default off). Last registration wins, so these
+            // replace the on-disk ArenaManager / BlobArenaManager wired above.
+            builder
+                .AddSingleton<IArenaManager>(_ => new InMemoryArenaManager())
+                .AddSingleton<IBlobArenaManager, IFlatDbConfig>(cfg =>
+                    new InMemoryBlobArenaManager(cfg.ArenaFileSizeBytes));
         }
 
         if (flatDbConfig.ImportFromPruningTrieState)

--- a/src/Nethermind/Nethermind.State.Flat.Test/InMemoryArenaRoundTripTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/InMemoryArenaRoundTripTests.cs
@@ -130,6 +130,19 @@ public class InMemoryArenaRoundTripTests
     }
 
     [Test]
+    public void BlobArena_FreedId_IsReusedBeforeMintingNew()
+    {
+        // A cancelled writer frees its slot; the id must return to the free-list and be reused, so the
+        // ushort cap counts concurrently live files, not the cumulative count over the session.
+        ushort first;
+        using (BlobArenaWriter w0 = _blobs.CreateWriter(64))
+            first = w0.BlobArenaId; // disposed without Complete -> OnWriteCancelled frees the id
+
+        using BlobArenaWriter w1 = _blobs.CreateWriter(64);
+        Assert.That(w1.BlobArenaId, Is.EqualTo(first), "a freed blob id must be reused before a fresh one is minted");
+    }
+
+    [Test]
     public void Arena_RawWriteReadRoundTrip_ThroughReservation()
     {
         byte[] payload = new byte[8000];

--- a/src/Nethermind/Nethermind.State.Flat.Test/InMemoryArenaRoundTripTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/InMemoryArenaRoundTripTests.cs
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Int256;
+using Nethermind.State.Flat.PersistedSnapshots;
+using Nethermind.State.Flat.PersistedSnapshots.Storage;
+using Nethermind.Trie;
+using NUnit.Framework;
+using WholeReadScanner = Nethermind.State.Flat.PersistedSnapshots.PersistedSnapshotScanner<
+    Nethermind.State.Flat.PersistedSnapshots.Storage.WholeReadSession,
+    Nethermind.State.Flat.PersistedSnapshots.Storage.WholeReadSessionReader,
+    Nethermind.State.Flat.Io.NoOpPin>;
+
+namespace Nethermind.State.Flat.Test;
+
+/// <summary>
+/// Runs the persisted-snapshot round trip against the RAM-backed arena backings
+/// (<see cref="InMemoryArenaManager"/> / <see cref="InMemoryBlobArenaManager"/>) instead of the
+/// on-disk ones, exercising the native-buffer write path plus both read paths (point reads via
+/// <see cref="ArenaByteReader"/> and the whole-read session via <see cref="WholeReadSession"/>).
+/// </summary>
+[TestFixture]
+public class InMemoryArenaRoundTripTests
+{
+    private ResourcePool _resourcePool = null!;
+    private InMemoryArenaManager _arena = null!;
+    private InMemoryBlobArenaManager _blobs = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _resourcePool = new ResourcePool(new FlatDbConfig());
+        _arena = new InMemoryArenaManager();
+        _blobs = new InMemoryBlobArenaManager(4L * 1024 * 1024);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _blobs.Dispose();
+        _arena.Dispose();
+    }
+
+    private static void PopulateAllDataTypes(SnapshotContent c)
+    {
+        c.Accounts[TestItem.AddressA] = Build.An.Account.WithBalance(12345).WithNonce(7).TestObject;
+        c.Accounts[TestItem.AddressB] = Build.An.Account
+            .WithBalance(0).WithNonce(0)
+            .WithCode([0x60, 0x00])
+            .WithStorageRoot(Keccak.Compute("storage")).TestObject;
+        c.Accounts[TestItem.AddressC] = null;
+
+        byte[] slotVal1 = new byte[32]; slotVal1[31] = 0xFF;
+        byte[] slotVal2 = new byte[32]; slotVal2[0] = 0x01; slotVal2[31] = 0x02;
+        c.Storages[(TestItem.AddressA, (UInt256)1)] = new SlotValue(slotVal1);
+        c.Storages[(TestItem.AddressA, (UInt256)2)] = new SlotValue(slotVal2);
+        c.Storages[(TestItem.AddressB, (UInt256)42)] = null;
+
+        c.SelfDestructedStorageAddresses[TestItem.AddressD] = false;
+        c.SelfDestructedStorageAddresses[TestItem.AddressE] = true;
+
+        c.StateNodes[new TreePath(Keccak.Compute("tp"), 3)] = new TrieNode(NodeType.Leaf, [0xC1, 0x80]);
+        c.StateNodes[new TreePath(Keccak.Compute("sp"), 8)] = new TrieNode(NodeType.Leaf, [0xC2, 0x80, 0x80]);
+        c.StateNodes[new TreePath(Keccak.Compute("lp"), 20)] = new TrieNode(NodeType.Extension, [0xC2, 0x80, 0x81]);
+
+        Hash256 storageAddr = Keccak.Compute("storageAddr");
+        c.StorageNodes[(storageAddr, new TreePath(Keccak.Compute("tsp"), 3))] = new TrieNode(NodeType.Leaf, [0xC1, 0x80]);
+        c.StorageNodes[(storageAddr, new TreePath(Keccak.Compute("ssp"), 6))] = new TrieNode(NodeType.Branch, [0xC1, 0x80]);
+        c.StorageNodes[(storageAddr, new TreePath(Keccak.Compute("lsp"), 18))] = new TrieNode(NodeType.Leaf, [0xC3, 0x80, 0x81, 0x82]);
+    }
+
+    [Test]
+    public void RoundTrip_AllDataTypes_ValidatesAgainstSource()
+    {
+        StateId from = new(0, Keccak.EmptyTreeHash);
+        StateId to = new(1, Keccak.Compute("inmem"));
+
+        SnapshotContent content = new();
+        PopulateAllDataTypes(content);
+
+        Snapshot snapshot = new(from, to, content, _resourcePool, ResourcePool.Usage.MainBlockProcessing);
+        byte[] data = PersistedSnapshotBuilderTestExtensions.Build(snapshot, _blobs);
+        using PersistedSnapshot persisted = TestFixtureHelpers.CreatePersistedSnapshot(_arena, _blobs, from, to, data);
+
+        // Point-read path: full replay of every entry kind back out of the RAM arena + blob buffers.
+        Assert.DoesNotThrow(() => PersistedSnapshotUtils.ValidatePersistedSnapshot(snapshot, persisted));
+    }
+
+    [Test]
+    public void RoundTrip_WholeReadSession_ScansSlotsFromRam()
+    {
+        StateId from = new(0, Keccak.EmptyTreeHash);
+        StateId to = new(1, Keccak.Compute("inmem-scan"));
+
+        byte[] small = new byte[32]; small[31] = 0x05;
+        byte[] high = new byte[32]; high[31] = 0xFF;
+        byte[] full = new byte[32];
+        for (int i = 0; i < 32; i++) full[i] = (byte)(i + 1);
+
+        SnapshotContent content = new();
+        content.Storages[(TestItem.AddressA, (UInt256)1)] = new SlotValue(small);
+        content.Storages[(TestItem.AddressA, (UInt256)2)] = new SlotValue(high);
+        content.Storages[(TestItem.AddressA, (UInt256)3)] = null;
+        content.Storages[(TestItem.AddressB, (UInt256)4)] = new SlotValue(full);
+
+        Snapshot snapshot = new(from, to, content, _resourcePool, ResourcePool.Usage.MainBlockProcessing);
+        byte[] data = PersistedSnapshotBuilderTestExtensions.Build(snapshot, _blobs);
+        using PersistedSnapshot persisted = TestFixtureHelpers.CreatePersistedSnapshot(_arena, _blobs, from, to, data);
+
+        Dictionary<(Address, UInt256), SlotValue?> scanned = [];
+        // Whole-read path: exercises the RAM MmapWholeView (null-accessor) branch.
+        using (WholeReadSession session = persisted.BeginWholeReadSession())
+        {
+            WholeReadScanner scanner = PersistedSnapshotScanner.ForWholeRead(session, persisted);
+            foreach (WholeReadScanner.PerAddressEntry entry in scanner.PerAddresses)
+                foreach (WholeReadScanner.SlotEntry slot in entry.Slots)
+                    scanned[(entry.Address, slot.Slot)] = slot.Value;
+        }
+
+        Assert.That(scanned[(TestItem.AddressA, (UInt256)1)]!.Value.AsReadOnlySpan.ToArray(), Is.EqualTo(small));
+        Assert.That(scanned[(TestItem.AddressA, (UInt256)2)]!.Value.AsReadOnlySpan.ToArray(), Is.EqualTo(high));
+        Assert.That(scanned[(TestItem.AddressA, (UInt256)3)], Is.Null, "deleted slot must surface as null");
+        Assert.That(scanned[(TestItem.AddressB, (UInt256)4)]!.Value.AsReadOnlySpan.ToArray(), Is.EqualTo(full));
+    }
+
+    [Test]
+    public void Arena_RawWriteReadRoundTrip_ThroughReservation()
+    {
+        byte[] payload = new byte[8000];
+        for (int i = 0; i < payload.Length; i++) payload[i] = (byte)(i * 31 + 7);
+
+        SnapshotLocation location;
+        ArenaReservation reservation;
+        using (ArenaWriter writer = _arena.CreateWriter(payload.Length))
+        {
+            Span<byte> span = writer.GetWriter().GetSpan(payload.Length);
+            payload.CopyTo(span);
+            writer.GetWriter().Advance(payload.Length);
+            (location, reservation) = writer.Complete();
+        }
+
+        try
+        {
+            Assert.That(reservation.Size, Is.EqualTo(payload.Length));
+
+            // Point reader over the native buffer.
+            ArenaByteReader reader = reservation.CreateReader();
+            byte[] readBack = new byte[payload.Length];
+            Assert.That(reader.TryRead(0, readBack), Is.True);
+            Assert.That(readBack, Is.EqualTo(payload));
+
+            // Re-open the same location and read again — the RAM arena resolves it like the disk one.
+            using ArenaReservation reopened = _arena.Open(location);
+            ArenaByteReader reopenedReader = reopened.CreateReader();
+            byte[] readBack2 = new byte[payload.Length];
+            Assert.That(reopenedReader.TryRead(0, readBack2), Is.True);
+            Assert.That(readBack2, Is.EqualTo(payload));
+        }
+        finally
+        {
+            reservation.Dispose();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/LongFinalityIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/LongFinalityIntegrationTests.cs
@@ -222,6 +222,45 @@ public class LongFinalityIntegrationTests
     }
 
 
+    // With the RAM-backed arena a durable catalog row outlives the slice that backed it: on the next
+    // boot the arena is empty. Reload must reconcile — no crash on Open for a never-minted id — yield an
+    // empty persisted tier, and purge the orphaned catalog row so a further restart has nothing to trip on.
+    [Test]
+    public void Restart_InMemoryArena_DropsOrphanedCatalogAndReloadsEmpty()
+    {
+        StateId s0 = new(0, Keccak.EmptyTreeHash);
+        StateId s1 = new(1, Keccak.Compute("1"));
+        MemDb catalogDb = new();
+
+        static FlatDbConfig RamConfig() => new()
+        {
+            EnableLongFinality = true,
+            FlatNodeStorageInMemoryArena = true,
+            CompactSize = 16,
+        };
+
+        using (FlatTestContainer tier1 = new(config: RamConfig(), baseDbPath: _testDir, catalogDb: catalogDb))
+        {
+            tier1.ConvertToPersistedBase(CreateSnapshot(s0, s1, c =>
+                c.Accounts[TestItem.AddressA] = Build.An.Account.WithBalance(1).TestObject)).Dispose();
+            Assert.That(tier1.Repository.PersistedSnapshotCount, Is.EqualTo(1));
+        }
+
+        // A durable catalog row survived session 1; its RAM arena did not.
+        Assert.That(new SnapshotCatalog(catalogDb).Load(), Is.Not.Empty,
+            "session 1 must leave a durable catalog row");
+
+        using (FlatTestContainer tier2 = new(config: RamConfig(), baseDbPath: _testDir, catalogDb: catalogDb))
+        {
+            // Reaching this line at all proves Load() did not throw on the unbacked catalog row.
+            Assert.That(tier2.Repository.PersistedSnapshotCount, Is.EqualTo(0),
+                "RAM tier is session-ephemeral; the persisted tier must reload empty");
+        }
+
+        Assert.That(new SnapshotCatalog(catalogDb).Load(), Is.Empty,
+            "orphaned catalog rows must be purged on reload, not accumulate across restarts");
+    }
+
     [Test]
     public void MergeSnapshotData_AllEntryTypes()
     {

--- a/src/Nethermind/Nethermind.State.Flat.Test/PageResidencyTrackerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PageResidencyTrackerTests.cs
@@ -72,6 +72,9 @@ public class PageResidencyTrackerTests
         public ArenaWriter CreateWriter(long estimatedSize, bool small = false) => throw new NotSupportedException();
         public void Initialize(IReadOnlyList<CatalogEntry> entries) => throw new NotSupportedException();
         public ArenaReservation Open(in SnapshotLocation location) => throw new NotSupportedException();
+        public void OnWriteCompleted(ArenaFile file, long newFrontier, bool hasHeadroom) => throw new NotSupportedException();
+        public void OnWriteCancelledShared(ArenaFile file) => throw new NotSupportedException();
+        public void OnWriteCancelledDedicated(ArenaFile file) => throw new NotSupportedException();
         // No-op so reservation disposal doesn't blow up in tests.
         public bool MarkDead(ArenaFile file, long deadSize) => false;
         public void ForgetTrackerRange(int arenaId, long byteOffset, long byteSize) { }

--- a/src/Nethermind/Nethermind.State.Flat.Test/PageResidencyTrackerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PageResidencyTrackerTests.cs
@@ -70,7 +70,7 @@ public class PageResidencyTrackerTests
         public PageResidencyTracker PageTracker => tracker;
         public void QueueEviction(int arenaId, uint pageIdx) => handler.OnPageEvicted(arenaId, (int)pageIdx);
         public ArenaWriter CreateWriter(long estimatedSize, bool small = false) => throw new NotSupportedException();
-        public void Initialize(IReadOnlyList<CatalogEntry> entries) => throw new NotSupportedException();
+        public IReadOnlyList<CatalogEntry> Initialize(IReadOnlyList<CatalogEntry> entries) => throw new NotSupportedException();
         public ArenaReservation Open(in SnapshotLocation location) => throw new NotSupportedException();
         public void OnWriteCompleted(ArenaFile file, long newFrontier, bool hasHeadroom) => throw new NotSupportedException();
         public void OnWriteCancelledShared(ArenaFile file) => throw new NotSupportedException();

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotBuilderTestExtensions.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotBuilderTestExtensions.cs
@@ -21,7 +21,7 @@ internal static class PersistedSnapshotBuilderTestExtensions
     /// file via the same manager — mirroring how production wires <c>BlobArenaManager</c> as
     /// a long-lived shared component.
     /// </summary>
-    public static byte[] Build(Snapshot snapshot, BlobArenaManager blobs)
+    public static byte[] Build(Snapshot snapshot, IBlobArenaManager blobs)
     {
         int estimatedSize = checked((int)PersistedSnapshotBuilder.EstimateSize(snapshot));
         using PooledByteBufferWriter pooled = new(estimatedSize);

--- a/src/Nethermind/Nethermind.State.Flat.Test/TestFixtureHelpers.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/TestFixtureHelpers.cs
@@ -51,7 +51,7 @@ internal static class TestFixtureHelpers
     /// refcounts balanced. No-op when there are no ref_ids (raw test bytes that aren't
     /// a real sorted table).
     /// </summary>
-    public static void LeaseBlobIds(ArenaReservation reservation, BlobArenaManager blobs)
+    public static void LeaseBlobIds(ArenaReservation reservation, IBlobArenaManager blobs)
     {
         using WholeReadSession session = reservation.BeginWholeReadSession();
         WholeReadSessionReader reader = session.CreateReader();
@@ -126,7 +126,7 @@ internal static class TestFixtureHelpers
     /// <see cref="PersistedSnapshot"/> over <paramref name="blobs"/>.
     /// </summary>
     public static PersistedSnapshot CreatePersistedSnapshot(
-        IArenaManager arena, BlobArenaManager blobs, StateId from, StateId to, byte[] data,
+        IArenaManager arena, IBlobArenaManager blobs, StateId from, StateId to, byte[] data,
         bool leaseBlobIds = true)
     {
         using ArenaWriter writer = arena.CreateWriter(data.Length);

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -55,7 +55,7 @@ public interface ISnapshotRepository
     /// over the same reservation carrying a lease on the shared bloom. Best-effort and lock-free across
     /// buckets — a racing prune just leaves a snapshot with its own bloom. Pure live-memory optimization:
     /// blooms are not persisted, so reload rebuilds independent blooms.</summary>
-    void ShareBloomAcrossRange(StateId from, StateId to, RefCountedBloomFilter sharedBloom, BlobArenaManager blobs);
+    void ShareBloomAcrossRange(StateId from, StateId to, RefCountedBloomFilter sharedBloom, IBlobArenaManager blobs);
 
     /// <summary>Lease every persisted base snapshot tiling <c>(from, to]</c>. Caller disposes the list.</summary>
     PersistedSnapshotList LeaseBaseSnapshotsInRange(StateId from, StateId to);

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshot.cs
@@ -33,7 +33,7 @@ public sealed class PersistedSnapshot : SmallRefCountingDisposable
     private readonly PersistedSnapshotLabel _label;
     // Each id is resolved on demand via _blobManager.GetFile(id), a lock-free O(1) array read. The
     // canonical leased-id list lives on disk in this snapshot's metadata under the "ref_ids" key.
-    private readonly BlobArenaManager _blobManager;
+    private readonly IBlobArenaManager _blobManager;
 
     public StateId From { get; }
     public StateId To { get; }
@@ -79,7 +79,7 @@ public sealed class PersistedSnapshot : SmallRefCountingDisposable
     /// metadata reservation lease and stashes the manager ref for later id → file resolution.
     /// </summary>
     public PersistedSnapshot(StateId from, StateId to, ArenaReservation reservation,
-        BlobArenaManager blobManager, SnapshotTier tier, RefCountedBloomFilter bloom)
+        IBlobArenaManager blobManager, SnapshotTier tier, RefCountedBloomFilter bloom)
     {
         From = from;
         To = to;

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotCompactor.cs
@@ -35,7 +35,7 @@ namespace Nethermind.State.Flat.PersistedSnapshots;
 public class PersistedSnapshotCompactor(
     ISnapshotRepository snapshotRepository,
     IArenaManager arenaManager,
-    BlobArenaManager blobs,
+    IBlobArenaManager blobs,
     ISnapshotCatalog catalog,
     IFlatDbConfig config,
     ICompactionSchedule schedule,

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotLoader.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotLoader.cs
@@ -22,7 +22,7 @@ namespace Nethermind.State.Flat.PersistedSnapshots;
 public sealed class PersistedSnapshotLoader(
     ISnapshotRepository repository,
     IArenaManager arena,
-    BlobArenaManager blobs,
+    IBlobArenaManager blobs,
     ISnapshotCatalog catalog,
     IFlatDbConfig config,
     ILogManager logManager) : IPersistedSnapshotLoader

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotLoader.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotLoader.cs
@@ -60,19 +60,45 @@ public sealed class PersistedSnapshotLoader(
 
         // Can be millions of entries on a long-running node — materialised once and shared by the
         // arena init and the parallel load below.
-        List<CatalogEntry> entries = [.. _catalog.Load()];
-        arena.Initialize(entries);
+        List<CatalogEntry> catalogued = [.. _catalog.Load()];
+        // The arena reconciles the catalog against the slices it can back and hands back the loadable
+        // subset. The on-disk arena returns the whole catalog (a missing file surfaces on Open); the RAM
+        // arena is session-ephemeral and backs nothing across a restart, so it returns an empty set. Purge
+        // the dropped rows so orphaned entries don't accumulate — and, for the RAM tier, don't re-trip a
+        // later restart.
+        IReadOnlyList<CatalogEntry> loadable = arena.Initialize(catalogued);
+        if (loadable.Count != catalogued.Count) PurgeOrphanedEntries(catalogued, loadable);
 
-        LoadSnapshotsParallel(entries);
+        LoadSnapshotsParallel(loadable);
 
         // Delete any blob arena file no loaded snapshot referenced — recoverable
         // orphans from a mid-write crash.
         blobs.SweepUnreferenced();
 
-        ReconstructBloom(entries);
+        ReconstructBloom(loadable);
     }
 
-    private void LoadSnapshotsParallel(List<CatalogEntry> entries)
+    /// <summary>
+    /// Remove the durable catalog rows for entries the arena could not back (present in
+    /// <paramref name="catalogued"/> but not <paramref name="loadable"/>), so they don't accumulate — and,
+    /// for the session-ephemeral RAM tier where every row is orphaned on restart, so a later reload has
+    /// nothing to trip over.
+    /// </summary>
+    private void PurgeOrphanedEntries(IReadOnlyList<CatalogEntry> catalogued, IReadOnlyList<CatalogEntry> loadable)
+    {
+        HashSet<CatalogEntry> keep = [.. loadable];
+        int purged = 0;
+        foreach (CatalogEntry entry in catalogued)
+        {
+            if (keep.Contains(entry)) continue;
+            _catalog.Remove(entry.To, (long)(entry.To.BlockNumber - entry.From.BlockNumber));
+            purged++;
+        }
+        if (purged > 0 && _logger.IsInfo)
+            _logger.Info($"Dropped {purged} persisted-snapshot catalog row(s) with no backing arena slice.");
+    }
+
+    private void LoadSnapshotsParallel(IReadOnlyList<CatalogEntry> entries)
     {
         if (entries.Count == 0) return;
 
@@ -158,7 +184,7 @@ public sealed class PersistedSnapshotLoader(
     /// oldest loaded snapshot's <c>From</c>. The few wide blooms are rebuilt in parallel; chain ranges are
     /// disjoint, so the per-range <see cref="ISnapshotRepository.ShareBloomAcrossRange"/> calls don't collide.
     /// </remarks>
-    private void ReconstructBloom(List<CatalogEntry> entries)
+    private void ReconstructBloom(IReadOnlyList<CatalogEntry> entries)
     {
         if (!BloomEnabled || entries.Count == 0) return;
         if (repository.GetLastSnapshotId() is not StateId head) return;

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaFile.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaFile.cs
@@ -36,20 +36,25 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     [DllImport("libc", EntryPoint = "madvise", SetLastError = true)]
     private static extern int Madvise(void* addr, nuint length, int advice);
 
-    private readonly SafeFileHandle _handle;
-    private MemoryMappedFile _mmf;
-    private MemoryMappedViewAccessor _accessor;
+    private readonly SafeFileHandle? _handle;
+    private MemoryMappedFile? _mmf;
+    private MemoryMappedViewAccessor? _accessor;
     private byte* _basePtr;
     // Treated as bool; 0 = delete on CleanUp, 1 = keep the on-disk file. Set by
     // PersistOnShutdown via Interlocked.Exchange so it is safe to call from any path.
     private int _preserveOnDispose;
+    // RAM-backed mode (InMemoryArenaManager): the slice lives in a native buffer instead of an
+    // mmap'd file, so BasePtr points into _mem and every disk-only op below no-ops.
+    private readonly bool _inMemory;
+    private readonly NativeArenaBuffer? _mem;
+    private long _mappedSize;
 
-    /// <summary>Raw pointer to the first byte of the arena's mmap. Long-offset arithmetic OK across the full <see cref="MappedSize"/>.</summary>
-    public byte* BasePtr => _basePtr;
+    /// <summary>Raw pointer to the first byte of the arena's mmap (or RAM buffer). Long-offset arithmetic OK across the full <see cref="MappedSize"/>.</summary>
+    public byte* BasePtr => _inMemory ? _mem!.Pointer : _basePtr;
 
     public int Id { get; }
     private string Path { get; }
-    public long MappedSize { get; private set; }
+    public long MappedSize => _inMemory ? _mem!.Capacity : _mappedSize;
 
     /// <summary>
     /// True for arenas holding sub-CompactSize snapshots (the <c>PersistedBase</c> and
@@ -116,7 +121,7 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     {
         Id = id;
         Path = path;
-        MappedSize = mappedSize;
+        _mappedSize = mappedSize;
         Small = small;
 
         _handle = File.OpenHandle(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
@@ -128,6 +133,23 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
         OpenMmap(mappedSize);
     }
 
+    private ArenaFile(int id, long initialCapacity, bool small)
+    {
+        Id = id;
+        Path = string.Empty;
+        Small = small;
+        _inMemory = true;
+        _mem = new NativeArenaBuffer(initialCapacity);
+    }
+
+    /// <summary>
+    /// Create a RAM-backed arena file whose bytes live in a growable native buffer instead of an
+    /// mmap'd on-disk file. Used by <see cref="InMemoryArenaManager"/> to hold one slice per file;
+    /// the buffer grows on write and is frozen (read-only) once the writer completes.
+    /// </summary>
+    internal static ArenaFile CreateInMemory(int id, long initialCapacity, bool small = false)
+        => new(id, initialCapacity, small);
+
     /// <summary>
     /// Try to acquire a lease without throwing on a disposing file. Returns false when the
     /// file is already in cleanup.
@@ -138,8 +160,10 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     /// Create a write stream seeked to <paramref name="startOffset"/>.
     /// The caller is responsible for disposing the returned stream.
     /// </summary>
-    internal FileStream CreateWriteStream(long startOffset)
+    internal Stream CreateWriteStream(long startOffset)
     {
+        // RAM mode packs one slice per file starting at offset 0, so the append-only stream needs no seek.
+        if (_inMemory) return new NativeArenaWriteStream(_mem!);
         FileStream fs = new(Path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite, bufferSize: 1);
         fs.Seek(startOffset, SeekOrigin.Begin);
         return fs;
@@ -155,17 +179,20 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     /// </summary>
     internal void Truncate(long newSize)
     {
+        // RAM mode keeps the (possibly over-allocated) native buffer; MappedSize already tracks its
+        // capacity and the footprint math it feeds only drives madvise/punch, which no-op here.
+        if (_inMemory) return;
         if (newSize == MappedSize) return;
         CloseMmap();
-        RandomAccess.SetLength(_handle, newSize);
-        MappedSize = newSize;
+        RandomAccess.SetLength(_handle!, newSize);
+        _mappedSize = newSize;
         OpenMmap(newSize);
     }
 
     [MemberNotNull(nameof(_mmf), nameof(_accessor))]
     private void OpenMmap(long size)
     {
-        _mmf = MemoryMappedFile.CreateFromFile(_handle, mapName: null, size, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: true);
+        _mmf = MemoryMappedFile.CreateFromFile(_handle!, mapName: null, size, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: true);
         _accessor = _mmf.CreateViewAccessor(0, size, MemoryMappedFileAccess.Read);
         _basePtr = null;
         _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref _basePtr);
@@ -176,15 +203,15 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
 
     private void CloseMmap()
     {
-        _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+        _accessor!.SafeMemoryMappedViewHandle.ReleasePointer();
         _accessor.Dispose();
-        _mmf.Dispose();
+        _mmf!.Dispose();
         _basePtr = null;
     }
 
     public void AdviseDontNeed(long offset, long size)
     {
-        if (!OperatingSystem.IsLinux()) return;
+        if (_inMemory || !OperatingSystem.IsLinux()) return;
 
         if (TryAlignInward(offset, size, out nuint start, out nuint len))
             Madvise(_basePtr + start, len, MADV_DONTNEED);
@@ -207,7 +234,7 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     /// </summary>
     public void PopulateRead(long offset, long size)
     {
-        if (!OperatingSystem.IsLinux()) return;
+        if (_inMemory || !OperatingSystem.IsLinux()) return;
 
         if (TryAlignInward(offset, size, out nuint start, out nuint len))
             Madvise(_basePtr + start, len, MADV_POPULATE_READ);
@@ -220,7 +247,7 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     /// duration of the read — unlike <see cref="AdviseDontNeed"/>, a userspace load on a torn-down
     /// mapping would SIGSEGV instead of returning a syscall error.
     /// </summary>
-    public byte TouchByte(long offset) => Volatile.Read(ref *(_basePtr + offset));
+    public byte TouchByte(long offset) => _inMemory ? (byte)0 : Volatile.Read(ref *(_basePtr + offset));
 
     /// <summary>
     /// posix_fadvise(POSIX_FADV_DONTNEED) on the underlying file descriptor for the
@@ -231,8 +258,9 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     /// </summary>
     public void FadviseDontNeed(long offset, long size)
     {
+        if (_inMemory) return;
         bool refAdded = false;
-        _handle.DangerousAddRef(ref refAdded);
+        _handle!.DangerousAddRef(ref refAdded);
         try { PosixReclaim.FadviseDontNeed((int)_handle.DangerousGetHandle(), offset, size); }
         finally { if (refAdded) _handle.DangerousRelease(); }
     }
@@ -245,8 +273,9 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     /// <returns>The <see cref="PosixReclaim.PunchHoleOutcome"/> reported by the kernel.</returns>
     internal PosixReclaim.PunchHoleOutcome PunchHole(long offset, long size)
     {
+        if (_inMemory) return PosixReclaim.PunchHoleOutcome.Unsupported;
         bool refAdded = false;
-        _handle.DangerousAddRef(ref refAdded);
+        _handle!.DangerousAddRef(ref refAdded);
         try { return PosixReclaim.TryPunchHole((int)_handle.DangerousGetHandle(), offset, size); }
         finally { if (refAdded) _handle.DangerousRelease(); }
     }
@@ -259,8 +288,9 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     /// </summary>
     internal void Fsync()
     {
+        if (_inMemory) return;
         bool refAdded = false;
-        _handle.DangerousAddRef(ref refAdded);
+        _handle!.DangerousAddRef(ref refAdded);
         try { PosixReclaim.Fsync((int)_handle.DangerousGetHandle()); }
         finally { if (refAdded) _handle.DangerousRelease(); }
     }
@@ -274,7 +304,9 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     /// </summary>
     internal MmapWholeView OpenWholeView(long offset, long size, bool adviseDontNeedOnDispose)
     {
-        MemoryMappedViewAccessor accessor = _mmf.CreateViewAccessor(offset, size, MemoryMappedFileAccess.Read);
+        // RAM mode has no separate mapping — hand out a view straight over the native buffer slice.
+        if (_inMemory) return new MmapWholeView(null, BasePtr + offset, size, adviseDontNeedOnDispose);
+        MemoryMappedViewAccessor accessor = _mmf!.CreateViewAccessor(offset, size, MemoryMappedFileAccess.Read);
         byte* ptr = null;
         accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
         // The accessor's pointer is offset by an internal page-aligned skew; add it
@@ -292,7 +324,7 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
     /// kernel can reclaim those pages from the page cache.
     /// </summary>
     internal sealed unsafe class MmapWholeView(
-        MemoryMappedViewAccessor accessor, byte* dataPtr, long size, bool adviseDontNeedOnDispose) : IDisposable
+        MemoryMappedViewAccessor? accessor, byte* dataPtr, long size, bool adviseDontNeedOnDispose) : IDisposable
     {
         /// <summary>
         /// Raw pointer to the first byte of the view. Long-offset arithmetic is valid for the entire
@@ -304,6 +336,9 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
 
         public void Dispose()
         {
+            // RAM mode (null accessor): the view is a plain window into the owning file's native
+            // buffer — nothing to unmap or madvise.
+            if (accessor is null) return;
             if (adviseDontNeedOnDispose && OperatingSystem.IsLinux())
             {
                 // MADV_DONTNEED on a file-backed shared mapping drops the pages from the kernel
@@ -332,8 +367,15 @@ public sealed unsafe class ArenaFile : RefCountingDisposable
 
     protected override void CleanUp()
     {
+        // RAM mode: nothing on disk to close/delete — free the native buffer. The tier is
+        // session-ephemeral, so the preserve-on-shutdown flag is irrelevant.
+        if (_inMemory)
+        {
+            _mem!.Dispose();
+            return;
+        }
         CloseMmap();
-        _handle.Dispose();
+        _handle!.Dispose();
         // Preserve the on-disk file iff someone explicitly opted in via PersistOnShutdown;
         // otherwise delete it (the normal post-prune cleanup path).
         if (Volatile.Read(ref _preserveOnDispose) == 0)

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
@@ -79,7 +79,7 @@ public sealed class ArenaManager : IArenaManager
     /// Initialize from existing arena files and catalog entries.
     /// Computes allocation frontiers and dead bytes per arena.
     /// </summary>
-    public void Initialize(IReadOnlyList<CatalogEntry> entries)
+    public IReadOnlyList<CatalogEntry> Initialize(IReadOnlyList<CatalogEntry> entries)
     {
         using Lock.Scope scope = _lock.EnterScope();
         // Open existing arena files. Defer the per-file metric push until after frontier
@@ -139,6 +139,12 @@ public sealed class ArenaManager : IArenaManager
             kv.Value.DeadBytes = kv.Value.Frontier - live;
             kv.Value.ReportAdded();
         }
+
+        // Loadable set = the whole catalog. The on-disk arena files are the durable backing, so an entry
+        // whose file is missing is genuine drift the loader must surface (it throws on Open) — unchanged
+        // from before this method returned a set. The frontier reconcile above only excludes a missing
+        // arena from byte accounting; it does not decide what the loader attempts.
+        return entries;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
@@ -165,7 +165,7 @@ public sealed class ArenaManager : IArenaManager
             PoolFor(file).Remove(file.Id);
             file.WriterActive = true;
         }
-        FileStream stream = file.CreateWriteStream(offset);
+        Stream stream = file.CreateWriteStream(offset);
         return new ArenaWriter(this, file, dedicated, offset, stream);
     }
 
@@ -181,7 +181,7 @@ public sealed class ArenaManager : IArenaManager
     /// <paramref name="hasHeadroom"/> is true for shared writes whose post-frontier still leaves room for
     /// further packing.
     /// </summary>
-    internal void OnWriteCompleted(ArenaFile file, long newFrontier, bool hasHeadroom)
+    public void OnWriteCompleted(ArenaFile file, long newFrontier, bool hasHeadroom)
     {
         using Lock.Scope scope = _lock.EnterScope();
         file.WriterActive = false;
@@ -202,7 +202,7 @@ public sealed class ArenaManager : IArenaManager
     /// to the mutable pool (the writer didn't advance the frontier, so by construction it
     /// still has the same headroom it had when picked).
     /// </summary>
-    internal void OnWriteCancelledShared(ArenaFile file)
+    public void OnWriteCancelledShared(ArenaFile file)
     {
         using Lock.Scope scope = _lock.EnterScope();
         file.WriterActive = false;
@@ -221,7 +221,7 @@ public sealed class ArenaManager : IArenaManager
     /// the byte metric. <paramref name="file"/> is readable post-dispose (Id /
     /// ReportedFrontier are plain fields).
     /// </summary>
-    internal void OnWriteCancelledDedicated(ArenaFile file)
+    public void OnWriteCancelledDedicated(ArenaFile file)
     {
         using Lock.Scope scope = _lock.EnterScope();
         _arenas.TryRemove(file.Id, out _);

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaWriter.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaWriter.cs
@@ -11,13 +11,13 @@ namespace Nethermind.State.Flat.PersistedSnapshots.Storage;
 public sealed class ArenaWriter : IDisposable
 {
     private ArenaBufferWriter _writer;
-    private readonly ArenaManager _manager;
+    private readonly IArenaManager _manager;
     private readonly ArenaFile _file;
     private readonly bool _dedicated;
     private readonly long _startOffset;
     private bool _completed;
 
-    internal ArenaWriter(ArenaManager manager, ArenaFile file, bool dedicated, long startOffset, Stream stream)
+    internal ArenaWriter(IArenaManager manager, ArenaFile file, bool dedicated, long startOffset, Stream stream)
     {
         _manager = manager;
         _file = file;

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/BlobArenaFile.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/BlobArenaFile.cs
@@ -45,7 +45,12 @@ public sealed class BlobArenaFile : RefCountingDisposable
     /// <summary>Pre-extended file length (sparse on Linux). Writers append within this cap.</summary>
     public long MaxSize { get; }
 
-    private SafeFileHandle Handle { get; }
+    private SafeFileHandle? Handle { get; }
+
+    // RAM-backed mode (InMemoryBlobArenaManager): the RLP bytes live in a native buffer instead of an
+    // on-disk file; reads copy from it and every disk-only op below no-ops.
+    private readonly bool _inMemory;
+    private readonly NativeArenaBuffer? _mem;
 
     /// <summary>Next-write offset. Mutated under the manager's lock during writer registration.</summary>
     internal long Frontier { get; set; }
@@ -73,6 +78,26 @@ public sealed class BlobArenaFile : RefCountingDisposable
         if (frontier > 0)
             Interlocked.Add(ref Metrics._blobAllocatedBytes, frontier);
     }
+
+    private BlobArenaFile(ushort id, long maxSize, long initialCapacity)
+    {
+        BlobArenaId = id;
+        Path = string.Empty;
+        MaxSize = maxSize;
+        _inMemory = true;
+        _mem = new NativeArenaBuffer(initialCapacity);
+        Frontier = 0;
+        ReportedFrontier = 0;
+        Interlocked.Increment(ref Metrics._blobFileCount);
+    }
+
+    /// <summary>
+    /// Create a RAM-backed blob file whose RLP bytes live in a growable native buffer instead of an
+    /// on-disk file. Used by <see cref="InMemoryBlobArenaManager"/> — one file per snapshot; the
+    /// buffer is appended into by a single writer, then frozen and read via <see cref="RandomRead"/>.
+    /// </summary>
+    internal static BlobArenaFile CreateInMemory(ushort id, long maxSize, long initialCapacity)
+        => new(id, maxSize, initialCapacity);
 
     /// <summary>
     /// Mark this file as "preserve on disk when its refcount hits zero". Set by
@@ -113,10 +138,11 @@ public sealed class BlobArenaFile : RefCountingDisposable
     /// </summary>
     public int RandomRead(long offset, Span<byte> destination)
     {
+        if (_inMemory) return _mem!.ReadAt(offset, destination);
         int total = 0;
         while (total < destination.Length)
         {
-            int read = RandomAccess.Read(Handle, destination[total..], offset + total);
+            int read = RandomAccess.Read(Handle!, destination[total..], offset + total);
             if (read <= 0) break;
             total += read;
         }
@@ -126,8 +152,10 @@ public sealed class BlobArenaFile : RefCountingDisposable
     /// <summary>
     /// Open a write stream seeked to <paramref name="startOffset"/>. Caller disposes when done.
     /// </summary>
-    internal FileStream OpenWriteStream(long startOffset)
+    internal Stream OpenWriteStream(long startOffset)
     {
+        // RAM mode uses one fresh file per snapshot, so the append-only stream starts at offset 0.
+        if (_inMemory) return new NativeArenaWriteStream(_mem!);
         FileStream fs = new(Path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite, bufferSize: 1);
         fs.Seek(startOffset, SeekOrigin.Begin);
         return fs;
@@ -140,8 +168,9 @@ public sealed class BlobArenaFile : RefCountingDisposable
     /// </summary>
     internal void FadviseDontNeed(long offset, long size)
     {
+        if (_inMemory) return;
         bool refAdded = false;
-        Handle.DangerousAddRef(ref refAdded);
+        Handle!.DangerousAddRef(ref refAdded);
         try { PosixReclaim.FadviseDontNeed((int)Handle.DangerousGetHandle(), offset, size); }
         finally { if (refAdded) Handle.DangerousRelease(); }
     }
@@ -153,8 +182,9 @@ public sealed class BlobArenaFile : RefCountingDisposable
     /// </summary>
     internal void FadviseWillNeed(long offset, long size)
     {
+        if (_inMemory) return;
         bool refAdded = false;
-        Handle.DangerousAddRef(ref refAdded);
+        Handle!.DangerousAddRef(ref refAdded);
         try { PosixReclaim.FadviseWillNeed((int)Handle.DangerousGetHandle(), offset, size); }
         finally { if (refAdded) Handle.DangerousRelease(); }
     }
@@ -166,8 +196,9 @@ public sealed class BlobArenaFile : RefCountingDisposable
     /// </summary>
     internal void Fsync()
     {
+        if (_inMemory) return;
         bool refAdded = false;
-        Handle.DangerousAddRef(ref refAdded);
+        Handle!.DangerousAddRef(ref refAdded);
         try { PosixReclaim.Fsync((int)Handle.DangerousGetHandle()); }
         finally { if (refAdded) Handle.DangerousRelease(); }
     }
@@ -178,15 +209,26 @@ public sealed class BlobArenaFile : RefCountingDisposable
     /// to reclaim an orphaned file: zeros the logical length AND frees all disk blocks in
     /// a single syscall. The page cache for the truncated range is implicitly invalidated.
     /// </summary>
-    internal void SetFileLength(long newSize) =>
-        RandomAccess.SetLength(Handle, newSize);
+    internal void SetFileLength(long newSize)
+    {
+        if (_inMemory) return;
+        RandomAccess.SetLength(Handle!, newSize);
+    }
 
     protected override void CleanUp()
     {
-        Handle.Dispose();
-        if (Volatile.Read(ref _preserveOnDispose) == 0)
+        // RAM mode: free the native buffer, no on-disk file to close/delete.
+        if (_inMemory)
         {
-            try { File.Delete(Path); } catch { /* best-effort */ }
+            _mem!.Dispose();
+        }
+        else
+        {
+            Handle!.Dispose();
+            if (Volatile.Read(ref _preserveOnDispose) == 0)
+            {
+                try { File.Delete(Path); } catch { /* best-effort */ }
+            }
         }
         Interlocked.Decrement(ref Metrics._blobFileCount);
         long reported = ReportedFrontier;

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/BlobArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/BlobArenaManager.cs
@@ -43,7 +43,7 @@ namespace Nethermind.State.Flat.PersistedSnapshots.Storage;
 /// 65 536 × 8 B ≈ 512 KiB per manager.
 /// </para>
 /// </summary>
-public sealed class BlobArenaManager : IDisposable
+public sealed class BlobArenaManager : IBlobArenaManager
 {
     private const string BlobFilePrefix = "blob_";
     private const string BlobFileExtension = ".bin";
@@ -150,7 +150,7 @@ public sealed class BlobArenaManager : IDisposable
             throw new InvalidOperationException(
                 $"Blob arena {fileId} is mid-cleanup; cannot open writer.");
 
-        FileStream stream = file.OpenWriteStream(startOffset);
+        Stream stream = file.OpenWriteStream(startOffset);
         return new BlobArenaWriter(this, file, startOffset, stream);
     }
 
@@ -194,7 +194,7 @@ public sealed class BlobArenaManager : IDisposable
     /// candidate for the next writer and pushes the post-write frontier delta to
     /// <c>Metrics.BlobAllocatedBytes</c>.
     /// </summary>
-    internal void OnWriteCompleted(BlobArenaFile file, bool hasHeadroom)
+    public void OnWriteCompleted(BlobArenaFile file, bool hasHeadroom)
     {
         using Lock.Scope scope = _lock.EnterScope();
         if (hasHeadroom) _mutableFiles.Add(file.BlobArenaId);
@@ -214,7 +214,7 @@ public sealed class BlobArenaManager : IDisposable
     /// frontier didn't advance, so the file still has room by construction — re-add the
     /// id to the mutable pool. No file touch.
     /// </summary>
-    internal void OnWriteCancelled(ushort blobArenaId)
+    public void OnWriteCancelled(ushort blobArenaId)
     {
         using Lock.Scope scope = _lock.EnterScope();
         _mutableFiles.Add(blobArenaId);

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/BlobArenaWriter.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/BlobArenaWriter.cs
@@ -34,11 +34,11 @@ public sealed class BlobArenaWriter : IDisposable
 {
     private const int BufferSize = 1024 * 1024;
 
-    private readonly BlobArenaManager _manager;
+    private readonly IBlobArenaManager _manager;
     private readonly BlobArenaFile _file;
     private readonly ushort _blobArenaId;
     private readonly long _startOffset;
-    private readonly FileStream _stream;
+    private readonly Stream _stream;
     // Held at Count == Capacity so AsSpan() exposes the whole 1 MiB buffer; the writer slices
     // the free tail with its own _buffered cursor (same shape as ArenaBufferWriter).
     private readonly NativeMemoryList<byte> _buffer = new(BufferSize, BufferSize);
@@ -59,7 +59,7 @@ public sealed class BlobArenaWriter : IDisposable
     /// meantime, the file self-cleans (manager's array-slot ref is still 1, so the file
     /// stays alive — it only goes away on manager shutdown or sweep).
     /// </summary>
-    internal BlobArenaWriter(BlobArenaManager manager, BlobArenaFile file, long startOffset, FileStream stream)
+    internal BlobArenaWriter(IBlobArenaManager manager, BlobArenaFile file, long startOffset, Stream stream)
     {
         _manager = manager;
         _file = file;

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/IArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/IArenaManager.cs
@@ -19,6 +19,20 @@ public unsafe interface IArenaManager : IDisposable
     ArenaReservation Open(in SnapshotLocation location);
 
     /// <summary>
+    /// Post-<see cref="ArenaWriter.Complete"/> bookkeeping: publish the file's new
+    /// <paramref name="newFrontier"/> and (for a shared arena with room left,
+    /// <paramref name="hasHeadroom"/>) return it to the writable pool. Called by the writer, not the
+    /// application.
+    /// </summary>
+    void OnWriteCompleted(ArenaFile file, long newFrontier, bool hasHeadroom);
+
+    /// <summary>Bookkeeping after a cancelled write on a shared (non-dedicated) arena.</summary>
+    void OnWriteCancelledShared(ArenaFile file);
+
+    /// <summary>Bookkeeping after a cancelled write on a dedicated arena (the writer already dropped its ref).</summary>
+    void OnWriteCancelledDedicated(ArenaFile file);
+
+    /// <summary>
     /// Drop <paramref name="deadSize"/> bytes of <paramref name="file"/> as dead. The caller
     /// (typically <see cref="ArenaReservation.CleanUp"/>) handles file-side <c>madvise</c> /
     /// <c>posix_fadvise</c> and tracker-forget itself, so this method only does the atomic

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/IArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/IArenaManager.cs
@@ -5,7 +5,13 @@ namespace Nethermind.State.Flat.PersistedSnapshots.Storage;
 
 public unsafe interface IArenaManager : IDisposable
 {
-    void Initialize(IReadOnlyList<CatalogEntry> entries);
+    /// <summary>
+    /// Reconcile the durable catalog against the slices this manager can back and return the loadable
+    /// subset. On-disk managers back every catalogued entry (returning it unchanged; a missing file is
+    /// surfaced later on <see cref="Open"/>); a session-ephemeral RAM manager backs nothing across a
+    /// restart and returns an empty set so the loader skips — and purges — the orphaned catalog rows.
+    /// </summary>
+    IReadOnlyList<CatalogEntry> Initialize(IReadOnlyList<CatalogEntry> entries);
 
     /// <summary>
     /// Create an <see cref="ArenaWriter"/> for a new snapshot slice.

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/IBlobArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/IBlobArenaManager.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nethermind.State.Flat.PersistedSnapshots.Storage;
+
+/// <summary>
+/// File pool for trie-node RLP bytes: writers append RLP through a <see cref="BlobArenaWriter"/>
+/// and loaded snapshots resolve their referenced <see cref="BlobArenaFile"/>s by id. The disk
+/// implementation is <see cref="BlobArenaManager"/> (one packed pool of on-disk files);
+/// <see cref="InMemoryBlobArenaManager"/> is the RAM-backed, one-file-per-snapshot variant.
+/// </summary>
+public interface IBlobArenaManager : IDisposable
+{
+    /// <summary>Rehydrate the file pool before any snapshot is constructed. No-op for the RAM pool.</summary>
+    void Initialize();
+
+    /// <summary>Open a writer that appends RLP into an arena file with headroom (or a fresh one).</summary>
+    BlobArenaWriter CreateWriter(long estimatedSize);
+
+    /// <summary>Acquire a lease on the file identified by <paramref name="blobArenaId"/>.</summary>
+    bool TryLeaseFile(ushort blobArenaId, [NotNullWhen(true)] out BlobArenaFile? file);
+
+    /// <summary>Return the registered file for <paramref name="blobArenaId"/> (caller already holds a lease).</summary>
+    BlobArenaFile GetFile(ushort blobArenaId);
+
+    /// <summary>Delete arena files no loaded snapshot referenced after a restart. No-op for the RAM pool.</summary>
+    void SweepUnreferenced();
+
+    /// <summary>Reclaim a file whose last snapshot lease just dropped (reset frontier / free).</summary>
+    void TryResetOrphanedFrontier(BlobArenaFile file);
+
+    /// <summary>Post-<see cref="BlobArenaWriter.Complete"/> bookkeeping. Called by the writer.</summary>
+    void OnWriteCompleted(BlobArenaFile file, bool hasHeadroom);
+
+    /// <summary>Bookkeeping after a cancelled write. Called by the writer.</summary>
+    void OnWriteCancelled(ushort blobArenaId);
+}

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/InMemoryArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/InMemoryArenaManager.cs
@@ -25,8 +25,22 @@ public sealed class InMemoryArenaManager : IArenaManager
 
     public PageResidencyTracker PageTracker => _pageTracker;
 
-    /// <summary>No-op: the RAM tier holds nothing across a restart, so there is nothing to rehydrate.</summary>
-    public void Initialize(IReadOnlyList<CatalogEntry> entries) { }
+    /// <summary>
+    /// Reconciles the durable catalog against this session's RAM slices and returns the loadable subset.
+    /// The tier is session-ephemeral: at load <see cref="_arenas"/> is empty (nothing survived the
+    /// restart), so every catalog entry is orphaned and the returned set is empty. That makes the loader
+    /// skip — and purge — the orphaned rows instead of throwing on <see cref="Open"/> for an id this
+    /// manager never minted.
+    /// </summary>
+    public IReadOnlyList<CatalogEntry> Initialize(IReadOnlyList<CatalogEntry> entries)
+    {
+        // Keep only entries this manager actually backs. At restart-load that is none; a live re-init would
+        // keep whatever slices are still registered.
+        List<CatalogEntry> loadable = [];
+        foreach (CatalogEntry entry in entries)
+            if (_arenas.ContainsKey(entry.Location.ArenaId)) loadable.Add(entry);
+        return loadable;
+    }
 
     public ArenaWriter CreateWriter(long estimatedSize, bool small = false)
     {

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/InMemoryArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/InMemoryArenaManager.cs
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Concurrent;
+
+namespace Nethermind.State.Flat.PersistedSnapshots.Storage;
+
+/// <summary>
+/// RAM-backed <see cref="IArenaManager"/>: each snapshot slice lives in its own growable native
+/// buffer (<see cref="ArenaFile.CreateInMemory"/>) instead of being packed into an mmap'd on-disk
+/// arena file. Selected by <c>FlatNodeStorageInMemoryArena</c> to demote aged base snapshots into
+/// RAM. One file per slice (all "dedicated"), so there is no packing pool; the page-residency
+/// tracker is zero-capacity and every disk-only operation (punch-hole, fadvise, fsync, eviction)
+/// is a no-op per the <see cref="IArenaManager"/> contract. The tier is session-ephemeral —
+/// <see cref="Initialize"/> has nothing to rehydrate across a restart.
+/// </summary>
+public sealed class InMemoryArenaManager : IArenaManager
+{
+    private readonly ConcurrentDictionary<int, ArenaFile> _arenas = new();
+    // Zero-capacity tracker: TryTouch is a no-op returning Hit, so reservations never queue evictions.
+    private readonly PageResidencyTracker _pageTracker = PageResidencyTracker.FromByteBudget(0);
+    private readonly Lock _lock = new();
+    private int _nextArenaId;
+    private bool _disposed;
+
+    public PageResidencyTracker PageTracker => _pageTracker;
+
+    /// <summary>No-op: the RAM tier holds nothing across a restart, so there is nothing to rehydrate.</summary>
+    public void Initialize(IReadOnlyList<CatalogEntry> entries) { }
+
+    public ArenaWriter CreateWriter(long estimatedSize, bool small = false)
+    {
+        using Lock.Scope scope = _lock.EnterScope();
+        int id = _nextArenaId++;
+        // Size the per-slice buffer to the estimate; NativeArenaBuffer grows if the write overruns it.
+        ArenaFile file = ArenaFile.CreateInMemory(id, Math.Max(estimatedSize, 1), small);
+        _arenas[id] = file;
+        file.ReportAdded();
+        Stream stream = file.CreateWriteStream(0);
+        // Every slice owns its file (no packing), which is exactly the "dedicated" writer shape.
+        return new ArenaWriter(this, file, dedicated: true, 0, stream);
+    }
+
+    public ArenaReservation Open(in SnapshotLocation location)
+    {
+        if (!_arenas.TryGetValue(location.ArenaId, out ArenaFile? arenaFile))
+            throw new InvalidOperationException($"Arena {location.ArenaId} is not registered with this manager.");
+        return new ArenaReservation(this, arenaFile, location.ArenaId, location.Offset, location.Size);
+    }
+
+    public void OnWriteCompleted(ArenaFile file, long newFrontier, bool hasHeadroom)
+    {
+        using Lock.Scope scope = _lock.EnterScope();
+        file.WriterActive = false;
+        file.Frontier = newFrontier;
+        long delta = file.Frontier - file.ReportedFrontier;
+        if (delta != 0)
+        {
+            file.ReportedFrontier = file.Frontier;
+            Interlocked.Add(ref Metrics._arenaAllocatedBytes, delta);
+        }
+    }
+
+    // In-memory slices are always dedicated, so a shared-cancel is never reached in practice; drop the
+    // file defensively so a future change can't leak one.
+    public void OnWriteCancelledShared(ArenaFile file)
+    {
+        using Lock.Scope scope = _lock.EnterScope();
+        file.WriterActive = false;
+        if (_arenas.TryRemove(file.Id, out _))
+        {
+            file.ReportRemoved();
+            file.Dispose();
+        }
+    }
+
+    public void OnWriteCancelledDedicated(ArenaFile file)
+    {
+        // The writer already dropped the manager's ref (freeing the buffer); just clear the dict + metric.
+        using Lock.Scope scope = _lock.EnterScope();
+        _arenas.TryRemove(file.Id, out _);
+        file.ReportRemoved();
+    }
+
+    public bool MarkDead(ArenaFile file, long deadSize)
+    {
+        using Lock.Scope scope = _lock.EnterScope();
+        if (_disposed) return false;
+        file.DeadBytes += deadSize;
+        if (file.DeadBytes < file.Frontier || file.WriterActive) return true;
+        if (_arenas.TryRemove(file.Id, out _))
+        {
+            file.ReportRemoved();
+            file.Dispose();
+        }
+        return false;
+    }
+
+    // Disk-only surface — no-ops for a RAM arena (see the IArenaManager doc comments).
+    public bool TryPunchHole(ArenaFile file, long offset, long size) => false;
+    public void ForgetTrackerRange(int arenaId, long byteOffset, long byteSize) { }
+    public void QueueEviction(int arenaId, uint pageIdx) { }
+
+    public void Dispose()
+    {
+        using Lock.Scope scope = _lock.EnterScope();
+        if (_disposed) return;
+        _disposed = true;
+        foreach (KeyValuePair<int, ArenaFile> kv in _arenas)
+        {
+            kv.Value.ReportRemoved();
+            kv.Value.Dispose();
+        }
+        _arenas.Clear();
+        _pageTracker.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/InMemoryBlobArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/InMemoryBlobArenaManager.cs
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nethermind.State.Flat.PersistedSnapshots.Storage;
+
+/// <summary>
+/// RAM-backed <see cref="IBlobArenaManager"/>: trie-node RLP for a snapshot lives in its own
+/// growable native buffer (<see cref="BlobArenaFile.CreateInMemory"/>) — an "in-memory blob arena
+/// per snapshot" — instead of packed into on-disk blob files. Selected by
+/// <c>FlatNodeStorageInMemoryArena</c>. Files are not packed or reused: each <see cref="CreateWriter"/>
+/// mints a fresh id, and a file is freed as soon as its last snapshot lease drops. The tier is
+/// session-ephemeral (nothing survives a restart, so <see cref="Initialize"/> /
+/// <see cref="SweepUnreferenced"/> are no-ops).
+/// </summary>
+public sealed class InMemoryBlobArenaManager(long maxFileSize) : IBlobArenaManager
+{
+    private readonly Lock _lock = new();
+    // Indexed by blob arena id (same O(1) layout as the disk pool). Null slot = no file.
+    private readonly BlobArenaFile?[] _files = new BlobArenaFile?[ushort.MaxValue + 1];
+    private int _nextFileId;
+    private bool _disposed;
+
+    /// <summary>No-op: the RAM pool starts empty and holds nothing across a restart.</summary>
+    public void Initialize() { }
+
+    public BlobArenaWriter CreateWriter(long estimatedSize)
+    {
+        using Lock.Scope scope = _lock.EnterScope();
+        if (_disposed) throw new ObjectDisposedException(nameof(InMemoryBlobArenaManager));
+        // One file per snapshot, so ids are never reused — the ushort space caps the number of live +
+        // historical base snapshots in a session (ample for the intended experimental use).
+        if (_nextFileId > ushort.MaxValue)
+            throw new InvalidOperationException(
+                $"In-memory blob arena id space exhausted ({ushort.MaxValue + 1} files).");
+        ushort id = (ushort)_nextFileId++;
+        BlobArenaFile file = BlobArenaFile.CreateInMemory(id, maxFileSize, Math.Max(estimatedSize, 1));
+        _files[id] = file;
+        if (!file.TryAcquireLease())
+            throw new InvalidOperationException($"In-memory blob arena {id} is mid-cleanup; cannot open writer.");
+        Stream stream = file.OpenWriteStream(0);
+        return new BlobArenaWriter(this, file, 0, stream);
+    }
+
+    public bool TryLeaseFile(ushort blobArenaId, [NotNullWhen(true)] out BlobArenaFile? file)
+    {
+        BlobArenaFile? candidate = _files[blobArenaId];
+        if (candidate is null || !candidate.TryAcquireLease())
+        {
+            file = null;
+            return false;
+        }
+        file = candidate;
+        return true;
+    }
+
+    public BlobArenaFile GetFile(ushort blobArenaId) =>
+        _files[blobArenaId]
+            ?? throw new InvalidOperationException($"Blob arena {blobArenaId} not registered with this manager.");
+
+    /// <summary>No-op: no crash orphans exist in a fresh RAM pool.</summary>
+    public void SweepUnreferenced() { }
+
+    public void OnWriteCompleted(BlobArenaFile file, bool hasHeadroom)
+    {
+        using Lock.Scope scope = _lock.EnterScope();
+        long delta = file.Frontier - file.ReportedFrontier;
+        if (delta != 0)
+        {
+            file.ReportedFrontier = file.Frontier;
+            Interlocked.Add(ref Metrics._blobAllocatedBytes, delta);
+        }
+    }
+
+    // Cancelled write on a per-snapshot file — free it (drop the manager slot lease); the writer drops
+    // its own lease right after, so the last release frees the buffer.
+    public void OnWriteCancelled(ushort blobArenaId)
+    {
+        using Lock.Scope scope = _lock.EnterScope();
+        BlobArenaFile? file = _files[blobArenaId];
+        if (file is null) return;
+        _files[blobArenaId] = null;
+        file.Dispose();
+    }
+
+    // A per-snapshot RAM file is never reused, so when its last snapshot lease drops just free it
+    // (drop the manager slot lease) rather than resetting the frontier for packing.
+    public void TryResetOrphanedFrontier(BlobArenaFile file)
+    {
+        using Lock.Scope scope = _lock.EnterScope();
+        if (_disposed) return;
+        if (_files[file.BlobArenaId] != file) return;
+        if (!file.HasOnlyManagerLease) return;
+        _files[file.BlobArenaId] = null;
+        file.Dispose();
+    }
+
+    public void Dispose()
+    {
+        using Lock.Scope scope = _lock.EnterScope();
+        if (_disposed) return;
+        _disposed = true;
+        for (int id = 0; id < _files.Length; id++)
+        {
+            BlobArenaFile? file = _files[id];
+            if (file is null) continue;
+            _files[id] = null;
+            file.Dispose();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/InMemoryBlobArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/InMemoryBlobArenaManager.cs
@@ -9,8 +9,10 @@ namespace Nethermind.State.Flat.PersistedSnapshots.Storage;
 /// RAM-backed <see cref="IBlobArenaManager"/>: trie-node RLP for a snapshot lives in its own
 /// growable native buffer (<see cref="BlobArenaFile.CreateInMemory"/>) — an "in-memory blob arena
 /// per snapshot" — instead of packed into on-disk blob files. Selected by
-/// <c>FlatNodeStorageInMemoryArena</c>. Files are not packed or reused: each <see cref="CreateWriter"/>
-/// mints a fresh id, and a file is freed as soon as its last snapshot lease drops. The tier is
+/// <c>FlatNodeStorageInMemoryArena</c>. Files are not packed: each <see cref="CreateWriter"/> takes a
+/// dedicated file, and a file is freed as soon as its last snapshot lease drops. Its id is then reclaimed
+/// onto a free-list and reused before a fresh one is minted, so the ushort space caps the number of
+/// concurrently live base snapshots (not the cumulative count over a session). The tier is
 /// session-ephemeral (nothing survives a restart, so <see cref="Initialize"/> /
 /// <see cref="SweepUnreferenced"/> are no-ops).
 /// </summary>
@@ -19,6 +21,9 @@ public sealed class InMemoryBlobArenaManager(long maxFileSize) : IBlobArenaManag
     private readonly Lock _lock = new();
     // Indexed by blob arena id (same O(1) layout as the disk pool). Null slot = no file.
     private readonly BlobArenaFile?[] _files = new BlobArenaFile?[ushort.MaxValue + 1];
+    // Ids freed when a file's last lease drops, reused before minting new ones so the cap is on live
+    // (not cumulative) files. Only ever touched under _lock, on the same paths that null the slot.
+    private readonly Stack<ushort> _freeIds = new();
     private int _nextFileId;
     private bool _disposed;
 
@@ -29,12 +34,20 @@ public sealed class InMemoryBlobArenaManager(long maxFileSize) : IBlobArenaManag
     {
         using Lock.Scope scope = _lock.EnterScope();
         if (_disposed) throw new ObjectDisposedException(nameof(InMemoryBlobArenaManager));
-        // One file per snapshot, so ids are never reused — the ushort space caps the number of live +
-        // historical base snapshots in a session (ample for the intended experimental use).
-        if (_nextFileId > ushort.MaxValue)
-            throw new InvalidOperationException(
-                $"In-memory blob arena id space exhausted ({ushort.MaxValue + 1} files).");
-        ushort id = (ushort)_nextFileId++;
+        // Reuse a freed id before minting a new one; the ushort space then caps the number of
+        // concurrently live base snapshots (ample for the intended experimental use).
+        ushort id;
+        if (_freeIds.TryPop(out ushort reused))
+        {
+            id = reused;
+        }
+        else
+        {
+            if (_nextFileId > ushort.MaxValue)
+                throw new InvalidOperationException(
+                    $"In-memory blob arena id space exhausted ({ushort.MaxValue + 1} live files).");
+            id = (ushort)_nextFileId++;
+        }
         BlobArenaFile file = BlobArenaFile.CreateInMemory(id, maxFileSize, Math.Max(estimatedSize, 1));
         _files[id] = file;
         if (!file.TryAcquireLease())
@@ -81,6 +94,7 @@ public sealed class InMemoryBlobArenaManager(long maxFileSize) : IBlobArenaManag
         BlobArenaFile? file = _files[blobArenaId];
         if (file is null) return;
         _files[blobArenaId] = null;
+        _freeIds.Push(blobArenaId);
         file.Dispose();
     }
 
@@ -93,6 +107,7 @@ public sealed class InMemoryBlobArenaManager(long maxFileSize) : IBlobArenaManag
         if (_files[file.BlobArenaId] != file) return;
         if (!file.HasOnlyManagerLease) return;
         _files[file.BlobArenaId] = null;
+        _freeIds.Push(file.BlobArenaId);
         file.Dispose();
     }
 

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/NativeArenaBuffer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/NativeArenaBuffer.cs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.InteropServices;
+
+namespace Nethermind.State.Flat.PersistedSnapshots.Storage;
+
+/// <summary>
+/// A growable, native-memory-backed byte buffer that backs the RAM arena tiers
+/// (<see cref="InMemoryArenaManager"/> / <see cref="InMemoryBlobArenaManager"/>) in place of an
+/// mmap'd file. Appended into once during a single writer's lifetime, then frozen and read
+/// concurrently — the "written once, then read-only" property lets completed slices be spanned /
+/// copied without synchronisation. Growth only happens on the exclusive write path, so a
+/// <see cref="NativeMemory.Realloc"/> can move the block without racing a reader.
+/// </summary>
+internal sealed unsafe class NativeArenaBuffer : IDisposable
+{
+    private byte* _ptr;
+    private long _capacity;
+    private long _length;
+
+    public NativeArenaBuffer(long initialCapacity)
+    {
+        _capacity = Math.Max(initialCapacity, 1);
+        _ptr = (byte*)NativeMemory.AllocZeroed((nuint)_capacity);
+    }
+
+    /// <summary>Base pointer to the first byte. Stable once the buffer is frozen (no further appends).</summary>
+    public byte* Pointer => _ptr;
+    public long Length => _length;
+    public long Capacity => _capacity;
+
+    /// <summary>Append <paramref name="data"/> at the current end, growing the block if needed.</summary>
+    public void Append(ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty) return;
+        EnsureCapacity(_length + data.Length);
+        data.CopyTo(new Span<byte>(_ptr + _length, data.Length));
+        _length += data.Length;
+    }
+
+    private void EnsureCapacity(long required)
+    {
+        if (required <= _capacity) return;
+        long newCap = _capacity;
+        while (newCap < required) newCap *= 2;
+        _ptr = (byte*)NativeMemory.Realloc(_ptr, (nuint)newCap);
+        // Zero the grown tail so any unwritten padding reads back as zero, mirroring the sparse-file
+        // zeros the disk arena relies on.
+        NativeMemory.Clear(_ptr + _capacity, (nuint)(newCap - _capacity));
+        _capacity = newCap;
+    }
+
+    /// <summary>Copy up to <paramref name="destination"/>.Length bytes from <paramref name="offset"/>.
+    /// Returns the number copied; 0 at or past the written length (short read at EOF).</summary>
+    public int ReadAt(long offset, Span<byte> destination)
+    {
+        if (offset < 0 || offset >= _length) return 0;
+        int count = (int)Math.Min(destination.Length, _length - offset);
+        new ReadOnlySpan<byte>(_ptr + offset, count).CopyTo(destination[..count]);
+        return count;
+    }
+
+    public void Dispose()
+    {
+        if (_ptr is not null)
+        {
+            NativeMemory.Free(_ptr);
+            _ptr = null;
+        }
+    }
+}
+
+/// <summary>
+/// Append-only writable <see cref="Stream"/> over a <see cref="NativeArenaBuffer"/>, handed to the
+/// existing <see cref="ArenaWriter"/> / <see cref="BlobArenaWriter"/> in RAM mode in place of a
+/// <see cref="FileStream"/>. It does not own the buffer — the arena file frees it on cleanup.
+/// </summary>
+internal sealed class NativeArenaWriteStream(NativeArenaBuffer buffer) : Stream
+{
+    private readonly NativeArenaBuffer _buffer = buffer;
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => _buffer.Length;
+    public override long Position { get => _buffer.Length; set => throw new NotSupportedException(); }
+
+    public override void Write(ReadOnlySpan<byte> buffer) => _buffer.Append(buffer);
+    public override void Write(byte[] buffer, int offset, int count) => _buffer.Append(buffer.AsSpan(offset, count));
+
+    public override void Flush() { }
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+}

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/NativeArenaBuffer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/NativeArenaBuffer.cs
@@ -25,6 +25,9 @@ internal sealed unsafe class NativeArenaBuffer : IDisposable
         _ptr = (byte*)NativeMemory.AllocZeroed((nuint)_capacity);
     }
 
+    // Safety net: free the native block if a buffer is leaked without Dispose, so the RAM isn't lost.
+    ~NativeArenaBuffer() => FreeBuffer();
+
     /// <summary>Base pointer to the first byte. Stable once the buffer is frozen (no further appends).</summary>
     public byte* Pointer => _ptr;
     public long Length => _length;
@@ -43,7 +46,17 @@ internal sealed unsafe class NativeArenaBuffer : IDisposable
     {
         if (required <= _capacity) return;
         long newCap = _capacity;
-        while (newCap < required) newCap *= 2;
+        // Grow by doubling, but never below `required` and never overflow long: once doubling would
+        // wrap past long.MaxValue, jump straight to `required` (the true minimum).
+        while (newCap < required)
+        {
+            if (newCap > long.MaxValue / 2)
+            {
+                newCap = required;
+                break;
+            }
+            newCap *= 2;
+        }
         _ptr = (byte*)NativeMemory.Realloc(_ptr, (nuint)newCap);
         // Zero the grown tail so any unwritten padding reads back as zero, mirroring the sparse-file
         // zeros the disk arena relies on.
@@ -63,10 +76,19 @@ internal sealed unsafe class NativeArenaBuffer : IDisposable
 
     public void Dispose()
     {
-        if (_ptr is not null)
+        FreeBuffer();
+        GC.SuppressFinalize(this);
+    }
+
+    // Idempotent, thread-agnostic (NativeMemory.Free needs no managed state) so it is safe to run from
+    // either Dispose or the finalizer. Null the pointer before freeing so a double-call can't double-free.
+    private void FreeBuffer()
+    {
+        byte* p = _ptr;
+        if (p is not null)
         {
-            NativeMemory.Free(_ptr);
             _ptr = null;
+            NativeMemory.Free(p);
         }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -53,7 +53,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
 
     public SnapshotRepository(
         IArenaManager arenaManager,
-        BlobArenaManager blobArenaManager,
+        IBlobArenaManager blobArenaManager,
         ISnapshotCatalog catalog,
         IFlatDbConfig config,
         ILogManager logManager)
@@ -577,7 +577,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
     }
 
     /// <inheritdoc />
-    public void ShareBloomAcrossRange(StateId from, StateId to, RefCountedBloomFilter sharedBloom, BlobArenaManager blobs)
+    public void ShareBloomAcrossRange(StateId from, StateId to, RefCountedBloomFilter sharedBloom, IBlobArenaManager blobs)
     {
         StateId current = to;
         while (Height(current) > Height(from))
@@ -607,7 +607,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
     /// produce false negatives).
     /// </summary>
     private void ShareBloomAt(in StateId at, in StateId from, in StateId to,
-        RefCountedBloomFilter sharedBloom, BlobArenaManager blobs, SnapshotTier tier)
+        RefCountedBloomFilter sharedBloom, IBlobArenaManager blobs, SnapshotTier tier)
     {
         // Lease before reading the entry's fields so it cannot drain mid-build; the twin takes its own
         // reservation + blob leases in its ctor, so it is independent of this probe lease.


### PR DESCRIPTION
Variant 2 for the #12404 base-convert-on-compaction memory experiment - the "in-memory binary arena" option from the review discussion.

Adds `FlatNodeStorageInMemoryArena` (default off). When set, the persisted-snapshot tier's arena is backed by native memory instead of on-disk files, so aged base snapshots demote into RAM. Implemented behind the existing `IArenaManager` and a new `IBlobArenaManager` interface. `ConvertAndRegister`'s convert-and-drop flow is unchanged, so no TrieNode RLP is duplicated (per @asdacap's note about compacted snapshots sharing base TrieNode instances).

- one native buffer per slice, written once then frozen and read lock-free
- disk path is byte-for-byte unchanged when the flag is off
- the RAM tier is session-ephemeral (not reloaded on restart) - this is an in-session experiment to compare against the in-memory slab variant

Draft - mainnet memory + latency numbers vs baseline and vs the slab variant to follow.

## Types of changes
- [x] New feature
- [x] Optimization

## Testing
Full `Nethermind.State.Flat` test suite green with the flag off (disk path unchanged); 3 new in-memory round-trip tests (point read via ValidatePersistedSnapshot, whole-read-session scan, raw arena write/read/reopen). Mainnet benchmark pending.
