### PR TITLE
feat(evm): EIP-7708 transfer log in sender frame receipt

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
@@ -114,6 +114,11 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         if (_config.OnlyTopCall && Depth > 0)
             return;
 
+        // A frame transaction running entirely through default code (an EOA sender's codeless
+        // SENDER transfer) emits a log without any ReportAction, so the call stack can be empty.
+        if (_callStack.Count == 0)
+            return;
+
         NativeCallTracerCallFrame callFrame = _callStack[^1];
 
         NativeCallTracerLogEntry callLog = new(

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -84,12 +84,10 @@ public class Eip8141ScenarioTests
         Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1UL));
     }
 
-    // EIP-7708: a codeless SENDER frame's value transfer runs through default code, bypassing the
-    // VM, so the transfer log must still reach the SENDER frame receipt and the transaction log
-    // union, with the SYSTEM_ADDRESS emitter, Transfer topics, and 32-byte big-endian value data.
-    // The recipient does not exist beforehand, so this exercises the dead-recipient path, where
-    // default code (no gas metering) always emits the log, unlike the VM path, which suppresses
-    // it when the EIP-8037 NEW_ACCOUNT state gas is unaffordable.
+    // EIP-7708: a codeless SENDER frame transfers through default code, not the VM, so the log must
+    // still reach the frame receipt and the transaction log union. Recipient is fresh, exercising
+    // the dead-recipient path where default code always logs (the VM path suppresses it when the
+    // EIP-8037 NEW_ACCOUNT gas is unaffordable).
     [Test]
     public void CodelessSenderFrameTransfer_EmitsEip7708TransferLog()
     {

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Encoding;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
@@ -81,6 +82,39 @@ public class Eip8141ScenarioTests
             Is.EqualTo(1.Ether - transferred - (UInt256)receipt.GasUsed),
             "payer covers gas at the effective price on top of the transferred value");
         Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1UL));
+    }
+
+    // EIP-7708: a codeless SENDER frame's value transfer runs through default code, bypassing the
+    // VM, so the transfer log must still reach the SENDER frame receipt and the transaction log
+    // union, with the SYSTEM_ADDRESS emitter, Transfer topics, and 32-byte big-endian value data.
+    // The recipient does not exist beforehand, so this exercises the dead-recipient path, where
+    // default code (no gas metering) always emits the log, unlike the VM path, which suppresses
+    // it when the EIP-8037 NEW_ACCOUNT state gas is unaffordable.
+    [Test]
+    public void CodelessSenderFrameTransfer_EmitsEip7708TransferLog()
+    {
+        UInt256 transferred = 1_000_000;
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            SenderFrame(Recipient, value: transferred));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Success));
+        LogEntry expected = new(
+            Address.SystemUser,
+            transferred.ToBigEndian(),
+            [new Hash256("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), Sender.ToHash().ToHash256(), Recipient.ToHash().ToHash256()]);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_stateProvider.GetBalance(Recipient), Is.EqualTo(transferred));
+            Assert.That(receipt.FrameReceipts![0].Logs, Is.Empty);
+            receipt.FrameReceipts[1].Logs.AssertEquivalentTo([expected]);
+            receipt.Logs.AssertEquivalentTo([expected]);
+            Assert.That(receipt.Bloom, Is.EqualTo(new Bloom([expected])));
+        }
     }
 
     // Spec Example 1b: a DEFAULT deploy frame installs the smart-account code at the sender address

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
@@ -635,6 +635,20 @@ public class GethLikeCallTracerTests : VirtualMachineTestsBase
         Assert.That(frame!.Logs, Is.Null, "logs must be cleared on a failed CREATE frame even when _error is null");
     }
 
+    [Test]
+    public void Test_CallTrace_ReportLog_EmptyCallStack_DoesNotThrow()
+    {
+        // A frame transaction running entirely through default code (an EOA sender's codeless
+        // SENDER transfer) emits an EIP-7708 transfer log without any ReportAction, so the call
+        // stack is empty. debug_traceTransaction with callTracer and withLog must not throw.
+        Transaction tx = Build.A.Transaction.TestObject;
+        using NativeCallTracer tracer = new(tx, GetGethTraceOptions(WithLog));
+
+        Assert.That(
+            () => tracer.ReportLog(new LogEntry(TestItem.AddressA, [], [])),
+            Throws.Nothing);
+    }
+
 
     [Test]
     public void Test_CallTrace_DeepNesting_DoesNotThrow()

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -443,11 +443,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     /// EIP8141-ISSUE: the spec reads the signature from the hoisted <c>signatures</c> list at index
     /// 0; the ethrex public devnet carries it in the VERIFY frame's data instead — an open
     /// cross-client divergence to raise upstream. This follows the spec (hoisted list).
-    /// EIP8141: default-code gas metering is pending; the sig verification cost is already charged
-    /// in the intrinsic, so no gas is charged here yet. Two consequences for the transfer log: the
-    /// EIP-8037 NEW_ACCOUNT charge that suppresses it on the VM path never applies, so a transfer
-    /// to a dead recipient always logs; and nothing can fail after the transfer, so the log needs
-    /// no frame-journal snapshot. Adding a gas charge here requires revisiting both.
+    /// EIP8141: default-code gas metering is pending, so the transfer to a dead recipient always
+    /// logs (the EIP-8037 NEW_ACCOUNT charge that suppresses it on the VM path never applies) and
+    /// needs no frame-journal snapshot. A gas charge here would revisit both.
     /// </summary>
     /// <param name="accessTracker">Cross-frame log/warm journal; the transfer log is appended to
     /// its log list so it reaches the frame receipt and the transaction log union.</param>

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -380,7 +380,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // the protocol-defined behavior instead of the EVM.
         if (WorldState.GetCodeHash(resolvedTarget) == Keccak.OfAnEmptyString)
         {
-            return ExecuteDefaultCode(frame, resolvedTarget, caller, isStatic, frameContext, spec, tracer, out gasUsed);
+            return ExecuteDefaultCode(frame, resolvedTarget, caller, isStatic, frameContext, in accessTracker, spec, tracer, out gasUsed);
         }
 
         CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, spec, out _);
@@ -436,16 +436,22 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     /// <summary>
     /// EIP-8141 default code for a codeless target. VERIFY: require a canonical-hash SECP256K1
     /// signature at index 0 whose resolved signer is the target, then signal APPROVE with the
-    /// frame's allowed scope. SENDER/DEFAULT: succeed as empty code (value transfer only).
+    /// frame's allowed scope. SENDER/DEFAULT: succeed as empty code, performing the value transfer
+    /// and emitting its EIP-7708 transfer log into the frame receipt.
     /// The signature's cryptographic validity is already checked in pre-flight; default code checks
     /// only the structural conditions the spec pins.
     /// EIP8141-ISSUE: the spec reads the signature from the hoisted <c>signatures</c> list at index
     /// 0; the ethrex public devnet carries it in the VERIFY frame's data instead — an open
     /// cross-client divergence to raise upstream. This follows the spec (hoisted list).
     /// EIP8141: default-code gas metering is pending; the sig verification cost is already charged
-    /// in the intrinsic, so no gas is charged here yet.
+    /// in the intrinsic, so no gas is charged here yet. Two consequences for the transfer log: the
+    /// EIP-8037 NEW_ACCOUNT charge that suppresses it on the VM path never applies, so a transfer
+    /// to a dead recipient always logs; and nothing can fail after the transfer, so the log needs
+    /// no frame-journal snapshot. Adding a gas charge here requires revisiting both.
     /// </summary>
-    private TransactionSubstate ExecuteDefaultCode(TxFrame frame, Address resolvedTarget, Address caller, bool isStatic, FrameTxContext frameContext, IReleaseSpec spec, ITxTracer tracer, out ulong gasUsed)
+    /// <param name="accessTracker">Cross-frame log/warm journal; the transfer log is appended to
+    /// its log list so it reaches the frame receipt and the transaction log union.</param>
+    private TransactionSubstate ExecuteDefaultCode(TxFrame frame, Address resolvedTarget, Address caller, bool isStatic, FrameTxContext frameContext, in StackAccessTracker accessTracker, IReleaseSpec spec, ITxTracer tracer, out ulong gasUsed)
     {
         gasUsed = 0;
 
@@ -480,6 +486,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         {
             WorldState.SubtractFromBalance(caller, in value, spec);
             WorldState.AddToBalanceAndCreateIfNotExists(resolvedTarget, in value, spec);
+            // EIP-7708: self-transfers emit no log; zero value is excluded by the outer guard.
+            if (spec.IsEip7708Enabled && caller != resolvedTarget)
+            {
+                LogEntry transferLog = TransferLog.CreateTransfer(caller, resolvedTarget, in value);
+                accessTracker.Logs.Add(transferLog);
+                if (tracer.IsTracingLogs) tracer.ReportLog(transferLog);
+            }
         }
 
         return DefaultCodeSuccess();


### PR DESCRIPTION
## Changes

- Emit the EIP-7708 transfer log for value moved by a codeless `SENDER` frame (default code), and record it in that frame's receipt logs.

### Current behaviour and why it is wrong

EIP-8141 routes a frame whose resolved target has empty code through the protocol-defined default code instead of the EVM ("If `resolved_target` code hash is empty ... execute the logic described in default code"). The default-code path transfers `frame.value` directly on world state, bypassing the VM. When EIP-7708 is active, every nonzero value transfer must emit a `Transfer(from, to)` log from `SYSTEM_ADDRESS`; the VM call path already does this, but the frame-tx default-code path did not, so a plain ETH transfer via a codeless `SENDER` frame produced no transfer log. The log also has a defined place: EIP-8141 receipts carry per-frame log lists (`frame_receipt = [status, gas_used, logs]`), so the transfer log belongs to the `SENDER` frame's receipt sub-entry and, through it, the transaction's log union and bloom.

### What the change does

`ExecuteDefaultCode` now takes the frame's access tracker and, when `spec.IsEip7708Enabled` and the transfer is a real move (`caller != resolvedTarget`, nonzero value), appends `TransferLog.CreateTransfer(caller, resolvedTarget, value)` to the frame's log journal (and reports it to a log-tracing tracer). The journal placement means a reverted frame discards the log with the rest of its effects, same as VM-emitted logs.

Regression test `CodelessSenderFrameTransfer_EmitsEip7708TransferLog` asserts the balance moves and that the log - with the `SYSTEM_ADDRESS` emitter, `Transfer` topic, from/to topics, and 32-byte big-endian value data - appears in the `SENDER` frame's receipt (not the `VERIFY` frame's), in the receipt log union, and in the bloom.

### Evidence

Commands run on this branch:

- `dotnet build src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj -c release` - Build succeeded, 0 warnings, 0 errors.
- `dotnet test src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c release -- --filter FullyQualifiedName~FrameTx` - total: 63, failed: 0, succeeded: 63, skipped: 0.
- `dotnet test src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c release -- --filter FullyQualifiedName~Eip8141` - total: 14, failed: 0, succeeded: 14, skipped: 0 (includes the new test).
- `dotnet format whitespace src/Nethermind/ --folder` and `git diff --check` - clean.

### Stack note

Targets `eip8141-frame-txs-devnet7`. One of a series of independent EIP-8141 fixes; sibling PRs: #12591 (base fee burn), #12593 (zero-premium beneficiary BAL), #12594 (EIP-7623 calldata floor).

### Consensus risk and limits

- Changes receipt contents (frame logs, log union, bloom) for blocks with codeless SENDER frame transfers under EIP-7708, so the receipts root diverges from clients without the rule; all devnet clients must agree.
- Exact log placement (sender frame receipt vs a transaction-level position) is an interpretation of the per-frame receipt structure; flagged as "log-placement" for cross-client discussion.
- Covers the default-code SENDER path only; VM-path transfers already emit the log elsewhere. Fee-related EIP-7708 logs are out of scope here (the sender-side fee/burn logs land with the sibling PRs). No cross-client conformance fixture yet.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

See Evidence above.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
