### PR TITLE
fix(discovery): coalesce concurrent discv4 bonding pings to the same endpoint

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/Kademlia/KademliaAdapterTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/Kademlia/KademliaAdapterTests.cs
@@ -287,6 +287,34 @@ namespace Nethermind.Network.Discovery.Test.Discv4.Kademlia
 
         [Test]
         [CancelAfter(10000)]
+        public async Task Ping_concurrent_calls_to_same_unbonded_node_share_one_wire_ping(CancellationToken token)
+        {
+            TaskCompletionSource pongGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            _msgSender
+                .SendMsg(Arg.Any<PingMsg>())
+                .Returns(async ci =>
+                {
+                    PingMsg sent = (PingMsg)ci[0]!;
+                    await pongGate.Task;
+                    using DisposableByteBuffer buffer = _receiverSerializationManager.ZeroSerialize(sent).AsDisposable();
+                    PingMsg msg = _receiverSerializationManager.Deserialize<PingMsg>(buffer);
+                    PongMsg pong = new(msg.FarPublicKey!, _timestamper.UnixTime.SecondsLong + 1, sent.Mdc!.Value, null);
+                    pong.FarAddress = sent.FarAddress;
+                    await _adapter.OnIncomingMsg(pong);
+                });
+
+            Task<bool> first = _adapter.Ping(_receiver, token);
+            Task<bool> second = _adapter.Ping(_receiver, token);
+            pongGate.SetResult();
+
+            bool[] results = await Task.WhenAll(first, second);
+
+            Assert.That(results, Is.All.True);
+            await _msgSender.Received(1).SendMsg(Arg.Any<PingMsg>());
+        }
+
+        [Test]
+        [CancelAfter(10000)]
         public async Task Ping_should_not_publish_tcp_endpoint_learned_from_neighbours(CancellationToken token)
         {
             ConfigureBondCallback();

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/NodeSessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/NodeSessionTests.cs
@@ -6,7 +6,9 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Network.Discovery.Discv4;
+using Nethermind.Network.Discovery.Discv4.Messages;
 using Nethermind.Stats;
 using NSubstitute;
 using NUnit.Framework;
@@ -199,6 +201,76 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             }
 
             Assert.That(await waitTask, Is.False);
+        }
+
+        [Test]
+        public async Task GetOrStartBond_shares_in_flight_attempt_for_same_endpoint()
+        {
+            int startCount = 0;
+            TaskCompletionSource<PongMsg?> pending = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            Task<PongMsg?> first = _nodeSession.GetOrStartBond(TestEndpoint, () =>
+            {
+                Interlocked.Increment(ref startCount);
+                return pending.Task;
+            });
+            Task<PongMsg?> second = _nodeSession.GetOrStartBond(TestEndpoint, () =>
+            {
+                Interlocked.Increment(ref startCount);
+                return pending.Task;
+            });
+
+            Assert.That(second, Is.SameAs(first));
+            Assert.That(startCount, Is.EqualTo(1));
+
+            PongMsg pong = new(TestEndpoint, 0, default);
+            pending.SetResult(pong);
+
+            Assert.That(await first, Is.SameAs(pong));
+            Assert.That(await second, Is.SameAs(pong));
+        }
+
+        [Test]
+        public async Task GetOrStartBond_starts_a_new_attempt_once_the_previous_one_completes()
+        {
+            int startCount = 0;
+
+            Task<PongMsg?> first = _nodeSession.GetOrStartBond(TestEndpoint, () =>
+            {
+                Interlocked.Increment(ref startCount);
+                return Task.FromResult<PongMsg?>(null);
+            });
+            await first;
+
+            Task<PongMsg?> second = _nodeSession.GetOrStartBond(TestEndpoint, () =>
+            {
+                Interlocked.Increment(ref startCount);
+                return Task.FromResult<PongMsg?>(null);
+            });
+            await second;
+
+            Assert.That(startCount, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void GetOrStartBond_tracks_endpoints_independently()
+        {
+            IPEndPoint otherEndpoint = new(IPAddress.Parse("192.168.1.1"), TestEndpoint.Port);
+            int startCount = 0;
+            TaskCompletionSource<PongMsg?> pending = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            _nodeSession.GetOrStartBond(TestEndpoint, () =>
+            {
+                Interlocked.Increment(ref startCount);
+                return pending.Task;
+            });
+            _nodeSession.GetOrStartBond(otherEndpoint, () =>
+            {
+                Interlocked.Increment(ref startCount);
+                return pending.Task;
+            });
+
+            Assert.That(startCount, Is.EqualTo(2));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
@@ -230,8 +230,7 @@ public class KademliaAdapter(
         return bondTask.WaitAsync(token);
     }
 
-    // Runs against processExitSource.Token rather than a specific caller's token: it may be shared by several
-    // callers via GetOrStartBond, and one of them giving up must not cancel the attempt for the others.
+    
     private async Task<PongMsg?> SendBondingPing(Node receiver, NodeSession session, IPEndPoint endpoint)
     {
         CancellationToken token = processExitSource.Token;

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
@@ -222,8 +222,7 @@ public class KademliaAdapter(
         return true;
     }
 
-    // Coalesced via NodeSession.GetOrStartBond: concurrent lookups can each decide the same endpoint needs
-    // bonding at the same time, so callers share one in-flight ping rather than each sending their own.
+   
     private Task<PongMsg?> TryBond(Node receiver, NodeSession session, CancellationToken token)
     {
         IPEndPoint endpoint = receiver.DiscoveryAddress;

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
@@ -222,10 +222,20 @@ public class KademliaAdapter(
         return true;
     }
 
-    private async Task<PongMsg?> TryBond(Node receiver, NodeSession session, CancellationToken token)
+    // Coalesced via NodeSession.GetOrStartBond: concurrent lookups can each decide the same endpoint needs
+    // bonding at the same time, so callers share one in-flight ping rather than each sending their own.
+    private Task<PongMsg?> TryBond(Node receiver, NodeSession session, CancellationToken token)
     {
         IPEndPoint endpoint = receiver.DiscoveryAddress;
+        Task<PongMsg?> bondTask = session.GetOrStartBond(endpoint, () => SendBondingPing(receiver, session, endpoint));
+        return bondTask.WaitAsync(token);
+    }
 
+    // Runs against processExitSource.Token rather than a specific caller's token: it may be shared by several
+    // callers via GetOrStartBond, and one of them giving up must not cancel the attempt for the others.
+    private async Task<PongMsg?> SendBondingPing(Node receiver, NodeSession session, IPEndPoint endpoint)
+    {
+        CancellationToken token = processExitSource.Token;
         PingMsg msg = new(endpoint, CalculateExpirationTime(), kademliaConfig.CurrentNodeId.DiscoveryAddress, kademliaConfig.CurrentNodeId.Port, 0)
         {
             EnrSequence = (await nodeRecordProvider.GetCurrentAsync(token)).EnrSequence // optional and does not seem to be used anywhere.

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/NodeSession.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/NodeSession.cs
@@ -24,8 +24,6 @@ public sealed record NodeSession(INodeStats NodeStats, ITimestamper Timestamper)
     private EndpointBondTable _pendingBondingPings;
     private TaskCompletionSource? _endpointBondChanged;
 
-    // Separate from _endpointBondLock: startBond's synchronous prefix (e.g. OnPingSent) takes that lock, so
-    // invoking it while holding this one too would self-deadlock.
     private readonly Lock _bondCoalesceLock = new();
     private readonly Dictionary<EndpointKey, Task<PongMsg?>> _inFlightBonds = [];
 

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/NodeSession.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/NodeSession.cs
@@ -174,12 +174,7 @@ public sealed record NodeSession(INodeStats NodeStats, ITimestamper Timestamper)
     /// Returns the bonding attempt already in flight for <paramref name="endpoint"/>, or starts one via
     /// <paramref name="startBond"/> and shares it with any other caller that asks before it completes.
     /// </summary>
-    /// <remarks>
-    /// Concurrent Kademlia lookups can each decide the same endpoint needs (re-)bonding at the same time; without
-    /// coalescing, every one of them would send its own ping. Callers should give up on their own timeout via the
-    /// returned task's cancellation rather than cancelling <paramref name="startBond"/> itself, since cancelling it
-    /// would also fail every other caller sharing the same attempt.
-    /// </remarks>
+    
     public Task<PongMsg?> GetOrStartBond(IPEndPoint endpoint, Func<Task<PongMsg?>> startBond)
     {
         EndpointKey endpointKey = new(endpoint);

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/NodeSession.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/NodeSession.cs
@@ -24,6 +24,11 @@ public sealed record NodeSession(INodeStats NodeStats, ITimestamper Timestamper)
     private EndpointBondTable _pendingBondingPings;
     private TaskCompletionSource? _endpointBondChanged;
 
+    // Separate from _endpointBondLock: startBond's synchronous prefix (e.g. OnPingSent) takes that lock, so
+    // invoking it while holding this one too would self-deadlock.
+    private readonly Lock _bondCoalesceLock = new();
+    private readonly Dictionary<EndpointKey, Task<PongMsg?>> _inFlightBonds = [];
+
     public bool NotTooManyFailure => Volatile.Read(ref _authenticatedRequestFailureCount) <= AuthenticatedRequestFailureLimit;
     public bool HasTriedPingRecently => Volatile.Read(ref _lastPingSentTicks) + PingRetryTimeout.Ticks > Timestamper.UtcNow.Ticks;
 
@@ -165,6 +170,49 @@ public sealed record NodeSession(INodeStats NodeStats, ITimestamper Timestamper)
         {
             SignalEndpointBondChanged();
         }
+    }
+
+    /// <summary>
+    /// Returns the bonding attempt already in flight for <paramref name="endpoint"/>, or starts one via
+    /// <paramref name="startBond"/> and shares it with any other caller that asks before it completes.
+    /// </summary>
+    /// <remarks>
+    /// Concurrent Kademlia lookups can each decide the same endpoint needs (re-)bonding at the same time; without
+    /// coalescing, every one of them would send its own ping. Callers should give up on their own timeout via the
+    /// returned task's cancellation rather than cancelling <paramref name="startBond"/> itself, since cancelling it
+    /// would also fail every other caller sharing the same attempt.
+    /// </remarks>
+    public Task<PongMsg?> GetOrStartBond(IPEndPoint endpoint, Func<Task<PongMsg?>> startBond)
+    {
+        EndpointKey endpointKey = new(endpoint);
+        Task<PongMsg?> bondTask;
+        lock (_bondCoalesceLock)
+        {
+            // IsCompleted, not just presence: the cleanup continuation below races with callers waking up from
+            // the same completed task, so a finished entry may still be in the table when the next call arrives.
+            if (_inFlightBonds.TryGetValue(endpointKey, out Task<PongMsg?>? existing) && !existing.IsCompleted)
+            {
+                return existing;
+            }
+
+            bondTask = startBond();
+            _inFlightBonds[endpointKey] = bondTask;
+        }
+
+        _ = bondTask.ContinueWith(static (_, state) =>
+        {
+            (NodeSession session, EndpointKey key, Task<PongMsg?> task) = ((NodeSession, EndpointKey, Task<PongMsg?>))state!;
+            lock (session._bondCoalesceLock)
+            {
+                // Only remove our own attempt: a new one may have already replaced it after we completed.
+                if (session._inFlightBonds.TryGetValue(key, out Task<PongMsg?>? current) && ReferenceEquals(current, task))
+                {
+                    session._inFlightBonds.Remove(key);
+                }
+            }
+        }, (this, endpointKey, bondTask), TaskScheduler.Default);
+
+        return bondTask;
     }
 
     public async ValueTask<bool> WaitForEndpointBond(IPEndPoint endpoint, TimeSpan timeout, CancellationToken token)


### PR DESCRIPTION
## Changes

- `NodeSession.GetOrStartBond(endpoint, startBond)`: a single-flight cache keyed per discovery endpoint. When multiple concurrent Kademlia lookups decide the same peer endpoint needs (re-)bonding at the same time, they now share one in-flight ping/pong round-trip instead of each sending its own ping. Checks `Task.IsCompleted` at lookup time (not just dictionary presence) so a just-finished attempt is never mistakenly reused before its cleanup continuation runs.
- `KademliaAdapter.TryBond` split into a thin coalescing wrapper plus `SendBondingPing` (the original ping-and-wait logic, unchanged). The shared attempt runs against `processExitSource.Token` rather than any single caller's token, and each caller uses `Task.WaitAsync(callerToken)` so giving up on its own timeout never cancels the attempt for other callers waiting on the same bond.
- `FindNeighbours`/`SendEnrRequest` are untouched: their per-target payloads differ per call, so they can't be coalesced the same way.

## Context

Investigated with a user running a small private validator network (4 Nethermind-only nodes, discovery via bootnodes). Packet captures showed continuous discv4 Ping/Pong bursts between nodes far beyond what a normal bonding handshake needs. Root cause: concurrent Kademlia lookup rounds (driven by `RandomWalkKademliaDiscovery`, `Alpha`-parallel workers per round) each independently re-check bonding state and send their own ping when none is cached yet — harmless at internet scale where lookups rarely collide on the same node, but wasteful when the same handful of peers get hit by every lookup.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `NodeSessionTests`: `GetOrStartBond` shares an in-flight attempt for the same endpoint, starts a fresh attempt once the previous one completes, and tracks distinct endpoints independently.
- `KademliaAdapterTests`: two concurrent `Ping` calls to the same unbonded node produce exactly one wire-level `PingMsg`.
- Full `Nethermind.Network.Discovery.Test` suite (330 tests) and `Nethermind.Xdc.Test` discovery tests pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [ ] No

#### Requires explanation in Release Notes

- [ ] Yes
- [ ] No

## Remarks

This doesn't stop `ConcurrentDiscoveryJob`/`Kademlia.Alpha` from producing repeated lookup rounds against a small peer set — that's a separate, still-open gap (the random-walk discovery has no back-off when it stops finding new nodes). This PR only removes the redundant duplicate pings within/across those rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)