### PR TITLE
perf(state): parallelize whale storage verification and enable snapshot readahead in FlatTrieVerifier

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using Nethermind.Core.Crypto;
 using Nethermind.State.Flat;
+using Nethermind.State.Flat.Persistence;
 
 namespace Nethermind.Core.Test.Modules;
 
@@ -17,6 +18,8 @@ internal class FlatDbManagerTestCompat(IFlatDbManager flatDbManager) : IFlatDbMa
     public SnapshotBundle GatherSnapshotBundle(in StateId stateId, ResourcePool.Usage usage) => flatDbManager.GatherSnapshotBundle(NormalizeState(stateId), usage);
 
     public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId stateId) => flatDbManager.GatherReadOnlySnapshotBundle(NormalizeState(stateId));
+
+    public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId stateId, ReaderFlags readerFlags) => flatDbManager.GatherReadOnlySnapshotBundle(NormalizeState(stateId), readerFlags);
 
     public bool HasStateForBlock(in StateId stateId)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -148,25 +148,28 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) => _writeBatch.WriteBatch.Merge(key, value, _column._columnFamily, flags);
     }
 
-    IColumnDbSnapshot<T> IColumnsDb<T>.CreateSnapshot()
-    {
-        Snapshot snapshot = _db.CreateSnapshot();
-        return new ColumnDbSnapshot(this, snapshot);
-    }
+    IColumnDbSnapshot<T> IColumnsDb<T>.CreateSnapshot() => CreateSnapshotCore(sequentialReadAhead: false);
+
+    IColumnDbSnapshot<T> IColumnsDb<T>.CreateSnapshot(bool sequentialReadAhead) => CreateSnapshotCore(sequentialReadAhead);
+
+    private ColumnDbSnapshot CreateSnapshotCore(bool sequentialReadAhead) => new(this, _db.CreateSnapshot(), sequentialReadAhead);
 
     private class ColumnDbSnapshot : IColumnDbSnapshot<T>
     {
+        private readonly ColumnsDb<T> _columnsDb;
         private readonly Snapshot _snapshot;
         private readonly ReadOptions _sharedReadOptions;
         private readonly ReadOptions _sharedCacheMissReadOptions;
+        private ReadOptions? _readAheadReadOptions;
         private int _disposed;
 
         // Use a flat array indexed by enum ordinal instead of Dictionary<T, IReadOnlyKeyValueStore>.
         // This eliminates the dictionary + backing array allocation per snapshot.
         private readonly RocksDbReader[] _readers;
 
-        public ColumnDbSnapshot(ColumnsDb<T> columnsDb, Snapshot snapshot)
+        public ColumnDbSnapshot(ColumnsDb<T> columnsDb, Snapshot snapshot, bool sequentialReadAhead)
         {
+            _columnsDb = columnsDb;
             _snapshot = snapshot;
 
             // Create two shared ReadOptions for all column readers instead of 2 per reader.
@@ -180,17 +183,12 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
             // Note: each GetViewBetween call still creates a new ReadOptions with a finalizer;
             // that is pre-existing behavior not addressed by this PR.
             Func<ReadOptions> readOptionsFactory = () => CreateReadOptions(columnsDb, snapshot);
+            // Shared by all column iterator managers; the ReadOptions it returns is created lazily
+            // on the first HintReadAhead read, so snapshots that never iterate allocate nothing extra.
+            Func<ReadOptions>? readAheadOptionsFactory = sequentialReadAhead ? GetOrCreateReadAheadReadOptions : null;
             T[] keys = CreateKeyCache(columnsDb);
             GetCachedMaxOrdinal(columnsDb, keys);
             _readers = CreateReaders();
-
-            static ReadOptions CreateReadOptions(ColumnsDb<T> columnsDb, Snapshot snapshot)
-            {
-                ReadOptions options = new();
-                options.SetVerifyChecksums(columnsDb.VerifyChecksum);
-                options.SetSnapshot(snapshot);
-                return options;
-            }
 
             // Cache column keys and max ordinal on the parent ColumnsDb to avoid per-snapshot
             // recomputation. The race is benign (both threads compute identical results) and
@@ -233,16 +231,59 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
                 for (int i = 0; i < keys.Length; i++)
                 {
                     T k = keys[i];
-                    readers[EnumToInt(k)] = new RocksDbReader(
+                    int ordinal = EnumToInt(k);
+                    ColumnFamilyHandle columnFamily = columnsDb._columnDbs[k]._columnFamily;
+                    // Internally lazy — until a HintReadAhead read arrives this is just an object allocation.
+                    IteratorManager? iteratorManager = readAheadOptionsFactory is null
+                        ? null
+                        : new IteratorManager(columnsDb._db, columnFamily, readAheadOptionsFactory, sequentialKeys: true);
+                    readers[ordinal] = new RocksDbReader(
                         columnsDb,
                         _sharedReadOptions,
                         _sharedCacheMissReadOptions,
                         readOptionsFactory,
-                        columnFamily: columnsDb._columnDbs[k]._columnFamily);
+                        iteratorManager,
+                        columnFamily);
                 }
 
                 return readers;
             }
+        }
+
+        private static ReadOptions CreateReadOptions(ColumnsDb<T> columnsDb, Snapshot snapshot)
+        {
+            ReadOptions options = new();
+            options.SetVerifyChecksums(columnsDb.VerifyChecksum);
+            options.SetSnapshot(snapshot);
+            return options;
+        }
+
+        /// <summary>
+        /// Lazily creates the snapshot-bound <see cref="ReadOptions"/> shared by all column iterator managers.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="DbOnTheRocks._readAheadReadOptions"/> this must not be tailing: tailing iterators
+        /// ignore the snapshot and would observe writes made after it.
+        /// </remarks>
+        private ReadOptions GetOrCreateReadAheadReadOptions()
+        {
+            ReadOptions? options = Volatile.Read(ref _readAheadReadOptions);
+            if (options is not null) return options;
+
+            ReadOptions created = CreateReadOptions(_columnsDb, _snapshot);
+            if (_columnsDb._readAheadSize > 0)
+            {
+                created.SetReadaheadSize(_columnsDb._readAheadSize);
+            }
+
+            options = Interlocked.CompareExchange(ref _readAheadReadOptions, created, null);
+            if (options is not null)
+            {
+                RocksDbReader.DestroyReadOptions(created);
+                return options;
+            }
+
+            return created;
         }
 
         public IReadOnlyKeyValueStore GetColumn(T key)
@@ -262,10 +303,20 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         {
             if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
+            // Iterators pin the snapshot's resources — tear the managers down before releasing anything they read through.
+            foreach (RocksDbReader? reader in _readers)
+            {
+                reader?.IteratorManager?.Dispose();
+            }
+
             // Explicitly destroy native ReadOptions handles to prevent finalizer queue buildup.
             // GC.SuppressFinalize prevents the finalizer from running on already-destroyed handles.
             RocksDbReader.DestroyReadOptions(_sharedReadOptions);
             RocksDbReader.DestroyReadOptions(_sharedCacheMissReadOptions);
+            if (Interlocked.Exchange(ref _readAheadReadOptions, null) is { } readAheadOptions)
+            {
+                RocksDbReader.DestroyReadOptions(readAheadOptions);
+            }
 
             _snapshot.Dispose();
         }

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -58,6 +58,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     private ReadOptions _defaultReadOptions = null!;
     private ReadOptions _hintCacheMissOptions = null!;
     internal ReadOptions? _readAheadReadOptions = null;
+    internal ulong _readAheadSize;
 
     internal DbOptions? DbOptions { get; private set; }
     private readonly IRocksDbConfigFactory _rocksDbConfigFactory;
@@ -709,8 +710,9 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         // visitor on mainnet with 4GB memory budget and 4Gbps read bandwidth.
         if (dbConfig.ReadAheadSize != 0)
         {
+            _readAheadSize = dbConfig.ReadAheadSize ?? 256UL.KiB;
             _readAheadReadOptions = CreateReadOptions();
-            _readAheadReadOptions.SetReadaheadSize(dbConfig.ReadAheadSize ?? 256UL.KiB);
+            _readAheadReadOptions.SetReadaheadSize(_readAheadSize);
             _readAheadReadOptions.SetTailing(true);
         }
         #endregion
@@ -754,7 +756,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         using IteratorManager.RentWrapper wrapper = iteratorManager.Rent(flags);
         Iterator iterator = wrapper.Iterator;
 
-        if (iterator.Valid() && TryCloseReadAhead(iterator, key, out byte[]? closeRes))
+        if (iterator.Valid() && TryCloseReadAhead(iterator, key, iteratorManager.SequentialKeys, out byte[]? closeRes))
         {
             return closeRes;
         }
@@ -820,16 +822,23 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     /// <param name="key"></param>
     /// <param name="result"></param>
     /// <returns></returns>
-    private bool TryCloseReadAhead(Iterator iterator, ReadOnlySpan<byte> key, out byte[]? result)
+    private bool TryCloseReadAhead(Iterator iterator, ReadOnlySpan<byte> key, bool sequentialKeys, out byte[]? result)
     {
         // Probably hash db. Can't really do this with hashdb. Even with batched trie visitor, its going to skip a lot.
-        if (key.Length <= 32)
+        if (!sequentialKeys && key.Length <= 32)
         {
             result = null;
             return false;
         }
 
         iterator.Next();
+        // Next() can exhaust the iterator; key()/Next() on an invalid iterator is undefined per the RocksDB API.
+        if (!iterator.Valid())
+        {
+            result = null;
+            return false;
+        }
+
         ReadOnlySpan<byte> currentKey = iterator.GetKeySpan();
         int compareResult = currentKey.SequenceCompareTo(key);
         if (compareResult == 0)
@@ -848,17 +857,25 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         // This is only useful for state as storage have way too different different address range between different
         // contract. That said, there isn't any real good threshold. Threshold is for some reasonably high value
         // above the average distance.
-        ulong currentKeyInt = BinaryPrimitives.ReadUInt64BigEndian(currentKey);
-        ulong requestedKeyInt = BinaryPrimitives.ReadUInt64BigEndian(key);
-        ulong distance = requestedKeyInt - currentKeyInt;
-        if (distance > 1_000_000_000)
+        // Skipped for short keys (e.g. 3-byte StateTopNodes keys): the bounded probe below is enough there.
+        if (currentKey.Length >= sizeof(ulong) && key.Length >= sizeof(ulong))
         {
-            return false;
+            ulong currentKeyInt = BinaryPrimitives.ReadUInt64BigEndian(currentKey);
+            ulong requestedKeyInt = BinaryPrimitives.ReadUInt64BigEndian(key);
+            ulong distance = requestedKeyInt - currentKeyInt;
+            if (distance > 1_000_000_000)
+            {
+                return false;
+            }
         }
 
         for (int i = 0; i < 5 && compareResult < 0; i++)
         {
             iterator.Next();
+            if (!iterator.Valid())
+            {
+                return false;
+            }
             compareResult = iterator.GetKeySpan().SequenceCompareTo(key);
         }
 
@@ -1838,47 +1855,79 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     /// </summary>
     public class IteratorManager : IDisposable
     {
-        private readonly ManagedIterators _readaheadIterators = new();
-        private readonly ManagedIterators _readaheadIterators2 = new();
-        private readonly ManagedIterators _readaheadIterators3 = new();
+        private ManagedIterators? _readaheadIterators;
+        private ManagedIterators? _readaheadIterators2;
+        private ManagedIterators? _readaheadIterators3;
         private readonly RocksDb _rocksDb;
         private readonly ColumnFamilyHandle? _cf;
-        private readonly ReadOptions? _readOptions;
-        private readonly Timer _timer;
-        private bool _isDisposed;
+        private readonly Func<ReadOptions>? _readOptionsFactory;
+        private ReadOptions? _readOptions;
+        private readonly Lock _initLock = new();
+        private Timer? _timer;
+        private volatile bool _isDisposed;
 
         // This is about once every two second maybe at max throughput.
         private const int IteratorUsageLimit = 1000000;
+
+        /// <summary>
+        /// Whether <see cref="ReadFlags.HintReadAhead"/> keys arrive in near-sorted order, making the iterator
+        /// close-read-ahead path worthwhile even for keys of 32 bytes or less.
+        /// </summary>
+        internal bool SequentialKeys { get; }
 
         public IteratorManager(RocksDb rocksDb, ColumnFamilyHandle? cf, ReadOptions? readOptions)
         {
             _rocksDb = rocksDb;
             _cf = cf;
             _readOptions = readOptions;
+        }
 
-            _timer = new Timer(OnTimer, null, TimeSpan.Zero, TimeSpan.FromSeconds(10));
+        /// <summary>
+        /// Variant that resolves its <see cref="ReadOptions"/> on first rent instead of up front.
+        /// </summary>
+        /// <remarks>
+        /// The factory result is owned by the caller, which must keep it alive until this manager is disposed.
+        /// Used by snapshot-scoped readers so that snapshots that never iterate allocate no native handle.
+        /// </remarks>
+        public IteratorManager(RocksDb rocksDb, ColumnFamilyHandle? cf, Func<ReadOptions> readOptionsFactory, bool sequentialKeys = false)
+        {
+            _rocksDb = rocksDb;
+            _cf = cf;
+            _readOptionsFactory = readOptionsFactory;
+            SequentialKeys = sequentialKeys;
         }
 
         private void OnTimer(object? state)
         {
-            if (_isDisposed) return;
-            _readaheadIterators.ClearIterators();
-            _readaheadIterators2.ClearIterators();
-            _readaheadIterators3.ClearIterators();
+            // The lock keeps a clear from racing Dispose's DisposeAll.
+            lock (_initLock)
+            {
+                if (_isDisposed) return;
+                _readaheadIterators?.ClearIterators();
+                _readaheadIterators2?.ClearIterators();
+                _readaheadIterators3?.ClearIterators();
+            }
         }
 
         public void Dispose()
         {
-            if (_isDisposed) return;
-            _isDisposed = true;
-            _timer.Dispose();
-            _readaheadIterators.DisposeAll();
-            _readaheadIterators2.DisposeAll();
-            _readaheadIterators3.DisposeAll();
+            // The lock keeps a concurrent first Rent from initializing the timer after it was disposed here.
+            lock (_initLock)
+            {
+                if (_isDisposed) return;
+                _isDisposed = true;
+                _timer?.Dispose();
+                _readaheadIterators?.DisposeAll();
+                _readaheadIterators2?.DisposeAll();
+                _readaheadIterators3?.DisposeAll();
+            }
         }
 
         public RentWrapper Rent(ReadFlags flags)
         {
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
+            if (Volatile.Read(ref _timer) is null) Initialize();
+
             ManagedIterators iterators = GetIterators(flags);
             IteratorHolder holder = iterators.Value!;
             // If null, we create a new one.
@@ -1886,11 +1935,31 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             return new RentWrapper(iterator ?? _rocksDb.NewIterator(_cf, _readOptions), flags, this);
         }
 
+        /// <summary>
+        /// Creates the timer and thread-local iterator holders on first rent, so managers on paths that never
+        /// iterate (e.g. per-block snapshots) cost only the object allocation.
+        /// </summary>
+        private void Initialize()
+        {
+            lock (_initLock)
+            {
+                if (_timer is not null) return;
+                ObjectDisposedException.ThrowIf(_isDisposed, this);
+                _readOptions ??= _readOptionsFactory?.Invoke();
+                _readaheadIterators = new ManagedIterators();
+                _readaheadIterators2 = new ManagedIterators();
+                _readaheadIterators3 = new ManagedIterators();
+                // Volatile publish: threads taking the fast path in Rent must observe the fields above.
+                // First tick is delayed so it cannot clear the iterator pool under the rent that created it.
+                Volatile.Write(ref _timer, new Timer(OnTimer, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10)));
+            }
+        }
+
         private ManagedIterators GetIterators(ReadFlags flags) => flags switch
         {
-            _ when (flags & ReadFlags.HintReadAhead2) != 0 => _readaheadIterators2,
-            _ when (flags & ReadFlags.HintReadAhead3) != 0 => _readaheadIterators3,
-            _ => _readaheadIterators
+            _ when (flags & ReadFlags.HintReadAhead2) != 0 => _readaheadIterators2!,
+            _ when (flags & ReadFlags.HintReadAhead3) != 0 => _readaheadIterators3!,
+            _ => _readaheadIterators!
         };
 
         private void Return(Iterator iterator, ReadFlags flags)

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
@@ -38,6 +38,8 @@ public class RocksDbReader(DbOnTheRocks mainDb,
     private readonly bool _ownsReadOptions;
     private int _disposed;
 
+    internal DbOnTheRocks.IteratorManager? IteratorManager => _iteratorManager;
+
     public RocksDbReader(DbOnTheRocks mainDb,
         Func<ReadOptions> readOptionsFactory,
         DbOnTheRocks.IteratorManager? iteratorManager = null,

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using Nethermind.Core;
 using Nethermind.Core.Test;
@@ -122,6 +123,63 @@ public class ColumnsDbTests
 
         Assert.That(snapshot.GetColumn(ReceiptsColumns.Blocks)
             .Get(TestItem.KeccakA), Is.EqualTo(TestItem.KeccakA.BytesToArray()));
+    }
+
+    [Test]
+    public void Snapshot_Get_WithHintReadAhead_ReadsFromSnapshot()
+    {
+        IDb colA = _db.GetColumnDb(ReceiptsColumns.Blocks);
+
+        // Realistic flat-layout key shapes: a run of short (8-byte) keys followed by a run of long
+        // (34-byte) keys, ascending overall. Short keys pin the sequential-keys bypass of the
+        // "probably hash db" length guard on the iterator fast path.
+        byte[][] keys = new byte[64][];
+        for (int i = 0; i < keys.Length; i++)
+        {
+            keys[i] = new byte[i < 32 ? 8 : 34];
+            keys[i][0] = i < 32 ? (byte)0x10 : (byte)0x22;
+            BinaryPrimitives.WriteInt32BigEndian(keys[i].AsSpan(keys[i].Length - 4), i);
+            colA.Set(keys[i], [(byte)i, 1]);
+        }
+
+        IColumnsDb<ReceiptsColumns> asColumnsDb = _db;
+        using (IColumnDbSnapshot<ReceiptsColumns> snapshot = asColumnsDb.CreateSnapshot(sequentialReadAhead: true))
+        {
+            // Mutate after the snapshot: overwrite even keys, delete odd keys.
+            for (int i = 0; i < keys.Length; i++)
+            {
+                colA.Set(keys[i], i % 2 == 0 ? [(byte)i, 2] : null);
+            }
+
+            IReadOnlyKeyValueStore snapshotColumn = snapshot.GetColumn(ReceiptsColumns.Blocks);
+            Assert.That(((RocksDbReader)snapshotColumn).IteratorManager, Is.Not.Null,
+                "opt-in snapshot readers must be wired for the readahead iterator path");
+
+            // Ascending key order exercises the readahead iterator's forward-scan (Next) fast path;
+            // values must still come from the snapshot, not the mutated head state.
+            for (int i = 0; i < keys.Length; i++)
+            {
+                Assert.That(snapshotColumn.Get(keys[i], ReadFlags.HintReadAhead), Is.EqualTo(new byte[] { (byte)i, 1 }), $"key {i}");
+            }
+
+            // Probes past the last key (exhausts the iterator) and misses.
+            byte[] missingKey = new byte[34];
+            missingKey[0] = 0x23;
+            Assert.That(snapshotColumn.Get(missingKey, ReadFlags.HintReadAhead), Is.Null);
+        }
+
+        // Disposing the snapshot tears down its iterators; the head db must stay fully usable.
+        Assert.That(colA.Get(keys[0]), Is.EqualTo(new byte[] { 0, 2 }));
+    }
+
+    [Test]
+    public void Snapshot_Default_HasNoIteratorManager()
+    {
+        IColumnsDb<ReceiptsColumns> asColumnsDb = _db;
+        using IColumnDbSnapshot<ReceiptsColumns> snapshot = asColumnsDb.CreateSnapshot();
+
+        Assert.That(((RocksDbReader)snapshot.GetColumn(ReceiptsColumns.Blocks)).IteratorManager, Is.Null,
+            "snapshots without the sequential-read-ahead opt-in must keep point-Get behavior for HintReadAhead");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Db/IColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/IColumnsDb.cs
@@ -14,6 +14,15 @@ namespace Nethermind.Db
         public IReadOnlyColumnDb<TKey> CreateReadOnly(bool createInMemWriteStore) => new ReadOnlyColumnsDb<TKey>(this, createInMemWriteStore);
         IColumnsWriteBatch<TKey> StartWriteBatch();
         IColumnDbSnapshot<TKey> CreateSnapshot();
+
+        /// <summary>
+        /// Creates a snapshot whose readers may be tuned for sequential full scans.
+        /// </summary>
+        /// <param name="sequentialReadAhead">
+        /// Hint that the snapshot will serve <see cref="ReadFlags.HintReadAhead"/> reads over path-ordered keys
+        /// as part of a sequential full scan. Implementations may ignore it.
+        /// </param>
+        IColumnDbSnapshot<TKey> CreateSnapshot(bool sequentialReadAhead) => CreateSnapshot();
     }
 
     public interface IColumnsWriteBatch<in TKey> : IDisposable

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -370,14 +370,15 @@ public class FlatTrieVerifierTests(FlatLayout layout)
     }
 
     /// <summary>
-    /// Enough slots that the storage root is a branch with 16 hashed children,
-    /// which triggers the partitioned verification path in hashed mode.
+    /// Enough slots that the storage root and all 16 of its children are full branches,
+    /// which triggers the partitioned verification path in hashed mode
+    /// (pinned by <see cref="ShouldSplitStorage_SplitsOnlyLargeTries"/>).
     /// </summary>
-    private const int LargeStorageSlotCount = 512;
+    private const int LargeStorageSlotCount = 4096;
 
-    private static (UInt256 slot, byte[] value)[] CreateLargeStorageSlots()
+    private static (UInt256 slot, byte[] value)[] CreateLargeStorageSlots(int count = LargeStorageSlotCount)
     {
-        (UInt256 slot, byte[] value)[] slots = new (UInt256, byte[])[LargeStorageSlotCount];
+        (UInt256 slot, byte[] value)[] slots = new (UInt256, byte[])[count];
         for (int i = 0; i < slots.Length; i++)
         {
             slots[i] = ((UInt256)i, [(byte)(i % 255 + 1)]);
@@ -385,11 +386,8 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         return slots;
     }
 
-    [Test]
-    public void Verify_Storage_LargeTrie_AllMatch()
+    private Hash256 SetUpLargeStorageAccount(Address address, (UInt256 slot, byte[] value)[] slots, out StateId toState)
     {
-        Address address = TestItem.AddressA;
-        (UInt256 slot, byte[] value)[] slots = CreateLargeStorageSlots();
         StorageTree storageTree = CreateStorageTree(address, slots);
         Account account = new(1, 100, storageTree.RootHash, Keccak.Compute([1]));
 
@@ -397,8 +395,28 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         _stateTree.Commit();
         Hash256 stateRoot = _stateTree.RootHash;
 
-        StateId toState = new(1, stateRoot);
+        toState = new(1, stateRoot);
         WriteAccountToFlat(address, account, toState);
+        return stateRoot;
+    }
+
+    [TestCase(4, ExpectedResult = false)]
+    [TestCase(512, ExpectedResult = false)]
+    [TestCase(LargeStorageSlotCount, ExpectedResult = true)]
+    public bool ShouldSplitStorage_SplitsOnlyLargeTries(int slotCount)
+    {
+        Address address = TestItem.AddressA;
+        StorageTree storageTree = CreateStorageTree(address, CreateLargeStorageSlots(slotCount));
+        IScopedTrieStore storageTrieStore = (IScopedTrieStore)_trieStore.GetStorageTrieNodeResolver(Keccak.Compute(address.Bytes));
+        return FlatTrieVerifier.ShouldSplitStorage(storageTrieStore, storageTree.RootHash);
+    }
+
+    [Test]
+    public void Verify_Storage_LargeTrie_AllMatch()
+    {
+        Address address = TestItem.AddressA;
+        (UInt256 slot, byte[] value)[] slots = CreateLargeStorageSlots();
+        Hash256 stateRoot = SetUpLargeStorageAccount(address, slots, out _);
         foreach ((UInt256 slot, byte[] value) in slots)
         {
             WriteStorageDirectToDb(address, slot, value);
@@ -424,22 +442,14 @@ public class FlatTrieVerifierTests(FlatLayout layout)
     {
         Address address = TestItem.AddressA;
         (UInt256 slot, byte[] value)[] slots = CreateLargeStorageSlots();
-        StorageTree storageTree = CreateStorageTree(address, slots);
-        Account account = new(1, 100, storageTree.RootHash, Keccak.Compute([1]));
-
-        _stateTree.Set(address, account);
-        _stateTree.Commit();
-        Hash256 stateRoot = _stateTree.RootHash;
-
-        StateId toState = new(1, stateRoot);
-        WriteAccountToFlat(address, account, toState);
+        Hash256 stateRoot = SetUpLargeStorageAccount(address, slots, out _);
         // Slot 0 omitted from flat -> missing in flat
         for (int i = 1; i < slots.Length; i++)
         {
             WriteStorageDirectToDb(address, slots[i].slot, slots[i].value);
         }
         WriteStorageDirectToDb(address, slots[1].slot, [0xFF]); // Wrong value -> mismatched
-        WriteStorageDirectToDb(address, 1000, [0xAB]); // Not in trie -> missing in trie
+        WriteStorageDirectToDb(address, LargeStorageSlotCount, [0xAB]); // Not in trie -> missing in trie
 
         using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         FlatTrieVerifier verifier = new(_logManager);

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -386,7 +386,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         return slots;
     }
 
-    private Hash256 SetUpLargeStorageAccount(Address address, (UInt256 slot, byte[] value)[] slots, out StateId toState)
+    private Hash256 SetUpLargeStorageAccount(Address address, (UInt256 slot, byte[] value)[] slots)
     {
         StorageTree storageTree = CreateStorageTree(address, slots);
         Account account = new(1, 100, storageTree.RootHash, Keccak.Compute([1]));
@@ -395,8 +395,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         _stateTree.Commit();
         Hash256 stateRoot = _stateTree.RootHash;
 
-        toState = new(1, stateRoot);
-        WriteAccountToFlat(address, account, toState);
+        WriteAccountToFlat(address, account, new StateId(1, stateRoot));
         return stateRoot;
     }
 
@@ -416,7 +415,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
     {
         Address address = TestItem.AddressA;
         (UInt256 slot, byte[] value)[] slots = CreateLargeStorageSlots();
-        Hash256 stateRoot = SetUpLargeStorageAccount(address, slots, out _);
+        Hash256 stateRoot = SetUpLargeStorageAccount(address, slots);
         foreach ((UInt256 slot, byte[] value) in slots)
         {
             WriteStorageDirectToDb(address, slot, value);
@@ -442,7 +441,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
     {
         Address address = TestItem.AddressA;
         (UInt256 slot, byte[] value)[] slots = CreateLargeStorageSlots();
-        Hash256 stateRoot = SetUpLargeStorageAccount(address, slots, out _);
+        Hash256 stateRoot = SetUpLargeStorageAccount(address, slots);
         // Slot 0 omitted from flat -> missing in flat
         for (int i = 1; i < slots.Length; i++)
         {

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -369,11 +369,7 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         Assert.That(verifier.Stats.MismatchedSlot, Is.EqualTo(1));
     }
 
-    /// <summary>
-    /// Enough slots that the storage root and all 16 of its children are full branches,
-    /// which triggers the partitioned verification path in hashed mode
-    /// (pinned by <see cref="ShouldSplitStorage_SplitsOnlyLargeTries"/>).
-    /// </summary>
+    // Enough slots that the root and all 16 children are full branches, triggering the partitioned path.
     private const int LargeStorageSlotCount = 4096;
 
     private static (UInt256 slot, byte[] value)[] CreateLargeStorageSlots(int count = LargeStorageSlotCount)

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatTrieVerifierTests.cs
@@ -369,6 +369,91 @@ public class FlatTrieVerifierTests(FlatLayout layout)
         Assert.That(verifier.Stats.MismatchedSlot, Is.EqualTo(1));
     }
 
+    /// <summary>
+    /// Enough slots that the storage root is a branch with 16 hashed children,
+    /// which triggers the partitioned verification path in hashed mode.
+    /// </summary>
+    private const int LargeStorageSlotCount = 512;
+
+    private static (UInt256 slot, byte[] value)[] CreateLargeStorageSlots()
+    {
+        (UInt256 slot, byte[] value)[] slots = new (UInt256, byte[])[LargeStorageSlotCount];
+        for (int i = 0; i < slots.Length; i++)
+        {
+            slots[i] = ((UInt256)i, [(byte)(i % 255 + 1)]);
+        }
+        return slots;
+    }
+
+    [Test]
+    public void Verify_Storage_LargeTrie_AllMatch()
+    {
+        Address address = TestItem.AddressA;
+        (UInt256 slot, byte[] value)[] slots = CreateLargeStorageSlots();
+        StorageTree storageTree = CreateStorageTree(address, slots);
+        Account account = new(1, 100, storageTree.RootHash, Keccak.Compute([1]));
+
+        _stateTree.Set(address, account);
+        _stateTree.Commit();
+        Hash256 stateRoot = _stateTree.RootHash;
+
+        StateId toState = new(1, stateRoot);
+        WriteAccountToFlat(address, account, toState);
+        foreach ((UInt256 slot, byte[] value) in slots)
+        {
+            WriteStorageDirectToDb(address, slot, value);
+        }
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        FlatTrieVerifier verifier = new(_logManager);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(verifier.Stats.AccountCount, Is.EqualTo(1));
+            // Exact count also guards against double-counting at partition boundaries
+            Assert.That(verifier.Stats.SlotCount, Is.EqualTo(LargeStorageSlotCount));
+            Assert.That(verifier.Stats.MismatchedSlot, Is.EqualTo(0));
+            Assert.That(verifier.Stats.MissingInFlat, Is.EqualTo(0));
+            Assert.That(verifier.Stats.MissingInTrie, Is.EqualTo(0));
+        }
+    }
+
+    [Test]
+    public void Verify_Storage_LargeTrie_DetectsIssues()
+    {
+        Address address = TestItem.AddressA;
+        (UInt256 slot, byte[] value)[] slots = CreateLargeStorageSlots();
+        StorageTree storageTree = CreateStorageTree(address, slots);
+        Account account = new(1, 100, storageTree.RootHash, Keccak.Compute([1]));
+
+        _stateTree.Set(address, account);
+        _stateTree.Commit();
+        Hash256 stateRoot = _stateTree.RootHash;
+
+        StateId toState = new(1, stateRoot);
+        WriteAccountToFlat(address, account, toState);
+        // Slot 0 omitted from flat -> missing in flat
+        for (int i = 1; i < slots.Length; i++)
+        {
+            WriteStorageDirectToDb(address, slots[i].slot, slots[i].value);
+        }
+        WriteStorageDirectToDb(address, slots[1].slot, [0xFF]); // Wrong value -> mismatched
+        WriteStorageDirectToDb(address, 1000, [0xAB]); // Not in trie -> missing in trie
+
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        FlatTrieVerifier verifier = new(_logManager);
+        verifier.Verify(reader, _trieStore, stateRoot, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(verifier.Stats.SlotCount, Is.EqualTo(LargeStorageSlotCount + 1));
+            Assert.That(verifier.Stats.MismatchedSlot, Is.EqualTo(1));
+            Assert.That(verifier.Stats.MissingInFlat, Is.EqualTo(1));
+            Assert.That(verifier.Stats.MissingInTrie, Is.EqualTo(1));
+        }
+    }
+
     [Test]
     public void Verify_EmptyStorageRoot_DetectsOrphanedFlatStorage()
     {

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -244,11 +244,19 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     private static readonly StringLabel _depthInMemoryLabel = new("in_memory");
     private static readonly StringLabel _depthPersistedLabel = new("persisted");
 
-    public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock)
+    public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock) =>
+        GatherReadOnlySnapshotBundle(baseBlock, ReaderFlags.None);
+
+    public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock, ReaderFlags readerFlags)
     {
         // A linked-list snapshot chain was considered but rejected: the constantly moving chain makes
         // invalidation error-prone.
         if (_logger.IsTrace) _logger.Trace($"Gathering {baseBlock}.");
+
+        // Bundles built with non-default reader flags hold specially-configured readers; keep them out of
+        // the shared cache so ordinary consumers never inherit them, and never serve a cached (flagless)
+        // bundle for such a request.
+        bool shareable = readerFlags == ReaderFlags.None;
 
         if (baseBlock == StateId.PreGenesis)
         {
@@ -261,7 +269,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         while (true)
         {
             // Fastpath: Share a recently created ReadOnlySnapshotBundle
-            if (_readonlySnapshotBundleCache.TryGetValue(baseBlock, out ReadOnlySnapshotBundle? bundle) && bundle.TryLease()) return bundle;
+            if (shareable && _readonlySnapshotBundleCache.TryGetValue(baseBlock, out ReadOnlySnapshotBundle? bundle) && bundle.TryLease()) return bundle;
 
             if (attempt == 1) sw = Stopwatch.GetTimestamp();
             if (attempt != 0)
@@ -275,7 +283,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
                 Thread.Sleep(delayMs);
             }
 
-            IPersistence.IPersistenceReader persistenceReader = _persistenceManager.LeaseReader();
+            IPersistence.IPersistenceReader persistenceReader = _persistenceManager.LeaseReader(readerFlags);
             AssembledSnapshotResult assembled;
             try
             {
@@ -312,6 +320,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
             ReadOnlySnapshotBundle res = new(assembled.InMemory, persistenceReader, _enableDetailedMetrics,
                 new PersistedSnapshotStack(assembled.Persisted, _enableDetailedMetrics));
+
+            if (!shareable) return res;
 
             res.TryLease();
             if (!_readonlySnapshotBundleCache.TryAdd(baseBlock, res))

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -80,7 +80,10 @@ public class FlatTrieVerifier
             stateId = reader.CurrentState;
         }
 
-        using ReadOnlySnapshotBundle bundle = _flatDbManager.GatherReadOnlySnapshotBundle(stateId);
+        // FullScan on the bundle only: trie nodes are read through its persistence reader. `reader` just
+        // serves metadata and range iterators, which never take the readahead path, so it stays flagless
+        // and shares the cached reader instead of pinning a second snapshot.
+        using ReadOnlySnapshotBundle bundle = _flatDbManager.GatherReadOnlySnapshotBundle(stateId, ReaderFlags.FullScan);
         ReadOnlyStateTrieStoreAdapter trieStore = new(bundle);
 
         return VerifyCore(reader, trieStore, stateId.StateRoot.ToCommitment(), cancellationToken);
@@ -209,7 +212,9 @@ public class FlatTrieVerifier
         (ValueHash256 startKey, ValueHash256 endKey) = GetPartitionBounds(partition);
 
         using IPersistence.IFlatIterator flatIter = reader.CreateAccountIterator(startKey, endKey);
-        TrieLeafIterator trieIter = new(trieStore, stateRoot, LogTrieNodeException, startKey, endKey);
+        // Trie node keys are path-ordered, so this forward scan benefits from iterator readahead.
+        TrieNodeResolverWithReadFlags readAheadTrieStore = new(trieStore, ReadFlags.HintReadAhead);
+        TrieLeafIterator trieIter = new(readAheadTrieStore, stateRoot, LogTrieNodeException, startKey, endKey);
 
         bool hasFlat = flatIter.MoveNext();
         bool hasTrie = trieIter.MoveNext();
@@ -648,8 +653,10 @@ public class FlatTrieVerifier
         CancellationToken cancellationToken)
     {
         using IPersistence.IFlatIterator flatIter = reader.CreateStorageIterator(job.FlatAccountKey, startKey, endKey);
+        // Partitioned (whale) scans are long enough for iterator readahead to win; small tries stay on
+        // point gets since readahead iterator seeks skip the bloom filter.
         TrieLeafIterator trieIter = endExclusive
-            ? new(storageTrieStore, job.StorageRoot, LogTrieNodeException, startKey, endKey)
+            ? new(new TrieNodeResolverWithReadFlags(storageTrieStore, ReadFlags.HintReadAhead), job.StorageRoot, LogTrieNodeException, startKey, endKey)
             : new(storageTrieStore, job.StorageRoot, LogTrieNodeException);
 
         bool hasFlat = MoveNextFlat(flatIter, endExclusive, endKey);

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -524,6 +524,7 @@ public class FlatTrieVerifier
     {
         Task[]? offloaded = null;
         int offloadedCount = 0;
+        bool completedInline = false;
         try
         {
             for (int partition = 0; partition < PartitionCount; partition++)
@@ -532,6 +533,8 @@ public class FlatTrieVerifier
                 if (TryReserveOffloadSlot())
                 {
                     offloaded ??= new Task[PartitionCount];
+                    // No token on Task.Run: a task canceled before it starts would skip the
+                    // finally and leak the offload slot.
                     offloaded[offloadedCount++] = Task.Run(() =>
                     {
                         try
@@ -549,11 +552,25 @@ public class FlatTrieVerifier
                     VerifyStorageHashedRange(job, reader, storageTrieStore, startKey, endKey, endExclusive: true, cancellationToken);
                 }
             }
+
+            completedInline = true;
         }
         finally
         {
             // Offloaded partitions share this job's reader and stats — never let them outlive this frame.
-            if (offloaded is not null) Task.WaitAll(offloaded.AsSpan(0, offloadedCount));
+            if (offloaded is not null)
+            {
+                try
+                {
+                    Task.WaitAll(offloaded.AsSpan(0, offloadedCount));
+                }
+                catch (Exception ex) when (!completedInline)
+                {
+                    // An inline partition is already unwinding — keep it as the root cause
+                    // instead of letting this wait replace it.
+                    if (_logger.IsWarn) _logger.Warn($"Offloaded storage partition failed: {ex}");
+                }
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -512,7 +512,9 @@ public class FlatTrieVerifier
     /// the rest of the queue is done. Deciding per partition rather than once per job lets the same job
     /// run sequentially through the busy phase and fan out the moment other workers go idle — the
     /// single-worker tail this targets. <see cref="TryReserveOffloadSlot"/> caps busy workers plus
-    /// offloaded partitions at the worker count, so verification concurrency never exceeds the pool size.
+    /// offloaded partitions at the worker count at reservation time; workers turning busy afterwards can
+    /// transiently push concurrency past the pool size (by at most the partition count), self-correcting
+    /// as offloaded partitions finish.
     /// Unlike the sequential full range, the partitions exclude a slot hashed to exactly 0xFF…FF
     /// (probability 2⁻²⁵⁶) — the same asymmetry the account partitions already have.
     /// </remarks>
@@ -524,7 +526,7 @@ public class FlatTrieVerifier
     {
         Task[]? offloaded = null;
         int offloadedCount = 0;
-        bool completedInline = false;
+        bool loopCompleted = false;
         try
         {
             for (int partition = 0; partition < PartitionCount; partition++)
@@ -553,7 +555,7 @@ public class FlatTrieVerifier
                 }
             }
 
-            completedInline = true;
+            loopCompleted = true;
         }
         finally
         {
@@ -564,11 +566,13 @@ public class FlatTrieVerifier
                 {
                     Task.WaitAll(offloaded.AsSpan(0, offloadedCount));
                 }
-                catch (Exception ex) when (!completedInline)
+                catch (Exception ex) when (!loopCompleted)
                 {
                     // An inline partition is already unwinding — keep it as the root cause
-                    // instead of letting this wait replace it.
-                    if (_logger.IsWarn) _logger.Warn($"Offloaded storage partition failed: {ex}");
+                    // instead of letting this wait replace it. On cancellation both sides
+                    // throw the same thing, so logging it would only add shutdown noise.
+                    if (!cancellationToken.IsCancellationRequested && _logger.IsWarn)
+                        _logger.Warn($"Offloaded storage partition failed: {ex}");
                 }
             }
         }
@@ -1023,6 +1027,11 @@ public class FlatTrieVerifier
     {
         private long _hashMismatchCount;
 
+        /// <remarks>
+        /// Counted per RLP load, not per distinct node: snapshot misses hand out fresh unresolved
+        /// nodes, so re-descents (e.g. the whale split's gate probe plus its partitions) re-verify
+        /// and re-count the same corrupt node.
+        /// </remarks>
         public long HashMismatchCount => Interlocked.Read(ref _hashMismatchCount);
 
         public TrieNode FindCachedOrUnknown(in TreePath path, Hash256 hash) => inner.FindCachedOrUnknown(path, hash);

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -34,12 +34,16 @@ public class FlatTrieVerifier
     private readonly ILogManager _logManager;
     private readonly ILogger _logger;
 
+    private readonly int _storageWorkerCount = Math.Max(1, Environment.ProcessorCount - 1);
+
     private long _accountCount;
     private long _slotCount;
     private long _mismatchedAccount;
     private long _mismatchedSlot;
     private long _missingInFlat;
     private long _missingInTrie;
+    private int _busyStorageWorkers;
+    private int _offloadedPartitions;
 
     public FlatTrieVerifier(IFlatDbManager flatDbManager, IPersistence persistence, ILogManager logManager)
     {
@@ -97,9 +101,8 @@ public class FlatTrieVerifier
                 FullMode = BoundedChannelFullMode.Wait
             });
 
-        int workerCount = Math.Max(1, Environment.ProcessorCount - 1);
-        Task[] workers = new Task[workerCount];
-        for (int i = 0; i < workerCount; i++)
+        Task[] workers = new Task[_storageWorkerCount];
+        for (int i = 0; i < _storageWorkerCount; i++)
         {
             workers[i] = Task.Run(() => ProcessStorageQueue(channel.Reader, reader, verifyingTrieStore, cancellationToken));
         }
@@ -441,13 +444,21 @@ public class FlatTrieVerifier
     {
         await foreach (StorageVerificationJob job in channelReader.ReadAllAsync(cancellationToken))
         {
-            if (job.IsPreimageMode)
+            Interlocked.Increment(ref _busyStorageWorkers);
+            try
             {
-                VerifyStoragePreimage(job, reader, trieStore, cancellationToken);
+                if (job.IsPreimageMode)
+                {
+                    VerifyStoragePreimage(job, reader, trieStore, cancellationToken);
+                }
+                else
+                {
+                    VerifyStorageHashed(job, reader, trieStore, cancellationToken);
+                }
             }
-            else
+            finally
             {
-                VerifyStorageHashed(job, reader, trieStore, cancellationToken);
+                Interlocked.Decrement(ref _busyStorageWorkers);
             }
         }
     }
@@ -484,16 +495,7 @@ public class FlatTrieVerifier
         // co-iteration across the same key-space partitions used for accounts.
         if (ShouldSplitStorage(storageTrieStore, job.StorageRoot))
         {
-            ParallelOptions parallelOptions = new()
-            {
-                MaxDegreeOfParallelism = Math.Max(1, Environment.ProcessorCount / 2),
-                CancellationToken = cancellationToken
-            };
-            Parallel.For(0, PartitionCount, parallelOptions, partition =>
-            {
-                (ValueHash256 startKey, ValueHash256 endKey) = GetPartitionBounds(partition);
-                VerifyStorageHashedRange(job, reader, storageTrieStore, startKey, endKey, endExclusive: true, cancellationToken);
-            });
+            VerifyStorageHashedPartitioned(job, reader, storageTrieStore, cancellationToken);
         }
         else
         {
@@ -502,35 +504,119 @@ public class FlatTrieVerifier
     }
 
     /// <summary>
-    /// Decides whether a storage trie is large enough to verify partitioned in parallel.
+    /// Verifies a large storage trie partition by partition, offloading partitions to spare threads
+    /// only while other storage workers are idle.
     /// </summary>
     /// <remarks>
-    /// A root that is a branch with all 16 children stored by hash implies a trie of at least a few
-    /// hundred slots, where partitioning pays off; smaller tries stay on the cheaper sequential path.
-    /// Splitting is range-based and correct regardless of the root shape — this is only a size heuristic.
+    /// A whale job is usually dequeued while every worker is still busy, yet keeps draining long after
+    /// the rest of the queue is done. Deciding per partition rather than once per job lets the same job
+    /// run sequentially through the busy phase and fan out the moment other workers go idle — the
+    /// single-worker tail this targets. <see cref="TryReserveOffloadSlot"/> caps busy workers plus
+    /// offloaded partitions at the worker count, so verification concurrency never exceeds the pool size.
+    /// Unlike the sequential full range, the partitions exclude a slot hashed to exactly 0xFF…FF
+    /// (probability 2⁻²⁵⁶) — the same asymmetry the account partitions already have.
     /// </remarks>
-    private static bool ShouldSplitStorage(IScopedTrieStore storageTrieStore, Hash256 storageRoot)
+    private void VerifyStorageHashedPartitioned(
+        StorageVerificationJob job,
+        IPersistence.IPersistenceReader reader,
+        IScopedTrieStore storageTrieStore,
+        CancellationToken cancellationToken)
     {
-        TreePath emptyPath = TreePath.Empty;
-        TrieNode root = storageTrieStore.FindCachedOrUnknown(emptyPath, storageRoot);
+        Task[]? offloaded = null;
+        int offloadedCount = 0;
         try
         {
-            root.ResolveNode(storageTrieStore, emptyPath);
+            for (int partition = 0; partition < PartitionCount; partition++)
+            {
+                (ValueHash256 startKey, ValueHash256 endKey) = GetPartitionBounds(partition);
+                if (TryReserveOffloadSlot())
+                {
+                    offloaded ??= new Task[PartitionCount];
+                    offloaded[offloadedCount++] = Task.Run(() =>
+                    {
+                        try
+                        {
+                            VerifyStorageHashedRange(job, reader, storageTrieStore, startKey, endKey, endExclusive: true, cancellationToken);
+                        }
+                        finally
+                        {
+                            Interlocked.Decrement(ref _offloadedPartitions);
+                        }
+                    });
+                }
+                else
+                {
+                    VerifyStorageHashedRange(job, reader, storageTrieStore, startKey, endKey, endExclusive: true, cancellationToken);
+                }
+            }
         }
-        catch (TrieNodeException)
+        finally
         {
+            // Offloaded partitions share this job's reader and stats — never let them outlive this frame.
+            if (offloaded is not null) Task.WaitAll(offloaded.AsSpan(0, offloadedCount));
+        }
+    }
+
+    /// <summary>
+    /// Reserves one partition-offload slot if some storage workers are currently idle.
+    /// </summary>
+    private bool TryReserveOffloadSlot()
+    {
+        if (Interlocked.Increment(ref _offloadedPartitions) + Volatile.Read(ref _busyStorageWorkers) > _storageWorkerCount)
+        {
+            Interlocked.Decrement(ref _offloadedPartitions);
             return false;
         }
 
-        if (!root.IsBranch) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Decides whether a storage trie is large enough to verify partitioned.
+    /// </summary>
+    /// <remarks>
+    /// Storage leaves at these depths always exceed 32 bytes of RLP (their HP-encoded key alone is
+    /// 32 bytes), so a hashed child only proves its nibble is occupied — a single full branch level
+    /// means merely ~50+ slots. Requiring two full levels (root and all 16 children each carrying 16
+    /// hash-referenced children) means all 256 depth-2 prefixes are occupied, which for
+    /// keccak-distributed keys implies at least a couple thousand slots — large enough that the
+    /// partitioning overhead (extra iterator seeks and root descents) is noise.
+    /// Splitting is range-based and correct regardless of the root shape — this is only a size heuristic.
+    /// </remarks>
+    internal static bool ShouldSplitStorage(IScopedTrieStore storageTrieStore, Hash256 storageRoot)
+    {
+        TreePath rootPath = TreePath.Empty;
+        if (!TryResolveBranch(storageTrieStore, rootPath, storageRoot, out TrieNode root)) return false;
 
         for (int i = 0; i < 16; i++)
         {
             // A null child hash means the child is either absent or inlined — both imply a small subtree.
-            if (root.GetChildHash(i) is null) return false;
+            if (root.GetChildHash(i) is not Hash256 childHash) return false;
+            if (!TryResolveBranch(storageTrieStore, rootPath.Append(i), childHash, out TrieNode child)) return false;
+
+            for (int j = 0; j < 16; j++)
+            {
+                if (child.GetChildHash(j) is null) return false;
+            }
         }
 
         return true;
+    }
+
+    private static bool TryResolveBranch(IScopedTrieStore store, in TreePath path, Hash256 hash, out TrieNode node)
+    {
+        node = store.FindCachedOrUnknown(path, hash);
+        try
+        {
+            node.ResolveNode(store, path);
+        }
+        catch (TrieNodeException)
+        {
+            // Benign to swallow: the co-iteration resolves the same node again and reports through LogTrieNodeException.
+            return false;
+        }
+
+        return node.IsBranch;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -23,8 +23,7 @@ namespace Nethermind.State.Flat;
 /// </summary>
 public class FlatTrieVerifier
 {
-    // Deep enough that account partitions keep enqueuing while workers are stuck on large contracts;
-    // jobs are small (one struct per account), so the memory cost is negligible.
+    // Deep enough that account partitions keep enqueuing while workers are stuck on large contracts.
     private const int StorageChannelCapacity = 1024;
     private const int FlatKeyLength = 20;
     private const int PartitionCount = 8;
@@ -491,8 +490,7 @@ public class FlatTrieVerifier
 
         IScopedTrieStore storageTrieStore = (IScopedTrieStore)trieStore.GetStorageTrieNodeResolver(job.TrieAccountPath);
 
-        // A single whale contract otherwise pins one worker for the whole channel drain — split its
-        // co-iteration across the same key-space partitions used for accounts.
+        // A single whale contract otherwise pins one worker for the whole channel drain.
         if (ShouldSplitStorage(storageTrieStore, job.StorageRoot))
         {
             VerifyStorageHashedPartitioned(job, reader, storageTrieStore, cancellationToken);
@@ -508,15 +506,11 @@ public class FlatTrieVerifier
     /// only while other storage workers are idle.
     /// </summary>
     /// <remarks>
-    /// A whale job is usually dequeued while every worker is still busy, yet keeps draining long after
-    /// the rest of the queue is done. Deciding per partition rather than once per job lets the same job
-    /// run sequentially through the busy phase and fan out the moment other workers go idle — the
-    /// single-worker tail this targets. <see cref="TryReserveOffloadSlot"/> caps busy workers plus
-    /// offloaded partitions at the worker count at reservation time; workers turning busy afterwards can
-    /// transiently push concurrency past the pool size (by at most the partition count), self-correcting
-    /// as offloaded partitions finish.
-    /// Unlike the sequential full range, the partitions exclude a slot hashed to exactly 0xFF…FF
-    /// (probability 2⁻²⁵⁶) — the same asymmetry the account partitions already have.
+    /// Deciding per partition rather than once per job lets a whale dequeued while every worker is busy
+    /// run sequentially, then fan out the moment other workers go idle — the single-worker tail this
+    /// targets. The offload cap is checked at reservation time only, so concurrency can transiently
+    /// exceed the pool size by at most the partition count. Like the account partitions, the ranges
+    /// exclude a slot hashed to exactly 0xFF…FF (probability 2⁻²⁵⁶).
     /// </remarks>
     private void VerifyStorageHashedPartitioned(
         StorageVerificationJob job,
@@ -568,9 +562,8 @@ public class FlatTrieVerifier
                 }
                 catch (Exception ex) when (!loopCompleted)
                 {
-                    // An inline partition is already unwinding — keep it as the root cause
-                    // instead of letting this wait replace it. On cancellation both sides
-                    // throw the same thing, so logging it would only add shutdown noise.
+                    // An inline partition is already unwinding — keep it as the root cause. On
+                    // cancellation both sides throw alike, so logging would only add shutdown noise.
                     if (!cancellationToken.IsCancellationRequested && _logger.IsWarn)
                         _logger.Warn($"Offloaded storage partition failed: {ex}");
                 }
@@ -596,13 +589,10 @@ public class FlatTrieVerifier
     /// Decides whether a storage trie is large enough to verify partitioned.
     /// </summary>
     /// <remarks>
-    /// Storage leaves at these depths always exceed 32 bytes of RLP (their HP-encoded key alone is
-    /// 32 bytes), so a hashed child only proves its nibble is occupied — a single full branch level
-    /// means merely ~50+ slots. Requiring two full levels (root and all 16 children each carrying 16
-    /// hash-referenced children) means all 256 depth-2 prefixes are occupied, which for
-    /// keccak-distributed keys implies at least a couple thousand slots — large enough that the
-    /// partitioning overhead (extra iterator seeks and root descents) is noise.
-    /// Splitting is range-based and correct regardless of the root shape — this is only a size heuristic.
+    /// Storage leaves at these depths never inline (their HP-encoded key alone is 32 bytes of RLP), so
+    /// one full branch level means merely ~50+ slots; two full levels (all 256 depth-2 prefixes
+    /// occupied) imply thousands, enough that the partitioning overhead is noise. Purely a size
+    /// heuristic — splitting is range-based and correct regardless of the root shape.
     /// </remarks>
     internal static bool ShouldSplitStorage(IScopedTrieStore storageTrieStore, Hash256 storageRoot)
     {
@@ -644,10 +634,9 @@ public class FlatTrieVerifier
     /// Verifies one slot-key range of a storage trie by co-iterating flat and trie leaves.
     /// </summary>
     /// <remarks>
-    /// The flat storage iterator's end bound is inclusive while <see cref="TrieLeafIterator"/>'s is
-    /// exclusive. With <paramref name="endExclusive"/> the flat entry equal to <paramref name="endKey"/>
-    /// is dropped so partitioned calls cover disjoint [start, end) ranges on both sides; without it the
-    /// full-range behavior (flat inclusive of 0xFF…FF, trie unranged) is preserved.
+    /// The flat iterator's end bound is inclusive while <see cref="TrieLeafIterator"/>'s is exclusive;
+    /// <paramref name="endExclusive"/> drops the flat entry equal to <paramref name="endKey"/> so
+    /// partitioned calls cover disjoint [start, end) ranges on both sides.
     /// </remarks>
     private void VerifyStorageHashedRange(
         in StorageVerificationJob job,
@@ -1027,11 +1016,8 @@ public class FlatTrieVerifier
     {
         private long _hashMismatchCount;
 
-        /// <remarks>
-        /// Counted per RLP load, not per distinct node: snapshot misses hand out fresh unresolved
-        /// nodes, so re-descents (e.g. the whale split's gate probe plus its partitions) re-verify
-        /// and re-count the same corrupt node.
-        /// </remarks>
+        /// <remarks>Counted per RLP load, not per distinct node — re-descents re-verify and re-count
+        /// the same corrupt node.</remarks>
         public long HashMismatchCount => Interlocked.Read(ref _hashMismatchCount);
 
         public TrieNode FindCachedOrUnknown(in TreePath path, Hash256 hash) => inner.FindCachedOrUnknown(path, hash);

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -23,7 +23,9 @@ namespace Nethermind.State.Flat;
 /// </summary>
 public class FlatTrieVerifier
 {
-    private const int StorageChannelCapacity = 1;
+    // Deep enough that account partitions keep enqueuing while workers are stuck on large contracts;
+    // jobs are small (one struct per account), so the memory cost is negligible.
+    private const int StorageChannelCapacity = 1024;
     private const int FlatKeyLength = 20;
     private const int PartitionCount = 8;
 
@@ -476,11 +478,85 @@ public class FlatTrieVerifier
             return;
         }
 
-        using IPersistence.IFlatIterator flatIter = reader.CreateStorageIterator(job.FlatAccountKey, ValueKeccak.Zero, ValueKeccak.MaxValue);
         IScopedTrieStore storageTrieStore = (IScopedTrieStore)trieStore.GetStorageTrieNodeResolver(job.TrieAccountPath);
-        TrieLeafIterator trieIter = new(storageTrieStore, job.StorageRoot, LogTrieNodeException);
 
-        bool hasFlat = flatIter.MoveNext();
+        // A single whale contract otherwise pins one worker for the whole channel drain — split its
+        // co-iteration across the same key-space partitions used for accounts.
+        if (ShouldSplitStorage(storageTrieStore, job.StorageRoot))
+        {
+            ParallelOptions parallelOptions = new()
+            {
+                MaxDegreeOfParallelism = Math.Max(1, Environment.ProcessorCount / 2),
+                CancellationToken = cancellationToken
+            };
+            Parallel.For(0, PartitionCount, parallelOptions, partition =>
+            {
+                (ValueHash256 startKey, ValueHash256 endKey) = GetPartitionBounds(partition);
+                VerifyStorageHashedRange(job, reader, storageTrieStore, startKey, endKey, endExclusive: true, cancellationToken);
+            });
+        }
+        else
+        {
+            VerifyStorageHashedRange(job, reader, storageTrieStore, ValueKeccak.Zero, ValueKeccak.MaxValue, endExclusive: false, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Decides whether a storage trie is large enough to verify partitioned in parallel.
+    /// </summary>
+    /// <remarks>
+    /// A root that is a branch with all 16 children stored by hash implies a trie of at least a few
+    /// hundred slots, where partitioning pays off; smaller tries stay on the cheaper sequential path.
+    /// Splitting is range-based and correct regardless of the root shape — this is only a size heuristic.
+    /// </remarks>
+    private static bool ShouldSplitStorage(IScopedTrieStore storageTrieStore, Hash256 storageRoot)
+    {
+        TreePath emptyPath = TreePath.Empty;
+        TrieNode root = storageTrieStore.FindCachedOrUnknown(emptyPath, storageRoot);
+        try
+        {
+            root.ResolveNode(storageTrieStore, emptyPath);
+        }
+        catch (TrieNodeException)
+        {
+            return false;
+        }
+
+        if (!root.IsBranch) return false;
+
+        for (int i = 0; i < 16; i++)
+        {
+            // A null child hash means the child is either absent or inlined — both imply a small subtree.
+            if (root.GetChildHash(i) is null) return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Verifies one slot-key range of a storage trie by co-iterating flat and trie leaves.
+    /// </summary>
+    /// <remarks>
+    /// The flat storage iterator's end bound is inclusive while <see cref="TrieLeafIterator"/>'s is
+    /// exclusive. With <paramref name="endExclusive"/> the flat entry equal to <paramref name="endKey"/>
+    /// is dropped so partitioned calls cover disjoint [start, end) ranges on both sides; without it the
+    /// full-range behavior (flat inclusive of 0xFF…FF, trie unranged) is preserved.
+    /// </remarks>
+    private void VerifyStorageHashedRange(
+        in StorageVerificationJob job,
+        IPersistence.IPersistenceReader reader,
+        IScopedTrieStore storageTrieStore,
+        in ValueHash256 startKey,
+        in ValueHash256 endKey,
+        bool endExclusive,
+        CancellationToken cancellationToken)
+    {
+        using IPersistence.IFlatIterator flatIter = reader.CreateStorageIterator(job.FlatAccountKey, startKey, endKey);
+        TrieLeafIterator trieIter = endExclusive
+            ? new(storageTrieStore, job.StorageRoot, LogTrieNodeException, startKey, endKey)
+            : new(storageTrieStore, job.StorageRoot, LogTrieNodeException);
+
+        bool hasFlat = MoveNextFlat(flatIter, endExclusive, endKey);
         bool hasTrie = trieIter.MoveNext();
 
         while (hasFlat || hasTrie)
@@ -497,7 +573,7 @@ public class FlatTrieVerifier
             {
                 Interlocked.Increment(ref _slotCount);
                 VerifySlotMatch(flatIter.CurrentValue, trieIter.CurrentLeaf!, job.FlatAccountKey, flatIter.CurrentKey);
-                hasFlat = flatIter.MoveNext();
+                hasFlat = MoveNextFlat(flatIter, endExclusive, endKey);
                 hasTrie = trieIter.MoveNext();
             }
             else if (cmp < 0 || !hasTrie)
@@ -509,7 +585,7 @@ public class FlatTrieVerifier
                     if (_logger.IsWarn) _logger.Warn($"Storage slot in flat not in trie. Account: {job.FlatAccountKey}, Slot: {flatIter.CurrentKey}");
                     DiagnoseTriePath(storageTrieStore, job.StorageRoot, flatIter.CurrentKey);
                 }
-                hasFlat = flatIter.MoveNext();
+                hasFlat = MoveNextFlat(flatIter, endExclusive, endKey);
             }
             else
             {
@@ -520,6 +596,9 @@ public class FlatTrieVerifier
             }
         }
     }
+
+    private static bool MoveNextFlat(IPersistence.IFlatIterator flatIter, bool endExclusive, in ValueHash256 endKey) =>
+        flatIter.MoveNext() && (!endExclusive || flatIter.CurrentKey < endKey);
 
     private void VerifyStoragePreimage(
         StorageVerificationJob job,

--- a/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
@@ -1,12 +1,18 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.State.Flat.Persistence;
+
 namespace Nethermind.State.Flat;
 
 public interface IFlatDbManager : IFlatCommitTarget
 {
     SnapshotBundle GatherSnapshotBundle(in StateId baseBlock, ResourcePool.Usage usage);
     ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock);
+
+    /// <inheritdoc cref="GatherReadOnlySnapshotBundle(in StateId)"/>
+    /// <param name="readerFlags">Forwarded to the persistence reader backing the bundle; implementations may ignore it.</param>
+    ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock, ReaderFlags readerFlags) => GatherReadOnlySnapshotBundle(baseBlock);
     void FlushCache(CancellationToken cancellationToken);
     bool HasStateForBlock(in StateId stateId);
 }

--- a/src/Nethermind/Nethermind.State.Flat/IPersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/IPersistenceManager.cs
@@ -7,7 +7,8 @@ namespace Nethermind.State.Flat;
 
 public interface IPersistenceManager
 {
-    IPersistence.IPersistenceReader LeaseReader();
+    /// <param name="flags">Forwarded to <see cref="IPersistence.CreateReader"/>; implementations may ignore it.</param>
+    IPersistence.IPersistenceReader LeaseReader(ReaderFlags flags = ReaderFlags.None);
     StateId GetCurrentPersistedStateId();
     Task AddToPersistence(StateId latestSnapshot);
     StateId FlushToPersistence();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
@@ -216,8 +216,7 @@ public static class BaseFlatPersistence
 
         public ValueHash256 CurrentKey => _currentKey;
 
-        // Returned span is only valid until the next MoveNext (per IFlatIterator contract) — copying
-        // it per entry is measurable garbage over a few hundred million accounts in verifytrie.
+        // Not copied: valid only until the next MoveNext, per IFlatIterator contract.
         public ReadOnlySpan<byte> CurrentValue => view.CurrentValue;
 
         public void Dispose() => view.Dispose();
@@ -253,9 +252,8 @@ public static class BaseFlatPersistence
 
         public ValueHash256 CurrentKey => _currentKey;
 
-        // Re-derived per access instead of copied per slot: the RLP header parse is a few ns, while
-        // copying every slot value is billions of small allocations over a full verifytrie run. The
-        // span stays valid until the next MoveNext (per IFlatIterator contract).
+        // Re-derived per access instead of copied per slot; valid only until the next MoveNext,
+        // per IFlatIterator contract.
         public ReadOnlySpan<byte> CurrentValue => DecodeCurrentValue();
 
         private readonly ReadOnlySpan<byte> DecodeCurrentValue() =>

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BaseFlatPersistence.cs
@@ -200,7 +200,6 @@ public static class BaseFlatPersistence
     public struct AccountIterator(ISortedView view) : IPersistence.IFlatIterator
     {
         private ValueHash256 _currentKey = default;
-        private byte[]? _currentValue = null;
 
         public bool MoveNext()
         {
@@ -212,12 +211,14 @@ public static class BaseFlatPersistence
             // Build 32-byte ValueHash256 from 20-byte key (zero-padded)
             _currentKey = ValueKeccak.Zero;
             view.CurrentKey.CopyTo(_currentKey.BytesAsSpan);
-            _currentValue = view.CurrentValue.ToArray();
             return true;
         }
 
         public ValueHash256 CurrentKey => _currentKey;
-        public ReadOnlySpan<byte> CurrentValue => _currentValue;
+
+        // Returned span is only valid until the next MoveNext (per IFlatIterator contract) — copying
+        // it per entry is measurable garbage over a few hundred million accounts in verifytrie.
+        public ReadOnlySpan<byte> CurrentValue => view.CurrentValue;
 
         public void Dispose() => view.Dispose();
     }
@@ -226,7 +227,6 @@ public static class BaseFlatPersistence
     {
         // 16-byte suffix to match
         private ValueHash256 _currentKey = default;
-        private byte[]? _currentValue = null;
 
         public bool MoveNext()
         {
@@ -241,21 +241,27 @@ public static class BaseFlatPersistence
 
                 // Extract the 32-byte slot hash from the middle of the key
                 _currentKey = new ValueHash256(view.CurrentKey.Slice(slotOffset, StorageSlotKeySize));
-                ReadOnlySpan<byte> slotValue = rlpWrapSlots
-                    ? new RlpReader(view.CurrentValue).DecodeByteArraySpan()
-                    : view.CurrentValue;
+                ReadOnlySpan<byte> slotValue = DecodeCurrentValue();
                 // Mirror TryGetStorage: a slot value over 32 bytes means the encoding is mismatched (e.g. a
                 // marker-less DB read as raw). Fail loudly here too, rather than handing snap-sync healing a
                 // bad value that would build wrong trie nodes.
                 if (slotValue.Length > SlotValue.ByteCount) ThrowSlotValueTooLong(slotValue.Length, rlpWrapSlots);
-                _currentValue = slotValue.ToArray();
                 return true;
             }
             return false;
         }
 
         public ValueHash256 CurrentKey => _currentKey;
-        public ReadOnlySpan<byte> CurrentValue => _currentValue;
+
+        // Re-derived per access instead of copied per slot: the RLP header parse is a few ns, while
+        // copying every slot value is billions of small allocations over a full verifytrie run. The
+        // span stays valid until the next MoveNext (per IFlatIterator contract).
+        public ReadOnlySpan<byte> CurrentValue => DecodeCurrentValue();
+
+        private readonly ReadOnlySpan<byte> DecodeCurrentValue() =>
+            rlpWrapSlots
+                ? new RlpReader(view.CurrentValue).DecodeByteArraySpan()
+                : view.CurrentValue;
 
         public void Dispose() => view.Dispose();
     }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CachedReaderPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CachedReaderPersistence.cs
@@ -57,7 +57,8 @@ public class CachedReaderPersistence : IPersistence, IAsyncDisposable
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
-        if ((flags & ReaderFlags.Sync) != 0)
+        // The cached reader is created flagless, so flagged requests must go to the inner persistence directly.
+        if ((flags & (ReaderFlags.Sync | ReaderFlags.FullScan)) != 0)
             return _inner.CreateReader(flags);
 
         RefCountingPersistenceReader? cachedReader = _cachedReader;

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/FlatInTriePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/FlatInTriePersistence.cs
@@ -23,7 +23,7 @@ public class FlatInTriePersistence(IColumnsDb<FlatDbColumns> db, ILogManager log
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
-        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot();
+        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot((flags & ReaderFlags.FullScan) != 0);
         try
         {
             BaseTriePersistence.Reader trieReader = new(

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -82,6 +82,8 @@ public interface IPersistence
     /// <remarks>
     /// <see cref="CurrentValue"/> may point into the underlying store's buffer and is only valid
     /// until the next <see cref="MoveNext"/> or <see cref="IDisposable.Dispose"/> call.
+    /// Reading <see cref="CurrentKey"/> or <see cref="CurrentValue"/> before the first
+    /// <see cref="MoveNext"/>, or after one returned <c>false</c>, is undefined.
     /// </remarks>
     public interface IFlatIterator : IDisposable
     {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -82,8 +82,6 @@ public interface IPersistence
     /// <remarks>
     /// <see cref="CurrentValue"/> may point into the underlying store's buffer and is only valid
     /// until the next <see cref="MoveNext"/> or <see cref="IDisposable.Dispose"/> call.
-    /// Reading <see cref="CurrentKey"/> or <see cref="CurrentValue"/> before the first
-    /// <see cref="MoveNext"/>, or after one returned <c>false</c>, is undefined.
     /// </remarks>
     public interface IFlatIterator : IDisposable
     {

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -13,6 +13,13 @@ public enum ReaderFlags
 {
     None = 0,
     Sync = 1,
+
+    /// <summary>
+    /// The reader serves long sequential scans (e.g. flat-trie verification): backing snapshots may enable
+    /// readahead iterators for <see cref="ReadFlags.HintReadAhead"/> reads, and the shared reader cache in
+    /// <see cref="CachedReaderPersistence"/> is bypassed so the hint reaches the storage layer.
+    /// </summary>
+    FullScan = 2,
 }
 
 public interface IPersistence

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -79,6 +79,10 @@ public interface IPersistence
     /// <summary>
     /// Iterator for iterating over flat storage key-value pairs. This is mainly used in verifytrie.
     /// </summary>
+    /// <remarks>
+    /// <see cref="CurrentValue"/> may point into the underlying store's buffer and is only valid
+    /// until the next <see cref="MoveNext"/> or <see cref="IDisposable.Dispose"/> call.
+    /// </remarks>
     public interface IFlatIterator : IDisposable
     {
         bool MoveNext();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
@@ -41,7 +41,7 @@ public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManage
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
-        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot();
+        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot((flags & ReaderFlags.FullScan) != 0);
         BaseTriePersistence.Reader trieReader = new(
             snapshot.GetColumn(FlatDbColumns.StateTopNodes),
             snapshot.GetColumn(FlatDbColumns.StateNodes),

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -19,7 +19,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
-        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot();
+        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot((flags & ReaderFlags.FullScan) != 0);
         try
         {
             BaseTriePersistence.Reader trieReader = new(

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -72,7 +72,7 @@ public class PersistenceManager(
         set => Volatile.Write(ref _currentPersistedState, new StrongBox<StateId>(value));
     }
 
-    public IPersistence.IPersistenceReader LeaseReader() => persistence.CreateReader();
+    public IPersistence.IPersistenceReader LeaseReader(ReaderFlags flags = ReaderFlags.None) => persistence.CreateReader(flags);
 
     public StateId GetCurrentPersistedStateId()
     {


### PR DESCRIPTION
## Changes

Flat verification still copies each account/slot value and drains large storage tries through one worker on master. Snapshot trie reads also ignore `HintReadAhead`. This change removes the per-value copy, partitions large storage tries, and enables snapshot readahead only for the verifier.

- Split large storage tries into eight disjoint ranges when both initial branch levels are full. Offload work while storage workers are idle; retain the bounded queue and drain all offloaded work before releasing readers. The reservation budget is not a strict global concurrency ceiling: concurrency can temporarily exceed the worker pool by up to eight partitions.
- Route `ReaderFlags.FullScan` through snapshot bundles and persistence readers. Full-scan bundles bypass the ordinary reader cache on both lookup and insertion; peer-facing and ordinary snapshot reads keep point-Get behavior.
- Use snapshot-bound, non-tailing read options and master's `DisposableLazy<IteratorManager>`. Preserve master's disposal/timer synchronization and native handle disposal. Opted-in managers accept short Flat keys; exhausted iterators are checked before accessing keys or advancing again.
- Keep the current slot-value encoding checks while exposing iterator-owned spans until the next advance/disposal.

Merged master `be919fe160` and adapted the implementation to its current RocksDB reader and iterator APIs.

## Types of changes

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- Full `Nethermind.State.Flat.Test`: 1,107 passed, 8 skipped. Two additional cache-isolation cases passed with both pre-populated and empty caches.
- Full `Nethermind.Db.Test`: 627 passed, 544 skipped. After adding concurrent snapshot coverage, all 26 `ColumnsDbTests` passed.
- Windows native DB crash fixed by using short, unique test directory IDs instead of long test names. [Windows validation](https://github.com/NethermindEth/nethermind/actions/runs/35149010946): all 629 DB cases passed, 544 skipped; sequential and concurrent snapshot tests also passed independently.
- Coverage includes 3/8/28-byte keys followed by 34-byte keys, overwrites/deletes after snapshot creation, ascending/reverse/repeated reads, misses after exhaustion, independent concurrent columns with flushed/unflushed data, ordinary-reader isolation, and double disposal.
- Existing verifier tests cover split thresholds (4/512/4096 slots), exact counts across ranges, mismatches, missing entries, and all three Flat layouts.

### Performance evidence

The July measurements remain historical evidence, not refreshed speed guarantees. [Run 30545506031](https://github.com/NethermindEth/nethermind/actions/runs/30545506031) measured verification at 28.7 min on gnosis and 77.6 min on mainnet; its [preceding parallel-only run](https://github.com/NethermindEth/nethermind/actions/runs/30510874500) measured 69.6 and 100.0 min. Those runs used older code, chain state and peers. The bottlenecks still exist in current master and correctness tests pass after integration; a new matched full-sync A/B has not been run for this revision.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
