### PR TITLE
fix(txpool): do not apply EIP-3607 to frame transactions

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -412,6 +412,40 @@ namespace Nethermind.Blockchain.Test
             Assert.That(selectedTransactions[1], Is.SameAs(secondTx));
         }
 
+        // EIP-8141: the pool exempts frame transactions from EIP-3607, so without the same exemption
+        // here a smart account's own transaction is admitted and gossiped but never built into a block.
+        [TestCase(TxType.EIP1559, "Sender is contract", TestName = "CanAddTransaction_ContractSender_OrdinaryTx_Skipped")]
+        [TestCase(TxType.FrameTx, null, TestName = "CanAddTransaction_ContractSender_FrameTx_Added")]
+        public void CanAddTransaction_ContractSender_ExemptsOnlyFrameTransactions(TxType txType, string? expectedSkipReason)
+        {
+            IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+            using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+            IReleaseSpec spec = Prague.Instance;
+            stateProvider.CreateAccount(TestItem.AddressA, 1.Ether);
+            byte[] code = [0x00];
+            stateProvider.InsertCode(TestItem.AddressA, ValueKeccak.Compute(code), code, spec);
+
+            Transaction tx = new()
+            {
+                Type = txType,
+                SenderAddress = TestItem.AddressA,
+                Nonce = 0,
+                GasLimit = GasCostOf.Transaction,
+                GasPrice = 1,
+                DecodedMaxFeePerGas = 1,
+                Frames = txType == TxType.FrameTx ? [] : null,
+                FrameSignatures = txType == TxType.FrameTx ? [] : null,
+            };
+
+            Block block = Build.A.Block.WithGasLimit(GasCostOf.Transaction * 2).TestObject;
+            BlockProcessor.BlockProductionTransactionPicker picker = new(new TestSingleReleaseSpecProvider(spec));
+
+            BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(block, tx, new HashSet<Transaction>(), stateProvider);
+
+            Assert.That(args.Action, Is.EqualTo(expectedSkipReason is null ? BlockProcessor.TxAction.Add : BlockProcessor.TxAction.Skip));
+            if (expectedSkipReason is not null) Assert.That(args.Reason, Is.EqualTo(expectedSkipReason));
+        }
+
         private static Transaction[] RunBlockProduction(
             ITransactionProcessorAdapter transactionProcessor,
             IWorldState stateProvider,

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -74,7 +74,9 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, TransactionResult.TransactionSizeOverMaxInitCodeSize.ErrorDescription);
                 }
 
-                if (!ignoreEip3607 && stateProvider.IsInvalidContractSender(spec, currentTx.SenderAddress))
+                // EIP-8141 exempts frame transactions from EIP-3607, so the pool admits one from a
+                // contract sender; without the same exemption here it could never be built into a block.
+                if (!ignoreEip3607 && !currentTx.SupportsFrames && stateProvider.IsInvalidContractSender(spec, currentTx.SenderAddress))
                 {
                     return args.Set(TxAction.Skip, $"Sender is contract");
                 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2211,7 +2211,19 @@ namespace Nethermind.TxPool.Test
             Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.AddressA, deadline: null);
             AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
 
-            Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
+            // A legacy transaction from the same sender under the same spec pins that the exemption is
+            // by transaction type, not a disabled filter.
+            Transaction legacyTx = Build.A.Transaction
+                .WithGasLimit(TxGasLimit)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+            AcceptTxResult legacyResult = _txPool.SubmitTx(legacyTx, TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+                Assert.That(legacyResult, Is.EqualTo(AcceptTxResult.SenderIsContract));
+            }
         }
 
         private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline, UInt256? maxPriorityFeePerGas = null, UInt256? maxFeePerGas = null)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2199,6 +2199,21 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        [Test]
+        public void Frame_transaction_from_a_contract_sender_is_not_rejected_by_eip3607()
+        {
+            _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+            // A smart-account sender is the normal case for a frame transaction: its code runs in the
+            // validation prefix and authorises the transaction there.
+            _stateProvider.InsertCode(TestItem.AddressA, "A"u8.ToArray(), Bogota.Instance);
+
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.AddressA, deadline: null);
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+
+            Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
+        }
+
         private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline, UInt256? maxPriorityFeePerGas = null, UInt256? maxFeePerGas = null)
         {
             List<TxFrame> frames =

--- a/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
@@ -10,6 +10,7 @@ namespace Nethermind.TxPool.Filters
 {
     /// <summary>
     /// Filters out transactions that sender has any code deployed. If <see cref="IReleaseSpec.IsEip3607Enabled"/> is enabled.
+    /// EIP-8141 frame transactions are exempt.
     /// </summary>
     internal sealed class DeployedCodeFilter(IReadOnlyStateProvider worldState, IChainHeadSpecProvider specProvider) : IIncomingTxFilter
     {

--- a/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/DeployedCodeFilter.cs
@@ -16,6 +16,14 @@ namespace Nethermind.TxPool.Filters
         private readonly Func<Address, bool> _isDelegatedCode = worldState.IsDelegatedCode;
         public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
+            // EIP-8141 §Mempool: "Do not apply the restriction put in place by EIP-3607 to frame
+            // transactions." A frame transaction is authorised by the sender's own code running in
+            // the validation prefix, which is the situation EIP-3607 exists to prevent elsewhere.
+            if (tx.Type == TxType.FrameTx)
+            {
+                return AcceptTxResult.Accepted;
+            }
+
             IReleaseSpec spec = specProvider.GetCurrentHeadSpec();
             return state.SenderAccount.HasCode && worldState.IsInvalidContractSender(spec,
                 tx.SenderAddress!,


### PR DESCRIPTION
EIP-8141 says, in the Mempool section:

> Do not apply the restriction put in place by [EIP-3607](./eip-3607.md) to frame transactions.

`DeployedCodeFilter` applies it to every transaction type, so a frame transaction from a smart account is rejected at admission with `sender not an eoa`. That is the main use case of the EIP: the sender's own code runs in the validation prefix and authorises the transaction there.

I found this running a privacy-pool withdrawal from the pool's smart account on the two-client Kurtosis devnet; Nethermind refused it at admission while the other implementation accepted it. No unit test covered it because it only appears at mempool admission against a live head.

`Frame_transaction_from_a_contract_sender_is_not_rejected_by_eip3607` fails on the branch point and passes with the fix.
