### PR TITLE
test: make prewarmer env-return assertion pool-hit independent

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -1215,10 +1215,15 @@ public class BlockCachePreWarmerTests
             return new ThrowingBuildEnv();
         }
 
+        /// <remarks>
+        /// Refuses retention so every rental is a fresh <see cref="Create"/>: a pooled env rented
+        /// twice would otherwise increment <see cref="Returned"/> twice against a single create,
+        /// failing the <c>Returned == Created</c> assertion on timing-dependent pool hits.
+        /// </remarks>
         public bool Return(IReadOnlyTxProcessorSource obj)
         {
             Interlocked.Increment(ref _returned);
-            return true;
+            return false;
         }
 
         private sealed class ThrowingBuildEnv : IReadOnlyTxProcessorSource


### PR DESCRIPTION
## Changes

- Fix flaky `BlockCachePreWarmerTests.PreWarmCaches_ReturnsAddressWarmEnvWhenScopeBuildThrows`: `ThrowingBuildPolicy.Return` now refuses pool retention (`return false`), so every rental goes through `Create` and the `Returned == Created` assertion holds under any thread interleaving.

### Why

The test asserts `Returned == Created`, but with `maxPoolSize: 1` an env returned to the pool can be rented again **without** a `Create` (pool hit), so a second rental of the same object legitimately adds +1 to `Returned` and +0 to `Created`. Whether a pool hit occurs depends on how the address-warmer and tx-warmup workers interleave: it occasionally fails on CI (e.g. `Expected: 2 But was: 3` in [this run](https://github.com/NethermindEth/nethermind/actions/runs/30507777068/job/90762247495)) and fails deterministically on high-core-count machines (0/30 locally before the fix).

Stack-trace instrumentation of `Return` confirmed every rental is returned exactly once from the expected sites (`WarmingState.InitThreadState` catch, `TxWarmupWorker` finalizer) — the prewarmer itself is correct; only the test invariant was unsound.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bug fix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- Before: 0/30 passes locally on a high-core machine; after: 30/30.
- Full `BlockCachePreWarmerTests` class: 45/45 pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
