### PR TITLE
perf(state): make HintReadAhead effective through DB snapshots for flat verification

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Modules/FlatDbManagerTestCompat.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using Nethermind.Core.Crypto;
 using Nethermind.State.Flat;
+using Nethermind.State.Flat.Persistence;
 
 namespace Nethermind.Core.Test.Modules;
 
@@ -17,6 +18,8 @@ internal class FlatDbManagerTestCompat(IFlatDbManager flatDbManager) : IFlatDbMa
     public SnapshotBundle GatherSnapshotBundle(in StateId stateId, ResourcePool.Usage usage) => flatDbManager.GatherSnapshotBundle(NormalizeState(stateId), usage);
 
     public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId stateId) => flatDbManager.GatherReadOnlySnapshotBundle(NormalizeState(stateId));
+
+    public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId stateId, ReaderFlags readerFlags) => flatDbManager.GatherReadOnlySnapshotBundle(NormalizeState(stateId), readerFlags);
 
     public bool HasStateForBlock(in StateId stateId)
     {

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -148,11 +148,11 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) => _writeBatch.WriteBatch.Merge(key, value, _column._columnFamily, flags);
     }
 
-    IColumnDbSnapshot<T> IColumnsDb<T>.CreateSnapshot()
-    {
-        Snapshot snapshot = _db.CreateSnapshot();
-        return new ColumnDbSnapshot(this, snapshot);
-    }
+    IColumnDbSnapshot<T> IColumnsDb<T>.CreateSnapshot() => CreateSnapshotCore(sequentialReadAhead: false);
+
+    IColumnDbSnapshot<T> IColumnsDb<T>.CreateSnapshot(bool sequentialReadAhead) => CreateSnapshotCore(sequentialReadAhead);
+
+    private ColumnDbSnapshot CreateSnapshotCore(bool sequentialReadAhead) => new(this, _db.CreateSnapshot(), sequentialReadAhead);
 
     private class ColumnDbSnapshot : IColumnDbSnapshot<T>
     {
@@ -166,9 +166,8 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         // Use a flat array indexed by enum ordinal instead of Dictionary<T, IReadOnlyKeyValueStore>.
         // This eliminates the dictionary + backing array allocation per snapshot.
         private readonly RocksDbReader[] _readers;
-        private readonly IteratorManager?[] _iteratorManagers;
 
-        public ColumnDbSnapshot(ColumnsDb<T> columnsDb, Snapshot snapshot)
+        public ColumnDbSnapshot(ColumnsDb<T> columnsDb, Snapshot snapshot, bool sequentialReadAhead)
         {
             _columnsDb = columnsDb;
             _snapshot = snapshot;
@@ -186,10 +185,9 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
             Func<ReadOptions> readOptionsFactory = () => CreateReadOptions(columnsDb, snapshot);
             // Shared by all column iterator managers; the ReadOptions it returns is created lazily
             // on the first HintReadAhead read, so snapshots that never iterate allocate nothing extra.
-            Func<ReadOptions?> readAheadOptionsFactory = GetOrCreateReadAheadReadOptions;
+            Func<ReadOptions?>? readAheadOptionsFactory = sequentialReadAhead ? GetOrCreateReadAheadReadOptions : null;
             T[] keys = CreateKeyCache(columnsDb);
             GetCachedMaxOrdinal(columnsDb, keys);
-            _iteratorManagers = new IteratorManager?[columnsDb._cachedMaxOrdinal + 1];
             _readers = CreateReaders();
 
             // Cache column keys and max ordinal on the parent ColumnsDb to avoid per-snapshot
@@ -236,8 +234,9 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
                     int ordinal = EnumToInt(k);
                     ColumnFamilyHandle columnFamily = columnsDb._columnDbs[k]._columnFamily;
                     // Internally lazy — until a HintReadAhead read arrives this is just an object allocation.
-                    IteratorManager iteratorManager = new(columnsDb._db, columnFamily, readAheadOptionsFactory);
-                    _iteratorManagers[ordinal] = iteratorManager;
+                    IteratorManager? iteratorManager = readAheadOptionsFactory is null
+                        ? null
+                        : new IteratorManager(columnsDb._db, columnFamily, readAheadOptionsFactory, sequentialKeys: true);
                     readers[ordinal] = new RocksDbReader(
                         columnsDb,
                         _sharedReadOptions,
@@ -305,18 +304,18 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
             if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
             // Iterators pin the snapshot's resources — tear the managers down before releasing anything they read through.
-            foreach (IteratorManager? iteratorManager in _iteratorManagers)
+            foreach (RocksDbReader? reader in _readers)
             {
-                iteratorManager?.Dispose();
+                reader?.IteratorManager?.Dispose();
             }
 
             // Explicitly destroy native ReadOptions handles to prevent finalizer queue buildup.
             // GC.SuppressFinalize prevents the finalizer from running on already-destroyed handles.
             RocksDbReader.DestroyReadOptions(_sharedReadOptions);
             RocksDbReader.DestroyReadOptions(_sharedCacheMissReadOptions);
-            if (_readAheadReadOptions is not null)
+            if (Interlocked.Exchange(ref _readAheadReadOptions, null) is { } readAheadOptions)
             {
-                RocksDbReader.DestroyReadOptions(_readAheadReadOptions);
+                RocksDbReader.DestroyReadOptions(readAheadOptions);
             }
 
             _snapshot.Dispose();

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -156,17 +156,21 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
 
     private class ColumnDbSnapshot : IColumnDbSnapshot<T>
     {
+        private readonly ColumnsDb<T> _columnsDb;
         private readonly Snapshot _snapshot;
         private readonly ReadOptions _sharedReadOptions;
         private readonly ReadOptions _sharedCacheMissReadOptions;
+        private ReadOptions? _readAheadReadOptions;
         private int _disposed;
 
         // Use a flat array indexed by enum ordinal instead of Dictionary<T, IReadOnlyKeyValueStore>.
         // This eliminates the dictionary + backing array allocation per snapshot.
         private readonly RocksDbReader[] _readers;
+        private readonly IteratorManager?[] _iteratorManagers;
 
         public ColumnDbSnapshot(ColumnsDb<T> columnsDb, Snapshot snapshot)
         {
+            _columnsDb = columnsDb;
             _snapshot = snapshot;
 
             // Create two shared ReadOptions for all column readers instead of 2 per reader.
@@ -180,17 +184,13 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
             // Note: each GetViewBetween call still creates a new ReadOptions with a finalizer;
             // that is pre-existing behavior not addressed by this PR.
             Func<ReadOptions> readOptionsFactory = () => CreateReadOptions(columnsDb, snapshot);
+            // Shared by all column iterator managers; the ReadOptions it returns is created lazily
+            // on the first HintReadAhead read, so snapshots that never iterate allocate nothing extra.
+            Func<ReadOptions?> readAheadOptionsFactory = GetOrCreateReadAheadReadOptions;
             T[] keys = CreateKeyCache(columnsDb);
             GetCachedMaxOrdinal(columnsDb, keys);
+            _iteratorManagers = new IteratorManager?[columnsDb._cachedMaxOrdinal + 1];
             _readers = CreateReaders();
-
-            static ReadOptions CreateReadOptions(ColumnsDb<T> columnsDb, Snapshot snapshot)
-            {
-                ReadOptions options = new();
-                options.SetVerifyChecksums(columnsDb.VerifyChecksum);
-                options.SetSnapshot(snapshot);
-                return options;
-            }
 
             // Cache column keys and max ordinal on the parent ColumnsDb to avoid per-snapshot
             // recomputation. The race is benign (both threads compute identical results) and
@@ -233,16 +233,58 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
                 for (int i = 0; i < keys.Length; i++)
                 {
                     T k = keys[i];
-                    readers[EnumToInt(k)] = new RocksDbReader(
+                    int ordinal = EnumToInt(k);
+                    ColumnFamilyHandle columnFamily = columnsDb._columnDbs[k]._columnFamily;
+                    // Internally lazy — until a HintReadAhead read arrives this is just an object allocation.
+                    IteratorManager iteratorManager = new(columnsDb._db, columnFamily, readAheadOptionsFactory);
+                    _iteratorManagers[ordinal] = iteratorManager;
+                    readers[ordinal] = new RocksDbReader(
                         columnsDb,
                         _sharedReadOptions,
                         _sharedCacheMissReadOptions,
                         readOptionsFactory,
-                        columnFamily: columnsDb._columnDbs[k]._columnFamily);
+                        iteratorManager,
+                        columnFamily);
                 }
 
                 return readers;
             }
+        }
+
+        private static ReadOptions CreateReadOptions(ColumnsDb<T> columnsDb, Snapshot snapshot)
+        {
+            ReadOptions options = new();
+            options.SetVerifyChecksums(columnsDb.VerifyChecksum);
+            options.SetSnapshot(snapshot);
+            return options;
+        }
+
+        /// <summary>
+        /// Lazily creates the snapshot-bound <see cref="ReadOptions"/> shared by all column iterator managers.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="DbOnTheRocks._readAheadReadOptions"/> this must not be tailing: tailing iterators
+        /// ignore the snapshot and would observe writes made after it.
+        /// </remarks>
+        private ReadOptions GetOrCreateReadAheadReadOptions()
+        {
+            ReadOptions? options = Volatile.Read(ref _readAheadReadOptions);
+            if (options is not null) return options;
+
+            ReadOptions created = CreateReadOptions(_columnsDb, _snapshot);
+            if (_columnsDb._readAheadSize > 0)
+            {
+                created.SetReadaheadSize(_columnsDb._readAheadSize);
+            }
+
+            options = Interlocked.CompareExchange(ref _readAheadReadOptions, created, null);
+            if (options is not null)
+            {
+                RocksDbReader.DestroyReadOptions(created);
+                return options;
+            }
+
+            return created;
         }
 
         public IReadOnlyKeyValueStore GetColumn(T key)
@@ -262,10 +304,20 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
         {
             if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
 
+            // Iterators pin the snapshot's resources — tear the managers down before releasing anything they read through.
+            foreach (IteratorManager? iteratorManager in _iteratorManagers)
+            {
+                iteratorManager?.Dispose();
+            }
+
             // Explicitly destroy native ReadOptions handles to prevent finalizer queue buildup.
             // GC.SuppressFinalize prevents the finalizer from running on already-destroyed handles.
             RocksDbReader.DestroyReadOptions(_sharedReadOptions);
             RocksDbReader.DestroyReadOptions(_sharedCacheMissReadOptions);
+            if (_readAheadReadOptions is not null)
+            {
+                RocksDbReader.DestroyReadOptions(_readAheadReadOptions);
+            }
 
             _snapshot.Dispose();
         }

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -185,7 +185,7 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
             Func<ReadOptions> readOptionsFactory = () => CreateReadOptions(columnsDb, snapshot);
             // Shared by all column iterator managers; the ReadOptions it returns is created lazily
             // on the first HintReadAhead read, so snapshots that never iterate allocate nothing extra.
-            Func<ReadOptions?>? readAheadOptionsFactory = sequentialReadAhead ? GetOrCreateReadAheadReadOptions : null;
+            Func<ReadOptions>? readAheadOptionsFactory = sequentialReadAhead ? GetOrCreateReadAheadReadOptions : null;
             T[] keys = CreateKeyCache(columnsDb);
             GetCachedMaxOrdinal(columnsDb, keys);
             _readers = CreateReaders();

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -756,7 +756,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         using IteratorManager.RentWrapper wrapper = iteratorManager.Rent(flags);
         Iterator iterator = wrapper.Iterator;
 
-        if (iterator.Valid() && TryCloseReadAhead(iterator, key, out byte[]? closeRes))
+        if (iterator.Valid() && TryCloseReadAhead(iterator, key, iteratorManager.SequentialKeys, out byte[]? closeRes))
         {
             return closeRes;
         }
@@ -822,16 +822,23 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     /// <param name="key"></param>
     /// <param name="result"></param>
     /// <returns></returns>
-    private bool TryCloseReadAhead(Iterator iterator, ReadOnlySpan<byte> key, out byte[]? result)
+    private bool TryCloseReadAhead(Iterator iterator, ReadOnlySpan<byte> key, bool sequentialKeys, out byte[]? result)
     {
         // Probably hash db. Can't really do this with hashdb. Even with batched trie visitor, its going to skip a lot.
-        if (key.Length <= 32)
+        if (!sequentialKeys && key.Length <= 32)
         {
             result = null;
             return false;
         }
 
         iterator.Next();
+        // Next() can exhaust the iterator; key()/Next() on an invalid iterator is undefined per the RocksDB API.
+        if (!iterator.Valid())
+        {
+            result = null;
+            return false;
+        }
+
         ReadOnlySpan<byte> currentKey = iterator.GetKeySpan();
         int compareResult = currentKey.SequenceCompareTo(key);
         if (compareResult == 0)
@@ -850,17 +857,25 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         // This is only useful for state as storage have way too different different address range between different
         // contract. That said, there isn't any real good threshold. Threshold is for some reasonably high value
         // above the average distance.
-        ulong currentKeyInt = BinaryPrimitives.ReadUInt64BigEndian(currentKey);
-        ulong requestedKeyInt = BinaryPrimitives.ReadUInt64BigEndian(key);
-        ulong distance = requestedKeyInt - currentKeyInt;
-        if (distance > 1_000_000_000)
+        // Skipped for short keys (e.g. 3-byte StateTopNodes keys): the bounded probe below is enough there.
+        if (currentKey.Length >= sizeof(ulong) && key.Length >= sizeof(ulong))
         {
-            return false;
+            ulong currentKeyInt = BinaryPrimitives.ReadUInt64BigEndian(currentKey);
+            ulong requestedKeyInt = BinaryPrimitives.ReadUInt64BigEndian(key);
+            ulong distance = requestedKeyInt - currentKeyInt;
+            if (distance > 1_000_000_000)
+            {
+                return false;
+            }
         }
 
         for (int i = 0; i < 5 && compareResult < 0; i++)
         {
             iterator.Next();
+            if (!iterator.Valid())
+            {
+                return false;
+            }
             compareResult = iterator.GetKeySpan().SequenceCompareTo(key);
         }
 
@@ -1849,10 +1864,16 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         private ReadOptions? _readOptions;
         private readonly Lock _initLock = new();
         private Timer? _timer;
-        private bool _isDisposed;
+        private volatile bool _isDisposed;
 
         // This is about once every two second maybe at max throughput.
         private const int IteratorUsageLimit = 1000000;
+
+        /// <summary>
+        /// Whether <see cref="ReadFlags.HintReadAhead"/> keys arrive in near-sorted order, making the iterator
+        /// close-read-ahead path worthwhile even for keys of 32 bytes or less.
+        /// </summary>
+        internal bool SequentialKeys { get; }
 
         public IteratorManager(RocksDb rocksDb, ColumnFamilyHandle? cf, ReadOptions? readOptions)
         {
@@ -1868,19 +1889,24 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         /// The factory result is owned by the caller, which must keep it alive until this manager is disposed.
         /// Used by snapshot-scoped readers so that snapshots that never iterate allocate no native handle.
         /// </remarks>
-        public IteratorManager(RocksDb rocksDb, ColumnFamilyHandle? cf, Func<ReadOptions?> readOptionsFactory)
+        public IteratorManager(RocksDb rocksDb, ColumnFamilyHandle? cf, Func<ReadOptions?> readOptionsFactory, bool sequentialKeys = false)
         {
             _rocksDb = rocksDb;
             _cf = cf;
             _readOptionsFactory = readOptionsFactory;
+            SequentialKeys = sequentialKeys;
         }
 
         private void OnTimer(object? state)
         {
-            if (_isDisposed) return;
-            _readaheadIterators?.ClearIterators();
-            _readaheadIterators2?.ClearIterators();
-            _readaheadIterators3?.ClearIterators();
+            // The lock keeps a clear from racing Dispose's DisposeAll.
+            lock (_initLock)
+            {
+                if (_isDisposed) return;
+                _readaheadIterators?.ClearIterators();
+                _readaheadIterators2?.ClearIterators();
+                _readaheadIterators3?.ClearIterators();
+            }
         }
 
         public void Dispose()
@@ -1899,6 +1925,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
         public RentWrapper Rent(ReadFlags flags)
         {
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
             if (Volatile.Read(ref _timer) is null) Initialize();
 
             ManagedIterators iterators = GetIterators(flags);
@@ -1923,7 +1950,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                 _readaheadIterators2 = new ManagedIterators();
                 _readaheadIterators3 = new ManagedIterators();
                 // Volatile publish: threads taking the fast path in Rent must observe the fields above.
-                Volatile.Write(ref _timer, new Timer(OnTimer, null, TimeSpan.Zero, TimeSpan.FromSeconds(10)));
+                // First tick is delayed so it cannot clear the iterator pool under the rent that created it.
+                Volatile.Write(ref _timer, new Timer(OnTimer, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10)));
             }
         }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -58,6 +58,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     private ReadOptions _defaultReadOptions = null!;
     private ReadOptions _hintCacheMissOptions = null!;
     internal ReadOptions? _readAheadReadOptions = null;
+    internal ulong _readAheadSize;
 
     internal DbOptions? DbOptions { get; private set; }
     private readonly IRocksDbConfigFactory _rocksDbConfigFactory;
@@ -709,8 +710,9 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         // visitor on mainnet with 4GB memory budget and 4Gbps read bandwidth.
         if (dbConfig.ReadAheadSize != 0)
         {
+            _readAheadSize = dbConfig.ReadAheadSize ?? 256UL.KiB;
             _readAheadReadOptions = CreateReadOptions();
-            _readAheadReadOptions.SetReadaheadSize(dbConfig.ReadAheadSize ?? 256UL.KiB);
+            _readAheadReadOptions.SetReadaheadSize(_readAheadSize);
             _readAheadReadOptions.SetTailing(true);
         }
         #endregion
@@ -1838,13 +1840,15 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     /// </summary>
     public class IteratorManager : IDisposable
     {
-        private readonly ManagedIterators _readaheadIterators = new();
-        private readonly ManagedIterators _readaheadIterators2 = new();
-        private readonly ManagedIterators _readaheadIterators3 = new();
+        private ManagedIterators? _readaheadIterators;
+        private ManagedIterators? _readaheadIterators2;
+        private ManagedIterators? _readaheadIterators3;
         private readonly RocksDb _rocksDb;
         private readonly ColumnFamilyHandle? _cf;
-        private readonly ReadOptions? _readOptions;
-        private readonly Timer _timer;
+        private readonly Func<ReadOptions?>? _readOptionsFactory;
+        private ReadOptions? _readOptions;
+        private readonly Lock _initLock = new();
+        private Timer? _timer;
         private bool _isDisposed;
 
         // This is about once every two second maybe at max throughput.
@@ -1855,30 +1859,48 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             _rocksDb = rocksDb;
             _cf = cf;
             _readOptions = readOptions;
+        }
 
-            _timer = new Timer(OnTimer, null, TimeSpan.Zero, TimeSpan.FromSeconds(10));
+        /// <summary>
+        /// Variant that resolves its <see cref="ReadOptions"/> on first rent instead of up front.
+        /// </summary>
+        /// <remarks>
+        /// The factory result is owned by the caller, which must keep it alive until this manager is disposed.
+        /// Used by snapshot-scoped readers so that snapshots that never iterate allocate no native handle.
+        /// </remarks>
+        public IteratorManager(RocksDb rocksDb, ColumnFamilyHandle? cf, Func<ReadOptions?> readOptionsFactory)
+        {
+            _rocksDb = rocksDb;
+            _cf = cf;
+            _readOptionsFactory = readOptionsFactory;
         }
 
         private void OnTimer(object? state)
         {
             if (_isDisposed) return;
-            _readaheadIterators.ClearIterators();
-            _readaheadIterators2.ClearIterators();
-            _readaheadIterators3.ClearIterators();
+            _readaheadIterators?.ClearIterators();
+            _readaheadIterators2?.ClearIterators();
+            _readaheadIterators3?.ClearIterators();
         }
 
         public void Dispose()
         {
-            if (_isDisposed) return;
-            _isDisposed = true;
-            _timer.Dispose();
-            _readaheadIterators.DisposeAll();
-            _readaheadIterators2.DisposeAll();
-            _readaheadIterators3.DisposeAll();
+            // The lock keeps a concurrent first Rent from initializing the timer after it was disposed here.
+            lock (_initLock)
+            {
+                if (_isDisposed) return;
+                _isDisposed = true;
+                _timer?.Dispose();
+                _readaheadIterators?.DisposeAll();
+                _readaheadIterators2?.DisposeAll();
+                _readaheadIterators3?.DisposeAll();
+            }
         }
 
         public RentWrapper Rent(ReadFlags flags)
         {
+            if (Volatile.Read(ref _timer) is null) Initialize();
+
             ManagedIterators iterators = GetIterators(flags);
             IteratorHolder holder = iterators.Value!;
             // If null, we create a new one.
@@ -1886,11 +1908,30 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
             return new RentWrapper(iterator ?? _rocksDb.NewIterator(_cf, _readOptions), flags, this);
         }
 
+        /// <summary>
+        /// Creates the timer and thread-local iterator holders on first rent, so managers on paths that never
+        /// iterate (e.g. per-block snapshots) cost only the object allocation.
+        /// </summary>
+        private void Initialize()
+        {
+            lock (_initLock)
+            {
+                if (_timer is not null) return;
+                ObjectDisposedException.ThrowIf(_isDisposed, this);
+                _readOptions ??= _readOptionsFactory?.Invoke();
+                _readaheadIterators = new ManagedIterators();
+                _readaheadIterators2 = new ManagedIterators();
+                _readaheadIterators3 = new ManagedIterators();
+                // Volatile publish: threads taking the fast path in Rent must observe the fields above.
+                Volatile.Write(ref _timer, new Timer(OnTimer, null, TimeSpan.Zero, TimeSpan.FromSeconds(10)));
+            }
+        }
+
         private ManagedIterators GetIterators(ReadFlags flags) => flags switch
         {
-            _ when (flags & ReadFlags.HintReadAhead2) != 0 => _readaheadIterators2,
-            _ when (flags & ReadFlags.HintReadAhead3) != 0 => _readaheadIterators3,
-            _ => _readaheadIterators
+            _ when (flags & ReadFlags.HintReadAhead2) != 0 => _readaheadIterators2!,
+            _ when (flags & ReadFlags.HintReadAhead3) != 0 => _readaheadIterators3!,
+            _ => _readaheadIterators!
         };
 
         private void Return(Iterator iterator, ReadFlags flags)

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -1860,7 +1860,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         private ManagedIterators? _readaheadIterators3;
         private readonly RocksDb _rocksDb;
         private readonly ColumnFamilyHandle? _cf;
-        private readonly Func<ReadOptions?>? _readOptionsFactory;
+        private readonly Func<ReadOptions>? _readOptionsFactory;
         private ReadOptions? _readOptions;
         private readonly Lock _initLock = new();
         private Timer? _timer;
@@ -1889,7 +1889,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         /// The factory result is owned by the caller, which must keep it alive until this manager is disposed.
         /// Used by snapshot-scoped readers so that snapshots that never iterate allocate no native handle.
         /// </remarks>
-        public IteratorManager(RocksDb rocksDb, ColumnFamilyHandle? cf, Func<ReadOptions?> readOptionsFactory, bool sequentialKeys = false)
+        public IteratorManager(RocksDb rocksDb, ColumnFamilyHandle? cf, Func<ReadOptions> readOptionsFactory, bool sequentialKeys = false)
         {
             _rocksDb = rocksDb;
             _cf = cf;

--- a/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/RocksDbReader.cs
@@ -38,6 +38,8 @@ public class RocksDbReader(DbOnTheRocks mainDb,
     private readonly bool _ownsReadOptions;
     private int _disposed;
 
+    internal DbOnTheRocks.IteratorManager? IteratorManager => _iteratorManager;
+
     public RocksDbReader(DbOnTheRocks mainDb,
         Func<ReadOptions> readOptionsFactory,
         DbOnTheRocks.IteratorManager? iteratorManager = null,

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -130,16 +130,20 @@ public class ColumnsDbTests
     {
         IDb colA = _db.GetColumnDb(ReceiptsColumns.Blocks);
 
-        byte[][] keys = new byte[32][];
+        // Realistic flat-layout key shapes: a run of short (8-byte) keys followed by a run of long
+        // (34-byte) keys, ascending overall. Short keys pin the sequential-keys bypass of the
+        // "probably hash db" length guard on the iterator fast path.
+        byte[][] keys = new byte[64][];
         for (int i = 0; i < keys.Length; i++)
         {
-            keys[i] = new byte[4];
-            BinaryPrimitives.WriteInt32BigEndian(keys[i], i);
+            keys[i] = new byte[i < 32 ? 8 : 34];
+            keys[i][0] = i < 32 ? (byte)0x10 : (byte)0x22;
+            BinaryPrimitives.WriteInt32BigEndian(keys[i].AsSpan(keys[i].Length - 4), i);
             colA.Set(keys[i], [(byte)i, 1]);
         }
 
         IColumnsDb<ReceiptsColumns> asColumnsDb = _db;
-        using (IColumnDbSnapshot<ReceiptsColumns> snapshot = asColumnsDb.CreateSnapshot())
+        using (IColumnDbSnapshot<ReceiptsColumns> snapshot = asColumnsDb.CreateSnapshot(sequentialReadAhead: true))
         {
             // Mutate after the snapshot: overwrite even keys, delete odd keys.
             for (int i = 0; i < keys.Length; i++)
@@ -149,7 +153,7 @@ public class ColumnsDbTests
 
             IReadOnlyKeyValueStore snapshotColumn = snapshot.GetColumn(ReceiptsColumns.Blocks);
             Assert.That(((RocksDbReader)snapshotColumn).IteratorManager, Is.Not.Null,
-                "snapshot readers must be wired for the readahead iterator path");
+                "opt-in snapshot readers must be wired for the readahead iterator path");
 
             // Ascending key order exercises the readahead iterator's forward-scan (Next) fast path;
             // values must still come from the snapshot, not the mutated head state.
@@ -158,13 +162,24 @@ public class ColumnsDbTests
                 Assert.That(snapshotColumn.Get(keys[i], ReadFlags.HintReadAhead), Is.EqualTo(new byte[] { (byte)i, 1 }), $"key {i}");
             }
 
-            byte[] missingKey = new byte[4];
-            BinaryPrimitives.WriteInt32BigEndian(missingKey, keys.Length);
+            // Probes past the last key (exhausts the iterator) and misses.
+            byte[] missingKey = new byte[34];
+            missingKey[0] = 0x23;
             Assert.That(snapshotColumn.Get(missingKey, ReadFlags.HintReadAhead), Is.Null);
         }
 
         // Disposing the snapshot tears down its iterators; the head db must stay fully usable.
         Assert.That(colA.Get(keys[0]), Is.EqualTo(new byte[] { 0, 2 }));
+    }
+
+    [Test]
+    public void Snapshot_Default_HasNoIteratorManager()
+    {
+        IColumnsDb<ReceiptsColumns> asColumnsDb = _db;
+        using IColumnDbSnapshot<ReceiptsColumns> snapshot = asColumnsDb.CreateSnapshot();
+
+        Assert.That(((RocksDbReader)snapshot.GetColumn(ReceiptsColumns.Blocks)).IteratorManager, Is.Null,
+            "snapshots without the sequential-read-ahead opt-in must keep point-Get behavior for HintReadAhead");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
 using Nethermind.Core;
 using Nethermind.Core.Test;
@@ -122,6 +123,48 @@ public class ColumnsDbTests
 
         Assert.That(snapshot.GetColumn(ReceiptsColumns.Blocks)
             .Get(TestItem.KeccakA), Is.EqualTo(TestItem.KeccakA.BytesToArray()));
+    }
+
+    [Test]
+    public void Snapshot_Get_WithHintReadAhead_ReadsFromSnapshot()
+    {
+        IDb colA = _db.GetColumnDb(ReceiptsColumns.Blocks);
+
+        byte[][] keys = new byte[32][];
+        for (int i = 0; i < keys.Length; i++)
+        {
+            keys[i] = new byte[4];
+            BinaryPrimitives.WriteInt32BigEndian(keys[i], i);
+            colA.Set(keys[i], [(byte)i, 1]);
+        }
+
+        IColumnsDb<ReceiptsColumns> asColumnsDb = _db;
+        using (IColumnDbSnapshot<ReceiptsColumns> snapshot = asColumnsDb.CreateSnapshot())
+        {
+            // Mutate after the snapshot: overwrite even keys, delete odd keys.
+            for (int i = 0; i < keys.Length; i++)
+            {
+                colA.Set(keys[i], i % 2 == 0 ? [(byte)i, 2] : null);
+            }
+
+            IReadOnlyKeyValueStore snapshotColumn = snapshot.GetColumn(ReceiptsColumns.Blocks);
+            Assert.That(((RocksDbReader)snapshotColumn).IteratorManager, Is.Not.Null,
+                "snapshot readers must be wired for the readahead iterator path");
+
+            // Ascending key order exercises the readahead iterator's forward-scan (Next) fast path;
+            // values must still come from the snapshot, not the mutated head state.
+            for (int i = 0; i < keys.Length; i++)
+            {
+                Assert.That(snapshotColumn.Get(keys[i], ReadFlags.HintReadAhead), Is.EqualTo(new byte[] { (byte)i, 1 }), $"key {i}");
+            }
+
+            byte[] missingKey = new byte[4];
+            BinaryPrimitives.WriteInt32BigEndian(missingKey, keys.Length);
+            Assert.That(snapshotColumn.Get(missingKey, ReadFlags.HintReadAhead), Is.Null);
+        }
+
+        // Disposing the snapshot tears down its iterators; the head db must stay fully usable.
+        Assert.That(colA.Get(keys[0]), Is.EqualTo(new byte[] { 0, 2 }));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Db/IColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db/IColumnsDb.cs
@@ -14,6 +14,15 @@ namespace Nethermind.Db
         public IReadOnlyColumnDb<TKey> CreateReadOnly(bool createInMemWriteStore) => new ReadOnlyColumnsDb<TKey>(this, createInMemWriteStore);
         IColumnsWriteBatch<TKey> StartWriteBatch();
         IColumnDbSnapshot<TKey> CreateSnapshot();
+
+        /// <summary>
+        /// Creates a snapshot whose readers may be tuned for sequential full scans.
+        /// </summary>
+        /// <param name="sequentialReadAhead">
+        /// Hint that the snapshot will serve <see cref="ReadFlags.HintReadAhead"/> reads over path-ordered keys
+        /// as part of a sequential full scan. Implementations may ignore it.
+        /// </param>
+        IColumnDbSnapshot<TKey> CreateSnapshot(bool sequentialReadAhead) => CreateSnapshot();
     }
 
     public interface IColumnsWriteBatch<in TKey> : IDisposable

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -253,9 +253,10 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         // invalidation error-prone.
         if (_logger.IsTrace) _logger.Trace($"Gathering {baseBlock}.");
 
-        // FullScan bundles hold readahead-capable readers; keep them out of the shared cache so ordinary
-        // consumers never inherit them, and never serve a cached (flagless) bundle for such a request.
-        bool shareable = (readerFlags & ReaderFlags.FullScan) == 0;
+        // Bundles built with non-default reader flags hold specially-configured readers; keep them out of
+        // the shared cache so ordinary consumers never inherit them, and never serve a cached (flagless)
+        // bundle for such a request.
+        bool shareable = readerFlags == ReaderFlags.None;
 
         if (baseBlock == StateId.PreGenesis)
         {
@@ -282,11 +283,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
                 Thread.Sleep(delayMs);
             }
 
-            // Parameterless overload for the common case: substituted IPersistenceManager instances
-            // configure LeaseReader() and may not route the default interface method to it.
-            IPersistence.IPersistenceReader persistenceReader = readerFlags == ReaderFlags.None
-                ? _persistenceManager.LeaseReader()
-                : _persistenceManager.LeaseReader(readerFlags);
+            IPersistence.IPersistenceReader persistenceReader = _persistenceManager.LeaseReader(readerFlags);
             AssembledSnapshotResult assembled;
             try
             {

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -244,11 +244,18 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     private static readonly StringLabel _depthInMemoryLabel = new("in_memory");
     private static readonly StringLabel _depthPersistedLabel = new("persisted");
 
-    public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock)
+    public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock) =>
+        GatherReadOnlySnapshotBundle(baseBlock, ReaderFlags.None);
+
+    public ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock, ReaderFlags readerFlags)
     {
         // A linked-list snapshot chain was considered but rejected: the constantly moving chain makes
         // invalidation error-prone.
         if (_logger.IsTrace) _logger.Trace($"Gathering {baseBlock}.");
+
+        // FullScan bundles hold readahead-capable readers; keep them out of the shared cache so ordinary
+        // consumers never inherit them, and never serve a cached (flagless) bundle for such a request.
+        bool shareable = (readerFlags & ReaderFlags.FullScan) == 0;
 
         if (baseBlock == StateId.PreGenesis)
         {
@@ -261,7 +268,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         while (true)
         {
             // Fastpath: Share a recently created ReadOnlySnapshotBundle
-            if (_readonlySnapshotBundleCache.TryGetValue(baseBlock, out ReadOnlySnapshotBundle? bundle) && bundle.TryLease()) return bundle;
+            if (shareable && _readonlySnapshotBundleCache.TryGetValue(baseBlock, out ReadOnlySnapshotBundle? bundle) && bundle.TryLease()) return bundle;
 
             if (attempt == 1) sw = Stopwatch.GetTimestamp();
             if (attempt != 0)
@@ -275,7 +282,11 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
                 Thread.Sleep(delayMs);
             }
 
-            IPersistence.IPersistenceReader persistenceReader = _persistenceManager.LeaseReader();
+            // Parameterless overload for the common case: substituted IPersistenceManager instances
+            // configure LeaseReader() and may not route the default interface method to it.
+            IPersistence.IPersistenceReader persistenceReader = readerFlags == ReaderFlags.None
+                ? _persistenceManager.LeaseReader()
+                : _persistenceManager.LeaseReader(readerFlags);
             AssembledSnapshotResult assembled;
             try
             {
@@ -312,6 +323,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
             ReadOnlySnapshotBundle res = new(assembled.InMemory, persistenceReader, _enableDetailedMetrics,
                 new PersistedSnapshotStack(assembled.Persisted, _enableDetailedMetrics));
+
+            if (!shareable) return res;
 
             res.TryLease();
             if (!_readonlySnapshotBundleCache.TryAdd(baseBlock, res))

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -73,14 +73,16 @@ public class FlatTrieVerifier
         ArgumentNullException.ThrowIfNull(_flatDbManager);
 
         StateId stateId = new(stateAtBlock);
-        using IPersistence.IPersistenceReader reader = _persistence.CreateReader(ReaderFlags.FullScan);
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
         if (reader.CurrentState != stateId)
         {
             _logger.Warn($"With flat, only the persisted state can be verified. Will use current persisted state: {reader.CurrentState}");
             stateId = reader.CurrentState;
         }
 
-        // FullScan also on the bundle: the trie nodes are read through its persistence reader, not `reader`.
+        // FullScan on the bundle only: trie nodes are read through its persistence reader. `reader` just
+        // serves metadata and range iterators, which never take the readahead path, so it stays flagless
+        // and shares the cached reader instead of pinning a second snapshot.
         using ReadOnlySnapshotBundle bundle = _flatDbManager.GatherReadOnlySnapshotBundle(stateId, ReaderFlags.FullScan);
         ReadOnlyStateTrieStoreAdapter trieStore = new(bundle);
 

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -73,14 +73,15 @@ public class FlatTrieVerifier
         ArgumentNullException.ThrowIfNull(_flatDbManager);
 
         StateId stateId = new(stateAtBlock);
-        using IPersistence.IPersistenceReader reader = _persistence.CreateReader();
+        using IPersistence.IPersistenceReader reader = _persistence.CreateReader(ReaderFlags.FullScan);
         if (reader.CurrentState != stateId)
         {
             _logger.Warn($"With flat, only the persisted state can be verified. Will use current persisted state: {reader.CurrentState}");
             stateId = reader.CurrentState;
         }
 
-        using ReadOnlySnapshotBundle bundle = _flatDbManager.GatherReadOnlySnapshotBundle(stateId);
+        // FullScan also on the bundle: the trie nodes are read through its persistence reader, not `reader`.
+        using ReadOnlySnapshotBundle bundle = _flatDbManager.GatherReadOnlySnapshotBundle(stateId, ReaderFlags.FullScan);
         ReadOnlyStateTrieStoreAdapter trieStore = new(bundle);
 
         return VerifyCore(reader, trieStore, stateId.StateRoot.ToCommitment(), cancellationToken);

--- a/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatTrieVerifier.cs
@@ -209,7 +209,9 @@ public class FlatTrieVerifier
         (ValueHash256 startKey, ValueHash256 endKey) = GetPartitionBounds(partition);
 
         using IPersistence.IFlatIterator flatIter = reader.CreateAccountIterator(startKey, endKey);
-        TrieLeafIterator trieIter = new(trieStore, stateRoot, LogTrieNodeException, startKey, endKey);
+        // Trie node keys are path-ordered, so this forward scan benefits from iterator readahead.
+        TrieNodeResolverWithReadFlags readAheadTrieStore = new(trieStore, ReadFlags.HintReadAhead);
+        TrieLeafIterator trieIter = new(readAheadTrieStore, stateRoot, LogTrieNodeException, startKey, endKey);
 
         bool hasFlat = flatIter.MoveNext();
         bool hasTrie = trieIter.MoveNext();
@@ -648,8 +650,10 @@ public class FlatTrieVerifier
         CancellationToken cancellationToken)
     {
         using IPersistence.IFlatIterator flatIter = reader.CreateStorageIterator(job.FlatAccountKey, startKey, endKey);
+        // Partitioned (whale) scans are long enough for iterator readahead to win; small tries stay on
+        // point gets since readahead iterator seeks skip the bloom filter.
         TrieLeafIterator trieIter = endExclusive
-            ? new(storageTrieStore, job.StorageRoot, LogTrieNodeException, startKey, endKey)
+            ? new(new TrieNodeResolverWithReadFlags(storageTrieStore, ReadFlags.HintReadAhead), job.StorageRoot, LogTrieNodeException, startKey, endKey)
             : new(storageTrieStore, job.StorageRoot, LogTrieNodeException);
 
         bool hasFlat = MoveNextFlat(flatIter, endExclusive, endKey);

--- a/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/IFlatDbManager.cs
@@ -1,12 +1,18 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.State.Flat.Persistence;
+
 namespace Nethermind.State.Flat;
 
 public interface IFlatDbManager : IFlatCommitTarget
 {
     SnapshotBundle GatherSnapshotBundle(in StateId baseBlock, ResourcePool.Usage usage);
     ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock);
+
+    /// <inheritdoc cref="GatherReadOnlySnapshotBundle(in StateId)"/>
+    /// <param name="readerFlags">Forwarded to the persistence reader backing the bundle; implementations may ignore it.</param>
+    ReadOnlySnapshotBundle GatherReadOnlySnapshotBundle(in StateId baseBlock, ReaderFlags readerFlags) => GatherReadOnlySnapshotBundle(baseBlock);
     void FlushCache(CancellationToken cancellationToken);
     bool HasStateForBlock(in StateId stateId);
 }

--- a/src/Nethermind/Nethermind.State.Flat/IPersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/IPersistenceManager.cs
@@ -8,6 +8,10 @@ namespace Nethermind.State.Flat;
 public interface IPersistenceManager
 {
     IPersistence.IPersistenceReader LeaseReader();
+
+    /// <inheritdoc cref="LeaseReader()"/>
+    /// <param name="flags">Forwarded to <see cref="IPersistence.CreateReader"/>; implementations may ignore it.</param>
+    IPersistence.IPersistenceReader LeaseReader(ReaderFlags flags) => LeaseReader();
     StateId GetCurrentPersistedStateId();
     Task AddToPersistence(StateId latestSnapshot);
     StateId FlushToPersistence();

--- a/src/Nethermind/Nethermind.State.Flat/IPersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/IPersistenceManager.cs
@@ -7,11 +7,8 @@ namespace Nethermind.State.Flat;
 
 public interface IPersistenceManager
 {
-    IPersistence.IPersistenceReader LeaseReader();
-
-    /// <inheritdoc cref="LeaseReader()"/>
     /// <param name="flags">Forwarded to <see cref="IPersistence.CreateReader"/>; implementations may ignore it.</param>
-    IPersistence.IPersistenceReader LeaseReader(ReaderFlags flags) => LeaseReader();
+    IPersistence.IPersistenceReader LeaseReader(ReaderFlags flags = ReaderFlags.None);
     StateId GetCurrentPersistedStateId();
     Task AddToPersistence(StateId latestSnapshot);
     StateId FlushToPersistence();

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/CachedReaderPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/CachedReaderPersistence.cs
@@ -57,7 +57,8 @@ public class CachedReaderPersistence : IPersistence, IAsyncDisposable
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
-        if ((flags & ReaderFlags.Sync) != 0)
+        // The cached reader is created flagless, so flagged requests must go to the inner persistence directly.
+        if ((flags & (ReaderFlags.Sync | ReaderFlags.FullScan)) != 0)
             return _inner.CreateReader(flags);
 
         RefCountingPersistenceReader? cachedReader = _cachedReader;

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/FlatInTriePersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/FlatInTriePersistence.cs
@@ -23,7 +23,7 @@ public class FlatInTriePersistence(IColumnsDb<FlatDbColumns> db, ILogManager log
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
-        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot();
+        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot((flags & ReaderFlags.FullScan) != 0);
         try
         {
             BaseTriePersistence.Reader trieReader = new(

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -13,6 +13,13 @@ public enum ReaderFlags
 {
     None = 0,
     Sync = 1,
+
+    /// <summary>
+    /// The reader serves long sequential scans (e.g. flat-trie verification): backing snapshots may enable
+    /// readahead iterators for <see cref="ReadFlags.HintReadAhead"/> reads, and reader caches are bypassed
+    /// so the hint reaches the storage layer.
+    /// </summary>
+    FullScan = 2,
 }
 
 public interface IPersistence

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/IPersistence.cs
@@ -16,8 +16,8 @@ public enum ReaderFlags
 
     /// <summary>
     /// The reader serves long sequential scans (e.g. flat-trie verification): backing snapshots may enable
-    /// readahead iterators for <see cref="ReadFlags.HintReadAhead"/> reads, and reader caches are bypassed
-    /// so the hint reaches the storage layer.
+    /// readahead iterators for <see cref="ReadFlags.HintReadAhead"/> reads, and the shared reader cache in
+    /// <see cref="CachedReaderPersistence"/> is bypassed so the hint reaches the storage layer.
     /// </summary>
     FullScan = 2,
 }

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/PreimageRocksdbPersistence.cs
@@ -41,7 +41,7 @@ public class PreimageRocksdbPersistence(IColumnsDb<FlatDbColumns> db, ILogManage
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
-        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot();
+        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot((flags & ReaderFlags.FullScan) != 0);
         BaseTriePersistence.Reader trieReader = new(
             snapshot.GetColumn(FlatDbColumns.StateTopNodes),
             snapshot.GetColumn(FlatDbColumns.StateNodes),

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/RocksDbPersistence.cs
@@ -19,7 +19,7 @@ public class RocksDbPersistence(IColumnsDb<FlatDbColumns> db, ILogManager logMan
 
     public IPersistence.IPersistenceReader CreateReader(ReaderFlags flags = ReaderFlags.None)
     {
-        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot();
+        IColumnDbSnapshot<FlatDbColumns> snapshot = db.CreateSnapshot((flags & ReaderFlags.FullScan) != 0);
         try
         {
             BaseTriePersistence.Reader trieReader = new(

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -72,9 +72,7 @@ public class PersistenceManager(
         set => Volatile.Write(ref _currentPersistedState, new StrongBox<StateId>(value));
     }
 
-    public IPersistence.IPersistenceReader LeaseReader() => persistence.CreateReader();
-
-    public IPersistence.IPersistenceReader LeaseReader(ReaderFlags flags) => persistence.CreateReader(flags);
+    public IPersistence.IPersistenceReader LeaseReader(ReaderFlags flags = ReaderFlags.None) => persistence.CreateReader(flags);
 
     public StateId GetCurrentPersistedStateId()
     {

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -74,6 +74,8 @@ public class PersistenceManager(
 
     public IPersistence.IPersistenceReader LeaseReader() => persistence.CreateReader();
 
+    public IPersistence.IPersistenceReader LeaseReader(ReaderFlags flags) => persistence.CreateReader(flags);
+
     public StateId GetCurrentPersistedStateId()
     {
         StateId current = CurrentPersistedStateId;


### PR DESCRIPTION
## Changes

- Make `ReadFlags.HintReadAhead` effective for the Flat verifier's snapshot reads — **behind an explicit opt-in that only the verifier uses**. `RocksDbReader.Get` only takes the readahead-iterator path when it has an `IteratorManager`, and `ColumnDbSnapshot` built its readers without one, so every verifier trie-node load was a point-Get despite path-ordered keys.
- **Opt-in gate** (nothing changes for any other consumer): `IColumnsDb<T>.CreateSnapshot(bool sequentialReadAhead)` (default interface method — an ignorable hint, no implementer breaks) reached via a new Flat `ReaderFlags.FullScan`. The flag flows through both read paths the verifier uses: its direct `IPersistence.CreateReader(FullScan)` **and** `IFlatDbManager.GatherReadOnlySnapshotBundle(stateId, FullScan)` → `PersistenceManager.LeaseReader(FullScan)` — the latter is where trie-node loads actually happen. `FullScan` bundles bypass the shared bundle cache on both lookup and insert, so ordinary consumers (SnapServer — which sends `HintReadAhead` through flat snapshots since flat reports the HalfPath scheme —, `PatriciaTree` scans, per-block write-batch snapshots) can never inherit a readahead-capable reader and keep master-exact point-Get behavior.
- **Make the fast path reachable for flat key shapes**: `TryCloseReadAhead` rejects keys ≤ 32 bytes ("probably hash db" heuristic), but flat trie-node keys are 3–28 bytes on the dominant columns (`StateTopNodes`/`StateNodes`/`StorageNodes`). Opted-in managers carry `SequentialKeys`, which lifts that guard; the UInt64 distance heuristic is skipped when either key is under 8 bytes (bounded 5-step probe still applies), and `Next()` exhausting the iterator is now guarded (`Valid()` checks).
- `ColumnDbSnapshot` iterator managers are lazy end to end: the `Timer`/`ThreadLocal` pools materialize on first rent, and the snapshot-scoped `ReadOptions` (deliberately non-tailing — tailing iterators ignore snapshots) is CAS-created on the first `HintReadAhead` read. Snapshot `Dispose` tears managers down before releasing anything they read through.
- `FlatTrieVerifier`: the account-pass `TrieLeafIterator` and the partitioned whale-storage ranges resolve trie nodes through `TrieNodeResolverWithReadFlags(..., HintReadAhead)`, layered outside `HashVerifyingTrieStore` so hash verification is preserved. Small storage tries stay on point-Gets.

### Why

Follow-up to #12615 ("the next big verify lever" from its remarks). Flat verification is dominated by trie-node loads (~14 µs/slot measured single-thread, mostly `Get` cost); `iterator.Next()` on a forward scan is 10–20× cheaper than a seek or point-Get, and the verifier's reads are exactly path-ordered. The trie full-scan visitor already relies on the same mechanism through the main DB.

### Review history

The first cut wired managers into every snapshot reader unconditionally; review (correctly) flagged that (a) the ≤32-byte guard made the fast path unreachable for flat columns and (b) SnapServer's peer-facing random-access reads would inherit iterator seeks. Both addressed by the opt-in + `SequentialKeys` design above; tracing the fix also revealed the trie-node loads flow through the snapshot-bundle reader, not the verifier's own reader, which the gate now covers.

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `Snapshot_Get_WithHintReadAhead_ReadsFromSnapshot`: opt-in snapshot, 32 ascending 8-byte keys + 32 ascending 34-byte keys (short-key fast path and the length-change boundary), snapshot isolation under head overwrites/deletes, miss probe past the last key (pins the iterator-exhaustion edge), head DB usable after snapshot dispose.
- `Snapshot_Default_HasNoIteratorManager`: pins the gating — flagless snapshots get no iterator managers.
- `Nethermind.Db.Test`: 555 passed / 544 skipped / 0 failed. `Nethermind.State.Flat.Test`: 913 passed / 8 skipped / 0 failed.
- A/B validation on real CI (image `nethermindeth/nethermind:flat-verifier-readahead`), run [30545506031](https://github.com/NethermindEth/nethermind/actions/runs/30545506031) vs baseline run [30510874500](https://github.com/NethermindEth/nethermind/actions/runs/30510874500) (parent branch image):

  | Chain | Verify (baseline → this PR) | Job total |
  |---|---|---|
  | gnosis | 69.6 → **28.7 min (−59%)** | 203.3 → 170.4 min |
  | mainnet | 100.0 → **77.6 min (−22%)** | 245.8 → 237.8 min |

  Verification counters clean on both chains (`MismatchedAccounts=0, MismatchedSlots=0, MissingInFlat=0, MissingInTrie=0`; mainnet 406.5 M accounts / 1.62 B slots, gnosis 11.1 M / 1.15 B), no `Exception` / invalid-block signals. The snap/download phase (untouched by this PR) ran 12–15 min slower than baseline on both chains within its usual run-to-run spread, so the job-total deltas understate the verify win.
- EXPB reproducible benchmarks (run [30542717612](https://github.com/NethermindEth/nethermind/actions/runs/30542717612)): superblocks AVG −3.75% / P95 −23.65%, realblocks within noise — confirms the gate keeps live-sync block processing unaffected.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Left for follow-ups: `DbOnTheRocks.RocksDbSnapshot` (non-column snapshots) has no iterator manager; preimage-mode pass 2 is not wrapped; `HintReadAhead2/3` slots unused by the verifier.

