### PR TITLE
fix(jsonrpc): synchronise SubscriptionManager per-client subscription bag

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -1231,5 +1231,58 @@ namespace Nethermind.JsonRpc.Test.Modules
             string expectedResult = string.Concat("{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\",\"params\":{\"subscription\":\"", logsSubscription.Id, "\",\"result\":{\"address\":\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\",\"blockNumber\":\"0xd903\",\"blockTimestamp\":\"0xf4240\",\"data\":\"0x010203\",\"logIndex\":\"0x0\",\"removed\":true,\"topics\":[\"0x03783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760\"],\"transactionIndex\":\"0x0\"}}}");
             Assert.That(expectedResult, Is.EqualTo(serialized));
         }
+
+        [Test]
+        [Repeat(20)]
+        public async Task Concurrent_add_and_client_close_do_not_corrupt_the_bag()
+        {
+            ISubscriptionFactory factory = Substitute.For<ISubscriptionFactory>();
+            factory
+                .CreateSubscription(Arg.Any<IJsonRpcDuplexClient>(), Arg.Any<string>(), Arg.Any<string?>())
+                .Returns(ci => new NoopSubscription((IJsonRpcDuplexClient)ci[0]));
+            SubscriptionManager manager = new(factory, LimboLogs.Instance);
+
+            IJsonRpcDuplexClient client = Substitute.For<IJsonRpcDuplexClient>();
+            client.Id.Returns("concurrent-client");
+
+            const int adders = 8;
+            const int perAdder = 100;
+            ConcurrentQueue<Exception> failures = new();
+            using ManualResetEventSlim start = new();
+
+            Task Run(Action body) => Task.Run(() =>
+            {
+                start.Wait();
+                try { body(); }
+                catch (Exception e) { failures.Enqueue(e); }
+            });
+
+            List<Task> tasks = [];
+            for (int i = 0; i < adders; i++)
+            {
+                tasks.Add(Run(() =>
+                {
+                    for (int j = 0; j < perAdder; j++) manager.AddSubscription(client, "test");
+                }));
+            }
+            // Racing the enumerate-and-dispose path against the concurrent adds.
+            for (int i = 0; i < 4; i++)
+            {
+                tasks.Add(Run(() =>
+                {
+                    for (int j = 0; j < perAdder; j++) manager.RemoveClientSubscriptions(client);
+                }));
+            }
+
+            start.Set();
+            await Task.WhenAll(tasks);
+
+            Assert.That(failures, Is.Empty, () => string.Join(Environment.NewLine, failures));
+        }
+
+        private sealed class NoopSubscription(IJsonRpcDuplexClient jsonRpcDuplexClient) : Subscription(jsonRpcDuplexClient)
+        {
+            public override string Type => "test";
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -1234,7 +1234,7 @@ namespace Nethermind.JsonRpc.Test.Modules
 
         [Test]
         [Repeat(20)]
-        public async Task Concurrent_add_and_client_close_do_not_corrupt_the_bag()
+        public async Task Concurrent_add_unsubscribe_and_client_close_do_not_corrupt_the_bag()
         {
             ISubscriptionFactory factory = Substitute.For<ISubscriptionFactory>();
             factory
@@ -1257,12 +1257,24 @@ namespace Nethermind.JsonRpc.Test.Modules
                 catch (Exception e) { failures.Enqueue(e); }
             });
 
+            ConcurrentQueue<string> subscriptionIds = new();
             List<Task> tasks = [];
             for (int i = 0; i < adders; i++)
             {
                 tasks.Add(Run(() =>
                 {
-                    for (int j = 0; j < perAdder; j++) manager.AddSubscription(client, "test");
+                    for (int j = 0; j < perAdder; j++) subscriptionIds.Enqueue(manager.AddSubscription(client, "test"));
+                }));
+            }
+            // Racing the unsubscribe path against the concurrent adds.
+            for (int i = 0; i < 4; i++)
+            {
+                tasks.Add(Run(() =>
+                {
+                    for (int j = 0; j < perAdder; j++)
+                    {
+                        if (subscriptionIds.TryDequeue(out string? subscriptionId)) manager.RemoveSubscription(client, subscriptionId);
+                    }
                 }));
             }
             // Racing the enumerate-and-dispose path against the concurrent adds.

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionManager.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionManager.cs
@@ -15,6 +15,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private readonly ConcurrentDictionary<string, Subscription> _subscriptions =
             new();
+        // Bags are plain HashSets mutated from concurrent subscribe/unsubscribe/close; guard every access by locking the bag instance.
         private readonly ConcurrentDictionary<string, HashSet<Subscription>> _subscriptionsByJsonRpcClient =
             new();
 
@@ -54,8 +55,6 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
                 },
                 (k, b) =>
                 {
-                    // The bag is a plain HashSet; concurrent subscribe/unsubscribe/close on the same client
-                    // can otherwise mutate it from multiple threads at once. Lock on the bag for every access.
                     lock (b)
                     {
                         b.Add(subscription);
@@ -123,21 +122,18 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private void DisposeAndRemoveFromDictionary(HashSet<Subscription> subscriptionsBag)
         {
-            Subscription[] subscriptions;
             lock (subscriptionsBag)
             {
-                subscriptions = [.. subscriptionsBag];
-            }
-
-            foreach (Subscription subscriptionInBag in subscriptions)
-            {
-                if (_subscriptions.TryRemove(subscriptionInBag.Id, out Subscription subscription)
-                   && subscription is not null)
+                foreach (Subscription subscriptionInBag in subscriptionsBag)
                 {
-                    subscription.Dispose();
-                    if (_logger.IsTrace) _logger.Trace($"Subscription {subscription.Id} removed from dictionary _subscriptions.");
+                    if (_subscriptions.TryRemove(subscriptionInBag.Id, out Subscription subscription)
+                       && subscription is not null)
+                    {
+                        subscription.Dispose();
+                        if (_logger.IsTrace) _logger.Trace($"Subscription {subscription.Id} removed from dictionary _subscriptions.");
+                    }
+                    else if (_logger.IsDebug) _logger.Debug($"Failed trying to remove subscription {subscriptionInBag.Id} from dictionary _subscriptions.");
                 }
-                else if (_logger.IsDebug) _logger.Debug($"Failed trying to remove subscription {subscriptionInBag.Id} from dictionary _subscriptions.");
             }
         }
     }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionManager.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionManager.cs
@@ -54,7 +54,12 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
                 },
                 (k, b) =>
                 {
-                    b.Add(subscription);
+                    // The bag is a plain HashSet; concurrent subscribe/unsubscribe/close on the same client
+                    // can otherwise mutate it from multiple threads at once. Lock on the bag for every access.
+                    lock (b)
+                    {
+                        b.Add(subscription);
+                    }
                     if (_logger.IsTrace) _logger.Trace($"Subscription {subscription.Id} added to client's subscriptions bag.");
                     return b;
                 });
@@ -80,8 +85,16 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
             if (!_subscriptionsByJsonRpcClient.TryGetValue(subscription.JsonRpcDuplexClient.Id, out HashSet<Subscription> clientsSubscriptionsBag))
             {
                 if (_logger.IsDebug) _logger.Debug($"Failed trying to find subscription {subscription.Id} in subscriptions bag of client {subscription.JsonRpcDuplexClient.Id}.");
+                return;
             }
-            else if (!clientsSubscriptionsBag.Remove(subscription))
+
+            bool removed;
+            lock (clientsSubscriptionsBag)
+            {
+                removed = clientsSubscriptionsBag.Remove(subscription);
+            }
+
+            if (!removed)
             {
                 if (_logger.IsDebug) _logger.Debug($"Failed trying to remove subscription {subscription.Id} from client's subscriptions bag.");
             }
@@ -110,7 +123,13 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private void DisposeAndRemoveFromDictionary(HashSet<Subscription> subscriptionsBag)
         {
-            foreach (Subscription subscriptionInBag in subscriptionsBag)
+            Subscription[] subscriptions;
+            lock (subscriptionsBag)
+            {
+                subscriptions = [.. subscriptionsBag];
+            }
+
+            foreach (Subscription subscriptionInBag in subscriptions)
             {
                 if (_subscriptions.TryRemove(subscriptionInBag.Id, out Subscription subscription)
                    && subscription is not null)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionManager.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscriptionManager.cs
@@ -15,7 +15,6 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
 
         private readonly ConcurrentDictionary<string, Subscription> _subscriptions =
             new();
-        // Bags are plain HashSets mutated from concurrent subscribe/unsubscribe/close; guard every access by locking the bag instance.
         private readonly ConcurrentDictionary<string, HashSet<Subscription>> _subscriptionsByJsonRpcClient =
             new();
 


### PR DESCRIPTION
Fixes #12668

## Changes

- Synchronise access to each per-client subscription bag in `SubscriptionManager`. The bag is a `HashSet<Subscription>` stored as a `ConcurrentDictionary` value; `ConcurrentDictionary` makes the dictionary operations thread-safe but not mutations of the `HashSet` value itself. Concurrent subscribe (socket worker tasks), unsubscribe, and the `Closed` handler (fired from `JsonRpcSocketsClient.Dispose()` on connection teardown) could mutate/enumerate the same `HashSet` at once, corrupting it.
- Lock on the bag for `Add`, `Remove`, and take a snapshot under the lock before disposing on client close.

Corruption could drop a subscription from the bag so it was never disposed, leaving its event handler attached to `IBlockTree`/`ITxPool`/`IReceiptMonitor` and keeping the subscription, its channel and the duplex client rooted for the node's lifetime. Reachable by any JSON-RPC websocket/IPC client through subscribe + disconnect timing.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `Concurrent_add_and_client_close_do_not_corrupt_the_bag` (`[Repeat(20)]`) that races concurrent `AddSubscription` against `RemoveClientSubscriptions` for one client. It fails on master (throws from corrupted `HashSet` state) and passes with the fix. Full `SubscribeModuleTests` suite passes (53 tests).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
