### PR TITLE
fix(jsonrpc): bound proof_getProofWithMeta with the request timeout

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Proof/ProofRpcModule.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Linq;
+using System.Threading;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
@@ -153,7 +154,8 @@ namespace Nethermind.JsonRpc.Modules.Proof
                     ErrorCodes.ResourceUnavailable);
             }
 
-            AccountProofCollector accountProofCollector = new(accountAddress, storageKeys);
+            using CancellationTokenSource timeout = jsonRpcConfig.BuildTimeoutCancellationToken();
+            AccountProofCollector accountProofCollector = new(accountAddress, storageKeys, timeout.Token);
             VisitingStats diagnostics = new();
             blockchainBridge.RunTreeVisitor(accountProofCollector, header!, diagnostics: diagnostics);
 


### PR DESCRIPTION
## Changes

Follow-up to #12507. `proof_getProofWithMeta` (`ProofRpcModule.cs`) ran `RunTreeVisitor` with **no cancellation token** — the same uncancellable account+storage trie walk that #12507 fixed for `eth_getProof`. On cold state a single request could issue an unbounded number of RocksDB node reads with no wall-clock bound (only the 1000-key limit).

- Thread the RPC timeout token into `AccountProofCollector` (via the optional parameter added in #12507) so the walk aborts on timeout; `JsonRpcService` maps the resulting `OperationCanceledException` to `ErrorCodes.Timeout`.
- `proof_call` already bounds itself (`WitnessCall` uses `BuildTimeoutCancellationToken`), so `proof_getProofWithMeta` was the remaining gap in the `Proof` module (which is enabled by default).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

The cancellation itself is already covered by `AccountProofCollectorTests.ShouldVisit_throws_when_cancellation_requested` (added in #12507): the collector honors the token in `ShouldVisit` regardless of caller. This PR only wires that token in from `proof_getProofWithMeta`, mirroring `eth_getProof`. `Nethermind.JsonRpc` builds clean.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Raised by @hudem1 in review of #12507.
