### PR TITLE
Fix rpc-compat testing_buildBlockV1 gas limit

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/TestingRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/TestingRpcModuleTests.cs
@@ -67,6 +67,49 @@ public class TestingRpcModuleTests
     }
 
     [Test]
+    public async Task Build_block_uses_deterministic_testing_gas_limit()
+    {
+        (TestingRpcModule module, Hash256 parentHash, BlockHeader parentHeader) = CreateBuildTestingModule();
+
+        ResultWrapper<object> result = await module.testing_buildBlockV1(
+            parentHash, CreateDefaultPayloadAttributes(parentHeader), [], []);
+
+        Assert.That(result.Result.ResultType, Is.EqualTo(ResultType.Success));
+        GetPayloadV5Result payloadResult = (GetPayloadV5Result)result.Data!;
+        ulong expectedGasLimit = parentHeader.GasLimit + parentHeader.GasLimit / Osaka.Instance.GasLimitBoundDivisor - 1;
+        Assert.That(payloadResult.ExecutionPayload.GasLimit, Is.EqualTo(expectedGasLimit));
+    }
+
+    [Test]
+    public async Task Build_block_uses_deterministic_testing_gas_limit_when_parent_is_above_target()
+    {
+        (TestingRpcModule module, Hash256 parentHash, BlockHeader parentHeader) = CreateBuildTestingModule();
+        parentHeader.GasLimit = 200_000_000;
+
+        ResultWrapper<object> result = await module.testing_buildBlockV1(
+            parentHash, CreateDefaultPayloadAttributes(parentHeader), [], []);
+
+        Assert.That(result.Result.ResultType, Is.EqualTo(ResultType.Success));
+        GetPayloadV5Result payloadResult = (GetPayloadV5Result)result.Data!;
+        Assert.That(payloadResult.ExecutionPayload.GasLimit, Is.EqualTo(199_804_689));
+    }
+
+    [Test]
+    public async Task Build_block_preserves_explicit_target_gas_limit()
+    {
+        (TestingRpcModule module, Hash256 parentHash, BlockHeader parentHeader) = CreateBuildTestingModule();
+        parentHeader.GasLimit = 50_000_000;
+        PayloadAttributes payloadAttributes = CreateDefaultPayloadAttributes(parentHeader);
+        payloadAttributes.TargetGasLimit = 42_000_000;
+
+        ResultWrapper<object> result = await module.testing_buildBlockV1(parentHash, payloadAttributes, [], []);
+
+        Assert.That(result.Result.ResultType, Is.EqualTo(ResultType.Success));
+        GetPayloadV5Result payloadResult = (GetPayloadV5Result)result.Data!;
+        Assert.That(payloadResult.ExecutionPayload.GasLimit, Is.EqualTo(49_951_173));
+    }
+
+    [Test]
     public async Task Json_rpc_accepts_omitted_extraData()
     {
         (TestingRpcModule module, Hash256 parentHash, BlockHeader parentHeader) = CreateBuildTestingModule();
@@ -352,9 +395,6 @@ public class TestingRpcModuleTests
         ISpecProvider specProvider = Substitute.For<ISpecProvider>();
         specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec ?? Osaka.Instance);
 
-        IGasLimitCalculator gasLimitCalculator = Substitute.For<IGasLimitCalculator>();
-        gasLimitCalculator.GetGasLimit(Arg.Any<BlockHeader>(), Arg.Any<ulong?>()).Returns(parentHeader.GasLimit);
-
         IBlockchainProcessor blockchainProcessor = CreateBlockProcessor(processOverride, onProcess, onProcessWithOptions);
 
         IBlockProducerEnv blockProducerEnv = Substitute.For<IBlockProducerEnv>();
@@ -372,7 +412,7 @@ public class TestingRpcModuleTests
         IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
         IBlockTree tree = blockTree ?? Substitute.For<IBlockTree>();
 
-        TestingRpcModule module = new(blockProducerEnvFactory, mainStateBlockProducerEnvFactory, gasLimitCalculator, specProvider, blockFinder, tree, Substitute.For<IProcessExitSource>(), LimboLogs.Instance);
+        TestingRpcModule module = new(blockProducerEnvFactory, mainStateBlockProducerEnvFactory, specProvider, blockFinder, tree, Substitute.For<IProcessExitSource>(), LimboLogs.Instance);
         _disposables.Add(module);
         return (module, tree, blockFinder, parentHeader);
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/TestingRpcModule.cs
@@ -32,7 +32,6 @@ namespace Nethermind.Merge.Plugin;
 public class TestingRpcModule(
     IBlockProducerEnvFactory blockProducerEnvFactory,
     IMainStateBlockProducerEnvFactory mainStateBlockProducerEnvFactory,
-    IGasLimitCalculator gasLimitCalculator,
     ISpecProvider specProvider,
     IBlockFinder blockFinder,
     IBlockTree blockTree,
@@ -40,13 +39,33 @@ public class TestingRpcModule(
     ILogManager logManager)
     : ITestingRpcModule, IDisposable
 {
+    // Keep testing_buildBlockV1 deterministic across client configurations. This target matches
+    // the execution-spec-tests fixture generator; explicit payload targetGasLimit still overrides it.
+    internal const ulong DefaultTestingGasLimit = 60_000_000;
+
     private readonly ILogger _logger = logManager.GetClassLogger<TestingRpcModule>();
     private readonly SemaphoreSlim _commitLock = new(1, 1);
+    private readonly IGasLimitCalculator _testingGasLimitCalculator = new TargetAdjustedGasLimitCalculator(
+        specProvider, new BlocksConfig { TargetBlockGasLimit = DefaultTestingGasLimit });
 
     // The commit pass updates the head without re-processing, so it must run on the main
     // world state to persist the produced post-state. Reuse across calls is safe because
     // BranchProcessor.Process opens a fresh world-state scope on entry.
     private readonly IBlockProducerEnv _commitEnv = mainStateBlockProducerEnvFactory.CreatePersistent();
+
+    public TestingRpcModule(
+        IBlockProducerEnvFactory blockProducerEnvFactory,
+        IMainStateBlockProducerEnvFactory mainStateBlockProducerEnvFactory,
+        IGasLimitCalculator gasLimitCalculator,
+        ISpecProvider specProvider,
+        IBlockFinder blockFinder,
+        IBlockTree blockTree,
+        IProcessExitSource processExitSource,
+        ILogManager logManager)
+        : this(blockProducerEnvFactory, mainStateBlockProducerEnvFactory, specProvider, blockFinder,
+            blockTree, processExitSource, logManager)
+    {
+    }
 
     public void Dispose() => _commitLock.Dispose();
 
@@ -194,7 +213,7 @@ public class TestingRpcModule(
             blockAuthor,
             UInt256.Zero,
             parent.Number + 1,
-            payloadAttributes.GetGasLimit(parent, gasLimitCalculator),
+            payloadAttributes.GetGasLimit(parent, _testingGasLimitCalculator),
             payloadAttributes.Timestamp,
             extraData ?? [])
         {


### PR DESCRIPTION
## Scope

Fixes the exact Ethereum Hive rpc-compat failure:

- dashboard test #231: `testing_buildBlockV1/build-block-with-transactions (nethermind_default)`
- report: https://hive.ethpandaops.io/#/test/generic/1785052336-dfbc4227e5c3acf7849a53aa954e7c74?testnumber=231

The testing RPC previously inherited the node configured target gas limit. For the published fixture parent (`200,000,000`), this returned the unchanged parent gas limit instead of the deterministic fixture adjustment toward `60,000,000`, which also changed the block hash.

This change gives `testing_buildBlockV1` its deterministic fixture gas-limit calculator while preserving explicit payload `targetGasLimit` overrides and the existing constructor shape.

## Validation

- `TestingRpcModuleTests`: 17/17 passed
- fresh `nethermind:local`: `1.40.0-unstable+7aa4f777`
- exact Hive #231 test only, `--sim.parallelism=1`: 3/3 isolated runs passed
- each generated Hive JSON contains the exact named case with `pass=true`
- each Hive run exited 0 with `failed=0`
- blocker/high review: no blocker/high issues found
- `git diff --check`: passed

The related dashboard test #228 is not used as this PR acceptance gate and remains a separate follow-up candidate.