### PR TITLE
fix(xdc): disable automatic ENR refresh over discv4

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
@@ -20,7 +20,7 @@ using NonBlocking;
 
 namespace Nethermind.Network.Discovery.Discv4.Kademlia;
 
-public sealed class KademliaAdapter(
+public class KademliaAdapter(
     Lazy<IKademlia<PublicKey, Node>> kademlia, // Cyclic dependency
     Lazy<INodeHealthTracker<Node>> nodeHealthTracker,
     IDiscoveryConfig discoveryConfig,
@@ -261,7 +261,7 @@ public sealed class KademliaAdapter(
         return response.HasResponse ? response.Value : null;
     }
 
-    private Task RefreshRemoteRecordIfNewer(Node node, ulong? advertisedSequence, CancellationToken token)
+    protected virtual Task RefreshRemoteRecordIfNewer(Node node, ulong? advertisedSequence, CancellationToken token)
         => advertisedSequence is { } sequence
             ? base.RefreshRemoteRecordIfNewer(node, sequence, token)
             : Task.CompletedTask;

--- a/src/Nethermind/Nethermind.Xdc.Test/Discovery/XdcKademliaAdapterTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Discovery/XdcKademliaAdapterTests.cs
@@ -14,7 +14,6 @@ using Nethermind.Logging;
 using Nethermind.Network;
 using Nethermind.Network.Discovery;
 using Nethermind.Network.Discovery.Discv4;
-using Nethermind.Network.Discovery.Discv4.Kademlia;
 using Nethermind.Network.Discovery.Discv4.Messages;
 using Nethermind.Network.Enr;
 using Nethermind.Network.Test;

--- a/src/Nethermind/Nethermind.Xdc.Test/Discovery/XdcKademliaAdapterTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Discovery/XdcKademliaAdapterTests.cs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Kademlia;
+using Nethermind.Logging;
+using Nethermind.Network;
+using Nethermind.Network.Discovery;
+using Nethermind.Network.Discovery.Discv4;
+using Nethermind.Network.Discovery.Discv4.Kademlia;
+using Nethermind.Network.Discovery.Discv4.Messages;
+using Nethermind.Network.Enr;
+using Nethermind.Network.Test;
+using Nethermind.Network.Test.Builders;
+using Nethermind.Stats;
+using Nethermind.Stats.Model;
+using Nethermind.Xdc.Discovery;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test.Discovery;
+
+[TestFixture, Parallelizable(ParallelScope.All)]
+public class XdcKademliaAdapterTests
+{
+    private const int RequestTimeoutMs = 10_000;
+
+    private IKademlia<PublicKey, Node> _kademliaMessageReceiver = null!;
+    private INodeHealthTracker<Node> _nodeHealthTracker = null!;
+    private KademliaConfig<Node> _kademliaConfig = null!;
+    private ITimestamper _timestamper = null!;
+    private IMsgSender _msgSender = null!;
+    private INodeStatsManager _nodeStatsManager = null!;
+    private INodeRecordProvider _nodeRecordProvider = null!;
+    private IMessageSerializationService _receiverSerializationManager = null!;
+    private Node _receiver = null!;
+    private XdcKademliaAdapter _adapter = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        Node currentNode = new(TestItem.PublicKeyA, "192.168.1.1", 30303);
+        _kademliaMessageReceiver = Substitute.For<IKademlia<PublicKey, Node>>();
+        _nodeHealthTracker = Substitute.For<INodeHealthTracker<Node>>();
+        _kademliaConfig = new KademliaConfig<Node> { CurrentNodeId = currentNode };
+
+        _timestamper = Substitute.For<ITimestamper>();
+        DateTime now = new(2021, 5, 3, 0, 0, 0, DateTimeKind.Utc);
+        _timestamper.UtcNow.Returns(now);
+        _timestamper.UnixTime.Returns(new UnixTime(now));
+
+        _msgSender = Substitute.For<IMsgSender>();
+        _msgSender.SendMsg(Arg.Any<DiscoveryMsg>()).Returns(Task.CompletedTask);
+
+        _receiver = new(TestItem.PublicKeyB, "192.168.1.2", 30303);
+        SerializationBuilder builder = new();
+        builder.WithDiscovery(TestItem.PrivateKeyB);
+        _receiverSerializationManager = builder.TestObject;
+
+        _nodeRecordProvider = Substitute.For<INodeRecordProvider>();
+        _nodeRecordProvider.GetCurrentAsync(Arg.Any<CancellationToken>()).Returns(new ValueTask<NodeRecord>(new NodeRecord()));
+        _nodeStatsManager = Substitute.For<INodeStatsManager>();
+        _nodeStatsManager.GetOrAdd(Arg.Any<Node>()).Returns(Substitute.For<INodeStats>());
+
+        _adapter = new XdcKademliaAdapter(
+            new Lazy<IKademlia<PublicKey, Node>>(() => _kademliaMessageReceiver),
+            new Lazy<INodeHealthTracker<Node>>(() => _nodeHealthTracker),
+            new DiscoveryConfig
+            {
+                EnrTimeout = RequestTimeoutMs,
+                PingTimeout = RequestTimeoutMs,
+                SendNodeTimeout = RequestTimeoutMs,
+                BondWaitTime = 1,
+            },
+            _kademliaConfig,
+            _nodeRecordProvider,
+            _nodeStatsManager,
+            _timestamper,
+            Substitute.For<IProcessExitSource>(),
+            new Ecdsa(),
+            LimboLogs.Instance)
+        {
+            MsgSender = _msgSender,
+        };
+    }
+
+    [TearDown]
+    public async Task TearDown() => await _adapter.DisposeAsync();
+
+    private void ConfigureBondCallback(ulong? pongEnrSequence) =>
+        _msgSender
+            .SendMsg(Arg.Any<PingMsg>())
+            .Returns(ci =>
+            {
+                PingMsg sent = (PingMsg)ci[0]!;
+                using DisposableByteBuffer buffer = _receiverSerializationManager.ZeroSerialize(sent).AsDisposable();
+                PingMsg msg = _receiverSerializationManager.Deserialize<PingMsg>(buffer);
+                PongMsg pong = new(msg.FarPublicKey!, _timestamper.UnixTime.SecondsLong + 1, sent.Mdc!.Value, pongEnrSequence);
+                pong.FarAddress = sent.FarAddress;
+                return _adapter.OnIncomingMsg(pong);
+            });
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task Ping_should_bond_but_never_send_enr_request_even_when_pong_advertises_newer_sequence(CancellationToken token)
+    {
+        ConfigureBondCallback(pongEnrSequence: 42);
+
+        bool result = await _adapter.Ping(_receiver, token);
+
+        Assert.That(result, Is.True);
+        await _msgSender.DidNotReceive().SendMsg(Arg.Any<EnrRequestMsg>());
+        _kademliaMessageReceiver.DidNotReceive().AddOrRefresh(Arg.Is<Node>(n => n.Enr != null));
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc/Discovery/XdcDiscoveryApp.cs
+++ b/src/Nethermind/Nethermind.Xdc/Discovery/XdcDiscoveryApp.cs
@@ -4,11 +4,13 @@
 using Autofac;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Config;
+using Nethermind.Core;
 using Nethermind.Logging;
 using Nethermind.Network;
 using Nethermind.Network.Config;
 using Nethermind.Network.Discovery;
 using Nethermind.Network.Discovery.Discv4;
+using Nethermind.Network.Discovery.Discv4.Kademlia;
 
 namespace Nethermind.Xdc.Discovery;
 
@@ -28,9 +30,14 @@ public class XdcDiscoveryApp(
         ipResolver,
         processExitSource,
         logManager,
-        static builder => builder
-            .RegisterType<XdcNettyDiscoveryHandler>()
-            .As<NettyDiscoveryHandler>()
-            .WithAttributeFiltering())
+        static builder =>
+        {
+            builder.RegisterType<XdcNettyDiscoveryHandler>()
+                .As<NettyDiscoveryHandler>()
+                .WithAttributeFiltering();
+
+            // XDC does not implement the ENR request/response messages, so remote ENR refresh is disabled.
+            builder.AddSingleton<IKademliaAdapter, XdcKademliaAdapter>();
+        })
 {
 }

--- a/src/Nethermind/Nethermind.Xdc/Discovery/XdcKademliaAdapter.cs
+++ b/src/Nethermind/Nethermind.Xdc/Discovery/XdcKademliaAdapter.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Crypto;
+using Nethermind.Kademlia;
+using Nethermind.Logging;
+using Nethermind.Network.Discovery;
+using Nethermind.Network.Discovery.Discv4.Kademlia;
+using Nethermind.Stats;
+using Nethermind.Stats.Model;
+
+namespace Nethermind.Xdc.Discovery;
+
+/// <summary>
+/// XDC's discv4 fork repurposed the standard ENR request/response type bytes for its own ping,
+/// so there is no wire-compatible way to fetch a remote node's ENR. Remote ENR refresh is
+/// disabled entirely instead of racing XDC nodes with requests they will never answer.
+/// </summary>
+public sealed class XdcKademliaAdapter(
+    Lazy<IKademlia<PublicKey, Node>> kademlia,
+    Lazy<INodeHealthTracker<Node>> nodeHealthTracker,
+    IDiscoveryConfig discoveryConfig,
+    KademliaConfig<Node> kademliaConfig,
+    INodeRecordProvider nodeRecordProvider,
+    INodeStatsManager nodeStatsManager,
+    ITimestamper timestamper,
+    IProcessExitSource processExitSource,
+    IEcdsa ecdsa,
+    ILogManager logManager)
+    : KademliaAdapter(kademlia, nodeHealthTracker, discoveryConfig, kademliaConfig, nodeRecordProvider, nodeStatsManager, timestamper, processExitSource, ecdsa, logManager)
+{
+    protected override Task RefreshRemoteRecordIfNewer(Node node, ulong? advertisedSequence, CancellationToken token)
+        => Task.CompletedTask;
+}


### PR DESCRIPTION
Fixes ENR-request handling for the XDC network.

## Changes

- XDC's discv4 fork repurposed the standard ENR request/response type bytes (5/6) for its own ping. A real `EnrRequest` sent by Nethermind to an XDC peer is read as a ping by that peer, which never sends back the awaited `EnrResponse` — so every automatic ENR refresh (triggered whenever a peer advertises a newer ENR sequence via Ping/Pong) just times out. This produced a steady stream of failing ENR requests against XDC peers.
- Made `KademliaAdapter.RefreshRemoteRecordIfNewer` (the private helper called by `Ping()`/`HandlePing()`) `protected virtual`, and un-sealed `KademliaAdapter`.
- Added `XdcKademliaAdapter`, which overrides that method as a no-op, so XDC never enters the ENR-refresh flow (no wire request, no request/clear bookkeeping, no dead-end log entries).
- Registered `XdcKademliaAdapter` as `IKademliaAdapter` in `XdcDiscoveryApp`'s child-scope builder, the same override pattern already used there for `XdcNettyDiscoveryHandler`.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added `XdcKademliaAdapterTests` verifying that bonding with a peer that advertises a newer ENR sequence never sends an `EnrRequestMsg` and never caches a record. Also reran the existing `KademliaAdapterTests` (53 tests) and `EthereumRunnerTests` (271 shipped configs, including XDC) to confirm the shared `KademliaAdapter` and DI wiring are unaffected.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This only stops Nethermind from *sending* ENR requests on XDC. It does not address the separate, thornier ambiguity on the receiving side — an incoming byte-5 message from a peer is still routed through the standard Ping deserializer, which can crash if it's actually a fellow Nethermind node's genuine `EnrRequest` (XDC's ping and a standard discv4 ENR request share the same type byte). That would need a follow-up.