### PR TITLE
Deflake PreWarmCaches_ReturnsAddressWarmEnvWhenScopeBuildThrows

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -1218,7 +1218,7 @@ public class BlockCachePreWarmerTests
         public bool Return(IReadOnlyTxProcessorSource obj)
         {
             Interlocked.Increment(ref _returned);
-            return true;
+            return false;
         }
 
         private sealed class ThrowingBuildEnv : IReadOnlyTxProcessorSource


### PR DESCRIPTION
## Changes

- Make `ThrowingBuildPolicy.Return` return `false` so the env pool never retains returned envs in `PreWarmCaches_ReturnsAddressWarmEnvWhenScopeBuildThrows`.

The test (added in #12433) asserts `policy.Returned == policy.Created` to verify no env leaks when scope construction throws. With `Return` returning `true`, the `DefaultObjectPool` (`maxPoolSize: 1`) retains a returned env, so a later `Get()` from one of the concurrent renters (address warmer, sender warming, tx-warmup workers) can be served from the pool without a `Create()` call. Under that interleaving `Returned` exceeds `Created` and the test fails spuriously (e.g. [this run](https://github.com/NethermindEth/nethermind/actions/runs/30725804853/job/91437807253): expected 3, was 4). The production code returns each rental exactly once — only the test's accounting was racy.

Returning `false` forces every rental through `Create()`, making `Returned == Created` a sound no-leak check regardless of scheduling.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Other: test deflake

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Ran the affected test 20 times in a loop locally — 20/20 passes.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)