### PR TITLE
Handle short Snap trie paths

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapServerTest.cs
@@ -308,20 +308,29 @@ public class SnapServerTest
     }
 
     [Test]
-    public void TestGetTrieNode_Root()
+    public void TestGetTrieNode_RootAndShortAccountPath()
     {
         using ISnapServerContext context = CreateContext();
-        FillWithTestAccounts(context);
+        using (IWriteBatch batch = context.BeginWriteBatch())
+        {
+            batch.SetAccount(new Hash256("0100000000000000000000000000000000000000000000000000000000000000"), Build.An.Account.WithBalance(0).TestObject);
+            batch.SetAccount(new Hash256("0110000000000000000000000000000000000000000000000000000000000000"), Build.An.Account.WithBalance(1).TestObject);
+        }
 
         using RlpPathGroupList pathSet = PathGroup.EncodeToRlpPathGroupList([
             new PathGroup()
             {
                 Group = [[]]
+            },
+            new PathGroup()
+            {
+                Group = [[1], []]
             }
         ]);
         using IByteArrayList result = context.Server.GetTrieNodes(pathSet, context.RootHash, default)!;
 
         Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(ValueKeccak.Compute(result[0]), Is.EqualTo(context.RootHash));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
@@ -244,6 +244,7 @@ namespace Nethermind.Trie.Test
             Assert.That(checkTree.GetNodeByKey(Nibbles.CompactToHexEncode(emptyByteCompactEncoded), patriciaTree.RootHash), Is.EqualTo(rootNodeHash));
 
             Assert.That(checkTree.GetNodeByKey(branchNodeKey1, patriciaTree.RootHash), Is.EqualTo(branchNodeValue1));
+            Assert.That(checkTree.Get(branchNodeKey1).ToArray(), Is.Empty);
         }
 
         // [Test]

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -958,6 +958,11 @@ namespace Nethermind.Trie
                         return default;
                     }
 
+                    if (remainingKey.Length == 0)
+                    {
+                        return default;
+                    }
+
                     int nib = remainingKey[0];
                     path.AppendMut(nib);
                     TrieNode? child = node.GetChildWithChildPath(TrieStore, ref path, nib);


### PR DESCRIPTION
Revealed by snap hive tests

## Changes

- Return no value when a Patricia trie lookup ends at a branch, preventing an empty-span index for a short Snap account path.
- Add trie and Snap-server regressions for the root plus short account-path request.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Focused Patricia trie and Snap-server regressions pass.
- The locally built client passes the full Hive devp2p Snap suite.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
