### PR TITLE
fix(evm): execute a VERIFY frame as a truly static call

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -726,20 +726,22 @@ public class FrameTxProcessorTests
         }
     }
 
-    // A VERIFY frame runs as a STATICCALL, so a write inside it halts the frame and, because a failed
-    // VERIFY invalidates the transaction, drops the transaction. Without this the validation prefix
-    // could mutate state the mempool never simulated.
-    [Test]
-    public void Execute_VerifyFrameWritesState_InvalidatesTheTransaction()
+    /// <summary>A VERIFY frame runs as a STATICCALL, so a write inside it halts the frame, and a failed
+    /// VERIFY invalidates the transaction.</summary>
+    /// <remarks>
+    /// The write-free case is the control: without it a transaction dropped for any other reason would
+    /// satisfy the assertion, and the post-state is no evidence either — the failure path restores it.
+    /// </remarks>
+    [TestCase(true, ExpectedResult = false, TestName = "Execute_VerifyFrameWritesState_InvalidatesTheTransaction")]
+    [TestCase(false, ExpectedResult = true, TestName = "Execute_VerifyFrameWithoutWrite_Executes")]
+    public bool Execute_VerifyFrame_IsStatic(bool writesState)
     {
-        DeploySmartSender(Prepare.EvmCode
-            .PushData(1).PushData(0).Op(Instruction.SSTORE)
+        Prepare code = Prepare.EvmCode;
+        if (writesState) code = code.PushData(1).PushData(0).Op(Instruction.SSTORE);
+        DeploySmartSender(code
             .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done);
 
-        TransactionResult result = Process(FrameTx(nonce: 0, SelfVerifyFrame()));
-
-        Assert.That(result.TransactionExecuted, Is.False);
-        AssertStorage(Sender, 0, UInt256.Zero, "a VERIFY frame cannot write");
+        return Process(FrameTx(nonce: 0, SelfVerifyFrame())).TransactionExecuted;
     }
 
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -726,6 +726,22 @@ public class FrameTxProcessorTests
         }
     }
 
+    // A VERIFY frame runs as a STATICCALL, so a write inside it halts the frame and, because a failed
+    // VERIFY invalidates the transaction, drops the transaction. Without this the validation prefix
+    // could mutate state the mempool never simulated.
+    [Test]
+    public void Execute_VerifyFrameWritesState_InvalidatesTheTransaction()
+    {
+        DeploySmartSender(Prepare.EvmCode
+            .PushData(1).PushData(0).Op(Instruction.SSTORE)
+            .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done);
+
+        TransactionResult result = Process(FrameTx(nonce: 0, SelfVerifyFrame()));
+
+        Assert.That(result.TransactionExecuted, Is.False);
+        AssertStorage(Sender, 0, UInt256.Zero, "a VERIFY frame cannot write");
+    }
+
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)
     {
         Block block = Build.A.Block.WithNumber(1)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -481,7 +481,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             env,
             in frameTracker,
             in snapshot,
-            isStatic);
+            isStatic: isStatic);
 
         TransactionSubstate substate = VirtualMachine.ExecuteTransaction(state, WorldState, tracer);
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -480,7 +480,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             isStatic ? ExecutionType.STATICCALL : ExecutionType.TRANSACTION,
             env,
             in frameTracker,
-            in snapshot);
+            in snapshot,
+            isStatic);
 
         TransactionSubstate substate = VirtualMachine.ExecuteTransaction(state, WorldState, tracer);
 

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -70,7 +70,8 @@ public class VmState<TGasPolicy> : IDisposable
         ExecutionType executionType,
         ExecutionEnvironment env,
         in StackAccessTracker accessedItems,
-        in Snapshot snapshot)
+        in Snapshot snapshot,
+        bool isStatic = false)
     {
         VmState<TGasPolicy> state = Rent();
         state.Initialize(
@@ -79,7 +80,7 @@ public class VmState<TGasPolicy> : IDisposable
             outputLength: 0L,
             executionType: executionType,
             isTopLevel: true,
-            isStatic: false,
+            isStatic: isStatic,
             isCreateOnPreExistingAccount: false,
             isCreateStateGasCharged: false,
             newAccountCharged: false,


### PR DESCRIPTION
EIP-8141 says a `VERIFY` frame "is executed as a `STATICCALL`, disallowing all state manipulation". The frame's `VmState` is built through `RentTopLevel`, which hardcodes `isStatic: false`, so the execution type was `STATICCALL` while the state was not: a `VERIFY` frame could `SSTORE`, `CREATE`, `SELFDESTRUCT` or emit logs. The validation prefix is what the mempool simulates under `MAX_VERIFY_GAS` before accepting a transaction, so such a prefix can mutate the state its own validity is judged against, and it diverges from an implementation that enforces the static rule.

`RentTopLevel` gains an optional `isStatic` parameter defaulting to `false`, so existing top-level call sites are unchanged; the frame path passes the flag it already computed.

## Types of changes

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

`Execute_VerifyFrameWritesState_InvalidatesTheTransaction`: a sender whose approval code stores before approving. With the fix the frame halts, the failed `VERIFY` invalidates the transaction and the slot stays zero; without it the store lands and the transaction executes.

Full `Nethermind.Evm.Test`: 5086 tests, no failures.
