### PR TITLE
fix(rpc): reject new eth_filters once the queued-results budget is exhausted

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Blockchain.Test.Builders;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Exceptions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
@@ -284,6 +285,49 @@ public class FilterManagerTests
         );
     }
 
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void new_filters_are_rejected_when_queued_item_budget_is_exhausted()
+    {
+        const int maxQueuedItems = 4;
+        using FilterStore filterStore = new(new TimerFactory(), maxQueuedItems: maxQueuedItems);
+        BlockFilter blockFilter = new(_currentFilterId++);
+        filterStore.SaveFilter(blockFilter);
+        _filterManager = new FilterManager(filterStore, _mainProcessingContext, _txPool, _receiptMonitor, _logManager);
+
+        for (int i = 0; i < maxQueuedItems; i++)
+        {
+            _mainProcessingContext.TestBranchProcessor.RaiseBlockProcessed(
+                new BlockProcessedEventArgs(Build.A.Block.WithNumber(i).TestObject, []));
+        }
+
+        Assert.Throws<ConcurrencyLimitReachedException>(() => filterStore.SaveFilter(new BlockFilter(_currentFilterId++)));
+
+        // draining the queue frees the budget again
+        _filterManager.PollBlockHashes(blockFilter.Id);
+        Assert.DoesNotThrow(() => filterStore.SaveFilter(new BlockFilter(_currentFilterId++)));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void removing_a_filter_frees_its_queued_item_budget()
+    {
+        const int maxQueuedItems = 2;
+        using FilterStore filterStore = new(new TimerFactory(), maxQueuedItems: maxQueuedItems);
+        BlockFilter blockFilter = new(_currentFilterId++);
+        filterStore.SaveFilter(blockFilter);
+        _filterManager = new FilterManager(filterStore, _mainProcessingContext, _txPool, _receiptMonitor, _logManager);
+
+        for (int i = 0; i < maxQueuedItems; i++)
+        {
+            _mainProcessingContext.TestBranchProcessor.RaiseBlockProcessed(
+                new BlockProcessedEventArgs(Build.A.Block.WithNumber(i).TestObject, []));
+        }
+
+        Assert.Throws<ConcurrencyLimitReachedException>(() => filterStore.SaveFilter(new BlockFilter(_currentFilterId++)));
+
+        filterStore.RemoveFilter(blockFilter.Id);
+        Assert.DoesNotThrow(() => filterStore.SaveFilter(new BlockFilter(_currentFilterId++)));
+    }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
     public async Task concurrent_block_processing_and_poll_does_not_lose_data()

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -33,7 +33,6 @@ namespace Nethermind.Facade.Filters
         private readonly FilterStore _filterStore;
         private readonly ILogger _logger;
         private long _logIndex;
-        private long _queuedItems;
 
         public FilterManager(
             FilterStore filterStore,
@@ -50,7 +49,7 @@ namespace Nethermind.Facade.Filters
             mainProcessingContext.TransactionProcessed += OnTransactionProcessed;
             receiptMonitor.ReceiptsInserted += OnReceiptsInserted;
             _filterStore.FilterRemoved += OnFilterRemoved;
-            _filterStore.QueuedItemCount = () => Volatile.Read(ref _queuedItems);
+            _filterStore.QueuedItemCount = CountQueuedItems;
             txPool.NewPending += OnNewPendingTransaction;
             txPool.RemovedPending += OnRemovedPendingTransaction;
         }
@@ -58,30 +57,26 @@ namespace Nethermind.Facade.Filters
         private void OnFilterRemoved(object sender, FilterEventArgs e)
         {
             int id = e.FilterId;
-            if (_blockHashes.TryRemove(id, out ConcurrentQueue<Hash256>? blockHashes))
-            {
-                ReleaseQueued(blockHashes.Count);
-                return;
-            }
-
-            if (_logs.TryRemove(id, out ConcurrentQueue<FilterLog>? logs))
-            {
-                ReleaseQueued(logs.Count);
-                return;
-            }
-
-            if (_pendingTransactions.TryRemove(id, out ConcurrentQueue<Option<Hash256>>? pendingTransactions))
-            {
-                ReleaseQueued(pendingTransactions.Count);
-            }
+            if (_blockHashes.TryRemove(id, out _)) return;
+            if (_logs.TryRemove(id, out _)) return;
+            _pendingTransactions.TryRemove(id, out _);
         }
 
-        private void ReleaseQueued(int count)
+        /// <summary>
+        /// Sums the results currently queued across all filters.
+        /// </summary>
+        /// <remarks>
+        /// Computed on demand from the live queues rather than tracked incrementally, so it cannot drift
+        /// under the concurrent enqueue/poll/remove races on these lock-free collections. Called only from
+        /// <see cref="FilterStore.SaveFilter"/> (filter creation), which is rare relative to the store/poll paths.
+        /// </remarks>
+        private long CountQueuedItems()
         {
-            if (count > 0)
-            {
-                Interlocked.Add(ref _queuedItems, -count);
-            }
+            long total = 0;
+            foreach (KeyValuePair<int, ConcurrentQueue<FilterLog>> entry in _logs) total += entry.Value.Count;
+            foreach (KeyValuePair<int, ConcurrentQueue<Hash256>> entry in _blockHashes) total += entry.Value.Count;
+            foreach (KeyValuePair<int, ConcurrentQueue<Option<Hash256>>> entry in _pendingTransactions) total += entry.Value.Count;
+            return total;
         }
 
         private void OnBlockProcessed(object sender, BlockProcessedEventArgs e)
@@ -126,7 +121,6 @@ namespace Nethermind.Facade.Filters
                         {
                             logs ??= _logs.GetOrAdd(filter.Id, static _ => new ConcurrentQueue<FilterLog>());
                             logs.Enqueue(filterLog);
-                            Interlocked.Increment(ref _queuedItems);
                         }
                     }
                 }
@@ -141,7 +135,6 @@ namespace Nethermind.Facade.Filters
                 int filterId = filter.Id;
                 ConcurrentQueue<Option<Hash256>> transactions = _pendingTransactions.GetOrAdd(filterId, static _ => new ConcurrentQueue<Option<Hash256>>());
                 transactions.Enqueue(new Option<Hash256>(e.Transaction.Hash));
-                Interlocked.Increment(ref _queuedItems);
                 if (_logger.IsTrace) _logger.Trace($"Filter with id: {filterId} contains {transactions.Count} transactions.");
             }
         }
@@ -201,7 +194,6 @@ namespace Nethermind.Facade.Filters
             {
                 result.Add(hash);
             }
-            ReleaseQueued(result.Count);
             return result.ToArray();
         }
 
@@ -216,7 +208,6 @@ namespace Nethermind.Facade.Filters
             {
                 result.Add(log);
             }
-            ReleaseQueued(result.Count);
             return result.ToArray();
         }
 
@@ -227,16 +218,13 @@ namespace Nethermind.Facade.Filters
                 return [];
 
             using ArrayPoolListRef<Hash256> result = new(pendingTransactions.Count);
-            int dequeued = 0;
             while (pendingTransactions.TryDequeue(out Option<Hash256>? option))
             {
-                dequeued++;
                 if (!option.IsRemoved)
                 {
                     result.Add(option.Value);
                 }
             }
-            ReleaseQueued(dequeued);
             return result.ToArray();
         }
 
@@ -274,7 +262,6 @@ namespace Nethermind.Facade.Filters
 
             ConcurrentQueue<Hash256> blocks = _blockHashes.GetOrAdd(filter.Id, static _ => new ConcurrentQueue<Hash256>());
             blocks.Enqueue(block.Hash);
-            Interlocked.Increment(ref _queuedItems);
             if (_logger.IsTrace) _logger.Trace($"Filter with id: {filter.Id} contains {blocks.Count} blocks.");
         }
 
@@ -294,7 +281,6 @@ namespace Nethermind.Facade.Filters
                 {
                     logs ??= _logs.GetOrAdd(filter.Id, static _ => new ConcurrentQueue<FilterLog>());
                     logs.Enqueue(filterLog);
-                    Interlocked.Increment(ref _queuedItems);
                 }
             }
 

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterManager.cs
@@ -33,6 +33,7 @@ namespace Nethermind.Facade.Filters
         private readonly FilterStore _filterStore;
         private readonly ILogger _logger;
         private long _logIndex;
+        private long _queuedItems;
 
         public FilterManager(
             FilterStore filterStore,
@@ -49,6 +50,7 @@ namespace Nethermind.Facade.Filters
             mainProcessingContext.TransactionProcessed += OnTransactionProcessed;
             receiptMonitor.ReceiptsInserted += OnReceiptsInserted;
             _filterStore.FilterRemoved += OnFilterRemoved;
+            _filterStore.QueuedItemCount = () => Volatile.Read(ref _queuedItems);
             txPool.NewPending += OnNewPendingTransaction;
             txPool.RemovedPending += OnRemovedPendingTransaction;
         }
@@ -56,9 +58,30 @@ namespace Nethermind.Facade.Filters
         private void OnFilterRemoved(object sender, FilterEventArgs e)
         {
             int id = e.FilterId;
-            if (_blockHashes.TryRemove(id, out _)) return;
-            if (_logs.TryRemove(id, out _)) return;
-            _pendingTransactions.TryRemove(id, out _);
+            if (_blockHashes.TryRemove(id, out ConcurrentQueue<Hash256>? blockHashes))
+            {
+                ReleaseQueued(blockHashes.Count);
+                return;
+            }
+
+            if (_logs.TryRemove(id, out ConcurrentQueue<FilterLog>? logs))
+            {
+                ReleaseQueued(logs.Count);
+                return;
+            }
+
+            if (_pendingTransactions.TryRemove(id, out ConcurrentQueue<Option<Hash256>>? pendingTransactions))
+            {
+                ReleaseQueued(pendingTransactions.Count);
+            }
+        }
+
+        private void ReleaseQueued(int count)
+        {
+            if (count > 0)
+            {
+                Interlocked.Add(ref _queuedItems, -count);
+            }
         }
 
         private void OnBlockProcessed(object sender, BlockProcessedEventArgs e)
@@ -103,6 +126,7 @@ namespace Nethermind.Facade.Filters
                         {
                             logs ??= _logs.GetOrAdd(filter.Id, static _ => new ConcurrentQueue<FilterLog>());
                             logs.Enqueue(filterLog);
+                            Interlocked.Increment(ref _queuedItems);
                         }
                     }
                 }
@@ -117,6 +141,7 @@ namespace Nethermind.Facade.Filters
                 int filterId = filter.Id;
                 ConcurrentQueue<Option<Hash256>> transactions = _pendingTransactions.GetOrAdd(filterId, static _ => new ConcurrentQueue<Option<Hash256>>());
                 transactions.Enqueue(new Option<Hash256>(e.Transaction.Hash));
+                Interlocked.Increment(ref _queuedItems);
                 if (_logger.IsTrace) _logger.Trace($"Filter with id: {filterId} contains {transactions.Count} transactions.");
             }
         }
@@ -176,6 +201,7 @@ namespace Nethermind.Facade.Filters
             {
                 result.Add(hash);
             }
+            ReleaseQueued(result.Count);
             return result.ToArray();
         }
 
@@ -190,6 +216,7 @@ namespace Nethermind.Facade.Filters
             {
                 result.Add(log);
             }
+            ReleaseQueued(result.Count);
             return result.ToArray();
         }
 
@@ -200,13 +227,16 @@ namespace Nethermind.Facade.Filters
                 return [];
 
             using ArrayPoolListRef<Hash256> result = new(pendingTransactions.Count);
+            int dequeued = 0;
             while (pendingTransactions.TryDequeue(out Option<Hash256>? option))
             {
+                dequeued++;
                 if (!option.IsRemoved)
                 {
                     result.Add(option.Value);
                 }
             }
+            ReleaseQueued(dequeued);
             return result.ToArray();
         }
 
@@ -244,6 +274,7 @@ namespace Nethermind.Facade.Filters
 
             ConcurrentQueue<Hash256> blocks = _blockHashes.GetOrAdd(filter.Id, static _ => new ConcurrentQueue<Hash256>());
             blocks.Enqueue(block.Hash);
+            Interlocked.Increment(ref _queuedItems);
             if (_logger.IsTrace) _logger.Trace($"Filter with id: {filter.Id} contains {blocks.Count} blocks.");
         }
 
@@ -263,6 +294,7 @@ namespace Nethermind.Facade.Filters
                 {
                     logs ??= _logs.GetOrAdd(filter.Id, static _ => new ConcurrentQueue<FilterLog>());
                     logs.Enqueue(filterLog);
+                    Interlocked.Increment(ref _queuedItems);
                 }
             }
 

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterStore.cs
@@ -11,6 +11,7 @@ using Nethermind.Facade.Filters.Topics;
 using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Exceptions;
 using Nethermind.Core.Timers;
 using ITimer = Nethermind.Core.Timers.ITimer;
 
@@ -19,6 +20,7 @@ namespace Nethermind.Facade.Filters
     public sealed class FilterStore : IDisposable
     {
         private readonly TimeSpan _timeout;
+        private readonly int _maxQueuedItems;
         private int _currentFilterId = -1;
         private readonly Lock _locker = new();
         private readonly ConcurrentDictionary<int, FilterBase> _filters = new();
@@ -55,8 +57,9 @@ namespace Nethermind.Facade.Filters
         // https://github.com/dotnet/runtime/pull/38296
         private IEnumerator<KeyValuePair<int, FilterBase>>? _enumerator;
 
-        public FilterStore(ITimerFactory timerFactory, int timeout = 15 * 60 * 1000, int cleanupInterval = 5 * 60 * 1000)
+        public FilterStore(ITimerFactory timerFactory, int timeout = 15 * 60 * 1000, int cleanupInterval = 5 * 60 * 1000, int maxQueuedItems = 0)
         {
+            _maxQueuedItems = maxQueuedItems;
             _timeout = TimeSpan.FromMilliseconds(timeout);
             _timer = timerFactory.CreateTimer(TimeSpan.FromMilliseconds(cleanupInterval));
             _timer.AutoReset = false;
@@ -137,8 +140,23 @@ namespace Nethermind.Facade.Filters
 
         public event EventHandler<FilterEventArgs>? FilterRemoved;
 
+        /// <summary>
+        /// Reports the number of results currently queued across all filters.
+        /// </summary>
+        /// <remarks>
+        /// Set by <see cref="FilterManager"/>, which owns the queues. Filter results are only bounded by the
+        /// inactivity timeout, so without a budget a caller installing filters it never polls can grow them
+        /// until the node runs out of memory.
+        /// </remarks>
+        internal Func<long>? QueuedItemCount { get; set; }
+
         public void SaveFilter(FilterBase filter)
         {
+            if (_maxQueuedItems > 0 && QueuedItemCount?.Invoke() >= _maxQueuedItems)
+            {
+                throw new ConcurrencyLimitReachedException($"Cannot create a new filter: {_maxQueuedItems} queued filter results reached.");
+            }
+
             if (!_filters.TryAdd(filter.Id, filter))
             {
                 throw new InvalidOperationException($"Filter with ID {filter.Id} already exists");

--- a/src/Nethermind/Nethermind.Facade/Filters/FilterStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/FilterStore.cs
@@ -146,7 +146,9 @@ namespace Nethermind.Facade.Filters
         /// <remarks>
         /// Set by <see cref="FilterManager"/>, which owns the queues. Filter results are only bounded by the
         /// inactivity timeout, so without a budget a caller installing filters it never polls can grow them
-        /// until the node runs out of memory.
+        /// until the node runs out of memory. When a budget is configured (<c>maxQueuedItems &gt; 0</c>) this
+        /// delegate must be wired for the budget to take effect; a null delegate leaves it inert. In the
+        /// standard DI graph <see cref="FilterManager"/> always wires it, so the budget is never silently off.
         /// </remarks>
         internal Func<long>? QueuedItemCount { get; set; }
 

--- a/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
@@ -90,7 +90,7 @@ public class RpcModules(IJsonRpcConfig jsonRpcConfig) : Module
                 .AddScoped<IBlockchainBridge>((ctx) => ctx.Resolve<IBlockchainBridgeFactory>().CreateBlockchainBridge())
                     .AddSingleton<IFeeHistoryOracle, FeeHistoryOracle>()
                     .AddSingleton<IEthCapabilitiesProvider, EthCapabilitiesProvider>()
-                    .AddSingleton<FilterStore, ITimerFactory, IJsonRpcConfig>((timerFactory, rpcConfig) => new FilterStore(timerFactory, rpcConfig.FiltersTimeout))
+                    .AddSingleton<FilterStore, ITimerFactory, IJsonRpcConfig>((timerFactory, rpcConfig) => new FilterStore(timerFactory, rpcConfig.FiltersTimeout, maxQueuedItems: rpcConfig.FiltersMaxQueuedItems))
                     .AddSingleton<FilterManager>()
                     .AddSingleton<IWitnessGeneratingBlockProcessingEnvFactory, WitnessGeneratingBlockProcessingEnvFactory>()
                     .AddSingleton<ISimulateReadOnlyBlocksProcessingEnvFactory, SimulateReadOnlyBlocksProcessingEnvFactory>()

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -224,6 +224,11 @@ public interface IJsonRpcConfig : IConfig
     [ConfigItem(Description = "The eth_filters timeout, in milliseconds.", DefaultValue = "900000")]
     int FiltersTimeout { get; set; }
 
+    [ConfigItem(
+        Description = "The max number of results (logs, block hashes, or pending transaction hashes) queued across all `eth_filters`. New filters are rejected while this budget is exhausted. `0` to disable the limit.",
+        DefaultValue = "1000000")]
+    int FiltersMaxQueuedItems { get; set; }
+
     [ConfigItem(Description = "Preload rpc modules. Useful in rpc provider to reduce latency on first request.", DefaultValue = "false")]
     bool PreloadRpcModules { get; set; }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -83,6 +83,7 @@ public class JsonRpcConfig : IJsonRpcConfig
     public int IpcProcessingConcurrency { get; set; } = 1;
     public bool EnablePerMethodMetrics { get; set; } = true;
     public int FiltersTimeout { get; set; } = 900000;
+    public int FiltersMaxQueuedItems { get; set; } = 1_000_000;
     public bool PreloadRpcModules { get; set; }
     public bool StrictHexFormat { get; set; } = true;
     public int RpcTxSyncDefaultTimeoutMs { get; set; } = 20_000;


### PR DESCRIPTION
Fixes #12490

## Changes

- Track the number of results queued across all `eth_filters` in `FilterManager` (log, block-hash and pending-transaction queues), incrementing as results are stored and decrementing when they are polled or when a filter is removed.
- Reject new filter creation in `FilterStore.SaveFilter` once that budget is exhausted, via `ConcurrencyLimitReachedException`, which the JSON-RPC layer already maps to `-32005 LimitExceeded`.
- Add `JsonRpc.FiltersMaxQueuedItems` (default `1000000`, `0` disables the limit) and wire it through `RpcModules`.

Previously the queues only shrank on `Poll*` or filter removal, so a caller that installed filters and never polled them kept every match until the 15-minute inactivity timeout fired — the TTL bounds how long a filter lives, not how much it can accumulate in that window. Rejecting new filters keeps already-installed filters lossless rather than dropping results, which is the behaviour asked for in the issue.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Two regression tests in `FilterManagerTests` cover rejection once the budget is exhausted and budget release on both poll and filter removal. Both fail without the `SaveFilter` check and pass with it. Full `Filters` suite passes (135 tests), as does `Nethermind.Config.Test`.

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

_The new `JsonRpc.FiltersMaxQueuedItems` config item should be added to the configuration docs._

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
