### PR TITLE
perf(evm): fold through glued pushes and fuse PUSH1 into the DUP that follows

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/StreamGasFuzzTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/StreamGasFuzzTests.cs
@@ -113,7 +113,7 @@ public class StreamGasFuzzTests : VirtualMachineTestsBase
         int slots = 6 + random.Next(18);
         for (int i = 0; i < slots; i++)
         {
-            switch (random.Next(20))
+            switch (random.Next(22))
             {
                 case 0:
                     jumpDests.Add(code.Count);
@@ -217,6 +217,17 @@ public class StreamGasFuzzTests : VirtualMachineTestsBase
                     // A table handler that consumes its successor and lands past it - adjacent to a
                     // random JUMPDEST from case 0 this is the elided-marker landing.
                     code.AddRange([(byte)Instruction.PUSH1, (byte)random.Next(256), (byte)Instruction.EXTCODESIZE, (byte)Instruction.ISZERO]);
+                    break;
+                case 19:
+                    // PUSH1 feeding a DUP at mixed depths, and the glued PUSH1 pair followed by an
+                    // operator - the two shapes wave two rewrites.
+                    code.AddRange([(byte)Instruction.PUSH1, (byte)random.Next(256), (byte)((byte)Instruction.DUP1 + random.Next(8))]);
+                    break;
+                case 20:
+                    code.AddRange([
+                        (byte)Instruction.PUSH1, (byte)random.Next(256),
+                        (byte)Instruction.PUSH1, (byte)random.Next(9),
+                        (byte)(random.Next(4) switch { 0 => Instruction.SHL, 1 => Instruction.SHR, 2 => Instruction.ADD, _ => Instruction.DIV })]);
                     break;
                 case 18:
                     // Pushes of every width, so folds and pool references cross the PUSH8/PUSH9 seam.

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
@@ -62,6 +62,8 @@ internal static class FusedOpcode
     public const byte AndIsZero = 0x4C;
     public const byte PopPop = 0x4D;
     public const byte SwapPop = 0x4E;
+    // 0xA5..0xB4 is left alone: the frame-transaction work claims part of that range.
+    public const byte Push1Dup = 0xC0;
 
     /// <summary>Binary ops a preceding in-block PUSH folds into; must match the executor's fused cases exactly.</summary>
     public static bool TryMap(Instruction instruction, out byte fused)
@@ -419,6 +421,34 @@ internal sealed class InstructionStream
     /// </summary>
     private static bool TryFoldConstantPair(List<StreamOp> ops, List<UInt256> constants, ushort[] pcToEntry, Instruction instruction, int pc, byte size)
     {
+        if (ops.Count == 0)
+            return false;
+
+        // A glued PUSH1 pair holds both operands in one entry - the low byte was pushed first, so
+        // the high byte is what an operator consumes first. Folding through it is what stops the
+        // pair from leaving a runtime operation behind: on the measured workload this shape,
+        // followed by a shift, is 2.35% of all dispatches.
+        if (ops[^1].Opcode == FusedOpcode.Push1Push1
+            && ops[^1].Kind is StreamOpKind.FusedInBlock or StreamOpKind.FusedBlockFirst)
+        {
+            StreamOp pair = ops[^1];
+            int pairAdvance = pair.Advance + size;
+            if (pairAdvance > byte.MaxValue)
+                return false;
+
+            UInt256 pairA = (pair.Operand >> 8) & 0xFF;
+            UInt256 pairB = pair.Operand & 0xFF;
+            if (!TryApplyConstOperation(instruction, in pairA, in pairB, out UInt256 pairResult))
+                return false;
+
+            constants.Add(pairResult);
+            pcToEntry[pc] = InvalidEntry;
+            ops[^1] = new StreamOp((byte)Instruction.PUSH32,
+                pair.Kind == StreamOpKind.FusedBlockFirst ? StreamOpKind.BlockFirst : StreamOpKind.InBlock,
+                pair.Pc, pair.BlockIndex, (byte)pairAdvance, (ulong)(constants.Count - 1));
+            return true;
+        }
+
         if (ops.Count < 2)
             return false;
 
@@ -433,28 +463,8 @@ internal sealed class InstructionStream
         if (advance > byte.MaxValue)
             return false;
 
-        UInt256 result;
-        switch (instruction)
-        {
-            case Instruction.ADD: EvmInstructions.OpAdd.Operation(in a, in b, out result); break;
-            case Instruction.SUB: EvmInstructions.OpSub.Operation(in a, in b, out result); break;
-            case Instruction.MUL: EvmInstructions.OpMul.Operation(in a, in b, out result); break;
-            case Instruction.DIV: EvmInstructions.OpDiv.Operation(in a, in b, out result); break;
-            case Instruction.SDIV: EvmInstructions.OpSDiv.Operation(in a, in b, out result); break;
-            case Instruction.MOD: EvmInstructions.OpMod.Operation(in a, in b, out result); break;
-            case Instruction.SMOD: EvmInstructions.OpSMod.Operation(in a, in b, out result); break;
-            case Instruction.LT: EvmInstructions.OpLt.Operation(in a, in b, out result); break;
-            case Instruction.GT: EvmInstructions.OpGt.Operation(in a, in b, out result); break;
-            case Instruction.SLT: EvmInstructions.OpSLt.Operation(in a, in b, out result); break;
-            case Instruction.SGT: EvmInstructions.OpSGt.Operation(in a, in b, out result); break;
-            case Instruction.AND: result = a & b; break;
-            case Instruction.OR: result = a | b; break;
-            case Instruction.XOR: result = a ^ b; break;
-            case Instruction.EQ: result = a == b ? UInt256.One : default; break;
-            case Instruction.SHL: result = !a.IsUint64 || a.u0 >= 256 ? default : b << (int)a.u0; break;
-            case Instruction.SHR: result = !a.IsUint64 || a.u0 >= 256 ? default : b >> (int)a.u0; break;
-            default: return false;
-        }
+        if (!TryApplyConstOperation(instruction, in a, in b, out UInt256 result))
+            return false;
 
         constants.Add(result);
         pcToEntry[top.Pc] = InvalidEntry;
@@ -462,6 +472,38 @@ internal sealed class InstructionStream
         ops.RemoveAt(ops.Count - 1);
         ops[^1] = new StreamOp((byte)Instruction.PUSH32, under.Kind, under.Pc, under.BlockIndex, (byte)advance, (ulong)(constants.Count - 1));
         return true;
+    }
+
+    /// <summary>
+    /// Computes a binary operation over two analysis-time constants, where <paramref name="a"/> is
+    /// the operand the executor would consume first. ADD through SGT run the executor's own
+    /// implementations so those cannot disagree on wrapping or division by zero; the bitwise ops
+    /// and shifts are hand-mirrored from the executor's cores - the shift guard replicates
+    /// ShiftCore's saturation test - so a change to either side must be made to both.
+    /// </summary>
+    private static bool TryApplyConstOperation(Instruction instruction, in UInt256 a, in UInt256 b, out UInt256 result)
+    {
+        switch (instruction)
+        {
+            case Instruction.ADD: EvmInstructions.OpAdd.Operation(in a, in b, out result); return true;
+            case Instruction.SUB: EvmInstructions.OpSub.Operation(in a, in b, out result); return true;
+            case Instruction.MUL: EvmInstructions.OpMul.Operation(in a, in b, out result); return true;
+            case Instruction.DIV: EvmInstructions.OpDiv.Operation(in a, in b, out result); return true;
+            case Instruction.SDIV: EvmInstructions.OpSDiv.Operation(in a, in b, out result); return true;
+            case Instruction.MOD: EvmInstructions.OpMod.Operation(in a, in b, out result); return true;
+            case Instruction.SMOD: EvmInstructions.OpSMod.Operation(in a, in b, out result); return true;
+            case Instruction.LT: EvmInstructions.OpLt.Operation(in a, in b, out result); return true;
+            case Instruction.GT: EvmInstructions.OpGt.Operation(in a, in b, out result); return true;
+            case Instruction.SLT: EvmInstructions.OpSLt.Operation(in a, in b, out result); return true;
+            case Instruction.SGT: EvmInstructions.OpSGt.Operation(in a, in b, out result); return true;
+            case Instruction.AND: result = a & b; return true;
+            case Instruction.OR: result = a | b; return true;
+            case Instruction.XOR: result = a ^ b; return true;
+            case Instruction.EQ: result = a == b ? UInt256.One : default; return true;
+            case Instruction.SHL: result = !a.IsUint64 || a.u0 >= 256 ? default : b << (int)a.u0; return true;
+            case Instruction.SHR: result = !a.IsUint64 || a.u0 >= 256 ? default : b >> (int)a.u0; return true;
+            default: result = default; return false;
+        }
     }
 
     /// <summary>A plain, unfused in-block push whose value analysis knows exactly.</summary>
@@ -486,6 +528,8 @@ internal sealed class InstructionStream
 
         return false;
     }
+
+
 
     /// <summary>
     /// Fuses two adjacent glue ops into one entry when the previously emitted entry is the plain,
@@ -523,6 +567,13 @@ internal sealed class InstructionStream
             // one's in the next, and the executor pushes low then high in that order.
             fused = FusedOpcode.Push1Push1;
             operand = first.Operand | ((ulong)code[pc + 1] << 8);
+        }
+        else if (firstOp == Instruction.PUSH1 && second is >= Instruction.DUP1 and <= Instruction.DUP8)
+        {
+            // The immediate travels in the low byte and the dup depth in the next; the executor
+            // pushes then duplicates, so depth one duplicates the value just pushed.
+            fused = FusedOpcode.Push1Dup;
+            operand = first.Operand | ((ulong)(second - Instruction.DUP1 + 1) << 8);
         }
         else if (second == Instruction.POP && firstOp is >= Instruction.SWAP1 and <= Instruction.SWAP8)
         {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
@@ -113,6 +113,23 @@ public static partial class EvmInstructions
     }
 
     /// <summary>
+    /// Fused <c>PUSH1 v; DUPn</c>, with the immediate in the low byte of the operand and the dup
+    /// depth in the next. The push lands first, so the duplicate is taken relative to a stack that
+    /// already holds it - depth one duplicates the pushed value itself. Failure order matches the
+    /// unfused pair: a full stack overflows on the push, and a dup that reaches below the stack
+    /// underflows, which is what the depth check against the post-push head expresses.
+    /// </summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType FusedPush1DupCore<TTracingInst>(ref EvmStack stack, ulong packed)
+        where TTracingInst : struct, IFlag
+    {
+        EvmExceptionType result = stack.PushUInt64<TTracingInst>(packed & 0xFF);
+        if (result != EvmExceptionType.None) return result;
+        return stack.Dup<TTracingInst>((int)((packed >> 8) & 0xFF));
+    }
+
+    /// <summary>
     /// Fused <c>PUSH const; bitwise-op</c> over the stack-representation pool: one vector load per
     /// operand, no limb conversion.
     /// </summary>

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -175,6 +175,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                         case (Instruction)FusedOpcode.Shr:
                             exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShr>(ref stack, in constants[(int)entry.Operand]);
                             break;
+                        case (Instruction)FusedOpcode.Push1Dup:
+                            exceptionType = EvmInstructions.FusedPush1DupCore<OffFlag>(ref stack, entry.Operand);
+                            break;
                         case (Instruction)FusedOpcode.PopPop:
                             exceptionType = EvmInstructions.FusedPopPopCore(ref stack);
                             break;


### PR DESCRIPTION
Stacked on #12626 - the diff against that branch is this change alone.

Two shapes an opcode histogram of a pool-heavy `eth_call` workload puts at the top of what the first fusion wave left behind.

**A glued PUSH1 pair followed by an operator** was 2.35% of all dispatches, performing at run time arithmetic that analysis could have performed. The pair carries both immediates in one entry, and the constant fold only recognised two separate pushes, so it never reached through. It does now: the high immediate is the operand an operator consumes first, which is what makes the fold exact.

**PUSH1 feeding a DUP** is another 5.8%, and it glues the way the other stack pairs do. The push lands first, so depth one duplicates the value just pushed, and the failure order follows from that: a full stack overflows on the push, and a dup reaching below the stack underflows.

Total dispatches on the workload fall from 26.6B to 25.0B. Measured p50 267 -> 262.5 ms; individually that is inside the single-run noise band of this benchmark, which is why the dispatch count is quoted as well.

The randomized differential generates both shapes, and responses stay byte-identical to the bytecode loop on mainnet state (deep-check replay, `DIVERGENT: 0`).
