### PR TITLE
perf(engine): overlap the newPayload transactions-root computation with the serial prefix

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Benchmark/NewPayloadPrefixBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Benchmark/NewPayloadPrefixBenchmarks.cs
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Merge.Plugin.Data;
+using Nethermind.State.Proofs;
+
+namespace Nethermind.Merge.Plugin.Benchmark;
+
+/// <summary>
+/// Attributes the <c>engine_newPayload</c> serial prefix between transaction decode,
+/// transactions-trie root, withdrawals root, and the complete
+/// <see cref="ExecutionPayload.TryGetBlock"/> call.
+/// </summary>
+/// <remarks>
+/// <see cref="HandlerPrefix"/> reproduces the <c>NewPayloadHandler.HandleAsync</c> order:
+/// <c>TryGetTransactions</c> runs first (for sender recovery) on the handler thread, then
+/// <c>TryGetBlock</c> starts the transactions-root task and blocks on it. Transactions are
+/// real signed EIP-1559 transactions with a mainnet-like calldata mix, not opaque blobs,
+/// so decode and trie-leaf costs are honest.
+/// </remarks>
+[MemoryDiagnoser]
+public class NewPayloadPrefixBenchmarks
+{
+    // 200 transactions approximates the current mainnet median block; 400 a heavy one.
+    [Params(100, 200, 400)]
+    public int Txs;
+
+    private ExecutionPayloadV3 _payload = null!;
+    private byte[][] _encodedTransactions = null!;
+    private Withdrawal[] _withdrawals = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _withdrawals = EngineBenchmarkHost.BuildWithdrawals(EngineBenchmarkHost.CapellaMaxWithdrawals);
+        _payload = new ExecutionPayloadV3
+        {
+            ParentHash = TestItem.KeccakA,
+            FeeRecipient = TestItem.AddressA,
+            StateRoot = TestItem.KeccakB,
+            ReceiptsRoot = TestItem.KeccakC,
+            LogsBloom = Bloom.Empty,
+            PrevRandao = TestItem.KeccakD,
+            BlockNumber = 20_000_000,
+            GasLimit = 36_000_000,
+            GasUsed = 18_000_000,
+            Timestamp = 1_700_100_000,
+            ExtraData = new byte[32],
+            BaseFeePerGas = 10_000_000_000,
+            BlockHash = TestItem.KeccakE,
+            BlobGasUsed = 6 * Eip4844Constants.GasPerBlob,
+            ExcessBlobGas = 0x40000,
+            ParentBeaconBlockRoot = TestItem.KeccakA,
+            ExecutionRequests = [],
+            Withdrawals = _withdrawals,
+        };
+        _payload.SetTransactions(BuildTransactions(Txs));
+        _encodedTransactions = _payload.Transactions;
+    }
+
+    [Benchmark(Description = "TryGetTransactions (decode)")]
+    public Transaction[] DecodeTransactions()
+    {
+        _payload.Transactions = _encodedTransactions; // resets the decoded-transactions memo
+        return _payload.TryGetTransactions().Data!;
+    }
+
+    [Benchmark(Description = "TxTrie.CalculateRoot")]
+    public Hash256 TxRoot() => TxTrie.CalculateRoot(_encodedTransactions);
+
+    [Benchmark(Description = "WithdrawalTrie root")]
+    public Hash256 WithdrawalsRoot() => new WithdrawalTrie(_withdrawals).RootHash;
+
+    [Benchmark(Description = "TryGetBlock (decode memoized)")]
+    public Block TryGetBlockPreDecoded() => _payload.TryGetBlock().Data!;
+
+    [Benchmark(Description = "decode + TryGetBlock (handler order)", Baseline = true)]
+    public Block HandlerPrefix()
+    {
+        _payload.Transactions = _encodedTransactions; // resets the decoded-transactions memo
+        _payload.TryGetTransactions();
+        return _payload.TryGetBlock().Data!;
+    }
+
+    [Benchmark(Description = "early root + decode + TryGetBlock")]
+    public Block HandlerPrefixWithEarlyRoot()
+    {
+        _payload.Transactions = _encodedTransactions; // resets the decoded-transactions memo
+        _payload.StartTxRootComputation();
+        _payload.TryGetTransactions();
+        return _payload.TryGetBlock().Data!;
+    }
+
+    private static Transaction[] BuildTransactions(int count)
+    {
+        Transaction[] transactions = new Transaction[count];
+        for (int i = 0; i < count; i++)
+        {
+            // Rough mainnet mix: half plain transfers, the rest token transfers, swaps,
+            // heavier contract calls, and an occasional data-heavy transaction.
+            int callDataLength = (i % 20) switch
+            {
+                < 10 => 0,
+                < 14 => 68,
+                < 17 => 260,
+                < 19 => 1024,
+                _ => 8192,
+            };
+
+            TransactionBuilder<Transaction> builder = Build.A.Transaction
+                .WithType(TxType.EIP1559)
+                .WithChainId(BlockchainIds.Mainnet)
+                .WithNonce((ulong)i)
+                .WithGasLimit(callDataLength == 0 ? 21_000UL : 90_000UL + (ulong)callDataLength * 16)
+                .WithMaxFeePerGas(30 * Unit.GWei)
+                .WithMaxPriorityFeePerGas(1 * Unit.GWei)
+                .WithValue(1 * Unit.Ether)
+                .WithTo(TestItem.Addresses[i % TestItem.Addresses.Length]);
+
+            if (callDataLength > 0)
+            {
+                byte[] callData = new byte[callDataLength];
+                new Random(i).NextBytes(callData);
+                builder = builder.WithData(callData);
+            }
+
+            transactions[i] = builder.SignedAndResolved().TestObject;
+        }
+
+        return transactions;
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin.Benchmark/NewPayloadPrefixBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Benchmark/NewPayloadPrefixBenchmarks.cs
@@ -78,8 +78,8 @@ public class NewPayloadPrefixBenchmarks
     [Benchmark(Description = "WithdrawalTrie root")]
     public Hash256 WithdrawalsRoot() => new WithdrawalTrie(_withdrawals).RootHash;
 
-    [Benchmark(Description = "TryGetBlock (decode memoized)")]
-    public Block TryGetBlockPreDecoded() => _payload.TryGetBlock().Data!;
+    // No decode-memoized TryGetBlock arm: the memoized root task makes any in-loop measurement
+    // either reuse the completed task or re-include decode; derive it as HandlerPrefix minus decode.
 
     [Benchmark(Description = "decode + TryGetBlock (handler order)", Baseline = true)]
     public Block HandlerPrefix()

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionPayloadTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionPayloadTests.cs
@@ -1,10 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Serialization.Rlp;
+using Nethermind.State.Proofs;
 using NUnit.Framework;
 
 namespace Nethermind.Merge.Plugin.Test;
@@ -49,8 +52,7 @@ public class ExecutionPayloadTests
     public void TryGetTransactions_decodes_many_txs_in_order()
     {
         const int count = 64;
-        byte[][] rlps = new byte[count][];
-        for (int i = 0; i < count; i++) rlps[i] = EncodeTx(TxType.EIP1559, nonce: (ulong)i);
+        byte[][] rlps = EncodeTxs(count);
 
         ExecutionPayload payload = new() { Transactions = rlps };
         Result<Transaction[]> result = payload.TryGetTransactions();
@@ -69,14 +71,69 @@ public class ExecutionPayloadTests
     {
         const int count = 64;
         const int invalidIndex = 41;
-        byte[][] rlps = new byte[count][];
-        for (int i = 0; i < count; i++) rlps[i] = EncodeTx(TxType.EIP1559, nonce: (ulong)i);
+        byte[][] rlps = EncodeTxs(count);
         rlps[invalidIndex] = [.. rlps[invalidIndex], 0xDC, 0xAF];
 
         ExecutionPayload payload = new() { Transactions = rlps };
         Result<Transaction[]> result = payload.TryGetTransactions();
 
         Assert.That(result.Error, Contains.Substring($"Transaction {invalidIndex}"));
+    }
+
+    // The early-started root task must be the one TryGetBlock consumes, with an identical root
+    [Test]
+    public void TryGetBlock_uses_early_started_tx_root_computation()
+    {
+        byte[][] rlps = EncodeTxs(count: 64);
+
+        ExecutionPayload payload = new() { Transactions = rlps };
+        Task<Hash256>? rootTask = payload.StartTxRootComputation();
+        Result<Block> block = payload.TryGetBlock();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rootTask, Is.Not.Null);
+            Assert.That(block.Data!.Header.TxRoot, Is.EqualTo(TxTrie.CalculateRoot(rlps)));
+        }
+    }
+
+    // A root task started for one transaction set must never produce the root of a mutated payload
+    [Test]
+    public void TryGetBlock_recomputes_tx_root_when_transactions_change_after_early_start()
+    {
+        byte[][] originalRlps = EncodeTxs(count: 64);
+        byte[][] replacementRlps = EncodeTxs(count: 64, nonceOffset: 1000);
+
+        ExecutionPayload payload = new() { Transactions = originalRlps };
+        payload.StartTxRootComputation();
+        payload.Transactions = replacementRlps;
+        Result<Block> block = payload.TryGetBlock();
+
+        Assert.That(block.Data!.Header.TxRoot, Is.EqualTo(TxTrie.CalculateRoot(replacementRlps)));
+    }
+
+    // Below the background threshold the root is still computed, just inline
+    [Test]
+    public void TryGetBlock_computes_tx_root_inline_below_background_threshold()
+    {
+        byte[][] rlps = EncodeTxs(count: 1);
+
+        ExecutionPayload payload = new() { Transactions = rlps };
+        Task<Hash256>? rootTask = payload.StartTxRootComputation();
+        Result<Block> block = payload.TryGetBlock();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rootTask, Is.Null);
+            Assert.That(block.Data!.Header.TxRoot, Is.EqualTo(TxTrie.CalculateRoot(rlps)));
+        }
+    }
+
+    private static byte[][] EncodeTxs(int count, ulong nonceOffset = 0)
+    {
+        byte[][] rlps = new byte[count][];
+        for (int i = 0; i < count; i++) rlps[i] = EncodeTx(TxType.EIP1559, nonce: nonceOffset + (ulong)i);
+        return rlps;
     }
 
     private static byte[] EncodeTx(TxType txType, ulong nonce = 0)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -218,7 +218,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
     /// <returns>
     /// The started task, or <c>null</c> when the transaction count makes inline computation cheaper.
     /// </returns>
-    public Task<Hash256>? StartTxRootComputation()
+    internal Task<Hash256>? StartTxRootComputation()
     {
         byte[][] encodedTransactions = _encodedTransactions;
         return _txRootTask ??= encodedTransactions.Length >= MinTxsForParallelDecoding && Environment.ProcessorCount > 1

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -71,6 +71,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
             ArgumentNullException.ThrowIfNull(value);
             _encodedTransactions = value;
             _transactions = null;
+            _txRootTask = null;
         }
     }
 
@@ -157,9 +158,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
     public virtual Result<Block> TryGetBlock(UInt256? totalDifficulty = null)
     {
         byte[][] encodedTransactions = Transactions;
-        Task<Hash256>? txRootTask = encodedTransactions.Length >= MinTxsForParallelDecoding && Environment.ProcessorCount > 1
-            ? Task.Run(() => TxTrie.CalculateRoot(encodedTransactions))
-            : null;
+        Task<Hash256>? txRootTask = StartTxRootComputation();
 
         Result<Transaction[]> transactions = TryGetTransactions();
         if (transactions.IsError)
@@ -204,7 +203,24 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
 
     protected Transaction[]? _transactions = null;
 
+    private Task<Hash256>? _txRootTask;
+
     private const int MinTxsForParallelDecoding = 32;
+
+    /// <summary>
+    /// Starts computing the transactions-trie root in the background, letting callers overlap it
+    /// with serial work that precedes <see cref="TryGetBlock"/> (which consumes the started task).
+    /// </summary>
+    /// <returns>
+    /// The started task, or <c>null</c> when the transaction count makes inline computation cheaper.
+    /// </returns>
+    public Task<Hash256>? StartTxRootComputation()
+    {
+        byte[][] encodedTransactions = _encodedTransactions;
+        return _txRootTask ??= encodedTransactions.Length >= MinTxsForParallelDecoding && Environment.ProcessorCount > 1
+            ? Task.Run(() => TxTrie.CalculateRoot(encodedTransactions))
+            : null;
+    }
 
     /// <summary>
     /// Decodes and returns an array of <see cref="Transaction"/> from <see cref="Transactions"/>.

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -211,6 +211,10 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
     /// Starts computing the transactions-trie root in the background, letting callers overlap it
     /// with serial work that precedes <see cref="TryGetBlock"/> (which consumes the started task).
     /// </summary>
+    /// <remarks>
+    /// Not thread-safe: concurrent calls, or a concurrent <see cref="Transactions"/> assignment,
+    /// race the memoized task. Callers must invoke both sequentially per payload instance.
+    /// </remarks>
     /// <returns>
     /// The started task, or <c>null</c> when the transaction count makes inline computation cheaper.
     /// </returns>

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
@@ -72,6 +72,11 @@ public partial class EngineRpcModule : IEngineRpcModule
         ExecutionPayload executionPayload = executionPayloadParams.ExecutionPayload;
         executionPayload.ExecutionRequests = executionPayloadParams.ExecutionRequests;
 
+        // The transactions-trie root needs only the encoded transaction bytes, so its computation
+        // can hide under parameter validation (which decodes the transactions on V3+), the lock
+        // wait, and the no-GC-region start that precede TryGetBlock, which consumes the started task.
+        _ = executionPayload.StartTxRootComputation();
+
         if (!executionPayload.ValidateFork(_specProvider))
         {
             if (_logger.IsWarn) _logger.Warn($"The payload is not supported by the current fork");

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Paris.cs
@@ -72,11 +72,6 @@ public partial class EngineRpcModule : IEngineRpcModule
         ExecutionPayload executionPayload = executionPayloadParams.ExecutionPayload;
         executionPayload.ExecutionRequests = executionPayloadParams.ExecutionRequests;
 
-        // The transactions-trie root needs only the encoded transaction bytes, so its computation
-        // can hide under parameter validation (which decodes the transactions on V3+), the lock
-        // wait, and the no-GC-region start that precede TryGetBlock, which consumes the started task.
-        _ = executionPayload.StartTxRootComputation();
-
         if (!executionPayload.ValidateFork(_specProvider))
         {
             if (_logger.IsWarn) _logger.Warn($"The payload is not supported by the current fork");
@@ -98,6 +93,9 @@ public partial class EngineRpcModule : IEngineRpcModule
             long startTime = Stopwatch.GetTimestamp();
             try
             {
+                // Hide the tx-root computation (consumed by TryGetBlock) under the no-GC-region
+                // start; inside the lock so competing requests cannot run trie work concurrently.
+                _ = executionPayload.StartTxRootComputation();
                 using IDisposable region = _gcKeeper.TryStartNoGCRegion();
                 return await _newPayloadV1Handler.HandleAsync(executionPayload);
             }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/PeerRefresher.cs
@@ -18,6 +18,7 @@ using Nethermind.Synchronization.Peers;
 using ITimer = Nethermind.Core.Timers.ITimer;
 
 [assembly: InternalsVisibleTo("Nethermind.Merge.Plugin.Test")]
+[assembly: InternalsVisibleTo("Nethermind.Merge.Plugin.Benchmark")]
 namespace Nethermind.Merge.Plugin.Synchronization;
 
 public class PeerRefresher : IPeerRefresher, IAsyncDisposable

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoExecutionPayloadTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoExecutionPayloadTests.cs
@@ -4,7 +4,10 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
+using Nethermind.State.Proofs;
 using Nethermind.Taiko.TaikoSpec;
 using NUnit.Framework;
 
@@ -82,6 +85,50 @@ public class TaikoExecutionPayloadTests
         Assert.That(result.Data, Is.Not.Null);
         Assert.That(result.Data!.Header.BlobGasUsed, Is.EqualTo(0UL));
         Assert.That(result.Data.Header.ExcessBlobGas, Is.EqualTo(0UL));
+    }
+
+    // The shadowing setter must reach the base setter's memo invalidation: a tx-root task
+    // memoized by an earlier TryGetBlock must never supply the root for reassigned transactions
+    [Test]
+    public void TryGetBlock_recomputes_tx_root_when_transactions_change_between_calls()
+    {
+        TaikoExecutionPayload payload = BuildEmptyPayload();
+        payload.AttachSpecProvider(new TestSpecProvider(new TaikoReleaseSpec { IsUnzenEnabled = false, TaikoL2Address = Address.Zero }));
+
+        payload.Transactions = EncodeTxs(count: 64);
+        Hash256? originalRoot = payload.TryGetBlock().Data!.Header.TxRoot;
+
+        byte[][] replacementRlps = EncodeTxs(count: 64, nonceOffset: 1000);
+        payload.Transactions = replacementRlps;
+        Hash256? replacementRoot = payload.TryGetBlock().Data!.Header.TxRoot;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(replacementRoot, Is.EqualTo(TxTrie.CalculateRoot(replacementRlps)));
+            Assert.That(replacementRoot, Is.Not.EqualTo(originalRoot));
+        }
+    }
+
+    // The delegating setter must preserve the Taiko null <-> empty round-trip
+    [Test]
+    public void Transactions_setter_preserves_null_round_trip()
+    {
+        TaikoExecutionPayload payload = new() { Transactions = EncodeTxs(count: 1) };
+
+        payload.Transactions = null;
+
+        Assert.That(payload.Transactions, Is.Null);
+    }
+
+    private static byte[][] EncodeTxs(int count, ulong nonceOffset = 0)
+    {
+        byte[][] rlps = new byte[count][];
+        for (int i = 0; i < count; i++)
+        {
+            Transaction tx = Build.A.Transaction.WithNonce(nonceOffset + (ulong)i).SignedAndResolved().TestObject;
+            rlps[i] = TxDecoder.Instance.Encode(tx, RlpBehaviors.SkipTypedWrapping).Bytes;
+        }
+        return rlps;
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Taiko/TaikoExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoExecutionPayload.cs
@@ -75,11 +75,9 @@ public class TaikoExecutionPayload : ExecutionPayload, IExecutionPayloadParams, 
     public new byte[][]? Transactions
     {
         get => _encodedTransactions is [] ? null : _encodedTransactions;
-        set
-        {
-            _encodedTransactions = value ?? [];
-            _transactions = null;
-        }
+        // Delegates so the base setter's memo invalidation (decoded transactions, tx-root task)
+        // stays in one place.
+        set => base.Transactions = value ?? [];
     }
 
     // Note: the base GetExecutionPayloadVersion override is intentionally absent.


### PR DESCRIPTION
## Changes

- `ExecutionPayload.StartTxRootComputation()` (internal) starts the transactions-trie root task once and memoizes it; the `Transactions` setter invalidates the memo so a mutated payload can never consume a stale root. `TryGetBlock` consumes the same task instead of spawning its own, so the spawn logic lives in one place and a repeated `TryGetBlock` no longer recomputes the root.
- `EngineRpcModule.NewPayload` starts the computation inside the engine lock - after the metric stopwatch starts and immediately before `TryStartNoGCRegion` - so the root hides under the no-GC-region start and the handler work (sender-recovery kick-off, transaction decode on V1/V2, block-tree reads) that precede `TryGetBlock`. Starting inside the lock means rejected, timed-out, or still-queued requests never run parallel trie work beside the accepted head request, no task is orphaned on the validation-fail or lock-timeout exits, and `NewPayloadExecutionTime` keeps covering the root work.
- New `NewPayloadPrefixBenchmarks` attributes the newPayload serial prefix using realistically shaped signed EIP-1559 transactions (mainnet-like calldata mix, Capella-max withdrawals) rather than opaque byte blobs.

### Why

Benchmark attribution (Ryzen 9950X, .NET 10) shows the transactions-trie root, not transaction decode, is the newPayload serial prefix:

| Txs | decode | tx root | withdrawals root | decode + `TryGetBlock` |
|----:|-------:|--------:|-----------------:|------------------------:|
| 100 | 22.7 us | 94 us | 4.9 us | 155 us |
| 200 | 34.5 us | 250 us | 4.8 us | 363 us |
| 400 | 58.2 us | 664 us | 4.9 us | 854 us |

The root is ~70% of the prefix at every size and scales superlinearly with transaction bytes. 200 transactions approximates the current mainnet median block. A 2026-07-19 dotTrace of live mainnet head processing agreed on the shape: 22 ms of the 27 ms `TryGetBlock` was this root computation (profiler-inflated in absolute terms, but the same dominant share).

The benchmark's early-root arm can only overlap decode - the narrowest window available in-process - and still improves the prefix: 155 -> 143 us (-10%) at 100 txs, 363 -> 322 us (-11%) at 200, 854 -> 797 us (-6%) at 400. In production the hideable window is the whole pre-`TryGetBlock` stretch inside the lock, so the exposed root time on the handler thread should approach zero on median blocks.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Three new regression tests in `ExecutionPayloadTests`: the early-started task is the one `TryGetBlock` consumes with an identical root; changing `Transactions` after an early start recomputes the root for the new set (stale-task invalidation); below the background threshold the root is still computed inline. Full `Nethermind.Merge.Plugin.Test` suite passes: 1648 passed, 0 failed, 2 pre-existing skips.

There is intentionally no decode-memoized `TryGetBlock` benchmark arm: with the memoized root task, any in-loop measurement either reuses the completed task or re-includes decode; derive it as the handler-order arm minus the decode arm.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No