### PR TITLE
fix(prewarm): demote per-tx rejection logging to Trace to stop the Debug log flood

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Transactions/TxFilterPipeline.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/TxFilterPipeline.cs
@@ -27,7 +27,7 @@ public class TxFilterPipeline(ILogManager logManager) : ITxFilterPipeline
             bool isAllowed = filter.IsAllowed(tx, parentHeader, currentSpec);
             if (!isAllowed)
             {
-                if (_logger.IsDebug) _logger.Debug($"Rejected tx ({isAllowed}) {tx.ToShortString()}");
+                if (_logger.IsTrace) _logger.Trace($"Rejected tx ({isAllowed}) {tx.ToShortString()}");
                 return isAllowed;
             }
         }


### PR DESCRIPTION
## Changes

- Demote `TxFilterPipeline`'s per-transaction rejection log line from Debug to Trace.

## Why

Since mempool-driven speculative pre-warming became the default (#12344), the block producer's tx selection runs over the mempool every ~100 ms in the idle gap between blocks. Each pass re-rejects largely the same transactions, and this line logs every rejection **including the full tx data field**.

Measured on a Debug-level mainnet node (during RPC-mode benchmarking with the smoke-test VM infra, which runs `--log=DEBUG` and no docker log rotation):

- **~2–3 MB/s of sustained log output** on any node with `Blocks.PreWarming=BlockAndMempool` (the default)
- **130 GB docker json log + 214 GB NLog file in ~13 h** → disk-guard shutdown loop (exit 104) in under two days on a 630 GB disk; three test VMs were lost to this before diagnosis
- The formatting/write overhead is a performance bug too: in A/B benchmarks at 1000 rps/node, the flood inflated `eth_call` p99 **2–4×** and block-import times ~2.4× vs the same node at Info. With the flood removed, prewarming ON vs OFF is indistinguishable (±0.2 ms p99 across 14 runs on 8- and 16-core pairs) — i.e. the *feature* is fine; the *logging* was the cost.

The identical node with `PreWarming=Block` produced 835 MB in the same window — the flood is specifically the speculative passes re-filtering the pool at ~10 Hz. Per-tx rejection detail at that cadence is Trace-granularity information.

## Alternative considered

A rate-limited Debug summary (e.g. counts per pass) would preserve producer observability at Debug; happy to switch to that if reviewers prefer — this PR takes the minimal-diff route.

## Types of changes
- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing
- Log-level demotion only; no behavior change. Verified empirically on the benchmark VMs: at Info the line never fires, node behavior identical.

## Notes
- Draft: not yet compile-verified locally (one-line level swap; `ILogger.IsTrace`/`Trace` used per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)