### PR TITLE
Handle zero terminal total difficulty as merge from genesis

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/ChainSpecBasedSpecProviderTestsTheMerge.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/ChainSpecBasedSpecProviderTestsTheMerge.cs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.IO;
+using Nethermind.Core;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Facade.Eth;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
@@ -61,6 +64,26 @@ public class ChainSpecBasedSpecProviderTestsTheMerge
         ChainSpecBasedSpecProvider provider = new(chainSpec);
         Assert.That(provider.MergeBlockNumber, Is.EqualTo(null));
         Assert.That(provider.TransitionActivations.Length, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Block_for_rpc_omits_total_difficulty_for_zero_terminal_total_difficulty()
+    {
+        ChainSpec chainSpec = new()
+        {
+            Parameters = new ChainParameters { TerminalTotalDifficulty = UInt256.Zero },
+            EngineChainSpecParametersProvider = TestChainSpecParametersProvider.NethDev
+        };
+
+        ChainSpecBasedSpecProvider provider = new(chainSpec);
+        Block block = Build.A.Block.WithNumber(1).WithTotalDifficulty(UInt256.Zero).TestObject;
+        BlockForRpc blockForRpc = new(block, false, provider);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(provider.MergeBlockNumber?.BlockNumber, Is.EqualTo(0));
+            Assert.That(blockForRpc.TotalDifficulty, Is.Null);
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PoSSwitcherTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PoSSwitcherTests.cs
@@ -69,7 +69,7 @@ namespace Nethermind.Merge.Plugin.Test
             {
                 Assert.That(chainSpec.Parameters.TerminalTotalDifficulty?.IsZero, Is.True);
                 Assert.That(specProvider.TerminalTotalDifficulty?.IsZero, Is.True);
-                Assert.That(specProvider.MergeBlockNumber, Is.Null);
+                Assert.That(specProvider.MergeBlockNumber?.BlockNumber, Is.EqualTo(0));
                 Assert.That(isTerminal, Is.False);
                 Assert.That(isPostMerge, Is.True);
                 Assert.That(genesis.Header.IsPostMerge, Is.True);

--- a/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
@@ -237,8 +237,9 @@ namespace Nethermind.Merge.Plugin
 
         private void LoadTerminalBlock()
         {
+            ulong? mergeBlockNumber = _specProvider.MergeBlockNumber?.BlockNumber;
             _terminalBlockNumber = _mergeConfig.TerminalBlockNumber ??
-                                   _specProvider.MergeBlockNumber?.BlockNumber - 1;
+                                   (mergeBlockNumber is > 0 ? mergeBlockNumber - 1 : null);
 
             _terminalBlockExplicitSpecified = _terminalBlockNumber is not null;
             _terminalBlockNumber ??= LoadTerminalBlockNumberFromDb();

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -129,7 +129,11 @@ namespace Nethermind.Specs.ChainSpecStyle
             TransitionActivations = CreateTransitionActivations(transitionBlockNumbers, transitionTimestamps);
             _forkAware = ForkAwareForChain(_chainSpec.ChainId);
 
-            if (_chainSpec.Parameters.TerminalPoWBlockNumber is not null)
+            if (_chainSpec.Parameters.TerminalTotalDifficulty?.IsZero == true)
+            {
+                MergeBlockNumber = (ForkActivation)0;
+            }
+            else if (_chainSpec.Parameters.TerminalPoWBlockNumber is not null)
             {
                 MergeBlockNumber = (ForkActivation)(_chainSpec.Parameters.TerminalPoWBlockNumber.Value + 1);
             }


### PR DESCRIPTION
## What
- set `MergeBlockNumber` to block 0 for chain specs with terminal total difficulty 0
- avoid deriving a terminal PoW block from merge block 0
- add a regression covering `BlockForRpc` omission of `totalDifficulty`

## Why
Gnosis `rpc-compat` expects post-merge-from-genesis block responses to omit `totalDifficulty`. When the chain-spec TTD is zero, the unset merge block caused Nethermind to emit `totalDifficulty: 0x0`.

Report: https://storage.googleapis.com/gnosis-hive-ui-staging/index.html#/test/generic/1784763223-b7118fff3456fb49df0627cf6e609d22

## Checks
- `Nethermind.Merge.Plugin.Test`: 1,675 passed, 2 pre-existing RPC-dependent tests skipped
- `Nethermind.Specs.Test` chain-spec provider filter: 174 passed
- `Nethermind.JsonRpc.Test` block RPC filter: 40 passed