### PR TITLE
Allow contract creation at max valid nonce

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -105,6 +105,30 @@ public partial class TransactionProcessorTests(bool eip155Enabled)
     }
 
     [Test]
+    public void Can_process_contract_creation_with_max_valid_nonce()
+    {
+        // EIP-2681/EELS: only nonce 2^64-1 overflows; 2^64-2 is valid for contract creation
+        // (amsterdam transactions.py raises NonceOverflowError only when nonce >= U64.MAX_VALUE).
+        _stateProvider.SetNonce(TestItem.AddressA, ulong.MaxValue - 1);
+
+        ulong gasLimit = 100000ul;
+        Transaction tx = Build.A.Transaction.SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA, eip155Enabled)
+            .WithCode(Prepare.EvmCode.Op(Instruction.STOP).Done)
+            .WithNonce(ulong.MaxValue - 1)
+            .WithGasLimit(gasLimit)
+            .TestObject;
+        Block block = Build.A.Block.WithNumber(1).WithTransactions(tx).WithGasLimit(10 * gasLimit).TestObject;
+
+        TransactionResult result = Execute(tx, block);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Not.EqualTo(TransactionResult.NonceOverflow));
+            Assert.That(result.TransactionExecuted, Is.True);
+        }
+    }
+
+    [Test]
     public void Can_handle_quick_fail_on_missing_sender()
     {
         Transaction tx = Build.A.Transaction.Signed(_ethereumEcdsa, TestItem.PrivateKeyA, eip155Enabled).WithGasLimit(100000).TestObject;

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.cs
@@ -104,17 +104,17 @@ public partial class TransactionProcessorTests(bool eip155Enabled)
         Assert.That(result.TransactionExecuted, Is.False);
     }
 
-    [Test]
-    public void Can_process_contract_creation_with_max_valid_nonce()
+    [TestCase(ulong.MaxValue - 1, true)]
+    [TestCase(ulong.MaxValue, false)]
+    public void Can_process_contract_creation_at_nonce_overflow_boundary(ulong nonce, bool executed)
     {
-        // EIP-2681/EELS: only nonce 2^64-1 overflows; 2^64-2 is valid for contract creation
-        // (amsterdam transactions.py raises NonceOverflowError only when nonce >= U64.MAX_VALUE).
-        _stateProvider.SetNonce(TestItem.AddressA, ulong.MaxValue - 1);
+        // EIP-2681 rejects only a transaction nonce of 2^64-1, so 2^64-2 remains usable for contract creation.
+        _stateProvider.SetNonce(TestItem.AddressA, nonce);
 
         ulong gasLimit = 100000ul;
         Transaction tx = Build.A.Transaction.SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA, eip155Enabled)
             .WithCode(Prepare.EvmCode.Op(Instruction.STOP).Done)
-            .WithNonce(ulong.MaxValue - 1)
+            .WithNonce(nonce)
             .WithGasLimit(gasLimit)
             .TestObject;
         Block block = Build.A.Block.WithNumber(1).WithTransactions(tx).WithGasLimit(10 * gasLimit).TestObject;
@@ -123,8 +123,15 @@ public partial class TransactionProcessorTests(bool eip155Enabled)
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result, Is.Not.EqualTo(TransactionResult.NonceOverflow));
-            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(result.TransactionExecuted, Is.EqualTo(executed));
+            if (executed)
+            {
+                Assert.That(_stateProvider.GetNonce(TestItem.AddressA), Is.EqualTo(ulong.MaxValue));
+            }
+            else
+            {
+                Assert.That(result, Is.EqualTo(TransactionResult.NonceOverflow));
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -860,15 +860,11 @@ namespace Nethermind.Evm.TransactionProcessing
                 return TransactionResult.SenderNotSpecified;
             }
 
-            if (validate && tx.Nonce >= ulong.MaxValue - 1)
+            // EIP-2681 rejects the transaction nonce that would overflow the sender nonce after inclusion.
+            if (validate && tx.Nonce == ulong.MaxValue)
             {
-                // we are here if nonce is at least (ulong.MaxValue - 1). If tx is contract creation,
-                // it is max possible value. Otherwise, (ulong.MaxValue - 1) is allowed, but ulong.MaxValue not.
-                if (tx.IsContractCreation || tx.Nonce == ulong.MaxValue)
-                {
-                    TraceLogInvalidTx(tx, "NONCE_OVERFLOW");
-                    return TransactionResult.NonceOverflow;
-                }
+                TraceLogInvalidTx(tx, "NONCE_OVERFLOW");
+                return TransactionResult.NonceOverflow;
             }
 
             if (tx.IsAboveInitCode(spec))


### PR DESCRIPTION
## Changes

- Reject only transaction nonce `ulong.MaxValue` for EIP-2681 nonce overflow.
- Allow top-level contract creation at the highest usable nonce, `2^64 - 2`.
- Add a regression test for the contract-creation boundary case.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet test --project src/Nethermind/Nethermind.Blockchain.Test/Nethermind.Blockchain.Test.csproj -c release -- --filter "FullyQualifiedName~Can_process_contract_creation_with_max_valid_nonce"`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The previous guard treated `2^64 - 2` as overflowing for contract-creation transactions, but EIP-2681 only rejects a transaction nonce of `2^64 - 1`.
