### PR TITLE
Prevent negative pacing delay in random Kademlia discovery

### DIFF
--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -107,12 +107,6 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
                 }
 
                 if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace($"Found {count} nodes from random Kademlia lookup.");
-
-                TimeSpan elapsed = iterationTime.Elapsed;
-                if (elapsed < MinimumIterationDuration)
-                {
-                    await Task.Delay(MinimumIterationDuration - elapsed, token);
-                }
             }
             catch (OperationCanceledException) when (token.IsCancellationRequested)
             {
@@ -121,6 +115,19 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Random Kademlia discovery lookup failed.");
+            }
+
+            TimeSpan elapsed = iterationTime.Elapsed;
+            if (elapsed < MinimumIterationDuration)
+            {
+                try
+                {
+                    await Task.Delay(MinimumIterationDuration - elapsed, token);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    break;
+                }
             }
         }
     }

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -108,9 +108,10 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
 
                 if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace($"Found {count} nodes from random Kademlia lookup.");
 
-                if (iterationTime.Elapsed < MinimumIterationDuration)
+                TimeSpan elapsed = iterationTime.Elapsed;
+                if (elapsed < MinimumIterationDuration)
                 {
-                    await Task.Delay(MinimumIterationDuration - iterationTime.Elapsed, token);
+                    await Task.Delay(MinimumIterationDuration - elapsed, token);
                 }
             }
             catch (OperationCanceledException) when (token.IsCancellationRequested)

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -69,12 +69,12 @@ public class RandomWalkKademliaDiscoveryTests
             new KademliaConfig<int> { CurrentNodeId = 0 });
 
         Stopwatch stopwatch = Stopwatch.StartNew();
-        List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(2).ToListAsync(token);
+        List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(3).ToListAsync(token);
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(nodes, Is.EqualTo(new[] { 1, 2 }));
-            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2.5)));
+            Assert.That(nodes, Is.EqualTo(new[] { 1, 2, 1 }));
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2.7)));
         }
     }
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Kademlia;
@@ -34,6 +36,48 @@ public class RandomWalkKademliaDiscoveryTests
         }
     }
 
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_pace_iterations_to_minimum_iteration_duration(CancellationToken token)
+    {
+        TestKademlia kademlia = new();
+        RandomWalkKademliaDiscovery<int, int, int> discovery = new(
+            kademlia,
+            IntKeyOperator.Instance,
+            Int32KademliaDistance.Instance,
+            new KademliaConfig<int> { CurrentNodeId = 0 });
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(4).ToListAsync(token);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(nodes, Is.EqualTo(new[] { 1, 2, 1, 2 }));
+            Assert.That(stopwatch.Elapsed, Is.GreaterThanOrEqualTo(TimeSpan.FromMilliseconds(950)));
+        }
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_not_delay_when_lookup_exceeds_minimum_iteration_duration(CancellationToken token)
+    {
+        TestKademlia kademlia = new() { LookupDelay = TimeSpan.FromMilliseconds(1100) };
+        RandomWalkKademliaDiscovery<int, int, int> discovery = new(
+            kademlia,
+            IntKeyOperator.Instance,
+            Int32KademliaDistance.Instance,
+            new KademliaConfig<int> { CurrentNodeId = 0 });
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(2).ToListAsync(token);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(nodes, Is.EqualTo(new[] { 1, 2 }));
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)));
+        }
+    }
+
     private sealed class TestKademlia : IKademlia<int, int>
     {
         public event EventHandler<int>? OnNodeAdded { add { } remove { } }
@@ -41,6 +85,7 @@ public class RandomWalkKademliaDiscoveryTests
 
         public int LookupNodesCalls { get; private set; }
         public int? LastMaxResults { get; private set; }
+        public TimeSpan LookupDelay { get; set; }
 
         public void AddOrRefresh(int node) => throw new NotSupportedException();
 
@@ -56,7 +101,7 @@ public class RandomWalkKademliaDiscoveryTests
         {
             LookupNodesCalls++;
             LastMaxResults = maxResults;
-            return CreateAsyncEnumerable(1, 2);
+            return CreateAsyncEnumerable(LookupDelay, token, 1, 2);
         }
 
         public int[] GetKNeighbour(int target, int excluding = 0, bool excludeSelf = false) => throw new NotSupportedException();
@@ -77,8 +122,12 @@ public class RandomWalkKademliaDiscoveryTests
         public int CreateRandomKeyAtDistance(int nodePrefix, int depth) => depth;
     }
 
-    private static async IAsyncEnumerable<T> CreateAsyncEnumerable<T>(params IEnumerable<T> items)
+    private static async IAsyncEnumerable<T> CreateAsyncEnumerable<T>(TimeSpan delay, [EnumeratorCancellation] CancellationToken token, params IEnumerable<T> items)
     {
+        if (delay > TimeSpan.Zero)
+        {
+            await Task.Delay(delay, token);
+        }
         foreach (T item in items)
         {
             await Task.Yield();

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -74,7 +74,7 @@ public class RandomWalkKademliaDiscoveryTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(nodes, Is.EqualTo(new[] { 1, 2 }));
-            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)));
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2.5)));
         }
     }
 


### PR DESCRIPTION
## Changes

- Fix `ArgumentOutOfRangeException` from `Task.Delay` in `RandomWalkKademliaDiscovery.RunDiscoveryJob`: `iterationTime.Elapsed` was read once for the `< MinimumIterationDuration` check and again to compute the pacing delay, so time passing between the two reads could produce a negative delay. The exception was swallowed by the generic catch and surfaced in node logs as `Random Kademlia discovery lookup failed`. `Elapsed` is now captured once and reused for both the check and the delay.
- Move the pacing delay out of the `try` so failed iterations are paced too — previously a persistently failing lookup retried with no delay (tight spin + log spam).
- Add tests covering the pacing behavior: fast lookups are paced out to the minimum iteration duration, and a lookup exceeding the minimum is not delayed.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

The double-read race is not deterministically reproducible in a unit test — it requires `Elapsed` to cross the 1s boundary between two reads microseconds apart, which would need a `TimeProvider` seam we chose not to add for this fix. The new tests pin the surrounding pacing contract (a regression that drops or misapplies the delay fails them), not the race itself.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No