### PR TITLE
perf(state): trim burst-inflated collections and reduce cache contention

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/AccountChangesAtIndexTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/AccountChangesAtIndexTests.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using NUnit.Framework;
+using CoreCollectionExtensions = Nethermind.Core.Collections.CollectionExtensions;
+
+namespace Nethermind.Core.Test.BlockAccessLists;
+
+[TestFixture]
+public class AccountChangesAtIndexTests
+{
+    [Test]
+    public void Clear_trims_oversized_account_changes_before_pooling()
+    {
+        const int EntryCount = CoreCollectionExtensions.DefaultTrimAboveCapacity + 1;
+
+        BlockAccessListAtIndex blockAccessList = new();
+        AccountChangesAtIndex accountChanges = blockAccessList.RecordReadAndGet(TestItem.AddressA);
+        StorageChange storageChange = new(0, UInt256.One);
+        for (int i = 0; i < EntryCount; i++)
+        {
+            UInt256 slot = (UInt256)i;
+            accountChanges.SetStorageChange(slot, storageChange);
+            accountChanges.AddStorageRead(slot);
+            accountChanges.GetOrCapturePreTxStorage(slot, UInt256.One);
+        }
+
+        int changesCapacityBeforeClear = accountChanges.StorageChanges.Capacity;
+        int readsCapacityBeforeClear = accountChanges.StorageReads.Capacity;
+
+        blockAccessList.Clear();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(blockAccessList.AccountCount, Is.Zero);
+            Assert.That(accountChanges.StorageChanges, Is.Empty);
+            Assert.That(accountChanges.StorageChanges.Capacity, Is.GreaterThan(0));
+            Assert.That(accountChanges.StorageChanges.Capacity, Is.LessThan(changesCapacityBeforeClear));
+            Assert.That(accountChanges.StorageReads, Is.Empty);
+            Assert.That(accountChanges.StorageReads.Capacity, Is.GreaterThan(0));
+            Assert.That(accountChanges.StorageReads.Capacity, Is.LessThan(readsCapacityBeforeClear));
+        }
+
+        AccountChangesAtIndex reused = blockAccessList.RecordReadAndGet(TestItem.AddressB);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reused, Is.SameAs(accountChanges));
+            Assert.That(reused.Address, Is.EqualTo(TestItem.AddressB));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/BlockAccessListItemCountTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/BlockAccessListItemCountTests.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using NUnit.Framework;
+using CoreCollectionExtensions = Nethermind.Core.Collections.CollectionExtensions;
 
 namespace Nethermind.Core.Test.BlockAccessLists;
 
@@ -107,6 +109,32 @@ public class BlockAccessListItemCountTests
 
         Assert.That(bal.ItemCount, Is.EqualTo(5),
             "block 2: 1 account + 4 storage reads, no carryover from block 1");
+    }
+
+    [Test]
+    public void Reset_trims_oversized_account_dictionary()
+    {
+        const int OversizedCapacity = CoreCollectionExtensions.DefaultTrimAboveCapacity + 1;
+
+        GeneratedBlockAccessList bal = new();
+        object accountChanges = typeof(GeneratedBlockAccessList).GetField(
+            "_accountChanges",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(bal)!;
+        MethodInfo ensureCapacity = accountChanges.GetType().GetMethod(
+            nameof(Dictionary<int, int>.EnsureCapacity),
+            [typeof(int)])!;
+        PropertyInfo capacity = accountChanges.GetType().GetProperty(nameof(Dictionary<int, int>.Capacity))!;
+        ensureCapacity.Invoke(accountChanges, [OversizedCapacity]);
+        int capacityBeforeReset = (int)capacity.GetValue(accountChanges)!;
+
+        bal.Reset();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(capacityBeforeReset, Is.GreaterThan(CoreCollectionExtensions.DefaultTrimAboveCapacity));
+            Assert.That(capacity.GetValue(accountChanges), Is.GreaterThan(0));
+            Assert.That(capacity.GetValue(accountChanges), Is.LessThan(capacityBeforeReset));
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/AccountChangesAtIndex.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/AccountChangesAtIndex.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using Nethermind.Core.Collections;
 using Nethermind.Int256;
 
 namespace Nethermind.Core.BlockAccessLists;
@@ -89,8 +90,8 @@ public class AccountChangesAtIndex(Address address)
         CodeChange = null;
         PreTxBalance = null;
         PreTxCode = null;
-        _preTxStorage?.Clear();
-        _storageChanges.Clear();
-        _storageReads.Clear();
+        _preTxStorage?.ClearAndTrim();
+        _storageChanges.ClearAndTrim();
+        _storageReads.ClearAndTrim();
     }
 }

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessListAtIndex.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessListAtIndex.cs
@@ -64,10 +64,11 @@ public class BlockAccessListAtIndex : IJournal<int>, IResettable
         foreach (AccountChangesAtIndex value in _accountChanges.Values)
         {
             if (spareCount >= MaxPooledAccountChanges) break;
+            value.Reset(value.Address);
             _accountChangesPool.Push(value);
             spareCount++;
         }
-        _accountChanges.Clear();
+        _accountChanges.ClearAndTrim();
         _changes.Clear();
         _previousCodeChanges.Clear();
         _lastReadAddress = null;

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedBlockAccessList.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/GeneratedBlockAccessList.cs
@@ -70,7 +70,7 @@ public class GeneratedBlockAccessList
         }
     }
 
-    public void Clear() => _accountChanges.Clear();
+    public void Clear() => _accountChanges.ClearAndTrim();
     public void Reset() => Clear();
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Core/Collections/CollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/CollectionExtensions.cs
@@ -14,6 +14,12 @@ namespace Nethermind.Core.Collections
     {
         public static int LockPartitions { get; } = Environment.ProcessorCount * 16;
 
+        /// <summary>Default capacity above which <c>ClearAndTrim</c> shrinks a collection's backing storage.</summary>
+        public const int DefaultTrimAboveCapacity = 8192;
+
+        /// <summary>Default capacity <c>ClearAndTrim</c> shrinks a collection back to once <see cref="DefaultTrimAboveCapacity"/> is exceeded.</summary>
+        public const int DefaultTrimToCapacity = 1024;
+
         public static void AddRange<T>(this ICollection<T> list, IEnumerable<T> items)
         {
             switch (items)
@@ -76,11 +82,15 @@ namespace Nethermind.Core.Collections
             }
         }
 
-        /// <summary>
-        /// Clears the set and shrinks its backing storage when a past burst inflated capacity
-        /// far beyond current needs, so subsequent clears stop paying O(inflated capacity).
-        /// </summary>
-        public static void ClearAndTrim<T>(this HashSet<T> set, int trimAboveCapacity = 8192, int trimToCapacity = 1024)
+        /// <summary>Clears the set, optionally shrinking its backing storage.</summary>
+        /// <remarks>
+        /// <see cref="HashSet{T}.Clear"/> retains the grown capacity, so a past burst permanently
+        /// inflates the cost of every subsequent clear. Trimming once capacity exceeds
+        /// <paramref name="trimAboveCapacity"/> lets those clears stop paying O(inflated capacity).
+        /// </remarks>
+        /// <param name="trimAboveCapacity">Only trim when the current capacity exceeds this value.</param>
+        /// <param name="trimToCapacity">Capacity to shrink back to when trimming.</param>
+        public static void ClearAndTrim<T>(this HashSet<T> set, int trimAboveCapacity = DefaultTrimAboveCapacity, int trimToCapacity = DefaultTrimToCapacity)
         {
             set.Clear();
             if (set.Capacity > trimAboveCapacity)

--- a/src/Nethermind/Nethermind.Core/Collections/CollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/CollectionExtensions.cs
@@ -76,6 +76,19 @@ namespace Nethermind.Core.Collections
             }
         }
 
+        /// <summary>
+        /// Clears the set and shrinks its backing storage when a past burst inflated capacity
+        /// far beyond current needs, so subsequent clears stop paying O(inflated capacity).
+        /// </summary>
+        public static void ClearAndTrim<T>(this HashSet<T> set, int trimAboveCapacity = 8192, int trimToCapacity = 1024)
+        {
+            set.Clear();
+            if (set.Capacity > trimAboveCapacity)
+            {
+                set.TrimExcess(trimToCapacity);
+            }
+        }
+
         public static bool NoResizeClear<TKey, TValue>(this ConcurrentDictionary<TKey, TValue>? dictionary)
                 where TKey : notnull
         {

--- a/src/Nethermind/Nethermind.Core/Collections/CollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/CollectionExtensions.cs
@@ -82,16 +82,6 @@ namespace Nethermind.Core.Collections
             }
         }
 
-        /// <summary>Clears the set, optionally shrinking its backing storage.</summary>
-        /// <remarks>
-        /// <see cref="HashSet{T}.Clear"/> retains the grown capacity, so a past burst permanently
-        /// inflates the cost of every subsequent clear. Trimming once capacity exceeds
-        /// <paramref name="trimAboveCapacity"/> lets those clears stop paying O(inflated capacity).
-        /// To guarantee shrink-only behavior, <paramref name="trimToCapacity"/> must not exceed
-        /// <paramref name="trimAboveCapacity"/>.
-        /// </remarks>
-        /// <param name="trimAboveCapacity">Only trim when the current capacity exceeds this value.</param>
-        /// <param name="trimToCapacity">Capacity to shrink back to when trimming.</param>
         public static void ClearAndTrim<T>(this HashSet<T> set, int trimAboveCapacity = DefaultTrimAboveCapacity, int trimToCapacity = DefaultTrimToCapacity)
         {
             set.Clear();

--- a/src/Nethermind/Nethermind.Core/Collections/CollectionExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/CollectionExtensions.cs
@@ -87,6 +87,8 @@ namespace Nethermind.Core.Collections
         /// <see cref="HashSet{T}.Clear"/> retains the grown capacity, so a past burst permanently
         /// inflates the cost of every subsequent clear. Trimming once capacity exceeds
         /// <paramref name="trimAboveCapacity"/> lets those clears stop paying O(inflated capacity).
+        /// To guarantee shrink-only behavior, <paramref name="trimToCapacity"/> must not exceed
+        /// <paramref name="trimAboveCapacity"/>.
         /// </remarks>
         /// <param name="trimAboveCapacity">Only trim when the current capacity exceeds this value.</param>
         /// <param name="trimToCapacity">Capacity to shrink back to when trimming.</param>

--- a/src/Nethermind/Nethermind.Core/Collections/DictionaryExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/DictionaryExtensions.cs
@@ -76,6 +76,8 @@ public static class DictionaryExtensions
         /// <see cref="Dictionary{TKey,TValue}.Clear"/> retains the grown capacity, so a past burst
         /// permanently inflates the cost of every subsequent clear. Trimming once capacity exceeds
         /// <paramref name="trimAboveCapacity"/> lets those clears stop paying O(inflated capacity).
+        /// To guarantee shrink-only behavior, <paramref name="trimToCapacity"/> must not exceed
+        /// <paramref name="trimAboveCapacity"/>.
         /// </remarks>
         /// <param name="trimAboveCapacity">Only trim when the current capacity exceeds this value.</param>
         /// <param name="trimToCapacity">Capacity to shrink back to when trimming.</param>

--- a/src/Nethermind/Nethermind.Core/Collections/DictionaryExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/DictionaryExtensions.cs
@@ -71,16 +71,6 @@ public static class DictionaryExtensions
             return true;
         }
 
-        /// <summary>Clears the dictionary, optionally shrinking its backing storage.</summary>
-        /// <remarks>
-        /// <see cref="Dictionary{TKey,TValue}.Clear"/> retains the grown capacity, so a past burst
-        /// permanently inflates the cost of every subsequent clear. Trimming once capacity exceeds
-        /// <paramref name="trimAboveCapacity"/> lets those clears stop paying O(inflated capacity).
-        /// To guarantee shrink-only behavior, <paramref name="trimToCapacity"/> must not exceed
-        /// <paramref name="trimAboveCapacity"/>.
-        /// </remarks>
-        /// <param name="trimAboveCapacity">Only trim when the current capacity exceeds this value.</param>
-        /// <param name="trimToCapacity">Capacity to shrink back to when trimming.</param>
         public void ClearAndTrim(int trimAboveCapacity = CollectionExtensions.DefaultTrimAboveCapacity, int trimToCapacity = CollectionExtensions.DefaultTrimToCapacity)
         {
             dictionary.Clear();

--- a/src/Nethermind/Nethermind.Core/Collections/DictionaryExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/DictionaryExtensions.cs
@@ -71,11 +71,15 @@ public static class DictionaryExtensions
             return true;
         }
 
-        /// <summary>
-        /// Clears the dictionary and shrinks its backing storage when a past burst inflated capacity
-        /// far beyond current needs, so subsequent clears stop paying O(inflated capacity).
-        /// </summary>
-        public void ClearAndTrim(int trimAboveCapacity = 8192, int trimToCapacity = 1024)
+        /// <summary>Clears the dictionary, optionally shrinking its backing storage.</summary>
+        /// <remarks>
+        /// <see cref="Dictionary{TKey,TValue}.Clear"/> retains the grown capacity, so a past burst
+        /// permanently inflates the cost of every subsequent clear. Trimming once capacity exceeds
+        /// <paramref name="trimAboveCapacity"/> lets those clears stop paying O(inflated capacity).
+        /// </remarks>
+        /// <param name="trimAboveCapacity">Only trim when the current capacity exceeds this value.</param>
+        /// <param name="trimToCapacity">Capacity to shrink back to when trimming.</param>
+        public void ClearAndTrim(int trimAboveCapacity = CollectionExtensions.DefaultTrimAboveCapacity, int trimToCapacity = CollectionExtensions.DefaultTrimToCapacity)
         {
             dictionary.Clear();
             if (dictionary.Capacity > trimAboveCapacity)

--- a/src/Nethermind/Nethermind.Core/Collections/DictionaryExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/DictionaryExtensions.cs
@@ -70,6 +70,19 @@ public static class DictionaryExtensions
             dictionary.Clear();
             return true;
         }
+
+        /// <summary>
+        /// Clears the dictionary and shrinks its backing storage when a past burst inflated capacity
+        /// far beyond current needs, so subsequent clears stop paying O(inflated capacity).
+        /// </summary>
+        public void ClearAndTrim(int trimAboveCapacity = 8192, int trimToCapacity = 1024)
+        {
+            dictionary.Clear();
+            if (dictionary.Capacity > trimAboveCapacity)
+            {
+                dictionary.TrimExcess(trimToCapacity);
+            }
+        }
     }
 
     /// <param name="dictionary">The dictionary whose values will be returned and cleared.</param>

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotTests.cs
@@ -130,16 +130,19 @@ public class SnapshotTests
         }
     }
 
-    [Test]
-    public void AddressOwnedStorageNodesRetainEligibleInnerCapacityAfterQuiescentClear()
+    [TestCase(256, false)]
+    [TestCase(8_192, true)]
+    public void AddressOwnedStorageNodesRetainBoundedInnerCapacityAfterQuiescentClear(
+        int requestedCapacity,
+        bool shouldShrink)
     {
         AddressStorageNodeDictionary storageNodes = new();
         Hash256 addressA = TestItem.AddressA.ToAccountPath.ToCommitment();
         Hash256 addressB = TestItem.AddressB.ToAccountPath.ToCommitment();
         AddressStorageNodeDictionary.AddressNodes original = storageNodes.GetOrAddAddress(addressA);
-        original.EnsureAdditionalCapacity(256);
+        original.EnsureAdditionalCapacity(requestedCapacity);
         original.Set(TreePath.Empty, new TrieNode(NodeType.Unknown, TestItem.KeccakA));
-        int capacity = original.Nodes.Capacity;
+        int capacityBeforeClear = original.Nodes.Capacity;
 
         storageNodes.NoLockClear();
         AddressStorageNodeDictionary.AddressNodes reused = storageNodes.GetOrAddAddress(addressB);
@@ -147,8 +150,17 @@ public class SnapshotTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(original.Nodes, Is.Empty);
-            Assert.That(original.Nodes.Capacity, Is.EqualTo(capacity));
             Assert.That(reused.Nodes, Is.Empty);
+
+            if (shouldShrink)
+            {
+                Assert.That(original.Nodes.Capacity, Is.GreaterThan(0));
+                Assert.That(original.Nodes.Capacity, Is.LessThan(capacityBeforeClear));
+            }
+            else
+            {
+                Assert.That(original.Nodes.Capacity, Is.EqualTo(capacityBeforeClear));
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Flat/AddressStorageNodeDictionary.cs
+++ b/src/Nethermind/Nethermind.State.Flat/AddressStorageNodeDictionary.cs
@@ -21,7 +21,7 @@ namespace Nethermind.State.Flat;
 public sealed class AddressStorageNodeDictionary : IReadOnlyCollection<KeyValuePair<HashedKey<(Hash256, TreePath)>, TrieNode>>
 {
     private const int MaxPooledNodeDictionaries = 1_024;
-    private const int MaxPooledNodeCapacity = 4_096;
+    private const int PooledNodeCapacity = 4_096;
 
     private readonly ConcurrentDictionary<Hash256AsKey, AddressNodes> _byAddress = new();
     private IEnumerator<KeyValuePair<Hash256AsKey, AddressNodes>>? _cachedAddressEnumerator;
@@ -136,15 +136,13 @@ public sealed class AddressStorageNodeDictionary : IReadOnlyCollection<KeyValueP
 
         public static void Return(AddressNodes nodes)
         {
-            if (nodes.Nodes.Capacity > MaxPooledNodeCapacity) return;
-
             if (Interlocked.Increment(ref _count) > MaxPooledNodeDictionaries)
             {
                 Interlocked.Decrement(ref _count);
                 return;
             }
 
-            nodes.Nodes.Clear();
+            nodes.Nodes.ClearAndTrim(PooledNodeCapacity, PooledNodeCapacity);
             Pool.Enqueue(nodes);
         }
     }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
@@ -76,6 +76,9 @@ public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposa
 
     private void TryCacheAccount(Address address, Account? account, long readerGeneration)
     {
+        // Lock-free pre-check: repeat reads of already-cached entries are the common case and
+        // need no work; the cache is best-effort so a racing removal only loses a hint.
+        if (_accounts.ContainsKey(address)) return;
         using (_lock.EnterScope())
         {
             if (_generation != readerGeneration) return;
@@ -90,6 +93,7 @@ public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposa
 
     private void TryCacheSlot(in (Address, UInt256) key, in CachedSlot slot, long readerGeneration)
     {
+        if (_slots.ContainsKey(key)) return;
         using (_lock.EnterScope())
         {
             if (_generation != readerGeneration) return;

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CarryForwardCachingPersistence.cs
@@ -76,12 +76,13 @@ public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposa
 
     private void TryCacheAccount(Address address, Account? account, long readerGeneration)
     {
-        // Lock-free pre-check: repeat reads of already-cached entries are the common case and
-        // need no work; the cache is best-effort so a racing removal only loses a hint.
+        // Another reader can fill the same base miss while this reader is doing I/O.
+        // The cache is best-effort, so a racing removal only loses a hint.
         if (_accounts.ContainsKey(address)) return;
         using (_lock.EnterScope())
         {
             if (_generation != readerGeneration) return;
+            if (_accounts.ContainsKey(address)) return;
             if (_accountCount >= _maxEntriesPerKind)
             {
                 _accounts.Clear();
@@ -97,6 +98,7 @@ public sealed class CarryForwardCachingPersistence : IPersistence, IAsyncDisposa
         using (_lock.EnterScope())
         {
             if (_generation != readerGeneration) return;
+            if (_slots.ContainsKey(key)) return;
             if (_slotCount >= _maxEntriesPerKind)
             {
                 _slots.Clear();

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -366,8 +366,13 @@ public sealed class SnapshotBundle : IDisposable
         return count;
     }
 
-    public void SetAccount(Address address, Account? account) =>
+    public void SetAccount(Address address, Account? account)
+    {
+        // Read backfills (HintGet) repeat far more often than genuine changes; skip the locked
+        // indexer write when the entry already holds this exact account.
+        if (_changedAccounts.TryGetValue(address, out Account? existing) && ReferenceEquals(existing, account)) return;
         _changedAccounts[address] = account;
+    }
 
     internal void PromoteAccount(Address address, Account? account) =>
         _changedAccounts.TryAdd(address, account);

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -370,8 +370,9 @@ public sealed class SnapshotBundle : IDisposable
     {
         // Read backfills (HintGet) repeat far more often than genuine changes; skip the locked
         // indexer write when the entry already holds this exact account.
-        if (_changedAccounts.TryGetValue(address, out Account? existing) && ReferenceEquals(existing, account)) return;
-        _changedAccounts[address] = account;
+        HashedKey<Address> key = new(address);
+        if (_changedAccounts.TryGetValue(key, out Account? existing) && ReferenceEquals(existing, account)) return;
+        _changedAccounts[key] = account;
     }
 
     internal void PromoteAccount(Address address, Account? account) =>

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -366,14 +366,8 @@ public sealed class SnapshotBundle : IDisposable
         return count;
     }
 
-    public void SetAccount(Address address, Account? account)
-    {
-        // Read backfills (HintGet) repeat far more often than genuine changes; skip the locked
-        // indexer write when the entry already holds this exact account.
-        HashedKey<Address> key = new(address);
-        if (_changedAccounts.TryGetValue(key, out Account? existing) && ReferenceEquals(existing, account)) return;
-        _changedAccounts[key] = account;
-    }
+    public void SetAccount(Address address, Account? account) =>
+        _changedAccounts[address] = account;
 
     internal void PromoteAccount(Address address, Account? account) =>
         _changedAccounts.TryAdd(address, account);

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -23,6 +23,7 @@ using Nethermind.State;
 using Nethermind.Evm.Tracing.State;
 using NSubstitute;
 using NUnit.Framework;
+using CoreCollectionExtensions = Nethermind.Core.Collections.CollectionExtensions;
 
 namespace Nethermind.Store.Test;
 
@@ -88,6 +89,42 @@ public class StorageProviderTests(bool useFlat)
         }
     }
 
+    [Test]
+    public void Reset_trims_oversized_round_collections()
+    {
+        const int OversizedCapacity = CoreCollectionExtensions.DefaultTrimAboveCapacity + 1;
+
+        using Context ctx = new(useFlat);
+        WorldState provider = BuildStorageProvider(ctx);
+        object[] collections =
+        [
+            GetPrivateField(provider._stateProvider, "_intraTxCache"),
+            GetPrivateField(provider._stateProvider, "_committedThisRound"),
+            GetPrivateField(provider._stateProvider, "_nullAccountReads"),
+            GetPrivateField(provider._persistentStorageProvider, "_originalValues"),
+            GetPrivateField(provider._persistentStorageProvider, "_committedThisRound"),
+            GetPrivateField(provider._persistentStorageProvider, "_destroyedThisRound"),
+        ];
+        int[] capacitiesBeforeReset = new int[collections.Length];
+        for (int i = 0; i < collections.Length; i++)
+        {
+            EnsureCapacity(collections[i], OversizedCapacity);
+            capacitiesBeforeReset[i] = GetCollectionCapacity(collections[i]);
+        }
+
+        provider.Reset();
+
+        using (Assert.EnterMultipleScope())
+        {
+            for (int i = 0; i < collections.Length; i++)
+            {
+                Assert.That(capacitiesBeforeReset[i], Is.GreaterThan(CoreCollectionExtensions.DefaultTrimAboveCapacity));
+                Assert.That(GetCollectionCapacity(collections[i]), Is.GreaterThan(0));
+                Assert.That(GetCollectionCapacity(collections[i]), Is.LessThan(capacitiesBeforeReset[i]));
+            }
+        }
+    }
+
     private static object GetBlockChange(WorldState provider, Address address)
     {
         FieldInfo storagesField = typeof(PersistentStorageProvider).GetField(
@@ -110,6 +147,15 @@ public class StorageProviderTests(bool useFlat)
         object dictionary = dictionaryField.GetValue(collection)!;
         return (int)dictionary.GetType().GetProperty(nameof(System.Collections.Generic.Dictionary<int, int>.Capacity))!.GetValue(dictionary)!;
     }
+
+    private static object GetPrivateField(object owner, string fieldName) =>
+        owner.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(owner)!;
+
+    private static void EnsureCapacity(object collection, int capacity) =>
+        collection.GetType().GetMethod(nameof(System.Collections.Generic.Dictionary<int, int>.EnsureCapacity), [typeof(int)])!.Invoke(collection, [capacity]);
+
+    private static int GetCollectionCapacity(object collection) =>
+        (int)collection.GetType().GetProperty(nameof(System.Collections.Generic.Dictionary<int, int>.Capacity))!.GetValue(collection)!;
 
     [TestCase(-1)]
     [TestCase(0)]

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
+using System.Reflection;
 using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Core;
@@ -58,6 +60,56 @@ public class StorageProviderTests(bool useFlat)
     }
 
     private WorldState BuildStorageProvider(Context ctx) => ctx.StateProvider;
+
+    [Test]
+    [NonParallelizable]
+    public void Oversized_per_contract_state_dictionary_is_trimmed_when_returned()
+    {
+        const int ChangeCount = 1_024;
+
+        using Context ctx = new(useFlat);
+        WorldState provider = BuildStorageProvider(ctx);
+        for (int i = 0; i < ChangeCount; i++)
+        {
+            provider.Set(new StorageCell(ctx.Address1, (UInt256)i), _values[1]);
+        }
+
+        provider.Commit(Frontier.Instance);
+        object blockChange = GetBlockChange(provider, ctx.Address1);
+        int capacityBeforeReturn = GetCapacity(blockChange);
+
+        provider.Reset();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(capacityBeforeReturn, Is.GreaterThan(512));
+            Assert.That(GetCapacity(blockChange), Is.GreaterThan(0));
+            Assert.That(GetCapacity(blockChange), Is.LessThan(capacityBeforeReturn));
+        }
+    }
+
+    private static object GetBlockChange(WorldState provider, Address address)
+    {
+        FieldInfo storagesField = typeof(PersistentStorageProvider).GetField(
+            "_storages",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        IDictionary storages = (IDictionary)storagesField.GetValue(provider._persistentStorageProvider)!;
+        object contractState = storages[new AddressAsKey(address)]
+            ?? throw new InvalidOperationException("Contract state was not created.");
+        FieldInfo blockChangeField = contractState.GetType().GetField(
+            "BlockChange",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return blockChangeField.GetValue(contractState)!;
+    }
+
+    private static int GetCapacity(object collection)
+    {
+        FieldInfo dictionaryField = collection.GetType().GetField(
+            "_dictionary",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        object dictionary = dictionaryField.GetValue(collection)!;
+        return (int)dictionary.GetType().GetProperty(nameof(System.Collections.Generic.Dictionary<int, int>.Capacity))!.GetValue(dictionary)!;
+    }
 
     [TestCase(-1)]
     [TestCase(0)]

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Resettables;
 using Nethermind.Evm.Tracing.State;
 using Nethermind.Logging;
@@ -161,7 +162,7 @@ namespace Nethermind.State
             if (_logger.IsTrace) _logger.Trace("Resetting storage");
 
             _changes.Clear();
-            _intraBlockCache.Clear();
+            _intraBlockCache.ClearAndTrim();
             _transactionChangesSnapshots.Clear();
         }
 

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -417,12 +417,11 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         private readonly Dictionary<UInt256, StorageChangeTrace> _dictionary = new(Comparer.Instance);
         public int EstimatedSize => _dictionary.Count + (_missingAreDefault ? 1 : 0);
         public bool HasClear => _missingAreDefault;
-        public int Capacity => _dictionary.Capacity;
 
-        public void Reset()
+        public void Reset(int capacity)
         {
             _missingAreDefault = false;
-            _dictionary.Clear();
+            _dictionary.ClearAndTrim(capacity, capacity);
         }
         public void ClearAndSetMissingAsDefault()
         {
@@ -672,11 +671,8 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
             public static void Return(PerContractState item)
             {
-                const int MaxItemSize = 512;
+                const int PooledDictionaryCapacity = 512;
                 const int MaxPooledCount = 2048;
-
-                if (item.BlockChange.Capacity > MaxItemSize)
-                    return;
 
                 // shared pool fallback
                 if (Interlocked.Increment(ref _poolCount) > MaxPooledCount)
@@ -685,7 +681,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                     return;
                 }
 
-                item.BlockChange.Reset();
+                item.BlockChange.Reset(PooledDictionaryCapacity);
                 _pool.Enqueue(item);
             }
         }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -48,9 +48,9 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     public override void Reset(bool resetBlockChanges = true)
     {
         base.Reset();
-        _originalValues.Clear();
-        _committedThisRound.Clear();
-        _destroyedThisRound.Clear();
+        _originalValues.ClearAndTrim();
+        _committedThisRound.ClearAndTrim();
+        _destroyedThisRound.ClearAndTrim();
         if (resetBlockChanges)
         {
             _storages.ResetAndClear();
@@ -123,7 +123,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         int currentPosition = _changes.Count - 1;
         if (currentPosition < 0)
         {
-            _destroyedThisRound.Clear();
+            _destroyedThisRound.ClearAndTrim();
             return;
         }
         if (_changes[currentPosition].IsNull)
@@ -233,9 +233,9 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
 
         base.CommitCore(tracer);
-        _originalValues.Clear();
-        _committedThisRound.Clear();
-        _destroyedThisRound.Clear();
+        _originalValues.ClearAndTrim();
+        _committedThisRound.ClearAndTrim();
+        _destroyedThisRound.ClearAndTrim();
 
         if (isTracing)
         {
@@ -374,10 +374,10 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                     }
                 }
 
-                _originalValues.Clear();
+                _originalValues.ClearAndTrim();
             }
 
-            _destroyedThisRound.Clear();
+            _destroyedThisRound.ClearAndTrim();
             return;
         }
 

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -632,9 +632,9 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
         InvalidateFrontCache();
         _changes.Clear();
-        _committedThisRound.Clear();
-        _nullAccountReads.Clear();
-        _intraTxCache.Clear();
+        _committedThisRound.ClearAndTrim();
+        _nullAccountReads.ClearAndTrim();
+        _intraTxCache.ClearAndTrim();
 
         codeFlushTask.GetAwaiter().GetResult();
 

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -879,9 +879,9 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             _blockChanges.Clear();
             _codeBatch?.Clear();
         }
-        _intraTxCache.Clear();
-        _committedThisRound.Clear();
-        _nullAccountReads.Clear();
+        _intraTxCache.ClearAndTrim();
+        _committedThisRound.ClearAndTrim();
+        _nullAccountReads.ClearAndTrim();
         InvalidateFrontCache();
         _changes.Clear();
         _needsStateRootUpdate = false;


### PR DESCRIPTION
## Changes

- Shared `ClearAndTrim` extensions for `Dictionary` and `HashSet`: `Clear()` retains capacity, so a single storm block can permanently inflate every later transaction/block reset until restart. Collections above 8192 capacity are cleared and trimmed back toward 1024.
- State/storage commit and reset boundaries now use `ClearAndTrim`, as does `GeneratedBlockAccessList.Clear`, preventing burst-sized backing arrays from surviving into ordinary blocks.
- Pool return paths reuse trimmed collections instead of discarding them: `PerContractState` trims toward 512 capacity and address-owned storage-node dictionaries toward 4096. BAL account changes are reset before enqueue and trim their storage dictionaries/sets with the shared 8192→1024 policy.
- `CarryForwardCachingPersistence.TryCache*` keeps the lock-free miss pre-check and now checks again after acquiring the existing global lock. When another reader fills the same base miss during I/O, the waiter avoids a redundant `ConcurrentDictionary` operation and cannot rotate a full cache for a key that is already present. No additional lock is introduced.

Extracted from the monster-block campaign branch (`perf/monster-block-p1`, companion to #12425). The campaign-wide profile showed the `Monitor.Enter` leaf band fall from 1241→252 units across several changes; that aggregate is context for the contention audit, not an isolated A/B claim for this PR. The XEN batch-mint transaction shape that motivates the trim currently appears in ~5.8% of mainnet blocks.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added regression coverage for pooled dictionary/hash-set capacity retention, trimming, reuse, and the newly covered state/storage and generated-BAL reset boundaries. Focused suites pass on the pushed branch: `BlockAccessListItemCountTests` (11), `StorageProviderTests` (108 across both backends), and `CarryForwardCachingPersistenceTests` (11). Targeted `dotnet format whitespace` and `git diff --check` also pass.

Semantics are unchanged: trimming clears first and only shrinks capacity above the threshold; the cache double-check happens after acquiring the same existing lock; and racing invalidation can only lose a best-effort cache hint.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No