### PR TITLE
feat(rlp): decode the EIP-8272 recent-root references of a frame transaction

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -153,8 +153,7 @@ public class FrameTxDecoderTests
         }
     }
 
-    // The reference list is part of the signing payload, and an absent list is a different envelope
-    // from an empty one, so neither may reuse the other's hash.
+    // An absent list is a different envelope from an empty one, so neither may reuse the other's hash.
     [Test]
     public void ComputeSigHash_RecentRootReferencesChange_HashChanges()
     {
@@ -174,9 +173,7 @@ public class FrameTxDecoderTests
         }
     }
 
-    // Every rejection the reference list introduces: a tuple that is not three well-sized elements is
-    // not a reference, and a list longer than the cap is not decodable at all — both must throw rather
-    // than yield a transaction some other client would read differently.
+    // Anything another client would read differently must throw rather than decode.
     [TestCaseSource(nameof(MalformedReferenceListCases))]
     public void Decode_MalformedRecentRootReferenceList_Throws(Rlp references)
     {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -175,7 +175,49 @@ public class FrameTxDecoderTests
 
     // Anything another client would read differently must throw rather than decode.
     [TestCaseSource(nameof(MalformedReferenceListCases))]
-    public void Decode_MalformedRecentRootReferenceList_Throws(Rlp references)
+    public void Decode_MalformedRecentRootReferenceList_Throws(Rlp references) =>
+        Assert.That(() => DecodeReferenceEnvelope(references), Throws.InstanceOf<RlpException>());
+
+    // Control: the same envelope with a well-formed list must decode, or the malformed cases above
+    // would be satisfied by any exception the surrounding payload throws.
+    [Test]
+    public void Decode_WellFormedRecentRootReferenceList_Decodes()
+    {
+        Transaction tx = DecodeReferenceEnvelope(Rlp.Encode(new[]
+        {
+            EncodeReference(TestItem.KeccakA.BytesToArray(), 7, TestItem.KeccakB.BytesToArray())
+        }));
+
+        Assert.That(tx.RecentRootReferences, Has.Length.EqualTo(1));
+    }
+
+    private static IEnumerable<TestCaseData> MalformedReferenceListCases()
+    {
+        Rlp wellFormed = EncodeReference(TestItem.KeccakA.BytesToArray(), 7, TestItem.KeccakB.BytesToArray());
+
+        yield return new TestCaseData(Rlp.Encode(new[]
+        {
+            EncodeReference(new byte[31], 7, TestItem.KeccakB.BytesToArray())
+        })).SetName("Decode_ReferenceWithUndersizedSourceId_Throws");
+        yield return new TestCaseData(Rlp.Encode(new[]
+        {
+            Rlp.Encode(new[] { Rlp.Encode(TestItem.KeccakA.BytesToArray()), Rlp.Encode(7L) })
+        })).SetName("Decode_ReferenceMissingRoot_Throws");
+        yield return new TestCaseData(Rlp.Encode(Enumerable.Repeat(wellFormed, Eip8272Constants.MaxRecentRootReferences + 1).ToArray()))
+            .SetName("Decode_MoreReferencesThanTheCap_Throws");
+        yield return new TestCaseData(Rlp.Encode(new[] { Rlp.OfEmptyList }))
+            .SetName("Decode_EmptyListAsAReference_Throws");
+        yield return new TestCaseData(Rlp.Encode(new[]
+        {
+            Rlp.Encode(new[]
+            {
+                Rlp.Encode(TestItem.KeccakA.BytesToArray()), Rlp.Encode(7L),
+                Rlp.Encode(TestItem.KeccakB.BytesToArray()), Rlp.Encode(0L)
+            })
+        })).SetName("Decode_ReferenceWithAFourthElement_Throws");
+    }
+
+    private Transaction DecodeReferenceEnvelope(Rlp references)
     {
         Rlp sequence = Rlp.Encode(
             Rlp.Encode(TestBlockchainIds.ChainId),
@@ -193,26 +235,8 @@ public class FrameTxDecoderTests
         payload[0] = (byte)TxType.FrameTx;
         sequence.Bytes.CopyTo(payload, 1);
 
-        Assert.That(() => { RlpReader reader = new(payload); _txDecoder.Decode(ref reader); }, Throws.InstanceOf<RlpException>());
-    }
-
-    private static IEnumerable<TestCaseData> MalformedReferenceListCases()
-    {
-        Rlp wellFormed = EncodeReference(TestItem.KeccakA.BytesToArray(), 7, TestItem.KeccakB.BytesToArray());
-
-        yield return new TestCaseData(Rlp.Encode(EncodeReference(new byte[31], 7, TestItem.KeccakB.BytesToArray())))
-            .SetName("Decode_ReferenceWithUndersizedSourceId_Throws");
-        yield return new TestCaseData(Rlp.Encode(Rlp.Encode(new[] { Rlp.Encode(TestItem.KeccakA.BytesToArray()), Rlp.Encode(7L) })))
-            .SetName("Decode_ReferenceMissingRoot_Throws");
-        yield return new TestCaseData(Rlp.Encode(Enumerable.Repeat(wellFormed, Eip8272Constants.MaxRecentRootReferences + 1).ToArray()))
-            .SetName("Decode_MoreReferencesThanTheCap_Throws");
-        yield return new TestCaseData(Rlp.Encode(new[] { Rlp.OfEmptyList }))
-            .SetName("Decode_EmptyListAsAReference_Throws");
-        yield return new TestCaseData(Rlp.Encode(Rlp.Encode(new[]
-        {
-            Rlp.Encode(TestItem.KeccakA.BytesToArray()), Rlp.Encode(7L),
-            Rlp.Encode(TestItem.KeccakB.BytesToArray()), Rlp.Encode(0L)
-        }))).SetName("Decode_ReferenceWithAFourthElement_Throws");
+        RlpReader reader = new(payload);
+        return _txDecoder.DecodeGuardNotNull(ref reader, RlpBehaviors.SkipTypedWrapping);
     }
 
     private static Rlp EncodeReference(byte[] sourceId, ulong slot, byte[] root) =>

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -206,6 +206,13 @@ public class FrameTxDecoderTests
             .SetName("Decode_ReferenceMissingRoot_Throws");
         yield return new TestCaseData(Rlp.Encode(Enumerable.Repeat(wellFormed, Eip8272Constants.MaxRecentRootReferences + 1).ToArray()))
             .SetName("Decode_MoreReferencesThanTheCap_Throws");
+        yield return new TestCaseData(Rlp.Encode(new[] { Rlp.OfEmptyList }))
+            .SetName("Decode_EmptyListAsAReference_Throws");
+        yield return new TestCaseData(Rlp.Encode(Rlp.Encode(new[]
+        {
+            Rlp.Encode(TestItem.KeccakA.BytesToArray()), Rlp.Encode(7L),
+            Rlp.Encode(TestItem.KeccakB.BytesToArray()), Rlp.Encode(0L)
+        }))).SetName("Decode_ReferenceWithAFourthElement_Throws");
     }
 
     private static Rlp EncodeReference(byte[] sourceId, ulong slot, byte[] root) =>

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -32,6 +32,7 @@ public class FrameTxDecoderTests
         Assert.That(decoded.ChainId, Is.EqualTo(tx.ChainId));
         Assert.That(decoded.Nonce, Is.EqualTo(tx.Nonce));
         Assert.That(decoded.NonceKeys, Is.EqualTo(tx.NonceKeys));
+        AssertReferencesEqual(decoded.RecentRootReferences, tx.RecentRootReferences);
         // The sender is explicit in the payload — no envelope signature, no ECDSA recovery.
         Assert.That(decoded.SenderAddress, Is.EqualTo(tx.SenderAddress));
         Assert.That(decoded.GasPrice, Is.EqualTo(tx.GasPrice));
@@ -152,6 +153,48 @@ public class FrameTxDecoderTests
         }
     }
 
+    // The reference list is part of the signing payload, and an absent list is a different envelope
+    // from an empty one, so neither may reuse the other's hash.
+    [Test]
+    public void ComputeSigHash_RecentRootReferencesChange_HashChanges()
+    {
+        Transaction none = CreateFrameTx();
+        Transaction empty = CreateFrameTx();
+        empty.RecentRootReferences = [];
+        Transaction referencing = CreateFrameTx();
+        referencing.RecentRootReferences = [Reference(slot: 7)];
+        Transaction otherSlot = CreateFrameTx();
+        otherSlot.RecentRootReferences = [Reference(slot: 8)];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(FrameTxSigHash.ComputeValue(empty), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(none)));
+            Assert.That(FrameTxSigHash.ComputeValue(referencing), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(empty)));
+            Assert.That(FrameTxSigHash.ComputeValue(otherSlot), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(referencing)));
+        }
+    }
+
+    private static RecentRootReference Reference(ulong slot) =>
+        new(TestItem.KeccakA.ValueHash256, slot, TestItem.KeccakB.ValueHash256);
+
+    private static void AssertReferencesEqual(RecentRootReference[]? actual, RecentRootReference[]? expected)
+    {
+        if (expected is null)
+        {
+            Assert.That(actual, Is.Null);
+            return;
+        }
+
+        Assert.That(actual, Is.Not.Null);
+        Assert.That(actual!.Length, Is.EqualTo(expected.Length));
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.That(actual[i].SourceId, Is.EqualTo(expected[i].SourceId));
+            Assert.That(actual[i].Slot, Is.EqualTo(expected[i].Slot));
+            Assert.That(actual[i].Root, Is.EqualTo(expected[i].Root));
+        }
+    }
+
     private static IEnumerable<TestCaseData> RoundtripCases()
     {
         yield return new TestCaseData(CreateFrameTx()).SetName("Roundtrip_MinimalSingleFrame");
@@ -179,6 +222,14 @@ public class FrameTxDecoderTests
         Transaction multiKeyed = CreateFrameTx();
         multiKeyed.NonceKeys = [1, UInt256.MaxValue];
         yield return new TestCaseData(multiKeyed).SetName("Roundtrip_KeyedNonceEnvelope_MultipleKeys");
+
+        Transaction emptyReferences = CreateFrameTx();
+        emptyReferences.RecentRootReferences = [];
+        yield return new TestCaseData(emptyReferences).SetName("Roundtrip_EmptyRecentRootReferenceList");
+
+        Transaction referencing = CreateFrameTx();
+        referencing.RecentRootReferences = [Reference(slot: 0), Reference(slot: ulong.MaxValue)];
+        yield return new TestCaseData(referencing).SetName("Roundtrip_RecentRootReferences");
 
         Transaction blobCarrying = CreateFrameTx();
         blobCarrying.MaxFeePerBlobGas = 7;

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -174,6 +174,46 @@ public class FrameTxDecoderTests
         }
     }
 
+    // Every rejection the reference list introduces: a tuple that is not three well-sized elements is
+    // not a reference, and a list longer than the cap is not decodable at all — both must throw rather
+    // than yield a transaction some other client would read differently.
+    [TestCaseSource(nameof(MalformedReferenceListCases))]
+    public void Decode_MalformedRecentRootReferenceList_Throws(Rlp references)
+    {
+        Rlp sequence = Rlp.Encode(
+            Rlp.Encode(TestBlockchainIds.ChainId),
+            Rlp.Encode(0L),
+            Rlp.Encode(TestItem.AddressA.Bytes),
+            Rlp.Encode(Array.Empty<Rlp>()),
+            Rlp.Encode(Array.Empty<Rlp>()),
+            Rlp.Encode(0L),
+            Rlp.Encode(0L),
+            Rlp.Encode(0L),
+            Rlp.Encode(Array.Empty<Rlp>()),
+            references);
+
+        byte[] payload = new byte[1 + sequence.Length];
+        payload[0] = (byte)TxType.FrameTx;
+        sequence.Bytes.CopyTo(payload, 1);
+
+        Assert.That(() => { RlpReader reader = new(payload); _txDecoder.Decode(ref reader); }, Throws.InstanceOf<RlpException>());
+    }
+
+    private static IEnumerable<TestCaseData> MalformedReferenceListCases()
+    {
+        Rlp wellFormed = EncodeReference(TestItem.KeccakA.BytesToArray(), 7, TestItem.KeccakB.BytesToArray());
+
+        yield return new TestCaseData(Rlp.Encode(EncodeReference(new byte[31], 7, TestItem.KeccakB.BytesToArray())))
+            .SetName("Decode_ReferenceWithUndersizedSourceId_Throws");
+        yield return new TestCaseData(Rlp.Encode(Rlp.Encode(new[] { Rlp.Encode(TestItem.KeccakA.BytesToArray()), Rlp.Encode(7L) })))
+            .SetName("Decode_ReferenceMissingRoot_Throws");
+        yield return new TestCaseData(Rlp.Encode(Enumerable.Repeat(wellFormed, Eip8272Constants.MaxRecentRootReferences + 1).ToArray()))
+            .SetName("Decode_MoreReferencesThanTheCap_Throws");
+    }
+
+    private static Rlp EncodeReference(byte[] sourceId, ulong slot, byte[] root) =>
+        Rlp.Encode(new[] { Rlp.Encode(sourceId), Rlp.Encode(slot), Rlp.Encode(root) });
+
     private static RecentRootReference Reference(ulong slot) =>
         new(TestItem.KeccakA.ValueHash256, slot, TestItem.KeccakB.ValueHash256);
 

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -158,6 +158,10 @@ public class FrameTxValidationTests
         yield return Case("BlobFeeWithoutBlobHashes_BlobFeeWithoutBlobs",
             static tx => tx.MaxFeePerBlobGas = UInt256.One, FrameTxValidation.BlobFeeWithoutBlobs);
 
+        yield return Case("TooManyRecentRootReferences_TooManyRecentRootReferences",
+            static tx => tx.RecentRootReferences = new RecentRootReference[Eip8272Constants.MaxRecentRootReferences + 1],
+            FrameTxValidation.TooManyRecentRootReferences);
+
         // Expiry verifier frame: flags == 0, value == 0, len(data) == EXPIRY_DATA_LENGTH, at most one.
         yield return Case("ExpiryFrameWellFormed_Valid",
             static tx => tx.Frames = [SelfVerifyFrame(), ExpiryFrame()], null);

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -38,6 +38,7 @@ public static class FrameTxValidation
     public const string InvalidMsgLength = "signature msg must be empty or a 32-byte digest";
     public const string ZeroDigestMsg = "explicit signature msg must not be the zero digest";
     public const string BlobFeeWithoutBlobs = "max fee per blob gas must be 0 when there are no blob hashes";
+    public const string TooManyRecentRootReferences = "at most 16 recent root references are allowed";
 
     public static bool IsWellFormed(Transaction transaction, bool postTxEnabled, out string? error)
     {
@@ -208,6 +209,12 @@ public static class FrameTxValidation
                     return false;
                 }
             }
+        }
+
+        if (transaction.RecentRootReferences is { Length: > Eip8272Constants.MaxRecentRootReferences })
+        {
+            error = TooManyRecentRootReferences;
+            return false;
         }
 
         bool hasBlobs = transaction.BlobVersionedHashes is { Length: > 0 };

--- a/src/Nethermind/Nethermind.Core/RecentRootReference.cs
+++ b/src/Nethermind/Nethermind.Core/RecentRootReference.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// A recent-root reference declared by a frame transaction: <c>[source_id, slot, root]</c>.
+/// https://eips.ethereum.org/EIPS/eip-8272
+/// </summary>
+/// <remarks>The root is opaque to consensus — applications bind its meaning. The slot is a beacon slot number.</remarks>
+public class RecentRootReference(in ValueHash256 sourceId, ulong slot, in ValueHash256 root)
+{
+    public ValueHash256 SourceId { get; } = sourceId;
+    public ulong Slot { get; } = slot;
+    public ValueHash256 Root { get; } = root;
+}

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -235,6 +235,14 @@ namespace Nethermind.Core
         public UInt256[]? NonceKeys { get; set; }
 
         /// <summary>
+        /// Recent-root references declared by a frame transaction.
+        /// https://eips.ethereum.org/EIPS/eip-8272
+        /// </summary>
+        /// <remarks><see langword="null"/> for an envelope that predates EIP-8272, which is a different
+        /// signing payload from one carrying an empty reference list.</remarks>
+        public RecentRootReference[]? RecentRootReferences { get; set; }
+
+        /// <summary>
         /// Service transactions are free. The field added to handle baseFee validation after 1559
         /// </summary>
         /// <remarks>Used for AuRa consensus.</remarks>
@@ -355,6 +363,7 @@ namespace Nethermind.Core
                 obj.FrameSignatures = default;
                 obj.PayerAddress = default;
                 obj.NonceKeys = default;
+                obj.RecentRootReferences = default;
 
                 return true;
             }
@@ -391,6 +400,7 @@ namespace Nethermind.Core
             tx.FrameSignatures = FrameSignatures;
             tx.PayerAddress = PayerAddress;
             tx.NonceKeys = NonceKeys;
+            tx.RecentRootReferences = RecentRootReferences;
         }
 
         public virtual ProofVersion? GetProofVersion() =>

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
@@ -23,6 +23,8 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
 
     public FrameSignatureForRpc[]? Signatures { get; set; }
 
+    public RecentRootReferenceForRpc[]? RecentRootReferences { get; set; }
+
     [JsonConstructor]
     public FrameTransactionForRpc() { }
 
@@ -31,6 +33,7 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
     {
         Frames = FrameForRpc.FromFrames(transaction.Frames);
         Signatures = FrameSignatureForRpc.FromSignatures(transaction.FrameSignatures);
+        RecentRootReferences = RecentRootReferenceForRpc.FromReferences(transaction.RecentRootReferences);
     }
 
     public override Result<Transaction> ToTransaction(bool validateUserInput = false, ulong? gasCap = null, IReleaseSpec? spec = null)
@@ -41,6 +44,7 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
         Transaction tx = baseResult.Data;
         tx.Frames = FrameForRpc.ToFrames(Frames);
         tx.FrameSignatures = FrameSignatureForRpc.ToSignatures(Signatures);
+        tx.RecentRootReferences = RecentRootReferenceForRpc.ToReferences(RecentRootReferences);
         return tx;
     }
 

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/RecentRootReferenceForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/RecentRootReferenceForRpc.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Linq;
+using System.Text.Json.Serialization;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Facade.Eth.RpcTransaction;
+
+/// <summary>
+/// JSON-RPC view of an EIP-8272 recent-root reference <c>[source_id, slot, root]</c>.
+/// </summary>
+/// <remarks>
+/// The reference list is part of the signing payload, so an absent list and an empty one are different
+/// transactions; the mapping preserves that distinction rather than collapsing both to <c>null</c>.
+/// </remarks>
+public class RecentRootReferenceForRpc
+{
+    public Hash256 SourceId { get; set; } = Keccak.Zero;
+    public ulong Slot { get; set; }
+    public Hash256 Root { get; set; } = Keccak.Zero;
+
+    [JsonConstructor]
+    public RecentRootReferenceForRpc() { }
+
+    public RecentRootReferenceForRpc(in RecentRootReference reference)
+    {
+        SourceId = new Hash256(reference.SourceId);
+        Slot = reference.Slot;
+        Root = new Hash256(reference.Root);
+    }
+
+    public RecentRootReference ToReference() => new(SourceId.ValueHash256, Slot, Root.ValueHash256);
+
+    public static RecentRootReferenceForRpc[]? FromReferences(RecentRootReference[]? references) =>
+        references?.Select(static r => new RecentRootReferenceForRpc(r)).ToArray();
+
+    public static RecentRootReference[]? ToReferences(RecentRootReferenceForRpc[]? references) =>
+        references?.Select(static r => r.ToReference()).ToArray();
+}

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/RecentRootReferenceForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/RecentRootReferenceForRpc.cs
@@ -11,10 +11,7 @@ namespace Nethermind.Facade.Eth.RpcTransaction;
 /// <summary>
 /// JSON-RPC view of an EIP-8272 recent-root reference <c>[source_id, slot, root]</c>.
 /// </summary>
-/// <remarks>
-/// The reference list is part of the signing payload, so an absent list and an empty one are different
-/// transactions; the mapping preserves that distinction rather than collapsing both to <c>null</c>.
-/// </remarks>
+/// <remarks>An absent list and an empty one are different transactions; the mapping keeps them apart.</remarks>
 public class RecentRootReferenceForRpc
 {
     public Hash256 SourceId { get; set; } = Keccak.Zero;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RecentRootReferenceDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RecentRootReferenceDecoder.cs
@@ -38,15 +38,9 @@ public sealed class RecentRootReferenceDecoder : RlpDecoder<RecentRootReference>
         writer.Encode(item.Root);
     }
 
-    public void EncodeArray<TWriter>(ref TWriter writer, RecentRootReference[]? items)
+    public void EncodeArray<TWriter>(ref TWriter writer, RecentRootReference[] items)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
     {
-        if (items is null)
-        {
-            writer.WriteByte(Rlp.EmptyListByte);
-            return;
-        }
-
         writer.StartSequence(GetArrayContentLength(items));
         for (int i = 0; i < items.Length; i++)
         {
@@ -56,7 +50,7 @@ public sealed class RecentRootReferenceDecoder : RlpDecoder<RecentRootReference>
 
     public override int GetLength(RecentRootReference item, RlpBehaviors rlpBehaviors) => Rlp.LengthOfSequence(GetContentLength(item));
 
-    public int GetArrayLength(RecentRootReference[]? items) => items is null ? 1 : Rlp.LengthOfSequence(GetArrayContentLength(items));
+    public int GetArrayLength(RecentRootReference[] items) => Rlp.LengthOfSequence(GetArrayContentLength(items));
 
     private int GetArrayContentLength(RecentRootReference[] items)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RecentRootReferenceDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RecentRootReferenceDecoder.cs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Serialization.Rlp;
+
+/// <summary>Decodes the EIP-8272 recent-root reference tuple <c>[source_id, slot, root]</c>.</summary>
+public sealed class RecentRootReferenceDecoder : RlpDecoder<RecentRootReference>
+{
+    public static readonly RecentRootReferenceDecoder Instance = new();
+
+    protected override RecentRootReference DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    {
+        int length = decoderContext.ReadSequenceLength();
+        int check = length + decoderContext.Position;
+
+        ValueHash256 sourceId = decoderContext.DecodeValueKeccak() ?? ThrowMissingHash();
+        ulong slot = decoderContext.DecodeULong();
+        ValueHash256 root = decoderContext.DecodeValueKeccak() ?? ThrowMissingHash();
+
+        if (!rlpBehaviors.HasFlag(RlpBehaviors.AllowExtraBytes))
+        {
+            decoderContext.Check(check);
+        }
+
+        return new RecentRootReference(sourceId, slot, root);
+    }
+
+    public override void Encode<TWriter>(ref TWriter writer, RecentRootReference item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    {
+        writer.StartSequence(GetContentLength(item));
+        writer.Encode(item.SourceId);
+        writer.Encode(item.Slot);
+        writer.Encode(item.Root);
+    }
+
+    public void EncodeArray<TWriter>(ref TWriter writer, RecentRootReference[]? items)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct
+    {
+        if (items is null)
+        {
+            writer.WriteByte(Rlp.EmptyListByte);
+            return;
+        }
+
+        writer.StartSequence(GetArrayContentLength(items));
+        for (int i = 0; i < items.Length; i++)
+        {
+            Encode(ref writer, items[i]);
+        }
+    }
+
+    public override int GetLength(RecentRootReference item, RlpBehaviors rlpBehaviors) => Rlp.LengthOfSequence(GetContentLength(item));
+
+    public int GetArrayLength(RecentRootReference[]? items) => items is null ? 1 : Rlp.LengthOfSequence(GetArrayContentLength(items));
+
+    private int GetArrayContentLength(RecentRootReference[] items)
+    {
+        int length = 0;
+        for (int i = 0; i < items.Length; i++)
+        {
+            length += GetLength(items[i], RlpBehaviors.None);
+        }
+
+        return length;
+    }
+
+    [DoesNotReturn, StackTraceHidden]
+    private static ValueHash256 ThrowMissingHash() => throw new RlpException("recent root reference source id and root must be 32-byte hashes");
+
+    private static int GetContentLength(RecentRootReference item) =>
+        Rlp.LengthOf(item.SourceId)
+        + Rlp.LengthOf(item.Slot)
+        + Rlp.LengthOf(item.Root);
+}

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
@@ -31,7 +31,7 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
 
         if (decoderContext.Position < lastCheck)
         {
-            transaction.Signature = DecodeSignature(transaction, ref decoderContext, rlpBehaviors);
+            DecodeTrailing(transaction, ref decoderContext, rlpBehaviors);
         }
 
         if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) == 0)
@@ -44,6 +44,12 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
             CalculateHash(transaction, txSequenceStart, transactionSequence, ref decoderContext);
         }
     }
+
+    /// <summary>Decodes the element that follows the payload, entered only when bytes remain.</summary>
+    /// <remarks>The default reads the envelope ECDSA signature; a transaction type whose trailing element is
+    /// not a signature overrides this so the shared pre/post-payload framing stays in one place.</remarks>
+    protected virtual void DecodeTrailing(Transaction transaction, ref RlpReader decoderContext, RlpBehaviors rlpBehaviors) =>
+        transaction.Signature = DecodeSignature(transaction, ref decoderContext, rlpBehaviors);
 
     protected static void CalculateHash(Transaction transaction, int txSequenceStart, ReadOnlySpan<byte> transactionSequence, ref RlpReader decoderContext)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
@@ -45,9 +45,6 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
         }
     }
 
-    /// <summary>Decodes the element that follows the payload, entered only when bytes remain.</summary>
-    /// <remarks>The default reads the envelope ECDSA signature; a transaction type whose trailing element is
-    /// not a signature overrides this so the shared pre/post-payload framing stays in one place.</remarks>
     protected virtual void DecodeTrailing(Transaction transaction, ref RlpReader decoderContext, RlpBehaviors rlpBehaviors) =>
         transaction.Signature = DecodeSignature(transaction, ref decoderContext, rlpBehaviors);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -43,10 +43,9 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 
     /// <inheritdoc/>
     /// <remarks>
-    /// A frame transaction carries no envelope signature — the sender is explicit — so what follows the
-    /// EIP-8141 fields is the optional EIP-8272 reference list rather than a trailing <c>[v, r, s]</c>.
-    /// A non-list element there is padding and is rejected: accepting it would decode a spurious
-    /// signature that strict clients drop, diverging on the transaction hash.
+    /// A frame transaction carries no envelope signature, so what follows the EIP-8141 fields is the
+    /// optional EIP-8272 reference list. A non-list element there is padding: accepting it would decode
+    /// a spurious signature that strict clients drop, diverging on the transaction hash.
     /// </remarks>
     public override void Decode(ref Transaction? transaction, int txSequenceStart, ReadOnlySpan<byte> transactionSequence,
         ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -13,10 +13,8 @@ namespace Nethermind.Serialization.Rlp.TxDecoders;
 /// <summary>
 /// Decodes the EIP-8141 frame transaction payload
 /// <c>[chain_id, nonce, sender, frames, signatures, max_priority_fee_per_gas, max_fee_per_gas,
-/// max_fee_per_blob_gas, blob_versioned_hashes]</c>, or its EIP-8250 form, which replaces
-/// <c>nonce</c> with <c>nonce_keys, nonce_seq</c>.
-/// max_fee_per_blob_gas, blob_versioned_hashes]</c>, optionally followed by the EIP-8272
-/// <c>recent_root_references</c> list.
+/// max_fee_per_blob_gas, blob_versioned_hashes]</c> — in its EIP-8250 form <c>nonce</c> is replaced
+/// by <c>nonce_keys, nonce_seq</c> — optionally followed by the EIP-8272 <c>recent_root_references</c> list.
 /// The sender is explicit in the payload — there is no envelope ECDSA signature and no recovery.
 /// Encoding with <c>forSigning</c> produces the <c>compute_sig_hash</c> form: the raw signature
 /// bytes of canonical-hash (empty msg) entries are elided.
@@ -39,44 +37,20 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 
     private static readonly byte[][] EmptyVersionedHashes = [];
 
-    private readonly Func<T> _newTransaction = transactionFactory ?? (static () => new T());
-
     /// <inheritdoc/>
     /// <remarks>
-    /// A frame transaction carries no envelope signature, so what follows the EIP-8141 fields is the
-    /// optional EIP-8272 reference list. A non-list element there is padding: accepting it would decode
-    /// a spurious signature that strict clients drop, diverging on the transaction hash.
+    /// The trailing element of a frame transaction is the optional EIP-8272 reference list, never a
+    /// signature (the sender is explicit). A non-list element there is padding whose acceptance would
+    /// decode a spurious signature that strict clients drop, diverging on the transaction hash.
     /// </remarks>
-    public override void Decode(ref Transaction? transaction, int txSequenceStart, ReadOnlySpan<byte> transactionSequence,
-        ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override void DecodeTrailing(Transaction transaction, ref RlpReader decoderContext, RlpBehaviors rlpBehaviors)
     {
-        transaction ??= _newTransaction();
-        transaction.Type = Type;
-
-        int payloadLength = decoderContext.ReadSequenceLength();
-        int lastCheck = decoderContext.Position + payloadLength;
-
-        DecodePayload(transaction, ref decoderContext, rlpBehaviors);
-
-        if (decoderContext.Position < lastCheck)
+        if (!decoderContext.IsSequenceNext())
         {
-            if (!decoderContext.IsSequenceNext())
-            {
-                ThrowTrailingSignature();
-            }
-
-            transaction.RecentRootReferences = decoderContext.DecodeArray(RecentRootReferenceDecoder.Instance, limit: ReferencesCountLimit);
+            ThrowTrailingSignature();
         }
 
-        if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) == 0)
-        {
-            decoderContext.Check(lastCheck);
-        }
-
-        if ((rlpBehaviors & RlpBehaviors.ExcludeHashes) == 0)
-        {
-            CalculateHash(transaction, txSequenceStart, transactionSequence, ref decoderContext);
-        }
+        transaction.RecentRootReferences = decoderContext.DecodeArray(RecentRootReferenceDecoder.Instance, limit: ReferencesCountLimit);
     }
 
     protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -15,6 +15,8 @@ namespace Nethermind.Serialization.Rlp.TxDecoders;
 /// <c>[chain_id, nonce, sender, frames, signatures, max_priority_fee_per_gas, max_fee_per_gas,
 /// max_fee_per_blob_gas, blob_versioned_hashes]</c>, or its EIP-8250 form, which replaces
 /// <c>nonce</c> with <c>nonce_keys, nonce_seq</c>.
+/// max_fee_per_blob_gas, blob_versioned_hashes]</c>, optionally followed by the EIP-8272
+/// <c>recent_root_references</c> list.
 /// The sender is explicit in the payload — there is no envelope ECDSA signature and no recovery.
 /// Encoding with <c>forSigning</c> produces the <c>compute_sig_hash</c> form: the raw signature
 /// bytes of canonical-hash (empty msg) entries are elided.
@@ -33,7 +35,50 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     // EIP8141-GAP: the spec does not bound blob_versioned_hashes; mirrors the blob tx decode cap.
     private static readonly RlpLimit BlobVersionedHashesCountLimit = RlpLimit.For<Transaction>(128, nameof(Transaction.BlobVersionedHashes));
 
+    private static readonly RlpLimit ReferencesCountLimit = RlpLimit.For<Transaction>(Eip8272Constants.MaxRecentRootReferences, nameof(Transaction.RecentRootReferences));
+
     private static readonly byte[][] EmptyVersionedHashes = [];
+
+    private readonly Func<T> _newTransaction = transactionFactory ?? (static () => new T());
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// A frame transaction carries no envelope signature — the sender is explicit — so what follows the
+    /// EIP-8141 fields is the optional EIP-8272 reference list rather than a trailing <c>[v, r, s]</c>.
+    /// A non-list element there is padding and is rejected: accepting it would decode a spurious
+    /// signature that strict clients drop, diverging on the transaction hash.
+    /// </remarks>
+    public override void Decode(ref Transaction? transaction, int txSequenceStart, ReadOnlySpan<byte> transactionSequence,
+        ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    {
+        transaction ??= _newTransaction();
+        transaction.Type = Type;
+
+        int payloadLength = decoderContext.ReadSequenceLength();
+        int lastCheck = decoderContext.Position + payloadLength;
+
+        DecodePayload(transaction, ref decoderContext, rlpBehaviors);
+
+        if (decoderContext.Position < lastCheck)
+        {
+            if (!decoderContext.IsSequenceNext())
+            {
+                ThrowTrailingSignature();
+            }
+
+            transaction.RecentRootReferences = decoderContext.DecodeArray(RecentRootReferenceDecoder.Instance, limit: ReferencesCountLimit);
+        }
+
+        if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) == 0)
+        {
+            decoderContext.Check(lastCheck);
+        }
+
+        if ((rlpBehaviors & RlpBehaviors.ExcludeHashes) == 0)
+        {
+            CalculateHash(transaction, txSequenceStart, transactionSequence, ref decoderContext);
+        }
+    }
 
     protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,
         RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -110,6 +155,10 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         writer.Encode(transaction.DecodedMaxFeePerGas);
         writer.Encode(transaction.MaxFeePerBlobGas.GetValueOrDefault());
         writer.Encode(transaction.BlobVersionedHashes ?? EmptyVersionedHashes);
+        if (transaction.RecentRootReferences is { } references)
+        {
+            RecentRootReferenceDecoder.Instance.EncodeArray(ref writer, references);
+        }
     }
 
     protected override int GetContentLength(Transaction transaction, RlpBehaviors rlpBehaviors, bool forSigning,
@@ -123,7 +172,8 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         + Rlp.LengthOf(transaction.GasPrice)
         + Rlp.LengthOf(transaction.DecodedMaxFeePerGas)
         + Rlp.LengthOf(transaction.MaxFeePerBlobGas.GetValueOrDefault())
-        + Rlp.LengthOf(transaction.BlobVersionedHashes ?? EmptyVersionedHashes);
+        + Rlp.LengthOf(transaction.BlobVersionedHashes ?? EmptyVersionedHashes)
+        + (transaction.RecentRootReferences is { } references ? RecentRootReferenceDecoder.Instance.GetArrayLength(references) : 0);
 
     protected override int GetSignatureLength(Signature? signature, bool forSigning, bool isEip155Enabled = false, ulong chainId = 0) => 0;
 
@@ -132,12 +182,8 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     {
     }
 
-    // The payload is exactly 9 fields with no envelope signature (the sender is explicit). The base
-    // decoder reads a trailing [v, r, s] whenever elements remain after the payload; reject that so a
-    // padded encoding is not silently accepted with a spurious signature (which strict clients drop,
-    // diverging on the transaction hash).
-    protected override Signature? DecodeSignature(ulong v, ReadOnlySpan<byte> rBytes, ReadOnlySpan<byte> sBytes, Signature? fallbackSignature = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None) =>
-        throw new RlpException("frame transaction must not carry a trailing signature");
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowTrailingSignature() => throw new RlpException("frame transaction must not carry a trailing signature");
 
     /// <summary>Reads <c>nonce_keys</c> as a list of integers.</summary>
     /// <remarks>

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -37,12 +37,6 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 
     private static readonly byte[][] EmptyVersionedHashes = [];
 
-    /// <inheritdoc/>
-    /// <remarks>
-    /// The trailing element of a frame transaction is the optional EIP-8272 reference list, never a
-    /// signature (the sender is explicit). A non-list element there is padding whose acceptance would
-    /// decode a spurious signature that strict clients drop, diverging on the transaction hash.
-    /// </remarks>
     protected override void DecodeTrailing(Transaction transaction, ref RlpReader decoderContext, RlpBehaviors rlpBehaviors)
     {
         if (!decoderContext.IsSequenceNext())

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -68,6 +68,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         transaction.DecodedMaxFeePerGas = decoderContext.DecodeUInt256();
         transaction.MaxFeePerBlobGas = decoderContext.DecodeUInt256();
         transaction.BlobVersionedHashes = decoderContext.DecodeByteArrays(BlobVersionedHashesCountLimit, innerSize: Hash256.Size);
+        transaction.RecentRootReferences = null;
 
         // A frame transaction has no gas_limit field; expose the sum of frame gas limits as GasLimit
         // so pre-execution consumers (GasLimitTxFilter, block-production selection, pre-warming) that


### PR DESCRIPTION
## Changes

EIP-8272 appends `recent_root_references` to the frame transaction envelope, after `blob_versioned_hashes`. I add `RecentRootReference` (`[source_id, slot, root]`) and its decoder, capped at `MAX_RECENT_ROOT_REFERENCES`, plus `Transaction.RecentRootReferences`, `null` for an envelope predating EIP-8272 (a different signing payload from one carrying an empty list). `FrameTxDecoder` reads the list when elements remain after the EIP-8141 payload; a non-list element there is still rejected as a trailing signature, so the anti-padding guarantee is unchanged. Wire order matches the only other implementation, whose golden vector places the list last.

Validity against state is already implemented in `RecentRootStore` (#12528); this PR only makes the references reachable from the wire.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Testing

`Nethermind.Core.Test` 6047/6047. New cases: roundtrip of an empty and a populated reference list, and a signature-hash test proving absent, empty and populated lists hash differently.
