### PR TITLE
Accept 1,024 ETH body request hashes

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/GetBlockBodiesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/GetBlockBodiesMessageSerializerTests.cs
@@ -4,6 +4,7 @@
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages;
+using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62;
@@ -31,10 +32,44 @@ public class GetBlockBodiesMessageSerializerTests
         SerializerTester.TestZero(serializer, message);
     }
 
+    [TestCase(500)]
+    [TestCase(1024)]
+    public void Can_deserialize_body_request_up_to_message_limit(int hashCount)
+    {
+        GetBlockBodiesMessageSerializer serializer = new();
+        using GetBlockBodiesMessage message = new(CreateHashes(hashCount));
+        byte[] bytes = serializer.Serialize(message);
+
+        using GetBlockBodiesMessage deserialized = serializer.Deserialize(bytes);
+
+        Assert.That(deserialized.BlockHashes, Has.Count.EqualTo(hashCount));
+    }
+
+    [Test]
+    public void Rejects_body_request_above_message_limit()
+    {
+        GetBlockBodiesMessageSerializer serializer = new();
+        using GetBlockBodiesMessage message = new(CreateHashes(1025));
+        byte[] bytes = serializer.Serialize(message);
+
+        Assert.Throws<RlpLimitException>(() => serializer.Deserialize(bytes));
+    }
+
     [Test]
     public void To_string()
     {
         using GetBlockBodiesMessage newBlockMessage = new();
         _ = newBlockMessage.ToString();
+    }
+
+    private static Hash256[] CreateHashes(int count)
+    {
+        Hash256[] hashes = new Hash256[count];
+        for (int i = 0; i < hashes.Length; i++)
+        {
+            hashes[i] = Keccak.Zero;
+        }
+
+        return hashes;
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/GetBlockBodiesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Messages/GetBlockBodiesMessageSerializer.cs
@@ -4,13 +4,13 @@
 using DotNetty.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
-using Nethermind.Stats.SyncLimits;
 
 namespace Nethermind.Network.P2P.Subprotocols.Eth.V62.Messages
 {
     public class GetBlockBodiesMessageSerializer : IZeroInnerMessageSerializer<GetBlockBodiesMessage>
     {
-        private static readonly RlpLimit RlpLimit = RlpLimit.For<GetBlockBodiesMessage>(NethermindSyncLimits.MaxBodyFetch, nameof(GetBlockBodiesMessage.BlockHashes));
+        private const int MaxBodyHashesPerRequest = 1024;
+        private static readonly RlpLimit RlpLimit = RlpLimit.For<GetBlockBodiesMessage>(MaxBodyHashesPerRequest, nameof(GetBlockBodiesMessage.BlockHashes));
 
         public void Serialize(IByteBuffer byteBuffer, GetBlockBodiesMessage message)
         {


### PR DESCRIPTION
## Changes

- Accept up to 1,024 hashes in inbound ETH `GetBlockBodies` requests while retaining a bounded RLP allocation limit.
- Keep Nethermind's local 256-body outbound-fetch policy and the existing response-size limits unchanged.
- Cover a 500-hash interoperability request, the 1,024-hash boundary, and rejection at 1,025 hashes.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Serializer regression coverage, the complete Network test suite, and a warning-as-error solution build pass.
- Fresh Hive sync coverage passes all eight two-client cases with upstream Erigon `main`, including Erigon syncing from Nethermind.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

- The decoder previously used Nethermind's 256-body local fetch target as an inbound RLP limit, rejecting a normal 500-hash request from Erigon before the existing size-limited responder could return a partial response.
