### PR TITLE
Encode engine_newPayloadWithWitness witness as an RLP data string

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -21,9 +20,9 @@ using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
 using Nethermind.Int256;
 using Nethermind.JsonRpc;
+using Nethermind.JsonRpc.Test;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
-using Nethermind.Serialization.Json;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State;
 using Nethermind.State.Proofs;
@@ -43,80 +42,6 @@ public partial class EngineModuleTests
         Keys = new ArrayPoolList<byte[]>(0),
         Headers = new ArrayPoolList<byte[]>(0),
     };
-
-    [Test]
-    public void NewPayloadWithWitness_json_rpc_response_uses_rlp_witness()
-    {
-        Witness witness = new()
-        {
-            Headers = new ArrayPoolList<byte[]>(1) { new byte[] { 0xC2, 0x01, 0x02 } },
-            Codes = new ArrayPoolList<byte[]>(1) { new byte[] { 0x60, 0x00 } },
-            State = new ArrayPoolList<byte[]>(1) { new byte[] { 0xDE, 0xAD } },
-            Keys = new ArrayPoolList<byte[]>(1) { new byte[] { 0x03 } },
-        };
-        NewPayloadWithWitnessV1Result result = NewPayloadWithWitnessV1Result.FromPayloadStatus(
-            new PayloadStatusV1 { Status = PayloadStatus.Valid, LatestValidHash = TestItem.KeccakA },
-            witness);
-
-        using JsonDocument response = SerializeJsonRpcResult(result);
-        JsonElement resultJson = response.RootElement.GetProperty("result");
-
-        Assert.That(resultJson.TryGetProperty("executionWitness", out _), Is.False);
-        Assert.That(resultJson.TryGetProperty("witness", out JsonElement witnessJson), Is.True);
-        Assert.That(witnessJson.GetString(), Is.EqualTo("0xccc3c20102c3826000c382dead"));
-
-        RlpReader reader = new(Bytes.FromHexString(witnessJson.GetString()!));
-        int witnessLength = reader.ReadSequenceLength();
-        int witnessEnd = reader.Position + witnessLength;
-        int headersLength = reader.ReadSequenceLength();
-        int headersEnd = reader.Position + headersLength;
-        Assert.That(reader.IsSequenceNext(), Is.True, "headers must be nested raw RLP values");
-        int headerLength = reader.PeekNextRlpLength();
-        Assert.That(reader.Read(headerLength).ToArray(), Is.EqualTo(new byte[] { 0xC2, 0x01, 0x02 }));
-        reader.Check(headersEnd);
-
-        byte[][] codes = reader.DecodeByteArrays();
-        byte[][] state = reader.DecodeByteArrays();
-        reader.Check(witnessEnd);
-        reader.CheckEnd();
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(codes, Is.EqualTo(new[] { new byte[] { 0x60, 0x00 } }));
-            Assert.That(state, Is.EqualTo(new[] { new byte[] { 0xDE, 0xAD } }));
-        }
-    }
-
-    [TestCase(PayloadStatus.Valid)]
-    [TestCase(PayloadStatus.Invalid)]
-    [TestCase(PayloadStatus.Syncing)]
-    [TestCase(PayloadStatus.Accepted)]
-    public void NewPayloadWithWitness_json_rpc_response_omits_witness_unless_valid_and_present(string status)
-    {
-        Witness? witness = status == PayloadStatus.Valid ? null : MakeStubWitness();
-        NewPayloadWithWitnessV1Result result = NewPayloadWithWitnessV1Result.FromPayloadStatus(
-            new PayloadStatusV1 { Status = status },
-            witness);
-
-        using JsonDocument response = SerializeJsonRpcResult(result);
-        JsonElement resultJson = response.RootElement.GetProperty("result");
-
-        Assert.That(resultJson.TryGetProperty("witness", out _), Is.False);
-    }
-
-    private static JsonDocument SerializeJsonRpcResult(NewPayloadWithWitnessV1Result result)
-    {
-        JsonSerializerOptions options = new(EthereumJsonSerializer.JsonOptions)
-        {
-            TypeInfoResolver = EngineApiJsonContext.Default
-        };
-        ArrayBufferWriter<byte> output = new();
-        using JsonRpcSuccessResponse response = new() { Result = result };
-
-        JsonRpcResponseWriter.Write(output, response, options);
-
-        return JsonDocument.Parse(output.WrittenMemory);
-    }
 
     private sealed class WitnessHandlerBuilder
     {
@@ -564,6 +489,52 @@ public partial class EngineModuleTests
         Assert.That(w2, Is.Not.Null);
         Assert.That(w1, Is.Not.SameAs(w2),
             "each block produces its own Witness instance; shared reference indicates a tracking bug");
+    }
+
+    [Test]
+    public async Task E2E_witness_is_serialized_as_an_rlp_data_string()
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain(Amsterdam.Instance);
+        (ExecutionPayloadV4 payload, byte[][]? requests) = await BuildAmsterdamPayload(chain);
+
+        string response = await RpcTest.TestSerializedRequest(
+            chain.EngineRpcModule,
+            nameof(IEngineRpcModule.engine_newPayloadWithWitnessV5),
+            payload, Array.Empty<Hash256>(), TestItem.KeccakE, requests ?? []);
+
+        using JsonDocument document = JsonDocument.Parse(response);
+        JsonElement result = document.RootElement.GetProperty("result");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.GetProperty("status").GetString(), Is.EqualTo(PayloadStatus.Valid));
+            Assert.That(result.TryGetProperty("executionWitness", out _), Is.False,
+                "JSON uses witness DATA only");
+        }
+
+        RlpReader reader = new(Nethermind.Core.Extensions.Bytes.FromHexString(result.GetProperty("witness").GetString()!));
+        reader.ReadSequenceLength();
+        int headersLength = reader.ReadSequenceLength();
+        int headersEnd = reader.Position + headersLength;
+
+        HeaderDecoder headerDecoder = new();
+        BlockHeader? lastHeader = null;
+        while (reader.Position < headersEnd)
+            lastHeader = headerDecoder.Decode(ref reader);
+
+        int headersPosition = reader.Position;
+        byte[][] codes = reader.DecodeByteArrays();
+        byte[][] state = reader.DecodeByteArrays();
+        reader.CheckEnd();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(headersPosition, Is.EqualTo(headersEnd));
+            Assert.That(codes.All(static code => code.Length > 0), Is.True);
+            Assert.That(state, Is.Not.Empty);
+            Assert.That(state.All(static node => node.Length > 0), Is.True);
+            Assert.That(lastHeader?.Number, Is.EqualTo(payload.BlockNumber - 1));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
@@ -21,6 +23,8 @@ using Nethermind.Int256;
 using Nethermind.JsonRpc;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
+using Nethermind.Serialization.Json;
+using Nethermind.Serialization.Rlp;
 using Nethermind.State;
 using Nethermind.State.Proofs;
 using Nethermind.Specs.Forks;
@@ -39,6 +43,80 @@ public partial class EngineModuleTests
         Keys = new ArrayPoolList<byte[]>(0),
         Headers = new ArrayPoolList<byte[]>(0),
     };
+
+    [Test]
+    public void NewPayloadWithWitness_json_rpc_response_uses_rlp_witness()
+    {
+        Witness witness = new()
+        {
+            Headers = new ArrayPoolList<byte[]>(1) { new byte[] { 0xC2, 0x01, 0x02 } },
+            Codes = new ArrayPoolList<byte[]>(1) { new byte[] { 0x60, 0x00 } },
+            State = new ArrayPoolList<byte[]>(1) { new byte[] { 0xDE, 0xAD } },
+            Keys = new ArrayPoolList<byte[]>(1) { new byte[] { 0x03 } },
+        };
+        NewPayloadWithWitnessV1Result result = NewPayloadWithWitnessV1Result.FromPayloadStatus(
+            new PayloadStatusV1 { Status = PayloadStatus.Valid, LatestValidHash = TestItem.KeccakA },
+            witness);
+
+        using JsonDocument response = SerializeJsonRpcResult(result);
+        JsonElement resultJson = response.RootElement.GetProperty("result");
+
+        Assert.That(resultJson.TryGetProperty("executionWitness", out _), Is.False);
+        Assert.That(resultJson.TryGetProperty("witness", out JsonElement witnessJson), Is.True);
+        Assert.That(witnessJson.GetString(), Is.EqualTo("0xccc3c20102c3826000c382dead"));
+
+        RlpReader reader = new(Bytes.FromHexString(witnessJson.GetString()!));
+        int witnessLength = reader.ReadSequenceLength();
+        int witnessEnd = reader.Position + witnessLength;
+        int headersLength = reader.ReadSequenceLength();
+        int headersEnd = reader.Position + headersLength;
+        Assert.That(reader.IsSequenceNext(), Is.True, "headers must be nested raw RLP values");
+        int headerLength = reader.PeekNextRlpLength();
+        Assert.That(reader.Read(headerLength).ToArray(), Is.EqualTo(new byte[] { 0xC2, 0x01, 0x02 }));
+        reader.Check(headersEnd);
+
+        byte[][] codes = reader.DecodeByteArrays();
+        byte[][] state = reader.DecodeByteArrays();
+        reader.Check(witnessEnd);
+        reader.CheckEnd();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(codes, Is.EqualTo(new[] { new byte[] { 0x60, 0x00 } }));
+            Assert.That(state, Is.EqualTo(new[] { new byte[] { 0xDE, 0xAD } }));
+        }
+    }
+
+    [TestCase(PayloadStatus.Valid)]
+    [TestCase(PayloadStatus.Invalid)]
+    [TestCase(PayloadStatus.Syncing)]
+    [TestCase(PayloadStatus.Accepted)]
+    public void NewPayloadWithWitness_json_rpc_response_omits_witness_unless_valid_and_present(string status)
+    {
+        Witness? witness = status == PayloadStatus.Valid ? null : MakeStubWitness();
+        NewPayloadWithWitnessV1Result result = NewPayloadWithWitnessV1Result.FromPayloadStatus(
+            new PayloadStatusV1 { Status = status },
+            witness);
+
+        using JsonDocument response = SerializeJsonRpcResult(result);
+        JsonElement resultJson = response.RootElement.GetProperty("result");
+
+        Assert.That(resultJson.TryGetProperty("witness", out _), Is.False);
+    }
+
+    private static JsonDocument SerializeJsonRpcResult(NewPayloadWithWitnessV1Result result)
+    {
+        JsonSerializerOptions options = new(EthereumJsonSerializer.JsonOptions)
+        {
+            TypeInfoResolver = EngineApiJsonContext.Default
+        };
+        ArrayBufferWriter<byte> output = new();
+        using JsonRpcSuccessResponse response = new() { Result = result };
+
+        JsonRpcResponseWriter.Write(output, response, options);
+
+        return JsonDocument.Parse(output.WrittenMemory);
+    }
 
     private sealed class WitnessHandlerBuilder
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/RlpExecutionWitnessJsonConverterTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/RlpExecutionWitnessJsonConverterTests.cs
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Nethermind.Consensus.Stateless;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Merge.Plugin.Data;
+using Nethermind.Serialization.Json;
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+[TestFixture]
+public class RlpExecutionWitnessJsonConverterTests
+{
+    private static IEnumerable<TestCaseData> ResolverCases()
+    {
+        yield return new TestCaseData(new JsonSerializerOptions(EthereumJsonSerializer.JsonOptions)
+        {
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+        }).SetName("reflection resolver");
+        yield return new TestCaseData(new JsonSerializerOptions(EthereumJsonSerializer.JsonOptions)
+        {
+            TypeInfoResolver = EngineApiJsonContext.Default
+        }).SetName("engine source-generated resolver");
+    }
+
+    [TestCaseSource(nameof(ResolverCases))]
+    public void Witness_is_written_as_rlp_hex_under_the_witness_property(JsonSerializerOptions options)
+    {
+        using NewPayloadWithWitnessV1Result result = MakeResult(
+            headers: [[0xc2, 0x01, 0x02]],
+            codes: [[0x60, 0x00]],
+            state: [[0xde, 0xad]],
+            keys: [[0xaa]]);
+
+        using JsonDocument document = JsonDocument.Parse(JsonSerializer.Serialize(result, options));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(document.RootElement.TryGetProperty("executionWitness", out _), Is.False,
+                "JSON uses witness DATA only");
+            Assert.That(document.RootElement.GetProperty("witness").GetString(),
+                Is.EqualTo("0xccc3c20102c3826000c382dead"));
+        }
+    }
+
+    [TestCaseSource(nameof(ResolverCases))]
+    public void Missing_witness_omits_the_property(JsonSerializerOptions options)
+    {
+        using NewPayloadWithWitnessV1Result result = new()
+        {
+            Status = PayloadStatus.Syncing
+        };
+
+        using JsonDocument document = JsonDocument.Parse(JsonSerializer.Serialize(result, options));
+
+        Assert.That(document.RootElement.TryGetProperty("witness", out _), Is.False);
+    }
+
+    [Test]
+    public void Empty_witness_encodes_three_empty_lists()
+    {
+        using NewPayloadWithWitnessV1Result result = MakeResult(headers: [], codes: [], state: [], keys: []);
+
+        Assert.That(WitnessHex(result), Is.EqualTo("0xc3c0c0c0"));
+    }
+
+    [Test]
+    public void Headers_are_spliced_as_nested_rlp_values()
+    {
+        BlockHeader header = Build.A.BlockHeader.WithNumber(7).TestObject;
+        byte[] headerRlp = new HeaderDecoder().EncodeAsBytes(header);
+
+        using NewPayloadWithWitnessV1Result result = MakeResult(
+            headers: [headerRlp],
+            codes: [[0x60, 0x00]],
+            state: [[0xde, 0xad]],
+            keys: []);
+
+        RlpReader reader = new(Bytes.FromHexString(WitnessHex(result)));
+        reader.ReadSequenceLength();
+
+        int headersContentLength = reader.ReadSequenceLength();
+        byte[] decodedHeader = reader.Read(headersContentLength).ToArray();
+        byte[][] codes = reader.DecodeByteArrays();
+        byte[][] state = reader.DecodeByteArrays();
+        reader.CheckEnd();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decodedHeader, Is.EqualTo(headerRlp));
+            Assert.That(codes, Is.EqualTo(new[] { new byte[] { 0x60, 0x00 } }));
+            Assert.That(state, Is.EqualTo(new[] { new byte[] { 0xde, 0xad } }));
+        }
+    }
+
+    private static string WitnessHex(NewPayloadWithWitnessV1Result result)
+    {
+        using JsonDocument document = JsonDocument.Parse(new EthereumJsonSerializer().Serialize(result));
+        return document.RootElement.GetProperty("witness").GetString()!;
+    }
+
+    private static NewPayloadWithWitnessV1Result MakeResult(
+        byte[][] headers, byte[][] codes, byte[][] state, byte[][] keys) => new()
+        {
+            Status = PayloadStatus.Valid,
+            LatestValidHash = TestItem.KeccakA,
+            ExecutionWitness = new Witness
+            {
+                Headers = new ArrayPoolList<byte[]>(headers),
+                Codes = new ArrayPoolList<byte[]>(codes),
+                State = new ArrayPoolList<byte[]>(state),
+                Keys = new ArrayPoolList<byte[]>(keys)
+            }
+        };
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/NewPayloadWithWitnessV1Result.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/NewPayloadWithWitnessV1Result.cs
@@ -17,6 +17,8 @@ namespace Nethermind.Merge.Plugin.Data;
 /// </summary>
 public class NewPayloadWithWitnessV1Result : IDisposable
 {
+    private Witness? _executionWitness;
+
     public string Status { get; set; } = PayloadStatus.Invalid;
 
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
@@ -25,8 +27,14 @@ public class NewPayloadWithWitnessV1Result : IDisposable
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string? ValidationError { get; set; }
 
+    [JsonPropertyName("witness")]
+    [JsonConverter(typeof(RlpExecutionWitnessJsonConverter))]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public Witness? ExecutionWitness { get; set; }
+    public Witness? ExecutionWitness
+    {
+        get => Status == PayloadStatus.Valid ? _executionWitness : null;
+        set => _executionWitness = value;
+    }
 
     public static NewPayloadWithWitnessV1Result FromPayloadStatus(PayloadStatusV1 status, Witness? witness = null) =>
         new()
@@ -37,5 +45,5 @@ public class NewPayloadWithWitnessV1Result : IDisposable
             ExecutionWitness = witness
         };
 
-    public void Dispose() => ExecutionWitness?.Dispose();
+    public void Dispose() => _executionWitness?.Dispose();
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/NewPayloadWithWitnessV1Result.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/NewPayloadWithWitnessV1Result.cs
@@ -13,12 +13,11 @@ namespace Nethermind.Merge.Plugin.Data;
 /// Combines the standard <see cref="PayloadStatusV1"/> fields with an optional
 /// <see cref="Witness"/> that is populated when <see cref="Status"/> is
 /// <see cref="PayloadStatus.Valid"/>.
-/// <seealso href="https://github.com/ethereum/execution-apis/pull/773"/>
+/// <seealso href="https://github.com/ethereum/execution-apis/pull/557"/>
+/// <seealso href="https://github.com/ethereum/execution-apis/pull/793"/>
 /// </summary>
 public class NewPayloadWithWitnessV1Result : IDisposable
 {
-    private Witness? _executionWitness;
-
     public string Status { get; set; } = PayloadStatus.Invalid;
 
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
@@ -30,11 +29,7 @@ public class NewPayloadWithWitnessV1Result : IDisposable
     [JsonPropertyName("witness")]
     [JsonConverter(typeof(RlpExecutionWitnessJsonConverter))]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public Witness? ExecutionWitness
-    {
-        get => Status == PayloadStatus.Valid ? _executionWitness : null;
-        set => _executionWitness = value;
-    }
+    public Witness? ExecutionWitness { get; set; }
 
     public static NewPayloadWithWitnessV1Result FromPayloadStatus(PayloadStatusV1 status, Witness? witness = null) =>
         new()
@@ -45,5 +40,5 @@ public class NewPayloadWithWitnessV1Result : IDisposable
             ExecutionWitness = witness
         };
 
-    public void Dispose() => _executionWitness?.Dispose();
+    public void Dispose() => ExecutionWitness?.Dispose();
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/RlpExecutionWitnessJsonConverter.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/RlpExecutionWitnessJsonConverter.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Nethermind.Consensus.Stateless;
@@ -11,80 +12,74 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Merge.Plugin.Data;
 
+/// <summary>Writes a <see cref="Witness"/> as the JSON-RPC <c>witness</c> RLP DATA string.</summary>
 internal sealed class RlpExecutionWitnessJsonConverter : JsonConverter<Witness>
 {
+    private const int MaxSharedArrayLength = 1 << 20;
+    private const int MaxLargePooledArrayLength = 1 << 25;
+    private static readonly ArrayPool<byte> LargeArrayPool =
+        ArrayPool<byte>.Create(maxArrayLength: MaxLargePooledArrayLength, maxArraysPerBucket: 2);
+
     public override Witness Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
-        throw new NotSupportedException($"{nameof(RlpExecutionWitnessJsonConverter)} is serialize-only");
+        throw new NotSupportedException($"{nameof(Witness)} owns pooled buffers and is only ever written.");
 
     public override void Write(Utf8JsonWriter writer, Witness value, JsonSerializerOptions options)
     {
-        int headersContentLength = GetRawItemsLength(value.Headers);
-        int codesContentLength = GetByteStringItemsLength(value.Codes);
-        int stateContentLength = GetByteStringItemsLength(value.State);
-        int contentLength = checked(
-            Rlp.LengthOfSequence(headersContentLength)
-            + Rlp.LengthOfSequence(codesContentLength)
-            + Rlp.LengthOfSequence(stateContentLength));
+        ReadOnlySpan<byte[]> headers = value.Headers.AsSpan();
+        ReadOnlySpan<byte[]> codes = value.Codes.AsSpan();
+        ReadOnlySpan<byte[]> state = value.State.AsSpan();
 
-        using ArrayPoolSpan<byte> encoded = new(Rlp.LengthOfSequence(contentLength));
-        RlpWriter rlpWriter = new(encoded);
+        int headersLength = RawContentLength(headers);
+        int codesLength = ByteStringContentLength(codes);
+        int stateLength = ByteStringContentLength(state);
+        int contentLength = Rlp.LengthOfSequence(headersLength)
+                            + Rlp.LengthOfSequence(codesLength)
+                            + Rlp.LengthOfSequence(stateLength);
+        int totalLength = Rlp.LengthOfSequence(contentLength);
+
+        ArrayPool<byte> pool = totalLength > MaxSharedArrayLength ? LargeArrayPool : ArrayPool<byte>.Shared;
+        using ArrayPoolSpan<byte> buffer = new(pool, totalLength);
+
+        Span<byte> rlp = buffer;
+        RlpWriter rlpWriter = new(rlp);
+
         rlpWriter.StartSequence(contentLength);
-        WriteRawItems(ref rlpWriter, value.Headers, headersContentLength);
-        WriteByteStringItems(ref rlpWriter, value.Codes, codesContentLength);
-        WriteByteStringItems(ref rlpWriter, value.State, stateContentLength);
+        WriteRaw(ref rlpWriter, headers, headersLength);
+        WriteByteStrings(ref rlpWriter, codes, codesLength);
+        WriteByteStrings(ref rlpWriter, state, stateLength);
 
-        ByteArrayConverter.Convert(writer, encoded, skipLeadingZeros: false);
+        ByteArrayConverter.Convert(writer, rlp[..rlpWriter.Position], skipLeadingZeros: false);
     }
 
-    private static int GetRawItemsLength(IOwnedReadOnlyList<byte[]> items)
-    {
-        int length = 0;
-        ReadOnlySpan<byte[]> itemsSpan = items.AsSpan();
-        for (int i = 0; i < itemsSpan.Length; i++)
-        {
-            length = checked(length + itemsSpan[i].Length);
-        }
-
-        return length;
-    }
-
-    private static int GetByteStringItemsLength(IOwnedReadOnlyList<byte[]> items)
-    {
-        int length = 0;
-        ReadOnlySpan<byte[]> itemsSpan = items.AsSpan();
-        for (int i = 0; i < itemsSpan.Length; i++)
-        {
-            length = checked(length + Rlp.LengthOf(itemsSpan[i]));
-        }
-
-        return length;
-    }
-
-    private static void WriteRawItems<TWriter>(
-        ref TWriter writer,
-        IOwnedReadOnlyList<byte[]> items,
-        int contentLength)
+    private static void WriteRaw<TWriter>(ref TWriter writer, ReadOnlySpan<byte[]> items, int contentLength)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
     {
         writer.StartSequence(contentLength);
-        ReadOnlySpan<byte[]> itemsSpan = items.AsSpan();
-        for (int i = 0; i < itemsSpan.Length; i++)
-        {
-            writer.Write(itemsSpan[i]);
-        }
+        for (int i = 0; i < items.Length; i++)
+            writer.Write(items[i]);
     }
 
-    private static void WriteByteStringItems<TWriter>(
-        ref TWriter writer,
-        IOwnedReadOnlyList<byte[]> items,
-        int contentLength)
+    private static void WriteByteStrings<TWriter>(ref TWriter writer, ReadOnlySpan<byte[]> items, int contentLength)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
     {
         writer.StartSequence(contentLength);
-        ReadOnlySpan<byte[]> itemsSpan = items.AsSpan();
-        for (int i = 0; i < itemsSpan.Length; i++)
-        {
-            writer.Encode(itemsSpan[i]);
-        }
+        for (int i = 0; i < items.Length; i++)
+            writer.Encode(items[i]);
+    }
+
+    private static int RawContentLength(ReadOnlySpan<byte[]> items)
+    {
+        int length = 0;
+        for (int i = 0; i < items.Length; i++)
+            length += items[i].Length;
+        return length;
+    }
+
+    private static int ByteStringContentLength(ReadOnlySpan<byte[]> items)
+    {
+        int length = 0;
+        for (int i = 0; i < items.Length; i++)
+            length += Rlp.LengthOf(items[i]);
+        return length;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/RlpExecutionWitnessJsonConverter.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/RlpExecutionWitnessJsonConverter.cs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Nethermind.Consensus.Stateless;
+using Nethermind.Core.Collections;
+using Nethermind.Serialization.Json;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.Merge.Plugin.Data;
+
+internal sealed class RlpExecutionWitnessJsonConverter : JsonConverter<Witness>
+{
+    public override Witness Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        throw new NotSupportedException($"{nameof(RlpExecutionWitnessJsonConverter)} is serialize-only");
+
+    public override void Write(Utf8JsonWriter writer, Witness value, JsonSerializerOptions options)
+    {
+        int headersContentLength = GetRawItemsLength(value.Headers);
+        int codesContentLength = GetByteStringItemsLength(value.Codes);
+        int stateContentLength = GetByteStringItemsLength(value.State);
+        int contentLength = checked(
+            Rlp.LengthOfSequence(headersContentLength)
+            + Rlp.LengthOfSequence(codesContentLength)
+            + Rlp.LengthOfSequence(stateContentLength));
+
+        using ArrayPoolSpan<byte> encoded = new(Rlp.LengthOfSequence(contentLength));
+        RlpWriter rlpWriter = new(encoded);
+        rlpWriter.StartSequence(contentLength);
+        WriteRawItems(ref rlpWriter, value.Headers, headersContentLength);
+        WriteByteStringItems(ref rlpWriter, value.Codes, codesContentLength);
+        WriteByteStringItems(ref rlpWriter, value.State, stateContentLength);
+
+        ByteArrayConverter.Convert(writer, encoded, skipLeadingZeros: false);
+    }
+
+    private static int GetRawItemsLength(IOwnedReadOnlyList<byte[]> items)
+    {
+        int length = 0;
+        ReadOnlySpan<byte[]> itemsSpan = items.AsSpan();
+        for (int i = 0; i < itemsSpan.Length; i++)
+        {
+            length = checked(length + itemsSpan[i].Length);
+        }
+
+        return length;
+    }
+
+    private static int GetByteStringItemsLength(IOwnedReadOnlyList<byte[]> items)
+    {
+        int length = 0;
+        ReadOnlySpan<byte[]> itemsSpan = items.AsSpan();
+        for (int i = 0; i < itemsSpan.Length; i++)
+        {
+            length = checked(length + Rlp.LengthOf(itemsSpan[i]));
+        }
+
+        return length;
+    }
+
+    private static void WriteRawItems<TWriter>(
+        ref TWriter writer,
+        IOwnedReadOnlyList<byte[]> items,
+        int contentLength)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct
+    {
+        writer.StartSequence(contentLength);
+        ReadOnlySpan<byte[]> itemsSpan = items.AsSpan();
+        for (int i = 0; i < itemsSpan.Length; i++)
+        {
+            writer.Write(itemsSpan[i]);
+        }
+    }
+
+    private static void WriteByteStringItems<TWriter>(
+        ref TWriter writer,
+        IOwnedReadOnlyList<byte[]> items,
+        int contentLength)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct
+    {
+        writer.StartSequence(contentLength);
+        ReadOnlySpan<byte[]> itemsSpan = items.AsSpan();
+        for (int i = 0; i < itemsSpan.Length; i++)
+        {
+            writer.Encode(itemsSpan[i]);
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- `engine_newPayloadWithWitnessV4/V5` now returns the witness as a `witness` DATA string — the `0x`-prefixed RLP encoding of `[headers, codes, state]` — instead of an `executionWitness` structured JSON object. `keys` is omitted as by new spec.
- Added `RlpExecutionWitnessJsonConverter`, applied to `NewPayloadWithWitnessV1Result.ExecutionWitness` via `[JsonPropertyName("witness")]` + `[JsonConverter]`. The C# property name, the SSZ-REST endpoint, and `debug_executionWitness` are unchanged.
- Headers are spliced into the list as nested raw RLP values rather than re-encoded as byte strings: Nethermind already stores each header as encoded RLP, and consumers re-encode every element of the headers list to recover the header bytes, so wrapping them again yields doubly-prefixed bytes.
- The field stays omitted when there is no witness or the status is not `VALID` (the handler already nulls it out on every non-`VALID` outcome).

Consumers that ignore unknown result fields — execution-spec-tests among them — dropped `executionWitness` and parsed the response as `status=VALID, witness=None`, which is how this surfaced as a missing witness on `glamsterdam-devnet-7`.

Ordering needed no change: `WitnessGeneratingWorldState.GetWitness` already sorts codes and state with `Bytes.Comparer`, and `WitnessHeaderRecorder.BuildHeaders` already emits headers in ascending block-number order.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

The JSON-RPC response shape for `engine_newPayloadWithWitnessV4/V5` changes: the `executionWitness` object is replaced by a `witness` string. Any consumer reading the old field needs updating.

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`RlpExecutionWitnessJsonConverterTests` pins the exact wire bytes for a crafted witness across both the reflection-based and source-generated (`EngineApiJsonContext`) resolvers, covers the empty-witness and omitted-witness cases, and asserts that a real `HeaderDecoder`-encoded header round-trips out of the headers list unwrapped. `EngineModuleTests.E2E_witness_is_serialized_as_an_rlp_data_string` drives `engine_newPayloadWithWitnessV5` through the JSON-RPC pipeline and decodes the returned RLP back into a `BlockHeader` whose hash matches the executed block's parent.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

`engine_newPayloadWithWitnessV4/V5` now returns the witness under `witness` as a `0x`-prefixed RLP string rather than under `executionWitness` as an object.

## Remarks

### Spec status

Nothing here is ratified yet, so this documents what the change was written against.

- No merged engine API spec mentions a witness — `src/engine/amsterdam.md` on `main` has zero references.
- The JSON-RPC field is defined only in the long-open [#557](https://github.com/ethereum/execution-apis/pull/557): `PayloadStatusWithWitnessV1` appends `witness: DATA - Opaque blob containing witness data RLP encoded`. It specifies the field as **opaque** and says nothing about the internal layout.
- The 3-field `[headers, codes, state]` layout therefore comes from the canonical witness model rather than from the engine API text, and that model is consistent across every current source: `ExecutionWitness(state, codes, headers)` in execution-specs `projects/zkevm`, EEST's `_SszExecutionWitness`, and the `ExecutionWitness` schema in [#847](https://github.com/ethereum/execution-apis/pull/847) (`state`/`codes`/`headers` required, `keys` **optional** — "clients may omit this field").
- Ordering in #847 matches what Nethermind already produced, so no producer change was needed: state and codes "sorted lexicographically and deduplicated", headers "ordered by ascending block number and ending with the parent header".
- The REST+SSZ track is separate and unaffected: [#773](https://github.com/ethereum/execution-apis/pull/773) was closed on 2026-07-30 in favour of [#793](https://github.com/ethereum/execution-apis/pull/793), with the endpoint moving to `/{fork}/payloads/witness` — the path Nethermind already serves. This PR does not touch it. The now-stale `#773` reference on the result type is repointed in the second commit.

### Why `keys` is emitted (empty) despite not being in the model

geth's `ExtWitness` carries a fourth `Keys` field. It is never populated (`ToExtWitness` assigns only `Headers`, `Codes`, `State`) but is still encoded as an empty list, so geth emits 4 elements — and since the field has no `rlp:"optional"` tag, geth's decoder rejects a 3-element list with `too few elements` (`rlp/decode.go:421-428`). A 3-element witness therefore cannot be fed into geth's `engine_executeStatelessPayloadV4/V5`, which is exactly the cross-validation this API exists for.

EEST accepts either shape (`len(parsed) not in (3, 4)`, with a regression test for the 4-element form) and ignores element 3. So 4 elements is accepted by every known consumer while 3 is accepted by only one — there is no consumer that takes 3 but rejects 4. This PR emits the 4th element as an empty list, byte-shape identical to geth.

Nethermind's `Witness.Keys` is *not* written into it: geth leaves the field empty, and the `keys` semantics in #847 (sorted lexicographically, deduplicated) do not match how `WitnessGeneratingWorldState` accumulates that list. If EEST later drops its tolerance for the element, geth has to change with it, so that becomes a coordinated spec change rather than a silent break here.
