### PR TITLE
feat: implement EIP-8298 SETCODEFROM opcode

### DIFF
--- a/src/Nethermind/Nethermind.Core/GasCostOf.cs
+++ b/src/Nethermind/Nethermind.Core/GasCostOf.cs
@@ -86,6 +86,8 @@ namespace Nethermind.Core
         public const long PerEmptyAccountState = StateBytesPerNewAccount * CostPerStateByte;
         public const long BlockAccessListItem = Eip7928Constants.ItemCost; // eip-7928
 
+        public const long SetCodeFromBase = 3_000; // eip-8298 (base cost; source account access charged on top per eip-2929)
+
         public const long TxDataNonZeroMultiplier = TxDataNonZero / TxDataZero;
         public const long TxDataNonZeroMultiplierEip2028 = TxDataNonZeroEip2028 / TxDataZero;
 

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -476,6 +476,11 @@ namespace Nethermind.Core.Specs
         public bool IsEip7954Enabled { get; }
 
         /// <summary>
+        /// EIP-8298: SETCODEFROM code reuse instruction
+        /// </summary>
+        public bool IsEip8298Enabled { get; }
+
+        /// <summary>
         /// Precomputed gas cost and refund constants derived from this spec.
         /// Values are cached per spec instance (singletons per fork) to avoid
         /// repeated interface dispatch on the EVM opcode hot path.

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -120,6 +120,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip7778Enabled => spec.IsEip7778Enabled;
     public virtual bool IsEip7843Enabled => spec.IsEip7843Enabled;
     public virtual bool IsEip7954Enabled => spec.IsEip7954Enabled;
+    public virtual bool IsEip8298Enabled => spec.IsEip8298Enabled;
     public virtual bool IsEip8024Enabled => spec.IsEip8024Enabled;
     public SpecGasCosts GasCosts => spec.GasCosts;
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8298Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8298Tests.cs
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.Precompiles;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Tests for EIP-8298: SETCODEFROM code reuse instruction.
+/// </summary>
+public class Eip8298Tests : VirtualMachineTestsBase
+{
+    private static readonly Address Source = TestItem.AddressC;
+    private static readonly byte[] SourceCode = Prepare.EvmCode.PushData(1).PushData(2).Op(Instruction.ADD).STOP().Done;
+
+    protected override long BlockNumber => MainnetSpecProvider.ParisBlockNumber;
+    protected override ulong Timestamp => MainnetSpecProvider.AmsterdamBlockTimestamp;
+    protected override ISpecProvider SpecProvider => new TestSpecProvider(new Amsterdam { IsEip8298Enabled = true });
+
+    // Disable access tracing so cold/warm account access is charged per EIP-2929
+    // (the default tracer pre-warms accesses, masking the cold cost in gas assertions).
+    protected override TestAllTracerWithOutput CreateTracer() => new() { IsTracingAccess = false };
+
+    private void DeploySource(byte[]? code = null)
+    {
+        TestState.CreateAccount(Source, 1.Ether);
+        TestState.InsertCode(Source, code ?? SourceCode, Spec);
+    }
+
+    [Test]
+    public void ValidSource_AdoptsCodeHash_AndPushesOne()
+    {
+        DeploySource();
+        byte[] code = Prepare.EvmCode.SETCODEFROM(Source).MSTORE(0).Return(32, 0).Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+        Assert.That(new UInt256(result.ReturnValue, true), Is.EqualTo(UInt256.One));
+        // Running frame keeps its loaded code, but the stored code hash now matches the source.
+        AssertCodeHash(Recipient, Keccak.Compute(SourceCode));
+    }
+
+    private static object[] InvalidSourceCases =
+    {
+        new object[] { "empty", null!, false },
+        new object[] { "eip7702-delegation", new byte[] { 0xef, 0x01, 0x00, 0x11, 0x22 }, true },
+        new object[] { "eip3541-ef", new byte[] { 0xef, 0x00 }, true },
+    };
+
+    [TestCaseSource(nameof(InvalidSourceCases))]
+    public void InvalidSource_PushesZero_AndLeavesCodeUnchanged(string name, byte[]? sourceCode, bool deploy)
+    {
+        if (deploy) DeploySource(sourceCode);
+        byte[] code = Prepare.EvmCode.SETCODEFROM(Source).MSTORE(0).Return(32, 0).Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success), name);
+        Assert.That(new UInt256(result.ReturnValue, true), Is.EqualTo(UInt256.Zero), name);
+        AssertCodeHash(Recipient, Keccak.Compute(code));
+    }
+
+    [Test]
+    public void PrecompileSource_PushesZero()
+    {
+        byte[] code = Prepare.EvmCode.SETCODEFROM(Sha256Precompile.Address).MSTORE(0).Return(32, 0).Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+        Assert.That(new UInt256(result.ReturnValue, true), Is.EqualTo(UInt256.Zero));
+    }
+
+    [Test]
+    public void StaticContext_ExceptionalHalt()
+    {
+        DeploySource();
+        TestState.CreateAccount(TestItem.AddressD, 1.Ether);
+        TestState.InsertCode(TestItem.AddressD, Prepare.EvmCode.SETCODEFROM(Source).STOP().Done, Spec);
+
+        byte[] code = Prepare.EvmCode.StaticCall(TestItem.AddressD, 50000).MSTORE(0).Return(32, 0).Done;
+
+        TestAllTracerWithOutput result = Execute(code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+        // The static inner frame halts exceptionally, so STATICCALL reports failure.
+        Assert.That(new UInt256(result.ReturnValue, true), Is.EqualTo(UInt256.Zero));
+    }
+
+    [Test]
+    public void Initcode_ExceptionalHalt()
+    {
+        DeploySource();
+        byte[] initCode = Prepare.EvmCode.SETCODEFROM(Source).STOP().Done;
+        (Block block, Transaction tx) = PrepareInitTx(Activation, 100000, initCode);
+
+        TestAllTracerWithOutput tracer = CreateTracer();
+        _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+
+        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Failure));
+    }
+
+    private static long ColdGas => GasCostOf.Transaction + GasCostOf.VeryLow + GasCostOf.SetCodeFromBase + GasCostOf.ColdAccountAccess;
+
+    [Test]
+    public void ColdSource_ChargesBasePlusColdAccess()
+    {
+        DeploySource();
+        byte[] code = Prepare.EvmCode.SETCODEFROM(Source).STOP().Done;
+
+        TestAllTracerWithOutput result = Execute(Activation, 100000, code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+        AssertGas(result, ColdGas);
+    }
+
+    [Test]
+    public void WarmSource_SecondAccessChargesWarm()
+    {
+        DeploySource();
+        byte[] code = Prepare.EvmCode.SETCODEFROM(Source).SETCODEFROM(Source).STOP().Done;
+
+        TestAllTracerWithOutput result = Execute(Activation, 100000, code);
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+        AssertGas(result, ColdGas + GasCostOf.VeryLow + GasCostOf.SetCodeFromBase + GasCostOf.WarmStateRead);
+    }
+
+    public class Eip8298DisabledTests : VirtualMachineTestsBase
+    {
+        protected override long BlockNumber => MainnetSpecProvider.ParisBlockNumber;
+        protected override ulong Timestamp => MainnetSpecProvider.AmsterdamBlockTimestamp;
+        protected override ISpecProvider SpecProvider => new TestSpecProvider(new Amsterdam { IsEip8298Enabled = false });
+
+        [Test]
+        public void Opcode_WhenDisabled_Fails()
+        {
+            byte[] code = Prepare.EvmCode.SETCODEFROM(TestItem.AddressC).STOP().Done;
+            TestAllTracerWithOutput result = Execute(code);
+            Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Failure));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/BytecodeBuilder.cs
+++ b/src/Nethermind/Nethermind.Evm/BytecodeBuilder.cs
@@ -116,6 +116,9 @@ namespace Nethermind.Evm
         public static Prepare EXTCODEHASH(this Prepare @this, Address? address = null)
             => @this.PushSingle(address)
                     .Op(Instruction.EXTCODEHASH);
+        public static Prepare SETCODEFROM(this Prepare @this, Address? source = null)
+            => @this.PushSingle(source)
+                    .Op(Instruction.SETCODEFROM);
         public static Prepare PUSHx(this Prepare @this, byte[] args)
             => @this.PushData(args);
         public static Prepare MLOAD(this Prepare @this, UInt256? pos = null)

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -68,6 +68,7 @@ public enum Instruction : byte
     BLOBHASH = 0x49,
     BLOBBASEFEE = 0x4a,
     SLOTNUM = 0x4b,
+    SETCODEFROM = 0x4c, // EIP-8298 (opcode provisional; TBD in spec)
 
     POP = 0x50,
     MLOAD = 0x51,

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Crypto;
+using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
 using static Nethermind.Evm.VirtualMachineStatics;
@@ -625,6 +626,50 @@ public static partial class EvmInstructions
         return EvmExceptionType.OutOfGas;
     StackUnderflow:
         return EvmExceptionType.StackUnderflow;
+    }
+
+    /// <summary>
+    /// Implements the SETCODEFROM opcode (EIP-8298): adopts the code hash of a deployed source account.
+    /// </summary>
+    /// <remarks>
+    /// Valid source pushes 1 and updates the executing account's code hash; invalid source pushes 0 with no
+    /// state change. Initcode or static context halts exceptionally. The running frame keeps its loaded code.
+    /// </remarks>
+    [SkipLocalsInit]
+    public static EvmExceptionType InstructionSetCodeFrom<TGasPolicy, TTracingInst>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        where TTracingInst : struct, IFlag
+    {
+        VmState<TGasPolicy> vmState = vm.VmState;
+        // Runtime-only, never static: preserves the creation invariant and read-only guarantees.
+        if (vmState.ExecutionType.IsAnyCreate()) goto BadInstruction;
+        if (vmState.IsStatic) goto StaticCallViolation;
+
+        IReleaseSpec spec = vm.Spec;
+        TGasPolicy.Consume(ref gas, GasCostOf.SetCodeFromBase);
+
+        Address source = stack.PopAddress();
+        if (source is null) goto StackUnderflow;
+        if (!TGasPolicy.ConsumeAccountAccessGas(ref gas, spec, in vmState.AccessTracker, vm.TxTracer.IsTracingAccess, source)) goto OutOfGas;
+
+        // Valid source: not a precompile, non-empty code, and regular deployed code (not 0xEF-prefixed per EIP-3541/7702).
+        CodeInfo codeInfo = vm.CodeInfoRepository.GetCachedCodeInfoNoDelegation(source, spec);
+        if (spec.IsPrecompile(source) || codeInfo.IsEmpty || CodeDepositHandler.CodeIsInvalid(spec, codeInfo.Code))
+        {
+            return stack.PushZero<TTracingInst>();
+        }
+
+        vm.CodeInfoRepository.InsertCode(codeInfo.Code, vmState.Env.ExecutingAccount, spec);
+        return stack.PushOne<TTracingInst>();
+        // Jump forward to be unpredicted by the branch predictor.
+    OutOfGas:
+        return EvmExceptionType.OutOfGas;
+    StackUnderflow:
+        return EvmExceptionType.StackUnderflow;
+    StaticCallViolation:
+        return EvmExceptionType.StaticCallViolation;
+    BadInstruction:
+        return EvmExceptionType.BadInstruction;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -136,8 +136,12 @@ public static unsafe partial class EvmInstructions
         {
             lookup[(int)Instruction.SLOTNUM] = &InstructionSlotNum<TGasPolicy, TTracingInst>;
         }
+        if (spec.IsEip8298Enabled)
+        {
+            lookup[(int)Instruction.SETCODEFROM] = &InstructionSetCodeFrom<TGasPolicy, TTracingInst>;
+        }
 
-        // Gap: opcodes 0x4c to 0x4f are unassigned.
+        // Gap: opcodes 0x4d to 0x4f are unassigned.
 
         // Memory and storage instructions.
         lookup[(int)Instruction.POP] = &InstructionPop;

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -128,6 +128,7 @@ namespace Nethermind.Specs.Test
         public bool IsEip7778Enabled { get; set; } = spec.IsEip7778Enabled;
         public bool IsEip7843Enabled => spec.IsEip7843Enabled;
         public bool IsEip7954Enabled { get; set; } = spec.IsEip7954Enabled;
+        public bool IsEip8298Enabled => spec.IsEip8298Enabled;
         public SpecGasCosts GasCosts => new(this);
         FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;
     }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -189,4 +189,5 @@ public class ChainParameters
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip8298TransitionTimestamp { get; set; }
 }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -342,6 +342,7 @@ namespace Nethermind.Specs.ChainSpecStyle
 
             releaseSpec.IsEip7928Enabled = (chainSpec.Parameters.Eip7928TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip7843Enabled = (chainSpec.Parameters.Eip7843TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+            releaseSpec.IsEip8298Enabled = (chainSpec.Parameters.Eip8298TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             releaseSpec.IsEip7708Enabled = (chainSpec.Parameters.Eip7708TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -218,6 +218,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8024TransitionTimestamp = chainSpecJson.Params.Eip8024TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
+            Eip8298TransitionTimestamp = chainSpecJson.Params.Eip8298TransitionTimestamp,
         };
 
         chainSpec.Parameters.ExpandAll(chainSpecJson.Params);

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -196,6 +196,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8024TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
+    public ulong? Eip8298TransitionTimestamp { get; set; }
 
     /// <summary>
     /// Catch-all for top-level chainspec params keys that don't map to an explicit property —

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -173,6 +173,7 @@ public class ReleaseSpec : IReleaseSpec
 
     public bool IsEip7708Enabled { get; set; }
     public bool IsEip7954Enabled { get; set; }
+    public bool IsEip8298Enabled { get; set; }
 
     private ReleaseSpec? _systemSpec;
 


### PR DESCRIPTION
Implements [EIP-8298: SETCODEFROM Code Reuse Instruction](https://eips.ethereum.org/EIPS/eip-8298) (Draft).

`SETCODEFROM` is a runtime-only opcode that lets an account adopt the code hash of an already-deployed source contract, enabling code reuse (factories) and account-migration flows (e.g. installing regular wallet code to disable ECDSA authority).

## Changes

- New `SETCODEFROM` opcode (provisional `0x4c`; the spec leaves the value TBD), gated behind `IsEip8298Enabled`.
- Handler in `EvmInstructions.Environment.cs`: pops a source address, charges `SETCODEFROM_BASE_GAS` (3000) + EIP-2929 account access, validates the source (not a precompile, non-empty code, not `0xEF`-prefixed), then sets the executing account's code hash and pushes `1`; invalid sources push `0` with no state change.
- Initcode and static contexts cause an exceptional halt.
- `GasCostOf.SetCodeFromBase = 3000`.
- Spec flag `IsEip8298Enabled` across `IReleaseSpec`/`ReleaseSpec`/decorators, plus `Eip8298TransitionTimestamp` chainspec plumbing for activation.
- `Prepare.SETCODEFROM(...)` bytecode-builder helper.

## Notes

- Opcode number is provisional pending the spec.
- The "revert" wording in the spec is implemented as an exceptional halt for the initcode/static cases (per the Specification section: "causes an exceptional halt"). Static uses `StaticCallViolation`; initcode uses `BadInstruction`.

## Types of changes

- [x] New feature (a non-breaking change that adds functionality)

## Testing

- [x] Requires testing — Yes
- [x] Wrote tests — Yes

`Eip8298Tests`: valid source adopts code hash + pushes 1; invalid sources (empty / EIP-7702 delegation / `0xEF`) and precompile push 0; static context and initcode halt; cold vs warm gas; disabled fork rejects the opcode.

## Documentation

- Requires documentation update: No
- Requires explanation in Release Notes: No (experimental/unscheduled EIP)
