### PR TITLE
fix(simulate): fall back to the base block store in HasBlock so the overlay main-chain reset works

### DIFF
--- a/src/Nethermind/Nethermind.Facade.Test/Simulate/SimulateDictionaryBlockStoreTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/Simulate/SimulateDictionaryBlockStoreTests.cs
@@ -34,4 +34,13 @@ public class SimulateDictionaryBlockStoreTests
 
         Assert.That(store.HasBlock(block.Number, block.Hash!), Is.True);
     }
+
+    [Test]
+    public void HasBlock_returns_false_when_block_is_in_neither_store()
+    {
+        Block block = Build.A.Block.WithNumber(1).TestObject;
+        SimulateDictionaryBlockStore store = new(new BlockStore(new MemDb()));
+
+        Assert.That(store.HasBlock(block.Number, block.Hash!), Is.False);
+    }
 }

--- a/src/Nethermind/Nethermind.Facade.Test/Simulate/SimulateDictionaryBlockStoreTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/Simulate/SimulateDictionaryBlockStoreTests.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain.Blocks;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Facade.Simulate;
+using NUnit.Framework;
+
+namespace Nethermind.Facade.Test.Simulate;
+
+[Parallelizable(ParallelScope.All)]
+public class SimulateDictionaryBlockStoreTests
+{
+    [Test]
+    public void HasBlock_finds_block_present_only_in_base_store()
+    {
+        Block block = Build.A.Block.WithNumber(1).TestObject;
+        BlockStore baseStore = new(new MemDb());
+        baseStore.Insert(block);
+
+        SimulateDictionaryBlockStore store = new(baseStore);
+
+        Assert.That(store.HasBlock(block.Number, block.Hash!), Is.True);
+    }
+
+    [Test]
+    public void HasBlock_finds_block_cached_in_overlay()
+    {
+        Block block = Build.A.Block.WithNumber(1).TestObject;
+        SimulateDictionaryBlockStore store = new(new BlockStore(new MemDb()));
+        store.Cache(block);
+
+        Assert.That(store.HasBlock(block.Number, block.Hash!), Is.True);
+    }
+}

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
@@ -60,5 +60,5 @@ public class SimulateDictionaryBlockStore(IBlockStore readonlyBaseBlockStore) : 
         => Insert(block);
 
     public bool HasBlock(ulong blockNumber, Hash256 blockHash)
-        => _blockNumDict.ContainsKey(blockNumber);
+        => _blockNumDict.ContainsKey(blockNumber) || readonlyBaseBlockStore.HasBlock(blockNumber, blockHash);
 }


### PR DESCRIPTION
## Changes

- `SimulateDictionaryBlockStore.HasBlock` now falls back to the wrapped base store, matching its sibling methods (`Get`, `GetRlp`, `GetReceiptRecoveryBlock`), which all delegate when the overlay dictionary misses.
- Added unit tests for both lookup paths.

Since #11894 added a fast-fail guard to `BlockTree.TryUpdateMainChain` (`if (!_blockStore.HasBlock(newHead.Number, newHead.Hash!)) return false;`), the simulate env's `BlockTreeOverlay.ResetMainChain()` has been a silent no-op: it calls `TryUpdateMainChain(baseTree.Head!.Header, …)` on the overlay tree, whose block store is a fresh `SimulateDictionaryBlockStore` with an empty dictionary — so the guard always failed, even though the head body exists in the base store one delegation away. `ResetMainChain` is what `SimulateReadOnlyBlocksProcessingEnv.Begin` relies on to re-point the overlay at the live chain head on every `eth_simulateV1` call.

With the reset inert, the overlay tree's head stays frozen at whatever the env's temp block tree loaded at construction, and `BlockTreeOverlay.Head` prefers it over the live base head. `SimulateBridgeHelper.GetParent` then clamps the requested base block down to that stale head — which is how CI intermittently got a simulated block whose `ParentHash` was the genesis hash instead of the requested block #2 in `TestSimulate_TimestampIsComputedCorrectly_WhenNoTimestampOverride` ([no-intrinsics on master](https://github.com/NethermindEth/nethermind/actions/runs/29830862452/attempts/1), [checked](https://github.com/NethermindEth/nethermind/actions/runs/29808454793/attempts/1); the observed "wrong" hash `0x2167…b0e4` is the genesis hash from the golden vectors). Whether the temp tree observes a stale head at construction is timing-dependent, which is why the test only failed under CI load and passed on rerun; env pooling (#12506) extends any such stale head across reuses, since the per-`Begin` reset was the only corrector.

With `HasBlock` delegating, the guard passes, `ResetMainChain` actually resets, and the simulated block always builds on the requested base.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`SimulateDictionaryBlockStoreTests.HasBlock_finds_block_present_only_in_base_store` fails on master and passes with the fix; the overlay-cache path is covered by the second test. The flaky `EthSimulateTestsHiveBase` timestamp tests pass locally with the change.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No