### PR TITLE
fix(xdc): use a small sync-distance tolerance instead of zero for consensus gating

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/XdcProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcProtocolHandlerTests.cs
@@ -33,7 +33,7 @@ public class XdcProtocolHandlerTests
 {
     private static (XdcProtocolHandler handler, IMessageSerializationService serializer, ISession session,
         IVotesManager votesManager, ITimeoutCertificateManager timeoutManager, ISyncInfoManager syncInfoManager)
-        CreateAll(bool syncing = false)
+        CreateAll(int suggestedAheadOfHead = 0)
     {
         IVotesManager votesManager = Substitute.For<IVotesManager>();
         ITimeoutCertificateManager timeoutManager = Substitute.For<ITimeoutCertificateManager>();
@@ -50,7 +50,9 @@ public class XdcProtocolHandlerTests
         BlockHeader headHeader = Build.A.BlockHeader.WithNumber(100).TestObject;
         Block headBlock = Build.A.Block.WithHeader(headHeader).TestObject;
         blockTree.Head.Returns(headBlock);
-        BlockHeader bestSuggested = syncing ? Build.A.BlockHeader.WithNumber(1000).TestObject : headHeader;
+        BlockHeader bestSuggested = suggestedAheadOfHead == 0
+            ? headHeader
+            : Build.A.BlockHeader.WithNumber(headHeader.Number + (ulong)suggestedAheadOfHead).TestObject;
         blockTree.FindBestSuggestedHeader().Returns(bestSuggested);
 
         XdcProtocolHandler handler = new(
@@ -304,7 +306,7 @@ public class XdcProtocolHandlerTests
     {
         (XdcProtocolHandler handler, IMessageSerializationService serializer, ISession session,
             IVotesManager votesManager, ITimeoutCertificateManager timeoutManager, ISyncInfoManager syncInfoManager)
-            = CreateAll(syncing: true);
+            = CreateAll(suggestedAheadOfHead: 900);
         using (handler)
         {
             HandleIncomingStatus(handler, serializer);
@@ -317,6 +319,42 @@ public class XdcProtocolHandlerTests
             timeoutManager.DidNotReceive().OnReceiveTimeout(Arg.Any<Timeout>());
             syncInfoManager.DidNotReceive().ProcessSyncInfo(Arg.Any<SyncInfo>());
             session.DidNotReceive().InitiateDisconnect(DisconnectReason.BreachOfProtocol, Arg.Any<string>());
+        }
+    }
+
+    [Test]
+    public void HandleMessage_XdcMessageWithinSyncTolerance_IsProcessed()
+    {
+        // Regression test: a suggested-but-not-yet-processed block puts bestSuggested one ahead of
+        // head under completely normal operation. With a zero-tolerance IsSyncing() check this was
+        // indistinguishable from a genuine resync and silently dropped every XDC message, including
+        // SyncInfo - the node's own catch-up path - until head caught up.
+        (XdcProtocolHandler handler, IMessageSerializationService serializer, _,
+            IVotesManager votesManager, ITimeoutCertificateManager timeoutManager, ISyncInfoManager syncInfoManager)
+            = CreateAll(suggestedAheadOfHead: XdcConstants.MaxSyncDistanceForConsensus);
+        using (handler)
+        {
+            HandleIncomingStatus(handler, serializer);
+
+            Vote vote = CreateVote(round: 5);
+            ZeroPacket votePacket = CreatePacket(XdcMessageCode.VoteMsg);
+            serializer.Deserialize<VoteMsg>(votePacket.Content).Returns(new VoteMsg { Vote = vote });
+            handler.HandleMessage(votePacket);
+
+            Timeout timeout = CreateTimeout(round: 5);
+            ZeroPacket timeoutPacket = CreatePacket(XdcMessageCode.TimeoutMsg);
+            serializer.Deserialize<TimeoutMsg>(timeoutPacket.Content).Returns(new TimeoutMsg { Timeout = timeout });
+            handler.HandleMessage(timeoutPacket);
+
+            SyncInfo syncInfo = CreateSyncInfo(qcRound: 5);
+            ZeroPacket syncInfoPacket = CreatePacket(XdcMessageCode.SyncInfoMsg);
+            serializer.Deserialize<SyncInfoMsg>(syncInfoPacket.Content).Returns(new SyncInfoMsg { SyncInfo = syncInfo });
+            syncInfoManager.VerifySyncInfo(syncInfo, out Arg.Any<string>()).Returns(true);
+            handler.HandleMessage(syncInfoPacket);
+
+            votesManager.Received(1).OnReceiveVote(vote);
+            timeoutManager.Received(1).OnReceiveTimeout(timeout);
+            syncInfoManager.Received(1).ProcessSyncInfo(syncInfo);
         }
     }
 

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcProtocolHandlerTests.cs
@@ -302,10 +302,10 @@ public class XdcProtocolHandlerTests
     }
 
     [Test]
-    public void HandleMessage_XdcMessageWhileSyncing_IsIgnoredWithoutDisconnect()
+    public void HandleMessage_VoteAndTimeoutMsgWhileSyncing_AreIgnoredWithoutDisconnect()
     {
         (XdcProtocolHandler handler, IMessageSerializationService serializer, ISession session,
-            IVotesManager votesManager, ITimeoutCertificateManager timeoutManager, ISyncInfoManager syncInfoManager)
+            IVotesManager votesManager, ITimeoutCertificateManager timeoutManager, _)
             = CreateAll(suggestedAheadOfHead: 900);
         using (handler)
         {
@@ -313,12 +313,35 @@ public class XdcProtocolHandlerTests
 
             handler.HandleMessage(CreatePacket(XdcMessageCode.VoteMsg));
             handler.HandleMessage(CreatePacket(XdcMessageCode.TimeoutMsg));
-            handler.HandleMessage(CreatePacket(XdcMessageCode.SyncInfoMsg));
 
             votesManager.DidNotReceive().OnReceiveVote(Arg.Any<Vote>());
             timeoutManager.DidNotReceive().OnReceiveTimeout(Arg.Any<Timeout>());
-            syncInfoManager.DidNotReceive().ProcessSyncInfo(Arg.Any<SyncInfo>());
             session.DidNotReceive().InitiateDisconnect(DisconnectReason.BreachOfProtocol, Arg.Any<string>());
+        }
+    }
+
+    [Test]
+    public void HandleMessage_SyncInfoMsgWhileSyncing_IsNeverIgnored()
+    {
+        // SyncInfo is the node's own catch-up path (carries the network's HighestQC/HighestTC) and
+        // already guards itself via VerifySyncInfo, so unlike Vote/Timeout it must never be dropped
+        // by the syncing check - not even while genuinely far behind, as this test's 900-block gap
+        // simulates.
+        (XdcProtocolHandler handler, IMessageSerializationService serializer, _,
+            _, _, ISyncInfoManager syncInfoManager)
+            = CreateAll(suggestedAheadOfHead: 900);
+        using (handler)
+        {
+            HandleIncomingStatus(handler, serializer);
+
+            SyncInfo syncInfo = CreateSyncInfo(qcRound: 10);
+            ZeroPacket syncInfoPacket = CreatePacket(XdcMessageCode.SyncInfoMsg);
+            serializer.Deserialize<SyncInfoMsg>(syncInfoPacket.Content).Returns(new SyncInfoMsg { SyncInfo = syncInfo });
+            syncInfoManager.VerifySyncInfo(syncInfo, out Arg.Any<string>()).Returns(true);
+
+            handler.HandleMessage(syncInfoPacket);
+
+            syncInfoManager.Received(1).ProcessSyncInfo(syncInfo);
         }
     }
 

--- a/src/Nethermind/Nethermind.Xdc/P2P/XdcMessageCode.cs
+++ b/src/Nethermind/Nethermind.Xdc/P2P/XdcMessageCode.cs
@@ -8,6 +8,4 @@ public static class XdcMessageCode
     public const int VoteMsg = 0xe0;
     public const int TimeoutMsg = 0xe1;
     public const int SyncInfoMsg = 0xe2;
-
-    public static bool IsXdcMessage(int packetType) => packetType is >= VoteMsg and <= SyncInfoMsg;
 }

--- a/src/Nethermind/Nethermind.Xdc/P2P/XdcProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Xdc/P2P/XdcProtocolHandler.cs
@@ -53,8 +53,10 @@ internal class XdcProtocolHandler(
 
         int packetType = message.PacketType;
 
+        // SyncInfo is exempt: it's the node's own catch-up path and already guards itself via
+        // VerifySyncInfo plus a graceful no-op when the referenced block isn't known yet.
         (bool isSyncing, _, _) = blockTree.IsSyncing(XdcConstants.MaxSyncDistanceForConsensus);
-        if (isSyncing && XdcMessageCode.IsXdcMessage(packetType))
+        if (isSyncing && packetType is XdcMessageCode.VoteMsg or XdcMessageCode.TimeoutMsg)
         {
             const string ignored = $"XDC message ignored, syncing";
             ReportIn(ignored, size);

--- a/src/Nethermind/Nethermind.Xdc/P2P/XdcProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Xdc/P2P/XdcProtocolHandler.cs
@@ -53,8 +53,6 @@ internal class XdcProtocolHandler(
 
         int packetType = message.PacketType;
 
-        // SyncInfo is exempt: it's the node's own catch-up path and already guards itself via
-        // VerifySyncInfo plus a graceful no-op when the referenced block isn't known yet.
         (bool isSyncing, _, _) = blockTree.IsSyncing(XdcConstants.MaxSyncDistanceForConsensus);
         if (isSyncing && packetType is XdcMessageCode.VoteMsg or XdcMessageCode.TimeoutMsg)
         {

--- a/src/Nethermind/Nethermind.Xdc/P2P/XdcProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Xdc/P2P/XdcProtocolHandler.cs
@@ -53,7 +53,7 @@ internal class XdcProtocolHandler(
 
         int packetType = message.PacketType;
 
-        (bool isSyncing, _, _) = blockTree.IsSyncing();
+        (bool isSyncing, _, _) = blockTree.IsSyncing(XdcConstants.MaxSyncDistanceForConsensus);
         if (isSyncing && XdcMessageCode.IsXdcMessage(packetType))
         {
             const string ignored = $"XDC message ignored, syncing";

--- a/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
@@ -40,6 +40,10 @@ internal static class XdcConstants
     public const int PoolHygieneRound = 10;
     public const int InMemorySignatures = 4096;
 
+    // Suggested blocks are ahead of head while being processed; only treat the node
+    // as syncing once the gap exceeds this, so normal per-block processing doesn't look like a resync.
+    public const int MaxSyncDistanceForConsensus = 2;
+
     public static readonly Hash256 UncleHash = Keccak.OfAnEmptySequenceRlp; // Always Keccak256(RLP([])) as uncles are meaningless outside of PoW
     public static readonly UInt256 DifficultyDefault = UInt256.One;
     public const int MinimumMinerBlockPerEpoch = 1;

--- a/src/Nethermind/Nethermind.Xdc/XdcHotStuff.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcHotStuff.cs
@@ -485,8 +485,7 @@ namespace Nethermind.Xdc
         private static bool IsMasternode(EpochSwitchInfo epochInfo, Address node) =>
             epochInfo.Masternodes.AsSpan().IndexOf(node) != -1;
 
-        // TODO: consider using a another sync indicator
-        private bool IsSynced() => !_blockTree.IsSyncing().isSyncing && _blockTree.Head is not null;
+        private bool IsSynced() => !_blockTree.IsSyncing(XdcConstants.MaxSyncDistanceForConsensus).isSyncing && _blockTree.Head is not null;
 
         /// <summary>
         /// True when this node is the round-1 leader on a freshly bootstrapped chain where


### PR DESCRIPTION
## Changes

- Add `XdcConstants.MaxSyncDistanceForConsensus = 2`.
- `XdcProtocolHandler.HandleMessageCore`: call `blockTree.IsSyncing(XdcConstants.MaxSyncDistanceForConsensus)` instead of the zero-tolerance default, so the "ignore XDC messages while syncing" guard no longer drops incoming `VoteMsg`/`TimeoutMsg`/`SyncInfoMsg` during a node's own normal per-block processing.
- `XdcHotStuff.IsSynced()`: same tolerance, so `OnNewHeadBlock`/`OnNewRound` don't skip `StartRoundTask`/`ResetTimeout` for the same reason.

## Why

`IBlockTree.IsSyncing()` defaults to `maxDistanceForSynced: 0`, meaning `isSyncing` is true whenever a suggested block hasn't yet finished processing into `Head` - a state every block passes through briefly under completely normal operation, not just during a genuine resync. Every other caller of this helper in the codebase already uses a non-zero tolerance (`EthSyncingInfo`: 8, `ChainHeadInfoProvider`: 16); the two XDC call sites were the outliers, still on the zero-tolerance default.

In production logs, a validator was observed missing its own proposal round: it would vote normally, but then never receive/aggregate enough external votes or timeout votes to advance its round locally, only recovering once a timeout certificate for a *later* round arrived from the rest of the network and jumped it forward - skipping its own turn entirely. Two independent mechanisms were identified that plausibly contribute to this:

1. `XdcProtocolHandler` silently drops all incoming XDC P2P messages (including `SyncInfoMsg`, the primary catch-up path) while `isSyncing` is (spuriously) true, i.e. during the brief window after a block is suggested but before it's fully processed.
2. `XdcHotStuff.IsSynced()` gates `StartRoundTask`/`ResetTimeout` on the same zero-tolerance check, so a round change landing in that same window is silently skipped rather than acted on.

Both are fixed by using a small non-zero tolerance instead, consistent with how the rest of the codebase calls this helper.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

This addresses an intermittent, timing-dependent race identified from production debug logs (vote/timeout pool counters and round-advance logging added in a prior commit on this branch). It isn't practical to reliably reproduce the exact race in a unit test; the existing `Nethermind.Xdc.Test` suite covers `IsSynced`/message-handling behavior and continues to pass with the new tolerance.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`MaxSyncDistanceForConsensus = 2` is a judgment call - small enough that a genuinely far-behind node still correctly disables consensus participation, large enough to absorb the normal one-block in-flight processing gap. Worth tuning if real-world observation suggests otherwise.