### PR TITLE
Fix EIP-7708 tracing with logs

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerEip7708Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerEip7708Tests.cs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Text.Json;
+using Nethermind.Blockchain.Tracing.GethStyle;
+using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test.Tracing;
+
+[TestFixture]
+public class GethLikeCallTracerEip7708Tests : VirtualMachineTestsBase
+{
+    protected override ISpecProvider SpecProvider => new TestSpecProvider(new OverridableReleaseSpec(Prague.Instance) { IsEip7708Enabled = true });
+
+    private static GethTraceOptions GetGethTraceOptions(string? config) => GethTraceOptions.Default with
+    {
+        Tracer = NativeCallTracer.CallTracer,
+        TracerConfig = config is not null ? JsonSerializer.Deserialize<JsonElement>(config) : null
+    };
+
+    [TestCase(true, TestName = "value transfer to contract (EVM path)")]
+    [TestCase(false, TestName = "value transfer to EOA (simple-transfer path)")]
+    public void TopLevelValueTransfer_WithLog_IncludesTransferLogToTopFrame(bool recipientHasCode)
+    {
+        byte[]? recipientCode = recipientHasCode ? Prepare.EvmCode.Op(Instruction.STOP).Done : null;
+
+        const byte value = 1;
+        (Block block, Transaction tx) = PrepareTx(Activation, 100_000UL, recipientCode, value: value);
+        using NativeCallTracer tracer = new(tx, GetGethTraceOptions("{\"withLog\":true}"));
+
+        _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+
+        using GethLikeTxTrace trace = tracer.BuildResult();
+        NativeCallTracerCallFrame? frame = trace.CustomTracerResult?.Value as NativeCallTracerCallFrame;
+        Assert.That(frame?.Logs?.Count, Is.EqualTo(1));
+
+        NativeCallTracerLogEntry log = frame.Logs[0];
+        NativeCallTracerLogEntry expected = new(TransferLog.Sender, Hash256.FromBytesWithPadding([value]).BytesToArray(),
+            [TransferLog.TransferSignature, new(Sender.ToHash()), new(Recipient.ToHash())], 0UL);
+        Assert.That(log, Is.EqualTo(expected).UsingPropertiesComparer());
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerEip7708Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerEip7708Tests.cs
@@ -36,13 +36,16 @@ public class GethLikeCallTracerEip7708Tests : VirtualMachineTestsBase
     private static byte[] ForwardValueCode(Address target) =>
         Prepare.EvmCode.CallWithValue(target, 50_000, InnerValue).STOP().Done;
 
-    public sealed record TransferLogScenario(byte[]? RecipientCode, Address? InnerTarget);
+    private static byte[] CreateValueCode() =>
+        Prepare.EvmCode.Create(Prepare.EvmCode.STOP().Done, InnerValue).STOP().Done;
+
+    public sealed record TransferLogScenario(byte[]? RecipientCode, bool HasInner, string? Config = WithLog);
 
     [TestCaseSource(nameof(TransferLogCases))]
-    public void ValueTransfer_WithLog_AttachesLogToCorrectFrame(TransferLogScenario scenario)
+    public void ValueTransfer_WithLog_AddsLogsToCorrectFrames(TransferLogScenario scenario)
     {
         (Block block, Transaction tx) = PrepareTx(Activation, 200_000UL, scenario.RecipientCode, value: TopValue);
-        using NativeCallTracer tracer = new(tx, GetGethTraceOptions(WithLog));
+        using NativeCallTracer tracer = new(tx, GetGethTraceOptions(scenario.Config));
 
         _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
 
@@ -53,28 +56,35 @@ public class GethLikeCallTracerEip7708Tests : VirtualMachineTestsBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(topFrame.Logs, Is.EqualTo([expectedTop]).UsingPropertiesComparer());
-            Assert.That(topFrame.Calls, Has.Count.EqualTo(scenario.InnerTarget is null ? 0 : 1));
+            Assert.That(topFrame.Calls, Has.Count.EqualTo(scenario.HasInner ? 1 : 0));
         }
 
-        if (scenario.InnerTarget is not null)
+        if (scenario.HasInner)
         {
-            NativeCallTracerLogEntry expectedInner = ExpectedTransferLog(Recipient, scenario.InnerTarget, InnerValue, 0UL);
-            Assert.That(topFrame.Calls[0].Logs, Is.EqualTo([expectedInner]).UsingPropertiesComparer());
+            NativeCallTracerCallFrame childFrame = topFrame.Calls[0];
+            NativeCallTracerLogEntry expectedInner = ExpectedTransferLog(Recipient, childFrame.To!, InnerValue, 0UL);
+            Assert.That(childFrame.Logs, Is.EqualTo([expectedInner]).UsingPropertiesComparer());
         }
     }
 
     private static IEnumerable<TestCaseData> TransferLogCases()
     {
-        yield return new TestCaseData(new TransferLogScenario(null, null))
+        yield return new TestCaseData(new TransferLogScenario(null, false))
             .SetName("top-level value transfer to EOA (simple-transfer fast path)");
 
-        yield return new TestCaseData(new TransferLogScenario(Prepare.EvmCode.STOP().Done, null))
+        yield return new TestCaseData(new TransferLogScenario(Prepare.EvmCode.STOP().Done, false))
             .SetName("top-level value transfer to contract (EVM path)");
 
-        yield return new TestCaseData(new TransferLogScenario(ForwardValueCode(TestItem.AddressC), TestItem.AddressC))
+        yield return new TestCaseData(new TransferLogScenario(ForwardValueCode(TestItem.AddressC), true))
             .SetName("nested value transfer to EOA");
 
-        yield return new TestCaseData(new TransferLogScenario(ForwardValueCode(Precompile), Precompile))
+        yield return new TestCaseData(new TransferLogScenario(ForwardValueCode(Precompile), true))
             .SetName("nested value transfer to precompile");
+
+        yield return new TestCaseData(new TransferLogScenario(CreateValueCode(), true))
+            .SetName("nested value transfer to CREATE");
+
+        yield return new TestCaseData(new TransferLogScenario(ForwardValueCode(TestItem.AddressC), false, WithLogAndOnlyTopCall))
+            .SetName("nested value transfer is not hoisted into top frame under onlyTopCall");
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerEip7708Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerEip7708Tests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
-using System.Text.Json;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
 using Nethermind.Core;
@@ -15,6 +14,7 @@ using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
 using NUnit.Framework;
+using static Nethermind.Evm.Test.Tracing.GethLikeCallTracerTests;
 
 namespace Nethermind.Evm.Test.Tracing;
 
@@ -23,18 +23,10 @@ public class GethLikeCallTracerEip7708Tests : VirtualMachineTestsBase
 {
     protected override ISpecProvider SpecProvider => new TestSpecProvider(new OverridableReleaseSpec(Prague.Instance) { IsEip7708Enabled = true });
 
-    private const string WithLog = """{"withLog":true}""";
-
     private const byte TopValue = 1;
     private const byte InnerValue = 2;
 
     private static readonly Address Precompile = IdentityPrecompile.Address;
-
-    private static GethTraceOptions GetGethTraceOptions(string? config) => GethTraceOptions.Default with
-    {
-        Tracer = NativeCallTracer.CallTracer,
-        TracerConfig = config is not null ? JsonSerializer.Deserialize<JsonElement>(config) : null
-    };
 
     private static NativeCallTracerLogEntry ExpectedTransferLog(Address from, Address to, byte value, ulong position) => new(
         TransferLog.Sender, data: Hash256.FromBytesWithPadding([value]).BytesToArray(),

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerEip7708Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerEip7708Tests.cs
@@ -1,12 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using System.Text.Json;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
@@ -20,31 +23,66 @@ public class GethLikeCallTracerEip7708Tests : VirtualMachineTestsBase
 {
     protected override ISpecProvider SpecProvider => new TestSpecProvider(new OverridableReleaseSpec(Prague.Instance) { IsEip7708Enabled = true });
 
+    private const string WithLog = """{"withLog":true}""";
+
+    private const byte TopValue = 1;
+    private const byte InnerValue = 2;
+
+    private static readonly Address Precompile = IdentityPrecompile.Address;
+
     private static GethTraceOptions GetGethTraceOptions(string? config) => GethTraceOptions.Default with
     {
         Tracer = NativeCallTracer.CallTracer,
         TracerConfig = config is not null ? JsonSerializer.Deserialize<JsonElement>(config) : null
     };
 
-    [TestCase(true, TestName = "value transfer to contract (EVM path)")]
-    [TestCase(false, TestName = "value transfer to EOA (simple-transfer path)")]
-    public void TopLevelValueTransfer_WithLog_IncludesTransferLogToTopFrame(bool recipientHasCode)
-    {
-        byte[]? recipientCode = recipientHasCode ? Prepare.EvmCode.Op(Instruction.STOP).Done : null;
+    private static NativeCallTracerLogEntry ExpectedTransferLog(Address from, Address to, byte value, ulong position) => new(
+        TransferLog.Sender, data: Hash256.FromBytesWithPadding([value]).BytesToArray(),
+        topics: [TransferLog.TransferSignature, new(from.ToHash()), new(to.ToHash())], position
+    );
 
-        const byte value = 1;
-        (Block block, Transaction tx) = PrepareTx(Activation, 100_000UL, recipientCode, value: value);
-        using NativeCallTracer tracer = new(tx, GetGethTraceOptions("{\"withLog\":true}"));
+    private static byte[] ForwardValueCode(Address target) =>
+        Prepare.EvmCode.CallWithValue(target, 50_000, InnerValue).STOP().Done;
+
+    public sealed record TransferLogScenario(byte[]? RecipientCode, Address? InnerTarget);
+
+    [TestCaseSource(nameof(TransferLogCases))]
+    public void ValueTransfer_WithLog_AttachesLogToCorrectFrame(TransferLogScenario scenario)
+    {
+        (Block block, Transaction tx) = PrepareTx(Activation, 200_000UL, scenario.RecipientCode, value: TopValue);
+        using NativeCallTracer tracer = new(tx, GetGethTraceOptions(WithLog));
 
         _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
 
         using GethLikeTxTrace trace = tracer.BuildResult();
-        NativeCallTracerCallFrame? frame = trace.CustomTracerResult?.Value as NativeCallTracerCallFrame;
-        Assert.That(frame?.Logs?.Count, Is.EqualTo(1));
+        NativeCallTracerCallFrame topFrame = (NativeCallTracerCallFrame)trace.CustomTracerResult!.Value!;
 
-        NativeCallTracerLogEntry log = frame.Logs[0];
-        NativeCallTracerLogEntry expected = new(TransferLog.Sender, Hash256.FromBytesWithPadding([value]).BytesToArray(),
-            [TransferLog.TransferSignature, new(Sender.ToHash()), new(Recipient.ToHash())], 0UL);
-        Assert.That(log, Is.EqualTo(expected).UsingPropertiesComparer());
+        NativeCallTracerLogEntry expectedTop = ExpectedTransferLog(Sender, Recipient, TopValue, 0UL);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(topFrame.Logs, Is.EqualTo([expectedTop]).UsingPropertiesComparer());
+            Assert.That(topFrame.Calls, Has.Count.EqualTo(scenario.InnerTarget is null ? 0 : 1));
+        }
+
+        if (scenario.InnerTarget is not null)
+        {
+            NativeCallTracerLogEntry expectedInner = ExpectedTransferLog(Recipient, scenario.InnerTarget, InnerValue, 0UL);
+            Assert.That(topFrame.Calls[0].Logs, Is.EqualTo([expectedInner]).UsingPropertiesComparer());
+        }
+    }
+
+    private static IEnumerable<TestCaseData> TransferLogCases()
+    {
+        yield return new TestCaseData(new TransferLogScenario(null, null))
+            .SetName("top-level value transfer to EOA (simple-transfer fast path)");
+
+        yield return new TestCaseData(new TransferLogScenario(Prepare.EvmCode.STOP().Done, null))
+            .SetName("top-level value transfer to contract (EVM path)");
+
+        yield return new TestCaseData(new TransferLogScenario(ForwardValueCode(TestItem.AddressC), TestItem.AddressC))
+            .SetName("nested value transfer to EOA");
+
+        yield return new TestCaseData(new TransferLogScenario(ForwardValueCode(Precompile), Precompile))
+            .SetName("nested value transfer to precompile");
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerEip7708Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerEip7708Tests.cs
@@ -39,7 +39,7 @@ public class GethLikeCallTracerEip7708Tests : VirtualMachineTestsBase
     private static byte[] CreateValueCode() =>
         Prepare.EvmCode.Create(Prepare.EvmCode.STOP().Done, InnerValue).STOP().Done;
 
-    public sealed record TransferLogScenario(byte[]? RecipientCode, bool HasInner, string? Config = WithLog);
+    public sealed record TransferLogScenario(byte[]? RecipientCode, bool ExpectsChildFrame, string? Config = WithLog);
 
     [TestCaseSource(nameof(TransferLogCases))]
     public void ValueTransfer_WithLog_AddsLogsToCorrectFrames(TransferLogScenario scenario)
@@ -56,10 +56,10 @@ public class GethLikeCallTracerEip7708Tests : VirtualMachineTestsBase
         using (Assert.EnterMultipleScope())
         {
             Assert.That(topFrame.Logs, Is.EqualTo([expectedTop]).UsingPropertiesComparer());
-            Assert.That(topFrame.Calls, Has.Count.EqualTo(scenario.HasInner ? 1 : 0));
+            Assert.That(topFrame.Calls, Has.Count.EqualTo(scenario.ExpectsChildFrame ? 1 : 0));
         }
 
-        if (scenario.HasInner)
+        if (scenario.ExpectsChildFrame)
         {
             NativeCallTracerCallFrame childFrame = topFrame.Calls[0];
             NativeCallTracerLogEntry expectedInner = ExpectedTransferLog(Recipient, childFrame.To!, InnerValue, 0UL);

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
@@ -23,9 +23,9 @@ namespace Nethermind.Evm.Test.Tracing;
 public class GethLikeCallTracerTests : VirtualMachineTestsBase
 {
     private static readonly JsonSerializerOptions SerializerOptions = new(EthereumJsonSerializer.JsonOptionsIndented) { NewLine = "\n" };
-    private const string? WithLog = """{"withLog":true}""";
-    private const string? OnlyTopCall = """{"onlyTopCall":true}""";
-    private const string? WithLogAndOnlyTopCall = """{"withLog":true,"onlyTopCall":true}""";
+    internal const string? WithLog = """{"withLog":true}""";
+    internal const string? OnlyTopCall = """{"onlyTopCall":true}""";
+    internal const string? WithLogAndOnlyTopCall = """{"withLog":true,"onlyTopCall":true}""";
 
     private string ExecuteCallTrace(byte[] code, string? tracerConfig = null)
     {
@@ -35,7 +35,7 @@ public class GethLikeCallTracerTests : VirtualMachineTestsBase
         return JsonSerializer.Serialize(callTrace.CustomTracerResult?.Value, SerializerOptions);
     }
 
-    private static GethTraceOptions GetGethTraceOptions(string? config) => GethTraceOptions.Default with
+    internal static GethTraceOptions GetGethTraceOptions(string? config) => GethTraceOptions.Default with
     {
         Tracer = NativeCallTracer.CallTracer,
         TracerConfig = config is not null ? JsonSerializer.Deserialize<JsonElement>(config) : null

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -455,7 +455,6 @@ namespace Nethermind.Evm.TransactionProcessing
                 WorldState.AddToBalanceAndCreateIfNotExists(recipient, in hasValueTransfer ? ref value : ref UInt256.Zero, spec);
             }
 
-            // Report frame start before EIP-7708 transfer log so the log attaches to the top-level call frame
             if (isTracingActions)
             {
                 TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in gasAvailable);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -455,18 +455,18 @@ namespace Nethermind.Evm.TransactionProcessing
                 WorldState.AddToBalanceAndCreateIfNotExists(recipient, in hasValueTransfer ? ref value : ref UInt256.Zero, spec);
             }
 
+            // Report frame start before EIP-7708 transfer log so the log attaches to the top-level call frame
+            if (isTracingActions)
+            {
+                TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in gasAvailable);
+            }
+
             JournalCollection<LogEntry>? logs = null;
             if (spec.IsEip7708Enabled && hasValueTransfer && !senderIsRecipient && !newAccountOutOfGas)
             {
                 LogEntry transferLog = TransferLog.CreateTransfer(tx.SenderAddress!, recipient, in value);
                 logs = [transferLog];
                 if (tracer.IsTracingLogs) tracer.ReportLog(transferLog);
-            }
-
-            // Keep tracer event order aligned with VirtualMachine.ExecuteCall.
-            if (isTracingActions)
-            {
-                TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in gasAvailable);
             }
 
             TransactionSubstate substate = new(

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -194,16 +194,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                 {
                     if (!_currentState.IsContinuation)
                     {
-                        if (_currentState.IsTopLevel) // Top frame: report the action first
-                        {
-                            if (_isTracingActionsCached) TraceTransactionActionStart(_currentState);
-                            AddTransferLog(_currentState);
-                        }
-                        else // Nested frame: attach transfer log to the caller frame
-                        {
-                            AddTransferLog(_currentState);
-                            if (_isTracingActionsCached) TraceTransactionActionStart(_currentState);
-                        }
+                        // Report frame start before the EIP-7708 transfer log so it attaches to the frame being entered
+                        if (_isTracingActionsCached) TraceTransactionActionStart(_currentState);
+                        AddTransferLog(_currentState);
                     }
 
                     // Execute the regular EVM call if valid code is present; otherwise, mark as invalid.
@@ -834,8 +827,6 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     /// </returns>
     protected virtual CallResult ExecutePrecompile(VmState<TGasPolicy> currentState, bool isTracingActions, out Exception? failure, out string? substateError)
     {
-        AddTransferLog(currentState);
-
         // Report the precompile action if tracing is enabled.
         if (isTracingActions)
         {
@@ -848,6 +839,8 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                 currentState.ExecutionType,
                 true);
         }
+
+        AddTransferLog(currentState);
 
         // Execute the precompile operation with the current state.
         CallResult callResult = RunPrecompile(currentState);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -194,12 +194,15 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                 {
                     if (!_currentState.IsContinuation)
                     {
-                        AddTransferLog(_currentState);
-
-                        // Start transaction tracing for non-continuation frames if tracing is enabled.
-                        if (_isTracingActionsCached)
+                        if (_currentState.IsTopLevel) // Top frame: report the action first
                         {
-                            TraceTransactionActionStart(_currentState);
+                            if (_isTracingActionsCached) TraceTransactionActionStart(_currentState);
+                            AddTransferLog(_currentState);
+                        }
+                        else // Nested frame: attach transfer log to the caller frame
+                        {
+                            AddTransferLog(_currentState);
+                            if (_isTracingActionsCached) TraceTransactionActionStart(_currentState);
                         }
                     }
 


### PR DESCRIPTION
Fixes the crash in `debug_trace*` calls using `callTracer` with `withLog: true `on value-transferring transactions under EIP-7708, by reporting each call frame before its synthetic transfer log.

Very related @LukaszRozmej's comment: https://github.com/NethermindEth/nethermind/pull/11804#discussion_r3316249151

## Changes

- Reports the frame-entry action before emitting the EIP-7708 transfer log at all three value-transfer sites, so the log attaches to the frame being entered instead of the caller (or an empty stack):
  - `TransactionProcessor.ExecuteSimpleTransfer` - top-level codeless-recipient fast path.
  - `VirtualMachine.ExecuteTransaction` main loop - contract-code targets.
  - `VirtualMachine.ExecutePrecompile` - precompile targets.
- Adds `GethLikeCallTracerEip7708Tests` covering top-level (fast path and EVM), nested CALL to EOA, precompile, and CREATE, plus a `onlyTopCall` case asserting the nested transfer log is not hoisted into the top frame.
- Exposes the shared `WithLog`/`OnlyTopCall`/`WithLogAndOnlyTopCall` constants and `GetGethTraceOptions` helper in `GethLikeCallTracerTests` as `internal` so the new fixture reuses them.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
