### PR TITLE
fix(eip8141): record zero-premium frame-tx beneficiary access in BAL

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -691,6 +691,41 @@ public class FrameTxProcessorTests
         }
     }
 
+    [Test]
+    public void Execute_ZeroPriorityFee_TouchesBeneficiaryInBalWithoutBalanceChange()
+    {
+        // EIP-7928: fee accounting accesses the beneficiary even when the priority fee is zero, so
+        // the BAL must record an empty entry for it while omitting the zero balance change.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Address beneficiary = TestItem.AddressF;
+
+        TracedAccessWorldState tracedState = new(_stateProvider, parallel: false);
+        tracedState.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
+        EthereumCodeInfoRepository codeInfoRepository = new(tracedState);
+        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        EthereumTransactionProcessor tracedProcessor = new(BlobBaseFeeCalculator.Instance, _specProvider, tracedState, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.GasPrice = 0; // max_priority_fee_per_gas - zero premium, so the beneficiary credit is zero
+
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithBeneficiary(beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+        TransactionResult result = tracedProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        AccountChangesAtIndex? beneficiaryChanges = tracedState.GetGeneratingBlockAccessList()!.GetAccountChanges(beneficiary);
+        Assert.That(beneficiaryChanges, Is.Not.Null, "beneficiary accessed and recorded in the BAL");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(beneficiaryChanges.BalanceChange, Is.Null, "zero balance change omitted");
+            Assert.That(beneficiaryChanges.NonceChange, Is.Null);
+            Assert.That(beneficiaryChanges.CodeChange, Is.Null);
+        }
+    }
+
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)
     {
         Block block = Build.A.Block.WithNumber(1)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -312,11 +312,16 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             WorldState.AddToBalance(payer, maxCost - spentCost, spec);
         }
 
+        // EIP-1559/EIP-7928: fee accounting touches the beneficiary regardless of premium, so the
+        // credit is applied unconditionally like PayFees on the regular path; the BAL recorder drops
+        // the zero balance change and the EIP-158 commit clears a touched-empty beneficiary.
+        // PayFees also skips the credit for a beneficiary self-destructed within the tx (EIP-6780),
+        // but the frame path never finalizes its destroy list, so there is nothing to resurrect here;
+        // mirroring the guard would burn the premium while leaving the account live, matching neither
+        // path. Destroy-list finalization on the frame path (and the guard it would justify) is tracked
+        // separately.
         UInt256 fees = premiumPerGas * (UInt256)spentGas;
-        if (!fees.IsZero)
-        {
-            WorldState.AddToBalanceAndCreateIfNotExists(header.GasBeneficiary!, fees, spec);
-        }
+        WorldState.AddToBalanceAndCreateIfNotExists(header.GasBeneficiary!, fees, spec);
 
         bool commit = opts.HasFlag(ExecutionOptions.Commit);
         if (commit)


### PR DESCRIPTION
## Changes

- Record the block beneficiary in the block access list (EIP-7928) even when a frame transaction pays a zero priority fee.

### Current behaviour and why it is wrong

The EIP-8141 frame-tx settlement path only touched world state for the beneficiary when `premiumPerGas * spentGas` was nonzero. For a frame transaction with `max_priority_fee_per_gas = 0`, the beneficiary was never touched, so BAL generation (`TracedAccessWorldState`) never recorded it and the produced block access list diverged from the spec.

Under EIP-7928, accessed-but-unchanged accounts stay in the BAL: COINBASE follows normal access rules during fee accounting, so a zero balance change is omitted but the access itself is not (EIP-7928 master, BAL access rules and COINBASE fee-accounting rule; verified against commit `6c666b8d646df8ea6dcef9638de7b48e3c45ab96`, lines 92-109 and 254-264). EIP-8141 fee settlement pays the priority fee to the beneficiary per EIP-1559 (`effective_gas_price` rules, eip-8141.md "Fees" section), so fee accounting accesses the beneficiary on every frame transaction, including zero-premium ones.

The EIP-2929 access-tracker warmup at frame entry does not cover this: it is a warm/cold gas journal, not a BAL/world-state read.

### What the change does

Removes the `!fees.IsZero` guard and applies the beneficiary credit through `WorldState.AddToBalanceAndCreateIfNotExists` the same way `PayFees` does on the regular path, including for a zero premium. The BAL recorder omits the zero balance change but keeps the access entry, and the EIP-158 commit rules clear a touched-empty beneficiary, so no spurious account creation is persisted. This replaces the earlier `AddAccountRead`-before-the-guard approach: crediting like `PayFees` keeps the two settlement paths structurally aligned instead of adding a BAL-only side channel.

Known gap left open: the frame path never finalizes the destroy list, so an in-tx self-destructed account is not deleted at the end of a frame transaction the way the regular path deletes it.

### Regression tests

- `Execute_ZeroPriorityFee_TouchesBeneficiaryInBalWithoutBalanceChange` asserts the beneficiary is present in the generated BAL with no balance, nonce, or code change. It fails without the fix (beneficiary absent from the BAL) and passes with it.
- The destroyed-beneficiary divergence is documented via a code comment and destroy-list finalization on the frame path is tracked as a separate follow-up.

### Evidence

Commands run on this branch (rebased onto `eip8141-frame-txs-devnet7` with #12591 merged):

- `dotnet build src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj -c release` - Build succeeded, 0 errors.
- `dotnet test src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c release -- --filter FullyQualifiedName~FrameTx` - total: 69, failed: 0, succeeded: 69, skipped: 0.
- `dotnet test src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c release -- --filter FullyQualifiedName~Eip8141` - total: 13, failed: 0, succeeded: 13, skipped: 0.
- `dotnet format whitespace src/Nethermind/ --folder` and `git diff --check` - clean.

### Stack note

Targets `eip8141-frame-txs-devnet7`. One of a series of independent EIP-8141 fixes; sibling PRs: #12591 (base fee burn, merged into the base), #12592 (P256 precompile BAL), #12594 (EIP-7623 calldata floor), #12595 (EIP-7708 transfer log).

### Consensus risk and limits

- Changes BAL generation output for blocks containing zero-priority-fee frame transactions; block hashes/BALs produced before and after this change differ for such blocks, so all devnet clients must agree on this rule.
- The destroy list itself is still not finalized on the frame path; cross-client behaviour for in-tx self-destructs inside frame transactions still needs to be pinned upstream.
- Covered by unit-level regression tests only; no cross-client conformance fixture for these cases exists yet.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

See Regression tests above; the test exercises the frame-tx settlement path end to end through `TracedAccessWorldState` BAL generation.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

