### PR TITLE
perf(state): capture storage originals once per round

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -943,44 +943,38 @@ public class StorageProviderTests(bool useFlat)
 
     [TestCase(RoundBoundary.None)]
     [TestCase(RoundBoundary.ResetKeepingBlockChanges)]
-    [TestCase(RoundBoundary.Commit)]
+    [TestCase(RoundBoundary.ReadOnlyCommit)]
+    [TestCase(RoundBoundary.CommitAfterWrite)]
     public void Original_available_after_repeat_read(RoundBoundary boundary)
     {
         using Context ctx = new(useFlat);
         WorldState provider = BuildStorageProvider(ctx);
         StorageCell cell = new(ctx.Address1, 1);
 
+        provider.Set(cell, _values[1]);
+        provider.Commit(Frontier.Instance);
+
         provider.Get(cell);
 
-        if (boundary == RoundBoundary.ResetKeepingBlockChanges)
+        switch (boundary)
         {
-            provider.Reset(resetBlockChanges: false);
+            case RoundBoundary.ResetKeepingBlockChanges:
+                provider.Reset(resetBlockChanges: false);
+                break;
+            case RoundBoundary.ReadOnlyCommit:
+                provider.Commit(Frontier.Instance);
+                break;
+            case RoundBoundary.CommitAfterWrite:
+                // A write in the round is what routes the commit through CommitCore, the clear
+                // site that a read-only commit skips.
+                provider.Set(new StorageCell(ctx.Address1, 2), _values[2]);
+                provider.Commit(Frontier.Instance);
+                break;
         }
-        else if (boundary == RoundBoundary.Commit)
-        {
-            provider.Commit(Frontier.Instance);
-        }
 
         provider.Get(cell);
 
-        Assert.That(provider.GetOriginal(cell).ToArray(), Is.EqualTo(StorageTree.ZeroBytes));
-    }
-
-    [Test]
-    public void Repeat_read_reports_one_storage_read_to_tracer()
-    {
-        using Context ctx = new(useFlat);
-        WorldState provider = BuildStorageProvider(ctx);
-        StorageCell cell = new(ctx.Address1, 1);
-
-        provider.Get(cell);
-        provider.Get(cell);
-        provider.Get(cell);
-
-        ReadCollectingStorageTracer tracer = new();
-        provider.Commit(Frontier.Instance, tracer);
-
-        Assert.That(tracer.Reads, Is.EqualTo(new[] { cell }));
+        Assert.That(provider.GetOriginal(cell).ToArray(), Is.EqualTo(_values[1]));
     }
 
     [Test]
@@ -1259,11 +1253,12 @@ public class StorageProviderTests(bool useFlat)
         }
     }
 
-    public enum RoundBoundary
+    private enum RoundBoundary
     {
         None,
         ResetKeepingBlockChanges,
-        Commit,
+        ReadOnlyCommit,
+        CommitAfterWrite,
     }
 
     private sealed class ReadCollectingStorageTracer : IWorldStateTracer

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -1253,7 +1253,7 @@ public class StorageProviderTests(bool useFlat)
         }
     }
 
-    private enum RoundBoundary
+    public enum RoundBoundary
     {
         None,
         ResetKeepingBlockChanges,

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -941,6 +941,48 @@ public class StorageProviderTests(bool useFlat)
         Assert.That(secondRoundTracer.Reads, Is.Empty);
     }
 
+    [TestCase(RoundBoundary.None)]
+    [TestCase(RoundBoundary.ResetKeepingBlockChanges)]
+    [TestCase(RoundBoundary.Commit)]
+    public void Original_available_after_repeat_read(RoundBoundary boundary)
+    {
+        using Context ctx = new(useFlat);
+        WorldState provider = BuildStorageProvider(ctx);
+        StorageCell cell = new(ctx.Address1, 1);
+
+        provider.Get(cell);
+
+        if (boundary == RoundBoundary.ResetKeepingBlockChanges)
+        {
+            provider.Reset(resetBlockChanges: false);
+        }
+        else if (boundary == RoundBoundary.Commit)
+        {
+            provider.Commit(Frontier.Instance);
+        }
+
+        provider.Get(cell);
+
+        Assert.That(provider.GetOriginal(cell).ToArray(), Is.EqualTo(StorageTree.ZeroBytes));
+    }
+
+    [Test]
+    public void Repeat_read_reports_one_storage_read_to_tracer()
+    {
+        using Context ctx = new(useFlat);
+        WorldState provider = BuildStorageProvider(ctx);
+        StorageCell cell = new(ctx.Address1, 1);
+
+        provider.Get(cell);
+        provider.Get(cell);
+        provider.Get(cell);
+
+        ReadCollectingStorageTracer tracer = new();
+        provider.Commit(Frontier.Instance, tracer);
+
+        Assert.That(tracer.Reads, Is.EqualTo(new[] { cell }));
+    }
+
     [Test]
     public void Eip161_empty_account_with_storage_does_not_throw_on_commit()
     {
@@ -1215,6 +1257,13 @@ public class StorageProviderTests(bool useFlat)
                 writtenData.SelfDestructed[address] = true;
             }
         }
+    }
+
+    public enum RoundBoundary
+    {
+        None,
+        ResetKeepingBlockChanges,
+        Commit,
     }
 
     private sealed class ReadCollectingStorageTracer : IWorldStateTracer

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -45,7 +45,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     // Zero means never captured, which is what a default BlockChange entry carries.
     private uint _originalsRound = 1;
 
-    private void ClearOriginalValues()
+    private void EndOriginalsRound()
     {
         _originalValues.ClearAndTrim();
         if (++_originalsRound == 0) _originalsRound = 1;
@@ -57,7 +57,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     public override void Reset(bool resetBlockChanges = true)
     {
         base.Reset();
-        ClearOriginalValues();
+        EndOriginalsRound();
         _committedThisRound.ClearAndTrim();
         _destroyedThisRound.ClearAndTrim();
         if (resetBlockChanges)
@@ -239,7 +239,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
 
         base.CommitCore(tracer);
-        ClearOriginalValues();
+        EndOriginalsRound();
         _committedThisRound.ClearAndTrim();
         _destroyedThisRound.ClearAndTrim();
 
@@ -380,7 +380,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                     }
                 }
 
-                ClearOriginalValues();
+                EndOriginalsRound();
             }
 
             _destroyedThisRound.ClearAndTrim();

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -43,12 +43,28 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     private readonly HashSet<StorageCell> _committedThisRound = [];
 
     /// <summary>
+    /// Identifies the current caching round so a <see cref="PerContractState.BlockChange"/> entry can
+    /// record that its original value has already been captured for this round. Reads are not
+    /// journaled, so every repeat read of an unwritten cell reaches
+    /// <see cref="PerContractState.LoadFromTree"/>; without the stamp each one re-probes
+    /// <see cref="_originalValues"/> on a 52-byte key to re-record what is already there.
+    /// Zero is reserved for "never captured", which is what a default entry carries.
+    /// </summary>
+    private uint _originalsRound = 1;
+
+    private void AdvanceOriginalsRound()
+    {
+        if (++_originalsRound == 0) _originalsRound = 1;
+    }
+
+    /// <summary>
     /// Reset the storage state
     /// </summary>
     public override void Reset(bool resetBlockChanges = true)
     {
         base.Reset();
         _originalValues.ClearAndTrim();
+        AdvanceOriginalsRound();
         _committedThisRound.ClearAndTrim();
         _destroyedThisRound.ClearAndTrim();
         if (resetBlockChanges)
@@ -231,6 +247,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         base.CommitCore(tracer);
         _originalValues.ClearAndTrim();
+        AdvanceOriginalsRound();
         _committedThisRound.ClearAndTrim();
         _destroyedThisRound.ClearAndTrim();
 
@@ -372,6 +389,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 }
 
                 _originalValues.ClearAndTrim();
+                AdvanceOriginalsRound();
             }
 
             _destroyedThisRound.ClearAndTrim();
@@ -573,7 +591,15 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 _provider._metrics.IncrementStorageTreeCache();
             }
 
-            _provider.CaptureOriginalValue(storageCell, valueChange.After);
+            // First read of this cell in this round captures the original; later reads of the same
+            // cell would only re-record the same value, so they skip the 52-byte-keyed probe.
+            uint round = _provider._originalsRound;
+            if (valueChange.CapturedRound != round)
+            {
+                _provider.CaptureOriginalValue(storageCell, valueChange.After);
+                valueChange = valueChange.WithCapturedRound(round);
+            }
+
             return valueChange.After;
         }
 
@@ -702,8 +728,23 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             IsInitialValue = true;
         }
 
+        private StorageChangeTrace(byte[] before, byte[] after, bool isInitialValue, uint capturedRound)
+        {
+            Before = before;
+            After = after;
+            IsInitialValue = isInitialValue;
+            CapturedRound = capturedRound;
+        }
+
+        public StorageChangeTrace WithCapturedRound(uint round) => new(Before, After, IsInitialValue, round);
+
         public readonly byte[] Before;
         public readonly byte[] After;
         public readonly bool IsInitialValue;
+
+        /// <summary>
+        /// Caching round in which this cell's original value was last recorded, or zero if never.
+        /// </summary>
+        public readonly uint CapturedRound;
     }
 }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -42,18 +42,12 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     private readonly HashSet<AddressAsKey> _destroyedThisRound = [];
     private readonly HashSet<StorageCell> _committedThisRound = [];
 
-    /// <summary>
-    /// Identifies the current caching round so a <see cref="PerContractState.BlockChange"/> entry can
-    /// record that its original value has already been captured for this round. Reads are not
-    /// journaled, so every repeat read of an unwritten cell reaches
-    /// <see cref="PerContractState.LoadFromTree"/>; without the stamp each one re-probes
-    /// <see cref="_originalValues"/> on a 52-byte key to re-record what is already there.
-    /// Zero is reserved for "never captured", which is what a default entry carries.
-    /// </summary>
+    // Zero means never captured, which is what a default BlockChange entry carries.
     private uint _originalsRound = 1;
 
-    private void AdvanceOriginalsRound()
+    private void ClearOriginalValues()
     {
+        _originalValues.ClearAndTrim();
         if (++_originalsRound == 0) _originalsRound = 1;
     }
 
@@ -63,8 +57,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     public override void Reset(bool resetBlockChanges = true)
     {
         base.Reset();
-        _originalValues.ClearAndTrim();
-        AdvanceOriginalsRound();
+        ClearOriginalValues();
         _committedThisRound.ClearAndTrim();
         _destroyedThisRound.ClearAndTrim();
         if (resetBlockChanges)
@@ -246,8 +239,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
 
         base.CommitCore(tracer);
-        _originalValues.ClearAndTrim();
-        AdvanceOriginalsRound();
+        ClearOriginalValues();
         _committedThisRound.ClearAndTrim();
         _destroyedThisRound.ClearAndTrim();
 
@@ -388,8 +380,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                     }
                 }
 
-                _originalValues.ClearAndTrim();
-                AdvanceOriginalsRound();
+                ClearOriginalValues();
             }
 
             _destroyedThisRound.ClearAndTrim();
@@ -591,8 +582,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 _provider._metrics.IncrementStorageTreeCache();
             }
 
-            // First read of this cell in this round captures the original; later reads of the same
-            // cell would only re-record the same value, so they skip the 52-byte-keyed probe.
             uint round = _provider._originalsRound;
             if (valueChange.CapturedRound != round)
             {
@@ -741,10 +730,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         public readonly byte[] Before;
         public readonly byte[] After;
         public readonly bool IsInitialValue;
-
-        /// <summary>
-        /// Caching round in which this cell's original value was last recorded, or zero if never.
-        /// </summary>
         public readonly uint CapturedRound;
     }
 }


### PR DESCRIPTION
Reads are not journaled, so a repeat SLOAD of an unwritten cell reaches `PerContractState.LoadFromTree` every time and re-probes `_originalValues` on a 52-byte key (address + slot) to re-record a value that is already recorded. The per-contract `BlockChange` entry now carries the round in which its original was captured, so that probe happens on the first read of a cell per round only.

### Semantics

Unchanged:

- first capture wins, as before;
- the capture survives revert, because reads are not journaled and `BlockChange` is the read cache;
- all three sites that clear `_originalValues` (`Reset`, `CommitCore`, the read-only `Commit` path) advance the round, so a capture can never be skipped. Round 0 is reserved for "never captured", which is what a default entry carries, and the counter skips back to 1 on wrap.

`SaveChange` rebuilds the entry and so resets the stamp; the next read re-captures, which is harmless because capture is first-wins.

### Measurement

SLOAD-only workload, 4 slots re-read over 10000 iterations (40000 SLOADs), same machine, BenchmarkDotNet:

| | median | StdDev |
|---|---|---|
| master | 2.216 ms | 0.010 ms |
| this branch | **1.999 ms** | 0.010 ms |

-9.8%. The same delta shows on both interpreter paths (2.214 -> 1.994 ms on the bytecode loop), which is expected for a change in the state layer.

### Notes for review

- Consensus-adjacent file, so the State, Blockchain and Evm suites are the gate; I have not run them locally.
- A regression test for `GetOriginal` after a repeat read across rounds would strengthen this and I am happy to add it here.
