### PR TITLE
perf(state): cut per-slot and per-account work on the storage commit path

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
@@ -213,10 +213,7 @@ public sealed class ReadOnlySnapshotBundle(
         return value;
     }
 
-    private void GuardDispose()
-    {
-        if (_isDisposed) throw new ObjectDisposedException($"{nameof(ReadOnlySnapshotBundle)} is disposed");
-    }
+    private void GuardDispose() => ObjectDisposedException.ThrowIf(_isDisposed, this);
 
     public bool TryLease() => TryAcquireLease();
 

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -82,8 +82,9 @@ public class ScopeProviderTests(bool useFlat)
         }
     }
 
-    [Test]
-    public void Test_CanSaveToStorage()
+    [TestCase(1)]
+    [TestCase(17)]
+    public void Test_CanSaveToStorage(int estimatedEntries)
     {
         using Context ctx = new(useFlat);
 
@@ -96,7 +97,7 @@ public class ScopeProviderTests(bool useFlat)
             {
                 writeBatch.Set(TestItem.AddressA, new Account(100, 100));
 
-                using IWorldStateScopeProvider.IStorageWriteBatch storageSet = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1);
+                using IWorldStateScopeProvider.IStorageWriteBatch storageSet = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, estimatedEntries);
                 storageSet.Set(1, [1, 2, 3]);
             }
 

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -83,7 +83,7 @@ public class ScopeProviderTests(bool useFlat)
     }
 
     [TestCase(1)]
-    [TestCase(17)]
+    [TestCase(TrieStoreScopeProvider.StorageTreeBulkWriteBatch.MIN_ENTRIES_TO_BATCH + 1)]
     public void Test_CanSaveToStorage(int estimatedEntries)
     {
         using Context ctx = new(useFlat);

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -144,17 +144,14 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         for (int i = 0; i <= currentPosition; i++)
         {
             ref readonly Change change = ref changes[currentPosition - i];
-            if (_committedThisRound.Contains(change!.StorageCell))
+            if (!_committedThisRound.Add(change!.StorageCell))
             {
                 continue;
             }
 
-            _committedThisRound.Add(change.StorageCell);
-            int forAssertion = _intraBlockCache[change.StorageCell].CurrentIdx;
-            if (forAssertion != currentPosition - i)
-            {
-                throw new InvalidOperationException($"Expected checked value {forAssertion} to be equal to {currentPosition} - {i}");
-            }
+            // Debug-only: A broken index surfaces anyway as a storage-root mismatch on the block.
+            Debug.Assert(_intraBlockCache[change.StorageCell].CurrentIdx == currentPosition - i,
+                $"Expected the cached index to equal {currentPosition} - {i}");
 
             if (change.ChangeType == ChangeType.Update)
             {

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
+using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Evm.State;
@@ -71,13 +72,10 @@ namespace Nethermind.State
             ComputeKey(index, out key);
         }
 
-        private static byte[] EncodeValue(byte[]? value)
-        {
-            if (value.IsZero())
-            {
-                return [];
-            }
+        private static byte[] EncodeValue(byte[]? value) => value.IsZero() ? [] : EncodeNonZeroValue(value);
 
+        private static byte[] EncodeNonZeroValue(byte[] value)
+        {
             byte[] encoded = GC.AllocateUninitializedArray<byte>(Rlp.LengthOf(value));
             Rlp.Encode(value, encoded);
             return encoded;
@@ -159,10 +157,17 @@ namespace Nethermind.State
 
         private void SetInternal(in ValueHash256 hash, byte[] value, bool rlpEncode = true)
         {
-            byte[] encodedValue = value.IsZero() ?
-                [] :
-                rlpEncode ? EncodeValue(value) : value;
-            Set(hash.Bytes, encodedValue);
+            ReadOnlySpan<byte> rawKey = hash.Bytes;
+            if (value.IsZero())
+            {
+                Set(rawKey, []);
+            }
+            else
+            {
+                // Bind the CappedArray overload the Rlp one used to forward to, so a non-zero write
+                // keeps bypassing the virtual byte[] entry point that HealingStorageTree overrides.
+                Set(rawKey, new CappedArray<byte>(rlpEncode ? EncodeNonZeroValue(value) : value));
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -71,21 +71,19 @@ namespace Nethermind.State
             ComputeKey(index, out key);
         }
 
-        public static BulkSetEntry CreateBulkSetEntry(in ValueHash256 key, byte[]? value)
+        private static byte[] EncodeValue(byte[]? value)
         {
-            byte[] encodedValue;
             if (value.IsZero())
             {
-                encodedValue = [];
-            }
-            else
-            {
-                encodedValue = GC.AllocateUninitializedArray<byte>(Rlp.LengthOf(value));
-                Rlp.Encode(value, encodedValue);
+                return [];
             }
 
-            return new BulkSetEntry(in key, encodedValue);
+            byte[] encoded = GC.AllocateUninitializedArray<byte>(Rlp.LengthOf(value));
+            Rlp.Encode(value, encoded);
+            return encoded;
         }
+
+        public static BulkSetEntry CreateBulkSetEntry(in ValueHash256 key, byte[]? value) => new(in key, EncodeValue(value));
 
         [SkipLocalsInit]
         public byte[] Get(in UInt256 index, Hash256? storageRoot = null)
@@ -161,16 +159,10 @@ namespace Nethermind.State
 
         private void SetInternal(in ValueHash256 hash, byte[] value, bool rlpEncode = true)
         {
-            ReadOnlySpan<byte> rawKey = hash.Bytes;
-            if (value.IsZero())
-            {
-                Set(rawKey, []);
-            }
-            else
-            {
-                Rlp rlpEncoded = rlpEncode ? Rlp.Encode(value) : new Rlp(value);
-                Set(rawKey, rlpEncoded);
-            }
+            byte[] encodedValue = value.IsZero() ?
+                [] :
+                rlpEncode ? EncodeValue(value) : value;
+            Set(hash.Bytes, encodedValue);
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -72,8 +72,6 @@ namespace Nethermind.State
             ComputeKey(index, out key);
         }
 
-        private static byte[] EncodeValue(byte[]? value) => value.IsZero() ? [] : EncodeNonZeroValue(value);
-
         private static byte[] EncodeNonZeroValue(byte[] value)
         {
             byte[] encoded = GC.AllocateUninitializedArray<byte>(Rlp.LengthOf(value));
@@ -81,7 +79,8 @@ namespace Nethermind.State
             return encoded;
         }
 
-        public static BulkSetEntry CreateBulkSetEntry(in ValueHash256 key, byte[]? value) => new(in key, EncodeValue(value));
+        public static BulkSetEntry CreateBulkSetEntry(in ValueHash256 key, byte[]? value) =>
+            new(in key, value.IsZero() ? [] : EncodeNonZeroValue(value));
 
         [SkipLocalsInit]
         public byte[] Get(in UInt256 index, Hash256? storageRoot = null)

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -266,15 +266,16 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
     {
         private readonly Dictionary<AddressAsKey, Account?> _dirtyAccounts = new(estimatedAccountCount);
         private readonly ConcurrentQueue<(AddressAsKey, Hash256)> _dirtyStorageTree = new();
+        private Action<Address, Hash256>? _markDirty;
 
         public event EventHandler<IWorldStateScopeProvider.AccountUpdated>? OnAccountUpdated;
 
         public void Set(Address key, Account? account) => _dirtyAccounts[key] = account;
 
-        public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address address, int estimatedEntries) => new StorageTreeBulkWriteBatch(estimatedEntries, scope.LookupStorageTree(address),
-                (address, rootHash) => MarkDirty(address, rootHash), address);
+        public IWorldStateScopeProvider.IStorageWriteBatch CreateStorageWriteBatch(Address address, int estimatedEntries) =>
+            new StorageTreeBulkWriteBatch(estimatedEntries, scope.LookupStorageTree(address), _markDirty ??= MarkDirty, address);
 
-        public void MarkDirty(AddressAsKey address, Hash256 storageTreeRootHash) => _dirtyStorageTree.Enqueue((address, storageTreeRootHash));
+        private void MarkDirty(Address address, Hash256 storageTreeRootHash) => _dirtyStorageTree.Enqueue((address, storageTreeRootHash));
 
         public void Dispose()
         {


### PR DESCRIPTION
## Changes

Work the storage commit path repeated per changed slot or per changed account, removed with no behaviour change:

- **`StorageTree`** encoded every storage slot value into a throwaway `Rlp` wrapper that `PatriciaTree.Set` immediately unwrapped into a `CappedArray` and dropped, so each changed slot on the non-batched path allocated a wrapper plus an array for one call. It now encodes straight into the array through `EncodeNonZeroValue`, the one encoder both the batched and non-batched paths share, so the two cannot drift apart. The `rlpEncode: false` path hands the caller's array over directly, which is all that wrapping it in an `Rlp` did (`Rlp(byte[])` adopts the reference). The `CappedArray` is constructed explicitly rather than left as a `byte[]`: that is exactly what the `Rlp` overload forwarded to (`PatriciaTree.cs:568`), and it keeps a non-zero write off the *virtual* `Set(ReadOnlySpan<byte>, byte[])` entry point that `HealingStorageTree` overrides. Routing non-zero writes through synchronous trie recovery may well be the right thing, but it is a behaviour change on a path only covered for `Get`, so it is deliberately left for a separate PR with its own test.
  `StateTree` already carries this exact fix for accounts, with the reason in the code: *"EncodeAsBytes skips the throwaway Rlp wrapper that `_decoder.Encode(account)` would allocate for every changed account on each block commit."*
- **`PersistentStorageProvider.CommitCore`** hashed the same 52-byte `StorageCell` three times per change: once to test the dedupe set, once to add to it, and once more to read the index an assertion compared against. `HashSet.Add` already reports whether it inserted, and the assertion checks this method's own bookkeeping, so it moves behind `Debug` — leaving one hash on the release path. `StorageCell.GetHashCode` covers a 32-byte index plus a 20-byte address and `Address.GetHashCode` is not cached, so the duplicate probes were not free.
- **`TrieStoreScopeProvider`** allocated a fresh root-updated delegate per changed account, because the lambda captures the write batch and so cannot be cached by the compiler. It is now created once per batch. `MarkDirty` becomes private (it had no external callers) and takes `Address`, moving the `AddressAsKey` conversion from the call site to the enqueue.
- **`ReadOnlySnapshotBundle.GuardDispose`** uses `ObjectDisposedException.ThrowIf`. The manual check passed a whole sentence as the `objectName` argument, so the thrown message read `Object name: 'ReadOnlySnapshotBundle is disposed'`; it now reports the type.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`ScopeProviderTests.Test_CanSaveToStorage` is parameterised at 1 and 17 estimated entries, straddling `MIN_ENTRIES_TO_BATCH = 16`, so it now covers both the batched and the non-batched storage write path — the latter being the one the `StorageTree` change touches — for both the trie-store and flat layouts.

Everything else here is behaviour-identical and already covered: storage and state roots are asserted by the existing world-state and trie suites, so a byte difference in the encoding change fails them immediately. I deliberately did not add tests asserting "no `Rlp` wrapper was allocated" or "the assertion was compiled out", which would pin implementation details rather than behaviour.

- `Nethermind.State.Test`: 1164 passed, 0 failed, in **both** release and debug configurations. The debug run matters because it is the one that compiles in the new `Debug.Assert`; it never fires.
- To confirm that assertion is genuinely live rather than dead code, I inverted its condition and re-ran: it failed with `Expected the cached index to equal 999 - 0` and aborted the run, so the path is exercised and a violation is loud in debug builds. Condition restored afterwards.
- `Nethermind.State.Flat.Test`: 882 passed. The 14 failures are the pre-existing `StorageLayerTests.TearDown` file-lock `IOException`s on `arena_*.bin`, which fail on master too and are unrelated to this change.
- The `rlpEncode: false` branch is exercised by `Nethermind.Synchronization.Test` (`SnapServerTest`), which CI covers; that path is also provably identical, since both the old and the new code hand the caller's array to `new CappedArray<byte>(...)` without copying.
- Zero build warnings, `git diff --check` clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

**No performance gain is claimed.** These are allocation and probe reductions justified by their multiplicity — per changed storage slot, or per changed account, per block — and by an existing in-repo precedent for the same fix one layer up. None of them has been benchmarked in isolation, so please do not read a number into them.

**The one judgement call worth a reviewer's attention** is replacing a release-mode `throw new InvalidOperationException` with a `Debug.Assert`. The invariant is internal bookkeeping: the intra-block cache's current index must match the first occurrence the backward walk reaches. If it were ever violated, the code would commit a superseded slot value, which changes the storage root, which fails the block on root comparison regardless — so the failure stays loud, it just loses the specific exception. `Debug.Assert` is `[Conditional("DEBUG")]`, so in release the call *and its arguments* are not emitted and the dictionary probe disappears entirely. If that trade is unwelcome, the first half of that commit (collapsing `Contains` + `Add` into one `Add`) stands on its own and the assertion can be restored.

A more aggressive version is possible and I chose not to do it: `_intraBlockCache[cell].CurrentIdx == changeIndex` *is* the "not yet committed this round" predicate, so `_committedThisRound` is redundant with the cache and could be deleted outright. It saves the same single probe, but it turns a violated invariant from a loud failure into silently skipping a write, and it removes the dedupe's independence from the thing it was checking.

