### PR TITLE
fix(jsonrpc): emit removed logs on reorg for poll-based log filters

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
@@ -331,10 +331,15 @@ public class FilterManagerTests
         Assert.That(totalPolled, Is.EqualTo(blockCount));
     }
 
-    [Test, MaxTime(Timeout.MaxTestTime)]
-    public void reorg_removed_logs_are_polled_as_removed()
+    [TestCase(false)]
+    [TestCase(true)]
+    [MaxTime(Timeout.MaxTestTime)]
+    public void reorg_removed_logs_are_polled_as_removed(bool explicitNumericRange)
     {
-        LogFilter filter = BuildFilter(static f => f.FromBlock(1L));
+        Action<FilterBuilder> filterShape = explicitNumericRange
+            ? f => f.FromBlock(1L).ToBlock(10L)
+            : f => f.FromBlock(1L);
+        LogFilter filter = BuildFilter(filterShape);
         _filterStore.SaveFilter(filter);
         _filterManager = new FilterManager(_filterStore, _mainProcessingContext, _txPool, _receiptMonitor, _logManager);
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Nethermind.Facade.Filters;
+using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Test.Builders;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
@@ -25,6 +26,7 @@ public class FilterManagerTests
     private FilterStore _filterStore = null!;
     private TestMainProcessingContext _mainProcessingContext = null!;
     private ITxPool _txPool = null!;
+    private IReceiptMonitor _receiptMonitor = null!;
     private ILogManager _logManager = null!;
     private FilterManager _filterManager = null!;
 
@@ -37,11 +39,16 @@ public class FilterManagerTests
         _filterStore = new FilterStore(new TimerFactory(), 400, 100);
         _mainProcessingContext = new TestMainProcessingContext();
         _txPool = Substitute.For<ITxPool>();
+        _receiptMonitor = Substitute.For<IReceiptMonitor>();
         _logManager = LimboLogs.Instance;
     }
 
     [TearDown]
-    public void TearDown() => _filterStore.Dispose();
+    public void TearDown()
+    {
+        _filterStore.Dispose();
+        _receiptMonitor.Dispose();
+    }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
     public async Task removing_filter_removes_data()
@@ -283,7 +290,7 @@ public class FilterManagerTests
     {
         BlockFilter blockFilter = new(_currentFilterId++);
         _filterStore.SaveFilter(blockFilter);
-        _filterManager = new FilterManager(_filterStore, _mainProcessingContext, _txPool, _logManager);
+        _filterManager = new FilterManager(_filterStore, _mainProcessingContext, _txPool, _receiptMonitor, _logManager);
 
         Block block = Build.A.Block.TestObject;
 
@@ -322,6 +329,29 @@ public class FilterManagerTests
         await Task.WhenAll(allTasks);
 
         Assert.That(totalPolled, Is.EqualTo(blockCount));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void reorg_removed_logs_are_polled_as_removed()
+    {
+        LogFilter filter = BuildFilter(static f => f.FromBlock(1L));
+        _filterStore.SaveFilter(filter);
+        _filterManager = new FilterManager(_filterStore, _mainProcessingContext, _txPool, _receiptMonitor, _logManager);
+
+        Block block = Build.A.Block.TestObject;
+        TxReceipt receipt = BuildReceipt(static r => r.WithBlockNumber(2L));
+
+        _mainProcessingContext.TestBranchProcessor.RaiseBlockProcessed(new BlockProcessedEventArgs(block, []));
+        _mainProcessingContext.RaiseTransactionProcessed(new TxProcessedEventArgs(1, Build.A.Transaction.TestObject, block.Header, receipt));
+
+        _receiptMonitor.ReceiptsInserted += Raise.EventWith(_receiptMonitor, new ReceiptsEventArgs(block.Header, [receipt], wasRemoved: true));
+
+        FilterLog[] logs = _filterManager.PollLogs(filter.Id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(logs.Any(static l => l.Removed), Is.True);
+            Assert.That(logs.Any(static l => !l.Removed), Is.True);
+        });
     }
 
     private void LogsShouldNotBeEmpty(Action<FilterBuilder> filterBuilder, Action<ReceiptBuilder> receiptBuilder)
@@ -368,7 +398,7 @@ public class FilterManagerTests
 
         _filterStore.SaveFilters(filters.OfType<LogFilter>());
         _filterStore.SaveFilters(filters.OfType<BlockFilter>());
-        _filterManager = new FilterManager(_filterStore, _mainProcessingContext, _txPool, _logManager);
+        _filterManager = new FilterManager(_filterStore, _mainProcessingContext, _txPool, _receiptMonitor, _logManager);
 
         _mainProcessingContext.TestBranchProcessor.RaiseBlockProcessed(new BlockProcessedEventArgs(block, []));
 

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -302,7 +302,7 @@ namespace Nethermind.Facade.Filters
                 return new FilterLog(index, txReceipt, logEntry, blockTimestamp, removed);
             }
 
-            return new FilterLog(index, txReceipt, logEntry, blockTimestamp);
+            return new FilterLog(index, txReceipt, logEntry, blockTimestamp, removed);
         }
 
         private sealed class Option<T>(T value)

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
+using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
@@ -36,13 +38,16 @@ namespace Nethermind.Facade.Filters
             FilterStore filterStore,
             IMainProcessingContext mainProcessingContext,
             ITxPool txPool,
+            IReceiptMonitor receiptMonitor,
             ILogManager logManager)
         {
             _filterStore = filterStore ?? throw new ArgumentNullException(nameof(filterStore));
             txPool = txPool ?? throw new ArgumentNullException(nameof(txPool));
+            ArgumentNullException.ThrowIfNull(receiptMonitor);
             _logger = logManager?.GetClassLogger<FilterManager>() ?? throw new ArgumentNullException(nameof(logManager));
             mainProcessingContext.BranchProcessor.BlockProcessed += OnBlockProcessed;
             mainProcessingContext.TransactionProcessed += OnTransactionProcessed;
+            receiptMonitor.ReceiptsInserted += OnReceiptsInserted;
             _filterStore.FilterRemoved += OnFilterRemoved;
             txPool.NewPending += OnNewPendingTransaction;
             txPool.RemovedPending += OnRemovedPendingTransaction;
@@ -64,6 +69,45 @@ namespace Nethermind.Facade.Filters
         }
 
         private void OnTransactionProcessed(object sender, TxProcessedEventArgs e) => AddReceipts(e.TxReceipt, e.BlockHeader.Timestamp);
+
+        private void OnReceiptsInserted(object? sender, ReceiptsEventArgs e)
+        {
+            if (!e.WasRemoved)
+            {
+                return;
+            }
+
+            TxReceipt[] receipts = e.TxReceipts;
+            if (receipts is null || receipts.Length == 0)
+            {
+                return;
+            }
+
+            IEnumerable<LogFilter> filters = _filterStore.GetFilters<LogFilter>();
+            foreach (LogFilter filter in filters)
+            {
+                long logIndex = 0;
+                ConcurrentQueue<FilterLog>? logs = null;
+                for (int r = 0; r < receipts.Length; r++)
+                {
+                    LogEntry[]? entries = receipts[r].Logs;
+                    if (entries is null)
+                    {
+                        continue;
+                    }
+
+                    for (int i = 0; i < entries.Length; i++)
+                    {
+                        FilterLog? filterLog = CreateLog(filter, receipts[r], entries[i], logIndex++, e.BlockHeader.Timestamp, removed: true);
+                        if (filterLog is not null)
+                        {
+                            logs ??= _logs.GetOrAdd(filter.Id, static _ => new ConcurrentQueue<FilterLog>());
+                            logs.Enqueue(filterLog);
+                        }
+                    }
+                }
+            }
+        }
 
         private void OnNewPendingTransaction(object sender, TxPool.TxEventArgs e)
         {
@@ -226,7 +270,7 @@ namespace Nethermind.Facade.Filters
                 _logger.Trace($"Filter with id: {filter.Id} contains {logs.Count} logs.");
         }
 
-        private static FilterLog? CreateLog(LogFilter logFilter, TxReceipt txReceipt, LogEntry logEntry, long index, ulong blockTimestamp)
+        private static FilterLog? CreateLog(LogFilter logFilter, TxReceipt txReceipt, LogEntry logEntry, long index, ulong blockTimestamp, bool removed = false)
         {
             if (logFilter.FromBlock.Type == BlockParameterType.BlockNumber &&
                 logFilter.FromBlock.BlockNumber > txReceipt.BlockNumber)
@@ -249,13 +293,13 @@ namespace Nethermind.Facade.Filters
                 || logFilter.ToBlock.Type == BlockParameterType.Earliest
                 || logFilter.ToBlock.Type == BlockParameterType.Pending)
             {
-                return new FilterLog(index, txReceipt, logEntry, blockTimestamp);
+                return new FilterLog(index, txReceipt, logEntry, blockTimestamp, removed);
             }
 
             if (logFilter.FromBlock.Type == BlockParameterType.Latest || logFilter.ToBlock.Type == BlockParameterType.Latest)
             {
                 //TODO: check if is last mined block
-                return new FilterLog(index, txReceipt, logEntry, blockTimestamp);
+                return new FilterLog(index, txReceipt, logEntry, blockTimestamp, removed);
             }
 
             return new FilterLog(index, txReceipt, logEntry, blockTimestamp);


### PR DESCRIPTION
## Changes

Poll-based log filters (`eth_newFilter` → `eth_getFilterChanges`) only ever **appended** logs (driven by the processor's `TransactionProcessed` event) and had **no removal path**. After a reorg, the logs of blocks that left the canonical chain stayed in the filter's queue reported as canonical, and were never re-emitted with `removed = true`. The JSON-RPC spec requires filter changes to include reorg-removed logs. (The only existing removal handling in `FilterManager` was for pending transactions.)

The signal already exists: `IReceiptMonitor.ReceiptsInserted` fires with `WasRemoved = true` for the receipts of a block that leaves the canonical chain (this is what `LogsSubscription` uses for `eth_subscribe logs`). It just wasn't wired into `FilterManager`.

- Subscribe `FilterManager` to `IReceiptMonitor.ReceiptsInserted`.
- On a `WasRemoved` event, enqueue the reorged-out block's matching logs as `removed = true` `FilterLog`s (block-local log indexing, same filter/range matching as the canonical path).
- **Only** the `WasRemoved` case is handled here — canonical inserts continue to flow through the existing `TransactionProcessed` path, so there is no double counting.

`IReceiptMonitor` is already DI-registered alongside `FilterManager`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added `FilterManagerTests.reorg_removed_logs_are_polled_as_removed`: a canonical matching log is added, then `ReceiptsInserted(WasRemoved: true)` is raised for the same block; `PollLogs` returns both a `Removed == false` and a `Removed == true` entry. Full `FilterManagerTests` (35) and `BlockchainBridgeTests` (61, verifies DI still resolves `FilterManager` with the new dependency) pass.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] Yes

Fixes reorg-removed logs not being reported by poll-based log filters (`eth_getFilterChanges`).

## Remarks

Found during a review of the JSON-RPC read surface.
