### PR TITLE
test: eth_createAccessList affordability with omitted fee fields

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -2257,18 +2257,18 @@ public partial class EthRpcModuleTests
     {
         // execution-apis #854: when all gas-fee fields are omitted, the request must not fail
         // solely because the sender cannot afford client-selected default fees.
-        using Context ctx = await Context.Create();
+        // London-enabled so the head block has a nonzero base fee — the divergent client
+        // behavior is defaulting maxFeePerGas to the base fee and failing affordability.
+        using Context ctx = await Context.CreateWithLondonEnabled();
 
         // Unfunded sender, codeless recipient, zero value, no gas/fee fields.
-        object transaction = JsonSerializer.Deserialize<object>(
-            """{"from":"0x000000000000000000000000000000000000dead","to":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}""")!;
+        (JToken result, long gasUsed) = await CallCreateAccessList(ctx,
+            """{"from":"0x000000000000000000000000000000000000dead","to":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}""",
+            stateOverrideJson: null, optimize: true);
 
-        string serialized = await ctx.Test.TestEthRpc("eth_createAccessList", transaction, "latest", null, true);
-
-        JToken? result = JToken.Parse(serialized)["result"];
-        Assert.That(result, Is.Not.Null, $"expected success for an unfunded sender with omitted fee fields, got: {serialized}");
-        Assert.That(result!["accessList"]!.Children().Count(), Is.EqualTo(0), "expected empty access list for a plain transfer to a codeless account");
-        Assert.That(Convert.ToInt64(result["gasUsed"]!.Value<string>(), 16), Is.EqualTo(21000));
+        Assert.That(result["error"], Is.Null);
+        Assert.That(result["accessList"]!.ToArray(), Is.Empty, "expected empty access list for a plain transfer to a codeless account");
+        Assert.That(gasUsed, Is.EqualTo(21_000));
     }
 
     private static async Task<(JToken Result, long GasUsed)> CallCreateAccessList(
@@ -2280,8 +2280,9 @@ public partial class EthRpcModuleTests
             : JsonSerializer.Deserialize<object>(stateOverrideJson);
         string serialized = await ctx.Test.TestEthRpc(
             "eth_createAccessList", tx, "latest", stateOverride, optimize);
-        JToken result = JToken.Parse(serialized)["result"]!;
-        long gasUsed = Convert.ToInt64(result["gasUsed"]!.Value<string>(), 16);
+        JToken? result = JToken.Parse(serialized)["result"];
+        Assert.That(result, Is.Not.Null, $"expected a result, got: {serialized}");
+        long gasUsed = Convert.ToInt64(result!["gasUsed"]!.Value<string>(), 16);
         return (result, gasUsed);
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -2252,6 +2252,25 @@ public partial class EthRpcModuleTests
             Does.Contain("0x0000000000000000000000000000000000000000000000000000000000000001"));
     }
 
+    [Test]
+    public async Task Eth_createAccessList_unfunded_sender_without_fee_fields_succeeds()
+    {
+        // execution-apis #854: when all gas-fee fields are omitted, the request must not fail
+        // solely because the sender cannot afford client-selected default fees.
+        using Context ctx = await Context.Create();
+
+        // Unfunded sender, codeless recipient, zero value, no gas/fee fields.
+        object transaction = JsonSerializer.Deserialize<object>(
+            """{"from":"0x000000000000000000000000000000000000dead","to":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}""")!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_createAccessList", transaction, "latest", null, true);
+
+        JToken? result = JToken.Parse(serialized)["result"];
+        Assert.That(result, Is.Not.Null, $"expected success for an unfunded sender with omitted fee fields, got: {serialized}");
+        Assert.That(result!["accessList"]!.Children().Count(), Is.EqualTo(0), "expected empty access list for a plain transfer to a codeless account");
+        Assert.That(Convert.ToInt64(result["gasUsed"]!.Value<string>(), 16), Is.EqualTo(21000));
+    }
+
     private static async Task<(JToken Result, long GasUsed)> CallCreateAccessList(
         Context ctx, string txJson, string? stateOverrideJson, bool optimize)
     {


### PR DESCRIPTION
Part of #12599 (glamsterdam devnet-8). Covers execution-apis [#854](https://github.com/ethereum/execution-apis/pull/854).

## Changes

- Add a regression test asserting `eth_createAccessList` does not fail for an unfunded sender when all gas-fee fields are omitted: unfunded `from`, codeless `to`, zero value, no gas/fee fields → `{"accessList":[],"gasUsed":"0x5208"}`.

Nethermind already conforms — the upstream PR lists nethermind among the clients passing hive `rpc-compat`; go-ethereum is the sole divergence. This test locks the behavior in.

> Note: execution-apis #854 is still a draft pending ethereum/go-ethereum#35397. This change is test-only and already passing against current Nethermind.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: test coverage

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `Eth_createAccessList_unfunded_sender_without_fee_fields_succeeds`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
