### PR TITLE
feat(evm): add the EIP-7906 POST_TX frame mode

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -851,12 +851,11 @@ public class TxValidatorTests
 
 /// <summary>The EIP-7906 fork gate on the <c>POST_TX</c> frame mode.</summary>
 /// <remarks>
-/// The frame-list shape check accepts the mode without fork context, so admission is decided here.
 /// Before the fork the mode is undefined, and a node treating such a frame as DEFAULT would execute
 /// it with write access, which the assertion semantics forbid.
 /// </remarks>
 [TestFixture]
-public class FrameTxPostTxModeValidatorTests
+public class FrameTxPostTxModeGateTests
 {
     [TestCase(false, ExpectedResult = true, TestName = "PostTx frame is admitted once EIP-7906 is enabled")]
     [TestCase(true, ExpectedResult = false, TestName = "PostTx frame is rejected before EIP-7906")]
@@ -874,6 +873,6 @@ public class FrameTxPostTxModeValidatorTests
             ],
         };
 
-        return FrameTxPostTxModeValidator.Instance.IsWellFormed(tx, spec);
+        return FrameTxFieldsTxValidator.Instance.IsWellFormed(tx, spec);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -21,6 +21,7 @@ using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -845,5 +846,34 @@ public class TxValidatorTests
                 ExpectedResult = false
             };
         }
+    }
+}
+
+/// <summary>The EIP-7906 fork gate on the <c>POST_TX</c> frame mode.</summary>
+/// <remarks>
+/// The frame-list shape check accepts the mode without fork context, so admission is decided here.
+/// Before the fork the mode is undefined, and a node treating such a frame as DEFAULT would execute
+/// it with write access, which the assertion semantics forbid.
+/// </remarks>
+[TestFixture]
+public class FrameTxPostTxModeValidatorTests
+{
+    [TestCase(false, ExpectedResult = true, TestName = "PostTx frame is admitted once EIP-7906 is enabled")]
+    [TestCase(true, ExpectedResult = false, TestName = "PostTx frame is rejected before EIP-7906")]
+    public bool IsWellFormed_PostTxFrame_IsGatedOnTheFork(bool beforeTheFork)
+    {
+        OverridableReleaseSpec spec = new(Eip8141Prototype.Instance) { IsEip7906Enabled = !beforeTheFork };
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            SenderAddress = TestItem.AddressA,
+            Frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default),
+                new TxFrame(TxFrame.ModePostTx, 0, TestItem.AddressB, gasLimit: 100_000, UInt256.Zero, default),
+            ],
+        };
+
+        return FrameTxPostTxModeValidator.Instance.IsWellFormed(tx, spec);
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -81,7 +81,10 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
 
     protected TxReceipt BuildFailedReceipt(Address recipient, in GasConsumed gasSpent, string error, Hash256? stateRoot)
     {
-        TxReceipt receipt = BuildReceipt(recipient, gasSpent, StatusCode.Failure, [], stateRoot);
+        // EIP-7906: a failed assertion discards the body but keeps the validation prefix, whose logs
+        // stay in the surviving frame receipts and so in the transaction's log set and bloom.
+        LogEntry[] logs = _frameTxReceipts is { } frameReceipts ? TxFrameReceipt.ConcatLogs(frameReceipts) : [];
+        TxReceipt receipt = BuildReceipt(recipient, gasSpent, StatusCode.Failure, logs, stateRoot);
         receipt.Error = error;
         return receipt;
     }

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -92,7 +92,8 @@ public sealed class TxValidator : ITxValidator
             NonceCapTxValidator.Instance,
             expectedChainIdTxValidator,
             GasFieldsTxValidator.Instance,
-            FrameTxFieldsTxValidator.Instance
+            FrameTxFieldsTxValidator.Instance,
+            FrameTxPostTxModeValidator.Instance
         ]));
     }
 
@@ -191,6 +192,36 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
         FrameTxValidation.IsWellFormed(transaction, out string? error) ? ValidationResult.Success : error!;
+}
+
+/// <summary>Admits the EIP-7906 <c>POST_TX</c> frame mode only on forks that define it.</summary>
+/// <remarks>
+/// The mode is accepted without fork context wherever the frame list is checked structurally, so the
+/// fork that admits it is enforced here. Before the fork the mode is undefined, and executing such a
+/// frame as if it were <c>DEFAULT</c> would let it write state the assertion semantics forbid.
+/// </remarks>
+public sealed class FrameTxPostTxModeValidator : ITxValidator
+{
+    public static readonly FrameTxPostTxModeValidator Instance = new();
+    private FrameTxPostTxModeValidator() { }
+
+    public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
+    {
+        if (releaseSpec.IsEip7906Enabled || transaction.Frames is not { } frames)
+        {
+            return ValidationResult.Success;
+        }
+
+        foreach (TxFrame frame in frames)
+        {
+            if (frame.Mode == TxFrame.ModePostTx)
+            {
+                return "POST_TX frames are not enabled";
+            }
+        }
+
+        return ValidationResult.Success;
+    }
 }
 
 public sealed class ContractSizeTxValidator : ITxValidator

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -196,9 +196,9 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
 
 /// <summary>Admits the EIP-7906 <c>POST_TX</c> frame mode only on forks that define it.</summary>
 /// <remarks>
-/// The mode is accepted without fork context wherever the frame list is checked structurally, so the
-/// fork that admits it is enforced here. Before the fork the mode is undefined, and executing such a
-/// frame as if it were <c>DEFAULT</c> would let it write state the assertion semantics forbid.
+/// The frame-list shape check accepts the mode without fork context. Before the fork the mode is
+/// undefined, and running such a frame as <c>DEFAULT</c> would give it the write access the assertion
+/// semantics forbid.
 /// </remarks>
 public sealed class FrameTxPostTxModeValidator : ITxValidator
 {

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -92,8 +92,7 @@ public sealed class TxValidator : ITxValidator
             NonceCapTxValidator.Instance,
             expectedChainIdTxValidator,
             GasFieldsTxValidator.Instance,
-            FrameTxFieldsTxValidator.Instance,
-            FrameTxPostTxModeValidator.Instance
+            FrameTxFieldsTxValidator.Instance
         ]));
     }
 
@@ -191,37 +190,9 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
     private FrameTxFieldsTxValidator() { }
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
-        FrameTxValidation.IsWellFormed(transaction, out string? error) ? ValidationResult.Success : error!;
-}
-
-/// <summary>Admits the EIP-7906 <c>POST_TX</c> frame mode only on forks that define it.</summary>
-/// <remarks>
-/// The frame-list shape check accepts the mode without fork context. Before the fork the mode is
-/// undefined, and running such a frame as <c>DEFAULT</c> would give it the write access the assertion
-/// semantics forbid.
-/// </remarks>
-public sealed class FrameTxPostTxModeValidator : ITxValidator
-{
-    public static readonly FrameTxPostTxModeValidator Instance = new();
-    private FrameTxPostTxModeValidator() { }
-
-    public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
-    {
-        if (releaseSpec.IsEip7906Enabled || transaction.Frames is not { } frames)
-        {
-            return ValidationResult.Success;
-        }
-
-        foreach (TxFrame frame in frames)
-        {
-            if (frame.Mode == TxFrame.ModePostTx)
-            {
-                return "POST_TX frames are not enabled";
-            }
-        }
-
-        return ValidationResult.Success;
-    }
+        FrameTxValidation.IsWellFormed(transaction, releaseSpec.IsEip7906Enabled, out string? error)
+            ? ValidationResult.Success
+            : error!;
 }
 
 public sealed class ContractSizeTxValidator : ITxValidator

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -48,12 +48,11 @@ public class FrameTxValidationTests
         yield return Case("NullSender_MissingSender",
             static tx => tx.SenderAddress = null, FrameTxValidation.MissingSender);
 
-        // assert frame.mode < 4 (EIP-7906 widened it from 3; the fork that admits POST_TX is checked
-        // in validation, not here)
+        // assert frame.mode < 4 (EIP-7906 widened it from 3)
         yield return Case("FrameModeFour_InvalidMode",
             static tx => tx.Frames = [Frame(mode: 4)], FrameTxValidation.InvalidMode);
 
-        // EIP-7906: POST_TX frames form a trailing suffix and never approve
+        // POST_TX frames form a trailing suffix and never approve
         yield return Case("PostTxSuffix_Valid",
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModePostTx), Frame(mode: TxFrame.ModePostTx)], null);
         yield return Case("PostTxFollowedByDefault_PostTxNotTrailing",

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -97,6 +97,9 @@ public class FrameTxValidationTests
         yield return Case("AtomicBatchFlagOnVerifyFrame_AtomicBatchOnVerifyFrame",
             static tx => tx.Frames = [Frame(mode: TxFrame.ModeVerify, flags: TxFrame.AtomicBatchFlag), DefaultModeFrame()],
             FrameTxValidation.AtomicBatchOnVerifyFrame);
+        yield return Case("AtomicBatchFlagOnPostTxFrame_AtomicBatchOnPostTxFrame",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModePostTx, flags: TxFrame.AtomicBatchFlag), Frame(mode: TxFrame.ModePostTx)],
+            FrameTxValidation.AtomicBatchOnPostTxFrame);
         yield return Case("AtomicBatchFollowedByVerifyFrame_AtomicBatchFollowedByVerifyFrame",
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: TxFrame.AtomicBatchFlag), Frame(mode: TxFrame.ModeVerify)],
             FrameTxValidation.AtomicBatchFollowedByVerifyFrame);

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -48,9 +48,20 @@ public class FrameTxValidationTests
         yield return Case("NullSender_MissingSender",
             static tx => tx.SenderAddress = null, FrameTxValidation.MissingSender);
 
-        // assert frame.mode < 3
-        yield return Case("FrameModeThree_InvalidMode",
-            static tx => tx.Frames = [Frame(mode: 3)], FrameTxValidation.InvalidMode);
+        // assert frame.mode < 4 (EIP-7906 widened it from 3; the fork that admits POST_TX is checked
+        // in validation, not here)
+        yield return Case("FrameModeFour_InvalidMode",
+            static tx => tx.Frames = [Frame(mode: 4)], FrameTxValidation.InvalidMode);
+
+        // EIP-7906: POST_TX frames form a trailing suffix and never approve
+        yield return Case("PostTxSuffix_Valid",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModePostTx), Frame(mode: TxFrame.ModePostTx)], null);
+        yield return Case("PostTxFollowedByDefault_PostTxNotTrailing",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModePostTx), DefaultModeFrame()],
+            FrameTxValidation.PostTxNotTrailing);
+        yield return Case("PostTxAllowedToApprove_PostTxApproves",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModePostTx, flags: TxFrame.ApprovePayment)],
+            FrameTxValidation.PostTxApproves);
 
         // assert frame.flags < 8
         yield return Case("FrameFlagsEight_InvalidFlags",

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -52,15 +52,16 @@ public class FrameTxValidationTests
         yield return Case("FrameModeFour_InvalidMode",
             static tx => tx.Frames = [Frame(mode: 4)], FrameTxValidation.InvalidMode);
 
-        // POST_TX frames form a trailing suffix and never approve
+        // POST_TX frames form a trailing suffix; the approval scope they may carry is enforced at the
+        // opcode, so an unexercised permission bit is not an envelope defect.
         yield return Case("PostTxSuffix_Valid",
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModePostTx), Frame(mode: TxFrame.ModePostTx)], null);
         yield return Case("PostTxFollowedByDefault_PostTxNotTrailing",
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModePostTx), DefaultModeFrame()],
             FrameTxValidation.PostTxNotTrailing);
-        yield return Case("PostTxAllowedToApprove_PostTxApproves",
+        yield return Case("PostTxAllowedToApprove_Valid",
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModePostTx, flags: TxFrame.ApprovePayment)],
-            FrameTxValidation.PostTxApproves);
+            null);
 
         // assert frame.flags < 8
         yield return Case("FrameFlagsEight_InvalidFlags",

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -22,7 +22,7 @@ public class FrameTxValidationTests
     {
         Transaction tx = CreateValidFrameTx(mutate);
 
-        bool wellFormed = FrameTxValidation.IsWellFormed(tx, out string? error);
+        bool wellFormed = FrameTxValidation.IsWellFormed(tx, postTxEnabled: true, out string? error);
 
         Assert.That(wellFormed, Is.EqualTo(expectedError is null));
         Assert.That(error, Is.EqualTo(expectedError));
@@ -104,6 +104,9 @@ public class FrameTxValidationTests
         yield return Case("AtomicBatchFollowedByVerifyFrame_AtomicBatchFollowedByVerifyFrame",
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: TxFrame.AtomicBatchFlag), Frame(mode: TxFrame.ModeVerify)],
             FrameTxValidation.AtomicBatchFollowedByVerifyFrame);
+        yield return Case("AtomicBatchFollowedByPostTxFrame_AtomicBatchFollowedByPostTxFrame",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: TxFrame.AtomicBatchFlag), Frame(mode: TxFrame.ModePostTx)],
+            FrameTxValidation.AtomicBatchFollowedByPostTxFrame);
 
         // total_frame_gas accumulated across frames must not overflow 2^64 - 1
         yield return Case("TotalFrameGasOverflows_FrameGasOverflow",

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -17,6 +17,7 @@ public static class FrameTxValidation
     public const string MissingSender = "frame transaction sender must be set";
     public const string InvalidMode = "frame mode must be DEFAULT, VERIFY, SENDER, or POST_TX";
     public const string PostTxNotTrailing = "POST_TX frames must form a trailing suffix of the frame list";
+    public const string PostTxNotEnabled = "POST_TX frames are not enabled";
     public const string InvalidFlags = "frame flags must not use reserved bits";
     public const string ValueOutsideSenderMode = "frame value is only allowed in SENDER mode";
     public const string ExecutionApprovalWrongTarget = "frames allowed to approve execution must target the sender";
@@ -24,6 +25,7 @@ public static class FrameTxValidation
     public const string AtomicBatchOnVerifyFrame = "the atomic batch flag must not be set on a VERIFY frame";
     public const string AtomicBatchOnPostTxFrame = "the atomic batch flag must not be set on a POST_TX frame";
     public const string AtomicBatchFollowedByVerifyFrame = "an atomic batch frame must not be followed by a VERIFY frame";
+    public const string AtomicBatchFollowedByPostTxFrame = "an atomic batch frame must not be followed by a POST_TX frame";
     public const string FrameGasOverflow = "total frame gas must not exceed 2^64 - 1";
     public const string InvalidExpiryFrame = "expiry verifier frame must have zero flags, zero value, and 8-byte data";
     public const string MultipleExpiryFrames = "at most one expiry verifier frame is allowed";
@@ -33,7 +35,7 @@ public static class FrameTxValidation
     public const string ZeroDigestMsg = "explicit signature msg must not be the zero digest";
     public const string BlobFeeWithoutBlobs = "max fee per blob gas must be 0 when there are no blob hashes";
 
-    public static bool IsWellFormed(Transaction transaction, out string? error)
+    public static bool IsWellFormed(Transaction transaction, bool postTxEnabled, out string? error)
     {
         error = null;
 
@@ -59,6 +61,12 @@ public static class FrameTxValidation
             if (frame.Mode > TxFrame.ModePostTx)
             {
                 error = InvalidMode;
+                return false;
+            }
+
+            if (frame.Mode == TxFrame.ModePostTx && !postTxEnabled)
+            {
+                error = PostTxNotEnabled;
                 return false;
             }
 
@@ -119,6 +127,14 @@ public static class FrameTxValidation
                 if (i + 1 < frames.Length && frames[i + 1].Mode == TxFrame.ModeVerify)
                 {
                     error = AtomicBatchFollowedByVerifyFrame;
+                    return false;
+                }
+
+                // An unroll moves the terminal frame onto the successor and marks it skipped. On a POST_TX
+                // successor that silently drops the assertion, which is the case it exists to catch.
+                if (i + 1 < frames.Length && frames[i + 1].Mode == TxFrame.ModePostTx)
+                {
+                    error = AtomicBatchFollowedByPostTxFrame;
                     return false;
                 }
             }

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -62,8 +62,7 @@ public static class FrameTxValidation
                 return false;
             }
 
-            // EIP-7906: the assertion frames observe the finished transaction, so nothing may run after
-            // them, and a read-only frame has no valid reason to approve.
+            // Assertions observe the finished transaction, so nothing may run after them.
             if (frame.Mode == TxFrame.ModePostTx)
             {
                 if (i + 1 < frames.Length && frames[i + 1].Mode != TxFrame.ModePostTx)

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -23,6 +23,7 @@ public static class FrameTxValidation
     public const string ExecutionApprovalWrongTarget = "frames allowed to approve execution must target the sender";
     public const string AtomicBatchOnLastFrame = "the last frame must not have the atomic batch flag set";
     public const string AtomicBatchOnVerifyFrame = "the atomic batch flag must not be set on a VERIFY frame";
+    public const string AtomicBatchOnPostTxFrame = "the atomic batch flag must not be set on a POST_TX frame";
     public const string AtomicBatchFollowedByVerifyFrame = "an atomic batch frame must not be followed by a VERIFY frame";
     public const string FrameGasOverflow = "total frame gas must not exceed 2^64 - 1";
     public const string InvalidExpiryFrame = "expiry verifier frame must have zero flags, zero value, and 8-byte data";
@@ -74,6 +75,14 @@ public static class FrameTxValidation
                 if (frame.AllowedApproveScope != TxFrame.ApproveScopeNone)
                 {
                     error = PostTxApproves;
+                    return false;
+                }
+
+                // A batch opened by a POST_TX frame can never unroll — the assertion path exits the
+                // frame loop first — so the flag would be inert here and clients could diverge on it.
+                if ((frame.Flags & TxFrame.AtomicBatchFlag) != 0)
+                {
+                    error = AtomicBatchOnPostTxFrame;
                     return false;
                 }
             }

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -15,7 +15,9 @@ public static class FrameTxValidation
 {
     public const string MissingFrames = "frame transaction must contain between 1 and 64 frames";
     public const string MissingSender = "frame transaction sender must be set";
-    public const string InvalidMode = "frame mode must be DEFAULT, VERIFY, or SENDER";
+    public const string InvalidMode = "frame mode must be DEFAULT, VERIFY, SENDER, or POST_TX";
+    public const string PostTxNotTrailing = "POST_TX frames must form a trailing suffix of the frame list";
+    public const string PostTxApproves = "a POST_TX frame must not be allowed to approve";
     public const string InvalidFlags = "frame flags must not use reserved bits";
     public const string ValueOutsideSenderMode = "frame value is only allowed in SENDER mode";
     public const string ExecutionApprovalWrongTarget = "frames allowed to approve execution must target the sender";
@@ -54,10 +56,27 @@ public static class FrameTxValidation
         {
             TxFrame frame = frames[i];
 
-            if (frame.Mode > TxFrame.ModeSender)
+            if (frame.Mode > TxFrame.ModePostTx)
             {
                 error = InvalidMode;
                 return false;
+            }
+
+            // EIP-7906: the assertion frames observe the finished transaction, so nothing may run after
+            // them, and a read-only frame has no valid reason to approve.
+            if (frame.Mode == TxFrame.ModePostTx)
+            {
+                if (i + 1 < frames.Length && frames[i + 1].Mode != TxFrame.ModePostTx)
+                {
+                    error = PostTxNotTrailing;
+                    return false;
+                }
+
+                if (frame.AllowedApproveScope != TxFrame.ApproveScopeNone)
+                {
+                    error = PostTxApproves;
+                    return false;
+                }
             }
 
             if (frame.Flags > (TxFrame.ApproveScopeMask | TxFrame.AtomicBatchFlag))

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -17,7 +17,6 @@ public static class FrameTxValidation
     public const string MissingSender = "frame transaction sender must be set";
     public const string InvalidMode = "frame mode must be DEFAULT, VERIFY, SENDER, or POST_TX";
     public const string PostTxNotTrailing = "POST_TX frames must form a trailing suffix of the frame list";
-    public const string PostTxApproves = "a POST_TX frame must not be allowed to approve";
     public const string InvalidFlags = "frame flags must not use reserved bits";
     public const string ValueOutsideSenderMode = "frame value is only allowed in SENDER mode";
     public const string ExecutionApprovalWrongTarget = "frames allowed to approve execution must target the sender";
@@ -69,12 +68,6 @@ public static class FrameTxValidation
                 if (i + 1 < frames.Length && frames[i + 1].Mode != TxFrame.ModePostTx)
                 {
                     error = PostTxNotTrailing;
-                    return false;
-                }
-
-                if (frame.AllowedApproveScope != TxFrame.ApproveScopeNone)
-                {
-                    error = PostTxApproves;
                     return false;
                 }
 

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -331,6 +331,11 @@ namespace Nethermind.Core.Specs
         bool IsEip8250Enabled { get; }
 
         /// <summary>
+        /// EIP-7906: transaction outcome assertions.
+        /// </summary>
+        bool IsEip7906Enabled { get; }
+
+        /// <summary>
         /// EIP-8038: State-access gas cost update
         /// </summary>
         bool IsEip8038Enabled { get; }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -83,6 +83,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip8282Enabled => spec.IsEip8282Enabled;
     public virtual bool IsEip8141Enabled => spec.IsEip8141Enabled;
     public virtual bool IsEip8250Enabled => spec.IsEip8250Enabled;
+    public virtual bool IsEip7906Enabled => spec.IsEip7906Enabled;
     public virtual bool IsEip7702Enabled => spec.IsEip7702Enabled;
     public virtual bool IsEip7823Enabled => spec.IsEip7823Enabled;
     public virtual bool IsEip7825Enabled => spec.IsEip7825Enabled;

--- a/src/Nethermind/Nethermind.Core/TxFrame.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrame.cs
@@ -16,6 +16,9 @@ public class TxFrame(byte mode, byte flags, Address? target, ulong gasLimit, UIn
     public const byte ModeVerify = 1;
     public const byte ModeSender = 2;
 
+    /// <summary>EIP-7906: a read-only trailing frame that asserts the transaction's outcome.</summary>
+    public const byte ModePostTx = 3;
+
     public const byte ApproveScopeNone = 0x0;
     public const byte ApprovePayment = 0x1;
     public const byte ApproveExecution = 0x2;

--- a/src/Nethermind/Nethermind.Core/TxFrameReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrameReceipt.cs
@@ -40,4 +40,30 @@ public class TxFrameReceipt(byte status, ulong gasUsed, LogEntry[] logs)
 
         return StatusSuccess;
     }
+
+    /// <summary>The transaction's log set: the frame logs in frame order.</summary>
+    /// <remarks>
+    /// Derived rather than accumulated in parallel, so a frame whose logs are dropped — an unrolled
+    /// atomic batch, a body discarded by a failed EIP-7906 assertion — also drops out of the bloom.
+    /// </remarks>
+    public static LogEntry[] ConcatLogs(TxFrameReceipt[] frameReceipts)
+    {
+        int total = 0;
+        foreach (TxFrameReceipt frameReceipt in frameReceipts)
+        {
+            total += frameReceipt.Logs.Length;
+        }
+
+        if (total == 0) return [];
+
+        LogEntry[] logs = new LogEntry[total];
+        int offset = 0;
+        foreach (TxFrameReceipt frameReceipt in frameReceipts)
+        {
+            frameReceipt.Logs.CopyTo(logs, offset);
+            offset += frameReceipt.Logs.Length;
+        }
+
+        return logs;
+    }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
@@ -17,6 +17,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using Nethermind.State.Proofs;
 using NUnit.Framework;
 
@@ -32,6 +33,8 @@ public class FrameTxBlockReceiptsTests
 {
     private static readonly Address Sender = TestItem.AddressA;
     private static readonly Address Observer = TestItem.AddressB;
+    private static readonly Address Payer = TestItem.AddressC;
+    private static readonly Address Asserter = TestItem.AddressD;
 
     [Test]
     public void Execute_FrameTxUnderBlockReceiptsTracer_BuildsFrameAwareReceipt()
@@ -134,5 +137,74 @@ public class FrameTxBlockReceiptsTests
         Assert.That(receiptsTracer.TxReceipts.Length, Is.EqualTo(1));
 
         return (receiptsTracer.TxReceipts[0], block, spec);
+    }
+
+    // EIP-7906: a failed assertion drops the body's logs but keeps the validation prefix's, so the
+    // failed receipt still has to carry them — an empty log set would contradict the frame receipts
+    // it is built from and leave the prefix's logs out of the bloom.
+    [Test]
+    public void Execute_PostTxReverts_FailedReceiptKeepsThePrefixLogs()
+    {
+        ISpecProvider specProvider = new TestSpecProvider(new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip7906Enabled = true });
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        EthereumCodeInfoRepository codeInfoRepository = new(stateProvider);
+        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(specProvider), specProvider, LimboLogs.Instance);
+        EthereumTransactionProcessor processor = new(BlobBaseFeeCalculator.Instance, specProvider, stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+        IReleaseSpec spec = specProvider.GenesisSpec;
+
+        Deploy(stateProvider, spec, Sender, Approve(TxFrame.ApproveExecution), 1.Ether);
+        Deploy(stateProvider, spec, Payer, Approve(TxFrame.ApprovePayment), 1.Ether);
+        Deploy(stateProvider, spec, Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.LOG0).Op(Instruction.STOP).Done);
+        Deploy(stateProvider, spec, Asserter, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+        stateProvider.Commit(spec);
+        stateProvider.CommitTree(0);
+
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            Nonce = 0,
+            SenderAddress = Sender,
+            Frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, null, 200_000, UInt256.Zero, default),
+                new TxFrame(TxFrame.ModeSender, 0, Observer, 200_000, UInt256.Zero, default),
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApprovePayment, Payer, 200_000, UInt256.Zero, default),
+                new TxFrame(TxFrame.ModeSender, 0, Observer, 200_000, UInt256.Zero, default),
+                new TxFrame(TxFrame.ModePostTx, 0, Asserter, 200_000, UInt256.Zero, default),
+            ],
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+
+        BlockReceiptsTracer receiptsTracer = new();
+        receiptsTracer.StartNewBlockTrace(block);
+        receiptsTracer.StartNewTxTrace(tx);
+        TransactionResult result = processor.Execute(tx, new BlockExecutionContext(block.Header, spec), receiptsTracer);
+        receiptsTracer.EndTxTrace();
+        receiptsTracer.EndBlockTrace();
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        TxReceipt receipt = receiptsTracer.TxReceipts[0];
+        Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Failure));
+        Assert.That(receipt.FrameReceipts![1].Logs, Has.Length.EqualTo(1), "the prefix frame keeps its log");
+        Assert.That(receipt.FrameReceipts[3].Logs, Is.Empty, "the body's log goes with the state that produced it");
+        Assert.That(receipt.Logs, Has.Length.EqualTo(1), "receipt logs must stay the union of frame logs");
+    }
+
+    private static byte[] Approve(byte scope) =>
+        Prepare.EvmCode.PushData(scope).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
+
+    private static void Deploy(IWorldState state, IReleaseSpec spec, Address address, byte[] code, UInt256 balance = default)
+    {
+        state.CreateAccount(address, balance);
+        state.InsertCode(address, code, spec);
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
@@ -75,11 +75,17 @@ public class FrameTxBlockReceiptsTests
 
         (TxReceipt receipt, _, _) = RunFrameTx(revert);
 
+        ReceiptMessageDecoder decoder = new();
+        RlpReader reader = new(decoder.EncodeNew(receipt));
+        TxReceipt decoded = decoder.Decode(ref reader)!;
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(receipt.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
             Assert.That(receipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusFailure),
                 "a reverted frame must not be reported as a successful transaction");
+            Assert.That(decoded.StatusCode, Is.EqualTo(receipt.StatusCode),
+                "a node that only received the receipt must report the status the executing node reported");
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -51,8 +51,7 @@ public class FrameTxProcessorTests
     [SetUp]
     public void Setup()
     {
-        // The prototype fork carries EIP-8141 only; EIP-7906 is switched on here so a test can turn it
-        // back off and assert the fork gate rather than the feature.
+        // Switched on here so a test can turn it back off and assert the fork gate rather than the feature.
         _spec = new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip7906Enabled = true };
         _specProvider = new TestSpecProvider(_spec);
         _stateProvider = TestWorldStateFactory.CreateForTest();
@@ -762,9 +761,7 @@ public class FrameTxProcessorTests
         return Process(FrameTx(nonce: 0, SelfVerifyFrame())).TransactionExecuted;
     }
 
-    // EIP-7906: an assertion frame observes the finished body and, when it reverts, unwinds the body
-    // without invalidating the transaction — so the payer is still charged and the receipt fails. That
-    // is the whole difference from a VERIFY revert, which drops the transaction entirely.
+    // The difference from a VERIFY revert: the body unwinds but the transaction stays valid and pays.
     [TestCase(false, ExpectedResult = StatusCode.Success, TestName = "Execute_PostTxAsserts_TransactionSucceeds")]
     [TestCase(true, ExpectedResult = StatusCode.Failure, TestName = "Execute_PostTxReverts_TransactionFailsButIsIncluded")]
     public byte Execute_PostTxFrame_DecidesTheTransactionOutcomeWithoutInvalidatingIt(bool assertionFails)
@@ -791,8 +788,7 @@ public class FrameTxProcessorTests
         return tracer.StatusCode;
     }
 
-    // A POST_TX frame runs as a STATICCALL, so its own write halts it — and that halt is an assertion
-    // failure like any other, unwinding the body rather than being silently ignored.
+    // A write halts the static frame, and that halt is an assertion failure like any other.
     [Test]
     public void Execute_PostTxFrameWritesState_HaltsAndUnwindsTheBody()
     {
@@ -813,9 +809,7 @@ public class FrameTxProcessorTests
         AssertStorage(Observer, 0, UInt256.Zero, "the halted assertion unwound the body");
     }
 
-    // The unwind stops at the validation prefix rather than at the start of the transaction: the
-    // account the deploy frame created and the payment it approved are state the transaction is
-    // charged for, and they survive a failed assertion.
+    // The unwind stops at the validation prefix: that state is what the transaction is charged for.
     [Test]
     public void Execute_PostTxReverts_KeepsTheValidationPrefix()
     {

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -809,6 +809,47 @@ public class FrameTxProcessorTests
         AssertStorage(Observer, 0, UInt256.Zero, "the halted assertion unwound the body");
     }
 
+    // EIP-7906 forbids the APPROVE call, not the permission bits: a POST_TX frame carrying a scope it
+    // never exercises is a valid envelope, so rejecting it before execution would fork off a client
+    // that admits it.
+    [Test]
+    public void Execute_PostTxCarriesAnUnusedApprovalScope_Succeeds()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModePostTx, TxFrame.ApprovePayment, target: Recipient));
+
+        CallOutputTracer tracer = new();
+        Assert.That(Process(tx, tracer: tracer).TransactionExecuted, Is.True);
+        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
+    }
+
+    // Asserted through gas rather than status: every rejection of an APPROVE inside a POST_TX frame
+    // fails the assertion, but only an exceptional halt burns the frame's whole gas limit, and the
+    // difference is consensus-visible in the frame receipt.
+    [Test]
+    public void Execute_PostTxCallsApprove_HaltsExceptionally()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, ApproveCode(TxFrame.ApprovePayment));
+        DeployContract(Observer, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        CallOutputTracer approving = new();
+        Process(FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModePostTx, TxFrame.ApprovePayment, target: Recipient)),
+            tracer: approving);
+
+        CallOutputTracer reverting = new();
+        Process(FrameTx(nonce: 1, SelfVerifyFrame(), Frame(TxFrame.ModePostTx, target: Observer)),
+            tracer: reverting);
+
+        Assert.That(approving.StatusCode, Is.EqualTo(StatusCode.Failure));
+        Assert.That(approving.GasSpent - reverting.GasSpent, Is.GreaterThan(100_000L),
+            "an exceptional halt consumes the assertion frame's whole gas limit");
+    }
+
     // The unwind stops at the validation prefix: that state is what the transaction is charged for.
     [Test]
     public void Execute_PostTxReverts_KeepsTheValidationPrefix()

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -885,6 +885,51 @@ public class FrameTxProcessorTests
         Assert.That(Process(tx).TransactionExecuted, Is.False);
     }
 
+    // A batch that unrolls entirely inside the body leaves the assertion to run against the state the
+    // unroll restored, which is the ordering the prefix snapshot has to survive.
+    [Test]
+    public void Execute_AtomicBatchInTheBodyUnrolls_PostTxStillAsserts()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, TxFrame.AtomicBatchFlag, Observer, gasLimit: 200_000, UInt256.Zero, default),
+            Frame(TxFrame.ModeSender, target: Recipient),
+            Frame(TxFrame.ModePostTx, target: Observer));
+
+        CallOutputTracer tracer = new();
+
+        Assert.That(Process(tx, tracer: tracer).TransactionExecuted, Is.True);
+        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Failure),
+            "the POST_TX write halts against the state the unroll restored");
+        AssertStorage(Observer, 0, UInt256.Zero, "the batch write is gone and the assertion added none");
+    }
+
+    // The static rules admit several assertions, so a failure in a later one must unwind the whole body
+    // rather than only what ran after the first.
+    [Test]
+    public void Execute_SecondPostTxFrameFails_UnwindsTheWholeBody()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, target: Observer),
+            Frame(TxFrame.ModePostTx, target: Sender),
+            Frame(TxFrame.ModePostTx, target: Recipient));
+
+        CallOutputTracer tracer = new();
+
+        Assert.That(Process(tx, tracer: tracer).TransactionExecuted, Is.True);
+        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Failure));
+        AssertStorage(Observer, 0, UInt256.Zero, "a failure in the second assertion unwinds the body the first one passed on");
+    }
+
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)
     {
         Block block = Build.A.Block.WithNumber(1)

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -827,6 +827,23 @@ public class FrameTxProcessorTests
             "the sender nonce bump is part of the prefix that payment approval committed");
     }
 
+    // An unrolled batch truncates the journal past the prefix snapshot the approving frame inside it
+    // took, and the failed assertion below then unwinds to it — a restore into the future.
+    [Test]
+    public void Execute_AtomicBatchUnrollsTheApprovingFrame_InvalidatesTheTransaction()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, (byte)(TxFrame.ApproveExecutionAndPayment | TxFrame.AtomicBatchFlag),
+                target: null, gasLimit: 200_000, UInt256.Zero, default),
+            Frame(TxFrame.ModeSender, target: Recipient),
+            Frame(TxFrame.ModePostTx, target: Recipient));
+
+        Assert.That(Process(tx).TransactionExecuted, Is.False);
+    }
+
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)
     {
         Block block = Build.A.Block.WithNumber(1)

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -20,6 +20,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using Nethermind.State;
 using NUnit.Framework;
 
@@ -36,6 +37,7 @@ namespace Nethermind.Evm.Test;
 public class FrameTxProcessorTests
 {
     private ISpecProvider _specProvider;
+    private OverridableReleaseSpec _spec;
     private ITransactionProcessor _transactionProcessor;
     private IWorldState _stateProvider;
     private IDisposable _worldStateCloser;
@@ -49,7 +51,10 @@ public class FrameTxProcessorTests
     [SetUp]
     public void Setup()
     {
-        _specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
+        // The prototype fork carries EIP-8141 only; EIP-7906 is switched on here so a test can turn it
+        // back off and assert the fork gate rather than the feature.
+        _spec = new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip7906Enabled = true };
+        _specProvider = new TestSpecProvider(_spec);
         _stateProvider = TestWorldStateFactory.CreateForTest();
         _worldStateCloser = _stateProvider.BeginScope(IWorldState.PreGenesis);
         EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
@@ -755,6 +760,77 @@ public class FrameTxProcessorTests
             .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done);
 
         return Process(FrameTx(nonce: 0, SelfVerifyFrame())).TransactionExecuted;
+    }
+
+    // EIP-7906: an assertion frame observes the finished body and, when it reverts, unwinds the body
+    // without invalidating the transaction — so the payer is still charged and the receipt fails. That
+    // is the whole difference from a VERIFY revert, which drops the transaction entirely.
+    [TestCase(false, ExpectedResult = StatusCode.Success, TestName = "Execute_PostTxAsserts_TransactionSucceeds")]
+    [TestCase(true, ExpectedResult = StatusCode.Failure, TestName = "Execute_PostTxReverts_TransactionFailsButIsIncluded")]
+    public byte Execute_PostTxFrame_DecidesTheTransactionOutcomeWithoutInvalidatingIt(bool assertionFails)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        DeployContract(Recipient, assertionFails
+            ? Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done
+            : Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, target: Observer),
+            Frame(TxFrame.ModePostTx, target: Recipient));
+
+        UInt256 balanceBefore = _stateProvider.GetBalance(Sender);
+        CallOutputTracer tracer = new();
+        TransactionResult result = Process(tx, tracer: tracer);
+
+        Assert.That(result.TransactionExecuted, Is.True, "a POST_TX revert must not invalidate the transaction");
+        AssertStorage(Observer, 0, assertionFails ? UInt256.Zero : UInt256.One,
+            "the execution body is kept exactly when the assertion holds");
+        Assert.That(_stateProvider.GetBalance(Sender), Is.LessThan(balanceBefore), "the payer pays for what ran");
+        return tracer.StatusCode;
+    }
+
+    // A POST_TX frame runs as a STATICCALL, so its own write halts it — and that halt is an assertion
+    // failure like any other, unwinding the body rather than being silently ignored.
+    [Test]
+    public void Execute_PostTxFrameWritesState_HaltsAndUnwindsTheBody()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        DeployContract(Recipient, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, target: Observer),
+            Frame(TxFrame.ModePostTx, target: Recipient));
+
+        CallOutputTracer tracer = new();
+
+        Assert.That(Process(tx, tracer: tracer).TransactionExecuted, Is.True);
+        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Failure));
+        AssertStorage(Recipient, 0, UInt256.Zero, "a POST_TX frame cannot write");
+        AssertStorage(Observer, 0, UInt256.Zero, "the halted assertion unwound the body");
+    }
+
+    // The unwind stops at the validation prefix rather than at the start of the transaction: the
+    // account the deploy frame created and the payment it approved are state the transaction is
+    // charged for, and they survive a failed assertion.
+    [Test]
+    public void Execute_PostTxReverts_KeepsTheValidationPrefix()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, target: Observer),
+            Frame(TxFrame.ModePostTx, target: Recipient));
+
+        Assert.That(Process(tx).TransactionExecuted, Is.True);
+        Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1UL),
+            "the sender nonce bump is part of the prefix that payment approval committed");
     }
 
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -31,6 +31,11 @@ public static unsafe partial class EvmInstructions
             return EvmExceptionType.StackUnderflow;
 
         TxFrame frame = ctx.CurrentFrame;
+
+        // EIP-7906 forbids the call, not the permission bits: a POST_TX frame may carry an approval
+        // scope it never exercises, so the ban belongs here rather than in envelope validation.
+        if (frame.Mode == TxFrame.ModePostTx) return EvmExceptionType.BadInstruction;
+
         Address resolvedTarget = ctx.ResolvedTarget(ctx.CurrentFrameIndex);
 
         // Only the resolved target (or a DELEGATECALL from it, which preserves ADDRESS) may approve.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -143,6 +143,11 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         bool batchStartSenderApproved = false;
         long batchStartRefund = 0;
 
+        Snapshot prefixEndSnapshot = txSnapshot;
+        int prefixEndIndex = -1;
+        long prefixEndRefund = 0;
+        bool postTxReverted = false;
+
         for (int i = 0; i < frames.Length; i++)
         {
             TxFrame frame = frames[i];
@@ -174,7 +179,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
             Address resolvedTarget = frame.Target ?? sender;
             Address caller = isSender ? sender : Eip8141Constants.EntryPointAddress;
-            bool isStatic = frame.Mode == TxFrame.ModeVerify;
+            bool isStatic = frame.Mode is TxFrame.ModeVerify or TxFrame.ModePostTx;
 
             // ORIGIN returns the frame's caller throughout all call depths.
             VirtualMachine.SetTxExecutionContext(new TxExecutionContext(
@@ -228,9 +233,49 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 return TransactionResult.ErrorType.MalformedTransaction.WithDetail("VERIFY frame reverted");
             }
 
+            if (frame.Mode == TxFrame.ModePostTx && !frameSucceeded)
+            {
+                // EIP-7906: a failed assertion discards the execution body down to the validation
+                // prefix and overrides any atomic-batch unrolling, but unlike a VERIFY revert it leaves
+                // the transaction valid: it is still included, the payer still pays for what ran, and
+                // the receipt reports failure.
+                WorldState.Restore(prefixEndSnapshot);
+                refundCounter = prefixEndRefund;
+
+                // Body logs go with the state that produced them; the tx log set is derived from these
+                // receipts, so clearing them here also keeps them out of the bloom.
+                for (int s = prefixEndIndex + 1; s < i; s++)
+                {
+                    TxFrameReceipt reverted = frameReceipts[s];
+                    if (reverted.Logs.Length > 0)
+                    {
+                        frameReceipts[s] = new TxFrameReceipt(reverted.Status, reverted.GasUsed, []);
+                    }
+                }
+
+                for (int s = i + 1; s < frames.Length; s++)
+                {
+                    frameReceipts[s] = new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, []);
+                    frameContext.MarkFrameSkipped(s);
+                }
+
+                postTxReverted = true;
+                break;
+            }
+
             if (frameSucceeded)
             {
+                bool payerWasSet = frameContext.Payer is not null;
                 ApplyApproval(frameContext, resolvedTarget, spec);
+                if (!payerWasSet && frameContext.Payer is not null)
+                {
+                    // End of the validation prefix (the shortest prefix whose success sets the payer):
+                    // EIP-7906 keeps everything up to here and discards the execution body when a
+                    // POST_TX frame reverts.
+                    prefixEndSnapshot = WorldState.TakeSnapshot();
+                    prefixEndIndex = i;
+                    prefixEndRefund = refundCounter;
+                }
             }
             else
             {
@@ -358,7 +403,14 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             // union, so the two can't diverge: an unrolled batch clears its frames' logs above.
             LogEntry[] txLogs = ConcatFrameLogs(frameReceipts);
             GasConsumed gasConsumed = new(spentGas, spentGas, spentGas);
-            tracer.MarkAsSuccess(Eip8141Constants.EntryPointAddress, in gasConsumed, [], txLogs);
+            if (postTxReverted)
+            {
+                tracer.MarkAsFailed(Eip8141Constants.EntryPointAddress, in gasConsumed, [], "POST_TX frame reverted");
+            }
+            else
+            {
+                tracer.MarkAsSuccess(Eip8141Constants.EntryPointAddress, in gasConsumed, [], txLogs);
+            }
         }
 
         return TransactionResult.Ok;
@@ -533,7 +585,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     {
         gasUsed = 0;
 
-        if (isStatic)
+        // Keyed on VERIFY rather than on staticness: EIP-7906 POST_TX frames are static too, but the
+        // spec routes them through the SENDER / DEFAULT branch below.
+        if (frame.Mode == TxFrame.ModeVerify)
         {
             byte allowedScope = frame.AllowedApproveScope;
             if (allowedScope == 0)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -314,6 +314,15 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                     frameContext.SenderApproved = batchStartSenderApproved;
                     refundCounter = batchStartRefund;
 
+                    if (prefixEndIndex >= batchStartIndex)
+                    {
+                        // The prefix ended inside the batch, so its snapshot now points past the
+                        // truncated journal and unwinding a failed assertion to it would throw.
+                        prefixEndSnapshot = batchStartSnapshot;
+                        prefixEndIndex = batchStartIndex - 1;
+                        prefixEndRefund = batchStartRefund;
+                    }
+
                     int terminal = i;
                     while (terminal < frames.Length && frames[terminal].IsAtomicBatch) terminal++;
                     for (int s = i + 1; s <= terminal && s < frames.Length; s++)
@@ -399,7 +408,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
             // Derive the tx log set from the per-frame receipts rather than maintaining a parallel
             // union, so the two can't diverge: an unrolled batch clears its frames' logs above.
-            LogEntry[] txLogs = ConcatFrameLogs(frameReceipts);
+            LogEntry[] txLogs = TxFrameReceipt.ConcatLogs(frameReceipts);
             GasConsumed gasConsumed = new(spentGas, spentGas, spentGas);
             if (postTxReverted)
             {
@@ -412,31 +421,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         }
 
         return TransactionResult.Ok;
-    }
-
-    /// <summary>
-    /// The transaction log set: the frame-order concatenation of the per-frame receipt logs.
-    /// </summary>
-    private static LogEntry[] ConcatFrameLogs(TxFrameReceipt[] frameReceipts)
-    {
-        int total = 0;
-        foreach (TxFrameReceipt frameReceipt in frameReceipts)
-        {
-            total += frameReceipt.Logs.Length;
-        }
-
-        if (total == 0) return [];
-
-        LogEntry[] logs = new LogEntry[total];
-        int offset = 0;
-        foreach (TxFrameReceipt frameReceipt in frameReceipts)
-        {
-            LogEntry[] frameLogs = frameReceipt.Logs;
-            frameLogs.CopyTo(logs, offset);
-            offset += frameLogs.Length;
-        }
-
-        return logs;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -235,10 +235,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
             if (frame.Mode == TxFrame.ModePostTx && !frameSucceeded)
             {
-                // EIP-7906: a failed assertion discards the execution body down to the validation
-                // prefix and overrides any atomic-batch unrolling, but unlike a VERIFY revert it leaves
-                // the transaction valid: it is still included, the payer still pays for what ran, and
-                // the receipt reports failure.
+                // A failed assertion discards the body down to the validation prefix and overrides any
+                // atomic-batch unrolling, but unlike a VERIFY revert it leaves the transaction valid.
                 WorldState.Restore(prefixEndSnapshot);
                 refundCounter = prefixEndRefund;
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -493,7 +493,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // the protocol-defined behavior instead of the EVM.
         if (WorldState.GetCodeHash(resolvedTarget) == Keccak.OfAnEmptyString)
         {
-            return ExecuteDefaultCode(frame, resolvedTarget, caller, isStatic, frameContext, in accessTracker, spec, tracer, out gasUsed);
+            return ExecuteDefaultCode(frame, resolvedTarget, caller, frameContext, in accessTracker, spec, tracer, out gasUsed);
         }
 
         CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, spec, out _);
@@ -563,7 +563,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     /// </summary>
     /// <param name="accessTracker">Cross-frame log/warm journal; the transfer log is appended to
     /// its log list so it reaches the frame receipt and the transaction log union.</param>
-    private TransactionSubstate ExecuteDefaultCode(TxFrame frame, Address resolvedTarget, Address caller, bool isStatic, FrameTxContext frameContext, in StackAccessTracker accessTracker, IReleaseSpec spec, ITxTracer tracer, out ulong gasUsed)
+    private TransactionSubstate ExecuteDefaultCode(TxFrame frame, Address resolvedTarget, Address caller, FrameTxContext frameContext, in StackAccessTracker accessTracker, IReleaseSpec spec, ITxTracer tracer, out ulong gasUsed)
     {
         gasUsed = 0;
 

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -97,6 +97,8 @@ namespace Nethermind.Specs.Test
         public bool IsEip8282Enabled { get; set; } = spec.IsEip8282Enabled;
         public bool IsEip8141Enabled { get; set; } = spec.IsEip8141Enabled;
         public bool IsEip8250Enabled { get; set; } = spec.IsEip8250Enabled;
+
+        public bool IsEip7906Enabled { get; set; } = spec.IsEip7906Enabled;
         public bool IsEip4788Enabled { get; set; } = spec.IsEip4788Enabled;
         public bool IsEip4844FeeCollectorEnabled { get; set; } = spec.IsEip4844FeeCollectorEnabled;
         public Address? Eip4788ContractAddress { get; set; } = spec.Eip4788ContractAddress;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -192,6 +192,7 @@ public class ChainParameters
     public ulong? Eip8282TransitionTimestamp { get; set; }
     public ulong? Eip8141TransitionTimestamp { get; set; }
     public ulong? Eip8250TransitionTimestamp { get; set; }
+    public ulong? Eip7906TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip2780TransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -343,6 +343,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             releaseSpec.IsEip8282Enabled = (chainSpec.Parameters.Eip8282TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip8141Enabled = (chainSpec.Parameters.Eip8141TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip8250Enabled = (chainSpec.Parameters.Eip8250TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+            releaseSpec.IsEip7906Enabled = (chainSpec.Parameters.Eip7906TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             bool eip1559FeeCollector = releaseSpec.IsEip1559Enabled && BlockOf(chainSpec.Parameters.Eip1559FeeCollectorTransition) <= block;
             bool eip4844FeeCollector = releaseSpec.IsEip4844Enabled && (chainSpec.Parameters.Eip4844FeeCollectorTransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -221,6 +221,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8282TransitionTimestamp = chainSpecJson.Params.Eip8282TransitionTimestamp,
             Eip8141TransitionTimestamp = chainSpecJson.Params.Eip8141TransitionTimestamp,
             Eip8250TransitionTimestamp = chainSpecJson.Params.Eip8250TransitionTimestamp,
+            Eip7906TransitionTimestamp = chainSpecJson.Params.Eip7906TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
             Eip2780TransitionTimestamp = chainSpecJson.Params.Eip2780TransitionTimestamp,

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -199,6 +199,7 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8282TransitionTimestamp { get; set; }
     public ulong? Eip8141TransitionTimestamp { get; set; }
     public ulong? Eip8250TransitionTimestamp { get; set; }
+    public ulong? Eip7906TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip2780TransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -93,6 +93,7 @@ public class ReleaseSpec : IReleaseSpec
     public bool IsEip8282Enabled { get; set; }
     public bool IsEip8141Enabled { get; set; }
     public bool IsEip8250Enabled { get; set; }
+    public bool IsEip7906Enabled { get; set; }
     public bool IsEip4788Enabled { get; set; }
     public bool IsEip7702Enabled { get; set; }
     public bool IsEip7823Enabled { get; set; }


### PR DESCRIPTION
Adds the EIP-7906 `POST_TX` frame mode to the EIP-8141 frame transaction, on top of #12660.

`POST_TX` frames are read-only assertion frames that observe the finished transaction. The spec widens the mode constraint from `mode < 3` to `mode < 4`, requires them to form a trailing suffix of the frame list, and forbids them from approving.

The failure semantics differ from every other mode. A `POST_TX` revert does not invalidate the transaction: it is still included, the payer still pays for what ran, and the receipt reports failure. The revert discards the execution body down to the validation prefix (the shortest prefix whose success set the payer) and overrides atomic-batch unrolling, so what the prefix committed (payment approval, an account created by a deploy frame) survives, because the transaction is charged for it. The prefix boundary is captured where the payer is first set, so the unwind target is the frame the spec defines rather than one re-derived from the frame list.

The frames execute as `STATICCALL`, which is why this stacks on #12660: before that fix a static frame could still write state.

## Testing

An assertion that holds keeps the body and reports success, one that reverts discards the body and reports failure, the payer charged either way. A `POST_TX` frame that writes halts, and that halt unwinds the body like any other assertion failure. The unwind keeps the validation prefix (the sender nonce bump payment approval committed). The trailing-suffix and no-approval rules go into the per-constraint matrix in `FrameTxValidationTests`. The fork gate lives in transaction validation: before EIP-7906 the mode is undefined and the transaction is not admitted.

`Nethermind.Evm.Test` and `Nethermind.Core.Test` are green.
