### PR TITLE
Handle IPv6 enode text endpoints

### DIFF
--- a/src/Nethermind/Nethermind.Config.Test/EnodeTests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/EnodeTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.Config.Test/EnodeTests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/EnodeTests.cs
@@ -64,21 +64,23 @@ namespace Nethermind.Config.Test
             Assert.That(reparsed.HostIp, Is.EqualTo(IPAddress.Parse("192.168.2.54")));
         }
 
-        [Test]
-        public void info_brackets_native_ipv6_host()
+        [TestCase("fd00:beef:cafe::11", 30304, "@[fd00:beef:cafe::11]:30303?discport=30304")]
+        [TestCase("fd00:beef:cafe::11", 30303, "@[fd00:beef:cafe::11]:30303")]
+        [TestCase("::ffff:172.217.12.36", 30303, "@172.217.12.36:30303")]
+        public void info_formats_host_for_reparsing(string host, int discoveryPort, string expectedTail)
         {
             PublicKey publicKey = new("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
-            IPAddress ipv6 = IPAddress.Parse("fd00:beef:cafe::11");
-            Enode enode = new(publicKey, ipv6, 30303, 30304);
+            IPAddress hostIp = IPAddress.Parse(host);
+            Enode enode = new(publicKey, hostIp, 30303, discoveryPort);
 
-            Assert.That(enode.Info, Does.Contain("@[fd00:beef:cafe::11]:30303"));
+            Assert.That(enode.Info, Does.EndWith(expectedTail));
             Assert.That(Enode.IsEnode(enode.Info, out _), Is.True);
             Enode reparsed = new(enode.Info);
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(reparsed.HostIp, Is.EqualTo(ipv6));
+                Assert.That(reparsed.HostIp, Is.EqualTo(hostIp.IsIPv4MappedToIPv6 ? hostIp.MapToIPv4() : hostIp));
                 Assert.That(reparsed.Port, Is.EqualTo(30303));
-                Assert.That(reparsed.DiscoveryPort, Is.EqualTo(30304));
+                Assert.That(reparsed.DiscoveryPort, Is.EqualTo(discoveryPort));
             }
         }
 
@@ -101,33 +103,15 @@ namespace Nethermind.Config.Test
 
         [TestCase("/junk")]
         [TestCase("#?discport=30304")]
-        public void rejects_enode_with_unexpected_path_or_fragment(string suffix)
+        [TestCase("?discport=-1")]
+        [TestCase("?discport=65536")]
+        [TestCase("?discport=+30304")]
+        public void rejects_malformed_enode_suffix(string suffix)
         {
             PublicKey publicKey = new("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
 
             Assert.That(
                 () => new Enode($"enode://{publicKey.ToString(false)}@127.0.0.1:30303{suffix}"),
-                Throws.ArgumentException);
-        }
-
-        [TestCase(-1)]
-        [TestCase(65536)]
-        public void rejects_discovery_port_out_of_range(int discoveryPort)
-        {
-            PublicKey publicKey = new("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
-
-            Assert.That(
-                () => new Enode($"enode://{publicKey.ToString(false)}@127.0.0.1:30303?discport={discoveryPort}"),
-                Throws.ArgumentException);
-        }
-
-        [TestCase("+30304")]
-        public void rejects_discovery_port_with_non_decimal_format(string discoveryPort)
-        {
-            PublicKey publicKey = new("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
-
-            Assert.That(
-                () => new Enode($"enode://{publicKey.ToString(false)}@127.0.0.1:30303?discport={discoveryPort}"),
                 Throws.ArgumentException);
         }
 

--- a/src/Nethermind/Nethermind.Config.Test/EnodeTests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/EnodeTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -99,6 +99,28 @@ namespace Nethermind.Config.Test
             }
         }
 
+        [TestCase("/junk")]
+        [TestCase("#?discport=30304")]
+        public void rejects_enode_with_unexpected_path_or_fragment(string suffix)
+        {
+            PublicKey publicKey = new("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
+
+            Assert.That(
+                () => new Enode($"enode://{publicKey.ToString(false)}@127.0.0.1:30303{suffix}"),
+                Throws.ArgumentException);
+        }
+
+        [TestCase(-1)]
+        [TestCase(65536)]
+        public void rejects_discovery_port_out_of_range(int discoveryPort)
+        {
+            PublicKey publicKey = new("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
+
+            Assert.That(
+                () => new Enode($"enode://{publicKey.ToString(false)}@127.0.0.1:30303?discport={discoveryPort}"),
+                Throws.ArgumentException);
+        }
+
         public static IEnumerable Ipv4vs6TestCases
         {
             get
@@ -106,10 +128,13 @@ namespace Nethermind.Config.Test
                 IPAddress ipv6_1 = IPAddress.Parse("2607:f8b0:4002:c02::6a");
                 IPAddress ipv6_2 = IPAddress.Parse("2607:f8b0:4002:c02::67");
                 IPAddress ipv4 = IPAddress.Parse("172.217.12.36");
+                IPAddress ipv4Mapped = IPAddress.Parse("::ffff:172.217.12.36");
                 yield return new TestCaseData(new object[] { new[] { ipv4 } }).Returns(ipv4);
                 yield return new TestCaseData(new object[] { new[] { ipv6_1, ipv6_2, ipv4 } }).Returns(ipv4);
                 yield return new TestCaseData(new object[] { new[] { ipv4, ipv6_1, ipv6_2 } }).Returns(ipv4);
                 yield return new TestCaseData(new object[] { new[] { ipv6_1, ipv6_2 } }).Returns(ipv6_1);
+                yield return new TestCaseData(new object[] { new[] { ipv4Mapped } }).Returns(ipv4);
+                yield return new TestCaseData(new object[] { new[] { ipv6_1, ipv4Mapped } }).Returns(ipv4);
             }
         }
 

--- a/src/Nethermind/Nethermind.Config.Test/EnodeTests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/EnodeTests.cs
@@ -64,6 +64,41 @@ namespace Nethermind.Config.Test
             Assert.That(reparsed.HostIp, Is.EqualTo(IPAddress.Parse("192.168.2.54")));
         }
 
+        [Test]
+        public void info_brackets_native_ipv6_host()
+        {
+            PublicKey publicKey = new("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
+            IPAddress ipv6 = IPAddress.Parse("fd00:beef:cafe::11");
+            Enode enode = new(publicKey, ipv6, 30303, 30304);
+
+            Assert.That(enode.Info, Does.Contain("@[fd00:beef:cafe::11]:30303"));
+            Assert.That(Enode.IsEnode(enode.Info, out _), Is.True);
+            Enode reparsed = new(enode.Info);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(reparsed.HostIp, Is.EqualTo(ipv6));
+                Assert.That(reparsed.Port, Is.EqualTo(30303));
+                Assert.That(reparsed.DiscoveryPort, Is.EqualTo(30304));
+            }
+        }
+
+        [Test]
+        public void can_parse_bracketed_native_ipv6_host()
+        {
+            PublicKey publicKey = new("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
+            IPAddress ipv6 = IPAddress.Parse("fd00:beef:cafe::11");
+
+            Enode enode = new($"enode://{publicKey.ToString(false)}@[fd00:beef:cafe::11]:30303?discport=30304");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(enode.HostIp, Is.EqualTo(ipv6));
+                Assert.That(enode.Port, Is.EqualTo(30303));
+                Assert.That(enode.DiscoveryPort, Is.EqualTo(30304));
+                Assert.That(enode.PublicKey, Is.EqualTo(publicKey));
+            }
+        }
+
         public static IEnumerable Ipv4vs6TestCases
         {
             get
@@ -74,7 +109,7 @@ namespace Nethermind.Config.Test
                 yield return new TestCaseData(new object[] { new[] { ipv4 } }).Returns(ipv4);
                 yield return new TestCaseData(new object[] { new[] { ipv6_1, ipv6_2, ipv4 } }).Returns(ipv4);
                 yield return new TestCaseData(new object[] { new[] { ipv4, ipv6_1, ipv6_2 } }).Returns(ipv4);
-                yield return new TestCaseData(new object[] { new[] { ipv6_1, ipv6_2 } }).Returns(ipv6_1.MapToIPv4());
+                yield return new TestCaseData(new object[] { new[] { ipv6_1, ipv6_2 } }).Returns(ipv6_1);
             }
         }
 

--- a/src/Nethermind/Nethermind.Config.Test/EnodeTests.cs
+++ b/src/Nethermind/Nethermind.Config.Test/EnodeTests.cs
@@ -121,6 +121,16 @@ namespace Nethermind.Config.Test
                 Throws.ArgumentException);
         }
 
+        [TestCase("+30304")]
+        public void rejects_discovery_port_with_non_decimal_format(string discoveryPort)
+        {
+            PublicKey publicKey = new("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f");
+
+            Assert.That(
+                () => new Enode($"enode://{publicKey.ToString(false)}@127.0.0.1:30303?discport={discoveryPort}"),
+                Throws.ArgumentException);
+        }
+
         public static IEnumerable Ipv4vs6TestCases
         {
             get

--- a/src/Nethermind/Nethermind.Config/Enode.cs
+++ b/src/Nethermind/Nethermind.Config/Enode.cs
@@ -16,6 +16,7 @@ namespace Nethermind.Config
     {
         private const string DiscoveryPortQuery = "?discport=";
         private readonly PublicKey _nodeKey;
+        private string? _info;
 
         public Enode(PublicKey nodeKey, IPAddress hostIp, int port, int? discoveryPort = null)
         {
@@ -51,7 +52,7 @@ namespace Nethermind.Config
 
             if (parsed.AbsolutePath is not "/" || parsed.Fragment.Length > 0)
             {
-                throw GetInvalidEnodeException();
+                throw new ArgumentException($"Unexpected path or fragment in enode value '{enodeString}'.");
             }
 
             Port = parsed.Port;
@@ -111,20 +112,22 @@ namespace Nethermind.Config
         public IPAddress HostIp { get; }
         public int Port { get; }
         public int DiscoveryPort { get; }
-        public string Info => DiscoveryPort == Port
+        public string Info => _info ??= DiscoveryPort == Port
             ? $"enode://{_nodeKey.ToString(false)}@{FormattedHost}:{Port}"
             : $"enode://{_nodeKey.ToString(false)}@{FormattedHost}:{Port}{DiscoveryPortQuery}{DiscoveryPort}";
 
         public override string ToString() => Info;
 
-        private string FormattedHost
+        /// <summary>
+        /// Formats an IP address as an enode host: native IPv6 is bracketed and IPv4-mapped IPv6 is normalized to plain IPv4.
+        /// </summary>
+        public static string FormatEnodeHost(IPAddress hostIp)
         {
-            get
-            {
-                IPAddress hostIp = HostIp.IsIPv4MappedToIPv6 ? HostIp.MapToIPv4() : HostIp;
-                return hostIp.AddressFamily == AddressFamily.InterNetworkV6 ? $"[{hostIp}]" : hostIp.ToString();
-            }
+            IPAddress normalized = hostIp.IsIPv4MappedToIPv6 ? hostIp.MapToIPv4() : hostIp;
+            return normalized.AddressFamily == AddressFamily.InterNetworkV6 ? $"[{normalized}]" : normalized.ToString();
         }
+
+        private string FormattedHost => FormatEnodeHost(HostIp);
 
         public static bool IsEnode(string enodeString, [NotNullWhen(true)] out Uri? parsed) =>
             Uri.TryCreate(enodeString, new UriCreationOptions(), out parsed) && parsed.Scheme.Equals("enode", StringComparison.OrdinalIgnoreCase);

--- a/src/Nethermind/Nethermind.Config/Enode.cs
+++ b/src/Nethermind/Nethermind.Config/Enode.cs
@@ -6,7 +6,6 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 
@@ -37,38 +36,27 @@ namespace Nethermind.Config
                 throw new ArgumentException($"Invalid enode value '{enodeString}'");
             }
 
-            string[] enodeParts = enodeString.Split(':');
-            string[] enodeParts2 = enodeParts[1].Split('@');
             _nodeKey = new PublicKey(parsed.UserInfo);
-            string host = parsed.Host;
+            string host = TrimIpV6Brackets(parsed.Host);
 
             if (parsed.Port == -1)
             {
                 throw GetPortException(host);
             }
 
-            string[] portParts = enodeParts[2].Split("?discport=");
-
-            switch (portParts.Length)
+            Port = parsed.Port;
+            if (parsed.Query.Length == 0)
             {
-                case 1:
-                    if (int.TryParse(portParts[0], out int port))
-                    {
-                        Port = port;
-                        DiscoveryPort = port;
-                    }
-                    else throw GetPortException(host);
-                    break;
-                case 2:
-                    if (int.TryParse(portParts[0], out int listeningPort) && int.TryParse(portParts[1], out int discoveryPort))
-                    {
-                        Port = listeningPort;
-                        DiscoveryPort = discoveryPort;
-                    }
-                    else throw GetPortException(host);
-                    break;
-                default:
-                    throw GetPortException(host);
+                DiscoveryPort = Port;
+            }
+            else if (parsed.Query.StartsWith("?discport=", StringComparison.Ordinal) &&
+                     int.TryParse(parsed.Query["?discport=".Length..], out int discoveryPort))
+            {
+                DiscoveryPort = discoveryPort;
+            }
+            else
+            {
+                throw GetPortException(host);
             }
 
             try
@@ -85,16 +73,22 @@ namespace Nethermind.Config
 
         public static IPAddress? GetHostIpFromDnsAddresses(params IPAddress[] hostAddresses)
         {
+            IPAddress? mappedIpv4 = null;
             for (int index = 0; index < hostAddresses.Length; index++)
             {
                 IPAddress hostAddress = hostAddresses[index];
-                if (Equals(hostAddress, hostAddress.MapToIPv4()))
+                if (hostAddress.AddressFamily == AddressFamily.InterNetwork)
                 {
                     return hostAddress;
                 }
+
+                if (hostAddress.IsIPv4MappedToIPv6 && mappedIpv4 is null)
+                {
+                    mappedIpv4 = hostAddress.MapToIPv4();
+                }
             }
 
-            return hostAddresses.FirstOrDefault()?.MapToIPv4();
+            return mappedIpv4 ?? (hostAddresses.Length == 0 ? null : hostAddresses[0]);
         }
 
         public PublicKey PublicKey => _nodeKey;
@@ -103,14 +97,26 @@ namespace Nethermind.Config
         public int Port { get; }
         public int DiscoveryPort { get; }
         public string Info => DiscoveryPort == Port
-            ? $"enode://{_nodeKey.ToString(false)}@{FormattedHostIp}:{Port}"
-            : $"enode://{_nodeKey.ToString(false)}@{FormattedHostIp}:{Port}?discport={DiscoveryPort}";
+            ? $"enode://{_nodeKey.ToString(false)}@{FormattedHost}:{Port}"
+            : $"enode://{_nodeKey.ToString(false)}@{FormattedHost}:{Port}?discport={DiscoveryPort}";
 
         public override string ToString() => Info;
 
-        private IPAddress FormattedHostIp => HostIp.IsIPv4MappedToIPv6 ? HostIp.MapToIPv4() : HostIp;
+        private string FormattedHost
+        {
+            get
+            {
+                IPAddress hostIp = HostIp.IsIPv4MappedToIPv6 ? HostIp.MapToIPv4() : HostIp;
+                return hostIp.AddressFamily == AddressFamily.InterNetworkV6 ? $"[{hostIp}]" : hostIp.ToString();
+            }
+        }
 
         public static bool IsEnode(string enodeString, [NotNullWhen(true)] out Uri? parsed) =>
             Uri.TryCreate(enodeString, new UriCreationOptions(), out parsed) && parsed.Scheme.Equals("enode", StringComparison.OrdinalIgnoreCase);
+
+        private static string TrimIpV6Brackets(string host) =>
+            host.Length > 1 && host[0] == '[' && host[^1] == ']'
+                ? host[1..^1]
+                : host;
     }
 }

--- a/src/Nethermind/Nethermind.Config/Enode.cs
+++ b/src/Nethermind/Nethermind.Config/Enode.cs
@@ -13,6 +13,7 @@ namespace Nethermind.Config
 {
     public class Enode : IEnode
     {
+        private const string DiscoveryPortQuery = "?discport=";
         private readonly PublicKey _nodeKey;
 
         public Enode(PublicKey nodeKey, IPAddress hostIp, int port, int? discoveryPort = null)
@@ -37,9 +38,14 @@ namespace Nethermind.Config
             }
 
             _nodeKey = new PublicKey(parsed.UserInfo);
-            string host = TrimIpV6Brackets(parsed.Host);
+            string host = parsed.DnsSafeHost;
 
             if (parsed.Port == -1)
+            {
+                throw GetPortException(host);
+            }
+
+            if (parsed.AbsolutePath is not "/" || parsed.Fragment.Length > 0)
             {
                 throw GetPortException(host);
             }
@@ -49,8 +55,8 @@ namespace Nethermind.Config
             {
                 DiscoveryPort = Port;
             }
-            else if (parsed.Query.StartsWith("?discport=", StringComparison.Ordinal) &&
-                     int.TryParse(parsed.Query["?discport=".Length..], out int discoveryPort))
+            else if (parsed.Query.StartsWith(DiscoveryPortQuery, StringComparison.Ordinal) &&
+                     ushort.TryParse(parsed.Query[DiscoveryPortQuery.Length..], out ushort discoveryPort))
             {
                 DiscoveryPort = discoveryPort;
             }
@@ -88,7 +94,7 @@ namespace Nethermind.Config
                 }
             }
 
-            return mappedIpv4 ?? (hostAddresses.Length == 0 ? null : hostAddresses[0]);
+            return mappedIpv4 ?? (hostAddresses.Length > 0 ? hostAddresses[0] : null);
         }
 
         public PublicKey PublicKey => _nodeKey;
@@ -113,10 +119,5 @@ namespace Nethermind.Config
 
         public static bool IsEnode(string enodeString, [NotNullWhen(true)] out Uri? parsed) =>
             Uri.TryCreate(enodeString, new UriCreationOptions(), out parsed) && parsed.Scheme.Equals("enode", StringComparison.OrdinalIgnoreCase);
-
-        private static string TrimIpV6Brackets(string host) =>
-            host.Length > 1 && host[0] == '[' && host[^1] == ']'
-                ? host[1..^1]
-                : host;
     }
 }

--- a/src/Nethermind/Nethermind.Config/Enode.cs
+++ b/src/Nethermind/Nethermind.Config/Enode.cs
@@ -62,13 +62,11 @@ namespace Nethermind.Config
             {
                 throw GetInvalidEnodeException();
             }
-            else if (!ushort.TryParse(parsed.Query[DiscoveryPortQuery.Length..], out ushort discoveryPort))
-            {
-                throw GetPortException(host);
-            }
             else
             {
-                DiscoveryPort = discoveryPort;
+                DiscoveryPort = ushort.TryParse(parsed.Query[DiscoveryPortQuery.Length..], out ushort discoveryPort)
+                    ? discoveryPort
+                    : throw GetPortException(host);
             }
 
             try

--- a/src/Nethermind/Nethermind.Config/Enode.cs
+++ b/src/Nethermind/Nethermind.Config/Enode.cs
@@ -26,6 +26,9 @@ namespace Nethermind.Config
 
         public Enode(string enodeString)
         {
+            ArgumentException GetInvalidEnodeException() =>
+                new($"Invalid enode value '{enodeString}'");
+
             ArgumentException GetDnsException(string hostName, Exception? innerException = null) =>
                 new($"{hostName} is not a proper IP address nor it can be resolved by DNS.", innerException);
 
@@ -34,7 +37,7 @@ namespace Nethermind.Config
 
             if (!IsEnode(enodeString, out Uri? parsed))
             {
-                throw new ArgumentException($"Invalid enode value '{enodeString}'");
+                throw GetInvalidEnodeException();
             }
 
             _nodeKey = new PublicKey(parsed.UserInfo);
@@ -47,7 +50,7 @@ namespace Nethermind.Config
 
             if (parsed.AbsolutePath is not "/" || parsed.Fragment.Length > 0)
             {
-                throw GetPortException(host);
+                throw GetInvalidEnodeException();
             }
 
             Port = parsed.Port;

--- a/src/Nethermind/Nethermind.Config/Enode.cs
+++ b/src/Nethermind/Nethermind.Config/Enode.cs
@@ -6,6 +6,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
 
@@ -64,7 +65,11 @@ namespace Nethermind.Config
             }
             else
             {
-                DiscoveryPort = ushort.TryParse(parsed.Query[DiscoveryPortQuery.Length..], out ushort discoveryPort)
+                DiscoveryPort = ushort.TryParse(
+                    parsed.Query[DiscoveryPortQuery.Length..],
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out ushort discoveryPort)
                     ? discoveryPort
                     : throw GetPortException(host);
             }

--- a/src/Nethermind/Nethermind.Config/Enode.cs
+++ b/src/Nethermind/Nethermind.Config/Enode.cs
@@ -58,14 +58,17 @@ namespace Nethermind.Config
             {
                 DiscoveryPort = Port;
             }
-            else if (parsed.Query.StartsWith(DiscoveryPortQuery, StringComparison.Ordinal) &&
-                     ushort.TryParse(parsed.Query[DiscoveryPortQuery.Length..], out ushort discoveryPort))
+            else if (!parsed.Query.StartsWith(DiscoveryPortQuery, StringComparison.Ordinal))
             {
-                DiscoveryPort = discoveryPort;
+                throw GetInvalidEnodeException();
+            }
+            else if (!ushort.TryParse(parsed.Query[DiscoveryPortQuery.Length..], out ushort discoveryPort))
+            {
+                throw GetPortException(host);
             }
             else
             {
-                throw GetPortException(host);
+                DiscoveryPort = discoveryPort;
             }
 
             try
@@ -107,7 +110,7 @@ namespace Nethermind.Config
         public int DiscoveryPort { get; }
         public string Info => DiscoveryPort == Port
             ? $"enode://{_nodeKey.ToString(false)}@{FormattedHost}:{Port}"
-            : $"enode://{_nodeKey.ToString(false)}@{FormattedHost}:{Port}?discport={DiscoveryPort}";
+            : $"enode://{_nodeKey.ToString(false)}@{FormattedHost}:{Port}{DiscoveryPortQuery}{DiscoveryPort}";
 
         public override string ToString() => Info;
 

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -21,6 +21,7 @@ namespace Nethermind.Stats.Model
     public sealed class Node : IFormattable, IEquatable<Node>
     {
         private string _clientId;
+        private string _enodeHost;
         private string _paddedHost;
         private string _paddedPort;
         private ulong _requestingEnrSequence;
@@ -297,6 +298,7 @@ namespace Nethermind.Stats.Model
         {
             Address = address;
             _host = null;
+            _enodeHost = null;
             _paddedHost = null;
             _paddedPort = null;
             _discoveryAddress = null;
@@ -354,7 +356,7 @@ namespace Nethermind.Stats.Model
 
         // xxx.xxx.xxx.xxx = 15
         private string PaddedHost => _paddedHost ??= Host.PadLeft(15, ' ');
-        private string EnodeHost => Address.Address.AddressFamily == AddressFamily.InterNetworkV6 && !Address.Address.IsIPv4MappedToIPv6
+        private string EnodeHost => _enodeHost ??= Address.Address.AddressFamily == AddressFamily.InterNetworkV6 && !Address.Address.IsIPv4MappedToIPv6
             ? $"[{Host}]"
             : Host;
 

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Text.RegularExpressions;
 using System.Threading;
 using FastEnumUtility;
@@ -353,6 +354,10 @@ namespace Nethermind.Stats.Model
 
         // xxx.xxx.xxx.xxx = 15
         private string PaddedHost => _paddedHost ??= Host.PadLeft(15, ' ');
+        private string EnodeHost => Address.Address.AddressFamily == AddressFamily.InterNetworkV6 && !Address.Address.IsIPv4MappedToIPv6
+            ? $"[{Host}]"
+            : Host;
+
         private string PaddedPort
         {
             get
@@ -392,10 +397,10 @@ namespace Nethermind.Stats.Model
             Format.Short => $"{Host}:{Port}",
             Format.AlignedShort => $"{PaddedHost}:{PaddedPort}",
             Format.Console => $"[Node|{Host}:{Port}|{EthDetails}|{ClientId}]",
-            Format.WithId => $"enode://{Id.ToString(false)}@{Host}:{Port}|{ClientId}",
-            Format.ENode => $"enode://{Id.ToString(false)}@{Host}:{Port}",
-            Format.WithPublicKey => $"enode://{Id.ToString(false)}@{Host}:{Port}|{Id.Address}",
-            _ => $"enode://{Id.ToString(false)}@{Host}:{Port}"
+            Format.WithId => $"enode://{Id.ToString(false)}@{EnodeHost}:{Port}|{ClientId}",
+            Format.ENode => $"enode://{Id.ToString(false)}@{EnodeHost}:{Port}",
+            Format.WithPublicKey => $"enode://{Id.ToString(false)}@{EnodeHost}:{Port}|{Id.Address}",
+            _ => $"enode://{Id.ToString(false)}@{EnodeHost}:{Port}"
         };
 
         public bool Equals(Node other)

--- a/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/Model/Node.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
-using System.Net.Sockets;
 using System.Text.RegularExpressions;
 using System.Threading;
 using FastEnumUtility;
@@ -198,6 +197,10 @@ namespace Nethermind.Stats.Model
                     ClearDiscoveryEndpoint();
                 }
             }
+            else if (networkNode.DiscoveryPort == 0)
+            {
+                ClearDiscoveryEndpoint();
+            }
             else if (networkNode.DiscoveryPort != networkNode.Port)
             {
                 DiscoveryPort = networkNode.DiscoveryPort;
@@ -356,9 +359,7 @@ namespace Nethermind.Stats.Model
 
         // xxx.xxx.xxx.xxx = 15
         private string PaddedHost => _paddedHost ??= Host.PadLeft(15, ' ');
-        private string EnodeHost => _enodeHost ??= Address.Address.AddressFamily == AddressFamily.InterNetworkV6 && !Address.Address.IsIPv4MappedToIPv6
-            ? $"[{Host}]"
-            : Host;
+        private string EnodeHost => _enodeHost ??= Enode.FormatEnodeHost(Address.Address);
 
         private string PaddedPort
         {

--- a/src/Nethermind/Nethermind.Network.Test/NetworkNodeDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NetworkNodeDecoderTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Config;

--- a/src/Nethermind/Nethermind.Network.Test/NetworkNodeDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NetworkNodeDecoderTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Config;
@@ -58,21 +58,11 @@ namespace Nethermind.Network.Test
             }
         }
 
-        [Test]
-        public void Can_do_enode_with_discovery_port_roundtrip()
+        [TestCase("8.8.8.8")]
+        [TestCase("fd00:beef:cafe::11")]
+        public void Can_do_enode_with_discovery_port_roundtrip(string host)
         {
-            NetworkNode node = new(new Enode(TestItem.PublicKeyA, IPAddress.Parse("8.8.8.8"), 30303, 30304))
-            {
-                Reputation = 100L
-            };
-
-            AssertRoundtripPreservesFields(node);
-        }
-
-        [Test]
-        public void Can_do_ipv6_enode_with_discovery_port_roundtrip()
-        {
-            NetworkNode node = new(new Enode(TestItem.PublicKeyA, IPAddress.Parse("fd00:beef:cafe::11"), 30303, 30304))
+            NetworkNode node = new(new Enode(TestItem.PublicKeyA, IPAddress.Parse(host), 30303, 30304))
             {
                 Reputation = 100L
             };

--- a/src/Nethermind/Nethermind.Network.Test/NetworkNodeDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NetworkNodeDecoderTests.cs
@@ -70,6 +70,17 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
+        public void Can_do_ipv6_enode_with_discovery_port_roundtrip()
+        {
+            NetworkNode node = new(new Enode(TestItem.PublicKeyA, IPAddress.Parse("fd00:beef:cafe::11"), 30303, 30304))
+            {
+                Reputation = 100L
+            };
+
+            AssertRoundtripPreservesFields(node);
+        }
+
+        [Test]
         public void Can_do_enr_roundtrip()
         {
             NetworkNodeDecoder networkNodeDecoder = new();

--- a/src/Nethermind/Nethermind.Network.Test/NetworkNodePortTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NetworkNodePortTests.cs
@@ -44,6 +44,15 @@ public class NetworkNodePortTests
         Assert.That(node.Port, Is.EqualTo(30303));
     }
 
+    [Test]
+    public void Node_created_from_enode_with_zero_discport_has_no_discovery_endpoint()
+    {
+        NetworkNode networkNode = new($"enode://{TestItem.PublicKeyA.ToString(false)}@192.0.2.1:30303?discport=0");
+        Node node = new(networkNode);
+
+        Assert.That(node.HasDiscoveryEndpoint, Is.False);
+    }
+
     [TestCase("enode://{0}@192.0.2.1:30303", 30303, 30303)]
     [TestCase("enode://{0}@192.0.2.1:30303?discport=30301", 30303, 30301)]
     [TestCase("enode://{0}@192.0.2.1:0?discport=30301", 0, 30301)]

--- a/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
@@ -204,19 +204,20 @@ namespace Nethermind.Network.Test.Stats
             Assert.That(node.ToString(format), Is.EqualTo(expectedFormat));
         }
 
-        [Test]
-        public void To_string_brackets_native_ipv6_enode_host()
+        [TestCase("fd00:beef:cafe::11", "@[fd00:beef:cafe::11]:30303", "fd00:beef:cafe::11")]
+        [TestCase("::ffff:172.217.12.36", "@172.217.12.36:30303", "172.217.12.36")]
+        public void To_string_brackets_native_ipv6_enode_host(string host, string expectedTail, string expectedReparsedHost)
         {
-            Node node = new(TestItem.PublicKeyA, "fd00:beef:cafe::11", 30303);
+            Node node = new(TestItem.PublicKeyA, host, 30303);
 
             string enode = node.ToString(Node.Format.ENode);
 
-            Assert.That(enode, Does.Contain("@[fd00:beef:cafe::11]:30303"));
+            Assert.That(enode, Does.Contain(expectedTail));
             Assert.That(Enode.IsEnode(enode, out _), Is.True);
             Enode reparsed = new(enode);
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(reparsed.HostIp, Is.EqualTo(IPAddress.Parse("fd00:beef:cafe::11")));
+                Assert.That(reparsed.HostIp, Is.EqualTo(IPAddress.Parse(expectedReparsedHost)));
                 Assert.That(reparsed.Port, Is.EqualTo(30303));
             }
         }

--- a/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Stats/NodeTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using Nethermind.Config;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Network.Enr;
@@ -201,6 +202,23 @@ namespace Nethermind.Network.Test.Stats
 
             node = GetNode("::ffff:127.0.0.1");
             Assert.That(node.ToString(format), Is.EqualTo(expectedFormat));
+        }
+
+        [Test]
+        public void To_string_brackets_native_ipv6_enode_host()
+        {
+            Node node = new(TestItem.PublicKeyA, "fd00:beef:cafe::11", 30303);
+
+            string enode = node.ToString(Node.Format.ENode);
+
+            Assert.That(enode, Does.Contain("@[fd00:beef:cafe::11]:30303"));
+            Assert.That(Enode.IsEnode(enode, out _), Is.True);
+            Enode reparsed = new(enode);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(reparsed.HostIp, Is.EqualTo(IPAddress.Parse("fd00:beef:cafe::11")));
+                Assert.That(reparsed.Port, Is.EqualTo(30303));
+            }
         }
 
         [Test]


### PR DESCRIPTION
## Changes

- Bracket native IPv6 hosts when emitting `enode://` URI strings.
- Parse bracketed native IPv6 enodes through URI host, port, and query fields instead of splitting the full string on `:`.
- Preserve native IPv6 DNS results when no IPv4 address is available, while still preferring IPv4 when present.
- Add regression coverage for enode parsing/formatting, persisted `NetworkNode` round-trips, and `Node.Format.ENode` output.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Targeted Config and Network regression tests passed. The Nethermind solution builds with warnings as errors after restore.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No