### PR TITLE
Restore eth/68 blob violation handling

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -572,10 +572,10 @@ public class Eth68ProtocolHandlerTests
         _session.Received().InitiateDisconnect(DisconnectReason.BackgroundTaskFailure, "invalid pooled tx type or size");
     }
 
-    [Test]
-    public void Should_preserve_first_valid_shape_for_conservative_batched_retry()
+    [TestCase(TransactionsMessage.MaxPacketSize / 2 + 1)]
+    [TestCase(TransactionsMessage.MaxPacketSize + 1)]
+    public void Should_preserve_first_valid_shape_for_conservative_batched_retry(int largeSize)
     {
-        int largeSize = TransactionsMessage.MaxPacketSize + 1;
         _transactionPool.NotifyAboutTx(
                 Arg.Any<Hash256>(),
                 Arg.Any<IMessageHandler<PooledTransactionRequestMessage>>())

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -474,7 +474,9 @@ public class Eth68ProtocolHandlerTests
     [Test]
     public async Task Should_serve_multiple_oversized_pooled_transactions_within_soft_limit()
     {
+        const int transactionCount = 12;
         Transaction tx = Build.A.Transaction.WithData(new byte[200_000]).SignedAndResolved().TestObject;
+        int transactionsInResponse = 2 * MemorySizes.MiB / tx.GetLength();
         _transactionPool.TryGetPendingTransaction(Arg.Any<Hash256>(), out Arg.Any<Transaction>())
             .Returns(x =>
             {
@@ -482,10 +484,34 @@ public class Eth68ProtocolHandlerTests
                 return true;
             });
 
-        using Eth65GetPooledTransactionsMessage request = new(new Hash256[12].ToPooledList());
+        ArrayPoolList<Hash256> hashes = new(transactionCount);
+        for (int i = 0; i < transactionCount; i++)
+        {
+            hashes.Add(new Hash256(i.ToString("X64")));
+        }
+
+        using Eth65GetPooledTransactionsMessage request = new(hashes);
         using Eth65PooledTransactionsMessage response = await _handler.FulfillPooledTransactionsRequest(request, CancellationToken.None);
 
-        Assert.That(response.Transactions.Count, Is.EqualTo(10));
+        Assert.That(response.Transactions.Count, Is.EqualTo(transactionsInResponse));
+    }
+
+    [Test]
+    public async Task Should_serve_a_single_transaction_larger_than_the_soft_limit()
+    {
+        Transaction tx = Build.A.Transaction.WithData(new byte[2 * MemorySizes.MiB]).SignedAndResolved().TestObject;
+        _transactionPool.TryGetPendingTransaction(Arg.Any<Hash256>(), out Arg.Any<Transaction>())
+            .Returns(x =>
+            {
+                x[1] = tx;
+                return true;
+            });
+
+        ArrayPoolList<Hash256> hashes = new(1) { TestItem.KeccakA };
+        using Eth65GetPooledTransactionsMessage request = new(hashes);
+        using Eth65PooledTransactionsMessage response = await _handler.FulfillPooledTransactionsRequest(request, CancellationToken.None);
+
+        Assert.That(response.Transactions.Count, Is.EqualTo(1));
     }
 
     [Test]
@@ -502,11 +528,10 @@ public class Eth68ProtocolHandlerTests
         _transactionPool.Received(1).NotifyAboutTx(TestItem.KeccakA, Arg.Any<IMessageHandler<PooledTransactionRequestMessage>>());
     }
 
-    [TestCase(0, (byte)TxType.Legacy, false)]
-    [TestCase(100, (byte)TxType.Blob, true)]
-    [TestCase(100, (byte)TxType.DepositTx, false)]
-    [TestCase(100, byte.MaxValue, false)]
-    public void Should_not_request_or_register_invalid_transaction_shape(int size, byte type, bool shouldRetainShape)
+    [TestCase(0, (byte)TxType.Legacy)]
+    [TestCase(100, (byte)TxType.DepositTx)]
+    [TestCase(100, byte.MaxValue)]
+    public void Should_request_when_announcement_shape_is_invalid(int size, byte type)
     {
         using NewPooledTransactionHashesMessage68 hashesMsg = new(
             new ArrayPoolList<byte>(1) { type },
@@ -524,13 +549,33 @@ public class Eth68ProtocolHandlerTests
         _session.ClearReceivedCalls();
         _handler.HandleMessages([TestItem.KeccakA]);
 
-        _session.Received(shouldRetainShape ? 0 : 1).DeliverMessage(Arg.Any<GetPooledTransactionsMessage>());
+        _session.Received(1).DeliverMessage(Arg.Any<GetPooledTransactionsMessage>());
     }
 
     [Test]
-    public void Should_preserve_first_valid_shape_for_batched_retry()
+    public void Should_retain_decodable_but_unrequestable_shape_for_delivery_validation()
     {
-        int largeSize = TransactionsMessage.MaxPacketSize / 2 + 1;
+        Transaction tx = Build.A.Transaction.WithType(TxType.EIP1559).SignedAndResolved().WithHash(TestItem.KeccakA).TestObject;
+        using NewPooledTransactionHashesMessage68 hashesMsg = new(
+            new ArrayPoolList<byte>(1) { (byte)TxType.Blob },
+            new ArrayPoolList<int>(1) { tx.GetLength() },
+            new ArrayPoolList<Hash256>(1) { tx.Hash });
+        using PooledTransactionsMessage txsMsg = new(1111, new(new ArrayPoolList<Transaction>(1) { tx }));
+
+        HandleIncomingStatusMessage();
+        HandleZeroMessage(hashesMsg, Eth68MessageCode.NewPooledTransactionHashes);
+
+        _session.DidNotReceive().DeliverMessage(Arg.Any<GetPooledTransactionsMessage>());
+
+        HandleZeroMessage(txsMsg, Eth66MessageCode.PooledTransactions);
+
+        _session.Received().InitiateDisconnect(DisconnectReason.BackgroundTaskFailure, "invalid pooled tx type or size");
+    }
+
+    [Test]
+    public void Should_preserve_first_valid_shape_for_conservative_batched_retry()
+    {
+        int largeSize = TransactionsMessage.MaxPacketSize + 1;
         _transactionPool.NotifyAboutTx(
                 Arg.Any<Hash256>(),
                 Arg.Any<IMessageHandler<PooledTransactionRequestMessage>>())
@@ -588,7 +633,7 @@ public class Eth68ProtocolHandlerTests
 
     private void ReplaceHandler(ITxPoolConfig txPoolConfig)
     {
-        // Complete the discarded handler's handshake so its pending init timeout cannot disconnect the shared session substitute.
+        // Complete the outgoing handler's handshake so its pending protocol-init timeout cannot disconnect the shared session substitute.
         HandleIncomingStatusMessage();
         _handler.Dispose();
         _handler = CreateHandler(txPoolConfig);

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -70,19 +70,7 @@ public class Eth68ProtocolHandlerTests
         _txGossipPolicy = Substitute.For<ITxGossipPolicy>();
         _txGossipPolicy.ShouldListenToGossipedTransactions.Returns(true);
         _txGossipPolicy.ShouldGossipTransaction(Arg.Any<Transaction>()).Returns(true);
-        _handler = new Eth68ProtocolHandler(
-            _session,
-            _svc,
-            new NodeStatsManager(_timerFactory, LimboLogs.Instance),
-            _syncManager,
-            RunImmediatelyScheduler.Instance,
-            _transactionPool,
-            _gossipPolicy,
-            new ForkInfo(_specProvider, _syncManager),
-            LimboLogs.Instance,
-            Substitute.For<ITxPoolConfig>(),
-            Substitute.For<ISpecProvider>(),
-            _txGossipPolicy);
+        _handler = CreateHandler(Substitute.For<ITxPoolConfig>());
         _handler.Init();
     }
 
@@ -181,6 +169,32 @@ public class Eth68ProtocolHandlerTests
     }
 
     [Test]
+    public void Should_disconnect_if_unrequested_tx_violates_announced_shape()
+    {
+        ITxPoolConfig txPoolConfig = Substitute.For<ITxPoolConfig>();
+        txPoolConfig.MaxTxSize.Returns(128 * MemorySizes.KiB);
+        ReplaceHandler(txPoolConfig);
+
+        Transaction tx = Build.A.Transaction.WithShardBlobTxTypeAndFields().SignedAndResolved()
+            .WithData(new byte[200_000]).WithHash(TestItem.KeccakC).TestObject;
+
+        using NewPooledTransactionHashesMessage68 hashesMsg = new(
+            new ArrayPoolList<byte>(1) { (byte)TxType.EIP1559 },
+            new ArrayPoolList<int>(1) { tx.GetLength() },
+            new ArrayPoolList<Hash256>(1) { tx.Hash });
+        using PooledTransactionsMessage txsMsg = new(1111, new(new ArrayPoolList<Transaction>(1) { tx }));
+
+        HandleIncomingStatusMessage();
+        HandleZeroMessage(hashesMsg, Eth68MessageCode.NewPooledTransactionHashes);
+
+        _session.DidNotReceive().DeliverMessage(Arg.Any<GetPooledTransactionsMessage>());
+
+        HandleZeroMessage(txsMsg, Eth66MessageCode.PooledTransactions);
+
+        _session.Received().InitiateDisconnect(DisconnectReason.BackgroundTaskFailure, "invalid pooled tx type or size");
+    }
+
+    [Test]
     public void Should_process_huge_transaction()
     {
         Transaction tx = Build.A.Transaction.WithType(TxType.EIP1559).WithData(new byte[2 * MemorySizes.MiB])
@@ -254,19 +268,7 @@ public class Eth68ProtocolHandlerTests
     [Test]
     public void should_divide_GetPooledTransactionsMessage_if_max_message_size_is_exceeded([Values(0, 1, 100, 10_000)] int numberOfTransactions, [Values(97, TransactionsMessage.MaxPacketSize)] int sizeOfOneTx)
     {
-        _handler = new Eth68ProtocolHandler(
-            _session,
-            _svc,
-            new NodeStatsManager(_timerFactory, LimboLogs.Instance),
-            _syncManager,
-            RunImmediatelyScheduler.Instance,
-            _transactionPool,
-            _gossipPolicy,
-            new ForkInfo(_specProvider, _syncManager),
-            LimboLogs.Instance,
-            Substitute.For<ITxPoolConfig>(),
-            Substitute.For<ISpecProvider>(),
-            _txGossipPolicy);
+        ReplaceHandler(Substitute.For<ITxPoolConfig>());
 
         int maxNumberOfTxsInOneMsg = int.Min(sizeOfOneTx <= TransactionsMessage.MaxPacketSize ? TransactionsMessage.MaxPacketSize / sizeOfOneTx : 256, 256);
         int messagesCount = numberOfTransactions / maxNumberOfTxsInOneMsg + (numberOfTransactions % maxNumberOfTxsInOneMsg == 0 ? 0 : 1);
@@ -399,7 +401,7 @@ public class Eth68ProtocolHandlerTests
     }
 
     [Test]
-    public void Should_request_oversized_announced_transactions_separately()
+    public void Should_request_oversized_announced_transactions_in_one_message()
     {
         using ArrayPoolList<byte> types = new(3) { 0, 0, 0 };
         using ArrayPoolList<int> sizes = new(3) { 200_000, 200_000, 200_000 };
@@ -414,12 +416,12 @@ public class Eth68ProtocolHandlerTests
         HandleIncomingStatusMessage();
         HandleZeroMessage(hashesMsg, Eth68MessageCode.NewPooledTransactionHashes);
 
-        _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m =>
-            m.EthMessage.Hashes.Count == 1 && m.EthMessage.Hashes[0] == TestItem.KeccakA));
-        _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m =>
-            m.EthMessage.Hashes.Count == 1 && m.EthMessage.Hashes[0] == TestItem.KeccakB));
-        _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m =>
-            m.EthMessage.Hashes.Count == 1 && m.EthMessage.Hashes[0] == TestItem.KeccakC));
+        _session.Received(1).DeliverMessage(Arg.Any<GetPooledTransactionsMessage>());
+        _session.Received().DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m =>
+            m.EthMessage.Hashes.Count == 3 &&
+            m.EthMessage.Hashes[0] == TestItem.KeccakA &&
+            m.EthMessage.Hashes[1] == TestItem.KeccakB &&
+            m.EthMessage.Hashes[2] == TestItem.KeccakC));
     }
 
     [Test]
@@ -498,6 +500,29 @@ public class Eth68ProtocolHandlerTests
         using DisposableByteBuffer statusPacket = _svc.ZeroSerialize(statusMsg).AsDisposable();
         statusPacket.ReadByte();
         _handler.HandleMessage(new ZeroPacket(statusPacket) { PacketType = 0 });
+    }
+
+    private Eth68ProtocolHandler CreateHandler(ITxPoolConfig txPoolConfig) =>
+        new(
+            _session,
+            _svc,
+            new NodeStatsManager(_timerFactory, LimboLogs.Instance),
+            _syncManager,
+            RunImmediatelyScheduler.Instance,
+            _transactionPool,
+            _gossipPolicy,
+            new ForkInfo(_specProvider, _syncManager),
+            LimboLogs.Instance,
+            txPoolConfig,
+            Substitute.For<ISpecProvider>(),
+            _txGossipPolicy);
+
+    private void ReplaceHandler(ITxPoolConfig txPoolConfig)
+    {
+        HandleIncomingStatusMessage();
+        _handler.Dispose();
+        _handler = CreateHandler(txPoolConfig);
+        _handler.Init();
     }
 
     private void HandleZeroMessage<T>(T msg, byte messageCode) where T : MessageBase

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -5,6 +5,7 @@ using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
@@ -201,7 +202,7 @@ public class Eth68ProtocolHandlerTests
     [Test]
     public void Should_process_huge_transaction()
     {
-        Transaction tx = Build.A.Transaction.WithType(TxType.EIP1559).WithData(new byte[2 * MemorySizes.MiB])
+        Transaction tx = Build.A.Transaction.WithType(TxType.EIP1559).WithData(new byte[(int)2.MiB])
             .WithHash(TestItem.KeccakA).TestObject;
 
         using NewPooledTransactionHashesMessage68 msg = new(new ArrayPoolList<byte>(1) { (byte)tx.Type },
@@ -433,7 +434,7 @@ public class Eth68ProtocolHandlerTests
     {
         const int transactionSize = 200_000;
         const int transactionCount = 12;
-        int transactionsInFirstRequest = 2 * MemorySizes.MiB / transactionSize;
+        int transactionsInFirstRequest = (int)(2.MiB / transactionSize);
 
         using ArrayPoolList<byte> types = new(transactionCount);
         using ArrayPoolList<int> sizes = new(transactionCount);
@@ -475,7 +476,7 @@ public class Eth68ProtocolHandlerTests
     {
         const int transactionCount = 12;
         Transaction tx = Build.A.Transaction.WithData(new byte[200_000]).SignedAndResolved().TestObject;
-        int transactionsInResponse = 2 * MemorySizes.MiB / tx.GetLength();
+        int transactionsInResponse = (int)(2.MiB / tx.GetLength());
         _transactionPool.TryGetPendingTransaction(Arg.Any<Hash256>(), out Arg.Any<Transaction>())
             .Returns(x =>
             {
@@ -498,7 +499,7 @@ public class Eth68ProtocolHandlerTests
     [Test]
     public async Task Should_serve_a_single_transaction_larger_than_the_soft_limit()
     {
-        Transaction tx = Build.A.Transaction.WithData(new byte[2 * MemorySizes.MiB]).SignedAndResolved().TestObject;
+        Transaction tx = Build.A.Transaction.WithData(new byte[(int)2.MiB]).SignedAndResolved().TestObject;
         _transactionPool.TryGetPendingTransaction(Arg.Any<Hash256>(), out Arg.Any<Transaction>())
             .Returns(x =>
             {

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -5,7 +5,6 @@ using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -5,6 +5,7 @@ using Nethermind.Consensus;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
@@ -26,10 +27,14 @@ using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization;
 using Nethermind.TxPool;
+using Eth65GetPooledTransactionsMessage = Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages.GetPooledTransactionsMessage;
+using Eth65PooledTransactionsMessage = Nethermind.Network.P2P.Subprotocols.Eth.V65.Messages.PooledTransactionsMessage;
 using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V68;
 
@@ -401,7 +406,7 @@ public class Eth68ProtocolHandlerTests
     }
 
     [Test]
-    public void Should_request_oversized_announced_transactions_in_one_message()
+    public void Should_request_small_oversized_announcements_in_one_message()
     {
         using ArrayPoolList<byte> types = new(3) { 0, 0, 0 };
         using ArrayPoolList<int> sizes = new(3) { 200_000, 200_000, 200_000 };
@@ -425,6 +430,65 @@ public class Eth68ProtocolHandlerTests
     }
 
     [Test]
+    public void Should_split_large_oversized_announcements_by_response_size()
+    {
+        const int transactionSize = 200_000;
+        const int transactionCount = 12;
+        int transactionsInFirstRequest = 2 * MemorySizes.MiB / transactionSize;
+
+        using ArrayPoolList<byte> types = new(transactionCount);
+        using ArrayPoolList<int> sizes = new(transactionCount);
+        using ArrayPoolList<Hash256> hashes = new(transactionCount);
+
+        for (int i = 0; i < transactionCount; i++)
+        {
+            types.Add((byte)TxType.EIP1559);
+            sizes.Add(transactionSize);
+            hashes.Add(new Hash256(i.ToString("X64")));
+        }
+
+        using NewPooledTransactionHashesMessage68 hashesMsg = new(types, sizes, hashes);
+        HandleIncomingStatusMessage();
+        HandleZeroMessage(hashesMsg, Eth68MessageCode.NewPooledTransactionHashes);
+
+        _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m => m.EthMessage.Hashes.Count == transactionsInFirstRequest));
+        _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m => m.EthMessage.Hashes.Count == transactionCount - transactionsInFirstRequest));
+    }
+
+    [Test]
+    public void Should_not_mix_regular_and_oversized_announcements_in_one_request()
+    {
+        using ArrayPoolList<byte> types = new(3) { (byte)TxType.EIP1559, (byte)TxType.EIP1559, (byte)TxType.EIP1559 };
+        using ArrayPoolList<int> sizes = new(3) { 50_000, 200_000, 50_000 };
+        using ArrayPoolList<Hash256> hashes = new(3) { TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC };
+        using NewPooledTransactionHashesMessage68 hashesMsg = new(types, sizes, hashes);
+
+        HandleIncomingStatusMessage();
+        HandleZeroMessage(hashesMsg, Eth68MessageCode.NewPooledTransactionHashes);
+
+        _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m => m.EthMessage.Hashes.Count == 1 && m.EthMessage.Hashes[0] == TestItem.KeccakA));
+        _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m => m.EthMessage.Hashes.Count == 1 && m.EthMessage.Hashes[0] == TestItem.KeccakB));
+        _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m => m.EthMessage.Hashes.Count == 1 && m.EthMessage.Hashes[0] == TestItem.KeccakC));
+    }
+
+    [Test]
+    public async Task Should_serve_multiple_oversized_pooled_transactions_within_soft_limit()
+    {
+        Transaction tx = Build.A.Transaction.WithData(new byte[200_000]).SignedAndResolved().TestObject;
+        _transactionPool.TryGetPendingTransaction(Arg.Any<Hash256>(), out Arg.Any<Transaction>())
+            .Returns(x =>
+            {
+                x[1] = tx;
+                return true;
+            });
+
+        using Eth65GetPooledTransactionsMessage request = new(new Hash256[12].ToPooledList());
+        using Eth65PooledTransactionsMessage response = await _handler.FulfillPooledTransactionsRequest(request, CancellationToken.None);
+
+        Assert.That(response.Transactions.Count, Is.EqualTo(10));
+    }
+
+    [Test]
     public void Should_register_requested_hashes_for_timeout_retry()
     {
         using NewPooledTransactionHashesMessage68 hashesMsg = new(
@@ -438,11 +502,11 @@ public class Eth68ProtocolHandlerTests
         _transactionPool.Received(1).NotifyAboutTx(TestItem.KeccakA, Arg.Any<IMessageHandler<PooledTransactionRequestMessage>>());
     }
 
-    [TestCase(0, (byte)TxType.Legacy)]
-    [TestCase(100, (byte)TxType.Blob)]
-    [TestCase(100, (byte)TxType.DepositTx)]
-    [TestCase(100, byte.MaxValue)]
-    public void Should_not_request_or_register_invalid_transaction_shape(int size, byte type)
+    [TestCase(0, (byte)TxType.Legacy, false)]
+    [TestCase(100, (byte)TxType.Blob, true)]
+    [TestCase(100, (byte)TxType.DepositTx, false)]
+    [TestCase(100, byte.MaxValue, false)]
+    public void Should_not_request_or_register_invalid_transaction_shape(int size, byte type, bool shouldRetainShape)
     {
         using NewPooledTransactionHashesMessage68 hashesMsg = new(
             new ArrayPoolList<byte>(1) { type },
@@ -456,6 +520,11 @@ public class Eth68ProtocolHandlerTests
         _transactionPool.DidNotReceive().NotifyAboutTx(
             Arg.Any<Hash256>(),
             Arg.Any<IMessageHandler<PooledTransactionRequestMessage>>());
+
+        _session.ClearReceivedCalls();
+        _handler.HandleMessages([TestItem.KeccakA]);
+
+        _session.Received(shouldRetainShape ? 0 : 1).DeliverMessage(Arg.Any<GetPooledTransactionsMessage>());
     }
 
     [Test]
@@ -519,6 +588,7 @@ public class Eth68ProtocolHandlerTests
 
     private void ReplaceHandler(ITxPoolConfig txPoolConfig)
     {
+        // Complete the discarded handler's handshake so its pending init timeout cannot disconnect the shared session substitute.
         HandleIncomingStatusMessage();
         _handler.Dispose();
         _handler = CreateHandler(txPoolConfig);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -6,6 +6,7 @@ using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Network.Contract.Messages;
 using Nethermind.Network.Contract.P2P;
@@ -47,7 +48,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
         public override byte ProtocolVersion => EthVersions.Eth65;
 
         private const int MaxNumberOfTxsInOneMsg = 256;
-        private const int PooledTransactionsResponseSoftLimit = 2 * MemorySizes.MiB;
+        private static readonly int PooledTransactionsResponseSoftLimit = (int)2.MiB;
 
         protected override bool HandleMessageCore(ZeroPacket message)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -47,8 +47,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
         public override byte ProtocolVersion => EthVersions.Eth65;
 
         private const int MaxNumberOfTxsInOneMsg = 256;
-
-        protected virtual int PooledTransactionsResponseSizeLimit => TransactionsMessage.MaxPacketSize;
+        private const int PooledTransactionsResponseSoftLimit = 2 * MemorySizes.MiB;
 
         protected override bool HandleMessageCore(ZeroPacket message)
         {
@@ -128,7 +127,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
         {
             ArrayPoolList<Transaction> txsToSend = new(msg.Hashes.Count);
 
-            int packetSizeLeft = PooledTransactionsResponseSizeLimit;
+            // Eth/68 and later use the 2 MiB pooled-transactions soft response limit from the devp2p eth capability.
+            int packetSizeLeft = ProtocolVersion >= EthVersions.Eth68
+                ? PooledTransactionsResponseSoftLimit
+                : TransactionsMessage.MaxPacketSize;
             foreach (Hash256 hash in msg.Hashes.AsSpan())
             {
                 if (cancellationToken.IsCancellationRequested) break;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V65/Eth65ProtocolHandler.cs
@@ -48,6 +48,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
 
         private const int MaxNumberOfTxsInOneMsg = 256;
 
+        protected virtual int PooledTransactionsResponseSizeLimit => TransactionsMessage.MaxPacketSize;
+
         protected override bool HandleMessageCore(ZeroPacket message)
         {
             int size = message.Content.ReadableBytes;
@@ -126,7 +128,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V65
         {
             ArrayPoolList<Transaction> txsToSend = new(msg.Hashes.Count);
 
-            int packetSizeLeft = TransactionsMessage.MaxPacketSize;
+            int packetSizeLeft = PooledTransactionsResponseSizeLimit;
             foreach (Hash256 hash in msg.Hashes.AsSpan())
             {
                 if (cancellationToken.IsCancellationRequested) break;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -163,21 +163,18 @@ public class Eth68ProtocolHandler(ISession session,
                 : (sizes[index], (TxType)types[index]);
             int txSize = txShape.Size;
 
-            bool oversized = txSize > TransactionsMessage.MaxPacketSize;
-            if (ShouldSendCurrentRequest(txSize, packetSizeLeft, toRequestCount))
+            // Oversized transactions cannot fit the response budget, so let the responder truncate them by request order.
+            bool countsTowardPacketSize = txSize <= TransactionsMessage.MaxPacketSize;
+            if (ShouldSendCurrentRequest(countsTowardPacketSize, txSize, packetSizeLeft, toRequestCount))
             {
                 SendHashesToRequest();
             }
 
-            hashesToRequest ??= new ArrayPoolList<Hash256>(oversized ? 1 : requestCapacity);
+            hashesToRequest ??= new ArrayPoolList<Hash256>(requestCapacity);
             hashesToRequest.Add(hash);
             toRequestCount++;
 
-            if (oversized)
-            {
-                SendHashesToRequest();
-            }
-            else
+            if (countsTowardPacketSize)
             {
                 packetSizeLeft -= txSize;
             }
@@ -262,9 +259,9 @@ public class Eth68ProtocolHandler(ISession session,
         _ => false,
     };
 
-    private static bool ShouldSendCurrentRequest(int txSize, int packetSizeLeft, int toRequestCount) =>
+    private static bool ShouldSendCurrentRequest(bool countsTowardPacketSize, int txSize, int packetSizeLeft, int toRequestCount) =>
         toRequestCount >= MaxPooledTransactionHashesPerRequest
-        || (txSize > packetSizeLeft && toRequestCount > 0);
+        || (countsTowardPacketSize && txSize > packetSizeLeft && toRequestCount > 0);
 
     private ArrayPoolListRef<int> AddMarkUnknownHashes(
         ReadOnlySpan<Hash256> hashes,
@@ -279,16 +276,17 @@ public class Eth68ProtocolHandler(ISession session,
             if (!_txPool.IsKnown(hash))
             {
                 (int Size, TxType Type) txShape = (sizes[i], (TxType)types[i]);
+                // Delivered transactions must match their first announcement even when that announcement was not requestable.
+                if (!TxShapeAnnouncements.TryGet(hash, out _))
+                {
+                    TxShapeAnnouncements.Set(hash, txShape);
+                }
+
                 if (!CanRequestPooledTransaction(txShape.Type)
                     || txShape.Size <= 0
                     || txShape.Size > (txShape.Type.SupportsBlobs() ? _configuredMaxBlobTxSize : _configuredMaxTxSize))
                 {
                     continue;
-                }
-
-                if (!TxShapeAnnouncements.TryGet(hash, out _))
-                {
-                    TxShapeAnnouncements.Set(hash, txShape);
                 }
 
                 if (!registerForRetry || _txPool.NotifyAboutTx(hash, this) is AnnounceResult.RequestRequired)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -308,13 +308,14 @@ public class Eth68ProtocolHandler(ISession session,
                 }
 
                 // Delivered transactions must match their first decodable announcement even when that announcement was not requestable.
-                if (!TxShapeAnnouncements.TryGet(hash, out _))
+                if (!TxShapeAnnouncements.TryGet(hash, out (int Size, TxType Type) retainedShape))
                 {
                     TxShapeAnnouncements.Set(hash, txShape);
+                    retainedShape = txShape;
                 }
 
-                if (!CanRequestPooledTransaction(txShape.Type)
-                    || txShape.Size > (txShape.Type.SupportsBlobs() ? _configuredMaxBlobTxSize : _configuredMaxTxSize))
+                if (!CanRequestPooledTransaction(retainedShape.Type)
+                    || retainedShape.Size > (retainedShape.Type.SupportsBlobs() ? _configuredMaxBlobTxSize : _configuredMaxTxSize))
                 {
                     // Keep the valid shape for delivery validation, but make shaped retries a no-op for transactions this node cannot process.
                     continue;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -45,8 +45,6 @@ public class Eth68ProtocolHandler(ISession session,
     private const int MaxPooledTransactionHashesPerRequest = 256;
     private const int PooledTransactionsResponseSoftLimit = 2 * MemorySizes.MiB;
 
-    protected override int PooledTransactionsResponseSizeLimit => PooledTransactionsResponseSoftLimit;
-
     private readonly bool _blobSupportEnabled = txPoolConfig.BlobsSupport.IsEnabled();
     private readonly long _configuredMaxTxSize = txPoolConfig.MaxTxSize ?? long.MaxValue;
 
@@ -154,7 +152,9 @@ public class Eth68ProtocolHandler(ISession session,
         }
 
         int packetSizeLeft = TransactionsMessage.MaxPacketSize;
-        int responseSizeLeft = PooledTransactionsResponseSoftLimit;
+        // Retry batches must remain compatible with peers that still use the 100 KiB response target.
+        int responseSizeLimit = registerForRetry ? PooledTransactionsResponseSoftLimit : TransactionsMessage.MaxPacketSize;
+        int responseSizeLeft = responseSizeLimit;
         int requestCapacity = Math.Min(newTxHashesIndexes.Count, MaxPooledTransactionHashesPerRequest);
         ArrayPoolList<Hash256>? hashesToRequest = null;
         int toRequestCount = 0;
@@ -169,7 +169,7 @@ public class Eth68ProtocolHandler(ISession session,
             int txSize = txShape.Size;
 
             bool isOversized = txSize > TransactionsMessage.MaxPacketSize;
-            if (ShouldSendCurrentRequest(isOversized, txSize, packetSizeLeft, responseSizeLeft, toRequestCount, hasOversizedTransaction))
+            if (ShouldSendCurrentRequest(txSize, packetSizeLeft, responseSizeLeft, toRequestCount, hasOversizedTransaction))
             {
                 SendHashesToRequest();
             }
@@ -200,7 +200,7 @@ public class Eth68ProtocolHandler(ISession session,
             hashesToRequest = null;
             SendPooledTransactionRequest<V66.Messages.GetPooledTransactionsMessage>(request);
             packetSizeLeft = TransactionsMessage.MaxPacketSize;
-            responseSizeLeft = PooledTransactionsResponseSoftLimit;
+            responseSizeLeft = responseSizeLimit;
             toRequestCount = 0;
             hasOversizedTransaction = false;
         }
@@ -263,12 +263,8 @@ public class Eth68ProtocolHandler(ISession session,
         }
     }
 
-    private bool CanRequestPooledTransaction(TxType txType) => txType switch
-    {
-        TxType.Legacy or TxType.AccessList or TxType.EIP1559 or TxType.SetCode => true,
-        TxType.Blob => _blobSupportEnabled,
-        _ => false,
-    };
+    private bool CanRequestPooledTransaction(TxType txType) =>
+        CanDecodeTransactionType(txType) && (txType is not TxType.Blob || _blobSupportEnabled);
 
     private static bool CanDecodeTransactionType(TxType txType) => txType switch
     {
@@ -277,16 +273,21 @@ public class Eth68ProtocolHandler(ISession session,
     };
 
     private static bool ShouldSendCurrentRequest(
-        bool isOversized,
         int txSize,
         int packetSizeLeft,
         int responseSizeLeft,
         int toRequestCount,
-        bool hasOversizedTransaction) =>
-        toRequestCount >= MaxPooledTransactionHashesPerRequest
-        || (toRequestCount > 0 && isOversized != hasOversizedTransaction)
-        || (!isOversized && txSize > packetSizeLeft && toRequestCount > 0)
-        || (isOversized && txSize > responseSizeLeft && toRequestCount > 0);
+        bool hasOversizedTransaction)
+    {
+        if (toRequestCount == 0)
+        {
+            return false;
+        }
+
+        bool isOversized = txSize > TransactionsMessage.MaxPacketSize;
+        return isOversized != hasOversizedTransaction
+            || (isOversized ? txSize > responseSizeLeft : txSize > packetSizeLeft);
+    }
 
     private ArrayPoolListRef<int> AddMarkUnknownHashes(
         ReadOnlySpan<Hash256> hashes,
@@ -315,6 +316,7 @@ public class Eth68ProtocolHandler(ISession session,
                 if (!CanRequestPooledTransaction(txShape.Type)
                     || txShape.Size > (txShape.Type.SupportsBlobs() ? _configuredMaxBlobTxSize : _configuredMaxTxSize))
                 {
+                    // Keep the valid shape for delivery validation, but make shaped retries a no-op for transactions this node cannot process.
                     continue;
                 }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -43,6 +43,9 @@ public class Eth68ProtocolHandler(ISession session,
     : Eth67ProtocolHandler(session, serializer, nodeStatsManager, syncServer, backgroundTaskScheduler, txPool, gossipPolicy, forkInfo, logManager, transactionsGossipPolicy), IStaticProtocolInfo
 {
     private const int MaxPooledTransactionHashesPerRequest = 256;
+    private const int PooledTransactionsResponseSoftLimit = 2 * MemorySizes.MiB;
+
+    protected override int PooledTransactionsResponseSizeLimit => PooledTransactionsResponseSoftLimit;
 
     private readonly bool _blobSupportEnabled = txPoolConfig.BlobsSupport.IsEnabled();
     private readonly long _configuredMaxTxSize = txPoolConfig.MaxTxSize ?? long.MaxValue;
@@ -151,9 +154,11 @@ public class Eth68ProtocolHandler(ISession session,
         }
 
         int packetSizeLeft = TransactionsMessage.MaxPacketSize;
+        int responseSizeLeft = PooledTransactionsResponseSoftLimit;
         int requestCapacity = Math.Min(newTxHashesIndexes.Count, MaxPooledTransactionHashesPerRequest);
         ArrayPoolList<Hash256>? hashesToRequest = null;
         int toRequestCount = 0;
+        bool hasOversizedTransaction = false;
 
         foreach (int index in newTxHashesIndexes.AsSpan())
         {
@@ -163,9 +168,8 @@ public class Eth68ProtocolHandler(ISession session,
                 : (sizes[index], (TxType)types[index]);
             int txSize = txShape.Size;
 
-            // Oversized transactions cannot fit the response budget, so let the responder truncate them by request order.
-            bool countsTowardPacketSize = txSize <= TransactionsMessage.MaxPacketSize;
-            if (ShouldSendCurrentRequest(countsTowardPacketSize, txSize, packetSizeLeft, toRequestCount))
+            bool isOversized = txSize > TransactionsMessage.MaxPacketSize;
+            if (ShouldSendCurrentRequest(isOversized, txSize, packetSizeLeft, responseSizeLeft, toRequestCount, hasOversizedTransaction))
             {
                 SendHashesToRequest();
             }
@@ -174,7 +178,12 @@ public class Eth68ProtocolHandler(ISession session,
             hashesToRequest.Add(hash);
             toRequestCount++;
 
-            if (countsTowardPacketSize)
+            if (isOversized)
+            {
+                responseSizeLeft -= txSize;
+                hasOversizedTransaction = true;
+            }
+            else
             {
                 packetSizeLeft -= txSize;
             }
@@ -191,7 +200,9 @@ public class Eth68ProtocolHandler(ISession session,
             hashesToRequest = null;
             SendPooledTransactionRequest<V66.Messages.GetPooledTransactionsMessage>(request);
             packetSizeLeft = TransactionsMessage.MaxPacketSize;
+            responseSizeLeft = PooledTransactionsResponseSoftLimit;
             toRequestCount = 0;
+            hasOversizedTransaction = false;
         }
     }
 
@@ -259,9 +270,23 @@ public class Eth68ProtocolHandler(ISession session,
         _ => false,
     };
 
-    private static bool ShouldSendCurrentRequest(bool countsTowardPacketSize, int txSize, int packetSizeLeft, int toRequestCount) =>
+    private static bool CanDecodeTransactionType(TxType txType) => txType switch
+    {
+        TxType.Legacy or TxType.AccessList or TxType.EIP1559 or TxType.Blob or TxType.SetCode => true,
+        _ => false,
+    };
+
+    private static bool ShouldSendCurrentRequest(
+        bool isOversized,
+        int txSize,
+        int packetSizeLeft,
+        int responseSizeLeft,
+        int toRequestCount,
+        bool hasOversizedTransaction) =>
         toRequestCount >= MaxPooledTransactionHashesPerRequest
-        || (countsTowardPacketSize && txSize > packetSizeLeft && toRequestCount > 0);
+        || (toRequestCount > 0 && isOversized != hasOversizedTransaction)
+        || (!isOversized && txSize > packetSizeLeft && toRequestCount > 0)
+        || (isOversized && txSize > responseSizeLeft && toRequestCount > 0);
 
     private ArrayPoolListRef<int> AddMarkUnknownHashes(
         ReadOnlySpan<Hash256> hashes,
@@ -276,14 +301,18 @@ public class Eth68ProtocolHandler(ISession session,
             if (!_txPool.IsKnown(hash))
             {
                 (int Size, TxType Type) txShape = (sizes[i], (TxType)types[i]);
-                // Delivered transactions must match their first announcement even when that announcement was not requestable.
+                if (txShape.Size <= 0 || !CanDecodeTransactionType(txShape.Type))
+                {
+                    continue;
+                }
+
+                // Delivered transactions must match their first decodable announcement even when that announcement was not requestable.
                 if (!TxShapeAnnouncements.TryGet(hash, out _))
                 {
                     TxShapeAnnouncements.Set(hash, txShape);
                 }
 
                 if (!CanRequestPooledTransaction(txShape.Type)
-                    || txShape.Size <= 0
                     || txShape.Size > (txShape.Type.SupportsBlobs() ? _configuredMaxBlobTxSize : _configuredMaxTxSize))
                 {
                     continue;

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -43,7 +43,7 @@ public class Eth68ProtocolHandler(ISession session,
     : Eth67ProtocolHandler(session, serializer, nodeStatsManager, syncServer, backgroundTaskScheduler, txPool, gossipPolicy, forkInfo, logManager, transactionsGossipPolicy), IStaticProtocolInfo
 {
     private const int MaxPooledTransactionHashesPerRequest = 256;
-    private const int PooledTransactionsResponseSoftLimit = 2 * MemorySizes.MiB;
+    private static readonly int PooledTransactionsResponseSoftLimit = (int)2.MiB;
 
     private readonly bool _blobSupportEnabled = txPoolConfig.BlobsSupport.IsEnabled();
     private readonly long _configuredMaxTxSize = txPoolConfig.MaxTxSize ?? long.MaxValue;


### PR DESCRIPTION
## Changes

- Retain the first eth/68 transaction-shape announcement for delivered-transaction validation even when the announcement is not locally requestable.
- Group oversized transaction hashes into ordered requests capped at 256 hashes and the eth pooled-transaction soft response limit, allowing peers to truncate responses without receiving multiple concurrent requests.
- Use the 2 MiB pooled-transaction response limit for eth/68+ responders, matching the devp2p capability and Geth behavior.
- Use the legacy 100 KiB response target for batched retries so peers that have not adopted the 2 MiB responder limit can recover oversized hashes individually.
- Add regressions for unrequested shape violations, exact oversized request grouping, conservative retry batching, response-limit edge cases, and replacement-handler initialization lifetime.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added focused eth/68 regression coverage and verified the complete Network test assembly. The current Geth Hive `eth/BlobViolations` scenario passes with the fix.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The request behavior follows the ETH pooled-transaction response semantics, where responders may truncate results while preserving request order: https://github.com/ethereum/devp2p/blob/51dc101fddd52b5d90e59a2d695a92e4d600cfaf/caps/eth.md#L512-L529

Initial oversized requests use the 2 MiB soft limit so the two 3-blob Hive exchange remains one request. Batched retries use the legacy 100 KiB target so an older Nethermind responder returns each oversized transaction from its own request instead of repeatedly truncating the same batch. Eth/68+ responders serve up to the 2 MiB soft limit; this increases the per-request response target but remains bounded by the pooled transaction request and the protocol soft limit.

Geth reference test: https://github.com/ethereum/go-ethereum/blob/b988c00bf4cba86ef5c43691ce84f4f2aea2821f/cmd/devp2p/internal/ethtest/suite.go#L1051-L1121