### PR TITLE
Improve FastHash performance

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Core/FastHashBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/FastHashBenchmarks.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using BenchmarkDotNet.Attributes;
 using Nethermind.Core.Extensions;
 
@@ -13,6 +15,10 @@ namespace Nethermind.Benchmarks.Core;
 [MemoryDiagnoser]
 public class FastHashBenchmarks
 {
+    private const int OperationsPerInvoke = 1024;
+#if !ZK_EVM
+    private const long XxHashSeed = 0x510E527FADE682D1L;
+#endif
     private byte[] _data = null!;
 
     [Params(16, 20, 32, 64, 128, 256, 512, 1024)]
@@ -21,24 +27,133 @@ public class FastHashBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        _data = new byte[Size];
+        _data = new byte[Size * OperationsPerInvoke];
         Random.Shared.NextBytes(_data);
     }
 
-    [Benchmark(Baseline = true)]
-    public int FastHash() => ((ReadOnlySpan<byte>)_data).FastHash();
+    [Benchmark(Baseline = true, OperationsPerInvoke = OperationsPerInvoke)]
+    public int FastHash()
+    {
+        int hash = 0;
+        ref byte data = ref MemoryMarshal.GetArrayDataReference(_data);
+        for (int i = 0; i < OperationsPerInvoke; i++)
+        {
+            ReadOnlySpan<byte> input = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref data, i * Size), Size);
+            hash = unchecked(hash + input.FastHash());
+        }
+        return hash;
+    }
 
-    [Benchmark]
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public int FastHashAes()
     {
-        ref byte start = ref MemoryMarshal.GetReference<byte>(_data);
-        return SpanExtensions.FastHashAesX64(ref start, _data.Length, SpanExtensions.ComputeSeed(_data.Length));
+        int hash = 0;
+        ref byte data = ref MemoryMarshal.GetArrayDataReference(_data);
+        Vector128<byte> seed = SpanExtensions.ComputeAesSeed(Size);
+        for (int i = 0; i < OperationsPerInvoke; i++)
+        {
+            ref byte start = ref Unsafe.Add(ref data, i * Size);
+            hash = unchecked(hash + SpanExtensions.FastHashAes(ref start, Size, seed));
+        }
+        return hash;
     }
 
-    [Benchmark]
+#if ZK_EVM
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
     public int FastHashCrc()
     {
-        ref byte start = ref MemoryMarshal.GetReference<byte>(_data);
-        return SpanExtensions.FastHashCrc(ref start, _data.Length, SpanExtensions.ComputeSeed(_data.Length));
+        int hash = 0;
+        ref byte data = ref MemoryMarshal.GetArrayDataReference(_data);
+        uint seed = SpanExtensions.ComputeSeed(Size);
+        for (int i = 0; i < OperationsPerInvoke; i++)
+        {
+            ref byte start = ref Unsafe.Add(ref data, i * Size);
+            hash = unchecked(hash + SpanExtensions.FastHashCrc(ref start, Size, seed));
+        }
+        return hash;
     }
+#else
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public int FastHashXxHash3()
+    {
+        int hash = 0;
+        ref byte data = ref MemoryMarshal.GetArrayDataReference(_data);
+        for (int i = 0; i < OperationsPerInvoke; i++)
+        {
+            ReadOnlySpan<byte> input = MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref data, i * Size), Size);
+            hash = unchecked(hash + SpanExtensions.FastHashXxHash3(input, XxHashSeed));
+        }
+        return hash;
+    }
+#endif
+}
+
+[ShortRunJob]
+[DisassemblyDiagnoser]
+[MemoryDiagnoser]
+public class FastHash64Benchmarks
+{
+    private const int OperationsPerInvoke = 1024;
+#if !ZK_EVM
+    private const long XxHashSeed = 0x510E527FADE682D1L;
+#endif
+    private byte[] _data = null!;
+
+    [Params(20, 32)]
+    public int Size;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _data = new byte[Size * OperationsPerInvoke];
+        Random.Shared.NextBytes(_data);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = OperationsPerInvoke)]
+    public long FastHash64()
+    {
+        long hash = 0;
+        ref byte data = ref MemoryMarshal.GetArrayDataReference(_data);
+        for (int i = 0; i < OperationsPerInvoke; i++)
+        {
+            ref byte start = ref Unsafe.Add(ref data, i * Size);
+            long next = Size == 20
+                ? SpanExtensions.FastHash64For20Bytes(ref start)
+                : SpanExtensions.FastHash64For32Bytes(ref start);
+            hash = unchecked(hash + next);
+        }
+        return hash;
+    }
+
+#if ZK_EVM
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public long FastHash64Crc()
+    {
+        long hash = 0;
+        ref byte data = ref MemoryMarshal.GetArrayDataReference(_data);
+        uint seed = SpanExtensions.ComputeSeed(Size);
+        for (int i = 0; i < OperationsPerInvoke; i++)
+        {
+            ref byte start = ref Unsafe.Add(ref data, i * Size);
+            long next = Size == 20
+                ? SpanExtensions.FastHash64For20BytesCrc(ref start, seed)
+                : SpanExtensions.FastHash64For32BytesCrc(ref start, seed);
+            hash = unchecked(hash + next);
+        }
+        return hash;
+    }
+#else
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public long FastHash64XxHash3()
+    {
+        long hash = 0;
+        ref byte data = ref MemoryMarshal.GetArrayDataReference(_data);
+        for (int i = 0; i < OperationsPerInvoke; i++)
+        {
+            ref byte start = ref Unsafe.Add(ref data, i * Size);
+            hash = unchecked(hash + SpanExtensions.FastHash64XxHash3(ref start, Size, XxHashSeed));
+        }
+        return hash;
+    }
+#endif
 }

--- a/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BytesTests.cs
@@ -2,13 +2,18 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using Arm = System.Runtime.Intrinsics.Arm;
+using x64 = System.Runtime.Intrinsics.X86;
 using Nethermind.Core.Extensions;
+using Nethermind.Int256;
 using NUnit.Framework;
 
 namespace Nethermind.Core.Test
@@ -702,18 +707,9 @@ namespace Nethermind.Core.Test
             }
         }
 
-        [TestCase(1)]
-        [TestCase(7)]
-        [TestCase(8)]
-        [TestCase(15)]
-        [TestCase(16)]
-        [TestCase(31)]
-        [TestCase(32)]
-        [TestCase(33)]
-        [TestCase(64)]
-        [TestCase(128)]
-        [TestCase(256)]
-        [TestCase(500)]
+        private static readonly int[] FastHashLengths = [1, 4, 5, 7, 8, 15, 16, 31, 32, 33, 64, 128, 256, 500];
+
+        [TestCaseSource(nameof(FastHashLengths))]
         public void FastHash_VariousLengths_AllBytesContribute(int length)
         {
             byte[] input = new byte[length];
@@ -733,27 +729,394 @@ namespace Nethermind.Core.Test
             }
         }
 
-        [TestCase(1, 1000u, 2000u)]
-        [TestCase(8, 1000u, 2000u)]
-        [TestCase(16, 1000u, 2000u)]
-        [TestCase(16, 0u, 1u)]
-        [TestCase(16, 0u, 0xFFFFFFFFu)]
-        [TestCase(20, 1000u, 2000u)]
-        [TestCase(32, 1000u, 2000u)]
-        [TestCase(33, 1000u, 2000u)]
-        [TestCase(64, 1000u, 2000u)]
-        [TestCase(65, 1000u, 2000u)]
-        [TestCase(71, 1000u, 2000u)]
-        [TestCase(79, 1000u, 2000u)]
-        [TestCase(80, 1000u, 2000u)]
-        [TestCase(128, 1000u, 2000u)]
+        [TestCaseSource(nameof(FastHashSeedCases))]
         public void FastHash_SeedAffectsOutput(int length, uint seed1, uint seed2)
         {
+            Require(AesIsSupported, "AES path");
+
             byte[] input = new byte[length];
             for (int i = 0; i < length; i++)
                 input[i] = (byte)(i * 0x17 + 0x42);
 
-            Assert.That(SpanExtensions.FastHash(input, seed1), Is.Not.EqualTo(SpanExtensions.FastHash(input, seed2)), $"seeds {seed1} vs {seed2} for {length} bytes");
+            Assert.That(FastHashAes(input, seed1), Is.Not.EqualTo(FastHashAes(input, seed2)), $"seeds {seed1} vs {seed2} for {length} bytes");
+        }
+
+        private static IEnumerable<TestCaseData> FastHashSeedCases()
+        {
+            foreach (int length in new int[] { 1, 8, 16, 20, 32, 33, 64, 65, 71, 79, 80, 128 })
+                yield return new TestCaseData(length, 1000u, 2000u);
+
+            yield return new TestCaseData(16, 0u, 1u);
+            yield return new TestCaseData(16, 0u, uint.MaxValue);
+        }
+
+        private static int FastHashAes(byte[] input, uint seed)
+        {
+            ref byte start = ref MemoryMarshal.GetArrayDataReference(input);
+            Vector128<byte> aesSeed = Vector128.Create(seed).AsByte();
+            if (input.Length >= 16)
+                return SpanExtensions.FastHashAes(ref start, input.Length, aesSeed);
+
+            Vector128<byte> finalSeed = SpanExtensions.ComputeAesFinalSeed();
+            return SpanExtensions.FastHashAesShort(ref start, input.Length, aesSeed, finalSeed);
+        }
+
+#if !ZK_EVM
+        [TestCase(false, TestName = "FastHash_StructuredEightByteInputs_AreDistributed_PublicPath")]
+        [TestCase(true, TestName = "FastHash_StructuredEightByteInputs_AreDistributed_XxHash3Fallback")]
+        public void FastHash_StructuredEightByteInputs_AreDistributed(bool forceXxHash3)
+        {
+            const int count = 1024;
+            const long seed = 0x510E527FADE682D1L;
+            ulong pairedDelta = SolveCrcInput(0);
+            byte[] input0 = new byte[sizeof(ulong)];
+            byte[] input1 = new byte[sizeof(ulong)];
+            int equalPairs = 0;
+
+            for (uint value = 0; value < count; value++)
+            {
+                ulong word = value * 0x9E3779B97F4A7C15UL;
+                BinaryPrimitives.WriteUInt64LittleEndian(input0, word);
+                BinaryPrimitives.WriteUInt64LittleEndian(input1, word ^ pairedDelta);
+
+                int hash0 = forceXxHash3
+                    ? SpanExtensions.FastHashXxHash3(input0, seed)
+                    : input0.FastHash();
+                int hash1 = forceXxHash3
+                    ? SpanExtensions.FastHashXxHash3(input1, seed)
+                    : input1.FastHash();
+                if (hash0 == hash1) equalPairs++;
+            }
+
+            Assert.That(equalPairs, Is.LessThan(4), $"structured pairs produced {equalPairs}/{count} equal hashes");
+        }
+#endif
+
+        [Test]
+        public void FastHash_ShortPaddingIncludesLength()
+        {
+            byte[] input = [1, 2, 3, 4, 5, 6, 7, 8];
+            byte[] extended = [1, 2, 3, 4, 5, 6, 7, 8, 0];
+
+            Assert.That(input.FastHash(), Is.Not.EqualTo(extended.FastHash()));
+        }
+
+        private const int HashDistributionSampleCount = 4096;
+        private static readonly uint[] HashSeeds = [0u, 1u, 0xDEADBEEFu];
+        private static bool AesIsSupported => x64.Aes.IsSupported || Arm.Aes.IsSupported;
+
+        [Test]
+        public void ComputeAesSeed_LengthAffectsSeed()
+            => Assert.That(SpanExtensions.ComputeAesSeed(32), Is.Not.EqualTo(SpanExtensions.ComputeAesSeed(33)));
+
+        [TestCase(32, 0, 4)]
+        [TestCase(48, 20, 36)]
+        [TestCase(64, 20, 36)]
+        [TestCase(192, 68, 132)]
+        [TestCase(208, 68, 132)]
+        public void FastHashAes_StructuredWordsAreDistributed(int length, int offsetA, int offsetB)
+        {
+            Require(AesIsSupported, "AES path");
+
+            byte[] input = new byte[length];
+            AssertIntHashesAreDistributedForSeeds((value, seed) =>
+            {
+                BinaryPrimitives.WriteInt32LittleEndian(input.AsSpan(offsetA), value);
+                BinaryPrimitives.WriteInt32LittleEndian(input.AsSpan(offsetB), value);
+                return SpanExtensions.FastHashAes(
+                    ref MemoryMarshal.GetArrayDataReference(input), length, Vector128.Create(seed).AsByte());
+            }, $"{length}-byte structured inputs");
+        }
+
+        [Test]
+        public void FastHashAes_StructuredFirstRoundInputsAreDistributed()
+        {
+            Require(AesIsSupported, "AES path");
+
+            byte[] input = new byte[32];
+            Vector128<byte> zeroRound = AesRound(Vector128<byte>.Zero);
+            AssertIntHashesAreDistributed(value =>
+            {
+                BinaryPrimitives.WriteInt32LittleEndian(input.AsSpan(4), value);
+                Vector128<byte> first = MemoryMarshal.Read<Vector128<byte>>(input);
+                Vector128<byte> paired = zeroRound ^ AesRound(first);
+                MemoryMarshal.Write(input.AsSpan(16), in paired);
+                return SpanExtensions.FastHash(input);
+            }, "counterbalanced first-round inputs");
+        }
+
+        [Test]
+        public void StorageCell_GetHashCode_StructuredSlotsAreDistributed()
+        {
+            Require(AesIsSupported, "AES path");
+
+            byte[] slotBytes = new byte[32];
+            AssertIntHashesAreDistributed(value =>
+            {
+                Vector128<byte> second = Vector128.Create((uint)value, 0u, 0u, 0u).AsByte();
+                Vector128<byte> first = AesRound(second);
+                MemoryMarshal.Write(slotBytes, in first);
+                MemoryMarshal.Write(slotBytes.AsSpan(16), in second);
+
+                StorageCell cell = new(Address.Zero, new UInt256(slotBytes, isBigEndian: false));
+                return cell.GetHashCode();
+            }, "structured storage slots");
+        }
+
+        [Test]
+        public void StorageCell_PairedAddressAndSlotHashesAreDistributed()
+        {
+            Require(AesIsSupported, "AES path");
+
+            const uint lengthSeedDifference = Address.Size ^ 32;
+            byte[] addressBytes = new byte[Address.Size];
+            byte[] slotBytes = new byte[32];
+            int[] intHashes = new int[HashDistributionSampleCount];
+            long[] hashes = new long[HashDistributionSampleCount];
+            int equalComponentHashes = 0;
+            int inconsistentHashWidths = 0;
+
+            for (int value = 0; value < HashDistributionSampleCount; value++)
+            {
+                BinaryPrimitives.WriteInt32LittleEndian(addressBytes, value);
+                for (int offset = 0; offset < 16; offset += sizeof(uint))
+                {
+                    uint word = BinaryPrimitives.ReadUInt32LittleEndian(addressBytes.AsSpan(offset)) ^ lengthSeedDifference;
+                    BinaryPrimitives.WriteUInt32LittleEndian(slotBytes.AsSpan(offset), word);
+                }
+                addressBytes.AsSpan(16, sizeof(uint)).CopyTo(slotBytes.AsSpan(16));
+
+                Address address = new(addressBytes);
+                long indexHash = SpanExtensions.FastHash64For32Bytes(ref MemoryMarshal.GetArrayDataReference(slotBytes));
+                equalComponentHashes += indexHash == address.GetHashCode64() ? 1 : 0;
+
+                StorageCell cell = new(address, new UInt256(slotBytes, isBigEndian: false));
+                intHashes[value] = cell.GetHashCode();
+                hashes[value] = cell.GetHashCode64();
+                ulong hash = (ulong)hashes[value];
+                inconsistentHashWidths += intHashes[value] != (int)(hash ^ (hash >> 32)) ? 1 : 0;
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(equalComponentHashes, Is.LessThan(4), "fixed-size component hashes");
+                Assert.That(inconsistentHashWidths, Is.Zero, "32-bit hashes");
+                AssertIntHashesAreDistributed(value => intHashes[value], "paired storage cells");
+                AssertHash64WindowsAreDistributed(hashes, "paired storage cells");
+            }
+        }
+
+        [Test]
+        public void MumFold_EqualInputsAreDistributed()
+            => AssertIntHashesAreDistributed(
+                value => (int)SpanExtensions.MumFold((uint)value, (uint)value),
+                "equal input words");
+
+        private static Vector128<byte> AesRound(Vector128<byte> state)
+            => x64.Aes.IsSupported
+                ? x64.Aes.Encrypt(state, Vector128<byte>.Zero)
+                : Arm.Aes.MixColumns(Arm.Aes.Encrypt(state, Vector128<byte>.Zero));
+
+        [Test]
+        public void FastHashAes_StructuredTailInputsAreDistributed()
+        {
+            Require(AesIsSupported, "AES path");
+
+            byte[] input0 = new byte[72];
+            byte[] input1 = new byte[72];
+            BinaryPrimitives.WriteUInt64LittleEndian(input1.AsSpan(64), SolveCrcInput(0));
+
+            Assert.That(input0.FastHash(), Is.Not.EqualTo(input1.FastHash()));
+        }
+
+        [Test]
+        public void FastHashAes_Twin16ByteHalvesAreDistributed()
+        {
+            Require(AesIsSupported, "AES path");
+
+            byte[] input = new byte[32];
+            AssertIntHashesAreDistributedForSeeds((value, seed) =>
+            {
+                BinaryPrimitives.WriteInt32LittleEndian(input.AsSpan(4), value);
+                BinaryPrimitives.WriteInt32LittleEndian(input.AsSpan(20), value);
+                return SpanExtensions.FastHashAes(
+                    ref MemoryMarshal.GetArrayDataReference(input), input.Length, Vector128.Create(seed).AsByte());
+            }, "twin-half inputs");
+        }
+
+        // Exercise mirrored values across both pairs of the 4-lane AES fold.
+        [Test]
+        public void FastHash_PairedSiblingBlocksAreDistributed()
+        {
+            Require(AesIsSupported, "AES lane fold");
+
+            const int length = 96;       // exercises the 4-lane fold path (> 64 bytes)
+            const int blockA = 32;       // 16-byte block feeding one fold-pair lane
+            const int blockB = 48;       // 16-byte block feeding its pair
+            const int mirrorOffset = 4;  // same offset inside both blocks
+            byte[] input = new byte[length];
+            AssertIntHashesAreDistributedForSeeds((value, seed) =>
+            {
+                // Keep the two blocks byte-identical while varying the mirrored value in both.
+                BinaryPrimitives.WriteInt32LittleEndian(input.AsSpan(blockA + mirrorOffset), value);
+                BinaryPrimitives.WriteInt32LittleEndian(input.AsSpan(blockB + mirrorOffset), value);
+                return SpanExtensions.FastHashAes(
+                    ref MemoryMarshal.GetArrayDataReference(input), length, Vector128.Create(seed).AsByte());
+            }, "mirrored-block inputs");
+        }
+
+        // Exercise correlated values in two words feeding the same CRC lane.
+        [Test]
+        public void FastHashCrc_StructuredLaneInputsAreDistributed()
+        {
+            const int length = 64;    // one 64-byte unrolled iteration: words 0 and 32 both feed lane h0
+            byte[] input = new byte[length];
+            AssertIntHashesAreDistributedForSeeds((value, seed) =>
+            {
+                ulong delta0 = (uint)value;
+                uint target = BitOperations.Crc32C(BitOperations.Crc32C(0u, delta0), 0UL);
+                ulong f = SolveCrcInput(target);
+                BinaryPrimitives.WriteUInt64LittleEndian(input.AsSpan(0), delta0);
+                BinaryPrimitives.WriteUInt64LittleEndian(input.AsSpan(32), f);
+                return SpanExtensions.FastHashCrc(
+                    ref MemoryMarshal.GetArrayDataReference(input), length, seed);
+            }, "CRC intra-lane inputs");
+        }
+
+        private static void Require(bool supported, string feature)
+        {
+            if (!supported)
+                Assert.Ignore($"The {feature} is not available on this CPU.");
+        }
+
+        private static void AssertIntHashesAreDistributedForSeeds(Func<int, uint, int> getHash, string context)
+        {
+            foreach (uint seed in HashSeeds)
+                AssertIntHashesAreDistributed(value => getHash(value, seed), $"{context} for seed {seed}");
+        }
+
+        private static void AssertIntHashesAreDistributed(Func<int, int> getHash, string context)
+        {
+            HashSet<int> hashes = new(HashDistributionSampleCount);
+            for (int value = 0; value < HashDistributionSampleCount; value++)
+                hashes.Add(getHash(value));
+
+            Assert.That(hashes.Count, Is.GreaterThan(HashDistributionSampleCount - 32),
+                $"{context} collapsed to {hashes.Count}/{HashDistributionSampleCount} distinct hashes");
+        }
+
+        // Exercise correlated values across two lanes of the fixed-size CRC path.
+        [Test]
+        public void FastHash64For32BytesCrc_StructuredLaneInputsAreDistributed()
+        {
+            foreach (uint seed in HashSeeds)
+            {
+                byte[] input = new byte[32];
+                long[] hashes = new long[HashDistributionSampleCount];
+                for (ulong c = 0; c < HashDistributionSampleCount; c++)
+                {
+                    ulong e = SolveCrcInput(BitOperations.Crc32C(0u, c));
+                    BinaryPrimitives.WriteUInt64LittleEndian(input.AsSpan(0), c);
+                    BinaryPrimitives.WriteUInt64LittleEndian(input.AsSpan(16), e);
+                    hashes[c] = SpanExtensions.FastHash64For32BytesCrc(
+                        ref MemoryMarshal.GetArrayDataReference(input), seed);
+                }
+
+                AssertHash64WindowsAreDistributed(hashes, $"32-byte CRC lane inputs for seed {seed}");
+            }
+        }
+
+        [TestCase(20)]
+        [TestCase(32)]
+        public void FastHash64_CacheBitWindowsAreDistributed(int length)
+        {
+            const int count = 4096;
+            byte[] input = new byte[length];
+            long[] hashes = new long[count];
+            long[] crcHashes = new long[count];
+#if !ZK_EVM
+            long[] xxHashes = new long[count];
+#endif
+            uint seed = SpanExtensions.ComputeSeed(length);
+            for (ulong value = 0; value < count; value++)
+            {
+                BinaryPrimitives.WriteUInt64LittleEndian(input.AsSpan(length - 8), value);
+                ref byte start = ref MemoryMarshal.GetArrayDataReference(input);
+                hashes[value] = length == 20
+                    ? SpanExtensions.FastHash64For20Bytes(ref start)
+                    : SpanExtensions.FastHash64For32Bytes(ref start);
+                crcHashes[value] = length == 20
+                    ? SpanExtensions.FastHash64For20BytesCrc(ref start, seed)
+                    : SpanExtensions.FastHash64For32BytesCrc(ref start, seed);
+#if !ZK_EVM
+                xxHashes[value] = SpanExtensions.FastHash64XxHash3(ref start, length, seed);
+#endif
+            }
+
+            AssertHash64WindowsAreDistributed(hashes, $"{length}-byte hashes");
+            AssertHash64WindowsAreDistributed(crcHashes, $"{length}-byte CRC hashes");
+#if !ZK_EVM
+            AssertHash64WindowsAreDistributed(xxHashes, $"{length}-byte XXH3 hashes");
+#endif
+        }
+
+        private static void AssertHash64WindowsAreDistributed(long[] hashes, string context)
+        {
+            HashSet<long> fullHashes = new(hashes.Length);
+            HashSet<int> way0Sets = new(hashes.Length);
+            HashSet<int> signatures = new(hashes.Length);
+            HashSet<int> way1Sets = new(hashes.Length);
+
+            foreach (long hash in hashes)
+            {
+                ulong bits = (ulong)hash;
+                fullHashes.Add(hash);
+                way0Sets.Add((int)(bits & 0x3FFF));
+                signatures.Add((int)((bits >> 22) & 0xF_FFFF));
+                way1Sets.Add((int)((bits >> 42) & 0x3FFF));
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(fullHashes.Count, Is.GreaterThan(hashes.Length - 32), $"{context}: full hash");
+                Assert.That(way0Sets.Count, Is.GreaterThan(hashes.Length * 3 / 4), $"{context}: bits 0-13");
+                Assert.That(signatures.Count, Is.GreaterThan(hashes.Length - 32), $"{context}: bits 22-41");
+                Assert.That(way1Sets.Count, Is.GreaterThan(hashes.Length * 3 / 4), $"{context}: bits 42-55");
+            }
+        }
+
+        private static ulong SolveCrcInput(uint target)
+        {
+            Span<uint> pivBasis = stackalloc uint[32];
+            Span<ulong> pivSrc = stackalloc ulong[32];
+            pivBasis.Clear();
+            ulong dependentInput = 0;
+            for (int i = 0; i < 64; i++)
+            {
+                uint b = BitOperations.Crc32C(0u, 1UL << i);
+                ulong s = 1UL << i;
+                while (b != 0)
+                {
+                    int col = BitOperations.TrailingZeroCount(b);
+                    if (pivBasis[col] == 0) { pivBasis[col] = b; pivSrc[col] = s; break; }
+                    b ^= pivBasis[col];
+                    s ^= pivSrc[col];
+                }
+                if (b == 0 && dependentInput == 0) dependentInput = s;
+            }
+
+            if (target == 0) return dependentInput;
+
+            ulong f = 0;
+            uint t = target;
+            while (t != 0)
+            {
+                int col = BitOperations.TrailingZeroCount(t);
+                if (pivBasis[col] == 0) break; // target not in column space (does not happen for CRC32C)
+                t ^= pivBasis[col];
+                f ^= pivSrc[col];
+            }
+            return f;
         }
 
         // ── CountZeros edge-case tests ──

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -348,6 +348,8 @@ namespace Nethermind.Core.Extensions
             }
             else
             {
+                // len == 16 aliases the block that built acc0 as the round key. Safe because
+                // FastHashAesRound XORs the key in after SubBytes, so key and state cannot cancel.
                 Vector128<byte> data = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, len - 16));
                 acc0 = FastHashAesRound(acc0, data);
             }
@@ -600,8 +602,9 @@ namespace Nethermind.Core.Extensions
         public static ulong ToULong(this byte[] bytes) => ToULong((ReadOnlySpan<byte>)bytes);
 
         // Folds two 64-bit words to one with a multiply (mum/wymix): the product is non-linear in both
-        // words and spreads each word's high bits into the low output bits. The XOR constants keep an
-        // all-zero word from zeroing the product.
+        // words and spreads each word's high bits into the low output bits. The XOR constants move each
+        // factor's zeroing input off the common all-zero word; a factor still degenerates when a word
+        // equals its constant, which seeded inputs hit with probability 2^-64.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static long MumFold(ulong a, ulong b)
         {

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -13,25 +13,34 @@ using System.Runtime.Intrinsics;
 using Arm = System.Runtime.Intrinsics.Arm;
 using x64 = System.Runtime.Intrinsics.X86;
 using Nethermind.Core.Collections;
-#if ZK_EVM
-// RISC-V lacks CRC32C; route hashing to the guest substitute (see ZkEvmBitOperations).
-using BitOperations = Nethermind.Core.Extensions.ZkEvmBitOperations;
-#endif
 
 namespace Nethermind.Core.Extensions
 {
-    public static class SpanExtensions
+    public static partial class SpanExtensions
     {
-        // Ensure that hashes are different for every run of the node and every node, so if are any hash collisions on
-        // one node, they will not be the same on another node or across a restart so hash collision cannot be used to degrade
-        // the performance of the network as a whole.
-        public static readonly uint InstanceRandom =
-#if ZK_EVM
-            2098026241U;
-#else
-            (uint)System.Security.Cryptography.RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue);
-#endif
+        private const ulong ShortInputDomain = 0xD6E8FEB86659FD93UL;
+
         internal static uint ComputeSeed(int len) => InstanceRandom + (uint)len;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static Vector128<byte> ComputeAesSeed(int len)
+        {
+            ulong lengthSalt = (uint)len;
+            lengthSalt |= lengthSalt << 32;
+            return Vector128.Create(AesHashSeed0 ^ lengthSalt, AesHashSeed1 ^ lengthSalt).AsByte();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static Vector128<byte> ComputeAesFinalSeed()
+            => Vector128.Create(AesHashFinalSeed0, AesHashFinalSeed1).AsByte();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<byte> ComputeAes20Seed()
+            => Vector128.Create(AesHash20Seed0, AesHash20Seed1).AsByte();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<byte> ComputeAes32Seed()
+            => Vector128.Create(AesHash32Seed0, AesHash32Seed1).AsByte();
 
         public static string ToHexString(this in Memory<byte> memory, bool withZeroX = false) =>
             memory.Span.ToHexString(withZeroX, false, false);
@@ -187,106 +196,139 @@ namespace Nethermind.Core.Extensions
         /// </returns>
         /// <remarks>
         /// <para>
-        /// This routine is optimized for throughput and low overhead on modern CPUs. It is based on CRC32C (Castagnoli)
-        /// via <see cref="BitOperations.Crc32C(uint, ulong)"/> and related overloads, and will use hardware acceleration
-        /// when the runtime and processor support it.
+        /// This routine is optimized for throughput and low overhead on modern CPUs. It uses keyed AES rounds when
+        /// hardware acceleration is available. Otherwise, normal builds use process-seeded XXH3 and ZK builds use
+        /// their deterministic guest mixer.
         /// </para>
         /// <para>
         /// The hash is intended for in-memory data structures (for example, hash tables, caches, and quick bucketing).
-        /// It is not suitable for cryptographic purposes, integrity verification, or security-sensitive scenarios.
-        /// In particular, it is not collision resistant and should not be used as a MAC, signature, or authentication token.
+        /// It is not suitable for cryptographic purposes or integrity verification.
+        /// It must not be used as a MAC, signature, or authentication token.
         /// </para>
         /// <para>
-        /// The returned value is an implementation detail. It is seeded with an instance-random value and may be
-        /// platform and runtime dependent, so do not persist it or rely on it being stable across processes or versions.
+        /// The returned value is an implementation detail. Normal builds use process-random seeds; ZK builds are
+        /// deterministic. Do not persist it or rely on it being stable across platforms or versions.
         /// </para>
         /// </remarks>
         [SkipLocalsInit]
         public static int FastHash(this ReadOnlySpan<byte> input)
-            => FastHash(input, InstanceRandom + (uint)input.Length);
-
-        internal static int FastHash(ReadOnlySpan<byte> input, uint seed)
         {
             int len = input.Length;
             if (len == 0) return 0;
 
             ref byte start = ref MemoryMarshal.GetReference(input);
-
-            if (len >= 16)
+            if (x64.Aes.IsSupported || Arm.Aes.IsSupported)
             {
-                if (x64.Aes.IsSupported) return FastHashAesX64(ref start, len, seed);
-                if (Arm.Aes.IsSupported) return FastHashAesArm(ref start, len, seed);
+                return len < 16
+                    ? FastHashAesShort(ref start, len, ComputeAesSeed(0), ComputeAesFinalSeed())
+                    : FastHashAes(ref start, len, ComputeAesSeed(len));
             }
 
-            return FastHashCrc(ref start, len, seed);
+            return FastHashFallback(input);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<byte> LoadShortInput(ref byte start, int len)
+        {
+            Debug.Assert((uint)(len - 1) < 15u);
+
+            ulong lo;
+            ulong hi;
+            if (len >= 8)
+            {
+                lo = Unsafe.ReadUnaligned<ulong>(ref start);
+                int remaining = len - sizeof(ulong);
+                hi = ReadPartialWord(ref Unsafe.Add(ref start, sizeof(ulong)), remaining);
+                hi |= 0x80UL << (remaining * 8);
+            }
+            else
+            {
+                lo = ReadPartialWord(ref start, len);
+                lo |= 0x80UL << (len * 8);
+                hi = 0;
+            }
+
+            return Vector128.Create(lo, hi ^ ShortInputDomain).AsByte();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static ulong ReadPartialWord(ref byte p, int length)
+            {
+                Debug.Assert((uint)length < sizeof(ulong));
+
+                ulong value = 0;
+                int offset = 0;
+                if ((length & sizeof(uint)) != 0)
+                {
+                    value = Unsafe.ReadUnaligned<uint>(ref p);
+                    offset = sizeof(uint);
+                }
+                if ((length & sizeof(ushort)) != 0)
+                {
+                    value |= (ulong)Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref p, offset)) << (offset * 8);
+                    offset += sizeof(ushort);
+                }
+                if ((length & sizeof(byte)) != 0)
+                    value |= (ulong)Unsafe.Add(ref p, offset) << (offset * 8);
+
+                return value;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int FastHashAesShort(
+            ref byte start,
+            int len,
+            Vector128<byte> seedVec,
+            Vector128<byte> finalSeedVec)
+        {
+            Vector128<byte> mixed = FastHashAesRound(LoadShortInput(ref start, len), seedVec);
+            mixed = FastHashAesRound(mixed, finalSeedVec);
+            return (int)MumFold(mixed);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [SkipLocalsInit]
-        internal static int FastHashAesX64(ref byte start, int len, uint seed)
+        internal static int FastHashAes(ref byte start, int len, Vector128<byte> seedVec)
         {
-            Vector128<byte> seedVec = Vector128.CreateScalar(seed).AsByte();
-            Vector128<byte> acc0 = Unsafe.As<byte, Vector128<byte>>(ref start) ^ seedVec;
+            Vector128<byte> acc0 = FastHashAesRound(Unsafe.As<byte, Vector128<byte>>(ref start), seedVec);
 
             if (len > 64)
             {
-                Vector128<byte> acc1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, 16)) ^ seedVec;
-                Vector128<byte> acc2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, 32)) ^ seedVec;
-                Vector128<byte> acc3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, 48)) ^ seedVec;
+                Vector128<byte> acc1 = FastHashAesRound(Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, 16)), seedVec);
+                Vector128<byte> acc2 = FastHashAesRound(Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, 32)), seedVec);
+                Vector128<byte> acc3 = FastHashAesRound(Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, 48)), seedVec);
 
                 ref byte p = ref Unsafe.Add(ref start, 64);
                 int remaining = len - 64;
 
                 while (remaining >= 64)
                 {
-                    acc0 = x64.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref p), acc0);
-                    acc1 = x64.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref p, 16)), acc1);
-                    acc2 = x64.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref p, 32)), acc2);
-                    acc3 = x64.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref p, 48)), acc3);
+                    acc0 = FastHashAesRound(acc0, Unsafe.As<byte, Vector128<byte>>(ref p));
+                    acc1 = FastHashAesRound(acc1, Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref p, 16)));
+                    acc2 = FastHashAesRound(acc2, Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref p, 32)));
+                    acc3 = FastHashAesRound(acc3, Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref p, 48)));
 
                     p = ref Unsafe.Add(ref p, 64);
                     remaining -= 64;
                 }
 
-                // Fold 4 lanes: 3 XOR + 1 AES (minimal serial latency)
-                acc0 ^= acc1;
-                acc2 ^= acc3;
-                acc0 ^= acc2;
-                acc0 = x64.Aes.Encrypt(seedVec, acc0);
+                // Fold lanes with asymmetric AES mixing.
+                Vector128<byte> m01 = FastHashAesRound(acc0, acc1);
+                Vector128<byte> m23 = FastHashAesRound(acc2, acc3);
+                acc0 = FastHashAesRound(m01, m23);
 
                 // Drain remaining 0-63 bytes
                 while (remaining >= 16)
                 {
-                    acc0 = x64.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref p), acc0);
+                    acc0 = FastHashAesRound(acc0, Unsafe.As<byte, Vector128<byte>>(ref p));
                     p = ref Unsafe.Add(ref p, 16);
                     remaining -= 16;
                 }
 
-                // Remaining 1-15 bytes: use CRC to avoid overlap with drain blocks
                 if (remaining > 0)
                 {
-                    uint crc = seed;
-                    if (remaining >= 8)
-                    {
-                        crc = BitOperations.Crc32C(crc, Unsafe.ReadUnaligned<ulong>(ref p));
-                        p = ref Unsafe.Add(ref p, 8);
-                        remaining -= 8;
-                    }
-                    if ((remaining & 4) != 0)
-                    {
-                        crc = BitOperations.Crc32C(crc, Unsafe.ReadUnaligned<uint>(ref p));
-                        p = ref Unsafe.Add(ref p, 4);
-                    }
-                    if ((remaining & 2) != 0)
-                    {
-                        crc = BitOperations.Crc32C(crc, Unsafe.ReadUnaligned<ushort>(ref p));
-                        p = ref Unsafe.Add(ref p, 2);
-                    }
-                    if ((remaining & 1) != 0)
-                    {
-                        crc = BitOperations.Crc32C(crc, p);
-                    }
-                    acc0 = x64.Aes.Encrypt(Vector128.CreateScalar(crc).AsByte(), acc0);
+                    Vector128<byte> last = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, len - 16));
+                    acc0 = FastHashAesRound(acc0, last);
                 }
             }
             else if (len > 32)
@@ -296,123 +338,29 @@ namespace Nethermind.Core.Extensions
 
                 while (remaining > 16)
                 {
-                    acc0 = x64.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref p), acc0);
+                    acc0 = FastHashAesRound(acc0, Unsafe.As<byte, Vector128<byte>>(ref p));
                     p = ref Unsafe.Add(ref p, 16);
                     remaining -= 16;
                 }
 
                 Vector128<byte> last = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, len - 16));
-                acc0 = x64.Aes.Encrypt(last, acc0);
+                acc0 = FastHashAesRound(acc0, last);
             }
             else
             {
                 Vector128<byte> data = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, len - 16));
-                acc0 = x64.Aes.Encrypt(data, acc0);
+                acc0 = FastHashAesRound(acc0, data);
             }
 
-            ulong compressed = acc0.AsUInt64().GetElement(0) ^ acc0.AsUInt64().GetElement(1);
-            return (int)(uint)(compressed ^ (compressed >> 32));
+            return (int)MumFold(acc0);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        [SkipLocalsInit]
-        internal static int FastHashAesArm(ref byte start, int len, uint seed)
-        {
-            Vector128<byte> seedVec = Vector128.CreateScalar(seed).AsByte();
-            Vector128<byte> input0 = Unsafe.As<byte, Vector128<byte>>(ref start);
-            Vector128<byte> acc0 = input0 ^ seedVec;
-
-            if (len > 64)
-            {
-                Vector128<byte> acc1 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, 16)) ^ seedVec;
-                Vector128<byte> acc2 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, 32)) ^ seedVec;
-                Vector128<byte> acc3 = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, 48)) ^ seedVec;
-
-                ref byte p = ref Unsafe.Add(ref start, 64);
-                int remaining = len - 64;
-
-                while (remaining >= 64)
-                {
-                    acc0 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref p), acc0));
-                    acc1 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref p, 16)), acc1));
-                    acc2 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref p, 32)), acc2));
-                    acc3 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref p, 48)), acc3));
-
-                    p = ref Unsafe.Add(ref p, 64);
-                    remaining -= 64;
-                }
-
-                acc0 ^= acc1;
-                acc2 ^= acc3;
-                acc0 ^= acc2;
-                acc0 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(seedVec, acc0));
-
-                while (remaining >= 16)
-                {
-                    acc0 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref p), acc0));
-                    p = ref Unsafe.Add(ref p, 16);
-                    remaining -= 16;
-                }
-
-                if (remaining > 0)
-                {
-                    uint crc = seed;
-                    if (remaining >= 8)
-                    {
-                        crc = BitOperations.Crc32C(crc, Unsafe.ReadUnaligned<ulong>(ref p));
-                        p = ref Unsafe.Add(ref p, 8);
-                        remaining -= 8;
-                    }
-                    if ((remaining & 4) != 0)
-                    {
-                        crc = BitOperations.Crc32C(crc, Unsafe.ReadUnaligned<uint>(ref p));
-                        p = ref Unsafe.Add(ref p, 4);
-                    }
-                    if ((remaining & 2) != 0)
-                    {
-                        crc = BitOperations.Crc32C(crc, Unsafe.ReadUnaligned<ushort>(ref p));
-                        p = ref Unsafe.Add(ref p, 2);
-                    }
-                    if ((remaining & 1) != 0)
-                    {
-                        crc = BitOperations.Crc32C(crc, p);
-                    }
-                    acc0 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(Vector128.CreateScalar(crc).AsByte(), acc0));
-                }
-            }
-            else if (len > 32)
-            {
-                ref byte p = ref Unsafe.Add(ref start, 16);
-                int remaining = len - 16;
-
-                while (remaining > 16)
-                {
-                    acc0 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(Unsafe.As<byte, Vector128<byte>>(ref p), acc0));
-                    p = ref Unsafe.Add(ref p, 16);
-                    remaining -= 16;
-                }
-
-                Vector128<byte> last = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, len - 16));
-                acc0 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(last, acc0));
-            }
-            else if (len > 16)
-            {
-                Vector128<byte> data = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, len - 16));
-                acc0 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(data, acc0));
-            }
-            else
-            {
-                // len == 16: start+len-16 == start, so data would be the same bytes
-                // that built acc0. ARM Arm.Aes.Encrypt XORs its operands before scrambling,
-                // so Encrypt(input, input^seed) cancels input, losing all input dependence.
-                // Feed input and seedVec directly so the XOR yields (input ^ seed),
-                // then SubBytes and ShiftRows, and Arm.Aes.MixColumns completes the round.
-                acc0 = Arm.Aes.MixColumns(Arm.Aes.Encrypt(input0, seedVec));
-            }
-
-            ulong compressed = acc0.AsUInt64().GetElement(0) ^ acc0.AsUInt64().GetElement(1);
-            return (int)(uint)(compressed ^ (compressed >> 32));
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<byte> FastHashAesRound(Vector128<byte> state, Vector128<byte> roundKey)
+            => x64.Aes.IsSupported
+                ? x64.Aes.Encrypt(state, roundKey)
+                // Keep the round key outside AESE so state and roundKey have distinct roles in the mixer.
+                : Arm.Aes.MixColumns(Arm.Aes.Encrypt(state, Vector128<byte>.Zero)) ^ roundKey;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [SkipLocalsInit]
@@ -425,8 +373,8 @@ namespace Nethermind.Core.Extensions
                 {
                     ulong lo = Unsafe.ReadUnaligned<ulong>(ref start);
                     ulong hi = Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref start, len - 8));
-                    uint h0 = BitOperations.Crc32C(seed, lo);
-                    uint h1 = BitOperations.Crc32C(seed ^ 0x9E3779B9u, hi);
+                    uint h0 = CrcLane(seed, lo);
+                    uint h1 = CrcLane(seed ^ 0x9E3779B9u, hi);
                     hash = h0 + BitOperations.RotateLeft(h1, 11);
                 }
                 else
@@ -447,15 +395,15 @@ namespace Nethermind.Core.Extensions
 
                 while (remaining >= 64)
                 {
-                    h0 = BitOperations.Crc32C(h0, Unsafe.ReadUnaligned<ulong>(ref q));
-                    h1 = BitOperations.Crc32C(h1, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 8)));
-                    h2 = BitOperations.Crc32C(h2, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 16)));
-                    h3 = BitOperations.Crc32C(h3, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 24)));
+                    h0 = CrcLane(h0, Unsafe.ReadUnaligned<ulong>(ref q));
+                    h1 = CrcLane(h1, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 8)));
+                    h2 = CrcLane(h2, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 16)));
+                    h3 = CrcLane(h3, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 24)));
 
-                    h0 = BitOperations.Crc32C(h0, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 32)));
-                    h1 = BitOperations.Crc32C(h1, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 40)));
-                    h2 = BitOperations.Crc32C(h2, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 48)));
-                    h3 = BitOperations.Crc32C(h3, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 56)));
+                    h0 = CrcLane(h0, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 32)));
+                    h1 = CrcLane(h1, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 40)));
+                    h2 = CrcLane(h2, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 48)));
+                    h3 = CrcLane(h3, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 56)));
 
                     q = ref Unsafe.Add(ref q, 64);
                     remaining -= 64;
@@ -463,18 +411,18 @@ namespace Nethermind.Core.Extensions
 
                 if (remaining >= 32)
                 {
-                    h0 = BitOperations.Crc32C(h0, Unsafe.ReadUnaligned<ulong>(ref q));
-                    h1 = BitOperations.Crc32C(h1, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 8)));
-                    h2 = BitOperations.Crc32C(h2, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 16)));
-                    h3 = BitOperations.Crc32C(h3, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 24)));
+                    h0 = CrcLane(h0, Unsafe.ReadUnaligned<ulong>(ref q));
+                    h1 = CrcLane(h1, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 8)));
+                    h2 = CrcLane(h2, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 16)));
+                    h3 = CrcLane(h3, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 24)));
 
                     q = ref Unsafe.Add(ref q, 32);
                     remaining -= 32;
                 }
 
-                if (remaining >= 8) h0 = BitOperations.Crc32C(h0, Unsafe.ReadUnaligned<ulong>(ref q));
-                if (remaining >= 16) h1 = BitOperations.Crc32C(h1, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 8)));
-                if (remaining >= 24) h2 = BitOperations.Crc32C(h2, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 16)));
+                if (remaining >= 8) h0 = CrcLane(h0, Unsafe.ReadUnaligned<ulong>(ref q));
+                if (remaining >= 16) h1 = CrcLane(h1, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 8)));
+                if (remaining >= 24) h2 = CrcLane(h2, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref q, 16)));
 
                 h2 = BitOperations.RotateLeft(h2, 17) + BitOperations.RotateLeft(h3, 23);
                 h0 += BitOperations.RotateLeft(h1, 11);
@@ -498,17 +446,17 @@ namespace Nethermind.Core.Extensions
             {
                 if ((length & 4) != 0)
                 {
-                    hash = BitOperations.Crc32C(hash, Unsafe.ReadUnaligned<uint>(ref p));
+                    hash = Crc32C(hash, Unsafe.ReadUnaligned<uint>(ref p));
                     p = ref Unsafe.Add(ref p, 4);
                 }
                 if ((length & 2) != 0)
                 {
-                    hash = BitOperations.Crc32C(hash, Unsafe.ReadUnaligned<ushort>(ref p));
+                    hash = Crc32C(hash, Unsafe.ReadUnaligned<ushort>(ref p));
                     p = ref Unsafe.Add(ref p, 2);
                 }
                 if ((length & 1) != 0)
                 {
-                    hash = BitOperations.Crc32C(hash, p);
+                    hash = Crc32C(hash, p);
                 }
                 return hash;
             }
@@ -651,46 +599,56 @@ namespace Nethermind.Core.Extensions
 
         public static ulong ToULong(this byte[] bytes) => ToULong((ReadOnlySpan<byte>)bytes);
 
+        // Folds two 64-bit words to one with a multiply (mum/wymix): the product is non-linear in both
+        // words and spreads each word's high bits into the low output bits. The XOR constants keep an
+        // all-zero word from zeroing the product.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static long MumFold(ulong a, ulong b)
+        {
+            ulong low = Math.BigMul(a ^ 0x9E3779B97F4A7C15UL, b ^ 0xBF58476D1CE4E5B9UL, out ulong high);
+            return (long)(low ^ high);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long MumFold(Vector128<byte> mixed)
+            => MumFold(mixed.AsUInt64().GetElement(0), mixed.AsUInt64().GetElement(1));
+
         /// <summary>
         /// Computes a very fast, non-cryptographic 64-bit hash of exactly 32 bytes.
         /// </summary>
         /// <param name="start">Reference to the first byte of the 32-byte input.</param>
         /// <returns>A 64-bit hash value with good distribution across all bits.</returns>
         /// <remarks>
-        /// Uses AES hardware acceleration when available, falls back to CRC32C otherwise.
+        /// Uses AES hardware acceleration when available. Otherwise, normal builds use process-seeded XXH3 and ZK
+        /// builds use their deterministic guest mixer.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long FastHash64For32Bytes(ref byte start)
         {
-            uint seed = InstanceRandom + 32;
-
             if (x64.Aes.IsSupported || Arm.Aes.IsSupported)
             {
                 Vector128<byte> key = Unsafe.As<byte, Vector128<byte>>(ref start);
                 Vector128<byte> data = Unsafe.As<byte, Vector128<byte>>(ref Unsafe.Add(ref start, 16));
-                key ^= Vector128.CreateScalar(seed).AsByte();
+                key ^= ComputeAes32Seed();
                 // Two AES rounds for full diffusion: after round 1, variation spreads to one column;
                 // after round 2, every output byte depends on every input byte.
-                Vector128<byte> mixed;
-                if (x64.Aes.IsSupported)
-                {
-                    mixed = x64.Aes.Encrypt(data, key);
-                    mixed = x64.Aes.Encrypt(mixed, key);
-                }
-                else
-                {
-                    mixed = Arm.Aes.MixColumns(Arm.Aes.Encrypt(data, key));
-                    mixed = Arm.Aes.MixColumns(Arm.Aes.Encrypt(mixed, key));
-                }
-                return (long)(mixed.AsUInt64().GetElement(0) ^ mixed.AsUInt64().GetElement(1));
+                Vector128<byte> mixed = FastHashAesRound(data, key);
+                mixed = FastHashAesRound(mixed, key);
+                return MumFold(mixed);
             }
 
-            // Fallback: CRC32C-based 64-bit hash
-            ulong h0 = BitOperations.Crc32C(seed, Unsafe.ReadUnaligned<ulong>(ref start));
-            ulong h1 = BitOperations.Crc32C(seed ^ 0x9E3779B9u, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref start, 8)));
-            ulong h2 = BitOperations.Crc32C(seed ^ 0x85EBCA6Bu, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref start, 16)));
-            ulong h3 = BitOperations.Crc32C(seed ^ 0xC2B2AE35u, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref start, 24)));
-            return (long)((h0 | (h1 << 32)) ^ (h2 | (h3 << 32)));
+            return FastHash64For32BytesFallback(ref start);
+        }
+
+        // Deterministic CRC path; production fallback only in ZK builds (standard builds use XXH3).
+        // Kept internal for direct distribution tests.
+        internal static long FastHash64For32BytesCrc(ref byte start, uint seed)
+        {
+            ulong h0 = Crc32C(seed, Unsafe.ReadUnaligned<ulong>(ref start));
+            ulong h1 = Crc32C(seed ^ 0x9E3779B9u, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref start, 8)));
+            ulong h2 = Crc32C(seed ^ 0x85EBCA6Bu, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref start, 16)));
+            ulong h3 = Crc32C(seed ^ 0xC2B2AE35u, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref start, 24)));
+            return MumFold(h0 | (h1 << 32), h2 | (h3 << 32));
         }
 
         /// <summary>
@@ -699,41 +657,36 @@ namespace Nethermind.Core.Extensions
         /// <param name="start">Reference to the first byte of the 20-byte input.</param>
         /// <returns>A 64-bit hash value with good distribution across all bits.</returns>
         /// <remarks>
-        /// Uses AES hardware acceleration when available, falls back to CRC32C otherwise.
+        /// Uses AES hardware acceleration when available. Otherwise, normal builds use process-seeded XXH3 and ZK
+        /// builds use their deterministic guest mixer.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long FastHash64For20Bytes(ref byte start)
         {
-            uint seed = InstanceRandom + 20;
-
             if (x64.Aes.IsSupported || Arm.Aes.IsSupported)
             {
                 Vector128<byte> key = Unsafe.As<byte, Vector128<byte>>(ref start);
                 uint last4 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref start, 16));
                 Vector128<byte> data = Vector128.CreateScalar(last4).AsByte();
-                key ^= Vector128.CreateScalar(seed).AsByte();
+                key ^= ComputeAes20Seed();
                 // Two AES rounds for full diffusion: a single round only spreads the varying
                 // bytes (16-19) to one column, leaving the low 32 bits of the output constant
                 // when bytes 0-15 are constant (e.g., zero-padded small-integer addresses).
-                Vector128<byte> mixed;
-                if (x64.Aes.IsSupported)
-                {
-                    mixed = x64.Aes.Encrypt(data, key);
-                    mixed = x64.Aes.Encrypt(mixed, key);
-                }
-                else
-                {
-                    mixed = Arm.Aes.MixColumns(Arm.Aes.Encrypt(data, key));
-                    mixed = Arm.Aes.MixColumns(Arm.Aes.Encrypt(mixed, key));
-                }
-                return (long)(mixed.AsUInt64().GetElement(0) ^ mixed.AsUInt64().GetElement(1));
+                Vector128<byte> mixed = FastHashAesRound(data, key);
+                mixed = FastHashAesRound(mixed, key);
+                return MumFold(mixed);
             }
 
-            // Fallback: CRC32C-based 64-bit hash
-            ulong h0 = BitOperations.Crc32C(seed, Unsafe.ReadUnaligned<ulong>(ref start));
-            ulong h1 = BitOperations.Crc32C(seed ^ 0x9E3779B9u, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref start, 8)));
-            uint h2 = BitOperations.Crc32C(seed ^ 0x85EBCA6Bu, Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref start, 16)));
-            return (long)((h0 | (h1 << 32)) ^ ((ulong)h2 * 0x9E3779B97F4A7C15));
+            return FastHash64For20BytesFallback(ref start);
+        }
+
+        /// <inheritdoc cref="FastHash64For32BytesCrc"/>
+        internal static long FastHash64For20BytesCrc(ref byte start, uint seed)
+        {
+            ulong h0 = Crc32C(seed, Unsafe.ReadUnaligned<ulong>(ref start));
+            ulong h1 = Crc32C(seed ^ 0x9E3779B9u, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref start, 8)));
+            uint h2 = Crc32C(seed ^ 0x85EBCA6Bu, Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref start, 16)));
+            return MumFold(h0 | (h1 << 32), h2);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.std.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.std.cs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers.Binary;
+using System.IO.Hashing;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Core.Extensions
+{
+    public static partial class SpanExtensions
+    {
+        // Ensure that hashes are different for every run of the node and every node, so if there are any hash collisions
+        // on one node, they will not be the same on another node or across a restart and cannot degrade the network as a whole.
+        public static readonly uint InstanceRandom =
+            (uint)System.Security.Cryptography.RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue);
+
+        private static readonly ulong AesHashSeed0 = CreateAesHashSeed();
+        private static readonly ulong AesHashSeed1 = CreateAesHashSeed();
+        private static readonly ulong AesHash20Seed0 = CreateAesHashSeed();
+        private static readonly ulong AesHash20Seed1 = CreateAesHashSeed();
+        private static readonly ulong AesHash32Seed0 = CreateAesHashSeed();
+        private static readonly ulong AesHash32Seed1 = CreateAesHashSeed();
+        private static readonly ulong AesHashFinalSeed0 = CreateAesHashSeed();
+        private static readonly ulong AesHashFinalSeed1 = CreateAesHashSeed();
+        private static readonly long XxHashSeed = unchecked((long)CreateAesHashSeed());
+        private static readonly long FastHash20XxSeed = unchecked((long)CreateAesHashSeed());
+        private static readonly long FastHash32XxSeed = unchecked((long)CreateAesHashSeed());
+
+        [SkipLocalsInit]
+        private static ulong CreateAesHashSeed()
+        {
+            Span<byte> bytes = stackalloc byte[sizeof(ulong)];
+            System.Security.Cryptography.RandomNumberGenerator.Fill(bytes);
+            return BinaryPrimitives.ReadUInt64LittleEndian(bytes);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int FastHashFallback(ReadOnlySpan<byte> input)
+            => FastHashXxHash3(input, XxHashSeed);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long FastHash64For32BytesFallback(ref byte start)
+            => FastHash64XxHash3(ref start, 32, FastHash32XxSeed);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long FastHash64For20BytesFallback(ref byte start)
+            => FastHash64XxHash3(ref start, 20, FastHash20XxSeed);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int FastHashXxHash3(ReadOnlySpan<byte> input, long seed)
+        {
+            ulong hash = XxHash3.HashToUInt64(input, seed);
+            return (int)(hash ^ (hash >> 32));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static long FastHash64XxHash3(ref byte start, int length, long seed)
+            => unchecked((long)XxHash3.HashToUInt64(MemoryMarshal.CreateReadOnlySpan(ref start, length), seed));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Crc32C(uint crc, byte data) => BitOperations.Crc32C(crc, data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Crc32C(uint crc, ushort data) => BitOperations.Crc32C(crc, data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Crc32C(uint crc, uint data) => BitOperations.Crc32C(crc, data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Crc32C(uint crc, ulong data) => BitOperations.Crc32C(crc, data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint CrcLane(uint crc, ulong data) => BitOperations.Crc32C(crc, data) * 0xCC9E2D51u;
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.zkevm.cs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Core.Extensions
+{
+    public static partial class SpanExtensions
+    {
+        private const ulong AesHashSeed0 = 0x6A09E667F3BCC909UL;
+        private const ulong AesHashSeed1 = 0xBB67AE8584CAA73BUL;
+        private const ulong AesHash20Seed0 = 0x510E527FADE682D1UL;
+        private const ulong AesHash20Seed1 = 0x9B05688C2B3E6C1FUL;
+        private const ulong AesHash32Seed0 = 0x1F83D9ABFB41BD6BUL;
+        private const ulong AesHash32Seed1 = 0x5BE0CD19137E2179UL;
+        private const ulong AesHashFinalSeed0 = 0x3C6EF372FE94F82BUL;
+        private const ulong AesHashFinalSeed1 = 0xA54FF53A5F1D36F1UL;
+
+        // Guest execution requires stable hashes across runs.
+        public static readonly uint InstanceRandom = 2098026241U;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int FastHashFallback(ReadOnlySpan<byte> input)
+            => FastHashCrc(ref MemoryMarshal.GetReference(input), input.Length, ComputeSeed(input.Length));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long FastHash64For32BytesFallback(ref byte start)
+            => FastHash64For32BytesCrc(ref start, ComputeSeed(32));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static long FastHash64For20BytesFallback(ref byte start)
+            => FastHash64For20BytesCrc(ref start, ComputeSeed(20));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Crc32C(uint crc, byte data) => ZkEvmBitOperations.Crc32C(crc, data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Crc32C(uint crc, ushort data) => ZkEvmBitOperations.Crc32C(crc, data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Crc32C(uint crc, uint data) => ZkEvmBitOperations.Crc32C(crc, data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Crc32C(uint crc, ulong data) => ZkEvmBitOperations.Crc32C(crc, data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint CrcLane(uint crc, ulong data) => ZkEvmBitOperations.Crc32C(crc, data);
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
+++ b/src/Nethermind/Nethermind.Core/Nethermind.Core.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Nethermind.Numerics.Int256" />
     <PackageReference Include="Nethermind.Zkvm.Abstractions" Condition="'$(EnableZkEvm)' == 'true'" />
     <PackageReference Include="NonBlocking" />
+    <PackageReference Include="System.IO.Hashing" Condition="'$(EnableZkEvm)' != 'true'" />
     <PackageReference Include="Testably.Abstractions" />
   </ItemGroup>
 

--- a/src/Nethermind/Nethermind.Core/StorageCell.cs
+++ b/src/Nethermind/Nethermind.Core/StorageCell.cs
@@ -45,8 +45,13 @@ namespace Nethermind.Core
 
         public bool Equals(StorageCell other) => Equals(in other);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public long GetHashCode64()
-            => SpanExtensions.FastHash64For32Bytes(ref Unsafe.As<UInt256, byte>(ref Unsafe.AsRef(in _index))) ^ _address.Value.GetHashCode64();
+        {
+            long indexHash = SpanExtensions.FastHash64For32Bytes(ref Unsafe.As<UInt256, byte>(ref Unsafe.AsRef(in _index)));
+            long addressHash = _address.Value.GetHashCode64();
+            return SpanExtensions.MumFold((ulong)indexHash, (ulong)addressHash);
+        }
 
         public override bool Equals(object? obj)
         {
@@ -58,10 +63,11 @@ namespace Nethermind.Core
             return obj is StorageCell address && Equals(address);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode()
         {
-            int hash = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in _index), 1)).FastHash();
-            return hash ^ _address.Value.GetHashCode();
+            ulong hash = (ulong)GetHashCode64();
+            return (int)(hash ^ (hash >> 32));
         }
 
         public override string ToString() => $"{_address.Value}.{Index}";

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -722,6 +722,7 @@
           "Nethermind.Numerics.Int256": "[1.5.0, )",
           "Nethermind.Serialization.Ssz": "[1.40.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
+          "System.IO.Hashing": "[10.0.10, )",
           "Testably.Abstractions": "[10.3.0, )"
         }
       },


### PR DESCRIPTION
## Changes

- Unify the x64 and ARM AES hashing paths behind a single `FastHashAesRound` primitive so `FastHash`, `FastHash64For20Bytes`, and `FastHash64For32Bytes` share one implementation across platforms.
- Add an AES fast path for short inputs (1-15 bytes) with sentinel-padded loads, instead of dropping to the scalar CRC byte loop.
- Replace the scalar CRC tail drain in the block path with an overlapping final 16-byte block, keeping the whole hash on vector registers.
- Fold the four accumulator lanes with AES rounds and finalize through a multiply-based fold (`MumFold`) for stronger mixing and better bucket distribution of the final value.
- Widen seeding from a single 32-bit scalar to full 128-bit per-domain, length-salted process seeds.
- Split build-flavor specifics into partial files: standard builds (`SpanExtensions.std.cs`) use seeded XXH3 (`System.IO.Hashing`) when AES intrinsics are unavailable; ZK builds (`SpanExtensions.zkevm.cs`) keep their deterministic guest path.
- Combine `StorageCell` address and slot hashes with `MumFold` rather than XOR, and derive the 32-bit hash from the 64-bit one, improving distribution for the associative caches keyed on it.
- Rework `FastHashBenchmarks` with `OperationsPerInvoke` batching and add `FastHash64Benchmarks` covering the fixed-size 20/32-byte hashes.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Expanded the hash tests in `BytesTests` to cover every length branch (short-input padding, 16-32, 33-64, and the >64 lane fold) and to assert distribution quality across the AES, CRC, and XXH3 paths, including the bit windows the associative caches consume. All 374 tests pass locally on x64 with AES.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
