### PR TITLE
Add debug logging for XDC vote and timeout rejection paths

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
@@ -86,8 +86,12 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
         BroadcastTimeout(timeout);
 
         IXdcReleaseSpec spec = _specProvider.GetXdcSpec(xdcHeader, timeout.Round);
-        if (collectedTimeouts.Count < epochSwitchInfo.Masternodes.Length * spec.CertificateThreshold)
+        double requiredTimeouts = epochSwitchInfo.Masternodes.Length * spec.CertificateThreshold;
+        if (collectedTimeouts.Count < requiredTimeouts)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Round {timeout.Round}: {collectedTimeouts.Count}/{requiredTimeouts} timeout votes collected.");
             return Task.CompletedTask;
+        }
 
         if (!_tcBuildStartedByRound.TryAdd(timeout.Round, 0))
             return Task.CompletedTask;
@@ -258,18 +262,31 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
 
     internal bool FilterTimeout(Timeout timeout)
     {
-        if (timeout.Round < _consensusContext.CurrentRound) return false;
+        if (timeout.Round < _consensusContext.CurrentRound)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Discarded stale timeout for round {timeout.Round}, current round is {_consensusContext.CurrentRound}.");
+            return false;
+        }
         Snapshot snapshot = _snapshotManager.GetSnapshotByGapNumber(timeout.GapNumber);
-        if (snapshot is null || snapshot.NextEpochCandidates.Length == 0) return false;
+        if (snapshot is null || snapshot.NextEpochCandidates.Length == 0)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Rejected timeout for round {timeout.Round}: no snapshot/candidates for gap {timeout.GapNumber}.");
+            return false;
+        }
 
         if (timeout.Signature is null || !timeout.Signature.HasLowS())
+        {
+            if (_logger.IsDebug) _logger.Debug($"Rejected timeout for round {timeout.Round}: missing or malleable signature.");
             return false;
+        }
 
         ValueHash256 timeoutMsgHash = ComputeTimeoutMsgHash(timeout.Round, timeout.GapNumber);
         Address signer = _ethereumEcdsa.RecoverAddress(timeout.Signature, in timeoutMsgHash);
         timeout.Signer = signer;
 
-        return snapshot.NextEpochCandidates.Contains(signer);
+        bool isKnownSigner = snapshot.NextEpochCandidates.Contains(signer);
+        if (!isKnownSigner && _logger.IsDebug) _logger.Debug($"Rejected timeout for round {timeout.Round}: signer {signer} not in candidate set.");
+        return isKnownSigner;
     }
 
     internal SyncInfo GetSyncInfo() => new(_consensusContext.HighestQC, _consensusContext.HighestTC);

--- a/src/Nethermind/Nethermind.Xdc/VotesManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/VotesManager.cs
@@ -115,7 +115,10 @@ internal class VotesManager : IVotesManager, IDisposable
     public Task HandleVote(Vote vote)
     {
         if (vote.ProposedBlockInfo.Round < _ctx.CurrentRound)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Discarded stale vote for round {vote.ProposedBlockInfo.Round}, current round is {_ctx.CurrentRound}.");
             return Task.CompletedTask;
+        }
 
         // Collect votes
         _votePool.Add(vote);
@@ -130,6 +133,7 @@ internal class VotesManager : IVotesManager, IDisposable
         if (_blockTree.FindHeader(vote.ProposedBlockInfo.Hash, vote.ProposedBlockInfo.BlockNumber) is not XdcBlockHeader proposedHeader)
         {
             //This is a vote for a block we have not seen yet, just return for now
+            if (_logger.IsDebug) _logger.Debug($"Buffered vote for round {vote.ProposedBlockInfo.Round}, block {vote.ProposedBlockInfo.Hash} (#{vote.ProposedBlockInfo.BlockNumber}) — block not yet known locally. Pool size={roundVotes.Count}.");
             return Task.CompletedTask;
         }
 
@@ -175,7 +179,10 @@ internal class VotesManager : IVotesManager, IDisposable
         double certThreshold = _specProvider.GetXdcSpec(proposedHeader, proposedHeader.ExtraConsensusData!.BlockRound).CertificateThreshold;
         double requiredVotes = masternodeCount * certThreshold;
         if (roundVotes.Count < requiredVotes)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Round {proposedHeader.ExtraConsensusData.BlockRound}: {roundVotes.Count}/{requiredVotes} votes collected for block #{proposedHeader.ToString(BlockHeader.Format.Short)}.");
             return Task.CompletedTask;
+        }
 
         Vote sampleVote = roundVotes.First();
         if (!sampleVote.ProposedBlockInfo.ValidateBlockInfo(proposedHeader))
@@ -266,6 +273,7 @@ internal class VotesManager : IVotesManager, IDisposable
             Math.Abs((long)vote.ProposedBlockInfo.Round - (long)_ctx.CurrentRound) > _maxRoundDistance)
         {
             // Discarded propagated vote, too far away
+            if (_logger.IsDebug) _logger.Debug($"Discarded vote for round {vote.ProposedBlockInfo.Round} (current={_ctx.CurrentRound}), block #{voteBlockNumber} (head=#{currentBlockNumber}) — too far away.");
             return Task.CompletedTask;
         }
 
@@ -279,12 +287,21 @@ internal class VotesManager : IVotesManager, IDisposable
     private bool VerifyVote(Vote vote)
     {
         Snapshot snapshot = _snapshotManager.GetSnapshotByGapNumber(vote.GapNumber);
-        if (snapshot is null) return false;
-        if (vote.Signature is null || !vote.Signature.HasLowS())
+        if (snapshot is null)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Rejected vote for round {vote.ProposedBlockInfo.Round}: no snapshot for gap {vote.GapNumber}.");
             return false;
+        }
+        if (vote.Signature is null || !vote.Signature.HasLowS())
+        {
+            if (_logger.IsDebug) _logger.Debug($"Rejected vote for round {vote.ProposedBlockInfo.Round}: missing or malleable signature.");
+            return false;
+        }
 
         vote.Signer ??= _ethereumEcdsa.RecoverVoteSigner(vote);
-        return snapshot.NextEpochCandidates.Any(x => x == vote.Signer);
+        bool isKnownSigner = snapshot.NextEpochCandidates.Any(x => x == vote.Signer);
+        if (!isKnownSigner && _logger.IsDebug) _logger.Debug($"Rejected vote for round {vote.ProposedBlockInfo.Round}: signer {vote.Signer} not in candidate set.");
+        return isKnownSigner;
     }
 
     private void BroadcastVote(Vote vote)


### PR DESCRIPTION
## Changes

- Add `_logger.IsDebug` guarded debug log statements in `TimeoutCertificateManager` and `VotesManager` for every early-return / rejection path when handling timeouts and votes: stale round, insufficient quorum, missing snapshot/candidates, missing or malleable signature, unknown signer, buffered vote for an unseen block, and vote too far from the current round.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Debug-log-only change, no behavioral change to accept/reject logic; existing tests cover the unchanged control flow.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No