### PR TITLE
skip outbound filter

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/RlpxHostIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/RlpxHostIntegrationTests.cs
@@ -21,20 +21,18 @@ namespace Nethermind.Network.Test;
 [TestFixture]
 public class RlpxHostIntegrationTests
 {
-    [TestCase(true, false, null, "203.0.113.1", "203.0.113.1", false, Description = "Exact match: blocks same IP")]
-    [TestCase(true, false, null, "203.0.113.1", "198.51.100.1", true, Description = "Exact match: allows different IP")]
-    [TestCase(true, true, null, "203.0.113.1", "203.0.113.50", false, Description = "Subnet bucketing: blocks same subnet")]
-    [TestCase(false, false, null, "203.0.113.1", "203.0.113.1", true, Description = "Filtering disabled: always accepts")]
-    [TestCase(true, true, "192.168.1.100", "192.168.1.10", "192.168.1.20", true, Description = "Same local subnet uses exact matching")]
-    [TestCase(true, true, "203.0.113.100", "192.168.1.1", "192.168.1.2", true, Description = "Private remote IP uses exact matching")]
-    public async Task ShouldContact_FiltersCorrectly(bool filterEnabled, bool subnetBucketing, string? externalIp,
-        string addr1, string addr2, bool secondExpected)
+    [TestCase(true, false, null, "203.0.113.1", "203.0.113.1", Description = "Exact match config: repeat IP still accepted")]
+    [TestCase(true, true, null, "203.0.113.1", "203.0.113.50", Description = "Subnet bucketing config: repeat subnet still accepted")]
+    [TestCase(false, false, null, "203.0.113.1", "203.0.113.1", Description = "Filtering disabled: still accepted")]
+    public async Task ShouldContact_IsNeverRateLimitedByTheRecentIpFilter(bool filterEnabled, bool subnetBucketing, string? externalIp,
+        string addr1, string addr2)
     {
         RlpxHost host = CreateHost(filterEnabled, subnetBucketing, externalIp);
         try
         {
-            Assert.That(host.ShouldContact(IPAddress.Parse(addr1)), Is.True, "first IP should be accepted");
-            Assert.That(host.ShouldContact(IPAddress.Parse(addr2)), Is.EqualTo(secondExpected));
+            Assert.That(host.ShouldContact(IPAddress.Parse(addr1)), Is.True, "first attempt accepted");
+            Assert.That(host.ShouldContact(IPAddress.Parse(addr2)), Is.True,
+                "a repeat contact attempt must not be rejected: the recent-IP filter only gates inbound connections");
         }
         finally
         {
@@ -43,8 +41,11 @@ public class RlpxHostIntegrationTests
     }
 
     [Test]
-    public async Task TrackSessionActivity_RefreshesFilterOnReceivedAndDeliveredMessages()
+    public async Task TrackSessionActivity_DoesNotAffectShouldContact()
     {
+        // Regression guard: TrackSessionActivity feeds the same NodeFilter that ShouldRejectInbound consults for
+        // inbound connections. ShouldContact must stay independent of it, otherwise contacting (or receiving
+        // traffic from) a peer ourselves could make us reject that peer's own genuine inbound connection shortly after.
         RlpxHost host = CreateHost(filterEnabled: true, subnetBucketing: true);
         try
         {
@@ -55,7 +56,7 @@ public class RlpxHostIntegrationTests
             host.TrackSessionActivity(receivedSession);
             receivedSession.MsgReceived += Raise.EventWith(receivedSession, new PeerEventArgs(receivedSession.Node, "eth", 1, 32));
 
-            Assert.That(host.ShouldContact(receivedIp), Is.False, "received traffic should keep the active session filtered");
+            Assert.That(host.ShouldContact(receivedIp), Is.True, "received traffic must not block our own future outbound attempts");
 
             IPAddress deliveredIp = IPAddress.Parse("198.51.100.1");
             ISession deliveredSession = Substitute.For<ISession>();
@@ -64,7 +65,7 @@ public class RlpxHostIntegrationTests
             host.TrackSessionActivity(deliveredSession);
             deliveredSession.MsgDelivered += Raise.EventWith(deliveredSession, new PeerEventArgs(deliveredSession.Node, "eth", 2, 64));
 
-            Assert.That(host.ShouldContact(deliveredIp), Is.False, "sent traffic should keep the active session filtered");
+            Assert.That(host.ShouldContact(deliveredIp), Is.True, "sent traffic must not block our own future outbound attempts");
         }
         finally
         {
@@ -72,28 +73,7 @@ public class RlpxHostIntegrationTests
         }
     }
 
-    [Test]
-    public async Task ShouldContact_AlwaysAcceptsPrivilegedIp()
-    {
-        IPAddress privilegedIp = IPAddress.Parse("203.0.113.1");
-        IPrivilegedIpProvider privilegedIpProvider = Substitute.For<IPrivilegedIpProvider>();
-        privilegedIpProvider.IsPrivileged(privilegedIp).Returns(true);
-
-        // Exact-match filtering would otherwise block the second attempt from the same IP.
-        RlpxHost host = CreateHost(filterEnabled: true, subnetBucketing: false, privilegedIpProvider: privilegedIpProvider);
-        try
-        {
-            Assert.That(host.ShouldContact(privilegedIp), Is.True, "first attempt accepted");
-            Assert.That(host.ShouldContact(privilegedIp), Is.True, "privileged IP is never rate-limited");
-        }
-        finally
-        {
-            await host.Shutdown();
-        }
-    }
-
-    private static RlpxHost CreateHost(bool filterEnabled, bool subnetBucketing, string? externalIp = null,
-        IPrivilegedIpProvider? privilegedIpProvider = null)
+    private static RlpxHost CreateHost(bool filterEnabled, bool subnetBucketing, string? externalIp = null)
     {
         NetworkConfig networkConfig = new()
         {
@@ -116,7 +96,7 @@ public class RlpxHostIntegrationTests
             NullDisconnectsAnalyzer.Instance,
             networkConfig,
             ipResolver,
-            privilegedIpProvider ?? Substitute.For<IPrivilegedIpProvider>(),
+            Substitute.For<IPrivilegedIpProvider>(),
             LimboLogs.Instance);
     }
 

--- a/src/Nethermind/Nethermind.Network/Rlpx/IRlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/IRlpxHost.cs
@@ -26,18 +26,17 @@ namespace Nethermind.Network.Rlpx
         int LocalPort { get; }
 
         /// <summary>
-        /// Determines whether the host should attempt to contact a node at the specified IP address
-        /// and records the evaluation in the underlying contact filter.
-        /// Calling this method may update internal state and affect the outcome of future
-        /// <see cref="ShouldContact(System.Net.IPAddress, bool)"/> calls for the same or other addresses.
+        /// Determines whether the host should attempt to contact a node at the specified IP address.
         /// </summary>
-        /// <param name="ip">The IP address of the remote node to evaluate and record.</param>
+        /// <remarks>
+        /// The recent-IP filter that throttles unsolicited inbound connections is not applied here: a node we
+        /// choose to contact ourselves is never rate-limited by it, and this call does not feed that filter's
+        /// state either, so contacting a peer cannot cause a later inbound connection from it to be rejected.
+        /// </remarks>
+        /// <param name="ip">The IP address of the remote node to evaluate.</param>
         /// <param name="exactOnly">When <see langword="true"/>, only match the exact IP address (bypass subnet bucketing).
         /// Used for static peers and boot nodes that must always be reachable but should not reconnect to the same IP.</param>
-        /// <returns>
-        /// <see langword="true"/> if the host should attempt to contact the node and the attempt is
-        /// accepted by the internal filter; otherwise, <see langword="false"/>.
-        /// </returns>
+        /// <returns><see langword="true"/> if the host should attempt to contact the node.</returns>
         bool ShouldContact(IPAddress ip, bool exactOnly = false);
 
         event EventHandler<SessionEventArgs> SessionCreated;

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -110,9 +110,10 @@ namespace Nethermind.Network.Rlpx
             _nodeFilter = NodeFilter.Create(networkConfig.MaxActivePeers, networkConfig.FilterPeersByRecentIp, networkConfig.FilterPeersBySameSubnet, ips.ExternalIp);
         }
 
-        // Privileged addresses (static and trusted nodes) bypass the recent-IP filter so they can always connect.
-        public bool ShouldContact(IPAddress ip, bool exactOnly = false)
-            => _privilegedIpProvider.IsPrivileged(ip) || _nodeFilter.TryAccept(ip, exactOnly);
+        // The recent-IP filter only gates inbound connections (see ShouldRejectInbound): consulting it here too
+        // would let our own outbound dial to a peer mark that peer's IP as "recently seen", which could then
+        // cause us to reject that same peer's genuine inbound connection shortly after.
+        public bool ShouldContact(IPAddress ip, bool exactOnly = false) => true;
 
         public async Task Init()
         {
@@ -262,7 +263,7 @@ namespace Nethermind.Network.Rlpx
 
         /// <summary>
         /// Rejects inbound connections from IPs already seen within the filter window.
-        /// Outgoing connections are filtered earlier by <see cref="ShouldContact"/> before <see cref="ConnectAsync"/>.
+        /// Outgoing connections initiated by <see cref="ConnectAsync"/> are never filtered this way; see <see cref="ShouldContact"/>.
         /// </summary>
         private bool ShouldRejectInbound(ISession session, IChannel channel)
         {


### PR DESCRIPTION
## Changes

- `RlpxHost.ShouldContact` now always returns `true` instead of consulting the recent-IP `_nodeFilter` (privileged IPs still bypass via `_privilegedIpProvider`, but that check is now moot since the filter path is gone).
- The recent-IP filter is only meant to throttle unsolicited **inbound** connections (`ShouldRejectInbound`). Previously, `ShouldContact` fed the same filter that inbound checks consult, so dialing a peer ourselves (or `TrackSessionActivity` recording sent/received traffic) could mark that peer's IP as "recently seen" and cause a genuine inbound reconnect from it to be rejected shortly after.
- This prevented a stalemate on small networks: when all nodes start up and dial each other at roughly the same time, each node's own outgoing attempt touches the filter, so the peer's incoming connection to it gets rejected as a duplicate — while that same peer, on the receiving side, does the same thing back. Both sides end up blocking each other's legitimate connection, and the network fails to form.
- Updated `IRlpxHost.ShouldContact` XML docs to describe the new behavior instead of the old filter-recording semantics.
- Updated `RlpxHostIntegrationTests` to assert that repeated outbound contact attempts and prior session activity never cause `ShouldContact` to reject an IP, and removed the now-inapplicable privileged-IP rate-limiting test.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Updated `RlpxHostIntegrationTests` to cover the corrected behavior: `ShouldContact_IsNeverRateLimitedByTheRecentIpFilter` and `TrackSessionActivity_DoesNotAffectShouldContact` assert that outbound contact is never blocked by the recent-IP filter, regardless of filter config or prior session activity.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No
