### PR TITLE
perf(evm): fuse PUSH1 into the DUP that follows it

### DIFF
--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
@@ -50,6 +50,8 @@ internal static class FusedOpcode
     public const byte Shr = 0x2D;
     public const byte StaticJump = 0x2E;
     public const byte StaticJumpI = 0x2F;
+    // 0xA5..0xB4 is left alone: the frame-transaction work claims part of that range.
+    public const byte Push1Dup = 0xC0;
 
     /// <summary>Binary ops a preceding in-block PUSH folds into; must match the executor's fused cases exactly.</summary>
     public static bool TryMap(Instruction instruction, out byte fused)
@@ -189,6 +191,24 @@ internal sealed class InstructionStream
             else if (GetInBlockCost(instruction) is ulong cost && cost != NotInBlock && pc + immediates < code.Length)
             {
                 if (openBlock >= 0
+                    && instruction is >= Instruction.DUP1 and <= Instruction.DUP8
+                    && ops.Count > 0
+                    && ops[^1].Opcode == (byte)Instruction.PUSH1
+                    && ops[^1].Kind is StreamOpKind.InBlock or StreamOpKind.BlockFirst
+                    && ops[^1].Advance + size <= byte.MaxValue)
+                {
+                    // A small constant pushed and immediately duplicated over. The immediate rides
+                    // in the low byte of the operand and the dup depth in the next; the block still
+                    // charges and counts both, and nothing may land between them.
+                    StreamOp pushed = ops[^1];
+                    blockGas[openBlock] += cost;
+                    pcToEntry[pc] = InvalidEntry;
+                    ops[^1] = new StreamOp(FusedOpcode.Push1Dup,
+                        pushed.Kind == StreamOpKind.BlockFirst ? StreamOpKind.FusedBlockFirst : StreamOpKind.FusedInBlock,
+                        pushed.Pc, pushed.BlockIndex, (byte)(pushed.Advance + size),
+                        pushed.Operand | ((ulong)(instruction - Instruction.DUP1 + 1) << 8));
+                }
+                else if (openBlock >= 0
                     && FusedOpcode.TryMap(instruction, out byte fusedOpcode)
                     && TryTakePrecedingPush(ops, out StreamOp push))
                 {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Runtime.CompilerServices;
+using Nethermind.Core;
 using static System.Runtime.CompilerServices.Unsafe;
 
 namespace Nethermind.Evm;
@@ -76,4 +77,21 @@ public static partial class EvmInstructions
         WriteUnaligned(ref topRef, TOpBitwise.Operation(in a, in b));
         return EvmExceptionType.None;
     }
+    /// <summary>
+    /// Fused <c>PUSH1 v; DUPn</c>, with the immediate in the low byte of the operand and the dup
+    /// depth in the next. The push lands first, so the duplicate is taken relative to a stack that
+    /// already holds it - depth one duplicates the pushed value itself. Failure order matches the
+    /// unfused pair: a full stack overflows on the push, and a dup reaching below the stack
+    /// underflows.
+    /// </summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType FusedPush1DupCore<TTracingInst>(ref EvmStack stack, ulong packed)
+        where TTracingInst : struct, IFlag
+    {
+        EvmExceptionType result = stack.PushUInt64<TTracingInst>(packed & 0xFF);
+        if (result != EvmExceptionType.None) return result;
+        return stack.Dup<TTracingInst>((int)((packed >> 8) & 0xFF));
+    }
+
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -157,6 +157,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                         case (Instruction)FusedOpcode.Xor:
                             exceptionType = EvmInstructions.FusedConstBitwiseCore<EvmInstructions.OpBitwiseXor>(ref stack, ref constantBytes[(int)entry.Operand * 32]);
                             break;
+                        case (Instruction)FusedOpcode.Push1Dup:
+                            exceptionType = EvmInstructions.FusedPush1DupCore<OffFlag>(ref stack, entry.Operand);
+                            break;
                         case (Instruction)FusedOpcode.Shl:
                             exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShl>(ref stack, constants[(int)entry.Operand]);
                             break;


### PR DESCRIPTION
Self-contained; independent of the other interpreter work in flight.

A small constant pushed and immediately duplicated over is **5.8% of all dispatches** on a pool-heavy `eth_call` workload - the most frequent adjacent pair left after the existing PUSH-and-operator fusion, measured with an opcode histogram rather than guessed. It is also about as generic as EVM code gets: every Solidity function juggles the stack with small constants.

The immediate rides in the low byte of the entry operand and the dup depth in the next.

Points worth checking in review:
- **Order matters and is preserved.** The push lands first, so the duplicate is taken against a stack that already holds it - depth one duplicates the value just pushed, not the word beneath.
- **Failure order follows from that**: a full stack overflows on the push, and a dup reaching below the stack underflows, exactly as the unfused pair would.
- **Gas and the executed-op count are unchanged**; the block charges both original operations and only the second dispatch disappears.
- Nothing may land between the two - the pc map forgets the dup's start, the rule every existing fusion follows.
- The fused opcode takes a byte from the free 0xC0 range; 0xA5..0xB4 is deliberately avoided because the frame-transaction work claims part of it.

Correctness is covered by the randomized differential in #12647, which generates PUSH1 feeding a DUP at mixed depths and asserts gas, status and output against the bytecode loop.