### PR TITLE
feat(specs): EIP-8250 NONCE_MANAGER predeploy entry

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -27,6 +27,7 @@ using Nethermind.JsonRpc.Test.Modules;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using Nethermind.Evm.State;
 using Nethermind.State;
 using Nethermind.TxPool;
@@ -317,6 +318,8 @@ public class BlockProcessorTests
 
         Assert.That(stateProvider.GetCode(verifier), Is.EqualTo(Eip8141Constants.ExpiryVerifierCode));
         Assert.That(stateProvider.GetNonce(verifier), Is.EqualTo(1ul));
+        // EIP-8250 is not enabled here, so the NONCE_MANAGER predeploy must not be installed.
+        Assert.That(stateProvider.GetCode(Eip8250Constants.NonceManagerAddress), Is.Empty);
 
         // The install must appear in the generated block-level access list (code + nonce change).
         GeneratedAccountChanges? installChanges = processed1.GeneratedBlockAccessList!.GetAccountChanges(verifier);
@@ -336,6 +339,56 @@ public class BlockProcessorTests
         Assert.That(stateProvider.GetCode(verifier), Is.EqualTo(Eip8141Constants.ExpiryVerifierCode));
         Assert.That(stateProvider.GetNonce(verifier), Is.EqualTo(1ul));
         Assert.That(processed2.GeneratedBlockAccessList!.GetAccountChanges(verifier), Is.Null,
+            "a re-install must not churn state or the BAL once the code is already present");
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Installs_eip8250_nonce_manager_predeploy_once_and_captures_it_in_bal()
+    {
+        IReleaseSpec enabled8250 = new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip8250Enabled = true };
+        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(enabled8250);
+        (BlockProcessor processor, _, IWorldState stateProvider) = CreateProcessorAndBranch(specProvider: specProvider);
+        IReleaseSpec spec = specProvider.GetSpec((ForkActivation)1);
+        Address manager = Eip8250Constants.NonceManagerAddress;
+
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        // Eip8141Prototype builds on Amsterdam (execution requests EIP-7002/7251/8282); install those
+        // predeploys in genesis as a real chain does, otherwise ProcessExecutionRequests rejects the block.
+        stateProvider.CreateAccount(Eip7002Constants.WithdrawalRequestPredeployAddress, 0, Eip7002TestConstants.Nonce);
+        stateProvider.InsertCode(Eip7002Constants.WithdrawalRequestPredeployAddress, Eip7002TestConstants.CodeHash, Eip7002TestConstants.Code, spec);
+        stateProvider.CreateAccount(Eip7251Constants.ConsolidationRequestPredeployAddress, 0, Eip7251TestConstants.Nonce);
+        stateProvider.InsertCode(Eip7251Constants.ConsolidationRequestPredeployAddress, Eip7251TestConstants.CodeHash, Eip7251TestConstants.Code, spec);
+        stateProvider.CreateAccount(Eip8282Constants.BuilderDepositRequestPredeployAddress, 0, Eip8282TestConstants.BuilderDeposit.Nonce);
+        stateProvider.InsertCode(Eip8282Constants.BuilderDepositRequestPredeployAddress, Eip8282TestConstants.BuilderDeposit.CodeHash, Eip8282TestConstants.BuilderDeposit.Code, spec);
+        stateProvider.CreateAccount(Eip8282Constants.BuilderExitRequestPredeployAddress, 0, Eip8282TestConstants.BuilderExit.Nonce);
+        stateProvider.InsertCode(Eip8282Constants.BuilderExitRequestPredeployAddress, Eip8282TestConstants.BuilderExit.CodeHash, Eip8282TestConstants.BuilderExit.Code, spec);
+        stateProvider.Commit(spec);
+        stateProvider.CommitTree(0);
+
+        // First post-activation block installs the predeploy: code + nonce == 1.
+        Block block1 = Build.A.Block.WithNumber(1).WithAuthor(TestItem.AddressD).TestObject;
+        (Block processed1, _) = processor.ProcessOne(block1, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
+
+        Assert.That(stateProvider.GetCode(manager), Is.EqualTo(Eip8250Constants.NonceManagerCode));
+        Assert.That(stateProvider.GetNonce(manager), Is.EqualTo(1ul));
+
+        GeneratedAccountChanges? installChanges = processed1.GeneratedBlockAccessList!.GetAccountChanges(manager);
+        Assert.That(installChanges, Is.Not.Null, "nonce manager install must be captured in the BAL");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(installChanges!.CodeChanges, Has.Count.EqualTo(1));
+            Assert.That(installChanges.CodeChanges[0].Code, Is.EqualTo(Eip8250Constants.NonceManagerCode));
+            Assert.That(installChanges.NonceChanges, Has.Count.EqualTo(1));
+            Assert.That(installChanges.NonceChanges[0].Value, Is.EqualTo(1ul));
+        }
+
+        // Second block is a no-op: state unchanged and no BAL entry for the manager.
+        Block block2 = Build.A.Block.WithNumber(2).WithAuthor(TestItem.AddressD).TestObject;
+        (Block processed2, _) = processor.ProcessOne(block2, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
+
+        Assert.That(stateProvider.GetCode(manager), Is.EqualTo(Eip8250Constants.NonceManagerCode));
+        Assert.That(stateProvider.GetNonce(manager), Is.EqualTo(1ul));
+        Assert.That(processed2.GeneratedBlockAccessList!.GetAccountChanges(manager), Is.Null,
             "a re-install must not churn state or the BAL once the code is already present");
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -309,7 +309,7 @@ public class BlockProcessorTests
     {
         yield return new TestCaseData(Eip8141Prototype.Instance, Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode)
             .SetName("Installs_eip8141_expiry_verifier_predeploy_once_and_captures_it_in_bal");
-        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode)
+        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode.ToArray())
             .SetName("Installs_eip8250_nonce_manager_predeploy_once_and_captures_it_in_bal");
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -333,7 +333,7 @@ public class BlockProcessorTests
         Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(1ul));
         if (!spec.IsEip8250Enabled)
         {
-            // EIP-8250 is not enabled in this case, so the NONCE_MANAGER predeploy must not be installed.
+            // In the EIP-8141 case, the independent NONCE_MANAGER must stay absent, proving unrelated predeploys are not installed.
             Assert.That(stateProvider.GetCode(Eip8250Constants.NonceManagerAddress), Is.Empty);
         }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -309,7 +309,7 @@ public class BlockProcessorTests
     {
         yield return new TestCaseData(Eip8141Prototype.Instance, Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode)
             .SetName("Installs_eip8141_expiry_verifier_predeploy_once_and_captures_it_in_bal");
-        yield return new TestCaseData(new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode)
+        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode)
             .SetName("Installs_eip8250_nonce_manager_predeploy_once_and_captures_it_in_bal");
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -289,18 +289,12 @@ public class BlockProcessorTests
         return (processor, branchProcessor, stateProvider);
     }
 
-    [Test, MaxTime(Timeout.MaxTestTime)]
-    public void Installs_eip8141_expiry_verifier_predeploy_once_and_captures_it_in_bal()
+    /// <summary>
+    /// Installs the execution-request predeploys (EIP-7002/7251/8282) that Amsterdam-based specs read
+    /// while processing a post-genesis block; without them ProcessExecutionRequests rejects the block.
+    /// </summary>
+    private static void InstallExecutionRequestPredeploys(IWorldState stateProvider, IReleaseSpec spec)
     {
-        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(Eip8141Prototype.Instance);
-        (BlockProcessor processor, _, IWorldState stateProvider) = CreateProcessorAndBranch(specProvider: specProvider);
-        IReleaseSpec spec = specProvider.GetSpec((ForkActivation)1);
-        Address verifier = Eip8141Constants.ExpiryVerifierAddress;
-
-        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
-        // Eip8141Prototype builds on Amsterdam, which enables execution requests (EIP-7002/7251/8282);
-        // processing a post-genesis block reads them from their system-contract predeploys, so install
-        // those in genesis as a real chain does — otherwise ProcessExecutionRequests rejects the block.
         stateProvider.CreateAccount(Eip7002Constants.WithdrawalRequestPredeployAddress, 0, Eip7002TestConstants.Nonce);
         stateProvider.InsertCode(Eip7002Constants.WithdrawalRequestPredeployAddress, Eip7002TestConstants.CodeHash, Eip7002TestConstants.Code, spec);
         stateProvider.CreateAccount(Eip7251Constants.ConsolidationRequestPredeployAddress, 0, Eip7251TestConstants.Nonce);
@@ -309,59 +303,25 @@ public class BlockProcessorTests
         stateProvider.InsertCode(Eip8282Constants.BuilderDepositRequestPredeployAddress, Eip8282TestConstants.BuilderDeposit.CodeHash, Eip8282TestConstants.BuilderDeposit.Code, spec);
         stateProvider.CreateAccount(Eip8282Constants.BuilderExitRequestPredeployAddress, 0, Eip8282TestConstants.BuilderExit.Nonce);
         stateProvider.InsertCode(Eip8282Constants.BuilderExitRequestPredeployAddress, Eip8282TestConstants.BuilderExit.CodeHash, Eip8282TestConstants.BuilderExit.Code, spec);
-        stateProvider.Commit(spec);
-        stateProvider.CommitTree(0);
-
-        // First post-activation block installs the predeploy: code + nonce == 1.
-        Block block1 = Build.A.Block.WithNumber(1).WithAuthor(TestItem.AddressD).TestObject;
-        (Block processed1, _) = processor.ProcessOne(block1, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
-
-        Assert.That(stateProvider.GetCode(verifier), Is.EqualTo(Eip8141Constants.ExpiryVerifierCode));
-        Assert.That(stateProvider.GetNonce(verifier), Is.EqualTo(1ul));
-        // EIP-8250 is not enabled here, so the NONCE_MANAGER predeploy must not be installed.
-        Assert.That(stateProvider.GetCode(Eip8250Constants.NonceManagerAddress), Is.Empty);
-
-        // The install must appear in the generated block-level access list (code + nonce change).
-        GeneratedAccountChanges? installChanges = processed1.GeneratedBlockAccessList!.GetAccountChanges(verifier);
-        Assert.That(installChanges, Is.Not.Null, "expiry verifier install must be captured in the BAL");
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(installChanges!.CodeChanges, Has.Count.EqualTo(1));
-            Assert.That(installChanges.CodeChanges[0].Code, Is.EqualTo(Eip8141Constants.ExpiryVerifierCode));
-            Assert.That(installChanges.NonceChanges, Has.Count.EqualTo(1));
-            Assert.That(installChanges.NonceChanges[0].Value, Is.EqualTo(1ul));
-        }
-
-        // Second block is a no-op: state unchanged and no BAL entry for the verifier.
-        Block block2 = Build.A.Block.WithNumber(2).WithAuthor(TestItem.AddressD).TestObject;
-        (Block processed2, _) = processor.ProcessOne(block2, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
-
-        Assert.That(stateProvider.GetCode(verifier), Is.EqualTo(Eip8141Constants.ExpiryVerifierCode));
-        Assert.That(stateProvider.GetNonce(verifier), Is.EqualTo(1ul));
-        Assert.That(processed2.GeneratedBlockAccessList!.GetAccountChanges(verifier), Is.Null,
-            "a re-install must not churn state or the BAL once the code is already present");
     }
 
-    [Test, MaxTime(Timeout.MaxTestTime)]
-    public void Installs_eip8250_nonce_manager_predeploy_once_and_captures_it_in_bal()
+    private static IEnumerable<TestCaseData> PredeployInstallCases()
     {
-        IReleaseSpec enabled8250 = new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip8250Enabled = true };
-        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(enabled8250);
+        yield return new TestCaseData(Eip8141Prototype.Instance, Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode)
+            .SetName("Installs_eip8141_expiry_verifier_predeploy_once_and_captures_it_in_bal");
+        yield return new TestCaseData(new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode)
+            .SetName("Installs_eip8250_nonce_manager_predeploy_once_and_captures_it_in_bal");
+    }
+
+    [TestCaseSource(nameof(PredeployInstallCases)), MaxTime(Timeout.MaxTestTime)]
+    public void Installs_predeploy_once_and_captures_it_in_bal(IReleaseSpec releaseSpec, Address predeploy, byte[] code)
+    {
+        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(releaseSpec);
         (BlockProcessor processor, _, IWorldState stateProvider) = CreateProcessorAndBranch(specProvider: specProvider);
         IReleaseSpec spec = specProvider.GetSpec((ForkActivation)1);
-        Address manager = Eip8250Constants.NonceManagerAddress;
 
         using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
-        // Eip8141Prototype builds on Amsterdam (execution requests EIP-7002/7251/8282); install those
-        // predeploys in genesis as a real chain does, otherwise ProcessExecutionRequests rejects the block.
-        stateProvider.CreateAccount(Eip7002Constants.WithdrawalRequestPredeployAddress, 0, Eip7002TestConstants.Nonce);
-        stateProvider.InsertCode(Eip7002Constants.WithdrawalRequestPredeployAddress, Eip7002TestConstants.CodeHash, Eip7002TestConstants.Code, spec);
-        stateProvider.CreateAccount(Eip7251Constants.ConsolidationRequestPredeployAddress, 0, Eip7251TestConstants.Nonce);
-        stateProvider.InsertCode(Eip7251Constants.ConsolidationRequestPredeployAddress, Eip7251TestConstants.CodeHash, Eip7251TestConstants.Code, spec);
-        stateProvider.CreateAccount(Eip8282Constants.BuilderDepositRequestPredeployAddress, 0, Eip8282TestConstants.BuilderDeposit.Nonce);
-        stateProvider.InsertCode(Eip8282Constants.BuilderDepositRequestPredeployAddress, Eip8282TestConstants.BuilderDeposit.CodeHash, Eip8282TestConstants.BuilderDeposit.Code, spec);
-        stateProvider.CreateAccount(Eip8282Constants.BuilderExitRequestPredeployAddress, 0, Eip8282TestConstants.BuilderExit.Nonce);
-        stateProvider.InsertCode(Eip8282Constants.BuilderExitRequestPredeployAddress, Eip8282TestConstants.BuilderExit.CodeHash, Eip8282TestConstants.BuilderExit.Code, spec);
+        InstallExecutionRequestPredeploys(stateProvider, spec);
         stateProvider.Commit(spec);
         stateProvider.CommitTree(0);
 
@@ -369,26 +329,32 @@ public class BlockProcessorTests
         Block block1 = Build.A.Block.WithNumber(1).WithAuthor(TestItem.AddressD).TestObject;
         (Block processed1, _) = processor.ProcessOne(block1, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
 
-        Assert.That(stateProvider.GetCode(manager), Is.EqualTo(Eip8250Constants.NonceManagerCode));
-        Assert.That(stateProvider.GetNonce(manager), Is.EqualTo(1ul));
+        Assert.That(stateProvider.GetCode(predeploy), Is.EqualTo(code));
+        Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(1ul));
+        if (!spec.IsEip8250Enabled)
+        {
+            // EIP-8250 is not enabled in this case, so the NONCE_MANAGER predeploy must not be installed.
+            Assert.That(stateProvider.GetCode(Eip8250Constants.NonceManagerAddress), Is.Empty);
+        }
 
-        GeneratedAccountChanges? installChanges = processed1.GeneratedBlockAccessList!.GetAccountChanges(manager);
-        Assert.That(installChanges, Is.Not.Null, "nonce manager install must be captured in the BAL");
+        // The install must appear in the generated block-level access list (code + nonce change).
+        GeneratedAccountChanges? installChanges = processed1.GeneratedBlockAccessList!.GetAccountChanges(predeploy);
+        Assert.That(installChanges, Is.Not.Null, "predeploy install must be captured in the BAL");
         using (Assert.EnterMultipleScope())
         {
             Assert.That(installChanges!.CodeChanges, Has.Count.EqualTo(1));
-            Assert.That(installChanges.CodeChanges[0].Code, Is.EqualTo(Eip8250Constants.NonceManagerCode));
+            Assert.That(installChanges.CodeChanges[0].Code, Is.EqualTo(code));
             Assert.That(installChanges.NonceChanges, Has.Count.EqualTo(1));
             Assert.That(installChanges.NonceChanges[0].Value, Is.EqualTo(1ul));
         }
 
-        // Second block is a no-op: state unchanged and no BAL entry for the manager.
+        // Second block is a no-op: state unchanged and no BAL entry for the predeploy.
         Block block2 = Build.A.Block.WithNumber(2).WithAuthor(TestItem.AddressD).TestObject;
         (Block processed2, _) = processor.ProcessOne(block2, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
 
-        Assert.That(stateProvider.GetCode(manager), Is.EqualTo(Eip8250Constants.NonceManagerCode));
-        Assert.That(stateProvider.GetNonce(manager), Is.EqualTo(1ul));
-        Assert.That(processed2.GeneratedBlockAccessList!.GetAccountChanges(manager), Is.Null,
+        Assert.That(stateProvider.GetCode(predeploy), Is.EqualTo(code));
+        Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(1ul));
+        Assert.That(processed2.GeneratedBlockAccessList!.GetAccountChanges(predeploy), Is.Null,
             "a re-install must not churn state or the BAL once the code is already present");
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.SystemContractHandler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.SystemContractHandler.cs
@@ -19,8 +19,9 @@ public partial class BlockProcessor
     public interface ISystemContractHandler
         : IBeaconBlockRootHandler, IBlockhashStore, IWithdrawalProcessor, IExecutionRequestsProcessor
     {
-        /// <summary>Installs the EIP-8141 expiry-verifier predeploy so its code + nonce are captured
-        /// in the computed state root (and, on the BAL path, the block-level access list).</summary>
+        /// <summary>Installs every predeploy that <paramref name="spec"/> activates (as declared in
+        /// <see cref="PredeployInstaller"/>) so its code + nonce are captured in the computed state
+        /// root (and, on the BAL path, the block-level access list).</summary>
         void InstallPredeploys(IReleaseSpec spec);
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -164,7 +164,7 @@ public partial class BlockProcessor(
 
         _systemContractHandler.StoreBeaconRoot(block, spec, NullTxTracer.Instance);
         _systemContractHandler.ApplyBlockhashStateChanges(header, spec);
-        if (spec.IsEip8141Enabled && !block.IsGenesis)
+        if (!block.IsGenesis && PredeployInstaller.HasActivePredeploys(spec))
         {
             _systemContractHandler.InstallPredeploys(spec);
         }

--- a/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
@@ -29,6 +29,7 @@ public static class PredeployInstaller
     private static readonly Predeploy[] Predeploys =
     [
         new(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, 1, static spec => spec.IsEip8141Enabled),
+        new(Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode, 1, static spec => spec.IsEip8250Enabled),
     ];
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
@@ -33,6 +33,23 @@ public static class PredeployInstaller
     ];
 
     /// <summary>
+    /// Returns whether <paramref name="spec"/> activates any declared predeploy, i.e. whether
+    /// <see cref="Install"/> can write anything for a block using this spec.
+    /// </summary>
+    internal static bool HasActivePredeploys(IReleaseSpec spec)
+    {
+        foreach (Predeploy predeploy in Predeploys)
+        {
+            if (predeploy.IsActive(spec))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Ensures every predeploy activated by <paramref name="spec"/> has its canonical code + nonce present.
     /// </summary>
     /// <remarks>

--- a/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+
 namespace Nethermind.Core;
 
 /// <summary><see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see> (Keyed Nonces) parameters.</summary>
@@ -13,6 +15,7 @@ public static class Eip8250Constants
     // Provisional: spec address is TBD; mirrors the only existing implementation.
     public static readonly Address NonceManagerAddress = new("0x0000000000000000000000000000000000008250");
 
-    // Spec-pinned revert(0, 0): a storage namespace only, never callable.
-    public static readonly byte[] NonceManagerCode = [0x60, 0x00, 0x60, 0x00, 0xfd];
+    // Spec-pinned revert(0, 0): a storage namespace only, never callable. Exposed as memory rather
+    // than an array so the bytecode cannot be overwritten through the shared static.
+    public static ReadOnlyMemory<byte> NonceManagerCode { get; } = new byte[] { 0x60, 0x00, 0x60, 0x00, 0xfd };
 }

--- a/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
-
 namespace Nethermind.Core;
 
 /// <summary><see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see> (Keyed Nonces) parameters.</summary>
@@ -16,5 +14,5 @@ public static class Eip8250Constants
     public static readonly Address NonceManagerAddress = new("0x0000000000000000000000000000000000008250");
 
     // Spec-pinned revert(0, 0): a storage namespace only, never callable.
-    public static ReadOnlySpan<byte> NonceManagerCode => [0x60, 0x00, 0x60, 0x00, 0xfd];
+    public static readonly byte[] NonceManagerCode = [0x60, 0x00, 0x60, 0x00, 0xfd];
 }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -326,6 +326,11 @@ namespace Nethermind.Core.Specs
         bool IsEip8141Enabled { get; }
 
         /// <summary>
+        /// EIP-8250: keyed nonces for frame transactions.
+        /// </summary>
+        bool IsEip8250Enabled { get; }
+
+        /// <summary>
         /// EIP-8038: State-access gas cost update
         /// </summary>
         bool IsEip8038Enabled { get; }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -82,6 +82,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip8038Enabled => spec.IsEip8038Enabled;
     public virtual bool IsEip8282Enabled => spec.IsEip8282Enabled;
     public virtual bool IsEip8141Enabled => spec.IsEip8141Enabled;
+    public virtual bool IsEip8250Enabled => spec.IsEip8250Enabled;
     public virtual bool IsEip7702Enabled => spec.IsEip7702Enabled;
     public virtual bool IsEip7823Enabled => spec.IsEip7823Enabled;
     public virtual bool IsEip7825Enabled => spec.IsEip7825Enabled;

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -96,6 +96,7 @@ namespace Nethermind.Specs.Test
         public bool IsEip8038Enabled { get; set; } = spec.IsEip8038Enabled;
         public bool IsEip8282Enabled { get; set; } = spec.IsEip8282Enabled;
         public bool IsEip8141Enabled { get; set; } = spec.IsEip8141Enabled;
+        public bool IsEip8250Enabled { get; set; } = spec.IsEip8250Enabled;
         public bool IsEip4788Enabled { get; set; } = spec.IsEip4788Enabled;
         public bool IsEip4844FeeCollectorEnabled { get; set; } = spec.IsEip4844FeeCollectorEnabled;
         public Address? Eip4788ContractAddress { get; set; } = spec.Eip4788ContractAddress;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -191,6 +191,7 @@ public class ChainParameters
     public ulong? Eip8038TransitionTimestamp { get; set; }
     public ulong? Eip8282TransitionTimestamp { get; set; }
     public ulong? Eip8141TransitionTimestamp { get; set; }
+    public ulong? Eip8250TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip2780TransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -342,6 +342,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             releaseSpec.IsEip8038Enabled = (chainSpec.Parameters.Eip8038TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip8282Enabled = (chainSpec.Parameters.Eip8282TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip8141Enabled = (chainSpec.Parameters.Eip8141TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+            releaseSpec.IsEip8250Enabled = (chainSpec.Parameters.Eip8250TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             bool eip1559FeeCollector = releaseSpec.IsEip1559Enabled && BlockOf(chainSpec.Parameters.Eip1559FeeCollectorTransition) <= block;
             bool eip4844FeeCollector = releaseSpec.IsEip4844Enabled && (chainSpec.Parameters.Eip4844FeeCollectorTransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -220,6 +220,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8038TransitionTimestamp = chainSpecJson.Params.Eip8038TransitionTimestamp,
             Eip8282TransitionTimestamp = chainSpecJson.Params.Eip8282TransitionTimestamp,
             Eip8141TransitionTimestamp = chainSpecJson.Params.Eip8141TransitionTimestamp,
+            Eip8250TransitionTimestamp = chainSpecJson.Params.Eip8250TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
             Eip2780TransitionTimestamp = chainSpecJson.Params.Eip2780TransitionTimestamp,

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -198,6 +198,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8038TransitionTimestamp { get; set; }
     public ulong? Eip8282TransitionTimestamp { get; set; }
     public ulong? Eip8141TransitionTimestamp { get; set; }
+    public ulong? Eip8250TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip2780TransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -92,6 +92,7 @@ public class ReleaseSpec : IReleaseSpec
     public bool IsEip8038Enabled { get; set; }
     public bool IsEip8282Enabled { get; set; }
     public bool IsEip8141Enabled { get; set; }
+    public bool IsEip8250Enabled { get; set; }
     public bool IsEip4788Enabled { get; set; }
     public bool IsEip7702Enabled { get; set; }
     public bool IsEip7823Enabled { get; set; }


### PR DESCRIPTION
Stacked on #12526. Adds the EIP-8250 `NONCE_MANAGER` predeploy as a single `PredeployInstaller` entry, reusing the install-at-activation mechanism #12526 introduced (as suggested in the review there).

## Changes
- `Eip8250Constants` (new): `NonceManagerAddress` (provisional `0x…8250`; the spec value is `TBD`) and `NonceManagerCode` = `0x60006000fd` (runtime `revert(0, 0)`, per the EIP-8250 spec).
- `PredeployInstaller`: one new entry `(NonceManagerAddress, NonceManagerCode, nonce 1, IsEip8250Enabled)` — installed at the first block after EIP-8250 activation, idempotent, captured in the block-level access list, exactly like the expiry verifier.
- `IsEip8250Enabled` release-spec flag + `Eip8250TransitionTimestamp` chainspec param, wired through `IReleaseSpec` / `ReleaseSpec` / the decorators / `ChainParameters` / `ChainSpecParamsJson` / `ChainSpecLoader` / `ChainSpecBasedSpecProvider`, mirroring the EIP-8141 flag exactly.
- Tests: `NONCE_MANAGER` installs once + shows in the BAL when EIP-8250 is enabled and is a no-op on the next block; and is not installed when EIP-8250 is off.

EIP-8250 is not scheduled on any fork, so this is inert until a fork sets `eip8250TransitionTimestamp`.

The EIP-8272 `RECENT_ROOT` predeploy is intentionally left out: its `RECENT_ROOT_CODE` (and address) are still `TBD` in the spec, so its predeploy entry can't be defined yet without guessing a consensus-critical value.

> Base is #12526's branch; retarget to `master` once that merges.

Part of #12456, tracks #12454.
