### PR TITLE
Harden BAL gas accounting boundaries

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -677,9 +677,10 @@ public class BlockProcessorTests
             .SetName("BlockValidationTransactionsExecutor_skips_bal_validation_when_no_validation_requested");
     }
 
-    [TestCase(2000ul, false, TestName = "BAL_read_budget_at_2000_gas_passes")]
-    [TestCase(1999ul, true, TestName = "BAL_read_budget_at_1999_gas_fails")]
-    public void ValidateBlockAccessList_storage_read_budget_uses_ItemCost(ulong gasRemaining, bool shouldThrow)
+    [TestCase(2000ul, 0ul, false, TestName = "BAL_read_budget_at_2000_gas_passes")]
+    [TestCase(1999ul, 0ul, true, TestName = "BAL_read_budget_at_1999_gas_fails")]
+    [TestCase(2000ul, 2001ul, true, TestName = "BAL_read_budget_exhaustion_does_not_underflow")]
+    public void ValidateBlockAccessList_storage_read_budget_uses_ItemCost(ulong gasRemaining, ulong gasSpent, bool shouldThrow)
     {
         // One extra storage read in suggested BAL costs Eip7928Constants.ItemCost (2000) gas
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
@@ -707,6 +708,7 @@ public class BlockProcessorTests
             .TestObject;
 
         PrepareSetup(balManager, block, Amsterdam.Instance);
+        balManager.SpendGas(gasSpent);
         // Generated BAL has the account but no storage reads
         BlockAccessListAtIndex generatedAtIndex = new();
         generatedAtIndex.AddAccountRead(TestItem.AddressA);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -225,7 +225,7 @@ public partial class BlockAccessListManager(
     public void SpendGas(ulong gas)
     {
         CheckInitialized();
-        _gasRemaining -= gas;
+        _gasRemaining = _gasRemaining.Value.SaturatingSub(gas);
     }
 
     public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)

--- a/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
@@ -81,4 +81,25 @@ public class EthereumGasPolicyTests
         Assert.That(intrinsic.MinRequiredGasLimit, Is.EqualTo(30_000UL));
         Assert.That(intrinsic.MinRequiredGasLimit, Is.EqualTo(EthereumGasPolicy.GetRemainingGas(intrinsic.MinimalGas)));
     }
+
+    [TestCase(100UL, 40UL, 10L, 50UL)]
+    [TestCase(100UL, 40UL, -10L, 70UL)]
+    [TestCase(100UL, 101UL, 0L, 100UL)]
+    [TestCase(ulong.MaxValue, 0UL, -1L, ulong.MaxValue)]
+    public void GetPreRefundGas_handles_signed_reservoir_without_wrapping(
+        ulong gasLimit,
+        ulong remainingGas,
+        long stateReservoir,
+        ulong expected)
+    {
+        EthereumGasPolicy gas = new() { Value = remainingGas, StateReservoir = stateReservoir };
+
+        ulong preRefundGas = GetPreRefundGas(in gas, gasLimit);
+
+        Assert.That(preRefundGas, Is.EqualTo(expected));
+    }
+
+    private static ulong GetPreRefundGas<TGasPolicy>(in TGasPolicy gas, ulong gasLimit)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        => TGasPolicy.GetPreRefundGas(in gas, gasLimit);
 }

--- a/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
@@ -82,10 +82,13 @@ public class EthereumGasPolicyTests
         Assert.That(intrinsic.MinRequiredGasLimit, Is.EqualTo(EthereumGasPolicy.GetRemainingGas(intrinsic.MinimalGas)));
     }
 
-    [TestCase(100UL, 40UL, 10L, 50UL)]
-    [TestCase(100UL, 40UL, -10L, 70UL)]
-    [TestCase(100UL, 101UL, 0L, 100UL)]
-    [TestCase(ulong.MaxValue, 0UL, -1L, ulong.MaxValue)]
+    [TestCase(100UL, 40UL, 10L, 50UL, TestName = "positive_reservoir_is_subtracted")]
+    [TestCase(100UL, 40UL, -10L, 70UL, TestName = "negative_reservoir_spill_is_added_back")]
+#if !DEBUG
+    // In Debug, the invariant guard terminates the test process before the Release fallback can run.
+    [TestCase(100UL, 101UL, 0L, 100UL, TestName = "gas_left_above_limit_falls_back_to_gas_limit")]
+    [TestCase(ulong.MaxValue, 0UL, -1L, ulong.MaxValue, TestName = "spill_overflowing_ulong_falls_back_to_gas_limit")]
+#endif
     public void GetPreRefundGas_handles_signed_reservoir_without_wrapping(
         ulong gasLimit,
         ulong remainingGas,

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -29,16 +28,17 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     /// <summary>EIP-8037 pre-refund spent gas: <c>txGasLimit - gas_left - state reservoir</c>.</summary>
     /// <remarks>
-    /// Centralizes the regular↔state boundary conversion: the reservoir may be negative (net child
-    /// spill) and the ulong wrap still yields the correct signed total, asserted non-negative here.
+    /// The reservoir may be negative due to net child spill. If the accounting invariant is
+    /// violated, the full transaction gas limit is returned to keep accounting conservative
+    /// without unsigned wraparound.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong GetPreRefundGas(in TSelf gas, ulong txGasLimit)
     {
         ulong remainingGas = TSelf.GetRemainingGas(in gas);
-        Debug.Assert((long)txGasLimit - (long)remainingGas - TSelf.GetStateReservoir(in gas) >= 0,
-            $"Gas invariant violated: remaining ({remainingGas}) + reservoir ({TSelf.GetStateReservoir(in gas)}) exceeds gasLimit ({txGasLimit}).");
-        return txGasLimit - remainingGas - (ulong)TSelf.GetStateReservoir(in gas);
+        long stateReservoir = TSelf.GetStateReservoir(in gas);
+        Int128 preRefundGas = (Int128)txGasLimit - remainingGas - stateReservoir;
+        return preRefundGas >= 0 && preRefundGas <= ulong.MaxValue ? (ulong)preRefundGas : txGasLimit;
     }
 
     // EIP-8037 state-cost accessors. Pre-EIP-8037 policies return the constant fallback.

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -39,10 +39,11 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         ulong remainingGas = TSelf.GetRemainingGas(in gas);
         long stateReservoir = TSelf.GetStateReservoir(in gas);
         Int128 preRefundGas = (Int128)txGasLimit - remainingGas - stateReservoir;
-        Debug.Assert(preRefundGas >= 0 && preRefundGas <= ulong.MaxValue,
+        bool inRange = preRefundGas >= 0 && preRefundGas <= ulong.MaxValue;
+        Debug.Assert(inRange,
             $"Gas invariant violated: pre-refund gas ({preRefundGas}) must fit in ulong for gas limit ({txGasLimit}), remaining gas ({remainingGas}), and state reservoir ({stateReservoir}).");
         // Charging the full limit avoids undercharging and makes validation reject divergent gas accounting.
-        return preRefundGas >= 0 && preRefundGas <= ulong.MaxValue ? (ulong)preRefundGas : txGasLimit;
+        return inRange ? (ulong)preRefundGas : txGasLimit;
     }
 
     // EIP-8037 state-cost accessors. Pre-EIP-8037 policies return the constant fallback.
@@ -319,6 +320,7 @@ public readonly record struct IntrinsicGas<TGasPolicy>(TGasPolicy Standard, TGas
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator TGasPolicy(IntrinsicGas<TGasPolicy> gas) => gas.MinimalGas;
 
+    // The intrinsic reservoir holds the intrinsic state cost, non-negative by construction, so the cast cannot wrap.
     public ulong StandardGas => TGasPolicy.GetRemainingGas(Standard) + (ulong)TGasPolicy.GetStateReservoir(Standard);
     public ulong MinRequiredGasLimit => Math.Max(StandardGas, TGasPolicy.GetRemainingGas(FloorGas));
 

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -38,6 +39,9 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         ulong remainingGas = TSelf.GetRemainingGas(in gas);
         long stateReservoir = TSelf.GetStateReservoir(in gas);
         Int128 preRefundGas = (Int128)txGasLimit - remainingGas - stateReservoir;
+        Debug.Assert(preRefundGas >= 0 && preRefundGas <= ulong.MaxValue,
+            $"Gas invariant violated: pre-refund gas ({preRefundGas}) must fit in ulong for gas limit ({txGasLimit}), remaining gas ({remainingGas}), and state reservoir ({stateReservoir}).");
+        // Charging the full limit avoids undercharging and makes validation reject divergent gas accounting.
         return preRefundGas >= 0 && preRefundGas <= ulong.MaxValue ? (ulong)preRefundGas : txGasLimit;
     }
 


### PR DESCRIPTION
## Changes

- Saturate the EIP-7928 BAL surplus-read gas budget when transaction gas exceeds the suggested header budget.
- Calculate EIP-8037 pre-refund gas in the signed domain and conservatively bound violated accounting invariants without unsigned wraparound.
- Add regression coverage for BAL budget exhaustion and positive, negative, and out-of-range reservoir accounting.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Full Nethermind.Evm.Test and Nethermind.Blockchain.Test suites.
- Nethermind and Benchmarks solution release builds with warnings treated as errors.
- Focused regression tests after independent review.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The BAL surplus-read gas budget is an early-rejection heuristic: exact `storage_reads` equality is still enforced at the end of the block (`ValidateStructuralEquivalence` on the verify-only path, BAL-hash comparison otherwise). The previous underflow therefore could never have accepted an invalid BAL — it only disabled early rejection for the remaining indices. This is reliability hardening rather than a consensus fix.

`GetPreRefundGas` keeps its `Debug.Assert` alongside the new clamp, so a violated accounting invariant still fails hard in tests while Release builds no longer wrap. The two fallback test cases are compiled out in Debug, where the assert terminates the test host before the fallback can be observed.

Generic engine processing exceptions retain their existing RPC error behavior. Treating arbitrary local processing faults as consensus INVALID could incorrectly poison payload state; this change instead removes the identified arithmetic paths without broadening exception classification.

References: https://eips.ethereum.org/EIPS/eip-7928, https://eips.ethereum.org/EIPS/eip-8037, https://github.com/ethereum/execution-specs/blob/d28f7977069d1b71984ff88ed8040b671f6e6a77/src/ethereum/forks/amsterdam/fork.py
