### PR TITLE
fix(txpool): reject a frame transaction that cannot reach its calldata floor

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -85,14 +85,16 @@ public sealed class TxValidator : ITxValidator
             IntrinsicGasTxValidator.Instance
         ]));
         // Frame transactions have no envelope ECDSA signature (explicit sender, protocol-validated
-        // signature list) — signature/intrinsic-gas validators do not apply; per-frame gas and
-        // signature validation happen during processing.
+        // signature list) — the signature validators do not apply, and their intrinsic gas is derived
+        // from the frames rather than a gas_limit field; per-frame signature validation happens during
+        // processing.
         RegisterValidator(TxType.FrameTx, new CompositeTxValidator([
             new ReleaseSpecTxValidator(static spec => spec.IsEip8141Enabled),
             NonceCapTxValidator.Instance,
             expectedChainIdTxValidator,
             GasFieldsTxValidator.Instance,
-            FrameTxFieldsTxValidator.Instance
+            FrameTxFieldsTxValidator.Instance,
+            FrameTxIntrinsicGasTxValidator.Instance
         ]));
     }
 
@@ -191,6 +193,30 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
         FrameTxValidation.IsWellFormed(transaction, out string? error) ? ValidationResult.Success : error!;
+}
+
+/// <summary>Rejects a frame transaction whose frame gas limits cannot cover its EIP-7623 calldata floor.</summary>
+/// <remarks>
+/// A frame transaction is charged at least the floor of the data it carries, so a gas limit below the floor is
+/// unpayable and the transaction can never execute — the same condition <see cref="IntrinsicGasTxValidator"/>
+/// enforces for every other transaction type. Without it the processor rejects the transaction only once a block
+/// builder tries to execute it, by which point it has already been pooled and broadcast, and it sits on the sender's
+/// nonce blocking their later transactions.
+/// </remarks>
+public sealed class FrameTxIntrinsicGasTxValidator : ITxValidator
+{
+    public static readonly FrameTxIntrinsicGasTxValidator Instance = new();
+    private FrameTxIntrinsicGasTxValidator() { }
+
+    public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
+    {
+        // Runs after FrameTxFieldsTxValidator, which establishes the frame list and that the frame gas limits
+        // (summed into GasLimit at decode time) do not overflow.
+        ulong intrinsicGas = FrameTxIntrinsicGas.Calculate(transaction, transaction.Frames!, releaseSpec, out ulong floorGas);
+        return intrinsicGas + transaction.GasLimit < floorGas
+            ? new ValidationResult(TxErrorMessages.IntrinsicGasTooLow) { IsIntrinsicGasError = true }
+            : ValidationResult.Success;
+    }
 }
 
 public sealed class ContractSizeTxValidator : ITxValidator

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -150,9 +150,10 @@ public class Eip8141ScenarioTests
 
     // Spec Gas Accounting: charged gas = FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST
     // + per-scheme verification cost + max(standard token cost of frame data and signature fields
-    // + the gas each frame consumed, EIP-7623 floor token cost). Pinned against the spec constants
+    // + the gas each frame consumed, floor token cost). Pinned against the spec constants
     // with known payload bytes; ARBITRARY entries cost 100 verification gas, and their bytes are
-    // also calldata-priced.
+    // also calldata-priced. The fork under test schedules EIP-7976, so the floor prices every data
+    // byte as a non-zero token at 16 (64 per byte), as it does for an ordinary transaction.
     [Test]
     public void ChargedGas_MatchesSpecIntrinsicFormula()
     {
@@ -175,16 +176,17 @@ public class Eip8141ScenarioTests
 
         ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
         ulong tokens = CalldataTokens(frameData) + CalldataTokens(witnessBytes);
+        ulong floorTokens = (ulong)(frameData.Length + witnessBytes.Length) * 4;
         ulong expected = 15_000
                          + 2 * 475UL
                          + 100 // ARBITRARY signature verification cost
-                         + Math.Max(tokens * 4 + frameGasUsed, tokens * 10); // EIP-7623 floor (10/token)
+                         + Math.Max(tokens * 4 + frameGasUsed, floorTokens * 16); // EIP-7976 floor rate
         Assert.That((ulong)receipt.GasUsed, Is.EqualTo(expected));
         Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed),
             "the refund must return exactly max cost minus charged gas at the effective price");
     }
 
-    // EIP-7623 floor for frame transactions: the mandatory intrinsic, per-frame and signature
+    // The calldata floor for frame transactions: the mandatory intrinsic, per-frame and signature
     // verification costs stay outside the max, while the data tokens are charged at the floor rate
     // whenever it exceeds the standard rate plus the gas the frames actually consumed.
     [Test]
@@ -203,17 +205,17 @@ public class Eip8141ScenarioTests
         ulong mandatoryGas = 15_000 + 2 * 475UL;
         using (Assert.EnterMultipleScope())
         {
-            // EIP-8141 inherits the EIP-7623 floor (10 per token), NOT the EIP-7976 rate (16),
-            // even though the prototype fork also schedules EIP-7976 for the regular tx path.
-            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + 256 * 10UL));
+            // Every byte is a non-zero token under EIP-7976, priced at 16: 64 gas per data byte,
+            // the same rate an ordinary transaction's calldata floor uses under this fork.
+            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + 256 * 64UL));
             Assert.That((ulong)receipt.GasUsed, Is.GreaterThan(mandatoryGas + 256 * 4UL + frameGasUsed),
                 "the floor token cost must dominate the standard token cost plus execution gas");
             Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed));
         }
     }
 
-    // EIP-7623 regression: when the standard token cost plus consumed frame gas exceeds the floor
-    // token cost, the standard accounting is charged unchanged.
+    // Regression: when the standard token cost plus consumed frame gas exceeds the floor token cost,
+    // the standard accounting is charged unchanged.
     [Test]
     public void ChargedGas_ExecutionDominatesFloor_ChargesStandardTokenCostPlusExecution()
     {
@@ -232,10 +234,45 @@ public class Eip8141ScenarioTests
         ulong standardTokenCost = 64 * 4UL;
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(standardTokenCost + frameGasUsed, Is.GreaterThan(64 * 10UL),
+            Assert.That(standardTokenCost + frameGasUsed, Is.GreaterThan(64 * 64UL),
                 "the scenario must stay execution-dominant for this regression to bind");
             Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + standardTokenCost + frameGasUsed));
             Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed));
+        }
+    }
+
+    // The floor bounds the charge from below after the EIP-3529 refund is netted, not before. The
+    // scenario is chosen so the two orderings disagree: gross gas exceeds the floor (so the floor is
+    // not trivially the answer), while gross minus the refund falls under it (so applying the floor
+    // first would leave the refund to be subtracted from it).
+    [Test]
+    public void ChargedGas_RefundNetsBeforeFloorIsApplied()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        _stateProvider.Set(new StorageCell(Recipient, UInt256.Zero), new byte[] { 1 });
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+
+        // The payload size is chosen so the floor lands between the gross charge and the gross charge
+        // net of the refund: the floor grows 64 gas per byte while the standard cost grows 4.
+        byte[] frameData = new byte[160];
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeDefault, 0, Recipient, gasLimit: 200_000, UInt256.Zero, frameData));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        ulong floorGas = mandatoryGas + (ulong)frameData.Length * 64UL;
+        ulong grossGas = mandatoryGas + (ulong)frameData.Length * 4UL + frameGasUsed;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(grossGas, Is.GreaterThan(floorGas),
+                "gross gas must exceed the floor, or the ordering under test is not exercised");
+            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(floorGas),
+                "the refund may not push the charge below the floor");
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -149,9 +149,10 @@ public class Eip8141ScenarioTests
     }
 
     // Spec Gas Accounting: charged gas = FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST
-    // + EIP-7623 token cost of frame data and signature fields + per-scheme verification cost
-    // + the gas each frame consumed. Pinned against the spec constants with known payload bytes;
-    // ARBITRARY entries cost 100 verification gas, and their bytes are also calldata-priced.
+    // + per-scheme verification cost + max(standard token cost of frame data and signature fields
+    // + the gas each frame consumed, EIP-7623 floor token cost). Pinned against the spec constants
+    // with known payload bytes; ARBITRARY entries cost 100 verification gas, and their bytes are
+    // also calldata-priced.
     [Test]
     public void ChargedGas_MatchesSpecIntrinsicFormula()
     {
@@ -173,14 +174,69 @@ public class Eip8141ScenarioTests
         }
 
         ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong tokens = CalldataTokens(frameData) + CalldataTokens(witnessBytes);
         ulong expected = 15_000
                          + 2 * 475UL
-                         + (CalldataTokens(frameData) + CalldataTokens(witnessBytes)) * 4
                          + 100 // ARBITRARY signature verification cost
-                         + frameGasUsed;
+                         + Math.Max(tokens * 4 + frameGasUsed, tokens * 10); // EIP-7623 floor (10/token)
         Assert.That((ulong)receipt.GasUsed, Is.EqualTo(expected));
         Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed),
             "the refund must return exactly max cost minus charged gas at the effective price");
+    }
+
+    // EIP-7623 floor for frame transactions: the mandatory intrinsic, per-frame and signature
+    // verification costs stay outside the max, while the data tokens are charged at the floor rate
+    // whenever it exceeds the standard rate plus the gas the frames actually consumed.
+    [Test]
+    public void ChargedGas_FloorDominatesExecution_ChargesFloorTokenCost()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+
+        byte[] frameData = new byte[256];
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient, gasLimit: 200_000, UInt256.Zero, frameData));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        using (Assert.EnterMultipleScope())
+        {
+            // EIP-8141 inherits the EIP-7623 floor (10 per token), NOT the EIP-7976 rate (16),
+            // even though the prototype fork also schedules EIP-7976 for the regular tx path.
+            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + 256 * 10UL));
+            Assert.That((ulong)receipt.GasUsed, Is.GreaterThan(mandatoryGas + 256 * 4UL + frameGasUsed),
+                "the floor token cost must dominate the standard token cost plus execution gas");
+            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed));
+        }
+    }
+
+    // EIP-7623 regression: when the standard token cost plus consumed frame gas exceeds the floor
+    // token cost, the standard accounting is charged unchanged.
+    [Test]
+    public void ChargedGas_ExecutionDominatesFloor_ChargesStandardTokenCostPlusExecution()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        DeployContract(Recipient, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        byte[] frameData = new byte[64];
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient, gasLimit: 200_000, UInt256.Zero, frameData));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        ulong standardTokenCost = 64 * 4UL;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(standardTokenCost + frameGasUsed, Is.GreaterThan(64 * 10UL),
+                "the scenario must stay execution-dominant for this regression to bind");
+            Assert.That((ulong)receipt.GasUsed, Is.EqualTo(mandatoryGas + standardTokenCost + frameGasUsed));
+            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed));
+        }
     }
 
     // EIP-3529 storage refunds (ethereum/EIPs#11940) accumulate into one transaction-scoped counter,

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -112,6 +112,24 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_GasLimitBelowEip7623Floor_ReturnsGasLimitBelowFloorGas()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        // Enough zero-byte tokens that the floor rate (tokens * 10) outpaces the standard rate
+        // plus the declared frame gas (tokens * 4 + sum(frame.gas_limit)), even with the second
+        // frame's own limit at zero.
+        byte[] frameData = new byte[40_000];
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient, gasLimit: 0, UInt256.Zero, frameData));
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.False);
+        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.GasLimitBelowFloorGas));
+    }
+
+    [Test]
     public void Execute_SelfVerifyApprovesExecutionAndPayment_ChargesPayerAndIncrementsNonce()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));

--- a/src/Nethermind/Nethermind.Evm/FrameTxIntrinsicGas.cs
+++ b/src/Nethermind/Nethermind.Evm/FrameTxIntrinsicGas.cs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+
+namespace Nethermind.Evm;
+
+/// <summary>Gas an EIP-8141 frame transaction owes before any frame runs.</summary>
+public static class FrameTxIntrinsicGas
+{
+    /// <summary>
+    /// Computes the intrinsic gas of a frame transaction and, via <paramref name="floorGas"/>, the
+    /// least gas it may be charged.
+    /// </summary>
+    /// <remarks>
+    /// The intrinsic cost is <c>FRAME_TX_INTRINSIC_COST</c> + frames × <c>FRAME_TX_PER_FRAME_COST</c>
+    /// + per-scheme signature verification + the calldata cost of the frame data and signature
+    /// fields. The floor adds the same mandatory (non-data) costs to the data priced at
+    /// <see cref="SpecGasCosts.TotalCostFloorPerToken"/>, mirroring
+    /// <see cref="IntrinsicGasCalculator.CalculateFloorCost"/>: EIP-7976 prices every data byte as a
+    /// non-zero token, EIP-7623 weights zero bytes lower. Both the rate and the token weighting are
+    /// resolved from the spec so a frame transaction's floor cannot diverge from an ordinary
+    /// transaction's under the same fork.
+    /// </remarks>
+    /// <param name="tx">The frame transaction being charged.</param>
+    /// <param name="frames">The transaction's frames.</param>
+    /// <param name="spec">The release spec in effect.</param>
+    /// <param name="floorGas">The minimum chargeable gas, or 0 when floor pricing is not active.</param>
+    /// <returns>The intrinsic gas charged before execution.</returns>
+    public static ulong Calculate(Transaction tx, TxFrame[] frames, IReleaseSpec spec, out ulong floorGas)
+    {
+        ulong tokens = 0;
+        ulong dataLength = 0;
+        foreach (TxFrame frame in frames)
+        {
+            tokens += CountCalldataTokens(frame.Data.Span, spec);
+            dataLength += (ulong)frame.Data.Length;
+        }
+
+        ulong signatureVerificationCost = 0;
+        TxFrameSignature[]? signatures = tx.FrameSignatures;
+        if (signatures is not null)
+        {
+            foreach (TxFrameSignature signature in signatures)
+            {
+                tokens += signature.Signer is null ? 0 : CountCalldataTokens(signature.Signer.Bytes, spec);
+                tokens += CountCalldataTokens(signature.Msg.Span, spec);
+                tokens += CountCalldataTokens(signature.Signature.Span, spec);
+                dataLength += (ulong)(signature.Signer is null ? 0 : Address.Size)
+                              + (ulong)signature.Msg.Length
+                              + (ulong)signature.Signature.Length;
+                signatureVerificationCost += signature.Scheme switch
+                {
+                    TxFrameSignature.SchemeArbitrary => Eip8141Constants.ArbitraryVerificationGasCost,
+                    TxFrameSignature.SchemeSecp256k1 => Eip8141Constants.Secp256k1VerificationGasCost,
+                    TxFrameSignature.SchemeP256 => Eip8141Constants.P256VerificationGasCost,
+                    _ => 0,
+                };
+            }
+        }
+
+        ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost
+                             + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
+                             + signatureVerificationCost;
+        ulong floorTokens = spec.IsEip7976Enabled ? dataLength * spec.GasCosts.TxDataNonZeroMultiplier : tokens;
+        floorGas = spec.IsEip7623Enabled ? mandatoryGas + floorTokens * spec.GasCosts.TotalCostFloorPerToken : 0;
+        return mandatoryGas + tokens * GasCostOf.TxDataZero;
+    }
+
+    private static ulong CountCalldataTokens(ReadOnlySpan<byte> data, IReleaseSpec spec)
+    {
+        int zeros = data.CountZeros();
+        return (ulong)zeros + (ulong)(data.Length - zeros) * spec.GasCosts.TxDataNonZeroMultiplier;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -389,20 +389,32 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     }
 
     /// <summary>
-    /// FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST + calldata cost of frame data
-    /// and signature fields (EIP-7623 token pricing) + per-scheme signature verification cost.
-    /// EIP-8141 inherits the floor from EIP-7623 specifically: the floor prices tokens at
-    /// <see cref="GasCostOf.TotalCostFloorPerTokenEip7623"/> on top of the mandatory (non-data)
-    /// costs, so <paramref name="floorGas"/> is the minimum chargeable gas (0 when floor pricing is
-    /// not active). The frame-tx floor stays pinned to the EIP-7623 constant even when EIP-7976 is
-    /// also scheduled, because EIP-8141 defines the floor per EIP-7623, not EIP-7976.
+    /// Computes the intrinsic gas of a frame transaction and, via <paramref name="floorGas"/>, the
+    /// least gas it may be charged.
     /// </summary>
+    /// <remarks>
+    /// The intrinsic cost is <c>FRAME_TX_INTRINSIC_COST</c> + frames × <c>FRAME_TX_PER_FRAME_COST</c>
+    /// + per-scheme signature verification + the calldata cost of the frame data and signature
+    /// fields. The floor adds the same mandatory (non-data) costs to the data priced at
+    /// <see cref="SpecGasCosts.TotalCostFloorPerToken"/>, mirroring
+    /// <see cref="IntrinsicGasCalculator.CalculateFloorCost"/>: EIP-7976 prices every data byte as a
+    /// non-zero token, EIP-7623 weights zero bytes lower. Both the rate and the token weighting are
+    /// resolved from the spec so a frame transaction's floor cannot diverge from an ordinary
+    /// transaction's under the same fork.
+    /// </remarks>
+    /// <param name="tx">The frame transaction being charged.</param>
+    /// <param name="frames">The transaction's frames.</param>
+    /// <param name="spec">The release spec in effect.</param>
+    /// <param name="floorGas">The minimum chargeable gas, or 0 when floor pricing is not active.</param>
+    /// <returns>The intrinsic gas charged before execution.</returns>
     private static ulong CalculateFrameTxIntrinsicGas(Transaction tx, TxFrame[] frames, IReleaseSpec spec, out ulong floorGas)
     {
         ulong tokens = 0;
+        ulong dataLength = 0;
         foreach (TxFrame frame in frames)
         {
             tokens += CountCalldataTokens(frame.Data.Span, spec);
+            dataLength += (ulong)frame.Data.Length;
         }
 
         ulong signatureVerificationCost = 0;
@@ -414,6 +426,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 tokens += signature.Signer is null ? 0 : CountCalldataTokens(signature.Signer.Bytes, spec);
                 tokens += CountCalldataTokens(signature.Msg.Span, spec);
                 tokens += CountCalldataTokens(signature.Signature.Span, spec);
+                dataLength += (ulong)(signature.Signer is null ? 0 : Address.Size)
+                              + (ulong)signature.Msg.Length
+                              + (ulong)signature.Signature.Length;
                 signatureVerificationCost += signature.Scheme switch
                 {
                     TxFrameSignature.SchemeArbitrary => Eip8141Constants.ArbitraryVerificationGasCost,
@@ -427,7 +442,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost
                              + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
                              + signatureVerificationCost;
-        floorGas = spec.IsEip7623Enabled ? mandatoryGas + tokens * GasCostOf.TotalCostFloorPerTokenEip7623 : 0;
+        ulong floorTokens = spec.IsEip7976Enabled ? dataLength * spec.GasCosts.TxDataNonZeroMultiplier : tokens;
+        floorGas = spec.IsEip7623Enabled ? mandatoryGas + floorTokens * spec.GasCosts.TotalCostFloorPerToken : 0;
         return mandatoryGas + tokens * GasCostOf.TxDataZero;
     }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -60,7 +60,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // Spec gas: tx_gas_limit = intrinsic + per-frame + calldata + signature verification
         // + sum(frame.gas_limit); the sum is overflow-checked so the processor does not depend
         // on static validation having run.
-        ulong intrinsicGas = CalculateFrameTxIntrinsicGas(tx, frames, spec);
+        ulong intrinsicGas = CalculateFrameTxIntrinsicGas(tx, frames, spec, out ulong floorGas);
         ulong totalFrameGas = 0;
         foreach (TxFrame frame in frames)
         {
@@ -77,6 +77,14 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         if (txGasLimit < intrinsicGas)
         {
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction gas limit overflows");
+        }
+
+        // EIP-7623: the payer's max-cost reservation below is derived from the gas limit, so a
+        // limit that cannot cover the floor-priced charge is rejected rather than under-reserved.
+        if (txGasLimit < floorGas)
+        {
+            return TransactionResult.ErrorType.GasLimitBelowFloorGas.WithDetail(
+                $"frame transaction gas limit {txGasLimit} below EIP-7623 floor gas {floorGas}");
         }
 
         // max_cost is defined at basefee=max (TXPARAM 0x06): the payer solvency gate reserves at
@@ -294,9 +302,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         // EIP-3529 storage refunds are netted once at the transaction level (ethereum/EIPs#11940):
         // the accumulated counter is capped at a fifth of the gross gas and subtracted here. Per-frame
-        // receipts stay gross; only this transaction total is netted.
+        // receipts stay gross; only this transaction total is netted. The EIP-7623 floor then bounds
+        // the net charge from below.
         ulong grossGas = intrinsicGas + totalFrameGasUsed;
-        ulong spentGas = grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)refundCounter, spec);
+        ulong spentGas = Math.Max(grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)refundCounter, spec), floorGas);
         // Block-level gas accounting reads Transaction.BlockGasUsed, whose getter otherwise falls back
         // to tx.GasLimit (the frame-gas sum, not the gas actually spent). Set it explicitly like the
         // regular path so parallel block validation (BlockAccessListManager) accumulates the frame
@@ -382,10 +391,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     /// <summary>
     /// FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST + calldata cost of frame data
     /// and signature fields (EIP-7623 token pricing) + per-scheme signature verification cost.
-    /// EIP8141: whether the EIP-7623 floor applies to frame transactions is unspecified; the
-    /// standard token cost is used here.
+    /// EIP-8141 inherits the floor from EIP-7623 specifically: the floor prices tokens at
+    /// <see cref="GasCostOf.TotalCostFloorPerTokenEip7623"/> on top of the mandatory (non-data)
+    /// costs, so <paramref name="floorGas"/> is the minimum chargeable gas (0 when floor pricing is
+    /// not active). The frame-tx floor stays pinned to the EIP-7623 constant even when EIP-7976 is
+    /// also scheduled, because EIP-8141 defines the floor per EIP-7623, not EIP-7976.
     /// </summary>
-    private static ulong CalculateFrameTxIntrinsicGas(Transaction tx, TxFrame[] frames, IReleaseSpec spec)
+    private static ulong CalculateFrameTxIntrinsicGas(Transaction tx, TxFrame[] frames, IReleaseSpec spec, out ulong floorGas)
     {
         ulong tokens = 0;
         foreach (TxFrame frame in frames)
@@ -412,10 +424,11 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             }
         }
 
-        return (ulong)Eip8141Constants.IntrinsicGasCost
-               + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
-               + tokens * GasCostOf.TxDataZero
-               + signatureVerificationCost;
+        ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost
+                             + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
+                             + signatureVerificationCost;
+        floorGas = spec.IsEip7623Enabled ? mandatoryGas + tokens * GasCostOf.TotalCostFloorPerTokenEip7623 : 0;
+        return mandatoryGas + tokens * GasCostOf.TxDataZero;
     }
 
     private static ulong CountCalldataTokens(ReadOnlySpan<byte> data, IReleaseSpec spec)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -60,7 +60,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // Spec gas: tx_gas_limit = intrinsic + per-frame + calldata + signature verification
         // + sum(frame.gas_limit); the sum is overflow-checked so the processor does not depend
         // on static validation having run.
-        ulong intrinsicGas = CalculateFrameTxIntrinsicGas(tx, frames, spec, out ulong floorGas);
+        ulong intrinsicGas = FrameTxIntrinsicGas.Calculate(tx, frames, spec, out ulong floorGas);
         ulong totalFrameGas = 0;
         foreach (TxFrame frame in frames)
         {
@@ -386,71 +386,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         }
 
         return logs;
-    }
-
-    /// <summary>
-    /// Computes the intrinsic gas of a frame transaction and, via <paramref name="floorGas"/>, the
-    /// least gas it may be charged.
-    /// </summary>
-    /// <remarks>
-    /// The intrinsic cost is <c>FRAME_TX_INTRINSIC_COST</c> + frames × <c>FRAME_TX_PER_FRAME_COST</c>
-    /// + per-scheme signature verification + the calldata cost of the frame data and signature
-    /// fields. The floor adds the same mandatory (non-data) costs to the data priced at
-    /// <see cref="SpecGasCosts.TotalCostFloorPerToken"/>, mirroring
-    /// <see cref="IntrinsicGasCalculator.CalculateFloorCost"/>: EIP-7976 prices every data byte as a
-    /// non-zero token, EIP-7623 weights zero bytes lower. Both the rate and the token weighting are
-    /// resolved from the spec so a frame transaction's floor cannot diverge from an ordinary
-    /// transaction's under the same fork.
-    /// </remarks>
-    /// <param name="tx">The frame transaction being charged.</param>
-    /// <param name="frames">The transaction's frames.</param>
-    /// <param name="spec">The release spec in effect.</param>
-    /// <param name="floorGas">The minimum chargeable gas, or 0 when floor pricing is not active.</param>
-    /// <returns>The intrinsic gas charged before execution.</returns>
-    private static ulong CalculateFrameTxIntrinsicGas(Transaction tx, TxFrame[] frames, IReleaseSpec spec, out ulong floorGas)
-    {
-        ulong tokens = 0;
-        ulong dataLength = 0;
-        foreach (TxFrame frame in frames)
-        {
-            tokens += CountCalldataTokens(frame.Data.Span, spec);
-            dataLength += (ulong)frame.Data.Length;
-        }
-
-        ulong signatureVerificationCost = 0;
-        TxFrameSignature[]? signatures = tx.FrameSignatures;
-        if (signatures is not null)
-        {
-            foreach (TxFrameSignature signature in signatures)
-            {
-                tokens += signature.Signer is null ? 0 : CountCalldataTokens(signature.Signer.Bytes, spec);
-                tokens += CountCalldataTokens(signature.Msg.Span, spec);
-                tokens += CountCalldataTokens(signature.Signature.Span, spec);
-                dataLength += (ulong)(signature.Signer is null ? 0 : Address.Size)
-                              + (ulong)signature.Msg.Length
-                              + (ulong)signature.Signature.Length;
-                signatureVerificationCost += signature.Scheme switch
-                {
-                    TxFrameSignature.SchemeArbitrary => Eip8141Constants.ArbitraryVerificationGasCost,
-                    TxFrameSignature.SchemeSecp256k1 => Eip8141Constants.Secp256k1VerificationGasCost,
-                    TxFrameSignature.SchemeP256 => Eip8141Constants.P256VerificationGasCost,
-                    _ => 0,
-                };
-            }
-        }
-
-        ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost
-                             + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
-                             + signatureVerificationCost;
-        ulong floorTokens = spec.IsEip7976Enabled ? dataLength * spec.GasCosts.TxDataNonZeroMultiplier : tokens;
-        floorGas = spec.IsEip7623Enabled ? mandatoryGas + floorTokens * spec.GasCosts.TotalCostFloorPerToken : 0;
-        return mandatoryGas + tokens * GasCostOf.TxDataZero;
-    }
-
-    private static ulong CountCalldataTokens(ReadOnlySpan<byte> data, IReleaseSpec spec)
-    {
-        int zeros = data.CountZeros();
-        return (ulong)zeros + (ulong)(data.Length - zeros) * spec.GasCosts.TxDataNonZeroMultiplier;
     }
 
     private TransactionSubstate ExecuteFrame(TxFrame frame, Address resolvedTarget, Address caller, bool isStatic, FrameTxContext frameContext, in StackAccessTracker accessTracker, IReleaseSpec spec, ITxTracer tracer, out ulong gasUsed)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2199,11 +2199,35 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline, UInt256? maxPriorityFeePerGas = null, UInt256? maxFeePerGas = null)
+        // A frame transaction is charged at least the EIP-7623 floor of the data it carries, so frame gas
+        // limits that cannot reach that floor make it unexecutable. Admitting it parks a permanently
+        // unmineable transaction on the sender's nonce, where it blocks every later transaction from that
+        // sender until the pool evicts it.
+        [TestCase(10_000UL, false, TestName = "frame tx whose gas limit cannot reach the calldata floor is rejected")]
+        [TestCase(100_000UL, true, TestName = "frame tx reserving the calldata floor is accepted")]
+        public void Frame_transaction_below_the_calldata_floor_is_rejected_at_ingress(ulong gasLimit, bool expectedAccepted)
+        {
+            _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            // The gas limit of a frame transaction is the sum of its frame gas limits, so the two move together.
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null,
+                frameData: new byte[3000], gasLimit: gasLimit, frameGasLimit: gasLimit);
+
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result == AcceptTxResult.Accepted, Is.EqualTo(expectedAccepted));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(expectedAccepted ? 1 : 0));
+            }
+        }
+
+        private Transaction BuildFrameTx(ulong nonce, Address sender, ulong? deadline, UInt256? maxPriorityFeePerGas = null, UInt256? maxFeePerGas = null, byte[] frameData = null, ulong gasLimit = 1_000_000, ulong frameGasLimit = 100_000)
         {
             List<TxFrame> frames =
             [
-                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default),
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: frameGasLimit, UInt256.Zero, frameData ?? []),
             ];
 
             if (deadline is not null)
@@ -2221,7 +2245,7 @@ namespace Nethermind.TxPool.Test
                 SenderAddress = sender,
                 Frames = [.. frames],
                 FrameSignatures = [],
-                GasLimit = 1_000_000,
+                GasLimit = gasLimit,
                 GasPrice = maxPriorityFeePerGas ?? 1.GWei,
                 DecodedMaxFeePerGas = maxFeePerGas ?? 1.GWei,
             };


### PR DESCRIPTION
## Changes

A frame transaction is charged at least the EIP-7623 floor of the data it carries, so frame gas limits that cannot reach that floor make it unexecutable. Until now nothing checked this before execution: the pool admitted and broadcast such a transaction, and it only failed once a builder tried to execute it, having meanwhile parked itself on the sender's nonce and blocked their later transactions.

Every other transaction type gets this gate from `IntrinsicGasTxValidator`, which does not apply to a frame transaction because its gas limit is derived from the frames rather than read from a `gas_limit` field. This adds the equivalent validator for `TxType.FrameTx` and moves the intrinsic/floor computation out of the processor into `FrameTxIntrinsicGas` so the pool and the processor cannot disagree.

Found on the cross-client devnet: ethrex refuses such a transaction at `eth_sendRawTransaction` ("Total gas limit does not reserve the calldata floor") while Nethermind accepted it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`Frame_transaction_below_the_calldata_floor_is_rejected_at_ingress` in `TxPoolTests`, both branches. Verified red without the validator registration (the under-floor case is accepted and pooled) and green with it. `Nethermind.TxPool.Test` frame filter 8/8, `Nethermind.Evm.Test` frame 70/70.