### PR TITLE
Preserve Gnosis TTD-zero genesis hash

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaChainSpecLoaderTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaChainSpecLoaderTests.cs
@@ -3,11 +3,17 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using Nethermind.Blockchain;
+using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Int256;
 using Nethermind.Specs.ChainSpecStyle;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.AuRa.Test;
@@ -47,6 +53,55 @@ public class AuRaChainSpecLoaderTests
 
         Assert.That(chainSpec.Genesis, Is.SameAs(genesis));
         Assert.That(chainSpec.Genesis.Header, Is.Not.InstanceOf<AuRaBlockHeader>());
+    }
+
+    [Test]
+    public void Preserves_pos_genesis_shape_when_terminal_total_difficulty_is_zero()
+    {
+        ChainSpec chainSpec = new()
+        {
+            Parameters = new ChainParameters { TerminalTotalDifficulty = UInt256.Zero },
+            Genesis = new Block(Build.A.BlockHeader
+                .WithParentHash(Keccak.Zero)
+                .WithStateRoot(new Hash256("0x2bb23ed248ecca9e940055284bae1c80d9f924a4ce1ca8710b46b06c43f3c548"))
+                .WithTransactionsRoot(Keccak.EmptyTreeHash)
+                .WithReceiptsRoot(Keccak.EmptyTreeHash)
+                .WithDifficulty(UInt256.Zero)
+                .WithNumber(0)
+                .WithGasLimit(100_000_000)
+                .WithGasUsed(0)
+                .WithTimestamp(0)
+                .WithExtraData(System.Text.Encoding.UTF8.GetBytes("hivechain"))
+                .WithMixHash(Keccak.Zero)
+                .WithNonce(0)
+                .WithBaseFee(1_000_000_000)
+                .WithWithdrawalsRoot(Keccak.EmptyTreeHash)
+                .TestObject),
+            CustomSeal = ParseSeal("{\"authorityRound\":{\"step\":\"0x0\",\"signature\":\"0x" + new string('0', 130) + "\"}}"),
+        };
+
+        AuRaChainSpecLoader.ProcessChainSpec(chainSpec);
+        IPoSSwitcher poSSwitcher = Substitute.For<IPoSSwitcher>();
+        poSSwitcher.IsPostMerge(Arg.Any<BlockHeader>()).Returns(callInfo =>
+        {
+            callInfo.Arg<BlockHeader>().IsPostMerge = true;
+            return true;
+        });
+        Block genesis = new AuRaGenesisBuilder(new FixedGenesisBuilder(chainSpec.Genesis), poSSwitcher).Build();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(genesis.Header, Is.Not.InstanceOf<AuRaBlockHeader>());
+            Assert.That(genesis.Header.IsPostMerge, Is.True);
+            Assert.That(genesis.Header.CalculateHash(), Is.EqualTo(new Hash256("0x9469153ba75532411cbad308fadd1206ec5c919ef4a463549c9af05a8bad5641")));
+        }
+
+        poSSwitcher.Received(1).IsPostMerge(genesis.Header);
+    }
+
+    private sealed class FixedGenesisBuilder(Block genesis) : IGenesisBuilder
+    {
+        public Block Build() => genesis;
     }
 
     private static Dictionary<string, JsonElement> ParseSeal(string json) =>

--- a/src/Nethermind/Nethermind.AuRa.Test/AuRaChainSpecLoaderTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuRaChainSpecLoaderTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using Nethermind.Blockchain;
-using Nethermind.Consensus;
 using Nethermind.Consensus.AuRa;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -13,7 +12,6 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Specs.ChainSpecStyle;
-using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.AuRa.Test;
@@ -81,13 +79,8 @@ public class AuRaChainSpecLoaderTests
         };
 
         AuRaChainSpecLoader.ProcessChainSpec(chainSpec);
-        IPoSSwitcher poSSwitcher = Substitute.For<IPoSSwitcher>();
-        poSSwitcher.IsPostMerge(Arg.Any<BlockHeader>()).Returns(callInfo =>
-        {
-            callInfo.Arg<BlockHeader>().IsPostMerge = true;
-            return true;
-        });
-        Block genesis = new AuRaGenesisBuilder(new FixedGenesisBuilder(chainSpec.Genesis), poSSwitcher).Build();
+        Assert.That(chainSpec.Genesis.Header.IsPostMerge, Is.True);
+        Block genesis = new AuRaGenesisBuilder(new FixedGenesisBuilder(chainSpec.Genesis)).Build();
 
         using (Assert.EnterMultipleScope())
         {
@@ -95,8 +88,6 @@ public class AuRaChainSpecLoaderTests
             Assert.That(genesis.Header.IsPostMerge, Is.True);
             Assert.That(genesis.Header.CalculateHash(), Is.EqualTo(new Hash256("0x9469153ba75532411cbad308fadd1206ec5c919ef4a463549c9af05a8bad5641")));
         }
-
-        poSSwitcher.Received(1).IsPostMerge(genesis.Header);
     }
 
     private sealed class FixedGenesisBuilder(Block genesis) : IGenesisBuilder

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaChainSpecLoader.cs
@@ -12,8 +12,8 @@ namespace Nethermind.Consensus.AuRa;
 /// and stamps the step + signature parsed from <c>genesis.seal.authorityRound</c>.
 /// </summary>
 /// <remarks>
-/// A zero terminal total difficulty means the chain starts post-merge, so its genesis keeps the
-/// standard mixHash + nonce seal even when the chain spec contains a placeholder AuRa seal.
+/// A zero terminal total difficulty marks genesis as post-merge, so its header keeps the standard
+/// mixHash + nonce seal even when the chain spec contains a placeholder AuRa seal.
 /// </remarks>
 public static class AuRaChainSpecLoader
 {
@@ -38,8 +38,13 @@ public static class AuRaChainSpecLoader
         chainSpec.Genesis = chainSpec.Genesis.WithReplacedHeader(upgraded);
     }
 
-    private static bool IsPostMergeGenesis(ChainSpec chainSpec) =>
-        chainSpec.Parameters?.TerminalTotalDifficulty?.IsZero == true;
+    private static bool IsPostMergeGenesis(ChainSpec chainSpec)
+    {
+        if (chainSpec.Genesis is null || chainSpec.Parameters?.TerminalTotalDifficulty?.IsZero != true) return false;
+
+        chainSpec.Genesis.Header.IsPostMerge = true;
+        return true;
+    }
 
     private sealed class AuRaGenesisSealJson
     {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaChainSpecLoader.cs
@@ -11,6 +11,10 @@ namespace Nethermind.Consensus.AuRa;
 /// ChainSpec post-processor for AuRa: upgrades <c>Genesis.Header</c> to <see cref="AuRaBlockHeader"/>
 /// and stamps the step + signature parsed from <c>genesis.seal.authorityRound</c>.
 /// </summary>
+/// <remarks>
+/// A zero terminal total difficulty means the chain starts post-merge, so its genesis keeps the
+/// standard mixHash + nonce seal even when the chain spec contains a placeholder AuRa seal.
+/// </remarks>
 public static class AuRaChainSpecLoader
 {
     private static readonly EthereumJsonSerializer _jsonSerializer = new();
@@ -18,6 +22,7 @@ public static class AuRaChainSpecLoader
     public static void ProcessChainSpec(ChainSpec chainSpec)
     {
         if (chainSpec.Genesis is null
+            || IsPostMergeGenesis(chainSpec)
             || chainSpec.CustomSeal?.TryGetValue("authorityRound", out JsonElement sealJson) is not true)
         {
             return;
@@ -32,6 +37,9 @@ public static class AuRaChainSpecLoader
 
         chainSpec.Genesis = chainSpec.Genesis.WithReplacedHeader(upgraded);
     }
+
+    internal static bool IsPostMergeGenesis(ChainSpec chainSpec) =>
+        chainSpec.Parameters?.TerminalTotalDifficulty?.IsZero == true;
 
     private sealed class AuRaGenesisSealJson
     {

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaChainSpecLoader.cs
@@ -38,7 +38,7 @@ public static class AuRaChainSpecLoader
         chainSpec.Genesis = chainSpec.Genesis.WithReplacedHeader(upgraded);
     }
 
-    internal static bool IsPostMergeGenesis(ChainSpec chainSpec) =>
+    private static bool IsPostMergeGenesis(ChainSpec chainSpec) =>
         chainSpec.Parameters?.TerminalTotalDifficulty?.IsZero == true;
 
     private sealed class AuRaGenesisSealJson

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaHeaderModule.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaHeaderModule.cs
@@ -3,7 +3,6 @@
 
 using Autofac;
 using Nethermind.Blockchain;
-using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Facade.Eth;
@@ -42,12 +41,12 @@ public class AuRaHeaderModule : Module
 /// Ensures an AuRa genesis block carries an <see cref="AuRaBlockHeader"/>; pure post-merge
 /// genesis blocks remain in the standard PoS header shape.
 /// </summary>
-public class AuRaGenesisBuilder(IGenesisBuilder inner, IPoSSwitcher poSSwitcher) : IGenesisBuilder
+public class AuRaGenesisBuilder(IGenesisBuilder inner) : IGenesisBuilder
 {
     public Block Build()
     {
         Block genesis = inner.Build();
-        if (genesis.Header is AuRaBlockHeader || poSSwitcher.IsPostMerge(genesis.Header)) return genesis;
+        if (genesis.Header is AuRaBlockHeader || genesis.Header.IsPostMerge) return genesis;
 
         // Reached only if a chainspec declares `authorityRound` but omits the genesis signature
         // (no bundled chain does). The zero signature shifts genesis to a step+signature shape,

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaHeaderModule.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaHeaderModule.cs
@@ -3,6 +3,7 @@
 
 using Autofac;
 using Nethermind.Blockchain;
+using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Facade.Eth;
@@ -38,19 +39,19 @@ public class AuRaHeaderModule : Module
 }
 
 /// <summary>
-/// Ensures the genesis block carries an <see cref="AuRaBlockHeader"/>; no-op when the chainspec
-/// already stamped the seal (see <c>AuRaChainSpecLoader</c>).
+/// Ensures an AuRa genesis block carries an <see cref="AuRaBlockHeader"/>; pure post-merge
+/// genesis blocks remain in the standard PoS header shape.
 /// </summary>
-public class AuRaGenesisBuilder(IGenesisBuilder inner) : IGenesisBuilder
+public class AuRaGenesisBuilder(IGenesisBuilder inner, IPoSSwitcher poSSwitcher) : IGenesisBuilder
 {
     public Block Build()
     {
         Block genesis = inner.Build();
-        if (genesis.Header is AuRaBlockHeader) return genesis;
+        if (genesis.Header is AuRaBlockHeader || poSSwitcher.IsPostMerge(genesis.Header)) return genesis;
 
         // Reached only if a chainspec declares `authorityRound` but omits the genesis signature
         // (no bundled chain does). The zero signature shifts genesis to a step+signature shape,
-        // diverging from master's mixHash+nonce hash for that chainspec.
+        // diverging from the standard mixHash+nonce encoding for that chainspec.
         AuRaBlockHeader upgraded = AuRaBlockHeader.UpgradeFrom(genesis.Header);
         upgraded.AuRaSignature = new byte[65];
         upgraded.Hash = new Hash256(upgraded.CalculateHash());


### PR DESCRIPTION
## Changes

- Preserve the standard `mixHash`/`nonce` genesis header shape when `terminalTotalDifficulty = 0`, even when the generated AuRa chain spec contains a placeholder `authorityRound` seal.
- Reuse `IPoSSwitcher` in the AuRa genesis decorator so post-merge classification also sets `BlockHeader.IsPostMerge`.
- Add regression coverage for the reported Gnosis Hive genesis hash.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Release build with `UseArtifactsOutput=false`: passed with 0 warnings and 0 errors.
- `AuRaChainSpecLoaderTests`: 3 passed.
- `AuRaPluginTests`: 3 passed.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

The regression came from promoting a TTD-zero genesis carrying a placeholder AuRa seal to `AuRaBlockHeader`, which changed the hash from the expected `0x9469153b...` encoding to the Aura step/signature encoding.
