### PR TITLE
Validate ABI decode allocation bounds

### DIFF
--- a/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
+++ b/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
@@ -579,26 +579,30 @@ public class AbiTests
         Assert.Throws<AbiException>(() => new AbiEncoder().Decode(AbiEncodingStyle.None, abi, data));
     }
 
-    [TestCase(1_000_000)]
-    [TestCase(int.MaxValue)]
-    public void Should_reject_dynamic_bytes_length_before_allocating(int declaredLength)
+    [TestCaseSource(nameof(DynamicBytesAllocationCases))]
+    public void Should_reject_dynamic_bytes_length_before_allocating(
+        AbiEncodingStyle encodingStyle,
+        AbiType type,
+        UInt256 declaredLength,
+        int allocationLimit)
     {
-        AbiSignature signature = new("f", AbiType.DynamicBytes);
+        AbiSignature signature = new("f", type);
         byte[] data = DynamicValueWithMissingPayload(declaredLength);
 
         long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
-        Assert.Throws<AbiException>(() => _abiEncoder.Decode(AbiEncodingStyle.None, signature, data));
+        Assert.Throws<AbiException>(() => _abiEncoder.Decode(encodingStyle, signature, data));
         long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
 
-        Assert.That(allocatedBytes, Is.LessThan(declaredLength));
+        Assert.That(allocatedBytes, Is.LessThan(allocationLimit));
     }
 
     [TestCaseSource(nameof(DynamicArrayAllocationCases))]
     public void Should_reject_dynamic_array_length_before_allocating(
         AbiEncodingStyle encodingStyle,
         AbiType elementType,
-        int declaredLength,
-        int trailingDataLength)
+        UInt256 declaredLength,
+        int trailingDataLength,
+        int allocationLimit)
     {
         AbiSignature signature = new("f", new AbiArray(elementType));
         byte[] data = DynamicValueWithMissingPayload(declaredLength, trailingDataLength);
@@ -607,7 +611,42 @@ public class AbiTests
         Assert.Throws<AbiException>(() => _abiEncoder.Decode(encodingStyle, signature, data));
         long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
 
-        Assert.That(allocatedBytes, Is.LessThan(declaredLength));
+        Assert.That(allocatedBytes, Is.LessThan(allocationLimit));
+    }
+
+    [Test]
+    public void Should_bound_cumulative_nested_array_allocations()
+    {
+        const int outerLength = 128;
+        const int innerLength = 128;
+        AbiSignature signature = new("f", new AbiArray(new AbiArray(AbiType.UInt256)));
+        byte[] data = NestedArrayWithAliasedOffsets(outerLength, innerLength);
+
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Throws<AbiException>(() => _abiEncoder.Decode(AbiEncodingStyle.None, signature, data));
+        long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.That(allocatedBytes, Is.LessThan(1_000_000));
+    }
+
+    [Test]
+    public void Should_reject_fixed_array_length_before_allocating()
+    {
+        AbiFixedLengthArray type = new(AbiType.Bool, 10_000_000);
+
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Throws<AbiException>(() => type.Decode(new byte[32], 0, false));
+        long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.That(allocatedBytes, Is.LessThan(1_000_000));
+    }
+
+    [Test]
+    public void Should_wrap_oversized_composite_head()
+    {
+        AbiSignature signature = new("f", new AbiFixedLengthArray(AbiType.UInt256, int.MaxValue));
+
+        Assert.Throws<AbiException>(() => _abiEncoder.Decode(AbiEncodingStyle.None, signature, []));
     }
 
     [TestCase(AbiEncodingStyle.None)]
@@ -623,15 +662,15 @@ public class AbiTests
         Assert.That(decoded[0], Is.EqualTo(value));
     }
 
-    [TestCase(AbiEncodingStyle.None, false)]
-    [TestCase(AbiEncodingStyle.None, true)]
-    [TestCase(AbiEncodingStyle.Packed, false)]
-    [TestCase(AbiEncodingStyle.Packed, true)]
-    public void Empty_tuple_array_roundtrips(AbiEncodingStyle encodingStyle, bool fixedLength)
+    [TestCase(AbiEncodingStyle.None, false, 16_384)]
+    [TestCase(AbiEncodingStyle.None, true, 2)]
+    [TestCase(AbiEncodingStyle.Packed, false, 65)]
+    [TestCase(AbiEncodingStyle.Packed, true, 2)]
+    public void Empty_tuple_array_roundtrips(AbiEncodingStyle encodingStyle, bool fixedLength, int length)
     {
         AbiTuple elementType = new();
-        AbiType arrayType = fixedLength ? new AbiFixedLengthArray(elementType, 2) : new AbiArray(elementType);
-        ValueTuple[] value = [new(), new()];
+        AbiType arrayType = fixedLength ? new AbiFixedLengthArray(elementType, length) : new AbiArray(elementType);
+        ValueTuple[] value = new ValueTuple[length];
         AbiSignature signature = new("f", arrayType);
 
         byte[] encoded = _abiEncoder.Encode(encodingStyle, signature, value);
@@ -649,7 +688,7 @@ public class AbiTests
         Assert.Throws<AbiException>(() => _abiEncoder.Decode(encodingStyle, signature, []));
     }
 
-    private static byte[] DynamicValueWithMissingPayload(int declaredLength, int trailingDataLength = 0)
+    private static byte[] DynamicValueWithMissingPayload(UInt256 declaredLength, int trailingDataLength = 0)
     {
         byte[] data = new byte[64 + trailingDataLength];
         AbiType.UInt256.Encode(32, false).CopyTo(data, 0);
@@ -657,22 +696,63 @@ public class AbiTests
         return data;
     }
 
+    private static byte[] NestedArrayWithAliasedOffsets(int outerLength, int innerLength)
+    {
+        int innerDataPosition = 64 + outerLength * 32;
+        byte[] data = new byte[innerDataPosition + 32 + innerLength * 32];
+        AbiType.UInt256.Encode(32, false).CopyTo(data, 0);
+        AbiType.UInt256.Encode(outerLength, false).CopyTo(data, 32);
+        byte[] innerOffset = AbiType.UInt256.Encode(outerLength * 32, false);
+        for (int i = 0; i < outerLength; i++)
+        {
+            innerOffset.CopyTo(data, 64 + i * 32);
+        }
+
+        AbiType.UInt256.Encode(innerLength, false).CopyTo(data, innerDataPosition);
+        return data;
+    }
+
+    private static IEnumerable<TestCaseData> DynamicBytesAllocationCases()
+    {
+        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.DynamicBytes, (UInt256)1_000_000, 1_000_000)
+            .SetName("Should_reject_dynamic_bytes_length_before_allocating_standard");
+        yield return new TestCaseData(AbiEncodingStyle.Packed, AbiType.DynamicBytes, (UInt256)1_000_000, 1_000_000)
+            .SetName("Should_reject_dynamic_bytes_length_before_allocating_packed");
+        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.String, (UInt256)1_000_000, 1_000_000)
+            .SetName("Should_reject_dynamic_string_length_before_allocating_standard");
+        yield return new TestCaseData(AbiEncodingStyle.Packed, AbiType.String, (UInt256)1_000_000, 1_000_000)
+            .SetName("Should_reject_dynamic_string_length_before_allocating_packed");
+        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.DynamicBytes, (UInt256)int.MaxValue, 1_000_000)
+            .SetName("Should_reject_dynamic_bytes_max_int_length_before_allocating");
+        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.DynamicBytes, UInt256.MaxValue, 1_000_000)
+            .SetName("Should_reject_dynamic_bytes_uint256_max_length_before_allocating");
+    }
+
     private static IEnumerable<TestCaseData> DynamicArrayAllocationCases()
     {
-        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.Bool, 1_000_000, 0)
+        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.Bool, (UInt256)1_000_000, 0, 1_000_000)
             .SetName("Should_reject_dynamic_array_length_before_allocating_standard_bool");
-        yield return new TestCaseData(AbiEncodingStyle.None, new AbiFixedLengthArray(AbiType.UInt256, 2), 10_000, 320_000)
+        yield return new TestCaseData(AbiEncodingStyle.None, new AbiFixedLengthArray(AbiType.UInt256, 2), (UInt256)10_000, 320_000, 10_000)
             .SetName("Should_reject_dynamic_array_length_before_allocating_standard_composite");
-        yield return new TestCaseData(AbiEncodingStyle.Packed, AbiType.UInt256, 100_000, 100_000)
+        yield return new TestCaseData(AbiEncodingStyle.Packed, AbiType.UInt256, (UInt256)100_000, 100_000, 100_000)
             .SetName("Should_reject_dynamic_array_length_before_allocating_packed_uint256");
-        yield return new TestCaseData(AbiEncodingStyle.Packed, new AbiFixed(8, 1), 100_000, 100_000)
+        yield return new TestCaseData(AbiEncodingStyle.Packed, new AbiFixed(8, 1), (UInt256)100_000, 100_000, 100_000)
             .SetName("Should_reject_dynamic_array_length_before_allocating_packed_fixed");
-        yield return new TestCaseData(AbiEncodingStyle.Packed, new AbiUFixed(8, 1), 100_000, 100_000)
+        yield return new TestCaseData(AbiEncodingStyle.Packed, new AbiUFixed(8, 1), (UInt256)100_000, 100_000, 100_000)
             .SetName("Should_reject_dynamic_array_length_before_allocating_packed_ufixed");
-        yield return new TestCaseData(AbiEncodingStyle.None, new AbiTuple(), 1_000_000, 0)
+        yield return new TestCaseData(AbiEncodingStyle.None, new AbiTuple(), (UInt256)16_385, 0, 1_000_000)
             .SetName("Should_reject_dynamic_array_length_before_allocating_empty_tuple");
-        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.Bool, int.MaxValue, 0)
+        yield return new TestCaseData(
+                AbiEncodingStyle.None,
+                new AbiFixedLengthArray(new AbiTuple(), 16_384),
+                (UInt256)16_384,
+                0,
+                1_000_000)
+            .SetName("Should_bound_nested_zero_width_array_allocations");
+        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.Bool, (UInt256)int.MaxValue, 0, 1_000_000)
             .SetName("Should_reject_dynamic_array_length_before_allocating_max_length");
+        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.Bool, UInt256.MaxValue, 0, 1_000_000)
+            .SetName("Should_reject_dynamic_array_length_before_allocating_uint256_max_length");
     }
 
     private class UserOperationAbi

--- a/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
+++ b/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
@@ -579,6 +579,102 @@ public class AbiTests
         Assert.Throws<AbiException>(() => new AbiEncoder().Decode(AbiEncodingStyle.None, abi, data));
     }
 
+    [TestCase(1_000_000)]
+    [TestCase(int.MaxValue)]
+    public void Should_reject_dynamic_bytes_length_before_allocating(int declaredLength)
+    {
+        AbiSignature signature = new("f", AbiType.DynamicBytes);
+        byte[] data = DynamicValueWithMissingPayload(declaredLength);
+
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Throws<AbiException>(() => _abiEncoder.Decode(AbiEncodingStyle.None, signature, data));
+        long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.That(allocatedBytes, Is.LessThan(declaredLength));
+    }
+
+    [TestCaseSource(nameof(DynamicArrayAllocationCases))]
+    public void Should_reject_dynamic_array_length_before_allocating(
+        AbiEncodingStyle encodingStyle,
+        AbiType elementType,
+        int declaredLength,
+        int trailingDataLength)
+    {
+        AbiSignature signature = new("f", new AbiArray(elementType));
+        byte[] data = DynamicValueWithMissingPayload(declaredLength, trailingDataLength);
+
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Throws<AbiException>(() => _abiEncoder.Decode(encodingStyle, signature, data));
+        long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.That(allocatedBytes, Is.LessThan(declaredLength));
+    }
+
+    [TestCase(AbiEncodingStyle.None)]
+    [TestCase(AbiEncodingStyle.Packed)]
+    public void Empty_tuple_roundtrips(AbiEncodingStyle encodingStyle)
+    {
+        AbiSignature signature = new("f", new AbiTuple());
+        ValueTuple value = new();
+
+        byte[] encoded = _abiEncoder.Encode(encodingStyle, signature, value);
+        object[] decoded = _abiEncoder.Decode(encodingStyle, signature, encoded);
+
+        Assert.That(decoded[0], Is.EqualTo(value));
+    }
+
+    [TestCase(AbiEncodingStyle.None, false)]
+    [TestCase(AbiEncodingStyle.None, true)]
+    [TestCase(AbiEncodingStyle.Packed, false)]
+    [TestCase(AbiEncodingStyle.Packed, true)]
+    public void Empty_tuple_array_roundtrips(AbiEncodingStyle encodingStyle, bool fixedLength)
+    {
+        AbiTuple elementType = new();
+        AbiType arrayType = fixedLength ? new AbiFixedLengthArray(elementType, 2) : new AbiArray(elementType);
+        ValueTuple[] value = [new(), new()];
+        AbiSignature signature = new("f", arrayType);
+
+        byte[] encoded = _abiEncoder.Encode(encodingStyle, signature, value);
+        object[] decoded = _abiEncoder.Decode(encodingStyle, signature, encoded);
+
+        Assert.That(decoded[0], Is.EqualTo(value));
+    }
+
+    [TestCase(AbiEncodingStyle.None)]
+    [TestCase(AbiEncodingStyle.IncludeSignature)]
+    public void Should_wrap_out_of_range_decode_error(AbiEncodingStyle encodingStyle)
+    {
+        AbiSignature signature = new("f", AbiType.Bool);
+
+        Assert.Throws<AbiException>(() => _abiEncoder.Decode(encodingStyle, signature, []));
+    }
+
+    private static byte[] DynamicValueWithMissingPayload(int declaredLength, int trailingDataLength = 0)
+    {
+        byte[] data = new byte[64 + trailingDataLength];
+        AbiType.UInt256.Encode(32, false).CopyTo(data, 0);
+        AbiType.UInt256.Encode(declaredLength, false).CopyTo(data, 32);
+        return data;
+    }
+
+    private static IEnumerable<TestCaseData> DynamicArrayAllocationCases()
+    {
+        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.Bool, 1_000_000, 0)
+            .SetName("Should_reject_dynamic_array_length_before_allocating_standard_bool");
+        yield return new TestCaseData(AbiEncodingStyle.None, new AbiFixedLengthArray(AbiType.UInt256, 2), 10_000, 320_000)
+            .SetName("Should_reject_dynamic_array_length_before_allocating_standard_composite");
+        yield return new TestCaseData(AbiEncodingStyle.Packed, AbiType.UInt256, 100_000, 100_000)
+            .SetName("Should_reject_dynamic_array_length_before_allocating_packed_uint256");
+        yield return new TestCaseData(AbiEncodingStyle.Packed, new AbiFixed(8, 1), 100_000, 100_000)
+            .SetName("Should_reject_dynamic_array_length_before_allocating_packed_fixed");
+        yield return new TestCaseData(AbiEncodingStyle.Packed, new AbiUFixed(8, 1), 100_000, 100_000)
+            .SetName("Should_reject_dynamic_array_length_before_allocating_packed_ufixed");
+        yield return new TestCaseData(AbiEncodingStyle.None, new AbiTuple(), 1_000_000, 0)
+            .SetName("Should_reject_dynamic_array_length_before_allocating_empty_tuple");
+        yield return new TestCaseData(AbiEncodingStyle.None, AbiType.Bool, int.MaxValue, 0)
+            .SetName("Should_reject_dynamic_array_length_before_allocating_max_length");
+    }
+
     private class UserOperationAbi
     {
         public Address Target { get; set; }

--- a/src/Nethermind/Nethermind.Abi/AbiArray.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiArray.cs
@@ -32,7 +32,22 @@ public class AbiArray : AbiType
     public override (object, int) Decode(byte[] data, int position, bool packed)
     {
         (UInt256 length, position) = UInt256.DecodeUInt(data, position, packed);
-        return DecodeSequence(ElementType.CSharpType, (int)length, ElementTypes, data, packed, position);
+        int sequenceLength = (int)length;
+        int elementHeadSize = GetElementHeadSize(ElementType, packed);
+        int allocationBoundElementSize = Math.Max(elementHeadSize, 1);
+
+        if ((uint)position > (uint)data.Length)
+        {
+            throw new AbiException($"Insufficient data to decode ABI array of {sequenceLength} elements at position {position}");
+        }
+
+        int allocationBoundDataLength = elementHeadSize == 0 ? data.Length : data.Length - position;
+        if ((ulong)(uint)sequenceLength * (uint)allocationBoundElementSize > (uint)allocationBoundDataLength)
+        {
+            throw new AbiException($"Insufficient data to decode ABI array of {sequenceLength} elements at position {position}");
+        }
+
+        return DecodeSequence(ElementType.CSharpType, sequenceLength, ElementTypes, data, packed, position);
     }
 
     public override byte[] Encode(object? arg, bool packed)
@@ -72,5 +87,44 @@ public class AbiArray : AbiType
         {
             yield return ElementType;
         }
+    }
+
+    private static int GetElementHeadSize(AbiType type, bool packed)
+    {
+        if (type.IsDynamic)
+        {
+            return PaddingSize;
+        }
+
+        if (type.ComponentTypes is { } componentTypes)
+        {
+            int tupleHeadSize = 0;
+            for (int i = 0; i < componentTypes.Count; i++)
+            {
+                tupleHeadSize = checked(tupleHeadSize + GetElementHeadSize(componentTypes[i], packed));
+            }
+
+            return tupleHeadSize;
+        }
+
+        if (type is AbiFixedLengthArray array)
+        {
+            return checked(array.Length * GetElementHeadSize(array.ElementType, packed));
+        }
+
+        if (!packed)
+        {
+            return PaddingSize;
+        }
+
+        return type switch
+        {
+            AbiBytes bytes => bytes.Length,
+            AbiInt abiInt => abiInt.LengthInBytes,
+            AbiUInt abiUInt => abiUInt.LengthInBytes,
+            AbiFixed => PaddingSize,
+            AbiUFixed => PaddingSize,
+            _ => 1,
+        };
     }
 }

--- a/src/Nethermind/Nethermind.Abi/AbiArray.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiArray.cs
@@ -31,20 +31,30 @@ public class AbiArray : AbiType
 
     public override (object, int) Decode(byte[] data, int position, bool packed)
     {
+        using DecodeBudgetScope decodeBudget = EnterDecodeBudget(data.Length);
         (UInt256 length, position) = UInt256.DecodeUInt(data, position, packed);
-        int sequenceLength = (int)length;
-        int elementHeadSize = GetElementHeadSize(ElementType, packed);
-        int allocationBoundElementSize = Math.Max(elementHeadSize, 1);
-
-        if ((uint)position > (uint)data.Length)
+        if (length > (UInt256)int.MaxValue)
         {
-            throw new AbiException($"Insufficient data to decode ABI array of {sequenceLength} elements at position {position}");
+            throw new AbiException($"ABI array length {length} exceeds the supported maximum");
         }
 
-        int allocationBoundDataLength = elementHeadSize == 0 ? data.Length : data.Length - position;
-        if ((ulong)(uint)sequenceLength * (uint)allocationBoundElementSize > (uint)allocationBoundDataLength)
+        int sequenceLength = (int)length;
+        int elementHeadSize = ElementType.GetHeadSize(packed);
+        if (elementHeadSize is 0)
         {
-            throw new AbiException($"Insufficient data to decode ABI array of {sequenceLength} elements at position {position}");
+            ConsumeZeroWidthElementBudget(sequenceLength, ElementType);
+        }
+        else
+        {
+            int remainingDataLength = data.Length - position;
+            ulong allocationSize = (ulong)(uint)sequenceLength * (uint)elementHeadSize;
+            if (allocationSize > (uint)remainingDataLength)
+            {
+                throw new AbiException(
+                    $"ABI array of {sequenceLength} {ElementType} elements requires an allocation bound of {allocationSize} bytes, but only {remainingDataLength} bytes are available");
+            }
+
+            ConsumeDecodeBudget(allocationSize, ElementType);
         }
 
         return DecodeSequence(ElementType.CSharpType, sequenceLength, ElementTypes, data, packed, position);
@@ -87,44 +97,5 @@ public class AbiArray : AbiType
         {
             yield return ElementType;
         }
-    }
-
-    private static int GetElementHeadSize(AbiType type, bool packed)
-    {
-        if (type.IsDynamic)
-        {
-            return PaddingSize;
-        }
-
-        if (type.ComponentTypes is { } componentTypes)
-        {
-            int tupleHeadSize = 0;
-            for (int i = 0; i < componentTypes.Count; i++)
-            {
-                tupleHeadSize = checked(tupleHeadSize + GetElementHeadSize(componentTypes[i], packed));
-            }
-
-            return tupleHeadSize;
-        }
-
-        if (type is AbiFixedLengthArray array)
-        {
-            return checked(array.Length * GetElementHeadSize(array.ElementType, packed));
-        }
-
-        if (!packed)
-        {
-            return PaddingSize;
-        }
-
-        return type switch
-        {
-            AbiBytes bytes => bytes.Length,
-            AbiInt abiInt => abiInt.LengthInBytes,
-            AbiUInt abiUInt => abiUInt.LengthInBytes,
-            AbiFixed => PaddingSize,
-            AbiUFixed => PaddingSize,
-            _ => 1,
-        };
     }
 }

--- a/src/Nethermind/Nethermind.Abi/AbiBytes.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiBytes.cs
@@ -30,6 +30,8 @@ namespace Nethermind.Abi
 
         public override string Name { get; }
 
+        internal override int GetHeadSize(bool packed) => packed ? Length : PaddingSize;
+
         public override (object, int) Decode(byte[] data, int position, bool packed) =>
             (data.Slice(position, Length), position + (packed ? Length : MaxLength));
 

--- a/src/Nethermind/Nethermind.Abi/AbiDynamicBytes.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiDynamicBytes.cs
@@ -27,9 +27,23 @@ namespace Nethermind.Abi
 
         public override (object, int) Decode(byte[] data, int position, bool packed)
         {
+            using DecodeBudgetScope decodeBudget = EnterDecodeBudget(data.Length);
             (UInt256 length, int currentPosition) = UInt256.DecodeUInt(data, position, packed);
-            int paddingSize = packed ? (int)length : GetPaddingSize((int)length);
-            return (data.Slice(currentPosition, (int)length), currentPosition + paddingSize);
+            int remainingDataLength = data.Length - currentPosition;
+            if (length > (UInt256)remainingDataLength)
+            {
+                throw new AbiException($"Insufficient data to decode ABI {Name} of length {length} at position {currentPosition}");
+            }
+
+            int valueLength = (int)length;
+            int encodedLength = packed ? valueLength : GetPaddingSize(valueLength);
+            if (encodedLength > remainingDataLength)
+            {
+                throw new AbiException($"Insufficient data to decode padded ABI {Name} of length {length} at position {currentPosition}");
+            }
+
+            ConsumeDecodeBudget((uint)valueLength, this);
+            return (data.Slice(currentPosition, valueLength), currentPosition + encodedLength);
         }
 
         public override byte[] Encode(object? arg, bool packed)
@@ -56,7 +70,7 @@ namespace Nethermind.Abi
         private static int GetPaddingSize(int length)
         {
             int remainder = length % PaddingSize;
-            int paddingSize = length + (remainder == 0 ? 0 : (PaddingSize - remainder));
+            int paddingSize = checked(length + (remainder == 0 ? 0 : (PaddingSize - remainder)));
             return paddingSize;
         }
     }

--- a/src/Nethermind/Nethermind.Abi/AbiEncoder.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiEncoder.cs
@@ -46,6 +46,11 @@ namespace Nethermind.Abi
             int sigOffset = includeSig ? 4 : 0;
             if (includeSig)
             {
+                if (data.Length < sigOffset)
+                {
+                    throw new AbiException($"Insufficient data to decode ABI signature for {signature}");
+                }
+
                 if (!Bytes.AreEqual(AbiSignature.GetAddress(data), signature.Address))
                 {
                     throw new AbiException($"Signature in encoded ABI data is not consistent with {signature}");

--- a/src/Nethermind/Nethermind.Abi/AbiEncoder.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiEncoder.cs
@@ -44,6 +44,7 @@ namespace Nethermind.Abi
             bool packed = (encodingStyle & AbiEncodingStyle.Packed) == AbiEncodingStyle.Packed;
             bool includeSig = encodingStyle == AbiEncodingStyle.IncludeSignature;
             int sigOffset = includeSig ? 4 : 0;
+            using AbiType.DecodeBudgetScope decodeBudget = AbiType.EnterDecodeBudget(data.Length);
             if (includeSig)
             {
                 if (data.Length < sigOffset)
@@ -57,6 +58,7 @@ namespace Nethermind.Abi
                 }
             }
 
+            AbiType.ConsumeDecodeBudget((uint)AbiType.GetSequenceHeadSize(signature.Types, packed), null);
             (object[] arguments, int position) = AbiType.DecodeSequence(signature.Types.Length, signature.Types, data, packed, sigOffset);
 
             if (position != data.Length)

--- a/src/Nethermind/Nethermind.Abi/AbiFixed.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiFixed.cs
@@ -38,6 +38,8 @@ namespace Nethermind.Abi
         public int Length { get; }
         public int Precision { get; }
 
+        internal override int GetHeadSize(bool packed) => Int256.GetHeadSize(packed);
+
         public override (object, int) Decode(byte[] data, int position, bool packed)
         {
             (BigInteger nominator, int newPosition) = Int256.DecodeInt(data, position, packed);

--- a/src/Nethermind/Nethermind.Abi/AbiFixedLengthArray.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiFixedLengthArray.cs
@@ -30,10 +30,42 @@ namespace Nethermind.Abi
 
         public int Length { get; }
 
+        internal override int GetHeadSize(bool packed) =>
+            IsDynamic ? PaddingSize : GetRepeatedHeadSize(Length, ElementType.GetHeadSize(packed));
+
         public override string Name { get; }
 
-        public override (object, int) Decode(byte[] data, int position, bool packed) =>
-            DecodeSequence(ElementType.CSharpType, Length, ElementTypes, data, packed, position);
+        public override (object, int) Decode(byte[] data, int position, bool packed)
+        {
+            using DecodeBudgetScope decodeBudget = EnterDecodeBudget(data.Length);
+            int elementHeadSize = ElementType.GetHeadSize(packed);
+            if (elementHeadSize is 0)
+            {
+                ConsumeZeroWidthElementBudget(Length, ElementType);
+            }
+            else
+            {
+                if ((uint)position > (uint)data.Length)
+                {
+                    throw new AbiException($"Insufficient data to decode ABI {Name} at position {position}");
+                }
+
+                int remainingDataLength = data.Length - position;
+                ulong headSize = (ulong)(uint)Length * (uint)elementHeadSize;
+                if (headSize > (uint)remainingDataLength)
+                {
+                    throw new AbiException(
+                        $"ABI {Name} requires a head of {headSize} bytes, but only {remainingDataLength} bytes are available");
+                }
+
+                if (IsDynamic)
+                {
+                    ConsumeDecodeBudget(headSize, this);
+                }
+            }
+
+            return DecodeSequence(ElementType.CSharpType, Length, ElementTypes, data, packed, position);
+        }
 
         public override byte[] Encode(object? arg, bool packed)
         {

--- a/src/Nethermind/Nethermind.Abi/AbiInt.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiInt.cs
@@ -37,6 +37,8 @@ namespace Nethermind.Abi
 
         public override string Name { get; }
 
+        internal override int GetHeadSize(bool packed) => packed ? LengthInBytes : PaddingSize;
+
         public override (object, int) Decode(byte[] data, int position, bool packed)
         {
             (BigInteger value, int length) = DecodeInt(data, position, packed);

--- a/src/Nethermind/Nethermind.Abi/AbiTuple.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiTuple.cs
@@ -39,10 +39,17 @@ namespace Nethermind.Abi
 
         public override bool IsDynamic { get; }
 
-        internal override IReadOnlyList<AbiType> ComponentTypes => _elements;
+        internal override int GetHeadSize(bool packed) =>
+            IsDynamic ? PaddingSize : GetSequenceHeadSize(_elements, packed);
 
         public override (object, int) Decode(byte[] data, int position, bool packed)
         {
+            using DecodeBudgetScope decodeBudget = EnterDecodeBudget(data.Length);
+            if (IsDynamic)
+            {
+                ConsumeDecodeBudget((uint)GetSequenceHeadSize(_elements, packed), this);
+            }
+
             (object[] arguments, int movedPosition) = DecodeSequence(_elements.Length, _elements, data, packed, position);
             return (Activator.CreateInstance(CSharpType, arguments), movedPosition)!;
         }
@@ -95,7 +102,8 @@ namespace Nethermind.Abi
         public override string Name { get; }
         public override bool IsDynamic { get; }
 
-        internal override IReadOnlyList<AbiType> ComponentTypes => _elements;
+        internal override int GetHeadSize(bool packed) =>
+            IsDynamic ? PaddingSize : GetSequenceHeadSize(_elements, packed);
 
         public AbiTuple()
         {
@@ -107,6 +115,12 @@ namespace Nethermind.Abi
 
         public override (object, int) Decode(byte[] data, int position, bool packed)
         {
+            using DecodeBudgetScope decodeBudget = EnterDecodeBudget(data.Length);
+            if (IsDynamic)
+            {
+                ConsumeDecodeBudget((uint)GetSequenceHeadSize(_elements, packed), this);
+            }
+
             (object[] arguments, int movedPosition) = DecodeSequence(_elements.Length, _elements, data, packed, position);
 
             object item = new T();

--- a/src/Nethermind/Nethermind.Abi/AbiTuple.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiTuple.cs
@@ -39,6 +39,8 @@ namespace Nethermind.Abi
 
         public override bool IsDynamic { get; }
 
+        internal override IReadOnlyList<AbiType> ComponentTypes => _elements;
+
         public override (object, int) Decode(byte[] data, int position, bool packed)
         {
             (object[] arguments, int movedPosition) = DecodeSequence(_elements.Length, _elements, data, packed, position);
@@ -92,6 +94,8 @@ namespace Nethermind.Abi
         private readonly AbiType[] _elements;
         public override string Name { get; }
         public override bool IsDynamic { get; }
+
+        internal override IReadOnlyList<AbiType> ComponentTypes => _elements;
 
         public AbiTuple()
         {

--- a/src/Nethermind/Nethermind.Abi/AbiType.Sequence.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiType.Sequence.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Threading;
 using Nethermind.Int256;
 
 namespace Nethermind.Abi
@@ -11,6 +12,105 @@ namespace Nethermind.Abi
     public partial class AbiType
     {
         protected const int PaddingSize = 32;
+        // ABI zero-tuples have no encoded width, so their decoded count needs an explicit non-input-derived limit.
+        private const int MaxZeroWidthElementsPerDecode = 16 * 1024;
+        // Canonical dynamic bodies occupy distinct input regions. Charging those regions cumulatively bounds aliased tails.
+        private static readonly AsyncLocal<DecodeBudget?> CurrentDecodeBudget = new();
+
+        internal readonly struct DecodeBudgetScope : IDisposable
+        {
+            private readonly bool _ownsBudget;
+
+            public DecodeBudgetScope(int encodedLength)
+            {
+                _ownsBudget = CurrentDecodeBudget.Value is null;
+                if (_ownsBudget)
+                {
+                    CurrentDecodeBudget.Value = new DecodeBudget(encodedLength);
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_ownsBudget)
+                {
+                    CurrentDecodeBudget.Value = null;
+                }
+            }
+        }
+
+        private sealed class DecodeBudget(int encodedLength)
+        {
+            public ulong RemainingEncodedBytes { get; set; } = (uint)encodedLength;
+            public int RemainingZeroWidthElements { get; set; } = MaxZeroWidthElementsPerDecode;
+        }
+
+        internal static DecodeBudgetScope EnterDecodeBudget(int encodedLength) => new(encodedLength);
+
+        internal static void ConsumeDecodeBudget(ulong encodedBytes, AbiType? type)
+        {
+            DecodeBudget? budget = CurrentDecodeBudget.Value;
+            if (budget is null)
+            {
+                return;
+            }
+
+            if (encodedBytes > budget.RemainingEncodedBytes)
+            {
+                string subject = type is null ? "ABI arguments" : type.ToString();
+                throw new AbiException(
+                    $"ABI decode allocation bound exceeded while decoding {subject}: {encodedBytes} bytes requested with {budget.RemainingEncodedBytes} bytes remaining");
+            }
+
+            budget.RemainingEncodedBytes -= encodedBytes;
+        }
+
+        internal static void ConsumeZeroWidthElementBudget(int elementCount, AbiType type)
+        {
+            DecodeBudget? budget = CurrentDecodeBudget.Value;
+            if (budget is null)
+            {
+                return;
+            }
+
+            if (elementCount > budget.RemainingZeroWidthElements)
+            {
+                throw new AbiException(
+                    $"ABI decode exceeds the supported maximum of {MaxZeroWidthElementsPerDecode} zero-width elements while decoding {type}");
+            }
+
+            budget.RemainingZeroWidthElements -= elementCount;
+        }
+
+        internal static int GetSequenceHeadSize(IReadOnlyList<AbiType> types, bool packed)
+        {
+            try
+            {
+                int headSize = 0;
+                for (int i = 0; i < types.Count; i++)
+                {
+                    headSize = checked(headSize + types[i].GetHeadSize(packed));
+                }
+
+                return headSize;
+            }
+            catch (OverflowException e)
+            {
+                throw new AbiException("ABI sequence head size exceeds the supported maximum", e);
+            }
+        }
+
+        internal static int GetRepeatedHeadSize(int length, int elementHeadSize)
+        {
+            try
+            {
+                return checked(length * elementHeadSize);
+            }
+            catch (OverflowException e)
+            {
+                throw new AbiException("ABI array head size exceeds the supported maximum", e);
+            }
+        }
 
         internal static byte[][] EncodeSequence(int length, IEnumerable<AbiType> types, IEnumerable<object?> sequence, bool packed, int offset = 0)
         {
@@ -77,6 +177,7 @@ namespace Nethermind.Abi
 
         public static (object[], int) DecodeSequence(int length, IEnumerable<AbiType> types, byte[] data, bool packed, int startPosition)
         {
+            using DecodeBudgetScope decodeBudget = EnterDecodeBudget(data.Length);
             (Array array, int position) = DecodeSequence(typeof(object), length, types, data, packed, startPosition);
             return ((object[])array, position);
         }

--- a/src/Nethermind/Nethermind.Abi/AbiType.Sequence.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiType.Sequence.cs
@@ -109,7 +109,7 @@ namespace Nethermind.Abi
 
                     sequence.SetValue(item, i);
                 }
-                catch (Exception e) when (e is OverflowException or ArgumentException)
+                catch (Exception e) when (e is OverflowException or ArgumentException or IndexOutOfRangeException)
                 {
                     throw new AbiException($"Failed to decode ABI sequence at element {i} for type {type}", e);
                 }

--- a/src/Nethermind/Nethermind.Abi/AbiType.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiType.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Text.Json;
 using Nethermind.Blockchain.Contracts.Json;
@@ -35,6 +36,8 @@ namespace Nethermind.Abi
         public static AbiUFixed UFixed { get; } = new(128, 18);
 
         public virtual bool IsDynamic => false;
+
+        internal virtual IReadOnlyList<AbiType>? ComponentTypes => null;
 
         public abstract string Name { get; }
 

--- a/src/Nethermind/Nethermind.Abi/AbiType.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiType.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Text.Json;
 using Nethermind.Blockchain.Contracts.Json;
@@ -37,7 +36,7 @@ namespace Nethermind.Abi
 
         public virtual bool IsDynamic => false;
 
-        internal virtual IReadOnlyList<AbiType>? ComponentTypes => null;
+        internal virtual int GetHeadSize(bool packed) => IsDynamic || !packed ? PaddingSize : 1;
 
         public abstract string Name { get; }
 

--- a/src/Nethermind/Nethermind.Abi/AbiUFixed.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiUFixed.cs
@@ -38,6 +38,8 @@ namespace Nethermind.Abi
         public int Length { get; }
         public int Precision { get; }
 
+        internal override int GetHeadSize(bool packed) => Int256.GetHeadSize(packed);
+
         public override (object, int) Decode(byte[] data, int position, bool packed)
         {
             (BigInteger nominator, int newPosition) = Int256.DecodeInt(data, position, packed);

--- a/src/Nethermind/Nethermind.Abi/AbiUInt.cs
+++ b/src/Nethermind/Nethermind.Abi/AbiUInt.cs
@@ -45,6 +45,8 @@ namespace Nethermind.Abi
 
         public override string Name { get; }
 
+        internal override int GetHeadSize(bool packed) => packed ? LengthInBytes : PaddingSize;
+
         public override (object, int) Decode(byte[] data, int position, bool packed)
         {
             (UInt256 value, int length) = DecodeUInt(data, position, packed);

--- a/src/Nethermind/Nethermind.Core/Extensions/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/ByteArrayExtensions.cs
@@ -30,17 +30,8 @@ namespace Nethermind.Core.Extensions
             return slice;
         }
 
-        public static byte[] Slice(this byte[] bytes, int startIndex, int length)
-        {
-            if (length == 1)
-            {
-                return [bytes[startIndex]];
-            }
-
-            byte[] slice = new byte[length];
-            Buffer.BlockCopy(bytes, startIndex, slice, 0, length);
-            return slice;
-        }
+        public static byte[] Slice(this byte[] bytes, int startIndex, int length) =>
+            bytes.AsSpan(startIndex, length).ToArray();
 
         public static byte[] SliceWithZeroPaddingEmptyOnError(this byte[] bytes, int startIndex, int length)
         {

--- a/src/Nethermind/Nethermind.Core/Extensions/ByteArrayExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/ByteArrayExtensions.cs
@@ -30,8 +30,17 @@ namespace Nethermind.Core.Extensions
             return slice;
         }
 
-        public static byte[] Slice(this byte[] bytes, int startIndex, int length) =>
-            bytes.AsSpan(startIndex, length).ToArray();
+        public static byte[] Slice(this byte[] bytes, int startIndex, int length)
+        {
+            if (length == 1)
+            {
+                return [bytes[startIndex]];
+            }
+
+            byte[] slice = new byte[length];
+            Buffer.BlockCopy(bytes, startIndex, slice, 0, length);
+            return slice;
+        }
 
         public static byte[] SliceWithZeroPaddingEmptyOnError(this byte[] bytes, int startIndex, int length)
         {


### PR DESCRIPTION
## Changes

- Reject malformed dynamic byte and array lengths before creating attacker-sized managed arrays.
- Bound dynamic-array materialization by the encoded element head size for standard and packed ABI layouts, including nested tuples, fixed arrays, fixed-point values, and zero-width tuples.
- Normalize truncated signatures and out-of-range sequence reads as `AbiException` failures.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added allocation regressions for attacker-controlled dynamic byte and array lengths across standard and packed encodings, composite element heads, fixed-point types, maximum counts, and empty-tuple compatibility. The ABI and Core suites, deposit processor integration coverage, and warning-as-error client and benchmark builds pass.

The Ethereum test solution cannot build in this checkout because its external fixtures under `src/tests` are absent.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The head-size validation follows the [Solidity ABI encoding specification](https://docs.soliditylang.org/en/latest/abi-spec.html#formal-specification-of-the-encoding) and was cross-checked against [go-ethereum ABI unpacking](https://github.com/ethereum/go-ethereum/blob/454ca784c5aa2129ff5c9d168c4bf66fc4283d02/accounts/abi/unpack.go).