### PR TITLE
perf(evm): raise eth_call instruction-stream retained-size cap (256 → 512 KiB)

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
@@ -50,6 +50,33 @@ public class InstructionStreamTests
     }
 
     [Test]
+    public void TryBuild_MaxSizeTypicalContract_StaysWithinRetainedCap()
+    {
+        // A max EIP-170 (24 KiB) contract of typical output must stay within the retained-size cap.
+        const int maxCodeSize = 24 * 1024;
+        byte[] block =
+        [
+            (byte)Instruction.PUSH1, 0x07, (byte)Instruction.ADD,
+            (byte)Instruction.PUSH1, 0x03, (byte)Instruction.MUL,
+            (byte)Instruction.PUSH1, 0x02, (byte)Instruction.MUL,
+            (byte)Instruction.PUSH1, 0x05, (byte)Instruction.SWAP1, (byte)Instruction.SUB,
+            (byte)Instruction.DUP1, (byte)Instruction.POP,
+        ];
+        List<byte> code = new(maxCodeSize);
+        while (code.Count + block.Length < maxCodeSize)
+        {
+            code.AddRange(block);
+        }
+        code.Add((byte)Instruction.STOP);
+
+        InstructionStream stream = InstructionStream.TryBuild(code.ToArray())!;
+
+        Assert.That(stream, Is.Not.Null, "a max-size typical-output contract should build a retained stream");
+        Assert.That(stream.RetainedBytes, Is.LessThanOrEqualTo(StreamInterpreter.MaxStreamRetainedBytes),
+            $"a {code.Count}-byte contract retained {stream.RetainedBytes} bytes, over the {StreamInterpreter.MaxStreamRetainedBytes}-byte cap");
+    }
+
+    [Test]
     public void TryBuild_Jumpdest_GetsItsOwnSoloBlock()
     {
         byte[] code =

--- a/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
+++ b/src/Nethermind/Nethermind.Evm/MemoryAllowance.cs
@@ -6,6 +6,8 @@ namespace Nethermind.Evm
     public static class MemoryAllowance
     {
         public static int CodeCacheSize { get; } = 4_096 + 1_024;
-        public static int InstructionStreamCacheSize { get; } = 2_048;
+
+        // Halved when MaxStreamRetainedBytes doubled to 512 KiB, keeping the worst-case retained-bytes ceiling flat.
+        public static int InstructionStreamCacheSize { get; } = 1_024;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -25,8 +25,11 @@ internal static class StreamInterpreter
     // Executions before a CodeInfo's stream is built; keeps the one-time build off cold code. Minimum 1.
     public static int BuildThreshold = 4;
 
-    // Streams over this size aren't retained (fall back to the metered loop); 256 KiB covers any EIP-170 contract.
-    public const int MaxStreamRetainedBytes = 256 * 1024;
+    // Streams over this size aren't retained (fall back to the metered loop). The retained form is
+    // ~15-16x the bytecode, so a max EIP-170 contract (24 KiB) builds a ~400 KiB stream; 256 KiB
+    // silently excluded the largest ~21-24 KiB contracts, pinning them to the metered loop even
+    // though they are the ones that benefit most from streaming. 512 KiB covers any valid contract.
+    public const int MaxStreamRetainedBytes = 512 * 1024;
 
     // Per-thread diagnostic counter of stream frames executed, read by differential tests to assert the
     // stream engaged. [ThreadStatic] so each thread bumps its own slot with a plain write: no atomic and

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -25,10 +25,7 @@ internal static class StreamInterpreter
     // Executions before a CodeInfo's stream is built; keeps the one-time build off cold code. Minimum 1.
     public static int BuildThreshold = 4;
 
-    // Streams over this size aren't retained (fall back to the metered loop). The retained form is
-    // ~15-16x the bytecode, so a max EIP-170 contract (24 KiB) builds a ~400 KiB stream; 256 KiB
-    // silently excluded the largest ~21-24 KiB contracts, pinning them to the metered loop even
-    // though they are the ones that benefit most from streaming. 512 KiB covers any valid contract.
+    // Larger streams fall back to the metered loop; 512 KiB fits an EIP-170-sized contract of typical (~15-16x) output.
     public const int MaxStreamRetainedBytes = 512 * 1024;
 
     // Per-thread diagnostic counter of stream frames executed, read by differential tests to assert the


### PR DESCRIPTION
## Summary

The preprocessed instruction-stream interpreter (added in #11965) runs on the cancelable RPC surface (`eth_call` / `estimateGas` / `createAccessList` / `simulate`). A built stream is retained only if it is ≤ `MaxStreamRetainedBytes` (256 KiB); a larger stream is dropped and that contract permanently falls back to the slower metered bytecode loop.

The retained stream is ~15–16× the bytecode size, so a contract in the 21–24 KiB range (up to the EIP-170 max of 24 KiB) builds a ~276–400 KiB stream and was **silently excluded** by the 256 KiB cap. Those large contracts are the compute-heaviest ones — precisely where the stream interpreter pays off — so the cap was excluding exactly the cases that benefit most.

Raise the cap to **512 KiB**, which admits any EIP-170-sized contract of typical output, so the largest contracts stream too. `InstructionStreamCacheSize` is halved (2048 → 1024) in the same change so the worst-case *retained-bytes* ceiling (entry count × per-stream cap) is unchanged despite the doubled per-stream cap.

## Impact

Measured on a heavy contract-call (`Multicall3 aggregate3`) `eth_call` workload at 50 rps, medians of ≥3 runs each:

| metric | before (256 KiB) | after (512 KiB) | Δ |
|---|---:|---:|---:|
| p50 | 125.1 ms | 115.7 ms | −7.5% |
| p90 | 137.5 ms | 127.0 ms | −7.6% |
| p95 | 147.6 ms | 135.2 ms | −8.4% |
| p99 | 208.4 ms | 171.1 ms | −17.9% |

A dotTrace sampling profile of the same workload confirms the mechanism: execution of the large contracts moves out of the metered interpreter loop (`RunByteCodeCore`) into the fused stream interpreter (`RunStream`) — `RunByteCodeCore` own-time collapses from ~470k to ~0.7k samples and `RunStream` absorbs it. The cache halving (2048 → 1024) is perf-neutral (verified separately: the hot working set is far under either bound).

## Correctness

No semantic change — only *which* contracts get the (already differential-tested) stream. The stream produces identical gas and output; any per-block precharge that would exceed remaining gas falls back to the metered micro-loop so the halting opcode and failure type match per-opcode interpretation exactly. `InstructionStream` differential tests pass (25/25, including a new one asserting a max EIP-170 contract stays within the cap). Block processing is unaffected: the stream is never built or run there — the engagement gate short-circuits for non-cancelable frames.

## Memory

512 KiB is a per-stream *retention* cap, not a per-call allocation. Built streams are cached by code hash in the entry-bounded `InstructionStreamCache`, whose count was halved to 1024 alongside the cap so the worst-case retained-bytes product is unchanged; a max-size stream is ~400 KiB and the vast majority are far smaller, so the retained set for a hot working set stays in the low-MiB range.
