### PR TITLE
fix(rlp): advance struct-ref decode past frame-tx receipt extension

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Core.Crypto;
@@ -73,6 +74,73 @@ public class FrameTxReceiptDecoderTests
         AssertFrameReceiptsEqual(decodedFrame.FrameReceipts!, frameReceipt.FrameReceipts!);
         AssertLogsEqual(decodedFrame.Logs!, frameReceipt.Logs,
             "the stored union must stay the union, not get rebuilt from frame logs");
+    }
+
+    // Regression for eth_getLogs throwing on any block containing a frame-tx receipt.
+    // LogFinder reads receipts through ReceiptsIterator, which loops CompactReceiptStorageDecoder
+    // .DecodeStructRef over the array with RlpBehaviors.Storage (no AllowExtraBytes). The struct-ref
+    // path used to skip past the frame extension (payer + per-frame receipts) only when
+    // AllowExtraBytes was set, so a frame-tx receipt left the reader parked mid-sequence and the
+    // next DecodeStructRef misread the payer bytes as a receipt prefix, throwing an RlpException.
+    // The frame receipt is placed between two regular receipts so a misalignment corrupts a neighbor.
+    [Test]
+    public void StructRefIteration_OverArrayWithFrameTxReceipt_DoesNotThrowOrCorruptNeighbours()
+    {
+        LogEntry frameLog = Log(0x01);
+        TxReceipt frameReceipt = CreateReceipt(
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [frameLog]),
+            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, [Log(0x02)]));
+        frameReceipt.StatusCode = TxFrameReceipt.StatusSuccess;
+        frameReceipt.Sender = TestItem.AddressC;
+        frameReceipt.Logs = [frameLog];
+        frameReceipt.Bloom = new Bloom(frameReceipt.Logs);
+
+        TxReceipt before = Build.A.Receipt.WithAllFieldsFilled.WithCalculatedBloom().TestObject;
+        TxReceipt after = Build.A.Receipt.WithAllFieldsFilled.WithCalculatedBloom().TestObject;
+
+        CompactReceiptStorageDecoder decoder = new();
+        byte[] encoded = decoder.Encode([before, frameReceipt, after], RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts).Bytes;
+
+        // Mirror ReceiptsIterator.TryGetNext: read the outer sequence, then loop DecodeStructRef.
+        // TxReceiptStructRef is a ref struct, so scalar fields are captured per index as we go.
+        RlpReader reader = new(encoded);
+        int length = reader.ReadSequenceLength() + reader.Position;
+        int count = 0;
+        (byte Status, ulong Gas, string Sender, LogEntry[] Logs)[] decoded = new (byte, ulong, string, LogEntry[])[3];
+        while (reader.Position < length)
+        {
+            decoder.DecodeStructRef(ref reader, RlpBehaviors.Storage, out TxReceiptStructRef current);
+            if (count < decoded.Length)
+            {
+                decoded[count] = (current.StatusCode, current.GasUsedTotal, current.Sender.ToString(), DecodeLogs(current.LogsRlp));
+            }
+            count++;
+        }
+
+        Assert.That(count, Is.EqualTo(3), "every receipt must decode, including the neighbours");
+
+        Assert.That(decoded[1].Status, Is.EqualTo(frameReceipt.StatusCode), "frame status");
+        Assert.That(decoded[1].Gas, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
+        Assert.That(decoded[1].Sender, Is.EqualTo(frameReceipt.Sender.ToString()), "frame sender");
+        AssertLogsEqual(decoded[1].Logs, frameReceipt.Logs);
+
+        // The receipt after the frame tx must be intact, proving the reader realigned.
+        Assert.That(decoded[2].Sender, Is.EqualTo(after.Sender!.ToString()), "trailing receipt sender");
+        Assert.That(decoded[2].Gas, Is.EqualTo(after.GasUsedTotal), "trailing receipt gas used total");
+    }
+
+    private static LogEntry[] DecodeLogs(scoped ReadOnlySpan<byte> logsRlp)
+    {
+        RlpReader reader = new(logsRlp);
+        int end = reader.ReadSequenceLength() + reader.Position;
+        List<LogEntry> logs = [];
+        while (reader.Position < end)
+        {
+            LogEntry log = CompactLogEntryDecoder.Instance.Decode(ref reader, RlpBehaviors.AllowExtraBytes)!;
+            logs.Add(log);
+        }
+
+        return logs.ToArray();
     }
 
     private static IEnumerable<TestCaseData> RoundtripCases()

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -12,11 +12,8 @@ using NUnit.Framework;
 namespace Nethermind.Core.Test.Encoding;
 
 /// <summary>
-/// Round-trips of the EIP-8141 receipt payload <c>[cumulative_gas_used, payer,
-/// [[status, gas_used, logs], ...]]</c>. The wire form is spec-literal: no top-level status and no
-/// bloom. EIP8141-GAP: the decoder derives StatusCode from the frame statuses and unions frame logs
-/// into Logs so bloom calculation and log indexing keep working — asserted here as the pinned
-/// behavior.
+/// Round-trips of the EIP-8141 receipt payload (no top-level status or bloom on the wire): the
+/// decoder derives StatusCode from the frame statuses and unions the frame logs into Logs.
 /// </summary>
 [TestFixture]
 public class FrameTxReceiptDecoderTests
@@ -35,20 +32,17 @@ public class FrameTxReceiptDecoderTests
         AssertFrameReceiptsEqual(decoded.FrameReceipts!, receipt.FrameReceipts!);
         Assert.That(decoded.StatusCode, Is.EqualTo(expectedStatus),
             "the transaction status is absent from the wire and must be derived from the frame statuses");
-        // Decoded Logs must be the in-order union of frame logs.
         AssertLogsEqual(decoded.Logs!, receipt.FrameReceipts!.SelectMany(static f => f.Logs).ToArray());
     }
 
-    // Storage persists the union Logs and the per-frame logs as independent fields (unlike the wire
-    // form, which rebuilds the union from the frame logs on decode). The union here is deliberately
-    // NOT the frame-order concatenation, pinning that the decoder reads Logs back verbatim.
+    // Storage keeps the union Logs and the per-frame logs as independent fields; the union here is
+    // deliberately not the frame-order concatenation, pinning that Logs is read back verbatim.
     [Test]
     public void StorageRoundtrip_PreservesPayerFrameReceiptsAndUnionLogs(
         [Values(true, false)] bool compactEncoding)
     {
         LogEntry unionLog = Log(0x01);
         LogEntry frameOnlyLog = Log(0x02);
-        // Union omits frameOnlyLog, so it diverges from the frame-order concatenation on purpose.
         TxReceipt frameReceipt = CreateStorageFrameReceipt(
             [unionLog],
             new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [unionLog]),
@@ -75,11 +69,8 @@ public class FrameTxReceiptDecoderTests
             "the stored union must stay the union, not get rebuilt from frame logs");
     }
 
-    // Regression: ReceiptsIterator (eth_getLogs) loops DecodeStructRef over stored receipts. A
-    // frame-tx receipt used to leave the reader mid-sequence, breaking the next receipt. It sits
-    // between two regular ones so any misalignment surfaces on a neighbour. Runs over both storage
-    // decoders and both AllowExtraBytes settings: the realign must hold regardless, and the two
-    // decoders guarded it on opposite conditions before the fix.
+    // ReceiptsIterator (eth_getLogs) loops DecodeStructRef over stored receipts; a frame-tx receipt
+    // used to leave the reader mid-sequence and corrupt the next one, so it sits between two regulars.
     [Test]
     public void StructRefIteration_OverArrayWithFrameTxReceipt_DoesNotThrowOrCorruptNeighbours(
         [Values(true, false)] bool compactEncoding,
@@ -103,8 +94,8 @@ public class FrameTxReceiptDecoderTests
         IReceiptRefDecoder refDecoder = (IReceiptRefDecoder)decoder;
         byte[] encoded = decoder.Encode([before, frameReceipt, after], RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts).Bytes;
 
-        // Loop bound matches ReceiptsIterator: iterate while Position is below the content length
-        // from ReadSequenceLength. TxReceiptStructRef is a ref struct, so capture asserted fields.
+        // Iterate while Position is below the sequence content length. TxReceiptStructRef is a ref
+        // struct, so capture the asserted fields into a tuple.
         RlpReader reader = new(encoded);
         int length = reader.ReadSequenceLength();
         int count = 0;
@@ -128,8 +119,8 @@ public class FrameTxReceiptDecoderTests
         Assert.That(decoded[1].Status, Is.EqualTo(frameReceipt.StatusCode), "frame status");
         Assert.That(decoded[1].Gas, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
         Assert.That(decoded[1].Sender, Is.EqualTo(frameReceipt.Sender!.ToString()), "frame sender");
-        // Decoder-assigned TxType, seen only by callers that skip recovery; on eth_getLogs
-        // ReceiptsRecovery.RecoverReceiptData overwrites it from the matching transaction.
+        // TxType here is decoder-assigned and only observed by callers that skip recovery; on
+        // eth_getLogs recovery overwrites it from the matching transaction.
         Assert.That(decoded[1].Type, Is.EqualTo(TxType.FrameTx), "the frame-tx receipt must be typed FrameTx");
         AssertLogsEqual(decoded[1].Logs, frameReceipt.Logs!);
 
@@ -214,8 +205,7 @@ public class FrameTxReceiptDecoderTests
             FrameReceipts = frameReceipts,
         };
 
-    // Applies the storage-only fixups a frame receipt gets before persistence: success status,
-    // recovered sender, verbatim union Logs, and matching bloom.
+    // Storage-only fixups a frame receipt gets before persistence: status, sender, union Logs, bloom.
     private static TxReceipt CreateStorageFrameReceipt(LogEntry[] unionLogs, params TxFrameReceipt[] frameReceipts)
     {
         TxReceipt receipt = CreateReceipt(frameReceipts);

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -73,13 +73,9 @@ public class FrameTxReceiptDecoderTests
             "the stored union must stay the union, not get rebuilt from frame logs");
     }
 
-    // Regression for eth_getLogs throwing on any block containing a frame-tx receipt.
-    // LogFinder reads receipts through ReceiptsIterator, which loops CompactReceiptStorageDecoder
-    // .DecodeStructRef over the array with RlpBehaviors.Storage (no AllowExtraBytes). The struct-ref
-    // path used to skip past the frame extension (payer + per-frame receipts) only when
-    // AllowExtraBytes was set, so a frame-tx receipt left the reader parked mid-sequence and the
-    // next DecodeStructRef misread the payer bytes as a receipt prefix, throwing an RlpException.
-    // The frame receipt is placed between two regular receipts so a misalignment corrupts a neighbor.
+    // Regression: ReceiptsIterator (eth_getLogs) loops DecodeStructRef with RlpBehaviors.Storage.
+    // A frame-tx receipt used to leave the reader mid-sequence, breaking the next receipt. It sits
+    // between two regular ones so any misalignment surfaces on a neighbour.
     [Test]
     public void StructRefIteration_OverArrayWithFrameTxReceipt_DoesNotThrowOrCorruptNeighbours()
     {
@@ -98,10 +94,8 @@ public class FrameTxReceiptDecoderTests
         CompactReceiptStorageDecoder decoder = new();
         byte[] encoded = decoder.Encode([before, frameReceipt, after], RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts).Bytes;
 
-        // Mirror ReceiptsIterator.TryGetNext: read the outer sequence, then loop DecodeStructRef
-        // while the absolute Position stays within the content length returned by
-        // ReadSequenceLength(), exactly as ReceiptsIterator does. TxReceiptStructRef is a ref
-        // struct, so scalar fields are captured per index as we go.
+        // Mirror ReceiptsIterator.TryGetNext's loop bound exactly. TxReceiptStructRef is a ref
+        // struct, so capture the scalar fields we assert per index as we iterate.
         RlpReader reader = new(encoded);
         int length = reader.ReadSequenceLength();
         int count = 0;
@@ -194,9 +188,8 @@ public class FrameTxReceiptDecoderTests
             FrameReceipts = frameReceipts,
         };
 
-    // Applies the storage-only fixups a frame receipt gets before it is persisted: internal success
-    // status, a recovered sender, the verbatim union Logs (which may differ from the frame-order
-    // concatenation), and the matching bloom.
+    // Applies the storage-only fixups a frame receipt gets before persistence: success status,
+    // recovered sender, verbatim union Logs, and matching bloom.
     private static TxReceipt CreateStorageFrameReceipt(LogEntry[] unionLogs, params TxFrameReceipt[] frameReceipts)
     {
         TxReceipt receipt = CreateReceipt(frameReceipts);

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -75,13 +75,15 @@ public class FrameTxReceiptDecoderTests
             "the stored union must stay the union, not get rebuilt from frame logs");
     }
 
-    // Regression: ReceiptsIterator (eth_getLogs) loops DecodeStructRef with RlpBehaviors.Storage.
-    // A frame-tx receipt used to leave the reader mid-sequence, breaking the next receipt. It sits
+    // Regression: ReceiptsIterator (eth_getLogs) loops DecodeStructRef over stored receipts. A
+    // frame-tx receipt used to leave the reader mid-sequence, breaking the next receipt. It sits
     // between two regular ones so any misalignment surfaces on a neighbour. Runs over both storage
-    // decoders since ReceiptsIterator picks compact or legacy at runtime from the stored bytes.
+    // decoders and both AllowExtraBytes settings: the realign must hold regardless, and the two
+    // decoders guarded it on opposite conditions before the fix.
     [Test]
     public void StructRefIteration_OverArrayWithFrameTxReceipt_DoesNotThrowOrCorruptNeighbours(
-        [Values(true, false)] bool compactEncoding)
+        [Values(true, false)] bool compactEncoding,
+        [Values(RlpBehaviors.Storage, RlpBehaviors.Storage | RlpBehaviors.AllowExtraBytes)] RlpBehaviors decodeBehaviors)
     {
         LogEntry frameLog = Log(0x01);
         TxReceipt frameReceipt = CreateStorageFrameReceipt(
@@ -101,15 +103,15 @@ public class FrameTxReceiptDecoderTests
         IReceiptRefDecoder refDecoder = (IReceiptRefDecoder)decoder;
         byte[] encoded = decoder.Encode([before, frameReceipt, after], RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts).Bytes;
 
-        // Mirror ReceiptsIterator.TryGetNext's loop bound exactly. TxReceiptStructRef is a ref
-        // struct, so capture the scalar fields we assert per index as we iterate.
+        // Loop bound matches ReceiptsIterator: iterate while Position is below the content length
+        // from ReadSequenceLength. TxReceiptStructRef is a ref struct, so capture asserted fields.
         RlpReader reader = new(encoded);
         int length = reader.ReadSequenceLength();
         int count = 0;
         (byte Status, ulong Gas, string Sender, TxType Type, LogEntry[] Logs)[] decoded = new (byte, ulong, string, TxType, LogEntry[])[3];
         while (reader.Position < length)
         {
-            refDecoder.DecodeStructRef(ref reader, RlpBehaviors.Storage, out TxReceiptStructRef current);
+            refDecoder.DecodeStructRef(ref reader, decodeBehaviors, out TxReceiptStructRef current);
             if (count < decoded.Length)
             {
                 decoded[count] = (current.StatusCode, current.GasUsedTotal, current.Sender.ToString(), current.TxType, DecodeLogs(current.LogsRlp, compactEncoding));
@@ -126,13 +128,12 @@ public class FrameTxReceiptDecoderTests
         Assert.That(decoded[1].Status, Is.EqualTo(frameReceipt.StatusCode), "frame status");
         Assert.That(decoded[1].Gas, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
         Assert.That(decoded[1].Sender, Is.EqualTo(frameReceipt.Sender!.ToString()), "frame sender");
-        // This is the decoder's inferred TxType, observed only by callers that skip recovery. On the
-        // eth_getLogs path ReceiptsRecovery.RecoverReceiptData overwrites TxType from the matching
-        // transaction, so this value does not pin what that path ultimately reports.
-        Assert.That(decoded[1].Type, Is.EqualTo(TxType.FrameTx), "the decoder infers FrameTx from the extension's presence");
+        // Decoder-assigned TxType, seen only by callers that skip recovery; on eth_getLogs
+        // ReceiptsRecovery.RecoverReceiptData overwrites it from the matching transaction.
+        Assert.That(decoded[1].Type, Is.EqualTo(TxType.FrameTx), "the frame-tx receipt must be typed FrameTx");
         AssertLogsEqual(decoded[1].Logs, frameReceipt.Logs!);
 
-        // The receipt after the frame tx must be intact, proving the reader realigned.
+        // The trailing receipt decodes intact only if the reader advanced past the frame extension.
         Assert.That(decoded[2].Sender, Is.EqualTo(after.Sender!.ToString()), "trailing receipt sender");
         Assert.That(decoded[2].Gas, Is.EqualTo(after.GasUsedTotal), "trailing receipt gas used total");
         Assert.That(decoded[2].Type, Is.EqualTo(TxType.Legacy));

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -77,9 +77,11 @@ public class FrameTxReceiptDecoderTests
 
     // Regression: ReceiptsIterator (eth_getLogs) loops DecodeStructRef with RlpBehaviors.Storage.
     // A frame-tx receipt used to leave the reader mid-sequence, breaking the next receipt. It sits
-    // between two regular ones so any misalignment surfaces on a neighbour.
+    // between two regular ones so any misalignment surfaces on a neighbour. Runs over both storage
+    // decoders since ReceiptsIterator picks compact or legacy at runtime from the stored bytes.
     [Test]
-    public void StructRefIteration_OverArrayWithFrameTxReceipt_DoesNotThrowOrCorruptNeighbours()
+    public void StructRefIteration_OverArrayWithFrameTxReceipt_DoesNotThrowOrCorruptNeighbours(
+        [Values(true, false)] bool compactEncoding)
     {
         LogEntry frameLog = Log(0x01);
         TxReceipt frameReceipt = CreateStorageFrameReceipt(
@@ -93,7 +95,10 @@ public class FrameTxReceiptDecoderTests
         TxReceipt after = Build.A.Receipt.WithAllFieldsFilled
             .WithSender(TestItem.AddressE).WithGasUsedTotal(2000).WithCalculatedBloom().TestObject;
 
-        CompactReceiptStorageDecoder decoder = new();
+        RlpDecoder<TxReceipt> decoder = compactEncoding
+            ? new CompactReceiptStorageDecoder()
+            : new ReceiptStorageDecoder();
+        IReceiptRefDecoder refDecoder = (IReceiptRefDecoder)decoder;
         byte[] encoded = decoder.Encode([before, frameReceipt, after], RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts).Bytes;
 
         // Mirror ReceiptsIterator.TryGetNext's loop bound exactly. TxReceiptStructRef is a ref
@@ -104,10 +109,10 @@ public class FrameTxReceiptDecoderTests
         (byte Status, ulong Gas, string Sender, TxType Type, LogEntry[] Logs)[] decoded = new (byte, ulong, string, TxType, LogEntry[])[3];
         while (reader.Position < length)
         {
-            decoder.DecodeStructRef(ref reader, RlpBehaviors.Storage, out TxReceiptStructRef current);
+            refDecoder.DecodeStructRef(ref reader, RlpBehaviors.Storage, out TxReceiptStructRef current);
             if (count < decoded.Length)
             {
-                decoded[count] = (current.StatusCode, current.GasUsedTotal, current.Sender.ToString(), current.TxType, DecodeLogs(current.LogsRlp));
+                decoded[count] = (current.StatusCode, current.GasUsedTotal, current.Sender.ToString(), current.TxType, DecodeLogs(current.LogsRlp, compactEncoding));
             }
             count++;
         }
@@ -121,7 +126,10 @@ public class FrameTxReceiptDecoderTests
         Assert.That(decoded[1].Status, Is.EqualTo(frameReceipt.StatusCode), "frame status");
         Assert.That(decoded[1].Gas, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
         Assert.That(decoded[1].Sender, Is.EqualTo(frameReceipt.Sender!.ToString()), "frame sender");
-        Assert.That(decoded[1].Type, Is.EqualTo(TxType.FrameTx), "the extension's presence identifies a frame-tx receipt");
+        // This is the decoder's inferred TxType, observed only by callers that skip recovery. On the
+        // eth_getLogs path ReceiptsRecovery.RecoverReceiptData overwrites TxType from the matching
+        // transaction, so this value does not pin what that path ultimately reports.
+        Assert.That(decoded[1].Type, Is.EqualTo(TxType.FrameTx), "the decoder infers FrameTx from the extension's presence");
         AssertLogsEqual(decoded[1].Logs, frameReceipt.Logs!);
 
         // The receipt after the frame tx must be intact, proving the reader realigned.
@@ -130,14 +138,16 @@ public class FrameTxReceiptDecoderTests
         Assert.That(decoded[2].Type, Is.EqualTo(TxType.Legacy));
     }
 
-    private static LogEntry[] DecodeLogs(scoped ReadOnlySpan<byte> logsRlp)
+    private static LogEntry[] DecodeLogs(scoped ReadOnlySpan<byte> logsRlp, bool compact)
     {
         RlpReader reader = new(logsRlp);
         int end = reader.ReadSequenceLength() + reader.Position;
         List<LogEntry> logs = [];
         while (reader.Position < end)
         {
-            LogEntry log = CompactLogEntryDecoder.Instance.Decode(ref reader, RlpBehaviors.AllowExtraBytes)!;
+            LogEntry log = compact
+                ? CompactLogEntryDecoder.Instance.Decode(ref reader, RlpBehaviors.AllowExtraBytes)!
+                : LogEntryDecoder.Instance.Decode(ref reader, RlpBehaviors.AllowExtraBytes)!;
             logs.Add(log);
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -46,15 +46,12 @@ public class FrameTxReceiptDecoderTests
     {
         LogEntry unionLog = Log(0x01);
         LogEntry frameOnlyLog = Log(0x02);
-        TxReceipt frameReceipt = CreateReceipt(
+        // Union omits frameOnlyLog, so it diverges from the frame-order concatenation on purpose.
+        TxReceipt frameReceipt = CreateStorageFrameReceipt(
+            [unionLog],
             new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [unionLog]),
             new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, [frameOnlyLog]),
             new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, []));
-        frameReceipt.StatusCode = TxFrameReceipt.StatusSuccess;
-        frameReceipt.Sender = TestItem.AddressC;
-        // Union omits frameOnlyLog, so it diverges from the frame-order concatenation on purpose.
-        frameReceipt.Logs = [unionLog];
-        frameReceipt.Bloom = new Bloom(frameReceipt.Logs);
         TxReceipt legacyReceipt = Build.A.Receipt.WithAllFieldsFilled.WithCalculatedBloom().TestObject;
 
         ReceiptArrayStorageDecoder encoder = new(compactEncoding);
@@ -72,7 +69,7 @@ public class FrameTxReceiptDecoderTests
         Assert.That(decodedFrame.TxType, Is.EqualTo(TxType.FrameTx));
         Assert.That(decodedFrame.Payer, Is.EqualTo(frameReceipt.Payer));
         AssertFrameReceiptsEqual(decodedFrame.FrameReceipts!, frameReceipt.FrameReceipts!);
-        AssertLogsEqual(decodedFrame.Logs!, frameReceipt.Logs,
+        AssertLogsEqual(decodedFrame.Logs!, frameReceipt.Logs!,
             "the stored union must stay the union, not get rebuilt from frame logs");
     }
 
@@ -87,24 +84,26 @@ public class FrameTxReceiptDecoderTests
     public void StructRefIteration_OverArrayWithFrameTxReceipt_DoesNotThrowOrCorruptNeighbours()
     {
         LogEntry frameLog = Log(0x01);
-        TxReceipt frameReceipt = CreateReceipt(
+        TxReceipt frameReceipt = CreateStorageFrameReceipt(
+            [frameLog],
             new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [frameLog]),
             new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, [Log(0x02)]));
-        frameReceipt.StatusCode = TxFrameReceipt.StatusSuccess;
-        frameReceipt.Sender = TestItem.AddressC;
-        frameReceipt.Logs = [frameLog];
-        frameReceipt.Bloom = new Bloom(frameReceipt.Logs);
 
-        TxReceipt before = Build.A.Receipt.WithAllFieldsFilled.WithCalculatedBloom().TestObject;
-        TxReceipt after = Build.A.Receipt.WithAllFieldsFilled.WithCalculatedBloom().TestObject;
+        // Distinct sender/gas on the neighbours so realigning onto `after` is provably not `before`.
+        TxReceipt before = Build.A.Receipt.WithAllFieldsFilled
+            .WithSender(TestItem.AddressD).WithGasUsedTotal(1000).WithCalculatedBloom().TestObject;
+        TxReceipt after = Build.A.Receipt.WithAllFieldsFilled
+            .WithSender(TestItem.AddressE).WithGasUsedTotal(2000).WithCalculatedBloom().TestObject;
 
         CompactReceiptStorageDecoder decoder = new();
         byte[] encoded = decoder.Encode([before, frameReceipt, after], RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts).Bytes;
 
-        // Mirror ReceiptsIterator.TryGetNext: read the outer sequence, then loop DecodeStructRef.
-        // TxReceiptStructRef is a ref struct, so scalar fields are captured per index as we go.
+        // Mirror ReceiptsIterator.TryGetNext: read the outer sequence, then loop DecodeStructRef
+        // while the absolute Position stays within the content length returned by
+        // ReadSequenceLength(), exactly as ReceiptsIterator does. TxReceiptStructRef is a ref
+        // struct, so scalar fields are captured per index as we go.
         RlpReader reader = new(encoded);
-        int length = reader.ReadSequenceLength() + reader.Position;
+        int length = reader.ReadSequenceLength();
         int count = 0;
         (byte Status, ulong Gas, string Sender, LogEntry[] Logs)[] decoded = new (byte, ulong, string, LogEntry[])[3];
         while (reader.Position < length)
@@ -119,10 +118,13 @@ public class FrameTxReceiptDecoderTests
 
         Assert.That(count, Is.EqualTo(3), "every receipt must decode, including the neighbours");
 
+        Assert.That(decoded[0].Sender, Is.EqualTo(before.Sender!.ToString()), "leading receipt sender");
+        Assert.That(decoded[0].Gas, Is.EqualTo(before.GasUsedTotal), "leading receipt gas used total");
+
         Assert.That(decoded[1].Status, Is.EqualTo(frameReceipt.StatusCode), "frame status");
         Assert.That(decoded[1].Gas, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
-        Assert.That(decoded[1].Sender, Is.EqualTo(frameReceipt.Sender.ToString()), "frame sender");
-        AssertLogsEqual(decoded[1].Logs, frameReceipt.Logs);
+        Assert.That(decoded[1].Sender, Is.EqualTo(frameReceipt.Sender!.ToString()), "frame sender");
+        AssertLogsEqual(decoded[1].Logs, frameReceipt.Logs!);
 
         // The receipt after the frame tx must be intact, proving the reader realigned.
         Assert.That(decoded[2].Sender, Is.EqualTo(after.Sender!.ToString()), "trailing receipt sender");
@@ -191,6 +193,19 @@ public class FrameTxReceiptDecoderTests
             Payer = TestItem.AddressA,
             FrameReceipts = frameReceipts,
         };
+
+    // Applies the storage-only fixups a frame receipt gets before it is persisted: internal success
+    // status, a recovered sender, the verbatim union Logs (which may differ from the frame-order
+    // concatenation), and the matching bloom.
+    private static TxReceipt CreateStorageFrameReceipt(LogEntry[] unionLogs, params TxFrameReceipt[] frameReceipts)
+    {
+        TxReceipt receipt = CreateReceipt(frameReceipts);
+        receipt.StatusCode = TxFrameReceipt.StatusSuccess;
+        receipt.Sender = TestItem.AddressC;
+        receipt.Logs = unionLogs;
+        receipt.Bloom = new Bloom(unionLogs);
+        return receipt;
+    }
 
     private static LogEntry Log(byte marker) =>
         new(TestItem.AddressB, [marker], [Keccak.Compute([marker])]);

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -99,13 +99,13 @@ public class FrameTxReceiptDecoderTests
         RlpReader reader = new(encoded);
         int length = reader.ReadSequenceLength();
         int count = 0;
-        (byte Status, ulong Gas, string Sender, LogEntry[] Logs)[] decoded = new (byte, ulong, string, LogEntry[])[3];
+        (byte Status, ulong Gas, string Sender, TxType Type, LogEntry[] Logs)[] decoded = new (byte, ulong, string, TxType, LogEntry[])[3];
         while (reader.Position < length)
         {
             decoder.DecodeStructRef(ref reader, RlpBehaviors.Storage, out TxReceiptStructRef current);
             if (count < decoded.Length)
             {
-                decoded[count] = (current.StatusCode, current.GasUsedTotal, current.Sender.ToString(), DecodeLogs(current.LogsRlp));
+                decoded[count] = (current.StatusCode, current.GasUsedTotal, current.Sender.ToString(), current.TxType, DecodeLogs(current.LogsRlp));
             }
             count++;
         }
@@ -114,15 +114,18 @@ public class FrameTxReceiptDecoderTests
 
         Assert.That(decoded[0].Sender, Is.EqualTo(before.Sender!.ToString()), "leading receipt sender");
         Assert.That(decoded[0].Gas, Is.EqualTo(before.GasUsedTotal), "leading receipt gas used total");
+        Assert.That(decoded[0].Type, Is.EqualTo(TxType.Legacy), "a receipt without the extension must not be labelled FrameTx");
 
         Assert.That(decoded[1].Status, Is.EqualTo(frameReceipt.StatusCode), "frame status");
         Assert.That(decoded[1].Gas, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
         Assert.That(decoded[1].Sender, Is.EqualTo(frameReceipt.Sender!.ToString()), "frame sender");
+        Assert.That(decoded[1].Type, Is.EqualTo(TxType.FrameTx), "the extension's presence identifies a frame-tx receipt");
         AssertLogsEqual(decoded[1].Logs, frameReceipt.Logs!);
 
         // The receipt after the frame tx must be intact, proving the reader realigned.
         Assert.That(decoded[2].Sender, Is.EqualTo(after.Sender!.ToString()), "trailing receipt sender");
         Assert.That(decoded[2].Gas, Is.EqualTo(after.GasUsedTotal), "trailing receipt gas used total");
+        Assert.That(decoded[2].Type, Is.EqualTo(TxType.Legacy));
     }
 
     private static LogEntry[] DecodeLogs(scoped ReadOnlySpan<byte> logsRlp)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -119,12 +119,8 @@ namespace Nethermind.Serialization.Rlp
             item.LogsRlp = decoderContext.Data.Slice(decoderContext.Position, logsBytes);
             decoderContext.SkipItem();
 
-            // EIP-8141: a frame-tx receipt carries a trailing extension (payer + per-frame
-            // receipts) after the logs sequence. The struct-ref path does not surface those
-            // fields, but it must still advance past them to receiptEnd — the boundary of this
-            // receipt's own sequence — so the next receipt in the array decodes from the right
-            // offset. For pre-fork receipts Position already equals receiptEnd, so this is a no-op.
-            // Presence of the extension marks a frame-tx receipt, matching the object decode path.
+            // EIP-8141: skip a frame-tx receipt's trailing extension (payer + per-frame receipts) so
+            // the next receipt in the array stays aligned. Pre-fork receipts already end here (no-op).
             if (decoderContext.Position < receiptEnd)
             {
                 item.TxType = TxType.FrameTx;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -119,9 +119,12 @@ namespace Nethermind.Serialization.Rlp
             item.LogsRlp = decoderContext.Data.Slice(decoderContext.Position, logsBytes);
             decoderContext.SkipItem();
 
-            // Handle any remaining extra bytes
-            bool allowExtraBytes = (rlpBehaviors & RlpBehaviors.AllowExtraBytes) != 0;
-            if (decoderContext.Position < receiptEnd && allowExtraBytes)
+            // EIP-8141: a frame-tx receipt carries a trailing extension (payer + per-frame
+            // receipts) after the logs sequence. The struct-ref path does not surface those
+            // fields, but it must still advance past them to receiptEnd — the boundary of this
+            // receipt's own sequence — so the next receipt in the array decodes from the right
+            // offset. For pre-fork receipts Position already equals receiptEnd, so this is a no-op.
+            if (decoderContext.Position < receiptEnd)
             {
                 decoderContext.Position = receiptEnd;
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -124,8 +124,10 @@ namespace Nethermind.Serialization.Rlp
             // fields, but it must still advance past them to receiptEnd — the boundary of this
             // receipt's own sequence — so the next receipt in the array decodes from the right
             // offset. For pre-fork receipts Position already equals receiptEnd, so this is a no-op.
+            // Presence of the extension marks a frame-tx receipt, matching the object decode path.
             if (decoderContext.Position < receiptEnd)
             {
+                item.TxType = TxType.FrameTx;
                 decoderContext.Position = receiptEnd;
             }
         }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -414,9 +414,7 @@ namespace Nethermind.Serialization.Rlp
             }
 
             // EIP-8141: always realign to the receipt's end so the next receipt in an array stays
-            // aligned, regardless of AllowExtraBytes (matches CompactReceiptStorageDecoder). For a
-            // frame tx this skips the trailing [payer, per-frame receipts]; TxType already came from
-            // the type prefix above, so it is not inferred here.
+            // aligned; for a frame tx this skips the trailing [payer, per-frame receipts].
             if (decoderContext.Position < receiptEnd)
             {
                 decoderContext.Position = receiptEnd;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -411,12 +411,15 @@ namespace Nethermind.Serialization.Rlp
                 {
                     item.Error = decoderContext.DecodeString();
                 }
+            }
 
-                // EIP-8141: skip the frame extension — ref-struct consumers only iterate logs.
-                if (decoderContext.Position < receiptEnd)
-                {
-                    decoderContext.Position = receiptEnd;
-                }
+            // EIP-8141: always realign to the receipt's end so the next receipt in an array stays
+            // aligned, regardless of AllowExtraBytes (matches CompactReceiptStorageDecoder). For a
+            // frame tx this skips the trailing [payer, per-frame receipts]; TxType already came from
+            // the type prefix above, so it is not inferred here.
+            if (decoderContext.Position < receiptEnd)
+            {
+                decoderContext.Position = receiptEnd;
             }
         }
 


### PR DESCRIPTION
## Changes

`CompactReceiptStorageDecoder.DecodeStructRef` did not advance the RLP reader past the **frame-tx receipt extension** — the trailing data (payer + per-frame receipts) that a `FrameTx` receipt appends after its logs sequence. The object-decode path already skips it, but the struct-ref path did not.

`ReceiptsIterator` (the `eth_getLogs` / receipt-retrieval read path) struct-ref-decodes the stored receipt array with `RlpBehaviors.Storage`, looping `DecodeStructRef` per receipt. Because the reader was left mid-extension after a frame-tx receipt, **every following receipt in the block decoded from the wrong offset** (and subsequent ones cascaded). Concretely, **any block containing a frame transaction that is not the last transaction would have returned corrupt/failed receipt and log retrieval** — not merely an isolated array-decode. A single receipt, or a block whose only frame tx is last, decoded fine, which is why the bug hid.

- Advance the struct-ref decoder past the frame-tx receipt extension, matching the object-decode path, so decoding stays aligned across a mixed receipt array.
- Make `ReceiptStorageDecoder.DecodeStructRef` (the legacy/non-compact path) realign to the receipt end **unconditionally**, so it no longer diverges from the compact fix and cannot reintroduce the bug if `AllowExtraBytes` were ever passed alongside `Storage`.
- Add a regression test that struct-ref-decodes an array of three receipts with a `FrameTx` receipt between two regular ones and asserts each decodes at the correct offset. It is parameterized over **both storage decoders** (`ReceiptsIterator` picks either at runtime) **and both `AllowExtraBytes` settings** — the two decoders guarded the realign on opposite conditions before this fix, so both dimensions are needed to truly pin it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] New regression test `FrameTxReceiptDecoderTests` — struct-ref decode over a mixed receipt array (regular, frame-tx, regular), across both storage decoders and both `AllowExtraBytes` settings; reverting either realign hunk turns it red.
- [x] Existing receipt-decoder, `ReceiptsIterator`, and `ReceiptsRecovery` tests unaffected.

## Documentation

- [ ] N/A — internal serialization fix, no user-facing surface.
