### PR TITLE
fix(config): add options for persisted snapshot catalog in DbConfig

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -412,4 +412,7 @@ public class DbConfig : IDbConfig
 
     public string? PreimageDbRocksDbOptions { get; set; } = "";
     public string? PreimageDbAdditionalRocksDbOptions { get; set; }
+
+    public string? PersistedSnapshotCatalogDbRocksDbOptions { get; set; } = "";
+    public string? PersistedSnapshotCatalogDbAdditionalRocksDbOptions { get; set; }
 }

--- a/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/IDbConfig.cs
@@ -148,4 +148,7 @@ public interface IDbConfig : IConfig
 
     string? PreimageDbRocksDbOptions { get; set; }
     public string? PreimageDbAdditionalRocksDbOptions { get; set; }
+
+    string? PersistedSnapshotCatalogDbRocksDbOptions { get; set; }
+    string? PersistedSnapshotCatalogDbAdditionalRocksDbOptions { get; set; }
 }


### PR DESCRIPTION
## Changes

- Declare `PersistedSnapshotCatalogDbRocksDbOptions` / `PersistedSnapshotCatalogDbAdditionalRocksDbOptions` in `IDbConfig` + `DbConfig`.

The catalog DB (#12142) is opened via `PerTableDbConfig` under prefix `PersistedSnapshotCatalogDb`, but the matching config members were never added, so `EnsureConfigIsAvailable` throws on startup (DEBUG builds only).
