### PR TITLE
fix: burn base fee for frame transactions

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -166,6 +166,28 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_MaxFeeTimesGasLimitOverflows_RejectedWithoutCreditingBeneficiary()
+    {
+        // max_fee = max_priority = 2^255 with an even tx gas limit (415_950 here) wraps maxCost to
+        // 0 mod 2^256: unchecked, the payer gate passes for free and a wrapped premium is credited
+        // to the beneficiary out of nothing.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Recipient));
+        tx.GasPrice = UInt256.One << 255;
+        tx.DecodedMaxFeePerGas = UInt256.One << 255;
+
+        TransactionResult result = Process(tx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.False);
+            Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.InsufficientMaxFeePerGasForSenderBalance));
+            Assert.That(_stateProvider.GetBalance(Beneficiary), Is.EqualTo(UInt256.Zero), "beneficiary not credited");
+            Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0UL), "nonce not consumed");
+        }
+    }
+
+    [Test]
     public void Execute_SenderFrameBeforeExecutionApproval_TransactionInvalid()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -25,7 +26,7 @@ namespace Nethermind.Evm.Test;
 /// <summary>
 /// End-to-end EIP-8141 outer-loop scenarios from the spec "Behavior" section, executed through
 /// <c>TransactionProcessor.Execute</c> under the prototype fork. Frames run with a base fee of 0 and
-/// 1 wei fees so balance assertions stay simple.
+/// 1 wei fees by default so balance assertions stay simple.
 /// State is NOT rolled back when a frame transaction turns out invalid mid-loop — in block
 /// processing an invalid transaction invalidates the block, so nothing observes that state.
 /// </summary>
@@ -41,6 +42,7 @@ public class FrameTxProcessorTests
     private static readonly Address Sender = TestItem.AddressA;
     private static readonly Address Observer = TestItem.AddressB;
     private static readonly Address Recipient = TestItem.AddressC;
+    private static readonly Address Beneficiary = TestItem.AddressE;
 
     [SetUp]
     public void Setup()
@@ -123,6 +125,44 @@ public class FrameTxProcessorTests
         UInt256 balance = _stateProvider.GetBalance(Sender);
         Assert.That(balance, Is.LessThan(1.Ether), "payer charged");
         Assert.That(balance, Is.GreaterThan(1.Ether - (UInt256)frame.GasLimit), "unused gas refunded");
+    }
+
+    [TestCase(7ul, 2ul, 10ul, 2ul, TestName = "Execute_NonZeroBaseFee_PremiumIsTheRequestedPriorityFee")]
+    [TestCase(7ul, 5ul, 8ul, 1ul, TestName = "Execute_NonZeroBaseFee_PremiumCappedByMaxFeeMinusBaseFee")]
+    public void Execute_NonZeroBaseFee_PaysBeneficiaryThePremiumAndBurnsTheBaseFee(
+        ulong baseFee, ulong priorityFee, ulong maxFee, ulong expectedPremium)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.GasPrice = priorityFee;
+        tx.DecodedMaxFeePerGas = maxFee;
+
+        CallOutputTracer tracer = new();
+        TransactionResult result = Process(tx, baseFeePerGas: baseFee, tracer: tracer);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        UInt256 spentGas = (UInt256)tracer.GasSpent;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_stateProvider.GetBalance(Beneficiary), Is.EqualTo(spentGas * expectedPremium), "beneficiary gets the premium only");
+            Assert.That(_stateProvider.GetBalance(Sender) + _stateProvider.GetBalance(Beneficiary),
+                Is.EqualTo(1.Ether - spentGas * baseFee), "the base fee share is burned");
+        }
+    }
+
+    [Test]
+    public void Execute_MaxFeeBelowBaseFee_ReturnsMaxFeePerGasBelowBaseFee()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.DecodedMaxFeePerGas = 5;
+
+        TransactionResult result = Process(tx, baseFeePerGas: 10);
+
+        Assert.That(result.TransactionExecuted, Is.False);
+        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MaxFeePerGasBelowBaseFee));
+        Assert.That(_stateProvider.GetBalance(Beneficiary), Is.EqualTo(UInt256.Zero), "beneficiary not credited");
+        Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0UL), "nonce not consumed");
     }
 
     [Test]
@@ -563,13 +603,14 @@ public class FrameTxProcessorTests
         Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1UL));
     }
 
-    private TransactionResult Process(Transaction tx)
+    private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)
     {
         Block block = Build.A.Block.WithNumber(1)
-            .WithBaseFeePerGas(0)
+            .WithBaseFeePerGas(baseFeePerGas)
+            .WithBeneficiary(Beneficiary)
             .WithTransactions(tx)
             .WithGasLimit(30_000_000).TestObject;
-        return _transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance);
+        return _transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), tracer ?? NullTxTracer.Instance);
     }
 
     private void DeploySmartSender(byte[] code) => DeployContract(Sender, code, 1.Ether);

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -151,6 +151,28 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_TracingFees_ReportsThePremiumAndTheBurntBaseFee()
+    {
+        const ulong baseFee = 7;
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.DecodedMaxFeePerGas = 10;
+
+        FeesTracer tracer = new();
+        TransactionResult result = Process(tx, baseFeePerGas: baseFee, tracer: tracer);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        // The default 1-wei priority fee makes the beneficiary credit equal the spent gas.
+        UInt256 spentGas = _stateProvider.GetBalance(Beneficiary);
+        Assert.That(spentGas, Is.Not.EqualTo(UInt256.Zero));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Fees, Is.EqualTo(spentGas), "premium half");
+            Assert.That(tracer.BurntFees, Is.EqualTo(spentGas * baseFee), "burnt half");
+        }
+    }
+
+    [Test]
     public void Execute_MaxFeeBelowBaseFee_ReturnsMaxFeePerGasBelowBaseFee()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -321,6 +321,14 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             WorldState.Restore(txSnapshot);
         }
 
+        if (tracer.IsTracingFees)
+        {
+            // As in PayFees, the burnt half is capped at the effective price paid so validation-off
+            // runs with max fee below base fee do not over-report.
+            UInt256 effectiveBaseFee = UInt256.Min(header.BaseFeePerGas, effectiveGasPrice);
+            tracer.ReportFees(fees, effectiveBaseFee * spentGas);
+        }
+
         if (tracer.IsTracingReceipt)
         {
             if (tracer is IFrameTxReceiptTracer frameReceiptTracer)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -48,7 +48,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         TxFrame[] frames = tx.Frames!;
         UInt256 effectiveGasPrice = CalculateEffectiveGasPrice(tx, spec.IsEip1559Enabled, header.BaseFeePerGas, out _);
-        if (!TryCalculatePremiumPerGas(tx, header.BaseFeePerGas, out UInt256 premiumPerGas) && ShouldValidateGas(tx, opts))
+        UInt256 premiumPerGas = UInt256.Zero;
+        if (ShouldValidateGas(tx, opts) && !TryCalculatePremiumPerGas(tx, header.BaseFeePerGas, out premiumPerGas))
         {
             TraceLogInvalidTx(tx, "MINER_PREMIUM_IS_NEGATIVE");
             return TransactionResult.ErrorType.MaxFeePerGasBelowBaseFee.WithDetail(

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -47,7 +47,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         }
 
         TxFrame[] frames = tx.Frames!;
-        UInt256 effectiveGasPrice = CalculateEffectiveGasPrice(tx, spec.IsEip1559Enabled, header.BaseFeePerGas, out UInt256 premiumPerGas);
+        UInt256 effectiveGasPrice = CalculateEffectiveGasPrice(tx, spec.IsEip1559Enabled, header.BaseFeePerGas, out _);
+        if (!TryCalculatePremiumPerGas(tx, header.BaseFeePerGas, out UInt256 premiumPerGas) && ShouldValidateGas(tx, opts))
+        {
+            TraceLogInvalidTx(tx, "MINER_PREMIUM_IS_NEGATIVE");
+            return TransactionResult.ErrorType.MaxFeePerGasBelowBaseFee.WithDetail(
+                $"max fee per gas less than block base fee: address {tx.SenderAddress?.ToString(withEip55Checksum: true) ?? "unknown"}, maxFeePerGas: {tx.MaxFeePerGas}, baseFee: {header.BaseFeePerGas}");
+        }
 
         // Spec gas: tx_gas_limit = intrinsic + per-frame + calldata + signature verification
         // + sum(frame.gas_limit); the sum is overflow-checked so the processor does not depend

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -84,8 +84,16 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // would have its blob reservation fully refunded (blobs go uncharged) and BlobGasUsed is not
         // set. Blob support is deferred pending the upstream blob-semantics spec; devnets do not send
         // blob frame txs. Charge blob gas (and reject or account it) once that lands.
+        // Overflow-checked like BuyGas: premium <= max fee and spentGas <= txGasLimit, so bounding
+        // this product also bounds the settlement products (spentCost, fees) below.
         ulong blobGas = (ulong)(tx.BlobVersionedHashes?.Length ?? 0) * Eip4844Constants.GasPerBlob;
-        UInt256 maxCost = (UInt256)txGasLimit * tx.DecodedMaxFeePerGas + (UInt256)blobGas * tx.MaxFeePerBlobGas.GetValueOrDefault();
+        if (UInt256.MultiplyOverflow((UInt256)txGasLimit, tx.DecodedMaxFeePerGas, out UInt256 maxCost)
+            || UInt256.MultiplyOverflow((UInt256)blobGas, tx.MaxFeePerBlobGas.GetValueOrDefault(), out UInt256 maxBlobCost)
+            || UInt256.AddOverflow(maxCost, maxBlobCost, out maxCost))
+        {
+            TraceLogInvalidTx(tx, "INSUFFICIENT_MAX_FEE_PER_GAS_FOR_SENDER_BALANCE");
+            return RequiredBalanceExceeds256Bits(tx);
+        }
 
         FrameTxContext frameContext = new(
             sender,


### PR DESCRIPTION
## Changes

- Fix frame-transaction fee settlement so the base-fee share of the gas cost is burned instead of being credited to the block beneficiary.
- Before this change, the settlement path in `TransactionProcessorBase.FrameTx.cs` took `premiumPerGas` from the `out` parameter of `CalculateEffectiveGasPrice`, which returns the full effective gas price (base fee + priority fee), not the premium. The beneficiary was therefore paid `effective_gas_price * spent_gas`, so nothing was burned.
- EIP-8141 defines frame-tx fees via `tx_fee = tx_gas_limit * effective_gas_price + blob_fees` with "`effective_gas_price` ... calculated per EIP-1559" (spec "Gas accounting" section). Under EIP-1559 only the priority fee goes to the fee recipient; the base-fee share is burned. The existing code comment ("pay the beneficiary premium. The base-fee share stays deducted (burned)") already described the intended behaviour; the code did not match it.
- The fix derives the premium with `tx.TryCalculatePremiumPerGas(header.BaseFeePerGas, out premiumPerGas)` (same helper the regular tx path uses) and keeps charging the payer at the effective price, so the base-fee share stays deducted and is never credited anywhere.
- Test: `Execute_NonZeroBaseFee_PaysBeneficiaryThePriorityFeeAndBurnsTheBaseFee` runs a frame tx at `base_fee = 7`, `max_priority_fee_per_gas = 2`, `max_fee_per_gas = 10` and asserts the beneficiary receives exactly `spent_gas * priority_fee` while `sender + beneficiary` balances come out short by exactly `spent_gas * base_fee` (the burned share). The `Process` test helper gains optional `baseFeePerGas`/`tracer` parameters to support it.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Commands run locally on this branch:

```
dotnet build src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj -c release
# Build succeeded. 0 Warning(s), 0 Error(s)

dotnet test src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c release -- --filter FullyQualifiedName~FrameTx
# Test run summary: Passed! total: 64, failed: 0, succeeded: 64, skipped: 0

dotnet format whitespace src/Nethermind/ --folder && git diff --check
# clean, no changes
```

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Stack note: targets `eip8141-frame-txs-devnet7` and is one of a series of independent EIP-8141 fixes opened together. Siblings: SIBLINGS_PLACEHOLDER.

Consensus risk and limits: this changes fee settlement (beneficiary balance) for frame transactions only, on the prototype devnet branch; regular transaction types are untouched. There is no cross-client conformance fixture for this rule yet - coverage is the unit test above, so agreement with other EIP-8141 implementations still needs devnet/EEST validation.
