### PR TITLE
hotfix: Configurable and explicit eth_getLogs scan limit

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/IReceiptConfig.cs
@@ -28,6 +28,11 @@ public interface IReceiptConfig : IConfig
     [ConfigItem(Description = "The number of recent blocks to maintain transaction index for. `0` to never remove indices, `-1` to never index.", DefaultValue = "2350000")]
     long? TxLookupLimit { get; set; }
 
-    [ConfigItem(Description = "The max number of blocks per `eth_getLogs` request.", DefaultValue = "10000", HiddenFromDocs = true)]
+    [ConfigItem(Description =
+        """
+        The maximum block range (toBlock - fromBlock + 1) allowed in a single `eth_getLogs` request.
+        Requests exceeding this range are rejected with an "invalid params" (-32602) error.
+        Set to 0 to disable the limit. Value is ignored (no limits) if log index is enabled.
+        """, DefaultValue = "10000")]
     int MaxBlockDepth { get; set; }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptConfig.cs
@@ -12,5 +12,5 @@ public class ReceiptConfig : IReceiptConfig
     public bool CompactReceiptStore { get; set; } = true;
     public bool CompactTxIndex { get; set; } = true;
     public long? TxLookupLimit { get; set; } = 2350000;
-    public int MaxBlockDepth { get; set; } = 10000;
+    public int MaxBlockDepth { get; set; } = 10_000;
 }

--- a/src/Nethermind/Nethermind.Facade/Find/IndexedLogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Find/IndexedLogFinder.cs
@@ -25,9 +25,8 @@ public class IndexedLogFinder(
     ILogManager logManager,
     IReceiptsRecovery receiptsRecovery,
     ILogIndexStorage logIndexStorage,
-    int maxBlockDepth = 1000,
     int minBlocksToUseIndex = 32)
-    : LogFinder(blockFinder, receiptFinder, receiptStorage, logManager, receiptsRecovery, maxBlockDepth)
+    : LogFinder(blockFinder, receiptFinder, receiptStorage, logManager, receiptsRecovery)
 {
     private readonly ILogIndexStorage _logIndexStorage = logIndexStorage ?? throw new ArgumentNullException(nameof(logIndexStorage));
 

--- a/src/Nethermind/Nethermind.Facade/Find/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Find/LogFinder.cs
@@ -21,8 +21,7 @@ namespace Nethermind.Facade.Find
         IReceiptFinder? receiptFinder,
         IReceiptStorage? receiptStorage,
         ILogManager? logManager,
-        IReceiptsRecovery? receiptsRecovery,
-        int maxBlockDepth = 1000)
+        IReceiptsRecovery? receiptsRecovery)
         : ILogFinder
     {
         private static int ParallelExecutions = 0;
@@ -136,7 +135,7 @@ namespace Nethermind.Facade.Find
                 for (long i = 0; i < count; i++) yield return from + i;
             }
 
-            long rangeSize = Math.Min(maxBlockDepth, toBlock.Number - fromBlock.Number + 1);
+            long rangeSize = toBlock.Number - fromBlock.Number + 1;
             bool tryParallel = rangeSize >= _rpcConfigGetLogsThreads;
             return FilterLogsInBlocksParallel(filter, BlockNumbers(fromBlock.Number, rangeSize), tryParallel, cancellationToken);
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/EthModuleBenchmarks.cs
@@ -89,6 +89,7 @@ namespace Nethermind.JsonRpc.Benchmark
                 _container.Resolve<IProtocolsManager>(),
                 _container.Resolve<IForkInfo>(),
                 new LogIndexConfig(),
+                new ReceiptConfig(),
                 new BlocksConfig().SecondsPerSlot,
                 _headBlockSignal,
                 new EthCapabilitiesProvider(

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/BoundedModulePoolTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/BoundedModulePoolTests.cs
@@ -62,6 +62,7 @@ public class BoundedModulePoolTests
             new BlocksConfig(),
             Substitute.For<IForkInfo>(),
             Substitute.For<ILogIndexConfig>(),
+            new ReceiptConfig(),
             new EthCapabilitiesProvider(
                 blockTree.AsReadOnly(),
                 Substitute.For<IStateBoundary>(),

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -948,6 +948,41 @@ public partial class EthRpcModuleTests
         Assert.That(serialized, Is.EqualTo(expectedResponse));
     }
 
+    [TestCase(2, """{"fromBlock":"0x0","toBlock":"0x3"}""", false, true, TestName = "range 4 exceeds limit 2 -> rejected")]
+    [TestCase(4, """{"fromBlock":"0x0","toBlock":"0x3"}""", false, false, TestName = "range 4 within limit 4 -> allowed")]
+    [TestCase(0, """{"fromBlock":"0x0","toBlock":"0x3"}""", false, false, TestName = "limit disabled -> allowed")]
+    [TestCase(2, """{"toBlock":"0x3"}""", false, true, TestName = "fromBlock omitted -> Earliest (0x0), range 4 exceeds limit 2 -> rejected")]
+    [TestCase(4, """{"toBlock":"0x3"}""", false, false, TestName = "fromBlock omitted -> Earliest (0x0), range 4 within limit 4 -> allowed")]
+    [TestCase(2, """{"fromBlock":"0x0"}""", false, true, TestName = "toBlock omitted -> Latest (0x3), range 4 exceeds limit 2 -> rejected")]
+    [TestCase(4, """{"fromBlock":"0x0"}""", false, false, TestName = "toBlock omitted -> Latest (0x3), range 4 within limit 4 -> allowed")]
+    [TestCase(2, """{"fromBlock":"0x0","toBlock":"0x3"}""", true, false, TestName = "log index enabled, useIndex default -> limit skipped -> allowed")]
+    [TestCase(2, """{"fromBlock":"0x0","toBlock":"0x3","useIndex":false}""", true, true, TestName = "log index enabled but useIndex=false -> limit enforced -> rejected")]
+    public async Task Eth_get_logs_enforces_max_block_depth(int maxBlockDepth, string parameter, bool logIndexEnabled, bool shouldReject)
+    {
+        using Context ctx = await Context.Create();
+        IBlockchainBridge bridge = Substitute.For<IBlockchainBridge>();
+        bridge.GetLogs(Arg.Any<LogFilter>(), Arg.Any<BlockHeader>(), Arg.Any<BlockHeader>(), Arg.Any<CancellationToken>())
+            .Returns([CreateTestFilterLog()]);
+
+        ctx.Test = await CreateLogsTestBlockchainBuilder(enableLogsStreamMode: false)
+            .WithBlockchainBridge(bridge)
+            .WithReceiptConfig(new ReceiptConfig { MaxBlockDepth = maxBlockDepth })
+            .Build();
+        ctx.Test.LogIndexConfig.Enabled = logIndexEnabled;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_getLogs", parameter);
+
+        if (shouldReject)
+        {
+            Assert.That(serialized, Does.Contain($"\"code\":{ErrorCodes.InvalidParams}"));
+            Assert.That(serialized, Does.Contain(nameof(IReceiptConfig.MaxBlockDepth)));
+        }
+        else
+        {
+            Assert.That(serialized, Is.EqualTo(ExpectedFilterLogResponse));
+        }
+    }
+
     [TestCase("eth_getLogs", "{}")]
     [TestCase("eth_getFilterLogs", "0x01")]
     public async Task Eth_logs_ignore_max_logs_response_body_size_when_stream_mode_disabled(string method, string parameter)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SingletonModulePoolTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SingletonModulePoolTests.cs
@@ -62,6 +62,7 @@ namespace Nethermind.JsonRpc.Test.Modules
                 new BlocksConfig(),
                 Substitute.For<IForkInfo>(),
                 Substitute.For<ILogIndexConfig>(),
+                new ReceiptConfig(),
                 new EthCapabilitiesProvider(
                     blockTree.AsReadOnly(),
                     Substitute.For<IStateBoundary>(),

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -65,6 +65,7 @@ namespace Nethermind.JsonRpc.Test.Modules
         public IGasPriceOracle GasPriceOracle { get; private set; } = null!;
         public IProtocolsManager ProtocolsManager { get; private set; } = null!;
         public ILogIndexConfig LogIndexConfig { get; } = new LogIndexConfig();
+        public IReceiptConfig ReceiptConfig { get; private set; } = new ReceiptConfig();
 
         public IKeyStore KeyStore { get; } = new MemKeyStore(TestItem.PrivateKeys, Path.Combine("testKeyStoreDir", Path.GetRandomFileName()));
         public IWallet TestWallet { get; } =
@@ -127,6 +128,12 @@ namespace Nethermind.JsonRpc.Test.Modules
             public Builder<T> WithConfig(IJsonRpcConfig config)
             {
                 _blockchain.RpcConfig = config;
+                return this;
+            }
+
+            public Builder<T> WithReceiptConfig(IReceiptConfig receiptConfig)
+            {
+                _blockchain.ReceiptConfig = receiptConfig;
                 return this;
             }
 
@@ -196,6 +203,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             @this.ProtocolsManager,
             @this.ForkInfo,
             @this.LogIndexConfig,
+            @this.ReceiptConfig,
             @this.BlocksConfig.SecondsPerSlot,
             new HeadBlockSignal(@this.BlockTree),
             new EthCapabilitiesProvider(

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModuleFactory.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthModuleFactory.cs
@@ -36,6 +36,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
         IBlocksConfig blocksConfig,
         IForkInfo forkInfo,
         ILogIndexConfig logIndexConfig,
+        IReceiptConfig receiptConfig,
         IEthCapabilitiesProvider capabilitiesProvider)
         : ModuleFactoryBase<IEthRpcModule>
     {
@@ -61,6 +62,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
                 protocolsManager,
                 forkInfo,
                 logIndexConfig,
+                receiptConfig,
                 _secondsPerSlot,
                 _headBlockSignal,
                 capabilitiesProvider);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -72,6 +72,7 @@ public partial class EthRpcModule(
     IProtocolsManager protocolsManager,
     IForkInfo forkInfo,
     ILogIndexConfig? logIndexConfig,
+    IReceiptConfig receiptConfig,
     ulong? secondsPerSlot,
     HeadBlockSignal headBlockSignal,
     IEthCapabilitiesProvider capabilitiesProvider) : IEthRpcModule
@@ -98,6 +99,7 @@ public partial class EthRpcModule(
     protected readonly IProtocolsManager _protocolsManager = protocolsManager ?? throw new ArgumentNullException(nameof(protocolsManager));
     protected readonly ulong _secondsPerSlot = secondsPerSlot ?? throw new ArgumentNullException(nameof(secondsPerSlot));
     private readonly HeadBlockSignal _headBlockSignal = headBlockSignal ?? throw new ArgumentNullException(nameof(headBlockSignal));
+    private readonly IReceiptConfig _receiptConfig = receiptConfig ?? throw new ArgumentNullException(nameof(receiptConfig));
     private ResultWrapper<ulong>? _chainIdResponse;
     readonly JsonSerializerOptions UnchangedDictionaryKeyOptions = new(EthereumJsonSerializer.JsonOptionsIndented) { DictionaryKeyPolicy = null };
 
@@ -899,6 +901,9 @@ public partial class EthRpcModule(
             BlockHeader fromBlockHeader = fromResult.Object!;
             BlockHeader toBlockHeader = toResult.Object!;
 
+            if (EnsureBlockRangeWithinLimit(filter, fromBlockHeader, toBlockHeader) is { } rangeError)
+                return rangeError;
+
             LogFilter logFilter = _blockchainBridge.GetFilter(fromBlock, toBlock, filter.Address, filter.Topics);
 
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse - can be null in tests
@@ -1193,5 +1198,26 @@ public partial class EthRpcModule(
                 );
             }
         }
+    }
+
+    // cap block range of a logs query against unbounded sequential scans, skip if log index is enabled
+    private ResultWrapper<IEnumerable<FilterLog>>? EnsureBlockRangeWithinLimit(Filter filter, BlockHeader fromBlock, BlockHeader toBlock)
+    {
+        int maxBlockDepth = _receiptConfig.MaxBlockDepth;
+        bool usingLogIndex = logIndexConfig?.Enabled is true && filter.UseIndex;
+
+        if (usingLogIndex || maxBlockDepth <= 0 || toBlock.Number < fromBlock.Number)
+            return null;
+
+        long rangeSize = toBlock.Number - fromBlock.Number + 1;
+        if (rangeSize > maxBlockDepth)
+        {
+            return ResultWrapper<IEnumerable<FilterLog>>.Fail(
+                $"Block range {rangeSize} exceeds the maximum of {maxBlockDepth} blocks per logs request. " +
+                $"Use a narrower fromBlock/toBlock range or increase Receipt.{nameof(IReceiptConfig.MaxBlockDepth)}.",
+                ErrorCodes.InvalidParams);
+        }
+
+        return null;
     }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/Rpc/OptimismEthRpcModuleTest.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/Rpc/OptimismEthRpcModuleTest.cs
@@ -638,7 +638,7 @@ internal static class TestRpcBlockchainExt
             blockchain.ProtocolsManager,
             blockchain.ForkInfo,
             new BlocksConfig().SecondsPerSlot,
-            sequencerRpcClient, ecdsa, sealer, new LogIndexConfig(), opSpecHelper,
+            sequencerRpcClient, ecdsa, sealer, new LogIndexConfig(), new ReceiptConfig(), opSpecHelper,
             new HeadBlockSignal(blockchain.BlockTree),
             new EthCapabilitiesProvider(
                 blockchain.BlockTree.AsReadOnly(),

--- a/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthModuleFactory.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthModuleFactory.cs
@@ -50,6 +50,7 @@ public class OptimismEthModuleFactory : ModuleFactoryBase<IOptimismEthRpcModule>
     private readonly IProtocolsManager _protocolsManager;
     private readonly IForkInfo _forkInfo;
     private readonly ILogIndexConfig _logIndexConfig;
+    private readonly IReceiptConfig _receiptConfig;
     private readonly ulong? _secondsPerSlot;
     private readonly IJsonRpcClient? _sequencerRpcClient;
     private readonly HeadBlockSignal _headBlockSignal;
@@ -77,7 +78,8 @@ public class OptimismEthModuleFactory : ModuleFactoryBase<IOptimismEthRpcModule>
         IOptimismConfig config,
         IJsonSerializer jsonSerializer,
         ITimestamper timestamper,
-        ILogIndexConfig logIndexConfig
+        ILogIndexConfig logIndexConfig,
+        IReceiptConfig receiptConfig
     )
     {
         _secondsPerSlot = blocksConfig.SecondsPerSlot;
@@ -101,6 +103,7 @@ public class OptimismEthModuleFactory : ModuleFactoryBase<IOptimismEthRpcModule>
         _protocolsManager = protocolsManager;
         _forkInfo = forkInfo;
         _logIndexConfig = logIndexConfig;
+        _receiptConfig = receiptConfig;
         ILogger logger = logManager.GetClassLogger<OptimismEthModuleFactory>();
         if (config.SequencerUrl is null && logger.IsWarn)
         {
@@ -140,6 +143,7 @@ public class OptimismEthModuleFactory : ModuleFactoryBase<IOptimismEthRpcModule>
             _ecdsa,
             _sealer,
             _logIndexConfig,
+            _receiptConfig,
             _opSpecHelper,
             _headBlockSignal,
             _capabilitiesProvider

--- a/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthRpcModule.cs
@@ -56,6 +56,7 @@ public class OptimismEthRpcModule(
     IEthereumEcdsa ecdsa,
     ITxSealer sealer,
     ILogIndexConfig? logIndexConfig,
+    IReceiptConfig receiptConfig,
     IOptimismSpecHelper opSpecHelper,
     HeadBlockSignal headBlockSignal,
     IEthCapabilitiesProvider capabilitiesProvider)
@@ -76,6 +77,7 @@ public class OptimismEthRpcModule(
         protocolsManager,
         forkInfo,
         logIndexConfig,
+        receiptConfig,
         secondsPerSlot,
         headBlockSignal,
         capabilitiesProvider), IOptimismEthRpcModule


### PR DESCRIPTION
Hotfix targeting 1.39.2
- https://github.com/NethermindEth/nethermind/pull/12149
- Increase default limit to 10k
- Apply limit if user sets `"useIndex": false` in request