### PR TITLE
feat(xdc): add XdcHeaderModule for correct header/block decoder registration

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/DebugModuleTests.cs
@@ -38,8 +38,10 @@ public class DebugModuleTests
     private readonly IBlockchainBridge _blockchainBridge = Substitute.For<IBlockchainBridge>();
 
     [SetUp]
-    public void Setup() =>
-        new ContainerBuilder().AddModule(new XdcHeaderModule()).Build();
+    public void Setup()
+    {
+        using IContainer container = new ContainerBuilder().AddModule(new XdcHeaderModule()).Build();
+    }
 
     [TearDown]
     public void TearDown() => Rlp.ResetDecoders();

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/DebugModuleTests.cs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Autofac;
+using Nethermind.Blockchain.Find;
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Facade;
+using Nethermind.Facade.Eth;
+using Nethermind.JsonRpc;
+using Nethermind.JsonRpc.Modules.DebugModule;
+using Nethermind.JsonRpc.Test;
+using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Xdc.RLP;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test.ModuleTests;
+
+/// <summary>
+/// Verifies that <see cref="DebugRpcModule"/>'s raw header/block endpoints — which resolve their
+/// decoder from the static <see cref="Rlp"/> registry rather than DI — encode XDC headers correctly
+/// once <see cref="XdcHeaderModule"/> is loaded. Mirrors <c>Nethermind.JsonRpc.Test.Modules.DebugModuleTests</c>.
+/// </summary>
+[TestFixture, NonParallelizable]
+public class DebugModuleTests
+{
+    private readonly IJsonRpcConfig _jsonRpcConfig = new JsonRpcConfig();
+    private readonly ISpecProvider _specProvider = SpecProviderSubstitute.Create();
+    private readonly IDebugBridge _debugBridge = Substitute.For<IDebugBridge>();
+    private readonly IBlockFinder _blockFinder = Substitute.For<IBlockFinder>();
+    private readonly IBlockchainBridge _blockchainBridge = Substitute.For<IBlockchainBridge>();
+
+    [SetUp]
+    public void Setup() =>
+        new ContainerBuilder().AddModule(new XdcHeaderModule()).Build();
+
+    [TearDown]
+    public void TearDown() => Rlp.ResetDecoders();
+
+    private DebugRpcModule CreateModule() => new(
+        LimboLogs.Instance,
+        _debugBridge,
+        _jsonRpcConfig,
+        _specProvider,
+        _blockchainBridge,
+        new BlocksConfig(),
+        _blockFinder,
+        new BlockForRpcFactory());
+
+    private Task<JsonRpcResponse> Request(string method, params object?[]? parameters) =>
+        RpcTest.TestRequest<IDebugRpcModule>(CreateModule(), method, parameters);
+
+    [Test]
+    public async Task DebugGetRawHeader_WhenXdcHeader_ReturnsXdcShapedRlp()
+    {
+        XdcBlockHeader header = Build.A.XdcBlockHeader().WithNumber(0).TestObject;
+        Block block = Build.A.Block.WithHeader(header).TestObject;
+        _debugBridge.GetBlock(new BlockParameter(0UL)).Returns(block);
+
+        using JsonRpcResponse response = await Request("debug_getRawHeader", "0x0");
+
+        byte[] actual = RpcTest.AssertSuccess<ArrayPoolList<byte>>(response).AsSpan().ToArray();
+        Assert.That(actual, Is.EqualTo(new XdcHeaderDecoder().Encode(header).Bytes));
+        Assert.That(actual, Is.Not.EqualTo(new HeaderDecoder().Encode(header).Bytes));
+    }
+
+    [Test]
+    public async Task DebugGetRawBlock_WhenXdcHeader_ReturnsXdcShapedRlp()
+    {
+        XdcBlockHeader header = Build.A.XdcBlockHeader().WithNumber(1).TestObject;
+        Block block = Build.A.Block.WithHeader(header).TestObject;
+        _debugBridge.GetBlock(new BlockParameter(1UL)).Returns(block);
+
+        using JsonRpcResponse response = await Request("debug_getRawBlock", "0x1");
+
+        byte[] actual = RpcTest.AssertSuccess<ArrayPoolList<byte>>(response).AsSpan().ToArray();
+        Assert.That(actual, Is.EqualTo(new BlockDecoder(new XdcHeaderDecoder()).Encode(block).Bytes));
+        Assert.That(actual, Is.Not.EqualTo(new BlockDecoder(new HeaderDecoder()).Encode(block).Bytes));
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderModuleTests.cs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Xdc.RLP;
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test;
+
+/// <summary>
+/// Verifies that <see cref="XdcHeaderModule"/> wires the correct <see cref="BlockHeader"/> decoders
+/// </summary>
+[TestFixture, NonParallelizable]
+public class XdcHeaderModuleTests
+{
+    [TearDown]
+    public void TearDown() => Rlp.ResetDecoders();
+
+    [Test]
+    public void Default_constructor_registers_XdcHeaderDecoder()
+    {
+        using IContainer container = new ContainerBuilder()
+            .AddModule(new XdcHeaderModule())
+            .Build();
+
+        Assert.That(container.Resolve<IHeaderDecoder>(), Is.InstanceOf<XdcHeaderDecoder>());
+        Assert.That(container.Resolve<BlockDecoder>(), Is.Not.Null);
+        Assert.That(container.Resolve<BlockBodyDecoder>(), Is.Not.Null);
+    }
+
+    [Test]
+    public void Provided_decoder_instance_is_used_for_subnet_chains()
+    {
+        XdcSubnetHeaderDecoder subnetDecoder = new();
+
+        using IContainer container = new ContainerBuilder()
+            .AddModule(new XdcHeaderModule(subnetDecoder))
+            .Build();
+
+        Assert.That(container.Resolve<IHeaderDecoder>(), Is.SameAs(subnetDecoder));
+    }
+
+    [Test]
+    public void Load_registers_decoder_globally_so_static_Rlp_calls_use_it()
+    {
+        new ContainerBuilder()
+            .AddModule(new XdcHeaderModule())
+            .Build();
+
+        Assert.That(Rlp.GetDecoder<BlockHeader>(), Is.InstanceOf<XdcHeaderDecoder>());
+        Assert.That(Rlp.GetDecoder<Block>(), Is.Not.Null);
+        Assert.That(Rlp.GetDecoder<BlockBody>(), Is.Not.Null);
+    }
+
+    [Test]
+    public void Global_decoder_still_encodes_plain_BlockHeader()
+    {
+        new ContainerBuilder()
+            .AddModule(new XdcHeaderModule())
+            .Build();
+
+        BlockHeader plain = Build.A.BlockHeader.TestObject;
+
+        Rlp encoded = Rlp.Encode(plain);
+
+        Assert.That(encoded.Bytes, Is.Not.Empty);
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderModuleTests.cs
@@ -46,7 +46,7 @@ public class XdcHeaderModuleTests
     [Test]
     public void Load_registers_decoder_globally_so_static_Rlp_calls_use_it()
     {
-        new ContainerBuilder()
+        using IContainer container = new ContainerBuilder()
             .AddModule(new XdcHeaderModule())
             .Build();
 
@@ -58,7 +58,7 @@ public class XdcHeaderModuleTests
     [Test]
     public void Global_decoder_still_encodes_plain_BlockHeader()
     {
-        new ContainerBuilder()
+        using IContainer container = new ContainerBuilder()
             .AddModule(new XdcHeaderModule())
             .Build();
 

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderModuleTests.cs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Xdc.RLP;
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test;
+
+/// <summary>
+/// Verifies that <see cref="XdcHeaderModule"/> wires the correct <see cref="BlockHeader"/> decoders,
+/// both in DI and as the process-wide static <see cref="Rlp"/> default (mirrors
+/// <c>Nethermind.AuRa.Test.Encoding.AuRaHeaderDecoderTests</c>).
+/// </summary>
+[TestFixture, NonParallelizable]
+public class XdcHeaderModuleTests
+{
+    [TearDown]
+    public void TearDown() => Rlp.ResetDecoders();
+
+    [Test]
+    public void Default_constructor_registers_XdcHeaderDecoder()
+    {
+        using IContainer container = new ContainerBuilder()
+            .AddModule(new XdcHeaderModule())
+            .Build();
+
+        Assert.That(container.Resolve<IHeaderDecoder>(), Is.InstanceOf<XdcHeaderDecoder>());
+        Assert.That(container.Resolve<BlockDecoder>(), Is.Not.Null);
+        Assert.That(container.Resolve<BlockBodyDecoder>(), Is.Not.Null);
+    }
+
+    [Test]
+    public void Provided_decoder_instance_is_used_for_subnet_chains()
+    {
+        XdcSubnetHeaderDecoder subnetDecoder = new();
+
+        using IContainer container = new ContainerBuilder()
+            .AddModule(new XdcHeaderModule(subnetDecoder))
+            .Build();
+
+        Assert.That(container.Resolve<IHeaderDecoder>(), Is.SameAs(subnetDecoder));
+    }
+
+    [Test]
+    public void Load_registers_decoder_globally_so_static_Rlp_calls_use_it()
+    {
+        new ContainerBuilder()
+            .AddModule(new XdcHeaderModule())
+            .Build();
+
+        Assert.That(Rlp.GetDecoder<BlockHeader>(), Is.InstanceOf<XdcHeaderDecoder>());
+        Assert.That(Rlp.GetDecoder<Block>(), Is.Not.Null);
+        Assert.That(Rlp.GetDecoder<BlockBody>(), Is.Not.Null);
+    }
+
+    /// <summary>
+    /// Regression guard: once XDC's decoder is the global default, code that still encodes a plain
+    /// (non-XDC) <see cref="BlockHeader"/> — e.g. test fixtures shared with generic-chain tests —
+    /// must not start throwing.
+    /// </summary>
+    [Test]
+    public void Global_decoder_still_encodes_plain_BlockHeader()
+    {
+        new ContainerBuilder()
+            .AddModule(new XdcHeaderModule())
+            .Build();
+
+        BlockHeader plain = Build.A.BlockHeader.TestObject;
+
+        Rlp encoded = Rlp.Encode(plain);
+
+        Assert.That(encoded.Bytes, Is.Not.Empty);
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderModuleTests.cs
@@ -11,9 +11,7 @@ using NUnit.Framework;
 namespace Nethermind.Xdc.Test;
 
 /// <summary>
-/// Verifies that <see cref="XdcHeaderModule"/> wires the correct <see cref="BlockHeader"/> decoders,
-/// both in DI and as the process-wide static <see cref="Rlp"/> default (mirrors
-/// <c>Nethermind.AuRa.Test.Encoding.AuRaHeaderDecoderTests</c>).
+/// Verifies that <see cref="XdcHeaderModule"/> wires the correct <see cref="BlockHeader"/> decoders
 /// </summary>
 [TestFixture, NonParallelizable]
 public class XdcHeaderModuleTests
@@ -57,11 +55,6 @@ public class XdcHeaderModuleTests
         Assert.That(Rlp.GetDecoder<BlockBody>(), Is.Not.Null);
     }
 
-    /// <summary>
-    /// Regression guard: once XDC's decoder is the global default, code that still encodes a plain
-    /// (non-XDC) <see cref="BlockHeader"/> — e.g. test fixtures shared with generic-chain tests —
-    /// must not start throwing.
-    /// </summary>
     [Test]
     public void Global_decoder_still_encodes_plain_BlockHeader()
     {

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcHeaderModuleTests.cs
@@ -66,6 +66,15 @@ public class XdcHeaderModuleTests
 
         Rlp encoded = Rlp.Encode(plain);
 
-        Assert.That(encoded.Bytes, Is.Not.Empty);
+        Assert.That(encoded.Bytes, Is.EqualTo(new HeaderDecoder().Encode(plain).Bytes));
+    }
+
+    [Test]
+    public void Encode_throws_for_non_base_header_that_is_not_the_decoder_subtype()
+    {
+        XdcSubnetHeaderDecoder subnetDecoder = new();
+        XdcBlockHeader plainXdc = Build.A.XdcBlockHeader().TestObject;
+
+        Assert.That(() => subnetDecoder.Encode(plainXdc), Throws.InvalidOperationException);
     }
 }

--- a/src/Nethermind/Nethermind.Xdc/RLP/BaseXdcHeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/BaseXdcHeaderDecoder.cs
@@ -17,13 +17,6 @@ namespace Nethermind.Xdc.RLP;
 /// RLP content" at that point, so no reliable byte-shape check exists. This is safe because XDC nodes
 /// only ever decode XDC-shaped chain data through the global registry; it is not safe to decode
 /// arbitrary foreign headers once this decoder is registered as the process-wide default.
-/// <para>
-/// The encode fallback is deliberately restricted to a genuine base <see cref="BlockHeader"/>. Any
-/// other <see cref="XdcBlockHeader"/> subtype that is not <typeparamref name="TH"/> (e.g. a plain
-/// <see cref="XdcBlockHeader"/> routed through <c>XdcSubnetHeaderDecoder</c>) would silently drop its
-/// XDC-specific fields and produce a wrong block hash, so it throws instead — surfacing the wiring bug
-/// loudly rather than corrupting output.
-/// </para>
 /// </remarks>
 public abstract class BaseXdcHeaderDecoder<TH> : RlpDecoder<BlockHeader>, IHeaderDecoder where TH : XdcBlockHeader
 {

--- a/src/Nethermind/Nethermind.Xdc/RLP/BaseXdcHeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/BaseXdcHeaderDecoder.cs
@@ -10,10 +10,9 @@ using System;
 namespace Nethermind.Xdc.RLP;
 
 /// <remarks>
-/// The plain-header fallback (see <see cref="FallbackDecoder"/>) is encode-only. Decoding has no
-/// symmetric fallback: unlike AuRa's seal, which is disambiguated by a single field's length,
-/// distinguishing a foreign header from an XDC one after <c>mixHash</c>/<c>nonce</c> would require
-/// telling XDC's required <c>Validators</c>/<c>Penalties</c> tail apart from Ethereum's optional
+/// The plain-header fallback (see <see cref="FallbackDecoder"/>) is encode-only. 
+/// Distinguishing a foreign header from an XDC one after <c>mixHash</c>/<c>nonce</c> would require
+/// telling XDC's required <c>Validators</c>/<c>Penalties</c> fields apart from Ethereum's optional
 /// post-merge fields (<c>BaseFeePerGas</c>, <c>WithdrawalsRoot</c>, etc.) — both just look like "more
 /// RLP content" at that point, so no reliable byte-shape check exists. This is safe because XDC nodes
 /// only ever decode XDC-shaped chain data through the global registry; it is not safe to decode

--- a/src/Nethermind/Nethermind.Xdc/RLP/BaseXdcHeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/BaseXdcHeaderDecoder.cs
@@ -10,13 +10,20 @@ using System;
 namespace Nethermind.Xdc.RLP;
 
 /// <remarks>
-/// The plain-header fallback (see <see cref="FallbackDecoder"/>) is encode-only. 
+/// The plain-header fallback (see <see cref="FallbackDecoder"/>) is encode-only.
 /// Distinguishing a foreign header from an XDC one after <c>mixHash</c>/<c>nonce</c> would require
 /// telling XDC's required <c>Validators</c>/<c>Penalties</c> fields apart from Ethereum's optional
 /// post-merge fields (<c>BaseFeePerGas</c>, <c>WithdrawalsRoot</c>, etc.) — both just look like "more
 /// RLP content" at that point, so no reliable byte-shape check exists. This is safe because XDC nodes
 /// only ever decode XDC-shaped chain data through the global registry; it is not safe to decode
 /// arbitrary foreign headers once this decoder is registered as the process-wide default.
+/// <para>
+/// The encode fallback is deliberately restricted to a genuine base <see cref="BlockHeader"/>. Any
+/// other <see cref="XdcBlockHeader"/> subtype that is not <typeparamref name="TH"/> (e.g. a plain
+/// <see cref="XdcBlockHeader"/> routed through <c>XdcSubnetHeaderDecoder</c>) would silently drop its
+/// XDC-specific fields and produce a wrong block hash, so it throws instead — surfacing the wiring bug
+/// loudly rather than corrupting output.
+/// </para>
 /// </remarks>
 public abstract class BaseXdcHeaderDecoder<TH> : RlpDecoder<BlockHeader>, IHeaderDecoder where TH : XdcBlockHeader
 {
@@ -107,6 +114,7 @@ public abstract class BaseXdcHeaderDecoder<TH> : RlpDecoder<BlockHeader>, IHeade
 
         if (header is not TH h)
         {
+            EnsurePlainFallbackAllowed(header);
             FallbackDecoder.Encode(ref writer, header, rlpBehaviors);
             return;
         }
@@ -142,6 +150,7 @@ public abstract class BaseXdcHeaderDecoder<TH> : RlpDecoder<BlockHeader>, IHeade
 
         if (item is not TH header)
         {
+            EnsurePlainFallbackAllowed(item);
             return FallbackDecoder.Encode(item, rlpBehaviors);
         }
 
@@ -155,10 +164,22 @@ public abstract class BaseXdcHeaderDecoder<TH> : RlpDecoder<BlockHeader>, IHeade
     {
         if (item is not TH header)
         {
+            EnsurePlainFallbackAllowed(item);
             return FallbackDecoder.GetLength(item, rlpBehaviors);
         }
 
         return Rlp.LengthOfSequence(GetContentLength(header, rlpBehaviors));
+    }
+
+    // Only a genuine base BlockHeader may take the plain-shape fallback. Any other BlockHeader subtype
+    // that isn't TH (notably a different XdcBlockHeader subtype) would lose its XDC fields, so fail loudly.
+    private void EnsurePlainFallbackAllowed(BlockHeader header)
+    {
+        if (header.GetType() != typeof(BlockHeader))
+        {
+            throw new InvalidOperationException(
+                $"{GetType().Name} can only encode {typeof(TH).Name} or a plain {nameof(BlockHeader)}, but got {header.GetType().Name}.");
+        }
     }
 
     private int GetContentLength(TH header, RlpBehaviors rlpBehaviors)

--- a/src/Nethermind/Nethermind.Xdc/RLP/BaseXdcHeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/BaseXdcHeaderDecoder.cs
@@ -13,6 +13,12 @@ public abstract class BaseXdcHeaderDecoder<TH> : RlpDecoder<BlockHeader>, IHeade
 {
     private const int NonceLength = 8;
 
+    // Encodes headers that aren't TH (e.g. plain BlockHeader test fixtures) using the base Ethereum
+    // shape, mirroring AuRaHeaderDecoder's seal-only fallback. Needed once this decoder is registered
+    // as the process-wide Rlp default (see XdcHeaderModule), so foreign headers still encode correctly
+    // instead of throwing.
+    private static readonly HeaderDecoder FallbackDecoder = new();
+
     protected static bool IsForSealing(RlpBehaviors beh)
         => (beh & RlpBehaviors.ForSealing) == RlpBehaviors.ForSealing;
 
@@ -91,7 +97,10 @@ public abstract class BaseXdcHeaderDecoder<TH> : RlpDecoder<BlockHeader>, IHeade
         }
 
         if (header is not TH h)
-            throw new ArgumentException($"Must be {typeof(TH).Name}.", nameof(header));
+        {
+            FallbackDecoder.Encode(ref writer, header, rlpBehaviors);
+            return;
+        }
 
         writer.StartSequence(GetContentLength(h, rlpBehaviors));
 
@@ -123,7 +132,9 @@ public abstract class BaseXdcHeaderDecoder<TH> : RlpDecoder<BlockHeader>, IHeade
         }
 
         if (item is not TH header)
-            throw new ArgumentException($"Must be {typeof(TH).Name}.", nameof(item));
+        {
+            return FallbackDecoder.Encode(item, rlpBehaviors);
+        }
 
         byte[] bytes = new byte[GetLength(item, rlpBehaviors)];
         RlpWriter writer = new(bytes);
@@ -134,7 +145,9 @@ public abstract class BaseXdcHeaderDecoder<TH> : RlpDecoder<BlockHeader>, IHeade
     public override int GetLength(BlockHeader? item, RlpBehaviors rlpBehaviors)
     {
         if (item is not TH header)
-            throw new ArgumentException($"Must be {typeof(TH).Name}.", nameof(item));
+        {
+            return FallbackDecoder.GetLength(item, rlpBehaviors);
+        }
 
         return Rlp.LengthOfSequence(GetContentLength(header, rlpBehaviors));
     }

--- a/src/Nethermind/Nethermind.Xdc/RLP/BaseXdcHeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Xdc/RLP/BaseXdcHeaderDecoder.cs
@@ -9,6 +9,16 @@ using System;
 
 namespace Nethermind.Xdc.RLP;
 
+/// <remarks>
+/// The plain-header fallback (see <see cref="FallbackDecoder"/>) is encode-only. Decoding has no
+/// symmetric fallback: unlike AuRa's seal, which is disambiguated by a single field's length,
+/// distinguishing a foreign header from an XDC one after <c>mixHash</c>/<c>nonce</c> would require
+/// telling XDC's required <c>Validators</c>/<c>Penalties</c> tail apart from Ethereum's optional
+/// post-merge fields (<c>BaseFeePerGas</c>, <c>WithdrawalsRoot</c>, etc.) — both just look like "more
+/// RLP content" at that point, so no reliable byte-shape check exists. This is safe because XDC nodes
+/// only ever decode XDC-shaped chain data through the global registry; it is not safe to decode
+/// arbitrary foreign headers once this decoder is registered as the process-wide default.
+/// </remarks>
 public abstract class BaseXdcHeaderDecoder<TH> : RlpDecoder<BlockHeader>, IHeaderDecoder where TH : XdcBlockHeader
 {
     private const int NonceLength = 8;

--- a/src/Nethermind/Nethermind.Xdc/XdcHeaderModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcHeaderModule.cs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Core;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Xdc.RLP;
+
+namespace Nethermind.Xdc;
+
+/// <summary>
+/// Registers XDC header typing: the <see cref="BlockHeader"/> RLP decoders (globally and in DI)
+/// so that call sites which resolve decoders from the static <see cref="Rlp"/> registry instead of
+/// DI (e.g. <c>ProofRpcModule</c>) also encode/decode XDC headers correctly. Used by
+/// <see cref="XdcModule"/> for mainnet headers and by <see cref="XdcSubnetModule"/> with a
+/// subnet-specific decoder instance.
+/// </summary>
+/// <remarks>
+/// <see cref="BaseXdcHeaderDecoder{TH}"/> falls back to the base Ethereum shape when asked to encode
+/// a header that isn't its own subtype, mirroring <c>AuRaHeaderDecoder</c>'s seal-only fallback — this
+/// is what makes it safe to register as the process-wide default.
+/// </remarks>
+public class XdcHeaderModule(IHeaderDecoder headerDecoder) : Module
+{
+    public XdcHeaderModule() : this(new XdcHeaderDecoder()) { }
+
+    protected override void Load(ContainerBuilder builder)
+    {
+        base.Load(builder);
+
+        BlockDecoder blockDecoder = new(headerDecoder);
+        BlockBodyDecoder blockBodyDecoder = new(headerDecoder);
+        Rlp.RegisterDecoder(typeof(BlockHeader), headerDecoder);
+        Rlp.RegisterDecoder(typeof(Block), blockDecoder);
+        Rlp.RegisterDecoder(typeof(BlockBody), blockBodyDecoder);
+
+        builder
+            .AddSingleton<IHeaderDecoder>(headerDecoder)
+            .AddSingleton(blockDecoder)
+            .AddSingleton(blockBodyDecoder);
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc/XdcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcModule.cs
@@ -23,7 +23,6 @@ using Nethermind.JsonRpc.Modules;
 using Nethermind.Network;
 using Nethermind.Network.Discovery.Discv4;
 using Nethermind.Network.Discovery.Discv4.Messages;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastSync;
@@ -35,7 +34,6 @@ using Nethermind.Xdc.RPC;
 using Nethermind.Xdc.Spec;
 using Nethermind.Xdc.TxPool;
 using Nethermind.Xdc.Discovery;
-using Nethermind.Xdc.RLP;
 
 namespace Nethermind.Xdc;
 
@@ -46,6 +44,7 @@ public class XdcModule : Module
         base.Load(builder);
 
         builder
+            .AddModule(new XdcHeaderModule())
             .AddDecorator<IRocksDbConfigFactory, XdcRocksDbConfigFactory>() // Register custom RocksDb config factory that handles XdcSnapshots without validation
             .AddProtocolHandler<P2P.XdcProtocolHandler>() // Register XDC protocol handler using clean DSL (intercepts ETH protocol version 100)
             .AddStep(typeof(InitializeBlockchainXdc))
@@ -120,8 +119,6 @@ public class XdcModule : Module
 
             //Network
             .AddSingleton<IProtocolValidator, XdcProtocolValidator>()
-            .AddSingleton<IHeaderDecoder, XdcHeaderDecoder>()
-            .AddSingleton(new BlockDecoder(new XdcHeaderDecoder()))
             .AddMessageSerializer<VoteMsg, VoteMsgSerializer>()
             .AddMessageSerializer<SyncInfoMsg, SyncInfoMsgSerializer>()
             .AddMessageSerializer<TimeoutMsg, TimeoutMsgSerializer>()

--- a/src/Nethermind/Nethermind.Xdc/XdcSubnetModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcSubnetModule.cs
@@ -6,7 +6,6 @@ using Autofac.Features.AttributeFilters;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Rewards;
 using Nethermind.Core;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Xdc.RLP;
 using Nethermind.Xdc.Spec;
@@ -24,8 +23,7 @@ public class XdcSubnetModule : XdcModule
             .Add<StartXdcSubnetBlockProducer>()
             .AddSingleton<XdcSubnetBlockProducerFactory>()
             .Bind<IBlockProducerFactory, XdcSubnetBlockProducerFactory>() // overrides the base producer binding; runner stays XdcBlockProducerFactory
-            .AddSingleton<IHeaderDecoder, XdcSubnetHeaderDecoder>()
-            .AddSingleton(new BlockDecoder(new XdcSubnetHeaderDecoder()))
+            .AddModule(new XdcHeaderModule(new XdcSubnetHeaderDecoder())) // overrides the mainnet decoders registered by XdcModule.Load above
             .AddSingleton<IEpochSwitchManager, SubnetEpochSwitchManager>()
             .AddSingleton<ISubnetMasternodesCalculator, SubnetMasternodesCalculator>()
             .Bind<IMasternodesCalculator, ISubnetMasternodesCalculator>()


### PR DESCRIPTION
## Summary
- Add `XdcHeaderModule`, mirroring `Consensus.AuRa`'s `AuRaHeaderModule`, to register XDC's `BlockHeader`/`Block`/`BlockBody` RLP decoders both in DI and globally via `Rlp.RegisterDecoder` — fixing call sites that bypass DI and resolve decoders from the static `Rlp` registry instead (e.g. `DebugRpcModule.debug_getRawHeader`/`debug_getRawBlock`, which previously fell back to the plain Ethereum decoder and silently dropped XDC-specific header fields).
- Harden `BaseXdcHeaderDecoder<TH>` to gracefully fall back to the base `HeaderDecoder` shape when encoding a header that isn't its own XDC subtype (mirroring `AuRaHeaderDecoder`'s seal-only fallback), which is what makes registering it as the process-wide default safe — otherwise it throws for any non-XDC `BlockHeader`.
- Consolidate `XdcModule`/`XdcSubnetModule`'s previously inline, incomplete decoder registration (missing `BlockBodyDecoder`, used for uncle headers) into the new shared module.

## Testing
- `XdcHeaderModuleTests`: verifies the module wires the correct decoder in DI and as the static `Rlp` default, including a regression guard proving the global decoder still encodes plain (non-XDC) `BlockHeader` instances without throwing.
- `DebugModuleTests` (new, modeled on `Nethermind.JsonRpc.Test.Modules.DebugModuleTests`): verifies `debug_getRawHeader`/`debug_getRawBlock` return XDC-shaped RLP once `XdcHeaderModule` is loaded, and differ from the plain decoder's output.
- Full `Nethermind.Xdc.Test` suite (523 tests) passes.
- `dotnet format whitespace` clean on touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)