### PR TITLE
Batch RocksDB full enumerations

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -75,20 +75,20 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
 
     public IEnumerable<KeyValuePair<byte[], byte[]?>> GetAll(bool ordered = false)
     {
-        Iterator iterator = _mainDb.CreateIterator(ordered, _columnFamily);
-        return _mainDb.GetAllCore(iterator);
+        _mainDb.ThrowIfDisposing();
+        return _mainDb.GetAllCore(ordered, _columnFamily);
     }
 
     public IEnumerable<byte[]> GetAllKeys(bool ordered = false)
     {
-        Iterator iterator = _mainDb.CreateIterator(ordered, _columnFamily);
-        return _mainDb.GetAllKeysCore(iterator);
+        _mainDb.ThrowIfDisposing();
+        return _mainDb.GetAllKeysCore(ordered, _columnFamily);
     }
 
     public IEnumerable<byte[]> GetAllValues(bool ordered = false)
     {
-        Iterator iterator = _mainDb.CreateIterator(ordered, _columnFamily);
-        return _mainDb.GetAllValuesCore(iterator);
+        _mainDb.ThrowIfDisposing();
+        return _mainDb.GetAllValuesCore(ordered, _columnFamily);
     }
 
     public IWriteBatch StartWriteBatch() => new ColumnsDbWriteBatch(this, (DbOnTheRocks.RocksDbWriteBatch)_mainDb.StartWriteBatch());

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -21,6 +21,7 @@ using ConcurrentCollections;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
@@ -1115,19 +1116,12 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
     }
 
+    internal const int FullEnumerationBatchSize = 10_000;
+
     public IEnumerable<KeyValuePair<byte[], byte[]?>> GetAll(bool ordered = false)
     {
-        ObjectDisposedException.ThrowIf(_isDisposing, this);
-
-        Iterator iterator = CreateIterator(ordered);
-        return GetAllCore(iterator);
-    }
-
-    protected internal Iterator CreateIterator(bool ordered = false, ColumnFamilyHandle? ch = null)
-    {
-        ReadOptions readOptions = new();
-        readOptions.SetTailing(!ordered);
-        return CreateIterator(readOptions, ch);
+        ThrowIfDisposing();
+        return GetAllCore(ordered);
     }
 
     protected internal Iterator CreateIterator(ReadOptions readOptions, ColumnFamilyHandle? ch = null)
@@ -1145,25 +1139,36 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     public IEnumerable<byte[]> GetAllKeys(bool ordered = false)
     {
-        ObjectDisposedException.ThrowIf(_isDisposing, this);
-
-        Iterator iterator = CreateIterator(ordered);
-        return GetAllKeysCore(iterator);
+        ThrowIfDisposing();
+        return GetAllKeysCore(ordered);
     }
 
     public IEnumerable<byte[]> GetAllValues(bool ordered = false)
     {
-        ObjectDisposedException.ThrowIf(_isDisposing, this);
-
-        Iterator iterator = CreateIterator(ordered);
-        return GetAllValuesCore(iterator);
+        ThrowIfDisposing();
+        return GetAllValuesCore(ordered);
     }
+
+    internal void ThrowIfDisposing() => ObjectDisposedException.ThrowIf(_isDisposing, this);
 
     private void IteratorSeekToFirstWithErrorHandling(Iterator iterator)
     {
         try
         {
             iterator.SeekToFirst();
+        }
+        catch (RocksDbSharpException e)
+        {
+            HandleFatalDbError(e);
+            throw;
+        }
+    }
+
+    private void IteratorSeekWithErrorHandling(Iterator iterator, byte[] key)
+    {
+        try
+        {
+            iterator.Seek(key);
         }
         catch (RocksDbSharpException e)
         {
@@ -1198,59 +1203,98 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
     }
 
-    internal IEnumerable<byte[]> GetAllValuesCore(Iterator iterator)
-    {
-        try
-        {
-            IteratorSeekToFirstWithErrorHandling(iterator);
+    internal IEnumerable<KeyValuePair<byte[], byte[]?>> GetAllCore(bool ordered, ColumnFamilyHandle? ch = null) =>
+        GetAllCore(ordered, ch, static iterator => new KeyValuePair<byte[], byte[]?>(iterator.Key(), iterator.Value()));
 
-            while (iterator.Valid())
+    internal IEnumerable<byte[]> GetAllKeysCore(bool ordered, ColumnFamilyHandle? ch = null) =>
+        GetAllCore(ordered, ch, static iterator => iterator.Key());
+
+    internal IEnumerable<byte[]> GetAllValuesCore(bool ordered, ColumnFamilyHandle? ch = null) =>
+        GetAllCore(ordered, ch, static iterator => iterator.Value());
+
+    private IEnumerable<T> GetAllCore<T>(bool ordered, ColumnFamilyHandle? ch, Func<Iterator, T> projection)
+    {
+        byte[]? resumeKey = null;
+        bool hasMore;
+
+        do
+        {
+            using ArrayPoolList<T> batch = new(FullEnumerationBatchSize);
+            hasMore = ReadFullEnumerationBatch(ordered, ch, resumeKey, projection, batch, out resumeKey);
+
+            foreach (T item in batch)
             {
-                yield return iterator.Value();
-                IteratorNextWithErrorHandling(iterator);
+                yield return item;
             }
         }
-        finally
-        {
-            IteratorDisposeWithErrorHandling(iterator);
-        }
+        while (hasMore);
     }
 
-    internal IEnumerable<byte[]> GetAllKeysCore(Iterator iterator)
+    private bool ReadFullEnumerationBatch<T>(
+        bool ordered,
+        ColumnFamilyHandle? ch,
+        byte[]? resumeKey,
+        Func<Iterator, T> projection,
+        ArrayPoolList<T> batch,
+        out byte[]? nextResumeKey)
     {
-        try
-        {
-            IteratorSeekToFirstWithErrorHandling(iterator);
-
-            while (iterator.Valid())
-            {
-                yield return iterator.Key();
-                IteratorNextWithErrorHandling(iterator);
-            }
-        }
-        finally
-        {
-            IteratorDisposeWithErrorHandling(iterator);
-        }
-    }
-
-    public IEnumerable<KeyValuePair<byte[], byte[]?>> GetAllCore(Iterator iterator)
-    {
-        ObjectDisposedException.ThrowIf(_isDisposing, this);
+        ThrowIfDisposing();
+        nextResumeKey = null;
+        ReadOptions readOptions = new();
+        Iterator? iterator = null;
 
         try
         {
-            IteratorSeekToFirstWithErrorHandling(iterator);
+            readOptions.SetTailing(!ordered);
+            iterator = CreateIterator(readOptions, ch);
+
+            if (resumeKey is null)
+            {
+                IteratorSeekToFirstWithErrorHandling(iterator);
+            }
+            else
+            {
+                IteratorSeekWithErrorHandling(iterator, resumeKey);
+                if (iterator.Valid() && iterator.GetKeySpan().SequenceEqual(resumeKey))
+                {
+                    IteratorNextWithErrorHandling(iterator);
+                }
+            }
 
             while (iterator.Valid())
             {
-                yield return new KeyValuePair<byte[], byte[]?>(iterator.Key(), iterator.Value());
+                batch.Add(projection(iterator));
+                if (batch.Count == FullEnumerationBatchSize)
+                {
+                    byte[] boundaryKey = iterator.Key();
+                    IteratorNextWithErrorHandling(iterator);
+                    if (iterator.Valid())
+                    {
+                        nextResumeKey = boundaryKey;
+                        return true;
+                    }
+
+                    return false;
+                }
+
                 IteratorNextWithErrorHandling(iterator);
             }
+
+            return false;
         }
         finally
         {
-            IteratorDisposeWithErrorHandling(iterator);
+            try
+            {
+                if (iterator is not null)
+                {
+                    IteratorDisposeWithErrorHandling(iterator);
+                }
+            }
+            finally
+            {
+                RocksDbReader.DestroyReadOptions(readOptions);
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -577,6 +577,105 @@ namespace Nethermind.Db.Test
         }
 
         [Test]
+        public void Full_enumerations_can_be_repeated_across_batches()
+        {
+            (byte[][] expectedKeys, byte[][] expectedValues) = SeedFullEnumerationBatches();
+            IEnumerable<KeyValuePair<byte[], byte[]?>> all = _db.GetAll(ordered: true);
+            IEnumerable<byte[]> keys = _db.GetAllKeys(ordered: true);
+            IEnumerable<byte[]> values = _db.GetAllValues(ordered: true);
+
+            _ = all.Take(1).Single();
+            _ = keys.Take(1).Single();
+            _ = values.Take(1).Single();
+
+            KeyValuePair<byte[], byte[]?>[] firstAll = all.ToArray();
+            KeyValuePair<byte[], byte[]?>[] secondAll = all.ToArray();
+            byte[][] firstKeys = keys.ToArray();
+            byte[][] secondKeys = keys.ToArray();
+            byte[][] firstValues = values.ToArray();
+            byte[][] secondValues = values.ToArray();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(firstAll.Select(static item => item.Key), Is.EqualTo(expectedKeys));
+                Assert.That(firstAll.Select(static item => item.Value), Is.EqualTo(expectedValues));
+                Assert.That(secondAll.Select(static item => item.Key), Is.EqualTo(expectedKeys));
+                Assert.That(secondAll.Select(static item => item.Value), Is.EqualTo(expectedValues));
+                Assert.That(firstKeys, Is.EqualTo(expectedKeys));
+                Assert.That(secondKeys, Is.EqualTo(expectedKeys));
+                Assert.That(firstValues, Is.EqualTo(expectedValues));
+                Assert.That(secondValues, Is.EqualTo(expectedValues));
+            }
+        }
+
+        [Test]
+        public void Full_enumerations_resume_after_deleted_boundary()
+        {
+            (byte[][] expectedKeys, byte[][] expectedValues) = SeedFullEnumerationBatches();
+            int boundaryIndex = DbOnTheRocks.FullEnumerationBatchSize - 1;
+
+            AssertResumesAfterDeletedBoundary(
+                _db.GetAll(ordered: true).Select(static item => item.Key),
+                expectedKeys[boundaryIndex],
+                expectedValues[boundaryIndex],
+                expectedKeys[boundaryIndex + 1]);
+            AssertResumesAfterDeletedBoundary(
+                _db.GetAllKeys(ordered: true),
+                expectedKeys[boundaryIndex],
+                expectedValues[boundaryIndex],
+                expectedKeys[boundaryIndex + 1]);
+            AssertResumesAfterDeletedBoundary(
+                _db.GetAllValues(ordered: true),
+                expectedKeys[boundaryIndex],
+                expectedValues[boundaryIndex],
+                expectedValues[boundaryIndex + 1]);
+        }
+
+        private (byte[][] Keys, byte[][] Values) SeedFullEnumerationBatches()
+        {
+            int count = DbOnTheRocks.FullEnumerationBatchSize + 1;
+            byte[][] keys = new byte[count][];
+            byte[][] values = new byte[count][];
+
+            using IWriteBatch batch = _db.StartWriteBatch();
+            for (int i = 0; i < count; i++)
+            {
+                keys[i] = i.ToBigEndianByteArray();
+                values[i] = (i + count).ToBigEndianByteArray();
+                batch.Set(keys[i], values[i]);
+            }
+
+            return (keys, values);
+        }
+
+        private void AssertResumesAfterDeletedBoundary(
+            IEnumerable<byte[]> items,
+            byte[] boundaryKey,
+            byte[] boundaryValue,
+            byte[] expectedNext)
+        {
+            using IEnumerator<byte[]> enumerator = items.GetEnumerator();
+            for (int i = 0; i < DbOnTheRocks.FullEnumerationBatchSize; i++)
+            {
+                if (!enumerator.MoveNext())
+                {
+                    Assert.Fail($"Enumeration stopped at item {i} before reaching the batch boundary.");
+                }
+            }
+
+            _db.Remove(boundaryKey);
+            try
+            {
+                Assert.That(enumerator.MoveNext(), Is.True);
+                Assert.That(enumerator.Current, Is.EqualTo(expectedNext));
+            }
+            finally
+            {
+                _db.Set(boundaryKey, boundaryValue);
+            }
+        }
+
+        [Test]
         public void IteratorWorks()
         {
             Assert.That(_db, Is.AssignableTo<ISortedKeyValueStore>());


### PR DESCRIPTION
## Changes

- Read RocksDB full enumerations in bounded batches of 10,000 entries.
- Dispose iterators, read options, and pooled batch storage between batches.
- Resume main and column-family enumerations from the previous boundary key, including when that key is deleted.
- Add regression coverage for all full-enumeration APIs across multiple batches, repeated and partial enumeration, and deleted boundaries.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Focused full-enumeration regression tests: 4 passed.
- Full `Nethermind.Db.Test` test executable: passed.
- `git diff --check`: passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No