### PR TITLE
perf(evm): run byte-aligned fused constant shifts as byte moves

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using static System.Runtime.CompilerServices.Unsafe;
 
 namespace Nethermind.Evm;
@@ -47,6 +49,30 @@ public static partial class EvmInstructions
         if (!a.IsUint64 || a.u0 >= 256)
         {
             EvmStack.WriteUInt256ToSlot(ref topRef, in UInt256.Zero);
+            return EvmExceptionType.None;
+        }
+
+        int amount = (int)a.u0;
+        if ((amount & 7) == 0)
+        {
+            // Generated code shifts almost exclusively by whole bytes - address and selector
+            // packing, fixed-point scaling - and the amount is known at analysis time. Big-endian
+            // order makes a left shift a move toward index zero and a right shift a move away from
+            // it, so the aligned case is a byte move with no limb conversion and no shift
+            // arithmetic. CopyTo has move semantics, which the overlap here relies on.
+            int bytes = amount >> 3;
+            Span<byte> slot = MemoryMarshal.CreateSpan(ref topRef, EvmStack.WordSize);
+            if (typeof(TOpShift) == typeof(OpShl))
+            {
+                slot[bytes..].CopyTo(slot);
+                slot[(EvmStack.WordSize - bytes)..].Clear();
+            }
+            else
+            {
+                slot[..(EvmStack.WordSize - bytes)].CopyTo(slot[bytes..]);
+                slot[..bytes].Clear();
+            }
+
             return EvmExceptionType.None;
         }
 


### PR DESCRIPTION
Self-contained; touches one method.

A fused constant shift knows its amount at analysis time, and generated code shifts almost exclusively by whole bytes - 160 for an address, 224 for a selector, 96 in fixed-point scaling. For those amounts the operation is a byte move over the stack word: big-endian order makes a left shift a move toward index zero and a right shift a move away from it. No limb conversion, no shift arithmetic.

Sub-byte amounts fall through to the mirrored `ShiftCore` path unchanged, and the saturation rule at 256 or more is untouched.

One detail the review should confirm: the copy is deliberately overlapping, and `Span.CopyTo` has move semantics, so the source is read as it was before the destination is written. A plain copy would corrupt the word.

Measured p50 267.9 -> 266.5 ms on a pool-heavy `eth_call` workload; on its own that is inside the single-run noise band of this benchmark, which is why the mechanism rather than the number is the argument. Correctness is covered by the randomized differential in #12647, which generates both shift directions including saturating amounts.