### PR TITLE
fix(txpool): verify frame-transaction signatures at pool ingress

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Precompiles;
@@ -130,7 +131,7 @@ public static class FrameTxSignatureValidator
         }
 
         ReadOnlySpan<byte> publicKey = raw.Slice(64, 64); // qx || qy
-        Address derived = new(Keccak.Compute(publicKey).Bytes[12..]);
+        Address derived = new(ValueKeccak.Compute(publicKey).Bytes[12..]);
         if (derived != resolvedSigner) return Fail(InvalidP256Signer, out error);
 
         // The secp256r1 primitive is packaged above Nethermind.Evm and reached through the same
@@ -138,12 +139,20 @@ public static class FrameTxSignatureValidator
         // secp256r1 semantics. Input layout: message || r || s || qx || qy (32 + P256 signature).
         if (p256Precompile is null) return Fail(P256NotSupported, out error);
 
-        byte[] input = new byte[Hash256.Size + TxFrameSignature.P256SignatureLength];
-        message.Bytes.CopyTo(input);
-        raw.CopyTo(input.AsSpan(Hash256.Size));
+        const int InputLength = Hash256.Size + TxFrameSignature.P256SignatureLength;
+        byte[] input = ArrayPool<byte>.Shared.Rent(InputLength);
+        try
+        {
+            message.Bytes.CopyTo(input);
+            raw.CopyTo(input.AsSpan(Hash256.Size));
 
-        Result<byte[]> result = p256Precompile.Run(input, spec);
-        return result && result.Data.Length > 0 || Fail(InvalidSignature, out error);
+            Result<byte[]> result = p256Precompile.Run(input.AsMemory(0, InputLength), spec);
+            return result && result.Data.Length > 0 || Fail(InvalidSignature, out error);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(input);
+        }
     }
 
     private static bool Fail(string message, out string? error)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs
@@ -8,6 +8,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Int256;
+using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Evm.TransactionProcessing;
 
@@ -32,6 +33,16 @@ public static class FrameTxSignatureValidator
     public static readonly Address P256VerifyPrecompileAddress = Address.FromNumber(0x100);
 
     public static bool Validate(Transaction tx, in ValueHash256 sigHash, IEthereumEcdsa ecdsa, IPrecompile? p256Precompile, IReleaseSpec spec, out string? error)
+        => Validate(tx, sigHash, sigHashComputed: true, ecdsa, p256Precompile, spec, out error);
+
+    /// <summary>
+    /// Same validation, for callers that have no sig hash at hand: it is computed on the first entry
+    /// that needs it, so a transaction whose entries all carry an explicit digest never pays for it.
+    /// </summary>
+    public static bool Validate(Transaction tx, IEthereumEcdsa ecdsa, IPrecompile? p256Precompile, IReleaseSpec spec, out string? error)
+        => Validate(tx, default, sigHashComputed: false, ecdsa, p256Precompile, spec, out error);
+
+    private static bool Validate(Transaction tx, ValueHash256 sigHash, bool sigHashComputed, IEthereumEcdsa ecdsa, IPrecompile? p256Precompile, IReleaseSpec spec, out string? error)
     {
         error = null;
         TxFrameSignature[]? signatures = tx.FrameSignatures;
@@ -52,6 +63,12 @@ public static class FrameTxSignatureValidator
             if (!signature.Msg.IsEmpty && signature.Msg.Length != Hash256.Size)
             {
                 return Fail(InvalidMsgLength, out error);
+            }
+
+            if (signature.Msg.IsEmpty && !sigHashComputed)
+            {
+                sigHash = FrameTxSigHash.ComputeValue(tx);
+                sigHashComputed = true;
             }
 
             ValueHash256 message = signature.Msg.IsEmpty ? sigHash : new ValueHash256(signature.Msg.Span);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs
@@ -4,6 +4,7 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Precompiles;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Evm.Precompiles;
@@ -30,7 +31,7 @@ public static class FrameTxSignatureValidator
     public const string P256NotSupported = "frame transaction P256 signatures require the secp256r1 precompile";
 
     /// <summary>Address of the secp256r1 (P256VERIFY) precompile — EIP-7951 / RIP-7212.</summary>
-    public static readonly Address P256VerifyPrecompileAddress = Address.FromNumber(0x100);
+    public static readonly Address P256VerifyPrecompileAddress = PrecompiledAddresses.P256Verify;
 
     public static bool Validate(Transaction tx, in ValueHash256 sigHash, IEthereumEcdsa ecdsa, IPrecompile? p256Precompile, IReleaseSpec spec, out string? error)
         => Validate(tx, sigHash, sigHashComputed: true, ecdsa, p256Precompile, spec, out error);

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -65,8 +65,8 @@ namespace Nethermind.Specs.Test
         public bool IsEip3529Enabled { get; set; } = spec.IsEip3529Enabled;
         public bool IsEip3541Enabled { get; set; } = spec.IsEip3541Enabled;
         public bool IsEip4844Enabled { get; set; } = spec.IsEip4844Enabled;
-        public bool IsEip7951Enabled { get; set; } = spec.IsEip7951Enabled;
-        public bool IsRip7212Enabled { get; set; } = spec.IsRip7212Enabled;
+        public bool IsEip7951Enabled { get => field; set { field = value; _precompiles = null; } } = spec.IsEip7951Enabled;
+        public bool IsRip7212Enabled { get => field; set { field = value; _precompiles = null; } } = spec.IsRip7212Enabled;
         public bool IsEip7623Enabled { get; set; } = spec.IsEip7623Enabled;
         public bool IsEip7976Enabled { get; set; } = spec.IsEip7976Enabled;
         public bool IsEip7981Enabled { get; set; } = spec.IsEip7981Enabled;
@@ -132,7 +132,15 @@ namespace Nethermind.Specs.Test
         public bool IsEip8246Enabled { get; set; } = spec.IsEip8246Enabled;
         public bool IsEip2780Enabled { get; set; } = spec.IsEip2780Enabled;
         public SpecGasCosts GasCosts => new(this);
-        FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => BuildPrecompiles();
+
+        private FrozenSet<AddressAsKey>? _precompiles;
+
+        /// <remarks>
+        /// Memoized like the production spec: <c>IsPrecompile</c> reads it per code fetch, per
+        /// <c>CALL</c> and per cold account access, and the two flags that decide the set drop the
+        /// cache when they are overridden.
+        /// </remarks>
+        FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => _precompiles ??= BuildPrecompiles();
 
         private FrozenSet<AddressAsKey> BuildPrecompiles()
         {

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Frozen;
+using System.Collections.Generic;
 using Nethermind.Core;
+using Nethermind.Core.Precompiles;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
 
@@ -130,6 +132,21 @@ namespace Nethermind.Specs.Test
         public bool IsEip8246Enabled { get; set; } = spec.IsEip8246Enabled;
         public bool IsEip2780Enabled { get; set; } = spec.IsEip2780Enabled;
         public SpecGasCosts GasCosts => new(this);
-        FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;
+        FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => BuildPrecompiles();
+
+        private FrozenSet<AddressAsKey> BuildPrecompiles()
+        {
+            HashSet<AddressAsKey> precompiles = [.. spec.Precompiles];
+            if (IsRip7212Enabled || IsEip7951Enabled)
+            {
+                precompiles.Add(PrecompiledAddresses.P256Verify);
+            }
+            else
+            {
+                precompiles.Remove(PrecompiledAddresses.P256Verify);
+            }
+
+            return precompiles.ToFrozenSet();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -25,7 +25,6 @@ using Nethermind.Core.Test;
 using Nethermind.Core.Test.Blockchain;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
-using Nethermind.Evm.Precompiles;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2252,9 +2252,10 @@ namespace Nethermind.TxPool.Test
         // The pool must reach the same verdict as the processor: the EVM resolves P256VERIFY through the
         // code-info repository, so gating it on a fork flag here would refuse — and disconnect the peer
         // over — a transaction the processor accepts.
-        [TestCase(true, false, TestName = "P256VERIFY reached through EIP-7951")]
-        [TestCase(false, true, TestName = "P256VERIFY reached through RIP-7212")]
-        public void Frame_transaction_with_a_valid_p256_signature_is_pooled(bool eip7951, bool rip7212)
+        [TestCase(true, false, true, TestName = "P256VERIFY reached through EIP-7951")]
+        [TestCase(false, true, true, TestName = "P256VERIFY reached through RIP-7212")]
+        [TestCase(false, false, false, TestName = "P256VERIFY absent from the active precompiles")]
+        public void Frame_transaction_with_a_valid_p256_signature_is_pooled(bool eip7951, bool rip7212, bool expectedAccepted)
         {
             OverridableReleaseSpec spec = new(Bogota.Instance) { IsEip7951Enabled = eip7951, IsRip7212Enabled = rip7212 };
             _txPool = CreatePool(null, new TestSpecProvider(spec));
@@ -2266,8 +2267,11 @@ namespace Nethermind.TxPool.Test
 
             AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
 
-            Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
-            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result == AcceptTxResult.Accepted, Is.EqualTo(expectedAccepted), result.ToString());
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(expectedAccepted ? 1 : 0));
+            }
         }
 
         private static TxFrameSignature P256Signature(Transaction tx)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2329,8 +2329,8 @@ namespace Nethermind.TxPool.Test
         [TestCase(100_000UL, false, true, TestName = "prefix exactly at MAX_VERIFY_GAS is accepted")]
         [TestCase(100_001UL, false, false, TestName = "prefix one gas over MAX_VERIFY_GAS is rejected")]
         [TestCase(100_000UL, true, false, TestName = "signature verification cost pushes the prefix over the ceiling")]
-        [TestCase(93_300UL, true, true, TestName = "prefix plus signature cost exactly at the ceiling is accepted")]
-        public void Frame_transaction_prefix_is_bounded_by_max_verify_gas(ulong verifyGasLimit, bool withP256Signature, bool expectedAccepted)
+        [TestCase(97_200UL, true, true, TestName = "prefix plus signature cost exactly at the ceiling is accepted")]
+        public void Frame_transaction_prefix_is_bounded_by_max_verify_gas(ulong verifyGasLimit, bool withSignature, bool expectedAccepted)
         {
             _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 100_000 }, new TestSpecProvider(Bogota.Instance));
             EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
@@ -2339,10 +2339,12 @@ namespace Nethermind.TxPool.Test
             _txPool.AddPeer(peer);
 
             Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null, verifyGasLimit: verifyGasLimit);
-            if (withP256Signature)
+            if (withSignature)
             {
-                // 6 700 gas, so it decides the outcome on its own at a 93 300-gas prefix.
-                frameTx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeP256, null, default, new byte[TxFrameSignature.P256SignatureLength])];
+                // A secp256k1 entry verifies for 2 800 gas, so it decides the outcome on its own at a
+                // 97 200-gas prefix. It has to be a signature that verifies: the pool rejects one that
+                // does not before the budget is ever compared.
+                frameTx.FrameSignatures = [FrameSignature(frameTx, FrameSignatureDefect.None)];
                 frameTx.Hash = frameTx.CalculateHash();
             }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
@@ -24,6 +25,7 @@ using Nethermind.Core.Test;
 using Nethermind.Core.Test.Blockchain;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
+using Nethermind.Evm.Precompiles;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
@@ -2246,6 +2248,47 @@ namespace Nethermind.TxPool.Test
 
             Assert.That(result == AcceptTxResult.Accepted, Is.EqualTo(expectedAccepted), result.ToString());
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(expectedAccepted ? 1 : 0));
+        }
+
+        // The pool must reach the same verdict as the processor: the EVM resolves P256VERIFY through the
+        // code-info repository, so gating it on a fork flag here would refuse — and disconnect the peer
+        // over — a transaction the processor accepts.
+        [TestCase(true, false, TestName = "P256VERIFY reached through EIP-7951")]
+        [TestCase(false, true, TestName = "P256VERIFY reached through RIP-7212")]
+        public void Frame_transaction_with_a_valid_p256_signature_is_pooled(bool eip7951, bool rip7212)
+        {
+            OverridableReleaseSpec spec = new(Bogota.Instance) { IsEip7951Enabled = eip7951, IsRip7212Enabled = rip7212 };
+            _txPool = CreatePool(null, new TestSpecProvider(spec));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null);
+            frameTx.FrameSignatures = [P256Signature(frameTx)];
+            frameTx.Hash = frameTx.CalculateHash();
+
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+
+            Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+        }
+
+        private static TxFrameSignature P256Signature(Transaction tx)
+        {
+            using ECDsa key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+            ECPoint q = key.ExportParameters(false).Q;
+            byte[] publicKey = [.. q.X!, .. q.Y!];
+            Address signer = new(Keccak.Compute(publicKey).Bytes[12..]);
+
+            tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeP256, signer, default, default)];
+            byte[] signature = key.SignHash(FrameTxSigHash.ComputeValue(tx).Bytes);
+
+            UInt256 s = new(signature.AsSpan(32, 32), isBigEndian: true);
+            if (s > SecP256r1Curve.HalfN)
+            {
+                (SecP256r1Curve.N - s).ToBigEndian(signature.AsSpan(32, 32));
+            }
+
+            byte[] raw = [.. signature, .. publicKey];
+            return new TxFrameSignature(TxFrameSignature.SchemeP256, signer, default, raw);
         }
 
         public enum FrameSignatureDefect { None, HighS, LegacyRecoveryId, ForeignSigner }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -26,6 +26,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
@@ -2224,6 +2225,57 @@ namespace Nethermind.TxPool.Test
                 Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
                 Assert.That(legacyResult, Is.EqualTo(AcceptTxResult.SenderIsContract));
             }
+        }
+
+        // A protocol-validated signature is invalid for every future chain state, so pooling one and
+        // gossiping it costs peers work they must repeat and can only end in a peer-side rejection.
+        [TestCase(FrameSignatureDefect.None, true)]
+        [TestCase(FrameSignatureDefect.HighS, false)]
+        [TestCase(FrameSignatureDefect.LegacyRecoveryId, false)]
+        [TestCase(FrameSignatureDefect.ForeignSigner, false)]
+        public void Frame_transaction_signatures_are_verified_at_ingress(FrameSignatureDefect defect, bool expectedAccepted)
+        {
+            _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null);
+            frameTx.FrameSignatures = [FrameSignature(frameTx, defect)];
+            frameTx.Hash = frameTx.CalculateHash();
+
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+
+            Assert.That(result == AcceptTxResult.Accepted, Is.EqualTo(expectedAccepted), result.ToString());
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(expectedAccepted ? 1 : 0));
+        }
+
+        public enum FrameSignatureDefect { None, HighS, LegacyRecoveryId, ForeignSigner }
+
+        private static TxFrameSignature FrameSignature(Transaction tx, FrameSignatureDefect defect)
+        {
+            PrivateKey key = defect == FrameSignatureDefect.ForeignSigner ? TestItem.PrivateKeyB : TestItem.PrivateKeyA;
+            Address signer = TestItem.PrivateKeyA.Address;
+            // compute_sig_hash covers the entry's scheme/signer/msg and elides only the raw bytes, so
+            // the hash is taken with the entry already installed.
+            tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, signer, default, default)];
+            Signature signature = new Ecdsa().Sign(key, FrameTxSigHash.ComputeValue(tx));
+
+            byte[] bytes = new byte[TxFrameSignature.Secp256k1SignatureLength];
+            bytes[0] = signature.RecoveryId;
+            signature.Bytes.CopyTo(bytes.AsSpan(1));
+
+            switch (defect)
+            {
+                case FrameSignatureDefect.HighS:
+                    bytes[0] ^= 1;
+                    UInt256 s = new(bytes.AsSpan(33, 32), isBigEndian: true);
+                    (SecP256k1Curve.N - s).ToBigEndian(bytes.AsSpan(33, 32));
+                    break;
+                case FrameSignatureDefect.LegacyRecoveryId:
+                    bytes[0] += 27;
+                    break;
+            }
+
+            return new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, signer, default, bytes);
         }
 
         // MAX_VERIFY_GAS is a public-mempool DoS bound, not a validity rule: a prefix over the ceiling is

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSignatureFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSignatureFilter.cs
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Logging;
-using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.TxPool.Filters;
 
@@ -40,11 +38,13 @@ internal sealed class FrameTxSignatureFilter(
         }
 
         IReleaseSpec spec = specProvider.GetCurrentHeadSpec();
-        ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
-        // Mirrors the precompile set the EVM exposes, so a chain that reaches P256VERIFY through
-        // RIP-7212 is not refused here for a signature the processor verifies.
-        IPrecompile? p256Precompile = spec.IsEip7951Enabled || spec.IsRip7212Enabled ? SecP256r1Precompile.Instance : null;
-        if (!FrameTxSignatureValidator.Validate(tx, in sigHash, ecdsa, p256Precompile, spec, out string? error))
+        // Same availability test the processor resolves through ICodeInfoRepository.GetPrecompile, so a
+        // chain that reaches P256VERIFY through RIP-7212 rather than EIP-7951 is not refused here for a
+        // signature block processing verifies.
+        IPrecompile? p256Precompile = spec.IsPrecompile(FrameTxSignatureValidator.P256VerifyPrecompileAddress)
+            ? SecP256r1Precompile.Instance
+            : null;
+        if (!FrameTxSignatureValidator.Validate(tx, ecdsa, p256Precompile, spec, out string? error))
         {
             Metrics.PendingTransactionsMalformed++;
             if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, {error}.");

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSignatureFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSignatureFilter.cs
@@ -23,7 +23,8 @@ namespace Nethermind.TxPool.Filters;
 /// client must reject. Runs the same check the processor runs before any frame executes, so a pooled
 /// transaction cannot fail pre-flight on its signatures.
 /// Must run after <see cref="MalformedTxFilter"/>, which guarantees the frame and signature lists are
-/// structurally well-formed.
+/// structurally well-formed, and last among the incoming filters: the signature list is uncapped, so the
+/// cheap state filters must reject what they can before any elliptic-curve work is spent on a payload.
 /// </remarks>
 internal sealed class FrameTxSignatureFilter(
     IChainHeadSpecProvider specProvider,
@@ -40,7 +41,9 @@ internal sealed class FrameTxSignatureFilter(
 
         IReleaseSpec spec = specProvider.GetCurrentHeadSpec();
         ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
-        IPrecompile? p256Precompile = spec.IsEip7951Enabled ? SecP256r1Precompile.Instance : null;
+        // Mirrors the precompile set the EVM exposes, so a chain that reaches P256VERIFY through
+        // RIP-7212 is not refused here for a signature the processor verifies.
+        IPrecompile? p256Precompile = spec.IsEip7951Enabled || spec.IsRip7212Enabled ? SecP256r1Precompile.Instance : null;
         if (!FrameTxSignatureValidator.Validate(tx, in sigHash, ecdsa, p256Precompile, spec, out string? error))
         {
             Metrics.PendingTransactionsMalformed++;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSignatureFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSignatureFilter.cs
@@ -46,7 +46,7 @@ internal sealed class FrameTxSignatureFilter(
             : null;
         if (!FrameTxSignatureValidator.Validate(tx, ecdsa, p256Precompile, spec, out string? error))
         {
-            Metrics.PendingTransactionsMalformed++;
+            Metrics.PendingTransactionsFrameTxSignatureInvalid++;
             if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, {error}.");
             return AcceptTxResult.Invalid.WithMessage(error!);
         }

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSignatureFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSignatureFilter.cs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Crypto;
+using Nethermind.Evm.Precompiles;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.TxPool.Filters;
+
+/// <summary>
+/// Rejects an EIP-8141 frame transaction whose protocol-validated signatures do not verify.
+/// </summary>
+/// <remarks>
+/// The frame sender is explicit in the payload, so a frame transaction never goes through the sender
+/// recovery that rejects a bad signature on every other transaction type, and nothing else in the pool
+/// looks at <c>frame_signatures</c>. A signature that fails <c>validate_signature</c> can never verify
+/// at any future head, so pooling and gossiping one only spends peer work on a payload every conforming
+/// client must reject. Runs the same check the processor runs before any frame executes, so a pooled
+/// transaction cannot fail pre-flight on its signatures.
+/// Must run after <see cref="MalformedTxFilter"/>, which guarantees the frame and signature lists are
+/// structurally well-formed.
+/// </remarks>
+internal sealed class FrameTxSignatureFilter(
+    IChainHeadSpecProvider specProvider,
+    IEthereumEcdsa ecdsa,
+    ILogger logger)
+    : IIncomingTxFilter
+{
+    public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
+    {
+        if (!tx.SupportsFrames || tx.FrameSignatures is not { Length: > 0 })
+        {
+            return AcceptTxResult.Accepted;
+        }
+
+        IReleaseSpec spec = specProvider.GetCurrentHeadSpec();
+        ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
+        IPrecompile? p256Precompile = spec.IsEip7951Enabled ? SecP256r1Precompile.Instance : null;
+        if (!FrameTxSignatureValidator.Validate(tx, in sigHash, ecdsa, p256Precompile, spec, out string? error))
+        {
+            Metrics.PendingTransactionsMalformed++;
+            if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, {error}.");
+            return AcceptTxResult.Invalid.WithMessage(error!);
+        }
+
+        return AcceptTxResult.Accepted;
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool/Metrics.cs
+++ b/src/Nethermind/Nethermind.TxPool/Metrics.cs
@@ -41,6 +41,10 @@ namespace Nethermind.TxPool
         public static long PendingTransactionsFrameTxVerifyGasTooHigh { get; set; }
 
         [CounterMetric]
+        [Description("Number of pending EIP-8141 frame transactions received that were ignored because one of their protocol-validated signatures does not verify.")]
+        public static long PendingTransactionsFrameTxSignatureInvalid { get; set; }
+
+        [CounterMetric]
         [Description(
             "Number of pending transactions received that were ignored because of not having preceding nonce of this sender in TxPool.")]
         public static long PendingTransactionsNonceGap { get; set; }

--- a/src/Nethermind/Nethermind.TxPool/Nethermind.TxPool.csproj
+++ b/src/Nethermind/Nethermind.TxPool/Nethermind.TxPool.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\Nethermind.Crypto\Nethermind.Crypto.csproj" />
     <ProjectReference Include="..\Nethermind.Db\Nethermind.Db.csproj" />
     <ProjectReference Include="..\Nethermind.Evm\Nethermind.Evm.csproj" />
+    <ProjectReference Include="..\Nethermind.Evm.Precompiles\Nethermind.Evm.Precompiles.csproj" />
     <ProjectReference Include="..\Nethermind.Network.Contract\Nethermind.Network.Contract.csproj" />
     <ProjectReference Include="..\Nethermind.State\Nethermind.State.csproj" />
   </ItemGroup>

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -170,7 +170,6 @@ namespace Nethermind.TxPool
                 new NullHashTxFilter(), // needs to be first as it assigns the hash
                 new AlreadyKnownTxFilter(_hashCache, _logger),
                 new MalformedTxFilter(_specProvider, validator, ecdsa, _logger),
-                new FrameTxSignatureFilter(_specProvider, ecdsa, _logger), // after MalformedTxFilter: verifies signatures of an already well-formed frame tx
                 new ExpiredFrameTxFilter(chainHeadInfoProvider, _logger), // after MalformedTxFilter: reads the deadline from an already well-formed frame
                 new FrameTxVerifyGasFilter(txPoolConfig, _logger), // after MalformedTxFilter: reads gas limits from an already well-formed frame list
                 new TxTypeTxFilter(_transactions,
@@ -182,6 +181,7 @@ namespace Nethermind.TxPool
                 new GapNonceFilter(_transactions, _blobTransactions, _logger),
                 new RecoverAuthorityFilter(ecdsa),
                 new DelegatedAccountFilter(_specProvider, _transactions, _blobTransactions, chainHeadInfoProvider.ReadOnlyStateProvider, _pendingDelegations),
+                new FrameTxSignatureFilter(_specProvider, ecdsa, _logger), // last: elliptic-curve work over an uncapped signature list, so let the cheap filters reject first
             ];
 
             if (incomingTxFilter is not null)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -170,6 +170,7 @@ namespace Nethermind.TxPool
                 new NullHashTxFilter(), // needs to be first as it assigns the hash
                 new AlreadyKnownTxFilter(_hashCache, _logger),
                 new MalformedTxFilter(_specProvider, validator, ecdsa, _logger),
+                new FrameTxSignatureFilter(_specProvider, ecdsa, _logger), // after MalformedTxFilter: verifies signatures of an already well-formed frame tx
                 new ExpiredFrameTxFilter(chainHeadInfoProvider, _logger), // after MalformedTxFilter: reads the deadline from an already well-formed frame
                 new FrameTxVerifyGasFilter(txPoolConfig, _logger), // after MalformedTxFilter: reads gas limits from an already well-formed frame list
                 new TxTypeTxFilter(_transactions,


### PR DESCRIPTION
## Changes

A frame transaction carries its sender explicitly in the payload, so it never goes through the sender recovery that rejects a bad signature on every other transaction type, and no pool filter looked at `frame_signatures`. The pool accepted, stored and gossiped frame transactions whose signatures can never verify at any head.

`FrameTxSignatureFilter` runs the same `validate_signature` check the processor runs before any frame executes, right after `MalformedTxFilter`, which guarantees the lists are structurally well-formed.

Found on the cross-client devnet: `neg-high-s`, `neg-recovery-id-27` and `neg-wrong-sig-hash` were admitted by Nethermind and refused by another implementation. The block producer already rejected them, so there is no consensus divergence.

## Types of changes

- [x] Bug fix (a non-breaking change that fixes an issue)

## Testing

`Frame_transaction_signatures_are_verified_at_ingress` covers a verifying signature (pooled), a non-canonical high-s signature, a legacy 27/28 recovery id and a signature from a foreign key (all refused). Fails on the parent commit for the three defect cases.

Nethermind.TxPool.Test: 663 passed, 0 failed.
