### PR TITLE
ci: disable stateless glamsterdam-devnet-7 scheduled run

### DIFF
--- a/.github/workflows/stateless-glamsterdam-devnet-tests.yml
+++ b/.github/workflows/stateless-glamsterdam-devnet-tests.yml
@@ -1,8 +1,8 @@
 name: Stateless glamsterdam-devnet tests
 
 on:
-  schedule:
-    - cron: '12 */12 * * *'
+  # schedule:
+  #   - cron: '12 */12 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Changes

Temporarily disabled the glamsterdam-devnet-7 stateless tests run on schedule since the test sources no longer serviced.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: CI update

## Testing

#### Requires testing

- [ ] Yes
- [x] No
