### PR TITLE
perf(state): auto-scale FlatDb.BlockCacheSizeBudget with system memory

### DIFF
--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -22,7 +22,7 @@ public class FlatDbConfig : IFlatDbConfig
     public long PersistenceWriteBufferFloor { get; set; } = 16.MiB;
     public int TrieWarmerWorkerCount { get; set; } = -1;
     public int WarmReadConcurrency { get; set; } = -1;
-    public ulong BlockCacheSizeBudget { get; set; } = 1UL.GiB;
+    public ulong BlockCacheSizeBudget { get; set; } = 0;
     public long CompactionOffset { get; set; } = -1;
     public ulong TrieCacheMemoryBudget { get; set; } = 512UL.MiB;
     public bool EnableLongFinality { get; set; } = true;

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -7,7 +7,7 @@ namespace Nethermind.Db;
 
 public interface IFlatDbConfig : IConfig
 {
-    [ConfigItem(Description = "Block cache size budget", DefaultValue = "1073741824")]
+    [ConfigItem(Description = "Block cache size budget in bytes for the flat state columns. 0 to auto-scale to system memory / 8, clamped between 1 GiB and 32 GiB. Explicit values are used as-is.", DefaultValue = "0")]
     ulong BlockCacheSizeBudget { get; set; }
 
     [ConfigItem(Description = "Fixed compaction schedule offset in blocks. When 0 or greater, overrides the per-instance offset in the metadata DB, which is neither read nor updated. Only the value modulo CompactSize matters. -1 to use the stored offset, generating a random one when absent.", DefaultValue = "-1")]

--- a/src/Nethermind/Nethermind.Init/Modules/FlatRocksDbConfigAdjuster.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatRocksDbConfigAdjuster.cs
@@ -18,11 +18,35 @@ namespace Nethermind.Init.Modules;
 internal class FlatRocksDbConfigAdjuster(
     IRocksDbConfigFactory rocksDbConfigFactory,
     IFlatDbConfig flatDbConfig,
+    IHardwareInfo hardwareInfo,
     IDisposableStack disposeStack,
     ILogManager logManager)
     : IRocksDbConfigFactory
 {
+    private const int AutoScaleMemoryDivisor = 8;
+    private static readonly ulong AutoScaleFloor = 1UL.GiB;
+    private static readonly ulong AutoScaleCap = 32UL.GiB;
+
     private readonly ILogger _logger = logManager.GetClassLogger<FlatRocksDbConfigAdjuster>();
+    private ulong? _blockCacheSizeBudget;
+
+    internal ulong BlockCacheSizeBudget => _blockCacheSizeBudget ??= ResolveBlockCacheSizeBudget();
+
+    private ulong ResolveBlockCacheSizeBudget()
+    {
+        ulong totalMemory = (ulong)Math.Max(hardwareInfo.AvailableMemoryBytes, 0);
+        ulong configured = flatDbConfig.BlockCacheSizeBudget;
+        if (configured != 0)
+        {
+            if (configured > totalMemory / 2 && _logger.IsWarn)
+                _logger.Warn($"Flat db block cache budget of {configured / 1UL.MiB:N0} MB exceeds half of the {totalMemory / 1UL.MiB:N0} MB of system memory");
+            return configured;
+        }
+
+        ulong budget = Math.Clamp(totalMemory / AutoScaleMemoryDivisor, AutoScaleFloor, AutoScaleCap);
+        if (_logger.IsInfo) _logger.Info($"Auto-scaled flat db block cache budget to {budget / 1UL.MiB:N0} MB based on {totalMemory / 1UL.MiB:N0} MB of system memory");
+        return budget;
+    }
 
     public IRocksDbConfig GetForDatabase(string databaseName, string? columnName)
     {
@@ -43,7 +67,7 @@ internal class FlatRocksDbConfigAdjuster(
             IntPtr? cacheHandle = null;
             if (columnName == nameof(FlatDbColumns.Account))
             {
-                ulong cacheCapacity = (ulong)(flatDbConfig.BlockCacheSizeBudget * 0.3);
+                ulong cacheCapacity = (ulong)(BlockCacheSizeBudget * 0.3);
                 if (_logger.IsInfo) _logger.Info($"Setting {(cacheCapacity / 1UL.MiB):N0} MB of block cache to account");
                 HyperClockCacheWrapper cacheWrapper = new(cacheCapacity);
                 cacheHandle = cacheWrapper.Handle;
@@ -52,7 +76,7 @@ internal class FlatRocksDbConfigAdjuster(
 
             if (columnName == nameof(FlatDbColumns.Storage))
             {
-                ulong cacheCapacity = (ulong)(flatDbConfig.BlockCacheSizeBudget * 0.7);
+                ulong cacheCapacity = (ulong)(BlockCacheSizeBudget * 0.7);
                 if (_logger.IsInfo) _logger.Info($"Setting {(cacheCapacity / 1UL.MiB):N0} MB of block cache to storage");
                 HyperClockCacheWrapper cacheWrapper = new(cacheCapacity);
                 cacheHandle = cacheWrapper.Handle;

--- a/src/Nethermind/Nethermind.Runner.Test/Module/FlatRocksDbConfigAdjusterTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/FlatRocksDbConfigAdjusterTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Test;
 using Nethermind.Db;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Init.Modules;
@@ -18,6 +19,7 @@ public class FlatRocksDbConfigAdjusterTests
 {
     private IRocksDbConfigFactory _baseFactory = null!;
     private IFlatDbConfig _flatDbConfig = null!;
+    private IHardwareInfo _hardwareInfo = null!;
     private IDisposableStack _disposeStack = null!;
     private IRocksDbConfig _baseConfig = null!;
 
@@ -26,6 +28,7 @@ public class FlatRocksDbConfigAdjusterTests
     {
         _baseFactory = Substitute.For<IRocksDbConfigFactory>();
         _flatDbConfig = Substitute.For<IFlatDbConfig>();
+        _hardwareInfo = new TestHardwareInfo(64L << 30);
         _disposeStack = Substitute.For<IDisposableStack>();
         _baseConfig = Substitute.For<IRocksDbConfig>();
 
@@ -41,7 +44,7 @@ public class FlatRocksDbConfigAdjusterTests
         _flatDbConfig.Layout.Returns(FlatLayout.Flat);
         _flatDbConfig.BlockCacheSizeBudget.Returns(1_000_000_000UL);
 
-        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _disposeStack, LimboLogs.Instance);
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _hardwareInfo, _disposeStack, LimboLogs.Instance);
 
         IRocksDbConfig result = adjuster.GetForDatabase("State0", null);
 
@@ -54,7 +57,7 @@ public class FlatRocksDbConfigAdjusterTests
         _flatDbConfig.Layout.Returns(FlatLayout.Flat);
         _flatDbConfig.BlockCacheSizeBudget.Returns(1_000_000_000UL);
 
-        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _disposeStack, LimboLogs.Instance);
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _hardwareInfo, _disposeStack, LimboLogs.Instance);
 
         IRocksDbConfig result = adjuster.GetForDatabase(nameof(DbNames.Flat), nameof(FlatDbColumns.Metadata));
 
@@ -69,7 +72,7 @@ public class FlatRocksDbConfigAdjusterTests
         _flatDbConfig.Layout.Returns(FlatLayout.FlatInTrie);
         _flatDbConfig.BlockCacheSizeBudget.Returns(1_000_000_000UL);
 
-        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _disposeStack, LimboLogs.Instance);
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _hardwareInfo, _disposeStack, LimboLogs.Instance);
 
         IRocksDbConfig result = adjuster.GetForDatabase(nameof(DbNames.Flat), nameof(FlatDbColumns.Metadata));
 
@@ -84,10 +87,24 @@ public class FlatRocksDbConfigAdjusterTests
         _flatDbConfig.Layout.Returns(FlatLayout.Flat);
         _flatDbConfig.BlockCacheSizeBudget.Returns(1_000_000_000UL);
 
-        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _disposeStack, LimboLogs.Instance);
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _hardwareInfo, _disposeStack, LimboLogs.Instance);
 
         adjuster.GetForDatabase(nameof(DbNames.Flat), nameof(FlatDbColumns.Account));
 
         _baseFactory.Received(1).GetForDatabase(nameof(DbNames.Flat), nameof(FlatDbColumns.Account));
+    }
+
+    [TestCase(0UL, 4L << 30, 1UL << 30)] // auto: total / 8 clamped up to the 1 GiB floor
+    [TestCase(0UL, 64L << 30, 8UL << 30)] // auto: total / 8
+    [TestCase(0UL, 512L << 30, 32UL << 30)] // auto: total / 8 clamped down to the 32 GiB cap
+    [TestCase(1_000_000_000UL, 512L << 30, 1_000_000_000UL)] // explicit value passes through unchanged
+    [TestCase(48UL << 30, 64L << 30, 48UL << 30)] // explicit value above half of total memory still passes through
+    public void BlockCacheSizeBudget_ResolvesFromConfigAndSystemMemory(ulong configured, long availableMemory, ulong expected)
+    {
+        _flatDbConfig.BlockCacheSizeBudget.Returns(configured);
+
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, new TestHardwareInfo(availableMemory), _disposeStack, LimboLogs.Instance);
+
+        Assert.That(adjuster.BlockCacheSizeBudget, Is.EqualTo(expected));
     }
 }


### PR DESCRIPTION
## Changes

- `FlatDb.BlockCacheSizeBudget` default changes from a fixed 1 GiB to a sentinel `0` = auto: **system memory / 8, clamped to [1 GiB, 32 GiB]**, resolved once in `FlatRocksDbConfigAdjuster` via `IHardwareInfo` (container-aware total memory). Explicit values pass through unchanged; a warning is logged when an explicit value exceeds 50% of system memory.
- The 30/70 Account/Storage HyperClockCache split is unchanged; the resolved budget is logged at Info on startup.
- Motivation: on BAL benchmark workloads with repeated warm account/slot access (e.g. `ext_account_query_warm` bloatnet suites) the fixed 1 GiB block cache is a major disadvantage against clients whose mmap storage uses the whole OS page cache. A 64 GiB host now gets an 8 GiB budget out of the box; small hosts keep the current 1 GiB floor. HyperClockCache capacity is a limit, not an upfront allocation, so RSS grows only with use.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- New parameterized `FlatRocksDbConfigAdjusterTests` cases cover floor clamp (4 GiB host → 1 GiB), proportional scaling (64 GiB → 8 GiB), cap clamp (512 GiB → 32 GiB), and explicit-value passthrough (including above-half-memory). Existing adjuster tests updated for the `IHardwareInfo` dependency via `TestHardwareInfo`. 9/9 green locally.
- `StandardConfigTests` (ConfigItem default/description validation) green.
- `Nethermind.IntegrationTests/FlatDbTests` sets this key explicitly and remains on the passthrough path.
- End-to-end effect to be measured on the EXPB reproducible benchmarks (flat layout, warm-read-heavy payload sets), sweeping the divisor via `--FlatDb.BlockCacheSizeBudget` extra flags if needed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Default behavior change: nodes running the flat layout on hosts with >8 GiB RAM will use a larger RocksDB block cache for flat state columns (memory/8, capped at 32 GiB) unless `--FlatDb.BlockCacheSizeBudget` is set explicitly.

## Remarks

Part of the BAL benchmark performance workstream (see #12681 for the trie-warm gating change from the same investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)