### PR TITLE
feat(consensus): BAL apply metrics, shadow root comparison + journal-bypassing parallel bulk apply (opt-in)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BalBulkApplyTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BalBulkApplyTests.cs
@@ -13,7 +13,6 @@ using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Db;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
@@ -186,6 +185,43 @@ public class BalBulkApplyTests(bool useFlat)
     }
 
     [Test]
+    public void Bulk_apply_preserves_pending_pre_block_writes()
+    {
+        // Mirrors AuRa post-merge preprocessing: system accounts are materialised on the MAIN
+        // state (journaled, uncommitted) before the BAL apply runs. The bulk path must flush them
+        // first — both so they survive (when not in the BAL) and so BAL parents read correctly.
+        Action<IWorldState> genesisSetup = static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100);
+        Action<IWorldState> preBlockWrites = static stateProvider =>
+        {
+            stateProvider.CreateAccount(TestItem.AddressD, 5); // not in the BAL — must survive the bulk apply
+            stateProvider.CreateAccount(ContractAddress, 1);   // in the BAL — the BAL's final values win
+        };
+        ReadOnlyBlockAccessList bal = Build.A.BlockAccessList
+            .WithAccountChanges(Build.An.AccountChanges
+                .WithAddress(TestItem.AddressA)
+                .WithBalanceChanges(new BalanceChange(1, 150))
+                .TestObject)
+            .WithAccountChanges(Build.An.AccountChanges
+                .WithAddress(ContractAddress)
+                .WithNonceChanges(new NonceChange(1, 1))
+                .WithStorageChanges(1, new StorageChange(1, 0x2Au))
+                .TestObject)
+            .TestObject;
+
+        Hash256 journaledRoot = Apply(genesisSetup, bal, useBulk: false, out ArrayPoolList<AddressAsKey>? journaledChanges, preBlockWrites);
+        Hash256 bulkRoot = Apply(genesisSetup, bal, useBulk: true, out ArrayPoolList<AddressAsKey>? bulkChanges, preBlockWrites);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(bulkRoot, Is.EqualTo(journaledRoot));
+            Assert.That(AsSet(bulkChanges), Is.EquivalentTo(AsSet(journaledChanges)));
+        }
+
+        journaledChanges?.Dispose();
+        bulkChanges?.Dispose();
+    }
+
+    [Test]
     public void Manager_dispatches_to_bulk_apply_when_configured()
     {
         ReadOnlyBlockAccessList bal = Build.A.BlockAccessList
@@ -222,15 +258,20 @@ public class BalBulkApplyTests(bool useFlat)
         Action<IWorldState>? genesisSetup,
         ReadOnlyBlockAccessList bal,
         bool useBulk,
-        out ArrayPoolList<AddressAsKey>? accountChanges)
+        out ArrayPoolList<AddressAsKey>? accountChanges,
+        Action<IWorldState>? preBlockWrites = null)
     {
         using Context ctx = new(useFlat);
         IWorldState worldState = new WorldState(ctx.ScopeProvider, LimboLogs.Instance);
         Hash256 parentRoot = CommitGenesis(worldState, genesisSetup);
 
         using IDisposable scope = worldState.BeginScope(ParentHeader(parentRoot));
+        preBlockWrites?.Invoke(worldState);
         if (useBulk)
         {
+            // Mirrors BlockAccessListManager.ApplyBlockStateChanges: pending journal writes are
+            // committed before the bulk batch bypasses the journal.
+            worldState.Commit(Amsterdam.Instance);
             ((IBalBulkWorldState)worldState).BulkApplyBal(bal, Amsterdam.Instance);
             worldState.RecalculateStateRoot();
         }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BalBulkApplyTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BalBulkApplyTests.cs
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Autofac;
+using Nethermind.Config;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Withdrawals;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Db;
+using Nethermind.Evm;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.BlockAccessLists;
+
+/// <summary>
+/// Parity tests for the journal-bypassing bulk BAL applier
+/// (<see cref="IBalBulkWorldState.BulkApplyBal"/>, gated by <c>Blocks.ParallelBalBulkApply</c>):
+/// for the same parent state and BAL, the bulk path must produce the same post-block state root
+/// as the journaled replay (<see cref="BlockAccessListManager.ApplyStateChanges"/>) — on both the
+/// flat and the trie scope providers — and must keep the block-level account-change tracking
+/// (TxPool cache invalidation) populated.
+/// </summary>
+[TestFixture(true)]
+[TestFixture(false)]
+public class BalBulkApplyTests(bool useFlat)
+{
+    private static readonly Address ContractAddress = TestItem.AddressB;
+    private static readonly byte[] ContractCode = [0x60, 0x2A, 0x60, 0x00, 0x55];
+
+    private static IEnumerable<TestCaseData> Scenarios()
+    {
+        yield return new TestCaseData(
+            null,
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithBalanceChanges(new BalanceChange(1, 25))
+                    .WithNonceChanges(new NonceChange(1, 1))
+                    .TestObject)
+                .TestObject)
+            .SetName("{m}(created account)");
+
+        yield return new TestCaseData(
+            (Action<IWorldState>)(static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100)),
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithBalanceChanges(new BalanceChange(1, 150))
+                    .TestObject)
+                .TestObject)
+            .SetName("{m}(balance only)");
+
+        yield return new TestCaseData(
+            (Action<IWorldState>)(static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100)),
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithNonceChanges(new NonceChange(1, 7))
+                    .TestObject)
+                .TestObject)
+            .SetName("{m}(nonce only)");
+
+        yield return new TestCaseData(
+            (Action<IWorldState>)(static stateProvider =>
+            {
+                stateProvider.CreateAccount(ContractAddress, 1, 1);
+                stateProvider.InsertCode(ContractAddress, ContractCode, Amsterdam.Instance);
+                stateProvider.Set(new StorageCell(ContractAddress, 1), [0x2A]);
+                stateProvider.Set(new StorageCell(ContractAddress, 2), [0x0B]);
+            }),
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(ContractAddress)
+                    .WithStorageChanges(1, new StorageChange(1, 0x99u)) // overwrite
+                    .WithStorageChanges(2, new StorageChange(1, 0x00u)) // zero out => delete
+                    .WithStorageChanges(3, new StorageChange(1, 0x07u)) // create
+                    .TestObject)
+                .TestObject)
+            .SetName("{m}(storage only: overwrite, zero out, create)");
+
+        yield return new TestCaseData(
+            null,
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(ContractAddress)
+                    .WithNonceChanges(new NonceChange(1, 1))
+                    .WithCodeChanges(new CodeChange(1, ContractCode))
+                    .WithStorageChanges(1, new StorageChange(1, 0x2Au))
+                    .TestObject)
+                .TestObject)
+            .SetName("{m}(code deploy with storage)");
+
+        yield return new TestCaseData(
+            (Action<IWorldState>)(static stateProvider =>
+            {
+                stateProvider.CreateAccount(TestItem.AddressA, 100);
+                stateProvider.CreateAccount(TestItem.AddressC, 7); // survives, so the root is not the empty root
+            }),
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithBalanceChanges(new BalanceChange(1, UInt256.Zero))
+                    .TestObject)
+                .TestObject)
+            .SetName("{m}(eip158 swept account)");
+
+        yield return new TestCaseData(
+            (Action<IWorldState>)(static stateProvider =>
+            {
+                stateProvider.CreateAccount(TestItem.AddressA, 100);
+                stateProvider.Set(new StorageCell(TestItem.AddressA, 1), [0x2A]);
+                stateProvider.CreateAccount(TestItem.AddressC, 7);
+            }),
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithBalanceChanges(new BalanceChange(1, UInt256.Zero))
+                    .TestObject)
+                .TestObject)
+            .SetName("{m}(eip158 swept account with storage)");
+
+        yield return new TestCaseData(
+            (Action<IWorldState>)(static stateProvider =>
+            {
+                stateProvider.CreateAccount(TestItem.AddressA, 100);
+                stateProvider.CreateAccount(ContractAddress, 1, 1);
+                stateProvider.InsertCode(ContractAddress, ContractCode, Amsterdam.Instance);
+                stateProvider.Set(new StorageCell(ContractAddress, 1), [0x2A]);
+            }),
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithBalanceChanges(new BalanceChange(1, 60))
+                    .WithNonceChanges(new NonceChange(1, 1))
+                    .TestObject)
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(ContractAddress)
+                    .WithBalanceChanges(new BalanceChange(2, 40))
+                    .WithStorageChanges(1, new StorageChange(2, 0x99u))
+                    .WithStorageChanges(5, new StorageChange(2, 0x05u))
+                    .TestObject)
+                .TestObject)
+            .SetName("{m}(multiple accounts mixed)");
+
+        yield return new TestCaseData(
+            (Action<IWorldState>)(static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100)),
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithStorageReads((UInt256)1)
+                    .TestObject)
+                .TestObject)
+            .SetName("{m}(reads only row)");
+    }
+
+    [TestCaseSource(nameof(Scenarios))]
+    public void Bulk_apply_produces_the_journaled_root(Action<IWorldState>? genesisSetup, ReadOnlyBlockAccessList bal)
+    {
+        Hash256 journaledRoot = Apply(genesisSetup, bal, useBulk: false, out ArrayPoolList<AddressAsKey>? journaledChanges);
+        Hash256 bulkRoot = Apply(genesisSetup, bal, useBulk: true, out ArrayPoolList<AddressAsKey>? bulkChanges);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(bulkRoot, Is.EqualTo(journaledRoot), "bulk-applied state root must equal the journaled one");
+            Assert.That(
+                AsSet(bulkChanges),
+                Is.EquivalentTo(AsSet(journaledChanges)),
+                "block-level account-change tracking (TxPool cache invalidation) must match the journaled path");
+        }
+
+        journaledChanges?.Dispose();
+        bulkChanges?.Dispose();
+    }
+
+    [Test]
+    public void Manager_dispatches_to_bulk_apply_when_configured()
+    {
+        ReadOnlyBlockAccessList bal = Build.A.BlockAccessList
+            .WithAccountChanges(Build.An.AccountChanges
+                .WithAddress(TestItem.AddressA)
+                .WithBalanceChanges(new BalanceChange(1, 60))
+                .WithNonceChanges(new NonceChange(1, 1))
+                .TestObject)
+            .TestObject;
+        Action<IWorldState> genesisSetup = static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100);
+
+        Hash256 journaledRoot = Apply(genesisSetup, bal, useBulk: false, out ArrayPoolList<AddressAsKey>? journaledChanges);
+        journaledChanges?.Dispose();
+
+        using Context ctx = new(useFlat);
+        WorldState worldState = new(ctx.ScopeProvider, LimboLogs.Instance);
+        Hash256 parentRoot = CommitGenesis(worldState, genesisSetup);
+        using BlockAccessListManager manager = new(
+            worldState,
+            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
+            NSubstitute.Substitute.For<IBlockhashProvider>(),
+            LimboLogs.Instance,
+            new BlocksConfig { ParallelExecution = true, ParallelBalBulkApply = true },
+            new WithdrawalProcessorFactory(LimboLogs.Instance),
+            static ws => new EthereumCodeInfoRepository(ws));
+
+        using IDisposable scope = worldState.BeginScope(ParentHeader(parentRoot));
+        manager.ApplyBlockStateChanges(bal, worldState, Amsterdam.Instance, shouldComputeStateRoot: true);
+
+        Assert.That(worldState.StateRoot, Is.EqualTo(journaledRoot));
+    }
+
+    private Hash256 Apply(
+        Action<IWorldState>? genesisSetup,
+        ReadOnlyBlockAccessList bal,
+        bool useBulk,
+        out ArrayPoolList<AddressAsKey>? accountChanges)
+    {
+        using Context ctx = new(useFlat);
+        IWorldState worldState = new WorldState(ctx.ScopeProvider, LimboLogs.Instance);
+        Hash256 parentRoot = CommitGenesis(worldState, genesisSetup);
+
+        using IDisposable scope = worldState.BeginScope(ParentHeader(parentRoot));
+        if (useBulk)
+        {
+            ((IBalBulkWorldState)worldState).BulkApplyBal(bal, Amsterdam.Instance);
+            worldState.RecalculateStateRoot();
+        }
+        else
+        {
+            BlockAccessListManager.ApplyStateChanges(bal, worldState, Amsterdam.Instance, shouldComputeStateRoot: true);
+        }
+
+        accountChanges = worldState.GetAccountChanges();
+        return worldState.StateRoot;
+    }
+
+    private static Hash256 CommitGenesis(IWorldState worldState, Action<IWorldState>? genesisSetup)
+    {
+        using (worldState.BeginScope(IWorldState.PreGenesis))
+        {
+            genesisSetup?.Invoke(worldState);
+            worldState.Commit(Amsterdam.Instance, isGenesis: true);
+            worldState.CommitTree(0);
+            return worldState.StateRoot;
+        }
+    }
+
+    private static BlockHeader ParentHeader(Hash256 parentRoot) =>
+        Build.A.BlockHeader.WithNumber(0).WithStateRoot(parentRoot).TestObject;
+
+    private static HashSet<AddressAsKey> AsSet(ArrayPoolList<AddressAsKey>? changes)
+    {
+        HashSet<AddressAsKey> result = [];
+        if (changes is not null)
+        {
+            foreach (AddressAsKey address in changes.AsSpan())
+            {
+                result.Add(address);
+            }
+        }
+
+        return result;
+    }
+
+    private sealed class Context : IDisposable
+    {
+        public IWorldStateScopeProvider ScopeProvider { get; }
+        private readonly IContainer? _container;
+
+        public Context(bool useFlat)
+        {
+            if (useFlat)
+            {
+                (ScopeProvider, _container) = TestWorldStateFactory.CreateFlatScopeProvider();
+            }
+            else
+            {
+                ScopeProvider = new TrieStoreScopeProvider(new TestRawTrieStore(new TestMemDb()), new TestMemDb(), LimboLogs.Instance);
+            }
+        }
+
+        public void Dispose() => _container?.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BalShadowStateRootTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BalShadowStateRootTests.cs
@@ -9,7 +9,6 @@ using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Db;
@@ -119,7 +118,11 @@ public class BalShadowStateRootTests
             genesisSetup: static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100),
             canonicalRootOverride: TestItem.KeccakF);
 
-        Assert.That(result.MismatchDelta, Is.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.MismatchDelta, Is.EqualTo(1));
+            Assert.That(result.ComparisonsDelta, Is.EqualTo(1), "a mismatch still counts as a completed comparison");
+        }
     }
 
     [Test]
@@ -135,6 +138,7 @@ public class BalShadowStateRootTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.MismatchDelta, Is.Zero);
+            Assert.That(result.ComparisonsDelta, Is.Zero, "no comparison may be counted when the flag is off");
             Assert.That(result.Errors, Is.Empty);
             Assert.That(countingFactory.CreateCalls, Is.Zero, "the shadow env must not even be created when the flag is off");
         }
@@ -151,6 +155,8 @@ public class BalShadowStateRootTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.MismatchDelta, Is.Zero);
+            Assert.That(result.ComparisonsDelta, Is.Zero, "a failed attempt must not count as a comparison");
+            Assert.That(result.FailuresDelta, Is.EqualTo(1), "the failure must be observable in metrics, not just the log");
             Assert.That(result.Errors, Has.One.Contains("shadow state root computation failed"));
         }
     }
@@ -177,7 +183,7 @@ public class BalShadowStateRootTests
         Assert.That(result.MismatchDelta, Is.EqualTo(1), "the corrupt BAL must surface as a mismatch report, not a crash");
     }
 
-    private sealed record ShadowRunResult(long MismatchDelta, List<string> Errors);
+    private sealed record ShadowRunResult(long MismatchDelta, long ComparisonsDelta, long FailuresDelta, List<string> Errors);
 
     /// <summary>Captures error log lines including exception details, so scenario asserts can
     /// prove the shadow actually ran instead of silently swallowing a failure.</summary>
@@ -213,6 +219,7 @@ public class BalShadowStateRootTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Errors, Is.Empty, "the shadow run must complete without errors");
+            Assert.That(result.ComparisonsDelta, Is.EqualTo(1), "the shadow must actually compute and compare a root");
             Assert.That(result.MismatchDelta, Is.Zero, "shadow root must match the canonical BAL-applied root");
         }
     }
@@ -279,8 +286,14 @@ public class BalShadowStateRootTests
         block.Header.StateRoot = canonicalRootOverride ?? stateProvider.StateRoot;
 
         long mismatchesBefore = Evm.Metrics.BalShadowRootMismatches;
+        long comparisonsBefore = Evm.Metrics.BalShadowRootComparisons;
+        long failuresBefore = Evm.Metrics.BalShadowRootFailures;
         Assert.DoesNotThrow(() => balManager.RunShadowStateRootComparison(block));
-        return new ShadowRunResult(Evm.Metrics.BalShadowRootMismatches - mismatchesBefore, capturingLogger.Errors);
+        return new ShadowRunResult(
+            Evm.Metrics.BalShadowRootMismatches - mismatchesBefore,
+            Evm.Metrics.BalShadowRootComparisons - comparisonsBefore,
+            Evm.Metrics.BalShadowRootFailures - failuresBefore,
+            capturingLogger.Errors);
     }
 
     private static (TrieStore trieStore, IDb codeDb) CreateSharedStore()

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BalShadowStateRootTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BalShadowStateRootTests.cs
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Config;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Withdrawals;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Db;
+using Nethermind.Db;
+using Nethermind.Evm;
+using Nethermind.Evm.State;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.BlockAccessLists;
+
+/// <summary>
+/// Covers the diagnostics-only shadow BAL state-root recomputation
+/// (<c>IBlocksConfig.ParallelBalStateRootShadow</c>): the bulk post-value apply must reproduce
+/// the canonical <c>ApplyStateChanges</c> root, and failures must never escape into the pipeline.
+/// </summary>
+public class BalShadowStateRootTests
+{
+    private static readonly Address ContractAddress = TestItem.AddressB;
+    private static readonly byte[] ContractCode = [0x60, 0x2A, 0x60, 0x00, 0x55];
+
+    [Test]
+    public void Shadow_root_matches_canonical_for_created_account()
+        => AssertShadowMatchesCanonical(
+            genesisSetup: null,
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithBalanceChanges(new BalanceChange(1, 25))
+                    .WithNonceChanges(new NonceChange(1, 1))
+                    .TestObject)
+                .TestObject);
+
+    [Test]
+    public void Shadow_root_matches_canonical_for_balance_only_change()
+        => AssertShadowMatchesCanonical(
+            genesisSetup: static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100),
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithBalanceChanges(new BalanceChange(1, 150))
+                    .TestObject)
+                .TestObject);
+
+    [Test]
+    public void Shadow_root_matches_canonical_for_storage_changes()
+        => AssertShadowMatchesCanonical(
+            genesisSetup: static stateProvider =>
+            {
+                stateProvider.CreateAccount(ContractAddress, 1, 1);
+                stateProvider.InsertCode(ContractAddress, ContractCode, Amsterdam.Instance);
+                stateProvider.Set(new StorageCell(ContractAddress, 1), [0x2A]);
+                stateProvider.Set(new StorageCell(ContractAddress, 2), [0x0B]);
+            },
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(ContractAddress)
+                    .WithStorageChanges(1, new StorageChange(1, 0x99u)) // overwrite
+                    .WithStorageChanges(2, new StorageChange(1, 0x00u)) // zero out => delete
+                    .WithStorageChanges(3, new StorageChange(1, 0x07u)) // create
+                    .TestObject)
+                .TestObject);
+
+    [Test]
+    public void Shadow_root_matches_canonical_for_code_deploy()
+        => AssertShadowMatchesCanonical(
+            genesisSetup: null,
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(ContractAddress)
+                    .WithNonceChanges(new NonceChange(1, 1))
+                    .WithCodeChanges(new CodeChange(1, ContractCode))
+                    .WithStorageChanges(1, new StorageChange(1, 0x2Au))
+                    .TestObject)
+                .TestObject);
+
+    [Test]
+    public void Shadow_root_matches_canonical_for_eip158_swept_account()
+        => AssertShadowMatchesCanonical(
+            // Zeroing the balance leaves a touched, totally empty account: canonical relies on
+            // the EIP-158 commit sweep, the shadow on BalPostState returning null.
+            genesisSetup: static stateProvider =>
+            {
+                stateProvider.CreateAccount(TestItem.AddressA, 100);
+                stateProvider.CreateAccount(TestItem.AddressC, 7); // survives, so the root is not the empty root
+            },
+            Build.A.BlockAccessList
+                .WithAccountChanges(Build.An.AccountChanges
+                    .WithAddress(TestItem.AddressA)
+                    .WithBalanceChanges(new BalanceChange(1, UInt256.Zero))
+                    .TestObject)
+                .TestObject);
+
+    [Test]
+    public void Shadow_reports_mismatch_without_throwing()
+    {
+        ShadowRunResult result = RunShadowScenario(
+            SimpleTransferBal(),
+            genesisSetup: static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100),
+            canonicalRootOverride: TestItem.KeccakF);
+
+        Assert.That(result.MismatchDelta, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Shadow_is_inert_when_flag_is_off()
+    {
+        CountingEnvFactory countingFactory = new();
+        ShadowRunResult result = RunShadowScenario(
+            SimpleTransferBal(),
+            genesisSetup: static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100),
+            shadowEnabled: false,
+            shadowEnvFactory: countingFactory);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.MismatchDelta, Is.Zero);
+            Assert.That(result.Errors, Is.Empty);
+            Assert.That(countingFactory.CreateCalls, Is.Zero, "the shadow env must not even be created when the flag is off");
+        }
+    }
+
+    [Test]
+    public void Shadow_swallows_env_failures()
+    {
+        ShadowRunResult result = RunShadowScenario(
+            SimpleTransferBal(),
+            genesisSetup: static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100),
+            shadowEnvFactory: new ThrowingEnvFactory());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.MismatchDelta, Is.Zero);
+            Assert.That(result.Errors, Has.One.Contains("shadow state root computation failed"));
+        }
+    }
+
+    [Test]
+    public void Shadow_does_not_throw_for_corrupt_bal()
+    {
+        // Storage changes on an account that never materializes (no parent, no field changes):
+        // canonical processing rejects such a block elsewhere; the shadow must stay silent apart
+        // from a mismatch report.
+        ReadOnlyBlockAccessList corrupt = Build.A.BlockAccessList
+            .WithAccountChanges(Build.An.AccountChanges
+                .WithAddress(TestItem.AddressD)
+                .WithStorageChanges(1, new StorageChange(1, 0x99u))
+                .TestObject)
+            .TestObject;
+
+        ShadowRunResult result = RunShadowScenario(
+            corrupt,
+            genesisSetup: static stateProvider => stateProvider.CreateAccount(TestItem.AddressA, 100),
+            canonicalRootOverride: TestItem.KeccakF,
+            applyCanonical: false);
+
+        Assert.That(result.MismatchDelta, Is.EqualTo(1), "the corrupt BAL must surface as a mismatch report, not a crash");
+    }
+
+    private sealed record ShadowRunResult(long MismatchDelta, List<string> Errors);
+
+    /// <summary>Captures error log lines including exception details, so scenario asserts can
+    /// prove the shadow actually ran instead of silently swallowing a failure.</summary>
+    private sealed class CapturingLogger : InterfaceLogger
+    {
+        public List<string> Errors { get; } = [];
+
+        public void Info(string text) { }
+        public void Warn(string text) { }
+        public void Debug(string text) { }
+        public void Trace(string text) { }
+        public void Error(string text, Exception? ex = null) => Errors.Add(ex is null ? text : $"{text} {ex}");
+
+        public bool IsInfo => false;
+        public bool IsWarn => false;
+        public bool IsDebug => false;
+        public bool IsTrace => false;
+        public bool IsError => true;
+    }
+
+    private static ReadOnlyBlockAccessList SimpleTransferBal() =>
+        Build.A.BlockAccessList
+            .WithAccountChanges(Build.An.AccountChanges
+                .WithAddress(TestItem.AddressA)
+                .WithBalanceChanges(new BalanceChange(1, 60))
+                .WithNonceChanges(new NonceChange(1, 1))
+                .TestObject)
+            .TestObject;
+
+    private static void AssertShadowMatchesCanonical(Action<IWorldState>? genesisSetup, ReadOnlyBlockAccessList bal)
+    {
+        ShadowRunResult result = RunShadowScenario(bal, genesisSetup);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Errors, Is.Empty, "the shadow run must complete without errors");
+            Assert.That(result.MismatchDelta, Is.Zero, "shadow root must match the canonical BAL-applied root");
+        }
+    }
+
+    /// <summary>
+    /// Applies <paramref name="bal"/> canonically (via <see cref="BlockAccessListManager.ApplyStateChanges"/>)
+    /// on a real world state at a genesis parent, then runs the shadow comparison and returns the
+    /// change in <see cref="Evm.Metrics.BalShadowRootMismatches"/>.
+    /// </summary>
+    private static ShadowRunResult RunShadowScenario(
+        ReadOnlyBlockAccessList bal,
+        Action<IWorldState>? genesisSetup,
+        bool shadowEnabled = true,
+        Hash256? canonicalRootOverride = null,
+        IReadOnlyTxProcessingEnvFactory? shadowEnvFactory = null,
+        bool applyCanonical = true)
+    {
+        CapturingLogger capturingLogger = new();
+        // The main world state and the shadow env share one TrieStore, mirroring production where
+        // read-only envs read through the same store as the main processing world state.
+        (TrieStore trieStore, IDb codeDb) = CreateSharedStore();
+        IWorldState stateProvider = new WorldState(new TrieStoreScopeProvider(trieStore, codeDb, LimboLogs.Instance), LimboLogs.Instance);
+        Hash256 parentStateRoot;
+        using (stateProvider.BeginScope(IWorldState.PreGenesis))
+        {
+            genesisSetup?.Invoke(stateProvider);
+            stateProvider.Commit(Amsterdam.Instance, isGenesis: true);
+            stateProvider.CommitTree(0);
+            parentStateRoot = stateProvider.StateRoot;
+        }
+
+        Hash256 parentHash = TestItem.KeccakA;
+        BlockHeader parentHeader = Build.A.BlockHeader
+            .WithNumber(0)
+            .WithHash(parentHash)
+            .WithStateRoot(parentStateRoot)
+            .TestObject;
+
+        using IDisposable parentScope = stateProvider.BeginScope(parentHeader);
+        using BlockAccessListManager balManager = new(
+            stateProvider,
+            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
+            Substitute.For<IBlockhashProvider>(),
+            new OneLoggerLogManager(new ILogger(capturingLogger)),
+            new BlocksConfig { ParallelExecution = true, ParallelBalStateRootShadow = shadowEnabled },
+            new WithdrawalProcessorFactory(LimboLogs.Instance),
+            static worldState => new EthereumCodeInfoRepository(worldState),
+            readOnlyTxProcessingEnvFactory: shadowEnvFactory ?? new SharedStoreEnvFactory(trieStore, codeDb));
+
+        Block block = Build.A.Block
+            .WithNumber(1)
+            .WithParentHash(parentHash)
+            .WithBlockAccessList(bal)
+            .TestObject;
+
+        balManager.PrepareForProcessing(block, Amsterdam.Instance, ProcessingOptions.None);
+        Assert.That(balManager.ParallelExecutionEnabled, Is.True);
+
+        if (applyCanonical)
+        {
+            // The same state transition the parallel path performs in iteration 0.
+            BlockAccessListManager.ApplyStateChanges(bal, stateProvider, Amsterdam.Instance, shouldComputeStateRoot: true);
+        }
+        block.Header.StateRoot = canonicalRootOverride ?? stateProvider.StateRoot;
+
+        long mismatchesBefore = Evm.Metrics.BalShadowRootMismatches;
+        Assert.DoesNotThrow(() => balManager.RunShadowStateRootComparison(block));
+        return new ShadowRunResult(Evm.Metrics.BalShadowRootMismatches - mismatchesBefore, capturingLogger.Errors);
+    }
+
+    private static (TrieStore trieStore, IDb codeDb) CreateSharedStore()
+    {
+        PruningConfig pruningConfig = new();
+        TestFinalizedStateProvider finalizedStateProvider = new(pruningConfig.PruningBoundary);
+        IDbProvider dbProvider = TestMemDbProvider.Init();
+        TrieStore trieStore = new(
+            new NodeStorage(dbProvider.StateDb),
+            No.Pruning,
+            Persist.EveryBlock,
+            finalizedStateProvider,
+            pruningConfig,
+            LimboLogs.Instance);
+        finalizedStateProvider.TrieStore = trieStore;
+        return (trieStore, dbProvider.CodeDb);
+    }
+
+    /// <summary>
+    /// Real read-only env over the same trie store as the main world state: each Build opens
+    /// an independent <see cref="IWorldState"/> scope at the requested root.
+    /// </summary>
+    private sealed class SharedStoreEnvFactory(TrieStore trieStore, IDb codeDb) : IReadOnlyTxProcessingEnvFactory
+    {
+        public IReadOnlyTxProcessorSource Create() => new Source(trieStore, codeDb);
+
+        private sealed class Source(TrieStore trieStore, IDb codeDb) : IReadOnlyTxProcessorSource
+        {
+            public IReadOnlyTxProcessingScope Build(BlockHeader? baseBlock)
+            {
+                IWorldState worldState = new WorldState(new TrieStoreScopeProvider(trieStore, codeDb, LimboLogs.Instance), LimboLogs.Instance);
+                return new Scope(worldState, worldState.BeginScope(baseBlock));
+            }
+
+            public void Dispose() { }
+        }
+
+        private sealed class Scope(IWorldState worldState, IDisposable stateScope) : IReadOnlyTxProcessingScope
+        {
+            public ITransactionProcessor TransactionProcessor => throw new NotSupportedException();
+            public IWorldState WorldState => worldState;
+            public void Dispose() => stateScope.Dispose();
+        }
+    }
+
+    private sealed class CountingEnvFactory : IReadOnlyTxProcessingEnvFactory
+    {
+        public int CreateCalls { get; private set; }
+
+        public IReadOnlyTxProcessorSource Create()
+        {
+            CreateCalls++;
+            return Substitute.For<IReadOnlyTxProcessorSource>();
+        }
+    }
+
+    private sealed class ThrowingEnvFactory : IReadOnlyTxProcessingEnvFactory
+    {
+        public IReadOnlyTxProcessorSource Create() => throw new InvalidOperationException("shadow env unavailable");
+    }
+}

--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -72,6 +72,7 @@ namespace Nethermind.Config
 
         public bool ParallelExecution { get; set; } = true;
         public bool ParallelExecutionBatchRead { get; set; } = true;
+        public bool ParallelBalStateRootShadow { get; set; }
 
         public string ExtraData
         {

--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -73,6 +73,7 @@ namespace Nethermind.Config
         public bool ParallelExecution { get; set; } = true;
         public bool ParallelExecutionBatchRead { get; set; } = true;
         public bool ParallelBalStateRootShadow { get; set; }
+        public bool ParallelBalBulkApply { get; set; }
 
         public string ExtraData
         {

--- a/src/Nethermind/Nethermind.Config/BlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/BlocksConfig.cs
@@ -73,7 +73,7 @@ namespace Nethermind.Config
         public bool ParallelExecution { get; set; } = true;
         public bool ParallelExecutionBatchRead { get; set; } = true;
         public bool ParallelBalStateRootShadow { get; set; }
-        public bool ParallelBalBulkApply { get; set; }
+        public bool ParallelBalBulkApply { get; set; } = true;
 
         public string ExtraData
         {

--- a/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
@@ -80,6 +80,12 @@ public interface IBlocksConfig : IConfig
         HiddenFromDocs = true)]
     bool ParallelBalStateRootShadow { get; set; }
 
+    [ConfigItem(
+        Description = "On the parallel Block Level Access List path, apply the BAL's post-block values through the backend's bulk write batch (journal-bypassing, per-account parallel) instead of replaying them through the journaled world-state operations. Experimental; enable only after the shadow-mode soak (`ParallelBalStateRootShadow`) is clean.",
+        DefaultValue = "false",
+        HiddenFromDocs = true)]
+    bool ParallelBalBulkApply { get; set; }
+
     byte[] GetExtraDataBytes();
 
     [ConfigItem(Description = "The max blob count after which the block producer should stop adding blobs. Minimum value is `0`.", DefaultValue = "null")]

--- a/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
@@ -74,6 +74,12 @@ public interface IBlocksConfig : IConfig
         DefaultValue = "true")]
     bool ParallelExecutionBatchRead { get; set; }
 
+    [ConfigItem(
+        Description = "Diagnostics for the parallel Block Level Access List path: recompute the post-block state root by bulk-applying the BAL's final values on a shadow copy of the parent state and compare it with the canonical root, reporting mismatches via error logs and metrics. Never affects consensus results; adds one extra state-root computation per block.",
+        DefaultValue = "false",
+        HiddenFromDocs = true)]
+    bool ParallelBalStateRootShadow { get; set; }
+
     byte[] GetExtraDataBytes();
 
     [ConfigItem(Description = "The max blob count after which the block producer should stop adding blobs. Minimum value is `0`.", DefaultValue = "null")]

--- a/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
+++ b/src/Nethermind/Nethermind.Config/IBlocksConfig.cs
@@ -81,8 +81,8 @@ public interface IBlocksConfig : IConfig
     bool ParallelBalStateRootShadow { get; set; }
 
     [ConfigItem(
-        Description = "On the parallel Block Level Access List path, apply the BAL's post-block values through the backend's bulk write batch (journal-bypassing, per-account parallel) instead of replaying them through the journaled world-state operations. Experimental; enable only after the shadow-mode soak (`ParallelBalStateRootShadow`) is clean.",
-        DefaultValue = "false",
+        Description = "On the parallel Block Level Access List path, apply the BAL's post-block values through the backend's bulk write batch (journal-bypassing, per-account parallel) instead of replaying them through the journaled world-state operations. Experimental Amsterdam/BAL path; disabling falls back to the journaled replay.",
+        DefaultValue = "true",
         HiddenFromDocs = true)]
     bool ParallelBalBulkApply { get; set; }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
@@ -107,14 +107,14 @@ public partial class BlockAccessListManager
         CheckInitialized();
         MergeAndReturnBal(uint.MaxValue);
 
-        RunShadowStateRootComparison(block);
-
         if (VerifyOnly)
         {
             // IncrementalValidation only covered indices 0..txCount; the post-execution row
             // (txCount + 1) was just merged but not yet compared.
             ValidateBlockAccessList(block, (uint)(block.Transactions.Length + 1));
             ValidateStructuralEquivalence(block);
+            // After validation, so blocks about to be rejected don't pay for (or pollute) the shadow.
+            QueueShadowStateRootComparison(block);
             return;
         }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
@@ -37,10 +37,11 @@ public partial class BlockAccessListManager
     /// <remarks>
     /// Dispatches to <see cref="IBalBulkWorldState.BulkApplyBal"/> when
     /// <c>Blocks.ParallelBalBulkApply</c> is enabled and the backend supports it — the
-    /// journal-bypassing, per-account-parallel path. The bulk path skips
-    /// <see cref="IWorldState.Commit(IReleaseSpec)"/>: the journal is empty by the bulk applier's
-    /// precondition (this is the block's first mutation of the main state), and code/storage
-    /// writes go straight through the scope.
+    /// journal-bypassing, per-account-parallel path. Any journal writes made before the BAL apply
+    /// (e.g. AuRa post-merge preprocessing materialising system accounts on the main state) are
+    /// committed first, so the bulk batch reads correct parents through the scope and a later
+    /// <c>FlushToTree</c> cannot overwrite the bulk-applied values with stale journal entries;
+    /// on the common PoS path the journal is empty and that commit is a no-op.
     /// </remarks>
     public void ApplyBlockStateChanges(ReadOnlyBlockAccessList bal, IWorldState stateProvider, IReleaseSpec spec, bool shouldComputeStateRoot)
     {
@@ -48,6 +49,7 @@ public partial class BlockAccessListManager
         {
             using (MetricsTimer<BalApplyTimeSink> _ = new())
             {
+                stateProvider.Commit(spec);
                 bulkWorldState.BulkApplyBal(bal, spec);
             }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
@@ -8,6 +8,7 @@ using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Metric;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
@@ -34,52 +35,59 @@ public partial class BlockAccessListManager
     /// </remarks>
     public static void ApplyStateChanges(ReadOnlyBlockAccessList suggestedBlockAccessList, IWorldState stateProvider, IReleaseSpec spec, bool shouldComputeStateRoot)
     {
-        foreach (ReadOnlyAccountChanges accountChanges in suggestedBlockAccessList.AccountChanges)
+        using (MetricsTimer<BalApplyTimeSink> _ = new())
         {
-            if (accountChanges.BalanceChanges.Length > 0)
+            foreach (ReadOnlyAccountChanges accountChanges in suggestedBlockAccessList.AccountChanges)
             {
-                stateProvider.CreateAccountIfNotExists(accountChanges.Address, 0, 0);
-                UInt256 oldBalance = stateProvider.GetBalance(accountChanges.Address);
-                UInt256 newBalance = accountChanges.BalanceChanges[^1].Value;
-                if (newBalance > oldBalance)
+                if (accountChanges.BalanceChanges.Length > 0)
                 {
-                    stateProvider.AddToBalance(accountChanges.Address, newBalance - oldBalance, spec);
+                    stateProvider.CreateAccountIfNotExists(accountChanges.Address, 0, 0);
+                    UInt256 oldBalance = stateProvider.GetBalance(accountChanges.Address);
+                    UInt256 newBalance = accountChanges.BalanceChanges[^1].Value;
+                    if (newBalance > oldBalance)
+                    {
+                        stateProvider.AddToBalance(accountChanges.Address, newBalance - oldBalance, spec);
+                    }
+                    else if (newBalance < oldBalance)
+                    {
+                        stateProvider.SubtractFromBalance(accountChanges.Address, oldBalance - newBalance, spec);
+                    }
                 }
-                else if (newBalance < oldBalance)
+
+                if (accountChanges.NonceChanges.Length > 0)
                 {
-                    stateProvider.SubtractFromBalance(accountChanges.Address, oldBalance - newBalance, spec);
+                    stateProvider.CreateAccountIfNotExists(accountChanges.Address, 0, 0);
+                    stateProvider.SetNonce(accountChanges.Address, accountChanges.NonceChanges[^1].Value);
                 }
-            }
 
-            if (accountChanges.NonceChanges.Length > 0)
-            {
-                stateProvider.CreateAccountIfNotExists(accountChanges.Address, 0, 0);
-                stateProvider.SetNonce(accountChanges.Address, accountChanges.NonceChanges[^1].Value);
-            }
-
-            if (accountChanges.CodeChanges.Length > 0)
-            {
-                stateProvider.InsertCode(accountChanges.Address, accountChanges.CodeChanges[^1].Code, spec);
-            }
-
-            foreach (ReadOnlySlotChanges slotChange in accountChanges.StorageChanges)
-            {
-                StorageCell storageCell = new(accountChanges.Address, slotChange.Key);
-                int slotCount = slotChange.Changes.Length;
-                if (slotCount > 0)
+                if (accountChanges.CodeChanges.Length > 0)
                 {
-                    // StorageChange.Value is now EvmWord (Vector256<byte>) in big-endian wire form.
-                    EvmWord value = slotChange.Changes[^1].Value;
-                    ReadOnlySpan<byte> valueBytes = MemoryMarshal.CreateReadOnlySpan(
-                        ref Unsafe.As<EvmWord, byte>(ref value), 32);
-                    stateProvider.Set(storageCell, [.. valueBytes.WithoutLeadingZeros()]);
+                    stateProvider.InsertCode(accountChanges.Address, accountChanges.CodeChanges[^1].Code, spec);
+                }
+
+                foreach (ReadOnlySlotChanges slotChange in accountChanges.StorageChanges)
+                {
+                    StorageCell storageCell = new(accountChanges.Address, slotChange.Key);
+                    int slotCount = slotChange.Changes.Length;
+                    if (slotCount > 0)
+                    {
+                        // StorageChange.Value is now EvmWord (Vector256<byte>) in big-endian wire form.
+                        EvmWord value = slotChange.Changes[^1].Value;
+                        ReadOnlySpan<byte> valueBytes = MemoryMarshal.CreateReadOnlySpan(
+                            ref Unsafe.As<EvmWord, byte>(ref value), 32);
+                        stateProvider.Set(storageCell, [.. valueBytes.WithoutLeadingZeros()]);
+                    }
                 }
             }
         }
-        stateProvider.Commit(spec);
-        if (shouldComputeStateRoot)
+
+        using (MetricsTimer<BalStateRootTimeSink> _ = new())
         {
-            stateProvider.RecalculateStateRoot();
+            stateProvider.Commit(spec);
+            if (shouldComputeStateRoot)
+            {
+                stateProvider.RecalculateStateRoot();
+            }
         }
     }
 
@@ -98,6 +106,8 @@ public partial class BlockAccessListManager
 
         CheckInitialized();
         MergeAndReturnBal(uint.MaxValue);
+
+        RunShadowStateRootComparison(block);
 
         if (VerifyOnly)
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateChanges.cs
@@ -33,6 +33,38 @@ public partial class BlockAccessListManager
     /// is written. Storage <em>reads</em> (slots that appear in <c>StorageReads</c> only) are
     /// not applied — they describe what the block <em>observed</em>, not what it changed.
     /// </remarks>
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Dispatches to <see cref="IBalBulkWorldState.BulkApplyBal"/> when
+    /// <c>Blocks.ParallelBalBulkApply</c> is enabled and the backend supports it — the
+    /// journal-bypassing, per-account-parallel path. The bulk path skips
+    /// <see cref="IWorldState.Commit(IReleaseSpec)"/>: the journal is empty by the bulk applier's
+    /// precondition (this is the block's first mutation of the main state), and code/storage
+    /// writes go straight through the scope.
+    /// </remarks>
+    public void ApplyBlockStateChanges(ReadOnlyBlockAccessList bal, IWorldState stateProvider, IReleaseSpec spec, bool shouldComputeStateRoot)
+    {
+        if (blocksConfig.ParallelBalBulkApply && stateProvider is IBalBulkWorldState bulkWorldState)
+        {
+            using (MetricsTimer<BalApplyTimeSink> _ = new())
+            {
+                bulkWorldState.BulkApplyBal(bal, spec);
+            }
+
+            using (MetricsTimer<BalStateRootTimeSink> _ = new())
+            {
+                if (shouldComputeStateRoot)
+                {
+                    stateProvider.RecalculateStateRoot();
+                }
+            }
+
+            return;
+        }
+
+        ApplyStateChanges(bal, stateProvider, spec, shouldComputeStateRoot);
+    }
+
     public static void ApplyStateChanges(ReadOnlyBlockAccessList suggestedBlockAccessList, IWorldState stateProvider, IReleaseSpec spec, bool shouldComputeStateRoot)
     {
         using (MetricsTimer<BalApplyTimeSink> _ = new())

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateRoot.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateRoot.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
@@ -26,16 +27,36 @@ namespace Nethermind.Consensus.Processing;
 public partial class BlockAccessListManager
 {
     private IReadOnlyTxProcessorSource? _shadowRootEnv;
+    // Serializes background shadow runs: _shadowRootEnv is a single reusable env, and back-to-back
+    // blocks could otherwise overlap on it.
+    private readonly Lock _shadowRootLock = new();
 
     /// <summary>
-    /// When shadow mode is enabled on the parallel BAL path, recomputes the state root from the
-    /// suggested BAL on a parent-state env and compares it with <see cref="Block.StateRoot"/>.
+    /// When shadow mode is enabled on the parallel BAL path, queues a background recomputation of
+    /// the state root from the suggested BAL on a parent-state env, compared with
+    /// <see cref="Block.StateRoot"/>.
     /// </summary>
     /// <remarks>
-    /// Never throws: mismatches bump <c>Metrics.BalShadowRootMismatches</c> and log an error;
-    /// unexpected failures are logged and swallowed so the canonical pipeline is unaffected.
-    /// Internal for tests.
+    /// Runs off the block-processing thread so a shadow-enabled node does not add state-root and GC
+    /// work to <c>newPayload</c> latency — the same nodes report the <c>BalApplyTime</c> /
+    /// <c>BalStateRootTime</c> / <c>BalRootReadyLagTime</c> baselines this PR introduces. The gates
+    /// and the parent root are captured synchronously; the queued work never throws.
     /// </remarks>
+    private void QueueShadowStateRootComparison(Block block)
+    {
+        if (!blocksConfig.ParallelBalStateRootShadow || !ParallelExecutionEnabled)
+        {
+            return;
+        }
+
+        Hash256? parentStateRoot = _parentStateRoot;
+        ThreadPool.UnsafeQueueUserWorkItem(
+            static state => state.self.RunShadowStateRootComparisonCore(state.block, state.parentStateRoot),
+            (self: this, block, parentStateRoot),
+            preferLocal: false);
+    }
+
+    /// <summary>Synchronous shadow comparison for the current block; internal for tests.</summary>
     internal void RunShadowStateRootComparison(Block block)
     {
         if (!blocksConfig.ParallelBalStateRootShadow || !ParallelExecutionEnabled)
@@ -43,8 +64,18 @@ public partial class BlockAccessListManager
             return;
         }
 
+        RunShadowStateRootComparisonCore(block, _parentStateRoot);
+    }
+
+    /// <summary>
+    /// Never throws: completed comparisons bump <c>Metrics.BalShadowRootComparisons</c> (the soak's
+    /// positive signal — "0 mismatches" is meaningless while this stays 0), mismatches bump
+    /// <c>Metrics.BalShadowRootMismatches</c>, and unexpected failures bump
+    /// <c>Metrics.BalShadowRootFailures</c> and are swallowed so the canonical pipeline is unaffected.
+    /// </summary>
+    private void RunShadowStateRootComparisonCore(Block block, Hash256? parentStateRoot)
+    {
         ReadOnlyBlockAccessList? bal = block.BlockAccessList;
-        Hash256? parentStateRoot = _parentStateRoot;
         Hash256? canonicalRoot = block.StateRoot;
         if (bal is null || parentStateRoot is null || canonicalRoot is null)
         {
@@ -59,21 +90,33 @@ public partial class BlockAccessListManager
 
         try
         {
-            _shadowRootEnv ??= readOnlyTxProcessingEnvFactory.Create();
-            using IReadOnlyTxProcessingScope scope = _shadowRootEnv.Build(CreateParentStateHeader(block, parentStateRoot));
-            Hash256 shadowRoot = ComputeShadowStateRoot(bal, scope.WorldState, specProvider.GetSpec(block.Header));
+            Hash256 shadowRoot;
+            lock (_shadowRootLock)
+            {
+                _shadowRootEnv ??= readOnlyTxProcessingEnvFactory.Create();
+                using IReadOnlyTxProcessingScope scope = _shadowRootEnv.Build(CreateParentStateHeader(block, parentStateRoot));
+                shadowRoot = ComputeShadowStateRoot(bal, scope.WorldState, specProvider.GetSpec(block.Header));
+            }
+
+            Evm.Metrics.IncrementBalShadowRootComparisons();
             if (shadowRoot != canonicalRoot)
             {
-                Evm.Metrics.IncrementBalShadowRootMismatches();
-                if (_logger.IsError) _logger.Error($"BAL shadow state root mismatch for block {block.Number} ({block.Hash}): shadow {shadowRoot}, canonical {canonicalRoot}.");
+                long mismatches = Evm.Metrics.IncrementBalShadowRootMismatches();
+                if (ShouldLogShadowIssue(mismatches) && _logger.IsError) _logger.Error($"BAL shadow state root mismatch for block {block.Number} ({block.Hash}): shadow {shadowRoot}, canonical {canonicalRoot}.");
             }
         }
         catch (Exception ex)
         {
             // Shadow mode is diagnostics only: report and continue, never fail the block.
-            if (_logger.IsError) _logger.Error($"BAL shadow state root computation failed for block {block.Number} ({block.Hash}).", ex);
+            long failures = Evm.Metrics.IncrementBalShadowRootFailures();
+            if (ShouldLogShadowIssue(failures) && _logger.IsError) _logger.Error($"BAL shadow state root computation failed for block {block.Number} ({block.Hash}).", ex);
         }
     }
+
+    /// <summary>First occurrences always log, then sampled — the counters carry the totals, and a
+    /// sustained per-block issue (e.g. peer-fed blocks with bogus header roots) must not flood the
+    /// error log.</summary>
+    private static bool ShouldLogShadowIssue(long count) => count <= 10 || (count & 127) == 0;
 
     /// <summary>
     /// Bulk-applies the BAL's post-block values (account fields via <see cref="BalPostState"/>,

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateRoot.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.StateRoot.cs
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Metric;
+using Nethermind.Core.Specs;
+using Nethermind.Evm;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+
+namespace Nethermind.Consensus.Processing;
+
+/// <summary>
+/// Shadow-mode BAL bulk applier: recomputes the post-block state root by applying the suggested
+/// BAL's final per-account/per-slot values on an isolated copy of the parent state and compares
+/// it with the canonical post-block root. Diagnostics only, gated by
+/// <c>IBlocksConfig.ParallelBalStateRootShadow</c> (default off); never affects consensus results.
+/// </summary>
+public partial class BlockAccessListManager
+{
+    private IReadOnlyTxProcessorSource? _shadowRootEnv;
+
+    /// <summary>
+    /// When shadow mode is enabled on the parallel BAL path, recomputes the state root from the
+    /// suggested BAL on a parent-state env and compares it with <see cref="Block.StateRoot"/>.
+    /// </summary>
+    /// <remarks>
+    /// Never throws: mismatches bump <c>Metrics.BalShadowRootMismatches</c> and log an error;
+    /// unexpected failures are logged and swallowed so the canonical pipeline is unaffected.
+    /// Internal for tests.
+    /// </remarks>
+    internal void RunShadowStateRootComparison(Block block)
+    {
+        if (!blocksConfig.ParallelBalStateRootShadow || !ParallelExecutionEnabled)
+        {
+            return;
+        }
+
+        ReadOnlyBlockAccessList? bal = block.BlockAccessList;
+        Hash256? parentStateRoot = _parentStateRoot;
+        Hash256? canonicalRoot = block.StateRoot;
+        if (bal is null || parentStateRoot is null || canonicalRoot is null)
+        {
+            return;
+        }
+
+        if (readOnlyTxProcessingEnvFactory is null)
+        {
+            if (_logger.IsDebug) _logger.Debug("BAL shadow state root skipped: no read-only tx processing env factory available.");
+            return;
+        }
+
+        try
+        {
+            _shadowRootEnv ??= readOnlyTxProcessingEnvFactory.Create();
+            using IReadOnlyTxProcessingScope scope = _shadowRootEnv.Build(CreateParentStateHeader(block, parentStateRoot));
+            Hash256 shadowRoot = ComputeShadowStateRoot(bal, scope.WorldState, specProvider.GetSpec(block.Header));
+            if (shadowRoot != canonicalRoot)
+            {
+                Evm.Metrics.IncrementBalShadowRootMismatches();
+                if (_logger.IsError) _logger.Error($"BAL shadow state root mismatch for block {block.Number} ({block.Hash}): shadow {shadowRoot}, canonical {canonicalRoot}.");
+            }
+        }
+        catch (Exception ex)
+        {
+            // Shadow mode is diagnostics only: report and continue, never fail the block.
+            if (_logger.IsError) _logger.Error($"BAL shadow state root computation failed for block {block.Number} ({block.Hash}).", ex);
+        }
+    }
+
+    /// <summary>
+    /// Bulk-applies the BAL's post-block values (account fields via <see cref="BalPostState"/>,
+    /// last value per changed storage slot, code inserts) onto <paramref name="shadowState"/>
+    /// anchored at the parent state, then commits and returns the recalculated state root.
+    /// </summary>
+    private static Hash256 ComputeShadowStateRoot(ReadOnlyBlockAccessList bal, IWorldState shadowState, IReleaseSpec spec)
+    {
+        foreach (ReadOnlyAccountChanges accountChanges in bal.AccountChanges)
+        {
+            Address address = accountChanges.Address;
+            Account? parent = shadowState.TryGetAccount(address, out AccountStruct parentStruct)
+                ? new Account(parentStruct.Nonce, parentStruct.Balance, new Hash256(parentStruct.StorageRoot), new Hash256(parentStruct.CodeHash))
+                : null;
+
+            Account? post = BalPostState.Compute(parent, accountChanges, spec);
+            if (post is null)
+            {
+                // Absent post-block (EIP-158 empty or never materialized); storage goes with the account.
+                if (parent is not null)
+                {
+                    shadowState.DeleteAccount(address);
+                }
+                continue;
+            }
+
+            if (!ReferenceEquals(post, parent))
+            {
+                shadowState.CreateAccountIfNotExists(address, 0, 0);
+
+                UInt256 currentBalance = shadowState.GetBalance(address);
+                if (post.Balance > currentBalance)
+                {
+                    shadowState.AddToBalance(address, post.Balance - currentBalance, spec);
+                }
+                else if (post.Balance < currentBalance)
+                {
+                    shadowState.SubtractFromBalance(address, currentBalance - post.Balance, spec);
+                }
+
+                if (shadowState.GetNonce(address) != post.Nonce)
+                {
+                    shadowState.SetNonce(address, post.Nonce);
+                }
+
+                if (accountChanges.CodeChanges.Length > 0)
+                {
+                    shadowState.InsertCode(address, accountChanges.CodeChanges[^1].Code, spec);
+                }
+            }
+
+            foreach (ReadOnlySlotChanges slotChange in accountChanges.StorageChanges)
+            {
+                if (slotChange.Changes.Length > 0)
+                {
+                    // StorageChange.Value is EvmWord (Vector256<byte>) in big-endian wire form.
+                    EvmWord value = slotChange.Changes[^1].Value;
+                    ReadOnlySpan<byte> valueBytes = MemoryMarshal.CreateReadOnlySpan(
+                        ref Unsafe.As<EvmWord, byte>(ref value), 32);
+                    shadowState.Set(new StorageCell(address, slotChange.Key), [.. valueBytes.WithoutLeadingZeros()]);
+                }
+            }
+        }
+
+        shadowState.Commit(spec);
+        shadowState.RecalculateStateRoot();
+        return shadowState.StateRoot;
+    }
+
+    // Timing sinks for the BAL apply pipeline, mirroring BlockProcessor's sink pattern:
+    // IsEnabled folds to ExecutionMetricsFlag so the Stopwatch calls vanish when metrics are off.
+    private readonly struct BalWarmupWaitTimeSink : IMetricSink
+    {
+        public static void AddTicks(long ticks) => Evm.Metrics.IncrementBalWarmupWaitTime(ticks);
+        public static bool IsEnabled => ExecutionMetricsFlag.IsActive;
+    }
+
+    private readonly struct BalApplyTimeSink : IMetricSink
+    {
+        public static void AddTicks(long ticks) => Evm.Metrics.IncrementBalApplyTime(ticks);
+        public static bool IsEnabled => ExecutionMetricsFlag.IsActive;
+    }
+
+    private readonly struct BalStateRootTimeSink : IMetricSink
+    {
+        public static void AddTicks(long ticks) => Evm.Metrics.IncrementBalStateRootTime(ticks);
+        public static bool IsEnabled => ExecutionMetricsFlag.IsActive;
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
@@ -308,24 +308,24 @@ public partial class BlockAccessListManager
                 ? provider.Create(new ReadOnlyTxProcessingEnvPooledObjectPolicy(readOnlyTxProcessingEnvFactory))
                 : null;
         }
+    }
 
-        private static BlockHeader CreateParentStateHeader(Block block, Hash256 stateRoot)
+    private static BlockHeader CreateParentStateHeader(Block block, Hash256 stateRoot)
+    {
+        Hash256 parentHash = block.ParentHash ?? Keccak.Zero;
+        return new BlockHeader(
+            parentHash,
+            Keccak.OfAnEmptySequenceRlp,
+            Address.Zero,
+            UInt256.Zero,
+            block.Number == 0 ? 0 : block.Number - 1,
+            0,
+            0,
+            [])
         {
-            Hash256 parentHash = block.ParentHash ?? Keccak.Zero;
-            return new BlockHeader(
-                parentHash,
-                Keccak.OfAnEmptySequenceRlp,
-                Address.Zero,
-                UInt256.Zero,
-                block.Number == 0 ? 0 : block.Number - 1,
-                0,
-                0,
-                [])
-            {
-                StateRoot = stateRoot,
-                Hash = parentHash,
-            };
-        }
+            StateRoot = stateRoot,
+            Hash = parentHash,
+        };
     }
 
     private class SequentialTxProcessorWithWorldStateManager : ITxProcessorWithWorldStateManager

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Exceptions;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Metric;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.GasPolicy;
@@ -196,6 +197,7 @@ public partial class BlockAccessListManager(
         if (task is null) return;
         _balWarmupTask = null;
 
+        using MetricsTimer<BalWarmupWaitTimeSink> _ = new();
         try
         {
             task.GetAwaiter().GetResult();
@@ -274,6 +276,7 @@ public partial class BlockAccessListManager(
         {
             _parallelTxProcessorWithWorldStateManager.Value.Dispose();
         }
+        DisposableExtensions.DisposeAndNull(ref _shadowRootEnv);
         DisposableExtensions.DisposeAndNull(ref _suggestedValidationIndex);
         DisposableExtensions.DisposeAndNull(ref _generatedValidationIndex);
     }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -38,10 +38,13 @@ public partial class BlockProcessor
         private int[] _txExecutionOrder = [];
         private TxExecutionSortKey[] _txExecutionSortKeys = [];
 
-        // BalRootReadyLagTime tracking: Stopwatch timestamps of "all tx workers finished" and
-        // "BAL apply produced the root", captured per block only when detailed metrics are on.
-        private long _balRemainingTxWorkers;
-        private long _balWorkersDrainedAt;
+        // BalRootReadyLagTime tracking: per-tx completion Stopwatch timestamps (each slot is written
+        // by exactly one worker, so the stores are contention-free; the drain point is their max,
+        // taken after the parallel loop joins) plus the timestamp of "BAL apply produced the root".
+        // ExecutionMetricsFlag is a compile-time switch (NO_EXEC_METRICS), so in default builds this
+        // always runs; the per-tx cost is a single plain store.
+        private long[] _balTxFinishedAt = [];
+        private long _balTrackingStartAt;
         private long _balRootReadyAt;
 
         public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
@@ -133,7 +136,7 @@ public partial class BlockProcessor
             IncrementalValidationWorkItem incrementalValidation = _incrementalValidationWorkItem;
             incrementalValidation.Schedule(balManager, block, gasResults, receiptsTracers, transactionProcessedEventHandler, token);
             BuildTxExecutionOrder(block.Transactions, _txExecutionOrder, _txExecutionSortKeys, GetCanonicalExecutionLead(len));
-            ResetBalRootLagTracking(len);
+            ResetBalRootLagTracking();
 
             try
             {
@@ -207,7 +210,7 @@ public partial class BlockProcessor
                                     throw;
                                 }
 
-                                state.self.OnBalTxWorkerFinished();
+                                state.self.OnBalTxWorkerFinished(txIndex);
                                 return state;
                             }
                             finally
@@ -242,7 +245,7 @@ public partial class BlockProcessor
                 }
 
                 incrementalValidation.GetResult();
-                ReportBalRootReadyLag();
+                ReportBalRootReadyLag(len);
                 return CombineReceipts(receiptsTracers, len);
             }
             finally
@@ -255,22 +258,18 @@ public partial class BlockProcessor
             }
         }
 
-        private void ResetBalRootLagTracking(int txCount)
+        private void ResetBalRootLagTracking()
         {
             if (!ExecutionMetricsFlag.IsActive) return;
             Volatile.Write(ref _balRootReadyAt, 0);
-            Volatile.Write(ref _balRemainingTxWorkers, txCount);
             // With no tx workers the drain point is the start of the parallel loop.
-            Volatile.Write(ref _balWorkersDrainedAt, txCount == 0 ? Stopwatch.GetTimestamp() : 0);
+            _balTrackingStartAt = Stopwatch.GetTimestamp();
         }
 
-        private void OnBalTxWorkerFinished()
+        private void OnBalTxWorkerFinished(int txIndex)
         {
             if (!ExecutionMetricsFlag.IsActive) return;
-            if (Interlocked.Decrement(ref _balRemainingTxWorkers) == 0)
-            {
-                Volatile.Write(ref _balWorkersDrainedAt, Stopwatch.GetTimestamp());
-            }
+            _balTxFinishedAt[txIndex] = Stopwatch.GetTimestamp();
         }
 
         private void OnBalRootReady()
@@ -279,12 +278,20 @@ public partial class BlockProcessor
             Volatile.Write(ref _balRootReadyAt, Stopwatch.GetTimestamp());
         }
 
-        private void ReportBalRootReadyLag()
+        private void ReportBalRootReadyLag(int txCount)
         {
             if (!ExecutionMetricsFlag.IsActive) return;
             long rootReadyAt = Volatile.Read(ref _balRootReadyAt);
-            long workersDrainedAt = Volatile.Read(ref _balWorkersDrainedAt);
-            if (rootReadyAt == 0 || workersDrainedAt == 0) return;
+            if (rootReadyAt == 0) return;
+            // Only reached when every tx worker completed, so all txCount slots carry this block's
+            // timestamps; the parallel-loop join ordered those stores before these reads.
+            long workersDrainedAt = _balTrackingStartAt;
+            long[] txFinishedAt = _balTxFinishedAt;
+            for (int i = 0; i < txCount; i++)
+            {
+                if (txFinishedAt[i] > workersDrainedAt) workersDrainedAt = txFinishedAt[i];
+            }
+
             Metrics.IncrementBalRootReadyLagTime(
                 rootReadyAt > workersDrainedAt ? Stopwatch.GetElapsedTime(workersDrainedAt, rootReadyAt).Ticks : 0);
         }
@@ -305,6 +312,7 @@ public partial class BlockProcessor
             Array.Resize(ref _gasResultPool, newLength);
             Array.Resize(ref _txExecutionOrder, newLength);
             Array.Resize(ref _txExecutionSortKeys, newLength);
+            Array.Resize(ref _balTxFinishedAt, newLength);
             for (int i = currentLength; i < newLength; i++)
             {
                 _receiptsTracerPool[i] = new BlockReceiptsTracer(true);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,6 +37,12 @@ public partial class BlockProcessor
         private GasValidationResultSlot[] _gasResultPool = [];
         private int[] _txExecutionOrder = [];
         private TxExecutionSortKey[] _txExecutionSortKeys = [];
+
+        // BalRootReadyLagTime tracking: Stopwatch timestamps of "all tx workers finished" and
+        // "BAL apply produced the root", captured per block only when detailed metrics are on.
+        private long _balRemainingTxWorkers;
+        private long _balWorkersDrainedAt;
+        private long _balRootReadyAt;
 
         public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
         {
@@ -126,6 +133,7 @@ public partial class BlockProcessor
             IncrementalValidationWorkItem incrementalValidation = _incrementalValidationWorkItem;
             incrementalValidation.Schedule(balManager, block, gasResults, receiptsTracers, transactionProcessedEventHandler, token);
             BuildTxExecutionOrder(block.Transactions, _txExecutionOrder, _txExecutionSortKeys, GetCanonicalExecutionLead(len));
+            ResetBalRootLagTracking(len);
 
             try
             {
@@ -140,7 +148,7 @@ public partial class BlockProcessor
                         len + 1,
                         ParallelUnbalancedWork.DefaultOptions,
                         (block, processingOptions, stateProvider, balManager, receiptsTracers, gasResults, specProvider,
-                            txs: block.Transactions, txExecutionOrder: _txExecutionOrder, isBlockProcessingThread, inner),
+                            txs: block.Transactions, txExecutionOrder: _txExecutionOrder, isBlockProcessingThread, inner, self: this),
                         static (i, state) =>
                         {
                             // Propagate the parent thread's IsBlockProcessingThread flag onto the
@@ -154,6 +162,7 @@ public partial class BlockProcessor
                                 {
                                     state.balManager.WaitForBalWarmup();
                                     BlockAccessListManager.ApplyStateChanges(state.block.BlockAccessList, state.stateProvider, state.specProvider.GetSpec(state.block.Header), !state.block.Header.IsGenesis || !state.specProvider.GenesisStateUnavailable);
+                                    state.self.OnBalRootReady();
                                     return state;
                                 }
 
@@ -198,6 +207,7 @@ public partial class BlockProcessor
                                     throw;
                                 }
 
+                                state.self.OnBalTxWorkerFinished();
                                 return state;
                             }
                             finally
@@ -232,6 +242,7 @@ public partial class BlockProcessor
                 }
 
                 incrementalValidation.GetResult();
+                ReportBalRootReadyLag();
                 return CombineReceipts(receiptsTracers, len);
             }
             finally
@@ -242,6 +253,40 @@ public partial class BlockProcessor
                 // consistent on success.
                 HarvestPerTxReceiptsIntoOuter(receiptsTracers, len, outerReceiptsTracer);
             }
+        }
+
+        private void ResetBalRootLagTracking(int txCount)
+        {
+            if (!ExecutionMetricsFlag.IsActive) return;
+            Volatile.Write(ref _balRootReadyAt, 0);
+            Volatile.Write(ref _balRemainingTxWorkers, txCount);
+            // With no tx workers the drain point is the start of the parallel loop.
+            Volatile.Write(ref _balWorkersDrainedAt, txCount == 0 ? Stopwatch.GetTimestamp() : 0);
+        }
+
+        private void OnBalTxWorkerFinished()
+        {
+            if (!ExecutionMetricsFlag.IsActive) return;
+            if (Interlocked.Decrement(ref _balRemainingTxWorkers) == 0)
+            {
+                Volatile.Write(ref _balWorkersDrainedAt, Stopwatch.GetTimestamp());
+            }
+        }
+
+        private void OnBalRootReady()
+        {
+            if (!ExecutionMetricsFlag.IsActive) return;
+            Volatile.Write(ref _balRootReadyAt, Stopwatch.GetTimestamp());
+        }
+
+        private void ReportBalRootReadyLag()
+        {
+            if (!ExecutionMetricsFlag.IsActive) return;
+            long rootReadyAt = Volatile.Read(ref _balRootReadyAt);
+            long workersDrainedAt = Volatile.Read(ref _balWorkersDrainedAt);
+            if (rootReadyAt == 0 || workersDrainedAt == 0) return;
+            Metrics.IncrementBalRootReadyLagTime(
+                rootReadyAt > workersDrainedAt ? Stopwatch.GetElapsedTime(workersDrainedAt, rootReadyAt).Ticks : 0);
         }
 
         private void EnsureParallelBuffers(int length)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -164,7 +164,7 @@ public partial class BlockProcessor
                                 if (i == 0)
                                 {
                                     state.balManager.WaitForBalWarmup();
-                                    BlockAccessListManager.ApplyStateChanges(state.block.BlockAccessList, state.stateProvider, state.specProvider.GetSpec(state.block.Header), !state.block.Header.IsGenesis || !state.specProvider.GenesisStateUnavailable);
+                                    state.balManager.ApplyBlockStateChanges(state.block.BlockAccessList, state.stateProvider, state.specProvider.GetSpec(state.block.Header), !state.block.Header.IsGenesis || !state.specProvider.GenesisStateUnavailable);
                                     state.self.OnBalRootReady();
                                     return state;
                                 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/IBlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/IBlockAccessListManager.cs
@@ -7,6 +7,7 @@ using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
+using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 
 namespace Nethermind.Consensus.Processing;
@@ -53,6 +54,16 @@ public interface IBlockAccessListManager
         => new(GetTxProcessor(balIndex), this, balIndex);
 
     void IncrementalValidation(Block block, GasValidationResultSlot[] gasResults, BlockReceiptsTracer[] receiptsTracers, BlockProcessor.BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler? transactionProcessedEventHandler, CancellationToken token);
+
+    /// <summary>
+    /// The parallel path's canonical state transition: applies the suggested BAL's post-block
+    /// values onto <paramref name="stateProvider"/>. Default: the journaled replay
+    /// (<see cref="BlockAccessListManager.ApplyStateChanges"/>); implementations may dispatch to a
+    /// bulk applier.
+    /// </summary>
+    void ApplyBlockStateChanges(ReadOnlyBlockAccessList bal, IWorldState stateProvider, IReleaseSpec spec, bool shouldComputeStateRoot)
+        => BlockAccessListManager.ApplyStateChanges(bal, stateProvider, spec, shouldComputeStateRoot);
+
     void SetBlockAccessList(Block block);
     void ValidateBlockAccessList(Block block, uint index, bool validateStorageReads = true);
     void StoreBeaconRoot(Block block, IReleaseSpec spec);

--- a/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/BalPostStateTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/BalPostStateTests.cs
@@ -104,6 +104,24 @@ public class BalPostStateTests
         Assert.That(post, Is.EqualTo(new Account(7, 1, Keccak.EmptyTreeHash, CodeHash)));
     }
 
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Null_code_change_counts_as_no_code(bool eip158)
+    {
+        // CodeChange.CodeHash is the zero hash for null code; Compute must normalize it to
+        // Keccak.OfAnEmptyString so the EIP-158 empty check still fires on a swept account.
+        Account parent = new(0, 100);
+        ReadOnlyAccountChanges changes = Changes(
+            balanceChanges: [new BalanceChange(1, UInt256.Zero)],
+            codeChanges: [new CodeChange(1, null!)]);
+
+        Account? post = BalPostState.Compute(parent, changes, Spec(eip158));
+
+        Assert.That(post, eip158
+            ? Is.Null
+            : Is.EqualTo(new Account(0, UInt256.Zero, Keccak.EmptyTreeHash, Keccak.OfAnEmptyString)));
+    }
+
     [Test]
     public void Balance_only_change_keeps_parent_storage_root()
     {

--- a/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/BalPostStateTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/BalPostStateTests.cs
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.BlockAccessLists;
+
+[Parallelizable(ParallelScope.All)]
+public class BalPostStateTests
+{
+    private static readonly byte[] Code = [0x60, 0x01, 0x60, 0x02];
+    private static readonly Hash256 CodeHash = new(ValueKeccak.Compute(Code));
+
+    private static IReleaseSpec Spec(bool eip158 = true)
+    {
+        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        spec.IsEip158Enabled.Returns(eip158);
+        return spec;
+    }
+
+    private static ReadOnlyAccountChanges Changes(
+        BalanceChange[]? balanceChanges = null,
+        NonceChange[]? nonceChanges = null,
+        CodeChange[]? codeChanges = null)
+    {
+        AccountChangesBuilder builder = Build.An.AccountChanges.WithAddress(TestItem.AddressA);
+        if (balanceChanges is not null) builder.WithBalanceChanges(balanceChanges);
+        if (nonceChanges is not null) builder.WithNonceChanges(nonceChanges);
+        if (codeChanges is not null) builder.WithCodeChanges(codeChanges);
+        return builder.TestObject;
+    }
+
+    [Test]
+    public void Account_created_in_block_takes_all_fields_from_changes()
+    {
+        ReadOnlyAccountChanges changes = Changes(
+            balanceChanges: [new BalanceChange(1, 25)],
+            nonceChanges: [new NonceChange(1, 1)]);
+
+        Account? post = BalPostState.Compute(parent: null, changes, Spec());
+
+        Assert.That(post, Is.EqualTo(new Account(1, 25)));
+    }
+
+    [Test]
+    public void Unchanged_fields_fall_back_to_parent()
+    {
+        Account parent = new(5, 100, TestItem.KeccakB, CodeHash);
+        ReadOnlyAccountChanges changes = Changes(balanceChanges: [new BalanceChange(2, 42)]);
+
+        Account? post = BalPostState.Compute(parent, changes, Spec());
+
+        Assert.That(post, Is.EqualTo(new Account(5, 42, TestItem.KeccakB, CodeHash)));
+    }
+
+    [Test]
+    public void Last_change_wins_per_field()
+    {
+        ReadOnlyAccountChanges changes = Changes(
+            balanceChanges: [new BalanceChange(1, 10), new BalanceChange(3, 30)],
+            nonceChanges: [new NonceChange(1, 1), new NonceChange(3, 2)]);
+
+        Account? post = BalPostState.Compute(parent: null, changes, Spec());
+
+        Assert.That(post, Is.EqualTo(new Account(2, 30)));
+    }
+
+    [Test]
+    public void Eip158_totally_empty_post_account_is_absent()
+    {
+        Account parent = new(0, 100);
+        ReadOnlyAccountChanges changes = Changes(balanceChanges: [new BalanceChange(1, UInt256.Zero)]);
+
+        Account? post = BalPostState.Compute(parent, changes, Spec(eip158: true));
+
+        Assert.That(post, Is.Null);
+    }
+
+    [Test]
+    public void Pre_eip158_totally_empty_post_account_persists()
+    {
+        Account parent = new(0, 100);
+        ReadOnlyAccountChanges changes = Changes(balanceChanges: [new BalanceChange(1, UInt256.Zero)]);
+
+        Account? post = BalPostState.Compute(parent, changes, Spec(eip158: false));
+
+        Assert.That(post, Is.EqualTo(new Account(0, UInt256.Zero)));
+    }
+
+    [Test]
+    public void Code_change_keeps_unchanged_nonce_and_balance()
+    {
+        Account parent = new(7, 1);
+        ReadOnlyAccountChanges changes = Changes(codeChanges: [new CodeChange(1, Code)]);
+
+        Account? post = BalPostState.Compute(parent, changes, Spec());
+
+        Assert.That(post, Is.EqualTo(new Account(7, 1, Keccak.EmptyTreeHash, CodeHash)));
+    }
+
+    [Test]
+    public void Balance_only_change_keeps_parent_storage_root()
+    {
+        Account parent = new(1, 5, TestItem.KeccakC, Keccak.OfAnEmptyString);
+        ReadOnlyAccountChanges changes = Changes(balanceChanges: [new BalanceChange(1, 6)]);
+
+        Account? post = BalPostState.Compute(parent, changes, Spec());
+
+        Assert.That(post, Is.EqualTo(new Account(1, 6, TestItem.KeccakC, Keccak.OfAnEmptyString)));
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Reads_only_row_returns_parent_unchanged(bool parentExists)
+    {
+        Account? parent = parentExists ? new Account(0, 0) : null;
+        ReadOnlyAccountChanges changes = Build.An.AccountChanges
+            .WithAddress(TestItem.AddressA)
+            .WithStorageReads((UInt256)1)
+            .TestObject;
+
+        Account? post = BalPostState.Compute(parent, changes, Spec());
+
+        Assert.That(post, Is.SameAs(parent));
+    }
+}

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/BalPostState.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/BalPostState.cs
@@ -39,7 +39,12 @@ public static class BalPostState
 
         UInt256 balance = hasBalanceChange ? changes.BalanceChanges[^1].Value : parent?.Balance ?? UInt256.Zero;
         ulong nonce = hasNonceChange ? changes.NonceChanges[^1].Value : parent?.Nonce ?? 0;
-        Hash256 codeHash = hasCodeChange ? new Hash256(changes.CodeChanges[^1].CodeHash) : parent?.CodeHash ?? Keccak.OfAnEmptyString;
+        // CodeChange.CodeHash is the zero hash (not Keccak.OfAnEmptyString) when Code is null;
+        // normalize so null and empty code agree on "no code" — otherwise a null-code change would
+        // dodge the EIP-158 empty check below and diverge from the canonical InsertCode path.
+        Hash256 codeHash = hasCodeChange
+            ? changes.CodeChanges[^1].Code is null ? Keccak.OfAnEmptyString : new Hash256(changes.CodeChanges[^1].CodeHash)
+            : parent?.CodeHash ?? Keccak.OfAnEmptyString;
 
         // EIP-158: a touched, totally empty account (zero nonce, zero balance, no code) must be
         // absent from the post-block state.

--- a/src/Nethermind/Nethermind.Core/BlockAccessLists/BalPostState.cs
+++ b/src/Nethermind/Nethermind.Core/BlockAccessLists/BalPostState.cs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Int256;
+
+namespace Nethermind.Core.BlockAccessLists;
+
+/// <summary>
+/// Computes the post-block account fields implied by a BAL account row, mirroring the semantics
+/// of the canonical per-account BAL replay (<c>BlockAccessListManager.ApplyStateChanges</c>).
+/// </summary>
+public static class BalPostState
+{
+    /// <summary>
+    /// Computes the post-block account for <paramref name="changes"/> applied on top of
+    /// <paramref name="parent"/>; <c>null</c> means the account must be absent post-block.
+    /// </summary>
+    /// <remarks>
+    /// Each account field takes the value of the last recorded change, falling back to the
+    /// parent's value when that field has no changes. A row with no field changes leaves the
+    /// account untouched (<paramref name="parent"/> is returned as-is, including <c>null</c>):
+    /// storage reads are observations, not mutations. The returned account keeps the parent's
+    /// storage root — recomputing it from the BAL's storage writes is the applier's job.
+    /// Per EIP-158, a touched account that ends the block totally empty (zero nonce, zero
+    /// balance, no code) must be absent from the post state, which also implies its storage
+    /// is cleared.
+    /// </remarks>
+    public static Account? Compute(Account? parent, ReadOnlyAccountChanges changes, IReleaseSpec spec)
+    {
+        bool hasBalanceChange = changes.BalanceChanges.Length > 0;
+        bool hasNonceChange = changes.NonceChanges.Length > 0;
+        bool hasCodeChange = changes.CodeChanges.Length > 0;
+        if (!hasBalanceChange && !hasNonceChange && !hasCodeChange)
+        {
+            return parent;
+        }
+
+        UInt256 balance = hasBalanceChange ? changes.BalanceChanges[^1].Value : parent?.Balance ?? UInt256.Zero;
+        ulong nonce = hasNonceChange ? changes.NonceChanges[^1].Value : parent?.Nonce ?? 0;
+        Hash256 codeHash = hasCodeChange ? new Hash256(changes.CodeChanges[^1].CodeHash) : parent?.CodeHash ?? Keccak.OfAnEmptyString;
+
+        // EIP-158: a touched, totally empty account (zero nonce, zero balance, no code) must be
+        // absent from the post-block state.
+        if (spec.IsEip158Enabled && balance.IsZero && nonce == 0 && codeHash == Keccak.OfAnEmptyString)
+        {
+            return null;
+        }
+
+        return new Account(nonce, balance, parent?.StorageRoot ?? Keccak.EmptyTreeHash, codeHash);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -341,6 +341,56 @@ public class Metrics
         Interlocked.Add(ref IsBlockProcessingThread ? ref _mainReceiptsRootTime.Value : ref _otherReceiptsRootTime.Value, ticks);
     }
 
+    [Description("Time spent waiting for the BAL read warmup to finish before applying BAL state changes (ticks).")]
+    public static long BalWarmupWaitTime => _mainBalWarmupWaitTime.Value + _otherBalWarmupWaitTime.Value;
+    private static CacheLinePaddedLong _mainBalWarmupWaitTime;
+    private static CacheLinePaddedLong _otherBalWarmupWaitTime;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void IncrementBalWarmupWaitTime(long ticks)
+    {
+        if (!ExecutionMetricsFlag.IsActive) return;
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainBalWarmupWaitTime.Value : ref _otherBalWarmupWaitTime.Value, ticks);
+    }
+
+    [Description("Time spent replaying BAL account/storage deltas onto the world state, excluding commit and state root (ticks).")]
+    public static long BalApplyTime => _mainBalApplyTime.Value + _otherBalApplyTime.Value;
+    private static CacheLinePaddedLong _mainBalApplyTime;
+    private static CacheLinePaddedLong _otherBalApplyTime;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void IncrementBalApplyTime(long ticks)
+    {
+        if (!ExecutionMetricsFlag.IsActive) return;
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainBalApplyTime.Value : ref _otherBalApplyTime.Value, ticks);
+    }
+
+    [Description("Time spent committing and recalculating the state root after the BAL apply (ticks).")]
+    public static long BalStateRootTime => _mainBalStateRootTime.Value + _otherBalStateRootTime.Value;
+    private static CacheLinePaddedLong _mainBalStateRootTime;
+    private static CacheLinePaddedLong _otherBalStateRootTime;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void IncrementBalStateRootTime(long ticks)
+    {
+        if (!ExecutionMetricsFlag.IsActive) return;
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainBalStateRootTime.Value : ref _otherBalStateRootTime.Value, ticks);
+    }
+
+    [Description("Wall-clock time from the last parallel BAL validation worker finishing to the BAL-applied state root being ready; 0 when the root was ready first (ticks).")]
+    public static long BalRootReadyLagTime => _mainBalRootReadyLagTime.Value + _otherBalRootReadyLagTime.Value;
+    private static CacheLinePaddedLong _mainBalRootReadyLagTime;
+    private static CacheLinePaddedLong _otherBalRootReadyLagTime;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void IncrementBalRootReadyLagTime(long ticks)
+    {
+        if (!ExecutionMetricsFlag.IsActive) return;
+        Interlocked.Add(ref IsBlockProcessingThread ? ref _mainBalRootReadyLagTime.Value : ref _otherBalRootReadyLagTime.Value, ticks);
+    }
+
+    private static long _balShadowRootMismatches;
+    [CounterMetric]
+    [Description("Number of blocks where the shadow BAL-applied state root diverged from the canonical post-block state root.")]
+    public static long BalShadowRootMismatches => _balShadowRootMismatches;
+    internal static void IncrementBalShadowRootMismatches() => Interlocked.Increment(ref _balShadowRootMismatches);
+
     [GaugeMetric]
     [Description("The number of tasks currently scheduled in the background.")]
     public static long NumberOfBackgroundTasksScheduled { get; set; }

--- a/src/Nethermind/Nethermind.Evm/Metrics.cs
+++ b/src/Nethermind/Nethermind.Evm/Metrics.cs
@@ -374,7 +374,7 @@ public class Metrics
         Interlocked.Add(ref IsBlockProcessingThread ? ref _mainBalStateRootTime.Value : ref _otherBalStateRootTime.Value, ticks);
     }
 
-    [Description("Wall-clock time from the last parallel BAL validation worker finishing to the BAL-applied state root being ready; 0 when the root was ready first (ticks).")]
+    [Description("Wall-clock time from the last parallel transaction execution worker finishing to the BAL-applied state root being ready; 0 when the root was ready first (ticks).")]
     public static long BalRootReadyLagTime => _mainBalRootReadyLagTime.Value + _otherBalRootReadyLagTime.Value;
     private static CacheLinePaddedLong _mainBalRootReadyLagTime;
     private static CacheLinePaddedLong _otherBalRootReadyLagTime;
@@ -385,11 +385,23 @@ public class Metrics
         Interlocked.Add(ref IsBlockProcessingThread ? ref _mainBalRootReadyLagTime.Value : ref _otherBalRootReadyLagTime.Value, ticks);
     }
 
+    private static long _balShadowRootComparisons;
+    [CounterMetric]
+    [Description("Number of blocks where the shadow BAL-applied state root was actually computed and compared against the canonical post-block state root.")]
+    public static long BalShadowRootComparisons => _balShadowRootComparisons;
+    internal static long IncrementBalShadowRootComparisons() => Interlocked.Increment(ref _balShadowRootComparisons);
+
     private static long _balShadowRootMismatches;
     [CounterMetric]
     [Description("Number of blocks where the shadow BAL-applied state root diverged from the canonical post-block state root.")]
     public static long BalShadowRootMismatches => _balShadowRootMismatches;
-    internal static void IncrementBalShadowRootMismatches() => Interlocked.Increment(ref _balShadowRootMismatches);
+    internal static long IncrementBalShadowRootMismatches() => Interlocked.Increment(ref _balShadowRootMismatches);
+
+    private static long _balShadowRootFailures;
+    [CounterMetric]
+    [Description("Number of shadow BAL state-root attempts that failed with an exception before producing a comparison.")]
+    public static long BalShadowRootFailures => _balShadowRootFailures;
+    internal static long IncrementBalShadowRootFailures() => Interlocked.Increment(ref _balShadowRootFailures);
 
     [GaugeMetric]
     [Description("The number of tasks currently scheduled in the background.")]

--- a/src/Nethermind/Nethermind.Evm/State/IBalBulkWorldState.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IBalBulkWorldState.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Specs;
+
+namespace Nethermind.Evm.State;
+
+/// <summary>
+/// A world state that can bulk-apply a block's BAL post-values straight to the backend scope,
+/// bypassing the per-operation journal.
+/// </summary>
+public interface IBalBulkWorldState
+{
+    /// <summary>
+    /// Applies the BAL's final per-account/per-slot values (accounts via <see cref="BalPostState"/>,
+    /// last value per changed slot, code inserts) directly through the backend scope's write batch.
+    /// </summary>
+    /// <remarks>
+    /// Preconditions: an open scope, and no state mutations performed through this world state in
+    /// the current block — the bulk write bypasses the journal, so it must be the block's only
+    /// write to this instance up to this point. Storage roots are reconciled by the batch; the
+    /// caller computes the state root afterwards (e.g. <see cref="IWorldState.RecalculateStateRoot"/>).
+    /// Block-level change tracking (<see cref="IWorldState.GetAccountChanges"/>) is kept accurate.
+    /// </remarks>
+    void BulkApplyBal(ReadOnlyBlockAccessList bal, IReleaseSpec spec);
+}

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -738,6 +738,22 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             _metrics.IncrementStateSkippedWrites(skipped);
     }
 
+    /// <summary>
+    /// Records an account state that was applied directly to the backend scope (bulk BAL apply),
+    /// so block-level change tracking (<see cref="ChangedAddresses"/>) stays accurate.
+    /// </summary>
+    /// <remarks>
+    /// Stored with <c>Before == After</c>: the value is already in the tree, so a later
+    /// <see cref="FlushToTree"/> must skip it — flushing would clobber the batch-reconciled
+    /// storage root with the stale one carried by <paramref name="account"/>.
+    /// </remarks>
+    internal void TrackBulkAppliedState(AddressAsKey key, Account? account)
+    {
+        ref ChangeTrace change = ref GetOrAddBlockChange(key, out _);
+        change = new ChangeTrace(account, account);
+        _needsStateRootUpdate = true;
+    }
+
     public bool WarmUp(Address address)
         => GetState(address) is not null;
 

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -738,6 +738,18 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             _metrics.IncrementStateSkippedWrites(skipped);
     }
 
+    /// <summary>Whether any block-level change is still waiting to be flushed to the tree
+    /// (<c>Before != After</c>). Read-through traces (<c>Before == After</c>) don't count.</summary>
+    internal bool HasPendingBlockChanges()
+    {
+        foreach (ChangeTrace change in _blockChanges.Values)
+        {
+            if (change.Before != change.After) return true;
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Records an account state that was applied directly to the backend scope (bulk BAL apply),
     /// so block-level change tracking (<see cref="ChangedAddresses"/>) stays accurate.

--- a/src/Nethermind/Nethermind.State/WorldState.BalBulkApply.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.BalBulkApply.cs
@@ -31,8 +31,11 @@ public sealed partial class WorldState : IBalBulkWorldState
     public void BulkApplyBal(ReadOnlyBlockAccessList bal, IReleaseSpec spec)
     {
         GuardInScope();
-        Debug.Assert(_stateProvider.ChangedAccountCount == 0,
-            "BulkApplyBal must be the block's first mutation of this world state — pending journal entries would flush stale values over the bulk-applied ones.");
+        // Read-through traces (Before == After) are expected — pre-block validation reads populate
+        // them; only unflushed WRITES violate the precondition, as a later FlushToTree would clobber
+        // the bulk-applied values with the stale journal entries.
+        Debug.Assert(!_stateProvider.HasPendingBlockChanges(),
+            "BulkApplyBal must not run with unflushed journal writes — a later FlushToTree would overwrite the bulk-applied values.");
 
         IWorldStateScopeProvider.IScope scope = _currentScope!;
         using ArrayPoolList<(IWorldStateScopeProvider.IStorageWriteBatch Batch, ReadOnlyAccountChanges Changes)> storageBatches = new(bal.ItemCount);

--- a/src/Nethermind/Nethermind.State/WorldState.BalBulkApply.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.BalBulkApply.cs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
+
+namespace Nethermind.State;
+
+public sealed partial class WorldState : IBalBulkWorldState
+{
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Per account (sequentially): the parent account is read through the scope (warm from the BAL
+    /// read warmup), <see cref="BalPostState.Compute"/> derives the post-block account, and the
+    /// result goes straight into the scope's <see cref="IWorldStateScopeProvider.IWorldStateWriteBatch"/>
+    /// — no journal entries, no per-operation balance/nonce bookkeeping. Storage batches are then
+    /// filled and disposed in parallel (each owns an independent per-account tree whose root is
+    /// computed at its dispose); the outer batch's dispose reconciles those roots into the account
+    /// leaves. Block-level change tracking is fed via <see cref="StateProvider.TrackBulkAppliedState"/>
+    /// so <see cref="GetAccountChanges"/> (TxPool cache invalidation) matches the journaled path.
+    /// </remarks>
+    public void BulkApplyBal(ReadOnlyBlockAccessList bal, IReleaseSpec spec)
+    {
+        GuardInScope();
+        Debug.Assert(_stateProvider.ChangedAccountCount == 0,
+            "BulkApplyBal must be the block's first mutation of this world state — pending journal entries would flush stale values over the bulk-applied ones.");
+
+        IWorldStateScopeProvider.IScope scope = _currentScope!;
+        using ArrayPoolList<(IWorldStateScopeProvider.IStorageWriteBatch Batch, ReadOnlyAccountChanges Changes)> storageBatches = new(bal.ItemCount);
+        using IWorldStateScopeProvider.IWorldStateWriteBatch batch = scope.StartWriteBatch(bal.ItemCount);
+        using IWorldStateScopeProvider.ICodeSetter codeSetter = scope.CodeDb.BeginCodeWrite();
+
+        // Storage-root fixups fired at the batch's dispose must land in the change tracking
+        // too, so any later read through the journal sees the reconciled account.
+        batch.OnAccountUpdated += (_, updated) => _stateProvider.TrackBulkAppliedState(updated.Address, updated.Account);
+
+        foreach (ReadOnlyAccountChanges accountChanges in bal.AccountChanges)
+        {
+            Address address = accountChanges.Address;
+            Account? parent = scope.Get(address);
+            Account? post = BalPostState.Compute(parent, accountChanges, spec);
+
+            if (!ReferenceEquals(post, parent))
+            {
+                batch.Set(address, post);
+                _stateProvider.TrackBulkAppliedState(address, post);
+            }
+
+            if (post is null)
+            {
+                // Absent post-block (EIP-158 empty or never materialized): Set(null) drops the
+                // account (and clears its storage where the backend keeps one); the row's slot
+                // writes go with it, mirroring the journaled commit's sweep.
+                continue;
+            }
+
+            if (accountChanges.CodeChanges.Length > 0)
+            {
+                CodeChange codeChange = accountChanges.CodeChanges[^1];
+                if (codeChange.Code is { Length: > 0 })
+                {
+                    codeSetter.Set(codeChange.CodeHash, codeChange.Code);
+                }
+            }
+
+            if (HasStorageWrites(accountChanges))
+            {
+                storageBatches.Add((batch.CreateStorageWriteBatch(address, accountChanges.ChangedSlots.Length), accountChanges));
+            }
+        }
+
+        // Each storage batch owns an independent per-account tree — fill and dispose in
+        // parallel; the root computation happens inside each dispose. The outer batch's dispose
+        // (end of method) then reconciles the computed roots into the account leaves.
+        if (storageBatches.Count == 1)
+        {
+            WriteAndDisposeStorageBatch(storageBatches[0]);
+        }
+        else if (storageBatches.Count > 1)
+        {
+            ArrayPoolList<(IWorldStateScopeProvider.IStorageWriteBatch, ReadOnlyAccountChanges)> batches = storageBatches;
+            Parallel.For(0, storageBatches.Count, i => WriteAndDisposeStorageBatch(batches[i]));
+        }
+    }
+
+    private static bool HasStorageWrites(ReadOnlyAccountChanges accountChanges)
+    {
+        foreach (ReadOnlySlotChanges slotChanges in accountChanges.StorageChanges)
+        {
+            if (slotChanges.Changes.Length > 0) return true;
+        }
+
+        return false;
+    }
+
+    private static void WriteAndDisposeStorageBatch((IWorldStateScopeProvider.IStorageWriteBatch Batch, ReadOnlyAccountChanges Changes) entry)
+    {
+        using IWorldStateScopeProvider.IStorageWriteBatch storageBatch = entry.Batch;
+        foreach (ReadOnlySlotChanges slotChanges in entry.Changes.StorageChanges)
+        {
+            if (slotChanges.Changes.Length == 0) continue;
+
+            // StorageChange.Value is EvmWord (Vector256<byte>) in big-endian wire form; the batch
+            // expects the stripped bytes, and a zero value (empty bytes) is a slot delete.
+            EvmWord value = slotChanges.Changes[^1].Value;
+            ReadOnlySpan<byte> valueBytes = MemoryMarshal.CreateReadOnlySpan(
+                ref Unsafe.As<EvmWord, byte>(ref value), 32);
+            storageBatch.Set(slotChanges.Key, [.. valueBytes.WithoutLeadingZeros()]);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -28,7 +28,7 @@ using Nethermind.Logging;
 
 namespace Nethermind.State
 {
-    public sealed class WorldState : IWorldState
+    public sealed partial class WorldState : IWorldState
     {
         internal readonly StateProvider _stateProvider;
         internal readonly PersistentStorageProvider _persistentStorageProvider;


### PR DESCRIPTION
## Changes

BAL-driven parallel state root workstream: **observability, a zero-risk shadow mode, and the journal-bypassing bulk applier itself** (opt-in). No behavior change on the canonical path with default config.

- **Timing metrics** for the parallel-path BAL apply pipeline, following the existing `StateRootTimeSink` pattern (`CacheLinePaddedLong`, gated by `ExecutionMetricsFlag`):
  - `BalWarmupWaitTime` — time iteration 0 spends joining the `HintBal` prefetch
  - `BalApplyTime` / `BalStateRootTime` — the journal walk vs the `Commit` + `RecalculateStateRoot` tail of `ApplyStateChanges`
  - `BalRootReadyLagTime` — wall-clock from the last tx-execution worker finishing to root ready, instrumented entirely inside `ParallelBlockValidationTransactionsExecutor` via contention-free per-tx completion timestamps (no shared counter on the parallel hot path). This is the number that says whether root work or execution binds newPayload latency on BAL blocks.
- **`BalPostState`** (Nethermind.Core): pure static helper computing an account's post-block state from parent account + `ReadOnlyAccountChanges` — last-change-wins per field with parent fallback, EIP-158 touched-totally-empty ⇒ absent. The unit-testable core the bulk applier below builds on.
- **Shadow-mode root comparison** behind `Blocks.ParallelBalStateRootShadow` (default `false`, hidden from docs): when enabled on the parallel BAL path, an independent read-only env at the parent state applies the BAL post-values (accounts via `BalPostState`, last-value slot writes, code inserts), computes the state root, and compares with the canonical result. The comparison is queued off the block-processing thread (and only after BAL validation passes), so shadow-enabled canaries don't pollute the timing baselines above. `BalShadowRootComparisons` counts completed comparisons — the soak's positive signal; mismatch ⇒ `BalShadowRootMismatches`, swallowed failures ⇒ `BalShadowRootFailures`; the error logs are sampled after the first occurrences so peer-fed blocks can't flood them. The canonical result is never affected.

- **Journal-bypassing parallel BAL bulk apply** behind `Blocks.ParallelBalBulkApply` (**default `true` on this branch** so benchmarks and every parallel-BAL test exercise it; hidden from docs) — the optimization the metrics above measure. Iteration 0 currently replays the BAL through the journaled world-state operations (`CreateAccountIfNotExists`/`AddToBalance`/`SetNonce`/`InsertCode`/`Set` + `Commit`), paying per-operation journal and bookkeeping costs before the root can be computed. With the flag on, `WorldState.BulkApplyBal` (new `IBalBulkWorldState` seam) instead reads each parent account through the scope (warm from the BAL read warmup), derives the post-block account via `BalPostState`, and writes straight into the backend scope's `StartWriteBatch` — the same bulk seam `WorldState.Commit` funnels into, minus the journal — with per-account storage batches **filled and disposed in parallel** (storage-root computation happens inside each dispose; the outer batch reconciles the roots into the account leaves). Correctness notes:
  - Block-level change tracking is preserved: bulk-applied accounts (and the batch's storage-root fixups) are recorded via `StateProvider.TrackBulkAppliedState` with `Before == After`, so `GetAccountChanges` (TxPool cache invalidation) matches the journaled path and a later `FlushToTree` skips them instead of clobbering reconciled storage roots.
  - Absent post-block accounts (EIP-158 sweep) go through `Set(null)`; their row's slot writes are skipped, mirroring the journaled commit's sweep. Zero slot values become empty bytes, i.e. slot deletes, matching `StorageTree` semantics.
  - Dispatch is `BlockAccessListManager.ApplyBlockStateChanges` (interface default = journaled replay); `--Blocks.ParallelBalBulkApply=false` restores byte-for-byte today's path and is the benchmark A/B baseline.

Purpose: quantify where block latency goes on BAL blocks (warmup wait / apply / root tail), de-risk the bulk applier by soaking the BAL-derived root reconstruction on devnets with zero consensus exposure, and let benchmarks A/B the applier itself — bulk is the branch default, `--Blocks.ParallelBalBulkApply=false` is the journaled baseline (pair with `--Blocks.ParallelBalStateRootShadow=true` so the shadow's journaled replay cross-checks the bulk root block by block).

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `BalPostStateTests` (11): creation, parent fallbacks, last-change-wins, EIP-158 on/off, code change with unchanged nonce, null-code normalization, reads-only rows.
- `BalBulkApplyTests` (20): 9 parity scenarios × {flat, trie} scope providers assert the bulk-applied root equals the journaled root and the account-change sets match (created account, balance/nonce-only, storage overwrite/zero-out/create, code deploy, EIP-158 sweep with and without storage, storage-only change, multi-account mix, reads-only row), plus manager dispatch tests.
- `BalShadowStateRootTests` (9): shadow/canonical root equivalence over real tries (shared TrieStore mirroring production) for account creation, balance-only, storage overwrite/zero-out/create, code deploy, EIP-158 sweep; mismatch reported without throwing; flag-off fully inert (env never created); throwing env factory and corrupt BAL never crash. A capturing logger plus the `BalShadowRootComparisons`/`BalShadowRootFailures` deltas assert the shadow actually ran, guarding against vacuous passes.
- Regression: `BlockAccessList*` + `BlockProcessorTests` 79/79, `Eip7928Tests` 204/204, `StandardConfigTests` + metrics-description tests, `Nethermind.Consensus.Test` ProcessingStats/SlowBlock 17/17 — all green.
- Next step once merged: enable the shadow flag on glamsterdam devnet canaries; target is `BalShadowRootComparisons > 0` with 0 mismatches and 0 failures over ≥1 week — with `ParallelBalBulkApply` also enabled, the shadow's journaled replay cross-checks the bulk applier block by block — before the bulk applier's default is flipped on the canonical path.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Part of the BAL benchmark performance workstream (#12681, #12682). The bulk applier ships here behind `Blocks.ParallelBalBulkApply` (default on for this branch's benchmark/soak phase — revisit the default before merge if a longer soak is wanted); an optional persist-tail overlap PR will follow, gated on the benchmark, metrics, and shadow-soak results from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

