### PR TITLE
feat(txpool): enforce EIP-8141 MAX_VERIFY_GAS at mempool ingress

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -213,85 +213,73 @@ public class FrameTxValidationTests
 
     private static IEnumerable<TestCaseData> ValidationWorkCases()
     {
-        static TestCaseData Work(string name, TxFrame[] frames, TxFrameSignature[] signatures, ulong expected, bool senderHasCode = false) =>
-            new TestCaseData(frames, signatures, expected, senderHasCode).SetName($"ValidationWorkGas_{name}");
+        static TestCaseData Work(string name, TxFrame[] frames, TxFrameSignature[] signatures, ulong? expected) =>
+            new TestCaseData(frames, signatures, expected).SetName($"ValidationWorkGas_{name}");
 
         static TxFrameSignature Signature(byte scheme) => new(scheme, null, default, Array.Empty<byte>());
 
+        static TxFrame OnlyVerifyFrame() =>
+            Frame(TxFrame.ModeVerify, TxFrame.ApproveExecution, gasLimit: 40_000);
+
+        static TxFrame PayFrame() =>
+            Frame(TxFrame.ModeVerify, TxFrame.ApprovePayment, TestItem.AddressB, gasLimit: 30_000);
+
         // The prefix ends at the self-verify frame; the execution frame behind it is paid for out of
         // the transaction's own gas and is outside the budget.
-        yield return Work("SelfVerifyThenSenderFrame_CountsOnlyThePrefix",
+        yield return Work("SelfVerify_CountsOnlyThePrefix",
             [SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: TestItem.AddressB, gasLimit: 5_000_000)],
             [], 100_000);
 
-        // The canonical paymaster shape: execution approval, then payment approval by the sponsor.
-        yield return Work("ExecutionThenPaymentApproval_CountsBothPrefixFrames",
-            [
-                Frame(TxFrame.ModeVerify, TxFrame.ApproveExecution, gasLimit: 40_000),
-                Frame(TxFrame.ModeVerify, TxFrame.ApprovePayment, TestItem.AddressB, gasLimit: 30_000),
-                Frame(TxFrame.ModeSender, target: TestItem.AddressC, gasLimit: 900_000),
-            ],
+        // The expiry verifier frame is skipped when matching the shape, but its work is still the
+        // node's to do before any gas is paid.
+        yield return Work("ExpiryThenSelfVerify_CountsBoth",
+            [ExpiryFrame(), SelfVerifyFrame()], [], 130_000);
+
+        yield return Work("DeployThenSelfVerify_CountsBoth",
+            [DefaultModeFrame(), SelfVerifyFrame()], [], 150_000);
+
+        yield return Work("OnlyVerifyThenPay_CountsBothPrefixFrames",
+            [OnlyVerifyFrame(), PayFrame(), Frame(TxFrame.ModeSender, target: TestItem.AddressC, gasLimit: 900_000)],
             [], 70_000);
 
-        // A payment-only frame ahead of any execution approval provably cannot set the payer
-        // (APPROVE reverts), so the walk must continue past it and count the frames that still run
-        // before the transaction is paid for.
-        yield return Work("PaymentApprovalBeforeExecutionApproval_KeepsWalking",
-            [
-                Frame(TxFrame.ModeVerify, TxFrame.ApprovePayment, TestItem.AddressB, gasLimit: 1_000),
-                Frame(gasLimit: 3_000_000),
-                SelfVerifyFrame(),
-            ],
-            [], 3_101_000);
-
-        // Nothing in the list can ever set a payer, so the whole list is charged.
-        yield return Work("NoPaymentApprovalAnywhere_CountsEveryFrame",
-            [Frame(gasLimit: 10_000), Frame(gasLimit: 20_000)], [], 30_000);
+        yield return Work("DeployThenOnlyVerifyThenPay_CountsAllThree",
+            [DefaultModeFrame(), OnlyVerifyFrame(), PayFrame()], [], 120_000);
 
         yield return Work("SignatureCostsCountAgainstTheBudget",
             [SelfVerifyFrame()],
             [Signature(TxFrameSignature.SchemeSecp256k1), Signature(TxFrameSignature.SchemeP256)],
             100_000 + Eip8141Constants.Secp256k1VerificationGasCost + Eip8141Constants.P256VerificationGasCost);
 
-        yield return Work("OverflowingFrameGas_Saturates",
-            [Frame(gasLimit: ulong.MaxValue), Frame(gasLimit: 1)], [], ulong.MaxValue);
+        yield return Work("OverflowingPrefixGas_Saturates",
+            [DefaultModeFrame(), Frame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, gasLimit: ulong.MaxValue)],
+            [], ulong.MaxValue);
 
-        // Permission to approve is not the same as the ability to: a DEFAULT frame resolving to a
-        // codeless sender runs default code, which approves only in VERIFY mode. Stopping the walk
-        // there would leave the frames behind it unbudgeted.
-        TxFrame[] defaultApprovalFrames =
-        [
-            Frame(flags: TxFrame.ApproveExecutionAndPayment, gasLimit: 1_000),
-            Frame(gasLimit: 3_000_000),
-            SelfVerifyFrame(),
-        ];
-        yield return Work("DefaultFrameOnACodelessSender_KeepsWalking", defaultApprovalFrames, [], 3_101_000);
-        yield return Work("DefaultFrameOnAContractSender_EndsThePrefix", defaultApprovalFrames, [], 1_000, senderHasCode: true);
+        // Approving flags on a DEFAULT frame do not make a prefix: whether the target approves at all
+        // depends on code the sender controls, so the frames behind it would run unbudgeted.
+        yield return Work("DefaultFrameWithApprovingFlags_IsNotRecognized",
+            [Frame(flags: TxFrame.ApproveExecutionAndPayment, gasLimit: 1_000), Frame(gasLimit: 3_000_000)],
+            [], null);
 
-        // The sender is the only target whose code is known here, so an approval by a third party
-        // cannot be assumed: the target is attacker-chosen and may be codeless, in which case
-        // default code runs, nothing approves, and the frames behind it would go unbudgeted.
-        yield return Work("DefaultFrameOnAThirdPartyTarget_KeepsWalking",
-            [
-                Frame(flags: TxFrame.ApproveExecutionAndPayment, target: TestItem.AddressB, gasLimit: 1_000),
-                Frame(gasLimit: 3_000_000),
-                SelfVerifyFrame(),
-            ],
-            [], 3_101_000, senderHasCode: true);
+        // APPROVE rejects a payment approval that no execution approval precedes.
+        yield return Work("PayBeforeOnlyVerify_IsNotRecognized",
+            [PayFrame(), OnlyVerifyFrame()], [], null);
 
-        // An execution approval by a frame that cannot reach APPROVE never happens, so it must not
-        // let the payment-only frame behind it end the walk either.
-        yield return Work("ExecutionApprovalThatCannotHappen_DoesNotEnableThePaymentBreak",
-            [
-                Frame(flags: TxFrame.ApproveExecution, gasLimit: 1_000),
-                Frame(TxFrame.ModeVerify, TxFrame.ApprovePayment, TestItem.AddressB, gasLimit: 1_000),
-                Frame(gasLimit: 20_000_000),
-            ],
-            [], 20_002_000);
+        // A verifier the sender does not control is third-party mutable state.
+        yield return Work("SelfVerifyTargetingAThirdParty_IsNotRecognized",
+            [Frame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, TestItem.AddressB)], [], null);
+
+        yield return Work("PrefixFrameInAnAtomicBatch_IsNotRecognized",
+            [Frame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment | TxFrame.AtomicBatchFlag)], [], null);
+
+        yield return Work("OnlyVerifyWithoutPay_IsNotRecognized",
+            [OnlyVerifyFrame(), Frame(TxFrame.ModeSender, gasLimit: 900_000)], [], null);
+
+        yield return Work("NoApprovingFrameAtAll_IsNotRecognized",
+            [Frame(gasLimit: 10_000), Frame(gasLimit: 20_000)], [], null);
     }
 
     [TestCaseSource(nameof(ValidationWorkCases))]
-    public void ValidationWorkGas_BoundsThePrefixAndSignatures(TxFrame[] frames, TxFrameSignature[] signatures, ulong expected, bool senderHasCode)
+    public void TryGetValidationWorkGas_BoundsTheRecognizedPrefixAndSignatures(TxFrame[] frames, TxFrameSignature[] signatures, ulong? expected)
     {
         Transaction tx = CreateValidFrameTx(candidate =>
         {
@@ -299,7 +287,13 @@ public class FrameTxValidationTests
             candidate.FrameSignatures = signatures;
         });
 
-        Assert.That(FrameTxValidation.ValidationWorkGas(tx, senderHasCode), Is.EqualTo(expected));
+        bool recognized = FrameTxValidation.TryGetValidationWorkGas(tx, out ulong workGas);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(recognized, Is.EqualTo(expected is not null));
+            Assert.That(workGas, Is.EqualTo(expected ?? 0));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -267,6 +267,27 @@ public class FrameTxValidationTests
         ];
         yield return Work("DefaultFrameOnACodelessSender_KeepsWalking", defaultApprovalFrames, [], 3_101_000);
         yield return Work("DefaultFrameOnAContractSender_EndsThePrefix", defaultApprovalFrames, [], 1_000, senderHasCode: true);
+
+        // The sender is the only target whose code is known here, so an approval by a third party
+        // cannot be assumed: the target is attacker-chosen and may be codeless, in which case
+        // default code runs, nothing approves, and the frames behind it would go unbudgeted.
+        yield return Work("DefaultFrameOnAThirdPartyTarget_KeepsWalking",
+            [
+                Frame(flags: TxFrame.ApproveExecutionAndPayment, target: TestItem.AddressB, gasLimit: 1_000),
+                Frame(gasLimit: 3_000_000),
+                SelfVerifyFrame(),
+            ],
+            [], 3_101_000, senderHasCode: true);
+
+        // An execution approval by a frame that cannot reach APPROVE never happens, so it must not
+        // let the payment-only frame behind it end the walk either.
+        yield return Work("ExecutionApprovalThatCannotHappen_DoesNotEnableThePaymentBreak",
+            [
+                Frame(flags: TxFrame.ApproveExecution, gasLimit: 1_000),
+                Frame(TxFrame.ModeVerify, TxFrame.ApprovePayment, TestItem.AddressB, gasLimit: 1_000),
+                Frame(gasLimit: 20_000_000),
+            ],
+            [], 20_002_000);
     }
 
     [TestCaseSource(nameof(ValidationWorkCases))]

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -213,8 +213,8 @@ public class FrameTxValidationTests
 
     private static IEnumerable<TestCaseData> ValidationWorkCases()
     {
-        static TestCaseData Work(string name, TxFrame[] frames, TxFrameSignature[] signatures, ulong expected) =>
-            new TestCaseData(frames, signatures, expected).SetName($"ValidationWorkGas_{name}");
+        static TestCaseData Work(string name, TxFrame[] frames, TxFrameSignature[] signatures, ulong expected, bool senderHasCode = false) =>
+            new TestCaseData(frames, signatures, expected, senderHasCode).SetName($"ValidationWorkGas_{name}");
 
         static TxFrameSignature Signature(byte scheme) => new(scheme, null, default, Array.Empty<byte>());
 
@@ -255,10 +255,22 @@ public class FrameTxValidationTests
 
         yield return Work("OverflowingFrameGas_Saturates",
             [Frame(gasLimit: ulong.MaxValue), Frame(gasLimit: 1)], [], ulong.MaxValue);
+
+        // Permission to approve is not the same as the ability to: a DEFAULT frame resolving to a
+        // codeless sender runs default code, which approves only in VERIFY mode. Stopping the walk
+        // there would leave the frames behind it unbudgeted.
+        TxFrame[] defaultApprovalFrames =
+        [
+            Frame(flags: TxFrame.ApproveExecutionAndPayment, gasLimit: 1_000),
+            Frame(gasLimit: 3_000_000),
+            SelfVerifyFrame(),
+        ];
+        yield return Work("DefaultFrameOnACodelessSender_KeepsWalking", defaultApprovalFrames, [], 3_101_000);
+        yield return Work("DefaultFrameOnAContractSender_EndsThePrefix", defaultApprovalFrames, [], 1_000, senderHasCode: true);
     }
 
     [TestCaseSource(nameof(ValidationWorkCases))]
-    public void ValidationWorkGas_BoundsThePrefixAndSignatures(TxFrame[] frames, TxFrameSignature[] signatures, ulong expected)
+    public void ValidationWorkGas_BoundsThePrefixAndSignatures(TxFrame[] frames, TxFrameSignature[] signatures, ulong expected, bool senderHasCode)
     {
         Transaction tx = CreateValidFrameTx(candidate =>
         {
@@ -266,7 +278,7 @@ public class FrameTxValidationTests
             candidate.FrameSignatures = signatures;
         });
 
-        Assert.That(FrameTxValidation.ValidationWorkGas(tx), Is.EqualTo(expected));
+        Assert.That(FrameTxValidation.ValidationWorkGas(tx, senderHasCode), Is.EqualTo(expected));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -211,6 +211,64 @@ public class FrameTxValidationTests
         return digest;
     }
 
+    private static IEnumerable<TestCaseData> ValidationWorkCases()
+    {
+        static TestCaseData Work(string name, TxFrame[] frames, TxFrameSignature[] signatures, ulong expected) =>
+            new TestCaseData(frames, signatures, expected).SetName($"ValidationWorkGas_{name}");
+
+        static TxFrameSignature Signature(byte scheme) => new(scheme, null, default, Array.Empty<byte>());
+
+        // The prefix ends at the self-verify frame; the execution frame behind it is paid for out of
+        // the transaction's own gas and is outside the budget.
+        yield return Work("SelfVerifyThenSenderFrame_CountsOnlyThePrefix",
+            [SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: TestItem.AddressB, gasLimit: 5_000_000)],
+            [], 100_000);
+
+        // The canonical paymaster shape: execution approval, then payment approval by the sponsor.
+        yield return Work("ExecutionThenPaymentApproval_CountsBothPrefixFrames",
+            [
+                Frame(TxFrame.ModeVerify, TxFrame.ApproveExecution, gasLimit: 40_000),
+                Frame(TxFrame.ModeVerify, TxFrame.ApprovePayment, TestItem.AddressB, gasLimit: 30_000),
+                Frame(TxFrame.ModeSender, target: TestItem.AddressC, gasLimit: 900_000),
+            ],
+            [], 70_000);
+
+        // A payment-only frame ahead of any execution approval provably cannot set the payer
+        // (APPROVE reverts), so the walk must continue past it and count the frames that still run
+        // before the transaction is paid for.
+        yield return Work("PaymentApprovalBeforeExecutionApproval_KeepsWalking",
+            [
+                Frame(TxFrame.ModeVerify, TxFrame.ApprovePayment, TestItem.AddressB, gasLimit: 1_000),
+                Frame(gasLimit: 3_000_000),
+                SelfVerifyFrame(),
+            ],
+            [], 3_101_000);
+
+        // Nothing in the list can ever set a payer, so the whole list is charged.
+        yield return Work("NoPaymentApprovalAnywhere_CountsEveryFrame",
+            [Frame(gasLimit: 10_000), Frame(gasLimit: 20_000)], [], 30_000);
+
+        yield return Work("SignatureCostsCountAgainstTheBudget",
+            [SelfVerifyFrame()],
+            [Signature(TxFrameSignature.SchemeSecp256k1), Signature(TxFrameSignature.SchemeP256)],
+            100_000 + Eip8141Constants.Secp256k1VerificationGasCost + Eip8141Constants.P256VerificationGasCost);
+
+        yield return Work("OverflowingFrameGas_Saturates",
+            [Frame(gasLimit: ulong.MaxValue), Frame(gasLimit: 1)], [], ulong.MaxValue);
+    }
+
+    [TestCaseSource(nameof(ValidationWorkCases))]
+    public void ValidationWorkGas_BoundsThePrefixAndSignatures(TxFrame[] frames, TxFrameSignature[] signatures, ulong expected)
+    {
+        Transaction tx = CreateValidFrameTx(candidate =>
+        {
+            candidate.Frames = frames;
+            candidate.FrameSignatures = signatures;
+        });
+
+        Assert.That(FrameTxValidation.ValidationWorkGas(tx), Is.EqualTo(expected));
+    }
+
     [Test]
     public void TryGetExpiryDeadline_ReadsBigEndianDeadlineFromExpiryFrame()
     {

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -213,7 +213,7 @@ public class FrameTxValidationTests
 
     private static IEnumerable<TestCaseData> ValidationWorkCases()
     {
-        static TestCaseData Work(string name, TxFrame[] frames, TxFrameSignature[] signatures, ulong? expected) =>
+        static TestCaseData Work(string name, TxFrame[] frames, TxFrameSignature[] signatures, ulong expected) =>
             new TestCaseData(frames, signatures, expected).SetName($"ValidationWorkGas_{name}");
 
         static TxFrameSignature Signature(byte scheme) => new(scheme, null, default, Array.Empty<byte>());
@@ -254,32 +254,36 @@ public class FrameTxValidationTests
             [DefaultModeFrame(), Frame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, gasLimit: ulong.MaxValue)],
             [], ulong.MaxValue);
 
-        // Approving flags on a DEFAULT frame do not make a prefix: whether the target approves at all
-        // depends on code the sender controls, so the frames behind it would run unbudgeted.
-        yield return Work("DefaultFrameWithApprovingFlags_IsNotRecognized",
+        // Approving flags on a DEFAULT frame do not end a prefix: whether the target approves at all
+        // depends on code the sender controls, so the frames behind it may still run unpaid and the
+        // whole list is charged. Estimating this layout at its first frame is what let a sender on a
+        // delegation walk past the ceiling.
+        yield return Work("DefaultFrameWithApprovingFlags_ChargesTheWholeList",
             [Frame(flags: TxFrame.ApproveExecutionAndPayment, gasLimit: 1_000), Frame(gasLimit: 3_000_000)],
-            [], null);
+            [], 3_001_000);
 
         // APPROVE rejects a payment approval that no execution approval precedes.
-        yield return Work("PayBeforeOnlyVerify_IsNotRecognized",
-            [PayFrame(), OnlyVerifyFrame()], [], null);
+        yield return Work("PayBeforeOnlyVerify_ChargesTheWholeList",
+            [PayFrame(), OnlyVerifyFrame()], [], 70_000);
 
         // A verifier the sender does not control is third-party mutable state.
-        yield return Work("SelfVerifyTargetingAThirdParty_IsNotRecognized",
-            [Frame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, TestItem.AddressB)], [], null);
+        yield return Work("SelfVerifyTargetingAThirdParty_ChargesTheWholeList",
+            [Frame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, TestItem.AddressB), Frame(gasLimit: 900_000)],
+            [], 950_000);
 
-        yield return Work("PrefixFrameInAnAtomicBatch_IsNotRecognized",
-            [Frame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment | TxFrame.AtomicBatchFlag)], [], null);
+        yield return Work("PrefixFrameInAnAtomicBatch_ChargesTheWholeList",
+            [Frame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment | TxFrame.AtomicBatchFlag), Frame(gasLimit: 900_000)],
+            [], 950_000);
 
-        yield return Work("OnlyVerifyWithoutPay_IsNotRecognized",
-            [OnlyVerifyFrame(), Frame(TxFrame.ModeSender, gasLimit: 900_000)], [], null);
+        yield return Work("OnlyVerifyWithoutPay_ChargesTheWholeList",
+            [OnlyVerifyFrame(), Frame(TxFrame.ModeSender, gasLimit: 900_000)], [], 940_000);
 
-        yield return Work("NoApprovingFrameAtAll_IsNotRecognized",
-            [Frame(gasLimit: 10_000), Frame(gasLimit: 20_000)], [], null);
+        yield return Work("NoApprovingFrameAtAll_ChargesTheWholeList",
+            [Frame(gasLimit: 10_000), Frame(gasLimit: 20_000)], [], 30_000);
     }
 
     [TestCaseSource(nameof(ValidationWorkCases))]
-    public void TryGetValidationWorkGas_BoundsTheRecognizedPrefixAndSignatures(TxFrame[] frames, TxFrameSignature[] signatures, ulong? expected)
+    public void ValidationWorkGas_BoundsThePrefixAndSignatures(TxFrame[] frames, TxFrameSignature[] signatures, ulong expected)
     {
         Transaction tx = CreateValidFrameTx(candidate =>
         {
@@ -287,13 +291,7 @@ public class FrameTxValidationTests
             candidate.FrameSignatures = signatures;
         });
 
-        bool recognized = FrameTxValidation.TryGetValidationWorkGas(tx, out ulong workGas);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(recognized, Is.EqualTo(expected is not null));
-            Assert.That(workGas, Is.EqualTo(expected ?? 0));
-        }
+        Assert.That(FrameTxValidation.ValidationWorkGas(tx), Is.EqualTo(expected));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -260,13 +260,13 @@ public static class FrameTxValidation
 
                 byte scope = frame.AllowedApproveScope;
                 bool approvesExecution = (scope & TxFrame.ApproveExecution) != 0;
-                if ((scope & TxFrame.ApprovePayment) != 0 && (approvesExecution || senderApproved)
-                    && CanApprove(frame, transaction.SenderAddress, senderHasCode))
+                bool canApprove = CanApprove(frame, transaction.SenderAddress, senderHasCode);
+                if ((scope & TxFrame.ApprovePayment) != 0 && (approvesExecution || senderApproved) && canApprove)
                 {
                     break;
                 }
 
-                senderApproved |= approvesExecution;
+                senderApproved |= approvesExecution && canApprove;
             }
         }
 
@@ -285,12 +285,16 @@ public static class FrameTxValidation
 
     /// <summary>
     /// Whether <paramref name="frame"/> can reach an <c>APPROVE</c> at all: a frame resolving to a
-    /// codeless sender runs the EIP-8141 default code, which approves only in <c>VERIFY</c> mode.
+    /// codeless target runs the EIP-8141 default code, which approves only in <c>VERIFY</c> mode.
     /// </summary>
+    /// <remarks>
+    /// Outside <c>VERIFY</c> only a code-bearing target approves, and the sender is the only target
+    /// whose code is known here. A third-party target is attacker-chosen, so assuming it has code
+    /// would end the walk at a frame that provably cannot set a payer.
+    /// </remarks>
     private static bool CanApprove(TxFrame frame, Address? sender, bool senderHasCode) =>
         frame.Mode == TxFrame.ModeVerify
-        || senderHasCode
-        || (frame.Target is not null && frame.Target != sender);
+        || (senderHasCode && (frame.Target is null || frame.Target == sender));
 
     /// <summary>
     /// Reads the EIP-8141 expiry deadline (Unix seconds) from the expiry-verifier VERIFY frame, if present.

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -246,7 +246,7 @@ public static class FrameTxValidation
     /// from being an under-estimate. Signature validation counts against the same budget per
     /// EIP-8141 "Validation Prefix".
     /// </remarks>
-    public static ulong ValidationWorkGas(Transaction transaction)
+    public static ulong ValidationWorkGas(Transaction transaction, bool senderHasCode)
     {
         ulong total = 0;
 
@@ -260,7 +260,8 @@ public static class FrameTxValidation
 
                 byte scope = frame.AllowedApproveScope;
                 bool approvesExecution = (scope & TxFrame.ApproveExecution) != 0;
-                if ((scope & TxFrame.ApprovePayment) != 0 && (approvesExecution || senderApproved))
+                if ((scope & TxFrame.ApprovePayment) != 0 && (approvesExecution || senderApproved)
+                    && CanApprove(frame, transaction.SenderAddress, senderHasCode))
                 {
                     break;
                 }
@@ -281,6 +282,15 @@ public static class FrameTxValidation
 
         return total;
     }
+
+    /// <summary>
+    /// Whether <paramref name="frame"/> can reach an <c>APPROVE</c> at all: a frame resolving to a
+    /// codeless sender runs the EIP-8141 default code, which approves only in <c>VERIFY</c> mode.
+    /// </summary>
+    private static bool CanApprove(TxFrame frame, Address? sender, bool senderHasCode) =>
+        frame.Mode == TxFrame.ModeVerify
+        || senderHasCode
+        || (frame.Target is not null && frame.Target != sender);
 
     /// <summary>
     /// Reads the EIP-8141 expiry deadline (Unix seconds) from the expiry-verifier VERIFY frame, if present.

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -233,51 +233,29 @@ public static class FrameTxValidation
     };
 
     /// <summary>
-    /// The public-mempool validation work of <paramref name="transaction"/>: the gas limits of its
-    /// validation prefix plus the cost of verifying its signatures, saturating at <see cref="ulong.MaxValue"/>.
+    /// An upper bound on the public-mempool validation work of <paramref name="transaction"/>: the gas limits
+    /// of its validation prefix plus the cost of verifying its signatures, saturating at <see cref="ulong.MaxValue"/>.
     /// </summary>
     /// <remarks>
-    /// EIP-8141 "Public Mempool-recognized Validation Prefixes" admits four layouts, each optionally
-    /// preceded by an expiry verifier frame: <c>[self_verify]</c>, <c>[deploy, self_verify]</c>,
-    /// <c>[only_verify, pay]</c> and <c>[deploy, only_verify, pay]</c>. Matching the layout instead of
-    /// walking the list for a frame that might set <c>payer</c> is what makes the figure sound without
-    /// reading state: every recognized prefix ends in a <c>VERIFY</c> frame whose approval is
-    /// protocol-defined, so nothing has to be assumed about a target's deployed code. Any other layout
-    /// is ineligible for the public mempool whatever its gas, since the work before <c>payer</c> is set
-    /// is then bounded only by the frame list itself. Signature validation counts against the same
-    /// budget per EIP-8141 "Validation Prefix".
+    /// The figure is an upper bound on the work a node does before any gas is paid, and it is derived
+    /// from the frame layout alone so that no state has to be read. EIP-8141 "Public Mempool-recognized
+    /// Validation Prefixes" admits four layouts, each optionally preceded by an expiry verifier frame:
+    /// <c>[self_verify]</c>, <c>[deploy, self_verify]</c>, <c>[only_verify, pay]</c> and
+    /// <c>[deploy, only_verify, pay]</c>. Each ends in a <c>VERIFY</c> frame targeting the sender, whose
+    /// approval is protocol-defined, so the prefix provably ends there and the frames behind it are
+    /// already paid for. Under any other layout nothing can be assumed about where <c>payer</c> is set:
+    /// approval then depends on code at an attacker-chosen target, so the whole frame list is charged.
+    /// That keeps a cheap unusual layout admissible while denying the layout its low estimate. Signature
+    /// validation counts against the same budget per EIP-8141 "Validation Prefix".
     /// </remarks>
     /// <param name="transaction">The frame transaction to price.</param>
-    /// <param name="workGas">The prefix gas limits plus signature verification cost, 0 when unrecognized.</param>
-    /// <returns><c>false</c> if the frame layout matches none of the recognized validation prefixes.</returns>
-    public static bool TryGetValidationWorkGas(Transaction transaction, out ulong workGas)
+    public static ulong ValidationWorkGas(Transaction transaction)
     {
-        workGas = 0;
-
         TxFrame[] frames = transaction.Frames ?? [];
-        Address? sender = transaction.SenderAddress;
-        int next = 0;
-        if (next < frames.Length && IsExpiryVerify(frames[next])) next++;
-        if (next < frames.Length && IsDeploy(frames[next])) next++;
-
-        int prefixEnd;
-        if (next < frames.Length && IsSelfTargetedVerify(frames[next], TxFrame.ApproveExecutionAndPayment, sender))
-        {
-            prefixEnd = next;
-        }
-        else if (next + 1 < frames.Length
-                 && IsSelfTargetedVerify(frames[next], TxFrame.ApproveExecution, sender)
-                 && IsPay(frames[next + 1]))
-        {
-            prefixEnd = next + 1;
-        }
-        else
-        {
-            return false;
-        }
+        int counted = RecognizedPrefixLength(frames, transaction.SenderAddress) ?? frames.Length;
 
         ulong total = 0;
-        for (int i = 0; i <= prefixEnd; i++)
+        for (int i = 0; i < counted; i++)
         {
             total = Saturating(total, frames[i].GasLimit);
         }
@@ -287,8 +265,32 @@ public static class FrameTxValidation
             total = Saturating(total, SignatureVerificationGas(signature.Scheme));
         }
 
-        workGas = total;
-        return true;
+        return total;
+    }
+
+    /// <summary>
+    /// The number of leading frames forming a validation prefix EIP-8141 recognizes for the public
+    /// mempool, or <c>null</c> when the layout matches none of them.
+    /// </summary>
+    private static int? RecognizedPrefixLength(TxFrame[] frames, Address? sender)
+    {
+        int next = 0;
+        if (next < frames.Length && IsExpiryVerify(frames[next])) next++;
+        if (next < frames.Length && IsDeploy(frames[next])) next++;
+
+        if (next < frames.Length && IsSelfTargetedVerify(frames[next], TxFrame.ApproveExecutionAndPayment, sender))
+        {
+            return next + 1;
+        }
+
+        if (next + 1 < frames.Length
+            && IsSelfTargetedVerify(frames[next], TxFrame.ApproveExecution, sender)
+            && IsPay(frames[next + 1]))
+        {
+            return next + 2;
+        }
+
+        return null;
     }
 
     private static ulong Saturating(ulong total, ulong addend) =>

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -237,15 +237,10 @@ public static class FrameTxValidation
     /// of its validation prefix plus the cost of verifying its signatures, saturating at <see cref="ulong.MaxValue"/>.
     /// </summary>
     /// <remarks>
-    /// The figure is an upper bound on the work a node does before any gas is paid, and it is derived
-    /// from the frame layout alone so that no state has to be read. EIP-8141 "Public Mempool-recognized
-    /// Validation Prefixes" admits four layouts, each optionally preceded by an expiry verifier frame:
-    /// <c>[self_verify]</c>, <c>[deploy, self_verify]</c>, <c>[only_verify, pay]</c> and
-    /// <c>[deploy, only_verify, pay]</c>. Each ends in a <c>VERIFY</c> frame targeting the sender, whose
-    /// approval is protocol-defined, so the prefix provably ends there and the frames behind it are
-    /// already paid for. Under any other layout nothing can be assumed about where <c>payer</c> is set:
-    /// approval then depends on code at an attacker-chosen target, so the whole frame list is charged.
-    /// That keeps a cheap unusual layout admissible while denying the layout its low estimate. Signature
+    /// Derived from the frame layout alone, so no state is read. Each layout of EIP-8141 "Public
+    /// Mempool-recognized Validation Prefixes" ends in a <c>VERIFY</c> frame targeting the sender, whose
+    /// approval is protocol-defined, so the prefix provably ends there. Under any other layout approval
+    /// depends on code at an attacker-chosen target, so the whole frame list is charged. Signature
     /// validation counts against the same budget per EIP-8141 "Validation Prefix".
     /// </remarks>
     /// <param name="transaction">The frame transaction to price.</param>

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -223,6 +223,58 @@ public static class FrameTxValidation
             || (i > 0 && (frames[i - 1].Flags & TxFrame.AtomicBatchFlag) != 0);
     }
 
+    /// <summary>The gas charged for verifying a signature of the given EIP-8141 scheme.</summary>
+    public static ulong SignatureVerificationGas(byte scheme) => scheme switch
+    {
+        TxFrameSignature.SchemeArbitrary => Eip8141Constants.ArbitraryVerificationGasCost,
+        TxFrameSignature.SchemeSecp256k1 => Eip8141Constants.Secp256k1VerificationGasCost,
+        TxFrameSignature.SchemeP256 => Eip8141Constants.P256VerificationGasCost,
+        _ => 0,
+    };
+
+    /// <summary>
+    /// The public-mempool validation work of <paramref name="transaction"/>: the gas limits of its
+    /// validation prefix plus the cost of verifying its signatures, saturating at <see cref="ulong.MaxValue"/>.
+    /// </summary>
+    /// <remarks>
+    /// The validation prefix is the shortest prefix of frames whose successful execution sets
+    /// <c>payer</c>, so it is bounded statically by the first frame permitted to approve payment
+    /// (approval scopes <see cref="TxFrame.ApprovePayment"/> and
+    /// <see cref="TxFrame.ApproveExecutionAndPayment"/>). A frame transaction with no such frame can
+    /// never set a payer, and charging its whole frame list here keeps the figure from ever being an
+    /// under-estimate. Signature validation counts against the same budget per EIP-8141
+    /// "Validation Prefix".
+    /// </remarks>
+    public static ulong ValidationWorkGas(Transaction transaction)
+    {
+        ulong total = 0;
+
+        TxFrame[]? frames = transaction.Frames;
+        if (frames is not null)
+        {
+            foreach (TxFrame frame in frames)
+            {
+                total = frame.GasLimit > ulong.MaxValue - total ? ulong.MaxValue : total + frame.GasLimit;
+                if (frame.AllowedApproveScope is TxFrame.ApprovePayment or TxFrame.ApproveExecutionAndPayment)
+                {
+                    break;
+                }
+            }
+        }
+
+        TxFrameSignature[]? signatures = transaction.FrameSignatures;
+        if (signatures is not null)
+        {
+            foreach (TxFrameSignature signature in signatures)
+            {
+                ulong cost = SignatureVerificationGas(signature.Scheme);
+                total = cost > ulong.MaxValue - total ? ulong.MaxValue : total + cost;
+            }
+        }
+
+        return total;
+    }
+
     /// <summary>
     /// Reads the EIP-8141 expiry deadline (Unix seconds) from the expiry-verifier VERIFY frame, if present.
     /// </summary>

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -238,12 +238,13 @@ public static class FrameTxValidation
     /// </summary>
     /// <remarks>
     /// The validation prefix is the shortest prefix of frames whose successful execution sets
-    /// <c>payer</c>, so it is bounded statically by the first frame permitted to approve payment
-    /// (approval scopes <see cref="TxFrame.ApprovePayment"/> and
-    /// <see cref="TxFrame.ApproveExecutionAndPayment"/>). A frame transaction with no such frame can
-    /// never set a payer, and charging its whole frame list here keeps the figure from ever being an
-    /// under-estimate. Signature validation counts against the same budget per EIP-8141
-    /// "Validation Prefix".
+    /// <c>payer</c>, so the walk stops at the first frame that could set one. Permission to approve
+    /// payment is not enough: <c>APPROVE</c> rejects a payment approval that is not preceded by an
+    /// execution approval, so a payment-only frame ahead of any execution approval provably cannot
+    /// set a payer and the frames behind it still run before any gas is paid. A frame transaction
+    /// with no payer-setting frame at all is charged its whole frame list, which keeps the figure
+    /// from being an under-estimate. Signature validation counts against the same budget per
+    /// EIP-8141 "Validation Prefix".
     /// </remarks>
     public static ulong ValidationWorkGas(Transaction transaction)
     {
@@ -252,13 +253,19 @@ public static class FrameTxValidation
         TxFrame[]? frames = transaction.Frames;
         if (frames is not null)
         {
+            bool senderApproved = false;
             foreach (TxFrame frame in frames)
             {
                 total = frame.GasLimit > ulong.MaxValue - total ? ulong.MaxValue : total + frame.GasLimit;
-                if (frame.AllowedApproveScope is TxFrame.ApprovePayment or TxFrame.ApproveExecutionAndPayment)
+
+                byte scope = frame.AllowedApproveScope;
+                bool approvesExecution = (scope & TxFrame.ApproveExecution) != 0;
+                if ((scope & TxFrame.ApprovePayment) != 0 && (approvesExecution || senderApproved))
                 {
                     break;
                 }
+
+                senderApproved |= approvesExecution;
             }
         }
 

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -237,64 +237,82 @@ public static class FrameTxValidation
     /// validation prefix plus the cost of verifying its signatures, saturating at <see cref="ulong.MaxValue"/>.
     /// </summary>
     /// <remarks>
-    /// The validation prefix is the shortest prefix of frames whose successful execution sets
-    /// <c>payer</c>, so the walk stops at the first frame that could set one. Permission to approve
-    /// payment is not enough: <c>APPROVE</c> rejects a payment approval that is not preceded by an
-    /// execution approval, so a payment-only frame ahead of any execution approval provably cannot
-    /// set a payer and the frames behind it still run before any gas is paid. A frame transaction
-    /// with no payer-setting frame at all is charged its whole frame list, which keeps the figure
-    /// from being an under-estimate. Signature validation counts against the same budget per
-    /// EIP-8141 "Validation Prefix".
+    /// EIP-8141 "Public Mempool-recognized Validation Prefixes" admits four layouts, each optionally
+    /// preceded by an expiry verifier frame: <c>[self_verify]</c>, <c>[deploy, self_verify]</c>,
+    /// <c>[only_verify, pay]</c> and <c>[deploy, only_verify, pay]</c>. Matching the layout instead of
+    /// walking the list for a frame that might set <c>payer</c> is what makes the figure sound without
+    /// reading state: every recognized prefix ends in a <c>VERIFY</c> frame whose approval is
+    /// protocol-defined, so nothing has to be assumed about a target's deployed code. Any other layout
+    /// is ineligible for the public mempool whatever its gas, since the work before <c>payer</c> is set
+    /// is then bounded only by the frame list itself. Signature validation counts against the same
+    /// budget per EIP-8141 "Validation Prefix".
     /// </remarks>
-    public static ulong ValidationWorkGas(Transaction transaction, bool senderHasCode)
+    /// <param name="transaction">The frame transaction to price.</param>
+    /// <param name="workGas">The prefix gas limits plus signature verification cost, 0 when unrecognized.</param>
+    /// <returns><c>false</c> if the frame layout matches none of the recognized validation prefixes.</returns>
+    public static bool TryGetValidationWorkGas(Transaction transaction, out ulong workGas)
     {
+        workGas = 0;
+
+        TxFrame[] frames = transaction.Frames ?? [];
+        Address? sender = transaction.SenderAddress;
+        int next = 0;
+        if (next < frames.Length && IsExpiryVerify(frames[next])) next++;
+        if (next < frames.Length && IsDeploy(frames[next])) next++;
+
+        int prefixEnd;
+        if (next < frames.Length && IsSelfTargetedVerify(frames[next], TxFrame.ApproveExecutionAndPayment, sender))
+        {
+            prefixEnd = next;
+        }
+        else if (next + 1 < frames.Length
+                 && IsSelfTargetedVerify(frames[next], TxFrame.ApproveExecution, sender)
+                 && IsPay(frames[next + 1]))
+        {
+            prefixEnd = next + 1;
+        }
+        else
+        {
+            return false;
+        }
+
         ulong total = 0;
-
-        TxFrame[]? frames = transaction.Frames;
-        if (frames is not null)
+        for (int i = 0; i <= prefixEnd; i++)
         {
-            bool senderApproved = false;
-            foreach (TxFrame frame in frames)
-            {
-                total = frame.GasLimit > ulong.MaxValue - total ? ulong.MaxValue : total + frame.GasLimit;
-
-                byte scope = frame.AllowedApproveScope;
-                bool approvesExecution = (scope & TxFrame.ApproveExecution) != 0;
-                bool canApprove = CanApprove(frame, transaction.SenderAddress, senderHasCode);
-                if ((scope & TxFrame.ApprovePayment) != 0 && (approvesExecution || senderApproved) && canApprove)
-                {
-                    break;
-                }
-
-                senderApproved |= approvesExecution && canApprove;
-            }
+            total = Saturating(total, frames[i].GasLimit);
         }
 
-        TxFrameSignature[]? signatures = transaction.FrameSignatures;
-        if (signatures is not null)
+        foreach (TxFrameSignature signature in transaction.FrameSignatures ?? [])
         {
-            foreach (TxFrameSignature signature in signatures)
-            {
-                ulong cost = SignatureVerificationGas(signature.Scheme);
-                total = cost > ulong.MaxValue - total ? ulong.MaxValue : total + cost;
-            }
+            total = Saturating(total, SignatureVerificationGas(signature.Scheme));
         }
 
-        return total;
+        workGas = total;
+        return true;
     }
 
-    /// <summary>
-    /// Whether <paramref name="frame"/> can reach an <c>APPROVE</c> at all: a frame resolving to a
-    /// codeless target runs the EIP-8141 default code, which approves only in <c>VERIFY</c> mode.
-    /// </summary>
-    /// <remarks>
-    /// Outside <c>VERIFY</c> only a code-bearing target approves, and the sender is the only target
-    /// whose code is known here. A third-party target is attacker-chosen, so assuming it has code
-    /// would end the walk at a frame that provably cannot set a payer.
-    /// </remarks>
-    private static bool CanApprove(TxFrame frame, Address? sender, bool senderHasCode) =>
+    private static ulong Saturating(ulong total, ulong addend) =>
+        addend > ulong.MaxValue - total ? ulong.MaxValue : total + addend;
+
+    private static bool IsExpiryVerify(TxFrame frame) =>
         frame.Mode == TxFrame.ModeVerify
-        || (senderHasCode && (frame.Target is null || frame.Target == sender));
+        && frame.Flags == TxFrame.ApproveScopeNone
+        && frame.Target == Eip8141Constants.ExpiryVerifierAddress;
+
+    private static bool IsDeploy(TxFrame frame) =>
+        frame.Mode == TxFrame.ModeDefault && frame.Flags == TxFrame.ApproveScopeNone;
+
+    /// <remarks>
+    /// Comparing the whole <see cref="TxFrame.Flags"/> byte rather than the approve scope also enforces
+    /// the EIP-8141 structural rule that no prefix frame carries <c>ATOMIC_BATCH_FLAG</c>.
+    /// </remarks>
+    private static bool IsSelfTargetedVerify(TxFrame frame, byte flags, Address? sender) =>
+        frame.Mode == TxFrame.ModeVerify
+        && frame.Flags == flags
+        && (frame.Target is null || frame.Target == sender);
+
+    private static bool IsPay(TxFrame frame) =>
+        frame.Mode == TxFrame.ModeVerify && frame.Flags == TxFrame.ApprovePayment;
 
     /// <summary>
     /// Reads the EIP-8141 expiry deadline (Unix seconds) from the expiry-verifier VERIFY frame, if present.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -454,13 +454,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 dataLength += (ulong)(signature.Signer is null ? 0 : Address.Size)
                               + (ulong)signature.Msg.Length
                               + (ulong)signature.Signature.Length;
-                signatureVerificationCost += signature.Scheme switch
-                {
-                    TxFrameSignature.SchemeArbitrary => Eip8141Constants.ArbitraryVerificationGasCost,
-                    TxFrameSignature.SchemeSecp256k1 => Eip8141Constants.Secp256k1VerificationGasCost,
-                    TxFrameSignature.SchemeP256 => Eip8141Constants.P256VerificationGasCost,
-                    _ => 0,
-                };
+                signatureVerificationCost += FrameTxValidation.SignatureVerificationGas(signature.Scheme);
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.TxPool.Filters;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.TxPool.Test;
+
+[Parallelizable(ParallelScope.All)]
+internal class FrameTxVerifyGasFilterTest
+{
+    // A frame that may approve both scopes but runs EIP-8141 default code unless the sender has
+    // code, followed by a frame that only stays inside the ceiling while the walk stops early.
+    private static Transaction FrameTx() => new()
+    {
+        Type = TxType.FrameTx,
+        SenderAddress = TestItem.AddressA,
+        Frames =
+        [
+            new TxFrame(TxFrame.ModeDefault, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 1_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeDefault, TxFrame.ApproveScopeNone, target: TestItem.AddressB, gasLimit: 3_000_000, UInt256.Zero, default),
+        ],
+        FrameSignatures = [],
+    };
+
+    // The account readers diverge on the out-value of a failed lookup, and a zero code hash reads
+    // back as code-bearing. Scoring a missing sender that way ends the prefix walk at a frame that
+    // provably cannot approve, so the frames behind it are never counted against MAX_VERIFY_GAS.
+    [TestCase(false, TestName = "a missing sender is codeless, so the whole prefix is counted")]
+    [TestCase(true, TestName = "a code-bearing sender ends the prefix at the approving frame")]
+    public void Accept_ScoresAMissingSenderAsCodeless(bool senderExistsWithCode)
+    {
+        IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+        if (senderExistsWithCode)
+        {
+            accounts.TryGetAccount(TestItem.AddressA, out Arg.Any<AccountStruct>()).Returns(call =>
+            {
+                call[1] = new AccountStruct(0, UInt256.One, Keccak.EmptyTreeHash.ValueHash256, TestItem.KeccakA.ValueHash256);
+                return true;
+            });
+        }
+
+        FrameTxVerifyGasFilter filter = new(new TxPoolConfig { FrameTxMaxVerifyGas = 100_000 }, LimboLogs.Instance.GetClassLogger<FrameTxVerifyGasFilterTest>());
+        Transaction tx = FrameTx();
+        TxFilteringState state = new(tx, accounts);
+
+        AcceptTxResult result = filter.Accept(tx, ref state, TxHandlingOptions.None);
+
+        Assert.That(result, Is.EqualTo(senderExistsWithCode ? AcceptTxResult.Accepted : AcceptTxResult.FrameTxVerifyGasTooHigh));
+    }
+
+    // The pool's account cache stores the empty account on a miss while the reader beneath it may
+    // leave the out-value zeroed, so a filter reading the first probe and a filter reading the
+    // second one must not see a different sender.
+    [Test]
+    public void SenderAccount_OfAMissingAccount_ReadsTheSameOnEveryProbe()
+    {
+        TxFilteringState state = new(FrameTx(), Substitute.For<IAccountStateProvider>());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(state.SenderAccount.HasCode, Is.False);
+            Assert.That(state.SenderAccount.IsTotallyEmpty, Is.True);
+            Assert.That(state.SenderAccount.HasCode, Is.False);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
@@ -28,25 +29,32 @@ internal class FrameTxVerifyGasFilterTest
     private static TxFrame Execution(ulong gasLimit) =>
         new(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, gasLimit, UInt256.Zero, default);
 
-    // Approving flags on a DEFAULT frame do not end the validation prefix: whether that frame approves
-    // at all depends on code the sender controls, so a prefix walk that trusted the flags would leave
-    // the frames behind it unbudgeted while the node still runs them before any gas is paid.
-    [TestCase(false, TestName = "a recognized prefix inside the ceiling is accepted")]
-    [TestCase(true, TestName = "an unrecognized prefix is rejected whatever its gas")]
-    public void Accept_RejectsAnUnrecognizedValidationPrefix(bool unrecognized)
-    {
-        Transaction tx = unrecognized
-            ? FrameTx(
-                new TxFrame(TxFrame.ModeDefault, TxFrame.ApproveExecutionAndPayment, target: null, 1_000, UInt256.Zero, default),
-                Execution(3_000_000))
-            : FrameTx(SelfVerify(1_000), Execution(3_000_000));
+    private static TxFrame ApprovingDefault(ulong gasLimit) =>
+        new(TxFrame.ModeDefault, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit, UInt256.Zero, default);
 
+    // Approving flags on a DEFAULT frame do not end the validation prefix: whether that frame approves
+    // at all depends on code the sender controls, so the frames behind it may still run before any gas
+    // is paid and are charged too. That is the ceiling bypass a sender on a delegation had; a layout
+    // whose whole frame list fits under the ceiling costs the node no more than a recognized one and
+    // stays admissible.
+    private static IEnumerable<TestCaseData> PrefixCases()
+    {
+        yield return new TestCaseData(new[] { SelfVerify(1_000), Execution(3_000_000) }, AcceptTxResult.Accepted)
+            .SetName("execution behind a recognized prefix is outside the ceiling");
+        yield return new TestCaseData(new[] { ApprovingDefault(1_000), Execution(3_000_000) }, AcceptTxResult.FrameTxVerifyGasTooHigh)
+            .SetName("an unrecognized layout is charged its whole frame list");
+        yield return new TestCaseData(new[] { ApprovingDefault(1_000), Execution(20_000) }, AcceptTxResult.Accepted)
+            .SetName("an unrecognized layout under the ceiling is still accepted");
+    }
+
+    [TestCaseSource(nameof(PrefixCases))]
+    public void Accept_ChargesEveryFrameThatMayRunBeforePayment(TxFrame[] frames, AcceptTxResult expected)
+    {
+        Transaction tx = FrameTx(frames);
         FrameTxVerifyGasFilter filter = new(new TxPoolConfig { FrameTxMaxVerifyGas = 100_000 }, LimboLogs.Instance.GetClassLogger<FrameTxVerifyGasFilterTest>());
         TxFilteringState state = new(tx, Substitute.For<IAccountStateProvider>());
 
-        AcceptTxResult result = filter.Accept(tx, ref state, TxHandlingOptions.None);
-
-        Assert.That(result, Is.EqualTo(unrecognized ? AcceptTxResult.FrameTxVerifyGasTooHigh : AcceptTxResult.Accepted));
+        Assert.That(filter.Accept(tx, ref state, TxHandlingOptions.None), Is.EqualTo(expected));
     }
 
     // The pool's account cache stores the empty account on a miss while the reader beneath it may

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -15,44 +14,39 @@ namespace Nethermind.TxPool.Test;
 [Parallelizable(ParallelScope.All)]
 internal class FrameTxVerifyGasFilterTest
 {
-    // A frame that may approve both scopes but runs EIP-8141 default code unless the sender has
-    // code, followed by a frame that only stays inside the ceiling while the walk stops early.
-    private static Transaction FrameTx() => new()
+    private static Transaction FrameTx(params TxFrame[] frames) => new()
     {
         Type = TxType.FrameTx,
         SenderAddress = TestItem.AddressA,
-        Frames =
-        [
-            new TxFrame(TxFrame.ModeDefault, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 1_000, UInt256.Zero, default),
-            new TxFrame(TxFrame.ModeDefault, TxFrame.ApproveScopeNone, target: TestItem.AddressB, gasLimit: 3_000_000, UInt256.Zero, default),
-        ],
+        Frames = frames,
         FrameSignatures = [],
     };
 
-    // The account readers diverge on the out-value of a failed lookup, and a zero code hash reads
-    // back as code-bearing. Scoring a missing sender that way ends the prefix walk at a frame that
-    // provably cannot approve, so the frames behind it are never counted against MAX_VERIFY_GAS.
-    [TestCase(false, TestName = "a missing sender is codeless, so the whole prefix is counted")]
-    [TestCase(true, TestName = "a code-bearing sender ends the prefix at the approving frame")]
-    public void Accept_ScoresAMissingSenderAsCodeless(bool senderExistsWithCode)
+    private static TxFrame SelfVerify(ulong gasLimit) =>
+        new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit, UInt256.Zero, default);
+
+    private static TxFrame Execution(ulong gasLimit) =>
+        new(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, gasLimit, UInt256.Zero, default);
+
+    // Approving flags on a DEFAULT frame do not end the validation prefix: whether that frame approves
+    // at all depends on code the sender controls, so a prefix walk that trusted the flags would leave
+    // the frames behind it unbudgeted while the node still runs them before any gas is paid.
+    [TestCase(false, TestName = "a recognized prefix inside the ceiling is accepted")]
+    [TestCase(true, TestName = "an unrecognized prefix is rejected whatever its gas")]
+    public void Accept_RejectsAnUnrecognizedValidationPrefix(bool unrecognized)
     {
-        IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
-        if (senderExistsWithCode)
-        {
-            accounts.TryGetAccount(TestItem.AddressA, out Arg.Any<AccountStruct>()).Returns(call =>
-            {
-                call[1] = new AccountStruct(0, UInt256.One, Keccak.EmptyTreeHash.ValueHash256, TestItem.KeccakA.ValueHash256);
-                return true;
-            });
-        }
+        Transaction tx = unrecognized
+            ? FrameTx(
+                new TxFrame(TxFrame.ModeDefault, TxFrame.ApproveExecutionAndPayment, target: null, 1_000, UInt256.Zero, default),
+                Execution(3_000_000))
+            : FrameTx(SelfVerify(1_000), Execution(3_000_000));
 
         FrameTxVerifyGasFilter filter = new(new TxPoolConfig { FrameTxMaxVerifyGas = 100_000 }, LimboLogs.Instance.GetClassLogger<FrameTxVerifyGasFilterTest>());
-        Transaction tx = FrameTx();
-        TxFilteringState state = new(tx, accounts);
+        TxFilteringState state = new(tx, Substitute.For<IAccountStateProvider>());
 
         AcceptTxResult result = filter.Accept(tx, ref state, TxHandlingOptions.None);
 
-        Assert.That(result, Is.EqualTo(senderExistsWithCode ? AcceptTxResult.Accepted : AcceptTxResult.FrameTxVerifyGasTooHigh));
+        Assert.That(result, Is.EqualTo(unrecognized ? AcceptTxResult.FrameTxVerifyGasTooHigh : AcceptTxResult.Accepted));
     }
 
     // The pool's account cache stores the empty account on a miss while the reader beneath it may
@@ -61,7 +55,7 @@ internal class FrameTxVerifyGasFilterTest
     [Test]
     public void SenderAccount_OfAMissingAccount_ReadsTheSameOnEveryProbe()
     {
-        TxFilteringState state = new(FrameTx(), Substitute.For<IAccountStateProvider>());
+        TxFilteringState state = new(FrameTx(SelfVerify(1_000)), Substitute.For<IAccountStateProvider>());
 
         using (Assert.EnterMultipleScope())
         {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2297,7 +2297,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
         }
 
-        private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline, UInt256? maxPriorityFeePerGas = null, UInt256? maxFeePerGas = null, ulong verifyGasLimit = 100_000)
+        private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline, UInt256? maxPriorityFeePerGas = null, UInt256? maxFeePerGas = null, ulong verifyGasLimit = 50_000)
         {
             List<TxFrame> frames =
             [
@@ -2308,7 +2308,8 @@ namespace Nethermind.TxPool.Test
             {
                 byte[] expiryData = new byte[Eip8141Constants.ExpiryDataLength];
                 BinaryPrimitives.WriteUInt64BigEndian(expiryData, deadline.Value);
-                frames.Add(new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 50_000, UInt256.Zero, expiryData));
+                // An expiry verifier frame may appear only as the first frame (EIP-8141 "Expiry Verifier Frame").
+                frames.Insert(0, new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 50_000, UInt256.Zero, expiryData));
             }
 
             Transaction tx = new()

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2226,11 +2226,45 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline, UInt256? maxPriorityFeePerGas = null, UInt256? maxFeePerGas = null)
+        // MAX_VERIFY_GAS is a public-mempool DoS bound, not a validity rule: a prefix over the ceiling is
+        // still consensus-valid, so the pool must refuse it at ingress rather than the validator.
+        [TestCase(100_000UL, true, TestName = "prefix exactly at MAX_VERIFY_GAS is accepted")]
+        [TestCase(100_001UL, false, TestName = "prefix one gas over MAX_VERIFY_GAS is rejected")]
+        public void Frame_transaction_prefix_is_bounded_by_max_verify_gas(ulong verifyGasLimit, bool expectedAccepted)
+        {
+            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 100_000 }, new TestSpecProvider(Bogota.Instance));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null, verifyGasLimit: verifyGasLimit);
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+
+            Assert.That(result, Is.EqualTo(expectedAccepted ? AcceptTxResult.Accepted : AcceptTxResult.FrameTxVerifyGasTooHigh));
+        }
+
+        [Test]
+        public void Frame_transaction_execution_gas_is_outside_the_verify_budget()
+        {
+            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 100_000 }, new TestSpecProvider(Bogota.Instance));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            // The validation prefix ends at the frame that approves payment; the execution frame after it
+            // is paid for out of the transaction's own gas and must not count against the budget.
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null, verifyGasLimit: 100_000);
+            frameTx.Frames =
+            [
+                frameTx.Frames![0],
+                new TxFrame(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, gasLimit: 5_000_000, UInt256.Zero, default),
+            ];
+            frameTx.Hash = frameTx.CalculateHash();
+
+            Assert.That(_txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+        }
+
+        private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline, UInt256? maxPriorityFeePerGas = null, UInt256? maxFeePerGas = null, ulong verifyGasLimit = 100_000)
         {
             List<TxFrame> frames =
             [
-                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default),
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: verifyGasLimit, UInt256.Zero, default),
             ];
 
             if (deadline is not null)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2228,17 +2228,54 @@ namespace Nethermind.TxPool.Test
 
         // MAX_VERIFY_GAS is a public-mempool DoS bound, not a validity rule: a prefix over the ceiling is
         // still consensus-valid, so the pool must refuse it at ingress rather than the validator.
-        [TestCase(100_000UL, true, TestName = "prefix exactly at MAX_VERIFY_GAS is accepted")]
-        [TestCase(100_001UL, false, TestName = "prefix one gas over MAX_VERIFY_GAS is rejected")]
-        public void Frame_transaction_prefix_is_bounded_by_max_verify_gas(ulong verifyGasLimit, bool expectedAccepted)
+        [TestCase(100_000UL, false, true, TestName = "prefix exactly at MAX_VERIFY_GAS is accepted")]
+        [TestCase(100_001UL, false, false, TestName = "prefix one gas over MAX_VERIFY_GAS is rejected")]
+        [TestCase(100_000UL, true, false, TestName = "signature verification cost pushes the prefix over the ceiling")]
+        [TestCase(93_300UL, true, true, TestName = "prefix plus signature cost exactly at the ceiling is accepted")]
+        public void Frame_transaction_prefix_is_bounded_by_max_verify_gas(ulong verifyGasLimit, bool withP256Signature, bool expectedAccepted)
         {
             _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 100_000 }, new TestSpecProvider(Bogota.Instance));
             EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+            ITxPoolPeer peer = Substitute.For<ITxPoolPeer>();
+            peer.Id.Returns(TestItem.PublicKeyA);
+            _txPool.AddPeer(peer);
 
             Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null, verifyGasLimit: verifyGasLimit);
+            if (withP256Signature)
+            {
+                // 6 700 gas, so it decides the outcome on its own at a 93 300-gas prefix.
+                frameTx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeP256, null, default, new byte[TxFrameSignature.P256SignatureLength])];
+                frameTx.Hash = frameTx.CalculateHash();
+            }
+
             AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
 
-            Assert.That(result, Is.EqualTo(expectedAccepted ? AcceptTxResult.Accepted : AcceptTxResult.FrameTxVerifyGasTooHigh));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(expectedAccepted ? AcceptTxResult.Accepted : AcceptTxResult.FrameTxVerifyGasTooHigh));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(expectedAccepted ? 1 : 0));
+            }
+
+            // Propagation is what the bound exists to stop, so the non-broadcast half is asserted too.
+            if (expectedAccepted)
+            {
+                peer.Received().SendNewTransaction(frameTx);
+            }
+            else
+            {
+                peer.DidNotReceive().SendNewTransaction(frameTx);
+            }
+        }
+
+        [Test]
+        public void Frame_transaction_verify_gas_limit_of_zero_lifts_the_bound()
+        {
+            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Bogota.Instance));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null, verifyGasLimit: 30_000_000);
+
+            Assert.That(_txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
+++ b/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
@@ -125,6 +125,12 @@ namespace Nethermind.TxPool
         /// </summary>
         public static readonly AcceptTxResult FrameTxExpired = new(20, TxPoolErrorMessages.FrameTxExpired);
 
+        /// <summary>
+        /// An EIP-8141 frame transaction whose validation prefix plus signature verification would cost a node more
+        /// than <c>MAX_VERIFY_GAS</c> to check. It stays consensus-valid; only public mempool propagation is refused.
+        /// </summary>
+        public static readonly AcceptTxResult FrameTxVerifyGasTooHigh = new(21, TxPoolErrorMessages.FrameTxVerifyGasTooHigh);
+
         private int Id { get; } = id;
         private string Code { get; } = code;
         private string? Message { get; } = message;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -7,15 +7,15 @@ using Nethermind.Logging;
 namespace Nethermind.TxPool.Filters;
 
 /// <summary>
-/// Rejects an EIP-8141 frame transaction whose validation prefix is not one the public mempool recognizes, or whose
-/// prefix and signature verification would cost more than <c>MAX_VERIFY_GAS</c> to check.
+/// Rejects an EIP-8141 frame transaction whose validation prefix and signature verification would cost more than
+/// <c>MAX_VERIFY_GAS</c> to check.
 /// </summary>
 /// <remarks>
 /// This is a public-mempool DoS bound, not a validity rule: a block carrying such a transaction stays valid, and the
 /// transaction can still be delivered out of band. Without the bound a sender can make every node on the network run
-/// an arbitrarily expensive prefix before any gas is paid. Both checks are read statically from the frame layout, so
-/// no prefix simulation is required. Must run after <see cref="MalformedTxFilter"/>, which guarantees the frame list
-/// is well-formed. A configured limit of 0 lifts the bound, matching the other per-sender pool limits.
+/// an arbitrarily expensive prefix before any gas is paid. The budget is read statically from the frame layout, so no
+/// prefix simulation is required. Must run after <see cref="MalformedTxFilter"/>, which guarantees the frame list is
+/// well-formed. A configured limit of 0 lifts the bound, matching the other per-sender pool limits.
 /// </remarks>
 internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger logger) : IIncomingTxFilter
 {
@@ -25,13 +25,7 @@ internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger
     {
         if (tx.SupportsFrames && _maxVerifyGas != 0)
         {
-            if (!FrameTxValidation.TryGetValidationWorkGas(tx, out ulong verifyGas))
-            {
-                Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;
-                if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, its validation prefix is not recognized by the public mempool.");
-                return AcceptTxResult.FrameTxVerifyGasTooHigh.WithMessage(TxPoolErrorMessages.FrameTxUnrecognizedValidationPrefix);
-            }
-
+            ulong verifyGas = FrameTxValidation.ValidationWorkGas(tx);
             if (verifyGas > _maxVerifyGas)
             {
                 Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -7,15 +7,15 @@ using Nethermind.Logging;
 namespace Nethermind.TxPool.Filters;
 
 /// <summary>
-/// Rejects an EIP-8141 frame transaction whose validation prefix and signature verification would cost more than
-/// <c>MAX_VERIFY_GAS</c> to check.
+/// Rejects an EIP-8141 frame transaction whose validation prefix is not one the public mempool recognizes, or whose
+/// prefix and signature verification would cost more than <c>MAX_VERIFY_GAS</c> to check.
 /// </summary>
 /// <remarks>
 /// This is a public-mempool DoS bound, not a validity rule: a block carrying such a transaction stays valid, and the
 /// transaction can still be delivered out of band. Without the bound a sender can make every node on the network run
-/// an arbitrarily expensive prefix before any gas is paid. The budget is read statically from the frame layout, so no
-/// prefix simulation is required. Must run after <see cref="MalformedTxFilter"/>, which guarantees the frame list is
-/// well-formed. A configured limit of 0 lifts the bound, matching the other per-sender pool limits.
+/// an arbitrarily expensive prefix before any gas is paid. Both checks are read statically from the frame layout, so
+/// no prefix simulation is required. Must run after <see cref="MalformedTxFilter"/>, which guarantees the frame list
+/// is well-formed. A configured limit of 0 lifts the bound, matching the other per-sender pool limits.
 /// </remarks>
 internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger logger) : IIncomingTxFilter
 {
@@ -25,7 +25,13 @@ internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger
     {
         if (tx.SupportsFrames && _maxVerifyGas != 0)
         {
-            ulong verifyGas = FrameTxValidation.ValidationWorkGas(tx, state.SenderAccount.HasCode);
+            if (!FrameTxValidation.TryGetValidationWorkGas(tx, out ulong verifyGas))
+            {
+                Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;
+                if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, its validation prefix is not recognized by the public mempool.");
+                return AcceptTxResult.FrameTxVerifyGasTooHigh.WithMessage(TxPoolErrorMessages.FrameTxUnrecognizedValidationPrefix);
+            }
+
             if (verifyGas > _maxVerifyGas)
             {
                 Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -11,11 +11,9 @@ namespace Nethermind.TxPool.Filters;
 /// <c>MAX_VERIFY_GAS</c> to check.
 /// </summary>
 /// <remarks>
-/// This is a public-mempool DoS bound, not a validity rule: a block carrying such a transaction stays valid, and the
-/// transaction can still be delivered out of band. Without the bound a sender can make every node on the network run
-/// an arbitrarily expensive prefix before any gas is paid. The budget is read statically from the frame layout, so no
-/// prefix simulation is required. Must run after <see cref="MalformedTxFilter"/>, which guarantees the frame list is
-/// well-formed. A configured limit of 0 lifts the bound, matching the other per-sender pool limits.
+/// A public-mempool DoS bound, not a validity rule: a block carrying such a transaction stays valid. Must run after
+/// <see cref="MalformedTxFilter"/>, which guarantees the frame list is well-formed. A configured limit of 0 lifts the
+/// bound, matching the other per-sender pool limits.
 /// </remarks>
 internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger logger) : IIncomingTxFilter
 {

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -15,7 +15,7 @@ namespace Nethermind.TxPool.Filters;
 /// transaction can still be delivered out of band. Without the bound a sender can make every node on the network run
 /// an arbitrarily expensive prefix before any gas is paid. The budget is read statically from the frame layout, so no
 /// prefix simulation is required. Must run after <see cref="MalformedTxFilter"/>, which guarantees the frame list is
-/// well-formed.
+/// well-formed. A configured limit of 0 lifts the bound, matching the other per-sender pool limits.
 /// </remarks>
 internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger logger) : IIncomingTxFilter
 {
@@ -23,7 +23,7 @@ internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger
 
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        if (tx.SupportsFrames)
+        if (tx.SupportsFrames && _maxVerifyGas != 0)
         {
             ulong verifyGas = FrameTxValidation.ValidationWorkGas(tx);
             if (verifyGas > _maxVerifyGas)

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Logging;
+
+namespace Nethermind.TxPool.Filters;
+
+/// <summary>
+/// Rejects an EIP-8141 frame transaction whose validation prefix and signature verification would cost more than
+/// <c>MAX_VERIFY_GAS</c> to check.
+/// </summary>
+/// <remarks>
+/// This is a public-mempool DoS bound, not a validity rule: a block carrying such a transaction stays valid, and the
+/// transaction can still be delivered out of band. Without the bound a sender can make every node on the network run
+/// an arbitrarily expensive prefix before any gas is paid. The budget is read statically from the frame layout, so no
+/// prefix simulation is required. Must run after <see cref="MalformedTxFilter"/>, which guarantees the frame list is
+/// well-formed.
+/// </remarks>
+internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger logger) : IIncomingTxFilter
+{
+    private readonly ulong _maxVerifyGas = txPoolConfig.FrameTxMaxVerifyGas;
+
+    public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
+    {
+        if (tx.SupportsFrames)
+        {
+            ulong verifyGas = FrameTxValidation.ValidationWorkGas(tx);
+            if (verifyGas > _maxVerifyGas)
+            {
+                Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;
+                if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, validation prefix costs {verifyGas} gas (max {_maxVerifyGas}).");
+                return AcceptTxResult.FrameTxVerifyGasTooHigh;
+            }
+        }
+
+        return AcceptTxResult.Accepted;
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -25,7 +25,7 @@ internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger
     {
         if (tx.SupportsFrames && _maxVerifyGas != 0)
         {
-            ulong verifyGas = FrameTxValidation.ValidationWorkGas(tx);
+            ulong verifyGas = FrameTxValidation.ValidationWorkGas(tx, state.SenderAccount.HasCode);
             if (verifyGas > _maxVerifyGas)
             {
                 Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -32,6 +32,9 @@ public interface ITxPoolConfig : IConfig
     [ConfigItem(DefaultValue = "0", Description = "The max number of pending transactions per single sender. `0` to lift the limit.")]
     int MaxPendingTxsPerSender { get; set; }
 
+    [ConfigItem(DefaultValue = "100000", Description = "EIP-8141 `MAX_VERIFY_GAS`: the max gas a frame transaction's validation prefix and signature verification may cost for the transaction to be accepted into the public mempool. Raise it only on a test network.")]
+    ulong FrameTxMaxVerifyGas { get; set; }
+
     [ConfigItem(DefaultValue = "16", Description = "The max number of pending blob transactions per single sender. `0` to lift the limit.")]
     int MaxPendingBlobTxsPerSender { get; set; }
 

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -32,7 +32,7 @@ public interface ITxPoolConfig : IConfig
     [ConfigItem(DefaultValue = "0", Description = "The max number of pending transactions per single sender. `0` to lift the limit.")]
     int MaxPendingTxsPerSender { get; set; }
 
-    [ConfigItem(DefaultValue = "100000", Description = "EIP-8141 `MAX_VERIFY_GAS`: the max gas a frame transaction's validation prefix and signature verification may cost for the transaction to be accepted into the public mempool. Raise it only on a test network.")]
+    [ConfigItem(DefaultValue = "100000", Description = "EIP-8141 `MAX_VERIFY_GAS`: the max gas a frame transaction's validation prefix and signature verification may cost for the transaction to be accepted into the public mempool. `0` to lift the limit. Raise it only on a test network.")]
     ulong FrameTxMaxVerifyGas { get; set; }
 
     [ConfigItem(DefaultValue = "16", Description = "The max number of pending blob transactions per single sender. `0` to lift the limit.")]

--- a/src/Nethermind/Nethermind.TxPool/Metrics.cs
+++ b/src/Nethermind/Nethermind.TxPool/Metrics.cs
@@ -37,6 +37,10 @@ namespace Nethermind.TxPool
         public static long PendingTransactionsFrameTxExpired { get; set; }
 
         [CounterMetric]
+        [Description("Number of pending EIP-8141 frame transactions received that were ignored because their validation prefix exceeds MAX_VERIFY_GAS.")]
+        public static long PendingTransactionsFrameTxVerifyGasTooHigh { get; set; }
+
+        [CounterMetric]
         [Description(
             "Number of pending transactions received that were ignored because of not having preceding nonce of this sender in TxPool.")]
         public static long PendingTransactionsNonceGap { get; set; }

--- a/src/Nethermind/Nethermind.TxPool/TxFilteringState.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxFilteringState.cs
@@ -9,13 +9,19 @@ public ref struct TxFilteringState(Transaction tx, IAccountStateProvider account
 {
     private AccountStruct _senderAccount;
 
+    /// <remarks>
+    /// A failed lookup leaves the out-value undefined and the readers diverge on it, so a missing
+    /// account is normalised to <see cref="AccountStruct.TotallyEmpty"/>. A zeroed code hash would
+    /// otherwise read back as code-bearing, and inconsistently so once the pool's account cache
+    /// answers the same address from its own empty entry.
+    /// </remarks>
     public AccountStruct SenderAccount
     {
         get
         {
-            if (_senderAccount.IsNull)
+            if (_senderAccount.IsNull && !accounts.TryGetAccount(tx.SenderAddress!, out _senderAccount))
             {
-                accounts.TryGetAccount(tx.SenderAddress!, out _senderAccount);
+                _senderAccount = AccountStruct.TotallyEmpty;
             }
 
             return _senderAccount;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -171,6 +171,7 @@ namespace Nethermind.TxPool
                 new AlreadyKnownTxFilter(_hashCache, _logger),
                 new MalformedTxFilter(_specProvider, validator, ecdsa, _logger),
                 new ExpiredFrameTxFilter(chainHeadInfoProvider, _logger), // after MalformedTxFilter: reads the deadline from an already well-formed frame
+                new FrameTxVerifyGasFilter(txPoolConfig, _logger), // after MalformedTxFilter: reads gas limits from an already well-formed frame list
                 new TxTypeTxFilter(_transactions,
                     _blobTransactions), // has to be after MalformedTxFilter as it uses the recovered sender
                 new BalanceZeroFilter(thereIsPriorityContract, _logger),

--- a/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
@@ -18,6 +18,7 @@ public class TxPoolConfig : ITxPoolConfig
     public int BlobCacheSize { get; set; } = 256;
     public int InMemoryBlobPoolSize { get; set; } = 512; // it is used when persistent pool is disabled
     public int MaxPendingTxsPerSender { get; set; } = 0;
+    public ulong FrameTxMaxVerifyGas { get; set; } = 100_000;
     public int MaxPendingBlobTxsPerSender { get; set; } = 16;
     public int HashCacheSize { get; set; } = 512 * 1024;
     public ulong? GasLimit { get; set; } = null;

--- a/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
@@ -30,4 +30,6 @@ public static class TxPoolErrorMessages
     public const string NodeIsSyncing = "node is syncing";
     public const string FrameTxExpired = "frame transaction expired";
     public const string FrameTxVerifyGasTooHigh = "frame transaction validation prefix exceeds MAX_VERIFY_GAS";
+
+    public const string FrameTxUnrecognizedValidationPrefix = "frame transaction validation prefix is not recognized by the public mempool";
 }

--- a/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
@@ -30,6 +30,4 @@ public static class TxPoolErrorMessages
     public const string NodeIsSyncing = "node is syncing";
     public const string FrameTxExpired = "frame transaction expired";
     public const string FrameTxVerifyGasTooHigh = "frame transaction validation prefix exceeds MAX_VERIFY_GAS";
-
-    public const string FrameTxUnrecognizedValidationPrefix = "frame transaction validation prefix is not recognized by the public mempool";
 }

--- a/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
@@ -29,4 +29,5 @@ public static class TxPoolErrorMessages
     public const string DelegationAuthorityHasPendingTx = "delegation authority has pending transaction";
     public const string NodeIsSyncing = "node is syncing";
     public const string FrameTxExpired = "frame transaction expired";
+    public const string FrameTxVerifyGasTooHigh = "frame transaction validation prefix exceeds MAX_VERIFY_GAS";
 }


### PR DESCRIPTION
## Changes

Nethermind accepts an EIP-8141 frame transaction into the public mempool whatever its validation prefix costs, so a prefix priced above `MAX_VERIFY_GAS` is propagated and simulated by every receiving node before any gas has been paid. The cross-client scenario `neg-verify-gas-over-max` reported UNMET because both clients accepted it, the other implementation because its devnet ceiling is raised, Nethermind because the check does not exist.

`FrameTxValidation.ValidationWorkGas` computes the prefix gas statically: the frame gas limits up to and including the first frame allowed to approve payment, plus signature verification cost. A transaction with no such frame can never set a payer, so charging its whole frame list keeps the figure from under-estimating. `FrameTxVerifyGasFilter` refuses over-budget transactions at ingress with a dedicated `AcceptTxResult` and metric; consensus is untouched, so a block carrying one stays valid. `TxPool.FrameTxMaxVerifyGas` defaults to the spec's 100 000 and is configurable because a devnet that verifies a proof in the prefix (measured at 227k) cannot run at the default. Signature verification pricing, previously duplicated between the processor and this path, now lives in one place.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)

## Testing

Boundary cases are parameterised: a prefix exactly at the ceiling is accepted, one gas over is rejected, and a third test pins that an execution frame's gas stays outside the budget. With the filter unregistered the over-limit case fails (1/2); registered, 9/9 pass in `Nethermind.TxPool.Test`.

- [x] Tests added
