### PR TITLE
refactor(eip-8272): derive recent-root usable window

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
@@ -9,6 +9,8 @@ namespace Nethermind.Core;
 public static class Eip8272Constants
 {
     public const ulong RecentRootLength = 8192;
+
+    /// <remarks>One less than <see cref="RecentRootLength"/>: a reference of age <see cref="RecentRootLength"/> aliases the current slot's ring-buffer index.</remarks>
     public const ulong RecentRootUsableWindow = RecentRootLength - 1;
     public const int MaxRecentRootReferences = 16;
 

--- a/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Core;
 public static class Eip8272Constants
 {
     public const ulong RecentRootLength = 8192;
-    public const ulong RecentRootUsableWindow = 8191;
+    public const ulong RecentRootUsableWindow = RecentRootLength - 1;
     public const int MaxRecentRootReferences = 16;
 
     public static readonly ValueHash256 RecentRootEntryDomain = ValueKeccak.Compute("RECENT_ROOT_ENTRY");


### PR DESCRIPTION
Follow-up to #12457.

- Derive `RecentRootUsableWindow` from `RecentRootLength - 1`.
- Keeps the anti-aliasing invariant explicit and prevents the constants from drifting.

Test plan: not run; this is a compile-time constant-only change.