### PR TITLE
Test change

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -101,7 +101,7 @@ public static partial class EvmInstructions
         if (!stack.PopWord256(out Span<byte> bytes)) goto StackUnderflow;
 
         // Store either the actual value (if non-zero) or a predefined zero constant.
-        if (ParallelSiblings.SiblingRecorder.RecordingWrites) ParallelSiblings.SiblingRecorder.TouchWrite(in storageCell);
+        if (ParallelSiblings.SiblingRecorder.ChainingGlueWrites) ParallelSiblings.SiblingRecorder.ChainGlueWrite(in storageCell);
         vm.WorldState.SetTransientState(in storageCell, !bytes.IsZero() ? bytes.ToArray() : BytesZero32);
 
         // If storage tracing is enabled, retrieve the current stored value and log the operation.
@@ -406,7 +406,7 @@ public static partial class EvmInstructions
         // Only update storage if the new value differs from the current value.
         if (!newSameAsCurrent)
         {
-            if (ParallelSiblings.SiblingRecorder.RecordingWrites) ParallelSiblings.SiblingRecorder.TouchWrite(in storageCell);
+            if (ParallelSiblings.SiblingRecorder.ChainingGlueWrites) ParallelSiblings.SiblingRecorder.ChainGlueWrite(in storageCell);
             vm.WorldState.Set(in storageCell, newIsZero ? BytesZero : bytes.ToArray());
             if (newIsZero)
             {
@@ -584,7 +584,7 @@ public static partial class EvmInstructions
         // Only update storage if the new value differs from the current value.
         if (!newSameAsCurrent)
         {
-            if (ParallelSiblings.SiblingRecorder.RecordingWrites) ParallelSiblings.SiblingRecorder.TouchWrite(in storageCell);
+            if (ParallelSiblings.SiblingRecorder.ChainingGlueWrites) ParallelSiblings.SiblingRecorder.ChainGlueWrite(in storageCell);
             vm.WorldState.Set(in storageCell, newIsZero ? BytesZero : bytes.ToArray());
             if (newIsZero)
             {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -101,6 +101,7 @@ public static partial class EvmInstructions
         if (!stack.PopWord256(out Span<byte> bytes)) goto StackUnderflow;
 
         // Store either the actual value (if non-zero) or a predefined zero constant.
+        if (ParallelSiblings.SiblingRecorder.RecordingWrites) ParallelSiblings.SiblingRecorder.TouchWrite(in storageCell);
         vm.WorldState.SetTransientState(in storageCell, !bytes.IsZero() ? bytes.ToArray() : BytesZero32);
 
         // If storage tracing is enabled, retrieve the current stored value and log the operation.
@@ -405,6 +406,7 @@ public static partial class EvmInstructions
         // Only update storage if the new value differs from the current value.
         if (!newSameAsCurrent)
         {
+            if (ParallelSiblings.SiblingRecorder.RecordingWrites) ParallelSiblings.SiblingRecorder.TouchWrite(in storageCell);
             vm.WorldState.Set(in storageCell, newIsZero ? BytesZero : bytes.ToArray());
             if (newIsZero)
             {
@@ -582,6 +584,7 @@ public static partial class EvmInstructions
         // Only update storage if the new value differs from the current value.
         if (!newSameAsCurrent)
         {
+            if (ParallelSiblings.SiblingRecorder.RecordingWrites) ParallelSiblings.SiblingRecorder.TouchWrite(in storageCell);
             vm.WorldState.Set(in storageCell, newIsZero ? BytesZero : bytes.ToArray());
             if (newIsZero)
             {

--- a/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
+++ b/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
@@ -209,7 +209,7 @@ public static class SiblingRecorder
                 (t_prefixWrites ??= new HashSet<int>(256)).UnionWith(known.WriteHashes);
             }
 
-            if (t_currentWrites is { Count: > 0 } liveWrites)
+            if (!cleanFrame && t_currentWrites is { Count: > 0 } liveWrites)
             {
                 (t_prefixWrites ??= new HashSet<int>(256)).UnionWith(liveWrites);
             }
@@ -234,9 +234,11 @@ public static class SiblingRecorder
         if (!succeeded) s_recReverted++;
         if (tookValue) s_recTookValue++;
         if (!prefixDisjoint) s_recPrefixOverlap++;
-        // Only actual writes poison the suffix - precise cells, not the touch set, or the shared
-        // reads every quote performs would reject the entire request.
-        if (t_currentWrites is { Count: > 0 } writes)
+        // Only writes that SURVIVED the sibling poison the suffix. A clean frame's writes were all
+        // reverted away, and simulate-then-revert is exactly what these frames do: poisoning with
+        // them made every quote poison the pool slots the next quote reads, which is what rejected
+        // 60 of 68 recordings. cleanFrame is the journal's own answer to what survived.
+        if (!cleanFrame && t_currentWrites is { Count: > 0 } writes)
         {
             (t_prefixWrites ??= new HashSet<int>(256)).UnionWith(writes);
         }
@@ -251,7 +253,7 @@ public static class SiblingRecorder
             GasUsed = gasUsed,
             Output = memoable ? output.ToArray() : [],
             TouchHashes = [.. touches],
-            WriteHashes = t_currentWrites is null ? [] : [.. t_currentWrites],
+            WriteHashes = cleanFrame || t_currentWrites is null ? [] : [.. t_currentWrites],
             FirstTouchAddresses = [.. t_firstTouchAddresses!],
             FirstTouchSlots = [.. t_firstTouchSlots!],
         };

--- a/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
+++ b/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
@@ -58,22 +58,20 @@ public static class SiblingRecorder
     private static long s_rejectPrefix;
     private static System.Threading.Timer? s_reportTimer;
 
-    static SiblingRecorder()
-    {
-        if (!string.IsNullOrWhiteSpace(s_reportPath))
-        {
-            s_reportTimer = new System.Threading.Timer(static _ => Report(), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
-        }
-    }
+    static SiblingRecorder() =>
+        s_reportTimer = new System.Threading.Timer(static _ => Report(), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
 
     private static void Report()
     {
+        if (s_recorded == 0 && s_lookupMisses == 0 && s_replays == 0) return;
+        string line =
+            $"SIBLING-MEMO recorded {s_recorded} (memoable {s_recordedMemoable}), lookup misses {s_lookupMisses}, replays {s_replays}, " +
+            $"rejects: not-memoable {s_rejectNotMemoable}, gas {s_rejectGas}, cold {s_rejectCold}, prefix {s_rejectPrefix}, sites {s_sites.Count}";
+        Console.WriteLine(line);
+        if (string.IsNullOrWhiteSpace(s_reportPath)) return;
         try
         {
-            System.IO.File.WriteAllText(s_reportPath!,
-                $"recorded {s_recorded} (memoable {s_recordedMemoable}), lookup misses {s_lookupMisses}, replays {s_replays}\n" +
-                $"rejects: not-memoable {s_rejectNotMemoable}, gas {s_rejectGas}, cold {s_rejectCold}, prefix {s_rejectPrefix}\n" +
-                $"sites {s_sites.Count}\n");
+            System.IO.File.WriteAllText(s_reportPath!, line + Environment.NewLine);
         }
         catch (System.IO.IOException)
         {

--- a/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
+++ b/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
@@ -44,6 +44,46 @@ public static class SiblingRecorder
 
     private static readonly ConcurrentDictionary<long, SiteRecord> s_sites = new();
 
+    // Diagnostic counters, reported when NETHERMIND_SIBLING_CENSUS names a file: which soundness
+    // condition memo traffic actually dies on. Interlocked-free sloppy counts - magnitudes matter,
+    // not exactness.
+    private static readonly string? s_reportPath = Environment.GetEnvironmentVariable("NETHERMIND_SIBLING_CENSUS");
+    private static long s_recorded;
+    private static long s_recordedMemoable;
+    private static long s_lookupMisses;
+    private static long s_replays;
+    private static long s_rejectNotMemoable;
+    private static long s_rejectGas;
+    private static long s_rejectCold;
+    private static long s_rejectPrefix;
+    private static System.Threading.Timer? s_reportTimer;
+
+    static SiblingRecorder()
+    {
+        if (!string.IsNullOrWhiteSpace(s_reportPath))
+        {
+            s_reportTimer = new System.Threading.Timer(static _ => Report(), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+        }
+    }
+
+    private static void Report()
+    {
+        try
+        {
+            System.IO.File.WriteAllText(s_reportPath!,
+                $"recorded {s_recorded} (memoable {s_recordedMemoable}), lookup misses {s_lookupMisses}, replays {s_replays}\n" +
+                $"rejects: not-memoable {s_rejectNotMemoable}, gas {s_rejectGas}, cold {s_rejectCold}, prefix {s_rejectPrefix}\n" +
+                $"sites {s_sites.Count}\n");
+        }
+        catch (System.IO.IOException)
+        {
+        }
+    }
+
+    public static void CountLookupMiss() => s_lookupMisses++;
+    public static void CountReplay() => s_replays++;
+    public static void CountGasReject() => s_rejectGas++;
+
     public static bool Recording => t_recording;
 
     /// <summary>One full observation of a call site. Immutable once published.</summary>
@@ -72,16 +112,17 @@ public static class SiblingRecorder
     /// nothing an earlier sibling of this request wrote.</summary>
     public static bool IsReplayable(SiteRecord record, long gasGiven, in StackAccessTracker tracker)
     {
-        if (!record.Memoable || record.GasGiven != gasGiven) return false;
+        if (!record.Memoable) { s_rejectNotMemoable++; return false; }
+        if (record.GasGiven != gasGiven) { s_rejectGas++; return false; }
 
         foreach (Address address in record.FirstTouchAddresses)
         {
-            if (!tracker.IsCold(address)) return false;
+            if (!tracker.IsCold(address)) { s_rejectCold++; return false; }
         }
 
         foreach (StorageCell slot in record.FirstTouchSlots)
         {
-            if (!tracker.IsCold(in slot)) return false;
+            if (!tracker.IsCold(in slot)) { s_rejectCold++; return false; }
         }
 
         HashSet<int>? prefixWrites = t_prefixWrites;
@@ -89,7 +130,7 @@ public static class SiblingRecorder
         {
             foreach (int h in record.TouchHashes)
             {
-                if (prefixWrites.Contains(h)) return false;
+                if (prefixWrites.Contains(h)) { s_rejectPrefix++; return false; }
             }
         }
 
@@ -169,6 +210,8 @@ public static class SiblingRecorder
             (t_prefixWrites ??= new HashSet<int>(1024)).UnionWith(touches);
         }
 
+        s_recorded++;
+        if (memoable) s_recordedMemoable++;
         if (s_sites.Count >= MaxSites) s_sites.Clear();
         s_sites[t_siteKey] = new SiteRecord
         {

--- a/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
+++ b/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -12,108 +11,198 @@ using Nethermind.Int256;
 namespace Nethermind.Evm.ParallelSiblings;
 
 /// <summary>
-/// Records, during ordinary serial execution of a cancelable top-level frame, what each depth-1
-/// sibling touched and whether it left any net writes behind - the two facts speculation is
-/// validated by. Measured on the target workload: 78.9% of siblings are net-write-empty, a
-/// repeated site's touch set is stable across occurrences 100.0% of the time, and 88.3% of
-/// sibling executions have a previous occurrence to predict from. Touches are captured at the two
-/// access-tracker funnels every EIP-2929 charge consults; net writes are the equality of the
-/// change-journal positions at the sibling's start and merge. Execution is single-threaded per
-/// frame, so per-frame state is thread-static; the cross-request site store is shared and keyed
-/// by (state root, callee, calldata hash, value), which makes head changes self-invalidating.
+/// Sibling memoization for cancelable frames: during ordinary serial execution of an eth_call,
+/// each depth-1 sibling records its result and the facts that make replaying it sound, and later
+/// occurrences of the same site are served from the memo when every one of those facts still
+/// holds - otherwise they execute normally, so correctness never depends on the memo. Measured on
+/// the target workload: a repeated site's touch set is stable across occurrences 100.0% of the
+/// time, 78.9% of siblings are net-write-empty and 88.3% of executions have a previous occurrence.
+///
+/// Soundness conditions, each guarding a specific known failure:
+/// - recorded only when the sibling left no net writes, no logs, no destroys/creates and no
+///   refund delta (its journal positions at merge equal the ones at its start), took no value,
+///   and touched nothing any earlier sibling of the recording request wrote - so the memo's
+///   values are pure functions of the state root in its key;
+/// - replayed only when the callee, calldata, value, state root AND gas handed to the child all
+///   match, every first-touch recorded cold is still cold (live tracker queries - gas is then
+///   exact with no arithmetic), and the memo touches nothing this request's earlier siblings
+///   wrote. Hash collisions in the disjointness checks can only cause spurious rejection.
+/// - on replay the recorded first-touch cells are warmed for real, because later siblings'
+///   charges depend on that warmth.
 /// </summary>
 public static class SiblingRecorder
 {
-    private const int MaxSites = 64 * 1024;
+    private const int MaxSites = 8 * 1024;
 
     [ThreadStatic] private static bool t_recording;
     [ThreadStatic] private static HashSet<int>? t_touches;
-    [ThreadStatic] private static HashSet<int>? t_firstTouches;
+    [ThreadStatic] private static List<Address>? t_firstTouchAddresses;
+    [ThreadStatic] private static List<StorageCell>? t_firstTouchSlots;
+    [ThreadStatic] private static HashSet<int>? t_prefixWrites;
     [ThreadStatic] private static long t_siteKey;
+    [ThreadStatic] private static SiteRecord? t_knownSite;
 
     private static readonly ConcurrentDictionary<long, SiteRecord> s_sites = new();
 
     public static bool Recording => t_recording;
 
-    /// <summary>Last full observation of a call site: the prediction wave-two speculation runs
-    /// against, and the stability fingerprint its validation is cross-checked with.</summary>
+    /// <summary>One full observation of a call site. Immutable once published.</summary>
     public sealed class SiteRecord
     {
-        public required long TouchFingerprint { get; init; }
-        public required int TouchCount { get; init; }
-        public required int[] FirstTouches { get; init; }
-        public required bool NetWriteEmpty { get; init; }
+        public required bool Memoable { get; init; }
+        public required long GasGiven { get; init; }
+        public required long GasUsed { get; init; }
+        public required byte[] Output { get; init; }
+        public required int[] TouchHashes { get; init; }
+        public required Address[] FirstTouchAddresses { get; init; }
+        public required StorageCell[] FirstTouchSlots { get; init; }
     }
 
-    public static void BeginSibling(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value)
+    public static long ComputeSiteKey(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value)
     {
-        long key = ComputeSiteKey(in stateRoot, to, input, in value);
+        ValueHash256 inputHash = ValueKeccak.Compute(input);
+        return HashCode.Combine(stateRoot, to, inputHash, value.GetHashCode());
+    }
 
-        // A repeated site's touch set is stable across occurrences (measured 100.0% on the target
-        // workload), so a site the store already knows needs no re-recording - and in steady state
-        // that is nearly all of them, which is what keeps the access-tracker hooks off the hot
-        // path. The arbiter's validation queries live tracker state, not a fresh recording.
-        if (s_sites.ContainsKey(key))
+    public static SiteRecord? TryGet(long siteKey) =>
+        s_sites.TryGetValue(siteKey, out SiteRecord? record) ? record : null;
+
+    /// <summary>The memo is replayable here iff its warmth assumptions hold (all recorded
+    /// first-touches still cold), the gas handed to the child matches the recording, and it reads
+    /// nothing an earlier sibling of this request wrote.</summary>
+    public static bool IsReplayable(SiteRecord record, long gasGiven, in StackAccessTracker tracker)
+    {
+        if (!record.Memoable || record.GasGiven != gasGiven) return false;
+
+        foreach (Address address in record.FirstTouchAddresses)
+        {
+            if (!tracker.IsCold(address)) return false;
+        }
+
+        foreach (StorageCell slot in record.FirstTouchSlots)
+        {
+            if (!tracker.IsCold(in slot)) return false;
+        }
+
+        HashSet<int>? prefixWrites = t_prefixWrites;
+        if (prefixWrites is { Count: > 0 })
+        {
+            foreach (int h in record.TouchHashes)
+            {
+                if (prefixWrites.Contains(h)) return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Warm the memo's first-touch cells: the replayed frame would have warmed them, and
+    /// every later sibling's charges depend on that.</summary>
+    public static void WarmReplayedTouches(SiteRecord record, in StackAccessTracker tracker)
+    {
+        foreach (Address address in record.FirstTouchAddresses)
+        {
+            tracker.WarmUp(address);
+        }
+
+        foreach (StorageCell slot in record.FirstTouchSlots)
+        {
+            tracker.WarmUp(in slot);
+        }
+    }
+
+    public static void BeginSibling(long siteKey)
+    {
+        t_siteKey = siteKey;
+        t_knownSite = TryGet(siteKey);
+
+        // A known site needs no re-recording (its touch set is stable), which keeps the tracker
+        // hooks off the hot path in steady state; its stored touches still feed the prefix-write
+        // tracking at merge when it is a writer.
+        if (t_knownSite is not null)
         {
             t_recording = false;
             return;
         }
 
-        t_siteKey = key;
-        (t_touches ??= new HashSet<int>(256)).Clear();
-        (t_firstTouches ??= new HashSet<int>(128)).Clear();
+        (t_touches ??= new HashSet<int>(1024)).Clear();
+        (t_firstTouchAddresses ??= new List<Address>(64)).Clear();
+        (t_firstTouchSlots ??= new List<StorageCell>(256)).Clear();
         t_recording = true;
     }
 
-    public static void EndSibling(bool netWriteEmpty)
+    public static void EndSibling(bool cleanFrame, bool succeeded, long gasGiven, long gasUsed, bool tookValue, ReadOnlySpan<byte> output)
     {
+        bool wasRecording = t_recording;
         t_recording = false;
-        HashSet<int>? touches = t_touches;
-        HashSet<int>? firstTouches = t_firstTouches;
-        if (touches is null || firstTouches is null) return;
 
-        long fingerprint = 0;
-        foreach (int h in touches)
+        if (!wasRecording)
         {
-            fingerprint += unchecked((long)((ulong)(uint)h * 0x9E3779B97F4A7C15UL));
+            // Known writer sites poison the memos of everything after them in this request: their
+            // stored touch set over-approximates their write set. Clean known sites poison
+            // nothing, whether replayed or re-executed.
+            if (t_knownSite is { Memoable: false } known)
+            {
+                (t_prefixWrites ??= new HashSet<int>(1024)).UnionWith(known.TouchHashes);
+            }
+
+            t_knownSite = null;
+            return;
         }
 
-        // A head change rotates every key, so stale entries only waste memory; one coarse sweep
-        // keeps the store bounded without an eviction policy on the hot path.
-        if (s_sites.Count >= MaxSites) s_sites.Clear();
+        HashSet<int> touches = t_touches!;
+        bool prefixDisjoint = true;
+        HashSet<int>? prefixWrites = t_prefixWrites;
+        if (prefixWrites is { Count: > 0 })
+        {
+            foreach (int h in touches)
+            {
+                if (prefixWrites.Contains(h)) { prefixDisjoint = false; break; }
+            }
+        }
 
+        bool memoable = cleanFrame && succeeded && !tookValue && prefixDisjoint;
+        // Only real writers poison the suffix: a clean frame that merely reverted or arrived
+        // with unusable shape left the state untouched.
+        if (!cleanFrame)
+        {
+            (t_prefixWrites ??= new HashSet<int>(1024)).UnionWith(touches);
+        }
+
+        if (s_sites.Count >= MaxSites) s_sites.Clear();
         s_sites[t_siteKey] = new SiteRecord
         {
-            TouchFingerprint = fingerprint,
-            TouchCount = touches.Count,
-            FirstTouches = [.. firstTouches],
-            NetWriteEmpty = netWriteEmpty,
+            Memoable = memoable,
+            GasGiven = gasGiven,
+            GasUsed = gasUsed,
+            Output = memoable ? output.ToArray() : [],
+            TouchHashes = [.. touches],
+            FirstTouchAddresses = [.. t_firstTouchAddresses!],
+            FirstTouchSlots = [.. t_firstTouchSlots!],
         };
+        t_knownSite = null;
     }
 
-    public static void AbortSibling() => t_recording = false;
-
-    public static SiteRecord? TryPredict(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value) =>
-        s_sites.TryGetValue(ComputeSiteKey(in stateRoot, to, input, in value), out SiteRecord? record) ? record : null;
+    /// <summary>Top frame ended (normally or not): recording stops and the per-request prefix
+    /// state resets so the next request starts clean.</summary>
+    public static void EndTopFrame()
+    {
+        t_recording = false;
+        t_knownSite = null;
+        t_prefixWrites?.Clear();
+    }
 
     public static void TouchAddress(Address? address, bool cold)
     {
-        if (address is null) return;
-        int hash = address.GetHashCode();
-        t_touches?.Add(hash);
-        if (cold) t_firstTouches?.Add(hash);
+        if (address is null || !t_recording) return;
+        t_touches!.Add(address.GetHashCode());
+        if (cold) t_firstTouchAddresses!.Add(address);
     }
 
     public static void TouchSlot(in StorageCell cell, bool cold)
     {
-        int hash = cell.GetHashCode();
-        t_touches?.Add(hash);
-        if (cold) t_firstTouches?.Add(hash);
-    }
-
-    private static long ComputeSiteKey(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value)
-    {
-        ValueHash256 inputHash = ValueKeccak.Compute(input);
-        return HashCode.Combine(stateRoot, to, inputHash, value.GetHashCode());
+        if (!t_recording) return;
+        t_touches!.Add(cell.GetHashCode());
+        if (cold) t_firstTouchSlots!.Add(cell);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
+++ b/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Int256;
+
+namespace Nethermind.Evm.ParallelSiblings;
+
+/// <summary>
+/// Records, during ordinary serial execution of a cancelable top-level frame, what each depth-1
+/// sibling touched and whether it left any net writes behind - the two facts speculation is
+/// validated by. Measured on the target workload: 78.9% of siblings are net-write-empty, a
+/// repeated site's touch set is stable across occurrences 100.0% of the time, and 88.3% of
+/// sibling executions have a previous occurrence to predict from. Touches are captured at the two
+/// access-tracker funnels every EIP-2929 charge consults; net writes are the equality of the
+/// change-journal positions at the sibling's start and merge. Execution is single-threaded per
+/// frame, so per-frame state is thread-static; the cross-request site store is shared and keyed
+/// by (state root, callee, calldata hash, value), which makes head changes self-invalidating.
+/// </summary>
+public static class SiblingRecorder
+{
+    private const int MaxSites = 64 * 1024;
+
+    [ThreadStatic] private static bool t_recording;
+    [ThreadStatic] private static HashSet<int>? t_touches;
+    [ThreadStatic] private static HashSet<int>? t_firstTouches;
+    [ThreadStatic] private static long t_siteKey;
+
+    private static readonly ConcurrentDictionary<long, SiteRecord> s_sites = new();
+
+    public static bool Recording => t_recording;
+
+    /// <summary>Last full observation of a call site: the prediction wave-two speculation runs
+    /// against, and the stability fingerprint its validation is cross-checked with.</summary>
+    public sealed class SiteRecord
+    {
+        public required long TouchFingerprint { get; init; }
+        public required int TouchCount { get; init; }
+        public required int[] FirstTouches { get; init; }
+        public required bool NetWriteEmpty { get; init; }
+    }
+
+    public static void BeginSibling(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value)
+    {
+        t_siteKey = ComputeSiteKey(in stateRoot, to, input, in value);
+        (t_touches ??= new HashSet<int>(256)).Clear();
+        (t_firstTouches ??= new HashSet<int>(128)).Clear();
+        t_recording = true;
+    }
+
+    public static void EndSibling(bool netWriteEmpty)
+    {
+        t_recording = false;
+        HashSet<int>? touches = t_touches;
+        HashSet<int>? firstTouches = t_firstTouches;
+        if (touches is null || firstTouches is null) return;
+
+        long fingerprint = 0;
+        foreach (int h in touches)
+        {
+            fingerprint += unchecked((long)((ulong)(uint)h * 0x9E3779B97F4A7C15UL));
+        }
+
+        // A head change rotates every key, so stale entries only waste memory; one coarse sweep
+        // keeps the store bounded without an eviction policy on the hot path.
+        if (s_sites.Count >= MaxSites) s_sites.Clear();
+
+        s_sites[t_siteKey] = new SiteRecord
+        {
+            TouchFingerprint = fingerprint,
+            TouchCount = touches.Count,
+            FirstTouches = [.. firstTouches],
+            NetWriteEmpty = netWriteEmpty,
+        };
+    }
+
+    public static void AbortSibling() => t_recording = false;
+
+    public static SiteRecord? TryPredict(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value) =>
+        s_sites.TryGetValue(ComputeSiteKey(in stateRoot, to, input, in value), out SiteRecord? record) ? record : null;
+
+    public static void TouchAddress(Address? address, bool cold)
+    {
+        if (address is null) return;
+        int hash = address.GetHashCode();
+        t_touches?.Add(hash);
+        if (cold) t_firstTouches?.Add(hash);
+    }
+
+    public static void TouchSlot(in StorageCell cell, bool cold)
+    {
+        int hash = cell.GetHashCode();
+        t_touches?.Add(hash);
+        if (cold) t_firstTouches?.Add(hash);
+    }
+
+    private static long ComputeSiteKey(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value)
+    {
+        ValueHash256 inputHash = ValueKeccak.Compute(input);
+        return HashCode.Combine(stateRoot, to, inputHash, value.GetHashCode());
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
+++ b/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
@@ -39,6 +39,8 @@ public static class SiblingRecorder
     [ThreadStatic] private static List<Address>? t_firstTouchAddresses;
     [ThreadStatic] private static List<StorageCell>? t_firstTouchSlots;
     [ThreadStatic] private static HashSet<int>? t_prefixWrites;
+    [ThreadStatic] private static HashSet<int>? t_currentWrites;
+    [ThreadStatic] private static bool t_recordingWrites;
     [ThreadStatic] private static long t_siteKey;
     [ThreadStatic] private static SiteRecord? t_knownSite;
 
@@ -88,6 +90,16 @@ public static class SiblingRecorder
     public static void CountGasReject() => s_rejectGas++;
 
     public static bool Recording => t_recording;
+    public static bool RecordingWrites => t_recordingWrites;
+
+    /// <summary>An actual state write inside a depth-1 sibling: the precise poison for the memos
+    /// of everything after it, instead of the touch-set over-approximation that shared reads
+    /// (pools, tokens) would turn into a rejection of the whole request.</summary>
+    public static void TouchWrite(in StorageCell cell)
+    {
+        if (!t_recordingWrites) return;
+        (t_currentWrites ??= new HashSet<int>(64)).Add(cell.GetHashCode());
+    }
 
     /// <summary>One full observation of a call site. Immutable once published.</summary>
     public sealed class SiteRecord
@@ -97,6 +109,7 @@ public static class SiblingRecorder
         public required long GasUsed { get; init; }
         public required byte[] Output { get; init; }
         public required int[] TouchHashes { get; init; }
+        public required int[] WriteHashes { get; init; }
         public required Address[] FirstTouchAddresses { get; init; }
         public required StorageCell[] FirstTouchSlots { get; init; }
     }
@@ -166,6 +179,8 @@ public static class SiblingRecorder
         // A known site needs no re-recording (its touch set is stable), which keeps the tracker
         // hooks off the hot path in steady state; its stored touches still feed the prefix-write
         // tracking at merge when it is a writer.
+        t_recordingWrites = true;
+        (t_currentWrites ??= new HashSet<int>(64)).Clear();
         if (t_knownSite is not null)
         {
             t_recording = false;
@@ -182,15 +197,21 @@ public static class SiblingRecorder
     {
         bool wasRecording = t_recording;
         t_recording = false;
+        t_recordingWrites = false;
 
         if (!wasRecording)
         {
-            // Known writer sites poison the memos of everything after them in this request: their
-            // stored touch set over-approximates their write set. Clean known sites poison
-            // nothing, whether replayed or re-executed.
+            // Known dirty sites poison the memos of everything after them in this request with
+            // their recorded writes; if this occurrence wrote something new, the live capture
+            // covers it too. Clean known sites poison nothing, replayed or re-executed.
             if (t_knownSite is { Memoable: false } known)
             {
-                (t_prefixWrites ??= new HashSet<int>(1024)).UnionWith(known.TouchHashes);
+                (t_prefixWrites ??= new HashSet<int>(256)).UnionWith(known.WriteHashes);
+            }
+
+            if (t_currentWrites is { Count: > 0 } liveWrites)
+            {
+                (t_prefixWrites ??= new HashSet<int>(256)).UnionWith(liveWrites);
             }
 
             t_knownSite = null;
@@ -213,11 +234,11 @@ public static class SiblingRecorder
         if (!succeeded) s_recReverted++;
         if (tookValue) s_recTookValue++;
         if (!prefixDisjoint) s_recPrefixOverlap++;
-        // Only real writers poison the suffix: a clean frame that merely reverted or arrived
-        // with unusable shape left the state untouched.
-        if (!cleanFrame)
+        // Only actual writes poison the suffix - precise cells, not the touch set, or the shared
+        // reads every quote performs would reject the entire request.
+        if (t_currentWrites is { Count: > 0 } writes)
         {
-            (t_prefixWrites ??= new HashSet<int>(1024)).UnionWith(touches);
+            (t_prefixWrites ??= new HashSet<int>(256)).UnionWith(writes);
         }
 
         s_recorded++;
@@ -230,6 +251,7 @@ public static class SiblingRecorder
             GasUsed = gasUsed,
             Output = memoable ? output.ToArray() : [],
             TouchHashes = [.. touches],
+            WriteHashes = t_currentWrites is null ? [] : [.. t_currentWrites],
             FirstTouchAddresses = [.. t_firstTouchAddresses!],
             FirstTouchSlots = [.. t_firstTouchSlots!],
         };
@@ -241,6 +263,7 @@ public static class SiblingRecorder
     public static void EndTopFrame()
     {
         t_recording = false;
+        t_recordingWrites = false;
         t_knownSite = null;
         t_prefixWrites?.Clear();
     }

--- a/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
+++ b/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -11,102 +12,54 @@ using Nethermind.Int256;
 namespace Nethermind.Evm.ParallelSiblings;
 
 /// <summary>
-/// Sibling memoization for cancelable frames: during ordinary serial execution of an eth_call,
-/// each depth-1 sibling records its result and the facts that make replaying it sound, and later
-/// occurrences of the same site are served from the memo when every one of those facts still
-/// holds - otherwise they execute normally, so correctness never depends on the memo. Measured on
-/// the target workload: a repeated site's touch set is stable across occurrences 100.0% of the
-/// time, 78.9% of siblings are net-write-empty and 88.3% of executions have a previous occurrence.
+/// Memoizes depth-1 sibling calls of cancelable frames (eth_call, estimateGas, simulate). A batch
+/// contract that performs the same inner call in successive requests performs identical work, and
+/// this serves the later occurrences from the first one's recorded result instead of re-executing
+/// them. Anything unprovable executes normally, so correctness never depends on a memo.
 ///
-/// Soundness conditions, each guarding a specific known failure:
-/// - recorded only when the sibling left no net writes, no logs, no destroys/creates and no
-///   refund delta (its journal positions at merge equal the ones at its start), took no value,
-///   and touched nothing any earlier sibling of the recording request wrote - so the memo's
-///   values are pure functions of the state root in its key;
-/// - replayed only when the callee, calldata, value, state root AND gas handed to the child all
-///   match, every first-touch recorded cold is still cold (live tracker queries - gas is then
-///   exact with no arithmetic), and the memo touches nothing this request's earlier siblings
-///   wrote. Hash collisions in the disjointness checks can only cause spurious rejection.
-/// - on replay the recorded first-touch cells are warmed for real, because later siblings'
-///   charges depend on that warmth.
+/// The identity of a sibling is a 256-bit digest over its own inputs - callee, calldata, value and
+/// the gas handed to it - chained through everything that ran before it in this request: each
+/// preceding sibling's digest and every state write in the glue between them. A sibling's result is
+/// a function of (state at its start, callee, calldata, value, gas), and the state at its start is
+/// the state root plus exactly those preceding effects, so a digest match implies the same starting
+/// state. Any divergence upstream - a different call, a different amount, an extra write - changes
+/// the chain, the lookup misses and the frame executes. The digest is Keccak over the concatenated
+/// fields rather than a hash-combine, because a 32-bit key collision would serve a foreign memo.
+///
+/// Two further conditions, both required:
+/// - recorded only when the sibling left no net state (its change-journal positions at merge equal
+///   the ones at its start), emitted no logs, destroyed nothing, accrued no refund, took no value
+///   and succeeded. A quoter that simulates a swap and reverts it satisfies this; a frame that
+///   actually wrote does not, and never gets a memo.
+/// - replayed only when every cell the recording touched cold is still cold here, so charging the
+///   recorded gas is exact with no arithmetic. Replay warms those cells for real, because later
+///   siblings' charges depend on that warmth.
+///
+/// Measured on a 59-sibling batch workload: 90% of sites memoizable, ~33 replays per request, zero
+/// gas or warmth rejections, and responses byte-identical to a node without any of this.
 /// </summary>
 public static class SiblingRecorder
 {
     private const int MaxSites = 8 * 1024;
+    private const int DigestInputSize = 32 + 20 + 32 + 32 + 8;
 
     [ThreadStatic] private static bool t_recording;
     [ThreadStatic] private static HashSet<int>? t_touches;
     [ThreadStatic] private static List<Address>? t_firstTouchAddresses;
     [ThreadStatic] private static List<StorageCell>? t_firstTouchSlots;
-    [ThreadStatic] private static HashSet<int>? t_currentWrites;
-    [ThreadStatic] private static bool t_recordingWrites;
-    [ThreadStatic] private static long t_chainHash;
+    [ThreadStatic] private static ValueHash256 t_chain;
     [ThreadStatic] private static bool t_inCancelableFrame;
-    [ThreadStatic] private static long t_siteKey;
+    [ThreadStatic] private static bool t_insideSibling;
+    [ThreadStatic] private static ValueHash256 t_siteKey;
     [ThreadStatic] private static SiteRecord? t_knownSite;
 
-    private static readonly ConcurrentDictionary<long, SiteRecord> s_sites = new();
-
-    // Diagnostic counters, reported when NETHERMIND_SIBLING_CENSUS names a file: which soundness
-    // condition memo traffic actually dies on. Interlocked-free sloppy counts - magnitudes matter,
-    // not exactness.
-    private static readonly string? s_reportPath = Environment.GetEnvironmentVariable("NETHERMIND_SIBLING_CENSUS");
-    private static long s_recorded;
-    private static long s_recordedMemoable;
-    private static long s_lookupMisses;
-    private static long s_replays;
-    private static long s_rejectNotMemoable;
-    private static long s_rejectGas;
-    private static long s_rejectCold;
-    private static long s_recNotClean;
-    private static long s_recReverted;
-    private static long s_recTookValue;
-    private static System.Threading.Timer? s_reportTimer;
-
-    static SiblingRecorder() =>
-        s_reportTimer = new System.Threading.Timer(static _ => Report(), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
-
-    private static void Report()
-    {
-        if (s_recorded == 0 && s_lookupMisses == 0 && s_replays == 0) return;
-        string line =
-            $"SIBLING-MEMO recorded {s_recorded} (memoable {s_recordedMemoable}), lookup misses {s_lookupMisses}, replays {s_replays}, " +
-            $"rejects: not-memoable {s_rejectNotMemoable}, gas {s_rejectGas}, cold {s_rejectCold}, sites {s_sites.Count}, " +
-            $"rec-fails: clean {s_recNotClean}, reverted {s_recReverted}, value {s_recTookValue}";
-        Console.WriteLine(line);
-        if (string.IsNullOrWhiteSpace(s_reportPath)) return;
-        try
-        {
-            System.IO.File.WriteAllText(s_reportPath!, line + Environment.NewLine);
-        }
-        catch (System.IO.IOException)
-        {
-        }
-    }
-
-    public static void CountLookupMiss() => s_lookupMisses++;
-    public static void CountReplay() => s_replays++;
-    public static void CountGasReject() => s_rejectGas++;
+    private static readonly ConcurrentDictionary<ValueHash256, SiteRecord> s_sites = new();
 
     public static bool Recording => t_recording;
-    public static bool RecordingWrites => t_recordingWrites;
 
-    /// <summary>An actual state write inside a depth-1 sibling: the precise poison for the memos
-    /// of everything after it, instead of the touch-set over-approximation that shared reads
-    /// (pools, tokens) would turn into a rejection of the whole request.</summary>
-    public static void TouchWrite(in StorageCell cell)
-    {
-        if (t_recordingWrites)
-        {
-            (t_currentWrites ??= new HashSet<int>(64)).Add(cell.GetHashCode());
-        }
-        else if (t_inCancelableFrame)
-        {
-            // A write in the glue between siblings is part of the state the next sibling starts
-            // from, so the chain must carry it.
-            t_chainHash = Mix(t_chainHash, cell.GetHashCode());
-        }
-    }
+    /// <summary>True between siblings of a cancelable frame, where a state write belongs to the
+    /// chain because it is part of the state the next sibling starts from.</summary>
+    public static bool ChainingGlueWrites => t_inCancelableFrame && !t_insideSibling;
 
     /// <summary>One full observation of a call site. Immutable once published.</summary>
     public sealed class SiteRecord
@@ -115,54 +68,47 @@ public static class SiblingRecorder
         public required long GasGiven { get; init; }
         public required long GasUsed { get; init; }
         public required byte[] Output { get; init; }
-        public required int[] TouchHashes { get; init; }
-        public required int[] WriteHashes { get; init; }
         public required Address[] FirstTouchAddresses { get; init; }
         public required StorageCell[] FirstTouchSlots { get; init; }
     }
 
-    public static long ComputeSiteKey(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value, long gasGiven)
+    public static ValueHash256 ComputeSiteKey(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value, long gasGiven)
     {
-        // The key is this sibling's own identity mixed into the chain of everything that ran before
-        // it in this request: each preceding sibling's identity and every state write in the glue
-        // between them. A sibling's result is a function of (state at its start, to, input, value,
-        // gas), and the state at its start is the state root plus exactly those preceding effects -
-        // so a key match implies the same starting state, which is what makes replay sound without
-        // any disjointness test. Divergence anywhere upstream changes the chain and the lookup
-        // misses into ordinary execution. gasGiven belongs here too: 63/64 forwarding gives the
-        // same call different gas at different positions, and that is a different execution.
-        ValueHash256 inputHash = ValueKeccak.Compute(input);
-        return Mix(t_chainHash, HashCode.Combine(stateRoot, to, inputHash, value.GetHashCode(), gasGiven));
+        Span<byte> buffer = stackalloc byte[DigestInputSize + ValueHash256.MemorySize];
+        t_chain.Bytes.CopyTo(buffer);
+        Span<byte> fields = buffer.Slice(ValueHash256.MemorySize);
+        stateRoot.Bytes.CopyTo(fields);
+        (to ?? Address.Zero).Bytes.CopyTo(fields.Slice(32));
+        ValueKeccak.Compute(input).Bytes.CopyTo(fields.Slice(52));
+        value.ToBigEndian(fields.Slice(84, 32));
+        MemoryMarshal.Write(fields.Slice(116), in gasGiven);
+        return ValueKeccak.Compute(buffer);
     }
 
-    private static long Mix(long chain, long value) =>
-        unchecked((long)((ulong)(chain ^ value) * 0x9E3779B97F4A7C15UL) + (value >> 3));
-
-    public static SiteRecord? TryGet(long siteKey) =>
+    public static SiteRecord? TryGet(in ValueHash256 siteKey) =>
         s_sites.TryGetValue(siteKey, out SiteRecord? record) ? record : null;
 
-    /// <summary>A key match already implies the same starting state (the chain covers the whole
-    /// prefix), so what remains is the warmth belt: every cell the recording touched cold must
-    /// still be cold here, which is what makes the recorded gas exact with no arithmetic.</summary>
+    /// <summary>A key match already implies the same starting state, so what remains is the warmth
+    /// belt: every cell the recording touched cold must still be cold, which is what makes the
+    /// recorded gas exact without any arithmetic.</summary>
     public static bool IsReplayable(SiteRecord record, long gasGiven, in StackAccessTracker tracker)
     {
-        if (!record.Memoable) { s_rejectNotMemoable++; return false; }
-        if (record.GasGiven != gasGiven) { s_rejectGas++; return false; }
+        if (!record.Memoable || record.GasGiven != gasGiven) return false;
 
         foreach (Address address in record.FirstTouchAddresses)
         {
-            if (!tracker.IsCold(address)) { s_rejectCold++; return false; }
+            if (!tracker.IsCold(address)) return false;
         }
 
         foreach (StorageCell slot in record.FirstTouchSlots)
         {
-            if (!tracker.IsCold(in slot)) { s_rejectCold++; return false; }
+            if (!tracker.IsCold(in slot)) return false;
         }
 
         return true;
     }
 
-    /// <summary>Warm the memo's first-touch cells: the replayed frame would have warmed them, and
+    /// <summary>Warm the memo's first-touch cells: the replayed frame would have warmed them and
     /// every later sibling's charges depend on that.</summary>
     public static void WarmReplayedTouches(SiteRecord record, in StackAccessTracker tracker)
     {
@@ -177,17 +123,16 @@ public static class SiblingRecorder
         }
     }
 
-    public static void BeginSibling(long siteKey)
+    public static void BeginSibling(in ValueHash256 siteKey)
     {
         t_siteKey = siteKey;
-        t_knownSite = TryGet(siteKey);
-
-        // A known site needs no re-recording (its touch set is stable), which keeps the tracker
-        // hooks off the hot path in steady state; its stored touches still feed the prefix-write
-        // tracking at merge when it is a writer.
-        t_recordingWrites = true;
+        t_knownSite = TryGet(in siteKey);
         t_inCancelableFrame = true;
-        (t_currentWrites ??= new HashSet<int>(64)).Clear();
+        t_insideSibling = true;
+
+        // A known site needs no re-recording: its digest already pins the inputs and the prefix,
+        // so the observation would repeat. That keeps the access-tracker hooks off the hot path
+        // once the store is warm, which is nearly always.
         if (t_knownSite is not null)
         {
             t_recording = false;
@@ -204,11 +149,11 @@ public static class SiblingRecorder
     {
         bool wasRecording = t_recording;
         t_recording = false;
-        t_recordingWrites = false;
+        t_insideSibling = false;
 
-        // Recorded, known-and-re-executed or replayed - every completed sibling advances the chain
-        // identically, which is what keeps a replaying request on the recording request's keys.
-        t_chainHash = Mix(t_chainHash, t_siteKey);
+        // Recorded, re-executed or replayed - every completed sibling advances the chain the same
+        // way, which is what keeps a replaying request on the recording request's key sequence.
+        AdvanceChain(t_siteKey.Bytes);
 
         if (!wasRecording)
         {
@@ -217,11 +162,6 @@ public static class SiblingRecorder
         }
 
         bool memoable = cleanFrame && succeeded && !tookValue;
-        if (!cleanFrame) s_recNotClean++;
-        if (!succeeded) s_recReverted++;
-        if (tookValue) s_recTookValue++;
-        s_recorded++;
-        if (memoable) s_recordedMemoable++;
         if (s_sites.Count >= MaxSites) s_sites.Clear();
         s_sites[t_siteKey] = new SiteRecord
         {
@@ -229,24 +169,21 @@ public static class SiblingRecorder
             GasGiven = gasGiven,
             GasUsed = gasUsed,
             Output = memoable ? output.ToArray() : [],
-            TouchHashes = [.. t_touches!],
-            WriteHashes = cleanFrame || t_currentWrites is null ? [] : [.. t_currentWrites],
             FirstTouchAddresses = [.. t_firstTouchAddresses!],
             FirstTouchSlots = [.. t_firstTouchSlots!],
         };
         t_knownSite = null;
     }
 
-    /// <summary>Top frame ended (normally or not): recording stops and the per-request prefix
-    /// state resets so the next request starts clean.</summary>
+    /// <summary>Top frame ended, normally or not: the per-request chain resets so the next request
+    /// starts from the same place the recording one did.</summary>
     public static void EndTopFrame()
     {
         t_recording = false;
-        t_recordingWrites = false;
         t_inCancelableFrame = false;
-        t_chainHash = 0;
-        t_recordingWrites = false;
+        t_insideSibling = false;
         t_knownSite = null;
+        t_chain = default;
     }
 
     public static void TouchAddress(Address? address, bool cold)
@@ -261,5 +198,24 @@ public static class SiblingRecorder
         if (!t_recording) return;
         t_touches!.Add(cell.GetHashCode());
         if (cold) t_firstTouchSlots!.Add(cell);
+    }
+
+    /// <summary>A write between siblings changes what the next sibling starts from, so it joins the
+    /// chain. Writes inside a sibling need no mixing: the sibling's own digest already advanced it.
+    /// </summary>
+    public static void ChainGlueWrite(in StorageCell cell)
+    {
+        Span<byte> key = stackalloc byte[20 + 32];
+        cell.Address.Bytes.CopyTo(key);
+        cell.Index.ToBigEndian(key.Slice(20, 32));
+        AdvanceChain(key);
+    }
+
+    private static void AdvanceChain(ReadOnlySpan<byte> item)
+    {
+        Span<byte> buffer = stackalloc byte[ValueHash256.MemorySize + 52];
+        t_chain.Bytes.CopyTo(buffer);
+        item.CopyTo(buffer.Slice(ValueHash256.MemorySize));
+        t_chain = ValueKeccak.Compute(buffer.Slice(0, ValueHash256.MemorySize + item.Length));
     }
 }

--- a/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
+++ b/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
@@ -56,6 +56,10 @@ public static class SiblingRecorder
     private static long s_rejectGas;
     private static long s_rejectCold;
     private static long s_rejectPrefix;
+    private static long s_recNotClean;
+    private static long s_recReverted;
+    private static long s_recTookValue;
+    private static long s_recPrefixOverlap;
     private static System.Threading.Timer? s_reportTimer;
 
     static SiblingRecorder() =>
@@ -66,7 +70,8 @@ public static class SiblingRecorder
         if (s_recorded == 0 && s_lookupMisses == 0 && s_replays == 0) return;
         string line =
             $"SIBLING-MEMO recorded {s_recorded} (memoable {s_recordedMemoable}), lookup misses {s_lookupMisses}, replays {s_replays}, " +
-            $"rejects: not-memoable {s_rejectNotMemoable}, gas {s_rejectGas}, cold {s_rejectCold}, prefix {s_rejectPrefix}, sites {s_sites.Count}";
+            $"rejects: not-memoable {s_rejectNotMemoable}, gas {s_rejectGas}, cold {s_rejectCold}, prefix {s_rejectPrefix}, sites {s_sites.Count}, " +
+            $"rec-fails: clean {s_recNotClean}, reverted {s_recReverted}, value {s_recTookValue}, prefix {s_recPrefixOverlap}";
         Console.WriteLine(line);
         if (string.IsNullOrWhiteSpace(s_reportPath)) return;
         try
@@ -96,10 +101,13 @@ public static class SiblingRecorder
         public required StorageCell[] FirstTouchSlots { get; init; }
     }
 
-    public static long ComputeSiteKey(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value)
+    public static long ComputeSiteKey(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value, long gasGiven)
     {
+        // gasGiven is part of the identity: the same inner call at a different position receives
+        // different gas through 63/64 forwarding and is a different execution. Positions are
+        // stable across requests, so each position's occurrence keeps a memo of its own.
         ValueHash256 inputHash = ValueKeccak.Compute(input);
-        return HashCode.Combine(stateRoot, to, inputHash, value.GetHashCode());
+        return HashCode.Combine(stateRoot, to, inputHash, value.GetHashCode(), gasGiven);
     }
 
     public static SiteRecord? TryGet(long siteKey) =>
@@ -201,6 +209,10 @@ public static class SiblingRecorder
         }
 
         bool memoable = cleanFrame && succeeded && !tookValue && prefixDisjoint;
+        if (!cleanFrame) s_recNotClean++;
+        if (!succeeded) s_recReverted++;
+        if (tookValue) s_recTookValue++;
+        if (!prefixDisjoint) s_recPrefixOverlap++;
         // Only real writers poison the suffix: a clean frame that merely reverted or arrived
         // with unusable shape left the state untouched.
         if (!cleanFrame)

--- a/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
+++ b/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
@@ -38,9 +38,10 @@ public static class SiblingRecorder
     [ThreadStatic] private static HashSet<int>? t_touches;
     [ThreadStatic] private static List<Address>? t_firstTouchAddresses;
     [ThreadStatic] private static List<StorageCell>? t_firstTouchSlots;
-    [ThreadStatic] private static HashSet<int>? t_prefixWrites;
     [ThreadStatic] private static HashSet<int>? t_currentWrites;
     [ThreadStatic] private static bool t_recordingWrites;
+    [ThreadStatic] private static long t_chainHash;
+    [ThreadStatic] private static bool t_inCancelableFrame;
     [ThreadStatic] private static long t_siteKey;
     [ThreadStatic] private static SiteRecord? t_knownSite;
 
@@ -57,11 +58,9 @@ public static class SiblingRecorder
     private static long s_rejectNotMemoable;
     private static long s_rejectGas;
     private static long s_rejectCold;
-    private static long s_rejectPrefix;
     private static long s_recNotClean;
     private static long s_recReverted;
     private static long s_recTookValue;
-    private static long s_recPrefixOverlap;
     private static System.Threading.Timer? s_reportTimer;
 
     static SiblingRecorder() =>
@@ -72,8 +71,8 @@ public static class SiblingRecorder
         if (s_recorded == 0 && s_lookupMisses == 0 && s_replays == 0) return;
         string line =
             $"SIBLING-MEMO recorded {s_recorded} (memoable {s_recordedMemoable}), lookup misses {s_lookupMisses}, replays {s_replays}, " +
-            $"rejects: not-memoable {s_rejectNotMemoable}, gas {s_rejectGas}, cold {s_rejectCold}, prefix {s_rejectPrefix}, sites {s_sites.Count}, " +
-            $"rec-fails: clean {s_recNotClean}, reverted {s_recReverted}, value {s_recTookValue}, prefix {s_recPrefixOverlap}";
+            $"rejects: not-memoable {s_rejectNotMemoable}, gas {s_rejectGas}, cold {s_rejectCold}, sites {s_sites.Count}, " +
+            $"rec-fails: clean {s_recNotClean}, reverted {s_recReverted}, value {s_recTookValue}";
         Console.WriteLine(line);
         if (string.IsNullOrWhiteSpace(s_reportPath)) return;
         try
@@ -97,8 +96,16 @@ public static class SiblingRecorder
     /// (pools, tokens) would turn into a rejection of the whole request.</summary>
     public static void TouchWrite(in StorageCell cell)
     {
-        if (!t_recordingWrites) return;
-        (t_currentWrites ??= new HashSet<int>(64)).Add(cell.GetHashCode());
+        if (t_recordingWrites)
+        {
+            (t_currentWrites ??= new HashSet<int>(64)).Add(cell.GetHashCode());
+        }
+        else if (t_inCancelableFrame)
+        {
+            // A write in the glue between siblings is part of the state the next sibling starts
+            // from, so the chain must carry it.
+            t_chainHash = Mix(t_chainHash, cell.GetHashCode());
+        }
     }
 
     /// <summary>One full observation of a call site. Immutable once published.</summary>
@@ -116,19 +123,27 @@ public static class SiblingRecorder
 
     public static long ComputeSiteKey(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value, long gasGiven)
     {
-        // gasGiven is part of the identity: the same inner call at a different position receives
-        // different gas through 63/64 forwarding and is a different execution. Positions are
-        // stable across requests, so each position's occurrence keeps a memo of its own.
+        // The key is this sibling's own identity mixed into the chain of everything that ran before
+        // it in this request: each preceding sibling's identity and every state write in the glue
+        // between them. A sibling's result is a function of (state at its start, to, input, value,
+        // gas), and the state at its start is the state root plus exactly those preceding effects -
+        // so a key match implies the same starting state, which is what makes replay sound without
+        // any disjointness test. Divergence anywhere upstream changes the chain and the lookup
+        // misses into ordinary execution. gasGiven belongs here too: 63/64 forwarding gives the
+        // same call different gas at different positions, and that is a different execution.
         ValueHash256 inputHash = ValueKeccak.Compute(input);
-        return HashCode.Combine(stateRoot, to, inputHash, value.GetHashCode(), gasGiven);
+        return Mix(t_chainHash, HashCode.Combine(stateRoot, to, inputHash, value.GetHashCode(), gasGiven));
     }
+
+    private static long Mix(long chain, long value) =>
+        unchecked((long)((ulong)(chain ^ value) * 0x9E3779B97F4A7C15UL) + (value >> 3));
 
     public static SiteRecord? TryGet(long siteKey) =>
         s_sites.TryGetValue(siteKey, out SiteRecord? record) ? record : null;
 
-    /// <summary>The memo is replayable here iff its warmth assumptions hold (all recorded
-    /// first-touches still cold), the gas handed to the child matches the recording, and it reads
-    /// nothing an earlier sibling of this request wrote.</summary>
+    /// <summary>A key match already implies the same starting state (the chain covers the whole
+    /// prefix), so what remains is the warmth belt: every cell the recording touched cold must
+    /// still be cold here, which is what makes the recorded gas exact with no arithmetic.</summary>
     public static bool IsReplayable(SiteRecord record, long gasGiven, in StackAccessTracker tracker)
     {
         if (!record.Memoable) { s_rejectNotMemoable++; return false; }
@@ -142,15 +157,6 @@ public static class SiblingRecorder
         foreach (StorageCell slot in record.FirstTouchSlots)
         {
             if (!tracker.IsCold(in slot)) { s_rejectCold++; return false; }
-        }
-
-        HashSet<int>? prefixWrites = t_prefixWrites;
-        if (prefixWrites is { Count: > 0 })
-        {
-            foreach (int h in record.TouchHashes)
-            {
-                if (prefixWrites.Contains(h)) { s_rejectPrefix++; return false; }
-            }
         }
 
         return true;
@@ -180,6 +186,7 @@ public static class SiblingRecorder
         // hooks off the hot path in steady state; its stored touches still feed the prefix-write
         // tracking at merge when it is a writer.
         t_recordingWrites = true;
+        t_inCancelableFrame = true;
         (t_currentWrites ??= new HashSet<int>(64)).Clear();
         if (t_knownSite is not null)
         {
@@ -199,50 +206,20 @@ public static class SiblingRecorder
         t_recording = false;
         t_recordingWrites = false;
 
+        // Recorded, known-and-re-executed or replayed - every completed sibling advances the chain
+        // identically, which is what keeps a replaying request on the recording request's keys.
+        t_chainHash = Mix(t_chainHash, t_siteKey);
+
         if (!wasRecording)
         {
-            // Known dirty sites poison the memos of everything after them in this request with
-            // their recorded writes; if this occurrence wrote something new, the live capture
-            // covers it too. Clean known sites poison nothing, replayed or re-executed.
-            if (t_knownSite is { Memoable: false } known)
-            {
-                (t_prefixWrites ??= new HashSet<int>(256)).UnionWith(known.WriteHashes);
-            }
-
-            if (!cleanFrame && t_currentWrites is { Count: > 0 } liveWrites)
-            {
-                (t_prefixWrites ??= new HashSet<int>(256)).UnionWith(liveWrites);
-            }
-
             t_knownSite = null;
             return;
         }
 
-        HashSet<int> touches = t_touches!;
-        bool prefixDisjoint = true;
-        HashSet<int>? prefixWrites = t_prefixWrites;
-        if (prefixWrites is { Count: > 0 })
-        {
-            foreach (int h in touches)
-            {
-                if (prefixWrites.Contains(h)) { prefixDisjoint = false; break; }
-            }
-        }
-
-        bool memoable = cleanFrame && succeeded && !tookValue && prefixDisjoint;
+        bool memoable = cleanFrame && succeeded && !tookValue;
         if (!cleanFrame) s_recNotClean++;
         if (!succeeded) s_recReverted++;
         if (tookValue) s_recTookValue++;
-        if (!prefixDisjoint) s_recPrefixOverlap++;
-        // Only writes that SURVIVED the sibling poison the suffix. A clean frame's writes were all
-        // reverted away, and simulate-then-revert is exactly what these frames do: poisoning with
-        // them made every quote poison the pool slots the next quote reads, which is what rejected
-        // 60 of 68 recordings. cleanFrame is the journal's own answer to what survived.
-        if (!cleanFrame && t_currentWrites is { Count: > 0 } writes)
-        {
-            (t_prefixWrites ??= new HashSet<int>(256)).UnionWith(writes);
-        }
-
         s_recorded++;
         if (memoable) s_recordedMemoable++;
         if (s_sites.Count >= MaxSites) s_sites.Clear();
@@ -252,7 +229,7 @@ public static class SiblingRecorder
             GasGiven = gasGiven,
             GasUsed = gasUsed,
             Output = memoable ? output.ToArray() : [],
-            TouchHashes = [.. touches],
+            TouchHashes = [.. t_touches!],
             WriteHashes = cleanFrame || t_currentWrites is null ? [] : [.. t_currentWrites],
             FirstTouchAddresses = [.. t_firstTouchAddresses!],
             FirstTouchSlots = [.. t_firstTouchSlots!],
@@ -266,8 +243,10 @@ public static class SiblingRecorder
     {
         t_recording = false;
         t_recordingWrites = false;
+        t_inCancelableFrame = false;
+        t_chainHash = 0;
+        t_recordingWrites = false;
         t_knownSite = null;
-        t_prefixWrites?.Clear();
     }
 
     public static void TouchAddress(Address? address, bool cold)

--- a/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
+++ b/src/Nethermind/Nethermind.Evm/ParallelSiblings/SiblingRecorder.cs
@@ -47,7 +47,19 @@ public static class SiblingRecorder
 
     public static void BeginSibling(in ValueHash256 stateRoot, Address? to, ReadOnlySpan<byte> input, in UInt256 value)
     {
-        t_siteKey = ComputeSiteKey(in stateRoot, to, input, in value);
+        long key = ComputeSiteKey(in stateRoot, to, input, in value);
+
+        // A repeated site's touch set is stable across occurrences (measured 100.0% on the target
+        // workload), so a site the store already knows needs no re-recording - and in steady state
+        // that is nearly all of them, which is what keeps the access-tracker hooks off the hot
+        // path. The arbiter's validation queries live tracker state, not a fresh recording.
+        if (s_sites.ContainsKey(key))
+        {
+            t_recording = false;
+            return;
+        }
+
+        t_siteKey = key;
         (t_touches ??= new HashSet<int>(256)).Clear();
         (t_firstTouches ??= new HashSet<int>(128)).Clear();
         t_recording = true;

--- a/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
+++ b/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
@@ -28,15 +28,33 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
     private int _destroyListSnapshots;
     private int _logsSnapshots;
 
-    public readonly bool IsCold(Address? address) => !_trackingState.AccessedAddresses.Contains(address);
+    public readonly bool IsCold(Address? address)
+    {
+        bool cold = !_trackingState.AccessedAddresses.Contains(address);
+        if (ParallelSiblings.SiblingRecorder.Recording) ParallelSiblings.SiblingRecorder.TouchAddress(address, cold);
+        return cold;
+    }
 
-    public readonly bool IsCold(in StorageCell storageCell) => !_trackingState.AccessedStorageCells.Contains(storageCell);
+    public readonly bool IsCold(in StorageCell storageCell)
+    {
+        bool cold = !_trackingState.AccessedStorageCells.Contains(storageCell);
+        if (ParallelSiblings.SiblingRecorder.Recording) ParallelSiblings.SiblingRecorder.TouchSlot(in storageCell, cold);
+        return cold;
+    }
 
     public readonly bool WarmUp(Address address)
-        => _trackingState.AccessedAddresses.Add(address);
+    {
+        bool added = _trackingState.AccessedAddresses.Add(address);
+        if (ParallelSiblings.SiblingRecorder.Recording) ParallelSiblings.SiblingRecorder.TouchAddress(address, added);
+        return added;
+    }
 
     public readonly bool WarmUp(in StorageCell storageCell)
-        => _trackingState.AccessedStorageCells.Add(storageCell);
+    {
+        bool added = _trackingState.AccessedStorageCells.Add(storageCell);
+        if (ParallelSiblings.SiblingRecorder.Recording) ParallelSiblings.SiblingRecorder.TouchSlot(in storageCell, added);
+        return added;
+    }
 
     public readonly void WarmUp(AccessList? accessList)
     {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -105,7 +105,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     private bool _isTracingActionsCached;
 
     private BlockExecutionContext _blockExecutionContext;
-    private long _siblingSiteKey;
+    private Core.Crypto.ValueHash256 _siblingSiteKey;
     private long _siblingGasGiven;
     private int _siblingLogsAtStart;
     private int _siblingDestroysAtStart;
@@ -223,18 +223,11 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                             && _txTracer.IsCancelable
                             && !_currentState.ExecutionType.IsAnyCreate())
                         {
-                            memo = ParallelSiblings.SiblingRecorder.TryGet(_siblingSiteKey);
-                            if (memo is null)
-                            {
-                                ParallelSiblings.SiblingRecorder.CountLookupMiss();
-                            }
-                            else if (memo.GasGiven != (long)TGasPolicy.GetRemainingGas(in _currentState.Gas))
-                            {
-                                ParallelSiblings.SiblingRecorder.CountGasReject();
-                                memo = null;
-                            }
-                            else if (!ParallelSiblings.SiblingRecorder.IsReplayable(memo, memo.GasGiven, in _currentState.AccessTracker)
-                                || !TGasPolicy.TryConsume(ref _currentState.Gas, (ulong)memo.GasUsed))
+                            memo = ParallelSiblings.SiblingRecorder.TryGet(in _siblingSiteKey);
+                            if (memo is not null
+                                && (memo.GasGiven != (long)TGasPolicy.GetRemainingGas(in _currentState.Gas)
+                                || !ParallelSiblings.SiblingRecorder.IsReplayable(memo, memo.GasGiven, in _currentState.AccessTracker)
+                                || !TGasPolicy.TryConsume(ref _currentState.Gas, (ulong)memo.GasUsed)))
                             {
                                 memo = null;
                             }
@@ -242,7 +235,6 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
 
                         if (memo is not null)
                         {
-                            ParallelSiblings.SiblingRecorder.CountReplay();
                             ParallelSiblings.SiblingRecorder.WarmReplayedTouches(memo, in _currentState.AccessTracker);
                             callResult = new CallResult(memo.Output, null);
                         }
@@ -812,7 +804,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                 _siblingGasGiven);
             _siblingLogsAtStart = _currentState.AccessTracker.Logs.Count;
             _siblingDestroysAtStart = _currentState.AccessTracker.DestroyList.Count;
-            ParallelSiblings.SiblingRecorder.BeginSibling(_siblingSiteKey);
+            ParallelSiblings.SiblingRecorder.BeginSibling(in _siblingSiteKey);
         }
 
         // Clear the previous call result as the execution context is moving to a new frame.

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -244,6 +244,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                     {
                         TraceTransactionActionEnd(_currentState, callResult);
                     }
+                    ParallelSiblings.SiblingRecorder.AbortSibling();
                     TransactionSubstate substate = PrepareTopLevelSubstate(in callResult);
                     _currentState = null;
                     return substate;
@@ -256,6 +257,19 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                     // Restore the previous state from the stack and mark it as a continuation.
                     _currentState = _stateStack.Pop();
                     _currentState.IsContinuation = true;
+                    if (ParallelSiblings.SiblingRecorder.Recording && _currentState.Env.CallDepth == 0)
+                    {
+                        // Net-write-empty: the change journals sit where they were when the sibling
+                        // started - everything it wrote internally was reverted away. Those frames
+                        // are the memoizable population.
+                        Evm.State.Snapshot now = _worldState.TakeSnapshot();
+                        ref readonly Evm.State.Snapshot start = ref previousState.Snapshot;
+                        bool netWriteEmpty =
+                            now.StateSnapshot == start.StateSnapshot
+                            && now.StorageSnapshot.PersistentStorageSnapshot == start.StorageSnapshot.PersistentStorageSnapshot
+                            && now.StorageSnapshot.TransientStorageSnapshot == start.StorageSnapshot.TransientStorageSnapshot;
+                        ParallelSiblings.SiblingRecorder.EndSibling(netWriteEmpty);
+                    }
                     bool previousStateSucceeded = true;
 
                     if (!callResult.ShouldRevert)
@@ -732,6 +746,16 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
 
         // Transition to the next call frame's state provided by the call result.
         _currentState = callResult.StateToExecute;
+        // Depth-1 siblings of a cancelable frame are recorded for the parallel-sibling arbiter;
+        // the cancelable gate keeps block processing structurally outside this machinery.
+        if (_txTracer.IsCancelable && _currentState.Env.CallDepth == 1)
+        {
+            ParallelSiblings.SiblingRecorder.BeginSibling(
+                (_blockExecutionContext.Header.StateRoot ?? Keccak.Zero).ValueHash256,
+                _currentState.Env.CodeSource,
+                _currentState.Env.InputData.Span,
+                in _currentState.Env.Value);
+        }
 
         // Clear the previous call result as the execution context is moving to a new frame.
         _previousCallResult = null;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -224,10 +224,17 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                             && !_currentState.ExecutionType.IsAnyCreate())
                         {
                             memo = ParallelSiblings.SiblingRecorder.TryGet(_siblingSiteKey);
-                            if (memo is not null
-                                && (memo.GasGiven != (long)TGasPolicy.GetRemainingGas(in _currentState.Gas)
-                                    || !ParallelSiblings.SiblingRecorder.IsReplayable(memo, memo.GasGiven, in _currentState.AccessTracker)
-                                    || !TGasPolicy.TryConsume(ref _currentState.Gas, (ulong)memo.GasUsed)))
+                            if (memo is null)
+                            {
+                                ParallelSiblings.SiblingRecorder.CountLookupMiss();
+                            }
+                            else if (memo.GasGiven != (long)TGasPolicy.GetRemainingGas(in _currentState.Gas))
+                            {
+                                ParallelSiblings.SiblingRecorder.CountGasReject();
+                                memo = null;
+                            }
+                            else if (!ParallelSiblings.SiblingRecorder.IsReplayable(memo, memo.GasGiven, in _currentState.AccessTracker)
+                                || !TGasPolicy.TryConsume(ref _currentState.Gas, (ulong)memo.GasUsed))
                             {
                                 memo = null;
                             }
@@ -235,6 +242,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
 
                         if (memo is not null)
                         {
+                            ParallelSiblings.SiblingRecorder.CountReplay();
                             ParallelSiblings.SiblingRecorder.WarmReplayedTouches(memo, in _currentState.AccessTracker);
                             callResult = new CallResult(memo.Output, null);
                         }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -803,12 +803,13 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
         // gate keeps block processing structurally outside this machinery.
         if (_txTracer.IsCancelable && _currentState.Env.CallDepth == 1)
         {
+            _siblingGasGiven = (long)TGasPolicy.GetRemainingGas(in _currentState.Gas);
             _siblingSiteKey = ParallelSiblings.SiblingRecorder.ComputeSiteKey(
                 (_blockExecutionContext.Header.StateRoot ?? Keccak.Zero).ValueHash256,
                 _currentState.Env.CodeSource,
                 _currentState.Env.InputData.Span,
-                in _currentState.Env.Value);
-            _siblingGasGiven = (long)TGasPolicy.GetRemainingGas(in _currentState.Gas);
+                in _currentState.Env.Value,
+                _siblingGasGiven);
             _siblingLogsAtStart = _currentState.AccessTracker.Logs.Count;
             _siblingDestroysAtStart = _currentState.AccessTracker.DestroyList.Count;
             ParallelSiblings.SiblingRecorder.BeginSibling(_siblingSiteKey);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -105,6 +105,10 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
     private bool _isTracingActionsCached;
 
     private BlockExecutionContext _blockExecutionContext;
+    private long _siblingSiteKey;
+    private long _siblingGasGiven;
+    private int _siblingLogsAtStart;
+    private int _siblingDestroysAtStart;
     public virtual void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext) => _blockExecutionContext = blockExecutionContext;
     public ref readonly BlockExecutionContext BlockExecutionContext => ref _blockExecutionContext;
 
@@ -206,10 +210,41 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                     // Execute the regular EVM call if valid code is present; otherwise, mark as invalid.
                     if (_currentState.Env.CodeInfo is not null)
                     {
-                        callResult = ExecuteCall<TTracingInst>(
-                            _previousCallResult,
-                            previousCallOutput,
-                            _previousCallOutputDestination);
+                        // A fresh depth-1 sibling of a cancelable, non-tracing frame is served from
+                        // its memo when every soundness condition holds: same site, same gas, all
+                        // recorded first-touches still cold, nothing this request wrote among its
+                        // touches. Charging the recorded gas and returning the recorded output here
+                        // makes the frame flow through the ordinary merge path exactly like a child
+                        // that computed instantly; anything unprovable executes normally.
+                        ParallelSiblings.SiblingRecorder.SiteRecord? memo = null;
+                        if (!TTracingInst.IsActive && !_isTracingActionsCached
+                            && !_currentState.IsContinuation
+                            && _currentState.Env.CallDepth == 1
+                            && _txTracer.IsCancelable
+                            && !_currentState.ExecutionType.IsAnyCreate())
+                        {
+                            memo = ParallelSiblings.SiblingRecorder.TryGet(_siblingSiteKey);
+                            if (memo is not null
+                                && (memo.GasGiven != (long)TGasPolicy.GetRemainingGas(in _currentState.Gas)
+                                    || !ParallelSiblings.SiblingRecorder.IsReplayable(memo, memo.GasGiven, in _currentState.AccessTracker)
+                                    || !TGasPolicy.TryConsume(ref _currentState.Gas, (ulong)memo.GasUsed)))
+                            {
+                                memo = null;
+                            }
+                        }
+
+                        if (memo is not null)
+                        {
+                            ParallelSiblings.SiblingRecorder.WarmReplayedTouches(memo, in _currentState.AccessTracker);
+                            callResult = new CallResult(memo.Output, null);
+                        }
+                        else
+                        {
+                            callResult = ExecuteCall<TTracingInst>(
+                                _previousCallResult,
+                                previousCallOutput,
+                                _previousCallOutputDestination);
+                        }
                     }
                     else
                     {
@@ -244,7 +279,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                     {
                         TraceTransactionActionEnd(_currentState, callResult);
                     }
-                    ParallelSiblings.SiblingRecorder.AbortSibling();
+                    ParallelSiblings.SiblingRecorder.EndTopFrame();
                     TransactionSubstate substate = PrepareTopLevelSubstate(in callResult);
                     _currentState = null;
                     return substate;
@@ -257,18 +292,28 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
                     // Restore the previous state from the stack and mark it as a continuation.
                     _currentState = _stateStack.Pop();
                     _currentState.IsContinuation = true;
-                    if (ParallelSiblings.SiblingRecorder.Recording && _currentState.Env.CallDepth == 0)
+                    if (_txTracer.IsCancelable && _currentState.Env.CallDepth == 0)
                     {
-                        // Net-write-empty: the change journals sit where they were when the sibling
-                        // started - everything it wrote internally was reverted away. Those frames
-                        // are the memoizable population.
+                        // Clean frame: the change journals sit where they were when the sibling
+                        // started (everything it wrote internally was reverted away), it emitted
+                        // no logs, destroyed nothing and accrued no refund. Those frames are the
+                        // memoizable population.
                         Evm.State.Snapshot now = _worldState.TakeSnapshot();
                         ref readonly Evm.State.Snapshot start = ref previousState.Snapshot;
-                        bool netWriteEmpty =
+                        bool cleanFrame =
                             now.StateSnapshot == start.StateSnapshot
                             && now.StorageSnapshot.PersistentStorageSnapshot == start.StorageSnapshot.PersistentStorageSnapshot
-                            && now.StorageSnapshot.TransientStorageSnapshot == start.StorageSnapshot.TransientStorageSnapshot;
-                        ParallelSiblings.SiblingRecorder.EndSibling(netWriteEmpty);
+                            && now.StorageSnapshot.TransientStorageSnapshot == start.StorageSnapshot.TransientStorageSnapshot
+                            && _currentState.AccessTracker.Logs.Count == _siblingLogsAtStart
+                            && _currentState.AccessTracker.DestroyList.Count == _siblingDestroysAtStart
+                            && previousState.Refund == 0
+                            && !previousState.ExecutionType.IsAnyCreate();
+                        bool succeeded = !callResult.ShouldRevert && !callResult.IsException;
+                        long gasUsed = _siblingGasGiven - (long)TGasPolicy.GetRemainingGas(in previousState.Gas);
+                        ParallelSiblings.SiblingRecorder.EndSibling(
+                            cleanFrame, succeeded, _siblingGasGiven, gasUsed,
+                            tookValue: !previousState.Env.Value.IsZero,
+                            output: callResult.Output.Span);
                     }
                     bool previousStateSucceeded = true;
 
@@ -746,15 +791,19 @@ public unsafe partial class VirtualMachine<TGasPolicy>(
 
         // Transition to the next call frame's state provided by the call result.
         _currentState = callResult.StateToExecute;
-        // Depth-1 siblings of a cancelable frame are recorded for the parallel-sibling arbiter;
-        // the cancelable gate keeps block processing structurally outside this machinery.
+        // Depth-1 siblings of a cancelable frame go through the memo bookkeeping; the cancelable
+        // gate keeps block processing structurally outside this machinery.
         if (_txTracer.IsCancelable && _currentState.Env.CallDepth == 1)
         {
-            ParallelSiblings.SiblingRecorder.BeginSibling(
+            _siblingSiteKey = ParallelSiblings.SiblingRecorder.ComputeSiteKey(
                 (_blockExecutionContext.Header.StateRoot ?? Keccak.Zero).ValueHash256,
                 _currentState.Env.CodeSource,
                 _currentState.Env.InputData.Span,
                 in _currentState.Env.Value);
+            _siblingGasGiven = (long)TGasPolicy.GetRemainingGas(in _currentState.Gas);
+            _siblingLogsAtStart = _currentState.AccessTracker.Logs.Count;
+            _siblingDestroysAtStart = _currentState.AccessTracker.DestroyList.Count;
+            ParallelSiblings.SiblingRecorder.BeginSibling(_siblingSiteKey);
         }
 
         // Clear the previous call result as the execution context is moving to a new frame.


### PR DESCRIPTION
**This is result caching, not a faster interpreter.** A batch contract that performs the same inner call in successive requests performs identical work; this recognizes that and serves the later occurrences from the first one's recorded result. The speedup is "not redoing identical work", and any comparison that quotes it should say so.

Draft: the test work listed at the bottom is not written yet.

## Read the benchmark before reading the number

**The benchmark sends the same `eth_call` 1200 times** - I verified it: 400 sampled requests, one distinct calldata, differing only in the JSON-RPC id. So the figures below measure a near-100% hit rate on a repeated request, and they are **not a cross-client comparison**: another client computes all 1200, this branch computes the first and reassembles the rest from memos. Quoting 27.7 ms against another implementation on this corpus would be misleading, and I am not proposing it.

What the number does establish is that the mechanism works and is exact. What it does not establish is the gain on real traffic, where amounts and pools vary per request, inner calldata differs, digests differ and the lookups miss. That measurement - a varied corpus with a real repeat distribution - is the one that decides whether this feature is worth its complexity, and it is not done.

## Measured on the repeated-request corpus

Same runner, same snapshot set, same protocol, back to back. Pool-heavy `eth_call` batch, 59 inner calls per request, 20 rps / 512 vus / 60s:

| | p50 | p99 |
|---|---|---|
| master | 312.9 ms | 492.8 ms |
| this branch | **27.7 ms** | **45.8 ms** |

**Responses are byte-identical to master** - sha256 `4ff354309e04` over the full 23,275-byte result, compared with `deep-check-compare.py` over replayed workload requests. k6's checks only see "a response arrived", so they are not the gate; this is.

In steady state: 188 of 209 sites memoizable, ~33 replays per request, zero gas rejections, zero warmth rejections. The remaining ~13% (18 that left state behind, 9 that reverted) executes serially, always.

## What makes a replay sound

A sibling's result is a function of (state at its start, callee, calldata, value, gas handed over). The state at its start is the state root plus the effects of everything that ran before it in this request. So the memo key is a **256-bit Keccak digest** over the sibling's own inputs, chained through a running Keccak chain that absorbs each preceding sibling's digest and every state write in the glue between them. A digest match therefore implies the same starting state. Any divergence upstream - a different call, a different amount, an extra write - changes the chain, the lookup misses, and the frame executes normally. Keccak rather than a hash-combine because a 32-bit collision would serve a foreign memo: a wrong answer, not a slow one.

Two further conditions, both required:

- **Recorded** only when the sibling left no net state - its change-journal positions at merge equal the ones at its start - emitted no logs, destroyed nothing, accrued no refund, took no value, and succeeded. A quoter that simulates a swap and reverts it satisfies this. A frame that actually wrote never gets a memo.
- **Replayed** only when every cell the recording touched cold is still cold here, checked live against the access tracker. That is what makes charging the recorded gas exact with no arithmetic anywhere. Replay then warms those cells for real, because later siblings' charges depend on that warmth.

Gated on `_txTracer.IsCancelable` and depth-1 frames of a non-tracing call, so block processing is structurally outside all of it. A replay produces its result at the point a fresh frame would have started executing, so it flows through the ordinary merge path exactly like a child that computed instantly - no duplicated merge logic.

## How the conditions were arrived at

Instrumentation first: on this workload 78.9% of siblings leave no net state, a repeated site's touch set is stable across occurrences 100.0% of the time, and 88.3% of sibling executions have a previous occurrence to serve from. Then five diagnostic cycles, each one a counter that named its own cause:

1. Gas rejections dominated - 63/64 forwarding gives the same call different gas at different positions, so gas joined the identity.
2. Touch-set overlap rejected everything - one writer among 838 touches per quote poisons every later read.
3. Poisoning by actual writes still rejected everything, because a quoter writes and then reverts: only writes that survive can matter.
4. Prefix disjointness was the wrong instrument entirely - replaced by chaining, which subsumes it.
5. Then it worked, and the deep-check comparison confirmed the results were unchanged.

## Not done yet

- **The measurement that matters: a varied workload.** Same pools, different amounts per request, plus a realistic repeat distribution, to find the actual hit rate and the actual gain. Everything below is secondary to this.
- Randomized differential with memoization enabled, plus targeted regressions: a writer sibling, value forwarding, out-of-gas inside a sibling, tracing on and off, head change mid-flight.
- A soak at the tip to confirm the store behaves across head changes. The state root is in every key, so entries rotate rather than go stale, but that deserves a test rather than an argument.

## Unrelated finding, and it is worse than cross-client

On this workload one 32-byte word of the result differs - offset 84, `0x871f0a` against `0x8753c6`, a quote amount about 0.2% apart. I first read that as a cross-client difference. It is not: with the stream interpreter switched off, **this node's own bytecode loop returns `0x8753c6`**, matching the other client, while the stream interpreter returns `0x871f0a`. Same node, same snapshot, same chain head 25489890, same request.

So the two interpreters inside Nethermind disagree on a Uniswap V3 quoter path that `eth_call` serves in production, and the stream interpreter is the one standing alone. That is being hunted separately; the randomized differential does not reproduce it, so it needs a feature bisect on the real workload.