### PR TITLE
ci: pin the zisk image to the last working digest

### DIFF
--- a/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
+++ b/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
@@ -60,7 +60,7 @@ build: dotnet-build
 run:
 	docker run --rm -e RUST_BACKTRACE=full \
 		--mount type=bind,source="$(GUEST_DIR)/bin",target=/n \
-		nethermindeth/zisk:1.0.0-alpha \
+		nethermindeth/zisk@sha256:bad3982b10861adb452c90906ce8e93907ae6095205c89c1377a960c767b4e7a \
 		ziskemu -e /n/nethermind -i /n/$(INPUT)
 
 build-run: build run

--- a/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
+++ b/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
@@ -60,7 +60,7 @@ build: dotnet-build
 run:
 	docker run --rm -e RUST_BACKTRACE=full \
 		--mount type=bind,source="$(GUEST_DIR)/bin",target=/n \
-		nethermindeth/zisk@sha256:bad3982b10861adb452c90906ce8e93907ae6095205c89c1377a960c767b4e7a \
+		nethermindeth/zisk:1.0.0-alpha@sha256:bad3982b10861adb452c90906ce8e93907ae6095205c89c1377a960c767b4e7a \
 		ziskemu -e /n/nethermind -i /n/$(INPUT)
 
 build-run: build run


### PR DESCRIPTION
## Changes

- Pin `nethermindeth/zisk` in the `Nethermind.Stateless.ZiskGuest` Makefile `run` target to the digest that was green through 2026-07-21, instead of the mutable `1.0.0-alpha` tag.

Every "Stateless execution tests" run repo-wide has failed since ~08:00 UTC today, on all branches: `ziskemu` crashes on startup with `Caught signal 4 (Illegal instruction)` inside the container, e.g. [this run](https://github.com/NethermindEth/nethermind/actions/runs/29906976637/job/88881072046). The cause is that the `1.0.0-alpha` tag was re-pushed at 07:55 UTC today (digest changed `bad3982b…` → `5ba525cf…`, also tagged `4b9f758fabc4955cac20af837019ccc31b803a46`), and the new build appears to use an instruction set the GitHub-hosted runner CPUs don't have. Yesterday's green runs (e.g. [master 23:46 UTC](https://github.com/NethermindEth/nethermind/actions/runs/29878163470)) pulled the same tag at digest `bad3982b…`.

Pinning by digest restores green and makes the job immune to future re-pushes of the tag, matching the sibling `bflat-riscv64` image which is already pinned by commit tag. Note for the image owners: the good digest is currently untagged on Docker Hub (the tag moved), so it would be good to either re-tag it (so it cannot be garbage-collected) or fix the `4b9f758` build for older CPUs — then this pin can move forward.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

The "Stateless execution tests" workflow on this PR exercises the change directly; the pinned digest is the exact image every run was green on through yesterday. `docker manifest inspect` confirms the digest is still pullable.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No