### PR TITLE
test: keep the persisted-snapshot tier inert in test containers; capture full exceptions in the test runner

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModule.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModule.cs
@@ -37,6 +37,8 @@ public class PseudoNethermindModule(ChainSpec spec, IConfigProvider configProvid
         IInitConfig initConfig = configProvider.GetConfig<IInitConfig>();
         initConfig.AutoDump = DumpOptions.None;
 
+        configProvider.GetConfig<IFlatDbConfig>().EnableLongFinality = false;
+
         base.Load(builder);
         builder
             .AddModule(new NethermindModule(spec, configProvider, logManager))

--- a/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModuleTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/PseudoNethermindModuleTests.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using Nethermind.Db;
+using Nethermind.State.Flat.PersistedSnapshots;
+using Nethermind.State.Flat.PersistedSnapshots.Storage;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Modules;
+
+public class PseudoNethermindModuleTests
+{
+    [Test]
+    public void FlatDb_test_container_wires_inert_persisted_snapshot_tier()
+    {
+        using IContainer container = new ContainerBuilder()
+            .AddModule(new TestNethermindModule(new FlatDbConfig { Enabled = true }))
+            .Build();
+
+        Assert.That(container.Resolve<ISnapshotCatalog>(), Is.SameAs(NullSnapshotCatalog.Instance));
+        Assert.That(container.Resolve<IPersistedSnapshotLoader>(), Is.SameAs(NullPersistedSnapshotLoader.Instance));
+        Assert.That(container.Resolve<IPersistedSnapshotCompactor>(), Is.SameAs(NullPersistedSnapshotCompactor.Instance));
+    }
+}

--- a/src/Nethermind/Nethermind.Test.Runner/BlockchainTestsRunner.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/BlockchainTestsRunner.cs
@@ -107,7 +107,7 @@ public class BlockchainTestsRunner(in BlockchainTestsRunnerOptions options, ITes
         }
         catch (Exception ex)
         {
-            return new EthereumTestResult(test.Name, test.ForkName, ex.Message);
+            return new EthereumTestResult(test.Name, test.ForkName, ex.ToString());
         }
     }
 

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -290,7 +290,7 @@ internal class Program
                 {
                     string name = Path.GetFileNameWithoutExtension(file);
                     WriteFileExceptionStatus(name, ex);
-                    allResults.Add(new EthereumTestResult(name, ex.Message));
+                    allResults.Add(new EthereumTestResult(name, ex.ToString()));
                 }
             }
             return allResults;
@@ -319,7 +319,7 @@ internal class Program
                 {
                     string name = Path.GetFileNameWithoutExtension(item.file);
                     WriteFileExceptionStatus(name, ex);
-                    resultsByFile[item.index] = [new EthereumTestResult(name, ex.Message)];
+                    resultsByFile[item.index] = [new EthereumTestResult(name, ex.ToString())];
                 }
             });
 
@@ -539,7 +539,7 @@ internal class Program
                 string name = Path.GetFileNameWithoutExtension(files[index]);
                 Console.Error.WriteLine($"\x1b[31mEXCEPTION\x1b[0m {name} - {ex.Message}");
                 Console.Error.Flush();
-                fileResults.Add(new EthereumTestResult(name, ex.Message));
+                fileResults.Add(new EthereumTestResult(name, ex.ToString()));
             }
 
             resultsByFile[index] = fileResults;


### PR DESCRIPTION
## Changes

- `PseudoNethermindModule` now sets `EnableLongFinality = false` on the shared `IFlatDbConfig` before `NethermindModule` loads, so test containers wire the inert persisted-snapshot tier (`NullSnapshotCatalog` / `NullPersistedSnapshotLoader` / `NullPersistedSnapshotCompactor`) instead of the real one. Added a regression test asserting the composition.
- `Nethermind.Test.Runner` records `ex.ToString()` instead of `ex.Message` in test results, so the inner-exception chain and stack survive into `nethtest-results.json` and the per-test stderr `EXCEPTION` lines (which print the recorded error); the whole-file stderr status line intentionally keeps the concise `ex.Message`.

Since #12142, every per-test container in the flat EEST legs built the full persisted-snapshot tier: file-backed arenas under a fixed CWD-relative `db/persistedSnapshot/` path shared by all ~10k tests in a leg (`BaseDbPath` defaults to `db`), a ~8.5 MiB native page-residency-tracker allocation, a background drain task + 1s timer per test, and a synchronous `PersistedSnapshotLoader.Load()` in the `FlatDbManager` constructor enumerating those shared directories. With `WORKERS=2` two tests overlap on the same path.

This intermittently fails a random test with a `DependencyResolutionException` while activating `IFlatDbManager` — 5 occurrences on master between 2026-07-17 and 2026-07-21, e.g. [engineTest 8of9](https://github.com/NethermindEth/nethermind/actions/runs/29736798023/attempts/1), [blockTest 1of6](https://github.com/NethermindEth/nethermind/actions/runs/29732165112/attempts/1), [blockTest 2of6](https://github.com/NethermindEth/nethermind/actions/runs/29614205037/attempts/1). Only the outer Autofac message was recorded, which is why the runner change is bundled here: the actual inner exception never made it into any log.

The flag is set eagerly (not in the `Intercept<IFlatDbConfig>` callback) because `FlatWorldStateModule` reads it at module-load time to choose the registrations, while `Intercept` only runs on resolution.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`PseudoNethermindModuleTests.FlatDb_test_container_wires_inert_persisted_snapshot_tier` fails on master (resolves the real `PersistedSnapshotLoader`) and passes with this change. Only tests outside `Nethermind.State.Flat.Test` are affected; the flat-specific suites construct their own `FlatDbConfig` and keep exercising the real tier.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
