### PR TITLE
ci: bump gnosis Flat sync-validation timeout to 6h

### DIFF
--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -99,7 +99,7 @@ jobs:
                     + $run_id + "-master-" + $config.network
                   ),
                   timeout: (
-                    if $config.network == "mainnet" and $mode == "Flat" then 360
+                    if $mode == "Flat" and ($config.network == "mainnet" or $config.network == "gnosis") then 360
                     else $config.timeout end
                   )
                 }]')


### PR DESCRIPTION
## Changes

- Bump the `Sync gnosis (Flat)` job timeout in the Sync Master Validation workflow from 3h to 6h (360 min), matching the existing `mainnet` Flat override.
- Gnosis Flat sync was hitting the 180-min cap (killed at 3h0m32s in [run 30341007054](https://github.com/NethermindEth/nethermind/actions/runs/30341007054)). Flat DB sync is slower than HalfPath, so it needs the same 6h budget already granted to mainnet Flat.
- Implemented by extending the existing per-mode `timeout` override in the matrix `jq` expression rather than editing `testnet-matrix.json`, so only the Flat mode is affected. Gnosis HalfPath stays at 3h (it passed at 2h15m).

## Types of changes

#### What types of changes does your code introduce?

- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Verified the `jq` matrix expression locally produces: gnosis Flat = 360, gnosis HalfPath = 180, mainnet Flat/HalfPath = 360.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
