### PR TITLE
perf(consensus): cap the background bloom parallelism during commit [DRAFT - perf claim not established]

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BackgroundBloomCalculationTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BackgroundBloomCalculationTests.cs
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using NUnit.Framework;
+
+namespace Nethermind.Consensus.Test;
+
+/// <summary>
+/// The background bloom computation is capped so it stops competing with the state-commit phase for
+/// thread-pool workers. Capping must change scheduling only, never the blooms produced.
+/// </summary>
+public class BackgroundBloomCalculationTests
+{
+    [TestCase(0, false)]
+    [TestCase(1, false)]
+    [TestCase(BlockProcessor.BackgroundBloomCapThreshold - 1, false)]
+    [TestCase(BlockProcessor.BackgroundBloomCapThreshold, true)]
+    [TestCase(BlockProcessor.BackgroundBloomCapThreshold + 1, true)]
+    [TestCase(10_000, true)]
+    public void Caps_background_bloom_parallelism_only_from_the_threshold_up(int receiptCount, bool expectCapped)
+    {
+        ParallelOptions? options = BlockProcessor.SelectBackgroundBloomOptions(receiptCount);
+
+        if (expectCapped)
+        {
+            Assert.That(options, Is.Not.Null);
+            Assert.That(options!.MaxDegreeOfParallelism, Is.EqualTo(BlockProcessor.BackgroundBloomMaxParallelism));
+        }
+        else
+        {
+            Assert.That(options, Is.Null);
+        }
+    }
+
+    // Spans the serial path (<= ProcessorCount), the parallel path, and the capped range, so each
+    // receipt count exercises a different branch of CalculateBlooms.
+    [TestCase(1)]
+    [TestCase(8)]
+    [TestCase(64)]
+    [TestCase(BlockProcessor.BackgroundBloomCapThreshold)]
+    [TestCase(BlockProcessor.BackgroundBloomCapThreshold + 137)]
+    public void Capping_does_not_change_the_calculated_blooms(int receiptCount)
+    {
+        TxReceipt[] capped = BuildReceipts(receiptCount);
+        TxReceipt[] uncapped = BuildReceipts(receiptCount);
+
+        BlockProcessor.CalculateBlooms(capped, new ParallelOptions { MaxDegreeOfParallelism = BlockProcessor.BackgroundBloomMaxParallelism });
+        BlockProcessor.CalculateBlooms(uncapped, parallelOptions: null);
+
+        for (int i = 0; i < receiptCount; i++)
+        {
+            Assert.That(capped[i].Bloom, Is.EqualTo(uncapped[i].Bloom), $"receipt {i}");
+        }
+    }
+
+    [Test]
+    public void Calculates_a_bloom_for_every_receipt()
+    {
+        TxReceipt[] receipts = BuildReceipts(BlockProcessor.BackgroundBloomCapThreshold);
+
+        BlockProcessor.CalculateBlooms(receipts, BlockProcessor.SelectBackgroundBloomOptions(receipts.Length));
+
+        foreach (TxReceipt receipt in receipts)
+        {
+            Assert.That(receipt.Bloom, Is.Not.Null);
+            Assert.That(receipt.Bloom, Is.Not.EqualTo(Bloom.Empty), "a receipt with logs must produce a non-empty bloom");
+        }
+    }
+
+    [Test]
+    public void Blooms_match_the_logs_they_were_built_from()
+    {
+        TxReceipt[] receipts = BuildReceipts(BlockProcessor.BackgroundBloomCapThreshold);
+
+        BlockProcessor.CalculateBlooms(receipts, BlockProcessor.SelectBackgroundBloomOptions(receipts.Length));
+
+        for (int i = 0; i < receipts.Length; i++)
+        {
+            Bloom expected = new();
+            expected.Add(receipts[i].Logs!);
+            Assert.That(receipts[i].Bloom, Is.EqualTo(expected), $"receipt {i}");
+        }
+    }
+
+    /// <summary>
+    /// Receipts whose logs differ per index, so a bloom written to the wrong slot is detectable.
+    /// </summary>
+    private static TxReceipt[] BuildReceipts(int count)
+    {
+        TxReceipt[] receipts = new TxReceipt[count];
+        for (int i = 0; i < count; i++)
+        {
+            receipts[i] = new TxReceipt
+            {
+                Logs =
+                [
+                    new LogEntry(
+                        TestItem.Addresses[i % TestItem.Addresses.Length],
+                        BitConverter.GetBytes((long)i),
+                        [Keccak.Compute(BitConverter.GetBytes((long)i))])
+                ]
+            };
+        }
+
+        return receipts;
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -182,11 +182,7 @@ public partial class BlockProcessor(
         Task<(Bloom BlockBloom, Hash256 ReceiptsRoot)>? bloomsAndReceiptsRootTask = null;
         if (ShouldCalculateReceiptsInBackground(receipts))
         {
-            // Large bloom sets are capped because this task overlaps the state-commit phase, which
-            // takes its parallelism from the same thread pool: at full width the blooms occupy the
-            // workers the root hashing wants. Small sets are left at full width — they clear the pool
-            // fastest that way, and capping them only stretches the overlap.
-            ParallelOptions? bloomOptions = receipts.Length >= BackgroundBloomCapThreshold ? s_backgroundBloomOptions : null;
+            ParallelOptions? bloomOptions = SelectBackgroundBloomOptions(receipts.Length);
             bloomsAndReceiptsRootTask = Task.Run(() =>
             {
                 CalculateBlooms(receipts, bloomOptions);
@@ -303,14 +299,45 @@ public partial class BlockProcessor(
     }
 
     /// <summary>
-    /// Receipt count from which the background bloom computation is worth capping.
+    /// Receipt count from which the background bloom computation is capped.
     /// </summary>
-    private const int BackgroundBloomCapThreshold = 256;
+    /// <remarks>
+    /// Below this the blooms finish well before the commit phase needs the pool, so capping them only
+    /// stretches the overlap without freeing anything.
+    /// </remarks>
+    internal const int BackgroundBloomCapThreshold = 256;
 
-    private static readonly ParallelOptions s_backgroundBloomOptions = new() { MaxDegreeOfParallelism = 4 };
+    /// <summary>
+    /// Worker count the capped background bloom computation is limited to.
+    /// </summary>
+    /// <remarks>
+    /// Enough to keep the blooms comfortably inside the commit window on mainnet-sized receipt sets,
+    /// while leaving the rest of the machine to the root hashing that runs concurrently.
+    /// </remarks>
+    internal const int BackgroundBloomMaxParallelism = 4;
 
+    private static readonly ParallelOptions s_backgroundBloomOptions =
+        new() { MaxDegreeOfParallelism = BackgroundBloomMaxParallelism };
+
+    /// <summary>
+    /// Parallelism for the bloom computation when it runs on the background task, or <c>null</c> for
+    /// the default full width.
+    /// </summary>
+    /// <remarks>
+    /// The background task overlaps <see cref="CommitStateAndStorageRoots"/> and
+    /// <see cref="ComputeStateRoot"/>, which draw their parallelism from the same thread pool. At full
+    /// width a large bloom set occupies the workers the root hashing is waiting for, costing more block
+    /// time than the bloom work it hides.
+    /// </remarks>
+    internal static ParallelOptions? SelectBackgroundBloomOptions(int receiptCount) =>
+        receiptCount >= BackgroundBloomCapThreshold ? s_backgroundBloomOptions : null;
+
+    /// <param name="parallelOptions">
+    /// Parallelism to use, or <c>null</c> for the default full width. Only affects scheduling: the
+    /// blooms produced are identical either way.
+    /// </param>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void CalculateBlooms(TxReceipt[] receipts, ParallelOptions? parallelOptions = null)
+    internal static void CalculateBlooms(TxReceipt[] receipts, ParallelOptions? parallelOptions = null)
     {
         using MetricsTimer<BloomsTimeSink> _ = new();
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -182,9 +182,14 @@ public partial class BlockProcessor(
         Task<(Bloom BlockBloom, Hash256 ReceiptsRoot)>? bloomsAndReceiptsRootTask = null;
         if (ShouldCalculateReceiptsInBackground(receipts))
         {
+            // Large bloom sets are capped because this task overlaps the state-commit phase, which
+            // takes its parallelism from the same thread pool: at full width the blooms occupy the
+            // workers the root hashing wants. Small sets are left at full width — they clear the pool
+            // fastest that way, and capping them only stretches the overlap.
+            ParallelOptions? bloomOptions = receipts.Length >= BackgroundBloomCapThreshold ? s_backgroundBloomOptions : null;
             bloomsAndReceiptsRootTask = Task.Run(() =>
             {
-                CalculateBlooms(receipts);
+                CalculateBlooms(receipts, bloomOptions);
                 return (AccumulateBlockBloom(receipts), CalculateReceiptsRoot(receipts, spec, block));
             });
         }
@@ -297,8 +302,15 @@ public partial class BlockProcessor(
         return ReceiptsRootCalculator.Instance.GetReceiptsRoot(receipts, spec, block.ReceiptsRoot);
     }
 
+    /// <summary>
+    /// Receipt count from which the background bloom computation is worth capping.
+    /// </summary>
+    private const int BackgroundBloomCapThreshold = 256;
+
+    private static readonly ParallelOptions s_backgroundBloomOptions = new() { MaxDegreeOfParallelism = 4 };
+
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void CalculateBlooms(TxReceipt[] receipts)
+    private static void CalculateBlooms(TxReceipt[] receipts, ParallelOptions? parallelOptions = null)
     {
         using MetricsTimer<BloomsTimeSink> _ = new();
 
@@ -316,7 +328,7 @@ public partial class BlockProcessor(
         ParallelUnbalancedWork.For(
             0,
             receipts.Length,
-            ParallelUnbalancedWork.DefaultOptions,
+            parallelOptions ?? ParallelUnbalancedWork.DefaultOptions,
             receipts,
             static (i, receipts) =>
             {


### PR DESCRIPTION
> **Draft: the performance claim is not established. Do not merge on the numbers below.**
> A seventh master baseline arrived after this PR was opened and contradicted the effect. The measured
> delta is now within run-to-run noise, and the one strictly-paired comparison is *negative*. Details in
> [Measurements](#measurements). The code and tests are ready; the justification is not.

## Changes

- Cap the parallelism of the **background** bloom computation to 4 workers when a block has ≥256 receipts; leave smaller sets at full width.
- Extract the decision into `SelectBackgroundBloomOptions(int receiptCount)` and promote the two magic numbers to documented constants.
- Add `BackgroundBloomCalculationTests` (13 cases) covering the threshold boundaries and, more importantly, that capping does not change the blooms produced.

### Why (mechanism — unchanged, and independently supported)

The blooms and receipts root are computed on a background task specifically so they overlap `CommitStateAndStorageRoots` and `ComputeStateRoot`. All three draw their parallelism from the same thread pool, so at full width a large bloom set occupies workers the storage/state root hashing is waiting on.

That the background task interferes is not in doubt: removing it entirely moves `storage_merkle_ms + state_root_ms` by −0.65 ms (−11%) while making the block ~0.95 ms *slower* overall, which brackets the interference at ~0.65 ms of commit-window time. What is **not** established is that this particular cap converts that interference into a net block-time win.

This is a scheduling-only change. The blooms produced are bit-identical either way, which the tests assert across the serial, parallel and capped paths.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`BackgroundBloomCalculationTests`, 13 cases:

- Threshold selection at `0, 1, 255, 256, 257, 10_000`. Boundaries are derived from the constant, so they cannot silently drift if it is retuned.
- **Capped vs uncapped blooms are identical**, across five receipt counts spanning the serial path (`<= ProcessorCount`), the parallel path, and the capped range — so each count exercises a different branch of `CalculateBlooms`.
- Every receipt gets a non-empty bloom, and each bloom matches the logs it was built from. Fixture logs differ per index, so a bloom written into the wrong slot fails rather than passing by symmetry.

Mutation-checked: multiplying the threshold by 100 fails 3 of the 13. Suites green — `Nethermind.Consensus.Test` 144, `Nethermind.Blockchain.Test` 1572.

## Documentation

- [ ] Requires documentation update — Yes
- [x] No

- [ ] Requires explanation in Release Notes — Yes
- [x] No

## Remarks

### Measurements

EXPB reproducible benchmarks, `fusaka`, 10 000 blocks, `flat`, `delay_seconds=0`, blocks 25 490 001–25 500 000, per-block SSE metrics.

**Seven** master-code 10k runs on the same runner, chronological `total_ms`:

`36.472, 36.659, 36.587, 36.525, 36.557, 36.443, 36.220` → mean **36.495**, sd **0.130**, spread **0.439**

| | value | vs master mean |
| --- | --- | --- |
| this PR | 36.366 | −0.129 ms (**−1.0 sd** — not significant) |
| strictly-paired master (dispatched 3 s later) | 36.220 | this PR is **+0.146 ms worse** |

`storage_merkle_ms + state_root_ms` against the paired master: **+0.117 (+2.2%)**, i.e. no improvement to the commit phase either.

**Why the first version of this PR claimed −0.175 ms (−0.48%):** it used the first six baselines, which happened to cluster at 36.44–36.66 and gave sd 0.072. The seventh came in at 36.220 and widened the spread to 0.439 — larger than the effect being measured. Two earlier estimates were also wrong and are withdrawn: −0.49 ms, obtained by subtracting two separately-paired runs (additivity does not hold here), and the −0.175 ms above.

**What would settle it:** 3–5 repeats per arm, interleaved rather than blocked, so a drifting baseline cannot align with the arm ordering. At an effect size of ~0.15 ms against a 0.13 ms sd, that is the minimum needed for a defensible claim. Until then this stays a draft.

The companion branch `perf/block-commit-contention` (this cap plus per-thread trie node counters) measured 36.217, −2.1 sd, and is subject to exactly the same caveat.
