### PR TITLE
test(merge): give engine payload builds a CI-safe improvement budget

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -216,7 +216,19 @@ public abstract partial class BaseEngineModuleTests
                     ? new BlocksConfig { MinGasPrice = bc.MinGasPrice, ParallelExecution = ParallelExecutionOverride.Value }
                     : c);
             }
-            return configs;
+
+            List<IConfig> materialized = configs.ToList();
+            foreach (IConfig config in materialized)
+            {
+                // Production payload-improvement budget (SecondsPerSlot × 0.25 = 3s) is too tight under CI
+                // load: a starved thread pool truncates the first build to an empty block, which the
+                // parent-hash improvement wait accepts. Timeout tests register their own improvement factories.
+                if (config is IBlocksConfig blocksConfig)
+                {
+                    blocksConfig.SingleBlockImprovementOfSlot = 5;
+                }
+            }
+            return materialized;
         }
 
         /// <summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -217,13 +217,11 @@ public abstract partial class BaseEngineModuleTests
                     : c);
             }
 
+            double defaultImprovementOfSlot = new BlocksConfig().SingleBlockImprovementOfSlot;
             List<IConfig> materialized = configs.ToList();
             foreach (IConfig config in materialized)
             {
-                // Production payload-improvement budget (SecondsPerSlot × 0.25 = 3s) is too tight under CI
-                // load: a starved thread pool truncates the first build to an empty block, which the
-                // parent-hash improvement wait accepts. Timeout tests register their own improvement factories.
-                if (config is IBlocksConfig blocksConfig)
+                if (config is IBlocksConfig blocksConfig && blocksConfig.SingleBlockImprovementOfSlot == defaultImprovementOfSlot)
                 {
                     blocksConfig.SingleBlockImprovementOfSlot = 5;
                 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -193,6 +193,10 @@ public abstract partial class BaseEngineModuleTests
 
         private const double CiSafeSingleBlockImprovementOfSlot = 5;
 
+        /// <summary>
+        /// Overrides the payload improvement window as a fraction of a slot. Must be set before <c>Build()</c>;
+        /// assigning it afterwards is a no-op because the configs are materialized during build.
+        /// </summary>
         public double? SingleBlockImprovementOfSlotOverride { get; set; }
 
         public MergeTestBlockchain(IMergeConfig? mergeConfig = null)
@@ -221,19 +225,11 @@ public abstract partial class BaseEngineModuleTests
                     : c);
             }
 
-            double defaultImprovementOfSlot = new BlocksConfig().SingleBlockImprovementOfSlot;
             List<IConfig> materialized = configs.ToList();
             foreach (IConfig config in materialized)
             {
                 if (config is not IBlocksConfig blocksConfig) continue;
-                if (SingleBlockImprovementOfSlotOverride.HasValue)
-                {
-                    blocksConfig.SingleBlockImprovementOfSlot = SingleBlockImprovementOfSlotOverride.Value;
-                }
-                else if (blocksConfig.SingleBlockImprovementOfSlot == defaultImprovementOfSlot)
-                {
-                    blocksConfig.SingleBlockImprovementOfSlot = CiSafeSingleBlockImprovementOfSlot;
-                }
+                blocksConfig.SingleBlockImprovementOfSlot = SingleBlockImprovementOfSlotOverride ?? CiSafeSingleBlockImprovementOfSlot;
             }
             return materialized;
         }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -191,6 +191,10 @@ public abstract partial class BaseEngineModuleTests
 
         public bool? ParallelExecutionOverride { get; set; }
 
+        private const double CiSafeSingleBlockImprovementOfSlot = 5;
+
+        public double? SingleBlockImprovementOfSlotOverride { get; set; }
+
         public MergeTestBlockchain(IMergeConfig? mergeConfig = null)
         {
             MergeConfig = mergeConfig ?? new MergeConfig();
@@ -221,9 +225,14 @@ public abstract partial class BaseEngineModuleTests
             List<IConfig> materialized = configs.ToList();
             foreach (IConfig config in materialized)
             {
-                if (config is IBlocksConfig blocksConfig && blocksConfig.SingleBlockImprovementOfSlot == defaultImprovementOfSlot)
+                if (config is not IBlocksConfig blocksConfig) continue;
+                if (SingleBlockImprovementOfSlotOverride.HasValue)
                 {
-                    blocksConfig.SingleBlockImprovementOfSlot = 5;
+                    blocksConfig.SingleBlockImprovementOfSlot = SingleBlockImprovementOfSlotOverride.Value;
+                }
+                else if (blocksConfig.SingleBlockImprovementOfSlot == defaultImprovementOfSlot)
+                {
+                    blocksConfig.SingleBlockImprovementOfSlot = CiSafeSingleBlockImprovementOfSlot;
                 }
             }
             return materialized;


### PR DESCRIPTION
## Changes

- `MergeTestBlockchain.CreateConfigs` raises `SingleBlockImprovementOfSlot` from the production `0.25` to `5`, so the payload-improvement build budget becomes 60 s (with the 12 s test slot) instead of 3 s.

`EngineModuleTests.NewPayloadV5_accepts_valid_BAL` [failed on master](https://github.com/NethermindEth/nethermind/actions/runs/29841088412/attempts/1) with "Engine-built block hash mismatch" (got a hash matching neither the EIP-8037 nor the non-8037 expectation) and passed on rerun, after a 35 s runtime that points at thread-pool starvation. The mechanism: the improvement build runs in `Task.Run` against a `CancellationTokenSource(SecondsPerSlot × SingleBlockImprovementOfSlot = 3 s)`; when the pool is starved the token can already be expired when the build finally runs, the production tx loop breaks early and yields an empty/partial block, the task still completes successfully so `BlockImproved` fires, and `WaitForImprovedBlock` — which matches on parent hash only — accepts it. With no new pool txs there is no re-improvement, so `engine_getPayloadV6` returns the truncated block.

This mirrors the existing ctor bump of `NewPayloadBlockProcessingTimeout` to 60 s for the same class of CI-load spuriousness. The budget is an upper bound, not a wait, so healthy runs are unaffected; the improvement-cadence tests in `EngineModuleTests.PayloadProduction` register their own `IBlockImprovementContextFactory` with explicit timing and don't go through this default.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Test-only change to the shared merge test harness; the affected `NewPayloadV5*`/payload tests pass locally. The flake itself is CI-load-dependent and has no deterministic local reproduction.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No