### PR TITLE
Optimize generated SSZ byte collection codecs

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
@@ -126,6 +126,22 @@ public class EncodingTest
     }
 
     [Test]
+    public void Decode_collection_itself_byte_lists_supports_list_destinations()
+    {
+        ByteListListItself[] original = [new() { Bytes = [] }, new() { Bytes = [1, 2, 3] }];
+
+        byte[] encoded = ByteListListItself.Encode(original);
+        ByteListListItself.Decode(encoded, out ByteListListItself[] decoded);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded, Has.Length.EqualTo(2));
+            Assert.That(decoded[0].Bytes, Is.Empty);
+            Assert.That(decoded[1].Bytes, Is.EqualTo(new List<byte> { 1, 2, 3 }));
+        }
+    }
+
+    [Test]
     public void Decode_collection_itself_byte_vectors()
     {
         ByteVectorItself[] original = [new() { Bytes = [1, 2, 3] }, new() { Bytes = [4, 5, 6] }];

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
@@ -95,6 +95,22 @@ public class EncodingTest
     }
 
     [Test]
+    public void Decode_collection_itself_byte_lists_supports_class_items()
+    {
+        ByteListClassItself[] original = [new() { Bytes = [] }, new() { Bytes = [1, 2, 3] }];
+
+        byte[] encoded = ByteListClassItself.Encode(original);
+        ByteListClassItself.Decode(encoded, out ByteListClassItself[] decoded);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded, Has.Length.EqualTo(2));
+            Assert.That(decoded[0].Bytes, Is.Empty);
+            Assert.That(decoded[1].Bytes, Is.EqualTo(new byte[] { 1, 2, 3 }));
+        }
+    }
+
+    [Test]
     public void Decode_collection_itself_byte_vectors()
     {
         ByteVectorItself[] original = [new() { Bytes = [1, 2, 3] }, new() { Bytes = [4, 5, 6] }];

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
@@ -70,6 +70,30 @@ public class EncodingTest
         }
     }
 
+    [Test]
+    public void Decode_collection_itself_byte_lists()
+    {
+        ByteListItself[] original = [new() { Bytes = [] }, new() { Bytes = [1, 2, 3] }];
+
+        byte[] encoded = ByteListItself.Encode(original);
+        ByteListItself.Decode(encoded, out ByteListItself[] decoded);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded, Has.Length.EqualTo(2));
+            Assert.That(decoded[0].Bytes, Is.Empty);
+            Assert.That(decoded[1].Bytes, Is.EqualTo(new byte[] { 1, 2, 3 }));
+        }
+    }
+
+    [Test]
+    public void Decode_collection_itself_byte_lists_enforces_item_limit()
+    {
+        byte[] encoded = [8, 0, 0, 0, 12, 0, 0, 0, 1, 2, 3, 4];
+
+        Assert.That(() => ByteListItself.Decode(encoded, out ByteListItself[] _), Throws.InstanceOf<InvalidDataException>());
+    }
+
     private static BitArray MakeSampleBits10()
     {
         BitArray bits = new(10);

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
@@ -129,8 +129,11 @@ public class EncodingTest
     public void Encode_nonnullable_static_class_null_clears_output()
     {
         NonNullableStaticClassContainer container = new() { Child = null! };
+        byte[] reusedBuffer = Enumerable.Repeat((byte)0xFF, sizeof(ulong)).ToArray();
 
-        Assert.That(Encode(container), Is.EqualTo(new byte[sizeof(ulong)]));
+        NonNullableStaticClassContainer.Encode(reusedBuffer, container);
+
+        Assert.That(reusedBuffer, Is.EqualTo(new byte[sizeof(ulong)]));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
@@ -126,6 +126,14 @@ public class EncodingTest
     }
 
     [Test]
+    public void Encode_nonnullable_static_class_null_clears_output()
+    {
+        NonNullableStaticClassContainer container = new() { Child = null! };
+
+        Assert.That(Encode(container), Is.EqualTo(new byte[sizeof(ulong)]));
+    }
+
+    [Test]
     public void Decode_collection_itself_byte_lists_supports_list_destinations()
     {
         ByteListListItself[] original = [new() { Bytes = [] }, new() { Bytes = [1, 2, 3] }];

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
@@ -111,6 +111,21 @@ public class EncodingTest
     }
 
     [Test]
+    public void Encode_fixed_size_class_collection_clears_null_items()
+    {
+        StaticClassCollectionItem[] items = [new() { Value = 1 }, null!, new() { Value = 2 }];
+
+        byte[] encoded = StaticClassCollectionItem.Encode(items);
+
+        Assert.That(encoded, Is.EqualTo(new byte[]
+        {
+            1, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            2, 0, 0, 0, 0, 0, 0, 0,
+        }));
+    }
+
+    [Test]
     public void Decode_collection_itself_byte_vectors()
     {
         ByteVectorItself[] original = [new() { Bytes = [1, 2, 3] }, new() { Bytes = [4, 5, 6] }];

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/EncodingTest.cs
@@ -94,6 +94,30 @@ public class EncodingTest
         Assert.That(() => ByteListItself.Decode(encoded, out ByteListItself[] _), Throws.InstanceOf<InvalidDataException>());
     }
 
+    [Test]
+    public void Decode_collection_itself_byte_vectors()
+    {
+        ByteVectorItself[] original = [new() { Bytes = [1, 2, 3] }, new() { Bytes = [4, 5, 6] }];
+
+        byte[] encoded = ByteVectorItself.Encode(original);
+        ByteVectorItself.Decode(encoded, out ByteVectorItself[] decoded);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded, Has.Length.EqualTo(2));
+            Assert.That(decoded[0].Bytes, Is.EqualTo(new byte[] { 1, 2, 3 }));
+            Assert.That(decoded[1].Bytes, Is.EqualTo(new byte[] { 4, 5, 6 }));
+        }
+    }
+
+    [Test]
+    public void Decode_collection_itself_byte_vectors_rejects_wrong_item_length()
+    {
+        byte[] encoded = [1, 2, 3, 4, 5];
+
+        Assert.That(() => ByteVectorItself.Decode(encoded, out ByteVectorItself[] _), Throws.InstanceOf<InvalidDataException>());
+    }
+
     private static BitArray MakeSampleBits10()
     {
         BitArray bits = new(10);

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
@@ -124,6 +124,12 @@ namespace Nethermind.Serialization.SszGenerator.Test
         public ulong Value { get; set; }
     }
 
+    [SszContainer]
+    public partial struct NonNullableStaticClassContainer
+    {
+        public StaticClassCollectionItem Child { get; set; }
+    }
+
     [SszContainer(isCollectionItself: true)]
     public partial struct ByteListListItself
     {

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
@@ -103,6 +103,13 @@ namespace Nethermind.Serialization.SszGenerator.Test
         public ulong[]? Items { get; set; }
     }
 
+    [SszContainer(isCollectionItself: true)]
+    public partial struct ByteListItself
+    {
+        [SszList(3)]
+        public byte[]? Bytes { get; set; }
+    }
+
     [SszContainer]
     public partial struct ArrayPoolListContainer
     {

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
@@ -110,6 +110,13 @@ namespace Nethermind.Serialization.SszGenerator.Test
         public byte[]? Bytes { get; set; }
     }
 
+    [SszContainer(isCollectionItself: true)]
+    public partial struct ByteVectorItself
+    {
+        [SszVector(3)]
+        public byte[]? Bytes { get; set; }
+    }
+
     [SszContainer]
     public partial struct ArrayPoolListContainer
     {

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
@@ -117,6 +117,12 @@ namespace Nethermind.Serialization.SszGenerator.Test
         public byte[]? Bytes { get; set; }
     }
 
+    [SszContainer]
+    public partial class StaticClassCollectionItem
+    {
+        public ulong Value { get; set; }
+    }
+
     [SszContainer(isCollectionItself: true)]
     public partial struct ByteVectorItself
     {

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
@@ -111,6 +111,13 @@ namespace Nethermind.Serialization.SszGenerator.Test
     }
 
     [SszContainer(isCollectionItself: true)]
+    public partial class ByteListClassItself
+    {
+        [SszList(3)]
+        public byte[]? Bytes { get; set; }
+    }
+
+    [SszContainer(isCollectionItself: true)]
     public partial struct ByteVectorItself
     {
         [SszVector(3)]

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator.Test/SszTypes.cs
@@ -8,6 +8,7 @@ using Nethermind.Serialization.Ssz;
 using System;
 using System.Buffers.Binary;
 using System.Collections;
+using System.Collections.Generic;
 using Nethermind.Core.Collections;
 
 namespace Nethermind.Serialization.SszGenerator.Test
@@ -121,6 +122,13 @@ namespace Nethermind.Serialization.SszGenerator.Test
     public partial class StaticClassCollectionItem
     {
         public ulong Value { get; set; }
+    }
+
+    [SszContainer(isCollectionItself: true)]
+    public partial struct ByteListListItself
+    {
+        [SszList(3)]
+        public List<byte> Bytes { get; set; }
     }
 
     [SszContainer(isCollectionItself: true)]

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
@@ -309,6 +309,14 @@ internal static class SszCodecHelpers
         }
     }
 
+    internal static byte[] DecodeSszByteList(ReadOnlySpan<byte> data, ulong limit, string typeName, string fieldName)
+    {
+        ValidateSszListLimit(data, limit, typeName, fieldName);
+        byte[] result = global::System.GC.AllocateUninitializedArray<byte>(data.Length);
+        data.CopyTo(result);
+        return result;
+    }
+
     internal static void ValidateSszBitvectorLength(BitArray? bits, int expectedLength, string typeName, string fieldName)
     {
         int actualLength = bits?.Length ?? 0;
@@ -752,6 +760,9 @@ internal static class SszCodecHelpers
     private static string NullClearingEncodeStatement(string target, SszProperty property, string valueExpr, string statement) =>
         property.IsNullable ? $"if ({valueExpr} is null) {target}.Clear(); else {statement}" : statement;
 
+    private static bool IsByteList(SszProperty property) =>
+        property.Kind == Kind.List && property.Type is { Name: nameof(Byte), IsSszBasicType: true };
+
     private static string DecodeAndAssign(SszType decl, SszProperty property, string sliceExpression)
     {
         string variableName = VarName(property.Name);
@@ -770,6 +781,12 @@ internal static class SszCodecHelpers
                 .Replace("{1}", $"container.{property.Name}");
             string validation = ValidationStatement(decl, property, $"container.{property.Name}");
             return string.IsNullOrEmpty(validation) ? decodeStatement : $"{decodeStatement} {validation}";
+        }
+
+        if (IsByteList(property))
+        {
+            string assignment = DecodeAssignmentExpression(property, variableName, sourceIsArray: true);
+            return $"{{ byte[] {variableName} = DecodeSszByteList({sliceExpression}, {property.Limit}UL, nameof({decl.TypeReferenceName}), nameof({property.Name})); container.{property.Name} = {assignment}; }}";
         }
 
         if ((property.Kind is Kind.Vector or Kind.List or Kind.ProgressiveList) && property.Type.Kind == Kind.Basic && property.Type.HasCustomInlineCodec)
@@ -1169,6 +1186,10 @@ internal static class SszCodecHelpers
                     ..decl.Members.Select(m => MerkleizeFeedStatement(m, $"container.{m.Name}")),
                     "merkleizer.CalculateRoot(out root);",
                 ]);
+            bool isByteListItself = decl.IsSszListItself && IsByteList(variables[0]);
+            string DecodeCollectionItem(string sliceExpression, string destination) => isByteListItself
+                ? $"{destination}.{variables[0].Name} = DecodeSszByteList({sliceExpression}, {variables[0].Limit}UL, nameof({decl.TypeReferenceName}), nameof({variables[0].Name}));"
+                : $"Decode({sliceExpression}, out {destination});";
             string result = FixWhitespace(decl.IsSszListItself ?
 $@"using Nethermind.Serialization.Ssz.Merkleization;
 using Nethermind.Serialization.Ssz;
@@ -1275,11 +1296,11 @@ using static Nethermind.Serialization.SszCodecHelpers;
         {{
             int nextOffset = DecodeSszOffset(data.Slice(nextOffsetIndex, {SszType.PointerLength}));
             ValidateSszNextOffset(data, offset, nextOffset, ""{decl.TypeReferenceName}[]"");
-            Decode(data.Slice(offset, nextOffset - offset), out container[index]);
+            {DecodeCollectionItem("data.Slice(offset, nextOffset - offset)", "container[index]")}
             offset = nextOffset;
         }}
 {Whitespace}
-        Decode(data.Slice(offset), out container[index]);" : @$"int offset = 0;
+        {DecodeCollectionItem("data.Slice(offset)", "container[index]")}" : @$"int offset = 0;
         for(int index = 0; index < length; index++)
         {{
             Decode(data.Slice(offset, {decl.StaticLength}), out container[index]);

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
@@ -1212,7 +1212,7 @@ internal static class SszCodecHelpers
                     ..decl.Members.Select(m => MerkleizeFeedStatement(m, $"container.{m.Name}")),
                     "merkleizer.CalculateRoot(out root);",
                 ]);
-            bool isByteListItself = decl.IsSszListItself && IsByteList(variables[0]);
+            bool isByteListItself = decl.IsSszListItself && decl.IsStruct && IsByteList(variables[0]);
             string DecodeCollectionItem(string sliceExpression, string destination) => isByteListItself
                 ? $"{destination}.{variables[0].Name} = DecodeSszByteList({sliceExpression}, {variables[0].Limit}UL, nameof({decl.TypeReferenceName}), nameof({variables[0].Name}));"
                 : $"Decode({sliceExpression}, out {destination});";

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
@@ -1489,8 +1489,8 @@ using static Nethermind.Serialization.SszCodecHelpers;
         }}" : @$"int offset = 0;
         foreach({decl.TypeReferenceName} item in items)
         {{
-            int length = GetLength(item);
-            Encode(data.Slice(offset, length), item);
+            int length = {decl.StaticLength};
+            {(decl.IsStruct ? string.Empty : "if (item is null) data.Slice(offset, length).Clear(); else ")}Encode(data.Slice(offset, length), item);
             offset += length;
         }}")}
     }}

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
@@ -770,12 +770,12 @@ internal static class SszCodecHelpers
                 : $"{property.Type.StaticMemberAccess}.Encode({destSpan}, {encodedValueExpr});";
         }
 
-        // Nullable reference-typed static fields encode as zeros when null.
+        // Reference-typed static fields encode as zeros when null.
         return NullClearingEncodeStatement(destSpan, property, valueExpr, statement);
     }
 
     private static string NullClearingEncodeStatement(string target, SszProperty property, string valueExpr, string statement) =>
-        property.IsNullable ? $"if ({valueExpr} is null) {target}.Clear(); else {statement}" : statement;
+        property.IsNullable || property.IsReferenceType ? $"if ({valueExpr} is null) {target}.Clear(); else {statement}" : statement;
 
     private static bool IsByteList(SszProperty property) =>
         property.Kind == Kind.List && (property.IsArrayProperty || property.IsMemoryLikeProperty) && property.Type is { Name: nameof(Byte), IsSszBasicType: true };

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
@@ -778,10 +778,10 @@ internal static class SszCodecHelpers
         property.IsNullable ? $"if ({valueExpr} is null) {target}.Clear(); else {statement}" : statement;
 
     private static bool IsByteList(SszProperty property) =>
-        property.Kind == Kind.List && !property.IsSpanLikeProperty && property.Type is { Name: nameof(Byte), IsSszBasicType: true };
+        property.Kind == Kind.List && (property.IsArrayProperty || property.IsMemoryLikeProperty) && property.Type is { Name: nameof(Byte), IsSszBasicType: true };
 
     private static bool IsByteVector(SszProperty property) =>
-        property.Kind == Kind.Vector && !property.IsSpanLikeProperty && property.Type is { Name: nameof(Byte), IsSszBasicType: true };
+        property.Kind == Kind.Vector && (property.IsArrayProperty || property.IsMemoryLikeProperty) && property.Type is { Name: nameof(Byte), IsSszBasicType: true };
 
     private static string DecodeAndAssign(SszType decl, SszProperty property, string sliceExpression)
     {

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
@@ -1213,8 +1213,10 @@ internal static class SszCodecHelpers
                     "merkleizer.CalculateRoot(out root);",
                 ]);
             bool isByteListItself = decl.IsSszListItself && decl.IsStruct && IsByteList(variables[0]);
+            string byteListVariableName = isByteListItself ? VarName(variables[0].Name) : string.Empty;
+            string byteListAssignment = isByteListItself ? DecodeAssignmentExpression(variables[0], byteListVariableName, sourceIsArray: true) : string.Empty;
             string DecodeCollectionItem(string sliceExpression, string destination) => isByteListItself
-                ? $"{destination}.{variables[0].Name} = DecodeSszByteList({sliceExpression}, {variables[0].Limit}UL, nameof({decl.TypeReferenceName}), nameof({variables[0].Name}));"
+                ? $"{{ byte[] {byteListVariableName} = DecodeSszByteList({sliceExpression}, {variables[0].Limit}UL, nameof({decl.TypeReferenceName}), nameof({variables[0].Name})); {destination}.{variables[0].Name} = {byteListAssignment}; }}"
                 : $"Decode({sliceExpression}, out {destination});";
             string result = FixWhitespace(decl.IsSszListItself ?
 $@"using Nethermind.Serialization.Ssz.Merkleization;

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
@@ -179,6 +179,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Nethermind.Serialization;
@@ -187,9 +188,11 @@ internal static class SszCodecHelpers
 {
     private const int SszOffsetSize = 4;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void EncodeSszOffset(Span<byte> data, int offset) =>
         BinaryPrimitives.WriteInt32LittleEndian(data, offset);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int DecodeSszOffset(ReadOnlySpan<byte> data) =>
         BinaryPrimitives.ReadInt32LittleEndian(data);
 
@@ -309,10 +312,24 @@ internal static class SszCodecHelpers
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static byte[] DecodeSszByteList(ReadOnlySpan<byte> data, ulong limit, string typeName, string fieldName)
     {
         ValidateSszListLimit(data, limit, typeName, fieldName);
         byte[] result = global::System.GC.AllocateUninitializedArray<byte>(data.Length);
+        data.CopyTo(result);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static byte[] DecodeSszByteVector(ReadOnlySpan<byte> data, int expectedLength, string typeName, string fieldName)
+    {
+        if (data.Length != expectedLength)
+        {
+            ThrowInvalidSszValue(typeName, fieldName, $"expected {expectedLength} elements but found {data.Length}.");
+        }
+
+        byte[] result = global::System.GC.AllocateUninitializedArray<byte>(expectedLength);
         data.CopyTo(result);
         return result;
     }
@@ -761,7 +778,10 @@ internal static class SszCodecHelpers
         property.IsNullable ? $"if ({valueExpr} is null) {target}.Clear(); else {statement}" : statement;
 
     private static bool IsByteList(SszProperty property) =>
-        property.Kind == Kind.List && property.Type is { Name: nameof(Byte), IsSszBasicType: true };
+        property.Kind == Kind.List && !property.IsSpanLikeProperty && property.Type is { Name: nameof(Byte), IsSszBasicType: true };
+
+    private static bool IsByteVector(SszProperty property) =>
+        property.Kind == Kind.Vector && !property.IsSpanLikeProperty && property.Type is { Name: nameof(Byte), IsSszBasicType: true };
 
     private static string DecodeAndAssign(SszType decl, SszProperty property, string sliceExpression)
     {
@@ -787,6 +807,12 @@ internal static class SszCodecHelpers
         {
             string assignment = DecodeAssignmentExpression(property, variableName, sourceIsArray: true);
             return $"{{ byte[] {variableName} = DecodeSszByteList({sliceExpression}, {property.Limit}UL, nameof({decl.TypeReferenceName}), nameof({property.Name})); container.{property.Name} = {assignment}; }}";
+        }
+
+        if (IsByteVector(property))
+        {
+            string assignment = DecodeAssignmentExpression(property, variableName, sourceIsArray: true);
+            return $"{{ byte[] {variableName} = DecodeSszByteVector({sliceExpression}, {property.Length}, nameof({decl.TypeReferenceName}), nameof({property.Name})); container.{property.Name} = {assignment}; }}";
         }
 
         if ((property.Kind is Kind.Vector or Kind.List or Kind.ProgressiveList) && property.Type.Kind == Kind.Basic && property.Type.HasCustomInlineCodec)
@@ -1228,7 +1254,7 @@ using static Nethermind.Serialization.SszCodecHelpers;
         {
             return [];
         }")}
-        byte[] buf = new byte[GetLength(container)];
+        byte[] buf = global::System.GC.AllocateUninitializedArray<byte>(GetLength(container));
         Encode(buf, container);
         return buf;
     }}
@@ -1246,7 +1272,7 @@ using static Nethermind.Serialization.SszCodecHelpers;
 {Whitespace}
     public static byte[] Encode(ReadOnlySpan<{decl.TypeReferenceName}> items)
     {{
-        byte[] buf = new byte[GetLength(items)];
+        byte[] buf = global::System.GC.AllocateUninitializedArray<byte>(GetLength(items));
         Encode(buf, items);
         return buf;
     }}
@@ -1419,7 +1445,7 @@ using static Nethermind.Serialization.SszCodecHelpers;
         {
             return [];
         }")}
-        byte[] buf = new byte[GetLength(container)];
+        byte[] buf = global::System.GC.AllocateUninitializedArray<byte>(GetLength(container));
         Encode(buf, container);
         return buf;
     }}
@@ -1442,7 +1468,7 @@ using static Nethermind.Serialization.SszCodecHelpers;
 {Whitespace}
     public static byte[] Encode(ReadOnlySpan<{decl.TypeReferenceName}> items)
     {{
-        byte[] buf = new byte[GetLength(items)];
+        byte[] buf = global::System.GC.AllocateUninitializedArray<byte>(GetLength(items));
         Encode(buf, items);
         return buf;
     }}
@@ -1634,7 +1660,7 @@ using static Nethermind.Serialization.SszCodecHelpers;
         {
             return [];
         }")}
-        byte[] buf = new byte[GetLength(container)];
+        byte[] buf = global::System.GC.AllocateUninitializedArray<byte>(GetLength(container));
         Encode(buf, container);
         return buf;
     }}
@@ -1664,7 +1690,7 @@ using static Nethermind.Serialization.SszCodecHelpers;
 {Whitespace}
     public static byte[] Encode(ReadOnlySpan<{decl.TypeReferenceName}> items)
     {{
-        byte[] buf = new byte[GetLength(items)];
+        byte[] buf = global::System.GC.AllocateUninitializedArray<byte>(GetLength(items));
         Encode(buf, items);
         return buf;
     }}

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszProperty.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszProperty.cs
@@ -26,6 +26,7 @@ class SszProperty
             IsMemoryLikeProperty = SszTypeHelpers.IsMemoryType(prop.Type),
             IsReadOnlyMemoryProperty = SszTypeHelpers.IsReadOnlyMemoryType(prop.Type),
             IsNullable = prop.Type.NullableAnnotation == NullableAnnotation.Annotated,
+            IsReferenceType = prop.Type.IsReferenceType,
             IsListProperty = collection?.IsList ?? false,
             HasCollectionAsSpan = collection?.HasAsSpan ?? false,
             CanConstructCollectionFromReadOnlySpan = collection?.CanConstructFromReadOnlySpan ?? false,
@@ -193,6 +194,7 @@ class SszProperty
     public bool IsMemoryLikeProperty { get; init; }
     public bool IsReadOnlyMemoryProperty { get; init; }
     public bool IsNullable { get; init; }
+    public bool IsReferenceType { get; init; }
     public bool IsListProperty { get; init; }
     public bool HasCollectionAsSpan { get; init; }
     public bool CanConstructCollectionFromReadOnlySpan { get; init; }


### PR DESCRIPTION
## Summary

- Add generated fast paths for owned SSZ byte-list and byte-vector destinations.
- Validate vector lengths exactly while preserving the existing zero-copy path for span-backed properties.
- Allocate generated SSZ output buffers without zero-initialization; generated encoders overwrite every payload byte and clear nullable static fields explicitly.
- Add round-trip and malformed-length coverage for collection-itself byte vectors.

## Why

Byte collections have a contiguous byte representation, so routing them through element-oriented generated decoders adds avoidable dispatch and allocation work. Vectors also require exact-length validation, while lists retain their limit validation.

The RLP allocation audit found that RLP deserialization already allocates the same 154.32 KB as SSZ for the comparison workload. The larger RLP serialization allocation came from the comparison harness constructing intermediate `Rlp` objects; the existing `RlpWriter` path produces a final-buffer-only result. No unnecessary RLP decoder source change is included.

## Validation

- SSZ generator test suite: 57 passed.
- `Nethermind.Merge.Plugin` Release build with warnings as errors: passed.
- Post-change local probe using 250 transactions of 600 bytes: SSZ serialization 25.2 us/op and 147.5 KB/op; SSZ deserialization 14.5 us/op and 154.3 KB/op.
