### PR TITLE
Archive(sync) : Increase receipts blocks write buffer

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -114,7 +114,9 @@ public class DbConfig : IDbConfig
     public string? ReceiptsTransactionsDbAdditionalRocksDbOptions { get; set; }
 
     public string ReceiptsBlocksDbRocksDbOptions { get; set; } =
-        "compaction_pri=kOldestLargestSeqFirst;";
+        "compaction_pri=kOldestLargestSeqFirst;" +
+        "write_buffer_size=16000000;" +
+        "max_write_buffer_number=4;";
     public string? ReceiptsBlocksDbAdditionalRocksDbOptions { get; set; }
 
     public string BlocksDbRocksDbOptions { get; set; } =

--- a/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
+using Nethermind.Db.Rocks;
 using Nethermind.Db.Rocks.Config;
 using NUnit.Framework;
 
@@ -82,6 +84,18 @@ public class PerTableDbConfigTests
 
         PerTableDbConfig config = new(dbConfig, DbNames.Receipts);
         Assert.That(config.FlushOnExit, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ReceiptsBlocksDb_write_buffer_budget_is_not_shrunk_by_the_receipts_defaults()
+    {
+        PerTableDbConfig config = new(new DbConfig(), DbNames.Receipts, "Blocks");
+        IDictionary<string, string> options = DbOnTheRocks.ExtractOptions(config.RocksDbOptions + config.AdditionalRocksDbOptions);
+
+        ulong writeBufferSize = ulong.Parse(options["write_buffer_size"]);
+        int maxWriteBufferNumber = int.Parse(options["max_write_buffer_number"]);
+
+        Assert.That(writeBufferSize * (ulong)maxWriteBufferNumber, Is.EqualTo(64_000_000));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/Config/PerTableDbConfigTests.cs
@@ -87,15 +87,20 @@ public class PerTableDbConfigTests
     }
 
     [Test]
-    public void ReceiptsBlocksDb_write_buffer_budget_is_not_shrunk_by_the_receipts_defaults()
+    public void ReceiptsBlocksDb_write_buffer_is_not_shrunk_by_the_receipts_defaults()
     {
-        PerTableDbConfig config = new(new DbConfig(), DbNames.Receipts, "Blocks");
-        IDictionary<string, string> options = DbOnTheRocks.ExtractOptions(config.RocksDbOptions + config.AdditionalRocksDbOptions);
+        DbConfig dbConfig = new();
+        IDictionary<string, string> generic = DbOnTheRocks.ExtractOptions(dbConfig.RocksDbOptions);
+        IDictionary<string, string> receiptsBlocks = DbOnTheRocks.ExtractOptions(
+            new PerTableDbConfig(dbConfig, DbNames.Receipts, nameof(ReceiptsColumns.Blocks)).RocksDbOptions);
 
-        ulong writeBufferSize = ulong.Parse(options["write_buffer_size"]);
-        int maxWriteBufferNumber = int.Parse(options["max_write_buffer_number"]);
-
-        Assert.That(writeBufferSize * (ulong)maxWriteBufferNumber, Is.EqualTo(64_000_000));
+        Assert.Multiple(() =>
+        {
+            Assert.That(ulong.Parse(receiptsBlocks["write_buffer_size"]),
+                Is.GreaterThanOrEqualTo(ulong.Parse(generic["write_buffer_size"])));
+            Assert.That(int.Parse(receiptsBlocks["max_write_buffer_number"]),
+                Is.GreaterThanOrEqualTo(int.Parse(generic["max_write_buffer_number"])));
+        });
     }
 
     [Test]


### PR DESCRIPTION
## Changes

- Increase write buffer size for receipts blocks table in RocksDB configuration
- Add test case verifying the receipts blocks write buffer configuration

## Live Archive Node Processing

- Raises the write-buffer budget for the Blocks column of the receipts database (the receipt bodies) from 4 MB to 64 MB, by setting write_buffer_size=16000000 and max_write_buffer_number=4 in ReceiptsBlocksDbRocksDbOptions.

Why the current value stalls writes. ReceiptsDbRocksDbOptions lowers write_buffer_size to 2 MB but does not touch max_write_buffer_number, so the column inherits 2 from the global default, a total memtable budget of 4 MB for the highest-write-volume column in the node. A post-merge block produces roughly 100-200 KB of receipts, so that budget covers only 20-40 blocks. At sync rates (10-25 blocks/s) it is consumed in about two seconds, faster than flushes can retire it, and RocksDB then hard-stops writes:

```
    [Blocks] Stopping writes because we have 2 immutable memtables (waiting for flush),
    max_write_buffer_number is set to 2
```

How that reaches block processing. Receipt writes are normally off the processing path (Receipt.DeferredPersistence), which is why most of these stops are invisible. But when RocksDB stops writes, the deferred writer blocks, its queue reaches Receipt.MaxDeferredWrites (128), and block processing falls back to synchronous writing, surfacing as multi-second Processed times. During sync two writers share the same 4 MB: live block processing and the old-receipts backfill feed (DownloadReceiptsInFastSync, default true), which is why the spikes cluster around download progress.

Why 16 MB x 4. RocksDB's own sizing guidance is write_buffer_size x max_write_buffer_number ~= max_bytes_for_level_base, which is 256 MB here, so 4 MB was the outlier, not the new value. 64 MB is deliberately below that target to keep the memory cost small for constrained nodes (+60 MB); archive configurations can raise it further. Larger buffers also produce fewer, larger L0 files, which lowers compaction work and write amplification: the accumulated cost of the old default is visible on a long-running node as 382,814 SST files at level 4 of this column.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No