### PR TITLE
fix(sync): retry a fast-blocks batch slot when the canonical block info is not yet resolvable

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
@@ -115,7 +115,7 @@ public class BlockTreeOverlay(IReadOnlyBlockTree baseTree, IBlockTree overlayTre
 
     public ChainLevelInfo? FindLevel(ulong number) => _overlayTree.FindLevel(number) ?? _baseTree.FindLevel(number);
 
-    public BlockInfo FindCanonicalBlockInfo(ulong blockNumber) => _overlayTree.FindCanonicalBlockInfo(blockNumber) ?? _baseTree.FindCanonicalBlockInfo(blockNumber);
+    public BlockInfo? FindCanonicalBlockInfo(ulong blockNumber) => _overlayTree.FindCanonicalBlockInfo(blockNumber) ?? _baseTree.FindCanonicalBlockInfo(blockNumber);
 
     public Hash256 FindHash(ulong blockNumber) => _overlayTree.FindHash(blockNumber) ?? _baseTree.FindHash(blockNumber);
 

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -161,7 +161,7 @@ namespace Nethermind.Blockchain
 
         ChainLevelInfo? FindLevel(ulong number);
 
-        BlockInfo FindCanonicalBlockInfo(ulong blockNumber);
+        BlockInfo? FindCanonicalBlockInfo(ulong blockNumber);
 
         Hash256? FindHash(ulong blockNumber);
 

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -49,7 +49,7 @@ namespace Nethermind.Blockchain
             => _wrapped.Accept(blockTreeVisitor, cancellationToken);
 
         public ChainLevelInfo FindLevel(ulong number) => _wrapped.FindLevel(number);
-        public BlockInfo FindCanonicalBlockInfo(ulong blockNumber) => _wrapped.FindCanonicalBlockInfo(blockNumber);
+        public BlockInfo? FindCanonicalBlockInfo(ulong blockNumber) => _wrapped.FindCanonicalBlockInfo(blockNumber);
 
         public void BulkInsertHeader(IReadOnlyList<BlockHeader> headers,
             BlockTreeInsertHeaderOptions headerOptions = BlockTreeInsertHeaderOptions.None) =>

--- a/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockTree.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockTree.cs
@@ -141,7 +141,7 @@ public class StatelessBlockTree(IReadOnlyCollection<BlockHeader> headers)
     public ChainLevelInfo? FindLevel(ulong number)
         => throw new NotSupportedException();
 
-    public BlockInfo FindCanonicalBlockInfo(ulong blockNumber)
+    public BlockInfo? FindCanonicalBlockInfo(ulong blockNumber)
         => throw new NotSupportedException();
 
     public Hash256? FindHash(ulong blockNumber)

--- a/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeTestDouble.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/BlockTreeTestDouble.cs
@@ -189,7 +189,7 @@ public class BlockTreeTestDouble : IBlockTree
     public virtual (BlockInfo? Info, ChainLevelInfo? Level) GetInfo(ulong number, Hash256 blockHash) =>
         Inner?.GetInfo(number, blockHash) ?? (null, null);
     public virtual ChainLevelInfo? FindLevel(ulong number) => Inner?.FindLevel(number);
-    public virtual BlockInfo FindCanonicalBlockInfo(ulong blockNumber) => Inner?.FindCanonicalBlockInfo(blockNumber) ?? null!;
+    public virtual BlockInfo? FindCanonicalBlockInfo(ulong blockNumber) => Inner?.FindCanonicalBlockInfo(blockNumber);
     public virtual Hash256? FindHash(ulong blockNumber) => Inner?.FindHash(blockNumber);
     public virtual IOwnedReadOnlyList<BlockHeader> FindHeaders(Hash256 hash, int numberOfBlocks, int skip, bool reverse) =>
         Inner?.FindHeaders(hash, numberOfBlocks, skip, reverse) ?? new ArrayPoolList<BlockHeader>(0);

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/SyncStatusListTests.cs
@@ -90,6 +90,43 @@ public class SyncStatusListTests
     }
 
     [Test]
+    public void Transiently_unresolvable_block_is_retried_instead_of_orphaned_in_sent()
+    {
+        const ulong unsettled = 95;
+        bool settled = false;
+
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.FindCanonicalBlockInfo(Arg.Any<ulong>())
+            .Returns(ci =>
+            {
+                ulong blockNumber = ci.ArgAt<ulong>(0);
+                return blockNumber == unsettled && !settled
+                    ? null
+                    : new BlockInfo(TestItem.KeccakA, 0) { BlockNumber = blockNumber };
+            });
+
+        SyncStatusList syncStatusList = new(blockTree, 100, null, 90);
+
+        List<ulong> GetAndInsert()
+        {
+            syncStatusList.TryGetInfosForBatch(50, new AlwaysDownloadStrategy(), out BlockInfo?[] infos);
+            List<ulong> numbers = [.. infos.Where(static bi => bi is not null).Select(static bi => bi!.BlockNumber)];
+            foreach (ulong number in numbers)
+            {
+                syncStatusList.MarkInserted(number);
+            }
+            return numbers;
+        }
+
+        Assert.That(GetAndInsert(), Does.Not.Contain(unsettled));
+        settled = true;
+        Assert.That(GetAndInsert(), Does.Contain(unsettled));
+
+        syncStatusList.TryGetInfosForBatch(50, new AlwaysDownloadStrategy(), out _);
+        Assert.That(syncStatusList.LowestInsertWithoutGaps, Is.LessThan(unsettled));
+    }
+
+    [Test]
     public void Can_read_back_all_parallel_set_values()
     {
         const long length = 4096;

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -344,7 +344,7 @@ public class SyncServerTests
         Assert.That(ctx.LocalBlockTree.BestSuggestedHeader!.Number, Is.EqualTo(10));
         Assert.That(ctx.LocalBlockTree.FindBlock(poWBlockPostMerge.Hash!, BlockTreeLookupOptions.None), Is.Not.Null);
         Assert.That(ctx.LocalBlockTree.BestSuggestedHeader!.Hash, Is.EqualTo(newPostMergeBlock.Hash!));
-        Assert.That(ctx.LocalBlockTree.FindCanonicalBlockInfo(poWBlockPostMerge.Number).BlockHash, Is.Not.EqualTo(poWBlockPostMerge.Hash!));
+        Assert.That(ctx.LocalBlockTree.FindCanonicalBlockInfo(poWBlockPostMerge.Number)!.BlockHash, Is.Not.EqualTo(poWBlockPostMerge.Hash!));
     }
 
 

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/SyncStatusList.cs
@@ -52,17 +52,26 @@ namespace Nethermind.Synchronization.FastBlocks
 
                 if (_statuses.TrySet(currentNumber, FastBlockStatus.Sent, out FastBlockStatus status))
                 {
-                    if (_cache.TryGet(currentNumber, out BlockInfo blockInfo))
+                    BlockInfo? blockInfo;
+                    if (_cache.TryGet(currentNumber, out BlockInfo cachedInfo))
                     {
                         _cache.Delete(currentNumber);
+                        blockInfo = cachedInfo;
                     }
                     else
                     {
                         blockInfo = _blockTree.FindCanonicalBlockInfo(currentNumber);
                     }
 
-                    blockInfos[collected] = blockInfo;
-                    collected++;
+                    if (blockInfo is null)
+                    {
+                        _statuses.TrySet(currentNumber, FastBlockStatus.Pending);
+                    }
+                    else
+                    {
+                        blockInfos[collected] = blockInfo;
+                        collected++;
+                    }
                 }
                 else if (status == FastBlockStatus.Inserted)
                 {


### PR DESCRIPTION
## Changes

- `SyncStatusList.GetInfosForBatch` no longer leaves a block claimed as `Sent` when `FindCanonicalBlockInfo` returns null: the claim is reverted to `Pending` so a later scan retries it once the chain level settles.
- `IBlockTree.FindCanonicalBlockInfo` is now annotated `BlockInfo?` to match the `BlockTree` implementation, which returns null when the level is missing or has no main-chain block (implementor signatures updated mechanically; `BlockTreeOverlay` already null-coalesced the result despite the non-nullable annotation).
- Regression test: a transiently unresolvable block must be handed out again after it becomes resolvable, and the frontier must pass it. Fails on master (the block stays `Sent` forever), passes with the fix.

This is the cause of the dominant CI flake of the last week: `E2ESyncTests.FastSync_downloads_block_access_lists_over_eth71` / `FastSync_skips_pre_eip7928_block_access_lists_over_eth71` hanging for 10 minutes in `WaitUntilMode` and either failing the `Nethermind.Synchronization.Test` job or blowing the 15-minute macOS job budget — at least 6 occurrences on master and unrelated branches between 2026-07-17 and 2026-07-21 ([1](https://github.com/NethermindEth/nethermind/actions/runs/29784215444/attempts/1), [2](https://github.com/NethermindEth/nethermind/actions/runs/29844221141/attempts/1), [3](https://github.com/NethermindEth/nethermind/actions/runs/29772883884/attempts/1), [4](https://github.com/NethermindEth/nethermind/actions/runs/29773970221/attempts/1)), all after the earlier sleep/wake fixes (#12255, #12480) were merged.

Mechanism, matched against the captured node logs of the wedged runs: `GetInfosForBatch` claims a block `Sent` *before* resolving `FindCanonicalBlockInfo`. During `Full, FastReceipts` the forward downloader mutates chain levels concurrently with the receipts backfill, so the lookup can transiently return null. The null is stored into the batch without a check, and both consumers silently drop null entries (`ClearExistingBlock`, `CompileOutput`), so no request ever carries that block, nothing ever calls `MarkPending`/`MarkInserted` for it, and it stays `Sent` forever. The insert frontier only collapses across `Inserted` blocks, so it freezes on the orphan while every block below it is still downloaded and queued. The wedged logs match this exactly: with frozen frontier X, `inserted + queue == total` and `queue == X − 1` in both captured runs (2159+2776=4935, 56+879=935) — one stuck block, everything else done. The feed then idles forever and the awaited `Full` mode never arrives; the sole peer's terminal `Sleeping: Receipts` state is a consequence (empty batches → no-progress reports), not the cause.

`SyncStatusList` is shared by the bodies, receipts, and block-access-lists feeds, so the same orphan could wedge any of them; receipts is simply the slowest and last.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`SyncStatusListTests.Transiently_unresolvable_block_is_retried_instead_of_orphaned_in_sent` fails on master and passes with the fix; the full `SyncStatusListTests` suite passes. The E2E wedge itself is a CI-load race with no deterministic local reproduction — the unit test captures the orphan mechanism directly.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No