### PR TITLE
feat(evm): validate, consume and charge EIP-8250 keyed nonces

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Validation;
 using Nethermind.Crypto;
 using Nethermind.Evm;
 using Nethermind.Evm.GasPolicy;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 
 namespace Nethermind.Consensus.Validators;
@@ -94,7 +95,8 @@ public sealed class TxValidator : ITxValidator
             NonceCapTxValidator.Instance,
             expectedChainIdTxValidator,
             GasFieldsTxValidator.Instance,
-            FrameTxFieldsTxValidator.Instance
+            FrameTxFieldsTxValidator.Instance,
+            FrameTxNonceKeysTxValidator.Instance
         ]));
     }
 
@@ -214,6 +216,38 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
         }
 
         return ValidationResult.Success;
+    }
+}
+
+/// <summary>Admits the EIP-8250 keyed-nonce envelope only on forks that define it, and only well-formed.</summary>
+/// <remarks>
+/// The RLP decoder tells the two envelope shapes apart without fork context, so the fork that admits the
+/// keyed one is decided here. Pre-fork the keys carry no replay protection at all — the account nonce is
+/// left untouched — so admitting one would make the transaction replayable. Well-formedness is re-checked
+/// because a transaction can reach validation without passing through the decoder: <c>eth_call</c>,
+/// <c>eth_estimateGas</c> and block building all construct one directly.
+/// </remarks>
+public sealed class FrameTxNonceKeysTxValidator : ITxValidator
+{
+    public static readonly FrameTxNonceKeysTxValidator Instance = new();
+    private FrameTxNonceKeysTxValidator() { }
+
+    public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
+    {
+        UInt256[]? nonceKeys = transaction.NonceKeys;
+        if (nonceKeys is null)
+        {
+            return ValidationResult.Success;
+        }
+
+        if (!releaseSpec.IsEip8250Enabled)
+        {
+            return "keyed nonces are not enabled";
+        }
+
+        return KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys) && transaction.Nonce < Eip8250Constants.MaxNonceSeq
+            ? ValidationResult.Success
+            : "malformed nonce key set";
     }
 }
 

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -221,11 +221,9 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
 
 /// <summary>Admits the EIP-8250 keyed-nonce envelope only on forks that define it, and only well-formed.</summary>
 /// <remarks>
-/// The RLP decoder tells the two envelope shapes apart without fork context, so the fork that admits the
-/// keyed one is decided here. Pre-fork the keys carry no replay protection at all — the account nonce is
-/// left untouched — so admitting one would make the transaction replayable. Well-formedness is re-checked
-/// because a transaction can reach validation without passing through the decoder: <c>eth_call</c>,
-/// <c>eth_estimateGas</c> and block building all construct one directly.
+/// Pre-fork the keys carry no replay protection at all — the account nonce is left untouched — so admitting
+/// one would make the transaction replayable. Well-formedness is re-checked because <c>eth_call</c>,
+/// <c>eth_estimateGas</c> and block building construct a transaction without going through the decoder.
 /// </remarks>
 public sealed class FrameTxNonceKeysTxValidator : ITxValidator
 {

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -240,12 +240,12 @@ public sealed class FrameTxNonceKeysTxValidator : ITxValidator
 
         if (!releaseSpec.IsEip8250Enabled)
         {
-            return "keyed nonces are not enabled";
+            return FrameTxValidation.KeyedNoncesNotEnabled;
         }
 
         return KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys) && transaction.Nonce < Eip8250Constants.MaxNonceSeq
             ? ValidationResult.Success
-            : "malformed nonce key set";
+            : FrameTxValidation.MalformedNonceKeySet;
     }
 }
 

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -38,6 +38,8 @@ public static class FrameTxValidation
     public const string InvalidMsgLength = "signature msg must be empty or a 32-byte digest";
     public const string ZeroDigestMsg = "explicit signature msg must not be the zero digest";
     public const string BlobFeeWithoutBlobs = "max fee per blob gas must be 0 when there are no blob hashes";
+    public const string KeyedNoncesNotEnabled = "keyed nonces are not enabled";
+    public const string MalformedNonceKeySet = "malformed nonce key set";
 
     public static bool IsWellFormed(Transaction transaction, bool postTxEnabled, out string? error)
     {

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1297,9 +1297,7 @@ public class FrameTxProcessorTests
         Assert.That(actual, Is.EqualTo(expected), message ?? $"storage slot {slot} of {address}");
     }
 
-    // EIP-8250: a keyed transaction consumes every selected key as a unit at payment approval and
-    // leaves the account nonce alone, so a partially advanced set cannot be replayed. Each key used
-    // for the first time pays the state-growth surcharge against the approving frame's gas.
+    // A keyed transaction consumes the whole set at payment approval and leaves the account nonce alone.
     [Test]
     public void Execute_KeyedNonce_ConsumesEverySelectedKeyAndChargesFirstUse()
     {
@@ -1330,8 +1328,7 @@ public class FrameTxProcessorTests
             "only the first use of each key is surcharged");
     }
 
-    // The nonce sequence is per key, so a transaction is only valid when every selected key currently
-    // sits at its nonce_seq; a set where one key has moved on must not execute.
+    // The sequence is per key, so every selected key must currently sit at nonce_seq.
     [TestCase(0UL, 1UL, false, TestName = "a nonce sequence behind a consumed key is too low")]
     [TestCase(1UL, 1UL, true, TestName = "a nonce sequence matching every selected key executes")]
     [TestCase(2UL, 1UL, false, TestName = "a nonce sequence ahead of an unconsumed key is too high")]
@@ -1348,9 +1345,7 @@ public class FrameTxProcessorTests
         Assert.That(Process(tx).TransactionExecuted, Is.EqualTo(expectedExecuted));
     }
 
-    // The replay-protection property the set semantics exist for: if one key of a set has already moved
-    // on, the whole set is unusable at that sequence, so the transaction cannot be replayed against the
-    // keys that stayed behind.
+    // The property the set semantics exist for: one advanced key makes the whole set unusable.
     [Test]
     public void Execute_KeyedNonce_PartiallyAdvancedSetIsNotReplayable()
     {

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1380,25 +1380,29 @@ public class FrameTxProcessorTests
             "the legacy key owes no first-use surcharge");
     }
 
-    // EIP-8250 L174/L269: a payment approve's effects — payer and nonce consumption — are journaled outside the EIP-8141 atomic-batch snapshot, so an approval taken before a batch survives that batch unrolling.
+    // EIP-8250 "Nonce consumption": approval effects are journaled outside the atomic-batch snapshot,
+    // so a payment approval taken inside a batch survives the batch unrolling and the transaction still
+    // has a payer. The pre-8250 envelope keeps EIP-8141's unroll (see the sibling test above).
     [Test]
-    public void Execute_AtomicBatch_KeyedPaymentApprovalBeforeFailedBatch_SurvivesTheUnroll()
+    public void Execute_AtomicBatch_KeyedPaymentApprovalInsideFailedBatch_SurvivesTheUnroll()
     {
-        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecution));
+        DeployContract(Observer, ApproveCode(TxFrame.ApprovePayment), 1.Ether);
         DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
         UInt256[] keys = [1, 7];
 
         Transaction tx = FrameTx(nonce: 0,
-            SelfVerifyFrame(),
-            Frame(TxFrame.ModeSender, flags: TxFrame.AtomicBatchFlag, target: Recipient),
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            Frame(TxFrame.ModeDefault, flags: (byte)(TxFrame.ApprovePayment | TxFrame.AtomicBatchFlag), target: Observer),
             Frame(TxFrame.ModeSender, target: Recipient));
         tx.NonceKeys = keys;
 
         TransactionResult result = Process(tx);
 
-        Assert.That(result.TransactionExecuted, Is.True, "the payer approved before the batch survives its unroll");
+        Assert.That(result.TransactionExecuted, Is.True, "the payer recorded inside the batch survives the unroll");
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(_stateProvider.GetBalance(Observer), Is.LessThan(1.Ether), "the sponsor is charged");
             Assert.That(_stateProvider.GetNonce(Sender), Is.Zero, "a keyed transaction leaves the account nonce alone");
             foreach (UInt256 key in keys)
             {
@@ -1418,19 +1422,25 @@ public class FrameTxProcessorTests
         _stateProvider.CommitTree(0);
         UInt256[] keys = [1, 7];
 
+        Transaction firstUse = SelfSignedSelfVerifyTx(nonce: 0, keys);
+        FrameTxValidation.TryCalculateGasBudget(firstUse, Spec, out ulong firstUseIntrinsic, out _, out _);
         CallOutputTracer firstUseTracer = new();
-        Assert.That(Process(SelfSignedSelfVerifyTx(nonce: 0, keys), tracer: firstUseTracer).TransactionExecuted, Is.True);
+        Assert.That(Process(firstUse, tracer: firstUseTracer).TransactionExecuted, Is.True);
         foreach (UInt256 key in keys)
         {
             Assert.That(new UInt256(_stateProvider.Get(KeyedNonceManager.StorageSlot(Sender, key)), isBigEndian: true),
                 Is.EqualTo(UInt256.One));
         }
-
-        CallOutputTracer reuseTracer = new();
-        Assert.That(Process(SelfSignedSelfVerifyTx(nonce: 1, keys), tracer: reuseTracer).TransactionExecuted, Is.True);
-        Assert.That(firstUseTracer.GasSpent - reuseTracer.GasSpent,
+        Assert.That((long)firstUseTracer.GasSpent - (long)firstUseIntrinsic,
             Is.EqualTo((long)keys.Length * Eip8250Constants.KeyedNonceFirstUseGas),
             "the default-code approval owes the surcharge the APPROVE opcode charges");
+
+        Transaction reuse = SelfSignedSelfVerifyTx(nonce: 1, keys);
+        FrameTxValidation.TryCalculateGasBudget(reuse, Spec, out _, out ulong reuseFloor, out _);
+        CallOutputTracer reuseTracer = new();
+        Assert.That(Process(reuse, tracer: reuseTracer).TransactionExecuted, Is.True);
+        Assert.That(reuseTracer.GasSpent, Is.EqualTo(reuseFloor),
+            "a reused key adds no frame gas, so the transaction owes only its floor");
     }
 
     /// <summary>A codeless-sender self-verify transaction carrying the canonical-hash signature default code requires at index 0.</summary>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1345,6 +1345,47 @@ public class FrameTxProcessorTests
         Assert.That(Process(tx).TransactionExecuted, Is.EqualTo(expectedExecuted));
     }
 
+    [Test]
+    public void Execute_KeyedNonce_RecordsTheNonceManagerSlotInBal()
+    {
+        // EIP-7928: a keyed nonce lives in NONCE_MANAGER storage rather than in the account nonce, so the
+        // slot it consumes must reach the BAL. A parallel validator reads the pre-state through the block
+        // access list, and an omitted slot makes it reject a block every sequential node accepts.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+
+        TracedAccessWorldState tracedState = new(_stateProvider, parallel: false);
+        tracedState.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
+        EthereumCodeInfoRepository codeInfoRepository = new(tracedState);
+        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        EthereumTransactionProcessor tracedProcessor = new(BlobBaseFeeCalculator.Instance, _specProvider, tracedState, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+
+        UInt256[] keys = [1, 7];
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.NonceKeys = keys;
+
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+        TransactionResult result = tracedProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        AccountChangesAtIndex? managerChanges = tracedState.GetGeneratingBlockAccessList()!
+            .GetAccountChanges(Eip8250Constants.NonceManagerAddress);
+        Assert.That(managerChanges, Is.Not.Null, "the nonce manager is accessed and recorded in the BAL");
+        using (Assert.EnterMultipleScope())
+        {
+            foreach (UInt256 key in keys)
+            {
+                Assert.That(managerChanges.HasStorageChange(KeyedNonceManager.StorageSlot(Sender, key).Index), Is.True,
+                    $"the slot consumed for key {key} must be in the BAL");
+            }
+
+            Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0UL), "a keyed set leaves the account nonce alone");
+        }
+    }
+
     // The property the set semantics exist for: one advanced key makes the whole set unusable.
     [Test]
     public void Execute_KeyedNonce_PartiallyAdvancedSetIsNotReplayable()
@@ -1380,29 +1421,25 @@ public class FrameTxProcessorTests
             "the legacy key owes no first-use surcharge");
     }
 
-    // EIP-8250 "Nonce consumption": approval effects are journaled outside the atomic-batch snapshot,
-    // so a payment approval taken inside a batch survives the batch unrolling and the transaction still
-    // has a payer. The pre-8250 envelope keeps EIP-8141's unroll (see the sibling test above).
+    // EIP-8250 L174/L269: a payment approve's effects — payer and nonce consumption — are journaled outside the EIP-8141 atomic-batch snapshot, so an approval taken before a batch survives that batch unrolling.
     [Test]
-    public void Execute_AtomicBatch_KeyedPaymentApprovalInsideFailedBatch_SurvivesTheUnroll()
+    public void Execute_AtomicBatch_KeyedPaymentApprovalBeforeFailedBatch_SurvivesTheUnroll()
     {
-        DeploySmartSender(ApproveCode(TxFrame.ApproveExecution));
-        DeployContract(Observer, ApproveCode(TxFrame.ApprovePayment), 1.Ether);
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
         UInt256[] keys = [1, 7];
 
         Transaction tx = FrameTx(nonce: 0,
-            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 200_000, UInt256.Zero, default),
-            Frame(TxFrame.ModeDefault, flags: (byte)(TxFrame.ApprovePayment | TxFrame.AtomicBatchFlag), target: Observer),
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, flags: TxFrame.AtomicBatchFlag, target: Recipient),
             Frame(TxFrame.ModeSender, target: Recipient));
         tx.NonceKeys = keys;
 
         TransactionResult result = Process(tx);
 
-        Assert.That(result.TransactionExecuted, Is.True, "the payer recorded inside the batch survives the unroll");
+        Assert.That(result.TransactionExecuted, Is.True, "the payer approved before the batch survives its unroll");
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(_stateProvider.GetBalance(Observer), Is.LessThan(1.Ether), "the sponsor is charged");
             Assert.That(_stateProvider.GetNonce(Sender), Is.Zero, "a keyed transaction leaves the account nonce alone");
             foreach (UInt256 key in keys)
             {

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1380,6 +1380,28 @@ public class FrameTxProcessorTests
             "the legacy key owes no first-use surcharge");
     }
 
+    // An unchecked increment wraps the account nonce to zero, making every prior transaction from
+    // that sender replayable. The EIP-8250 envelope is already refused a sequence at the ceiling
+    // during stateful validity, so only the pre-8250 envelope reaches payment approval here.
+    [Test]
+    public void Execute_PaymentApprovalAtTheNonceCeiling_PerformsNoApprovalEffects()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        _stateProvider.SetNonce(Sender, Eip8250Constants.MaxNonceSeq);
+        _stateProvider.Commit(Spec);
+        UInt256 balanceBefore = _stateProvider.GetBalance(Sender);
+
+        Transaction tx = FrameTx(nonce: Eip8250Constants.MaxNonceSeq, SelfVerifyFrame());
+
+        Assert.That(Process(tx).TransactionExecuted, Is.False, "no payer approved");
+        Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(Eip8250Constants.MaxNonceSeq));
+        Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(balanceBefore), "max cost was not collected");
+
+        Transaction keyed = FrameTx(nonce: Eip8250Constants.MaxNonceSeq, SelfVerifyFrame());
+        keyed.NonceKeys = [UInt256.Zero];
+        Assert.That(Process(keyed).Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+    }
+
     private static UInt256 AddressAsWord(Address address) => new(address.Bytes, isBigEndian: true);
 
     private static byte[] ApproveCode(byte scope) =>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1380,6 +1380,76 @@ public class FrameTxProcessorTests
             "the legacy key owes no first-use surcharge");
     }
 
+    // EIP-8250 L174/L269: a payment approve's effects — payer and nonce consumption — are journaled outside the EIP-8141 atomic-batch snapshot, so an approval taken before a batch survives that batch unrolling.
+    [Test]
+    public void Execute_AtomicBatch_KeyedPaymentApprovalBeforeFailedBatch_SurvivesTheUnroll()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+        UInt256[] keys = [1, 7];
+
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, flags: TxFrame.AtomicBatchFlag, target: Recipient),
+            Frame(TxFrame.ModeSender, target: Recipient));
+        tx.NonceKeys = keys;
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.True, "the payer approved before the batch survives its unroll");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_stateProvider.GetNonce(Sender), Is.Zero, "a keyed transaction leaves the account nonce alone");
+            foreach (UInt256 key in keys)
+            {
+                Assert.That(new UInt256(_stateProvider.Get(KeyedNonceManager.StorageSlot(Sender, key)), isBigEndian: true),
+                    Is.EqualTo(UInt256.One), "the nonce set stays consumed");
+            }
+        }
+    }
+
+    // The default code approves without running APPROVE, so the same first-use surcharge has to be
+    // charged there or a codeless sender grows NONCE_MANAGER state for free.
+    [Test]
+    public void Execute_KeyedNonce_DefaultCodeApproval_ChargesFirstUse()
+    {
+        _stateProvider.CreateAccount(Sender, 1.Ether);
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+        UInt256[] keys = [1, 7];
+
+        CallOutputTracer firstUseTracer = new();
+        Assert.That(Process(SelfSignedSelfVerifyTx(nonce: 0, keys), tracer: firstUseTracer).TransactionExecuted, Is.True);
+        foreach (UInt256 key in keys)
+        {
+            Assert.That(new UInt256(_stateProvider.Get(KeyedNonceManager.StorageSlot(Sender, key)), isBigEndian: true),
+                Is.EqualTo(UInt256.One));
+        }
+
+        CallOutputTracer reuseTracer = new();
+        Assert.That(Process(SelfSignedSelfVerifyTx(nonce: 1, keys), tracer: reuseTracer).TransactionExecuted, Is.True);
+        Assert.That(firstUseTracer.GasSpent - reuseTracer.GasSpent,
+            Is.EqualTo((long)keys.Length * Eip8250Constants.KeyedNonceFirstUseGas),
+            "the default-code approval owes the surcharge the APPROVE opcode charges");
+    }
+
+    /// <summary>A codeless-sender self-verify transaction carrying the canonical-hash signature default code requires at index 0.</summary>
+    private static Transaction SelfSignedSelfVerifyTx(ulong nonce, UInt256[]? nonceKeys = null)
+    {
+        Transaction tx = FrameTx(nonce, SelfVerifyFrame());
+        tx.NonceKeys = nonceKeys;
+        // compute_sig_hash commits to the signature entries (bytes of empty-msg entries elided),
+        // so the entry must be present when the hash is computed and signed.
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, new byte[TxFrameSignature.Secp256k1SignatureLength])];
+        ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
+        Signature signature = new Ecdsa().Sign(TestItem.PrivateKeyA, in sigHash);
+        byte[] vrs = new byte[TxFrameSignature.Secp256k1SignatureLength];
+        vrs[0] = signature.RecoveryId;
+        signature.Bytes.CopyTo(vrs.AsSpan(1));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, vrs)];
+        return tx;
+    }
+
     // An unchecked increment wraps the account nonce to zero, making every prior transaction from
     // that sender replayable. The EIP-8250 envelope is already refused a sequence at the ceiling
     // during stateful validity, so only the pre-8250 envelope reaches payment approval here.

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1348,6 +1348,23 @@ public class FrameTxProcessorTests
         Assert.That(Process(tx).TransactionExecuted, Is.EqualTo(expectedExecuted));
     }
 
+    // The replay-protection property the set semantics exist for: if one key of a set has already moved
+    // on, the whole set is unusable at that sequence, so the transaction cannot be replayed against the
+    // keys that stayed behind.
+    [Test]
+    public void Execute_KeyedNonce_PartiallyAdvancedSetIsNotReplayable()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        KeyedNonceManager.ConsumeNonceSet(_stateProvider, Sender, [(UInt256)1], nonceSeq: 0);
+        _stateProvider.Commit(Spec);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.NonceKeys = [1, 7];
+
+        Assert.That(Process(tx).TransactionExecuted, Is.False,
+            "key 1 is at sequence 1 while key 7 is still at 0, so no sequence satisfies the set");
+    }
+
     private static UInt256 AddressAsWord(Address address) => new(address.Bytes, isBigEndian: true);
 
     private static byte[] ApproveCode(byte scope) =>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1360,6 +1360,26 @@ public class FrameTxProcessorTests
             "key 1 is at sequence 1 while key 7 is still at 0, so no sequence satisfies the set");
     }
 
+    // Key 0 is the account nonce itself, so the singleton set must advance that nonce and owe no
+    // first-use surcharge — the property that makes the EIP-8250 envelope a superset of EIP-8141's.
+    [Test]
+    public void Execute_KeyedNonce_LegacyKeyBehavesAsTheAccountNonce()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction keyed = FrameTx(nonce: 0, SelfVerifyFrame());
+        keyed.NonceKeys = [UInt256.Zero];
+
+        CallOutputTracer keyedTracer = new();
+        Assert.That(Process(keyed, tracer: keyedTracer).TransactionExecuted, Is.True);
+        Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1UL));
+
+        CallOutputTracer plainTracer = new();
+        Assert.That(Process(FrameTx(nonce: 1, SelfVerifyFrame()), tracer: plainTracer).TransactionExecuted, Is.True);
+        Assert.That(keyedTracer.GasSpent - plainTracer.GasSpent,
+            Is.LessThan((long)Eip8250Constants.KeyedNonceFirstUseGas),
+            "the legacy key owes no first-use surcharge");
+    }
+
     private static UInt256 AddressAsWord(Address address) => new(address.Bytes, isBigEndian: true);
 
     private static byte[] ApproveCode(byte scope) =>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1297,6 +1297,57 @@ public class FrameTxProcessorTests
         Assert.That(actual, Is.EqualTo(expected), message ?? $"storage slot {slot} of {address}");
     }
 
+    // EIP-8250: a keyed transaction consumes every selected key as a unit at payment approval and
+    // leaves the account nonce alone, so a partially advanced set cannot be replayed. Each key used
+    // for the first time pays the state-growth surcharge against the approving frame's gas.
+    [Test]
+    public void Execute_KeyedNonce_ConsumesEverySelectedKeyAndChargesFirstUse()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        UInt256[] keys = [1, 7];
+
+        Transaction firstUse = FrameTx(nonce: 0, SelfVerifyFrame());
+        firstUse.NonceKeys = keys;
+        CallOutputTracer firstUseTracer = new();
+        TransactionResult result = Process(firstUse, tracer: firstUseTracer);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(_stateProvider.GetNonce(Sender), Is.Zero,
+            "a keyed transaction must not advance the account nonce");
+        foreach (UInt256 key in keys)
+        {
+            Assert.That(new UInt256(_stateProvider.Get(KeyedNonceManager.StorageSlot(Sender, key)), isBigEndian: true),
+                Is.EqualTo(UInt256.One));
+        }
+
+        Transaction reuse = FrameTx(nonce: 1, SelfVerifyFrame());
+        reuse.NonceKeys = keys;
+        CallOutputTracer reuseTracer = new();
+
+        Assert.That(Process(reuse, tracer: reuseTracer).TransactionExecuted, Is.True);
+        Assert.That(firstUseTracer.GasSpent - reuseTracer.GasSpent,
+            Is.EqualTo((long)keys.Length * Eip8250Constants.KeyedNonceFirstUseGas),
+            "only the first use of each key is surcharged");
+    }
+
+    // The nonce sequence is per key, so a transaction is only valid when every selected key currently
+    // sits at its nonce_seq; a set where one key has moved on must not execute.
+    [TestCase(0UL, 1UL, false, TestName = "a nonce sequence behind a consumed key is too low")]
+    [TestCase(1UL, 1UL, true, TestName = "a nonce sequence matching every selected key executes")]
+    [TestCase(2UL, 1UL, false, TestName = "a nonce sequence ahead of an unconsumed key is too high")]
+    public void Execute_KeyedNonce_RequiresEverySelectedKeyAtTheSequence(ulong nonceSeq, ulong consumedSeq, bool expectedExecuted)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        UInt256[] keys = [1, 7];
+        KeyedNonceManager.ConsumeNonceSet(_stateProvider, Sender, keys, consumedSeq - 1);
+        _stateProvider.Commit(Spec);
+
+        Transaction tx = FrameTx(nonceSeq, SelfVerifyFrame());
+        tx.NonceKeys = keys;
+
+        Assert.That(Process(tx).TransactionExecuted, Is.EqualTo(expectedExecuted));
+    }
+
     private static UInt256 AddressAsWord(Address address) => new(address.Bytes, isBigEndian: true);
 
     private static byte[] ApproveCode(byte scope) =>

--- a/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
+++ b/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
@@ -24,10 +24,15 @@ public sealed class FrameTxContext(
     in UInt256 maxCost,
     in UInt256 maxPriorityFeePerGas,
     in UInt256 maxFeePerGas,
-    in UInt256 maxFeePerBlobGas)
+    in UInt256 maxFeePerBlobGas,
+    UInt256[]? nonceKeys = null)
 {
     public Address Sender { get; } = sender;
     public ulong Nonce { get; } = nonce;
+
+    /// <summary>The EIP-8250 nonce keys this transaction consumes, or <see langword="null"/> for a plain account nonce.</summary>
+    /// <remarks>When set, <see cref="Nonce"/> is the shared <c>nonce_seq</c> every key currently sits at.</remarks>
+    public UInt256[]? NonceKeys { get; } = nonceKeys;
     public TxFrame[] Frames { get; } = frames;
     public TxFrameSignature[] Signatures { get; } = signatures;
     public ValueHash256 SigHash { get; } = sigHash;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Evm.GasPolicy;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 
 namespace Nethermind.Evm;
@@ -64,6 +65,22 @@ public static unsafe partial class EvmInstructions
             if (ctx.Payer is not null) return EvmExceptionType.Revert;
             if (!approvesExecution && !ctx.SenderApproved) return EvmExceptionType.Revert;
             if (vm.WorldState.GetBalance(resolvedTarget) < ctx.MaxCost) return EvmExceptionType.Revert;
+
+            // EIP-8250: consumption happens at payment approval, so the state-growth surcharge for every
+            // key used for the first time is charged here, against this frame's remaining gas.
+            if (ctx.NonceKeys is { } nonceKeys)
+            {
+                ulong firstUseCount = 0;
+                foreach (UInt256 nonceKey in nonceKeys)
+                {
+                    if (KeyedNonceManager.IsFirstUse(vm.WorldState, ctx.Sender, in nonceKey)) firstUseCount++;
+                }
+
+                if (firstUseCount != 0 && !TGasPolicy.TryConsume(ref gas, firstUseCount * Eip8250Constants.KeyedNonceFirstUseGas))
+                {
+                    return EvmExceptionType.OutOfGas;
+                }
+            }
         }
 
         // Load the return data region (RETURN semantics). The outer loop applies the approval effects.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -66,8 +66,7 @@ public static unsafe partial class EvmInstructions
             if (!approvesExecution && !ctx.SenderApproved) return EvmExceptionType.Revert;
             if (vm.WorldState.GetBalance(resolvedTarget) < ctx.MaxCost) return EvmExceptionType.Revert;
 
-            // EIP-8250: consumption happens at payment approval, so the state-growth surcharge for every
-            // key used for the first time is charged here, against this frame's remaining gas.
+            // Consumption happens at payment approval, so first use is charged against this frame's gas.
             if (ctx.NonceKeys is { } nonceKeys
                 && !TGasPolicy.TryConsume(ref gas, KeyedNonceManager.FirstUseSurcharge(vm.WorldState, ctx.Sender, nonceKeys)))
             {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -68,18 +68,10 @@ public static unsafe partial class EvmInstructions
 
             // EIP-8250: consumption happens at payment approval, so the state-growth surcharge for every
             // key used for the first time is charged here, against this frame's remaining gas.
-            if (ctx.NonceKeys is { } nonceKeys)
+            if (ctx.NonceKeys is { } nonceKeys
+                && !TGasPolicy.TryConsume(ref gas, KeyedNonceManager.FirstUseSurcharge(vm.WorldState, ctx.Sender, nonceKeys)))
             {
-                ulong firstUseCount = 0;
-                foreach (UInt256 nonceKey in nonceKeys)
-                {
-                    if (KeyedNonceManager.IsFirstUse(vm.WorldState, ctx.Sender, in nonceKey)) firstUseCount++;
-                }
-
-                if (firstUseCount != 0 && !TGasPolicy.TryConsume(ref gas, firstUseCount * Eip8250Constants.KeyedNonceFirstUseGas))
-                {
-                    return EvmExceptionType.OutOfGas;
-                }
+                return EvmExceptionType.OutOfGas;
             }
         }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
@@ -41,6 +41,23 @@ public static class KeyedNonceManager
     public static bool IsFirstUse(IWorldState state, Address sender, in UInt256 nonceKey) =>
         !nonceKey.IsZero && CurrentNonceSeq(state, sender, nonceKey) == 0;
 
+    /// <summary>The state-growth surcharge <c>APPROVE</c> owes for the keys this set uses for the first time.</summary>
+    /// <remarks>
+    /// Charged against the approving frame's remaining gas, so it can exhaust that frame; every path that
+    /// grants payment approval must charge it, or the same transaction costs different gas depending on
+    /// whether the approving account carries code.
+    /// </remarks>
+    public static ulong FirstUseSurcharge(IWorldState state, Address sender, ReadOnlySpan<UInt256> nonceKeys)
+    {
+        ulong firstUseCount = 0;
+        foreach (ref readonly UInt256 nonceKey in nonceKeys)
+        {
+            if (IsFirstUse(state, sender, in nonceKey)) firstUseCount++;
+        }
+
+        return firstUseCount * Eip8250Constants.KeyedNonceFirstUseGas;
+    }
+
     public static void ConsumeNonceSet(IWorldState state, Address sender, ReadOnlySpan<UInt256> nonceKeys, ulong nonceSeq)
     {
         if (nonceKeys.Length == 1 && nonceKeys[0].IsZero)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
@@ -43,9 +43,8 @@ public static class KeyedNonceManager
 
     /// <summary>The state-growth surcharge <c>APPROVE</c> owes for the keys this set uses for the first time.</summary>
     /// <remarks>
-    /// Charged against the approving frame's remaining gas, so it can exhaust that frame; every path that
-    /// grants payment approval must charge it, or the same transaction costs different gas depending on
-    /// whether the approving account carries code.
+    /// Charged against the approving frame's remaining gas, so it can exhaust that frame. Every path that
+    /// grants payment approval must charge it, or the cost depends on whether the approver carries code.
     /// </remarks>
     public static ulong FirstUseSurcharge(IWorldState state, Address sender, ReadOnlySpan<UInt256> nonceKeys)
     {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
@@ -12,6 +12,12 @@ using Nethermind.Int256;
 namespace Nethermind.Evm.TransactionProcessing;
 
 /// <summary>State helper for <see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see> keyed nonces: NONCE_MANAGER slot derivation and per-key nonce reads/consumption.</summary>
+/// <remarks>
+/// Every read and write goes through <see cref="IWorldState"/> rather than around it, so the NONCE_MANAGER
+/// accesses enter the EIP-7928 block access list. A keyed nonce is consensus state a validator must be able
+/// to prefetch, unlike a precompile result, and a slot missing from the list makes a parallel validator
+/// reject a block every sequential node accepts.
+/// </remarks>
 public static class KeyedNonceManager
 {
     private const int SlotPreimageLength = 2 * 32;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -691,6 +691,15 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             // frame approves payment.
             if (WorldState.GetBalance(resolvedTarget) < frameContext.MaxCost) return;
 
+            // EIP-8250: the account nonce cannot advance past MAX_NONCE_SEQ, and an approval that
+            // cannot consume its nonce performs no approval effects at all.
+            UInt256[]? keys = frameContext.NonceKeys;
+            if ((keys is null || (keys.Length == 1 && keys[0].IsZero))
+                && WorldState.GetNonce(frameContext.Sender) >= Eip8250Constants.MaxNonceSeq)
+            {
+                return;
+            }
+
             // Charge the max cost up front from the payer and consume the sender nonce; unused
             // gas is refunded to the payer at the end of the transaction.
             WorldState.SubtractFromBalance(resolvedTarget, frameContext.MaxCost, spec);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -24,20 +24,54 @@ namespace Nethermind.Evm.TransactionProcessing;
 /// </summary>
 public abstract partial class TransactionProcessorBase<TGasPolicy>
 {
+    /// <summary>Checks a frame transaction's nonce against the sender's state, under either nonce shape.</summary>
+    /// <remarks>
+    /// Without <see cref="Transaction.NonceKeys"/> this is the EIP-8141 account nonce. With them, EIP-8250 replaces
+    /// the account nonce by a set of keyed sequences that must all currently sit at <see cref="Transaction.Nonce"/>
+    /// (the transaction's <c>nonce_seq</c>), so the set is consumed as a unit and a partially advanced set is not
+    /// replayable. A malformed set is rejected as malformed rather than as a nonce mismatch: no sequence it names
+    /// exists to be too low or too high.
+    /// </remarks>
+    private TransactionResult ValidateFrameTxNonce(Transaction tx, Address sender)
+    {
+        UInt256[]? nonceKeys = tx.NonceKeys;
+        if (nonceKeys is null)
+        {
+            UInt256 accountNonce = WorldState.GetNonce(sender);
+            return accountNonce == tx.Nonce
+                ? TransactionResult.Ok
+                : (tx.Nonce < accountNonce
+                    ? TransactionResult.ErrorType.TransactionNonceTooLow
+                    : TransactionResult.ErrorType.TransactionNonceTooHigh).WithDetail("frame transaction nonce mismatch");
+        }
+
+        if (!KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys) || tx.Nonce >= Eip8250Constants.MaxNonceSeq)
+        {
+            return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction nonce key set is not well-formed");
+        }
+
+        foreach (UInt256 nonceKey in nonceKeys)
+        {
+            ulong current = KeyedNonceManager.CurrentNonceSeq(WorldState, sender, in nonceKey);
+            if (current != tx.Nonce)
+            {
+                return (tx.Nonce < current
+                    ? TransactionResult.ErrorType.TransactionNonceTooLow
+                    : TransactionResult.ErrorType.TransactionNonceTooHigh).WithDetail("frame transaction nonce sequence mismatch");
+            }
+        }
+
+        return TransactionResult.Ok;
+    }
+
     private TransactionResult ExecuteFrameTx(Transaction tx, ITxTracer tracer, ExecutionOptions opts, BlockHeader header, IReleaseSpec spec)
     {
         Address sender = tx.SenderAddress!;
         Snapshot txSnapshot = WorldState.TakeSnapshot();
 
         // Pre-flight: nonce and protocol-validated signatures.
-        UInt256 accountNonce = WorldState.GetNonce(sender);
-        if (accountNonce != tx.Nonce)
-        {
-            TransactionResult.ErrorType nonceError = tx.Nonce < accountNonce
-                ? TransactionResult.ErrorType.TransactionNonceTooLow
-                : TransactionResult.ErrorType.TransactionNonceTooHigh;
-            return nonceError.WithDetail("frame transaction nonce mismatch");
-        }
+        TransactionResult nonceResult = ValidateFrameTxNonce(tx, sender);
+        if (!nonceResult) return nonceResult;
 
         ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
         // EIP-7928: resolved without recording an account access - a tx that never takes the P256
@@ -118,7 +152,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             in maxCost,
             in tx.MaxPriorityFeePerGas,
             tx.DecodedMaxFeePerGas,
-            tx.MaxFeePerBlobGas.GetValueOrDefault());
+            tx.MaxFeePerBlobGas.GetValueOrDefault(),
+            tx.NonceKeys);
 
         TxFrameReceipt[] frameReceipts = new TxFrameReceipt[frames.Length];
         ulong totalFrameGasUsed = 0;
@@ -651,7 +686,15 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             // Charge the max cost up front from the payer and consume the sender nonce; unused
             // gas is refunded to the payer at the end of the transaction.
             WorldState.SubtractFromBalance(resolvedTarget, frameContext.MaxCost, spec);
-            WorldState.IncrementNonce(frameContext.Sender);
+            if (frameContext.NonceKeys is { } nonceKeys)
+            {
+                KeyedNonceManager.ConsumeNonceSet(WorldState, frameContext.Sender, nonceKeys, frameContext.Nonce);
+            }
+            else
+            {
+                WorldState.IncrementNonce(frameContext.Sender);
+            }
+
             frameContext.Payer = resolvedTarget;
         }
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -49,9 +49,14 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         }
 
         // Cold path only: re-read to report the same too-low / too-high distinction as the account nonce.
-        if (!KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys) || tx.Nonce >= Eip8250Constants.MaxNonceSeq)
+        if (!KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys))
         {
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction nonce key set is not well-formed");
+        }
+
+        if (tx.Nonce >= Eip8250Constants.MaxNonceSeq)
+        {
+            return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction nonce sequence is exhausted");
         }
 
         ulong current = KeyedNonceManager.CurrentNonceSeq(WorldState, sender, nonceKeys[0]);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -26,11 +26,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 {
     /// <summary>Checks a frame transaction's nonce against the sender's state, under either nonce shape.</summary>
     /// <remarks>
-    /// Without <see cref="Transaction.NonceKeys"/> this is the EIP-8141 account nonce. With them, EIP-8250 replaces
-    /// the account nonce by a set of keyed sequences that must all currently sit at <see cref="Transaction.Nonce"/>
-    /// (the transaction's <c>nonce_seq</c>), so the set is consumed as a unit and a partially advanced set is not
-    /// replayable. A malformed set is rejected as malformed rather than as a nonce mismatch: no sequence it names
-    /// exists to be too low or too high.
+    /// With <see cref="Transaction.NonceKeys"/> every selected key must currently sit at
+    /// <see cref="Transaction.Nonce"/>, so the set is consumed as a unit and a partially advanced set is not
+    /// replayable. A malformed set is rejected as malformed, not as a nonce mismatch: it names no sequence.
     /// </remarks>
     private TransactionResult ValidateFrameTxNonce(Transaction tx, Address sender)
     {
@@ -50,8 +48,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return TransactionResult.Ok;
         }
 
-        // Cold path only: re-read to say which side of the sequence the transaction sits on, so a keyed
-        // transaction reports the same too-low / too-high distinction the account-nonce shape does.
+        // Cold path only: re-read to report the same too-low / too-high distinction as the account nonce.
         if (!KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys) || tx.Nonce >= Eip8250Constants.MaxNonceSeq)
         {
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction nonce key set is not well-formed");
@@ -628,9 +625,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 return new TransactionSubstate(EvmExceptionType.Revert, tracer.IsTracingInstructions);
             }
 
-            // The default code approves without running any EVM code, so the EIP-8250 surcharge the
-            // APPROVE opcode charges has to be charged here too — otherwise the same transaction costs
-            // less purely because its approving account carries no code.
+            // The default code approves without running EVM code, so it owes the surcharge APPROVE charges.
             if ((allowedScope & TxFrame.ApprovePayment) != 0 && frameContext.NonceKeys is { } nonceKeys)
             {
                 ulong surcharge = KeyedNonceManager.FirstUseSurcharge(WorldState, frameContext.Sender, nonceKeys);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -630,12 +630,23 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 return new TransactionSubstate(EvmExceptionType.Revert, tracer.IsTracingInstructions);
             }
 
-            // The default code approves without running EVM code, so it owes the surcharge APPROVE charges.
-            if ((allowedScope & TxFrame.ApprovePayment) != 0 && frameContext.NonceKeys is { } nonceKeys)
+            // The default code approves without running EVM code, so it owes the surcharge APPROVE
+            // charges — but only where APPROVE would charge it. The opcode reaches the surcharge
+            // only past a null payer, a prior execution approval and a solvent payer, and
+            // ApplyApproval discards the approval for those same reasons, so charging ahead of them
+            // would bill the frame for a consumption that never happens.
+            if ((allowedScope & TxFrame.ApprovePayment) != 0
+                && frameContext.Payer is null
+                && ((allowedScope & TxFrame.ApproveExecution) != 0 || frameContext.SenderApproved)
+                && WorldState.GetBalance(resolvedTarget) >= frameContext.MaxCost
+                && frameContext.NonceKeys is { } nonceKeys)
             {
                 ulong surcharge = KeyedNonceManager.FirstUseSurcharge(WorldState, frameContext.Sender, nonceKeys);
                 if (surcharge > frame.GasLimit)
                 {
+                    // An error frame reports its whole gas limit on the EVM path; halting for free
+                    // here would price the same failure differently.
+                    gasUsed = frame.GasLimit;
                     return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
                 }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -45,23 +45,22 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                     : TransactionResult.ErrorType.TransactionNonceTooHigh).WithDetail("frame transaction nonce mismatch");
         }
 
+        if (KeyedNonceManager.IsNonceSetValid(WorldState, sender, nonceKeys, tx.Nonce))
+        {
+            return TransactionResult.Ok;
+        }
+
+        // Cold path only: re-read to say which side of the sequence the transaction sits on, so a keyed
+        // transaction reports the same too-low / too-high distinction the account-nonce shape does.
         if (!KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys) || tx.Nonce >= Eip8250Constants.MaxNonceSeq)
         {
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction nonce key set is not well-formed");
         }
 
-        foreach (UInt256 nonceKey in nonceKeys)
-        {
-            ulong current = KeyedNonceManager.CurrentNonceSeq(WorldState, sender, in nonceKey);
-            if (current != tx.Nonce)
-            {
-                return (tx.Nonce < current
-                    ? TransactionResult.ErrorType.TransactionNonceTooLow
-                    : TransactionResult.ErrorType.TransactionNonceTooHigh).WithDetail("frame transaction nonce sequence mismatch");
-            }
-        }
-
-        return TransactionResult.Ok;
+        ulong current = KeyedNonceManager.CurrentNonceSeq(WorldState, sender, nonceKeys[0]);
+        return (tx.Nonce < current
+            ? TransactionResult.ErrorType.TransactionNonceTooLow
+            : TransactionResult.ErrorType.TransactionNonceTooHigh).WithDetail("frame transaction nonce sequence mismatch");
     }
 
     private TransactionResult ExecuteFrameTx(Transaction tx, ITxTracer tracer, ExecutionOptions opts, BlockHeader header, IReleaseSpec spec)
@@ -627,6 +626,20 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 || frameContext.ResolvedSigner(sigIndex) != resolvedTarget)
             {
                 return new TransactionSubstate(EvmExceptionType.Revert, tracer.IsTracingInstructions);
+            }
+
+            // The default code approves without running any EVM code, so the EIP-8250 surcharge the
+            // APPROVE opcode charges has to be charged here too — otherwise the same transaction costs
+            // less purely because its approving account carries no code.
+            if ((allowedScope & TxFrame.ApprovePayment) != 0 && frameContext.NonceKeys is { } nonceKeys)
+            {
+                ulong surcharge = KeyedNonceManager.FirstUseSurcharge(WorldState, frameContext.Sender, nonceKeys);
+                if (surcharge > frame.GasLimit)
+                {
+                    return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+                }
+
+                gasUsed = surcharge;
             }
 
             frameContext.ApprovalScopeSignal = allowedScope;


### PR DESCRIPTION
Wires the EIP-8250 keyed nonces decoded by #12653 into execution: nonce validation, consumption, and the first-use surcharge.

Without keys nothing changes, the account nonce is checked and incremented as before. With keys the account nonce is left alone and every selected key must currently sit at the transaction's `nonce_seq`; the set is consumed as a unit at payment approval, so a partially advanced set is not replayable. A malformed key set is rejected as malformed rather than as a nonce mismatch, since no sequence it names exists to be too low or too high.

`KEYED_NONCE_FIRST_USE_GAS` is charged inside the `APPROVE` handler against the approving frame's remaining gas, where the spec places it, so it can exhaust that frame and shows up in the frame's `gas_used`.

`KeyedNonceManager` and `Eip8250Constants` already existed with unit tests; this only connects them.

### Testing
- `FrameTxProcessorTests`: a keyed transaction consumes every selected key, leaves the account nonce untouched, and pays the surcharge only on first use of each key; a sequence behind or ahead of the selected keys does not execute. Both verified red without the corresponding branch.
- Frame-transaction, keyed-nonce and recent-root suites in `Nethermind.Evm.Test`: 112 passing.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)
