### PR TITLE
fix(evm): do not record the P256 precompile in the BAL for frame transactions

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/PrecompileCachedCodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PrecompileCachedCodeInfoRepositoryTests.cs
@@ -33,14 +33,17 @@ public class PrecompileCachedCodeInfoRepositoryTests
         return spec;
     }
 
-    private static PrecompileCachedCodeInfoRepository BuildRepository(PreBlockCaches? caches, params (Address Address, IPrecompile Precompile)[] precompiles)
+    private static PrecompileCachedCodeInfoRepository BuildRepository(PreBlockCaches? caches, params (Address Address, IPrecompile Precompile)[] precompiles) =>
+        BuildRepository(caches, Substitute.For<IWorldState>(), precompiles);
+
+    private static PrecompileCachedCodeInfoRepository BuildRepository(PreBlockCaches? caches, IWorldState worldState, params (Address Address, IPrecompile Precompile)[] precompiles)
     {
         FrozenDictionary<AddressAsKey, CodeInfo> map = precompiles
             .ToDictionary(p => (AddressAsKey)p.Address, p => new CodeInfo(p.Precompile))
             .ToFrozenDictionary();
         IPrecompileProvider provider = Substitute.For<IPrecompileProvider>();
         provider.GetPrecompiles().Returns(map);
-        return new PrecompileCachedCodeInfoRepository(Substitute.For<IWorldState>(), provider, Substitute.For<ICodeInfoRepository>(), caches);
+        return new PrecompileCachedCodeInfoRepository(worldState, provider, Substitute.For<ICodeInfoRepository>(), caches);
     }
 
     private static IPrecompile ResolvePrecompile(PreBlockCaches? caches, IPrecompile precompile, Address? address = null)
@@ -99,6 +102,20 @@ public class PrecompileCachedCodeInfoRepositoryTests
             Assert.That(sha256, Is.Not.SameAs(Sha256Precompile.Instance), "sha256 supports caching and must be wrapped");
             Assert.That(identity, Is.SameAs(IdentityPrecompile.Instance), "identity does not support caching and must stay unwrapped");
         }
+    }
+
+    [Test]
+    public void GetPrecompile_ForPrecompileAddress_SharesCachedInstanceWithoutRecordingAccountRead()
+    {
+        IWorldState worldState = Substitute.For<IWorldState>();
+        PrecompileCachedCodeInfoRepository repository = BuildRepository(CreateCaches(), worldState, (PrecompileAddress, new TestPrecompile(supportsCaching: true)));
+        IReleaseSpec spec = CreateSpecWithPrecompiles(PrecompileAddress);
+
+        IPrecompile? resolved = repository.GetPrecompile(PrecompileAddress, spec);
+
+        worldState.DidNotReceive().AddAccountRead(Arg.Any<Address>());
+        Assert.That(resolved, Is.SameAs(repository.GetCachedCodeInfo(PrecompileAddress, false, spec, out _).Precompile),
+            "frame-tx signature validation must share the block-cache-decorated instance with EVM calls");
     }
 
     [TestCase(true, 1, 1, TestName = "Run_ForRepeatedInputWhenCaching_ComputesOnce")]

--- a/src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs
@@ -41,6 +41,11 @@ public class PrecompileCachedCodeInfoRepository(
         return baseCodeInfoRepository.GetCachedCodeInfo(codeSource, followDelegation, vmSpec, out delegationAddress);
     }
 
+    public IPrecompile? GetPrecompile(Address codeSource, IReleaseSpec vmSpec) =>
+        vmSpec.IsPrecompile(codeSource) && _cachedPrecompile.TryGetValue(codeSource, out CodeInfo cachedCodeInfo)
+            ? cachedCodeInfo.Precompile
+            : baseCodeInfoRepository.GetPrecompile(codeSource, vmSpec);
+
     public void InsertCode(ReadOnlyMemory<byte> code, Address codeOwner, IReleaseSpec spec) =>
         baseCodeInfoRepository.InsertCode(code, codeOwner, spec);
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -19,6 +20,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;
@@ -645,6 +647,48 @@ public class FrameTxProcessorTests
         Assert.That(result.TransactionExecuted, Is.True);
         Assert.That(_stateProvider.GetBalance(sponsor), Is.LessThan(1.Ether), "the sponsor pays the gas");
         Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1UL));
+    }
+
+    [Test]
+    public void Execute_Secp256k1SignatureOnly_DoesNotRecordP256PrecompileInBal()
+    {
+        // EIP-7928: precompiles are BAL-included only when accessed. A frame tx whose signatures
+        // never take the EIP-8141 P256 branch never accesses P256VERIFY, so resolving the handle
+        // for potential validation must not create a BAL entry for its address.
+        _stateProvider.CreateAccount(Sender, 1.Ether);
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+
+        TracedAccessWorldState tracedState = new(_stateProvider, parallel: false);
+        tracedState.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
+        EthereumCodeInfoRepository codeInfoRepository = new(tracedState);
+        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        EthereumTransactionProcessor tracedProcessor = new(BlobBaseFeeCalculator.Instance, _specProvider, tracedState, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, new byte[TxFrameSignature.Secp256k1SignatureLength])];
+        Ecdsa ecdsa = new();
+        ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
+        Signature signature = ecdsa.Sign(TestItem.PrivateKeyA, in sigHash);
+        byte[] vrs = new byte[TxFrameSignature.Secp256k1SignatureLength];
+        vrs[0] = signature.RecoveryId;
+        signature.Bytes.CopyTo(vrs.AsSpan(1));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, vrs)];
+
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+        TransactionResult result = tracedProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        BlockAccessListAtIndex bal = tracedState.GetGeneratingBlockAccessList()!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(bal.GetAccountChanges(Sender), Is.Not.Null, "the sender is accessed and recorded in the BAL");
+            Assert.That(bal.GetAccountChanges(FrameTxSignatureValidator.P256VerifyPrecompileAddress), Is.Null,
+                "no P256-scheme signature, so the P256VERIFY precompile is never accessed");
+        }
     }
 
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)

--- a/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
@@ -6,6 +6,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.State;
 
 namespace Nethermind.Evm;
@@ -48,6 +49,9 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
 
     public CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec, out Address? delegationAddress) =>
         _inner.GetCachedCodeInfo(codeSource, followDelegation, vmSpec, out delegationAddress);
+
+    public IPrecompile? GetPrecompile(Address codeSource, IReleaseSpec vmSpec) =>
+        _inner.GetPrecompile(codeSource, vmSpec);
 
     public bool TryGetDelegation(Address address, IReleaseSpec spec, out Address? delegatedAddress) =>
         _inner.TryGetDelegation(address, spec, out delegatedAddress);

--- a/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
@@ -11,6 +11,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.State;
 
 namespace Nethermind.Evm;
@@ -62,11 +63,7 @@ public class CodeInfoRepository : ICodeInfoRepository
         {
             _worldState.AddAccountRead(codeSource);
             _worldState.RecordAccountAccess(codeSource);
-#if ZK_EVM
-            return _localPrecompileArray[codeSource.PrecompileIndexOrNegative()];
-#else
-            return _localPrecompiles[codeSource];
-#endif
+            return PrecompileCodeInfo(codeSource);
         }
 
         CodeInfo codeInfo = InternalGetCodeInfo(codeSource, vmSpec);
@@ -81,6 +78,17 @@ public class CodeInfoRepository : ICodeInfoRepository
 
         return codeInfo;
     }
+
+    public IPrecompile? GetPrecompile(Address codeSource, IReleaseSpec vmSpec) =>
+        vmSpec.IsPrecompile(codeSource) ? PrecompileCodeInfo(codeSource).Precompile : null;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private CodeInfo PrecompileCodeInfo(Address codeSource) =>
+#if ZK_EVM
+        _localPrecompileArray[codeSource.PrecompileIndexOrNegative()];
+#else
+        _localPrecompiles[codeSource];
+#endif
 
     private CodeInfo InternalGetCodeInfo(Address codeSource, IReleaseSpec vmSpec)
     {

--- a/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Evm.Precompiles;
 namespace Nethermind.Evm;
 
 public interface ICodeInfoRepository
@@ -14,6 +15,14 @@ public interface ICodeInfoRepository
     /// <remarks>Wrapping implementations must forward this, else the fast path is wrongly taken under overrides.</remarks>
     bool IsCodeOverridable { get; }
     CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec, out Address? delegationAddress);
+
+    /// <summary>Resolves the precompile at <paramref name="codeSource"/>, or null when <paramref name="vmSpec"/> enables none there.</summary>
+    /// <remarks>
+    /// Unlike <see cref="GetCachedCodeInfo"/> this records no account access, so it creates no EIP-7928 block
+    /// access list entry. For protocol-level uses (EIP-8141 frame-signature validation) that evaluate a
+    /// precompile as a primitive without the transaction accessing its address.
+    /// </remarks>
+    IPrecompile? GetPrecompile(Address codeSource, IReleaseSpec vmSpec);
     void InsertCode(ReadOnlyMemory<byte> code, Address codeOwner, IReleaseSpec spec);
     void SetDelegation(Address codeSource, Address authority, IReleaseSpec spec);
     bool TryGetDelegation(Address address, IReleaseSpec spec, [NotNullWhen(true)] out Address? delegatedAddress);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -40,7 +40,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         }
 
         ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
-        IPrecompile? p256Precompile = _codeInfoRepository.GetCachedCodeInfo(FrameTxSignatureValidator.P256VerifyPrecompileAddress, spec, out _).Precompile;
+        // EIP-7928: resolved without recording an account access - a tx that never takes the P256
+        // signature branch never accesses the precompile, so it must not enter the BAL.
+        IPrecompile? p256Precompile = _codeInfoRepository.GetPrecompile(FrameTxSignatureValidator.P256VerifyPrecompileAddress, spec);
         if (!FrameTxSignatureValidator.Validate(tx, in sigHash, Ecdsa, p256Precompile, spec, out string? signatureError))
         {
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail(signatureError!);

--- a/src/Nethermind/Nethermind.State/OverridableEnv/OverridableCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/OverridableCodeInfoRepository.cs
@@ -9,6 +9,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.State;
 
 namespace Nethermind.State.OverridableEnv;
@@ -36,6 +37,11 @@ public class OverridableCodeInfoRepository(ICodeInfoRepository codeInfoRepositor
 
         return codeInfoRepository.GetCachedCodeInfo(codeSource, followDelegation, vmSpec, out delegationAddress);
     }
+
+    public IPrecompile? GetPrecompile(Address codeSource, IReleaseSpec vmSpec) =>
+        _precompileOverrides.TryGetValue(codeSource, out (CodeInfo codeInfo, Address initialAddr) precompile) ? precompile.codeInfo.Precompile
+        : _codeOverrides.TryGetValue(codeSource, out (CodeInfo codeInfo, ValueHash256 codeHash) result) ? result.codeInfo.Precompile
+        : codeInfoRepository.GetPrecompile(codeSource, vmSpec);
 
     public void InsertCode(ReadOnlyMemory<byte> code, Address codeOwner, IReleaseSpec spec) =>
         codeInfoRepository.InsertCode(code, codeOwner, spec);


### PR DESCRIPTION
## Changes

Nethermind's EIP-8141 frame-tx pre-flight resolves the P256VERIFY precompile handle (for potential P256-scheme signature validation) through `ICodeInfoRepository.GetCachedCodeInfo`, which records a BAL account read for precompile addresses. As a result, every frame transaction produced a read-only, empty-change EIP-7928 BAL entry for `0x0000000000000000000000000000000000000100`, even when the transaction carries no P256-scheme signature.

This is spec-incorrect. EIP-7928:

> **Precompiled contracts:** Precompiles MUST be included when accessed. If a precompile receives value, it is recorded with a balance change. Otherwise, it is included with empty change lists.

> Only addresses and storage slots that are actually touched or changed during execution are recorded.

The EIP-8141 `validate_signature` pseudocode invokes `P256VERIFY` only on the `sig.scheme == P256` branch, so a SECP256K1-only frame tx never accesses the precompile. The prefetch is an implementation artifact, not an execution access - by analogy, the ecrecover precompile (0x01) is never BAL-included for ordinary transaction sender recovery even though the same math runs for every transaction.

What the change does:

- Adds a side-effect-free `ICodeInfoRepository.GetPrecompile(Address, IReleaseSpec)` that resolves a precompile handle without recording an account access, implemented in `CodeInfoRepository`, `CacheCodeInfoRepository`, `PrecompileCachedCodeInfoRepository` (returns the same block-cache-decorated instance the EVM uses), and `OverridableCodeInfoRepository` (forwards to the wrapped repository).
- The frame-tx pre-flight (`TransactionProcessorBase.FrameTx.cs`) resolves the P256 handle through it. The `spec.IsPrecompile` gate preserves the pre-EIP-7951 null result, so the `P256NotSupported` validation path is unchanged.
- Genuine EVM calls to precompiles still record through `GetCachedCodeInfo`; that path is untouched.
- Regression test: `Execute_Secp256k1SignatureOnly_DoesNotRecordP256PrecompileInBal` asserts a SECP256K1-only frame tx generates a BAL with a sender entry and no `0x...0100` entry. It fails on the base branch (the entry is present) and passes with the fix.

## Evidence

Cross-client replay (Nethermind vs ethrex, both on their EIP-8141 integration branches): at block 137, each client consensus-rejected the other's frame-tx block with `InvalidBlockLevelAccessListHash` and fork choice fell back to the empty block. The suggested (ethrex) header carried `blockAccessListHash 0xb11d3eb716f3c32ffb61ac2ff6b135f645781997c3d946ed12f33db3583784a1` (9 account entries); Nethermind re-derived `0xa9d6bdbe101468ba4fecc4a8b0e83f845e16881f5f2f26b6ca8a5683a9b30094` (10 entries). Both BALs were reconstructed from source + genesis + header and keccak-verified against those exact hashes; they differ by exactly the one read-only `0x...0100` entry. Everything else in the block already matched (gasUsed 21260, receipts, logs, state roots, balances, nonces).

Verification on this branch:

- `dotnet build src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj -c release`: 0 warnings, 0 errors.
- `dotnet test ... --filter FullyQualifiedName~FrameTx`: 64 total, 64 succeeded, 0 failed.
- `dotnet test ... --filter FullyQualifiedName~Eip7928`: 204 total, 204 succeeded, 0 failed.
- New regression test confirmed failing before the fix (BAL contained an `AccountChangesAtIndex` for `0x...0100`) and passing after.
- `dotnet format whitespace` and `git diff --check` clean.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

The regression test builds a `TracedAccessWorldState` with a generating BAL, executes a frame tx carrying a single SECP256K1 signature, and asserts the generated BAL has no entry for the P256VERIFY address while still recording the sender.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Stack: targets `eip8141-frame-txs-devnet7`, alongside the other EIP-8141 draft PRs from this series.

This change is consensus-affecting: it changes the derived `blockAccessListHash` for every frame transaction, aligning Nethermind with ethrex and with EIP-7928.

Limits: this PR intentionally does NOT settle whether verifying an actual P256-scheme frame signature should create a `0x...0100` BAL entry. EIP-8141's pseudocode uses `P256VERIFY` as a cryptographic function outside EVM execution, and EIP-7928 does not address it. Both clients currently record nothing for signature validation (ethrex's validation is pure crypto; Nethermind's, after this fix, resolves the handle without recording), which matches the ecrecover analogy, but the rule should be pinned in EIP-8141 upstream before P256-signed frame txs appear on a devnet.
