### PR TITLE
perf(evm): run the four comparisons over the stack representation

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Bitwise.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Bitwise.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using Nethermind.Core;
@@ -136,5 +137,59 @@ public static partial class EvmInstructions
 #else
         public static EvmWord Operation(in EvmWord a, in EvmWord b) => a == b ? One : default;
 #endif
+    }
+
+    public interface IOpCompare
+    {
+        static abstract bool IsSigned { get; }
+        static abstract bool IsGreater { get; }
+    }
+
+    public struct OpLtBytes : IOpCompare { public static bool IsSigned => false; public static bool IsGreater => false; }
+    public struct OpGtBytes : IOpCompare { public static bool IsSigned => false; public static bool IsGreater => true; }
+    public struct OpSLtBytes : IOpCompare { public static bool IsSigned => true; public static bool IsGreater => false; }
+    public struct OpSGtBytes : IOpCompare { public static bool IsSigned => true; public static bool IsGreater => true; }
+
+    /// <summary>
+    /// Comparison run straight over the stack representation: big-endian byte order is numeric order
+    /// for unsigned words, so the most significant differing byte decides, and flipping the sign bit
+    /// of the leading byte extends the same order to signed comparisons. Neither operand is converted
+    /// to limbs.
+    /// </summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType CompareCore<TOpCompare>(ref EvmStack stack)
+        where TOpCompare : struct, IOpCompare
+    {
+        ref byte aRef = ref stack.PopBytesByRef();
+        if (IsNullRef(ref aRef)) goto StackUnderflow;
+        ref byte bRef = ref stack.PeekBytesByRef();
+        if (IsNullRef(ref bRef)) goto StackUnderflow;
+
+        EvmWord a = ReadUnaligned<EvmWord>(ref aRef);
+        EvmWord b = ReadUnaligned<EvmWord>(ref bRef);
+
+        bool result = false;
+        uint differing = ~Vector256.Equals(a, b).ExtractMostSignificantBits();
+        if (differing != 0)
+        {
+            int index = BitOperations.TrailingZeroCount(differing);
+            uint left = Unsafe.Add(ref aRef, index);
+            uint right = Unsafe.Add(ref bRef, index);
+            if (TOpCompare.IsSigned && index == 0)
+            {
+                left ^= 0x80;
+                right ^= 0x80;
+            }
+
+            result = TOpCompare.IsGreater ? left > right : left < right;
+        }
+
+        WriteUnaligned(ref bRef, default(EvmWord));
+        if (result) Unsafe.Add(ref bRef, 31) = 1;
+        return EvmExceptionType.None;
+        // Jump forward to be unpredicted by the branch predictor.
+    StackUnderflow:
+        return EvmExceptionType.StackUnderflow;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -185,16 +185,16 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                             exceptionType = EvmInstructions.Math2ParamCore<EvmInstructions.OpSMod, OffFlag>(ref stack);
                             break;
                         case Instruction.LT:
-                            exceptionType = EvmInstructions.Math2ParamCore<EvmInstructions.OpLt, OffFlag>(ref stack);
+                            exceptionType = EvmInstructions.CompareCore<EvmInstructions.OpLtBytes>(ref stack);
                             break;
                         case Instruction.GT:
-                            exceptionType = EvmInstructions.Math2ParamCore<EvmInstructions.OpGt, OffFlag>(ref stack);
+                            exceptionType = EvmInstructions.CompareCore<EvmInstructions.OpGtBytes>(ref stack);
                             break;
                         case Instruction.SLT:
-                            exceptionType = EvmInstructions.Math2ParamCore<EvmInstructions.OpSLt, OffFlag>(ref stack);
+                            exceptionType = EvmInstructions.CompareCore<EvmInstructions.OpSLtBytes>(ref stack);
                             break;
                         case Instruction.SGT:
-                            exceptionType = EvmInstructions.Math2ParamCore<EvmInstructions.OpSGt, OffFlag>(ref stack);
+                            exceptionType = EvmInstructions.CompareCore<EvmInstructions.OpSGtBytes>(ref stack);
                             break;
                         case Instruction.EQ:
                             exceptionType = EvmInstructions.BitwiseCore<EvmInstructions.OpBitwiseEq>(ref stack);


### PR DESCRIPTION
Self-contained; no dependency on other interpreter work in flight.

`LT`, `GT`, `SLT` and `SGT` currently convert both operands from the stack's byte representation into limbs and compare the results. That conversion is unnecessary: big-endian byte order **is** numeric order for unsigned words, so the most significant differing byte decides the answer on its own. Flipping the sign bit of the leading byte maps the signed range onto the same order, which is what makes one routine serve all four.

The comparison reads both words as vectors, extracts the first differing byte with a mask and a trailing-zero count, and answers from that byte alone. When the words are equal the mask is empty and the result falls out without touching either operand further.

Two details worth checking in review:
- **Operand order** is the same as the arithmetic core it replaces - the top of stack is the left-hand side - so `LT` still means "top is less than the word beneath".
- **The sign flip is applied only at index zero**, because only the leading byte carries the sign; applying it anywhere else would corrupt the comparison.

Reached through the stream interpreter's in-block dispatch. The randomized differential in #12647 generates comparisons at mixed depths and asserts gas, status and output against the bytecode loop.