### PR TITLE
fix(evm): derive frame-tx receipt status from the frame statuses

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Receipts/ReceiptsRecoveryTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Receipts/ReceiptsRecoveryTests.cs
@@ -67,4 +67,31 @@ public class ReceiptsRecoveryTests
         Assert.That(result, Is.EqualTo(ReceiptsRecoveryResult.NeedReinsert));
         Assert.That(receipt.ContractAddress, Is.EqualTo(new Address("0x3a6e7897affdf344781bb9098a605e9839ac131b")));
     }
+
+    // Recovery re-derives a non-success status from the log count, which holds pre-EIP-8141: a failed
+    // transaction has no logs. A frame transaction breaks it — its status is derived from the frame
+    // statuses, so it can fail while carrying the logs of the frames that succeeded. Without the
+    // exemption a node serving this receipt from the database reports success where the node that
+    // executed the block reports failure.
+    [Test]
+    public void TryRecover_should_keep_a_failed_frame_transaction_status_with_logs()
+    {
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            SenderAddress = TestItem.AddressA,
+            Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, default, default)],
+            FrameSignatures = [],
+        };
+        tx.Hash = tx.CalculateHash();
+        Block block = Build.A.Block.WithTransactions(tx).TestObject;
+        TxReceipt receipt = Build.A.Receipt.WithBlockHash(block.Hash!).TestObject;
+        receipt.TxType = TxType.FrameTx;
+        receipt.StatusCode = TxFrameReceipt.StatusFailure;
+        receipt.Logs = [new LogEntry(TestItem.AddressB, [1], [])];
+
+        _receiptsRecovery.TryRecover(block, [receipt]);
+
+        Assert.That(receipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusFailure));
+    }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsRecovery.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsRecovery.cs
@@ -98,7 +98,10 @@ namespace Nethermind.Blockchain.Receipts
                 // how would it be in CREATE2?
                 receipt.ContractAddress = transaction.IsContractCreation && transaction.SenderAddress is not null ? ContractAddress.From(receipt.Sender, transaction.Nonce) : null;
                 receipt.GasUsed = receipt.GasUsedTotal - _gasUsedBefore;
-                if (receipt.StatusCode != StatusCode.Success)
+                // The log-count heuristic below rests on a pre-EIP-8141 invariant: a failed transaction
+                // has no logs. A frame transaction breaks it — its status is derived from the frame
+                // statuses, so it can be a failure while carrying the logs of the frames that succeeded.
+                if (receipt.StatusCode != StatusCode.Success && receipt.TxType != TxType.FrameTx)
                 {
                     receipt.StatusCode = (receipt.Logs?.Length ?? 0) == 0 ? StatusCode.Failure : StatusCode.Success;
                 }
@@ -129,7 +132,8 @@ namespace Nethermind.Blockchain.Receipts
                 // how would it be in CREATE2?
                 receipt.ContractAddress = (transaction.IsContractCreation && transaction.SenderAddress is not null ? ContractAddress.From(receipt.Sender.ToAddress(), transaction.Nonce) : Address.Zero)!.ToStructRef();
                 receipt.GasUsed = receipt.GasUsedTotal - _gasUsedBefore;
-                if (receipt.StatusCode != StatusCode.Success)
+                // See the note on the same heuristic in the overload above.
+                if (receipt.StatusCode != StatusCode.Success && receipt.TxType != TxType.FrameTx)
                 {
                     receipt.StatusCode = (receipt.Logs?.Length ?? 0) == 0 ? StatusCode.Failure : StatusCode.Success;
                 }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -164,9 +164,15 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         {
             txReceipt.Payer = _frameTxPayer;
             txReceipt.FrameReceipts = _frameTxReceipts;
-            // The transaction is charged and included whatever its frames did, so the processor
-            // always reports success; the status a caller sees comes from the frames instead.
-            txReceipt.StatusCode = TxFrameReceipt.AggregateStatus(_frameTxReceipts);
+            if (_frameTxReceipts is not null)
+            {
+                // The tx is charged and included whatever its frames did, so the processor always goes
+                // through MarkAsSuccess; the status a caller sees has to come from the frames instead.
+                // Without reported frame receipts there is nothing to derive from, and overwriting
+                // would promote a failed receipt to success.
+                txReceipt.StatusCode = TxFrameReceipt.AggregateStatus(_frameTxReceipts);
+            }
+
             _frameTxPayer = null;
             _frameTxReceipts = null;
         }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -164,6 +164,9 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         {
             txReceipt.Payer = _frameTxPayer;
             txReceipt.FrameReceipts = _frameTxReceipts;
+            // The transaction is charged and included whatever its frames did, so the processor
+            // always reports success; the status a caller sees comes from the frames instead.
+            txReceipt.StatusCode = TxFrameReceipt.AggregateStatus(_frameTxReceipts);
             _frameTxPayer = null;
             _frameTxReceipts = null;
         }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -13,14 +13,15 @@ namespace Nethermind.Core.Test.Encoding;
 /// <summary>
 /// Round-trips of the EIP-8141 receipt payload <c>[cumulative_gas_used, payer,
 /// [[status, gas_used, logs], ...]]</c>. The wire form is spec-literal: no top-level status and no
-/// bloom. EIP8141-GAP: internally the decoder sets StatusCode to success and unions frame logs into
-/// Logs so bloom calculation and log indexing keep working — asserted here as the pinned behavior.
+/// bloom. EIP8141-GAP: the decoder derives StatusCode from the frame statuses and unions frame logs
+/// into Logs so bloom calculation and log indexing keep working — asserted here as the pinned
+/// behavior.
 /// </summary>
 [TestFixture]
 public class FrameTxReceiptDecoderTests
 {
     [TestCaseSource(nameof(RoundtripCases))]
-    public void Roundtrip_FrameTxReceipt_PreservesPayloadFields(TxReceipt receipt)
+    public void Roundtrip_FrameTxReceipt_PreservesPayloadFields(TxReceipt receipt, byte expectedStatus)
     {
         ReceiptMessageDecoder decoder = new();
 
@@ -31,7 +32,8 @@ public class FrameTxReceiptDecoderTests
         Assert.That(decoded.GasUsedTotal, Is.EqualTo(receipt.GasUsedTotal));
         Assert.That(decoded.Payer, Is.EqualTo(receipt.Payer));
         AssertFrameReceiptsEqual(decoded.FrameReceipts!, receipt.FrameReceipts!);
-        Assert.That(decoded.StatusCode, Is.EqualTo(TxFrameReceipt.StatusSuccess));
+        Assert.That(decoded.StatusCode, Is.EqualTo(expectedStatus),
+            "the transaction status is absent from the wire and must be derived from the frame statuses");
         // Decoded Logs must be the in-order union of frame logs.
         AssertLogsEqual(decoded.Logs!, receipt.FrameReceipts!.SelectMany(static f => f.Logs).ToArray());
     }
@@ -78,17 +80,27 @@ public class FrameTxReceiptDecoderTests
     private static IEnumerable<TestCaseData> RoundtripCases()
     {
         yield return new TestCaseData(CreateReceipt(
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [Log(0x01)])))
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [Log(0x01)])),
+            TxFrameReceipt.StatusSuccess)
             .SetName("Roundtrip_SingleSuccessfulFrameWithLog");
 
         yield return new TestCaseData(CreateReceipt(
             new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 50_000, [Log(0x01), Log(0x02)]),
             new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, []),
-            new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, [])))
+            new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, [])),
+            TxFrameReceipt.StatusFailure)
             .SetName("Roundtrip_SuccessFailureAndSkippedStatuses");
 
+        // A frame skipped by a failed atomic batch is not a success either.
         yield return new TestCaseData(CreateReceipt(
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 0, [])))
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, []),
+            new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, [])),
+            TxFrameReceipt.StatusFailure)
+            .SetName("Roundtrip_SkippedFrameIsNotASuccess");
+
+        yield return new TestCaseData(CreateReceipt(
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 0, [])),
+            TxFrameReceipt.StatusSuccess)
             .SetName("Roundtrip_EmptyLogsAndZeroGas");
     }
 

--- a/src/Nethermind/Nethermind.Core/TxFrameReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrameReceipt.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+
 namespace Nethermind.Core;
 
 /// <summary>
@@ -26,16 +28,13 @@ public class TxFrameReceipt(byte status, ulong gasUsed, LogEntry[] logs)
     /// succeeded — keeps a node that executed the block and a node that only received its receipts in
     /// agreement, which a value taken from local execution state cannot do.
     /// </remarks>
-    public static byte AggregateStatus(TxFrameReceipt[]? frameReceipts)
+    public static byte AggregateStatus(ReadOnlySpan<TxFrameReceipt> frameReceipts)
     {
-        if (frameReceipts is not null)
+        foreach (TxFrameReceipt frameReceipt in frameReceipts)
         {
-            foreach (TxFrameReceipt frameReceipt in frameReceipts)
+            if (frameReceipt.Status != StatusSuccess)
             {
-                if (frameReceipt.Status != StatusSuccess)
-                {
-                    return StatusFailure;
-                }
+                return StatusFailure;
             }
         }
 

--- a/src/Nethermind/Nethermind.Core/TxFrameReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrameReceipt.cs
@@ -18,4 +18,27 @@ public class TxFrameReceipt(byte status, ulong gasUsed, LogEntry[] logs)
     public byte Status { get; } = status;
     public ulong GasUsed { get; } = gasUsed;
     public LogEntry[] Logs { get; } = logs;
+
+    /// <summary>The transaction-level status reported for a frame transaction with these frame receipts.</summary>
+    /// <remarks>
+    /// The EIP-8141 receipt payload carries no transaction-level status, so the value JSON-RPC reports
+    /// has to be derived. Deriving it from the frame statuses — success only when every frame
+    /// succeeded — keeps a node that executed the block and a node that only received its receipts in
+    /// agreement, which a value taken from local execution state cannot do.
+    /// </remarks>
+    public static byte AggregateStatus(TxFrameReceipt[]? frameReceipts)
+    {
+        if (frameReceipts is not null)
+        {
+            foreach (TxFrameReceipt frameReceipt in frameReceipts)
+            {
+                if (frameReceipt.Status != StatusSuccess)
+                {
+                    return StatusFailure;
+                }
+            }
+        }
+
+        return StatusSuccess;
+    }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
@@ -99,8 +99,71 @@ public class FrameTxBlockReceiptsTests
         Assert.That(tx.BlockGasUsed, Is.EqualTo((ulong)receipt.GasUsed),
             "frame tx must report block gas via Transaction.BlockGasUsed for parallel block validation");
 
+        Assert.That(receipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusSuccess));
+
         // The frame-aware wire encoding must produce a computable receipts root.
         Hash256 receiptsRoot = ReceiptTrie.CalculateRoot(spec, [receipt], new ReceiptMessageDecoder());
         Assert.That(receiptsRoot, Is.Not.EqualTo(Keccak.EmptyTreeHash));
+    }
+
+    // The transaction-level status is absent from the EIP-8141 receipt payload, so it is derived from
+    // the frame statuses. A reverted frame therefore surfaces as a failed transaction even though the
+    // transaction itself executed and was charged.
+    [Test]
+    public void Execute_FrameTxWithRevertedFrame_ReportsFailureStatus()
+    {
+        ISpecProvider specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        EthereumCodeInfoRepository codeInfoRepository = new(stateProvider);
+        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(specProvider), specProvider, LimboLogs.Instance);
+        EthereumTransactionProcessor processor = new(BlobBaseFeeCalculator.Instance, specProvider, stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+        IReleaseSpec spec = specProvider.GenesisSpec;
+
+        stateProvider.CreateAccount(Sender, 1.Ether);
+        stateProvider.InsertCode(Sender, Prepare.EvmCode
+            .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done, spec);
+        stateProvider.CreateAccount(Observer, UInt256.Zero);
+        stateProvider.InsertCode(Observer, Prepare.EvmCode
+            .PushData(0).PushData(0).Op(Instruction.REVERT).Done, spec);
+        stateProvider.Commit(spec);
+        stateProvider.CommitTree(0);
+
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            Nonce = 0,
+            SenderAddress = Sender,
+            Frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, null, 200_000, UInt256.Zero, default),
+                new TxFrame(TxFrame.ModeSender, 0, Observer, 200_000, UInt256.Zero, default),
+            ],
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+
+        BlockReceiptsTracer receiptsTracer = new();
+        receiptsTracer.StartNewBlockTrace(block);
+        receiptsTracer.StartNewTxTrace(tx);
+        TransactionResult result = processor.Execute(tx, new BlockExecutionContext(block.Header, spec), receiptsTracer);
+        receiptsTracer.EndTxTrace();
+        receiptsTracer.EndBlockTrace();
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        TxReceipt receipt = receiptsTracer.TxReceipts[0];
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
+            Assert.That(receipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusFailure),
+                "a reverted frame must not be reported as a successful transaction");
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
@@ -36,6 +36,56 @@ public class FrameTxBlockReceiptsTests
     [Test]
     public void Execute_FrameTxUnderBlockReceiptsTracer_BuildsFrameAwareReceipt()
     {
+        byte[] emitLog = Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.LOG0).Op(Instruction.STOP).Done;
+
+        (TxReceipt receipt, Block block, IReleaseSpec spec) = RunFrameTx(emitLog);
+
+        Assert.That(receipt.TxType, Is.EqualTo(TxType.FrameTx));
+        Assert.That(receipt.Payer, Is.EqualTo(Sender));
+        // No top-level `to` and no top-level creation: naming either would invent an address, and the
+        // receipt-recovery path derives these independently, so both must answer the same.
+        Assert.That(receipt.FrameReceipts, Has.Length.EqualTo(2));
+        Assert.That(receipt.FrameReceipts![0].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess));
+        Assert.That(receipt.FrameReceipts[1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess));
+        Assert.That(receipt.FrameReceipts[1].Logs, Has.Length.EqualTo(1), "SENDER frame log must land in its frame receipt");
+        Assert.That(receipt.Logs, Has.Length.EqualTo(1), "receipt logs must be the union of frame logs");
+        Assert.That(receipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusSuccess));
+        Assert.That(receipt.GasUsed, Is.GreaterThanOrEqualTo((long)Eip8141Constants.IntrinsicGasCost),
+            "spec gas includes the frame tx intrinsic cost");
+        Assert.That(block.Header.GasUsed, Is.EqualTo(receipt.GasUsedTotal),
+            "block header GasUsed must equal the cumulative receipt gas (production/processing parity)");
+        Assert.That(block.Transactions[0].BlockGasUsed, Is.EqualTo((ulong)receipt.GasUsed),
+            "frame tx must report block gas via Transaction.BlockGasUsed for parallel block validation");
+
+        // The frame-aware wire encoding must produce a computable receipts root.
+        Hash256 receiptsRoot = ReceiptTrie.CalculateRoot(spec, [receipt], new ReceiptMessageDecoder());
+        Assert.That(receiptsRoot, Is.Not.EqualTo(Keccak.EmptyTreeHash));
+    }
+
+    // The transaction-level status is absent from the EIP-8141 receipt payload, so it is derived from
+    // the frame statuses. A reverted frame therefore surfaces as a failed transaction even though the
+    // transaction itself executed and was charged.
+    [Test]
+    public void Execute_FrameTxWithRevertedFrame_ReportsFailureStatus()
+    {
+        byte[] revert = Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done;
+
+        (TxReceipt receipt, _, _) = RunFrameTx(revert);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
+            Assert.That(receipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusFailure),
+                "a reverted frame must not be reported as a successful transaction");
+        }
+    }
+
+    /// <summary>
+    /// Runs a two-frame transaction (self-verify, then a SENDER frame calling <paramref name="observerCode"/>)
+    /// through the real receipts tracer and returns the single receipt it produced.
+    /// </summary>
+    private static (TxReceipt Receipt, Block Block, IReleaseSpec Spec) RunFrameTx(byte[] observerCode)
+    {
         ISpecProvider specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
         using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
@@ -48,8 +98,7 @@ public class FrameTxBlockReceiptsTests
         stateProvider.InsertCode(Sender, Prepare.EvmCode
             .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done, spec);
         stateProvider.CreateAccount(Observer, UInt256.Zero);
-        stateProvider.InsertCode(Observer, Prepare.EvmCode
-            .PushData(1).PushData(0).Op(Instruction.LOG0).Op(Instruction.STOP).Done, spec);
+        stateProvider.InsertCode(Observer, observerCode, spec);
         stateProvider.Commit(spec);
         stateProvider.CommitTree(0);
 
@@ -84,86 +133,6 @@ public class FrameTxBlockReceiptsTests
         Assert.That(result.TransactionExecuted, Is.True);
         Assert.That(receiptsTracer.TxReceipts.Length, Is.EqualTo(1));
 
-        TxReceipt receipt = receiptsTracer.TxReceipts[0];
-        Assert.That(receipt.TxType, Is.EqualTo(TxType.FrameTx));
-        Assert.That(receipt.Payer, Is.EqualTo(Sender));
-        Assert.That(receipt.FrameReceipts, Has.Length.EqualTo(2));
-        Assert.That(receipt.FrameReceipts![0].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess));
-        Assert.That(receipt.FrameReceipts[1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess));
-        Assert.That(receipt.FrameReceipts[1].Logs, Has.Length.EqualTo(1), "SENDER frame log must land in its frame receipt");
-        Assert.That(receipt.Logs, Has.Length.EqualTo(1), "receipt logs must be the union of frame logs");
-        Assert.That(receipt.GasUsed, Is.GreaterThanOrEqualTo((long)Eip8141Constants.IntrinsicGasCost),
-            "spec gas includes the frame tx intrinsic cost");
-        Assert.That(block.Header.GasUsed, Is.EqualTo(receipt.GasUsedTotal),
-            "block header GasUsed must equal the cumulative receipt gas (production/processing parity)");
-        Assert.That(tx.BlockGasUsed, Is.EqualTo((ulong)receipt.GasUsed),
-            "frame tx must report block gas via Transaction.BlockGasUsed for parallel block validation");
-
-        Assert.That(receipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusSuccess));
-
-        // The frame-aware wire encoding must produce a computable receipts root.
-        Hash256 receiptsRoot = ReceiptTrie.CalculateRoot(spec, [receipt], new ReceiptMessageDecoder());
-        Assert.That(receiptsRoot, Is.Not.EqualTo(Keccak.EmptyTreeHash));
-    }
-
-    // The transaction-level status is absent from the EIP-8141 receipt payload, so it is derived from
-    // the frame statuses. A reverted frame therefore surfaces as a failed transaction even though the
-    // transaction itself executed and was charged.
-    [Test]
-    public void Execute_FrameTxWithRevertedFrame_ReportsFailureStatus()
-    {
-        ISpecProvider specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
-        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
-        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
-        EthereumCodeInfoRepository codeInfoRepository = new(stateProvider);
-        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(specProvider), specProvider, LimboLogs.Instance);
-        EthereumTransactionProcessor processor = new(BlobBaseFeeCalculator.Instance, specProvider, stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);
-        IReleaseSpec spec = specProvider.GenesisSpec;
-
-        stateProvider.CreateAccount(Sender, 1.Ether);
-        stateProvider.InsertCode(Sender, Prepare.EvmCode
-            .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done, spec);
-        stateProvider.CreateAccount(Observer, UInt256.Zero);
-        stateProvider.InsertCode(Observer, Prepare.EvmCode
-            .PushData(0).PushData(0).Op(Instruction.REVERT).Done, spec);
-        stateProvider.Commit(spec);
-        stateProvider.CommitTree(0);
-
-        Transaction tx = new()
-        {
-            Type = TxType.FrameTx,
-            ChainId = TestBlockchainIds.ChainId,
-            Nonce = 0,
-            SenderAddress = Sender,
-            Frames =
-            [
-                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, null, 200_000, UInt256.Zero, default),
-                new TxFrame(TxFrame.ModeSender, 0, Observer, 200_000, UInt256.Zero, default),
-            ],
-            FrameSignatures = [],
-            GasPrice = 1,
-            DecodedMaxFeePerGas = 1,
-        };
-
-        Block block = Build.A.Block.WithNumber(1)
-            .WithBaseFeePerGas(0)
-            .WithTransactions(tx)
-            .WithGasLimit(30_000_000).TestObject;
-
-        BlockReceiptsTracer receiptsTracer = new();
-        receiptsTracer.StartNewBlockTrace(block);
-        receiptsTracer.StartNewTxTrace(tx);
-        TransactionResult result = processor.Execute(tx, new BlockExecutionContext(block.Header, spec), receiptsTracer);
-        receiptsTracer.EndTxTrace();
-        receiptsTracer.EndBlockTrace();
-
-        Assert.That(result.TransactionExecuted, Is.True);
-        TxReceipt receipt = receiptsTracer.TxReceipts[0];
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(receipt.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
-            Assert.That(receipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusFailure),
-                "a reverted frame must not be reported as a successful transaction");
-        }
+        return (receiptsTracer.TxReceipts[0], block, spec);
     }
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -96,9 +96,10 @@ namespace Nethermind.Serialization.Rlp
         // EIP-8141 ReceiptPayload: [cumulative_gas_used, payer, [frame_receipt, ...]],
         // frame_receipt = [status, gas_used, logs]. Spec-literal — no top-level status and no bloom
         // on the wire (receipts-root parity with other clients).
-        // EIP8141-GAP: the spec receipt has no top-level status or bloom; internally StatusCode is
-        // set to success for included transactions and Logs holds the union of frame logs so bloom
-        // calculation and log indexing keep working.
+        // EIP8141-GAP: the spec receipt has no top-level status or bloom; StatusCode is derived from
+        // the frame statuses (see TxFrameReceipt.AggregateStatus) so a receipt taken off the wire
+        // reads the same as one produced by executing the block, and Logs holds the union of frame
+        // logs so bloom calculation and log indexing keep working.
         private void DecodeFrameTxReceipt(TxReceipt txReceipt, ref RlpReader ctx, RlpBehaviors rlpBehaviors)
         {
             int sequenceLength = ctx.ReadSequenceLength();
@@ -133,7 +134,7 @@ namespace Nethermind.Serialization.Rlp
             }
 
             txReceipt.FrameReceipts = frameReceipts;
-            txReceipt.StatusCode = TxFrameReceipt.StatusSuccess;
+            txReceipt.StatusCode = TxFrameReceipt.AggregateStatus(frameReceipts);
 
             LogEntry[] allLogs = new LogEntry[totalLogs];
             int offset = 0;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -111,6 +111,13 @@ namespace Nethermind.Serialization.Rlp
             int framesEnd = ctx.ReadSequenceLength() + ctx.Position;
             int frameCount = ctx.PeekNumberOfItemsRemaining(framesEnd, Eip8141Constants.MaxFrames + 1);
             ctx.GuardLimit(frameCount, FrameReceiptsRlpLimit);
+            if (frameCount == 0)
+            {
+                // A frame transaction has at least one frame, so a receipt without one is malformed.
+                // Accepting it would derive a successful transaction status from nothing.
+                ThrowEmptyFrameReceipts();
+            }
+
             TxFrameReceipt[] frameReceipts = new TxFrameReceipt[frameCount];
             int totalLogs = 0;
             for (int i = 0; i < frameCount; i++)
@@ -155,6 +162,10 @@ namespace Nethermind.Serialization.Rlp
             {
                 ctx.Position = receiptEnd;
             }
+
+            [DoesNotReturn, StackTraceHidden]
+            static void ThrowEmptyFrameReceipts()
+                => throw new RlpException("Frame transaction receipt carries no frame receipts");
         }
 
         private static (int Total, int Frames) GetFrameTxContentLength(TxReceipt item)


### PR DESCRIPTION
## Changes

The EIP-8141 receipt payload is `[cumulative_gas_used, payer, [frame_receipt, ...]]`, with no transaction-level status field, so the `status` reported over JSON-RPC has to be derived. Nethermind pinned it to `StatusSuccess` for every included frame transaction, and `ReceiptMessageDecoder` did the same, so a node that received a receipt off the wire also disagreed with a node that executed the block. On the cross-client devnet a SENDER frame that reverts came back as `0x1` from Nethermind and `0x0` from the other implementation, with byte-identical per-frame receipts on both sides.

Both sites now derive the status from the frame statuses (`TxFrameReceipt.AggregateStatus`): success only when every frame succeeded, and a skipped frame (failed atomic batch) is not a success. The consensus receipt payload, receipts root and `gasUsed` are unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The cross-client scenario `pos-reverted-frame-bal` found the divergence; block hash, state root, receipts root and block access list hash all matched, only `status` differed.

- `FrameTxBlockReceiptsTests.Execute_FrameTxWithRevertedFrame_ReportsFailureStatus`, new
- `FrameTxReceiptDecoderTests.Roundtrip_*`, parameterised over the expected derived status, with a skipped-frame case added
- `Nethermind.Core.Test ~FrameTxReceipt` 6/6, `Nethermind.Evm.Test ~FrameTx|~Eip8141` 85/85

### Requires testing

- [x] Unit tests
