### PR TITLE
Evict expired EIP-8141 frame transactions on new head

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Scheduler/BackgroundTaskSchedulerBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Scheduler/BackgroundTaskSchedulerBenchmarks.cs
@@ -167,6 +167,7 @@ public class BackgroundTaskSchedulerBenchmarks
         public IChainHeadSpecProvider SpecProvider => null!;
         public IReadOnlyStateProvider ReadOnlyStateProvider => null!;
         public ulong HeadNumber => 0;
+        public ulong HeadTimestamp => 0;
         public ulong? BlockGasLimit => null;
         public UInt256 CurrentBaseFee => UInt256.Zero;
         public UInt256 CurrentFeePerBlobGas => UInt256.Zero;

--- a/src/Nethermind/Nethermind.Blockchain/ChainHeadInfoProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ChainHeadInfoProvider.cs
@@ -42,6 +42,8 @@ namespace Nethermind.Blockchain
 
         public ulong HeadNumber { get; private set; }
 
+        public ulong HeadTimestamp { get; private set; }
+
         public ulong? BlockGasLimit { get; internal set; }
 
         public UInt256 CurrentBaseFee { get; private set; }
@@ -72,6 +74,7 @@ namespace Nethermind.Blockchain
         {
             IReleaseSpec spec = SpecProvider.GetSpec(e.Block.Header);
             HeadNumber = e.Block.Number;
+            HeadTimestamp = e.Block.Timestamp;
             BlockGasLimit = e.Block!.GasLimit;
             CurrentBaseFee = e.Block.Header.BaseFeePerGas;
             CurrentFeePerBlobGas =

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -178,4 +178,43 @@ public class FrameTxValidationTests
         digest[31] = 1;
         return digest;
     }
+
+    [Test]
+    public void TryGetExpiryDeadline_ReadsBigEndianDeadlineFromExpiryFrame()
+    {
+        const ulong expected = 0x0102_0304_0506_0708UL;
+        byte[] data = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        Transaction tx = CreateValidFrameTx(t => t.Frames =
+        [
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeVerify, flags: 0, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 30_000, UInt256.Zero, data),
+        ]);
+
+        bool found = FrameTxValidation.TryGetExpiryDeadline(tx, out ulong deadline);
+
+        Assert.That(found, Is.True);
+        Assert.That(deadline, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void TryGetExpiryDeadline_WithoutExpiryFrame_ReturnsFalse()
+    {
+        Transaction tx = CreateValidFrameTx(static _ => { });
+
+        bool found = FrameTxValidation.TryGetExpiryDeadline(tx, out ulong deadline);
+
+        Assert.That(found, Is.False);
+        Assert.That(deadline, Is.EqualTo(0UL));
+    }
+
+    [Test]
+    public void TryGetExpiryDeadline_NoFrames_ReturnsFalse()
+    {
+        Transaction tx = new() { Type = TxType.FrameTx, Frames = null };
+
+        bool found = FrameTxValidation.TryGetExpiryDeadline(tx, out ulong deadline);
+
+        Assert.That(found, Is.False);
+        Assert.That(deadline, Is.EqualTo(0UL));
+    }
 }

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -186,6 +186,10 @@ public static class FrameTxValidation
     /// <param name="transaction">The frame transaction to inspect.</param>
     /// <param name="deadline">The expiry deadline in Unix seconds when an expiry-verifier frame is present.</param>
     /// <returns><c>true</c> if an expiry-verifier frame is present and its deadline was read; otherwise <c>false</c>.</returns>
+    /// <exception cref="System.ArgumentOutOfRangeException">
+    /// The expiry frame carries fewer than <see cref="Eip8141Constants.ExpiryDataLength"/> bytes, i.e. the
+    /// <see cref="IsWellFormed"/> precondition was not met.
+    /// </exception>
     public static bool TryGetExpiryDeadline(Transaction transaction, out ulong deadline)
     {
         deadline = 0;

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -181,8 +181,10 @@ public static class FrameTxValidation
     /// The deadline is the big-endian <c>uint64</c> carried in the 8-byte data of the single VERIFY frame that
     /// targets <see cref="Eip8141Constants.ExpiryVerifierAddress"/>. The predeploy installed at that address reverts
     /// when <c>block.timestamp &gt; deadline</c>, so a frame transaction whose deadline has passed can never satisfy
-    /// its validation prefix and must be dropped from the public mempool (ethereum/EIPs#8141, "Revalidation").
-    /// Callers should invoke this only on well-formed frame transactions; the 8-byte data length is assumed.
+    /// its validation prefix and must be dropped from the public mempool (ethereum/EIPs#12007, "Revalidation").
+    /// Callers must invoke this only on well-formed frame transactions: <see cref="IsWellFormed"/> already rejects an
+    /// expiry-verifier frame whose data is not exactly <see cref="Eip8141Constants.ExpiryDataLength"/> bytes
+    /// (<c>InvalidExpiryFrame</c>), so the 8-byte length is an invariant here and is not re-checked.
     /// </remarks>
     /// <param name="transaction">The frame transaction to inspect.</param>
     /// <param name="deadline">The expiry deadline in Unix seconds when an expiry-verifier frame is present.</param>
@@ -201,8 +203,7 @@ public static class FrameTxValidation
         {
             TxFrame frame = frames[i];
             if (frame.Mode == TxFrame.ModeVerify
-                && frame.Target == Eip8141Constants.ExpiryVerifierAddress
-                && frame.Data.Length == Eip8141Constants.ExpiryDataLength)
+                && frame.Target == Eip8141Constants.ExpiryVerifierAddress)
             {
                 deadline = BinaryPrimitives.ReadUInt64BigEndian(frame.Data.Span);
                 return true;

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -178,9 +178,10 @@ public static class FrameTxValidation
     /// Reads the EIP-8141 expiry deadline (Unix seconds) from the expiry-verifier VERIFY frame, if present.
     /// </summary>
     /// <remarks>
-    /// The deadline is the big-endian <c>uint64</c> in that frame's 8-byte data. Must be called only on well-formed
-    /// frame txs: <see cref="IsWellFormed"/> already enforces the <see cref="Eip8141Constants.ExpiryDataLength"/>
-    /// length, so it is not re-checked here.
+    /// The deadline is the big-endian <c>uint64</c> in that frame's 8-byte data; a tx whose deadline has passed can
+    /// never be included and is dropped from the mempool (ethereum/EIPs#12007, "Revalidation"). Must be called only
+    /// on well-formed frame txs: <see cref="IsWellFormed"/> already enforces the
+    /// <see cref="Eip8141Constants.ExpiryDataLength"/> length, so it is not re-checked here.
     /// </remarks>
     /// <param name="transaction">The frame transaction to inspect.</param>
     /// <param name="deadline">The expiry deadline in Unix seconds when an expiry-verifier frame is present.</param>

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -175,16 +175,12 @@ public static class FrameTxValidation
     }
 
     /// <summary>
-    /// Extracts the expiry deadline (Unix seconds) enforced by the EIP-8141 expiry-verifier frame, when present.
+    /// Reads the EIP-8141 expiry deadline (Unix seconds) from the expiry-verifier VERIFY frame, if present.
     /// </summary>
     /// <remarks>
-    /// The deadline is the big-endian <c>uint64</c> carried in the 8-byte data of the single VERIFY frame that
-    /// targets <see cref="Eip8141Constants.ExpiryVerifierAddress"/>. The predeploy installed at that address reverts
-    /// when <c>block.timestamp &gt; deadline</c>, so a frame transaction whose deadline has passed can never satisfy
-    /// its validation prefix and must be dropped from the public mempool (ethereum/EIPs#12007, "Revalidation").
-    /// Callers must invoke this only on well-formed frame transactions: <see cref="IsWellFormed"/> already rejects an
-    /// expiry-verifier frame whose data is not exactly <see cref="Eip8141Constants.ExpiryDataLength"/> bytes
-    /// (<c>InvalidExpiryFrame</c>), so the 8-byte length is an invariant here and is not re-checked.
+    /// The deadline is the big-endian <c>uint64</c> in that frame's 8-byte data. Must be called only on well-formed
+    /// frame txs: <see cref="IsWellFormed"/> already enforces the <see cref="Eip8141Constants.ExpiryDataLength"/>
+    /// length, so it is not re-checked here.
     /// </remarks>
     /// <param name="transaction">The frame transaction to inspect.</param>
     /// <param name="deadline">The expiry deadline in Unix seconds when an expiry-verifier frame is present.</param>

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Buffers.Binary;
 using Nethermind.Core.Extensions;
 
 namespace Nethermind.Core;
@@ -171,5 +172,43 @@ public static class FrameTxValidation
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Extracts the expiry deadline (Unix seconds) enforced by the EIP-8141 expiry-verifier frame, when present.
+    /// </summary>
+    /// <remarks>
+    /// The deadline is the big-endian <c>uint64</c> carried in the 8-byte data of the single VERIFY frame that
+    /// targets <see cref="Eip8141Constants.ExpiryVerifierAddress"/>. The predeploy installed at that address reverts
+    /// when <c>block.timestamp &gt; deadline</c>, so a frame transaction whose deadline has passed can never satisfy
+    /// its validation prefix and must be dropped from the public mempool (ethereum/EIPs#8141, "Revalidation").
+    /// Callers should invoke this only on well-formed frame transactions; the 8-byte data length is assumed.
+    /// </remarks>
+    /// <param name="transaction">The frame transaction to inspect.</param>
+    /// <param name="deadline">The expiry deadline in Unix seconds when an expiry-verifier frame is present.</param>
+    /// <returns><c>true</c> if an expiry-verifier frame is present and its deadline was read; otherwise <c>false</c>.</returns>
+    public static bool TryGetExpiryDeadline(Transaction transaction, out ulong deadline)
+    {
+        deadline = 0;
+
+        TxFrame[]? frames = transaction.Frames;
+        if (frames is null)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < frames.Length; i++)
+        {
+            TxFrame frame = frames[i];
+            if (frame.Mode == TxFrame.ModeVerify
+                && frame.Target == Eip8141Constants.ExpiryVerifierAddress
+                && frame.Data.Length == Eip8141Constants.ExpiryDataLength)
+            {
+                deadline = BinaryPrimitives.ReadUInt64BigEndian(frame.Data.Span);
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TestChainHeadInfoProvider.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TestChainHeadInfoProvider.cs
@@ -20,6 +20,7 @@ internal class TestChainHeadInfoProvider : IChainHeadInfoProvider
     public IChainHeadSpecProvider SpecProvider { get; set; } = null!;
     public IReadOnlyStateProvider ReadOnlyStateProvider { get; set; } = null!;
     public ulong HeadNumber { get; set; }
+    public ulong HeadTimestamp { get; set; }
     public ulong? BlockGasLimit { get; set; } = 30_000_000;
     public UInt256 CurrentBaseFee { get; set; }
     public UInt256 CurrentFeePerBlobGas { get; set; }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2162,6 +2162,43 @@ namespace Nethermind.TxPool.Test
                 "the replacement inherits the deadline and must still be evicted by the expiry pass");
         }
 
+        // EIP-8141: a frame tx whose expiry deadline is already behind the current head must be rejected at submit —
+        // never pooled, never broadcast — mirroring the on-head eviction predicate. deadline == head timestamp is the
+        // boundary the expiry-verifier predeploy still accepts (strict >), so it must be admitted.
+        [TestCase(1_000UL, 1_500UL, false, TestName = "already-expired frame tx is rejected at ingress")]
+        [TestCase(2_000UL, 1_500UL, true, TestName = "not-yet-expired frame tx is accepted at ingress")]
+        [TestCase(1_500UL, 1_500UL, true, TestName = "boundary deadline equal to head timestamp is accepted at ingress")]
+        public async Task Expired_frame_transaction_is_rejected_at_ingress(ulong deadline, ulong headTimestamp, bool expectedAccepted)
+        {
+            _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+            ITxPoolPeer peer = Substitute.For<ITxPoolPeer>();
+            peer.Id.Returns(TestItem.PublicKeyA);
+            _txPool.AddPeer(peer);
+
+            // Advance the head so the ingress filter has a current timestamp to compare the deadline against.
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(headTimestamp).TestObject);
+
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline);
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(expectedAccepted ? AcceptTxResult.Accepted : AcceptTxResult.FrameTxExpired));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(expectedAccepted ? 1 : 0),
+                    "an already-expired frame transaction must not enter the pool");
+            }
+
+            if (expectedAccepted)
+            {
+                peer.Received().SendNewTransaction(frameTx);
+            }
+            else
+            {
+                peer.DidNotReceive().SendNewTransaction(frameTx);
+            }
+        }
+
         private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline, UInt256? maxPriorityFeePerGas = null, UInt256? maxFeePerGas = null)
         {
             List<TxFrame> frames =

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -2075,6 +2076,53 @@ namespace Nethermind.TxPool.Test
                 Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted), "frame transactions must enter the pool once the EIP-8141 fork is active");
                 Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1), "the frame transaction must be pending");
             }
+        }
+
+        // EIP-8141 (ethereum/EIPs#12007): the expiry-verifier predeploy reverts once block.timestamp > deadline,
+        // so a pending frame transaction whose deadline has passed can never be included and must be evicted on the
+        // new head. deadline == timestamp is still valid (revert is strictly greater-than).
+        [TestCase(1_000UL, 1_500UL, 0, TestName = "deadline in the past is dropped")]
+        [TestCase(2_000UL, 1_500UL, 1, TestName = "deadline in the future is retained")]
+        [TestCase(1_500UL, 1_500UL, 1, TestName = "deadline equal to head timestamp is retained")]
+        public async Task Expired_frame_transaction_is_dropped_on_new_head(ulong deadline, ulong headTimestamp, int expectedPending)
+        {
+            _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
+            Transaction frameTx = BuildFrameTxWithExpiry(nonce: 0, TestItem.PrivateKeyA.Address, deadline);
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+            Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted), "the frame transaction must first enter the pool");
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(headTimestamp).TestObject);
+
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(expectedPending),
+                "expired frame transactions must be evicted on the new head, unexpired ones retained");
+        }
+
+        private Transaction BuildFrameTxWithExpiry(ulong nonce, Address sender, ulong deadline)
+        {
+            byte[] expiryData = new byte[Eip8141Constants.ExpiryDataLength];
+            BinaryPrimitives.WriteUInt64BigEndian(expiryData, deadline);
+
+            Transaction tx = new()
+            {
+                Type = TxType.FrameTx,
+                ChainId = _specProvider.ChainId,
+                Nonce = nonce,
+                SenderAddress = sender,
+                Frames =
+                [
+                    new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, Array.Empty<byte>()),
+                    new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 50_000, UInt256.Zero, expiryData),
+                ],
+                FrameSignatures = [],
+                GasLimit = 1_000_000,
+                GasPrice = 1.GWei,
+                DecodedMaxFeePerGas = 1.GWei,
+            };
+            tx.Hash = tx.CalculateHash();
+            return tx;
         }
 
         static IEnumerable<(byte[], AcceptTxResult)> CodeCases()

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2078,9 +2078,8 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        // EIP-8141 (ethereum/EIPs#12007): the expiry-verifier predeploy reverts once block.timestamp > deadline,
-        // so a pending frame transaction whose deadline has passed can never be included and must be evicted on the
-        // new head. deadline == timestamp is still valid (revert is strictly greater-than).
+        // EIP-8141: expired frame txs must be evicted on the new head; deadline == timestamp is still valid
+        // (the predeploy reverts only on strictly greater-than).
         [TestCase(1_000UL, 1_500UL, 0, TestName = "deadline in the past is dropped")]
         [TestCase(2_000UL, 1_500UL, 1, TestName = "deadline in the future is retained")]
         [TestCase(1_500UL, 1_500UL, 1, TestName = "deadline equal to head timestamp is retained")]
@@ -2100,9 +2099,8 @@ namespace Nethermind.TxPool.Test
                 "expired frame transactions must be evicted on the new head, unexpired ones retained");
         }
 
-        // A frame tx carrying no expiry-verifier frame has no deadline, so the expiry pass must never evict it,
-        // regardless of the new head's timestamp. This pins the branch a future expiry-indexing optimisation is
-        // most likely to break (TryGetExpiryDeadline returning false).
+        // No expiry frame means no deadline, so the expiry pass (and the count guard that gates it) must never
+        // evict it, whatever the head timestamp.
         [Test]
         public async Task Frame_transaction_without_expiry_frame_survives_new_head()
         {
@@ -2118,6 +2116,25 @@ namespace Nethermind.TxPool.Test
 
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1),
                 "a frame transaction without an expiry frame has no deadline and must never be evicted by the expiry pass");
+        }
+
+        // Fast path: a non-frame tx is never counted or evicted by the expiry pass, even with the fork active
+        // and an extreme head timestamp.
+        [Test]
+        public async Task Regular_transaction_survives_expiry_pass_when_fork_active()
+        {
+            _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
+            Transaction tx = Build.A.Transaction.SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+            EnsureSenderBalance(tx);
+
+            AcceptTxResult result = _txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast);
+            Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(ulong.MaxValue).TestObject);
+
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1),
+                "the expiry pass must only ever touch frame transactions carrying a deadline");
         }
 
         private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2137,7 +2137,32 @@ namespace Nethermind.TxPool.Test
                 "the expiry pass must only ever touch frame transactions carrying a deadline");
         }
 
-        private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline)
+        // Symmetry of _expiringFrameTxCount across the replacement path: replacing A with B fires Removed(A) and
+        // Inserted(B) inside a single DistinctValueSortedPool.InsertCore call. If those ever netted the count to
+        // zero the expiry pass would be skipped and B would silently survive past its deadline; assert it is evicted.
+        [Test]
+        public async Task Replaced_expiring_frame_transaction_is_still_evicted_on_new_head()
+        {
+            _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            Transaction a = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: 1_000);
+            Assert.That(_txPool.SubmitTx(a, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted),
+                "the original expiring frame transaction must first enter the pool");
+
+            // Same sender + nonce + deadline, both fees bumped well past the 10% replacement threshold.
+            Transaction b = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: 1_000, maxPriorityFeePerGas: 2.GWei, maxFeePerGas: 2.GWei);
+            Assert.That(_txPool.SubmitTx(b, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted),
+                "the fee-bumped replacement must be accepted");
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1), "the replacement must displace the original");
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(1_500).TestObject);
+
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(0),
+                "the replacement inherits the deadline and must still be evicted by the expiry pass");
+        }
+
+        private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline, UInt256? maxPriorityFeePerGas = null, UInt256? maxFeePerGas = null)
         {
             List<TxFrame> frames =
             [
@@ -2160,8 +2185,8 @@ namespace Nethermind.TxPool.Test
                 Frames = [.. frames],
                 FrameSignatures = [],
                 GasLimit = 1_000_000,
-                GasPrice = 1.GWei,
-                DecodedMaxFeePerGas = 1.GWei,
+                GasPrice = maxPriorityFeePerGas ?? 1.GWei,
+                DecodedMaxFeePerGas = maxFeePerGas ?? 1.GWei,
             };
             tx.Hash = tx.CalculateHash();
             return tx;

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2087,7 +2087,7 @@ namespace Nethermind.TxPool.Test
         public async Task Expired_frame_transaction_is_dropped_on_new_head(ulong deadline, ulong headTimestamp, int expectedPending)
         {
             _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
-            Transaction frameTx = BuildFrameTxWithExpiry(nonce: 0, TestItem.PrivateKeyA.Address, deadline);
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline);
             EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
 
             AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
@@ -2100,10 +2100,39 @@ namespace Nethermind.TxPool.Test
                 "expired frame transactions must be evicted on the new head, unexpired ones retained");
         }
 
-        private Transaction BuildFrameTxWithExpiry(ulong nonce, Address sender, ulong deadline)
+        // A frame tx carrying no expiry-verifier frame has no deadline, so the expiry pass must never evict it,
+        // regardless of the new head's timestamp. This pins the branch a future expiry-indexing optimisation is
+        // most likely to break (TryGetExpiryDeadline returning false).
+        [Test]
+        public async Task Frame_transaction_without_expiry_frame_survives_new_head()
         {
-            byte[] expiryData = new byte[Eip8141Constants.ExpiryDataLength];
-            BinaryPrimitives.WriteUInt64BigEndian(expiryData, deadline);
+            _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null);
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+            Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted), "the frame transaction must first enter the pool");
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(ulong.MaxValue).TestObject);
+
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1),
+                "a frame transaction without an expiry frame has no deadline and must never be evicted by the expiry pass");
+        }
+
+        private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline)
+        {
+            List<TxFrame> frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default),
+            ];
+
+            if (deadline is not null)
+            {
+                byte[] expiryData = new byte[Eip8141Constants.ExpiryDataLength];
+                BinaryPrimitives.WriteUInt64BigEndian(expiryData, deadline.Value);
+                frames.Add(new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 50_000, UInt256.Zero, expiryData));
+            }
 
             Transaction tx = new()
             {
@@ -2111,11 +2140,7 @@ namespace Nethermind.TxPool.Test
                 ChainId = _specProvider.ChainId,
                 Nonce = nonce,
                 SenderAddress = sender,
-                Frames =
-                [
-                    new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, Array.Empty<byte>()),
-                    new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 50_000, UInt256.Zero, expiryData),
-                ],
+                Frames = [.. frames],
                 FrameSignatures = [],
                 GasLimit = 1_000_000,
                 GasPrice = 1.GWei,

--- a/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
+++ b/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
@@ -119,6 +119,12 @@ namespace Nethermind.TxPool
         // Message field with ErrorCodes.AccountLocked (-32020), so the Code string never reaches RPC callers.
         public static readonly AcceptTxResult SignFailed = new(19, nameof(SignFailed), "authentication needed: password or unlock");
 
+        /// <summary>
+        /// An EIP-8141 frame transaction whose expiry-verifier deadline is already behind the current head; it can
+        /// never be included, so it must not enter the pool or be broadcast.
+        /// </summary>
+        public static readonly AcceptTxResult FrameTxExpired = new(20, TxPoolErrorMessages.FrameTxExpired);
+
         private int Id { get; } = id;
         private string Code { get; } = code;
         private string? Message { get; } = message;

--- a/src/Nethermind/Nethermind.TxPool/Filters/ExpiredFrameTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/ExpiredFrameTxFilter.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Logging;
+
+namespace Nethermind.TxPool.Filters;
+
+/// <summary>
+/// Rejects an EIP-8141 frame transaction whose expiry-verifier deadline is already behind the current head.
+/// </summary>
+/// <remarks>
+/// The expiry-verifier predeploy reverts once <c>block.timestamp &gt; deadline</c>, so such a transaction could never
+/// satisfy its validation prefix and must not be pooled or broadcast (ethereum/EIPs#12007, "Revalidation"). This is the
+/// admission-time counterpart of the on-head eviction pass and uses the exact same strict-greater-than predicate, so a
+/// transaction the predeploy would still accept at the boundary (<c>deadline == head.timestamp</c>) is never dropped.
+/// The deadline is read statically from the expiry-verifier frame, so no validation-prefix simulation is required.
+/// Must run after <see cref="MalformedTxFilter"/>, which guarantees the frame is well-formed.
+/// </remarks>
+internal sealed class ExpiredFrameTxFilter(IChainHeadInfoProvider chainHeadInfoProvider, ILogger logger) : IIncomingTxFilter
+{
+    public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
+    {
+        if (tx.SupportsFrames
+            && FrameTxValidation.TryGetExpiryDeadline(tx, out ulong deadline)
+            && chainHeadInfoProvider.HeadTimestamp > deadline)
+        {
+            Metrics.PendingTransactionsFrameTxExpired++;
+            if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, frame transaction expired at {deadline} (head timestamp {chainHeadInfoProvider.HeadTimestamp}).");
+            return AcceptTxResult.FrameTxExpired;
+        }
+
+        return AcceptTxResult.Accepted;
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
@@ -33,6 +33,17 @@ internal sealed class NotSupportedTxFilter(ITxPoolConfig txPoolConfig, IChainHea
         // rex/tooling submit frame txs for end-to-end devnet testing. Before frame txs may enter a
         // public mempool this gate must be tightened to also require those DoS filters. Static
         // well-formedness is already enforced downstream by MalformedTxFilter regardless.
+        //
+        // EIP8141: remaining pieces of the merged mempool lifecycle rules (ethereum/EIPs#12007) are
+        // deferred because they all require a frame-tx validation-prefix simulation + payer resolution
+        // layer that does not exist yet:
+        //   - per-payer / canonical-paymaster exposure accounting (reserved_pending_cost <= balance),
+        //     with atomic payer-switch on replacement;
+        //   - dependency-set-indexed revalidation on head change, incl. the payer balance/code trigger;
+        //   - the full eviction ordering (invalidated-first tier).
+        // The expiry-deadline eviction tier is implemented in TxPool.RemoveExpiredFrameTransactions,
+        // and the (sender, nonce) + both-fee bump replacement rule is already provided by the shared
+        // CompareReplacedTxByFee path.
         if (tx.SupportsFrames && !_specProvider.GetCurrentHeadSpec().IsEip8141Enabled)
         {
             Metrics.PendingTransactionsNotSupportedTxType++;

--- a/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
@@ -25,17 +25,11 @@ internal sealed class NotSupportedTxFilter(ITxPoolConfig txPoolConfig, IChainHea
             return AcceptTxResult.NotSupportedTxType;
         }
 
-        // EIP8141-GAP (TEMPORARY — devnet only, must change before any public activation): the
-        // public mempool DoS rules for frame transactions (validation prefixes, MAX_VERIFY_GAS,
-        // canonical paymaster reservation, failed-APPROVE replay bound) are NOT implemented yet.
-        // Admitting frame txs here is safe only because the EIP-8141 fork (Bogota) is not scheduled on
-        // any public network, so this branch is exercised on devnets alone; it exists purely to let
-        // rex/tooling submit frame txs for end-to-end devnet testing. Before frame txs may enter a
-        // public mempool this gate must be tightened to also require those DoS filters. Static
-        // well-formedness is already enforced downstream by MalformedTxFilter regardless.
-        //
-        // EIP8141: remaining ethereum/EIPs#12007 mempool rules (payer exposure accounting, dependency-set
-        // revalidation, full eviction ordering) are deferred — they need validation-prefix simulation.
+        // EIP8141-GAP (devnet only): frame txs are admitted while the fork is unscheduled on public networks.
+        // The public-mempool DoS rules (validation-prefix simulation, MAX_VERIFY_GAS, paymaster reservation,
+        // failed-APPROVE replay bound, payer-exposure accounting, dependency-set revalidation/eviction ordering)
+        // are NOT implemented and must gate this branch before any public activation. MalformedTxFilter still
+        // enforces static well-formedness downstream.
         if (tx.SupportsFrames && !_specProvider.GetCurrentHeadSpec().IsEip8141Enabled)
         {
             Metrics.PendingTransactionsNotSupportedTxType++;

--- a/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
@@ -34,16 +34,8 @@ internal sealed class NotSupportedTxFilter(ITxPoolConfig txPoolConfig, IChainHea
         // public mempool this gate must be tightened to also require those DoS filters. Static
         // well-formedness is already enforced downstream by MalformedTxFilter regardless.
         //
-        // EIP8141: remaining pieces of the merged mempool lifecycle rules (ethereum/EIPs#12007) are
-        // deferred because they all require a frame-tx validation-prefix simulation + payer resolution
-        // layer that does not exist yet:
-        //   - per-payer / canonical-paymaster exposure accounting (reserved_pending_cost <= balance),
-        //     with atomic payer-switch on replacement;
-        //   - dependency-set-indexed revalidation on head change, incl. the payer balance/code trigger;
-        //   - the full eviction ordering (invalidated-first tier).
-        // The expiry-deadline eviction tier is implemented in TxPool.RemoveExpiredFrameTransactions,
-        // and the (sender, nonce) + both-fee bump replacement rule is already provided by the shared
-        // CompareReplacedTxByFee path.
+        // EIP8141: remaining ethereum/EIPs#12007 mempool rules (payer exposure accounting, dependency-set
+        // revalidation, full eviction ordering) are deferred — they need validation-prefix simulation.
         if (tx.SupportsFrames && !_specProvider.GetCurrentHeadSpec().IsEip8141Enabled)
         {
             Metrics.PendingTransactionsNotSupportedTxType++;

--- a/src/Nethermind/Nethermind.TxPool/IChainHeadInfoProvider.cs
+++ b/src/Nethermind/Nethermind.TxPool/IChainHeadInfoProvider.cs
@@ -17,6 +17,9 @@ namespace Nethermind.TxPool
 
         ulong HeadNumber { get; }
 
+        /// <summary>Timestamp (Unix seconds) of the current chain head.</summary>
+        ulong HeadTimestamp { get; }
+
         ulong? BlockGasLimit { get; }
 
         UInt256 CurrentBaseFee { get; }

--- a/src/Nethermind/Nethermind.TxPool/Metrics.cs
+++ b/src/Nethermind/Nethermind.TxPool/Metrics.cs
@@ -33,6 +33,10 @@ namespace Nethermind.TxPool
         public static long PendingTransactionsNotSupportedTxType { get; set; }
 
         [CounterMetric]
+        [Description("Number of pending EIP-8141 frame transactions received that were ignored because their expiry deadline is already behind the current head.")]
+        public static long PendingTransactionsFrameTxExpired { get; set; }
+
+        [CounterMetric]
         [Description(
             "Number of pending transactions received that were ignored because of not having preceding nonce of this sender in TxPool.")]
         public static long PendingTransactionsNonceGap { get; set; }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -170,6 +170,7 @@ namespace Nethermind.TxPool
                 new NullHashTxFilter(), // needs to be first as it assigns the hash
                 new AlreadyKnownTxFilter(_hashCache, _logger),
                 new MalformedTxFilter(_specProvider, validator, ecdsa, _logger),
+                new ExpiredFrameTxFilter(chainHeadInfoProvider, _logger), // after MalformedTxFilter: reads the deadline from an already well-formed frame
                 new TxTypeTxFilter(_transactions,
                     _blobTransactions), // has to be after MalformedTxFilter as it uses the recovered sender
                 new BalanceZeroFilter(thereIsPriorityContract, _logger),
@@ -502,6 +503,10 @@ namespace Nethermind.TxPool
                 {
                     if (RemoveTransaction(tx.Hash))
                     {
+                        // Surface as a genuine drop to eth_subscribe("droppedPendingTransactions"): an expired
+                        // frame tx can never be included. Unlike a capacity eviction it is deliberately left in
+                        // _hashCache (RemoveTransaction does not touch it) so it cannot re-enter the pool.
+                        EvictedPending?.Invoke(this, new TxEventArgs(tx));
                         Metrics.PendingTransactionsEvicted++;
                         if (_logger.IsTrace) _logger.Trace($"Evicted expired frame transaction {tx.Hash} (deadline {deadline} < head timestamp {timestamp}).");
                     }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -460,9 +460,16 @@ namespace Nethermind.TxPool
         /// <remarks>
         /// An expired frame transaction can never satisfy its validation prefix (the expiry-verifier predeploy
         /// reverts once <c>block.timestamp &gt; deadline</c>), so it must be evicted rather than re-propagated
-        /// (ethereum/EIPs#8141, "Revalidation"). The deadline is read statically from the expiry-verifier frame, so
+        /// (ethereum/EIPs#12007, "Revalidation"). The deadline is read statically from the expiry-verifier frame, so
         /// no validation-prefix re-simulation is required. Guarded by the fork flag so there is no cost on networks
         /// where EIP-8141 is not active.
+        /// <para>
+        /// The eviction predicate is <c>timestamp &gt; deadline</c> — deliberately the predeploy's exact revert
+        /// condition, not the tighter <c>timestamp &gt;= deadline</c>. Because block timestamps strictly increase, a
+        /// tx with <c>deadline == head.Timestamp</c> is already unincludable, so retaining it costs at most one slot;
+        /// keeping the pool predicate textually identical to the consensus rule guarantees the pool never evicts a tx
+        /// the predeploy would still accept.
+        /// </para>
         /// </remarks>
         private void RemoveExpiredFrameTransactions(Block block)
         {
@@ -480,7 +487,11 @@ namespace Nethermind.TxPool
                     && FrameTxValidation.TryGetExpiryDeadline(tx, out ulong deadline)
                     && timestamp > deadline)
                 {
-                    RemoveTransaction(tx.Hash);
+                    if (RemoveTransaction(tx.Hash))
+                    {
+                        Metrics.PendingTransactionsEvicted++;
+                        if (_logger.IsTrace) _logger.Trace($"Evicted expired frame transaction {tx.Hash} (deadline {deadline} < head timestamp {timestamp}).");
+                    }
                 }
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -475,10 +475,13 @@ namespace Nethermind.TxPool
         /// </summary>
         /// <remarks>
         /// An expired frame tx can never be included (the expiry-verifier predeploy reverts once
-        /// <c>block.timestamp &gt; deadline</c>), so it is evicted rather than re-propagated. The predicate matches
-        /// that revert condition exactly (not <c>&gt;=</c>) so the pool never drops a tx the predeploy would accept.
+        /// <c>block.timestamp &gt; deadline</c>), so it is evicted rather than re-propagated
+        /// (ethereum/EIPs#12007, "Revalidation"). The predicate matches that revert condition exactly (not
+        /// <c>&gt;=</c>) so the pool never drops a tx the predeploy would accept.
         /// The count guard skips the pool walk when no expiring frame tx is present.
-        /// EIP8141: a deadline-ordered index (evict without scanning) is deferred to the scalable eviction layer.
+        /// EIP8141: a deadline-ordered index (evict without scanning) is deferred to the scalable eviction layer;
+        /// so is sweeping expired frame txs held only in the broadcaster's persistent-broadcast pool (locally
+        /// submitted, then cheap-evicted from <see cref="_transactions"/>), which this pass does not yet reach.
         /// </remarks>
         private void RemoveExpiredFrameTransactions(Block block)
         {

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -299,6 +299,7 @@ namespace Nethermind.TxPool
 
                         ReAddReorganisedTransactions(args.PreviousBlock);
                         RemoveProcessedTransactions(args.Block);
+                        RemoveExpiredFrameTransactions(args.Block);
 
                         if (!_headInfo.IsSyncing || AcceptTxWhenNotSynced || args.PreviousBlock is not null)
                         {
@@ -451,6 +452,37 @@ namespace Nethermind.TxPool
             bool removed = RemoveTransaction(tx.Hash);
             _broadcaster.EnsureStopBroadcastUpToNonce(tx.SenderAddress!, tx.Nonce);
             return removed;
+        }
+
+        /// <summary>
+        /// Drops pending EIP-8141 frame transactions whose expiry deadline has passed as of the new head.
+        /// </summary>
+        /// <remarks>
+        /// An expired frame transaction can never satisfy its validation prefix (the expiry-verifier predeploy
+        /// reverts once <c>block.timestamp &gt; deadline</c>), so it must be evicted rather than re-propagated
+        /// (ethereum/EIPs#8141, "Revalidation"). The deadline is read statically from the expiry-verifier frame, so
+        /// no validation-prefix re-simulation is required. Guarded by the fork flag so there is no cost on networks
+        /// where EIP-8141 is not active.
+        /// </remarks>
+        private void RemoveExpiredFrameTransactions(Block block)
+        {
+            if (!_specProvider.GetSpec(block.Header).IsEip8141Enabled)
+            {
+                return;
+            }
+
+            ulong timestamp = block.Timestamp;
+            Transaction[] snapshot = _transactions.GetSnapshot();
+            for (int i = 0; i < snapshot.Length; i++)
+            {
+                Transaction tx = snapshot[i];
+                if (tx.SupportsFrames
+                    && FrameTxValidation.TryGetExpiryDeadline(tx, out ulong deadline)
+                    && timestamp > deadline)
+                {
+                    RemoveTransaction(tx.Hash);
+                }
+            }
         }
 
         public void AddPeer(ITxPoolPeer peer)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -84,6 +84,11 @@ namespace Nethermind.TxPool
         private bool _isDisposed;
         private long _pendingTransactionsAdded = 0;
 
+        // Count of pending frame txs carrying an EIP-8141 expiry deadline; lets the per-head expiry
+        // pass skip the pool walk entirely when there is nothing to expire (the case on every network
+        // where the fork is inactive). Maintained under the pool lock via the Inserted/Removed events.
+        private int _expiringFrameTxCount;
+
         /// <summary>
         /// This class stores all known pending transactions that can be used for block production
         /// (by miners or validators) or simply informing other nodes about known pending transactions (broadcasting).
@@ -236,8 +241,19 @@ namespace Nethermind.TxPool
             Span<byte[]?> blobs, Span<ReadOnlyMemory<byte[]>> proofs)
             => _blobTransactions.TryGetBlobsAndProofsV1(requestedBlobVersionedHashes, blobs, proofs);
 
-        private void OnInsertedTx(object? sender, SortedPool<ValueHash256, Transaction, AddressAsKey>.SortedPoolEventArgs args) => AddPendingDelegations(args.Value);
-        private void OnRemovedTx(object? sender, SortedPool<ValueHash256, Transaction, AddressAsKey>.SortedPoolRemovedEventArgs args) => RemovePendingDelegations(args.Value);
+        private void OnInsertedTx(object? sender, SortedPool<ValueHash256, Transaction, AddressAsKey>.SortedPoolEventArgs args)
+        {
+            AddPendingDelegations(args.Value);
+            if (HasExpiryDeadline(args.Value)) Interlocked.Increment(ref _expiringFrameTxCount);
+        }
+
+        private void OnRemovedTx(object? sender, SortedPool<ValueHash256, Transaction, AddressAsKey>.SortedPoolRemovedEventArgs args)
+        {
+            RemovePendingDelegations(args.Value);
+            if (HasExpiryDeadline(args.Value)) Interlocked.Decrement(ref _expiringFrameTxCount);
+        }
+
+        private static bool HasExpiryDeadline(Transaction tx) => tx.SupportsFrames && FrameTxValidation.TryGetExpiryDeadline(tx, out _);
         private void OnHeadChange(object? sender, BlockReplacementEventArgs e)
         {
             if (_headInfo.IsSyncing)
@@ -458,22 +474,16 @@ namespace Nethermind.TxPool
         /// Drops pending EIP-8141 frame transactions whose expiry deadline has passed as of the new head.
         /// </summary>
         /// <remarks>
-        /// An expired frame transaction can never satisfy its validation prefix (the expiry-verifier predeploy
-        /// reverts once <c>block.timestamp &gt; deadline</c>), so it must be evicted rather than re-propagated
-        /// (ethereum/EIPs#12007, "Revalidation"). The deadline is read statically from the expiry-verifier frame, so
-        /// no validation-prefix re-simulation is required. Guarded by the fork flag so there is no cost on networks
-        /// where EIP-8141 is not active.
-        /// <para>
-        /// The eviction predicate is <c>timestamp &gt; deadline</c> — deliberately the predeploy's exact revert
-        /// condition, not the tighter <c>timestamp &gt;= deadline</c>. Because block timestamps strictly increase, a
-        /// tx with <c>deadline == head.Timestamp</c> is already unincludable, so retaining it costs at most one slot;
-        /// keeping the pool predicate textually identical to the consensus rule guarantees the pool never evicts a tx
-        /// the predeploy would still accept.
-        /// </para>
+        /// An expired frame tx can never be included (the expiry-verifier predeploy reverts once
+        /// <c>block.timestamp &gt; deadline</c>), so it is evicted rather than re-propagated. The predicate matches
+        /// that revert condition exactly (not <c>&gt;=</c>) so the pool never drops a tx the predeploy would accept.
+        /// The count guard skips the pool walk when no expiring frame tx is present.
+        /// EIP8141: a deadline-ordered index (evict without scanning) is deferred to the scalable eviction layer.
         /// </remarks>
         private void RemoveExpiredFrameTransactions(Block block)
         {
-            if (!_specProvider.GetSpec(block.Header).IsEip8141Enabled)
+            if (Volatile.Read(ref _expiringFrameTxCount) == 0
+                || !_specProvider.GetSpec(block.Header).IsEip8141Enabled)
             {
                 return;
             }

--- a/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
@@ -28,4 +28,5 @@ public static class TxPoolErrorMessages
     public const string DelegationNonceGap = "delegation nonce gap";
     public const string DelegationAuthorityHasPendingTx = "delegation authority has pending transaction";
     public const string NodeIsSyncing = "node is syncing";
+    public const string FrameTxExpired = "frame transaction expired";
 }


### PR DESCRIPTION
## Changes

Implements the smallest static, consensus-safe slice of the merged public-mempool lifecycle rules for EIP-8141 frame transactions (ethereum/EIPs#12007): **expiry-based eviction**.

- `FrameTxValidation.TryGetExpiryDeadline` reads the deadline statically from the expiry-verifier frame's 8-byte big-endian data (no validation-prefix re-simulation).
- `TxPool.RemoveExpiredFrameTransactions` drops, on each new head, any pending frame transaction whose deadline has passed (`block.timestamp > deadline`, matching the predeploy's strict-greater-than revert). An expired frame tx can never satisfy its validation prefix, so it is evicted rather than re-propagated. The pass is guarded by `IsEip8141Enabled`, so there is zero overhead on networks where the fork is not active.
- The `NotSupportedTxFilter` ingress-gate comment is updated to reference the now-normative merged rules and enumerate the deferred pieces as `EIP8141:` follow-ups.

### Scope: in vs. deferred

The other three #12007 pieces are **deferred** because they all sit on top of a frame-tx **validation-prefix simulation + payer-resolution** layer that does not exist in the client yet (the ingress gate currently admits frame txs with no mempool policy, marked `EIP8141-GAP TEMPORARY`):

- per-payer / canonical-paymaster exposure accounting (`reserved_pending_cost <= balance`), with atomic payer-switch on replacement;
- dependency-set-indexed revalidation on head change, including the payer balance/code trigger;
- the full eviction ordering (the invalidated-first tier).

The `(sender, nonce)` identity + both-fee ≥10% bump replacement rule (#12007 piece 1) is already provided for frame transactions by the shared `CompareReplacedTxByFee` / `CompetingTransactionEqualityComparer` path, since frame txs are 1559-type; only the payer-switch reservation move is deferred with the exposure work.

References ethereum/EIPs#12007.

## Types of changes

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `FrameTxValidationTests.TryGetExpiryDeadline_*` (3 cases): big-endian decode, no expiry frame, no frames.
- `TxPoolTests.Expired_frame_transaction_is_dropped_on_new_head` (3 cases): deadline in the past is dropped; deadline in the future is retained; `deadline == head timestamp` is retained (revert is strictly greater-than).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Draft: this is one increment of a larger work package; see the in/deferred scope above.