### PR TITLE
ci: remove NuGet package caching from test jobs

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -139,9 +139,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Download test binaries
         if: runner.os == 'Linux'
@@ -240,9 +237,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Download test binaries
         if: runner.os == 'Linux'
@@ -323,9 +317,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Download test binaries
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Changes

- Remove `cache: true` / `cache-dependency-path` from the `actions/setup-dotnet` steps of the test jobs in `nethermind-tests.yml`, so no NuGet cache post-step runs in these jobs at all.

`setup-dotnet`'s post-job cache save resolves the packages folder by spawning `dotnet nuget locals all --list`. On memory-exhausted macOS runners that process is intermittently OOM-killed, and the action reports the failure via `setFailed`, so the whole job goes red *after every test has passed*. Four jobs failed this way over the last 5 days, all with `Test run summary: Passed!` followed by `The 'dotnet nuget locals all --list --force-english-output' command failed with exit code: 137`:

- [Nethermind.Sockets.Test (macos-latest)](https://github.com/NethermindEth/nethermind/actions/runs/29824969971/attempts/1)
- [Nethermind.Network.Discovery.Test (macos-latest)](https://github.com/NethermindEth/nethermind/actions/runs/29777107870/attempts/1)
- [Nethermind.Synchronization.Test (2of4) (macos-latest)](https://github.com/NethermindEth/nethermind/actions/runs/29740209506/attempts/1)
- [Ethereum.Legacy.Blockchain.Test (4of8) (macos-latest)](https://github.com/NethermindEth/nethermind/actions/runs/29854042323/attempts/1)

NuGet caching in these workflows was already disabled as flaky in #11653 and came back with the test-binaries rework in #12371. This restores the #11653 state for the test jobs: the Linux legs run from prebuilt test binaries anyway, and the Windows/macOS legs restore from nuget.org as they did between #11653 and #12371.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Workflow-only change; verified against the CI run on this PR.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### If yes, in which section(s)?

## Remarks
