### PR TITLE
fix(state): tolerate an already-disposed flush target during shutdown

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/StatePersistenceBarrierTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/StatePersistenceBarrierTests.cs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test;
+
+// Regression: on shutdown, TrieStore.Dispose() can invoke a registered flush after its target database was
+// already disposed by Autofac - the barrier registration is a runtime callback, not a graph edge Autofac's
+// dispose ordering can see. The database already flushed itself on Dispose (see DbOnTheRocks' FlushOnExit),
+// so a disposed flush target should not fail the whole shutdown flush.
+[Parallelizable(ParallelScope.Self)]
+public class StatePersistenceBarrierTests
+{
+    [Test]
+    public void FlushDeferred_does_not_throw_when_a_flush_target_is_already_disposed()
+    {
+        StatePersistenceBarrier barrier = new();
+        bool laterFlushRan = false;
+
+        barrier.RegisterFlush(() => throw new ObjectDisposedException("SomeDb"));
+        barrier.RegisterFlush(() => laterFlushRan = true);
+
+        Assert.That(() => barrier.FlushDeferred(), Throws.Nothing);
+        Assert.That(laterFlushRan, Is.True, "a flush registered after a disposed target must still run");
+    }
+}

--- a/src/Nethermind/Nethermind.Core/IStatePersistenceBarrier.cs
+++ b/src/Nethermind/Nethermind.Core/IStatePersistenceBarrier.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Nethermind.Logging;
 
 namespace Nethermind.Core;
 
@@ -36,12 +37,13 @@ public interface IStatePersistenceBarrier
 }
 
 /// <inheritdoc cref="IStatePersistenceBarrier"/>
-public sealed class StatePersistenceBarrier : IStatePersistenceBarrier
+public sealed class StatePersistenceBarrier(ILogManager? logManager = null) : IStatePersistenceBarrier
 {
     // Copy-on-write: rare startup registration rebuilds the arrays under a lock; FlushDeferred reads lock-free.
     private readonly Lock _registrationLock = new();
     private volatile Action[] _drains = [];
     private volatile Action[] _flushes = [];
+    private readonly ILogger _logger = (logManager ?? LimboLogs.Instance).GetClassLogger<StatePersistenceBarrier>();
 
     public bool IsEnabled => true;
 
@@ -63,7 +65,22 @@ public sealed class StatePersistenceBarrier : IStatePersistenceBarrier
         for (int i = 0; i < drains.Length; i++) drains[i]();
 
         Action[] flushes = _flushes;
-        for (int i = 0; i < flushes.Length; i++) flushes[i]();
+        for (int i = 0; i < flushes.Length; i++)
+        {
+            try
+            {
+                flushes[i]();
+            }
+            catch (ObjectDisposedException e)
+            {
+                // On shutdown, a flush target's database can already be disposed by the time the trie store
+                // (this barrier's caller, via BarrierNodeStorage) is disposed - the registration is a runtime
+                // callback, not a graph edge Autofac's dispose ordering can see. The database already flushed
+                // itself on Dispose (see DbOnTheRocks' FlushOnExit), so this is a redundant flush racing
+                // shutdown, not a lost write.
+                if (_logger.IsDebug) _logger.Debug($"Skipped a block-data flush during shutdown: {e.Message}");
+            }
+        }
     }
 
     private static Action[] Append(Action[] existing, Action callback)

--- a/src/Nethermind/Nethermind.Core/IStatePersistenceBarrier.cs
+++ b/src/Nethermind/Nethermind.Core/IStatePersistenceBarrier.cs
@@ -74,10 +74,7 @@ public sealed class StatePersistenceBarrier(ILogManager? logManager = null) : IS
             catch (ObjectDisposedException e)
             {
                 // On shutdown, a flush target's database can already be disposed by the time the trie store
-                // (this barrier's caller, via BarrierNodeStorage) is disposed - the registration is a runtime
-                // callback, not a graph edge Autofac's dispose ordering can see. The database already flushed
-                // itself on Dispose (see DbOnTheRocks' FlushOnExit), so this is a redundant flush racing
-                // shutdown, not a lost write.
+                // is disposed. The database already flushed itself on Dispose (see DbOnTheRocks' FlushOnExit)
                 if (_logger.IsDebug) _logger.Debug($"Skipped a block-data flush during shutdown: {e.Message}");
             }
         }


### PR DESCRIPTION
## Changes

- `IStatePersistenceBarrier.FlushDeferred()` now catches `ObjectDisposedException` per registered flush callback (logging at debug) instead of letting one already-disposed target abort the whole shutdown flush.
- Added a regression test verifying `FlushDeferred` doesn't throw when an early flush target is disposed, and that later-registered flushes still run.

## Why

On shutdown, `TrieStore.Dispose()` → `PersistOnShutdown()` → `BarrierNodeStorage.Flush()` invokes flush callbacks that `PersistentReceiptStorage`, `BlockStore`, and `BlockAccessListStore` each register with `IStatePersistenceBarrier` to fsync their own database's WAL. Those registrations are runtime callbacks on a shared singleton, not constructor-injection edges, so Autofac's automatic (reverse-activation-order) disposal has no way to know that `TrieStore`'s disposal transitively needs those databases to still be open. When Autofac happens to dispose one of those databases before `TrieStore`, the flush callback throws `ObjectDisposedException` and crashes the whole shutdown sequence:

```
23 Jul 00:11:31 | A critical error has occurred. System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Nethermind.Db.Rocks.ColumnsDb`1[[Nethermind.Db.ReceiptsColumns, ...
   at Nethermind.Db.Rocks.DbOnTheRocks.Flush(Boolean onlyWal)
   at Nethermind.Db.Rocks.ColumnsDb`1.Flush(Boolean onlyWal)
   at Nethermind.Blockchain.Receipts.PersistentReceiptStorage.<.ctor>b__30_1()
   at Nethermind.Core.StatePersistenceBarrier.FlushDeferred()
   at Nethermind.Init.BarrierNodeStorage.Flush(Boolean onlyWal)
   at Nethermind.Trie.Pruning.TrieStore.ParallelPersistBlockCommitSet(...)
   at Nethermind.Trie.Pruning.TrieStore.PersistOnShutdown()
   at Nethermind.Trie.Pruning.TrieStore.Dispose()
   ...
```

This is safe to tolerate: `DbOnTheRocks.Dispose()` already runs its own flush per `FlushOnExit` (default `WalOnly`) before releasing its handle, so a database that's already disposed has already durably flushed itself — the barrier's flush is redundant in that case, not a lost write.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added `StatePersistenceBarrierTests.FlushDeferred_does_not_throw_when_a_flush_target_is_already_disposed`. Also ran the existing deferred-write/receipts/block-store/BAL-store test suites in `Nethermind.Blockchain.Test` to confirm no regressions.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No