### PR TITLE
perf(rpc): use Content-Length for unbuffered HTTP/1.1 responses and drop the Server header

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
@@ -284,6 +284,52 @@ public class StartupTests
         Assert.That(response, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"out of gas\"},\"id\":1}"));
     }
 
+    [TestCase(true, "HTTP/1.1", true)]
+    [TestCase(true, "HTTP/2", false)]
+    [TestCase(false, "HTTP/1.1", true)]
+    public async Task HttpJsonRpcResponseSink_SetsContentLengthForUnflushedHttp11Response(
+        bool isAuthenticated,
+        string protocol,
+        bool expectedContentLength)
+    {
+        HttpJsonRpcResponseSinkFixture fixture = CreateHttpJsonRpcResponseSink(isAuthenticated: isAuthenticated);
+        fixture.Context.Request.Protocol = protocol;
+        JsonRpcSuccessResponse response = new() { Id = JsonRpcId.FromObject(1), Result = "ok" };
+
+        await fixture.Sink.WriteSingleAsync(response, new RpcReport("test", 0, true), CancellationToken.None);
+        long bytesWritten = fixture.Sink.BytesWritten;
+        await fixture.Sink.CompleteAsync(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(fixture.Context.Response.ContentLength, expectedContentLength ? Is.EqualTo(bytesWritten) : Is.Null);
+            Assert.That(fixture.ResponseBody.Length, Is.EqualTo(bytesWritten));
+        }
+    }
+
+    [Test]
+    public async Task HttpJsonRpcResponseSink_DoesNotSetContentLengthAfterStreamFlush()
+    {
+        bool hasStarted = false;
+        IHttpResponseFeature responseFeature = Substitute.For<IHttpResponseFeature>();
+        responseFeature.Headers.Returns(new HeaderDictionary());
+        responseFeature.HasStarted.Returns(_ => hasStarted);
+        HttpJsonRpcResponseSinkFixture fixture = CreateHttpJsonRpcResponseSink(
+            isAuthenticated: true,
+            responseFeature: responseFeature);
+        fixture.Context.Request.Protocol = "HTTP/1.1";
+        JsonRpcSuccessResponse response = new()
+        {
+            Id = JsonRpcId.FromObject(1),
+            Result = new FlushingStreamableResult(() => hasStarted = true)
+        };
+
+        await fixture.Sink.WriteSingleAsync(response, new RpcReport(GetBlobsV2Method, 0, true), CancellationToken.None);
+        await fixture.Sink.CompleteAsync(CancellationToken.None);
+
+        Assert.That(fixture.Context.Response.ContentLength, Is.Null);
+    }
+
     [Test]
     [NonParallelizable]
     public async Task HttpJsonRpcResponseSink_ReportsStreamableFlushCount()
@@ -509,10 +555,16 @@ public class StartupTests
         JsonRpcConfig? rpcConfig = null,
         bool isAuthenticated = false,
         bool enableLocalStats = false,
-        IJsonRpcLocalStats? jsonRpcLocalStats = null)
+        IJsonRpcLocalStats? jsonRpcLocalStats = null,
+        IHttpResponseFeature? responseFeature = null)
     {
         DefaultHttpContext ctx = new();
         MemoryStream responseBody = new();
+        if (responseFeature is not null)
+        {
+            ctx.Features.Set(responseFeature);
+        }
+
         ctx.Features.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(responseBody));
 
         jsonRpcLocalStats ??= Substitute.For<IJsonRpcLocalStats>();
@@ -598,14 +650,16 @@ public class StartupTests
         public void Dispose() => DisposeCount++;
     }
 
-    private sealed class FlushingStreamableResult : IStreamableResult
+    private sealed class FlushingStreamableResult(Action? onFlushed = null) : IStreamableResult
     {
         public async ValueTask WriteToAsync(PipeWriter writer, CancellationToken cancellationToken)
         {
             writer.Write("["u8);
             await writer.FlushAsync(cancellationToken);
+            onFlushed?.Invoke();
             writer.Write("null"u8);
             await writer.FlushAsync(cancellationToken);
+            onFlushed?.Invoke();
             writer.Write("]"u8);
         }
     }

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/HttpJsonRpcResponseSink.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/HttpJsonRpcResponseSink.cs
@@ -139,6 +139,13 @@ internal sealed class HttpJsonRpcResponseSink(
         }
 
         _completed = true;
+        if (_bufferedStream is null &&
+            HttpProtocol.IsHttp11(context.Request.Protocol) &&
+            !context.Response.HasStarted)
+        {
+            context.Response.ContentLength = BytesWritten;
+        }
+
         ValueTask writerCompleteTask = _writer.CompleteAsync();
         return writerCompleteTask.IsCompletedSuccessfully
             ? CompleteResponseAsync(cancellationToken)

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -98,6 +98,7 @@ public class Startup : IStartup
 
         services.Configure<KestrelServerOptions>(options =>
         {
+            options.AddServerHeader = false;
             options.Limits.MaxRequestBodySize = jsonRpcConfig.MaxRequestBodySize;
             options.ConfigureHttpsDefaults(co => co.SslProtocols |= SslProtocols.Tls13);
 


### PR DESCRIPTION
## Changes

- Set `Content-Length` on completed unbuffered HTTP/1.1 JSON-RPC responses. Single responses on the authenticated engine port are never buffered, so Kestrel previously emitted `Transfer-Encoding: chunked`; `HttpJsonRpcResponseSink.CompleteAsync` now sets the already-counted body length before completing the writer, but only when the response is unbuffered, HTTP/1.1, and has not started. Short engine responses (`newPayload`, FCU) therefore use `Content-Length`; streamable responses that already flushed (e.g. `getBlobs`) keep their existing framing. `CountingPipeWriter.Advance` counts exactly the bytes advanced into the response pipe, so the header is byte-exact and Kestrel's `VerifyResponseContentLength` guards any future mismatch loudly. Response compression is unaffected: the engine port and localhost are excluded from compression entirely, and for compressed remote public RPC the middleware clears the uncompressed length when it selects gzip/Brotli.
- Disable `KestrelServerOptions.AddServerHeader` for the JSON-RPC server, dropping `Server: Kestrel` from every response.

For an `id: 1` VALID `engine_newPayload` probe (162-byte body), replacing chunked framing reduces the complete response from 306 to 288 bytes and removing the Server header brings it to 271; all variants fit one MSS. Cumulative wire micro-optimization on the latency-sensitive engine path, not an expected end-to-end mover on its own.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New tests cover authenticated and unauthenticated HTTP/1.1 responses gaining an exact `Content-Length`, HTTP/2 exclusion, and the flushed-streamable exclusion (via a faked `IHttpResponseFeature.HasStarted`, since `StreamResponseBodyFeature` never sets it). Full `StartupTests` fixture passes (56 tests).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No