### PR TITLE
Lead preimage flat DB storage keys with the full address

### DIFF
--- a/src/Nethermind/Nethermind.Db/FlatLayout.cs
+++ b/src/Nethermind/Nethermind.Db/FlatLayout.cs
@@ -7,5 +7,6 @@ public enum FlatLayout
 {
     Flat,
     FlatInTrie,
+    PreimageFlatV1,
     PreimageFlat,
 }

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -102,7 +102,6 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
             .AddSingleton<FlatInTriePersistence>()
             .AddDecorator<IRocksDbConfigFactory, FlatRocksDbConfigAdjuster>()
 
-            .AddSingleton<PreimageRocksdbPersistence>()
             .AddDatabase(DbNames.Preimage)
 
             .AddSingleton<IPersistence, IFlatDbConfig, IProcessExitSource, ILogManager, IComponentContext>((flatDbConfig, exitSource, logManager, ctx) =>
@@ -111,7 +110,8 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                 {
                     FlatLayout.Flat => ctx.Resolve<RocksDbPersistence>(),
                     FlatLayout.FlatInTrie => ctx.Resolve<FlatInTriePersistence>(),
-                    FlatLayout.PreimageFlat => ctx.Resolve<PreimageRocksdbPersistence>(),
+                    FlatLayout.PreimageFlatV1 or FlatLayout.PreimageFlat =>
+                        new PreimageRocksdbPersistence(ctx.Resolve<IColumnsDb<FlatDbColumns>>(), logManager, flatDbConfig.Layout),
                     _ => throw new NotSupportedException($"Unsupported layout {flatDbConfig.Layout}")
                 };
 

--- a/src/Nethermind/Nethermind.Init/Steps/ImportFlatDb.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/ImportFlatDb.cs
@@ -35,11 +35,11 @@ public class ImportFlatDb(
 
     public async Task Execute(CancellationToken cancellationToken)
     {
-        // Validate that we're not using PreimageFlat layout
-        if (flatDbConfig.Layout == FlatLayout.PreimageFlat)
+        // Validate that we're not using a preimage layout
+        if (flatDbConfig.Layout is FlatLayout.PreimageFlatV1 or FlatLayout.PreimageFlat)
         {
-            if (_logger.IsError) _logger.Error("Cannot import with FlatLayout.PreimageFlat. Use FlatLayout.Flat or FlatLayout.FlatInTrie instead.");
-            if (_logger.IsError) _logger.Error("PreimageFlat mode does not support importing from trie state because the importer uses hash-based raw operations.");
+            if (_logger.IsError) _logger.Error($"Cannot import with FlatLayout.{flatDbConfig.Layout}. Use FlatLayout.Flat or FlatLayout.FlatInTrie instead.");
+            if (_logger.IsError) _logger.Error("Preimage mode does not support importing from trie state because the importer uses hash-based raw operations.");
             exitSource.Exit(1);
             return;
         }

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -23,9 +23,12 @@ namespace Nethermind.State.Flat.Test;
 /// and preimage mode (two-pass verification).
 /// </summary>
 [TestFixture(FlatLayout.Flat)]
+[TestFixture(FlatLayout.PreimageFlatV1)]
 [TestFixture(FlatLayout.PreimageFlat)]
 public class FlatTrieVerifierTests(FlatLayout layout)
 {
+    private bool IsPreimage => layout is FlatLayout.PreimageFlatV1 or FlatLayout.PreimageFlat;
+
     private static readonly AccountDecoder SlimAccountDecoder = AccountDecoder.Slim;
     private MemDb _trieDb = null!;
     private RawScopedTrieStore _trieStore = null!;
@@ -46,8 +49,8 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         // These tests seed the Storage column with raw (un-wrapped) bytes after the persistence is built,
         // so slot-presence detection can't kick in — pin the raw encoding up front.
         BasePersistence.SetSlotEncoding(_columnsDb.GetColumnDb(FlatDbColumns.Metadata), BasePersistence.SlotEncodingRaw);
-        _persistence = layout == FlatLayout.PreimageFlat
-            ? new PreimageRocksdbPersistence(_columnsDb, _logManager)
+        _persistence = IsPreimage
+            ? new PreimageRocksdbPersistence(_columnsDb, _logManager, layout)
             : new RocksDbPersistence(_columnsDb, _logManager);
     }
 
@@ -88,7 +91,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         ValueHash256 addrHash;
         ValueHash256 slotHash;
 
-        if (layout == FlatLayout.PreimageFlat)
+        if (IsPreimage)
         {
             addrHash = CreatePreimageAddressKey(address);
             slotHash = ValueKeccak.Zero;
@@ -103,9 +106,17 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         }
 
         byte[] storageKey = new byte[52];
-        addrHash.Bytes[..4].CopyTo(storageKey.AsSpan()[..4]);
-        slotHash.Bytes.CopyTo(storageKey.AsSpan()[4..36]);
-        addrHash.Bytes[4..20].CopyTo(storageKey.AsSpan()[36..52]);
+        if (layout == FlatLayout.PreimageFlat)
+        {
+            addrHash.Bytes[..20].CopyTo(storageKey.AsSpan()[..20]);
+            slotHash.Bytes.CopyTo(storageKey.AsSpan()[20..52]);
+        }
+        else
+        {
+            addrHash.Bytes[..4].CopyTo(storageKey.AsSpan()[..4]);
+            slotHash.Bytes.CopyTo(storageKey.AsSpan()[4..36]);
+            addrHash.Bytes[4..20].CopyTo(storageKey.AsSpan()[36..52]);
+        }
 
         storageDb.PutSpan(storageKey, ((ReadOnlySpan<byte>)value).WithoutLeadingZeros());
     }
@@ -113,7 +124,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
     private void CorruptAccountInFlat(Address address, Account corruptedAccount)
     {
         IDb accountDb = _columnsDb.GetColumnDb(FlatDbColumns.Account);
-        ValueHash256 addrKey = layout == FlatLayout.PreimageFlat
+        ValueHash256 addrKey = IsPreimage
             ? CreatePreimageAddressKey(address)
             : ValueKeccak.Compute(address.Bytes);
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/LayoutMetadataTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/LayoutMetadataTests.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Collections.Generic;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
 using Nethermind.Db;
@@ -12,6 +14,17 @@ namespace Nethermind.State.Flat.Test.Persistence;
 [TestFixture]
 public class LayoutMetadataTests
 {
+    private static IEnumerable<FlatLayout> Layouts() => Enum.GetValues<FlatLayout>();
+
+    /// <summary>Every ordered pair of distinct layouts, so a newly added layout is covered without further edits.</summary>
+    private static IEnumerable<object[]> LayoutMismatches()
+    {
+        foreach (FlatLayout stored in Layouts())
+            foreach (FlatLayout configured in Layouts())
+                if (stored != configured)
+                    yield return [stored, configured];
+    }
+
     [Test]
     public void ReadLayout_ReturnsNull_OnEmptyStore()
     {
@@ -19,9 +32,7 @@ public class LayoutMetadataTests
         Assert.That(BasePersistence.ReadLayout(db.GetColumnDb(FlatDbColumns.Metadata)), Is.Null);
     }
 
-    [TestCase(FlatLayout.Flat)]
-    [TestCase(FlatLayout.FlatInTrie)]
-    [TestCase(FlatLayout.PreimageFlat)]
+    [TestCaseSource(nameof(Layouts))]
     public void SetLayout_Then_ReadLayout_RoundTrips(FlatLayout layout)
     {
         using MemColumnsDb<FlatDbColumns> db = new();
@@ -44,18 +55,14 @@ public class LayoutMetadataTests
             Is.EqualTo(new[] { BasePersistence.SlotEncodingRlp }));
     }
 
-    [TestCase(FlatLayout.Flat)]
-    [TestCase(FlatLayout.FlatInTrie)]
-    [TestCase(FlatLayout.PreimageFlat)]
+    [TestCaseSource(nameof(Layouts))]
     public void ValidateLayout_DoesNotThrow_OnFreshDb(FlatLayout layout)
     {
         using MemColumnsDb<FlatDbColumns> db = new();
         Assert.DoesNotThrow(() => BasePersistence.ValidateLayout(db, layout));
     }
 
-    [TestCase(FlatLayout.Flat)]
-    [TestCase(FlatLayout.FlatInTrie)]
-    [TestCase(FlatLayout.PreimageFlat)]
+    [TestCaseSource(nameof(Layouts))]
     public void ValidateLayout_DoesNotThrow_WhenStoredMatches(FlatLayout layout)
     {
         using MemColumnsDb<FlatDbColumns> db = new();
@@ -63,21 +70,14 @@ public class LayoutMetadataTests
         Assert.DoesNotThrow(() => BasePersistence.ValidateLayout(db, layout));
     }
 
-    [TestCase(FlatLayout.Flat)]
-    [TestCase(FlatLayout.FlatInTrie)]
-    [TestCase(FlatLayout.PreimageFlat)]
+    [TestCaseSource(nameof(Layouts))]
     public void ValidateLayoutReturnFlag_ReturnsZero(FlatLayout layout)
     {
         using MemColumnsDb<FlatDbColumns> db = new();
         Assert.That(BasePersistence.ValidateLayoutReturnFlag(db, layout), Is.EqualTo(0));
     }
 
-    [TestCase(FlatLayout.Flat, FlatLayout.FlatInTrie)]
-    [TestCase(FlatLayout.FlatInTrie, FlatLayout.Flat)]
-    [TestCase(FlatLayout.Flat, FlatLayout.PreimageFlat)]
-    [TestCase(FlatLayout.FlatInTrie, FlatLayout.PreimageFlat)]
-    [TestCase(FlatLayout.PreimageFlat, FlatLayout.Flat)]
-    [TestCase(FlatLayout.PreimageFlat, FlatLayout.FlatInTrie)]
+    [TestCaseSource(nameof(LayoutMismatches))]
     public void ValidateLayout_Throws_WhenStoredDiffers(FlatLayout stored, FlatLayout configured)
     {
         using MemColumnsDb<FlatDbColumns> db = new();
@@ -90,9 +90,7 @@ public class LayoutMetadataTests
         Assert.That(ex.Message, Does.Contain(configured.ToString()));
     }
 
-    [TestCase(FlatLayout.Flat)]
-    [TestCase(FlatLayout.FlatInTrie)]
-    [TestCase(FlatLayout.PreimageFlat)]
+    [TestCaseSource(nameof(Layouts))]
     public void RecordLayoutOnFirstBatch_WritesAndFlipsFlag_WhenZero(FlatLayout layout)
     {
         using MemColumnsDb<FlatDbColumns> db = new();

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/PreimageStorageKeyTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/PreimageStorageKeyTests.cs
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Db;
+using Nethermind.Int256;
+using Nethermind.State.Flat.Persistence;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test.Persistence;
+
+/// <summary>
+/// Covers the two preimage storage key shapes. In preimage mode the address is not hashed, so whatever leads the
+/// key is attacker-chosen: the 4-byte lead of <see cref="FlatLayout.PreimageFlatV1"/> is cheap to mine and vanity
+/// addresses really do share one (all Seaport contracts lead with zero bytes), which turns a per-account slot
+/// scan into a scan of every account sharing the lead.
+/// </summary>
+[TestFixture]
+public class PreimageStorageKeyTests
+{
+    private const int SlotsPerAccount = 4;
+
+    // Two addresses sharing a mined 4-byte lead.
+    private static readonly Address AddressA = new("0x00000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    private static readonly Address AddressB = new("0x00000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    private const string SlotOneKey = "0000000000000000000000000000000000000000000000000000000000000001";
+    private const string AddressALead = "00000000";
+    private const string AddressARest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    [TestCase(FlatLayout.PreimageFlat, AddressALead + AddressARest + SlotOneKey)]
+    [TestCase(FlatLayout.PreimageFlatV1, AddressALead + SlotOneKey + AddressARest)]
+    public void StorageKey_HasExpectedShape(FlatLayout layout, string expectedKey)
+    {
+        using SnapshotableMemDb state = new();
+        using SnapshotableMemDb storage = new();
+        WriteSlots(state, storage, AddressA, layout, slotCount: 1);
+
+        Assert.That(storage.FirstKey, Is.EqualTo(Bytes.FromHexString(expectedKey)));
+    }
+
+    [TestCase(FlatLayout.PreimageFlat, SlotsPerAccount)]
+    [TestCase(FlatLayout.PreimageFlatV1, SlotsPerAccount * 2)]
+    public void StorageScan_WalksOnlyOwnAccountSlots(FlatLayout layout, int expectedKeysWalked)
+    {
+        using SnapshotableMemDb state = new();
+        using SnapshotableMemDb storage = new();
+        WriteSlots(state, storage, AddressA, layout, SlotsPerAccount);
+        WriteSlots(state, storage, AddressB, layout, SlotsPerAccount);
+
+        CountingSortedStore countingStorage = new(storage);
+        BaseFlatPersistence.Reader reader = new(
+            state,
+            countingStorage,
+            isPreimageMode: true,
+            rlpWrapSlots: true,
+            fullAddressStorageKey: IsFullAddressKey(layout));
+
+        List<UInt256> scannedSlots = [];
+        using (IPersistence.IFlatIterator iterator = reader.CreateStorageIterator(AsPreimageKey(AddressA), ValueKeccak.Zero, ValueKeccak.MaxValue))
+        {
+            while (iterator.MoveNext()) scannedSlots.Add(new UInt256(iterator.CurrentKey.Bytes, isBigEndian: true));
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Both shapes yield the same slots — only the shape decides how much of the column has to be read
+            // to get them, which is what makes a scan over vanity-prefixed accounts quadratic under V1.
+            Assert.That(scannedSlots, Is.EqualTo(Slots(SlotsPerAccount)));
+            Assert.That(countingStorage.KeysWalked, Is.EqualTo(expectedKeysWalked));
+        }
+    }
+
+    private static bool IsFullAddressKey(FlatLayout layout) => layout is not FlatLayout.PreimageFlatV1;
+
+    private static List<UInt256> Slots(int slotCount)
+    {
+        List<UInt256> slots = [];
+        for (int i = 1; i <= slotCount; i++) slots.Add((UInt256)i);
+        return slots;
+    }
+
+    private static void WriteSlots(SnapshotableMemDb state, SnapshotableMemDb storage, Address address, FlatLayout layout, int slotCount)
+    {
+        using IWriteBatch stateBatch = state.StartWriteBatch();
+        using IWriteBatch storageBatch = storage.StartWriteBatch();
+        BaseFlatPersistence.WriteBatch writeBatch = new(
+            state,
+            storage,
+            stateBatch,
+            storageBatch,
+            WriteFlags.None,
+            rlpWrapSlots: true,
+            fullAddressStorageKey: IsFullAddressKey(layout));
+
+        foreach (UInt256 slot in Slots(slotCount))
+        {
+            writeBatch.SetStorage(AsPreimageKey(address), AsPreimageKey(slot), SlotValue.FromSpanWithoutLeadingZero(Bytes.FromHexString("0x01")));
+        }
+    }
+
+    /// <summary>Preimage mode fakes the address hash by copying the address into the leading bytes.</summary>
+    private static ValueHash256 AsPreimageKey(Address address)
+    {
+        ValueHash256 key = ValueKeccak.Zero;
+        address.Bytes.CopyTo(key.BytesAsSpan);
+        return key;
+    }
+
+    /// <summary>Preimage mode fakes the slot hash with the big-endian slot index.</summary>
+    private static ValueHash256 AsPreimageKey(in UInt256 slot)
+    {
+        ValueHash256 key = ValueKeccak.Zero;
+        slot.ToBigEndian(key.BytesAsSpan);
+        return key;
+    }
+
+    /// <summary>Counts how many keys a range scan actually walks, including the ones it filters back out.</summary>
+    private sealed class CountingSortedStore(ISortedKeyValueStore inner) : ISortedKeyValueStore
+    {
+        public int KeysWalked { get; private set; }
+
+        public byte[]? Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) => inner.Get(key, flags);
+        public byte[]? FirstKey => inner.FirstKey;
+        public byte[]? LastKey => inner.LastKey;
+
+        public ISortedView GetViewBetween(ReadOnlySpan<byte> firstKeyInclusive, ReadOnlySpan<byte> lastKeyExclusive) =>
+            new CountingSortedView(this, inner.GetViewBetween(firstKeyInclusive, lastKeyExclusive));
+
+        private sealed class CountingSortedView(CountingSortedStore owner, ISortedView inner) : ISortedView
+        {
+            public bool StartBefore(ReadOnlySpan<byte> value) => inner.StartBefore(value);
+
+            public bool MoveNext()
+            {
+                if (!inner.MoveNext()) return false;
+                owner.KeysWalked++;
+                return true;
+            }
+
+            public ReadOnlySpan<byte> CurrentKey => inner.CurrentKey;
+            public ReadOnlySpan<byte> CurrentValue => inner.CurrentValue;
+
+            public void Dispose() => inner.Dispose();
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceScenario.cs
@@ -50,22 +50,17 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
 
     public static IEnumerable<TestConfiguration> TestConfigs()
     {
-        yield return new TestConfiguration(new FlatDbConfig()
+        foreach (FlatLayout layout in Enum.GetValues<FlatLayout>())
         {
-            Enabled = true,
-            Layout = FlatLayout.Flat
-        }, "Flat");
-        yield return new TestConfiguration(new FlatDbConfig()
-        {
-            Enabled = true,
-            Layout = FlatLayout.FlatInTrie
-        }, "FlatInTrie");
-        yield return new TestConfiguration(new FlatDbConfig()
-        {
-            Enabled = true,
-            Layout = FlatLayout.PreimageFlat
-        }, "PreimageFlat");
+            yield return new TestConfiguration(new FlatDbConfig()
+            {
+                Enabled = true,
+                Layout = layout
+            }, layout.ToString());
+        }
     }
+
+    private static bool IsPreimage(FlatLayout layout) => layout is FlatLayout.PreimageFlatV1 or FlatLayout.PreimageFlat;
 
     [SetUp]
     public void Setup()
@@ -310,7 +305,7 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
     [Test]
     public void TestRawOperations()
     {
-        if (configuration.FlatDbConfig.Layout == FlatLayout.PreimageFlat) Assert.Ignore("Preimage mode does not support raw operation");
+        if (IsPreimage(configuration.FlatDbConfig.Layout)) Assert.Ignore("Preimage mode does not support raw operation");
 
         Account acc = TestItem.GenerateIndexedAccount(0);
         Hash256 addrHash = new(TestItem.AddressA.ToAccountPath.Bytes);
@@ -876,8 +871,8 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
     [Test]
     public void TestStorageIterator_EnumeratesAccountStorage()
     {
-        // PreimageFlat uses raw address, others use hashed address paths
-        if (configuration.FlatDbConfig.Layout == FlatLayout.PreimageFlat)
+        // Preimage layouts use raw address, others use hashed address paths
+        if (IsPreimage(configuration.FlatDbConfig.Layout))
             Assert.Ignore("Preimage mode uses raw address format which differs from hashed mode");
 
         // Write account with storage
@@ -913,7 +908,7 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
     [Test]
     public void TestStorageIterator_NoStorage_ReturnsEmpty()
     {
-        if (configuration.FlatDbConfig.Layout == FlatLayout.PreimageFlat)
+        if (IsPreimage(configuration.FlatDbConfig.Layout))
             Assert.Ignore("Preimage mode uses raw address format which differs from hashed mode");
 
         // Write account without storage
@@ -943,7 +938,7 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
     [Test]
     public void TestStorageIterator_IsolatesAccountStorage()
     {
-        if (configuration.FlatDbConfig.Layout == FlatLayout.PreimageFlat)
+        if (IsPreimage(configuration.FlatDbConfig.Layout))
             Assert.Ignore("Preimage mode uses raw address format which differs from hashed mode");
 
         // Write storage for two accounts
@@ -985,8 +980,8 @@ public class PersistenceScenario(PersistenceScenario.TestConfiguration configura
     {
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
 
-        // PreimageFlat layout should return true, others false
-        bool expected = configuration.FlatDbConfig.Layout == FlatLayout.PreimageFlat;
+        // Preimage layouts should return true, others false
+        bool expected = IsPreimage(configuration.FlatDbConfig.Layout);
         Assert.That(reader.IsPreimageMode, Is.EqualTo(expected));
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
@@ -22,6 +22,10 @@ namespace Nethermind.State.Flat.Persistence;
 /// This helps RocksDB's comparator skip bytes during comparison and enables index shortening,
 /// reducing memory usage. The tradeoff is that SelfDestruct must verify the 16-byte suffix.
 ///
+/// The <c>fullAddressStorageKey</c> flag switches to the unsplit shape, where the whole address leads the key.
+/// That is required whenever the address is not a hash — see <see cref="Nethermind.Db.FlatLayout.PreimageFlat"/>,
+/// where a split prefix is attacker-chosen and collapses per-account scans into whole-range scans.
+///
 /// <code>
 /// ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 /// │ State Key (Account)                                                                       Total: 20 bytes  │
@@ -56,18 +60,38 @@ public static class BaseFlatPersistence
         return buffer[..AccountKeyLength];
     }
 
-    private static ReadOnlySpan<byte> EncodeStorageKeyHashedWithShortPrefix(Span<byte> buffer, in ValueHash256 addrHash, in ValueHash256 slotHash)
+    private static ReadOnlySpan<byte> EncodeStorageKey(Span<byte> buffer, in ValueHash256 addrHash, in ValueHash256 slotHash, bool fullAddressStorageKey)
     {
-        // So we store the key with only a small part of the addr early then put the rest at the end.
-        // This helps with rocksdb comparator skipping 16 bytes during comparison, and with index shortening, which reduces
-        // memory usage. The downside is that during selfdestruct, it will need to double-check the 16 byte postfix.
-        // <4-byte-address><32-byte-slot><16-byte-address>
-        addrHash.Bytes[..StoragePrefixPortion].CopyTo(buffer);
-        slotHash.Bytes.CopyTo(buffer[StoragePrefixPortion..(StoragePrefixPortion + StorageSlotKeySize)]);
-        addrHash.Bytes[StoragePrefixPortion..(StoragePrefixPortion + StoragePostfixPortion)].CopyTo(buffer[(StoragePrefixPortion + StorageSlotKeySize)..]);
+        if (fullAddressStorageKey)
+        {
+            // <20-byte-address><32-byte-slot>
+            addrHash.Bytes[..AccountKeyLength].CopyTo(buffer);
+            slotHash.Bytes.CopyTo(buffer[AccountKeyLength..StorageKeyLength]);
+        }
+        else
+        {
+            // So we store the key with only a small part of the addr early then put the rest at the end.
+            // This helps with rocksdb comparator skipping 16 bytes during comparison, and with index shortening, which reduces
+            // memory usage. The downside is that during selfdestruct, it will need to double-check the 16 byte postfix.
+            // <4-byte-address><32-byte-slot><16-byte-address>
+            addrHash.Bytes[..StoragePrefixPortion].CopyTo(buffer);
+            slotHash.Bytes.CopyTo(buffer[StoragePrefixPortion..(StoragePrefixPortion + StorageSlotKeySize)]);
+            addrHash.Bytes[StoragePrefixPortion..(StoragePrefixPortion + StoragePostfixPortion)].CopyTo(buffer[(StoragePrefixPortion + StorageSlotKeySize)..StorageKeyLength]);
+        }
 
         return buffer[..StorageKeyLength];
     }
+
+    /// <summary>Length of the leading address portion of a storage key, which is also the slot offset.</summary>
+    private static int StoragePrefixLength(bool fullAddressStorageKey) =>
+        fullAddressStorageKey ? AccountKeyLength : StoragePrefixPortion;
+
+    /// <summary>
+    /// The trailing address bytes that a range scan must re-verify, since keys of other addresses sharing the
+    /// leading portion fall inside the scanned range. Empty when the whole address leads the key.
+    /// </summary>
+    private static ReadOnlySpan<byte> StorageAddressSuffix(in ValueHash256 addrHash, bool fullAddressStorageKey) =>
+        fullAddressStorageKey ? default : addrHash.Bytes[StoragePrefixPortion..(StoragePrefixPortion + StoragePostfixPortion)];
 
     [DoesNotReturn, StackTraceHidden]
     private static void ThrowSlotValueTooLong(int length, bool rlpWrapSlots) =>
@@ -80,7 +104,8 @@ public static class BaseFlatPersistence
         ISortedKeyValueStore state,
         ISortedKeyValueStore storage,
         bool isPreimageMode = false,
-        bool rlpWrapSlots = false
+        bool rlpWrapSlots = false,
+        bool fullAddressStorageKey = false
     ) : BasePersistence.IHashedFlatReader
     {
         public bool IsPreimageMode => isPreimageMode;
@@ -94,7 +119,7 @@ public static class BaseFlatPersistence
         [SkipLocalsInit]
         public bool TryGetStorage(in ValueHash256 address, in ValueHash256 slot, ref SlotValue outValue)
         {
-            ReadOnlySpan<byte> storageKey = EncodeStorageKeyHashedWithShortPrefix(stackalloc byte[StorageKeyLength], address, slot);
+            ReadOnlySpan<byte> storageKey = EncodeStorageKey(stackalloc byte[StorageKeyLength], address, slot, fullAddressStorageKey);
 
             Span<byte> buffer = stackalloc byte[RlpSlotValueBufferSize];
             int resultSize = GetStorageBuffer(storageKey, buffer);
@@ -156,15 +181,18 @@ public static class BaseFlatPersistence
         {
             // Storage key layout: <4-byte-addr><32-byte-slot><16-byte-addr>
             // We need to iterate all keys with the same 4-byte prefix and 16-byte suffix
+            // With the full address leading instead, the range holds only this account's slots, so there is no
+            // suffix left to re-check and the scan no longer walks addresses that merely share a prefix.
             Span<byte> firstKey = stackalloc byte[StorageKeyLength];
             Span<byte> lastKey = stackalloc byte[StorageKeyLength + 1];
-            EncodeStorageKeyHashedWithShortPrefix(firstKey, accountKey, startSlotKey);
-            EncodeStorageKeyHashedWithShortPrefix(lastKey[..StorageKeyLength], accountKey, endSlotKey);
+            EncodeStorageKey(firstKey, accountKey, startSlotKey, fullAddressStorageKey);
+            EncodeStorageKey(lastKey[..StorageKeyLength], accountKey, endSlotKey, fullAddressStorageKey);
             lastKey[StorageKeyLength] = 0; // Exclusive upper bound
 
             return new StorageIterator(
                 storage.GetViewBetween(firstKey, lastKey),
-                accountKey.Bytes[StoragePrefixPortion..(StoragePrefixPortion + StoragePostfixPortion)].ToArray(),
+                StorageAddressSuffix(accountKey, fullAddressStorageKey).ToArray(),
+                StoragePrefixLength(fullAddressStorageKey),
                 rlpWrapSlots);
         }
     }
@@ -194,7 +222,7 @@ public static class BaseFlatPersistence
         public void Dispose() => view.Dispose();
     }
 
-    public struct StorageIterator(ISortedView view, byte[] addressSuffix, bool rlpWrapSlots) : IPersistence.IFlatIterator
+    public struct StorageIterator(ISortedView view, byte[] addressSuffix, int slotOffset, bool rlpWrapSlots) : IPersistence.IFlatIterator
     {
         // 16-byte suffix to match
         private ValueHash256 _currentKey = default;
@@ -208,11 +236,11 @@ public static class BaseFlatPersistence
                 if (view.CurrentKey.Length != StorageKeyLength) continue;
 
                 // Verify the 16-byte address suffix matches
-                if (!Bytes.AreEqual(view.CurrentKey[(StoragePrefixPortion + StorageSlotKeySize)..], addressSuffix))
+                if (!Bytes.AreEqual(view.CurrentKey[(slotOffset + StorageSlotKeySize)..], addressSuffix))
                     continue;
 
                 // Extract the 32-byte slot hash from the middle of the key
-                _currentKey = new ValueHash256(view.CurrentKey.Slice(StoragePrefixPortion, StorageSlotKeySize));
+                _currentKey = new ValueHash256(view.CurrentKey.Slice(slotOffset, StorageSlotKeySize));
                 ReadOnlySpan<byte> slotValue = rlpWrapSlots
                     ? new RlpReader(view.CurrentValue).DecodeByteArraySpan()
                     : view.CurrentValue;
@@ -238,17 +266,18 @@ public static class BaseFlatPersistence
         IWriteBatch state,
         IWriteBatch storage,
         WriteFlags flags,
-        bool rlpWrapSlots = false
+        bool rlpWrapSlots = false,
+        bool fullAddressStorageKey = false
     ) : BasePersistence.IHashedFlatWriteBatch
     {
         [SkipLocalsInit]
         public void SelfDestruct(in ValueHash256 accountPath)
         {
-            Span<byte> firstKey = stackalloc byte[StoragePrefixPortion];
+            Span<byte> firstKey = stackalloc byte[StoragePrefixLength(fullAddressStorageKey)];
             Span<byte> lastKey = stackalloc byte[StorageKeyLength + 1];
-            BasePersistence.CreateStorageRange(accountPath.Bytes, firstKey, lastKey);
+            BasePersistence.CreateStorageRange(accountPath.Bytes, firstKey, lastKey, StoragePrefixLength(fullAddressStorageKey));
             BasePersistence.DeleteMatchingKeys(storageSnap, storage, firstKey, lastKey,
-                StoragePrefixPortion + StorageSlotKeySize, accountPath.Bytes[StoragePrefixPortion..(StoragePrefixPortion + StoragePostfixPortion)]);
+                StoragePrefixLength(fullAddressStorageKey) + StorageSlotKeySize, StorageAddressSuffix(accountPath, fullAddressStorageKey));
         }
 
         public void RemoveAccount(in ValueHash256 addrHash)
@@ -260,7 +289,7 @@ public static class BaseFlatPersistence
         [SkipLocalsInit]
         public void SetStorage(in ValueHash256 addrHash, in ValueHash256 slotHash, in SlotValue? slot)
         {
-            ReadOnlySpan<byte> theKey = EncodeStorageKeyHashedWithShortPrefix(stackalloc byte[StorageKeyLength], addrHash, slotHash);
+            ReadOnlySpan<byte> theKey = EncodeStorageKey(stackalloc byte[StorageKeyLength], addrHash, slotHash, fullAddressStorageKey);
 
             if (slot.HasValue)
             {
@@ -289,7 +318,7 @@ public static class BaseFlatPersistence
             // only when wrapping is on. In raw mode there is no verbatim shortcut, so this path is unsupported.
             if (!rlpWrapSlots) throw new NotSupportedException("Encoded slot writes require RLP slot wrapping");
 
-            ReadOnlySpan<byte> theKey = EncodeStorageKeyHashedWithShortPrefix(stackalloc byte[StorageKeyLength], addrHash, slotHash);
+            ReadOnlySpan<byte> theKey = EncodeStorageKey(stackalloc byte[StorageKeyLength], addrHash, slotHash, fullAddressStorageKey);
 
             // The bytes are stored verbatim — no decode + re-encode round-trip. The single DecodeByteArraySpan
             // call validates canonical form and bounds the item exactly (trimming any trailing bytes).
@@ -320,11 +349,11 @@ public static class BaseFlatPersistence
         {
             Span<byte> firstKey = stackalloc byte[StorageKeyLength];
             Span<byte> lastKey = stackalloc byte[StorageKeyLength + 1];
-            EncodeStorageKeyHashedWithShortPrefix(firstKey, addressHash, fromPath);
-            EncodeStorageKeyHashedWithShortPrefix(lastKey[..StorageKeyLength], addressHash, toPath);
+            EncodeStorageKey(firstKey, addressHash, fromPath, fullAddressStorageKey);
+            EncodeStorageKey(lastKey[..StorageKeyLength], addressHash, toPath, fullAddressStorageKey);
             lastKey[StorageKeyLength] = 0;
             BasePersistence.DeleteMatchingKeys(storageSnap, storage, firstKey, lastKey,
-                StoragePrefixPortion + StorageSlotKeySize, addressHash.Bytes[StoragePrefixPortion..(StoragePrefixPortion + StoragePostfixPortion)]);
+                StoragePrefixLength(fullAddressStorageKey) + StorageSlotKeySize, StorageAddressSuffix(addressHash, fullAddressStorageKey));
         }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BasePersistence.cs
@@ -216,12 +216,13 @@ public static class BasePersistence
     internal static void CreateStorageRange(
         ReadOnlySpan<byte> accountPath,
         Span<byte> firstKey,
-        Span<byte> lastKey)
+        Span<byte> lastKey,
+        int prefixPortion)
     {
-        accountPath[..StoragePrefixPortion].CopyTo(firstKey);
-        accountPath[..StoragePrefixPortion].CopyTo(lastKey);
-        firstKey[StoragePrefixPortion..].Clear();
-        lastKey[StoragePrefixPortion..].Fill(0xff);
+        accountPath[..prefixPortion].CopyTo(firstKey);
+        accountPath[..prefixPortion].CopyTo(lastKey);
+        firstKey[prefixPortion..].Clear();
+        lastKey[prefixPortion..].Fill(0xff);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseTriePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseTriePersistence.cs
@@ -145,7 +145,7 @@ public static class BaseTriePersistence
 
             // Technically, this is kinda not needed for nodes as it's always traversed so orphaned trie just get skipped.
             // Delete from StorageNodes
-            BasePersistence.CreateStorageRange(accountPath.Bytes, firstKey[..StoragePrefixPortion], lastKey[..(ShortenedStorageNodesKeyLength + 1)]);
+            BasePersistence.CreateStorageRange(accountPath.Bytes, firstKey[..StoragePrefixPortion], lastKey[..(ShortenedStorageNodesKeyLength + 1)], StoragePrefixPortion);
             BasePersistence.DeleteMatchingKeys(storageNodesSnap, storageNodes,
                 firstKey[..StoragePrefixPortion], lastKey[..(ShortenedStorageNodesKeyLength + 1)],
                 StoragePrefixPortion + ShortenedPathLength, addressSuffix);
@@ -153,7 +153,7 @@ public static class BaseTriePersistence
             // Delete from FallbackNodes (prefix 0x01)
             firstKey[0] = 1;
             lastKey[0] = 1;
-            BasePersistence.CreateStorageRange(accountPath.Bytes, firstKey[1..], lastKey[1..]);
+            BasePersistence.CreateStorageRange(accountPath.Bytes, firstKey[1..], lastKey[1..], StoragePrefixPortion);
             BasePersistence.DeleteMatchingKeys(fallbackNodesSnap, fallbackNodes, firstKey, lastKey,
                 1 + StoragePrefixPortion + FullPathLength + PathLengthLength, addressSuffix);
         }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
@@ -22,11 +22,17 @@ namespace Nethermind.State.Flat.Persistence;
 /// - Cannot snap sync.
 /// - Cannot import without a complete preimage db.
 /// </summary>
-public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logManager) : IPersistence
+public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logManager, FlatLayout layout) : IPersistence
 {
     private static readonly AccountDecoder SlimAccountDecoder = AccountDecoder.Slim;
     private readonly WriteBufferAdjuster _adjuster = new(db);
-    private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, FlatLayout.PreimageFlat);
+    private readonly bool _fullAddressStorageKey = layout switch
+    {
+        FlatLayout.PreimageFlat => true,
+        FlatLayout.PreimageFlatV1 => false,
+        _ => throw new ArgumentOutOfRangeException(nameof(layout), layout, "Not a preimage layout")
+    };
+    private int _layoutPersisted = BasePersistence.ValidateLayoutReturnFlag(db, layout);
     private readonly bool _rlpWrapSlots = BasePersistence.ResolveSlotEncoding(db, (ISortedKeyValueStore)db.GetColumnDb(FlatDbColumns.Storage), logManager.GetClassLogger<PreimageRocksdbPersistence>());
 
     public void Flush() => db.Flush();
@@ -53,7 +59,8 @@ public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManage
                 state,
                 storage,
                 isPreimageMode: true,
-                rlpWrapSlots: _rlpWrapSlots
+                rlpWrapSlots: _rlpWrapSlots,
+                fullAddressStorageKey: _fullAddressStorageKey
             )
         );
 
@@ -94,7 +101,8 @@ public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManage
                 accountBatch,
                 storageBatch,
                 flags,
-                rlpWrapSlots: _rlpWrapSlots
+                rlpWrapSlots: _rlpWrapSlots,
+                fullAddressStorageKey: _fullAddressStorageKey
             )
         );
 
@@ -119,7 +127,7 @@ public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManage
                 if (fromCopy != StateId.Sync && toCopy != StateId.Sync)
                     BasePersistence.SetCurrentState(batch.GetColumnBatch(FlatDbColumns.Metadata), toCopy);
                 if (_rlpWrapSlots)
-                    BasePersistence.RecordLayoutOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, FlatLayout.PreimageFlat);
+                    BasePersistence.RecordLayoutOnFirstBatch(batch.GetColumnBatch(FlatDbColumns.Metadata), ref _layoutPersisted, layout);
                 batch.Dispose();
                 dbSnap.Dispose();
                 _adjuster.OnBatchDisposed();


### PR DESCRIPTION
## Changes

Preimage mode keys the flat DB by the raw address instead of its hash, but kept the hashed layout's split storage key: `address[0..4] + slot + address[4..20]`. Under keccak that 4-byte lead is uniformly distributed; under preimage mode it is attacker-chosen and cheap to mine, and vanity addresses already cluster on it — every Seaport contract leads with zero bytes (Seaport 1.6 with seven), as do `0x1111...`/`0x8888...` style addresses. At block 20M, **1079 accounts share the 4-zero-byte lead**.

`CreateStorageIterator` seeks a range bounded only by that lead and filters on the 16-byte suffix, so scanning one account's slots walks every slot of every account sharing the lead. Point lookups never notice; anything scanning by account — `FlatTrieVerifier`'s preimage pass, or importing into another tree — crawls.

- Lead preimage storage keys with the whole address instead: `address + slot`, still 52 bytes, so an account's slots form a contiguous, exactly-bounded range. This matches the persisted-snapshot tier, which already keys slots that way. No short lead is safe here, since any length is minable.
- `BaseFlatPersistence.Reader`/`WriteBatch` take a `fullAddressStorageKey` flag selecting the shape. The scan path falls out of it: the seek range now bounds exactly one account, and the suffix re-check degenerates to a no-op on an empty suffix, so one code path serves both shapes.
- The old shape stays available as `FlatLayout.PreimageFlatV1` (keeping on-disk byte 2); `FlatLayout.PreimageFlat` is the new shape. `PreimageRocksdbPersistence` takes the layout and throws if handed a non-preimage one.
- `BasePersistence.CreateStorageRange` takes the prefix length explicitly (both `BaseTriePersistence` call sites pass `StoragePrefixPortion`, unchanged behaviour).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New `PreimageStorageKeyTests` pins both key shapes as hex and, with a counting `ISortedView`, asserts the actual regression: two addresses sharing a 4-zero-byte lead, 4 slots each — the new layout walks 4 keys to return 4 slots, V1 walks 8.

`PersistenceScenario` and `LayoutMetadataTests` are now driven off `Enum.GetValues<FlatLayout>()` so future layouts are covered without edits; `FlatTrieVerifierTests` runs all three layouts.

`Nethermind.State.Flat.Test` (905), `Nethermind.State.Test` (1162) and `Nethermind.Db.Test` (1089) pass; full `Nethermind.slnx` lint build is clean.

Not covered by unit tests, and worth doing before merge: sync a chain on `PreimageFlat` and run `--FlatDb.VerifyWithTrie true`, which exercises the real per-account scan this fixes.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Existing preimage flat DBs must now be configured as `--FlatDb.Layout PreimageFlatV1`; `PreimageFlat` selects the new key shape and requires a fresh sync. Running a V1 DB as `PreimageFlat` fails loudly at startup via the existing layout validation, which names both the stored and configured layouts.

## Remarks

Accepted tradeoff: RocksDB index separators for the storage column must now span the address, so index memory for that column will be higher than V1. Unmeasured — only a real sync will show by how much.

The node-info version postfix is left untouched, so `PreimageFlatV1` falls through to the empty arm and gets no postfix (`PreimageFlat` keeps `-pf`). Happy to add `-pfv1` if that matters.

Written by Claude Opus 4.8 (Claude Code) on behalf of @asdacap.
