### PR TITLE
refactor(evm): move call-frame metadata from VmState to ExecutionEnvironment

### DIFF
--- a/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
@@ -57,6 +57,50 @@ namespace Nethermind.Evm
         /// </summary>
         public ReadOnlyMemory<byte> InputData { get; private set; }
 
+        // The following describe how this frame was invoked. They are populated by
+        // <see cref="VmState{TGasPolicy}"/> when the frame is rented and cleared on Dispose.
+
+        /// <summary>
+        /// Offset in the caller's memory where this frame's output is written.
+        /// </summary>
+        internal long OutputDestination { get; set; }
+
+        /// <summary>
+        /// Number of output bytes the caller expects written back into its memory.
+        /// </summary>
+        internal long OutputLength { get; set; }
+
+        /// <summary>
+        /// The kind of call that created this frame (CALL, DELEGATECALL, CREATE, ...).
+        /// </summary>
+        public ExecutionType ExecutionType { get; internal set; }
+
+        /// <summary>
+        /// Whether this is the top-level frame of the transaction.
+        /// </summary>
+        public bool IsTopLevel { get; internal set; }
+
+        /// <summary>
+        /// Whether this frame executes in a static context (no state modifications allowed).
+        /// </summary>
+        public bool IsStatic { get; internal set; }
+
+        /// <summary>
+        /// Whether this CREATE targets an account that already exists.
+        /// </summary>
+        public bool IsCreateOnPreExistingAccount { get; internal set; }
+
+        /// <summary>
+        /// Whether CREATE state gas has been charged for this frame.
+        /// </summary>
+        public bool IsCreateStateGasCharged { get; internal set; }
+
+        /// <summary>
+        /// EIP-8037: the parent <c>*CALL</c> charged NEW_ACCOUNT state gas up-front for this (dead)
+        /// recipient; on this frame's error/revert no account is created, so the parent refunds it.
+        /// </summary>
+        public bool NewAccountCharged { get; internal set; }
+
         private ExecutionEnvironment() { }
 
         /// <summary>
@@ -96,6 +140,14 @@ namespace Nethermind.Evm
                 CallDepth = 0;
                 _value = default;
                 InputData = default;
+                OutputDestination = 0;
+                OutputLength = 0;
+                ExecutionType = default;
+                IsTopLevel = false;
+                IsStatic = false;
+                IsCreateOnPreExistingAccount = false;
+                IsCreateStateGasCharged = false;
+                NewAccountCharged = false;
                 _pool.Enqueue(this);
             }
 #if DEBUG

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -36,24 +36,12 @@ public class VmState<TGasPolicy> : IDisposable
     // State-gas refund already made spendable in this frame while its accounting correction
     // still has to reach the ancestor frame that originally paid the state gas.
     public long StateGasRefundAdvanced;
-    internal long OutputDestination { get; private set; } // TODO: move to CallEnv
-    internal long OutputLength { get; private set; } // TODO: move to CallEnv
     public long Refund { get; set; }
     public int DataStackHead;
-    public ExecutionType ExecutionType { get; private set; } // TODO: move to CallEnv
     public int ProgramCounter { get; set; }
-    public bool IsTopLevel { get; private set; } // TODO: move to CallEnv
+    // Mutable frame-lifecycle state: flipped true when a child call returns and this frame resumes.
+    public bool IsContinuation { get; set; }
     private bool _canRestore;
-    public bool IsStatic { get; private set; } // TODO: move to CallEnv
-    public bool IsContinuation { get; set; } // TODO: move to CallEnv
-    public bool IsCreateOnPreExistingAccount { get; private set; } // TODO: move to CallEnv
-    public bool IsCreateStateGasCharged { get; private set; } // TODO: move to CallEnv
-
-    /// <summary>
-    /// EIP-8037: the parent <c>*CALL</c> charged NEW_ACCOUNT state gas up-front for this (dead)
-    /// recipient; on this frame's error/revert no account is created, so the parent refunds it.
-    /// </summary>
-    public bool NewAccountCharged { get; private set; } // TODO: move to CallEnv
 
     private bool _isDisposed = true;
 
@@ -162,19 +150,19 @@ public class VmState<TGasPolicy> : IDisposable
         Gas = gas;
         InitialStateGasUsed = TGasPolicy.GetStateGasUsed(in gas);
         StateGasRefundAdvanced = 0;
-        OutputDestination = outputDestination;
-        OutputLength = outputLength;
         Refund = 0;
         DataStackHead = 0;
         ProgramCounter = 0;
-        ExecutionType = executionType;
-        IsTopLevel = isTopLevel;
-        _canRestore = !isTopLevel;
-        IsStatic = isStatic;
         IsContinuation = false;
-        IsCreateOnPreExistingAccount = isCreateOnPreExistingAccount;
-        IsCreateStateGasCharged = isCreateStateGasCharged;
-        NewAccountCharged = newAccountCharged;
+        _canRestore = !isTopLevel;
+        env.OutputDestination = outputDestination;
+        env.OutputLength = outputLength;
+        env.ExecutionType = executionType;
+        env.IsTopLevel = isTopLevel;
+        env.IsStatic = isStatic;
+        env.IsCreateOnPreExistingAccount = isCreateOnPreExistingAccount;
+        env.IsCreateStateGasCharged = isCreateStateGasCharged;
+        env.NewAccountCharged = newAccountCharged;
 
         if (!_isDisposed)
         {
@@ -199,6 +187,15 @@ public class VmState<TGasPolicy> : IDisposable
 
     public Address To => Env.CodeSource ?? Env.ExecutingAccount;
     public bool IsPrecompile => Env.CodeInfo?.IsPrecompile ?? false;
+
+    internal long OutputDestination => Env.OutputDestination;
+    internal long OutputLength => Env.OutputLength;
+    public ExecutionType ExecutionType => Env.ExecutionType;
+    public bool IsTopLevel => Env.IsTopLevel;
+    public bool IsStatic => Env.IsStatic;
+    public bool IsCreateOnPreExistingAccount => Env.IsCreateOnPreExistingAccount;
+    public bool IsCreateStateGasCharged => Env.IsCreateStateGasCharged;
+    public bool NewAccountCharged => Env.NewAccountCharged;
 
     public ref readonly StackAccessTracker AccessTracker => ref _accessTracker;
     public ExecutionEnvironment Env => _env!;


### PR DESCRIPTION
## Changes

Resolves the standing `// TODO: move to CallEnv` markers in `VmState<TGasPolicy>` by relocating the invocation-describing fields onto `ExecutionEnvironment` (the "CallEnv"):

- `OutputDestination`, `OutputLength`
- `ExecutionType`
- `IsTopLevel`, `IsStatic`
- `IsCreateOnPreExistingAccount`, `IsCreateStateGasCharged`
- `NewAccountCharged`

These describe *how a frame was invoked* and never change during execution, so they belong on the per-frame `ExecutionEnvironment` (1:1 with `VmState`, otherwise set-once) alongside the other call inputs — matching the Yellow Paper's split between the execution environment *I* and the mutable machine state *μ*. `VmState` populates them on the env when a frame is rented and keeps thin **forwarding properties** into `Env` — mirroring the existing `From`/`To`/`IsPrecompile` forwarders — so hot-path call sites stay untouched and the diff is confined to two files. `ExecutionEnvironment.Dispose` clears them before the instance returns to the pool.

**`IsContinuation` is intentionally left on `VmState`.** Unlike the others it is *mutable lifecycle state* (flipped `true` when a child call returns and the frame resumes), not an invocation input; moving it would force a mutable public setter onto the otherwise set-once `ExecutionEnvironment`.

Pure relocation — no behavioural change. With the forwarders, `vmState.IsStatic` compiles to the same `_env.IsStatic` access a direct `.Env.IsStatic` would; the only delta from the original is one extra dependent load (through `VmState._env`) for fields that are read at frame setup/teardown and inside already-expensive opcodes (CALL/CREATE/SSTORE), not in the innermost dispatch loop.

## Types of changes

- [x] Refactoring (a code change that neither fixes a bug nor adds a feature)

## Testing

- `dotnet build src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj -c release` — succeeds (also verified with `-p:EnableZkEvm=true` to cover the `#if ZK_EVM` paths).
- `dotnet test src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c release` — 4940 passed, 0 failed, 8 skipped (pre-existing macOS skips).

Performance: this is a pure relocation whose only runtime effect is a single, well-predicted pointer indirection off the innermost loop, so the expected impact is below the gas-benchmark's run-to-run noise floor (~1–2% CV). Local EVM microbenchmark validation was attempted but is currently blocked by an unrelated, pre-existing breakage in the `Nethermind.Evm.Benchmark` harness (`WorldState.Commit` NRE in `GlobalSetup` — `_currentScope` is null). Reviewers can run the gas-benchmark via `@claude-bench` if empirical confirmation is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)