### PR TITLE
feat(rlp): decode the EIP-8250 keyed-nonce frame transaction envelope

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -134,8 +134,8 @@ public class FrameTxDecoderTests
         Assert.That(FrameTxSigHash.ComputeValue(second), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(first)));
     }
 
-    // The keyed envelope is part of the signing payload, so selecting different keys — or none at all,
-    // which is a different envelope rather than the key 0 — must not reuse another transaction's hash.
+    // Selecting different keys — or none at all, which is a different envelope rather than the key 0 —
+    // must not reuse another transaction's signing hash.
     [Test]
     public void ComputeSigHash_NonceKeysChange_HashChanges()
     {
@@ -186,8 +186,7 @@ public class FrameTxDecoderTests
         yield return new TestCaseData(blobCarrying).SetName("Roundtrip_WithBlobFields");
     }
 
-    // A nonce key encoded as an empty list is not a key: decoding it as one would admit `c1 c0` as the
-    // set [0], whose sequence lives in the sender's account nonce rather than in NONCE_MANAGER.
+    // Decoding `c1 c0` as the set [0] would move the sequence into the sender's account nonce.
     [Test]
     public void Decode_NonceKeyEncodedAsAnEmptyList_Throws()
     {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
@@ -177,13 +178,38 @@ public class FrameTxDecoderTests
 
         Transaction multiKeyed = CreateFrameTx();
         multiKeyed.NonceKeys = [1, UInt256.MaxValue];
-        multiKeyed.Nonce = 42;
         yield return new TestCaseData(multiKeyed).SetName("Roundtrip_KeyedNonceEnvelope_MultipleKeys");
 
         Transaction blobCarrying = CreateFrameTx();
         blobCarrying.MaxFeePerBlobGas = 7;
         blobCarrying.BlobVersionedHashes = [FilledBytes(32, 0x01), FilledBytes(32, 0x02)];
         yield return new TestCaseData(blobCarrying).SetName("Roundtrip_WithBlobFields");
+    }
+
+    // A nonce key encoded as an empty list is not a key: decoding it as one would admit `c1 c0` as the
+    // set [0], whose sequence lives in the sender's account nonce rather than in NONCE_MANAGER.
+    [Test]
+    public void Decode_NonceKeyEncodedAsAnEmptyList_Throws()
+    {
+        Transaction keyed = CreateFrameTx();
+        keyed.NonceKeys = [1];
+        byte[] bytes = new byte[_txDecoder.GetLength(keyed, RlpBehaviors.None)];
+        RlpWriter writer = new(bytes);
+        _txDecoder.Encode(ref writer, keyed);
+        // The one-byte key `01` and the empty list `c0` occupy the same slot, so no length changes.
+        int keyIndex = Array.IndexOf(bytes, (byte)0xc1) + 1;
+        bytes[keyIndex] = 0xc0;
+
+        Assert.That(() => { RlpReader reader = new(bytes); _txDecoder.Decode(ref reader); }, Throws.InstanceOf<RlpException>());
+    }
+
+    [Test]
+    public void Decode_MoreNonceKeysThanTheCap_Throws()
+    {
+        Transaction keyed = CreateFrameTx();
+        keyed.NonceKeys = [.. Enumerable.Range(1, Eip8250Constants.MaxNonceKeys + 1).Select(static i => (UInt256)i)];
+
+        Assert.That(() => EncodeDecode(keyed), Throws.InstanceOf<RlpException>());
     }
 
     private static Transaction EncodeDecode(Transaction tx)

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -30,6 +30,7 @@ public class FrameTxDecoderTests
         Assert.That(decoded.Type, Is.EqualTo(TxType.FrameTx));
         Assert.That(decoded.ChainId, Is.EqualTo(tx.ChainId));
         Assert.That(decoded.Nonce, Is.EqualTo(tx.Nonce));
+        Assert.That(decoded.NonceKeys, Is.EqualTo(tx.NonceKeys));
         // The sender is explicit in the payload — no envelope signature, no ECDSA recovery.
         Assert.That(decoded.SenderAddress, Is.EqualTo(tx.SenderAddress));
         Assert.That(decoded.GasPrice, Is.EqualTo(tx.GasPrice));
@@ -132,6 +133,24 @@ public class FrameTxDecoderTests
         Assert.That(FrameTxSigHash.ComputeValue(second), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(first)));
     }
 
+    // The keyed envelope is part of the signing payload, so selecting different keys — or none at all,
+    // which is a different envelope rather than the key 0 — must not reuse another transaction's hash.
+    [Test]
+    public void ComputeSigHash_NonceKeysChange_HashChanges()
+    {
+        Transaction legacy = CreateFrameTx();
+        Transaction legacyKey = CreateFrameTx();
+        legacyKey.NonceKeys = [UInt256.Zero];
+        Transaction otherKey = CreateFrameTx();
+        otherKey.NonceKeys = [1];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(FrameTxSigHash.ComputeValue(legacyKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacy)));
+            Assert.That(FrameTxSigHash.ComputeValue(otherKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacyKey)));
+        }
+    }
+
     private static IEnumerable<TestCaseData> RoundtripCases()
     {
         yield return new TestCaseData(CreateFrameTx()).SetName("Roundtrip_MinimalSingleFrame");
@@ -151,6 +170,15 @@ public class FrameTxDecoderTests
             new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, TestItem.AddressC, FilledBytes(32, 0xab), FilledBytes(TxFrameSignature.Secp256k1SignatureLength, 0x22)),
             new TxFrameSignature(TxFrameSignature.SchemeP256, TestItem.AddressD, default, FilledBytes(TxFrameSignature.P256SignatureLength, 0x33)),
         ])).SetName("Roundtrip_AllSignatureSchemes");
+
+        Transaction keyed = CreateFrameTx();
+        keyed.NonceKeys = [UInt256.Zero];
+        yield return new TestCaseData(keyed).SetName("Roundtrip_KeyedNonceEnvelope_LegacyKeyOnly");
+
+        Transaction multiKeyed = CreateFrameTx();
+        multiKeyed.NonceKeys = [1, UInt256.MaxValue];
+        multiKeyed.Nonce = 42;
+        yield return new TestCaseData(multiKeyed).SetName("Roundtrip_KeyedNonceEnvelope_MultipleKeys");
 
         Transaction blobCarrying = CreateFrameTx();
         blobCarrying.MaxFeePerBlobGas = 7;

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -227,6 +227,14 @@ namespace Nethermind.Core
         public Address? PayerAddress { get; set; }
 
         /// <summary>
+        /// Nonce keys selected by a frame transaction, sharing the sequence number held by <see cref="Nonce"/>.
+        /// https://eips.ethereum.org/EIPS/eip-8250
+        /// </summary>
+        /// <remarks><see langword="null"/> for the EIP-8141 envelope, whose single nonce is the sender's
+        /// linear account nonce — the same domain EIP-8250 addresses as the key <c>0</c>.</remarks>
+        public UInt256[]? NonceKeys { get; set; }
+
+        /// <summary>
         /// Service transactions are free. The field added to handle baseFee validation after 1559
         /// </summary>
         /// <remarks>Used for AuRa consensus.</remarks>
@@ -346,6 +354,7 @@ namespace Nethermind.Core
                 obj.Frames = default;
                 obj.FrameSignatures = default;
                 obj.PayerAddress = default;
+                obj.NonceKeys = default;
 
                 return true;
             }
@@ -381,6 +390,7 @@ namespace Nethermind.Core
             tx.Frames = Frames;
             tx.FrameSignatures = FrameSignatures;
             tx.PayerAddress = PayerAddress;
+            tx.NonceKeys = NonceKeys;
         }
 
         public virtual ProofVersion? GetProofVersion() =>

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -41,8 +41,6 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         // EIP8141-DEVIATION: the spec allows chain_id < 2^256; decoded as u64 like every other
         // Nethermind transaction type (codebase-wide ChainId width).
         transaction.ChainId = decoderContext.DecodeULong();
-        // The two shapes are self-describing — `nonce` is an integer and `nonce_keys` a list — so the
-        // fork that admits each is enforced in validation, where the spec is available.
         transaction.NonceKeys = decoderContext.IsSequenceNext() ? DecodeNonceKeys(ref decoderContext) : null;
         transaction.Nonce = decoderContext.DecodeULong();
         transaction.SenderAddress = decoderContext.DecodeAddress() ?? ThrowMissingSender();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -41,9 +41,8 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         // EIP8141-DEVIATION: the spec allows chain_id < 2^256; decoded as u64 like every other
         // Nethermind transaction type (codebase-wide ChainId width).
         transaction.ChainId = decoderContext.DecodeULong();
-        // EIP-8250 replaces `nonce` with `nonce_keys, nonce_seq`. The two shapes are self-describing —
-        // `nonce` is an integer and `nonce_keys` a list — so the payload is read without fork context and
-        // the fork that admits each shape is enforced where the spec is available, in validation.
+        // The two shapes are self-describing — `nonce` is an integer and `nonce_keys` a list — so the
+        // fork that admits each is enforced in validation, where the spec is available.
         transaction.NonceKeys = decoderContext.IsSequenceNext() ? DecodeNonceKeys(ref decoderContext) : null;
         transaction.Nonce = decoderContext.DecodeULong();
         transaction.SenderAddress = decoderContext.DecodeAddress() ?? ThrowMissingSender();
@@ -144,9 +143,8 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 
     /// <summary>Reads <c>nonce_keys</c> as a list of integers.</summary>
     /// <remarks>
-    /// Read element by element rather than through <c>DecodeArray</c>, which substitutes the default value
-    /// for an empty-list element: that would silently turn the wire bytes <c>c1 c0</c> into the key set
-    /// <c>[0]</c>, whose sequence lives in the sender's account nonce, rather than rejecting them.
+    /// Not <c>DecodeArray</c>: it substitutes the default for an empty-list element, turning the wire
+    /// bytes <c>c1 c0</c> into the key set <c>[0]</c> instead of rejecting them.
     /// </remarks>
     private static UInt256[] DecodeNonceKeys(ref RlpReader decoderContext)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -44,9 +44,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         // EIP-8250 replaces `nonce` with `nonce_keys, nonce_seq`. The two shapes are self-describing —
         // `nonce` is an integer and `nonce_keys` a list — so the payload is read without fork context and
         // the fork that admits each shape is enforced where the spec is available, in validation.
-        transaction.NonceKeys = decoderContext.IsSequenceNext()
-            ? decoderContext.DecodeArray(static (ref RlpReader ctx) => ctx.DecodeUInt256(), limit: NonceKeysCountLimit)
-            : null;
+        transaction.NonceKeys = decoderContext.IsSequenceNext() ? DecodeNonceKeys(ref decoderContext) : null;
         transaction.Nonce = decoderContext.DecodeULong();
         transaction.SenderAddress = decoderContext.DecodeAddress() ?? ThrowMissingSender();
         transaction.Frames = decoderContext.DecodeArray(TxFrameDecoder.Instance, limit: FramesCountLimit);
@@ -143,6 +141,31 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     // diverging on the transaction hash).
     protected override Signature? DecodeSignature(ulong v, ReadOnlySpan<byte> rBytes, ReadOnlySpan<byte> sBytes, Signature? fallbackSignature = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None) =>
         throw new RlpException("frame transaction must not carry a trailing signature");
+
+    /// <summary>Reads <c>nonce_keys</c> as a list of integers.</summary>
+    /// <remarks>
+    /// Read element by element rather than through <c>DecodeArray</c>, which substitutes the default value
+    /// for an empty-list element: that would silently turn the wire bytes <c>c1 c0</c> into the key set
+    /// <c>[0]</c>, whose sequence lives in the sender's account nonce, rather than rejecting them.
+    /// </remarks>
+    private static UInt256[] DecodeNonceKeys(ref RlpReader decoderContext)
+    {
+        int contentLength = decoderContext.ReadSequenceLength();
+        int end = decoderContext.Position + contentLength;
+        Span<UInt256> buffer = stackalloc UInt256[Eip8250Constants.MaxNonceKeys];
+        int count = 0;
+        while (decoderContext.Position < end)
+        {
+            if (count == buffer.Length)
+            {
+                throw new RlpLimitException($"Exceeded {NonceKeysCountLimit.CollectionExpression}");
+            }
+
+            buffer[count++] = decoderContext.DecodeUInt256();
+        }
+
+        return buffer[..count].ToArray();
+    }
 
     private static int NonceKeysContentLength(UInt256[] nonceKeys)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -6,13 +6,15 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Int256;
 
 namespace Nethermind.Serialization.Rlp.TxDecoders;
 
 /// <summary>
 /// Decodes the EIP-8141 frame transaction payload
 /// <c>[chain_id, nonce, sender, frames, signatures, max_priority_fee_per_gas, max_fee_per_gas,
-/// max_fee_per_blob_gas, blob_versioned_hashes]</c>.
+/// max_fee_per_blob_gas, blob_versioned_hashes]</c>, or its EIP-8250 form, which replaces
+/// <c>nonce</c> with <c>nonce_keys, nonce_seq</c>.
 /// The sender is explicit in the payload — there is no envelope ECDSA signature and no recovery.
 /// Encoding with <c>forSigning</c> produces the <c>compute_sig_hash</c> form: the raw signature
 /// bytes of canonical-hash (empty msg) entries are elided.
@@ -27,6 +29,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 
     private static readonly RlpLimit FramesCountLimit = RlpLimit.For<Transaction>(Eip8141Constants.MaxFrames, nameof(Transaction.Frames));
     private static readonly RlpLimit SignaturesCountLimit = RlpLimit.For<Transaction>(SignaturesDecodeCap, nameof(Transaction.FrameSignatures));
+    private static readonly RlpLimit NonceKeysCountLimit = RlpLimit.For<Transaction>(Eip8250Constants.MaxNonceKeys, nameof(Transaction.NonceKeys));
     // EIP8141-GAP: the spec does not bound blob_versioned_hashes; mirrors the blob tx decode cap.
     private static readonly RlpLimit BlobVersionedHashesCountLimit = RlpLimit.For<Transaction>(128, nameof(Transaction.BlobVersionedHashes));
 
@@ -38,6 +41,12 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         // EIP8141-DEVIATION: the spec allows chain_id < 2^256; decoded as u64 like every other
         // Nethermind transaction type (codebase-wide ChainId width).
         transaction.ChainId = decoderContext.DecodeULong();
+        // EIP-8250 replaces `nonce` with `nonce_keys, nonce_seq`. The two shapes are self-describing —
+        // `nonce` is an integer and `nonce_keys` a list — so the payload is read without fork context and
+        // the fork that admits each shape is enforced where the spec is available, in validation.
+        transaction.NonceKeys = decoderContext.IsSequenceNext()
+            ? decoderContext.DecodeArray(static (ref RlpReader ctx) => ctx.DecodeUInt256(), limit: NonceKeysCountLimit)
+            : null;
         transaction.Nonce = decoderContext.DecodeULong();
         transaction.SenderAddress = decoderContext.DecodeAddress() ?? ThrowMissingSender();
         transaction.Frames = decoderContext.DecodeArray(TxFrameDecoder.Instance, limit: FramesCountLimit);
@@ -90,6 +99,14 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
     {
         writer.Encode(transaction.ChainId ?? 0);
+        if (transaction.NonceKeys is { } nonceKeys)
+        {
+            writer.StartSequence(NonceKeysContentLength(nonceKeys));
+            foreach (UInt256 nonceKey in nonceKeys)
+            {
+                writer.Encode(nonceKey);
+            }
+        }
         writer.Encode(transaction.Nonce);
         writer.Encode(transaction.SenderAddress);
         TxFrameDecoder.Instance.EncodeArray(ref writer, transaction.Frames);
@@ -103,6 +120,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     protected override int GetContentLength(Transaction transaction, RlpBehaviors rlpBehaviors, bool forSigning,
         bool isEip155Enabled = false, ulong chainId = 0) =>
         Rlp.LengthOf(transaction.ChainId ?? 0)
+        + (transaction.NonceKeys is { } nonceKeys ? Rlp.LengthOfSequence(NonceKeysContentLength(nonceKeys)) : 0)
         + Rlp.LengthOf(transaction.Nonce)
         + Rlp.LengthOf(transaction.SenderAddress)
         + TxFrameDecoder.Instance.GetArrayLength(transaction.Frames)
@@ -125,6 +143,17 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     // diverging on the transaction hash).
     protected override Signature? DecodeSignature(ulong v, ReadOnlySpan<byte> rBytes, ReadOnlySpan<byte> sBytes, Signature? fallbackSignature = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None) =>
         throw new RlpException("frame transaction must not carry a trailing signature");
+
+    private static int NonceKeysContentLength(UInt256[] nonceKeys)
+    {
+        int contentLength = 0;
+        foreach (UInt256 nonceKey in nonceKeys)
+        {
+            contentLength += Rlp.LengthOf(nonceKey);
+        }
+
+        return contentLength;
+    }
 
     [DoesNotReturn, StackTraceHidden]
     private static Address ThrowMissingSender() => throw new RlpException("frame transaction sender must be a 20-byte address");


### PR DESCRIPTION
## Changes

EIP-8250 replaces the frame transaction's single `nonce` with `nonce_keys, nonce_seq`, growing the envelope from 9 fields to 10. I teach `FrameTxDecoder` both shapes and carry the keys on `Transaction.NonceKeys`. The shapes are self describing on the wire (`nonce` is an integer, `nonce_keys` a list), so I decode without fork context and enforce the admitting fork in validation. `NonceKeys == null` is the EIP-8141 envelope, whose single nonce is the sender's account nonce, the same domain EIP-8250 addresses as key `0`. `nonce_keys` is part of the signing payload, so `compute_sig_hash` covers it.

Wire half only; consuming the keys against `NONCE_MANAGER` and the mempool identity change land separately. Another implementation's cross-client devnet already ships this envelope, which Nethermind cannot currently decode.

## Types of changes

- [x] New feature (a non-breaking change that adds functionality)

## Testing

`Nethermind.Core.Test` `FrameTxDecoderTests`: 11/11. Roundtrips for the legacy-key-only and multi-key envelopes, plus a signature-hash test pinning that the legacy envelope, `[0]` and `[1]` hash differently.

- [x] Tests added
