### PR TITLE
fix(jsonrpc): don't leak eth_getLogs parallel slot when result is unenumerated

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Blocks;
@@ -112,6 +113,20 @@ public class LogFinderTests
         FilterLog[] logs = _logFinder.FindLogs(logFilter).ToArray();
         int[] indexes = logs.Select(static l => (int)l.LogIndex).ToArray();
         Assert.That(indexes, Is.EqualTo([0, 1, 0, 1, 2]));
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void Unenumerated_parallel_getLogs_does_not_leak_parallel_slot()
+    {
+        SetUp(allowReceiptIterator: true, chainLength: Environment.ProcessorCount + 2);
+
+        FieldInfo lockField = typeof(LogFinder).GetField("ParallelLock", BindingFlags.NonPublic | BindingFlags.Static)!;
+        int before = (int)lockField.GetValue(null)!;
+
+        _ = _logFinder.FindLogs(AllBlockFilter().Build());
+
+        Assert.That((int)lockField.GetValue(null)!, Is.EqualTo(before), "building an unenumerated parallel getLogs result must not acquire the process-wide parallel slot");
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Blocks;
@@ -121,12 +120,11 @@ public class LogFinderTests
     {
         SetUp(allowReceiptIterator: true, chainLength: Environment.ProcessorCount + 2);
 
-        FieldInfo lockField = typeof(LogFinder).GetField("ParallelLock", BindingFlags.NonPublic | BindingFlags.Static)!;
-        int before = (int)lockField.GetValue(null)!;
+        bool before = LogFinder.IsParallelScanSlotHeld;
 
         _ = _logFinder.FindLogs(AllBlockFilter().Build());
 
-        Assert.That((int)lockField.GetValue(null)!, Is.EqualTo(before), "building an unenumerated parallel getLogs result must not acquire the process-wide parallel slot");
+        Assert.That(LogFinder.IsParallelScanSlotHeld, Is.EqualTo(before), "building an unenumerated parallel getLogs result must not acquire the process-wide parallel slot");
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Facade/Find/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Find/LogFinder.cs
@@ -85,47 +85,39 @@ namespace Nethermind.Facade.Find
                 return source.SelectMany(worker);
             }
 
-            static IEnumerable<T> ReleaseLockOnDispose(IEnumerable<T> source, bool runParallel, CancellationToken ct)
-            {
-                try
-                {
-                    foreach (T item in source)
-                    {
-                        yield return item;
-                        ct.ThrowIfCancellationRequested();
-                    }
-                }
-                finally
-                {
-                    if (runParallel)
-                    {
-                        Interlocked.CompareExchange(ref ParallelLock, 0, 1);
-                    }
-                    Interlocked.Decrement(ref ParallelExecutions);
-                }
-            }
-
             // we want to support one parallel eth_getLogs call for maximum performance
             // we don't want support more than one eth_getLogs call so we don't starve CPU and threads
-            int parallelLock = Interlocked.CompareExchange(ref ParallelLock, 1, 0);
+            return RunParallelLazy(source, worker, cancellationToken);
+        }
+
+        private IEnumerable<FilterLog> RunParallelLazy<T>(IEnumerable<T> source, Func<T, IEnumerable<FilterLog>> worker, CancellationToken cancellationToken)
+        {
+            bool canRunParallel = Interlocked.CompareExchange(ref ParallelLock, 1, 0) == 0;
             int parallelExecutions = Interlocked.Increment(ref ParallelExecutions) - 1;
-            bool canRunParallel = parallelLock == 0;
-
-            IEnumerable<T> wrapped = ReleaseLockOnDispose(source, canRunParallel, cancellationToken);
-
-            if (canRunParallel)
+            try
             {
-                if (_logger.IsTrace) _logger.Trace($"Allowing parallel eth_getLogs, already parallel executions: {parallelExecutions}.");
-                wrapped = wrapped.AsParallel() // can yield big performance improvements
-                    .AsOrdered() // we want to keep block order
-                    .WithDegreeOfParallelism(_rpcConfigGetLogsThreads); // explicitly provide number of threads
-            }
-            else
-            {
-                if (_logger.IsTrace) _logger.Trace($"Not allowing parallel eth_getLogs, already parallel executions: {parallelExecutions}.");
-            }
+                if (_logger.IsTrace) _logger.Trace(canRunParallel
+                    ? $"Allowing parallel eth_getLogs, already parallel executions: {parallelExecutions}."
+                    : $"Not allowing parallel eth_getLogs, already parallel executions: {parallelExecutions}.");
 
-            return wrapped.SelectMany(worker);
+                IEnumerable<T> wrapped = canRunParallel
+                    ? source.AsParallel().AsOrdered().WithDegreeOfParallelism(_rpcConfigGetLogsThreads)
+                    : source;
+
+                foreach (FilterLog log in wrapped.SelectMany(worker))
+                {
+                    yield return log;
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+            }
+            finally
+            {
+                if (canRunParallel)
+                {
+                    Interlocked.CompareExchange(ref ParallelLock, 0, 1);
+                }
+                Interlocked.Decrement(ref ParallelExecutions);
+            }
         }
 
         private IEnumerable<FilterLog> FilterLogsIteratively(LogFilter filter, BlockHeader fromBlock, BlockHeader toBlock, CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.Facade/Find/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Find/LogFinder.cs
@@ -27,6 +27,8 @@ namespace Nethermind.Facade.Find
         private static int ParallelExecutions = 0;
         private static int ParallelLock = 0;
 
+        public static bool IsParallelScanSlotHeld => Volatile.Read(ref ParallelLock) != 0;
+
         private readonly IReceiptFinder _receiptFinder = receiptFinder ?? throw new ArgumentNullException(nameof(receiptFinder));
         private readonly IReceiptStorage _receiptStorage = receiptStorage ?? throw new ArgumentNullException(nameof(receiptStorage));
         private readonly IReceiptsRecovery _receiptsRecovery = receiptsRecovery ?? throw new ArgumentNullException(nameof(receiptsRecovery));

--- a/src/Nethermind/Nethermind.Facade/Find/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Find/LogFinder.cs
@@ -90,6 +90,9 @@ namespace Nethermind.Facade.Find
             return RunParallelLazy(source, worker, cancellationToken);
         }
 
+        // Must stay a lazy iterator: the lock is acquired on the first MoveNext and released in the finally,
+        // so acquire and release share one enumerator lifetime. An eager version would leak the lock when the
+        // result is never enumerated.
         private IEnumerable<FilterLog> RunParallelLazy<T>(IEnumerable<T> source, Func<T, IEnumerable<FilterLog>> worker, CancellationToken cancellationToken)
         {
             bool canRunParallel = Interlocked.CompareExchange(ref ParallelLock, 1, 0) == 0;


### PR DESCRIPTION
## Changes

`LogFinder.RunParallel` throttles `eth_getLogs` to a single in-flight parallel scan via a process-wide static `ParallelLock`. The bug: it **acquired** the lock (and incremented `ParallelExecutions`) *eagerly* when the method was invoked, but **released** them only from the `finally` of an inner iterator (`ReleaseLockOnDispose`) that runs when the returned enumerable is enumerated or disposed.

If a getLogs result is built but never enumerated — e.g. the streamable response is dropped/short-circuited before `WriteToAsync` ever pulls from it — the `finally` never runs, so `ParallelLock` stays at `1` **forever** and every subsequent `eth_getLogs` process-wide falls back to single-threaded until the node restarts.

Fix: move the acquire into a lazy iterator (`RunParallelLazy`) so acquire and release share one enumerator lifetime — nothing is acquired unless enumeration actually starts, and the `finally` always releases once it does. For the normal (enumerated) path, behavior is unchanged: the same static-typed `IEnumerable<T>` binding is preserved, so the parallel/serial decision and ordering are identical.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

Existing `LogFinderTests` (42) pass, covering both the parallel and serial scan paths — regression coverage that the refactor preserves output. A targeted leak test (build the result, drop it without enumerating, assert the next call still runs parallel) isn't included because `ParallelLock` is a private static field with no observable hook; the fix is argued structurally (acquire and release now share the iterator lifetime).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Found during a review of the JSON-RPC read surface. The single-parallel throttle itself is intentional (CPU/thread protection) and is preserved as-is; this only fixes its lock lifecycle.
