### PR TITLE
test(network): make Eth62 tx-packing tests deterministic in size

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -774,8 +775,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             {
                 byte[] s = new byte[32];
                 s.AsSpan().Fill(0x22);
-                s[30] = (byte)(i >> 8);
-                s[31] = (byte)i;
+                BinaryPrimitives.WriteInt32BigEndian(s.AsSpan(28), i);
                 txs[i] = Build.A.Transaction
                     .WithData(new byte[dataSize])
                     .WithSignature(new Signature(r, s, TestBlockchainIds.ChainId * 2 + 35))

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -765,17 +765,32 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _handler.SubprotocolRequested -= HandlerOnSubprotocolRequested;
         }
 
+        private static Transaction[] BuildTransactionsWithEqualSerializedLength(int txCount, int dataSize)
+        {
+            byte[] r = new byte[32];
+            r.AsSpan().Fill(0x11);
+            Transaction[] txs = new Transaction[txCount];
+            for (int i = 0; i < txCount; i++)
+            {
+                byte[] s = new byte[32];
+                s.AsSpan().Fill(0x22);
+                s[30] = (byte)(i >> 8);
+                s[31] = (byte)i;
+                txs[i] = Build.A.Transaction
+                    .WithData(new byte[dataSize])
+                    .WithSignature(new Signature(r, s, TestBlockchainIds.ChainId * 2 + 35))
+                    .TestObject;
+            }
+
+            return txs;
+        }
+
         [TestCase(1, true)]
         [TestCase(1055, true)]
         [TestCase(1056, false)]
         public void should_send_txs_with_size_up_to_MaxPacketSize_in_one_TransactionsMessage(int txCount, bool shouldBeSentInJustOneMessage)
         {
-            Transaction[] txs = new Transaction[txCount];
-
-            for (int i = 0; i < txCount; i++)
-            {
-                txs[i] = Build.A.Transaction.SignedAndResolved(Build.A.PrivateKey.TestObject).TestObject;
-            }
+            Transaction[] txs = BuildTransactionsWithEqualSerializedLength(txCount, dataSize: 0);
 
             _handler.SendNewTransactions(txs);
 
@@ -797,17 +812,12 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         [TestCase(10000)]
         public void should_send_txs_with_size_exceeding_MaxPacketSize_in_more_than_one_TransactionsMessage(int txCount)
         {
-            int sizeOfOneTestTransaction = Build.A.Transaction.SignedAndResolved().TestObject.GetLength();
+            Transaction[] txs = BuildTransactionsWithEqualSerializedLength(txCount, dataSize: 0);
+
+            int sizeOfOneTestTransaction = txs[0].GetLength();
             int maxNumberOfTxsInOneMsg = TransactionsMessage.MaxPacketSize / sizeOfOneTestTransaction; // it's 1055
             int nonFullMsgTxsCount = txCount % maxNumberOfTxsInOneMsg;
             int messagesCount = txCount / maxNumberOfTxsInOneMsg + (nonFullMsgTxsCount > 0 ? 1 : 0);
-
-            Transaction[] txs = new Transaction[txCount];
-
-            for (int i = 0; i < txCount; i++)
-            {
-                txs[i] = Build.A.Transaction.SignedAndResolved(Build.A.PrivateKey.TestObject).TestObject;
-            }
 
             _handler.SendNewTransactions(txs);
 
@@ -824,34 +834,16 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         {
             const int txCount = 512;
 
-            Transaction[] txs = new Transaction[txCount];
-            for (int i = 0; i < txCount; i++)
-            {
-                txs[i] = Build.A.Transaction.WithData(new byte[dataSize]).SignedAndResolved(Build.A.PrivateKey.TestObject).TestObject;
-            }
+            Transaction[] txs = BuildTransactionsWithEqualSerializedLength(txCount, dataSize);
 
             int sizeOfOneTx = txs[0].GetLength();
             int numberOfTxsInOneMsg = Math.Max(TransactionsMessage.MaxPacketSize / sizeOfOneTx, 1);
             int nonFullMsgTxsCount = txCount % numberOfTxsInOneMsg;
             int messagesCount = txCount / numberOfTxsInOneMsg + (nonFullMsgTxsCount > 0 ? 1 : 0);
 
-            CountdownEvent delivered = new(messagesCount);
-            int matchingDeliveries = 0;
-            _session.When(s => s.DeliverMessage(Arg.Any<TransactionsMessage>()))
-                .Do(call =>
-                {
-                    TransactionsMessage msg = (TransactionsMessage)call[0];
-                    if (msg.Transactions.Count == numberOfTxsInOneMsg || msg.Transactions.Count == nonFullMsgTxsCount)
-                    {
-                        Interlocked.Increment(ref matchingDeliveries);
-                        if (!delivered.IsSet) delivered.Signal();
-                    }
-                });
-
             _handler.SendNewTransactions(txs);
 
-            Assert.That(delivered.Wait(TimeSpan.FromSeconds(30)), Is.True, "Not all expected messages were delivered within 30s");
-            Assert.That(matchingDeliveries, Is.EqualTo(messagesCount));
+            _session.Received(messagesCount).DeliverMessage(Arg.Is<TransactionsMessage>(m => m.Transactions.Count == numberOfTxsInOneMsg || m.Transactions.Count == nonFullMsgTxsCount));
         }
 
         private void HandleZeroMessage<T>(T msg, int messageCode) where T : MessageBase


### PR DESCRIPTION
## Changes

- `Eth62ProtocolHandlerTests.should_send_single_transaction_even_if_exceed_MaxPacketSize(128)` failed on CI (`ubuntu-24.04-arm`, run [29806899202](https://github.com/NethermindEth/nethermind/actions/runs/29806899202/attempts/1), both in-job attempts) with "Not all expected messages were delivered within 30s", and passed on re-run.
- Root cause: each transaction is signed with a fresh random key, and RLP drops leading zero bytes of `r`/`s`, so transaction sizes vary by a byte in ~0.8 % of signatures. The expected message segmentation is derived from `txs[0].GetLength()` alone, so when `txs[0]` happens to encode shorter, the computed txs-per-message count (e.g. 455 instead of 453) no longer matches the actual greedy packing in `SendNewTransactionsCore`, no delivered message matches the assertion predicate, and the test burns the full 30-second wait before failing.
- Fix: build the transactions with a fixed full-length synthetic signature (hashes stay distinct via distinct `s` content, which the transaction hash covers), so every transaction serializes to the same length and the packing arithmetic is exact. The two sibling packing tests use the same construction and had the same latent flake, so they now share the helper.
- The `CountdownEvent`/30-second wait is removed: `SendNewTransactions` → `Session.DeliverMessage` is fully synchronous, so the wait could never rescue a mismatch — a plain `Received(...)` assertion is equivalent and fails fast.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Other: test flakiness fix

## Testing

### Requires testing

- [x] Yes
- [ ] No

If yes, did you write tests?

- [x] Yes
- [ ] No

### Notes on testing

`Eth62ProtocolHandlerTests` suite (59 tests) passes locally on arm64; the three packing tests were additionally run 3× in a loop. The 1055/1056 boundary cases confirm the synthetic transactions serialize to the same length as the previous `SignedAndResolved` ones.

## Documentation

### Requires documentation update

- [ ] Yes
- [x] No

### Requires explanation in Release Notes

- [ ] Yes
- [x] No