### PR TITLE
perf(evm): optimize zero-value handling in SSTORE, SLOAD, and WithoutLeadingZeros

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
@@ -849,26 +849,23 @@ namespace Nethermind.Core.Test
             }
         }
 
-        [TestCase("", true, "00")]
-        [TestCase("00", true, "00")]
-        [TestCase("0000000000", true, "00")]
-        [TestCase("0001", false, "01")]
-        [TestCase("0000000000000000000000000000000000000000000000000000000000000001", false, "01")]
-        [TestCase("0100", false, "0100")]
-        [TestCase("ff", false, "ff")]
-        [TestCase("00000000000000000000000000000000000000000000000000000000000000ff", false, "ff")]
-        [TestCase("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", false, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")]
-        public void WithoutLeadingZeros_reports_zero_and_trims_in_one_scan(string hex, bool expectedIsZero, string expectedHex)
+        private static IEnumerable<TestCaseData> LeadingZerosCountCases()
         {
-            ReadOnlySpan<byte> bytes = hex.Length == 0 ? [] : Bytes.FromHexString(hex);
-
-            ReadOnlySpan<byte> trimmed = bytes.WithoutLeadingZeros(out bool isZero);
-
-            Assert.That(isZero, Is.EqualTo(expectedIsZero));
-            Assert.That(trimmed.ToHexString(), Is.EqualTo(expectedHex));
-            // The fused overload must agree with the separate helpers it replaces
-            Assert.That(isZero, Is.EqualTo(bytes.IsZero()));
-            Assert.That(trimmed.SequenceEqual(bytes.WithoutLeadingZeros()), Is.True);
+            yield return new TestCaseData(Array.Empty<byte>(), 0).Returns(0).SetName("empty");
+            yield return new TestCaseData(new byte[] { 0 }, 0).Returns(1).SetName("single zero");
+            yield return new TestCaseData(new byte[32], 0).Returns(32).SetName("all-zero word");
+            yield return new TestCaseData(new byte[] { 1 }, 0).Returns(0).SetName("single non-zero");
+            yield return new TestCaseData(new byte[] { 0, 1 }, 0).Returns(1).SetName("one leading zero");
+            yield return new TestCaseData(new byte[] { 1, 0 }, 0).Returns(0).SetName("trailing zero only");
+            byte[] word = new byte[32];
+            word[31] = 0xFF;
+            yield return new TestCaseData(word, 0).Returns(31).SetName("value in last byte of word");
+            yield return new TestCaseData(new byte[] { 0, 0, 1 }, 1).Returns(1).SetName("start index skips first byte");
+            yield return new TestCaseData(new byte[] { 0, 0 }, 1).Returns(1).SetName("start index in all-zero");
         }
+
+        [TestCaseSource(nameof(LeadingZerosCountCases))]
+        public int LeadingZerosCount_cases(byte[] bytes, int startIndex) =>
+            new ReadOnlySpan<byte>(bytes).LeadingZerosCount(startIndex);
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
@@ -848,5 +848,27 @@ namespace Nethermind.Core.Test
                 Assert.That(data.AsSpan().CountZeros(), Is.EqualTo(1), $"single zero at position {pos} should be counted");
             }
         }
+
+        [TestCase("", true, "00")]
+        [TestCase("00", true, "00")]
+        [TestCase("0000000000", true, "00")]
+        [TestCase("0001", false, "01")]
+        [TestCase("0000000000000000000000000000000000000000000000000000000000000001", false, "01")]
+        [TestCase("0100", false, "0100")]
+        [TestCase("ff", false, "ff")]
+        [TestCase("00000000000000000000000000000000000000000000000000000000000000ff", false, "ff")]
+        [TestCase("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", false, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")]
+        public void WithoutLeadingZeros_reports_zero_and_trims_in_one_scan(string hex, bool expectedIsZero, string expectedHex)
+        {
+            ReadOnlySpan<byte> bytes = hex.Length == 0 ? [] : Bytes.FromHexString(hex);
+
+            ReadOnlySpan<byte> trimmed = bytes.WithoutLeadingZeros(out bool isZero);
+
+            Assert.That(isZero, Is.EqualTo(expectedIsZero));
+            Assert.That(trimmed.ToHexString(), Is.EqualTo(expectedHex));
+            // The fused overload must agree with the separate helpers it replaces
+            Assert.That(isZero, Is.EqualTo(bytes.IsZero()));
+            Assert.That(trimmed.SequenceEqual(bytes.WithoutLeadingZeros()), Is.True);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
@@ -867,5 +867,21 @@ namespace Nethermind.Core.Test
         [TestCaseSource(nameof(LeadingZerosCountCases))]
         public int LeadingZerosCount_cases(byte[] bytes, int startIndex) =>
             new ReadOnlySpan<byte>(bytes).LeadingZerosCount(startIndex);
+
+        private static IEnumerable<TestCaseData> WithoutLeadingZerosCases()
+        {
+            yield return new TestCaseData(Array.Empty<byte>()).Returns(new byte[] { 0 }).SetName("empty keeps one zero byte");
+            yield return new TestCaseData(new byte[] { 0 }).Returns(new byte[] { 0 }).SetName("single zero");
+            yield return new TestCaseData(new byte[32]).Returns(new byte[] { 0 }).SetName("all-zero word keeps one zero byte");
+            yield return new TestCaseData(new byte[] { 0, 1 }).Returns(new byte[] { 1 }).SetName("one leading zero");
+            yield return new TestCaseData(new byte[] { 1, 0 }).Returns(new byte[] { 1, 0 }).SetName("trailing zero kept");
+            byte[] word = new byte[32];
+            word[31] = 0xFF;
+            yield return new TestCaseData(word).Returns(new byte[] { 0xFF }).SetName("value in last byte of word");
+        }
+
+        [TestCaseSource(nameof(WithoutLeadingZerosCases))]
+        public byte[] WithoutLeadingZeros_cases(byte[] bytes) =>
+            new ReadOnlySpan<byte>(bytes).WithoutLeadingZeros().ToArray();
     }
 }

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -149,8 +149,8 @@ namespace Nethermind.Core.Extensions
         public static ReadOnlySpan<byte> WithoutLeadingZeros(this ReadOnlySpan<byte> bytes)
         {
             int nonZeroIndex = bytes.IndexOfAnyExcept((byte)0);
-            // Keep one zero byte or it will be interpreted as null; the data-section-backed
-            // ZeroByteSpan avoids returning an interior reference that keeps the source alive.
+            // Keep one zero byte or it will be interpreted as null; return the shared constant
+            // instead of aliasing the source.
             return nonZeroIndex < 0 ? ZeroByteSpan : bytes[nonZeroIndex..];
         }
 

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -146,24 +146,13 @@ namespace Nethermind.Core.Extensions
 
         public static ReadOnlySpan<byte> WithoutLeadingZeros(this Span<byte> bytes) => ((ReadOnlySpan<byte>)bytes).WithoutLeadingZeros();
 
-        public static ReadOnlySpan<byte> WithoutLeadingZeros(this ReadOnlySpan<byte> bytes) =>
-            bytes.WithoutLeadingZeros(out _);
-
-        /// <summary>
-        /// Strips leading zero bytes and reports whether the value is entirely zero, in one scan.
-        /// </summary>
-        public static ReadOnlySpan<byte> WithoutLeadingZeros(this ReadOnlySpan<byte> bytes, out bool isZero)
+        public static ReadOnlySpan<byte> WithoutLeadingZeros(this ReadOnlySpan<byte> bytes)
         {
-            if (bytes.Length == 0)
-            {
-                isZero = true;
-                return ZeroByteSpan;
-            }
+            if (bytes.Length == 0) return ZeroByteSpan;
 
             int nonZeroIndex = bytes.IndexOfAnyExcept((byte)0);
-            isZero = nonZeroIndex < 0;
             // Keep one or it will be interpreted as null
-            return isZero ? bytes[^1..] : bytes[nonZeroIndex..];
+            return nonZeroIndex < 0 ? bytes[^1..] : bytes[nonZeroIndex..];
         }
 
         public static byte[] Concat(byte prefix, byte[] bytes)

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -146,13 +146,24 @@ namespace Nethermind.Core.Extensions
 
         public static ReadOnlySpan<byte> WithoutLeadingZeros(this Span<byte> bytes) => ((ReadOnlySpan<byte>)bytes).WithoutLeadingZeros();
 
-        public static ReadOnlySpan<byte> WithoutLeadingZeros(this ReadOnlySpan<byte> bytes)
+        public static ReadOnlySpan<byte> WithoutLeadingZeros(this ReadOnlySpan<byte> bytes) =>
+            bytes.WithoutLeadingZeros(out _);
+
+        /// <summary>
+        /// Strips leading zero bytes and reports whether the value is entirely zero, in one scan.
+        /// </summary>
+        public static ReadOnlySpan<byte> WithoutLeadingZeros(this ReadOnlySpan<byte> bytes, out bool isZero)
         {
-            if (bytes.Length == 0) return ZeroByteSpan;
+            if (bytes.Length == 0)
+            {
+                isZero = true;
+                return ZeroByteSpan;
+            }
 
             int nonZeroIndex = bytes.IndexOfAnyExcept((byte)0);
+            isZero = nonZeroIndex < 0;
             // Keep one or it will be interpreted as null
-            return nonZeroIndex < 0 ? bytes[^1..] : bytes[nonZeroIndex..];
+            return isZero ? bytes[^1..] : bytes[nonZeroIndex..];
         }
 
         public static byte[] Concat(byte prefix, byte[] bytes)

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -148,11 +148,10 @@ namespace Nethermind.Core.Extensions
 
         public static ReadOnlySpan<byte> WithoutLeadingZeros(this ReadOnlySpan<byte> bytes)
         {
-            if (bytes.Length == 0) return ZeroByteSpan;
-
             int nonZeroIndex = bytes.IndexOfAnyExcept((byte)0);
-            // Keep one or it will be interpreted as null
-            return nonZeroIndex < 0 ? bytes[^1..] : bytes[nonZeroIndex..];
+            // Keep one zero byte or it will be interpreted as null; the data-section-backed
+            // ZeroByteSpan avoids returning an interior reference that keeps the source alive.
+            return nonZeroIndex < 0 ? ZeroByteSpan : bytes[nonZeroIndex..];
         }
 
         public static byte[] Concat(byte prefix, byte[] bytes)

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -364,9 +364,10 @@ public static partial class EvmInstructions
         if (!stack.PopWord256(out Span<byte> bytesSpan)) goto StackUnderflow;
         ReadOnlySpan<byte> bytes = bytesSpan;
 
-        // Strips to a single zero byte when the value is all-zero; the newIsZero-guarded
-        // paths below still substitute the shared BytesZero where an array is stored.
-        bytes = bytes.WithoutLeadingZeros(out bool newIsZero);
+        // Detect an all-zero value and strip leading zeros from a single scan.
+        int leadingZeros = bytes.LeadingZerosCount();
+        bool newIsZero = leadingZeros == bytes.Length;
+        bytes = newIsZero ? BytesZero : bytes[leadingZeros..];
 
         // Construct the storage cell for the executing account.
         StorageCell storageCell = new(vmState.Env.ExecutingAccount, in result);
@@ -477,9 +478,10 @@ public static partial class EvmInstructions
         if (!stack.PopWord256(out Span<byte> bytesSpan)) goto StackUnderflow;
         ReadOnlySpan<byte> bytes = bytesSpan;
 
-        // Strips to a single zero byte when the value is all-zero; the newIsZero-guarded
-        // paths below still substitute the shared BytesZero where an array is stored.
-        bytes = bytes.WithoutLeadingZeros(out bool newIsZero);
+        // Detect an all-zero value and strip leading zeros from a single scan.
+        int leadingZeros = bytes.LeadingZerosCount();
+        bool newIsZero = leadingZeros == bytes.Length;
+        bytes = newIsZero ? BytesZero : bytes[leadingZeros..];
 
         // Construct the storage cell for the executing account.
         StorageCell storageCell = new(vmState.Env.ExecutingAccount, in result);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -364,9 +364,9 @@ public static partial class EvmInstructions
         if (!stack.PopWord256(out Span<byte> bytesSpan)) goto StackUnderflow;
         ReadOnlySpan<byte> bytes = bytesSpan;
 
-        // Determine if the new value is effectively zero and normalize non-zero values by stripping leading zeros.
-        bool newIsZero = bytes.IsZero();
-        bytes = !newIsZero ? bytes.WithoutLeadingZeros() : BytesZero;
+        // Strips to a single zero byte when the value is all-zero; the newIsZero-guarded
+        // paths below still substitute the shared BytesZero where an array is stored.
+        bytes = bytes.WithoutLeadingZeros(out bool newIsZero);
 
         // Construct the storage cell for the executing account.
         StorageCell storageCell = new(vmState.Env.ExecutingAccount, in result);
@@ -477,9 +477,9 @@ public static partial class EvmInstructions
         if (!stack.PopWord256(out Span<byte> bytesSpan)) goto StackUnderflow;
         ReadOnlySpan<byte> bytes = bytesSpan;
 
-        // Determine if the new value is effectively zero and normalize non-zero values by stripping leading zeros.
-        bool newIsZero = bytes.IsZero();
-        bytes = !newIsZero ? bytes.WithoutLeadingZeros() : BytesZero;
+        // Strips to a single zero byte when the value is all-zero; the newIsZero-guarded
+        // paths below still substitute the shared BytesZero where an array is stored.
+        bytes = bytes.WithoutLeadingZeros(out bool newIsZero);
 
         // Construct the storage cell for the executing account.
         StorageCell storageCell = new(vmState.Env.ExecutingAccount, in result);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -656,9 +656,12 @@ public static partial class EvmInstructions
         if (!TGasPolicy.ConsumeStorageAccessGas(ref gas, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, in storageCell, StorageAccessType.SLOAD, spec))
             goto OutOfGas;
 
-        // Retrieve the persistent storage value and push it onto the stack.
+        // Retrieve the persistent storage value and push it onto the stack. Zero slots come back
+        // as a single zero byte; PushZero writes the word directly instead of packing the byte.
         ReadOnlySpan<byte> value = vm.WorldState.Get(in storageCell);
-        EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(value);
+        EvmExceptionType pushResult = value.Length == 1 && value[0] == 0
+            ? stack.PushZero<TTracingInst>()
+            : stack.PushBytes<TTracingInst>(value);
 
         // Log the storage load operation if tracing is enabled.
         if (vm.TxTracer.IsTracingOpLevelStorage)


### PR DESCRIPTION
## Changes

- **SSTORE (legacy and EIP-8037): one scan instead of two.** Both variants normalized the popped 32-byte value with back-to-back `IsZero()` + `WithoutLeadingZeros()` - the same vectorized `IndexOfAnyExcept((byte)0)` scan executed twice on the same bytes. They now use the existing `LeadingZerosCount`, where `count == length` is the zero verdict and `count` is the trim offset, from a single scan. No new API surface; the zero case keeps its exact shared-`BytesZero` substitution.
- **`WithoutLeadingZeros`: static `ZeroByteSpan` for all-zero input** instead of `bytes[^1..]`. The old slice was an interior reference that kept the entire source array GC-live to hand back one constant zero byte; `ZeroByteSpan` is data-section backed (no heap object to track) and content-identical. `IndexOfAnyExcept` returns -1 for empty input too, so the empty-input special case folds into the same branch.
- **SLOAD: zero-slot results push via `PushZero`.** Zero slots come back from `WorldState.Get` as a single zero byte, which `PushBytes` routes through the partial path (a `PackHiU64` byte pack plus two `Vector128` zero stores); `PushZero` writes the stack word with one store and no source read. Content check (`Length == 1 && value[0] == 0`) rather than reference check: several shared zero statics exist, and an un-normalized all-zero value still falls through to `PushBytes` correctly. Deliberately not extended to TLOAD, whose zero is stored as 32 zero bytes and already pushes as a single full-word copy.
- Added `TestCaseSource`-based coverage for `LeadingZerosCount` and `WithoutLeadingZeros`, neither of which had direct tests (empty, single zero, all-zero 32-byte word, trim offsets, trailing-zero retention, `startIndex`).

An audit of every `WithoutLeadingZeros` call site found the SSTORE pair to be the only true double-scan in the codebase. Magnitude is honest micro: a ~3 ns scan saved per SSTORE and a slimmer push per zero-slot SLOAD (reading unset/cleared slots is common), together single-digit microseconds per typical block - a cleanliness win on consensus hot paths more than a headline number.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New `TestCaseSource` cases for `LeadingZerosCount` (9) and `WithoutLeadingZeros` (6) in `BytesTests` (352 total pass). Full `Nethermind.Evm.Test` suite passes after each commit: 4906 passed, 8 pre-existing skips - identical to the master baseline; zero-slot SLOAD semantics are exercised pervasively by the state tests. Downstream uses of the normalized SSTORE value were audited: the value-equality compare is content-based and short-circuited in the both-zero case, and the storage write and tracer calls substitute the shared `BytesZero` under the zero guard exactly as before. `PushZero` reports `ZeroByteSpan` to `ReportStackPush`, content-identical to what `PushBytes` reported for the same value.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No