### PR TITLE
perf(evm): absorb the subtraction that follows a constant shift

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/StreamGasFuzzTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/StreamGasFuzzTests.cs
@@ -113,7 +113,7 @@ public class StreamGasFuzzTests : VirtualMachineTestsBase
         int slots = 6 + random.Next(18);
         for (int i = 0; i < slots; i++)
         {
-            switch (random.Next(23))
+            switch (random.Next(24))
             {
                 case 0:
                     jumpDests.Add(code.Count);
@@ -217,6 +217,14 @@ public class StreamGasFuzzTests : VirtualMachineTestsBase
                     // A table handler that consumes its successor and lands past it - adjacent to a
                     // random JUMPDEST from case 0 this is the elided-marker landing.
                     code.AddRange([(byte)Instruction.PUSH1, (byte)random.Next(256), (byte)Instruction.EXTCODESIZE, (byte)Instruction.ISZERO]);
+                    break;
+                case 22:
+                    // A constant shift feeding a subtraction, and the same shape at saturating
+                    // amounts so the fused path and the mirrored core must agree on both.
+                    code.AddRange([
+                        (byte)Instruction.PUSH1, (byte)random.Next(256),
+                        (byte)Instruction.PUSH1, (byte)(random.Next(4) == 0 ? 0xFF : random.Next(40)),
+                        (byte)Instruction.SHL, (byte)Instruction.SUB]);
                     break;
                 case 21:
                     // SUB feeding AND at real depth, the masked-difference pair.

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
@@ -65,6 +65,7 @@ internal static class FusedOpcode
     // 0xA5..0xB4 is left alone: the frame-transaction work claims part of that range.
     public const byte Push1Dup = 0xC0;
     public const byte SubAnd = 0xC1;
+    public const byte ShlSub = 0xC2;
 
     /// <summary>Binary ops a preceding in-block PUSH folds into; must match the executor's fused cases exactly.</summary>
     public static bool TryMap(Instruction instruction, out byte fused)
@@ -581,6 +582,14 @@ internal sealed class InstructionStream
             // Swap depth as the executor takes it: SWAP1 exchanges the top with the slot two down.
             fused = FusedOpcode.SwapPop;
             operand = (ulong)(firstOp - Instruction.SWAP1 + 2);
+        }
+        else if (first.Opcode == FusedOpcode.Shl && second == Instruction.SUB)
+        {
+            // The already-fused shift keeps its pooled constant and absorbs the subtraction, so the
+            // shifted value never reaches the stack. Top pair on the wave-two histogram after the
+            // glued pushes.
+            fused = FusedOpcode.ShlSub;
+            operand = first.Operand;
         }
         else if (firstOp == Instruction.SUB && second == Instruction.AND)
         {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
@@ -113,6 +113,33 @@ public static partial class EvmInstructions
     }
 
     /// <summary>
+    /// Fused <c>PUSH shift; SHL; SUB</c> - shifting a value up and subtracting what sits beneath it,
+    /// the shape a shifted-mask difference takes. The shift amount is the analysis-time constant, so
+    /// only two stack words are read and one is written. The leading full-stack check stands in for
+    /// the push that was fused away, exactly as the plain fused shift does, and the saturation at
+    /// 256 or more mirrors ShiftCore.
+    /// </summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType FusedShlSubCore(ref EvmStack stack, in UInt256 shift)
+    {
+        if (stack.Head == EvmStack.MaxStackSize - 1) return EvmExceptionType.StackOverflow;
+        if (stack.Head < 2) return EvmExceptionType.StackUnderflow;
+
+        ref byte top = ref stack.PeekBytesByRef();
+        EvmStack.ReadUInt256FromSlot(ref top, out UInt256 value);
+        UInt256 shifted = !shift.IsUint64 || shift.u0 >= 256 ? default : value << (int)shift.u0;
+
+        ref byte second = ref Subtract(ref top, EvmStack.WordSize);
+        EvmStack.ReadUInt256FromSlot(ref second, out UInt256 subtrahend);
+        OpSub.Operation(in shifted, in subtrahend, out UInt256 result);
+
+        EvmStack.WriteUInt256ToSlot(ref second, in result);
+        stack.Head--;
+        return EvmExceptionType.None;
+    }
+
+    /// <summary>
     /// Fused <c>SUB; AND</c>, the second most frequent adjacent pair the first fusion wave left
     /// behind on the measured workload - masking a difference. Three words in, one out, no
     /// intermediate write to the stack. One depth check covers both halves for the same reason the

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -175,6 +175,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                         case (Instruction)FusedOpcode.Shr:
                             exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShr>(ref stack, in constants[(int)entry.Operand]);
                             break;
+                        case (Instruction)FusedOpcode.ShlSub:
+                            exceptionType = EvmInstructions.FusedShlSubCore(ref stack, in constants[(int)entry.Operand]);
+                            break;
                         case (Instruction)FusedOpcode.SubAnd:
                             exceptionType = EvmInstructions.FusedSubAndCore(ref stack);
                             break;


### PR DESCRIPTION
Stacked on #12645 - the diff against that branch is this change alone.

2.39% of dispatches on the measured workload: an already-fused constant shift immediately feeding a subtraction. The fused entry keeps the pooled shift amount and consumes the word beneath it, so the shifted value never reaches the stack - two words read, one written, one dispatch instead of two.

The leading full-stack check stands in for the push that was fused away, exactly as the plain fused shift does, and the saturation at 256 or more mirrors `ShiftCore`. The randomized differential generates the shape with saturating amounts as well, so the fused path and the mirrored core have to agree past 256, not only below it.

Measured p50 259.9 -> 258.5 ms; that is inside the noise band on its own, which is why the dispatch share is the number to weigh. Responses stay byte-identical to the bytecode loop on mainnet state.
