### PR TITLE
perf(evm): fuse SUB into the AND that masks it

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/StreamGasFuzzTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/StreamGasFuzzTests.cs
@@ -113,7 +113,7 @@ public class StreamGasFuzzTests : VirtualMachineTestsBase
         int slots = 6 + random.Next(18);
         for (int i = 0; i < slots; i++)
         {
-            switch (random.Next(22))
+            switch (random.Next(23))
             {
                 case 0:
                     jumpDests.Add(code.Count);
@@ -217,6 +217,13 @@ public class StreamGasFuzzTests : VirtualMachineTestsBase
                     // A table handler that consumes its successor and lands past it - adjacent to a
                     // random JUMPDEST from case 0 this is the elided-marker landing.
                     code.AddRange([(byte)Instruction.PUSH1, (byte)random.Next(256), (byte)Instruction.EXTCODESIZE, (byte)Instruction.ISZERO]);
+                    break;
+                case 21:
+                    // SUB feeding AND at real depth, the masked-difference pair.
+                    code.AddRange([
+                        (byte)Instruction.PUSH1, (byte)random.Next(256),
+                        (byte)Instruction.PUSH1, (byte)random.Next(256),
+                        (byte)Instruction.SUB, (byte)Instruction.AND]);
                     break;
                 case 19:
                     // PUSH1 feeding a DUP at mixed depths, and the glued PUSH1 pair followed by an

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
@@ -64,6 +64,7 @@ internal static class FusedOpcode
     public const byte SwapPop = 0x4E;
     // 0xA5..0xB4 is left alone: the frame-transaction work claims part of that range.
     public const byte Push1Dup = 0xC0;
+    public const byte SubAnd = 0xC1;
 
     /// <summary>Binary ops a preceding in-block PUSH folds into; must match the executor's fused cases exactly.</summary>
     public static bool TryMap(Instruction instruction, out byte fused)
@@ -580,6 +581,13 @@ internal sealed class InstructionStream
             // Swap depth as the executor takes it: SWAP1 exchanges the top with the slot two down.
             fused = FusedOpcode.SwapPop;
             operand = (ulong)(firstOp - Instruction.SWAP1 + 2);
+        }
+        else if (firstOp == Instruction.SUB && second == Instruction.AND)
+        {
+            // Masking a difference is the second most frequent adjacent pair the first fusion wave
+            // left behind on the measured workload, and both halves are plain in-block binary ops.
+            fused = FusedOpcode.SubAnd;
+            operand = 0;
         }
         else if (firstOp == Instruction.AND && second == Instruction.ISZERO)
         {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
@@ -113,6 +113,34 @@ public static partial class EvmInstructions
     }
 
     /// <summary>
+    /// Fused <c>SUB; AND</c>, the second most frequent adjacent pair the first fusion wave left
+    /// behind on the measured workload - masking a difference. Three words in, one out, no
+    /// intermediate write to the stack. One depth check covers both halves for the same reason the
+    /// pop pair needs only one: the depths it rejects are exactly the depths at which one of the two
+    /// would have underflowed, and an exceptional halt discards the stack either way.
+    /// </summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType FusedSubAndCore(ref EvmStack stack)
+    {
+        if (stack.Head < 3) return EvmExceptionType.StackUnderflow;
+
+        ref byte top = ref stack.PeekBytesByRef();
+        EvmStack.ReadUInt256FromSlot(ref top, out UInt256 a);
+        ref byte second = ref Subtract(ref top, EvmStack.WordSize);
+        EvmStack.ReadUInt256FromSlot(ref second, out UInt256 b);
+        OpSub.Operation(in a, in b, out UInt256 difference);
+
+        ref byte third = ref Subtract(ref second, EvmStack.WordSize);
+        EvmStack.ReadUInt256FromSlot(ref third, out UInt256 mask);
+        UInt256 result = difference & mask;
+
+        EvmStack.WriteUInt256ToSlot(ref third, in result);
+        stack.Head -= 2;
+        return EvmExceptionType.None;
+    }
+
+    /// <summary>
     /// Fused <c>PUSH1 v; DUPn</c>, with the immediate in the low byte of the operand and the dup
     /// depth in the next. The push lands first, so the duplicate is taken relative to a stack that
     /// already holds it - depth one duplicates the pushed value itself. Failure order matches the

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -175,6 +175,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                         case (Instruction)FusedOpcode.Shr:
                             exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShr>(ref stack, in constants[(int)entry.Operand]);
                             break;
+                        case (Instruction)FusedOpcode.SubAnd:
+                            exceptionType = EvmInstructions.FusedSubAndCore(ref stack);
+                            break;
                         case (Instruction)FusedOpcode.Push1Dup:
                             exceptionType = EvmInstructions.FusedPush1DupCore<OffFlag>(ref stack, entry.Operand);
                             break;


### PR DESCRIPTION
Stacked on #12644 - the diff against that branch is this change alone.

Masking a difference is 2.07% of dispatches on the measured workload once the earlier fusions have run, and both halves are plain in-block binary operations, so the pair becomes one entry: three words read, one written, no intermediate store to the stack.

One depth check covers both halves, for the same reason the existing pop pair needs only one: the depths it rejects are exactly the depths at which one of the two would have underflowed, and an exceptional halt discards the stack either way.

Measured p50 262.5 -> 259.9 ms, responses byte-identical to the bytecode loop on mainnet state, and the randomized differential generates the shape at real stack depth.
