### PR TITLE
perf(evm): fuse SUB into the AND that masks it

### DIFF
--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
@@ -50,6 +50,8 @@ internal static class FusedOpcode
     public const byte Shr = 0x2D;
     public const byte StaticJump = 0x2E;
     public const byte StaticJumpI = 0x2F;
+    // 0xA5..0xB4 is left alone: the frame-transaction work claims part of that range.
+    public const byte SubAnd = 0xC1;
 
     /// <summary>Binary ops a preceding in-block PUSH folds into; must match the executor's fused cases exactly.</summary>
     public static bool TryMap(Instruction instruction, out byte fused)
@@ -189,6 +191,23 @@ internal sealed class InstructionStream
             else if (GetInBlockCost(instruction) is ulong cost && cost != NotInBlock && pc + immediates < code.Length)
             {
                 if (openBlock >= 0
+                    && instruction == Instruction.AND
+                    && ops.Count > 0
+                    && ops[^1].Opcode == (byte)Instruction.SUB
+                    && ops[^1].Kind is StreamOpKind.InBlock or StreamOpKind.BlockFirst
+                    && ops[^1].Advance + size <= byte.MaxValue)
+                {
+                    // Masking a difference: two plain in-block binary operations behind one entry.
+                    // The block still charges and counts both, the stream just stops dispatching
+                    // the second, and nothing may land between them.
+                    StreamOp subtract = ops[^1];
+                    blockGas[openBlock] += cost;
+                    pcToEntry[pc] = InvalidEntry;
+                    ops[^1] = new StreamOp(FusedOpcode.SubAnd,
+                        subtract.Kind == StreamOpKind.BlockFirst ? StreamOpKind.FusedBlockFirst : StreamOpKind.FusedInBlock,
+                        subtract.Pc, subtract.BlockIndex, (byte)(subtract.Advance + size), 0);
+                }
+                else if (openBlock >= 0
                     && FusedOpcode.TryMap(instruction, out byte fusedOpcode)
                     && TryTakePrecedingPush(ops, out StreamOp push))
                 {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
@@ -76,4 +76,31 @@ public static partial class EvmInstructions
         WriteUnaligned(ref topRef, TOpBitwise.Operation(in a, in b));
         return EvmExceptionType.None;
     }
+    /// <summary>
+    /// Fused <c>SUB; AND</c> - masking a difference. Three words in, one out, with no intermediate
+    /// write to the stack. One depth check covers both halves: the depths it rejects are exactly
+    /// the depths at which one of the two would have underflowed, and an exceptional halt discards
+    /// the stack either way.
+    /// </summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType FusedSubAndCore(ref EvmStack stack)
+    {
+        if (stack.Head < 3) return EvmExceptionType.StackUnderflow;
+
+        ref byte top = ref stack.PeekBytesByRef();
+        EvmStack.ReadUInt256FromSlot(ref top, out UInt256 a);
+        ref byte second = ref Subtract(ref top, EvmStack.WordSize);
+        EvmStack.ReadUInt256FromSlot(ref second, out UInt256 b);
+        OpSub.Operation(in a, in b, out UInt256 difference);
+
+        ref byte third = ref Subtract(ref second, EvmStack.WordSize);
+        EvmStack.ReadUInt256FromSlot(ref third, out UInt256 mask);
+        UInt256 result = difference & mask;
+
+        EvmStack.WriteUInt256ToSlot(ref third, in result);
+        stack.Head -= 2;
+        return EvmExceptionType.None;
+    }
+
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -157,6 +157,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                         case (Instruction)FusedOpcode.Xor:
                             exceptionType = EvmInstructions.FusedConstBitwiseCore<EvmInstructions.OpBitwiseXor>(ref stack, ref constantBytes[(int)entry.Operand * 32]);
                             break;
+                        case (Instruction)FusedOpcode.SubAnd:
+                            exceptionType = EvmInstructions.FusedSubAndCore(ref stack);
+                            break;
                         case (Instruction)FusedOpcode.Shl:
                             exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShl>(ref stack, constants[(int)entry.Operand]);
                             break;


### PR DESCRIPTION
Self-contained; independent of the other interpreter work in flight.

Masking a difference - `SUB` immediately followed by `AND` - is 2.1% of all dispatches on a pool-heavy `eth_call` workload, measured with an opcode histogram rather than guessed. Both halves are plain in-block binary operations, so the pair collapses into one entry: three words read, one written, and the intermediate difference never reaches the stack.

Points worth checking in review:
- **Gas and the executed-op count are unchanged.** The block charges both original operations exactly as before; only the second dispatch disappears.
- **Nothing may land between the two.** The pc map forgets the second operation's start, which is the same rule every existing fusion follows.
- **One depth check covers both halves**, for the same reason a fused pair generally needs only one: the depths it rejects are exactly the depths at which one of the two would have underflowed, and an exceptional halt discards the stack either way.
- The fused opcode takes a byte from the free 0xC0 range; 0xA5..0xB4 is deliberately avoided because the frame-transaction work claims part of it.

Correctness is covered by the randomized differential in #12647, which generates the shape at real stack depth and asserts gas, status and output against the bytecode loop.