### PR TITLE
feat(evm): EIP-8272 reference-set validity

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -142,6 +142,65 @@ public class RecentRootStoreTests
         }
     }
 
+    [Test]
+    public void AreReferencesValid_true_for_empty_set()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            (ValueHash256, ulong, ValueHash256)[] references = [];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+        }
+    }
+
+    [Test]
+    public void AreReferencesValid_true_when_every_reference_is_valid()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            RecentRootStore.Write(state, Source, Salt, OtherRoot, 150, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+
+            (ValueHash256, ulong, ValueHash256)[] references =
+            [
+                (sourceId, 100UL, Root),
+                (sourceId, 150UL, OtherRoot)
+            ];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+        }
+    }
+
+    [Test]
+    public void AreReferencesValid_false_when_a_reference_is_invalid()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+
+            (ValueHash256, ulong, ValueHash256)[] references =
+            [
+                (sourceId, 100UL, Root),
+                (sourceId, 100UL, OtherRoot)
+            ];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
+        }
+    }
+
+    [Test]
+    public void AreReferencesValid_false_over_the_reference_cap()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + 1];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
+        }
+    }
+
     private static IWorldState CreateState(out IDisposable scope)
     {
         IWorldState state = TestWorldStateFactory.CreateForTest();

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -201,6 +201,24 @@ public class RecentRootStoreTests
         }
     }
 
+    [Test]
+    public void AreReferencesValid_true_at_the_reference_cap()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences];
+            for (int i = 0; i < references.Length; i++)
+            {
+                ulong slot = (ulong)(100 + i);
+                RecentRootStore.Write(state, Source, Salt, Root, slot, Spec);
+                references[i] = (sourceId, slot, Root);
+            }
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 500), Is.True);
+        }
+    }
+
     private static IWorldState CreateState(out IDisposable scope)
     {
         IWorldState state = TestWorldStateFactory.CreateForTest();

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -33,6 +33,19 @@ public class RecentRootStoreTests
         Assert.That(RecentRootStore.SourceId(Source, OtherRoot), Is.Not.EqualTo(baseline));
     }
 
+    // Every concatenation in EIP-8272 is fixed-width, and an address is 20 bytes there, so the
+    // preimage is 52 bytes. Left-padding the address to a word changes every source id, which is
+    // consensus-visible on the first reference-carrying transaction.
+    [Test]
+    public void SourceId_hashes_the_address_unpadded()
+    {
+        Span<byte> preimage = stackalloc byte[Address.Size + ValueHash256.MemorySize];
+        Source.Bytes.CopyTo(preimage);
+        Salt.Bytes.CopyTo(preimage[Address.Size..]);
+
+        Assert.That(RecentRootStore.SourceId(Source, Salt), Is.EqualTo(ValueKeccak.Compute(preimage)));
+    }
+
     [Test]
     public void EntryHash_is_deterministic_and_distinct_per_input()
     {

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -191,6 +191,24 @@ public class RecentRootStoreTests
     }
 
     [Test]
+    public void AreReferencesValid_true_for_duplicate_valid_references()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+
+            (ValueHash256, ulong, ValueHash256)[] references =
+            [
+                (sourceId, 100UL, Root),
+                (sourceId, 100UL, Root)
+            ];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+        }
+    }
+
+    [Test]
     public void AreReferencesValid_false_over_the_reference_cap()
     {
         IWorldState state = CreateState(out IDisposable scope);

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -208,32 +208,23 @@ public class RecentRootStoreTests
         }
     }
 
-    [Test]
-    public void AreReferencesValid_false_over_the_reference_cap()
-    {
-        IWorldState state = CreateState(out IDisposable scope);
-        using (scope)
-        {
-            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + 1];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
-        }
-    }
-
-    [Test]
-    public void AreReferencesValid_true_at_the_reference_cap()
+    [TestCase(0, ExpectedResult = true)]
+    [TestCase(1, ExpectedResult = false)]
+    public bool AreReferencesValid_enforces_the_reference_cap(int overCap)
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
-            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences];
+            // every reference is individually valid, so only the count decides the result
+            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + overCap];
             for (int i = 0; i < references.Length; i++)
             {
                 ulong slot = (ulong)(100 + i);
                 RecentRootStore.Write(state, Source, Salt, Root, slot, Spec);
                 references[i] = (sourceId, slot, Root);
             }
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 500), Is.True);
+            return RecentRootStore.AreReferencesValid(state, references, currentSlot: 500);
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -75,6 +75,24 @@ public static class RecentRootStore
         state.Set(cell, entryHash.Bytes.WithoutLeadingZeros().ToArray());
     }
 
+    public static bool AreReferencesValid(IWorldState state, ReadOnlySpan<(ValueHash256 SourceId, ulong Slot, ValueHash256 Root)> references, ulong currentSlot)
+    {
+        if (references.Length > Eip8272Constants.MaxRecentRootReferences)
+        {
+            return false;
+        }
+
+        foreach ((ValueHash256 sourceId, ulong slot, ValueHash256 root) in references)
+        {
+            if (!IsReferenceValid(state, sourceId, slot, root, currentSlot))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private static StorageCell RingBufferCell(in ValueHash256 sourceId, ulong ringIndex) =>
         new(Eip8272Constants.RecentRootAddress, StorageKey(sourceId, ringIndex).ToUInt256());
 }

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -18,12 +18,11 @@ public static class RecentRootStore
     private const int AddressLength = Address.Size;
     private const int SlotLength = sizeof(ulong);
 
-    // Consensus-critical, spec-ambiguous: 32-byte-padded address matches the only existing implementation (spec text says 20 bytes).
     public static ValueHash256 SourceId(Address sourceAddress, in ValueHash256 salt)
     {
-        Span<byte> input = stackalloc byte[HashLength + HashLength];
-        sourceAddress.Bytes.CopyTo(input.Slice(HashLength - AddressLength, AddressLength));
-        salt.Bytes.CopyTo(input.Slice(HashLength));
+        Span<byte> input = stackalloc byte[AddressLength + HashLength];
+        sourceAddress.Bytes.CopyTo(input);
+        salt.Bytes.CopyTo(input.Slice(AddressLength));
         return ValueKeccak.Compute(input);
     }
 


### PR DESCRIPTION
Stacked on #12457. Adds a reference-set validator to `RecentRootStore`, rounding out the recent-root primitive alongside the existing single-reference `IsReferenceValid`. Still an independent building block: no integration into the frame-transaction pipeline.

## Changes

- `AreReferencesValid(state, references, currentSlot)` — validates a whole `recent_root_references` set against pre-state: the count must not exceed `MAX_RECENT_ROOT_REFERENCES`, and every `(source_id, slot, root)` reference must pass `IsReferenceValid` (usable window + ring-buffer entry match).
- Tests: empty set, all-valid, one-invalid, and over-the-cap.

The per-reference RLP/field decoding (32-byte `source_id`/`root`, `slot < 2**64`) belongs to the payload decoder and is out of scope here.

> Base is #12457's branch; retarget to `master` once that merges.

Part of #12456, tracks #12455.
