### PR TITLE
perf(evm): absorb the subtraction that follows a constant shift

### DIFF
--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
@@ -50,6 +50,8 @@ internal static class FusedOpcode
     public const byte Shr = 0x2D;
     public const byte StaticJump = 0x2E;
     public const byte StaticJumpI = 0x2F;
+    // 0xA5..0xB4 is left alone: the frame-transaction work claims part of that range.
+    public const byte ShlSub = 0xC2;
 
     /// <summary>Binary ops a preceding in-block PUSH folds into; must match the executor's fused cases exactly.</summary>
     public static bool TryMap(Instruction instruction, out byte fused)
@@ -189,6 +191,22 @@ internal sealed class InstructionStream
             else if (GetInBlockCost(instruction) is ulong cost && cost != NotInBlock && pc + immediates < code.Length)
             {
                 if (openBlock >= 0
+                    && instruction == Instruction.SUB
+                    && ops.Count > 0
+                    && ops[^1].Opcode == FusedOpcode.Shl
+                    && ops[^1].Kind is StreamOpKind.FusedInBlock or StreamOpKind.FusedBlockFirst
+                    && ops[^1].Advance + size <= byte.MaxValue)
+                {
+                    // A constant shift feeding a subtraction: the entry keeps its pooled shift
+                    // amount and consumes the word beneath, so the shifted value never reaches the
+                    // stack. The block still charges and counts both original operations.
+                    StreamOp shift = ops[^1];
+                    blockGas[openBlock] += cost;
+                    pcToEntry[pc] = InvalidEntry;
+                    ops[^1] = new StreamOp(FusedOpcode.ShlSub, shift.Kind, shift.Pc, shift.BlockIndex,
+                        (byte)(shift.Advance + size), shift.Operand);
+                }
+                else if (openBlock >= 0
                     && FusedOpcode.TryMap(instruction, out byte fusedOpcode)
                     && TryTakePrecedingPush(ops, out StreamOp push))
                 {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
@@ -76,4 +76,30 @@ public static partial class EvmInstructions
         WriteUnaligned(ref topRef, TOpBitwise.Operation(in a, in b));
         return EvmExceptionType.None;
     }
+    /// <summary>
+    /// Fused <c>PUSH shift; SHL; SUB</c> - a constant shift feeding a subtraction. The shift amount
+    /// is the analysis-time constant, so only two stack words are read and one is written. The
+    /// leading full-stack check stands in for the push that was fused away, exactly as the plain
+    /// fused shift does, and the saturation at 256 or more mirrors ShiftCore.
+    /// </summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType FusedShlSubCore(ref EvmStack stack, in UInt256 shift)
+    {
+        if (stack.Head == EvmStack.MaxStackSize - 1) return EvmExceptionType.StackOverflow;
+        if (stack.Head < 2) return EvmExceptionType.StackUnderflow;
+
+        ref byte top = ref stack.PeekBytesByRef();
+        EvmStack.ReadUInt256FromSlot(ref top, out UInt256 value);
+        UInt256 shifted = !shift.IsUint64 || shift.u0 >= 256 ? default : value << (int)shift.u0;
+
+        ref byte second = ref Subtract(ref top, EvmStack.WordSize);
+        EvmStack.ReadUInt256FromSlot(ref second, out UInt256 subtrahend);
+        OpSub.Operation(in shifted, in subtrahend, out UInt256 result);
+
+        EvmStack.WriteUInt256ToSlot(ref second, in result);
+        stack.Head--;
+        return EvmExceptionType.None;
+    }
+
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -157,6 +157,12 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                         case (Instruction)FusedOpcode.Xor:
                             exceptionType = EvmInstructions.FusedConstBitwiseCore<EvmInstructions.OpBitwiseXor>(ref stack, ref constantBytes[(int)entry.Operand * 32]);
                             break;
+                        case (Instruction)FusedOpcode.ShlSub:
+                            // Three original operations behind one entry, and the shared counter
+                            // above only credits the two a fused entry normally stands for.
+                            opCodeCount++;
+                            exceptionType = EvmInstructions.FusedShlSubCore(ref stack, in constants[(int)entry.Operand]);
+                            break;
                         case (Instruction)FusedOpcode.Shl:
                             exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShl>(ref stack, constants[(int)entry.Operand]);
                             break;


### PR DESCRIPTION
Self-contained; independent of the other interpreter work in flight.

An already-fused constant shift immediately feeding a subtraction is 2.4% of all dispatches on a pool-heavy `eth_call` workload, measured with an opcode histogram. The fused entry keeps its pooled shift amount and consumes the word beneath it, so the shifted value never reaches the stack: two words read, one written, one dispatch instead of two.

Points worth checking in review:
- **The leading full-stack check stands in for the push that was fused away**, exactly as the plain fused shift already does, so a full stack still fails as an overflow rather than executing.
- **Saturation at 256 or more mirrors `ShiftCore`** - the shifted value is zero, and the subtraction then runs against it.
- **The executed-op counter is credited three times**, because one entry now stands for a push, a shift and a subtraction, while the shared counter above only credits the two a fused entry normally represents.
- Gas is unchanged: the block charges all three original operations as before.
- The fused opcode takes a byte from the free 0xC0 range; 0xA5..0xB4 is deliberately avoided because the frame-transaction work claims part of it.

Correctness is covered by the randomized differential in #12647, which generates the shape with saturating shift amounts as well as ordinary ones, so the fused path and the mirrored core have to agree past 256, not only below it.