### PR TITLE
test(rlp): pin the frame-transaction envelope against a foreign encoder's vector

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -92,7 +92,8 @@ public sealed class TxValidator : ITxValidator
             NonceCapTxValidator.Instance,
             expectedChainIdTxValidator,
             GasFieldsTxValidator.Instance,
-            FrameTxFieldsTxValidator.Instance
+            FrameTxFieldsTxValidator.Instance,
+            FrameTxEnvelopeTxValidator.Instance
         ]));
     }
 
@@ -191,6 +192,34 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
         FrameTxValidation.IsWellFormed(transaction, out string? error) ? ValidationResult.Success : error!;
+}
+
+/// <summary>Admits the frame-transaction envelope extensions only on forks that define them.</summary>
+/// <remarks>
+/// The RLP decoder tells the envelope shapes apart without fork context, so the fork that admits each
+/// one is decided here. The reference cap is re-checked because a transaction can reach validation
+/// without passing through the decoder at all — <c>eth_call</c>, <c>eth_estimateGas</c> and block
+/// building all construct one directly.
+/// </remarks>
+public sealed class FrameTxEnvelopeTxValidator : ITxValidator
+{
+    public static readonly FrameTxEnvelopeTxValidator Instance = new();
+    private FrameTxEnvelopeTxValidator() { }
+
+    public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
+    {
+        RecentRootReference[]? references = transaction.RecentRootReferences;
+        if (references is null)
+        {
+            return ValidationResult.Success;
+        }
+
+        return releaseSpec.IsEip8272Enabled
+            ? references.Length <= Eip8272Constants.MaxRecentRootReferences
+                ? ValidationResult.Success
+                : "too many recent root references"
+            : "recent root references are not enabled";
+    }
 }
 
 public sealed class ContractSizeTxValidator : ITxValidator

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxCrossClientVectorTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxCrossClientVectorTests.cs
@@ -10,16 +10,15 @@ using NUnit.Framework;
 namespace Nethermind.Core.Test.Encoding;
 
 /// <summary>
-/// Decodes a frame-transaction payload produced by another client's encoder, covering the EIP-8250
-/// keyed nonce and EIP-8272 reference fields.
+/// Decodes a frame-transaction payload produced by a second implementation's encoder, covering the
+/// EIP-8250 keyed nonce and EIP-8272 reference fields.
 /// </summary>
 /// <remarks>
-/// A round-trip test only proves this decoder agrees with this encoder. The vector below was produced
-/// by ethrex's own encoder (`crates/common/types/transaction.rs`, branch `hegota-devnet`) rather than
-/// by this one — regenerating it with our encoder would silently reduce this file to a round-trip
-/// test. It pins the field order and the signature-hash preimage against a
-/// second implementation: a transaction the two clients decode differently is a consensus split, and
-/// a signature hash they compute differently makes every cross-client transaction unspendable.
+/// A round-trip test only proves this decoder agrees with this encoder. The vector below comes from a
+/// second implementation, so regenerating it here would silently reduce this file to a round-trip test.
+/// It pins the field order and the signature-hash preimage against that implementation: a transaction
+/// the two clients decode differently is a consensus split, and a signature hash they compute
+/// differently makes every cross-client transaction unspendable.
 /// </remarks>
 public class FrameTxCrossClientVectorTests
 {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxCrossClientVectorTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxCrossClientVectorTests.cs
@@ -15,7 +15,9 @@ namespace Nethermind.Core.Test.Encoding;
 /// </summary>
 /// <remarks>
 /// A round-trip test only proves this decoder agrees with this encoder. The vector below was produced
-/// by the ethrex tooling, so it also pins the field order and the signature-hash preimage against a
+/// by ethrex's own encoder (`crates/common/types/transaction.rs`, branch `hegota-devnet`) rather than
+/// by this one — regenerating it with our encoder would silently reduce this file to a round-trip
+/// test. It pins the field order and the signature-hash preimage against a
 /// second implementation: a transaction the two clients decode differently is a consensus split, and
 /// a signature hash they compute differently makes every cross-client transaction unspendable.
 /// </remarks>
@@ -51,7 +53,13 @@ public class FrameTxCrossClientVectorTests
             Assert.That(tx.GasPrice, Is.EqualTo(UInt256.One));
             Assert.That(tx.DecodedMaxFeePerGas, Is.EqualTo((UInt256)8));
             Assert.That(tx.RecentRootReferences!.Length, Is.EqualTo(1));
+            // The two 32-byte members are deliberately distinguishable: asserting only the slot
+            // between them leaves a swapped source_id/root decoding round-tripping identically.
+            Assert.That(tx.RecentRootReferences[0].SourceId,
+                Is.EqualTo(new ValueHash256("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")));
             Assert.That(tx.RecentRootReferences[0].Slot, Is.EqualTo(9007UL));
+            Assert.That(tx.RecentRootReferences[0].Root,
+                Is.EqualTo(new ValueHash256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
             Assert.That(FrameTxSigHash.ComputeValue(tx), Is.EqualTo(new ValueHash256(ExpectedSigHash)));
         }
     }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxCrossClientVectorTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxCrossClientVectorTests.cs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Encoding;
+
+/// <summary>
+/// Decodes a frame-transaction payload produced by another client's encoder, covering the EIP-8250
+/// keyed nonce and EIP-8272 reference fields.
+/// </summary>
+/// <remarks>
+/// A round-trip test only proves this decoder agrees with this encoder. The vector below was produced
+/// by the ethrex tooling, so it also pins the field order and the signature-hash preimage against a
+/// second implementation: a transaction the two clients decode differently is a consensus split, and
+/// a signature hash they compute differently makes every cross-client transaction unspendable.
+/// </remarks>
+public class FrameTxCrossClientVectorTests
+{
+    private const string Raw =
+        "06f8f583301824c201070394aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaecc901038083030d" +
+        "408080e1028094bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb82c35082303983010203f85cf8" +
+        "5a0194aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa80b8411111111111111111111111111111" +
+        "11111111111111111111111111111111111111111111111111111111111111111111111111111111" +
+        "1111111111111111111111010880c0f847f845a0000102030405060708090a0b0c0d0e0f10111213" +
+        "1415161718191a1b1c1d1e1f82232fa0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+        "aaaaaaaaaaaaaaaa";
+
+    private const string ExpectedSigHash = "abf6cf6612f31e28109ddc498492f29e1b34c1be1f7890a5bc917a8d0b438892";
+
+    [Test]
+    public void Decode_KeyedAndReferencingVector_MatchesTheProducingClient()
+    {
+        Transaction tx = Rlp.Decode<Transaction>(Bytes.FromHexString(Raw), RlpBehaviors.SkipTypedWrapping);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tx.Type, Is.EqualTo(TxType.FrameTx));
+            Assert.That(tx.ChainId, Is.EqualTo(3151908UL));
+            Assert.That(tx.NonceKeys, Is.EqualTo(new UInt256[] { 1, 7 }));
+            Assert.That(tx.Nonce, Is.EqualTo(3UL));
+            Assert.That(tx.SenderAddress, Is.EqualTo(new Address("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
+            Assert.That(tx.Frames!.Length, Is.EqualTo(2));
+            Assert.That(tx.Frames[0].Target, Is.Null, "an empty target resolves to the sender");
+            Assert.That(tx.Frames[1].Value, Is.EqualTo((UInt256)12345));
+            Assert.That(tx.FrameSignatures!.Length, Is.EqualTo(1));
+            Assert.That(tx.GasPrice, Is.EqualTo(UInt256.One));
+            Assert.That(tx.DecodedMaxFeePerGas, Is.EqualTo((UInt256)8));
+            Assert.That(tx.RecentRootReferences!.Length, Is.EqualTo(1));
+            Assert.That(tx.RecentRootReferences[0].Slot, Is.EqualTo(9007UL));
+            Assert.That(FrameTxSigHash.ComputeValue(tx), Is.EqualTo(new ValueHash256(ExpectedSigHash)));
+        }
+    }
+
+    [Test]
+    public void Encode_KeyedAndReferencingVector_ReproducesTheProducingClientsBytes()
+    {
+        Transaction tx = Rlp.Decode<Transaction>(Bytes.FromHexString(Raw), RlpBehaviors.SkipTypedWrapping);
+
+        Assert.That(Rlp.Encode(tx, RlpBehaviors.SkipTypedWrapping).Bytes.ToHexString(), Is.EqualTo(Raw));
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxCrossClientVectorTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxCrossClientVectorTests.cs
@@ -1,10 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -31,6 +31,7 @@ public class FrameTxDecoderTests
         Assert.That(decoded.ChainId, Is.EqualTo(tx.ChainId));
         Assert.That(decoded.Nonce, Is.EqualTo(tx.Nonce));
         Assert.That(decoded.NonceKeys, Is.EqualTo(tx.NonceKeys));
+        AssertReferencesEqual(decoded.RecentRootReferences, tx.RecentRootReferences);
         // The sender is explicit in the payload — no envelope signature, no ECDSA recovery.
         Assert.That(decoded.SenderAddress, Is.EqualTo(tx.SenderAddress));
         Assert.That(decoded.GasPrice, Is.EqualTo(tx.GasPrice));
@@ -125,6 +126,45 @@ public class FrameTxDecoderTests
         {
             Assert.That(FrameTxSigHash.ComputeValue(legacyKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacy)));
             Assert.That(FrameTxSigHash.ComputeValue(otherKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacyKey)));
+    // The reference list is part of the signing payload, and an absent list is a different envelope
+    // from an empty one, so neither may reuse the other's hash.
+    [Test]
+    public void ComputeSigHash_RecentRootReferencesChange_HashChanges()
+    {
+        Transaction none = CreateFrameTx();
+        Transaction empty = CreateFrameTx();
+        empty.RecentRootReferences = [];
+        Transaction referencing = CreateFrameTx();
+        referencing.RecentRootReferences = [Reference(slot: 7)];
+        Transaction otherSlot = CreateFrameTx();
+        otherSlot.RecentRootReferences = [Reference(slot: 8)];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(FrameTxSigHash.ComputeValue(empty), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(none)));
+            Assert.That(FrameTxSigHash.ComputeValue(referencing), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(empty)));
+            Assert.That(FrameTxSigHash.ComputeValue(otherSlot), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(referencing)));
+        }
+    }
+
+    private static RecentRootReference Reference(ulong slot) =>
+        new(TestItem.KeccakA.ValueHash256, slot, TestItem.KeccakB.ValueHash256);
+
+    private static void AssertReferencesEqual(RecentRootReference[]? actual, RecentRootReference[]? expected)
+    {
+        if (expected is null)
+        {
+            Assert.That(actual, Is.Null);
+            return;
+        }
+
+        Assert.That(actual, Is.Not.Null);
+        Assert.That(actual!.Length, Is.EqualTo(expected.Length));
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.That(actual[i].SourceId, Is.EqualTo(expected[i].SourceId));
+            Assert.That(actual[i].Slot, Is.EqualTo(expected[i].Slot));
+            Assert.That(actual[i].Root, Is.EqualTo(expected[i].Root));
         }
     }
 
@@ -156,6 +196,13 @@ public class FrameTxDecoderTests
         multiKeyed.NonceKeys = [1, UInt256.MaxValue];
         multiKeyed.Nonce = 42;
         yield return new TestCaseData(multiKeyed).SetName("Roundtrip_KeyedNonceEnvelope_MultipleKeys");
+        Transaction emptyReferences = CreateFrameTx();
+        emptyReferences.RecentRootReferences = [];
+        yield return new TestCaseData(emptyReferences).SetName("Roundtrip_EmptyRecentRootReferenceList");
+
+        Transaction referencing = CreateFrameTx();
+        referencing.RecentRootReferences = [Reference(slot: 0), Reference(slot: ulong.MaxValue)];
+        yield return new TestCaseData(referencing).SetName("Roundtrip_RecentRootReferences");
 
         Transaction blobCarrying = CreateFrameTx();
         blobCarrying.MaxFeePerBlobGas = 7;

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -30,6 +30,7 @@ public class FrameTxDecoderTests
         Assert.That(decoded.Type, Is.EqualTo(TxType.FrameTx));
         Assert.That(decoded.ChainId, Is.EqualTo(tx.ChainId));
         Assert.That(decoded.Nonce, Is.EqualTo(tx.Nonce));
+        Assert.That(decoded.NonceKeys, Is.EqualTo(tx.NonceKeys));
         // The sender is explicit in the payload — no envelope signature, no ECDSA recovery.
         Assert.That(decoded.SenderAddress, Is.EqualTo(tx.SenderAddress));
         Assert.That(decoded.GasPrice, Is.EqualTo(tx.GasPrice));
@@ -109,6 +110,24 @@ public class FrameTxDecoderTests
         Assert.That(FrameTxSigHash.ComputeValue(second), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(first)));
     }
 
+    // The keyed envelope is part of the signing payload, so selecting different keys — or none at all,
+    // which is a different envelope rather than the key 0 — must not reuse another transaction's hash.
+    [Test]
+    public void ComputeSigHash_NonceKeysChange_HashChanges()
+    {
+        Transaction legacy = CreateFrameTx();
+        Transaction legacyKey = CreateFrameTx();
+        legacyKey.NonceKeys = [UInt256.Zero];
+        Transaction otherKey = CreateFrameTx();
+        otherKey.NonceKeys = [1];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(FrameTxSigHash.ComputeValue(legacyKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacy)));
+            Assert.That(FrameTxSigHash.ComputeValue(otherKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacyKey)));
+        }
+    }
+
     private static IEnumerable<TestCaseData> RoundtripCases()
     {
         yield return new TestCaseData(CreateFrameTx()).SetName("Roundtrip_MinimalSingleFrame");
@@ -128,6 +147,15 @@ public class FrameTxDecoderTests
             new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, TestItem.AddressC, FilledBytes(32, 0xab), FilledBytes(TxFrameSignature.Secp256k1SignatureLength, 0x22)),
             new TxFrameSignature(TxFrameSignature.SchemeP256, TestItem.AddressD, default, FilledBytes(TxFrameSignature.P256SignatureLength, 0x33)),
         ])).SetName("Roundtrip_AllSignatureSchemes");
+
+        Transaction keyed = CreateFrameTx();
+        keyed.NonceKeys = [UInt256.Zero];
+        yield return new TestCaseData(keyed).SetName("Roundtrip_KeyedNonceEnvelope_LegacyKeyOnly");
+
+        Transaction multiKeyed = CreateFrameTx();
+        multiKeyed.NonceKeys = [1, UInt256.MaxValue];
+        multiKeyed.Nonce = 42;
+        yield return new TestCaseData(multiKeyed).SetName("Roundtrip_KeyedNonceEnvelope_MultipleKeys");
 
         Transaction blobCarrying = CreateFrameTx();
         blobCarrying.MaxFeePerBlobGas = 7;

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -126,6 +126,9 @@ public class FrameTxDecoderTests
         {
             Assert.That(FrameTxSigHash.ComputeValue(legacyKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacy)));
             Assert.That(FrameTxSigHash.ComputeValue(otherKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacyKey)));
+        }
+    }
+
     // The reference list is part of the signing payload, and an absent list is a different envelope
     // from an empty one, so neither may reuse the other's hash.
     [Test]

--- a/src/Nethermind/Nethermind.Core/RecentRootReference.cs
+++ b/src/Nethermind/Nethermind.Core/RecentRootReference.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// A recent-root reference declared by a frame transaction: <c>[source_id, slot, root]</c>.
+/// https://eips.ethereum.org/EIPS/eip-8272
+/// </summary>
+/// <remarks>The root is opaque to consensus — applications bind its meaning. The slot is a beacon slot number.</remarks>
+public class RecentRootReference(in ValueHash256 sourceId, ulong slot, in ValueHash256 root)
+{
+    public ValueHash256 SourceId { get; } = sourceId;
+    public ulong Slot { get; } = slot;
+    public ValueHash256 Root { get; } = root;
+}

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -331,6 +331,11 @@ namespace Nethermind.Core.Specs
         bool IsEip8250Enabled { get; }
 
         /// <summary>
+        /// EIP-8272: recent roots for frame transactions.
+        /// </summary>
+        bool IsEip8272Enabled { get; }
+
+        /// <summary>
         /// EIP-8038: State-access gas cost update
         /// </summary>
         bool IsEip8038Enabled { get; }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -83,6 +83,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip8282Enabled => spec.IsEip8282Enabled;
     public virtual bool IsEip8141Enabled => spec.IsEip8141Enabled;
     public virtual bool IsEip8250Enabled => spec.IsEip8250Enabled;
+    public virtual bool IsEip8272Enabled => spec.IsEip8272Enabled;
     public virtual bool IsEip7702Enabled => spec.IsEip7702Enabled;
     public virtual bool IsEip7823Enabled => spec.IsEip7823Enabled;
     public virtual bool IsEip7825Enabled => spec.IsEip7825Enabled;

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -221,6 +221,8 @@ namespace Nethermind.Core
         /// <remarks><see langword="null"/> for the EIP-8141 envelope, whose single nonce is the sender's
         /// linear account nonce — the same domain EIP-8250 addresses as the key <c>0</c>.</remarks>
         public UInt256[]? NonceKeys { get; set; }
+
+        /// <summary>
         /// Recent-root references declared by a frame transaction.
         /// https://eips.ethereum.org/EIPS/eip-8272
         /// </summary>

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -221,6 +221,12 @@ namespace Nethermind.Core
         /// <remarks><see langword="null"/> for the EIP-8141 envelope, whose single nonce is the sender's
         /// linear account nonce — the same domain EIP-8250 addresses as the key <c>0</c>.</remarks>
         public UInt256[]? NonceKeys { get; set; }
+        /// Recent-root references declared by a frame transaction.
+        /// https://eips.ethereum.org/EIPS/eip-8272
+        /// </summary>
+        /// <remarks><see langword="null"/> for an envelope that predates EIP-8272, which is a different
+        /// signing payload from one carrying an empty reference list.</remarks>
+        public RecentRootReference[]? RecentRootReferences { get; set; }
 
         /// <summary>
         /// Service transactions are free. The field added to handle baseFee validation after 1559
@@ -342,6 +348,7 @@ namespace Nethermind.Core
                 obj.Frames = default;
                 obj.FrameSignatures = default;
                 obj.NonceKeys = default;
+                obj.RecentRootReferences = default;
 
                 return true;
             }
@@ -377,6 +384,7 @@ namespace Nethermind.Core
             tx.Frames = Frames;
             tx.FrameSignatures = FrameSignatures;
             tx.NonceKeys = NonceKeys;
+            tx.RecentRootReferences = RecentRootReferences;
         }
 
         public virtual ProofVersion? GetProofVersion() =>

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -215,6 +215,14 @@ namespace Nethermind.Core
         public TxFrameSignature[]? FrameSignatures { get; set; }
 
         /// <summary>
+        /// Nonce keys selected by a frame transaction, sharing the sequence number held by <see cref="Nonce"/>.
+        /// https://eips.ethereum.org/EIPS/eip-8250
+        /// </summary>
+        /// <remarks><see langword="null"/> for the EIP-8141 envelope, whose single nonce is the sender's
+        /// linear account nonce — the same domain EIP-8250 addresses as the key <c>0</c>.</remarks>
+        public UInt256[]? NonceKeys { get; set; }
+
+        /// <summary>
         /// Service transactions are free. The field added to handle baseFee validation after 1559
         /// </summary>
         /// <remarks>Used for AuRa consensus.</remarks>
@@ -333,6 +341,7 @@ namespace Nethermind.Core
                 obj.AuthorizationList = default;
                 obj.Frames = default;
                 obj.FrameSignatures = default;
+                obj.NonceKeys = default;
 
                 return true;
             }
@@ -367,6 +376,7 @@ namespace Nethermind.Core
             tx.AuthorizationList = AuthorizationList;
             tx.Frames = Frames;
             tx.FrameSignatures = FrameSignatures;
+            tx.NonceKeys = NonceKeys;
         }
 
         public virtual ProofVersion? GetProofVersion() =>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -20,6 +20,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using Nethermind.State;
 using NUnit.Framework;
 
@@ -36,6 +37,7 @@ namespace Nethermind.Evm.Test;
 public class FrameTxProcessorTests
 {
     private ISpecProvider _specProvider;
+    private OverridableReleaseSpec _spec;
     private ITransactionProcessor _transactionProcessor;
     private IWorldState _stateProvider;
     private IDisposable _worldStateCloser;
@@ -49,7 +51,10 @@ public class FrameTxProcessorTests
     [SetUp]
     public void Setup()
     {
-        _specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
+        // The prototype fork carries EIP-8141 only; the later frame-transaction EIPs are switched on
+        // here so a test can turn one back off and assert the fork gate rather than the feature.
+        _spec = new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip8250Enabled = true, IsEip8272Enabled = true };
+        _specProvider = new TestSpecProvider(_spec);
         _stateProvider = TestWorldStateFactory.CreateForTest();
         _worldStateCloser = _stateProvider.BeginScope(IWorldState.PreGenesis);
         EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
@@ -785,6 +790,10 @@ public class FrameTxProcessorTests
         Assert.That(referencing.TransactionExecuted, Is.EqualTo(expectedExecuted));
         if (!expectedExecuted)
         {
+            // Pinned to the reference check specifically: every other rejection in the outer loop also
+            // leaves TransactionExecuted false, so the weaker assertion would survive an unrelated break.
+            Assert.That(referencing.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+            Assert.That(referencing.ErrorDescription, Does.Contain("recent root reference"));
             return;
         }
 
@@ -794,6 +803,27 @@ public class FrameTxProcessorTests
         Assert.That(unreferencing.TransactionExecuted, Is.True);
         Assert.That(referencingTracer.GasSpent, Is.GreaterThan(plainTracer.GasSpent),
             "the reference's calldata and prepaid accesses must be charged");
+    }
+
+    // An empty reference list is a different envelope from an absent one and still occupies a byte on
+    // the wire, so it is priced: EIP-8272 short-circuits the per-reference term at zero references, not
+    // the calldata term over `rlp(recent_root_references)`.
+    [Test]
+    public void Execute_EmptyRecentRootReferenceList_IsPricedAsTheBytesItAdds()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+
+        Transaction empty = FrameTx(nonce: 0, SelfVerifyFrame());
+        empty.RecentRootReferences = [];
+        CallOutputTracer emptyTracer = new();
+        CallOutputTracer absentTracer = new();
+
+        Assert.That(Process(empty, tracer: emptyTracer).TransactionExecuted, Is.True);
+        Assert.That(Process(FrameTx(nonce: 1, SelfVerifyFrame()), tracer: absentTracer).TransactionExecuted, Is.True);
+
+        // rlp([]) is the single non-zero byte 0xc0, which is TxDataNonZeroMultiplier tokens.
+        Assert.That(emptyTracer.GasSpent - absentTracer.GasSpent,
+            Is.EqualTo((long)(Spec.GasCosts.TxDataNonZeroMultiplier * GasCostOf.TxDataZero)));
     }
 
     private static TxFrame SelfVerifyFrame() =>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -726,12 +726,13 @@ public class FrameTxProcessorTests
         }
     }
 
-    private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)
+    private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null, ulong? slotNumber = null)
     {
         Block block = Build.A.Block.WithNumber(1)
             .WithBaseFeePerGas(baseFeePerGas)
             .WithBeneficiary(Beneficiary)
             .WithTransactions(tx)
+            .WithSlotNumber(slotNumber)
             .WithGasLimit(30_000_000).TestObject;
         return _transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), tracer ?? NullTxTracer.Instance);
     }
@@ -757,6 +758,43 @@ public class FrameTxProcessorTests
     private static byte[] ApproveCode(byte scope) =>
         // APPROVE stack order (top to bottom): offset, length, scope.
         Prepare.EvmCode.PushData(scope).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
+
+    // EIP-8272: a declared reference is only satisfied by the commitment the predeploy actually holds
+    // for that slot, so an uncommitted or out-of-window reference invalidates the transaction. The
+    // committed case also proves the reference's intrinsic gas is charged, since the transaction pays
+    // more than the same transaction declaring nothing.
+    [TestCase(1_000UL, true, TestName = "a committed reference inside the window executes")]
+    [TestCase(1_001UL, false, TestName = "a reference to the current slot is not yet referenceable")]
+    [TestCase(9_193UL, false, TestName = "a reference older than the usable window has been overwritten")]
+    public void Execute_RecentRootReference_IsCheckedAgainstTheCommittedEntry(ulong committedSlot, bool expectedExecuted)
+    {
+        const ulong HeadSlot = 1_001;
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        ValueHash256 sourceId = RecentRootStore.SourceId(Observer, TestItem.KeccakA.ValueHash256);
+        ValueHash256 root = TestItem.KeccakB.ValueHash256;
+        _stateProvider.Set(RecentRootStore.ReferenceCell(sourceId, committedSlot),
+            RecentRootStore.EntryHash(sourceId, committedSlot, root).Bytes.WithoutLeadingZeros().ToArray());
+        _stateProvider.Commit(Spec);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.RecentRootReferences = [new RecentRootReference(sourceId, committedSlot, root)];
+
+        CallOutputTracer referencingTracer = new();
+        TransactionResult referencing = Process(tx, tracer: referencingTracer, slotNumber: HeadSlot);
+
+        Assert.That(referencing.TransactionExecuted, Is.EqualTo(expectedExecuted));
+        if (!expectedExecuted)
+        {
+            return;
+        }
+
+        CallOutputTracer plainTracer = new();
+        TransactionResult unreferencing = Process(FrameTx(nonce: 1, SelfVerifyFrame()), tracer: plainTracer, slotNumber: HeadSlot);
+
+        Assert.That(unreferencing.TransactionExecuted, Is.True);
+        Assert.That(referencingTracer.GasSpent, Is.GreaterThan(plainTracer.GasSpent),
+            "the reference's calldata and prepaid accesses must be charged");
+    }
 
     private static TxFrame SelfVerifyFrame() =>
         new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default);

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -142,6 +142,65 @@ public class RecentRootStoreTests
         }
     }
 
+    [Test]
+    public void AreReferencesValid_true_for_empty_set()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            (ValueHash256, ulong, ValueHash256)[] references = [];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+        }
+    }
+
+    [Test]
+    public void AreReferencesValid_true_when_every_reference_is_valid()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            RecentRootStore.Write(state, Source, Salt, OtherRoot, 150, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+
+            (ValueHash256, ulong, ValueHash256)[] references =
+            [
+                (sourceId, 100UL, Root),
+                (sourceId, 150UL, OtherRoot)
+            ];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+        }
+    }
+
+    [Test]
+    public void AreReferencesValid_false_when_a_reference_is_invalid()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+
+            (ValueHash256, ulong, ValueHash256)[] references =
+            [
+                (sourceId, 100UL, Root),
+                (sourceId, 100UL, OtherRoot)
+            ];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
+        }
+    }
+
+    [Test]
+    public void AreReferencesValid_false_over_the_reference_cap()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + 1];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
+        }
+    }
+
     private static IWorldState CreateState(out IDisposable scope)
     {
         IWorldState state = TestWorldStateFactory.CreateForTest();

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -201,6 +201,24 @@ public class RecentRootStoreTests
         }
     }
 
+    [Test]
+    public void AreReferencesValid_true_at_the_reference_cap()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences];
+            for (int i = 0; i < references.Length; i++)
+            {
+                ulong slot = (ulong)(100 + i);
+                RecentRootStore.Write(state, Source, Salt, Root, slot, Spec);
+                references[i] = (sourceId, slot, Root);
+            }
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 500), Is.True);
+        }
+    }
+
     private static IWorldState CreateState(out IDisposable scope)
     {
         IWorldState state = TestWorldStateFactory.CreateForTest();

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -33,6 +33,19 @@ public class RecentRootStoreTests
         Assert.That(RecentRootStore.SourceId(Source, OtherRoot), Is.Not.EqualTo(baseline));
     }
 
+    // Every concatenation in EIP-8272 is fixed-width, and an address is 20 bytes there, so the
+    // preimage is 52 bytes. Left-padding the address to a word changes every source id, which is
+    // consensus-visible on the first reference-carrying transaction.
+    [Test]
+    public void SourceId_hashes_the_address_unpadded()
+    {
+        Span<byte> preimage = stackalloc byte[Address.Size + ValueHash256.MemorySize];
+        Source.Bytes.CopyTo(preimage);
+        Salt.Bytes.CopyTo(preimage[Address.Size..]);
+
+        Assert.That(RecentRootStore.SourceId(Source, Salt), Is.EqualTo(ValueKeccak.Compute(preimage)));
+    }
+
     [Test]
     public void EntryHash_is_deterministic_and_distinct_per_input()
     {

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -191,6 +191,24 @@ public class RecentRootStoreTests
     }
 
     [Test]
+    public void AreReferencesValid_true_for_duplicate_valid_references()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+
+            (ValueHash256, ulong, ValueHash256)[] references =
+            [
+                (sourceId, 100UL, Root),
+                (sourceId, 100UL, Root)
+            ];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+        }
+    }
+
+    [Test]
     public void AreReferencesValid_false_over_the_reference_cap()
     {
         IWorldState state = CreateState(out IDisposable scope);

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -208,32 +208,23 @@ public class RecentRootStoreTests
         }
     }
 
-    [Test]
-    public void AreReferencesValid_false_over_the_reference_cap()
-    {
-        IWorldState state = CreateState(out IDisposable scope);
-        using (scope)
-        {
-            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + 1];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
-        }
-    }
-
-    [Test]
-    public void AreReferencesValid_true_at_the_reference_cap()
+    [TestCase(0, ExpectedResult = true)]
+    [TestCase(1, ExpectedResult = false)]
+    public bool AreReferencesValid_enforces_the_reference_cap(int overCap)
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
-            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences];
+            // every reference is individually valid, so only the count decides the result
+            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + overCap];
             for (int i = 0; i < references.Length; i++)
             {
                 ulong slot = (ulong)(100 + i);
                 RecentRootStore.Write(state, Source, Salt, Root, slot, Spec);
                 references[i] = (sourceId, slot, Root);
             }
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 500), Is.True);
+            return RecentRootStore.AreReferencesValid(state, references, currentSlot: 500);
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -155,19 +155,25 @@ public class RecentRootStoreTests
         }
     }
 
+    // The consensus check the processor runs: a set is admissible only when every reference matches
+    // the commitment the predeploy holds, and only up to the reference cap.
     [Test]
-    public void AreReferencesValid_true_for_empty_set()
+    public void Validate_true_for_an_absent_and_an_empty_set()
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            (ValueHash256, ulong, ValueHash256)[] references = [];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+            using StackAccessTracker accessTracker = new(false);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(RecentRootReferences.Validate(state, null, currentSlot: 200, in accessTracker), Is.True);
+                Assert.That(RecentRootReferences.Validate(state, [], currentSlot: 200, in accessTracker), Is.True);
+            }
         }
     }
 
     [Test]
-    public void AreReferencesValid_true_when_every_reference_is_valid()
+    public void Validate_true_when_every_reference_is_committed()
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
@@ -176,17 +182,12 @@ public class RecentRootStoreTests
             RecentRootStore.Write(state, Source, Salt, OtherRoot, 150, Spec);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
-            (ValueHash256, ulong, ValueHash256)[] references =
-            [
-                (sourceId, 100UL, Root),
-                (sourceId, 150UL, OtherRoot)
-            ];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+            Assert.That(Validate(state, [new(sourceId, 100, Root), new(sourceId, 150, OtherRoot)]), Is.True);
         }
     }
 
     [Test]
-    public void AreReferencesValid_false_when_a_reference_is_invalid()
+    public void Validate_false_when_a_reference_names_a_root_the_slot_does_not_hold()
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
@@ -194,17 +195,12 @@ public class RecentRootStoreTests
             RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
-            (ValueHash256, ulong, ValueHash256)[] references =
-            [
-                (sourceId, 100UL, Root),
-                (sourceId, 100UL, OtherRoot)
-            ];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
+            Assert.That(Validate(state, [new(sourceId, 100, Root), new(sourceId, 100, OtherRoot)]), Is.False);
         }
     }
 
     [Test]
-    public void AreReferencesValid_true_for_duplicate_valid_references()
+    public void Validate_true_for_a_repeated_committed_reference()
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
@@ -212,33 +208,50 @@ public class RecentRootStoreTests
             RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
-            (ValueHash256, ulong, ValueHash256)[] references =
-            [
-                (sourceId, 100UL, Root),
-                (sourceId, 100UL, Root)
-            ];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+            Assert.That(Validate(state, [new(sourceId, 100, Root), new(sourceId, 100, Root)]), Is.True);
+        }
+    }
+
+    // A header without a slot number cannot place a reference in the window, so it admits none.
+    [Test]
+    public void Validate_false_without_a_slot_number()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            using StackAccessTracker accessTracker = new(false);
+
+            Assert.That(RecentRootReferences.Validate(state, [new(sourceId, 100, Root)], currentSlot: null, in accessTracker), Is.False);
         }
     }
 
     [TestCase(0, ExpectedResult = true)]
     [TestCase(1, ExpectedResult = false)]
-    public bool AreReferencesValid_enforces_the_reference_cap(int overCap)
+    public bool Validate_enforces_the_reference_cap(int overCap)
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
             // every reference is individually valid, so only the count decides the result
-            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + overCap];
+            RecentRootReference[] references = new RecentRootReference[Eip8272Constants.MaxRecentRootReferences + overCap];
             for (int i = 0; i < references.Length; i++)
             {
                 ulong slot = (ulong)(100 + i);
                 RecentRootStore.Write(state, Source, Salt, Root, slot, Spec);
-                references[i] = (sourceId, slot, Root);
+                references[i] = new RecentRootReference(sourceId, slot, Root);
             }
-            return RecentRootStore.AreReferencesValid(state, references, currentSlot: 500);
+
+            return Validate(state, references, currentSlot: 500);
         }
+    }
+
+    private static bool Validate(IWorldState state, RecentRootReference[] references, ulong currentSlot = 200)
+    {
+        using StackAccessTracker accessTracker = new(false);
+        return RecentRootReferences.Validate(state, references, currentSlot, in accessTracker);
     }
 
     private static IWorldState CreateState(out IDisposable scope)

--- a/src/Nethermind/Nethermind.Evm/RecentRootReferences.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootReferences.cs
@@ -14,11 +14,16 @@ namespace Nethermind.Evm;
 /// </summary>
 public static class RecentRootReferences
 {
-    /// <summary>The <c>recent_root_calldata</c> the references add to the payload, priced as frame data is.</summary>
-    /// <remarks>Empty for a transaction that declares no reference, so its gas is exactly the EIP-8141 figure.</remarks>
+    /// <summary>
+    /// The <c>recent_root_calldata</c> the references add to the payload, priced as frame data is.
+    /// </summary>
+    /// <remarks>
+    /// Only an absent list is free: a present-but-empty list still encodes as <c>0xc0</c>, and EIP-8272
+    /// short-circuits the per-reference intrinsic term at zero references but not the calldata term.
+    /// </remarks>
     public static byte[] Calldata(RecentRootReference[]? references)
     {
-        if (references is null || references.Length == 0)
+        if (references is null)
         {
             return [];
         }
@@ -79,8 +84,9 @@ public static class RecentRootReferences
         accessTracker.WarmUp(Eip8272Constants.RecentRootAddress);
         foreach (RecentRootReference reference in references)
         {
-            accessTracker.WarmUp(RecentRootStore.ReferenceCell(reference.SourceId, reference.Slot));
-            if (!RecentRootStore.IsReferenceValid(state, reference.SourceId, reference.Slot, reference.Root, slot))
+            StorageCell cell = RecentRootStore.ReferenceCell(reference.SourceId, reference.Slot);
+            accessTracker.WarmUp(cell);
+            if (!RecentRootStore.IsReferenceValid(state, in cell, reference.SourceId, reference.Slot, reference.Root, slot))
             {
                 return false;
             }

--- a/src/Nethermind/Nethermind.Evm/RecentRootReferences.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootReferences.cs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.Evm;
+
+/// <summary>
+/// Gas and pre-state validity of the <see href="https://eips.ethereum.org/EIPS/eip-8272">EIP-8272</see>
+/// recent-root references declared by a frame transaction.
+/// </summary>
+public static class RecentRootReferences
+{
+    /// <summary>The <c>recent_root_calldata</c> the references add to the payload, priced as frame data is.</summary>
+    /// <remarks>Empty for a transaction that declares no reference, so its gas is exactly the EIP-8141 figure.</remarks>
+    public static byte[] Calldata(RecentRootReference[]? references)
+    {
+        if (references is null || references.Length == 0)
+        {
+            return [];
+        }
+
+        byte[] bytes = new byte[RecentRootReferenceDecoder.Instance.GetArrayLength(references)];
+        RlpWriter writer = new(bytes);
+        RecentRootReferenceDecoder.Instance.EncodeArray(ref writer, references);
+        return bytes;
+    }
+
+    /// <summary>
+    /// The <c>recent_root_reference_intrinsic_gas</c> that prepays warming the predeploy and each derived
+    /// storage key, plus the two Keccak computations deriving the key and the committed entry hash.
+    /// </summary>
+    /// <remarks>
+    /// A mandatory cost charged outside the EIP-7623 floored term. The access-list rates are resolved from
+    /// the spec, so a reference cannot be priced against a fork the transaction does not execute under.
+    /// </remarks>
+    public static ulong IntrinsicGas(RecentRootReference[]? references, IReleaseSpec spec)
+    {
+        if (references is null || references.Length == 0)
+        {
+            return 0;
+        }
+
+        ulong addressCost = spec.IsEip8038Enabled ? Eip8038Constants.AccessListAddressCost : GasCostOf.AccessAccountListEntry;
+        ulong storageKeyCost = spec.IsEip8038Enabled ? Eip8038Constants.AccessListStorageKeyCost : GasCostOf.AccessStorageListEntry;
+        ulong perReference = storageKeyCost + 2 * GasCostOf.Sha3 + 7 * GasCostOf.Sha3Word;
+        return addressCost + (ulong)references.Length * perReference;
+    }
+
+    /// <summary>
+    /// Checks every declared reference against the pre-state commitment in <c>RECENT_ROOT_ADDRESS</c> and
+    /// warms the predeploy and the keys read, which the intrinsic gas has already paid for.
+    /// </summary>
+    /// <remarks>
+    /// A reference at or ahead of <paramref name="currentSlot"/> is not yet referenceable and one older than
+    /// the usable window has been overwritten by ring-buffer aliasing; both fail, as does a commitment that
+    /// does not match. The reads are real predeploy reads rather than declared access-list entries, so they
+    /// belong in the block access list once the whole pass succeeds — a failed reference invalidates the
+    /// transaction and the block carrying it.
+    /// </remarks>
+    /// <returns><see langword="true"/> when every reference is committed and in range.</returns>
+    public static bool Validate(IWorldState state, RecentRootReference[]? references, ulong? currentSlot, in StackAccessTracker accessTracker)
+    {
+        if (references is null || references.Length == 0)
+        {
+            return true;
+        }
+
+        // References are anchored to slots, so a header that carries no slot number cannot place them
+        // in the window at all.
+        if (currentSlot is not { } slot || references.Length > Eip8272Constants.MaxRecentRootReferences)
+        {
+            return false;
+        }
+
+        accessTracker.WarmUp(Eip8272Constants.RecentRootAddress);
+        foreach (RecentRootReference reference in references)
+        {
+            accessTracker.WarmUp(RecentRootStore.ReferenceCell(reference.SourceId, reference.Slot));
+            if (!RecentRootStore.IsReferenceValid(state, reference.SourceId, reference.Slot, reference.Root, slot))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -75,6 +75,24 @@ public static class RecentRootStore
         state.Set(cell, entryHash.Bytes.WithoutLeadingZeros().ToArray());
     }
 
+    public static bool AreReferencesValid(IWorldState state, ReadOnlySpan<(ValueHash256 SourceId, ulong Slot, ValueHash256 Root)> references, ulong currentSlot)
+    {
+        if (references.Length > Eip8272Constants.MaxRecentRootReferences)
+        {
+            return false;
+        }
+
+        foreach ((ValueHash256 sourceId, ulong slot, ValueHash256 root) in references)
+        {
+            if (!IsReferenceValid(state, sourceId, slot, root, currentSlot))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private static StorageCell RingBufferCell(in ValueHash256 sourceId, ulong ringIndex) =>
         new(Eip8272Constants.RecentRootAddress, StorageKey(sourceId, ringIndex).ToUInt256());
 }

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -45,7 +45,14 @@ public static class RecentRootStore
         return ValueKeccak.Compute(input);
     }
 
-    public static bool IsReferenceValid(IWorldState state, in ValueHash256 sourceId, ulong slot, in ValueHash256 root, ulong currentSlot)
+    public static bool IsReferenceValid(IWorldState state, in ValueHash256 sourceId, ulong slot, in ValueHash256 root, ulong currentSlot) =>
+        IsReferenceValid(state, ReferenceCell(sourceId, slot), sourceId, slot, root, currentSlot);
+
+    /// <summary>
+    /// Checks a reference against the commitment held in <paramref name="cell"/>, which the caller has
+    /// already derived — the ring-buffer key costs a Keccak the gas schedule pays for once per reference.
+    /// </summary>
+    public static bool IsReferenceValid(IWorldState state, in StorageCell cell, in ValueHash256 sourceId, ulong slot, in ValueHash256 root, ulong currentSlot)
     {
         ulong age = currentSlot - slot; // unsigned: a future or same slot underflows and is rejected below
         if (age is 0 || age > Eip8272Constants.RecentRootUsableWindow)
@@ -53,7 +60,6 @@ public static class RecentRootStore
             return false;
         }
 
-        StorageCell cell = RingBufferCell(sourceId, slot % Eip8272Constants.RecentRootLength);
         ReadOnlySpan<byte> stored = state.Get(cell);
         if (stored.Length > HashLength)
         {
@@ -72,24 +78,6 @@ public static class RecentRootStore
         StorageCell cell = RingBufferCell(sourceId, currentSlot % Eip8272Constants.RecentRootLength);
         ValueHash256 entryHash = EntryHash(sourceId, currentSlot, root);
         state.Set(cell, entryHash.Bytes.WithoutLeadingZeros().ToArray());
-    }
-
-    public static bool AreReferencesValid(IWorldState state, ReadOnlySpan<(ValueHash256 SourceId, ulong Slot, ValueHash256 Root)> references, ulong currentSlot)
-    {
-        if (references.Length > Eip8272Constants.MaxRecentRootReferences)
-        {
-            return false;
-        }
-
-        foreach ((ValueHash256 sourceId, ulong slot, ValueHash256 root) in references)
-        {
-            if (!IsReferenceValid(state, sourceId, slot, root, currentSlot))
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /// <summary>The predeploy storage cell a reference to <paramref name="slot"/> reads.</summary>

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -92,6 +92,10 @@ public static class RecentRootStore
         return true;
     }
 
+    /// <summary>The predeploy storage cell a reference to <paramref name="slot"/> reads.</summary>
+    public static StorageCell ReferenceCell(in ValueHash256 sourceId, ulong slot) =>
+        RingBufferCell(sourceId, slot % Eip8272Constants.RecentRootLength);
+
     private static StorageCell RingBufferCell(in ValueHash256 sourceId, ulong ringIndex) =>
         new(Eip8272Constants.RecentRootAddress, StorageKey(sourceId, ringIndex).ToUInt256());
 }

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -18,12 +18,11 @@ public static class RecentRootStore
     private const int AddressLength = Address.Size;
     private const int SlotLength = sizeof(ulong);
 
-    // Consensus-critical, spec-ambiguous: 32-byte-padded address matches the only existing implementation (spec text says 20 bytes).
     public static ValueHash256 SourceId(Address sourceAddress, in ValueHash256 salt)
     {
-        Span<byte> input = stackalloc byte[HashLength + HashLength];
-        sourceAddress.Bytes.CopyTo(input.Slice(HashLength - AddressLength, AddressLength));
-        salt.Bytes.CopyTo(input.Slice(HashLength));
+        Span<byte> input = stackalloc byte[AddressLength + HashLength];
+        sourceAddress.Bytes.CopyTo(input);
+        salt.Bytes.CopyTo(input.Slice(AddressLength));
         return ValueKeccak.Compute(input);
     }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -128,6 +128,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             accessTracker.WarmUp(sender);
         }
 
+        // EIP-8272: every declared reference must match the commitment RECENT_ROOT_ADDRESS holds in the
+        // pre-state, so the transaction is invalid — and the block carrying it with it — when one does not.
+        if (!RecentRootReferences.Validate(WorldState, tx.RecentRootReferences, header.SlotNumber, in accessTracker))
+        {
+            return TransactionResult.ErrorType.MalformedTransaction.WithDetail("recent root reference is not committed or out of range");
+        }
+
         // Atomic batch state: a maximal contiguous run [i, j] where i..j-1 have ATOMIC_BATCH_FLAG
         // and j does not. On any failure inside the run, state rolls back to before the run began
         // and the remaining frames are skipped (spec: Behavior, atomic batch).
@@ -417,10 +424,15 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             }
         }
 
+        // EIP-8272 prices the bytes its reference list adds to the payload exactly as EIP-8141 prices
+        // frame and signature data, and prepays the predeploy and storage-key accesses the checks make.
+        tokens += CountCalldataTokens(RecentRootReferences.Calldata(tx.RecentRootReferences), spec);
+
         return (ulong)Eip8141Constants.IntrinsicGasCost
                + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
                + tokens * GasCostOf.TxDataZero
-               + signatureVerificationCost;
+               + signatureVerificationCost
+               + RecentRootReferences.IntrinsicGas(tx.RecentRootReferences, spec);
     }
 
     private static ulong CountCalldataTokens(ReadOnlySpan<byte> data, IReleaseSpec spec)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RecentRootReferenceDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RecentRootReferenceDecoder.cs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Serialization.Rlp;
+
+/// <summary>Decodes the EIP-8272 recent-root reference tuple <c>[source_id, slot, root]</c>.</summary>
+public sealed class RecentRootReferenceDecoder : RlpDecoder<RecentRootReference>
+{
+    public static readonly RecentRootReferenceDecoder Instance = new();
+
+    protected override RecentRootReference DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    {
+        int length = decoderContext.ReadSequenceLength();
+        int check = length + decoderContext.Position;
+
+        ValueHash256 sourceId = decoderContext.DecodeValueKeccak() ?? ThrowMissingHash();
+        ulong slot = decoderContext.DecodeULong();
+        ValueHash256 root = decoderContext.DecodeValueKeccak() ?? ThrowMissingHash();
+
+        if (!rlpBehaviors.HasFlag(RlpBehaviors.AllowExtraBytes))
+        {
+            decoderContext.Check(check);
+        }
+
+        return new RecentRootReference(sourceId, slot, root);
+    }
+
+    public override void Encode<TWriter>(ref TWriter writer, RecentRootReference item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    {
+        writer.StartSequence(GetContentLength(item));
+        writer.Encode(item.SourceId);
+        writer.Encode(item.Slot);
+        writer.Encode(item.Root);
+    }
+
+    public void EncodeArray<TWriter>(ref TWriter writer, RecentRootReference[]? items)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct
+    {
+        if (items is null)
+        {
+            writer.WriteByte(Rlp.EmptyListByte);
+            return;
+        }
+
+        writer.StartSequence(GetArrayContentLength(items));
+        for (int i = 0; i < items.Length; i++)
+        {
+            Encode(ref writer, items[i]);
+        }
+    }
+
+    public override int GetLength(RecentRootReference item, RlpBehaviors rlpBehaviors) => Rlp.LengthOfSequence(GetContentLength(item));
+
+    public int GetArrayLength(RecentRootReference[]? items) => items is null ? 1 : Rlp.LengthOfSequence(GetArrayContentLength(items));
+
+    private int GetArrayContentLength(RecentRootReference[] items)
+    {
+        int length = 0;
+        for (int i = 0; i < items.Length; i++)
+        {
+            length += GetLength(items[i], RlpBehaviors.None);
+        }
+
+        return length;
+    }
+
+    [DoesNotReturn, StackTraceHidden]
+    private static ValueHash256 ThrowMissingHash() => throw new RlpException("recent root reference source id and root must be 32-byte hashes");
+
+    private static int GetContentLength(RecentRootReference item) =>
+        Rlp.LengthOf(item.SourceId)
+        + Rlp.LengthOf(item.Slot)
+        + Rlp.LengthOf(item.Root);
+}

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -15,6 +15,8 @@ namespace Nethermind.Serialization.Rlp.TxDecoders;
 /// <c>[chain_id, nonce, sender, frames, signatures, max_priority_fee_per_gas, max_fee_per_gas,
 /// max_fee_per_blob_gas, blob_versioned_hashes]</c>, or its EIP-8250 form, which replaces
 /// <c>nonce</c> with <c>nonce_keys, nonce_seq</c>.
+/// max_fee_per_blob_gas, blob_versioned_hashes]</c>, optionally followed by the EIP-8272
+/// <c>recent_root_references</c> list.
 /// The sender is explicit in the payload — there is no envelope ECDSA signature and no recovery.
 /// Encoding with <c>forSigning</c> produces the <c>compute_sig_hash</c> form: the raw signature
 /// bytes of canonical-hash (empty msg) entries are elided.
@@ -33,7 +35,50 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     // EIP8141-GAP: the spec does not bound blob_versioned_hashes; mirrors the blob tx decode cap.
     private static readonly RlpLimit BlobVersionedHashesCountLimit = RlpLimit.For<Transaction>(128, nameof(Transaction.BlobVersionedHashes));
 
+    private static readonly RlpLimit ReferencesCountLimit = RlpLimit.For<Transaction>(Eip8272Constants.MaxRecentRootReferences, nameof(Transaction.RecentRootReferences));
+
     private static readonly byte[][] EmptyVersionedHashes = [];
+
+    private readonly Func<T> _newTransaction = transactionFactory ?? (static () => new T());
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// A frame transaction carries no envelope signature — the sender is explicit — so what follows the
+    /// EIP-8141 fields is the optional EIP-8272 reference list rather than a trailing <c>[v, r, s]</c>.
+    /// A non-list element there is padding and is rejected: accepting it would decode a spurious
+    /// signature that strict clients drop, diverging on the transaction hash.
+    /// </remarks>
+    public override void Decode(ref Transaction? transaction, int txSequenceStart, ReadOnlySpan<byte> transactionSequence,
+        ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    {
+        transaction ??= _newTransaction();
+        transaction.Type = Type;
+
+        int payloadLength = decoderContext.ReadSequenceLength();
+        int lastCheck = decoderContext.Position + payloadLength;
+
+        DecodePayload(transaction, ref decoderContext, rlpBehaviors);
+
+        if (decoderContext.Position < lastCheck)
+        {
+            if (!decoderContext.IsSequenceNext())
+            {
+                ThrowTrailingSignature();
+            }
+
+            transaction.RecentRootReferences = decoderContext.DecodeArray(RecentRootReferenceDecoder.Instance, limit: ReferencesCountLimit);
+        }
+
+        if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) == 0)
+        {
+            decoderContext.Check(lastCheck);
+        }
+
+        if ((rlpBehaviors & RlpBehaviors.ExcludeHashes) == 0)
+        {
+            CalculateHash(transaction, txSequenceStart, transactionSequence, ref decoderContext);
+        }
+    }
 
     protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,
         RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -115,6 +160,10 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         writer.Encode(transaction.DecodedMaxFeePerGas);
         writer.Encode(transaction.MaxFeePerBlobGas.GetValueOrDefault());
         writer.Encode(transaction.BlobVersionedHashes ?? EmptyVersionedHashes);
+        if (transaction.RecentRootReferences is { } references)
+        {
+            RecentRootReferenceDecoder.Instance.EncodeArray(ref writer, references);
+        }
     }
 
     protected override int GetContentLength(Transaction transaction, RlpBehaviors rlpBehaviors, bool forSigning,
@@ -128,7 +177,8 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         + Rlp.LengthOf(transaction.GasPrice)
         + Rlp.LengthOf(transaction.DecodedMaxFeePerGas)
         + Rlp.LengthOf(transaction.MaxFeePerBlobGas.GetValueOrDefault())
-        + Rlp.LengthOf(transaction.BlobVersionedHashes ?? EmptyVersionedHashes);
+        + Rlp.LengthOf(transaction.BlobVersionedHashes ?? EmptyVersionedHashes)
+        + (transaction.RecentRootReferences is { } references ? RecentRootReferenceDecoder.Instance.GetArrayLength(references) : 0);
 
     protected override int GetSignatureLength(Signature? signature, bool forSigning, bool isEip155Enabled = false, ulong chainId = 0) => 0;
 
@@ -137,12 +187,8 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     {
     }
 
-    // The payload is exactly 9 fields with no envelope signature (the sender is explicit). The base
-    // decoder reads a trailing [v, r, s] whenever elements remain after the payload; reject that so a
-    // padded encoding is not silently accepted with a spurious signature (which strict clients drop,
-    // diverging on the transaction hash).
-    protected override Signature? DecodeSignature(ulong v, ReadOnlySpan<byte> rBytes, ReadOnlySpan<byte> sBytes, Signature? fallbackSignature = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None) =>
-        throw new RlpException("frame transaction must not carry a trailing signature");
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowTrailingSignature() => throw new RlpException("frame transaction must not carry a trailing signature");
 
     private static int NonceKeysContentLength(UInt256[] nonceKeys)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -6,13 +6,15 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Int256;
 
 namespace Nethermind.Serialization.Rlp.TxDecoders;
 
 /// <summary>
 /// Decodes the EIP-8141 frame transaction payload
 /// <c>[chain_id, nonce, sender, frames, signatures, max_priority_fee_per_gas, max_fee_per_gas,
-/// max_fee_per_blob_gas, blob_versioned_hashes]</c>.
+/// max_fee_per_blob_gas, blob_versioned_hashes]</c>, or its EIP-8250 form, which replaces
+/// <c>nonce</c> with <c>nonce_keys, nonce_seq</c>.
 /// The sender is explicit in the payload — there is no envelope ECDSA signature and no recovery.
 /// Encoding with <c>forSigning</c> produces the <c>compute_sig_hash</c> form: the raw signature
 /// bytes of canonical-hash (empty msg) entries are elided.
@@ -27,6 +29,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 
     private static readonly RlpLimit FramesCountLimit = RlpLimit.For<Transaction>(Eip8141Constants.MaxFrames, nameof(Transaction.Frames));
     private static readonly RlpLimit SignaturesCountLimit = RlpLimit.For<Transaction>(SignaturesDecodeCap, nameof(Transaction.FrameSignatures));
+    private static readonly RlpLimit NonceKeysCountLimit = RlpLimit.For<Transaction>(Eip8250Constants.MaxNonceKeys, nameof(Transaction.NonceKeys));
     // EIP8141-GAP: the spec does not bound blob_versioned_hashes; mirrors the blob tx decode cap.
     private static readonly RlpLimit BlobVersionedHashesCountLimit = RlpLimit.For<Transaction>(128, nameof(Transaction.BlobVersionedHashes));
 
@@ -38,6 +41,12 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         // EIP8141-DEVIATION: the spec allows chain_id < 2^256; decoded as u64 like every other
         // Nethermind transaction type (codebase-wide ChainId width).
         transaction.ChainId = decoderContext.DecodeULong();
+        // EIP-8250 replaces `nonce` with `nonce_keys, nonce_seq`. The two shapes are self-describing —
+        // `nonce` is an integer and `nonce_keys` a list — so the payload is read without fork context and
+        // the fork that admits each shape is enforced where the spec is available, in validation.
+        transaction.NonceKeys = decoderContext.IsSequenceNext()
+            ? decoderContext.DecodeArray(static (ref RlpReader ctx) => ctx.DecodeUInt256(), limit: NonceKeysCountLimit)
+            : null;
         transaction.Nonce = decoderContext.DecodeULong();
         transaction.SenderAddress = decoderContext.DecodeAddress() ?? ThrowMissingSender();
         transaction.Frames = decoderContext.DecodeArray(TxFrameDecoder.Instance, limit: FramesCountLimit);
@@ -90,6 +99,14 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
     {
         writer.Encode(transaction.ChainId ?? 0);
+        if (transaction.NonceKeys is { } nonceKeys)
+        {
+            writer.StartSequence(NonceKeysContentLength(nonceKeys));
+            foreach (UInt256 nonceKey in nonceKeys)
+            {
+                writer.Encode(nonceKey);
+            }
+        }
         writer.Encode(transaction.Nonce);
         writer.Encode(transaction.SenderAddress);
         TxFrameDecoder.Instance.EncodeArray(ref writer, transaction.Frames);
@@ -103,6 +120,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     protected override int GetContentLength(Transaction transaction, RlpBehaviors rlpBehaviors, bool forSigning,
         bool isEip155Enabled = false, ulong chainId = 0) =>
         Rlp.LengthOf(transaction.ChainId ?? 0)
+        + (transaction.NonceKeys is { } nonceKeys ? Rlp.LengthOfSequence(NonceKeysContentLength(nonceKeys)) : 0)
         + Rlp.LengthOf(transaction.Nonce)
         + Rlp.LengthOf(transaction.SenderAddress)
         + TxFrameDecoder.Instance.GetArrayLength(transaction.Frames)
@@ -125,6 +143,17 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     // diverging on the transaction hash).
     protected override Signature? DecodeSignature(ulong v, ReadOnlySpan<byte> rBytes, ReadOnlySpan<byte> sBytes, Signature? fallbackSignature = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None) =>
         throw new RlpException("frame transaction must not carry a trailing signature");
+
+    private static int NonceKeysContentLength(UInt256[] nonceKeys)
+    {
+        int contentLength = 0;
+        foreach (UInt256 nonceKey in nonceKeys)
+        {
+            contentLength += Rlp.LengthOf(nonceKey);
+        }
+
+        return contentLength;
+    }
 
     [DoesNotReturn, StackTraceHidden]
     private static Address ThrowMissingSender() => throw new RlpException("frame transaction sender must be a 20-byte address");

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -97,6 +97,7 @@ namespace Nethermind.Specs.Test
         public bool IsEip8282Enabled { get; set; } = spec.IsEip8282Enabled;
         public bool IsEip8141Enabled { get; set; } = spec.IsEip8141Enabled;
         public bool IsEip8250Enabled { get; set; } = spec.IsEip8250Enabled;
+        public bool IsEip8272Enabled { get; set; } = spec.IsEip8272Enabled;
         public bool IsEip4788Enabled { get; set; } = spec.IsEip4788Enabled;
         public bool IsEip4844FeeCollectorEnabled { get; set; } = spec.IsEip4844FeeCollectorEnabled;
         public Address? Eip4788ContractAddress { get; set; } = spec.Eip4788ContractAddress;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -192,6 +192,8 @@ public class ChainParameters
     public ulong? Eip8282TransitionTimestamp { get; set; }
     public ulong? Eip8141TransitionTimestamp { get; set; }
     public ulong? Eip8250TransitionTimestamp { get; set; }
+
+    public ulong? Eip8272TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip2780TransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -343,6 +343,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             releaseSpec.IsEip8282Enabled = (chainSpec.Parameters.Eip8282TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip8141Enabled = (chainSpec.Parameters.Eip8141TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip8250Enabled = (chainSpec.Parameters.Eip8250TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+            releaseSpec.IsEip8272Enabled = (chainSpec.Parameters.Eip8272TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             bool eip1559FeeCollector = releaseSpec.IsEip1559Enabled && BlockOf(chainSpec.Parameters.Eip1559FeeCollectorTransition) <= block;
             bool eip4844FeeCollector = releaseSpec.IsEip4844Enabled && (chainSpec.Parameters.Eip4844FeeCollectorTransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -221,6 +221,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8282TransitionTimestamp = chainSpecJson.Params.Eip8282TransitionTimestamp,
             Eip8141TransitionTimestamp = chainSpecJson.Params.Eip8141TransitionTimestamp,
             Eip8250TransitionTimestamp = chainSpecJson.Params.Eip8250TransitionTimestamp,
+            Eip8272TransitionTimestamp = chainSpecJson.Params.Eip8272TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
             Eip2780TransitionTimestamp = chainSpecJson.Params.Eip2780TransitionTimestamp,

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -199,6 +199,8 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8282TransitionTimestamp { get; set; }
     public ulong? Eip8141TransitionTimestamp { get; set; }
     public ulong? Eip8250TransitionTimestamp { get; set; }
+
+    public ulong? Eip8272TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip2780TransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -93,6 +93,7 @@ public class ReleaseSpec : IReleaseSpec
     public bool IsEip8282Enabled { get; set; }
     public bool IsEip8141Enabled { get; set; }
     public bool IsEip8250Enabled { get; set; }
+    public bool IsEip8272Enabled { get; set; }
     public bool IsEip4788Enabled { get; set; }
     public bool IsEip7702Enabled { get; set; }
     public bool IsEip7823Enabled { get; set; }


### PR DESCRIPTION
Pins the frame-transaction wire format against a second implementation.

The existing decoder tests round-trip our own encoder, which cannot catch a field-order or signing-payload disagreement: a transaction two clients decode differently is a consensus split, and a signature hash they compute differently makes every cross-client frame transaction unspendable. The vector here was produced by the other client's encoder and carries both extension fields, an EIP-8250 keyed nonce set and an EIP-8272 recent-root reference. Three properties are asserted against the foreign bytes: every field decodes to the value the producer put in, re-encoding reproduces the bytes exactly, and `compute_sig_hash` matches the producer's digest.

### Testing
- `FrameTxCrossClientVectorTests`: 2 passing. Both fail against an envelope missing either extension field.

### Types of changes
- [x] Test
