### PR TITLE
Update Glamsterdam devnet tests to v8.1.0

### DIFF
--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -25,7 +25,7 @@ on:
       eest_version:
         description: EEST release tag, or latest / latest-<keyword> to resolve dynamically
         required: false
-        default: tests-glamsterdam-devnet@v7.2.0
+        default: tests-glamsterdam-devnet@v8.1.0
         type: string
       zkevm_version:
         description: zkEVM fixtures release tag (zkevmTest only), or latest / latest-<keyword>
@@ -71,7 +71,7 @@ on:
       eest_version:
         description: EEST release tag, or latest / latest-<keyword> to resolve dynamically
         required: false
-        default: tests-glamsterdam-devnet@v7.2.0
+        default: tests-glamsterdam-devnet@v8.1.0
         type: string
       zkevm_version:
         description: zkEVM fixtures release tag (zkevmTest only), or latest / latest-<keyword>
@@ -100,10 +100,10 @@ env:
   FILTER: ${{ inputs.filter || '' }}
   IDLE_TIMEOUT_MINUTES: ${{ inputs.idle_timeout_minutes || '10' }}
   # Fixture source: the glamsterdam-devnet releases of ethereum/execution-specs. They ship
-  # fixtures for all forks (Frontier..Amsterdam) with the devnet-7 Amsterdam semantics
-  # this branch implements. Pass an exact tag (e.g. tests-glamsterdam-devnet@v7.2.0) to pin.
+  # fixtures for all forks (Frontier..Amsterdam) with the devnet-8 Amsterdam semantics
+  # this branch implements. Pass an exact tag (e.g. tests-glamsterdam-devnet@v8.1.0) to pin.
   EEST_REPOSITORY: ethereum/execution-specs
-  EEST_VERSION: ${{ inputs.eest_version || 'tests-glamsterdam-devnet@v7.2.0' }}
+  EEST_VERSION: ${{ inputs.eest_version || 'tests-glamsterdam-devnet@v8.1.0' }}
   EEST_ARCHIVE: fixtures_glamsterdam-devnet.tar.gz
   # zkEVM stateless-preview fixtures ship in their own release line of the same repo;
   # zkevmTest jobs resolve this instead of EEST_VERSION. Pinned to v0.6.2, which this

--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
@@ -6,6 +6,6 @@ namespace Ethereum.Blockchain.Pyspec.Test;
 public class Constants
 {
     public const string ARCHIVE_URL_TEMPLATE = "https://github.com/ethereum/execution-specs/releases/download/{0}/{1}";
-    public const string DEFAULT_ARCHIVE_VERSION = "tests-glamsterdam-devnet@v7.2.0";
+    public const string DEFAULT_ARCHIVE_VERSION = "tests-glamsterdam-devnet@v8.1.0";
     public const string DEFAULT_ARCHIVE_NAME = "fixtures_glamsterdam-devnet.tar.gz";
 }


### PR DESCRIPTION
## Changes

- Pin the Pyspec fixture loader to tests-glamsterdam-devnet@v8.1.0.
- Use the same v8.1.0 release by default in reusable and manually dispatched nethtest runs.
- Update the workflow guidance to identify the devnet-8 semantics.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [x] Other: Test fixture update

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The main solution, benchmark solution, and changed Pyspec project build cleanly with warnings treated as errors on the refreshed master base. The v8.1.0 release tag and expected fixture archive were verified before pinning.

The aggregate legacy EthereumTests solution cannot complete in this checkout because its src/tests submodule is intentionally uninitialized; the changed Pyspec project itself builds cleanly. The EEST matrix will report the remaining devnet-8 compatibility gaps tracked in #12599.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Part of #12599.