### PR TITLE
Align EIP-8037 block inclusion check with counterpart-intrinsic subtraction

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Eip8037BlockGasIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Eip8037BlockGasIntegrationTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm;
+using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
 using Nethermind.Logging;
 using Nethermind.Specs;
@@ -104,8 +105,9 @@ public class Eip8037BlockGasIntegrationTests
     }
 
     /// <summary>
-    /// The inclusion check reserves <c>min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic.state)</c> in the
-    /// regular dimension, so a creation tx whose worst-case contribution fits is accepted.
+    /// For a creation tx <c>intrinsic.state</c> is 0 under Nethermind's top-frame state-gas charging
+    /// model (NEW_ACCOUNT is charged at runtime, not intrinsically), so the regular-dimension
+    /// reservation stays the flat <c>min(TX_MAX_GAS_LIMIT, tx.gas)</c> and an exact fit is accepted.
     /// </summary>
     [Test]
     public void Eip8037_creation_tx_regular_check_actual_usage_modest_accepts()
@@ -139,19 +141,54 @@ public class Eip8037BlockGasIntegrationTests
     public void Eip8037_single_tx_state_check_exceeds_block_limit_rejects()
     {
         ulong blockGasLimit = 16_777_216ul + 100ul; // cap + tiny headroom
+        Transaction onlyTx = Build.A.Transaction.WithHash(TestItem.KeccakA).SignedAndResolved().TestObject;
         // tx.gas = blockGasLimit + intrinsic_regular + 1 -> spec inclusion check rejects on state dim.
-        Transaction onlyTx = Build.A.Transaction.WithHash(TestItem.KeccakA)
-            .WithGasLimit(blockGasLimit + 21_000ul + 1ul).TestObject;
+        ulong intrinsicRegular = EthereumGasPolicy.CalculateIntrinsicGas(onlyTx, Amsterdam.Instance).Standard.Value;
+        onlyTx.GasLimit = blockGasLimit + intrinsicRegular + 1ul;
         (BlockAccessListManager mgr, Block block) = BuildAmsterdamBlock(blockGasLimit, onlyTx);
 
         GasValidationResultSlot[] results = ResultsForCount(1);
         // Simulate execution finishing with modest actual gas (post-execution view).
         // Spec inclusion check rejects before execution even though post-execution gas would fit.
-        results[0].TrySetResult(GasResult(block, 0, 21_000ul, 0ul));
+        results[0].TrySetResult(GasResult(block, 0, intrinsicRegular, 0ul));
 
         Assert.Throws<InvalidBlockException>(() =>
             mgr.IncrementalValidation(block, results, new BlockReceiptsTracer[1], null, CancellationToken.None),
             "EIP-8037 requires rejection at inclusion when tx.gas - intrinsic.regular > state_gas_available");
+    }
+
+    /// <summary>
+    /// Exact state-dimension boundary through the production intrinsic-gas path: with
+    /// <c>tx.gas = state_available + intrinsic.regular (+ delta)</c> the flat reservation rejects,
+    /// while subtracting the actual intrinsic regular gas fits exactly (delta 0) or exceeds by one
+    /// (delta 1). Pins <c>CheckPerTxInclusion</c>'s wiring — passing 0 or swapping the intrinsic
+    /// arguments flips the delta-0 verdict back to a rejection.
+    /// </summary>
+    [TestCase(0ul, true, TestName = "Eip8037_state_dimension_subtracts_intrinsic_regular_exact_fit_accepts")]
+    [TestCase(1ul, false, TestName = "Eip8037_state_dimension_subtracts_intrinsic_regular_exceeded_by_one_rejects")]
+    public void Eip8037_state_dimension_subtracts_intrinsic_regular(ulong delta, bool accepts)
+    {
+        ulong blockGasLimit = Eip7825Constants.DefaultTxGasLimitCap + 100_000ul;
+        Transaction tx = Build.A.Transaction.WithHash(TestItem.KeccakA).SignedAndResolved().TestObject;
+        ulong intrinsicRegular = EthereumGasPolicy.CalculateIntrinsicGas(tx, Amsterdam.Instance).Standard.Value;
+        Assert.That(intrinsicRegular, Is.GreaterThan(0ul), "vacuous if the production intrinsic regular gas is zero");
+        tx.GasLimit = blockGasLimit + intrinsicRegular + delta;
+        (BlockAccessListManager mgr, Block block) = BuildAmsterdamBlock(blockGasLimit, tx);
+
+        GasValidationResultSlot[] results = ResultsForCount(1);
+        results[0].TrySetResult(GasResult(block, 0, intrinsicRegular, 0ul));
+
+        if (accepts)
+        {
+            Assert.DoesNotThrow(() =>
+                mgr.IncrementalValidation(block, results, new BlockReceiptsTracer[1], null, CancellationToken.None));
+        }
+        else
+        {
+            InvalidBlockException? ex = Assert.Throws<InvalidBlockException>(() =>
+                mgr.IncrementalValidation(block, results, new BlockReceiptsTracer[1], null, CancellationToken.None));
+            Assert.That(ex!.Message, Does.Contain("StateDimensionExceeded"));
+        }
     }
 
     /// <summary>
@@ -215,9 +252,10 @@ public class Eip8037BlockGasIntegrationTests
             static worldState => new EthereumCodeInfoRepository(worldState));
 
         ulong blockGasLimit = Eip7825Constants.DefaultTxGasLimitCap + 100ul;
-        Transaction tx = Build.A.Transaction.WithHash(TestItem.KeccakA)
-            .WithGasLimit(blockGasLimit + 21_000ul + 1ul)
-            .TestObject;
+        Transaction tx = Build.A.Transaction.WithHash(TestItem.KeccakA).SignedAndResolved().TestObject;
+        // tx.gas = blockGasLimit + intrinsic_regular + 1 -> spec inclusion check rejects on state dim.
+        ulong intrinsicRegular = EthereumGasPolicy.CalculateIntrinsicGas(tx, Amsterdam.Instance).Standard.Value;
+        tx.GasLimit = blockGasLimit + intrinsicRegular + 1ul;
         Block block = Build.A.Block
             .WithNumber(1ul)
             .WithGasLimit(blockGasLimit)

--- a/src/Nethermind/Nethermind.Blockchain.Test/Eip8037BlockGasIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Eip8037BlockGasIntegrationTests.cs
@@ -104,8 +104,8 @@ public class Eip8037BlockGasIntegrationTests
     }
 
     /// <summary>
-    /// The inclusion check reserves <c>min(TX_MAX_GAS_LIMIT, tx.gas)</c> in the regular dimension
-    /// with no <c>intrinsic.state</c> subtraction, so a creation tx whose full gas fits is accepted.
+    /// The inclusion check reserves <c>min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic.state)</c> in the
+    /// regular dimension, so a creation tx whose worst-case contribution fits is accepted.
     /// </summary>
     [Test]
     public void Eip8037_creation_tx_regular_check_actual_usage_modest_accepts()
@@ -151,7 +151,7 @@ public class Eip8037BlockGasIntegrationTests
 
         Assert.Throws<InvalidBlockException>(() =>
             mgr.IncrementalValidation(block, results, new BlockReceiptsTracer[1], null, CancellationToken.None),
-            "EIP-8037 requires rejection at inclusion when tx.gas > state_gas_available (full reservation, no intrinsic subtraction)");
+            "EIP-8037 requires rejection at inclusion when tx.gas - intrinsic.regular > state_gas_available");
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.Validation.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.Validation.cs
@@ -106,12 +106,12 @@ public partial class BlockAccessListManager
         EthereumGasPolicy intrinsicStandard = intrinsicGas.Standard;
 
         Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
-            block.Header.GasLimit,
-            cumulativeRegular,
-            cumulativeState,
-            tx.GasLimit,
-            intrinsicStandard.Value,
-            (ulong)Math.Max(0, intrinsicStandard.StateReservoir));
+            blockGasLimit: block.Header.GasLimit,
+            cumulativeBlockRegular: cumulativeRegular,
+            cumulativeBlockState: cumulativeState,
+            txGas: tx.GasLimit,
+            intrinsicRegular: intrinsicStandard.Value,
+            intrinsicState: (ulong)Math.Max(0, intrinsicStandard.StateReservoir));
 
         if (outcome != Eip8037BlockGasInclusionCheck.Outcome.Ok)
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.Validation.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.Validation.cs
@@ -100,11 +100,18 @@ public partial class BlockAccessListManager
     {
         if (!spec.IsEip8037Enabled) return;
 
+        // Memoized on the tx keyed by spec + EIP-2780 self-transfer classification; the sender is
+        // already recovered on block validation paths, so this matches the value execution charges.
+        IntrinsicGas<EthereumGasPolicy> intrinsicGas = EthereumGasPolicy.CalculateIntrinsicGas(tx, spec);
+        EthereumGasPolicy intrinsicStandard = intrinsicGas.Standard;
+
         Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
             block.Header.GasLimit,
             cumulativeRegular,
             cumulativeState,
-            tx.GasLimit);
+            tx.GasLimit,
+            intrinsicStandard.Value,
+            (ulong)Math.Max(0, intrinsicStandard.StateReservoir));
 
         if (outcome != Eip8037BlockGasInclusionCheck.Outcome.Ok)
         {

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037BlockGasInclusionCheckTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037BlockGasInclusionCheckTests.cs
@@ -18,7 +18,10 @@ public class Eip8037BlockGasInclusionCheckTests
     private const ulong BaseIntrinsicRegular = 21_000;
     private const ulong CreateIntrinsicRegular = 53_000;
     private const ulong SStoreStateGas = 64 * CostPerStateByte; // GasCostOf.SSetState
+    private const ulong BlockGasLimit60M = 60_000_000;
 
+    // State-dimension boundary: the worst-case state contribution (tx.gas - intrinsic.regular)
+    // fits the remaining state budget exactly (accept) vs exceeds it by one (reject).
     [TestCase(0UL, Eip8037BlockGasInclusionCheck.Outcome.Ok, TestName = "Boundary_state_exact_fit_accepts")]
     [TestCase(1UL, Eip8037BlockGasInclusionCheck.Outcome.StateDimensionExceeded, TestName = "Boundary_state_exceeded_by_one_rejects_on_state_dimension")]
     public void Boundary_state(ulong delta, Eip8037BlockGasInclusionCheck.Outcome expected)
@@ -32,19 +35,20 @@ public class Eip8037BlockGasInclusionCheckTests
         ulong cumS_afterTx1 = tx1State;
 
         ulong stateAvailable = blockGasLimit - cumS_afterTx1;
-        // EIP-8037: the state dimension reserves the full tx.gas (no intrinsic subtraction).
-        ulong tx2Gas = stateAvailable + delta;
+        // EIP-8037: the state dimension reserves tx.gas - intrinsic.regular.
+        ulong tx2Gas = stateAvailable + BaseIntrinsicRegular + delta;
 
         Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
-            blockGasLimit, cumR_afterTx1, cumS_afterTx1, tx2Gas);
+            blockGasLimit, cumR_afterTx1, cumS_afterTx1, tx2Gas, BaseIntrinsicRegular, intrinsicState: 0);
 
         Assert.That(outcome, Is.EqualTo(expected));
     }
 
-    // Regression (spec test creation_tx_regular_check_uses_full_tx_gas): the regular check
-    // reserves FULL tx.gas, rejecting even when tx.gas - intrinsic.state would have fit.
+    // Regression (spec test creation_tx_regular_check_uses_full_tx_gas, now accepts): the regular
+    // check reserves tx.gas - intrinsic.state, so a creation tx whose gas exceeds the remaining
+    // regular budget only by its intrinsic state gas is valid.
     [Test]
-    public void Creation_tx_regular_check_uses_full_tx_gas_rejects()
+    public void Creation_tx_regular_check_subtracts_intrinsic_state_accepts()
     {
         ulong intrinsicState = IntrinsicNewAccountState;
         ulong intrinsicRegular = CreateIntrinsicRegular;
@@ -59,34 +63,36 @@ public class Eip8037BlockGasInclusionCheckTests
         ulong createTxGas = intrinsicTotal;
 
         Assert.That(createTxGas, Is.GreaterThan(remainingRegular),
-            "full tx.gas must exceed remaining regular so the strict check rejects");
+            "full tx.gas must exceed remaining regular so the flat reservation would have rejected");
         Assert.That(createTxGas - intrinsicState, Is.LessThanOrEqualTo(remainingRegular),
-            "a formula subtracting intrinsic.state would have wrongly accepted");
+            "tx.gas - intrinsic.state must fit the remaining regular budget");
 
         Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
-            blockGasLimit, cumR_afterFiller, cumS_afterFiller, createTxGas);
+            blockGasLimit, cumR_afterFiller, cumS_afterFiller, createTxGas, intrinsicRegular, intrinsicState);
 
-        Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.RegularDimensionExceeded));
+        Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.Ok));
     }
 
-    // Single tx whose full gas exceeds the block gas limit in the state dimension -> reject.
+    // Single tx whose worst-case state contribution (tx.gas - intrinsic.regular) exceeds the
+    // block gas limit -> reject on the state dimension.
     [Test]
     public void Single_tx_state_check_exceeds_block_limit_rejects()
     {
         ulong blockGasLimit = Eip7825Constants.DefaultTxGasLimitCap + 100;
-        // One over state_available; regular still fits because of the EIP-7825 cap.
-        ulong txGas = blockGasLimit + 1;
+        // One over state_available after the intrinsic.regular subtraction; regular still fits
+        // because of the EIP-7825 cap.
+        ulong txGas = blockGasLimit + BaseIntrinsicRegular + 1;
 
         Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
-            blockGasLimit, 0, 0, txGas);
+            blockGasLimit, 0, 0, txGas, BaseIntrinsicRegular, intrinsicState: 0);
 
         Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.StateDimensionExceeded));
     }
 
-    // Regression: the state check reserves the FULL tx.gas (no intrinsic.regular subtraction).
-    // Mirrors the spec test creation_tx_state_check_exceeded.
+    // Regression: the state check reserves tx.gas - intrinsic.regular. Mirrors the spec test
+    // creation_tx_state_check_exceeded.
     [Test]
-    public void Creation_tx_state_check_uses_full_tx_gas_rejects_on_state_dimension()
+    public void Creation_tx_state_check_exceeded_rejects_on_state_dimension()
     {
         const int numSstores = 50;
         ulong tx1State = numSstores * SStoreStateGas;
@@ -96,23 +102,24 @@ public class Eip8037BlockGasInclusionCheckTests
         ulong cumS_afterTx1 = tx1State;
         ulong stateAvailable = blockGasLimit - cumS_afterTx1;
 
-        // tx2 (creation): full tx.gas = state_available + 1 -> reject on the state dimension.
-        ulong createTxGas = stateAvailable + 1;
+        // tx2 (creation): tx.gas - intrinsic.regular = state_available + 1 -> reject on the state dimension.
+        ulong createTxGas = stateAvailable + CreateIntrinsicRegular + 1;
 
         // Regular dimension check must pass so rejection is pinned to state.
         ulong regularAvailable = blockGasLimit - cumR_afterTx1;
-        ulong worstCaseRegular = Math.Min(Eip7825Constants.DefaultTxGasLimitCap, createTxGas);
+        ulong worstCaseRegular = Math.Min(Eip7825Constants.DefaultTxGasLimitCap, createTxGas - IntrinsicNewAccountState);
         Assert.That(worstCaseRegular, Is.LessThanOrEqualTo(regularAvailable),
             "regular check must pass so rejection is pinned to state dimension");
 
         Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
-            blockGasLimit, cumR_afterTx1, cumS_afterTx1, createTxGas);
+            blockGasLimit, cumR_afterTx1, cumS_afterTx1, createTxGas, CreateIntrinsicRegular, IntrinsicNewAccountState);
 
         Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.StateDimensionExceeded));
     }
 
-    // EIP-7825 cap: the regular worst-case is clamped to TX_MAX_GAS_LIMIT regardless of tx.gas,
-    // so a huge tx.gas passes the regular dimension but is rejected on the (uncapped) state one.
+    // EIP-7825 cap: the regular worst-case is clamped to TX_MAX_GAS_LIMIT regardless of the
+    // headroom the intrinsic.state subtraction leaves, so a huge tx.gas passes the regular
+    // dimension but is rejected on the (uncapped) state one.
     [Test]
     public void Regular_check_caps_worst_case_at_tx_max_gas_limit()
     {
@@ -121,9 +128,25 @@ public class Eip8037BlockGasInclusionCheckTests
         ulong txGas = Eip7825Constants.DefaultTxGasLimitCap * 10;
 
         Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
-            blockGasLimit, 0, 0, txGas);
+            blockGasLimit, 0, 0, txGas, BaseIntrinsicRegular, IntrinsicNewAccountState);
 
         Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.StateDimensionExceeded));
+    }
+
+    // When intrinsic gas exceeds tx.gas the tx is underfunded and rejected on intrinsic grounds;
+    // the min() clamps floor the subtraction at zero so the 2D check does not reject spuriously.
+    [Test]
+    public void Intrinsic_above_tx_gas_clamps_worst_case_to_zero()
+    {
+        Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
+            blockGasLimit: 30_000_000,
+            cumulativeBlockRegular: 29_999_999,
+            cumulativeBlockState: 29_999_999,
+            txGas: 20_000,
+            intrinsicRegular: 21_000,
+            intrinsicState: 21_000);
+
+        Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.Ok));
     }
 
     [Test]
@@ -133,7 +156,77 @@ public class Eip8037BlockGasInclusionCheckTests
             blockGasLimit: 30_000_000,
             cumulativeBlockRegular: 0,
             cumulativeBlockState: 0,
-            txGas: 21_000);
+            txGas: 21_000,
+            intrinsicRegular: 21_000,
+            intrinsicState: 0);
+
+        Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.Ok));
+    }
+
+    // 60M-block regression scenarios for the counterpart-intrinsic subtraction (EIPs PR 11536).
+
+    // (a) Exact fit under both the flat and the subtracting formulas -> valid.
+    [Test]
+    public void Exact_fit_under_both_formulas_accepts()
+    {
+        const ulong available = 1_000_000;
+        // Zero intrinsic gas: both formulas reserve the full tx.gas in each dimension.
+        const ulong txGas = available;
+
+        Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
+            BlockGasLimit60M, BlockGasLimit60M - available, BlockGasLimit60M - available,
+            txGas, intrinsicRegular: 0, intrinsicState: 0);
+
+        Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.Ok));
+    }
+
+    // (b) tx.gas one over the remaining regular budget. The state-side subtraction still fits,
+    // pinning the rejection to the regular dimension.
+    [Test]
+    public void Tx_gas_one_over_regular_budget_rejects_on_regular_dimension()
+    {
+        const ulong regularAvailable = 1_000_000;
+        const ulong txGas = regularAvailable + 1;
+
+        Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
+            BlockGasLimit60M, BlockGasLimit60M - regularAvailable, cumulativeBlockState: 0,
+            txGas, BaseIntrinsicRegular, intrinsicState: 0);
+
+        Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.RegularDimensionExceeded));
+    }
+
+    // (c) tx.gas exceeds the remaining regular budget by exactly intrinsic.state. The flat
+    // reservation rejected; subtracting the counterpart intrinsic fits exactly -> valid.
+    [Test]
+    public void Tx_gas_exceeding_regular_budget_by_intrinsic_state_accepts()
+    {
+        const ulong regularAvailable = 1_000_000;
+        const ulong txGas = regularAvailable + IntrinsicNewAccountState;
+
+        Assert.That(Math.Min(Eip7825Constants.DefaultTxGasLimitCap, txGas), Is.GreaterThan(regularAvailable),
+            "flat reservation must exceed the budget so the old rule rejected");
+
+        Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
+            BlockGasLimit60M, BlockGasLimit60M - regularAvailable, cumulativeBlockState: 0,
+            txGas, CreateIntrinsicRegular, IntrinsicNewAccountState);
+
+        Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.Ok));
+    }
+
+    // State-dimension counterpart of (c): tx.gas exceeds the remaining state budget by exactly
+    // intrinsic.regular -> valid under the new rule (was invalid under flat).
+    [Test]
+    public void Tx_gas_exceeding_state_budget_by_intrinsic_regular_accepts()
+    {
+        const ulong stateAvailable = 1_000_000;
+        const ulong txGas = stateAvailable + BaseIntrinsicRegular;
+
+        Assert.That(txGas, Is.GreaterThan(stateAvailable),
+            "flat reservation must exceed the budget so the old rule rejected");
+
+        Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
+            BlockGasLimit60M, cumulativeBlockRegular: 0, BlockGasLimit60M - stateAvailable,
+            txGas, BaseIntrinsicRegular, intrinsicState: 0);
 
         Assert.That(outcome, Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.Ok));
     }

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/Eip8037BlockGasInclusionCheck.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/Eip8037BlockGasInclusionCheck.cs
@@ -8,8 +8,9 @@ using Nethermind.Core.Extensions;
 namespace Nethermind.Evm.GasPolicy;
 
 // EIP-8037 per-tx 2D block-gas inclusion check.
-// Both regular and state dimensions must independently fit in the remaining per-dim block
-// budget at inclusion time. Block-end validation still enforces max(R, S) <= gas_limit.
+// Each dimension's worst-case contribution must fit in the remaining per-dim block budget at
+// inclusion time, subtracting the counterpart dimension's intrinsic gas. Block-end validation
+// still enforces max(R, S) <= gas_limit.
 public static class Eip8037BlockGasInclusionCheck
 {
     public enum Outcome { Ok, RegularDimensionExceeded, StateDimensionExceeded }
@@ -18,7 +19,9 @@ public static class Eip8037BlockGasInclusionCheck
         ulong blockGasLimit,
         ulong cumulativeBlockRegular,
         ulong cumulativeBlockState,
-        ulong txGas)
+        ulong txGas,
+        ulong intrinsicRegular,
+        ulong intrinsicState)
     {
         // A cumulative dimension that already exceeded the block limit must reject — silent saturation
         // would otherwise let the worst-case check pass and admit a tx that block-end validation rejects.
@@ -28,13 +31,17 @@ public static class Eip8037BlockGasInclusionCheck
         ulong regularAvailable = blockGasLimit - cumulativeBlockRegular;
         ulong stateAvailable = blockGasLimit - cumulativeBlockState;
 
-        // EIP-8037: reserve the full gas limit in each dimension (no intrinsic subtraction). Only the
-        // regular dimension is bounded by the EIP-7825 per-tx cap; state work can exceed it via the reservoir.
-        ulong worstCaseRegular = Math.Min(Eip7825Constants.DefaultTxGasLimitCap, txGas);
+        // EIP-8037: reserve tx.gas minus the counterpart dimension's intrinsic gas. The min() clamps
+        // floor the subtraction at zero when intrinsic exceeds tx.gas — such a tx is underfunded and
+        // rejected on intrinsic grounds, so the 2D check must not spuriously reject on saturation.
+        // Only the regular dimension is bounded by the EIP-7825 per-tx cap; state work can exceed it
+        // via the reservoir.
+        ulong worstCaseRegular = Math.Min(Eip7825Constants.DefaultTxGasLimitCap, txGas - Math.Min(txGas, intrinsicState));
         if (worstCaseRegular > regularAvailable)
             return Outcome.RegularDimensionExceeded;
 
-        if (txGas > stateAvailable)
+        ulong worstCaseState = txGas - Math.Min(txGas, intrinsicRegular);
+        if (worstCaseState > stateAvailable)
             return Outcome.StateDimensionExceeded;
 
         return Outcome.Ok;

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/Eip8037BlockGasInclusionCheck.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/Eip8037BlockGasInclusionCheck.cs
@@ -15,6 +15,16 @@ public static class Eip8037BlockGasInclusionCheck
 {
     public enum Outcome { Ok, RegularDimensionExceeded, StateDimensionExceeded }
 
+    /// <summary>
+    /// Validates that a transaction's worst-case per-dimension gas contribution fits in the
+    /// remaining block budget at inclusion time.
+    /// </summary>
+    /// <param name="blockGasLimit">Block gas limit bounding each dimension.</param>
+    /// <param name="cumulativeBlockRegular">Cumulative regular gas of all previously included txs.</param>
+    /// <param name="cumulativeBlockState">Cumulative state gas of all previously included txs.</param>
+    /// <param name="txGas">The candidate transaction's gas limit.</param>
+    /// <param name="intrinsicRegular">Intrinsic regular gas of the tx; subtracted from the state-dimension reservation.</param>
+    /// <param name="intrinsicState">Intrinsic state gas of the tx; subtracted from the regular-dimension reservation (cross-wired by design).</param>
     public static Outcome Validate(
         ulong blockGasLimit,
         ulong cumulativeBlockRegular,


### PR DESCRIPTION
## Changes

- Align the EIP-8037 per-tx 2D block-gas inclusion check with the counterpart-intrinsic subtraction rule implemented by geth, besu, and ethrex ([EIPs PR 11536](https://github.com/ethereum/EIPs/pull/11536) wording, execution-specs PR 2703). Each dimension now reserves `tx.gas` minus the counterpart dimension's intrinsic gas: `min(TX_MAX_GAS_LIMIT, tx.gas - min(tx.gas, intrinsic_state))` in the regular dimension and `tx.gas - min(tx.gas, intrinsic_regular)` in the state dimension, replacing the flat full-`tx.gas` reservation. The `min()` clamps floor the subtraction at zero when intrinsic gas exceeds `tx.gas`; such txs are underfunded and rejected on intrinsic grounds, so the 2D check must not reject them spuriously.
- `Eip8037BlockGasInclusionCheck.Validate` now takes the per-tx intrinsic gas (regular + state) as parameters. `BlockAccessListManager.CheckPerTxInclusion` obtains it through the existing intrinsic-gas path (`EthereumGasPolicy.CalculateIntrinsicGas`), memoized on the transaction keyed by spec + EIP-2780 self-transfer classification, so it matches the value execution charges (senders are already recovered on block validation paths).
- This intentionally diverges from the EELS `devnets/glamsterdam/7` branch formula (flat reservation), per the cross-client audit decision to align Nethermind with geth/besu/ethrex.
- Updated `Eip8037BlockGasInclusionCheckTests` to the new semantics and added 60M-block regression scenarios: exact fit under both formulas (valid), `tx.gas = regular_available + 1` (rejected on the regular dimension), `tx.gas = regular_available + intrinsic_state` (valid under the new rule, rejected under the flat one), the state-dimension counterparts, and the intrinsic-above-`tx.gas` clamp.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `Eip8037BlockGasInclusionCheckTests` updated to the subtraction semantics plus new boundary/regression cases (Nethermind.Evm.Test, 195/195 passed together with the other Eip8037/Eip8246 suites).
- `Eip8037BlockGasIntegrationTests` and the `BlockAccessList*` validation suites pass unchanged (18/18 and 25/25 in Nethermind.Blockchain.Test); TransactionProcessor gas-related tests pass (24/24).
- Release builds of Nethermind.Evm.Test, Nethermind.Blockchain.Test, and Nethermind.Consensus.Test (and their dependencies) succeed with `-warnaserror`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

EIP-8037 (Amsterdam devnet): the per-transaction 2D block-inclusion check now subtracts the counterpart dimension's intrinsic gas from each dimension's reservation, aligning Nethermind with geth, besu, and ethrex and intentionally diverging from the EELS `devnets/glamsterdam/7` formula.

## Remarks

- The block production picker (`BlockProductionTransactionPicker`) is intentionally left unchanged: it stays stricter (full `tx.gas` against the remaining `max(R, S)` budget), which always yields blocks that satisfy the validation rule but may underfill them. Aligning it needs per-dimension cumulative accumulators on the production path — left for a follow-up.
- Under the current intrinsic calculator the intrinsic state component is zero (state costs are charged at runtime, matching the devnet-7 execution model), so the regular-dimension reservation is unchanged in practice; the check now matches the reference clients' formula structurally, and the state dimension subtracts intrinsic regular gas.
