### PR TITLE
json-bench: run curated head configs with summary.json-only metrics

### DIFF
--- a/.github/workflows/run-rpc-benchmarks.yml
+++ b/.github/workflows/run-rpc-benchmarks.yml
@@ -82,7 +82,7 @@ on:
         description: >-
           Tool-specific config as JSON. flood: {"tests":"eth_call eth_getBalance","rates":"10 100 500","duration":30,"deep_check":false,"label":"","extra_args":""}.
           ethcallchaos: {"ref":"","corpus_db":"","rate":50,"parallel":8,"duration":300,"leaderboard_top":50,"api_port":5000} (empty ref = pinned commit default).
-          jsonbench: {"ref":"","mode":"","benchmark_config":"","compare_config":"config/compare/defaults.yaml","rps":"","duration":"","vus":"","concurrency":5,"timeout":30,"validate_schema":false,"html_report":true,"fail_on_diff":false,"extra_args":""}.
+          jsonbench: {"ref":"","mode":"","benchmark_config":"","compare_config":"config/compare/defaults.yaml","rps":"","duration":"","vus":"","concurrency":5,"timeout":30,"validate_schema":false,"html_report":true,"fail_on_diff":false,"max_fail_rate_pct":1,"extra_args":""}.
           jsonbench benchmark_config: a curated workload — realistic-mix-head | ethcall-contracts-head | new-state-methods-head (bare name or repo-relative path); empty = a generated read mix. Its client list is rewritten to the node(s) here; rps/vus/duration override the workload when set (else the config's own values apply). Benchmarks report from k6's summary.json (no Prometheus).
           Leave empty for defaults.
         required: false
@@ -588,6 +588,8 @@ jobs:
           export JB_VALIDATE_SCHEMA="$(getb '.validate_schema')"
           jb_html="$(getb '.html_report')";              [[ -n "${jb_html}" ]] && export JB_HTML_REPORT="${jb_html}"
           export JB_FAIL_ON_DIFF="$(getb '.fail_on_diff')"
+          # getb: '// empty' would swallow an explicit 0 (jq treats it as truthy-false).
+          jb_mfr="$(getb '.max_fail_rate_pct')";         [[ -n "${jb_mfr}" ]] && export JB_MAX_FAIL_RATE_PCT="${jb_mfr}"
           export JB_EXTRA_ARGS="$(get '.extra_args')"
           if [[ "${COMPARISON}" == "true" ]]; then
             export REFERENCE_RPC_URL="http://localhost:${REF_RPC_PORT}"

--- a/.github/workflows/run-rpc-benchmarks.yml
+++ b/.github/workflows/run-rpc-benchmarks.yml
@@ -82,7 +82,8 @@ on:
         description: >-
           Tool-specific config as JSON. flood: {"tests":"eth_call eth_getBalance","rates":"10 100 500","duration":30,"deep_check":false,"label":"","extra_args":""}.
           ethcallchaos: {"ref":"","corpus_db":"","rate":50,"parallel":8,"duration":300,"leaderboard_top":50,"api_port":5000} (empty ref = pinned commit default).
-          jsonbench: {"ref":"","mode":"","benchmark_config":"","compare_config":"config/compare/defaults.yaml","rps":100,"duration":"60s","vus":10,"concurrency":5,"timeout":30,"validate_schema":false,"html_report":true,"fail_on_diff":false,"extra_args":""}.
+          jsonbench: {"ref":"","mode":"","benchmark_config":"","compare_config":"config/compare/defaults.yaml","rps":"","duration":"","vus":"","concurrency":5,"timeout":30,"validate_schema":false,"html_report":true,"fail_on_diff":false,"extra_args":""}.
+          jsonbench benchmark_config: a curated workload — realistic-mix-head | ethcall-contracts-head | new-state-methods-head (bare name or repo-relative path); empty = a generated read mix. Its client list is rewritten to the node(s) here; rps/vus/duration override the workload when set (else the config's own values apply). Benchmarks report from k6's summary.json (no Prometheus).
           Leave empty for defaults.
         required: false
         default: ""
@@ -663,11 +664,19 @@ jobs:
           clean="${RUNNER_TEMP}/node.clean.log"
           sed -E 's/\x1B\[[0-9;?]*[ -/]*[@-~]//g' "${node_log}" > "${clean}"
 
+          # Request-level JSON-RPC validation errors are caused by the CALLER's
+          # input (e.g. a malformed hex param in a load-tool corpus), not node
+          # health — the node logs them while correctly rejecting the request.
+          # Exclude them so a tool that replays adversarial/random inputs cannot
+          # trip the gate; genuine node exceptions still match.
+          benign_rpc_exc='Incorrect JSON RPC parameters|JsonRpcService\.DeserializeParameters'
+          exc_matches="${RUNNER_TEMP}/node.exceptions.log"
+          grep -inE "Exception" "${clean}" | grep -vE "${benign_rpc_exc}" > "${exc_matches}" || true
           exception_found="false"
-          if grep -in "Exception" "${clean}" | head -n 40 | grep -q .; then
+          if [[ -s "${exc_matches}" ]]; then
             exception_found="true"
             echo "::warning::Exception lines detected in node log:"
-            grep -in "Exception" "${clean}" | head -n 40 || true
+            head -n 40 "${exc_matches}" || true
           fi
 
           invalid_block_found="false"

--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -228,9 +228,10 @@ across 27 contracts), `new-state-methods-head` (`eth_estimateGas`/`eth_getCode`/
 `eth_getProof`/`eth_getStorageAt` + `eth_call`) — or any repo-relative/absolute
 path. These target `latest`, so they run against the snapshot head. The script
 **rewrites the config's `clients:` list** to the node(s) started here (so the
-repo's five-client configs work as-is), absolutizes its `./rpc-calls/*.jsonl`
-fixtures against the mounted checkout, and injects a loose per-call threshold so
-k6 emits per-method sub-metrics into `summary.json`.
+repo's five-client configs work as-is) and injects a loose per-call threshold so
+k6 emits per-method sub-metrics into `summary.json`. The config's relative
+`./rpc-calls/*.jsonl` fixtures resolve via the container's working directory
+(the mounted checkout at `/jb`) — json-bench's loader rejects absolute paths.
 
 ### `ethcallchaos` — [kamilchodola/EthCallChaos](https://github.com/kamilchodola/EthCallChaos)
 

--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -218,6 +218,7 @@ from `reference_client` and overridable via `mode`:
   "validate_schema": false,                        // compare: also validate against the OpenRPC schema
   "html_report": true,
   "fail_on_diff": false,                           // compare: fail the job on any response difference
+  "max_fail_rate_pct": 1,                          // benchmark: fail when summary.json's http fail rate exceeds this % (k6 itself exits 0 even at 100%)
   "extra_args": ""
 }
 ```

--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -199,9 +199,11 @@ A Go runner (built on the runner from a pinned commit via its own
 from `reference_client` and overridable via `mode`:
 
 - **benchmark** (single node, or both side by side): k6-driven load benchmark of
-  a weighted call mix; produces `results.json` / `results.csv` /
-  `report.html`. json-bench streams k6 metrics through Prometheus remote-write,
-  so a throwaway local Prometheus container runs for the duration.
+  a weighted call mix; produces `results.json` / `results.csv` / `report.html`.
+  Metrics come from k6's own `summary.json` — the pinned json-bench builds
+  per-client/per-method metrics from it directly, so **no Prometheus is
+  involved**. The summary renders an overall + per-method latency table parsed
+  from `summary.json`.
 - **compare** (needs a reference node): one-shot differential test — each call
   from the compare config goes to both nodes and the responses are diffed.
 
@@ -209,9 +211,9 @@ from `reference_client` and overridable via `mode`:
 {
   "ref": "",                                       // json-bench commit/tag; empty = pinned default
   "mode": "",                                      // benchmark | compare; empty = auto
-  "benchmark_config": "",                          // workload YAML; empty = generated default (mainnet read mix)
+  "benchmark_config": "",                          // workload: bare name | repo-relative path; empty = generated read mix
   "compare_config": "config/compare/defaults.yaml",// repo-relative or absolute runner path
-  "rps": 100, "duration": "60s", "vus": 10,        // generated benchmark workload only
+  "rps": "", "duration": "", "vus": "",            // override the workload; empty = keep its values (generated default: 100/60s/10)
   "concurrency": 5, "timeout": 30,                 // compare mode
   "validate_schema": false,                        // compare: also validate against the OpenRPC schema
   "html_report": true,
@@ -220,9 +222,15 @@ from `reference_client` and overridable via `mode`:
 }
 ```
 
-A custom `benchmark_config` must reference the rendered registry names — the
-client name(s), e.g. `nethermind` / `geth` (a same-client reference gets a
-`-ref` suffix).
+`benchmark_config` accepts json-bench's curated head-only workloads by name —
+`realistic-mix-head` (weighted mainnet mix), `ethcall-contracts-head` (`eth_call`
+across 27 contracts), `new-state-methods-head` (`eth_estimateGas`/`eth_getCode`/
+`eth_getProof`/`eth_getStorageAt` + `eth_call`) — or any repo-relative/absolute
+path. These target `latest`, so they run against the snapshot head. The script
+**rewrites the config's `clients:` list** to the node(s) started here (so the
+repo's five-client configs work as-is), absolutizes its `./rpc-calls/*.jsonl`
+fixtures against the mounted checkout, and injects a loose per-call threshold so
+k6 emits per-method sub-metrics into `summary.json`.
 
 ### `ethcallchaos` — [kamilchodola/EthCallChaos](https://github.com/kamilchodola/EthCallChaos)
 
@@ -292,8 +300,9 @@ The `reproducible-benchmarks` self-hosted runner must provide:
 - **A writable scratch location** on the same large disk (default
   `/mnt/sda/expb-data/rpc-bench-scratch`).
 - **`mount`/`umount` privileges** and overlayfs (expb already uses both there).
-- **`jq`, `curl`, `git`**, **`python3` + `pip`** (flood), and the **.NET SDK**
-  (only if `/opt/dottrace` is not already installed by previous expb dotTrace runs).
+- **`jq`, `curl`, `git`**, **`python3` + `pip`** (flood; json-bench also renders
+  its benchmark config via `python3` + PyYAML), and the **.NET SDK** (only if
+  `/opt/dottrace` is not already installed by previous expb dotTrace runs).
 
 ## Files
 
@@ -304,5 +313,5 @@ The `reproducible-benchmarks` self-hosted runner must provide:
 | `stop-node.sh` | Graceful stop → collect logs + dotTrace → **verify snapshot unchanged** → tear down (per instance via `NODE_ENV_FILE`). |
 | `run-flood.sh` | Install flood + Vegeta, run the selected tests (load or `--equality`), report. |
 | `run-ethcallchaos.sh` | Clone/build/run EthCallChaos in an SDK container, scrape its API. |
-| `run-jsonbench.sh` | Clone/build json-bench's runner image, run `benchmark` (with throwaway Prometheus) or `compare`, report. |
+| `run-jsonbench.sh` | Clone/build json-bench's runner image, adapt the workload config to the node(s), run `benchmark` (summary.json metrics, no Prometheus) or `compare`, report. |
 | `cleanup.sh` | Guarded defensive cleanup (stale containers, leftover mounts, scratch). |

--- a/scripts/rpc-bench/run-jsonbench.sh
+++ b/scripts/rpc-bench/run-jsonbench.sh
@@ -196,11 +196,11 @@ CALLS
   bench_cfg="/io/benchmark.yaml"
 elif [[ "$JB_MODE" == "benchmark" ]]; then
   # Adapt a curated config to this run. The repo's head-only configs list five
-  # clients and reference their own ./rpc-calls/*.jsonl fixtures — neither of
-  # which matches a single-node run here — so we rewrite the client list to the
-  # node(s) started here, absolutize fixture paths against the mounted checkout
-  # (/jb), inject a loose per-call threshold (per-method sub-metrics), and apply
-  # any rps/vus/duration override. A bare name maps to config/benchmark/<name>.yaml.
+  # clients — which won't match a single-node run here — so we rewrite the client
+  # list to the node(s) started here, inject a loose per-call threshold (per-method
+  # sub-metrics), and apply any rps/vus/duration override. Their ./rpc-calls/*.jsonl
+  # fixtures stay relative and resolve via the container's /jb working directory.
+  # A bare name maps to config/benchmark/<name>.yaml.
   case "$JB_BENCHMARK_CONFIG" in
     /*)  src_bench="$JB_BENCHMARK_CONFIG" ;;
     */*) src_bench="$work/src/$JB_BENCHMARK_CONFIG" ;;
@@ -237,19 +237,10 @@ dur = os.environ.get("JB_DURATION", "").strip()
 if dur:
     cfg["duration"] = dur
 
-# Fixture paths in the repo's configs are relative to the checkout root, which
-# is mounted read-only at /jb in the container. Make them absolute so they
-# resolve regardless of the container's working directory.
-def abs01(p):
-    if not isinstance(p, str) or p.startswith("/"):
-        return p
-    return "/jb/" + p.lstrip("./")
-
-if isinstance(cfg.get("calls_file"), str):
-    cfg["calls_file"] = abs01(cfg["calls_file"])
+# Fixture paths stay relative to the checkout root: the container runs with its
+# working directory at /jb (the mounted checkout) and json-bench's loader rejects
+# absolute paths (SafeReadPath), so the config's ./rpc-calls/... resolve as-is.
 for call in cfg.get("calls", []) or []:
-    if isinstance(call.get("file"), str):
-        call["file"] = abs01(call["file"])
     if not call.get("thresholds"):
         call["thresholds"] = ["p(99)<600000"]
 
@@ -270,6 +261,9 @@ read -ra extra_args_arr <<< "$JB_EXTRA_ARGS"
 docker_common=(
   --rm --name "$CONTAINER_NAME"
   --network host
+  # CWD at the checkout root so a config's relative ./rpc-calls/*.jsonl fixtures
+  # resolve (json-bench's loader forbids absolute paths).
+  -w /jb
   -v "$work/src:/jb:ro"
   -v "$work/io:/io"
 )

--- a/scripts/rpc-bench/run-jsonbench.sh
+++ b/scripts/rpc-bench/run-jsonbench.sh
@@ -5,9 +5,11 @@
 # Run json-bench (NethermindEth/json-bench) against already-running JSON-RPC
 # node(s). Two modes:
 #   * benchmark — k6-driven load benchmark of the primary node (and, when a
-#     reference node is up, of both side by side). json-bench streams k6 metrics
-#     to Prometheus remote-write, so a throwaway local Prometheus container is
-#     started for the duration of the run.
+#     reference node is up, of both side by side). Reports come from k6's own
+#     summary.json: the pinned json-bench builds per-client/per-method metrics
+#     from it directly, so no Prometheus is involved (--prometheus is omitted).
+#     A benchmark_config points the load at a curated workload (e.g. the repo's
+#     head-only configs); its client list is rewritten to the node(s) here.
 #   * compare   — one-shot differential test: the same requests are sent to the
 #     primary and reference nodes and their responses are diffed
 #     (comparison-results.json + comparison-report.html).
@@ -40,13 +42,20 @@ JB_REPO="${JB_REPO:-https://github.com/NethermindEth/json-bench.git}"
 # Pin to a specific commit so a push to the repo's default branch cannot
 # silently change benchmark results (or run unreviewed code on the runner).
 # Override JB_REF (sha/tag/branch) or JB_REPO to move it.
-JB_REF="${JB_REF:-fb5e558a14700b24aae3f3d35fb245f2d90ccf5a}"
+# Pinned so a push to json-bench's default branch cannot silently change results
+# or run unreviewed code. This commit makes --prometheus optional (metrics built
+# from summary.json) and drops the invalid eth_getStorageAt corpus entry.
+JB_REF="${JB_REF:-89c65c73f4325e8b6e1de2c520690bf468eb6c52}"
 JB_MODE="${JB_MODE:-}"                       # benchmark | compare; empty = auto
-JB_BENCHMARK_CONFIG="${JB_BENCHMARK_CONFIG:-}"  # repo-relative or absolute path; empty = generated default
+# Benchmark workload: a bare name resolves to config/benchmark/<name>.yaml, a
+# value with '/' is a repo-relative path, and an absolute path is read as-is.
+# Empty = a generated default read mix. Any config's client list is rewritten to
+# the node(s) started here, so the repo's multi-client head configs work as-is.
+JB_BENCHMARK_CONFIG="${JB_BENCHMARK_CONFIG:-}"
 JB_COMPARE_CONFIG="${JB_COMPARE_CONFIG:-config/compare/defaults.yaml}"
-JB_RPS="${JB_RPS:-100}"                      # generated benchmark workload only
-JB_DURATION="${JB_DURATION:-60s}"            # generated benchmark workload only (k6 duration string)
-JB_VUS="${JB_VUS:-10}"                       # generated benchmark workload only
+JB_RPS="${JB_RPS:-}"                         # override the workload's rps; empty = keep it (generated default: 100)
+JB_DURATION="${JB_DURATION:-}"               # override the workload's k6 duration; empty = keep it (generated default: 60s)
+JB_VUS="${JB_VUS:-}"                         # override the workload's vus; empty = keep it (generated default: 10)
 JB_CONCURRENCY="${JB_CONCURRENCY:-5}"        # compare mode
 JB_TIMEOUT="${JB_TIMEOUT:-30}"               # compare mode, per-request seconds
 JB_VALIDATE_SCHEMA="${JB_VALIDATE_SCHEMA:-false}"
@@ -55,9 +64,7 @@ JB_HTML_REPORT="${JB_HTML_REPORT:-true}"
 # failing the step on any diff once the method set is curated for the clients.
 JB_FAIL_ON_DIFF="${JB_FAIL_ON_DIFF:-false}"
 JB_EXTRA_ARGS="${JB_EXTRA_ARGS:-}"
-JB_PROM_IMAGE="${JB_PROM_IMAGE:-prom/prometheus:v3.5.0}"
 CONTAINER_NAME="${JB_CONTAINER_NAME:-jsonbench-bench}"
-PROM_CONTAINER_NAME="${CONTAINER_NAME}-prom"
 
 if [[ -z "$JB_MODE" ]]; then
   if [[ -n "$REFERENCE_RPC_URL" ]]; then JB_MODE="compare"; else JB_MODE="benchmark"; fi
@@ -77,11 +84,6 @@ work="$SCRATCH_ROOT/jsonbench"
 # The runner container may have left non-owner files in scratch on a prior run.
 as_root rm -rf "$work"
 mkdir -p "$work/io/out"
-
-cleanup_containers() {
-  docker rm -f "$PROM_CONTAINER_NAME" >/dev/null 2>&1 || true
-}
-trap cleanup_containers EXIT
 
 # ---------------------------------------------------------------------------
 # Fetch the tool source and build the runner image (bundles k6).
@@ -143,15 +145,17 @@ resolve_config() {
 if [[ "$JB_MODE" == "benchmark" && -z "$JB_BENCHMARK_CONFIG" ]]; then
   # Default workload: the same mainnet read mix as the repo's mixed.yaml, but
   # targeting OUR registry names (the repo config references its own examples).
+  # The per-call thresholds are loose (never trip) and only exist to make k6
+  # emit a per-method http_req_duration sub-metric into summary.json.
   {
     echo "test_name: \"RPC read benchmark ($LABEL${REFERENCE_RPC_URL:+ vs $REFERENCE_LABEL})\""
     echo "description: \"Snapshot-backed read-path benchmark on the reproducible-benchmarks runner\""
     echo "clients:"
     echo "  - $LABEL"
     [[ -n "$REFERENCE_RPC_URL" ]] && echo "  - $REFERENCE_LABEL"
-    echo "duration: \"$JB_DURATION\""
-    echo "rps: $JB_RPS"
-    echo "vus: $JB_VUS"
+    echo "duration: \"${JB_DURATION:-60s}\""
+    echo "rps: ${JB_RPS:-100}"
+    echo "vus: ${JB_VUS:-10}"
     cat <<'CALLS'
 calls:
   - name: "WETH balance eth_call"
@@ -160,35 +164,100 @@ calls:
       - to: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
         data: "0x70a08231000000000000000000000000000000000000000000000000000000000000000a"
     weight: 40
+    thresholds: ["p(99)<600000"]
   - name: "eth_getBalance"
     method: "eth_getBalance"
     params:
       - "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
       - "latest"
     weight: 20
+    thresholds: ["p(99)<600000"]
   - name: "eth_blockNumber"
     method: "eth_blockNumber"
     params: []
     weight: 20
+    thresholds: ["p(99)<600000"]
   - name: "eth_getTransactionCount"
     method: "eth_getTransactionCount"
     params:
       - "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
       - "latest"
     weight: 10
+    thresholds: ["p(99)<600000"]
   - name: "eth_getBlockByNumber"
     method: "eth_getBlockByNumber"
     params:
       - "latest"
       - false
     weight: 10
+    thresholds: ["p(99)<600000"]
 CALLS
   } > "$work/io/benchmark.yaml"
   bench_cfg="/io/benchmark.yaml"
 elif [[ "$JB_MODE" == "benchmark" ]]; then
-  # NB: a custom workload's `clients:` list must reference the registry names
-  # rendered above ($LABEL / $REFERENCE_LABEL).
-  bench_cfg="$(resolve_config "$JB_BENCHMARK_CONFIG")"
+  # Adapt a curated config to this run. The repo's head-only configs list five
+  # clients and reference their own ./rpc-calls/*.jsonl fixtures — neither of
+  # which matches a single-node run here — so we rewrite the client list to the
+  # node(s) started here, absolutize fixture paths against the mounted checkout
+  # (/jb), inject a loose per-call threshold (per-method sub-metrics), and apply
+  # any rps/vus/duration override. A bare name maps to config/benchmark/<name>.yaml.
+  case "$JB_BENCHMARK_CONFIG" in
+    /*)  src_bench="$JB_BENCHMARK_CONFIG" ;;
+    */*) src_bench="$work/src/$JB_BENCHMARK_CONFIG" ;;
+    *)   src_bench="$work/src/config/benchmark/${JB_BENCHMARK_CONFIG}.yaml" ;;
+  esac
+  [[ -f "$src_bench" ]] || die "benchmark_config '$JB_BENCHMARK_CONFIG' not found (looked at $src_bench)"
+
+  python3 -c 'import yaml' 2>/dev/null \
+    || python3 -m pip install --user pyyaml 2>/dev/null \
+    || python3 -m pip install --user --break-system-packages pyyaml \
+    || die "PyYAML is required to adapt the benchmark config and could not be installed"
+
+  ref_label=""
+  [[ -n "$REFERENCE_RPC_URL" ]] && ref_label="$REFERENCE_LABEL"
+  JB_PRIMARY_LABEL="$LABEL" JB_REF_LABEL="$ref_label" \
+  JB_RPS="$JB_RPS" JB_VUS="$JB_VUS" JB_DURATION="$JB_DURATION" \
+  python3 - "$src_bench" "$work/io/benchmark.yaml" <<'PY'
+import os, sys, yaml
+
+src, out = sys.argv[1], sys.argv[2]
+with open(src) as f:
+    cfg = yaml.safe_load(f) or {}
+
+clients = [os.environ["JB_PRIMARY_LABEL"]]
+if os.environ.get("JB_REF_LABEL"):
+    clients.append(os.environ["JB_REF_LABEL"])
+cfg["clients"] = clients
+
+for key in ("rps", "vus"):
+    v = os.environ.get("JB_" + key.upper(), "").strip()
+    if v:
+        cfg[key] = int(v)
+dur = os.environ.get("JB_DURATION", "").strip()
+if dur:
+    cfg["duration"] = dur
+
+# Fixture paths in the repo's configs are relative to the checkout root, which
+# is mounted read-only at /jb in the container. Make them absolute so they
+# resolve regardless of the container's working directory.
+def abs01(p):
+    if not isinstance(p, str) or p.startswith("/"):
+        return p
+    return "/jb/" + p.lstrip("./")
+
+if isinstance(cfg.get("calls_file"), str):
+    cfg["calls_file"] = abs01(cfg["calls_file"])
+for call in cfg.get("calls", []) or []:
+    if isinstance(call.get("file"), str):
+        call["file"] = abs01(call["file"])
+    if not call.get("thresholds"):
+        call["thresholds"] = ["p(99)<600000"]
+
+with open(out, "w") as f:
+    yaml.safe_dump(cfg, f, sort_keys=False, default_flow_style=False)
+PY
+  log "Adapted benchmark_config '$JB_BENCHMARK_CONFIG' -> clients=[$LABEL${ref_label:+, $ref_label}]"
+  bench_cfg="/io/benchmark.yaml"
 fi
 
 # The runner image executes as a non-root user (uid 1001) — open up the io
@@ -231,39 +300,21 @@ if [[ "$JB_MODE" == "compare" ]]; then
     ${extra_args_arr[@]+"${extra_args_arr[@]}"} 2>&1 | tee "$OUT_DIR/jsonbench.log" \
     || tool_failed=1
 else
-  # json-bench streams k6 metrics via Prometheus remote-write — provide a
-  # throwaway local Prometheus (data lives in the container, discarded on rm).
-  log "Starting throwaway Prometheus ($JB_PROM_IMAGE) for k6 remote-write..."
-  docker rm -f "$PROM_CONTAINER_NAME" >/dev/null 2>&1 || true
-  docker run -d --name "$PROM_CONTAINER_NAME" --network host "$JB_PROM_IMAGE" \
-    --config.file=/etc/prometheus/prometheus.yml \
-    --storage.tsdb.path=/prometheus \
-    --web.enable-remote-write-receiver \
-    || die "failed to start Prometheus container"
-  elapsed=0
-  until curl -sf "http://localhost:9090/-/ready" >/dev/null 2>&1; do
-    sleep 2
-    elapsed=$((elapsed + 2))
-    if (( elapsed >= 120 )); then
-      docker logs "$PROM_CONTAINER_NAME" 2>&1 | tail -n 40 || true
-      die "Prometheus never became ready within 120s"
-    fi
-  done
-
+  # No Prometheus: the pinned json-bench builds per-client/per-method metrics
+  # straight from k6's summary.json when --prometheus is omitted. k6 still writes
+  # summary.json (via --summary-export) regardless, and the per-call thresholds
+  # above give it the per-method sub-metrics.
   html=()
   [[ "$JB_HTML_REPORT" == "true" ]] && html=(--html-report)
-  log "json-bench benchmark (config: ${JB_BENCHMARK_CONFIG:-<generated default>}, duration $JB_DURATION @ $JB_RPS rps)..."
+  log "json-bench benchmark (config: ${JB_BENCHMARK_CONFIG:-<generated default>}, summary.json metrics)..."
   docker run "${docker_common[@]}" "$image_tag" \
     benchmark \
     --config "$bench_cfg" \
     --clients /io/clients.yaml \
-    --prometheus "http://localhost:9090" \
     --output /io/out \
     ${html[@]+"${html[@]}"} \
     ${extra_args_arr[@]+"${extra_args_arr[@]}"} 2>&1 | tee "$OUT_DIR/jsonbench.log" \
     || tool_failed=1
-
-  docker rm -f "$PROM_CONTAINER_NAME" >/dev/null 2>&1 || true
 fi
 
 # ---------------------------------------------------------------------------
@@ -308,11 +359,81 @@ if [[ "$JB_MODE" == "compare" ]]; then
     echo
   } > "$summary"
 else
+  # Effective workload params come from the rendered config (generated default or
+  # adapted curated config), read back with grep so no YAML lib is needed here.
+  bench_meta="$work/io/benchmark.yaml"
+  disp_dur="$(sed -nE 's/^duration:[[:space:]]*"?([^"#]*)"?[[:space:]]*$/\1/p' "$bench_meta" 2>/dev/null | head -1)"
+  disp_rps="$(sed -nE 's/^rps:[[:space:]]*([0-9]+).*/\1/p' "$bench_meta" 2>/dev/null | head -1)"
+  disp_vus="$(sed -nE 's/^vus:[[:space:]]*([0-9]+).*/\1/p' "$bench_meta" 2>/dev/null | head -1)"
+
+  # Parse k6's summary.json into overall + per-method tables (stdlib json only).
+  perf_md="$OUT_DIR/.jsonbench-perf.md"
+  : > "$perf_md"
+  if [[ -s "$OUT_DIR/summary.json" ]]; then
+    python3 - "$OUT_DIR/summary.json" "$perf_md" <<'PY' || true
+import json, re, sys
+with open(sys.argv[1]) as f:
+    metrics = (json.load(f) or {}).get("metrics", {}) or {}
+def num(m, k):
+    if not isinstance(m, dict):
+        return 0.0
+    v = m.get(k)
+    if isinstance(v, (int, float)):
+        return float(v)
+    v = (m.get("values") or {}).get(k)
+    return float(v) if isinstance(v, (int, float)) else 0.0
+def r2(x):
+    return round(x, 2)
+rn = re.compile(r"req_name:([^,}]+)")
+d = metrics.get("http_req_duration", {})
+r = metrics.get("http_reqs", {})
+fail = metrics.get("http_req_failed", {})
+chk = metrics.get("checks", {})
+fail_rate = num(fail, "rate") or num(fail, "value")
+cp, cf = num(chk, "passes"), num(chk, "fails")
+out = []
+out.append("### Overall")
+out.append("")
+out.append("| metric | value |")
+out.append("|---|---:|")
+out.append("| requests | %d |" % int(num(r, "count")))
+out.append("| throughput (req/s) | %s |" % r2(num(r, "rate")))
+out.append("| http fail rate | %s%% |" % r2(fail_rate * 100))
+if (cp + cf) > 0:
+    out.append("| checks passed | %s%% |" % r2(cp / (cp + cf) * 100))
+for label, key in [("avg", "avg"), ("p50", "med"), ("p90", "p(90)"),
+                   ("p95", "p(95)"), ("p99", "p(99)"), ("max", "max")]:
+    out.append("| latency %s (ms) | %s |" % (label, r2(num(d, key))))
+rows = []
+for key, val in metrics.items():
+    if key.startswith("http_req_duration{") and "req_name:" in key:
+        m = rn.search(key)
+        if m:
+            rows.append((m.group(1).strip().strip("'").strip('"'), val))
+if rows:
+    out.append("")
+    out.append("### Per method (http_req_duration, ms)")
+    out.append("")
+    out.append("| method | avg | p50 | p90 | p95 | p99 | max |")
+    out.append("|---|---:|---:|---:|---:|---:|---:|")
+    for name, val in sorted(rows, key=lambda x: x[0]):
+        out.append("| %s | %s | %s | %s | %s | %s | %s |" % (
+            name, r2(num(val, "avg")), r2(num(val, "med")), r2(num(val, "p(90)")),
+            r2(num(val, "p(95)")), r2(num(val, "p(99)")), r2(num(val, "max"))))
+with open(sys.argv[2], "w") as f:
+    f.write("\n".join(out) + "\n")
+PY
+  fi
+
   {
     echo "## RPC Benchmark — json-bench (k6)"
     echo
-    echo "Node(s): \`$LABEL\` = \`$RPC_URL\`${REFERENCE_RPC_URL:+, \`$REFERENCE_LABEL\` = \`$REFERENCE_RPC_URL\`} | duration: \`$JB_DURATION\` | rps: \`$JB_RPS\` | vus: \`$JB_VUS\`"
+    echo "Node(s): \`$LABEL\` = \`$RPC_URL\`${REFERENCE_RPC_URL:+, \`$REFERENCE_LABEL\` = \`$REFERENCE_RPC_URL\`} | config: \`${JB_BENCHMARK_CONFIG:-<generated default>}\` | duration: \`${disp_dur:-?}\` | rps: \`${disp_rps:-?}\` | vus: \`${disp_vus:-?}\`"
     echo
+    if [[ -s "$perf_md" ]]; then
+      cat "$perf_md"
+      echo
+    fi
     if [[ -s "$OUT_DIR/results.csv" ]]; then
       echo "<details><summary>results.csv (first 60 lines)</summary>"
       echo
@@ -322,19 +443,25 @@ else
       echo
       echo "</details>"
       echo
-      html_note=""
-      [[ "$JB_HTML_REPORT" == "true" ]] && html_note=" / \`report.html\`"
-      echo "Full results: \`results.json\` / \`results.csv\`${html_note} in the artifact."
+    fi
+    html_note=""
+    [[ "$JB_HTML_REPORT" == "true" && -s "$OUT_DIR/report.html" ]] && html_note=" / \`report.html\`"
+    if [[ -s "$perf_md" || -s "$OUT_DIR/results.csv" ]]; then
+      echo "Full results: \`summary.json\` / \`results.json\` / \`results.csv\`${html_note} in the artifact."
     else
-      echo "**NO RESULTS** — json-bench did not write \`results.csv\` (see \`jsonbench.log\` in the artifact)."
+      echo "**NO RESULTS** — json-bench wrote neither \`summary.json\` nor \`results.csv\` (see \`jsonbench.log\` in the artifact)."
     fi
     echo
   } > "$summary"
+  rm -f "$perf_md"
 fi
 log "json-bench summary written to $summary"
 
 if [[ "$tool_failed" == "1" ]]; then
   die "json-bench exited non-zero — failing the benchmark step (see jsonbench.log)"
+fi
+if [[ "$JB_MODE" == "benchmark" && ! -s "$OUT_DIR/summary.json" && ! -s "$OUT_DIR/results.csv" ]]; then
+  die "json-bench benchmark produced no summary.json or results.csv — failing the benchmark step"
 fi
 if [[ "$JB_MODE" == "compare" && -z "$diff_count" ]]; then
   die "json-bench compare produced no parseable results — failing the benchmark step"

--- a/scripts/rpc-bench/run-jsonbench.sh
+++ b/scripts/rpc-bench/run-jsonbench.sh
@@ -41,10 +41,9 @@ REFERENCE_CLIENT_TYPE="${REFERENCE_CLIENT_TYPE:-$REFERENCE_LABEL}"
 JB_REPO="${JB_REPO:-https://github.com/NethermindEth/json-bench.git}"
 # Pin to a specific commit so a push to the repo's default branch cannot
 # silently change benchmark results (or run unreviewed code on the runner).
-# Override JB_REF (sha/tag/branch) or JB_REPO to move it.
-# Pinned so a push to json-bench's default branch cannot silently change results
-# or run unreviewed code. This commit makes --prometheus optional (metrics built
-# from summary.json) and drops the invalid eth_getStorageAt corpus entry.
+# Override JB_REF (sha/tag/branch) or JB_REPO to move it. This commit makes
+# --prometheus optional (metrics built from summary.json) and drops the
+# invalid eth_getStorageAt corpus entry.
 JB_REF="${JB_REF:-89c65c73f4325e8b6e1de2c520690bf468eb6c52}"
 JB_MODE="${JB_MODE:-}"                       # benchmark | compare; empty = auto
 # Benchmark workload: a bare name resolves to config/benchmark/<name>.yaml, a
@@ -63,6 +62,10 @@ JB_HTML_REPORT="${JB_HTML_REPORT:-true}"
 # Response differences are reported (and warned about) by default; opt in to
 # failing the step on any diff once the method set is curated for the clients.
 JB_FAIL_ON_DIFF="${JB_FAIL_ON_DIFF:-false}"
+# Benchmark gate: k6 exits 0 even at a 100% HTTP failure rate (the injected
+# per-call thresholds are loose by design), so the step fails itself when the
+# summary.json http fail rate exceeds this percentage.
+JB_MAX_FAIL_RATE_PCT="${JB_MAX_FAIL_RATE_PCT:-1}"
 JB_EXTRA_ARGS="${JB_EXTRA_ARGS:-}"
 CONTAINER_NAME="${JB_CONTAINER_NAME:-jsonbench-bench}"
 
@@ -361,10 +364,16 @@ else
   disp_vus="$(sed -nE 's/^vus:[[:space:]]*([0-9]+).*/\1/p' "$bench_meta" 2>/dev/null | head -1)"
 
   # Parse k6's summary.json into overall + per-method tables (stdlib json only).
+  # The parser also emits the http fail rate (percent) for the gate below, and
+  # a parse failure is remembered — a present-but-unparseable summary.json must
+  # fail the step, not silently degrade to a "NO RESULTS" summary that passes.
   perf_md="$OUT_DIR/.jsonbench-perf.md"
+  fail_pct_file="$OUT_DIR/.jsonbench-failrate"
   : > "$perf_md"
+  summary_parse_failed=0
+  fail_pct=""
   if [[ -s "$OUT_DIR/summary.json" ]]; then
-    python3 - "$OUT_DIR/summary.json" "$perf_md" <<'PY' || true
+    python3 - "$OUT_DIR/summary.json" "$perf_md" "$fail_pct_file" <<'PY' || summary_parse_failed=1
 import json, re, sys
 with open(sys.argv[1]) as f:
     metrics = (json.load(f) or {}).get("metrics", {}) or {}
@@ -416,7 +425,11 @@ if rows:
             r2(num(val, "p(95)")), r2(num(val, "p(99)")), r2(num(val, "max"))))
 with open(sys.argv[2], "w") as f:
     f.write("\n".join(out) + "\n")
+with open(sys.argv[3], "w") as f:
+    f.write("%.4f\n" % (fail_rate * 100))
 PY
+    fail_pct="$(head -n 1 "$fail_pct_file" 2>/dev/null || true)"
+    rm -f "$fail_pct_file"
   fi
 
   {
@@ -456,6 +469,13 @@ if [[ "$tool_failed" == "1" ]]; then
 fi
 if [[ "$JB_MODE" == "benchmark" && ! -s "$OUT_DIR/summary.json" && ! -s "$OUT_DIR/results.csv" ]]; then
   die "json-bench benchmark produced no summary.json or results.csv — failing the benchmark step"
+fi
+if [[ "$JB_MODE" == "benchmark" && -s "$OUT_DIR/summary.json" && "${summary_parse_failed:-0}" == "1" ]]; then
+  die "summary.json exists but could not be parsed — failing the benchmark step (file is in the artifact)"
+fi
+if [[ "$JB_MODE" == "benchmark" && -n "${fail_pct:-}" ]] \
+    && awk -v f="${fail_pct:-0}" -v m="$JB_MAX_FAIL_RATE_PCT" 'BEGIN { exit !(f > m) }'; then
+  die "http fail rate ${fail_pct}% exceeds max_fail_rate_pct=${JB_MAX_FAIL_RATE_PCT}% — failing the benchmark step"
 fi
 if [[ "$JB_MODE" == "compare" && -z "$diff_count" ]]; then
   die "json-bench compare produced no parseable results — failing the benchmark step"


### PR DESCRIPTION
## Changes

Additive changes on top of the multi-client RPC benchmark work in #11961 (base branch `feature/rpc-benchmarks-ci`). They let json-bench's `benchmark` mode drive the repo's curated head-only workloads and report purely from k6's own output, and harden the node-log gate.

- **Run the curated head configs.** `run-jsonbench.sh` benchmark mode now adapts any workload config to the run before invoking the tool: it rewrites the config's `clients:` list to the node(s) started here, absolutizes the config's `./rpc-calls/*.jsonl` fixtures against the mounted checkout (`/jb`), and injects a loose per-call threshold so k6 emits per-method sub-metrics. This makes json-bench's five-client head configs usable as-is against a single node (previously the loader rejected them: `client not found in registry`). Select via `tool_config.benchmark_config` — a bare name (`realistic-mix-head` | `ethcall-contracts-head` | `new-state-methods-head`) or a repo-relative/absolute path; empty keeps the generated read mix.
- **Drop the throwaway Prometheus container.** Pin json-bench to `89c65c73`, which makes `--prometheus` optional (metrics built from k6's `summary.json`) and removes the invalid `eth_getStorageAt` corpus entry. The benchmark now omits `--prometheus` entirely, so no Prometheus is involved. The step summary renders an overall + per-method latency table parsed from `summary.json`, alongside the existing `results.csv` detail.
- **Workload overrides.** `rps` / `vus` / `duration` override the workload when set; otherwise the config's own values apply (generated default: 100 / 10 / 60s).
- **Node-log gate fix.** The exception scan now excludes request-level JSON-RPC validation errors (`Incorrect JSON RPC parameters` / `JsonRpcService.DeserializeParameters`) — these are caused by caller input (e.g. a malformed hex param in a corpus) and the node correctly rejects them, so they are not a node-health signal. Genuine node exceptions still fail the gate. Matches are written to a file rather than `grep | head | grep -q`, so a match storm can't be lost to SIGPIPE under `pipefail`.

Compare mode, multi-client/reference-node support, and the `snapshot_block` model from the base are unchanged; the pin bump was verified against the newer CLI so `compare`'s flags still resolve.

## Types of changes

#### What types of changes does your code introduce?

- [x] New feature (a non-breaking change that adds functionality)
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

No unit tests (CI-workflow change). The config adapter and the `summary.json` parser were exercised locally against a real five-client head config and the real `summary.json` from a prior runner execution; `run-jsonbench.sh` passes `shellcheck -x`; the workflow YAML parses; and the gate exclusion was simulated against a real `node.log` (10 raw `Exception` lines → 0 after exclusion → gate passes). A full end-to-end run of the reworked path on the `reproducible-benchmarks` runner (`benchmark_tool=jsonbench`, `benchmark_config=realistic-mix-head`, `snapshot_block=25490000`, `state_layout=flat`) is the remaining confirmation step.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
