### PR TITLE
feat(evm): EIP-8250 nonce-set validity

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
@@ -159,6 +159,15 @@ public class KeyedNonceManagerTests
         Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [(UInt256)5], nonceSeq: ulong.MaxValue), Is.False);
 
     [Test]
+    public void IsNonceSetValid_for_key_zero_matches_the_account_nonce()
+    {
+        _state.SetNonce(TestItem.AddressA, 4);
+
+        Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [UInt256.Zero], nonceSeq: 4), Is.True);
+        Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [UInt256.Zero], nonceSeq: 5), Is.False);
+    }
+
+    [Test]
     public void AreNonceKeysWellFormed_accepts_max_keys() =>
         Assert.That(KeyedNonceManager.AreNonceKeysWellFormed(StrictlyIncreasing(Eip8250Constants.MaxNonceKeys)), Is.True);
 

--- a/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
@@ -157,4 +157,22 @@ public class KeyedNonceManagerTests
     [Test]
     public void IsNonceSetValid_false_at_max_nonce_seq() =>
         Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [(UInt256)5], nonceSeq: ulong.MaxValue), Is.False);
+
+    [Test]
+    public void AreNonceKeysWellFormed_accepts_max_keys() =>
+        Assert.That(KeyedNonceManager.AreNonceKeysWellFormed(StrictlyIncreasing(Eip8250Constants.MaxNonceKeys)), Is.True);
+
+    [Test]
+    public void AreNonceKeysWellFormed_rejects_over_max_keys() =>
+        Assert.That(KeyedNonceManager.AreNonceKeysWellFormed(StrictlyIncreasing(Eip8250Constants.MaxNonceKeys + 1)), Is.False);
+
+    private static UInt256[] StrictlyIncreasing(int count)
+    {
+        UInt256[] keys = new UInt256[count];
+        for (int i = 0; i < count; i++)
+        {
+            keys[i] = (UInt256)(i + 1);
+        }
+        return keys;
+    }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
@@ -112,4 +112,49 @@ public class KeyedNonceManagerTests
     [Test]
     public void IsFirstUse_for_key_zero_is_false() =>
         Assert.That(KeyedNonceManager.IsFirstUse(_state, TestItem.AddressA, UInt256.Zero), Is.False);
+
+    [TestCaseSource(nameof(WellFormedKeySets))]
+    public void AreNonceKeysWellFormed_accepts_valid_sets(UInt256[] nonceKeys) =>
+        Assert.That(KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys), Is.True);
+
+    private static UInt256[][] WellFormedKeySets() =>
+    [
+        [UInt256.Zero],
+        [(UInt256)5],
+        [(UInt256)5, (UInt256)9],
+        [(UInt256)1, (UInt256)2, (UInt256)3]
+    ];
+
+    [TestCaseSource(nameof(MalformedKeySets))]
+    public void AreNonceKeysWellFormed_rejects_invalid_sets(UInt256[] nonceKeys) =>
+        Assert.That(KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys), Is.False);
+
+    private static UInt256[][] MalformedKeySets() =>
+    [
+        [],
+        [UInt256.Zero, (UInt256)5],
+        [(UInt256)5, (UInt256)5],
+        [(UInt256)9, (UInt256)5],
+        [(UInt256)5, UInt256.Zero]
+    ];
+
+    [Test]
+    public void IsNonceSetValid_true_when_every_key_matches_seq()
+    {
+        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [(UInt256)5, (UInt256)9], nonceSeq: 41);
+
+        Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [(UInt256)5, (UInt256)9], nonceSeq: 42), Is.True);
+    }
+
+    [Test]
+    public void IsNonceSetValid_false_when_a_key_mismatches()
+    {
+        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [(UInt256)5], nonceSeq: 41);
+
+        Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [(UInt256)5, (UInt256)9], nonceSeq: 42), Is.False);
+    }
+
+    [Test]
+    public void IsNonceSetValid_false_at_max_nonce_seq() =>
+        Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [(UInt256)5], nonceSeq: ulong.MaxValue), Is.False);
 }

--- a/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
@@ -154,6 +154,10 @@ public class KeyedNonceManagerTests
         Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [(UInt256)5, (UInt256)9], nonceSeq: 42), Is.False);
     }
 
+    [TestCaseSource(nameof(MalformedKeySets))]
+    public void IsNonceSetValid_false_for_malformed_sets(UInt256[] nonceKeys) =>
+        Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, nonceKeys, nonceSeq: 0), Is.False);
+
     [Test]
     public void IsNonceSetValid_false_at_max_nonce_seq() =>
         Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [(UInt256)5], nonceSeq: ulong.MaxValue), Is.False);

--- a/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
@@ -171,13 +171,18 @@ public class KeyedNonceManagerTests
         Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [UInt256.Zero], nonceSeq: 5), Is.False);
     }
 
-    [Test]
-    public void AreNonceKeysWellFormed_accepts_max_keys() =>
-        Assert.That(KeyedNonceManager.AreNonceKeysWellFormed(StrictlyIncreasing(Eip8250Constants.MaxNonceKeys)), Is.True);
+    [TestCase(Eip8250Constants.MaxNonceKeys, true)]
+    [TestCase(Eip8250Constants.MaxNonceKeys + 1, false)]
+    public void AreNonceKeysWellFormed_enforces_the_length_upper_bound(int count, bool expected) =>
+        Assert.That(KeyedNonceManager.AreNonceKeysWellFormed(StrictlyIncreasing(count)), Is.EqualTo(expected));
 
     [Test]
-    public void AreNonceKeysWellFormed_rejects_over_max_keys() =>
-        Assert.That(KeyedNonceManager.AreNonceKeysWellFormed(StrictlyIncreasing(Eip8250Constants.MaxNonceKeys + 1)), Is.False);
+    public void IsNonceSetValid_true_at_max_nonce_seq_minus_one()
+    {
+        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, [(UInt256)5], nonceSeq: ulong.MaxValue - 2);
+
+        Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, [(UInt256)5], nonceSeq: ulong.MaxValue - 1), Is.True);
+    }
 
     private static UInt256[] StrictlyIncreasing(int count)
     {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
@@ -59,4 +59,52 @@ public static class KeyedNonceManager
             state.Set(StorageSlot(sender, nonceKey), nextSeq);
         }
     }
+
+    public static bool AreNonceKeysWellFormed(ReadOnlySpan<UInt256> nonceKeys)
+    {
+        if (nonceKeys.Length < 1 || nonceKeys.Length > Eip8250Constants.MaxNonceKeys)
+        {
+            return false;
+        }
+
+        // Key 0 is valid only as the singleton [0].
+        if (nonceKeys[0].IsZero)
+        {
+            return nonceKeys.Length == 1;
+        }
+
+        // Strictly increasing; as the first key is non-zero this also rejects any later 0.
+        for (int i = 1; i < nonceKeys.Length; i++)
+        {
+            if (nonceKeys[i] <= nonceKeys[i - 1])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool IsNonceSetValid(IWorldState state, Address sender, ReadOnlySpan<UInt256> nonceKeys, ulong nonceSeq)
+    {
+        if (!AreNonceKeysWellFormed(nonceKeys))
+        {
+            return false;
+        }
+
+        if (nonceSeq >= Eip8250Constants.MaxNonceSeq)
+        {
+            return false;
+        }
+
+        foreach (UInt256 nonceKey in nonceKeys)
+        {
+            if (CurrentNonceSeq(state, sender, nonceKey) != nonceSeq)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
@@ -60,6 +60,11 @@ public static class KeyedNonceManager
         }
     }
 
+    /// <summary>Checks whether <paramref name="nonceKeys"/> is a well-formed <see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see> nonce-key set.</summary>
+    /// <remarks>
+    /// Well-formed means: length in <c>[1, <see cref="Eip8250Constants.MaxNonceKeys"/>]</c>; key 0 appears only as the
+    /// singleton set <c>[0]</c>; and any multi-key set is strictly increasing, which also excludes a later 0.
+    /// </remarks>
     public static bool AreNonceKeysWellFormed(ReadOnlySpan<UInt256> nonceKeys)
     {
         if (nonceKeys.Length < 1 || nonceKeys.Length > Eip8250Constants.MaxNonceKeys)
@@ -85,6 +90,12 @@ public static class KeyedNonceManager
         return true;
     }
 
+    /// <summary>Checks whether <paramref name="nonceKeys"/>/<paramref name="nonceSeq"/> is a valid set to consume against <paramref name="sender"/>'s current state.</summary>
+    /// <remarks>
+    /// Requires all of: <paramref name="nonceKeys"/> is well-formed (see <see cref="AreNonceKeysWellFormed"/>),
+    /// <paramref name="nonceSeq"/> is below <see cref="Eip8250Constants.MaxNonceSeq"/>, and every key in the set is
+    /// currently at <paramref name="nonceSeq"/> (per <see cref="CurrentNonceSeq"/>). Safe to call on undecoded/untrusted input.
+    /// </remarks>
     public static bool IsNonceSetValid(IWorldState state, Address sender, ReadOnlySpan<UInt256> nonceKeys, ulong nonceSeq)
     {
         if (!AreNonceKeysWellFormed(nonceKeys))
@@ -97,7 +108,7 @@ public static class KeyedNonceManager
             return false;
         }
 
-        foreach (UInt256 nonceKey in nonceKeys)
+        foreach (ref readonly UInt256 nonceKey in nonceKeys)
         {
             if (CurrentNonceSeq(state, sender, nonceKey) != nonceSeq)
             {


### PR DESCRIPTION
Stacked on #12458. Adds the EIP-8250 nonce-set validity to `KeyedNonceManager` — the counterpart of #12457's `IsReferenceValid`. Still an independent building block: no integration into the frame-transaction pipeline (payload decode, validity wiring, and gas follow in a later PR).

## Changes

- `AreNonceKeysWellFormed` — the state-independent EIP-8250 constraints on a decoded `nonce_keys` set: `1..MAX_NONCE_KEYS` entries, strictly increasing, and key `0` only as the singleton `[0]`.
- `IsNonceSetValid` — the stateful check: `nonce_seq < MAX_NONCE_SEQ`, and `nonce_seq == current_nonce_seq(sender, key)` for every selected key. Asserts well-formedness first.
- Tests: valid/invalid key sets (empty, mixed `[0, 5]`, equal, decreasing, trailing `0`) and the stateful match / mismatch / max-seq cases.

The RLP/canonical-encoding decode rejections (non-list, non-minimal integers, `>= 2**256`) belong to the payload decoder and are out of scope here.

> Base is #12458's branch; retarget to `master` once that merges.

Part of #12456, tracks #12454.
