### PR TITLE
fix(persistence): halfpath shutdown crash — skip disposed registrants in StatePersistenceBarrier

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BlockAccessListStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BlockAccessListStoreTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
@@ -163,7 +164,7 @@ public class BlockAccessListStoreTests
     public async Task Barrier_flush_drains_queued_bal_and_fsyncs_before_state_persists()
     {
         TestMemDb db = new();
-        StatePersistenceBarrier barrier = new();
+        StatePersistenceBarrier barrier = new(LimboLogs.Instance);
         await using DeferredBlockDataWriter writer = DeferredWriteTestHelpers.ManualWriter(barrier);
         BlockAccessListStore store = new(db, null, writer, persistenceBarrier: barrier);
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Blocks/DeferredBlockStoreTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Blocks/DeferredBlockStoreTests.cs
@@ -8,6 +8,7 @@ using Nethermind.Blockchain.Blocks;
 using Nethermind.Core;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
@@ -18,7 +19,7 @@ namespace Nethermind.Blockchain.Test.Blocks;
 public class DeferredBlockStoreTests
 {
     private readonly TestMemDb _db = new();
-    private readonly StatePersistenceBarrier _barrier = new();
+    private readonly StatePersistenceBarrier _barrier = new(LimboLogs.Instance);
     private DeferredBlockDataWriter _writer = null!;
     private BlockStore _store = null!;
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/DeferredReceiptStorageTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/DeferredReceiptStorageTests.cs
@@ -53,7 +53,7 @@ public class DeferredReceiptStorageTests(bool useCompactReceipts)
         _blockTree = Substitute.For<IBlockTree>();
         _blockStore = Substitute.For<IBlockStore>();
         _decoder = new ReceiptArrayStorageDecoder(useCompactReceipts);
-        _barrier = new StatePersistenceBarrier();
+        _barrier = new StatePersistenceBarrier(LimboLogs.Instance);
         _writer = DeferredWriteTestHelpers.ManualWriter(_barrier);
         _logger = Substitute.For<InterfaceLogger>();
         _logger.IsWarn.Returns(true);
@@ -399,7 +399,7 @@ public class DeferredReceiptStorageTests(bool useCompactReceipts)
     [Test, MaxTime(Timeout.MaxTestTime)]
     public async Task Barrier_drain_returns_after_writer_completed_normally()
     {
-        StatePersistenceBarrier barrier = new();
+        StatePersistenceBarrier barrier = new(LimboLogs.Instance);
         DeferredBlockDataWriter writer = new(enabled: true, capacity: 8, LimboLogs.Instance, barrier);
         await writer.DisposeAsync();
 

--- a/src/Nethermind/Nethermind.Core.Test/StatePersistenceBarrierTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/StatePersistenceBarrierTests.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Logging;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test;
+
+public class StatePersistenceBarrierTests
+{
+    [Test]
+    public void FlushDeferred_runs_drains_then_flushes()
+    {
+        StatePersistenceBarrier barrier = new(LimboLogs.Instance);
+        int order = 0;
+        int drainedAt = 0;
+        int flushedAt = 0;
+        barrier.RegisterDrain(() => drainedAt = ++order);
+        barrier.RegisterFlush(() => flushedAt = ++order);
+
+        barrier.FlushDeferred();
+
+        Assert.That(drainedAt, Is.EqualTo(1));
+        Assert.That(flushedAt, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void FlushDeferred_skips_disposed_registrant_and_still_runs_the_rest()
+    {
+        // Regression: on shutdown the container can dispose a block-data DB before
+        // TrieStore.PersistOnShutdown flushes state through the barrier. The disposed
+        // registrant's callback must not abort the teardown — the remaining callbacks
+        // (and the caller's own state flush) must still run.
+        StatePersistenceBarrier barrier = new(LimboLogs.Instance);
+        bool laterFlushRan = false;
+        barrier.RegisterFlush(() => throw new ObjectDisposedException("DbOnTheRocks"));
+        barrier.RegisterFlush(() => laterFlushRan = true);
+
+        Assert.DoesNotThrow(barrier.FlushDeferred);
+        Assert.That(laterFlushRan, Is.True);
+    }
+
+    [Test]
+    public void FlushDeferred_propagates_other_exceptions()
+    {
+        // Only the well-understood disposed-registrant case is tolerated — a genuine
+        // flush failure must still surface to the caller.
+        StatePersistenceBarrier barrier = new(LimboLogs.Instance);
+        barrier.RegisterFlush(() => throw new InvalidOperationException("disk on fire"));
+
+        Assert.Throws<InvalidOperationException>(barrier.FlushDeferred);
+    }
+}

--- a/src/Nethermind/Nethermind.Core/IStatePersistenceBarrier.cs
+++ b/src/Nethermind/Nethermind.Core/IStatePersistenceBarrier.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Nethermind.Logging;
 
 namespace Nethermind.Core;
 
@@ -36,10 +37,11 @@ public interface IStatePersistenceBarrier
 }
 
 /// <inheritdoc cref="IStatePersistenceBarrier"/>
-public sealed class StatePersistenceBarrier : IStatePersistenceBarrier
+public sealed class StatePersistenceBarrier(ILogManager logManager) : IStatePersistenceBarrier
 {
     // Copy-on-write: rare startup registration rebuilds the arrays under a lock; FlushDeferred reads lock-free.
     private readonly Lock _registrationLock = new();
+    private readonly ILogger _logger = logManager.GetClassLogger<StatePersistenceBarrier>();
     private volatile Action[] _drains = [];
     private volatile Action[] _flushes = [];
 
@@ -60,10 +62,27 @@ public sealed class StatePersistenceBarrier : IStatePersistenceBarrier
     public void FlushDeferred()
     {
         Action[] drains = _drains;
-        for (int i = 0; i < drains.Length; i++) drains[i]();
+        for (int i = 0; i < drains.Length; i++) Invoke(drains[i]);
 
         Action[] flushes = _flushes;
-        for (int i = 0; i < flushes.Length; i++) flushes[i]();
+        for (int i = 0; i < flushes.Length; i++) Invoke(flushes[i]);
+    }
+
+    private void Invoke(Action callback)
+    {
+        try
+        {
+            callback();
+        }
+        catch (ObjectDisposedException e)
+        {
+            // A disposed registrant has already made its data durable (the DBs flush on dispose),
+            // so the barrier invariant holds without its callback. This happens on shutdown when
+            // the container disposes a block-data DB before TrieStore.PersistOnShutdown flushes
+            // state through the barrier; the remaining callbacks — and, critically, the caller's
+            // own state flush — must still run rather than abort the teardown.
+            if (_logger.IsDebug) _logger.Debug($"Skipping disposed persistence-barrier registrant: {e.Message}");
+        }
     }
 
     private static Action[] Append(Action[] existing, Action callback)


### PR DESCRIPTION
## Changes

Every halfpath node on master crashes on shutdown since #12349 (found by the RPC-benchmark validation matrix on #11961, reproduced 2/2 — runs [29910366733](https://github.com/NethermindEth/nethermind/actions/runs/29910366733), [29920423892](https://github.com/NethermindEth/nethermind/actions/runs/29920423892)):

```
Disposing DB Receipts
A critical error has occurred. System.ObjectDisposedException:
  ColumnsDb<ReceiptsColumns>.Flush ← StatePersistenceBarrier.FlushDeferred
  ← BarrierNodeStorage.Flush ← TrieStore.PersistOnShutdown ← Autofac Disposer
terminate called after throwing an instance of 'std::bad_alloc'
```

- **Cause**: #12349's block-data stores (receipts/blocks/BAL) register flush callbacks with `IStatePersistenceBarrier` that capture their DB references. On shutdown, Autofac disposes those DBs before the TrieStore; `TrieStore.PersistOnShutdown` then flushes state through `BarrierNodeStorage`, whose `barrier.FlushDeferred()` invokes the captured callbacks against the already-disposed receipts `ColumnsDb`. Deterministic dispose-graph ordering — crashes on every halfpath shutdown regardless of workload or pruning mode. Flat is unaffected (`BarrierNodeStorage` is wired only via `PruningTrieStateFactory`).
- **Consequence beyond the crash**: the throw happens before `inner.Flush(onlyWal: false)`, so the state DB's final full flush — the very thing `PersistOnShutdown` exists for — never ran, and the aborted teardown ended in a native `std::bad_alloc`.
- **Fix**: `StatePersistenceBarrier.FlushDeferred` tolerates exactly `ObjectDisposedException` per callback (debug-logged), keeps running the remaining callbacks and the caller's state flush. This is invariant-preserving: a disposed registrant has already made its data durable (`DbOnTheRocks.Dispose` runs its `FlushOnExit` flush before releasing native resources), so `state(N) durable => block-data(<=N) durable` holds without its callback. Any other exception still propagates.
- The barrier now takes an `ILogManager` (auto-resolved by DI); test call sites updated.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- New `StatePersistenceBarrierTests`: a registrant throwing `ObjectDisposedException` must not abort `FlushDeferred` and later callbacks must still run; other exceptions must still propagate; drain-before-flush ordering.
- `Nethermind.Core.Test` (5,852) and `Nethermind.Blockchain.Test` (1,566, incl. the #12349 deferred-persistence suites) all pass locally.
- End-to-end: the previously 2/2-crashing scenario (halfpath `nethermind-25490000` snapshot, SIGINT shutdown) re-run on this fix via the #11961 benchmark workflow — validation run [29991495756](https://github.com/NethermindEth/nethermind/actions/runs/29991495756) (gates require no exceptions + the `Nethermind is shut down` marker).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] Yes

Fixes a crash (`ObjectDisposedException` + native `std::bad_alloc`) on every shutdown of halfpath-layout nodes, introduced after 1.36 by the deferred block-data persistence work; the crash also skipped the final state flush on shutdown.
