### PR TITLE
fix(rpc-bench): run benchmarked nodes the way production runs them

### DIFF
--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -35,16 +35,10 @@ which uses the same snapshots on this runner:
 - The node gets expb's stability flags (`--Init.DiscoveryEnabled=false`,
   `--Network.MaxActivePeers=0`, `--Merge.SweepMemory=NoGC`,
   `--Merge.CompactMemory=No`, `--Merge.CollectionsPerDecommit=-1`,
-  `--Pruning.Mode=None`). **Deliberate divergence from expb:** no
-  `DOTNET_TieredCompilation=0` / `DOTNET_GCLatencyLevel=0` env pins — the node
-  runs production-default code generation (tiered compilation + dynamic PGO),
-  because the pin disables dynamic PGO and misrepresents live nodes (a same-code
-  A/B showed it alone costs ~27% useful throughput on heavy eth_call). Timings
-  are therefore not directly comparable with expb runs or with rpc-bench results
-  produced before this change. JIT warm-up currently lands **inside** the
-  measured window; treat the first test/rate of a run as warm-up when reading
-  results. One-off code-gen experiments can set `NODE_ENV_VARS` instead of
-  editing the script.
+  `--Pruning.Mode=None`). Unlike expb, no `DOTNET_*` env pins: the node runs
+  production-default code generation (tiered compilation + dynamic PGO), so JIT
+  warm-up lands inside the measured window — treat a run's first test/rate as
+  warm-up. One-off code-gen experiments: set `NODE_ENV_VARS`.
 
 ## Multi-client snapshot sets
 
@@ -290,11 +284,8 @@ in the tool repo → fresh evolution from scratch.
 
 `dottrace=true` (requires `client=nethermind`) uses the same mechanism as expb's
 `--dottrace`, so it works with **any** Nethermind image (no special diag build).
-Note: reports captured before the removal of the `DOTNET_TieredCompilation=0`
-pin are not comparable with newer ones — restoring tiering shifts
-OwnTime/TotalTime attribution (tier-0 frames appear, dynamic-PGO inlining
-reshapes the call tree), so `dottrace-report.sh compare` across that boundary
-shows spurious deltas.
+Reports captured before the `DOTNET_TieredCompilation=0` pin removal are not
+comparable with newer ones (tiering shifts OwnTime/TotalTime attribution).
 
 1. The host-installed dotTrace CLI (`/opt/dottrace`, installed on demand via
    `dotnet tool install JetBrains.dotTrace.GlobalTools`) is mounted read-only

--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -32,13 +32,11 @@ which uses the same snapshots on this runner:
 - The default `overlay` isolation matches expb's `snapshot_backend: overlay`,
   including `redirect_dir=on,metacopy=on,volatile` mount options (plain-options
   fallback).
-- The node gets expb's stability flags (`--Init.DiscoveryEnabled=false`,
-  `--Network.MaxActivePeers=0`, `--Merge.SweepMemory=NoGC`,
-  `--Merge.CompactMemory=No`, `--Merge.CollectionsPerDecommit=-1`,
-  `--Pruning.Mode=None`). Unlike expb, no `DOTNET_*` env pins: the node runs
-  production-default code generation (tiered compilation + dynamic PGO), so JIT
-  warm-up lands inside the measured window — treat a run's first test/rate as
-  warm-up. One-off code-gen experiments: set `NODE_ENV_VARS`.
+- The node is isolated from network and pruning noise (`--Init.DiscoveryEnabled=false`,
+  `--Network.MaxActivePeers=0`, `--Pruning.Mode=None`) but otherwise runs
+  production defaults — no GC or `DOTNET_*` overrides — so JIT warm-up lands
+  inside the measured window; treat a run's first test/rate as warm-up. One-off
+  code-gen experiments: set `NODE_ENV_VARS`.
 
 ## Multi-client snapshot sets
 
@@ -59,7 +57,7 @@ Per-client node profiles in `start-node.sh`:
 
 | Client | Image default | Datadir handling | Parked-at-head flags |
 |---|---|---|---|
-| `nethermind` | branch resolution (build/reuse), like before | snapshot = datadir, mounted at `/execution-data` | discovery off, 0 peers, expb stability flags |
+| `nethermind` | branch resolution (build/reuse), like before | snapshot = datadir, mounted at `/execution-data` | discovery off, 0 peers, pruning off |
 | `geth` | `ethereum/client-go:stable` | snapshot holds the contents of `<datadir>/geth` → mounted at `/execution-data/geth` | `--nodiscover --maxpeers=0` |
 | `reth` | `ghcr.io/paradigmxyz/reth:latest` | snapshot = datadir (`db/`, `static_files/`), mounted at `/execution-data` | `--disable-discovery --max-*-peers=0` |
 

--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -35,8 +35,16 @@ which uses the same snapshots on this runner:
 - The node gets expb's stability flags (`--Init.DiscoveryEnabled=false`,
   `--Network.MaxActivePeers=0`, `--Merge.SweepMemory=NoGC`,
   `--Merge.CompactMemory=No`, `--Merge.CollectionsPerDecommit=-1`,
-  `--Pruning.Mode=None`) and env (`DOTNET_TieredCompilation=0`,
-  `DOTNET_GCLatencyLevel=0`).
+  `--Pruning.Mode=None`). **Deliberate divergence from expb:** no
+  `DOTNET_TieredCompilation=0` / `DOTNET_GCLatencyLevel=0` env pins — the node
+  runs production-default code generation (tiered compilation + dynamic PGO),
+  because the pin disables dynamic PGO and misrepresents live nodes (a same-code
+  A/B showed it alone costs ~27% useful throughput on heavy eth_call). Timings
+  are therefore not directly comparable with expb runs or with rpc-bench results
+  produced before this change. JIT warm-up currently lands **inside** the
+  measured window; treat the first test/rate of a run as warm-up when reading
+  results. One-off code-gen experiments can set `NODE_ENV_VARS` instead of
+  editing the script.
 
 ## Multi-client snapshot sets
 
@@ -281,7 +289,12 @@ in the tool repo → fresh evolution from scratch.
 ## dotTrace flow (goal #3)
 
 `dottrace=true` (requires `client=nethermind`) uses the same mechanism as expb's
-`--dottrace`, so it works with **any** Nethermind image (no special diag build):
+`--dottrace`, so it works with **any** Nethermind image (no special diag build).
+Note: reports captured before the removal of the `DOTNET_TieredCompilation=0`
+pin are not comparable with newer ones — restoring tiering shifts
+OwnTime/TotalTime attribution (tier-0 frames appear, dynamic-PGO inlining
+reshapes the call tree), so `dottrace-report.sh compare` across that boundary
+shows spurious deltas.
 
 1. The host-installed dotTrace CLI (`/opt/dottrace`, installed on demand via
    `dotnet tool install JetBrains.dotTrace.GlobalTools`) is mounted read-only

--- a/scripts/rpc-bench/start-node.sh
+++ b/scripts/rpc-bench/start-node.sh
@@ -258,13 +258,7 @@ docker_args=(
   -p "127.0.0.1:${RPC_PORT}:8545"
   -v "$DATA_DIR_SOURCE:$DATA_MOUNT_TARGET:$MOUNT_OPT"
 )
-# No DOTNET_TieredCompilation/GCLatencyLevel pins: the node must run with
-# production-default code generation (tiered compilation + dynamic PGO), or every
-# measurement misrepresents live nodes and any code-gen A/B. Consequence: JIT
-# warm-up lands inside the measured window — treat a run's first test/rate as
-# warm-up when reading results.
-# Deliberate code-gen experiments (e.g. reproducing an old pinned measurement) go
-# through NODE_ENV_VARS instead of edits here, so the default stays production-like.
+# Production-default code generation (no DOTNET_* pins); one-off experiments use NODE_ENV_VARS.
 # shellcheck disable=SC2086
 for kv in $NODE_ENV_VARS; do docker_args+=(-e "$kv"); done
 [[ -n "$NODE_CPUSET" ]] && docker_args+=(--cpuset-cpus "$NODE_CPUSET")

--- a/scripts/rpc-bench/start-node.sh
+++ b/scripts/rpc-bench/start-node.sh
@@ -257,12 +257,10 @@ docker_args=(
   -p "127.0.0.1:${RPC_PORT}:8545"
   -v "$DATA_DIR_SOURCE:$DATA_MOUNT_TARGET:$MOUNT_OPT"
 )
-if [[ "$CLIENT" == "nethermind" ]]; then
-  docker_args+=(
-    -e "DOTNET_TieredCompilation=0"
-    -e "DOTNET_GCLatencyLevel=0"
-  )
-fi
+# Production-default runtime (diagnostic branch): no TieredCompilation/GCLatencyLevel
+# pins, so tiered compilation and dynamic PGO behave as they do on live nodes.
+# The master harness pins DOTNET_TieredCompilation=0 for determinism, which disables
+# dynamic PGO and misrepresents both the JIT baseline and any R2R/static-PGO candidate.
 [[ -n "$NODE_CPUSET" ]] && docker_args+=(--cpuset-cpus "$NODE_CPUSET")
 [[ -n "$NODE_MEMORY" ]] && docker_args+=(--memory "$NODE_MEMORY")
 

--- a/scripts/rpc-bench/start-node.sh
+++ b/scripts/rpc-bench/start-node.sh
@@ -257,10 +257,10 @@ docker_args=(
   -p "127.0.0.1:${RPC_PORT}:8545"
   -v "$DATA_DIR_SOURCE:$DATA_MOUNT_TARGET:$MOUNT_OPT"
 )
-# Production-default runtime (diagnostic branch): no TieredCompilation/GCLatencyLevel
-# pins, so tiered compilation and dynamic PGO behave as they do on live nodes.
-# The master harness pins DOTNET_TieredCompilation=0 for determinism, which disables
-# dynamic PGO and misrepresents both the JIT baseline and any R2R/static-PGO candidate.
+# No DOTNET_TieredCompilation/GCLatencyLevel pins: the node must run with
+# production-default code generation (tiered compilation + dynamic PGO), or every
+# measurement misrepresents live nodes and any code-gen A/B. Fight warm-up variance
+# with a warm-up phase, not a different compiler mode.
 [[ -n "$NODE_CPUSET" ]] && docker_args+=(--cpuset-cpus "$NODE_CPUSET")
 [[ -n "$NODE_MEMORY" ]] && docker_args+=(--memory "$NODE_MEMORY")
 

--- a/scripts/rpc-bench/start-node.sh
+++ b/scripts/rpc-bench/start-node.sh
@@ -207,10 +207,7 @@ case "$CLIENT" in
       # Park the node at the snapshot head: no peers, no discovery, no sync writes.
       "--Init.DiscoveryEnabled=false"
       "--Network.MaxActivePeers=0"
-      # expb's stability flags: no forced GC between blocks, no background pruning.
-      "--Merge.SweepMemory=NoGC"
-      "--Merge.CompactMemory=No"
-      "--Merge.CollectionsPerDecommit=-1"
+      # No background pruning while serving a parked snapshot.
       "--Pruning.Mode=None"
       "--HealthChecks.Enabled=false"
       "--Metrics.Enabled=false"

--- a/scripts/rpc-bench/start-node.sh
+++ b/scripts/rpc-bench/start-node.sh
@@ -282,10 +282,9 @@ if [[ "$DOTTRACE" == "true" ]]; then
     --entrypoint /opt/dottrace/dottrace
   )
   entry_args=(start --framework=NetCore "--save-to=/dottrace-output/rpcbench-${NETWORK}${SUFFIX}.dtp" --propagate-exit-code -- /nethermind/nethermind)
-elif [[ "$CLIENT" == "nethermind" ]]; then
-  # Run the binary directly (as expb does) — skips entrypoint.sh host tuning.
-  docker_args+=(--entrypoint /nethermind/nethermind)
 fi
+# Nethermind keeps the image's entrypoint.sh (as expb and production do): it applies
+# host tuning and enables a shipped PGO profile, which a direct binary call skips.
 # geth/reth official images already have the client binary as their entrypoint;
 # node_args are passed as the container command.
 

--- a/scripts/rpc-bench/start-node.sh
+++ b/scripts/rpc-bench/start-node.sh
@@ -48,6 +48,7 @@ RETH_HTTP_API="${RETH_HTTP_API:-eth,net,web3,debug,trace,txpool}"
 RPC_GAS_CAP="${RPC_GAS_CAP:-1000000000}"
 LAYOUT_FLAGS="${LAYOUT_FLAGS:-}"                   # e.g. --FlatDb.Enabled=true for the flat snapshot (nethermind only)
 ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS:-}"
+NODE_ENV_VARS="${NODE_ENV_VARS:-}"                 # extra docker -e assignments, e.g. "DOTNET_TieredCompilation=0"
 NODE_CPUSET="${NODE_CPUSET:-}"                     # e.g. 2-7,10-15 (expb pins the client to these cores)
 NODE_MEMORY="${NODE_MEMORY:-}"                     # e.g. 64g
 
@@ -259,8 +260,13 @@ docker_args=(
 )
 # No DOTNET_TieredCompilation/GCLatencyLevel pins: the node must run with
 # production-default code generation (tiered compilation + dynamic PGO), or every
-# measurement misrepresents live nodes and any code-gen A/B. Fight warm-up variance
-# with a warm-up phase, not a different compiler mode.
+# measurement misrepresents live nodes and any code-gen A/B. Consequence: JIT
+# warm-up lands inside the measured window — treat a run's first test/rate as
+# warm-up when reading results.
+# Deliberate code-gen experiments (e.g. reproducing an old pinned measurement) go
+# through NODE_ENV_VARS instead of edits here, so the default stays production-like.
+# shellcheck disable=SC2086
+for kv in $NODE_ENV_VARS; do docker_args+=(-e "$kv"); done
 [[ -n "$NODE_CPUSET" ]] && docker_args+=(--cpuset-cpus "$NODE_CPUSET")
 [[ -n "$NODE_MEMORY" ]] && docker_args+=(--memory "$NODE_MEMORY")
 


### PR DESCRIPTION
## Changes

- Remove the `DOTNET_TieredCompilation=0` and `DOTNET_GCLatencyLevel=0` pins, so nodes use production-default code generation (tiered compilation with dynamic PGO).
- Keep the image's `entrypoint.sh` instead of calling the binary directly. It applies host tuning and enables a shipped PGO profile; skipping it meant this harness could not observe either. (dotTrace still overrides the entrypoint, as before.)
- Drop the three `Merge.*` GC flags: `GCKeeper` only runs on Engine API calls, and this harness parks the node at a snapshot head, so they changed nothing while implying a non-production GC configuration.
- Add a `NODE_ENV_VARS` passthrough so deliberate one-off code-gen experiments are a variable rather than a script edit.
- README: document what still deliberately differs (long RPC timeout, raised gas cap for cross-client parity, pruning off) and that JIT warm-up now lands inside the measured window.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other

## Testing

### Requires testing

- [x] Yes

### If yes, did you write tests?

- [ ] Yes
- [x] No

### Notes on testing

Runner-validated: jsonbench-sweep run 30574061038 and three ethcallchaos runs (30573968372/30573977240/30573985255) were dispatched from this branch and completed cleanly, with identical response correctness across arms (deep-check).

## Remarks

The tiering pin was intended to reduce run-to-run variance, but it disables dynamic PGO, so measurements described a runtime nobody runs. A same-code A/B showed the pin alone costs ~27% useful throughput on a heavy eth_call workload, and on block processing it costs the baseline ~12% while inflating an apparent ReadyToRun penalty five-fold (+13.6% pinned vs +2.6% unpinned). Any code-generation conclusion drawn under the pin needs re-checking. The equivalent overrides were removed from expb in NethermindEth/execution-payloads-benchmarks#22.

On the entrypoint: the previous comment claimed the direct binary call matched expb, but expb only overrides the entrypoint for dotTrace runs. Verified on the benchmark runner (`HugePages_Total: 0`), the host-tuning branch of `entrypoint.sh` is currently inert there, so this change is about correctness and about not silently skipping a shipped PGO profile rather than an immediate performance delta.

A proper warm-up/discard phase in the runners remains a worthwhile follow-up; until then warm-up is inside the measurement window.