### PR TITLE
Align unrolled-batch frame logs with EIP-8141 #12008

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -38,21 +38,23 @@ public class FrameTxReceiptDecoderTests
 
     // The storage form appends [payer, [frame_receipt, ...]] after the standard fields, so a
     // restart round-trips the execution results the block cannot reproduce. The union Logs and the
-    // per-frame logs are stored independently — a rolled-back batch frame keeps its log in the
-    // frame receipt while the union omits it, and storage must preserve exactly that divergence.
+    // per-frame logs are stored independently and must both survive; the receipt models a
+    // post-#12008 unrolled batch — an earlier frame that executed but was unrolled retains its
+    // status and gas_used with empty logs, so the stored union equals the frame-order
+    // concatenation of the surviving frame logs.
     [Test]
     public void StorageRoundtrip_PreservesPayerFrameReceiptsAndUnionLogs(
         [Values(true, false)] bool compactEncoding)
     {
-        LogEntry unionLog = Log(0x01);
-        LogEntry rolledBackLog = Log(0x02);
+        LogEntry survivorLog = Log(0x01);
         TxReceipt frameReceipt = CreateReceipt(
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [unionLog]),
-            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, [rolledBackLog]),
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [survivorLog]),
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 30_000, []),
+            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 40_000, []),
             new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, []));
         frameReceipt.StatusCode = TxFrameReceipt.StatusSuccess;
         frameReceipt.Sender = TestItem.AddressC;
-        frameReceipt.Logs = [unionLog];
+        frameReceipt.Logs = [survivorLog];
         frameReceipt.Bloom = new Bloom(frameReceipt.Logs);
         TxReceipt legacyReceipt = Build.A.Receipt.WithAllFieldsFilled.WithCalculatedBloom().TestObject;
 

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -37,24 +37,28 @@ public class FrameTxReceiptDecoderTests
     }
 
     // The storage form appends [payer, [frame_receipt, ...]] after the standard fields, so a
-    // restart round-trips the execution results the block cannot reproduce. The union Logs and the
-    // per-frame logs are stored independently and must both survive; the receipt models a
-    // post-#12008 unrolled batch — an earlier frame that executed but was unrolled retains its
-    // status and gas_used with empty logs, so the stored union equals the frame-order
-    // concatenation of the surviving frame logs.
+    // restart round-trips the execution results the block cannot reproduce. Unlike the wire form
+    // (which drops the union and rebuilds it from the frame logs on decode), storage persists the
+    // union Logs and the per-frame logs as INDEPENDENT fields and reads Logs back from its own
+    // stored field. To pin that field-level fidelity — that the decoder round-trips the union
+    // verbatim and never re-derives it — the union here is deliberately NOT the frame-order
+    // concatenation. This shape is artificial (post-#12008 a real receipt's union equals the
+    // concatenation); a decoder that rebuilt Logs from the frame receipts would fail the final
+    // assertion below.
     [Test]
     public void StorageRoundtrip_PreservesPayerFrameReceiptsAndUnionLogs(
         [Values(true, false)] bool compactEncoding)
     {
-        LogEntry survivorLog = Log(0x01);
+        LogEntry unionLog = Log(0x01);
+        LogEntry frameOnlyLog = Log(0x02);
         TxReceipt frameReceipt = CreateReceipt(
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [survivorLog]),
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 30_000, []),
-            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 40_000, []),
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [unionLog]),
+            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, [frameOnlyLog]),
             new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, []));
         frameReceipt.StatusCode = TxFrameReceipt.StatusSuccess;
         frameReceipt.Sender = TestItem.AddressC;
-        frameReceipt.Logs = [survivorLog];
+        // Union omits frameOnlyLog, so it diverges from the frame-order concatenation on purpose.
+        frameReceipt.Logs = [unionLog];
         frameReceipt.Bloom = new Bloom(frameReceipt.Logs);
         TxReceipt legacyReceipt = Build.A.Receipt.WithAllFieldsFilled.WithCalculatedBloom().TestObject;
 

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -36,15 +36,9 @@ public class FrameTxReceiptDecoderTests
         AssertLogsEqual(decoded.Logs!, receipt.FrameReceipts!.SelectMany(static f => f.Logs).ToArray());
     }
 
-    // The storage form appends [payer, [frame_receipt, ...]] after the standard fields, so a
-    // restart round-trips the execution results the block cannot reproduce. Unlike the wire form
-    // (which drops the union and rebuilds it from the frame logs on decode), storage persists the
-    // union Logs and the per-frame logs as INDEPENDENT fields and reads Logs back from its own
-    // stored field. To pin that field-level fidelity — that the decoder round-trips the union
-    // verbatim and never re-derives it — the union here is deliberately NOT the frame-order
-    // concatenation. This shape is artificial (post-#12008 a real receipt's union equals the
-    // concatenation); a decoder that rebuilt Logs from the frame receipts would fail the final
-    // assertion below.
+    // Storage persists the union Logs and the per-frame logs as independent fields (unlike the wire
+    // form, which rebuilds the union from the frame logs on decode). The union here is deliberately
+    // NOT the frame-order concatenation, pinning that the decoder reads Logs back verbatim.
     [Test]
     public void StorageRoundtrip_PreservesPayerFrameReceiptsAndUnionLogs(
         [Values(true, false)] bool compactEncoding)

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -313,6 +313,69 @@ public class Eip8141ScenarioTests
         AssertBloomAndReceiptLogsAgree(receipt);
     }
 
+    // Two batches in one transaction, the load-bearing multi-batch case the single-batch fixtures
+    // can't reach: per-batch bounds depend on batchStartIndex being re-seeded when batch B opens,
+    // which rests on inBatch being reset once batch A closes (unroll path here). A lost reset would
+    // leave batch B reusing batch A's start index, so batch B's unroll would clear back through the
+    // committed "between" frame and under-fill the bloom.
+    // Batch A always unrolls (its log discarded); a committed "between" frame follows; batch B then
+    // either commits (secondBatchReverts=false: its log survives) or unrolls (its log discarded).
+    // Either way the pre-, between-, and post-batch committed logs must survive in frame order — the
+    // guard bites in the revert case, where a stale batch start would wipe the between frame's log.
+    [TestCase(false)]
+    [TestCase(true)]
+    public void TwoBatches_EachClearsOnlyItsOwnFrames_CommittedLogsBetweenSurvive(bool secondBatchReverts)
+    {
+        Address logger = TestItem.AddressD;
+        Address tokenA = TestItem.AddressE;
+        Address dexRevert = TestItem.AddressF;
+        Address tokenB = Sponsor;
+        Address dexB = Recipient;
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        // Emits a log and commits — used for the pre-, between-, and post-batch frames.
+        DeployContract(logger, Prepare.EvmCode.Log(0, 0).Op(Instruction.STOP).Done);
+        byte[] recordAllowanceAndLog = Prepare.EvmCode
+            .PushData(1).PushData(0).Op(Instruction.SSTORE)
+            .Log(0, 0)
+            .Op(Instruction.STOP).Done;
+        DeployContract(tokenA, recordAllowanceAndLog);
+        DeployContract(tokenB, recordAllowanceAndLog);
+        DeployContract(dexRevert, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+        DeployContract(dexB, secondBatchReverts
+            ? Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done
+            : Prepare.EvmCode.PushData(1).PushData(1).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),                                    // 0
+            SenderFrame(logger),                                 // 1: pre-batch log survives
+            SenderFrame(tokenA, flags: TxFrame.AtomicBatchFlag), // 2: batch A, log discarded
+            SenderFrame(dexRevert),                              // 3: batch A unrolls
+            SenderFrame(logger),                                 // 4: between batches, log survives
+            SenderFrame(tokenB, flags: TxFrame.AtomicBatchFlag), // 5: batch B
+            SenderFrame(dexB),                                   // 6: batch B commits or unrolls
+            SenderFrame(logger));                                // 7: post-batch log survives
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        Assert.That(FrameStatuses(receipt), Is.EqualTo(new[]
+        {
+            TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusSuccess,
+            TxFrameReceipt.StatusFailure, TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusSuccess,
+            secondBatchReverts ? TxFrameReceipt.StatusFailure : TxFrameReceipt.StatusSuccess,
+            TxFrameReceipt.StatusSuccess,
+        }));
+        Assert.That(receipt.FrameReceipts![1].Logs, Has.Length.EqualTo(1), "the pre-batch log survives both batches");
+        Assert.That(receipt.FrameReceipts[2].Logs, Is.Empty, "batch A unrolled — its log is discarded");
+        Assert.That(receipt.FrameReceipts[4].Logs, Has.Length.EqualTo(1),
+            "the committed between-batch log survives — batch B must clear only its own frames, not back through batch A");
+        Assert.That(receipt.FrameReceipts[5].Logs, Has.Length.EqualTo(secondBatchReverts ? 0 : 1),
+            secondBatchReverts ? "batch B unrolled — its log is discarded" : "batch B committed — its log survives");
+        Assert.That(receipt.FrameReceipts[7].Logs, Has.Length.EqualTo(1), "the post-batch log survives both batches");
+        Assert.That(receipt.Logs, Has.Length.EqualTo(secondBatchReverts ? 3 : 4),
+            "exactly the surviving committed frame logs land in the tx log set");
+        AssertBloomAndReceiptLogsAgree(receipt);
+    }
+
     // Asserts the tx log set equals the frame-order concatenation of the surviving frame logs, and
     // that a wire round-trip yields the same bloom — i.e. the header logsBloom and the receipts-root
     // logs agree.
@@ -322,6 +385,8 @@ public class Eip8141ScenarioTests
         // Same LogEntry references, so reference equality is enough to pin contents and order.
         Assert.That(receipt.Logs, Is.EqualTo(frameOrderConcatenation),
             "the tx log set must be the frame-order concatenation of the surviving frame logs");
+        Assert.That(receipt.Bloom, Is.EqualTo(new Bloom(frameOrderConcatenation)),
+            "the producer header bloom must reflect exactly the surviving frame logs");
 
         ReceiptMessageDecoder decoder = new();
         byte[] encoded = decoder.EncodeNew(receipt, RlpBehaviors.None);

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -259,16 +259,20 @@ public class Eip8141ScenarioTests
         AssertBloomAndReceiptLogsAgree(receipt);
     }
 
-    // Pins the lower bound of the unrolled-batch log-clear window. AtomicApproveAndSwap can't catch a
-    // batchStartIndex that is too low: its only log-emitting frame is inside the batch, so an over-wide
-    // clear still passes. Here a pre-batch frame emits a surviving log, so clearing at or below the
-    // batch start would wipe it and fail.
+    // Pins the bounds of the unrolled-batch log-clear window and that the batch can unroll in the
+    // middle of the frame list. AtomicApproveAndSwap can't catch a batchStartIndex that is too low
+    // (its only log-emitting frame is inside the batch, so an over-wide clear still passes) nor a
+    // clear that runs past the batch, because nothing runs after its terminal frame. Here a pre-batch
+    // frame and a post-batch frame each emit a surviving log, so the derived tx log union must be
+    // exactly [pre-batch log] ++ [] ++ [post-batch log] in frame order: clearing at or below the batch
+    // start wipes the pre-batch log, and resuming at i = terminal must leave the post-batch log intact.
     [Test]
-    public void UnrolledBatch_DiscardsBatchLogsButKeepsPreBatchLogs()
+    public void UnrolledBatch_DiscardsBatchLogsKeepsPreAndPostBatchLogs()
     {
         Address logger = TestItem.AddressD;
         Address token = TestItem.AddressE;
         Address dex = TestItem.AddressF;
+        Address postLogger = Recipient;
         DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
         // Pre-batch frame: emits a log and commits normally, outside the batch.
         DeployContract(logger, Prepare.EvmCode.Log(0, 0).Op(Instruction.STOP).Done);
@@ -279,26 +283,33 @@ public class Eip8141ScenarioTests
             .Op(Instruction.STOP).Done);
         // Terminal batch frame reverts, unrolling the batch.
         DeployContract(dex, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+        // Post-batch frame: runs after the unroll resumes at i = terminal, emits a surviving log.
+        DeployContract(postLogger, Prepare.EvmCode.Log(0, 0).Op(Instruction.STOP).Done);
 
         Transaction tx = FrameTx(Sender, nonce: 0,
             SelfVerifyFrame(),
             SenderFrame(logger),
             SenderFrame(token, flags: TxFrame.AtomicBatchFlag),
-            SenderFrame(dex));
+            SenderFrame(dex),
+            SenderFrame(postLogger));
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
         Assert.That(FrameStatuses(receipt), Is.EqualTo(new[]
         {
-            TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusSuccess,
-            TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusFailure,
+            TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusSuccess,
+            TxFrameReceipt.StatusFailure, TxFrameReceipt.StatusSuccess,
         }));
         Assert.That(receipt.FrameReceipts![1].Logs, Has.Length.EqualTo(1),
             "the pre-batch frame's log survives — the clear window must not reach below the batch start");
         Assert.That(receipt.FrameReceipts[2].Logs, Is.Empty, "the unrolled batch frame's log is discarded");
-        Assert.That(receipt.Logs, Has.Length.EqualTo(1), "exactly the one pre-batch log survives the unroll");
+        Assert.That(receipt.FrameReceipts[4].Logs, Has.Length.EqualTo(1),
+            "the post-batch frame's log survives — the clear window must not run past the batch");
+        Assert.That(receipt.Logs, Has.Length.EqualTo(2), "exactly the pre- and post-batch logs survive the unroll");
         Assert.That(receipt.Logs![0], Is.SameAs(receipt.FrameReceipts[1].Logs[0]),
-            "the surviving tx log is precisely the pre-batch frame's log");
+            "the first surviving tx log is the pre-batch frame's log");
+        Assert.That(receipt.Logs[1], Is.SameAs(receipt.FrameReceipts[4].Logs[0]),
+            "the second surviving tx log is the post-batch frame's log — frame order is preserved");
         AssertBloomAndReceiptLogsAgree(receipt);
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -253,13 +253,58 @@ public class Eip8141ScenarioTests
             Assert.That(receipt.FrameReceipts[1].GasUsed, Is.GreaterThan(0UL),
                 "the unrolled frame retains its recorded gas_used");
             Assert.That(receipt.Logs, Is.Empty, "no logs survive the unrolled batch");
-            AssertBloomAndReceiptLogsAgree(receipt);
         }
         else
         {
             Assert.That(receipt.Logs, Has.Length.EqualTo(1), "the committed approval log lands in the receipt");
-            AssertBloomAndReceiptLogsAgree(receipt);
         }
+
+        AssertBloomAndReceiptLogsAgree(receipt);
+    }
+
+    // Pins the lower bound of the unrolled-batch log-clear window. A frame that runs and commits
+    // BEFORE the batch emits a log that must survive the unroll, while the batch's own frame logs
+    // are discarded. AtomicApproveAndSwap cannot catch a `batchStartIndex` that is too low (a stale
+    // value or a hard-coded 0): its only log-emitting frame is inside the batch, so an over-wide
+    // clear window still leaves receipt.Logs empty and passes. Here an off-by-one that started
+    // clearing at or below the pre-batch frame would wipe the surviving log and fail.
+    [Test]
+    public void UnrolledBatch_DiscardsBatchLogsButKeepsPreBatchLogs()
+    {
+        Address logger = TestItem.AddressD;
+        Address token = TestItem.AddressE;
+        Address dex = TestItem.AddressF;
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        // Pre-batch frame: emits a log and commits normally, outside the batch.
+        DeployContract(logger, Prepare.EvmCode.Log(0, 0).Op(Instruction.STOP).Done);
+        // Batch frame: records an allowance and emits a log that the unroll must discard.
+        DeployContract(token, Prepare.EvmCode
+            .PushData(1).PushData(0).Op(Instruction.SSTORE)
+            .Log(0, 0)
+            .Op(Instruction.STOP).Done);
+        // Terminal batch frame reverts, unrolling the batch.
+        DeployContract(dex, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            SenderFrame(logger),
+            SenderFrame(token, flags: TxFrame.AtomicBatchFlag),
+            SenderFrame(dex));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        Assert.That(FrameStatuses(receipt), Is.EqualTo(new[]
+        {
+            TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusSuccess,
+            TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusFailure,
+        }));
+        Assert.That(receipt.FrameReceipts![1].Logs, Has.Length.EqualTo(1),
+            "the pre-batch frame's log survives — the clear window must not reach below the batch start");
+        Assert.That(receipt.FrameReceipts[2].Logs, Is.Empty, "the unrolled batch frame's log is discarded");
+        Assert.That(receipt.Logs, Has.Length.EqualTo(1), "exactly the one pre-batch log survives the unroll");
+        Assert.That(receipt.Logs![0], Is.SameAs(receipt.FrameReceipts[1].Logs[0]),
+            "the surviving tx log is precisely the pre-batch frame's log");
+        AssertBloomAndReceiptLogsAgree(receipt);
     }
 
     // The transaction log set (built for the header logsBloom and log indexing) must equal the
@@ -270,7 +315,8 @@ public class Eip8141ScenarioTests
     private static void AssertBloomAndReceiptLogsAgree(TxReceipt receipt)
     {
         LogEntry[] frameOrderConcatenation = receipt.FrameReceipts!.SelectMany(static f => f.Logs).ToArray();
-        Assert.That(receipt.Logs!.Length, Is.EqualTo(frameOrderConcatenation.Length),
+        // Same LogEntry references, so reference equality is enough to pin contents and order.
+        Assert.That(receipt.Logs, Is.EqualTo(frameOrderConcatenation),
             "the tx log set must be the frame-order concatenation of the surviving frame logs");
 
         ReceiptMessageDecoder decoder = new();
@@ -278,9 +324,10 @@ public class Eip8141ScenarioTests
         RlpReader reader = new(encoded);
         TxReceipt decoded = decoder.Decode(ref reader)!;
 
-        Assert.That(decoded.Logs!.Length, Is.EqualTo(receipt.Logs.Length),
+        Assert.That(decoded.Logs!.Length, Is.EqualTo(frameOrderConcatenation.Length),
             "the wire receipt (hashed into the receipts root) must carry the same logs as the bloom reflects");
-        Assert.That(decoded.Bloom, Is.EqualTo(receipt.Bloom),
+        // LogEntry has no value equality, so compare the derived bloom rather than the entries.
+        Assert.That(decoded.Bloom, Is.EqualTo(new Bloom(frameOrderConcatenation)),
             "the receipts-root logs and the header bloom must agree");
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -243,11 +243,8 @@ public class Eip8141ScenarioTests
 
         if (swapReverts)
         {
-            // ethereum/EIPs#12008: an unrolled batch discards the logs of frames that executed
-            // before the failure together with their state changes; those frame receipts retain
-            // their execution status and gas_used with empty logs. The transaction log set (the
-            // frame-order concatenation used for the header logsBloom and log indexing) therefore
-            // matches the per-frame receipts — the earlier union-vs-per-frame divergence is gone.
+            // ethereum/EIPs#12008: an unrolled batch discards the logs of frames that ran before the
+            // failure along with their state, but keeps their status and gas_used.
             Assert.That(receipt.FrameReceipts![1].Logs, Is.Empty,
                 "the unrolled frame's per-frame receipt logs must be discarded");
             Assert.That(receipt.FrameReceipts[1].GasUsed, Is.GreaterThan(0UL),
@@ -262,12 +259,10 @@ public class Eip8141ScenarioTests
         AssertBloomAndReceiptLogsAgree(receipt);
     }
 
-    // Pins the lower bound of the unrolled-batch log-clear window. A frame that runs and commits
-    // BEFORE the batch emits a log that must survive the unroll, while the batch's own frame logs
-    // are discarded. AtomicApproveAndSwap cannot catch a `batchStartIndex` that is too low (a stale
-    // value or a hard-coded 0): its only log-emitting frame is inside the batch, so an over-wide
-    // clear window still leaves receipt.Logs empty and passes. Here an off-by-one that started
-    // clearing at or below the pre-batch frame would wipe the surviving log and fail.
+    // Pins the lower bound of the unrolled-batch log-clear window. AtomicApproveAndSwap can't catch a
+    // batchStartIndex that is too low: its only log-emitting frame is inside the batch, so an over-wide
+    // clear still passes. Here a pre-batch frame emits a surviving log, so clearing at or below the
+    // batch start would wipe it and fail.
     [Test]
     public void UnrolledBatch_DiscardsBatchLogsButKeepsPreBatchLogs()
     {
@@ -307,11 +302,9 @@ public class Eip8141ScenarioTests
         AssertBloomAndReceiptLogsAgree(receipt);
     }
 
-    // The transaction log set (built for the header logsBloom and log indexing) must equal the
-    // frame-order concatenation of the surviving per-frame receipt logs — the exact form the wire
-    // receipt is hashed into for the receipts root. Round-tripping through the receipts-message
-    // decoder rebuilds the union from the per-frame logs, so a match proves the bloom the header
-    // carries and the logs the receipts root commits to agree (ethereum/EIPs#12008).
+    // Asserts the tx log set equals the frame-order concatenation of the surviving frame logs, and
+    // that a wire round-trip yields the same bloom — i.e. the header logsBloom and the receipts-root
+    // logs agree.
     private static void AssertBloomAndReceiptLogsAgree(TxReceipt receipt)
     {
         LogEntry[] frameOrderConcatenation = receipt.FrameReceipts!.SelectMany(static f => f.Logs).ToArray();

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -243,17 +243,45 @@ public class Eip8141ScenarioTests
 
         if (swapReverts)
         {
-            // EIP8141-ISSUE: on batch rollback the approval log is dropped from the receipt's log
-            // union (and so from the bloom), but the per-frame receipt keeps it — the spec does not
-            // say which representation a rolled-back frame's logs should have, and the two diverge.
-            Assert.That(receipt.Logs, Is.Empty, "rolled-back batch logs must not reach the receipt log union");
-            Assert.That(receipt.FrameReceipts![1].Logs, Has.Length.EqualTo(1),
-                "the per-frame receipt currently keeps the rolled-back frame's log");
+            // ethereum/EIPs#12008: an unrolled batch discards the logs of frames that executed
+            // before the failure together with their state changes; those frame receipts retain
+            // their execution status and gas_used with empty logs. The transaction log set (the
+            // frame-order concatenation used for the header logsBloom and log indexing) therefore
+            // matches the per-frame receipts — the earlier union-vs-per-frame divergence is gone.
+            Assert.That(receipt.FrameReceipts![1].Logs, Is.Empty,
+                "the unrolled frame's per-frame receipt logs must be discarded");
+            Assert.That(receipt.FrameReceipts[1].GasUsed, Is.GreaterThan(0UL),
+                "the unrolled frame retains its recorded gas_used");
+            Assert.That(receipt.Logs, Is.Empty, "no logs survive the unrolled batch");
+            AssertBloomAndReceiptLogsAgree(receipt);
         }
         else
         {
             Assert.That(receipt.Logs, Has.Length.EqualTo(1), "the committed approval log lands in the receipt");
+            AssertBloomAndReceiptLogsAgree(receipt);
         }
+    }
+
+    // The transaction log set (built for the header logsBloom and log indexing) must equal the
+    // frame-order concatenation of the surviving per-frame receipt logs — the exact form the wire
+    // receipt is hashed into for the receipts root. Round-tripping through the receipts-message
+    // decoder rebuilds the union from the per-frame logs, so a match proves the bloom the header
+    // carries and the logs the receipts root commits to agree (ethereum/EIPs#12008).
+    private static void AssertBloomAndReceiptLogsAgree(TxReceipt receipt)
+    {
+        LogEntry[] frameOrderConcatenation = receipt.FrameReceipts!.SelectMany(static f => f.Logs).ToArray();
+        Assert.That(receipt.Logs!.Length, Is.EqualTo(frameOrderConcatenation.Length),
+            "the tx log set must be the frame-order concatenation of the surviving frame logs");
+
+        ReceiptMessageDecoder decoder = new();
+        byte[] encoded = decoder.EncodeNew(receipt, RlpBehaviors.None);
+        RlpReader reader = new(encoded);
+        TxReceipt decoded = decoder.Decode(ref reader)!;
+
+        Assert.That(decoded.Logs!.Length, Is.EqualTo(receipt.Logs.Length),
+            "the wire receipt (hashed into the receipts root) must carry the same logs as the bloom reflects");
+        Assert.That(decoded.Bloom, Is.EqualTo(receipt.Bloom),
+            "the receipts-root logs and the header bloom must agree");
     }
 
     // Spec Expiry Verifier Frame: a VERIFY frame targeting EXPIRY_VERIFIER whose 8-byte big-endian

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -343,14 +343,12 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         if (total == 0) return [];
 
         LogEntry[] logs = new LogEntry[total];
-        int written = 0;
+        int offset = 0;
         foreach (TxFrameReceipt frameReceipt in frameReceipts)
         {
             LogEntry[] frameLogs = frameReceipt.Logs;
-            for (int j = 0; j < frameLogs.Length; j++)
-            {
-                logs[written++] = frameLogs[j];
-            }
+            frameLogs.CopyTo(logs, offset);
+            offset += frameLogs.Length;
         }
 
         return logs;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -93,7 +92,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             tx.MaxFeePerBlobGas.GetValueOrDefault());
 
         TxFrameReceipt[] frameReceipts = new TxFrameReceipt[frames.Length];
-        List<LogEntry> allLogs = [];
         ulong totalFrameGasUsed = 0;
         // EIP-3529 storage refunds accumulate into a single transaction-scoped counter (ethereum/EIPs#11940).
         long refundCounter = 0;
@@ -119,7 +117,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         bool inBatch = false;
         Snapshot batchStartSnapshot = default;
         StackAccessTracker batchTracker = default;
-        int batchStartLogCount = 0;
         int batchStartIndex = 0;
         Address? batchStartPayer = null;
         bool batchStartSenderApproved = false;
@@ -137,7 +134,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 batchStartSnapshot = WorldState.TakeSnapshot();
                 batchTracker = accessTracker;
                 batchTracker.TakeSnapshot();
-                batchStartLogCount = allLogs.Count;
                 batchStartIndex = i;
                 batchStartPayer = frameContext.Payer;
                 batchStartSenderApproved = frameContext.SenderApproved;
@@ -203,7 +199,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 frameSucceeded ? TxFrameReceipt.StatusSuccess : TxFrameReceipt.StatusFailure,
                 frameGasUsed,
                 frameLogs);
-            allLogs.AddRange(frameLogs);
 
             if (frame.Mode == TxFrame.ModeVerify && !frameSucceeded)
             {
@@ -227,18 +222,17 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             {
                 if (!frameSucceeded)
                 {
-                    // Unroll the batch: restore state to before it began, drop its logs, and mark
-                    // every remaining frame in the batch as skipped (status 0x2, gas refunded by
-                    // not being consumed). The failed frame keeps its failure receipt.
+                    // Unroll the batch: restore state to before it began and mark every remaining
+                    // frame in the batch as skipped (status 0x2, gas refunded by not being
+                    // consumed). The failed frame keeps its failure receipt.
                     WorldState.Restore(batchStartSnapshot);
                     batchTracker.Restore();
-                    allLogs.RemoveRange(batchStartLogCount, allLogs.Count - batchStartLogCount);
 
                     // Frames that executed before the failure keep their execution status and
                     // gas_used but have their logs discarded together with their state changes when
-                    // the batch is unrolled (ethereum/EIPs#12008). This keeps the per-frame receipt
-                    // logs consistent with the transaction log set (the frame-order concatenation
-                    // used for the header logsBloom and log indexing), which drops them above.
+                    // the batch is unrolled (ethereum/EIPs#12008). Clearing the per-frame receipts
+                    // is sufficient: the transaction log set is derived from them after the loop, so
+                    // the cleared frames drop out of the header logsBloom and log indexing too.
                     for (int s = batchStartIndex; s < i; s++)
                     {
                         TxFrameReceipt earlier = frameReceipts[s];
@@ -327,11 +321,48 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 frameReceiptTracer.ReportFrameTxReceipt(payer, frameReceipts);
             }
 
+            // The transaction log set is definitionally the frame-order concatenation of the
+            // surviving per-frame receipt logs (ethereum/EIPs#12008). Deriving it here rather than
+            // maintaining a parallel union during the loop keeps the two representations from ever
+            // diverging: an unrolled batch clears its frames' logs above, so they drop out of both.
+            LogEntry[] txLogs = ConcatFrameLogs(frameReceipts);
             GasConsumed gasConsumed = new(spentGas, spentGas, spentGas);
-            tracer.MarkAsSuccess(Eip8141Constants.EntryPointAddress, in gasConsumed, [], allLogs.ToArray());
+            tracer.MarkAsSuccess(Eip8141Constants.EntryPointAddress, in gasConsumed, [], txLogs);
         }
 
         return TransactionResult.Ok;
+    }
+
+    /// <summary>
+    /// The transaction log set: the frame-order concatenation of the per-frame receipt logs.
+    /// </summary>
+    /// <remarks>
+    /// After an atomic batch is unrolled its frames carry empty logs, so this derivation yields
+    /// exactly the surviving logs and cannot diverge from the per-frame receipts by construction
+    /// (ethereum/EIPs#12008).
+    /// </remarks>
+    private static LogEntry[] ConcatFrameLogs(TxFrameReceipt[] frameReceipts)
+    {
+        int total = 0;
+        foreach (TxFrameReceipt frameReceipt in frameReceipts)
+        {
+            total += frameReceipt.Logs.Length;
+        }
+
+        if (total == 0) return [];
+
+        LogEntry[] logs = new LogEntry[total];
+        int written = 0;
+        foreach (TxFrameReceipt frameReceipt in frameReceipts)
+        {
+            LogEntry[] frameLogs = frameReceipt.Logs;
+            for (int j = 0; j < frameLogs.Length; j++)
+            {
+                logs[written++] = frameLogs[j];
+            }
+        }
+
+        return logs;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -222,17 +222,15 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             {
                 if (!frameSucceeded)
                 {
-                    // Unroll the batch: restore state to before it began and mark every remaining
-                    // frame in the batch as skipped (status 0x2, gas refunded by not being
-                    // consumed). The failed frame keeps its failure receipt.
+                    // Unroll the batch: restore pre-batch state and mark remaining frames skipped
+                    // (status 0x2, gas refunded by not being consumed). The failed frame keeps its
+                    // failure receipt.
                     WorldState.Restore(batchStartSnapshot);
                     batchTracker.Restore();
 
-                    // Frames that executed before the failure keep their execution status and
-                    // gas_used but have their logs discarded together with their state changes when
-                    // the batch is unrolled (ethereum/EIPs#12008). Clearing the per-frame receipts
-                    // is sufficient: the transaction log set is derived from them after the loop, so
-                    // the cleared frames drop out of the header logsBloom and log indexing too.
+                    // Discard the logs of frames that ran before the failure, along with their state
+                    // (ethereum/EIPs#12008), keeping status and gas_used. The tx log set is derived
+                    // from these receipts after the loop, so cleared frames drop out of the bloom too.
                     for (int s = batchStartIndex; s < i; s++)
                     {
                         TxFrameReceipt earlier = frameReceipts[s];
@@ -321,10 +319,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 frameReceiptTracer.ReportFrameTxReceipt(payer, frameReceipts);
             }
 
-            // The transaction log set is definitionally the frame-order concatenation of the
-            // surviving per-frame receipt logs (ethereum/EIPs#12008). Deriving it here rather than
-            // maintaining a parallel union during the loop keeps the two representations from ever
-            // diverging: an unrolled batch clears its frames' logs above, so they drop out of both.
+            // Derive the tx log set from the per-frame receipts rather than maintaining a parallel
+            // union, so the two can't diverge: an unrolled batch clears its frames' logs above.
             LogEntry[] txLogs = ConcatFrameLogs(frameReceipts);
             GasConsumed gasConsumed = new(spentGas, spentGas, spentGas);
             tracer.MarkAsSuccess(Eip8141Constants.EntryPointAddress, in gasConsumed, [], txLogs);
@@ -336,11 +332,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     /// <summary>
     /// The transaction log set: the frame-order concatenation of the per-frame receipt logs.
     /// </summary>
-    /// <remarks>
-    /// After an atomic batch is unrolled its frames carry empty logs, so this derivation yields
-    /// exactly the surviving logs and cannot diverge from the per-frame receipts by construction
-    /// (ethereum/EIPs#12008).
-    /// </remarks>
     private static LogEntry[] ConcatFrameLogs(TxFrameReceipt[] frameReceipts)
     {
         int total = 0;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -120,6 +120,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         Snapshot batchStartSnapshot = default;
         StackAccessTracker batchTracker = default;
         int batchStartLogCount = 0;
+        int batchStartIndex = 0;
         Address? batchStartPayer = null;
         bool batchStartSenderApproved = false;
         long batchStartRefund = 0;
@@ -137,6 +138,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 batchTracker = accessTracker;
                 batchTracker.TakeSnapshot();
                 batchStartLogCount = allLogs.Count;
+                batchStartIndex = i;
                 batchStartPayer = frameContext.Payer;
                 batchStartSenderApproved = frameContext.SenderApproved;
                 batchStartRefund = refundCounter;
@@ -228,12 +230,23 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                     // Unroll the batch: restore state to before it began, drop its logs, and mark
                     // every remaining frame in the batch as skipped (status 0x2, gas refunded by
                     // not being consumed). The failed frame keeps its failure receipt.
-                    // EIP8141-ISSUE: the spec does not state the receipt status of frames that ran
-                    // successfully earlier in the batch before the rollback; earlier frames keep
-                    // their recorded receipts while their state and logs are rolled back.
                     WorldState.Restore(batchStartSnapshot);
                     batchTracker.Restore();
                     allLogs.RemoveRange(batchStartLogCount, allLogs.Count - batchStartLogCount);
+
+                    // Frames that executed before the failure keep their execution status and
+                    // gas_used but have their logs discarded together with their state changes when
+                    // the batch is unrolled (ethereum/EIPs#12008). This keeps the per-frame receipt
+                    // logs consistent with the transaction log set (the frame-order concatenation
+                    // used for the header logsBloom and log indexing), which drops them above.
+                    for (int s = batchStartIndex; s < i; s++)
+                    {
+                        TxFrameReceipt earlier = frameReceipts[s];
+                        if (earlier.Logs.Length > 0)
+                        {
+                            frameReceipts[s] = new TxFrameReceipt(earlier.Status, earlier.GasUsed, []);
+                        }
+                    }
                     // EIP-8141 (ethereum/EIPs#11955): a failed batch unrolls ALL effects of any APPROVE
                     // it contained. Restore reverts the payer debit and sender nonce (world state); the
                     // approval context (payer, sender_approved) and refund counter are not world state,


### PR DESCRIPTION
## Changes

Aligns EIP-8141 frame-transaction receipts with the now-merged spec [ethereum/EIPs#12008](https://github.com/ethereum/EIPs/pull/12008) (transaction log set / unrolled-batch log semantics).

Previously, when an atomic batch was unrolled (any frame in the batch failed), the frames that had executed successfully before the failure **kept** their logs in their per-frame receipts, while the transaction log union used for the header `logsBloom` had those logs removed. The wire-encoded receipt (which is hashed into `receiptsRoot`, and from which a receiving node rebuilds the log union) therefore carried logs the bloom did not reflect — a union-vs-per-frame divergence that would cause a `logsBloom`/`receiptsRoot` mismatch across clients.

Per the merged spec:
- **Line ~388:** "Logs emitted by frames that executed before the failure are discarded together with their state changes when the batch is unrolled. Those frame receipts retain their execution status and gas used, with empty logs."
- **Line ~213:** the transaction's logs for `logsBloom` and log indexing are "the concatenation of the `logs` fields of its frame receipts, in frame order."

This PR:
- In the atomic-batch unroll path (`TransactionProcessorBase.FrameTx.cs`), sets the pre-failure frames' per-frame receipt `logs` to **empty** while retaining their execution status and `gas_used`. The already-skipped frames keep status `0x2`; batch membership is still readable from the frame status flags. The transaction log union (already pruned on unroll) now equals the frame-order concatenation of the surviving per-frame receipt logs — the divergence is gone.
- Updates the atomic-batch scenario test to assert the new behavior: on rollback the pre-failure frame's receipt logs are empty, its status + `gas_used` are retained, and the log union / bloom equals the frame-order concatenation of the surviving logs. A round-trip through `ReceiptMessageDecoder` asserts the receipts-root logs and header bloom now agree.
- Updates the receipt storage-roundtrip test to model the post-#12008 unrolled-batch shape (empty logs for the unrolled frame) and removes the comment that documented the old divergence as intended.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Extended `Eip8141ScenarioTests.AtomicApproveAndSwap_NoDanglingApprovalWhenSwapReverts` and updated `FrameTxReceiptDecoderTests` storage round-trip. All affected suites pass (`Eip8141ScenarioTests`, `FrameTxProcessorTests`, `FrameTxBlockReceiptsTests`, `FrameTxReceiptDecoderTests`); build shows 0 errors / 0 warnings.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Draft: targets the `eip8141-frame-txs-devnet7` feature branch. References the merged spec ethereum/EIPs#12008.