### PR TITLE
fix(receipts): restore the post-merge flag before regeneration

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/Nethermind.Consensus.Test.csproj
+++ b/src/Nethermind/Nethermind.Consensus.Test/Nethermind.Consensus.Test.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
     <ProjectReference Include="..\Nethermind.Evm.Test\Nethermind.Evm.Test.csproj" />
     <ProjectReference Include="..\Nethermind.Init\Nethermind.Init.csproj" />
+    <ProjectReference Include="..\Nethermind.Merge.Plugin\Nethermind.Merge.Plugin.csproj" />
     <ProjectReference Include="..\Nethermind.Specs.Test\Nethermind.Specs.Test.csproj" />
     <ProjectReference Include="..\Nethermind.Specs\Nethermind.Specs.csproj" />
   </ItemGroup>

--- a/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
@@ -77,7 +77,7 @@ public class ReceiptsRegenerationTests
             _chain.Container.Resolve<ILifetimeScope>(),
             [.. _chain.Container.Resolve<IEnumerable<IBlockValidationModule>>()]);
         _envSource = factory.Create(maxConcurrent: 2);
-        _regenerator = new ReceiptsRegenerator(_envSource, _chain.BlockFinder, _chain.SpecProvider, _chain.EthereumEcdsa, LimboLogs.Instance);
+        _regenerator = new ReceiptsRegenerator(_envSource, _chain.BlockFinder, _chain.SpecProvider, _chain.EthereumEcdsa, _chain.PoSSwitcher, LimboLogs.Instance);
     }
 
     [OneTimeTearDown]
@@ -103,11 +103,13 @@ public class ReceiptsRegenerationTests
     }
 
     // Storage does not persist the post-merge flag, so a queried block re-executes with it cleared; the regenerator
-    // must restore it or PREVRANDAO evaluates to the pre-merge difficulty — zero on every post-merge header — and
-    // any transaction reading it regenerates receipts that fail the root check.
+    // must restore it from the switcher or PREVRANDAO evaluates to the difficulty field instead of the mix hash,
+    // and any transaction reading it regenerates receipts that fail the root check.
     [Test]
     public void Regenerates_a_post_merge_block_whose_stored_header_lost_the_flag()
     {
+        ReceiptsRegenerator regenerator = new(
+            _envSource, _chain.BlockFinder, _chain.SpecProvider, _chain.EthereumEcdsa, AlwaysPoS.Instance, LimboLogs.Instance);
         BlockHeader parent = _chain.BlockTree.Head!.Header;
         ulong nonce = _chain.WorldStateManager.GlobalStateReader.GetNonce(parent, TestItem.PrivateKeyA.Address);
         Block postMerge = Build.A.Block
@@ -133,7 +135,7 @@ public class ReceiptsRegenerationTests
         Block reloaded = new(postMerge.Header.Clone(), postMerge.Body);
         reloaded.Header.IsPostMerge = false;
 
-        Assert.That(_regenerator.TryRegenerate(reloaded, out TxReceipt[] regenerated), Is.True,
+        Assert.That(regenerator.TryRegenerate(reloaded, out TxReceipt[] regenerated), Is.True,
             "re-execution must read PREVRANDAO from the mix hash, not the zeroed difficulty");
         Assert.That(ReceiptsRootCalculator.Instance.GetReceiptsRoot(regenerated, spec, reloaded.Header.ReceiptsRoot),
             Is.EqualTo(reloaded.Header.ReceiptsRoot));
@@ -181,6 +183,7 @@ public class ReceiptsRegenerationTests
             Substitute.For<IBlockFinder>(),
             new TestSpecProvider(Frontier.Instance),
             Substitute.For<IEthereumEcdsa>(),
+            NoPoS.Instance,
             LimboLogs.Instance);
 
         Assert.That(regenerator.TryRegenerate(Build.A.Block.TestObject, out _), Is.False);
@@ -199,6 +202,7 @@ public class ReceiptsRegenerationTests
             Substitute.For<IBlockFinder>(),
             new TestSpecProvider(Frontier.Instance),
             Substitute.For<IEthereumEcdsa>(),
+            NoPoS.Instance,
             LimboLogs.Instance);
         IReceiptFinder inner = Substitute.For<IReceiptFinder>();
         inner.Get(Arg.Any<Block>(), Arg.Any<bool>(), Arg.Any<bool>()).Returns([]);

--- a/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
@@ -127,6 +127,7 @@ public class ReceiptsRegenerationTests
                 postMerge, ProcessingOptions.ReadOnlyChain | ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
             postMerge.Header.ReceiptsRoot = ReceiptsRootCalculator.Instance.GetReceiptsRoot(processed, spec, postMerge.Header.ReceiptsRoot);
         }
+        postMerge.DisposeAccountChanges();
         postMerge.Header.Hash = postMerge.Header.CalculateHash();
 
         Block reloaded = new(postMerge.Header.Clone(), postMerge.Body);
@@ -136,6 +137,8 @@ public class ReceiptsRegenerationTests
             "re-execution must read PREVRANDAO from the mix hash, not the zeroed difficulty");
         Assert.That(ReceiptsRootCalculator.Instance.GetReceiptsRoot(regenerated, spec, reloaded.Header.ReceiptsRoot),
             Is.EqualTo(reloaded.Header.ReceiptsRoot));
+        Assert.That(regenerated[0].Logs[0].Data, Is.EqualTo(TestItem.KeccakB.BytesToArray()),
+            "the logged PREVRANDAO bytes must be the mix hash itself");
     }
 
     [TestCase(true, Description = "receipts on disk are served as-is, without re-execution")]

--- a/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
@@ -10,7 +10,9 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
+using Nethermind.Blockchain.Tracing;
 using Nethermind.Config;
+using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Receipts;
 using Nethermind.Core;
 using Nethermind.Core.Container;
@@ -45,6 +47,8 @@ public class ReceiptsRegenerationTests
     private static readonly byte[] LogEmittingInitCode = [0x60, 0x00, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xf3];
     // REVERT immediately — a create that fails, so its receipt carries status 0 and no contract address.
     private static readonly byte[] RevertingInitCode = [0x60, 0x00, 0x60, 0x00, 0xfd];
+    // PREVRANDAO, MSTORE at 0, LOG0 the 32 bytes, RETURN nothing — the receipts root commits to the opcode's value.
+    private static readonly byte[] PrevRandaoLoggingInitCode = [0x44, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xa0, 0x60, 0x00, 0x60, 0x00, 0xf3];
 
     public enum Scenario
     {
@@ -96,6 +100,42 @@ public class ReceiptsRegenerationTests
 
         Assert.That(_regenerator.TryRegenerate(block, out TxReceipt[] regenerated), Is.True);
         AssertReceiptsMatch(stored, regenerated, block);
+    }
+
+    // Storage does not persist the post-merge flag, so a queried block re-executes with it cleared; the regenerator
+    // must restore it or PREVRANDAO evaluates to the pre-merge difficulty — zero on every post-merge header — and
+    // any transaction reading it regenerates receipts that fail the root check.
+    [Test]
+    public void Regenerates_a_post_merge_block_whose_stored_header_lost_the_flag()
+    {
+        BlockHeader parent = _chain.BlockTree.Head!.Header;
+        ulong nonce = _chain.WorldStateManager.GlobalStateReader.GetNonce(parent, TestItem.PrivateKeyA.Address);
+        Block postMerge = Build.A.Block
+            .WithParent(parent)
+            .WithDifficulty(0)
+            .WithMixHash(TestItem.KeccakB)
+            .WithPostMergeFlag(true)
+            .WithTransactions(Create(nonce, PrevRandaoLoggingInitCode))
+            .TestObject;
+
+        // Ground truth mirroring live processing: execute with the flag intact and commit the resulting receipts
+        // root, which captures the logged PREVRANDAO bytes.
+        IReleaseSpec spec = _chain.SpecProvider.GetSpec(postMerge.Header);
+        using (Scope<ReceiptsRegenerationEnv> scope = _envSource.BuildAndOverride(parent.Clone()))
+        {
+            (Block _, TxReceipt[] processed) = scope.Component.BlockProcessor.ProcessOne(
+                postMerge, ProcessingOptions.ReadOnlyChain | ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
+            postMerge.Header.ReceiptsRoot = ReceiptsRootCalculator.Instance.GetReceiptsRoot(processed, spec, postMerge.Header.ReceiptsRoot);
+        }
+        postMerge.Header.Hash = postMerge.Header.CalculateHash();
+
+        Block reloaded = new(postMerge.Header.Clone(), postMerge.Body);
+        reloaded.Header.IsPostMerge = false;
+
+        Assert.That(_regenerator.TryRegenerate(reloaded, out TxReceipt[] regenerated), Is.True,
+            "re-execution must read PREVRANDAO from the mix hash, not the zeroed difficulty");
+        Assert.That(ReceiptsRootCalculator.Instance.GetReceiptsRoot(regenerated, spec, reloaded.Header.ReceiptsRoot),
+            Is.EqualTo(reloaded.Header.ReceiptsRoot));
     }
 
     [TestCase(true, Description = "receipts on disk are served as-is, without re-execution")]

--- a/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
@@ -110,31 +110,47 @@ public class ReceiptsRegenerationTests
     // and any transaction reading it regenerates receipts that fail the root check.
     [Test]
     public void Regenerates_a_post_merge_block_whose_stored_header_lost_the_flag() =>
-        AssertRegeneratesPostMergeBlock(AlwaysPoS.Instance);
+        AssertRegeneratesPostMergeBlock(_chain, _envSource, Regenerator(AlwaysPoS.Instance));
 
     // The production failure arrived as a mainnet-shaped header with TotalDifficulty unset; this pins the real
     // switcher's TD-null derivation end to end, not only the honour-the-switcher contract AlwaysPoS covers.
     [Test]
-    public void Regenerates_a_post_merge_block_through_the_real_switcher()
+    public void Regenerates_a_post_merge_block_through_the_real_switcher() =>
+        AssertRegeneratesPostMergeBlock(_chain, _envSource, Regenerator(RealSwitcher(Substitute.For<IBlockTree>())));
+
+    // The direct-injection cases above would keep passing if a composition change left the container-resolved
+    // regenerator on the NoPoS default; this resolves it from a graph whose switcher registration is overridden
+    // the way a merge-enabled node overrides it.
+    [Test]
+    public async Task Container_resolved_regenerator_uses_the_registered_switcher()
     {
-        TestSpecProvider mergeSpecProvider = new(Berlin.Instance) { TerminalTotalDifficulty = 1 };
-        PoSSwitcher poSSwitcher = new(
-            new MergeConfig(),
-            new SyncConfig(),
-            new MemDb(),
-            Substitute.For<IBlockTree>(),
-            mergeSpecProvider,
-            new ChainSpec(),
-            LimboLogs.Instance);
-        AssertRegeneratesPostMergeBlock(poSSwitcher);
+        using RecoverReceiptsBlockchain chain = await RecoverReceiptsBlockchain.Create(builder =>
+            builder.AddSingleton<IPoSSwitcher>(ctx => RealSwitcher(ctx.Resolve<IBlockTree>())));
+
+        AssertRegeneratesPostMergeBlock(chain,
+            chain.Container.Resolve<IShareableOverridableEnvSource<ReceiptsRegenerationEnv>>(),
+            chain.Container.Resolve<ReceiptsRegenerator>());
     }
 
-    private void AssertRegeneratesPostMergeBlock(IPoSSwitcher poSSwitcher)
+    private ReceiptsRegenerator Regenerator(IPoSSwitcher poSSwitcher) => new(
+        _envSource, _chain.BlockFinder, _chain.SpecProvider, _chain.EthereumEcdsa, poSSwitcher, LimboLogs.Instance);
+
+    private static PoSSwitcher RealSwitcher(IBlockTree blockTree) => new(
+        new MergeConfig(),
+        new SyncConfig(),
+        new MemDb(),
+        blockTree,
+        new TestSpecProvider(Berlin.Instance) { TerminalTotalDifficulty = 1 },
+        new ChainSpec(),
+        LimboLogs.Instance);
+
+    private static void AssertRegeneratesPostMergeBlock(
+        BasicTestBlockchain chain,
+        IShareableOverridableEnvSource<ReceiptsRegenerationEnv> envSource,
+        ReceiptsRegenerator regenerator)
     {
-        ReceiptsRegenerator regenerator = new(
-            _envSource, _chain.BlockFinder, _chain.SpecProvider, _chain.EthereumEcdsa, poSSwitcher, LimboLogs.Instance);
-        BlockHeader parent = _chain.BlockTree.Head!.Header;
-        ulong nonce = _chain.WorldStateManager.GlobalStateReader.GetNonce(parent, TestItem.PrivateKeyA.Address);
+        BlockHeader parent = chain.BlockTree.Head!.Header;
+        ulong nonce = chain.WorldStateManager.GlobalStateReader.GetNonce(parent, TestItem.PrivateKeyA.Address);
         Block postMerge = Build.A.Block
             .WithParent(parent)
             .WithDifficulty(0)
@@ -145,8 +161,8 @@ public class ReceiptsRegenerationTests
 
         // Ground truth mirroring live processing: execute with the flag intact and commit the resulting receipts
         // root, which captures the logged PREVRANDAO bytes.
-        IReleaseSpec spec = _chain.SpecProvider.GetSpec(postMerge.Header);
-        using (Scope<ReceiptsRegenerationEnv> scope = _envSource.BuildAndOverride(parent.Clone()))
+        IReleaseSpec spec = chain.SpecProvider.GetSpec(postMerge.Header);
+        using (Scope<ReceiptsRegenerationEnv> scope = envSource.BuildAndOverride(parent.Clone()))
         {
             (Block _, TxReceipt[] processed) = scope.Component.BlockProcessor.ProcessOne(
                 postMerge, ProcessingOptions.ReadOnlyChain | ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
@@ -413,10 +429,14 @@ public class ReceiptsRegenerationTests
 
     private sealed class RecoverReceiptsBlockchain : BasicTestBlockchain
     {
-        public static async Task<RecoverReceiptsBlockchain> Create()
+        public static async Task<RecoverReceiptsBlockchain> Create(Action<ContainerBuilder> configure = null)
         {
             RecoverReceiptsBlockchain chain = new();
-            await chain.Build(builder => builder.AddSingleton<ISpecProvider>(new TestSpecProvider(Berlin.Instance)));
+            await chain.Build(builder =>
+            {
+                builder.AddSingleton<ISpecProvider>(new TestSpecProvider(Berlin.Instance));
+                configure?.Invoke(builder);
+            });
 
             // TestBlockchain runs no init steps or persist cycles: establish the genesis floor and prove capture
             // through its already-covered completion path (the walk itself is covered by HistoryWriterTests).

--- a/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
+using Nethermind.Blockchain.Synchronization;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Config;
 using Nethermind.Consensus.Processing;
@@ -27,7 +28,9 @@ using Nethermind.JsonRpc.Data;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.Db;
 using Nethermind.Logging;
+using Nethermind.Merge.Plugin;
 using Nethermind.Specs;
+using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
 using Nethermind.State.Flat;
@@ -106,10 +109,30 @@ public class ReceiptsRegenerationTests
     // must restore it from the switcher or PREVRANDAO evaluates to the difficulty field instead of the mix hash,
     // and any transaction reading it regenerates receipts that fail the root check.
     [Test]
-    public void Regenerates_a_post_merge_block_whose_stored_header_lost_the_flag()
+    public void Regenerates_a_post_merge_block_whose_stored_header_lost_the_flag() =>
+        AssertRegeneratesPostMergeBlock(AlwaysPoS.Instance);
+
+    // The production failure arrived as a mainnet-shaped header with TotalDifficulty unset; this pins the real
+    // switcher's TD-null derivation end to end, not only the honour-the-switcher contract AlwaysPoS covers.
+    [Test]
+    public void Regenerates_a_post_merge_block_through_the_real_switcher()
+    {
+        TestSpecProvider mergeSpecProvider = new(Berlin.Instance) { TerminalTotalDifficulty = 1 };
+        PoSSwitcher poSSwitcher = new(
+            new MergeConfig(),
+            new SyncConfig(),
+            new MemDb(),
+            Substitute.For<IBlockTree>(),
+            mergeSpecProvider,
+            new ChainSpec(),
+            LimboLogs.Instance);
+        AssertRegeneratesPostMergeBlock(poSSwitcher);
+    }
+
+    private void AssertRegeneratesPostMergeBlock(IPoSSwitcher poSSwitcher)
     {
         ReceiptsRegenerator regenerator = new(
-            _envSource, _chain.BlockFinder, _chain.SpecProvider, _chain.EthereumEcdsa, AlwaysPoS.Instance, LimboLogs.Instance);
+            _envSource, _chain.BlockFinder, _chain.SpecProvider, _chain.EthereumEcdsa, poSSwitcher, LimboLogs.Instance);
         BlockHeader parent = _chain.BlockTree.Head!.Header;
         ulong nonce = _chain.WorldStateManager.GlobalStateReader.GetNonce(parent, TestItem.PrivateKeyA.Address);
         Block postMerge = Build.A.Block
@@ -134,6 +157,7 @@ public class ReceiptsRegenerationTests
 
         Block reloaded = new(postMerge.Header.Clone(), postMerge.Body);
         reloaded.Header.IsPostMerge = false;
+        reloaded.Header.TotalDifficulty = null;
 
         Assert.That(regenerator.TryRegenerate(reloaded, out TxReceipt[] regenerated), Is.True,
             "re-execution must read PREVRANDAO from the mix hash, not the zeroed difficulty");

--- a/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Receipts/ReceiptsRegenerationTests.cs
@@ -429,7 +429,7 @@ public class ReceiptsRegenerationTests
 
     private sealed class RecoverReceiptsBlockchain : BasicTestBlockchain
     {
-        public static async Task<RecoverReceiptsBlockchain> Create(Action<ContainerBuilder> configure = null)
+        public static new async Task<RecoverReceiptsBlockchain> Create(Action<ContainerBuilder> configure = null)
         {
             RecoverReceiptsBlockchain chain = new();
             await chain.Build(builder =>

--- a/src/Nethermind/Nethermind.Consensus/Receipts/ReceiptsRegenerator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Receipts/ReceiptsRegenerator.cs
@@ -63,7 +63,12 @@ public sealed class ReceiptsRegenerator(
         // buffers, and generated access list, and this runs on RPC threads against the shared block-tree instance —
         // so it must never see that instance. The parent header is cloned for the same reason (BuildAndOverride
         // assigns the resolved state root into whatever header it is handed).
-        Block isolated = new(block.Header.Clone(), block.Body, block.BlockAccessList);
+        BlockHeader isolatedHeader = block.Header.Clone();
+        // Storage does not persist the post-merge flag and this path bypasses the recovery step that restores it;
+        // without it PREVRANDAO evaluates to the pre-merge difficulty — zero — and any transaction reading it
+        // regenerates receipts that fail the root check. Same derivation as BlockchainBridge's call header.
+        isolatedHeader.IsPostMerge = isolatedHeader.Difficulty == 0;
+        Block isolated = new(isolatedHeader, block.Body, block.BlockAccessList);
         try
         {
             using Scope<ReceiptsRegenerationEnv> scope = envSource.BuildAndOverride(parent.Clone());

--- a/src/Nethermind/Nethermind.Consensus/Receipts/ReceiptsRegenerator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Receipts/ReceiptsRegenerator.cs
@@ -35,6 +35,7 @@ public sealed class ReceiptsRegenerator(
     IBlockFinder blockFinder,
     ISpecProvider specProvider,
     IEthereumEcdsa ecdsa,
+    IPoSSwitcher poSSwitcher,
     ILogManager logManager)
 {
     private readonly ILogger _logger = logManager.GetClassLogger<ReceiptsRegenerator>();
@@ -65,9 +66,10 @@ public sealed class ReceiptsRegenerator(
         // assigns the resolved state root into whatever header it is handed).
         BlockHeader isolatedHeader = block.Header.Clone();
         // Storage does not persist the post-merge flag and this path bypasses the recovery step that restores it;
-        // without it PREVRANDAO evaluates to the pre-merge difficulty — zero — and any transaction reading it
-        // regenerates receipts that fail the root check. Same derivation as BlockchainBridge's call header.
-        isolatedHeader.IsPostMerge = isolatedHeader.Difficulty == 0;
+        // without it PREVRANDAO evaluates to the pre-merge difficulty and any transaction reading it regenerates
+        // receipts that fail the root check. The switcher owns the classification - a difficulty heuristic would
+        // misread chains that repurpose the field, like Taiko's per-block ZK gas.
+        isolatedHeader.IsPostMerge = poSSwitcher.IsPostMerge(isolatedHeader);
         Block isolated = new(isolatedHeader, block.Body, block.BlockAccessList);
         try
         {


### PR DESCRIPTION
## Problem

On an archive running `--Receipt.DeriveFromState=true`, ~7% of post-merge blocks refuse to serve receipts: `eth_getBlockReceipts`/`eth_getTransactionReceipt` return `-32602 "neither stored nor reproducible"`, `eth_getLogs` returns `4444`, and the log shows the regenerated receipts root disagreeing with the header. Deterministic per block; pre-merge blocks are unaffected.

## Cause

`RegeneratingReceiptFinder` loads the block from storage, and `IsPostMerge` is not part of the header RLP. `ReceiptsRegenerator` then calls `BlockProcessor.ProcessOne` directly, bypassing `MergeProcessingRecoveryStep`, which is what restores the flag on the main processing path. With the flag cleared, `BlockExecutionContext.GetDefaultPrevRandao` falls back to the difficulty - zero on every post-merge header - so any transaction reading PREVRANDAO diverges, and the (correct) root check refuses the result. `eth_call` already compensates for the same round-trip (`BlockchainBridge` derives the flag from `Difficulty == 0`); regeneration missed the same step.

## Fix

Derive the flag on the isolated header the same way the bridge does. Regression test: a post-merge-shaped block whose transaction logs PREVRANDAO, so the committed receipts root captures the value - fails without the fix.

Nothing wrong is ever persisted (regeneration is read-path only), so affected nodes recover by upgrading, without resync.
