### PR TITLE
Fix zero-tip SYSTEM_ADDRESS beneficiary BAL entry

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
@@ -82,6 +82,25 @@ public class BlockAccessListSequentialValidationTests
         Assert.DoesNotThrow(() => RunSequentialValidation(tampered, processingOptions));
     }
 
+    [Test]
+    public void Generated_bal_includes_system_address_fee_recipient_credited_with_zero_fee()
+    {
+        (IWorldState stateProvider, BlockAccessListManager balManager) = CreateFundedAmsterdamSetup();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        FundSender(stateProvider);
+
+        // Zero priority fee (gasPrice == baseFee == 0) with SYSTEM_ADDRESS as fee recipient.
+        // EELS credits the coinbase unconditionally per tx (amsterdam fork.py create_ether), and a
+        // zero-fee credit is still a state access, so per EIP-7928 SYSTEM_ADDRESS must appear in
+        // the BAL as a touched-but-unchanged account.
+        Block block = BuildBlock();
+        block.Header.Beneficiary = Address.SystemUser;
+        RunSequential(stateProvider, balManager, block, blockAccessList: null);
+
+        Assert.That(balManager.GeneratedBlockAccessList.HasAccount(Address.SystemUser), Is.True,
+            "SYSTEM_ADDRESS fee recipient must be recorded in the BAL even when the credited fee is zero");
+    }
+
     /// <summary>
     /// Runs the block once on the sequential path with no suggested BAL so the executor
     /// constructs the generated BAL, then re-encodes it as a wire <see cref="ReadOnlyBlockAccessList"/>.

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
@@ -28,10 +28,9 @@ using System.Threading;
 namespace Nethermind.Blockchain.Test;
 
 /// <summary>
-/// Covers the column-index fast path on the sequential execution path, reachable only because
-/// <c>MergeAndReturnBal</c> feeds each per-tx slice into the generated validation index. Drives
-/// real execution to produce a BAL, then re-validates it: a matching BAL is accepted (and the
-/// generated index that gates the fast path is shown to be populated), a tampered BAL is rejected.
+/// Covers BAL generation and the column-index fast path on the sequential execution path,
+/// reachable only because <c>MergeAndReturnBal</c> feeds each per-tx slice into the generated
+/// validation index.
 /// </summary>
 [Parallelizable(ParallelScope.All)]
 public class BlockAccessListSequentialValidationTests
@@ -85,33 +84,34 @@ public class BlockAccessListSequentialValidationTests
     [Test]
     public void Generated_bal_includes_system_address_fee_recipient_credited_with_zero_fee()
     {
-        (IWorldState stateProvider, BlockAccessListManager balManager) = CreateFundedAmsterdamSetup();
-        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
-        FundSender(stateProvider);
+        ReadOnlyBlockAccessList generated = GenerateBlockAccessList(static block => block.Header.Beneficiary = Address.SystemUser);
 
-        // Zero priority fee (gasPrice == baseFee == 0) with SYSTEM_ADDRESS as fee recipient.
-        // EELS credits the coinbase unconditionally per tx (amsterdam fork.py create_ether), and a
-        // zero-fee credit is still a state access, so per EIP-7928 SYSTEM_ADDRESS must appear in
-        // the BAL as a touched-but-unchanged account.
-        Block block = BuildBlock();
-        block.Header.Beneficiary = Address.SystemUser;
-        RunSequential(stateProvider, balManager, block, blockAccessList: null);
+        // EIP-7928 BAL generation records touched accounts even when no state value changes.
+        ReadOnlyAccountChanges? systemAccount = generated.GetAccountChanges(Address.SystemUser);
 
-        Assert.That(balManager.GeneratedBlockAccessList.HasAccount(Address.SystemUser), Is.True,
-            "SYSTEM_ADDRESS fee recipient must be recorded in the BAL even when the credited fee is zero");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(systemAccount, Is.Not.Null);
+            Assert.That(systemAccount!.BalanceChanges, Is.Empty);
+            Assert.That(systemAccount.NonceChanges, Is.Empty);
+            Assert.That(systemAccount.CodeChanges, Is.Empty);
+            Assert.That(systemAccount.StorageChanges, Is.Empty);
+            Assert.That(systemAccount.StorageReads, Is.Empty);
+        }
     }
 
     /// <summary>
     /// Runs the block once on the sequential path with no suggested BAL so the executor
     /// constructs the generated BAL, then re-encodes it as a wire <see cref="ReadOnlyBlockAccessList"/>.
     /// </summary>
-    private static ReadOnlyBlockAccessList GenerateBlockAccessList()
+    private static ReadOnlyBlockAccessList GenerateBlockAccessList(Action<Block>? configureBlock = null)
     {
         (IWorldState stateProvider, BlockAccessListManager balManager) = CreateFundedAmsterdamSetup();
         using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
         FundSender(stateProvider);
 
         Block block = BuildBlock();
+        configureBlock?.Invoke(block);
         RunSequential(stateProvider, balManager, block, blockAccessList: null);
 
         byte[] encoded = BlockAccessListDecoder.EncodeToBytes(balManager.GeneratedBlockAccessList);

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
@@ -88,10 +88,10 @@ public class BlockAccessListSequentialValidationTests
 
         // EIP-7928 BAL generation records touched accounts even when no state value changes.
         ReadOnlyAccountChanges? systemAccount = generated.GetAccountChanges(Address.SystemUser);
+        Assert.That(systemAccount, Is.Not.Null);
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(systemAccount, Is.Not.Null);
             Assert.That(systemAccount!.BalanceChanges, Is.Empty);
             Assert.That(systemAccount.NonceChanges, Is.Empty);
             Assert.That(systemAccount.CodeChanges, Is.Empty);

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessListAtIndex.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessListAtIndex.cs
@@ -83,13 +83,11 @@ public class BlockAccessListAtIndex : IJournal<int>, IResettable
 
     public void AddBalanceChange(Address address, UInt256 before, UInt256 after)
     {
-        bool isZeroBalanceChange = before == after;
         AccountChangesAtIndex accountChanges = GetOrAddAccountChanges(address);
 
-        // Don't add zero balance transfers, but DO add empty account changes — EELS/pyspec
-        // include touched-but-unchanged accounts (e.g. EIP-1559 zero-tip coinbase credits) in
-        // the suggested BAL, so dropping them on our side would diverge from the BAL hash.
-        if (isZeroBalanceChange)
+        // Don't add zero balance transfers, but DO add empty account changes: EIP-7928 includes
+        // touched-but-unchanged accounts in the suggested BAL, so dropping them diverges from the hash.
+        if (before == after)
         {
             return;
         }

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessListAtIndex.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/BlockAccessListAtIndex.cs
@@ -84,11 +84,6 @@ public class BlockAccessListAtIndex : IJournal<int>, IResettable
     public void AddBalanceChange(Address address, UInt256 before, UInt256 after)
     {
         bool isZeroBalanceChange = before == after;
-        if (address == Address.SystemUser && isZeroBalanceChange)
-        {
-            return;
-        }
-
         AccountChangesAtIndex accountChanges = GetOrAddAccountChanges(address);
 
         // Don't add zero balance transfers, but DO add empty account changes — EELS/pyspec

--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -409,18 +409,29 @@ public class TracedAccessWorldStateTests(bool parallel)
         }
     }
 
-    [Test]
-    public void AddToBalanceAndCreateIfNotExists_DoesNotRecordSystemUserZeroChangeDuringSuppression()
+    [TestCase(true, true, TestName = "AddToBalance suppressed")]
+    [TestCase(true, false, TestName = "AddToBalanceAndCreateIfNotExists suppressed")]
+    [TestCase(false, true, TestName = "AddToBalance not suppressed")]
+    [TestCase(false, false, TestName = "AddToBalanceAndCreateIfNotExists not suppressed")]
+    public void Zero_balance_credit_to_system_user_recorded_only_outside_suppression(bool suppressed, bool plainAdd)
     {
-        (TracedAccessWorldState tws, IDisposable scope) = CreateTracingState();
+        (TracedAccessWorldState tws, IDisposable scope) = CreateTracingState(ws =>
+            ws.CreateAccount(Address.SystemUser, 0));
         using (scope)
         {
-            using IDisposable? systemAccountReadSuppression = tws.BeginSystemAccountReadSuppression();
+            using IDisposable? systemAccountReadSuppression = suppressed ? tws.BeginSystemAccountReadSuppression() : null;
 
-            tws.AddToBalanceAndCreateIfNotExists(Address.SystemUser, 0u, Spec, out _);
+            if (plainAdd)
+            {
+                tws.AddToBalance(Address.SystemUser, 0u, Spec, out _);
+            }
+            else
+            {
+                tws.AddToBalanceAndCreateIfNotExists(Address.SystemUser, 0u, Spec, out _);
+            }
 
             AccountChangesAtIndex? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(Address.SystemUser);
-            Assert.That(ac, Is.Null);
+            Assert.That(ac, suppressed ? Is.Null : Is.Not.Null);
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -409,6 +409,21 @@ public class TracedAccessWorldStateTests(bool parallel)
         }
     }
 
+    [Test]
+    public void AddToBalanceAndCreateIfNotExists_DoesNotRecordSystemUserZeroChangeDuringSuppression()
+    {
+        (TracedAccessWorldState tws, IDisposable scope) = CreateTracingState();
+        using (scope)
+        {
+            using IDisposable? systemAccountReadSuppression = tws.BeginSystemAccountReadSuppression();
+
+            tws.AddToBalanceAndCreateIfNotExists(Address.SystemUser, 0u, Spec, out _);
+
+            AccountChangesAtIndex? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(Address.SystemUser);
+            Assert.That(ac, Is.Null);
+        }
+    }
+
     // Repeated same-tx balance/nonce/code/storage writes must reuse the BAL-recorded value as
     // their "old" baseline (not the inner state) and collapse to a single entry at this index.
 

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -157,6 +157,8 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
     {
         oldBalance = 0;
 
+        // Intentionally not gated on read suppression: system transactions debit Address.SystemUser
+        // as their sender, and that zero touch must stay out of BALs.
         if (address == Address.SystemUser && balanceChange.IsZero)
         {
             return;

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -48,7 +48,10 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
         oldBalance = currentBalance ?? oldBalance;
 
         UInt256 newBalance = oldBalance + balanceChange;
-        _generatingBlockAccessList.AddBalanceChange(address, oldBalance, newBalance);
+        if (!ShouldSuppressSystemUserZeroBalanceChange(address, in balanceChange))
+        {
+            _generatingBlockAccessList.AddBalanceChange(address, oldBalance, newBalance);
+        }
     }
 
     public override bool AddToBalanceAndCreateIfNotExists(Address address, in UInt256 balanceChange, IReleaseSpec spec, out UInt256 oldBalance)
@@ -60,7 +63,10 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
         res = currentlyExists ?? res;
 
         UInt256 newBalance = oldBalance + balanceChange;
-        _generatingBlockAccessList.AddBalanceChange(address, oldBalance, newBalance);
+        if (!ShouldSuppressSystemUserZeroBalanceChange(address, in balanceChange))
+        {
+            _generatingBlockAccessList.AddBalanceChange(address, oldBalance, newBalance);
+        }
 
         return res;
     }
@@ -200,6 +206,9 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
             _generatingBlockAccessList.AddAccountRead(address);
         }
     }
+
+    private bool ShouldSuppressSystemUserZeroBalanceChange(Address address, in UInt256 balanceChange)
+        => _systemAccountReadSuppressionDepth != 0 && address == Address.SystemUser && balanceChange.IsZero;
 
     /// <summary>Records the account read (honoring SystemUser suppression) and returns its change entry in one probe.</summary>
     private AccountChangesAtIndex? RecordReadAndGetChanges(Address address)


### PR DESCRIPTION
## Changes

- Preserve zero-fee balance touches for `SYSTEM_ADDRESS` when it is the block beneficiary.
- Keep zero-balance `SYSTEM_ADDRESS` touches suppressed during system-account read suppression.
- Add regression coverage for the encoded/decoded BAL wire form and direct traced-state suppression behavior.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet test --project src/Nethermind/Nethermind.State.Test/Nethermind.State.Test.csproj -c release -- --filter FullyQualifiedName~TracedAccessWorldStateTests`
- `dotnet test --project src/Nethermind/Nethermind.Blockchain.Test/Nethermind.Blockchain.Test.csproj -c release -- --filter FullyQualifiedName~BlockAccessListSequentialValidationTests`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The root cause was an over-broad `SYSTEM_ADDRESS` zero-balance special case that suppressed real fee-recipient state touches. Before this change, Nethermind could generate a BAL for a zero-fee `SYSTEM_ADDRESS` beneficiary that its own BAL validation path would reject because the encoded BAL omitted the touched account.