### PR TITLE
feat(evm): EIP-7623 calldata floor for frame transactions

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -149,11 +149,7 @@ public class Eip8141ScenarioTests
     }
 
     // Spec Gas Accounting: charged gas = FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST
-    // + per-scheme verification cost + max(standard token cost of frame data and signature fields
-    // + the gas each frame consumed, floor token cost). Pinned against the spec constants
-    // with known payload bytes; ARBITRARY entries cost 100 verification gas, and their bytes are
-    // also calldata-priced. The fork under test schedules EIP-7976, so the floor prices every data
-    // byte as a non-zero token at 16 (64 per byte), as it does for an ordinary transaction.
+    // + per-scheme verification cost + max(standard token cost + frame gas consumed, floor token cost).
     [Test]
     public void ChargedGas_MatchesSpecIntrinsicFormula()
     {
@@ -186,9 +182,7 @@ public class Eip8141ScenarioTests
             "the refund must return exactly max cost minus charged gas at the effective price");
     }
 
-    // The calldata floor for frame transactions: the mandatory intrinsic, per-frame and signature
-    // verification costs stay outside the max, while the data tokens are charged at the floor rate
-    // whenever it exceeds the standard rate plus the gas the frames actually consumed.
+    // Only the data tokens go through the max; the mandatory costs stay outside it.
     [Test]
     public void ChargedGas_FloorDominatesExecution_ChargesFloorTokenCost()
     {
@@ -205,8 +199,7 @@ public class Eip8141ScenarioTests
         ulong mandatoryGas = 15_000 + 2 * 475UL;
         using (Assert.EnterMultipleScope())
         {
-            // Every byte is a non-zero token under EIP-7976, priced at 16: 64 gas per data byte,
-            // the same rate an ordinary transaction's calldata floor uses under this fork.
+            // EIP-7976 prices every byte as a non-zero token: 64 gas per data byte.
             Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + 256 * 64UL));
             Assert.That((ulong)receipt.GasUsed, Is.GreaterThan(mandatoryGas + 256 * 4UL + frameGasUsed),
                 "the floor token cost must dominate the standard token cost plus execution gas");
@@ -214,8 +207,6 @@ public class Eip8141ScenarioTests
         }
     }
 
-    // Regression: when the standard token cost plus consumed frame gas exceeds the floor token cost,
-    // the standard accounting is charged unchanged.
     [Test]
     public void ChargedGas_ExecutionDominatesFloor_ChargesStandardTokenCostPlusExecution()
     {
@@ -241,10 +232,8 @@ public class Eip8141ScenarioTests
         }
     }
 
-    // A frame transaction whose frames reserve less gas than its own calldata floor is valid: the
-    // spec resolves the shortfall by reserving `max(standard_gas_limit, calldata_floor_gas)`, not by
-    // rejecting the transaction. Rejecting it would fork away from any client that reserves the max,
-    // since the same block is then valid for one and invalid for the other.
+    // Rejecting a transaction that reserves less than its floor would fork away from any client that
+    // reserves `max(standard_gas_limit, calldata_floor_gas)` instead, as the spec requires.
     [Test]
     public void ChargedGas_FloorExceedsTheFramesGasReservation_ReservesTheFloorAndExecutes()
     {
@@ -271,10 +260,7 @@ public class Eip8141ScenarioTests
         }
     }
 
-    // The floor bounds the charge from below after the EIP-3529 refund is netted, not before. The
-    // scenario is chosen so the two orderings disagree: gross gas exceeds the floor (so the floor is
-    // not trivially the answer), while gross minus the refund falls under it (so applying the floor
-    // first would leave the refund to be subtracted from it).
+    // The floor bounds the charge after the EIP-3529 refund is netted, not before.
     [Test]
     public void ChargedGas_RefundNetsBeforeFloorIsApplied()
     {
@@ -284,8 +270,7 @@ public class Eip8141ScenarioTests
         _stateProvider.Commit(Spec);
         _stateProvider.CommitTree(0);
 
-        // The payload size is chosen so the floor lands between the gross charge and the gross charge
-        // net of the refund: the floor grows 64 gas per byte while the standard cost grows 4.
+        // Sized so the floor lands between the gross charge and the gross charge net of the refund.
         byte[] frameData = new byte[160];
         Transaction tx = FrameTx(Sender, nonce: 0,
             SelfVerifyFrame(),

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -150,9 +150,10 @@ public class Eip8141ScenarioTests
 
     // Spec Gas Accounting: charged gas = FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST
     // + per-scheme verification cost + max(standard token cost of frame data and signature fields
-    // + the gas each frame consumed, EIP-7623 floor token cost). Pinned against the spec constants
+    // + the gas each frame consumed, floor token cost). Pinned against the spec constants
     // with known payload bytes; ARBITRARY entries cost 100 verification gas, and their bytes are
-    // also calldata-priced.
+    // also calldata-priced. The fork under test schedules EIP-7976, so the floor prices every data
+    // byte as a non-zero token at 16 (64 per byte), as it does for an ordinary transaction.
     [Test]
     public void ChargedGas_MatchesSpecIntrinsicFormula()
     {
@@ -175,16 +176,17 @@ public class Eip8141ScenarioTests
 
         ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
         ulong tokens = CalldataTokens(frameData) + CalldataTokens(witnessBytes);
+        ulong floorTokens = (ulong)(frameData.Length + witnessBytes.Length) * 4;
         ulong expected = 15_000
                          + 2 * 475UL
                          + 100 // ARBITRARY signature verification cost
-                         + Math.Max(tokens * 4 + frameGasUsed, tokens * 10); // EIP-7623 floor (10/token)
+                         + Math.Max(tokens * 4 + frameGasUsed, floorTokens * 16); // EIP-7976 floor rate
         Assert.That((ulong)receipt.GasUsed, Is.EqualTo(expected));
         Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed),
             "the refund must return exactly max cost minus charged gas at the effective price");
     }
 
-    // EIP-7623 floor for frame transactions: the mandatory intrinsic, per-frame and signature
+    // The calldata floor for frame transactions: the mandatory intrinsic, per-frame and signature
     // verification costs stay outside the max, while the data tokens are charged at the floor rate
     // whenever it exceeds the standard rate plus the gas the frames actually consumed.
     [Test]
@@ -203,17 +205,17 @@ public class Eip8141ScenarioTests
         ulong mandatoryGas = 15_000 + 2 * 475UL;
         using (Assert.EnterMultipleScope())
         {
-            // EIP-8141 inherits the EIP-7623 floor (10 per token), NOT the EIP-7976 rate (16),
-            // even though the prototype fork also schedules EIP-7976 for the regular tx path.
-            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + 256 * 10UL));
+            // Every byte is a non-zero token under EIP-7976, priced at 16: 64 gas per data byte,
+            // the same rate an ordinary transaction's calldata floor uses under this fork.
+            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + 256 * 64UL));
             Assert.That((ulong)receipt.GasUsed, Is.GreaterThan(mandatoryGas + 256 * 4UL + frameGasUsed),
                 "the floor token cost must dominate the standard token cost plus execution gas");
             Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed));
         }
     }
 
-    // EIP-7623 regression: when the standard token cost plus consumed frame gas exceeds the floor
-    // token cost, the standard accounting is charged unchanged.
+    // Regression: when the standard token cost plus consumed frame gas exceeds the floor token cost,
+    // the standard accounting is charged unchanged.
     [Test]
     public void ChargedGas_ExecutionDominatesFloor_ChargesStandardTokenCostPlusExecution()
     {
@@ -232,10 +234,45 @@ public class Eip8141ScenarioTests
         ulong standardTokenCost = 64 * 4UL;
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(standardTokenCost + frameGasUsed, Is.GreaterThan(64 * 10UL),
+            Assert.That(standardTokenCost + frameGasUsed, Is.GreaterThan(64 * 64UL),
                 "the scenario must stay execution-dominant for this regression to bind");
             Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + standardTokenCost + frameGasUsed));
             Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed));
+        }
+    }
+
+    // The floor bounds the charge from below after the EIP-3529 refund is netted, not before. The
+    // scenario is chosen so the two orderings disagree: gross gas exceeds the floor (so the floor is
+    // not trivially the answer), while gross minus the refund falls under it (so applying the floor
+    // first would leave the refund to be subtracted from it).
+    [Test]
+    public void ChargedGas_RefundNetsBeforeFloorIsApplied()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        _stateProvider.Set(new StorageCell(Recipient, UInt256.Zero), new byte[] { 1 });
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+
+        // The payload size is chosen so the floor lands between the gross charge and the gross charge
+        // net of the refund: the floor grows 64 gas per byte while the standard cost grows 4.
+        byte[] frameData = new byte[160];
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeDefault, 0, Recipient, gasLimit: 200_000, UInt256.Zero, frameData));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        ulong floorGas = mandatoryGas + (ulong)frameData.Length * 64UL;
+        ulong grossGas = mandatoryGas + (ulong)frameData.Length * 4UL + frameGasUsed;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(grossGas, Is.GreaterThan(floorGas),
+                "gross gas must exceed the floor, or the ordering under test is not exercised");
+            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(floorGas),
+                "the refund may not push the charge below the floor");
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -241,6 +241,36 @@ public class Eip8141ScenarioTests
         }
     }
 
+    // A frame transaction whose frames reserve less gas than its own calldata floor is valid: the
+    // spec resolves the shortfall by reserving `max(standard_gas_limit, calldata_floor_gas)`, not by
+    // rejecting the transaction. Rejecting it would fork away from any client that reserves the max,
+    // since the same block is then valid for one and invalid for the other.
+    [Test]
+    public void ChargedGas_FloorExceedsTheFramesGasReservation_ReservesTheFloorAndExecutes()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+
+        byte[] frameData = new byte[2_000];
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 20_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient, gasLimit: 20_000, UInt256.Zero, frameData));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        ulong standardGasLimit = mandatoryGas + (ulong)frameData.Length * 16UL + 40_000UL;
+        ulong floorGas = mandatoryGas + (ulong)frameData.Length * 64UL;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(floorGas, Is.GreaterThan(standardGasLimit),
+                "the frames must reserve less than the floor, or this regression does not bind");
+            Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Success));
+            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(floorGas));
+            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed),
+                "the payer is charged the floor and refunded the rest of the raised reservation");
+        }
+    }
+
     // The floor bounds the charge from below after the EIP-3529 refund is netted, not before. The
     // scenario is chosen so the two orderings disagree: gross gas exceeds the floor (so the floor is
     // not trivially the answer), while gross minus the refund falls under it (so applying the floor

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -149,9 +149,10 @@ public class Eip8141ScenarioTests
     }
 
     // Spec Gas Accounting: charged gas = FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST
-    // + EIP-7623 token cost of frame data and signature fields + per-scheme verification cost
-    // + the gas each frame consumed. Pinned against the spec constants with known payload bytes;
-    // ARBITRARY entries cost 100 verification gas, and their bytes are also calldata-priced.
+    // + per-scheme verification cost + max(standard token cost of frame data and signature fields
+    // + the gas each frame consumed, EIP-7623 floor token cost). Pinned against the spec constants
+    // with known payload bytes; ARBITRARY entries cost 100 verification gas, and their bytes are
+    // also calldata-priced.
     [Test]
     public void ChargedGas_MatchesSpecIntrinsicFormula()
     {
@@ -173,14 +174,69 @@ public class Eip8141ScenarioTests
         }
 
         ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong tokens = CalldataTokens(frameData) + CalldataTokens(witnessBytes);
         ulong expected = 15_000
                          + 2 * 475UL
-                         + (CalldataTokens(frameData) + CalldataTokens(witnessBytes)) * 4
                          + 100 // ARBITRARY signature verification cost
-                         + frameGasUsed;
+                         + Math.Max(tokens * 4 + frameGasUsed, tokens * 10); // EIP-7623 floor (10/token)
         Assert.That((ulong)receipt.GasUsed, Is.EqualTo(expected));
         Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed),
             "the refund must return exactly max cost minus charged gas at the effective price");
+    }
+
+    // EIP-7623 floor for frame transactions: the mandatory intrinsic, per-frame and signature
+    // verification costs stay outside the max, while the data tokens are charged at the floor rate
+    // whenever it exceeds the standard rate plus the gas the frames actually consumed.
+    [Test]
+    public void ChargedGas_FloorDominatesExecution_ChargesFloorTokenCost()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+
+        byte[] frameData = new byte[256];
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient, gasLimit: 200_000, UInt256.Zero, frameData));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        using (Assert.EnterMultipleScope())
+        {
+            // EIP-8141 inherits the EIP-7623 floor (10 per token), NOT the EIP-7976 rate (16),
+            // even though the prototype fork also schedules EIP-7976 for the regular tx path.
+            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + 256 * 10UL));
+            Assert.That((ulong)receipt.GasUsed, Is.GreaterThan(mandatoryGas + 256 * 4UL + frameGasUsed),
+                "the floor token cost must dominate the standard token cost plus execution gas");
+            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed));
+        }
+    }
+
+    // EIP-7623 regression: when the standard token cost plus consumed frame gas exceeds the floor
+    // token cost, the standard accounting is charged unchanged.
+    [Test]
+    public void ChargedGas_ExecutionDominatesFloor_ChargesStandardTokenCostPlusExecution()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        DeployContract(Recipient, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        byte[] frameData = new byte[64];
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient, gasLimit: 200_000, UInt256.Zero, frameData));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        ulong standardTokenCost = 64 * 4UL;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(standardTokenCost + frameGasUsed, Is.GreaterThan(64 * 10UL),
+                "the scenario must stay execution-dominant for this regression to bind");
+            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + standardTokenCost + frameGasUsed));
+            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed));
+        }
     }
 
     // EIP-3529 storage refunds (ethereum/EIPs#11940) accumulate into one transaction-scoped counter,

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -111,14 +111,11 @@ public class FrameTxProcessorTests
         Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
     }
 
-    // A frame carrying more data than its own gas limit can pay for at the floor rate does not
-    // invalidate the transaction: the spec reserves max(standard_gas_limit, calldata_floor_gas).
+    // The spec reserves max(standard_gas_limit, calldata_floor_gas) rather than invalidating.
     [Test]
     public void Execute_FramesReserveLessGasThanTheCalldataFloor_StillExecutes()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
-        // Enough tokens that the floor rate outpaces the standard rate plus the declared frame gas,
-        // even with the second frame's own limit at zero.
         byte[] frameData = new byte[40_000];
         Transaction tx = FrameTx(nonce: 0,
             SelfVerifyFrame(),

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -111,22 +111,20 @@ public class FrameTxProcessorTests
         Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
     }
 
+    // A frame carrying more data than its own gas limit can pay for at the floor rate does not
+    // invalidate the transaction: the spec reserves max(standard_gas_limit, calldata_floor_gas).
     [Test]
-    public void Execute_GasLimitBelowEip7623Floor_ReturnsGasLimitBelowFloorGas()
+    public void Execute_FramesReserveLessGasThanTheCalldataFloor_StillExecutes()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
-        // Enough zero-byte tokens that the floor rate (tokens * 10) outpaces the standard rate
-        // plus the declared frame gas (tokens * 4 + sum(frame.gas_limit)), even with the second
-        // frame's own limit at zero.
+        // Enough tokens that the floor rate outpaces the standard rate plus the declared frame gas,
+        // even with the second frame's own limit at zero.
         byte[] frameData = new byte[40_000];
         Transaction tx = FrameTx(nonce: 0,
             SelfVerifyFrame(),
             new TxFrame(TxFrame.ModeSender, 0, Recipient, gasLimit: 0, UInt256.Zero, frameData));
 
-        TransactionResult result = Process(tx);
-
-        Assert.That(result.TransactionExecuted, Is.False);
-        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.GasLimitBelowFloorGas));
+        Assert.That(Process(tx).TransactionExecuted, Is.True);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -112,6 +112,24 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_GasLimitBelowEip7623Floor_ReturnsGasLimitBelowFloorGas()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        // Enough zero-byte tokens that the floor rate (tokens * 10) outpaces the standard rate
+        // plus the declared frame gas (tokens * 4 + sum(frame.gas_limit)), even with the second
+        // frame's own limit at zero.
+        byte[] frameData = new byte[40_000];
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient, gasLimit: 0, UInt256.Zero, frameData));
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.False);
+        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.GasLimitBelowFloorGas));
+    }
+
+    [Test]
     public void Execute_SelfVerifyApprovesExecutionAndPayment_ChargesPayerAndIncrementsNonce()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -389,20 +389,32 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     }
 
     /// <summary>
-    /// FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST + calldata cost of frame data
-    /// and signature fields (EIP-7623 token pricing) + per-scheme signature verification cost.
-    /// EIP-8141 inherits the floor from EIP-7623 specifically: the floor prices tokens at
-    /// <see cref="GasCostOf.TotalCostFloorPerTokenEip7623"/> on top of the mandatory (non-data)
-    /// costs, so <paramref name="floorGas"/> is the minimum chargeable gas (0 when floor pricing is
-    /// not active). The frame-tx floor stays pinned to the EIP-7623 constant even when EIP-7976 is
-    /// also scheduled, because EIP-8141 defines the floor per EIP-7623, not EIP-7976.
+    /// Computes the intrinsic gas of a frame transaction and, via <paramref name="floorGas"/>, the
+    /// least gas it may be charged.
     /// </summary>
+    /// <remarks>
+    /// The intrinsic cost is <c>FRAME_TX_INTRINSIC_COST</c> + frames × <c>FRAME_TX_PER_FRAME_COST</c>
+    /// + per-scheme signature verification + the calldata cost of the frame data and signature
+    /// fields. The floor adds the same mandatory (non-data) costs to the data priced at
+    /// <see cref="SpecGasCosts.TotalCostFloorPerToken"/>, mirroring
+    /// <see cref="IntrinsicGasCalculator.CalculateFloorCost"/>: EIP-7976 prices every data byte as a
+    /// non-zero token, EIP-7623 weights zero bytes lower. Both the rate and the token weighting are
+    /// resolved from the spec so a frame transaction's floor cannot diverge from an ordinary
+    /// transaction's under the same fork.
+    /// </remarks>
+    /// <param name="tx">The frame transaction being charged.</param>
+    /// <param name="frames">The transaction's frames.</param>
+    /// <param name="spec">The release spec in effect.</param>
+    /// <param name="floorGas">The minimum chargeable gas, or 0 when floor pricing is not active.</param>
+    /// <returns>The intrinsic gas charged before execution.</returns>
     private static ulong CalculateFrameTxIntrinsicGas(Transaction tx, TxFrame[] frames, IReleaseSpec spec, out ulong floorGas)
     {
         ulong tokens = 0;
+        ulong dataLength = 0;
         foreach (TxFrame frame in frames)
         {
             tokens += CountCalldataTokens(frame.Data.Span, spec);
+            dataLength += (ulong)frame.Data.Length;
         }
 
         ulong signatureVerificationCost = 0;
@@ -414,6 +426,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 tokens += signature.Signer is null ? 0 : CountCalldataTokens(signature.Signer.Bytes, spec);
                 tokens += CountCalldataTokens(signature.Msg.Span, spec);
                 tokens += CountCalldataTokens(signature.Signature.Span, spec);
+                dataLength += (ulong)(signature.Signer is null ? 0 : Address.Size)
+                              + (ulong)signature.Msg.Length
+                              + (ulong)signature.Signature.Length;
                 signatureVerificationCost += signature.Scheme switch
                 {
                     TxFrameSignature.SchemeArbitrary => Eip8141Constants.ArbitraryVerificationGasCost,
@@ -427,7 +442,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost
                              + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
                              + signatureVerificationCost;
-        floorGas = spec.IsEip7623Enabled ? mandatoryGas + tokens * GasCostOf.TotalCostFloorPerTokenEip7623 : 0;
+        ulong floorTokens = spec.IsEip7976Enabled ? dataLength * spec.GasCosts.TxDataNonZeroMultiplier : tokens;
+        floorGas = spec.IsEip7623Enabled ? mandatoryGas + floorTokens * spec.GasCosts.TotalCostFloorPerToken : 0;
         return mandatoryGas + tokens * GasCostOf.TxDataZero;
     }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -60,7 +60,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // Spec gas: tx_gas_limit = intrinsic + per-frame + calldata + signature verification
         // + sum(frame.gas_limit); the sum is overflow-checked so the processor does not depend
         // on static validation having run.
-        ulong intrinsicGas = CalculateFrameTxIntrinsicGas(tx, frames, spec);
+        ulong intrinsicGas = CalculateFrameTxIntrinsicGas(tx, frames, spec, out ulong floorGas);
         ulong totalFrameGas = 0;
         foreach (TxFrame frame in frames)
         {
@@ -77,6 +77,14 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         if (txGasLimit < intrinsicGas)
         {
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction gas limit overflows");
+        }
+
+        // EIP-7623: the payer's max-cost reservation below is derived from the gas limit, so a
+        // limit that cannot cover the floor-priced charge is rejected rather than under-reserved.
+        if (txGasLimit < floorGas)
+        {
+            return TransactionResult.ErrorType.GasLimitBelowFloorGas.WithDetail(
+                $"frame transaction gas limit {txGasLimit} below EIP-7623 floor gas {floorGas}");
         }
 
         // max_cost is defined at basefee=max (TXPARAM 0x06): the payer solvency gate reserves at
@@ -294,9 +302,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         // EIP-3529 storage refunds are netted once at the transaction level (ethereum/EIPs#11940):
         // the accumulated counter is capped at a fifth of the gross gas and subtracted here. Per-frame
-        // receipts stay gross; only this transaction total is netted.
+        // receipts stay gross; only this transaction total is netted. The EIP-7623 floor then bounds
+        // the net charge from below.
         ulong grossGas = intrinsicGas + totalFrameGasUsed;
-        ulong spentGas = grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)refundCounter, spec);
+        ulong spentGas = Math.Max(grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)refundCounter, spec), floorGas);
         // Block-level gas accounting reads Transaction.BlockGasUsed, whose getter otherwise falls back
         // to tx.GasLimit (the frame-gas sum, not the gas actually spent). Set it explicitly like the
         // regular path so parallel block validation (BlockAccessListManager) accumulates the frame
@@ -382,10 +391,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     /// <summary>
     /// FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST + calldata cost of frame data
     /// and signature fields (EIP-7623 token pricing) + per-scheme signature verification cost.
-    /// EIP8141: whether the EIP-7623 floor applies to frame transactions is unspecified; the
-    /// standard token cost is used here.
+    /// EIP-8141 inherits the floor from EIP-7623 specifically: the floor prices tokens at
+    /// <see cref="GasCostOf.TotalCostFloorPerTokenEip7623"/> on top of the mandatory (non-data)
+    /// costs, so <paramref name="floorGas"/> is the minimum chargeable gas (0 when floor pricing is
+    /// not active). The frame-tx floor stays pinned to the EIP-7623 constant even when EIP-7976 is
+    /// also scheduled, because EIP-8141 defines the floor per EIP-7623, not EIP-7976.
     /// </summary>
-    private static ulong CalculateFrameTxIntrinsicGas(Transaction tx, TxFrame[] frames, IReleaseSpec spec)
+    private static ulong CalculateFrameTxIntrinsicGas(Transaction tx, TxFrame[] frames, IReleaseSpec spec, out ulong floorGas)
     {
         ulong tokens = 0;
         foreach (TxFrame frame in frames)
@@ -412,10 +424,11 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             }
         }
 
-        return (ulong)Eip8141Constants.IntrinsicGasCost
-               + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
-               + tokens * GasCostOf.TxDataZero
-               + signatureVerificationCost;
+        ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost
+                             + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
+                             + signatureVerificationCost;
+        floorGas = spec.IsEip7623Enabled ? mandatoryGas + tokens * GasCostOf.TotalCostFloorPerTokenEip7623 : 0;
+        return mandatoryGas + tokens * GasCostOf.TxDataZero;
     }
 
     private static ulong CountCalldataTokens(ReadOnlySpan<byte> data, IReleaseSpec spec)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -79,13 +79,12 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction gas limit overflows");
         }
 
-        // EIP-7623: the payer's max-cost reservation below is derived from the gas limit, so a
-        // limit that cannot cover the floor-priced charge is rejected rather than under-reserved.
-        if (txGasLimit < floorGas)
-        {
-            return TransactionResult.ErrorType.GasLimitBelowFloorGas.WithDetail(
-                $"frame transaction gas limit {txGasLimit} below EIP-7623 floor gas {floorGas}");
-        }
+        // max_gas: frames that reserve less than the transaction's own calldata floor raise the
+        // reservation rather than invalidate the transaction, so the payer can always cover the
+        // floor-priced charge settled below. The frames keep their own allocations — the headroom
+        // is reserved and refunded, never spendable — and the block gas pool is credited the same
+        // max_gas minus gas_used.
+        txGasLimit = Math.Max(txGasLimit, floorGas);
 
         // max_cost is defined at basefee=max (TXPARAM 0x06): the payer solvency gate reserves at
         // max_fee_per_gas plus blob cost, not the effective price, so it is not under-reserved.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -79,11 +79,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction gas limit overflows");
         }
 
-        // max_gas: frames that reserve less than the transaction's own calldata floor raise the
-        // reservation rather than invalidate the transaction, so the payer can always cover the
-        // floor-priced charge settled below. The frames keep their own allocations — the headroom
-        // is reserved and refunded, never spendable — and the block gas pool is credited the same
-        // max_gas minus gas_used.
+        // max_gas: frames reserving less than the calldata floor raise the reservation rather than
+        // invalidate the transaction. The headroom is reserved and refunded, never spendable.
         txGasLimit = Math.Max(txGasLimit, floorGas);
 
         // max_cost is defined at basefee=max (TXPARAM 0x06): the payer solvency gate reserves at
@@ -388,24 +385,15 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     }
 
     /// <summary>
-    /// Computes the intrinsic gas of a frame transaction and, via <paramref name="floorGas"/>, the
-    /// least gas it may be charged.
+    /// FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST + calldata cost of frame data
+    /// and signature fields + per-scheme signature verification cost.
     /// </summary>
     /// <remarks>
-    /// The intrinsic cost is <c>FRAME_TX_INTRINSIC_COST</c> + frames × <c>FRAME_TX_PER_FRAME_COST</c>
-    /// + per-scheme signature verification + the calldata cost of the frame data and signature
-    /// fields. The floor adds the same mandatory (non-data) costs to the data priced at
-    /// <see cref="SpecGasCosts.TotalCostFloorPerToken"/>, mirroring
-    /// <see cref="IntrinsicGasCalculator.CalculateFloorCost"/>: EIP-7976 prices every data byte as a
-    /// non-zero token, EIP-7623 weights zero bytes lower. Both the rate and the token weighting are
-    /// resolved from the spec so a frame transaction's floor cannot diverge from an ordinary
-    /// transaction's under the same fork.
+    /// The rate and token weighting behind <paramref name="floorGas"/> are resolved from the spec, as
+    /// <see cref="IntrinsicGasCalculator.CalculateFloorCost"/> does, so a frame transaction's floor
+    /// cannot diverge from an ordinary transaction's under the same fork.
     /// </remarks>
-    /// <param name="tx">The frame transaction being charged.</param>
-    /// <param name="frames">The transaction's frames.</param>
-    /// <param name="spec">The release spec in effect.</param>
     /// <param name="floorGas">The minimum chargeable gas, or 0 when floor pricing is not active.</param>
-    /// <returns>The intrinsic gas charged before execution.</returns>
     private static ulong CalculateFrameTxIntrinsicGas(Transaction tx, TxFrame[] frames, IReleaseSpec spec, out ulong floorGas)
     {
         ulong tokens = 0;


### PR DESCRIPTION
## Changes

- Apply the EIP-7623 calldata floor to frame transactions (EIP-8141), pinned to the EIP-7623 rate of 10 gas per token.
- Reject a frame transaction whose computed gas limit cannot cover the floor-priced charge (`GasLimitBelowFloorGas`).

The frame-tx gas path charges frame data and signature fields at the standard token cost only, with no floor. EIP-8141 applies the EIP-7623 floor to that data (eip-8141.md, "Gas" section):

```
gas_charged = mandatory_costs + max(standard_token_cost * calldata_tokens + execution_gas, TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens)
```

and a transaction whose `tx_gas_limit` is below `FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + signature_verification_cost + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens` is invalid, so the floor is reserved independently of execution as EIP-7623 requires.

EIP-8141 `requires` EIP-7623 (not EIP-7976) and defines `TOTAL_COST_FLOOR_PER_TOKEN` as the EIP-7623 value, 10 per token. Resolving it through `spec.GasCosts.TotalCostFloorPerToken` would silently become 16 per token once a chainspec also schedules EIP-7976, diverging from the spec and from another implementation, which charges 10. I pinned it to `GasCostOf.TotalCostFloorPerTokenEip7623`.

`CalculateFrameTxIntrinsicGas` now also returns `floorGas = mandatory_costs + tokens * 10` (0 when EIP-7623 is not active); the mandatory intrinsic, per-frame and signature verification costs stay outside the max, matching the spec formula. I validate the computed transaction gas limit against `floorGas` before the payer's max-cost reservation is derived from it, so an under-floor limit is rejected rather than under-reserved. At settlement, `spentGas` is bounded from below by `floorGas` after EIP-3529 refund netting.

Tests cover gas-limit-below-floor rejection, floor-dominant charging asserting 10 per token under the prototype fork (which also schedules EIP-7976 for the regular tx path, so the test binds the pin), an execution-dominant regression asserting standard accounting is unchanged, and the spec intrinsic-formula test extended with the floor max.

`Execute_GasLimitBelowEip7623Floor_ReturnsGasLimitBelowFloorGas` uses 40,000 zero-byte tokens: at 10/token, rejection requires `tokens * (10 - 4) > sum(frame.gas_limit)` (200,000 declared here), i.e. more than ~33,334 tokens.

Commands run on this branch:

- `dotnet build src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj -c release`, 0 warnings, 0 errors
- `dotnet test src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c release -- --filter FullyQualifiedName~FrameTx`, 64 succeeded, 0 failed
- `dotnet test src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c release -- --filter FullyQualifiedName~Eip8141`, 15 succeeded, 0 failed
- `dotnet format whitespace src/Nethermind/ --folder` and `git diff --check`, clean

Targets `eip8141-frame-txs-devnet7`. One of a series of independent EIP-8141 fixes; sibling PRs #12591 (base fee burn), #12593 (zero-premium beneficiary BAL), #12595 (EIP-7708 transfer log).

Every devnet client has to apply the same floor at the same 10/token rate or blocks carrying such transactions split the network. The 10-vs-16 divergence only manifests on chainspecs that schedule both EIP-8141 and EIP-7976; the prototype fork used in tests does. Coverage is unit-level only, and mempool-side static validation of the floor rule is not part of this change.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Both the FrameTx processor tests and the EIP-8141 scenario suite were run; see the commands above.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
