### PR TITLE
EIP-8141: validation-prefix simulation admission for frame transactions (MAX_VERIFY_GAS bound)

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip8141Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8141Constants.cs
@@ -23,6 +23,7 @@ public static class Eip8141Constants
     public const ulong MaxVerifyGas = 100_000;
 
     /// <summary>Per-signature verification gas for <paramref name="scheme"/>, as counted against <see cref="MaxVerifyGas"/>.</summary>
+    /// <remarks>The <c>_ => 0</c> fallback is only safe because <c>FrameTxValidation</c> rejects an unknown scheme before this is reached; otherwise it would price such a signature for free.</remarks>
     public static ulong SignatureVerificationGasCost(byte scheme) => scheme switch
     {
         TxFrameSignature.SchemeArbitrary => ArbitraryVerificationGasCost,

--- a/src/Nethermind/Nethermind.Core/Eip8141Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8141Constants.cs
@@ -19,6 +19,18 @@ public static class Eip8141Constants
     public const ulong P256VerificationGasCost = 6_700;
     public const int ExpiryDataLength = 8;
 
+    /// <summary>Maximum gas a node expends validating signatures and the validation prefix at admission (ethereum/EIPs#12007).</summary>
+    public const ulong MaxVerifyGas = 100_000;
+
+    /// <summary>Per-signature verification gas for <paramref name="scheme"/>, as counted against <see cref="MaxVerifyGas"/>.</summary>
+    public static ulong SignatureVerificationGasCost(byte scheme) => scheme switch
+    {
+        TxFrameSignature.SchemeArbitrary => ArbitraryVerificationGasCost,
+        TxFrameSignature.SchemeSecp256k1 => Secp256k1VerificationGasCost,
+        TxFrameSignature.SchemeP256 => P256VerificationGasCost,
+        _ => 0,
+    };
+
     public static readonly Address EntryPointAddress = new("0x00000000000000000000000000000000000000aa");
     public static readonly Address ExpiryVerifierAddress = new("0x0000000000000000000000000000000000008141");
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -344,13 +344,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 tokens += signature.Signer is null ? 0 : CountCalldataTokens(signature.Signer.Bytes, spec);
                 tokens += CountCalldataTokens(signature.Msg.Span, spec);
                 tokens += CountCalldataTokens(signature.Signature.Span, spec);
-                signatureVerificationCost += signature.Scheme switch
-                {
-                    TxFrameSignature.SchemeArbitrary => Eip8141Constants.ArbitraryVerificationGasCost,
-                    TxFrameSignature.SchemeSecp256k1 => Eip8141Constants.Secp256k1VerificationGasCost,
-                    TxFrameSignature.SchemeP256 => Eip8141Constants.P256VerificationGasCost,
-                    _ => 0,
-                };
+                signatureVerificationCost += Eip8141Constants.SignatureVerificationGasCost(signature.Scheme);
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTests.cs
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using Nethermind.Core;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.TxPool.Filters;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.TxPool.Test;
+
+/// <summary>
+/// EIP-8141 <c>MAX_VERIFY_GAS</c> admission bound: a frame tx is rejected once its validation-prefix
+/// gas plus signature-validation cost exceeds the budget, and accepted while it stays within.
+/// </summary>
+public class FrameTxVerifyGasFilterTests
+{
+    private static readonly Address Sender = TestItem.AddressA;
+    private static readonly Address Sponsor = TestItem.AddressB;
+
+    // secp256k1 verification = 2_800, so the prefix gas budget below it is 97_200.
+    private const ulong SecpCost = Eip8141Constants.Secp256k1VerificationGasCost;
+
+    [Test]
+    public void Accept_SelfVerify_WithinBudget_Accepted()
+    {
+        // 90_000 prefix gas + 2_800 signature = 92_800 <= 100_000.
+        Transaction tx = FrameTx([SelfVerify(90_000)], [Secp(Sender)]);
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+    }
+
+    [Test]
+    public void Accept_SelfVerify_AtBudget_Accepted()
+    {
+        // Exactly MAX_VERIFY_GAS: (100_000 - 2_800) prefix gas + 2_800 signature = 100_000.
+        Transaction tx = FrameTx([SelfVerify(Eip8141Constants.MaxVerifyGas - SecpCost)], [Secp(Sender)]);
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+    }
+
+    [Test]
+    public void Accept_SelfVerify_OneOverBudget_Rejected()
+    {
+        // One gas over: prefix (100_000 - 2_800 + 1) + 2_800 signature = 100_001.
+        Transaction tx = FrameTx([SelfVerify(Eip8141Constants.MaxVerifyGas - SecpCost + 1)], [Secp(Sender)]);
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.VerifyGasExceeded));
+    }
+
+    [Test]
+    public void Accept_SignatureCostAlonePushesOverBudget_Rejected()
+    {
+        // Prefix gas is within budget, but two secp256k1 signatures (5_600) tip the total over.
+        Transaction tx = FrameTx([OnlyVerify(Eip8141Constants.MaxVerifyGas - SecpCost), Pay(Sponsor, 0)], [Secp(Sender), Secp(Sponsor)]);
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.VerifyGasExceeded));
+    }
+
+    [Test]
+    public void Accept_OnlyVerifyPay_SummedPrefixGasOverBudget_Rejected()
+    {
+        // The pay frame's gas counts toward the prefix: 60_000 + 60_000 + 2_800 > 100_000.
+        Transaction tx = FrameTx([OnlyVerify(60_000), Pay(Sponsor, 60_000)], [Secp(Sender), Secp(Sponsor)]);
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.VerifyGasExceeded));
+    }
+
+    [Test]
+    public void Accept_ExpiryFrameGasCountsTowardPrefix()
+    {
+        // expiry (50_000) + self_verify (48_000) + 2_800 = 100_800 > 100_000.
+        Transaction tx = FrameTx([Expiry(9999, 50_000), SelfVerify(48_000)], [Secp(Sender)]);
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.VerifyGasExceeded));
+    }
+
+    [Test]
+    public void Accept_FramesAfterPrefix_NotCounted()
+    {
+        // A huge user_op after the self_verify prefix does not count toward the verify-gas bound.
+        Transaction tx = FrameTx([SelfVerify(10_000), Frame(TxFrame.ModeSender, ulong.MaxValue / 2)], [Secp(Sender)]);
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+    }
+
+    [Test]
+    public void Accept_UnrecognizedPrefix_PassesThrough()
+    {
+        // A leading DEFAULT (deploy) frame is not analyzed here; the bound is not enforced (deferred).
+        Transaction tx = FrameTx([Frame(TxFrame.ModeDefault, ulong.MaxValue / 2), SelfVerify(10_000)], [Secp(Sender)]);
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+    }
+
+    [Test]
+    public void Accept_PrefixGasOverflow_Rejected()
+    {
+        Transaction tx = FrameTx([OnlyVerify(ulong.MaxValue), Pay(Sponsor, 10)], [Secp(Sender)]);
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.VerifyGasExceeded));
+    }
+
+    [Test]
+    public void Accept_NonFrameTx_PassesThrough()
+    {
+        Transaction tx = Build.A.Transaction.WithSenderAddress(Sender).WithGasLimit(long.MaxValue).TestObject;
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+    }
+
+    private static AcceptTxResult Accept(Transaction tx)
+    {
+        FrameTxVerifyGasFilter filter = new(LimboLogs.Instance.GetClassLogger<FrameTxVerifyGasFilterTests>());
+        TxFilteringState filteringState = new(tx, Substitute.For<IAccountStateProvider>());
+        return filter.Accept(tx, ref filteringState, TxHandlingOptions.None);
+    }
+
+    private static Transaction FrameTx(TxFrame[] frames, TxFrameSignature[] signatures) => new()
+    {
+        Type = TxType.FrameTx,
+        SenderAddress = Sender,
+        Frames = frames,
+        FrameSignatures = signatures,
+    };
+
+    private static TxFrameSignature Secp(Address signer) =>
+        new(TxFrameSignature.SchemeSecp256k1, signer, default, new byte[TxFrameSignature.Secp256k1SignatureLength]);
+
+    private static TxFrame SelfVerify(ulong gasLimit) =>
+        new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit, UInt256.Zero, default);
+
+    private static TxFrame OnlyVerify(ulong gasLimit) =>
+        new(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit, UInt256.Zero, default);
+
+    private static TxFrame Pay(Address target, ulong gasLimit) =>
+        new(TxFrame.ModeVerify, TxFrame.ApprovePayment, target, gasLimit, UInt256.Zero, default);
+
+    private static TxFrame Frame(byte mode, ulong gasLimit) =>
+        new(mode, flags: 0, target: null, gasLimit, UInt256.Zero, default);
+
+    private static TxFrame Expiry(ulong deadline, ulong gasLimit)
+    {
+        byte[] data = new byte[Eip8141Constants.ExpiryDataLength];
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64BigEndian(data, deadline);
+        return new TxFrame(TxFrame.ModeVerify, flags: 0, Eip8141Constants.ExpiryVerifierAddress, gasLimit, UInt256.Zero, data);
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTests.cs
@@ -3,8 +3,8 @@
 
 #nullable enable
 
+using System.Collections.Generic;
 using Nethermind.Core;
-using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -23,102 +23,93 @@ public class FrameTxVerifyGasFilterTests
     private static readonly Address Sender = TestItem.AddressA;
     private static readonly Address Sponsor = TestItem.AddressB;
 
-    // secp256k1 verification = 2_800, so the prefix gas budget below it is 97_200.
-    private const ulong SecpCost = Eip8141Constants.Secp256k1VerificationGasCost;
+    // Per-scheme signature-verification costs counted against MAX_VERIFY_GAS.
+    private const ulong SecpCost = Eip8141Constants.Secp256k1VerificationGasCost;   // 2_800
+    private const ulong P256Cost = Eip8141Constants.P256VerificationGasCost;        // 6_700
+    private const ulong ArbitraryCost = Eip8141Constants.ArbitraryVerificationGasCost; // 100
+    private const ulong Max = Eip8141Constants.MaxVerifyGas;                        // 100_000
 
-    [Test]
-    public void Accept_SelfVerify_WithinBudget_Accepted()
+    private static IEnumerable<TestCaseData> VerifyGasCases()
     {
-        // 90_000 prefix gas + 2_800 signature = 92_800 <= 100_000.
-        Transaction tx = FrameTx([SelfVerify(90_000)], [Secp(Sender)]);
+        // self_verify: the single verify frame is the whole prefix.
+        yield return Case("self_verify within budget", [SelfVerify(90_000)], [Secp(Sender)], AcceptTxResult.Accepted);
+        yield return Case("self_verify at budget", [SelfVerify(Max - SecpCost)], [Secp(Sender)], AcceptTxResult.Accepted);
+        yield return Case("self_verify one over budget", [SelfVerify(Max - SecpCost + 1)], [Secp(Sender)], AcceptTxResult.VerifyGasExceeded);
 
-        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+        // only_verify + pay: both frames are in the prefix; both signatures are counted.
+        yield return Case("signature cost alone pushes over budget",
+            [OnlyVerify(Max - SecpCost), Pay(Sponsor, 0)], [Secp(Sender), Secp(Sponsor)], AcceptTxResult.VerifyGasExceeded);
+        yield return Case("only_verify+pay summed prefix gas over budget",
+            [OnlyVerify(60_000), Pay(Sponsor, 60_000)], [Secp(Sender), Secp(Sponsor)], AcceptTxResult.VerifyGasExceeded);
+
+        // A leading expiry_verify frame is skipped for shape matching but its gas counts.
+        yield return Case("expiry frame gas counts toward prefix",
+            [Expiry(9999, 50_000), SelfVerify(48_000)], [Secp(Sender)], AcceptTxResult.VerifyGasExceeded);
+
+        // Frames after the prefix are not counted.
+        yield return Case("frames after prefix not counted",
+            [SelfVerify(10_000), Frame(TxFrame.ModeSender, ulong.MaxValue / 2)], [Secp(Sender)], AcceptTxResult.Accepted);
+
+        // Unrecognized prefixes (e.g. a leading deploy frame) and expiry-only prefixes are not bounded here.
+        yield return Case("unrecognized (deploy-led) prefix passes through",
+            [Frame(TxFrame.ModeDefault, ulong.MaxValue / 2), SelfVerify(10_000)], [Secp(Sender)], AcceptTxResult.Accepted);
+        yield return Case("expiry-only prefix has no verify frame, passes through",
+            [Expiry(9999, ulong.MaxValue / 2)], [], AcceptTxResult.Accepted);
+
+        // Overflow in the summed prefix gas is treated as definitively over budget.
+        yield return Case("prefix gas overflow rejected",
+            [OnlyVerify(ulong.MaxValue), Pay(Sponsor, 10)], [Secp(Sender)], AcceptTxResult.VerifyGasExceeded);
+
+        // P256 signature cost (6_700) exercises the P256 branch of the scheme→cost switch.
+        yield return Case("P256 signature at budget", [SelfVerify(Max - P256Cost)], [P256(Sender)], AcceptTxResult.Accepted);
+        yield return Case("P256 signature one over budget", [SelfVerify(Max - P256Cost + 1)], [P256(Sender)], AcceptTxResult.VerifyGasExceeded);
+
+        // Arbitrary signature cost (100) exercises the Arbitrary branch.
+        yield return Case("arbitrary signature at budget", [SelfVerify(Max - ArbitraryCost)], [Arbitrary()], AcceptTxResult.Accepted);
+        yield return Case("arbitrary signature one over budget", [SelfVerify(Max - ArbitraryCost + 1)], [Arbitrary()], AcceptTxResult.VerifyGasExceeded);
+
+        // Mixed-scheme signatures (secp256k1 2_800 + P256 6_700 = 9_500) are summed per scheme.
+        yield return Case("mixed-scheme signatures at budget",
+            [OnlyVerify(Max - SecpCost - P256Cost - 500), Pay(Sponsor, 500)], [Secp(Sender), P256(Sponsor)], AcceptTxResult.Accepted);
+        yield return Case("mixed-scheme signatures one over budget",
+            [OnlyVerify(Max - SecpCost - P256Cost - 500), Pay(Sponsor, 501)], [Secp(Sender), P256(Sponsor)], AcceptTxResult.VerifyGasExceeded);
     }
 
-    [Test]
-    public void Accept_SelfVerify_AtBudget_Accepted()
-    {
-        // Exactly MAX_VERIFY_GAS: (100_000 - 2_800) prefix gas + 2_800 signature = 100_000.
-        Transaction tx = FrameTx([SelfVerify(Eip8141Constants.MaxVerifyGas - SecpCost)], [Secp(Sender)]);
-
-        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
-    }
+    [TestCaseSource(nameof(VerifyGasCases))]
+    public AcceptTxResult BoundsVerifyGas(TxFrame[] frames, TxFrameSignature[] signatures) =>
+        Accept(FrameTx(frames, signatures));
 
     [Test]
-    public void Accept_SelfVerify_OneOverBudget_Rejected()
-    {
-        // One gas over: prefix (100_000 - 2_800 + 1) + 2_800 signature = 100_001.
-        Transaction tx = FrameTx([SelfVerify(Eip8141Constants.MaxVerifyGas - SecpCost + 1)], [Secp(Sender)]);
-
-        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.VerifyGasExceeded));
-    }
-
-    [Test]
-    public void Accept_SignatureCostAlonePushesOverBudget_Rejected()
-    {
-        // Prefix gas is within budget, but two secp256k1 signatures (5_600) tip the total over.
-        Transaction tx = FrameTx([OnlyVerify(Eip8141Constants.MaxVerifyGas - SecpCost), Pay(Sponsor, 0)], [Secp(Sender), Secp(Sponsor)]);
-
-        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.VerifyGasExceeded));
-    }
-
-    [Test]
-    public void Accept_OnlyVerifyPay_SummedPrefixGasOverBudget_Rejected()
-    {
-        // The pay frame's gas counts toward the prefix: 60_000 + 60_000 + 2_800 > 100_000.
-        Transaction tx = FrameTx([OnlyVerify(60_000), Pay(Sponsor, 60_000)], [Secp(Sender), Secp(Sponsor)]);
-
-        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.VerifyGasExceeded));
-    }
-
-    [Test]
-    public void Accept_ExpiryFrameGasCountsTowardPrefix()
-    {
-        // expiry (50_000) + self_verify (48_000) + 2_800 = 100_800 > 100_000.
-        Transaction tx = FrameTx([Expiry(9999, 50_000), SelfVerify(48_000)], [Secp(Sender)]);
-
-        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.VerifyGasExceeded));
-    }
-
-    [Test]
-    public void Accept_FramesAfterPrefix_NotCounted()
-    {
-        // A huge user_op after the self_verify prefix does not count toward the verify-gas bound.
-        Transaction tx = FrameTx([SelfVerify(10_000), Frame(TxFrame.ModeSender, ulong.MaxValue / 2)], [Secp(Sender)]);
-
-        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
-    }
-
-    [Test]
-    public void Accept_UnrecognizedPrefix_PassesThrough()
-    {
-        // A leading DEFAULT (deploy) frame is not analyzed here; the bound is not enforced (deferred).
-        Transaction tx = FrameTx([Frame(TxFrame.ModeDefault, ulong.MaxValue / 2), SelfVerify(10_000)], [Secp(Sender)]);
-
-        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
-    }
-
-    [Test]
-    public void Accept_PrefixGasOverflow_Rejected()
-    {
-        Transaction tx = FrameTx([OnlyVerify(ulong.MaxValue), Pay(Sponsor, 10)], [Secp(Sender)]);
-
-        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.VerifyGasExceeded));
-    }
-
-    [Test]
-    public void Accept_NonFrameTx_PassesThrough()
+    public void NonFrameTx_PassesThrough()
     {
         Transaction tx = Build.A.Transaction.WithSenderAddress(Sender).WithGasLimit(long.MaxValue).TestObject;
 
         Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
     }
 
-    private static AcceptTxResult Accept(Transaction tx)
+    [Test]
+    public void LocalTx_ExemptFromBound()
+    {
+        // The bound targets gossiped public-mempool traffic; a locally-submitted over-budget tx is exempt.
+        Transaction tx = FrameTx([SelfVerify(Max)], [Secp(Sender)]);
+
+        Assert.That(Accept(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+    }
+
+    [TestCase(TxFrameSignature.SchemeArbitrary, ArbitraryCost)]
+    [TestCase(TxFrameSignature.SchemeSecp256k1, SecpCost)]
+    [TestCase(TxFrameSignature.SchemeP256, P256Cost)]
+    public void SignatureVerificationGasCost_MapsSchemeToConstant(byte scheme, ulong expected) =>
+        Assert.That(Eip8141Constants.SignatureVerificationGasCost(scheme), Is.EqualTo(expected));
+
+    private static TestCaseData Case(string name, TxFrame[] frames, TxFrameSignature[] signatures, AcceptTxResult expected) =>
+        new TestCaseData(frames, signatures).Returns(expected).SetName(name);
+
+    private static AcceptTxResult Accept(Transaction tx, TxHandlingOptions handlingOptions = TxHandlingOptions.None)
     {
         FrameTxVerifyGasFilter filter = new(LimboLogs.Instance.GetClassLogger<FrameTxVerifyGasFilterTests>());
         TxFilteringState filteringState = new(tx, Substitute.For<IAccountStateProvider>());
-        return filter.Accept(tx, ref filteringState, TxHandlingOptions.None);
+        return filter.Accept(tx, ref filteringState, handlingOptions);
     }
 
     private static Transaction FrameTx(TxFrame[] frames, TxFrameSignature[] signatures) => new()
@@ -131,6 +122,12 @@ public class FrameTxVerifyGasFilterTests
 
     private static TxFrameSignature Secp(Address signer) =>
         new(TxFrameSignature.SchemeSecp256k1, signer, default, new byte[TxFrameSignature.Secp256k1SignatureLength]);
+
+    private static TxFrameSignature P256(Address signer) =>
+        new(TxFrameSignature.SchemeP256, signer, default, default);
+
+    private static TxFrameSignature Arbitrary() =>
+        new(TxFrameSignature.SchemeArbitrary, signer: null, default, default);
 
     private static TxFrame SelfVerify(ulong gasLimit) =>
         new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit, UInt256.Zero, default);

--- a/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
+++ b/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
@@ -124,6 +124,11 @@ namespace Nethermind.TxPool
         /// </summary>
         public static readonly AcceptTxResult PayerExposureExceeded = new(20, TxPoolErrorMessages.PayerExposureExceeded);
 
+        /// <summary>
+        /// An EIP-8141 frame transaction whose validation-prefix gas plus signature-validation cost exceeds <c>MAX_VERIFY_GAS</c>.
+        /// </summary>
+        public static readonly AcceptTxResult VerifyGasExceeded = new(21, TxPoolErrorMessages.VerifyGasExceeded);
+
         private int Id { get; } = id;
         private string Code { get; } = code;
         private string? Message { get; } = message;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Logging;
+
+namespace Nethermind.TxPool.Filters;
+
+/// <summary>
+/// Enforces the EIP-8141 <c>MAX_VERIFY_GAS</c> admission bound: rejects a frame transaction whose
+/// validation-prefix gas plus signature-validation cost exceeds <see cref="Eip8141Constants.MaxVerifyGas"/>.
+/// </summary>
+/// <remarks>
+/// State-free structural gate, so it runs first among the EIP-8141 post-hash filters. Only frame txs
+/// with a recognized validation prefix are bounded; other txs pass through (structural-match gate
+/// deferred). This is the Direct Evaluation form of the bound and needs no simulation
+/// (ethereum/EIPs#12007, "the sum of gas_limit values across the validation prefix, plus the intrinsic
+/// cost of validating tx.signatures, must not exceed MAX_VERIFY_GAS").
+/// https://eips.ethereum.org/EIPS/eip-8141
+/// </remarks>
+internal sealed class FrameTxVerifyGasFilter(ILogger logger) : IIncomingTxFilter
+{
+    public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
+    {
+        if (!tx.SupportsFrames || !FrameTxPayerResolver.TryGetValidationPrefixVerifyGas(tx, out ulong verifyGas))
+        {
+            return AcceptTxResult.Accepted;
+        }
+
+        if (verifyGas > Eip8141Constants.MaxVerifyGas)
+        {
+            if (logger.IsTrace)
+                logger.Trace($"Skipped adding frame transaction {tx.Hash}, validation-prefix verify gas {verifyGas} exceeds MAX_VERIFY_GAS {Eip8141Constants.MaxVerifyGas}.");
+            return AcceptTxResult.VerifyGasExceeded;
+        }
+
+        return AcceptTxResult.Accepted;
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -11,18 +11,22 @@ namespace Nethermind.TxPool.Filters;
 /// validation-prefix gas plus signature-validation cost exceeds <see cref="Eip8141Constants.MaxVerifyGas"/>.
 /// </summary>
 /// <remarks>
-/// State-free structural gate, so it runs first among the EIP-8141 post-hash filters. Only frame txs
-/// with a recognized validation prefix are bounded; other txs pass through (structural-match gate
+/// State-free structural gate, so it runs right after <c>MalformedTxFilter</c> (which recovers the
+/// sender and establishes a well-formed frame array) and before any state-reading filter. Only frame
+/// txs with a recognized validation prefix are bounded; other txs pass through (structural-match gate
 /// deferred). This is the Direct Evaluation form of the bound and needs no simulation
 /// (ethereum/EIPs#12007, "the sum of gas_limit values across the validation prefix, plus the intrinsic
-/// cost of validating tx.signatures, must not exceed MAX_VERIFY_GAS").
+/// cost of validating tx.signatures, must not exceed MAX_VERIFY_GAS"). The bound targets gossiped
+/// public-mempool traffic, so locally-submitted (persistent-broadcast) txs — the operator's own — are
+/// exempt; an over-budget local tx still won't propagate, as peers apply the same bound.
 /// https://eips.ethereum.org/EIPS/eip-8141
 /// </remarks>
 internal sealed class FrameTxVerifyGasFilter(ILogger logger) : IIncomingTxFilter
 {
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        if (!tx.SupportsFrames || !FrameTxPayerResolver.TryGetValidationPrefixVerifyGas(tx, out ulong verifyGas))
+        bool isLocal = (txHandlingOptions & TxHandlingOptions.PersistentBroadcast) != 0;
+        if (isLocal || !tx.SupportsFrames || !FrameTxPayerResolver.TryGetValidationPrefixVerifyGas(tx, out ulong verifyGas))
         {
             return AcceptTxResult.Accepted;
         }

--- a/src/Nethermind/Nethermind.TxPool/FrameTxPayerResolver.cs
+++ b/src/Nethermind/Nethermind.TxPool/FrameTxPayerResolver.cs
@@ -134,6 +134,76 @@ internal static class FrameTxPayerResolver
     }
 
     /// <summary>
+    /// Computes the EIP-8141 validation-prefix verification gas of <paramref name="tx"/> — the sum of
+    /// <c>gas_limit</c> across the validation-prefix frames plus the intrinsic cost of validating
+    /// <c>tx.signatures</c> — which admission bounds by <see cref="Eip8141Constants.MaxVerifyGas"/>.
+    /// </summary>
+    /// <remarks>
+    /// State-free structural analysis: the prefix span depends only on frame shapes, so it applies to
+    /// the recognized shapes whether or not the payer resolves natively. This is the Direct Evaluation
+    /// form of the bound (ethereum/EIPs#12007 "Direct evaluation MUST apply the same limits as
+    /// simulation"); no EVM execution is needed. Returns <c>false</c> when the prefix is not one of the
+    /// recognized shapes (bound not computable here; structural-match gate deferred). Arithmetic
+    /// overflow is reported as <see cref="ulong.MaxValue"/> so the caller treats it as over budget.
+    /// <c>deploy</c>-prefixed shapes are not analyzed here (deferred with the simulation layer).
+    /// </remarks>
+    /// <returns><c>true</c> with <paramref name="verifyGas"/> set for a recognized prefix; otherwise <c>false</c>.</returns>
+    public static bool TryGetValidationPrefixVerifyGas(Transaction tx, out ulong verifyGas)
+    {
+        verifyGas = 0;
+        TxFrame[]? frames = tx.Frames;
+        Address? sender = tx.SenderAddress;
+        if (frames is null || frames.Length == 0 || sender is null)
+        {
+            return false;
+        }
+
+        // A leading expiry_verify frame is skipped for shape matching but counts toward the prefix gas.
+        int index = IsExpiryVerifyFrame(frames[0]) ? 1 : 0;
+        if (index >= frames.Length)
+        {
+            return false;
+        }
+
+        int prefixLength;
+        TxFrame verifyFrame = frames[index];
+        if (IsSelfVerify(verifyFrame, sender))
+        {
+            prefixLength = index + 1;
+        }
+        else if (IsOnlyVerify(verifyFrame, sender) && index + 1 < frames.Length && IsPay(frames[index + 1]))
+        {
+            prefixLength = index + 2;
+        }
+        else
+        {
+            return false;
+        }
+
+        ulong prefixGas = 0;
+        for (int i = 0; i < prefixLength; i++)
+        {
+            ulong next = prefixGas + frames[i].GasLimit;
+            if (next < prefixGas)
+            {
+                verifyGas = ulong.MaxValue;
+                return true;
+            }
+            prefixGas = next;
+        }
+
+        ulong signatureCost = 0;
+        foreach (TxFrameSignature signature in tx.FrameSignatures ?? [])
+        {
+            signatureCost += Eip8141Constants.SignatureVerificationGasCost(signature.Scheme);
+        }
+
+        ulong total = prefixGas + signatureCost;
+        verifyGas = total < prefixGas ? ulong.MaxValue : total;
+        return true;
+    }
+
+    /// <summary>
     /// Mirrors the execution default-code VERIFY approval check for a self_verify prefix: an index-0
     /// canonical-hash (empty <c>msg</c>) secp256k1 signature whose resolved signer is the sender.
     /// Cryptographic verification is a separate deferred gate; this checks only the structural conditions.

--- a/src/Nethermind/Nethermind.TxPool/FrameTxPayerResolver.cs
+++ b/src/Nethermind/Nethermind.TxPool/FrameTxPayerResolver.cs
@@ -148,7 +148,7 @@ internal static class FrameTxPayerResolver
     /// <c>deploy</c>-prefixed shapes are not analyzed here (deferred with the simulation layer).
     /// </remarks>
     /// <returns><c>true</c> with <paramref name="verifyGas"/> set for a recognized prefix; otherwise <c>false</c>.</returns>
-    public static bool TryGetValidationPrefixVerifyGas(Transaction tx, out ulong verifyGas)
+    internal static bool TryGetValidationPrefixVerifyGas(Transaction tx, out ulong verifyGas)
     {
         verifyGas = 0;
         TxFrame[]? frames = tx.Frames;
@@ -241,4 +241,8 @@ internal static class FrameTxPayerResolver
         frame.Mode == TxFrame.ModeVerify
         && frame.Flags == TxFrame.ApproveExecution
         && (frame.Target is null || frame.Target == sender);
+
+    private static bool IsPay(TxFrame frame) =>
+        frame.Mode == TxFrame.ModeVerify
+        && frame.Flags == TxFrame.ApprovePayment;
 }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -184,6 +184,10 @@ namespace Nethermind.TxPool
 
             postHashFilters.Add(new DeployedCodeFilter(chainHeadInfoProvider.ReadOnlyStateProvider, _specProvider));
 
+            // EIP-8141: bound the validation-prefix verify gas by MAX_VERIFY_GAS; a state-free
+            // structural DoS gate, so it runs before payer resolution and exposure accounting.
+            postHashFilters.Add(new FrameTxVerifyGasFilter(_logger));
+
             // EIP-8141: resolve and record the frame-tx payer for downstream mempool policy, and reject
             // provably-payerless prefixes. Runs last so only otherwise-admissible frame txs (sender
             // already recovered) are resolved. The earlier balance filters gate on the sender balance, so

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -166,6 +166,9 @@ namespace Nethermind.TxPool
                 new NullHashTxFilter(), // needs to be first as it assigns the hash
                 new AlreadyKnownTxFilter(_hashCache, _logger),
                 new MalformedTxFilter(_specProvider, validator, ecdsa, _logger),
+                // EIP-8141: MAX_VERIFY_GAS is a state-free structural DoS gate, so it runs right after
+                // MalformedTxFilter (sender recovered, frame array well-formed) and before any state read.
+                new FrameTxVerifyGasFilter(_logger),
                 new TxTypeTxFilter(_transactions,
                     _blobTransactions), // has to be after MalformedTxFilter as it uses the recovered sender
                 new BalanceZeroFilter(thereIsPriorityContract, _logger),
@@ -183,10 +186,6 @@ namespace Nethermind.TxPool
             }
 
             postHashFilters.Add(new DeployedCodeFilter(chainHeadInfoProvider.ReadOnlyStateProvider, _specProvider));
-
-            // EIP-8141: bound the validation-prefix verify gas by MAX_VERIFY_GAS; a state-free
-            // structural DoS gate, so it runs before payer resolution and exposure accounting.
-            postHashFilters.Add(new FrameTxVerifyGasFilter(_logger));
 
             // EIP-8141: resolve and record the frame-tx payer for downstream mempool policy, and reject
             // provably-payerless prefixes. Runs last so only otherwise-admissible frame txs (sender

--- a/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
@@ -28,5 +28,6 @@ public static class TxPoolErrorMessages
     public const string DelegationNonceGap = "delegation nonce gap";
     public const string DelegationAuthorityHasPendingTx = "delegation authority has pending transaction";
     public const string PayerExposureExceeded = "payer exposure exceeds balance";
+    public const string VerifyGasExceeded = "validation prefix exceeds MAX_VERIFY_GAS";
     public const string NodeIsSyncing = "node is syncing";
 }


### PR DESCRIPTION
## Summary

Stacks on #12617 (`eip8141-mempool-rules`), which stacks on #12610 (`eip8141-payer-resolution`).

Implements the next EIP-8141 public-mempool admission slice: the **`MAX_VERIFY_GAS` bound** (spec Structural Rule 6 / Validation Trace Rules). A frame transaction is rejected at admission when the sum of `gas_limit` across its validation prefix, plus the intrinsic cost of validating `tx.signatures`, exceeds `MAX_VERIFY_GAS` (100_000).

This is implemented as the **Direct Evaluation** form of the bound (EIP-8141: *"Direct evaluation MUST apply the same limits as simulation: signature validation and the evaluated frames' work count against `MAX_VERIFY_GAS`"*) — a **state-free, arithmetic-only structural gate** over the frame `gas_limit`s and signature schemes. It needs no EVM and no extra state reads, and it is the exact piece the payer-resolution and per-payer-exposure filters on the parent branches explicitly defer to.

## Why this slice (and not full simulation)

The candidate "next slice" was the `MAX_VERIFY_GAS`-bounded validation-prefix **simulation** that resolves `RequiresSimulation` payers (deployed-code sender/sponsor, non-canonical paymaster) in a bounded EVM. Confirmed against the code, the mempool admission pipeline is handed only `IChainHeadInfoProvider.ReadOnlyStateProvider` — there is **no** `ITransactionProcessor` / `IVirtualMachine` / code repository anywhere in `TxPool` or its filters. In-pool simulation would mean threading the whole transaction-processing/EVM stack into the pool hot path plus new per-admission DoS bounds and a result cache — a large architectural layer and a genuine design fork. This PR takes the smallest coherent, correct, proportionate increment instead and leaves that fork open (see design doc).

## Implemented

- `Eip8141Constants.MaxVerifyGas` (100_000) + `SignatureVerificationGasCost(byte scheme)` helper.
- `FrameTxPayerResolver.TryGetValidationPrefixVerifyGas` — state-free prefix span + verify-gas computation, co-located with the existing shape predicates (no duplicated shape logic); overflow reported as over-budget.
- `FrameTxVerifyGasFilter` (`IIncomingTxFilter`) — runs first among the EIP-8141 post-hash filters (cheapest, state-free DoS gate before payer resolution/exposure).
- `AcceptTxResult.VerifyGasExceeded` + message.
- Tests: within/at/over budget, signature-cost-tips-over, summed prefix gas (incl. `pay`), expiry-frame gas counted, frames-after-prefix not counted, unrecognized-prefix pass-through, overflow, non-frame pass-through.

## Deferred (with `EIP8141:` markers referencing `MEMPOOL-RULES-DESIGN.md`)

- Full in-pool validation-prefix **simulation** resolving `RequiresSimulation` payers, and the `deploy`-prefixed shape span/gas bound — the design fork.
- Rules 2–6 and 8 from the design doc (canonical-paymaster reservation, non-canonical cap, replacement payer-switch atomicity, eviction ordering, dependency-indexed revalidation, tightening the `NotSupportedTxFilter` gate).
- Refining the exposure filter's max-cost to include the signature-verification add-on in `TXPARAM(0x06)` exactly (distinct from this admission bound).

Design: `MEMPOOL-RULES-DESIGN.md` (new "`MAX_VERIFY_GAS` admission bound" section). Spec: ethereum/EIPs#12007 / https://eips.ethereum.org/EIPS/eip-8141

## Changes

- New feature

## Testing

- `Nethermind.TxPool.Test` green (683; 10 new in `FrameTxVerifyGasFilterTests`); `Nethermind.Evm.Test` frame-tx/Eip8141 suites green (74).
