### PR TITLE
fix(jsonrpc): bound eth_getProof with the request timeout

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -1025,7 +1025,8 @@ public partial class EthRpcModule(
             return GetStateFailureResult<AccountProof>(header);
         }
 
-        AccountProofCollector accountProofCollector = new(accountAddress, storageKeys);
+        using CancellationTokenSource timeout = _rpcConfig.BuildTimeoutCancellationToken();
+        AccountProofCollector accountProofCollector = new(accountAddress, storageKeys, timeout.Token);
         _blockchainBridge.RunTreeVisitor(accountProofCollector, header!);
         return ResultWrapper<AccountProof>.Success(accountProofCollector.BuildResult());
     }

--- a/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -45,6 +46,16 @@ namespace Nethermind.Store.Test.Proofs
             AccountProofCollector collector = new(addressBytes, storageKeys);
             tree.Accept(collector, tree.RootHash);
             return collector.BuildResult();
+        }
+
+        [Test]
+        public void ShouldVisit_throws_when_cancellation_requested()
+        {
+            using CancellationTokenSource cts = new();
+            cts.Cancel();
+            AccountProofCollector collector = new(TestItem.AddressA, Array.Empty<UInt256>(), cts.Token);
+
+            Assert.That(() => collector.ShouldVisit(default, default), Throws.InstanceOf<OperationCanceledException>());
         }
 
         private static StateTree CreateTwoAccountTree(Account account1, Account account2)

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -30,6 +31,7 @@ namespace Nethermind.State.Proofs
 
         private readonly List<byte[]> _accountProofItems = [];
         private readonly List<byte[]>[] _storageProofItems;
+        private readonly CancellationToken _cancellationToken;
 
         private static ValueHash256 ToKey(byte[] index) => ValueKeccak.Compute(index);
 
@@ -90,8 +92,9 @@ namespace Nethermind.State.Proofs
         public AccountProofCollector(Address? address, IEnumerable<UInt256> storageKeys)
             : this(address, storageKeys.Select(ToKey).ToArray()) { }
 
-        public AccountProofCollector(Address? address, IReadOnlyCollection<UInt256> storageKeys)
+        public AccountProofCollector(Address? address, IReadOnlyCollection<UInt256> storageKeys, CancellationToken cancellationToken = default)
         {
+            _cancellationToken = cancellationToken;
             _accountProof = new AccountProof
             {
                 StorageProofs = new StorageProof[storageKeys.Count],
@@ -142,6 +145,8 @@ namespace Nethermind.State.Proofs
 
         public bool ShouldVisit(in TreePathContextWithStorage ctx, in ValueHash256 nextNode)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
+
             if (ctx.Storage is null)
             {
                 // Account trie: follow the path leading to our target account. Once we've reached


### PR DESCRIPTION
## Changes

- `eth_getProof` called `RunTreeVisitor` with **no cancellation token**, so — unlike `eth_call`/`eth_estimateGas`, which honor the 20s RPC timeout on every tracer callback — its account + storage trie walk had no wall-clock bound. The only limit was `GetProofStorageKeyLimit` (1000 storage keys). On cold state, a single small request could issue thousands of uncancellable RocksDB node reads, tying up a worker thread past the timeout and evicting the shared state cache that block processing relies on.
- Thread the RPC timeout token (`IJsonRpcConfig.BuildTimeoutCancellationToken()`) into `AccountProofCollector` and check it in `ShouldVisit`, which is invoked before each node descent. The walk now aborts between node fetches once the timeout elapses. `JsonRpcService` already maps the resulting `OperationCanceledException` to an RPC timeout error (`ErrorCodes.Timeout`), so the caller gets a clean timeout instead of a wrong/partial proof.
- The new constructor parameter is optional (`CancellationToken cancellationToken = default`), so all other `AccountProofCollector` callers are unaffected (token defaults to `None`, making the check a no-op).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added `AccountProofCollectorTests.ShouldVisit_throws_when_cancellation_requested`: constructs the collector with an already-cancelled token and asserts `ShouldVisit` throws `OperationCanceledException`. Deterministic, pins the wall-clock bound so it can't silently regress.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Found during a review of the JSON-RPC read surface. `eth_getProof` is in the `Eth` module, which is enabled by default, so this is reachable by an untrusted caller once RPC is exposed. The related `proof_*` module methods use a similar visitor path and could get the same treatment as a follow-up.
