### PR TITLE
ci: cut wasted CI spend on unchanged and perpetually-failing paths

### DIFF
--- a/.github/workflows/collect-pgo-profile.yml
+++ b/.github/workflows/collect-pgo-profile.yml
@@ -356,7 +356,7 @@ jobs:
         with:
           name: nethermind-pgo-profile
           path: ${{ steps.convert.outputs.mibc_file }}
-          retention-days: 90
+          retention-days: 14
 
       - name: Upload trimmed .jit.gz artifact
         if: always() && steps.convert.outputs.jit_gz != ''
@@ -364,7 +364,7 @@ jobs:
         with:
           name: nethermind-pgo-jit
           path: ${{ steps.convert.outputs.jit_gz }}
-          retention-days: 90
+          retention-days: 14
 
       - name: Upload raw PGO data
         if: always()

--- a/.github/workflows/rpc-comparison.yml
+++ b/.github/workflows/rpc-comparison.yml
@@ -672,6 +672,7 @@ jobs:
             rpc-results/
             integration/*/results/
           if-no-files-found: warn
+          retention-days: 30
 
   cleanup_spawned_nodes:
     name: Destroy spawned nodes

--- a/.github/workflows/test-assertoor.yml
+++ b/.github/workflows/test-assertoor.yml
@@ -1,12 +1,11 @@
 name: Assertoor tests
 
 on:
+  # Auto-run on every master Docker publish is disabled: this suite has been red on effectively
+  # every run for a long time, so the per-publish runs only burn CI without producing signal.
+  # Left as manual dispatch until the underlying failure is fixed; restore the workflow_run
+  # trigger below once it's green again.
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Publish Docker image"]
-    branches: [master]
-    types:
-      - completed
 
 jobs:
   get_tests:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'Dockerfile'
       - 'src/**'
+      - 'scripts/entrypoint.sh'
       - 'Directory.Packages.props'
       - 'Directory.Build.props'
       - 'Directory.Build.targets'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,6 +3,18 @@ name: Trivy scanner
 on:
   pull_request:
     branches: [master]
+    # Trivy scans the built Docker image; only re-scan on PRs that can change that image's
+    # contents. Docs-only PRs skip it. The weekly `schedule` still catches newly-disclosed CVEs
+    # in unchanged dependencies, and `push: master` scans every merge.
+    paths:
+      - 'Dockerfile'
+      - 'src/**'
+      - 'Directory.Packages.props'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'nuget.config'
+      - 'global.json'
+      - '.github/workflows/trivy.yml'
   push:
     branches: [master]
   schedule:


### PR DESCRIPTION
Low-risk CI hygiene — no product/`src` code touched. Three independent, self-contained changes:

### 1. `trivy.yml` — path-filter the PR trigger
Trivy builds and scans the Docker image on **every** PR, including docs-only ones. Added a `paths:` filter so the PR scan only runs when something that can change the image contents changes (Dockerfile, `src/**`, package/build props, nuget/global config, the workflow itself). The weekly `schedule` still catches newly-disclosed CVEs in unchanged deps, and `push: master` still scans every merge. (Trivy is not a required check, so filtering it won't block PRs.)

### 2. `test-assertoor.yml` — stop auto-running while red
Assertoor has been red on effectively every run for a long time, yet it re-runs on every master Docker publish, burning CI for no signal. Disabled the `workflow_run` auto-trigger; kept `workflow_dispatch` so it's still runnable on demand. Restore the trigger once it's green again.

### 3. Artifact retention trims
`collect-pgo-profile` PGO artifacts 90d → 14d (consumed within the same run), and `rpc-comparison` results get an explicit 30d (was the 90d default).

None of these change build/test behavior.