### PR TITLE
fix(xdc): break equal-TD fork-choice ties by round instead of self-mined

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/XdcBlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcBlockTreeTests.cs
@@ -6,6 +6,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Xdc.RLP;
@@ -120,6 +121,62 @@ internal class XdcBlockTreeTests
 
         Block disconnected = XdcBlock(2UL, Keccak.Compute("other"));
         Assert.That(blockTree.SuggestBlock(disconnected), Is.EqualTo(AddBlockResult.UnknownParent));
+    }
+
+    [TestCase(5UL, false, true)] // higher round from a remote (non-self-mined) block overrides an equal-TD self-mined head
+    [TestCase(1UL, false, false)] // same round from a remote block does not override - self-mined tie-break still applies
+    [TestCase(1UL, true, true)] // same round, also self-mined, overrides (unchanged proposal-race behavior)
+    [TestCase(0UL, true, false)] // lower round does not override, even if self-mined
+    public void IsSameTdButPreferred_BreaksEqualTdTieByRoundThenSelfMined(ulong candidateRound, bool candidateSelfMined, bool expectedOverride)
+    {
+        XdcBlockHeader head = XdcHeaderWithRound(1UL, Keccak.Zero, round: 1, selfMined: true);
+        head.TotalDifficulty = 2;
+        XdcBlockHeader candidate = XdcHeaderWithRound(1UL, Keccak.Zero, round: candidateRound, selfMined: candidateSelfMined, nonce: 1UL);
+        candidate.TotalDifficulty = head.TotalDifficulty;
+
+        Assert.That(XdcBlockTree.IsSameTdButPreferred(candidate, head), Is.EqualTo(expectedOverride));
+    }
+
+    [Test]
+    public void IsSameTdButPreferred_DifferentTotalDifficulty_NeverOverrides()
+    {
+        XdcBlockHeader head = XdcHeaderWithRound(1UL, Keccak.Zero, round: 1, selfMined: false);
+        XdcBlockHeader candidate = XdcHeaderWithRound(1UL, Keccak.Zero, round: 5, selfMined: true, nonce: 1UL);
+        head.TotalDifficulty = 2;
+        candidate.TotalDifficulty = 3;
+
+        Assert.That(XdcBlockTree.IsSameTdButPreferred(candidate, head), Is.False);
+    }
+
+    [Test]
+    public void IsSameTdButPreferred_MissingConsensusData_NeverOverrides()
+    {
+        XdcBlockHeader head = XdcHeaderWithRound(1UL, Keccak.Zero, round: 1, selfMined: false);
+        head.TotalDifficulty = 2;
+        XdcBlockHeader candidate = Build.A.XdcBlockHeader().WithNumber(1UL).TestObject;
+        candidate.TotalDifficulty = head.TotalDifficulty;
+
+        Assert.That(XdcBlockTree.IsSameTdButPreferred(candidate, head), Is.False);
+    }
+
+    private static XdcBlockHeader XdcHeaderWithRound(ulong number, Hash256 parentHash, ulong round, bool selfMined, ulong nonce = 0)
+    {
+        XdcBlockHeader header = new(
+            parentHash,
+            Keccak.OfAnEmptySequenceRlp,
+            Address.Zero,
+            UInt256.One,
+            number,
+            XdcConstants.DefaultTargetGasLimit,
+            1_700_000_000,
+            [],
+            isSelfMined: selfMined)
+        {
+            Nonce = nonce
+        };
+        header.ExtraConsensusData = new ExtraFieldsV2(round, null!);
+        header.Hash = header.CalculateHash().ToHash256();
+        return header;
     }
 
     private static Block XdcBlock(ulong number, Hash256 parentHash, ulong nonce = 0)

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockTree.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockTree.cs
@@ -72,7 +72,7 @@ internal class XdcBlockTree(
             return true;
 
         return header is XdcBlockHeader newBlock && Head?.Header is XdcBlockHeader headBlock &&
-            IsSameTdButSelfMined(newBlock, headBlock);
+            IsSameTdButPreferred(newBlock, headBlock);
     }
 
     protected override bool BestSuggestedImprovementRequirementsSatisfied(BlockHeader header)
@@ -81,19 +81,39 @@ internal class XdcBlockTree(
             return true;
 
         return header is XdcBlockHeader newBlock && BestSuggestedBody?.Header is XdcBlockHeader bestBlock &&
-            IsSameTdButSelfMined(newBlock, bestBlock);
+            IsSameTdButPreferred(newBlock, bestBlock);
     }
 
     public override bool IsBetterThanHead(BlockHeader? header)
     {
-        if (base.IsBetterThanHead(header))
-            return true;
+        // Base falls back to comparing hashes on an equal-TD tie, which is meaningless for XDPoS
+        // (every proposal at a height ties on TD) and would let an arbitrary hash ordering override
+        // the round-based tie-break below. Decide equal-TD ties between two XDC headers here first.
+        if (header is XdcBlockHeader newBlock && Head?.Header is XdcBlockHeader headBlock &&
+            newBlock.TotalDifficulty == headBlock.TotalDifficulty)
+            return IsSameTdButPreferred(newBlock, headBlock);
 
-        return header is XdcBlockHeader newBlock && Head?.Header is XdcBlockHeader bestBlock &&
-            IsSameTdButSelfMined(newBlock, bestBlock);
+        return base.IsBetterThanHead(header);
     }
 
-    // Allow overriding head with self-mined blocks with the same TD
-    private static bool IsSameTdButSelfMined(XdcBlockHeader newHeader, XdcBlockHeader oldHeader) =>
-        newHeader.TotalDifficulty == oldHeader.TotalDifficulty && newHeader.IsSelfMined;
+    /// <remarks>
+    /// XDPoS difficulty is fixed per block (always parent + 1), so every validator's competing
+    /// proposal at a given height ties on TD - the tie must be broken by round instead of TD.
+    /// Otherwise a node that already adopted an earlier round's self-mined proposal as head could
+    /// never adopt a later, network-agreed round's block proposed by another validator, since a
+    /// remote block is never self-mined. Within the same round (a proposal race), fall back to
+    /// preferring the self-mined block.
+    /// </remarks>
+    internal static bool IsSameTdButPreferred(XdcBlockHeader newHeader, XdcBlockHeader oldHeader)
+    {
+        if (newHeader.TotalDifficulty != oldHeader.TotalDifficulty)
+            return false;
+
+        ulong? newRound = newHeader.ExtraConsensusData?.BlockRound;
+        ulong? oldRound = oldHeader.ExtraConsensusData?.BlockRound;
+        if (newRound is null || oldRound is null)
+            return false;
+
+        return newRound != oldRound ? newRound > oldRound : newHeader.IsSelfMined;
+    }
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockTree.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockTree.cs
@@ -96,14 +96,6 @@ internal class XdcBlockTree(
         return base.IsBetterThanHead(header);
     }
 
-    /// <remarks>
-    /// XDPoS difficulty is fixed per block (always parent + 1), so every validator's competing
-    /// proposal at a given height ties on TD - the tie must be broken by round instead of TD.
-    /// Otherwise a node that already adopted an earlier round's self-mined proposal as head could
-    /// never adopt a later, network-agreed round's block proposed by another validator, since a
-    /// remote block is never self-mined. Within the same round (a proposal race), fall back to
-    /// preferring the self-mined block.
-    /// </remarks>
     internal static bool IsSameTdButPreferred(XdcBlockHeader newHeader, XdcBlockHeader oldHeader)
     {
         if (newHeader.TotalDifficulty != oldHeader.TotalDifficulty)


### PR DESCRIPTION
## Changes

- `XdcBlockTree`: replace the `IsSameTdButSelfMined` head-improvement tie-break with `IsSameTdButPreferred`, which breaks equal-total-difficulty ties by consensus **round** first, falling back to preferring the self-mined block only when both proposals are for the *same* round (preserving the original proposal-race fix from #10809).
- `IsBetterThanHead` no longer falls through to the base `BlockTree` implementation's hash-order tie-break before the round check runs. That base tie-break is essentially a coin flip on equal TD, so it was masking the round-based fix roughly half the time.
- Added regression tests in `XdcBlockTreeTests.cs` covering: higher round overrides a self-mined head, same round preserves the self-mined tie-break, lower round never overrides, and differing TD / missing consensus data never override.

## Why

XDPoS blocks always use `difficulty = parent + 1` regardless of round, so every validator's independent proposal at a given height ties on total difficulty - there's nothing in the TD to tell round 17's proposal from round 18's. The old tie-break only let a *self-mined* block override an equal-TD head. Once a validator became leader and adopted its own proposal as head, no later round's block proposed by another validator could ever replace it (a received block is never self-mined for the receiver), permanently freezing that validator's view of the chain.

With 4 validators cycling through leadership every few rounds, every node ends up wedged on its own personal version of block #1 in short order. Since a follower only casts its own vote once a proposal becomes its local chain head (`OnNewHeadBlock` -> `Vote()`), and that can never happen for anyone else's round once you're wedged, the whole committee gets stuck permanently re-broadcasting round proposals and timing out - the observed symptom of "1/2.668 votes collected" repeating forever with no consensus progress.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added `IsSameTdButPreferred_*` unit tests in `Nethermind.Xdc.Test/XdcBlockTreeTests.cs`. Full `Nethermind.Xdc.Test` suite (534 tests) passes.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No

## Remarks

This only fixes the fork-choice tie-break going forward. A validator that is already wedged on its own self-mined block from a prior run needs a restart (or a later block/QC that naturally supersedes it via strictly-greater TD) to recover - the fix changes which block wins *future* comparisons, not past state.