### PR TITLE
test(benchmark): flat-state base point-read benchmark (RocksDB vs sorted-arena vs LMDB)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="Grpc.Tools" Version="2.82.0" />
     <PackageVersion Include="JetBrains.Profiler.Api" Version="1.4.11" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
+    <PackageVersion Include="LightningDB" Version="0.22.0" />
     <PackageVersion Include="MathNet.Numerics.FSharp" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.10" />

--- a/src/Nethermind/Nethermind.Benchmark/Nethermind.Benchmark.csproj
+++ b/src/Nethermind/Nethermind.Benchmark/Nethermind.Benchmark.csproj
@@ -6,11 +6,15 @@
   
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <!-- LMDB reference backend for the flat-base point-read benchmark. Benchmark-only — never
+         reference this from shipping projects. -->
+    <PackageReference Include="LightningDB" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Consensus.Ethash\Nethermind.Consensus.Ethash.csproj" />
     <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
+    <ProjectReference Include="..\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj" />
     <ProjectReference Include="..\Nethermind.Network.Stats\Nethermind.Network.Stats.csproj" />
     <ProjectReference Include="..\Nethermind.State.Flat\Nethermind.State.Flat.csproj" />
   </ItemGroup>

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/IFlatPointReadBackend.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/IFlatPointReadBackend.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+namespace Nethermind.Benchmarks.State.FlatBase;
+
+/// <summary>
+/// A storage backend under test in the flat-base point-read benchmark: uniform point reads of
+/// account (20-byte key) and storage-slot (52-byte key) records.
+/// </summary>
+public interface IFlatPointReadBackend : IDisposable
+{
+    /// <summary>Open a read session. Sessions are cheap and not thread-safe — each reader thread
+    /// creates (and disposes) its own; for LMDB a session wraps a read transaction.</summary>
+    IFlatReadSession BeginSession();
+}
+
+/// <summary>Per-thread read handle of an <see cref="IFlatPointReadBackend"/>.</summary>
+public interface IFlatReadSession : IDisposable
+{
+    /// <summary>Read the account record at <paramref name="key20"/> into <paramref name="valueOut"/>.</summary>
+    /// <returns>The value length in bytes, or 0 on a miss.</returns>
+    int GetAccount(ReadOnlySpan<byte> key20, Span<byte> valueOut);
+
+    /// <summary>Read the storage-slot record at <paramref name="key52"/> into <paramref name="valueOut"/>.</summary>
+    /// <returns>The value length in bytes, or 0 on a miss.</returns>
+    int GetSlot(ReadOnlySpan<byte> key52, Span<byte> valueOut);
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/LmdbFlatBackend.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/LmdbFlatBackend.cs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.IO;
+using LightningDB;
+
+namespace Nethermind.Benchmarks.State.FlatBase;
+
+/// <summary>
+/// LMDB reference backend via the LightningDB binding: two named databases ("account", "storage")
+/// in one environment. Referenced ONLY by this benchmark project — never from shipping projects.
+/// </summary>
+/// <remarks>
+/// Writes append in globally ascending key order (shards are written in order, sorted within), so
+/// <see cref="PutOptions.AppendData"/> bulk-loads the B-tree without page splits. Reads open the
+/// environment with <c>MDB_NOTLS</c> (read transactions per benchmark worker, not per OS thread slot)
+/// and <c>MDB_NORDAHEAD</c> (no OS readahead — the workload is uniform random point reads).
+/// </remarks>
+internal sealed class LmdbFlatBackend : IFlatPointReadBackend
+{
+    private readonly LightningEnvironment _env;
+    private readonly LightningDatabase _accountDb;
+    private readonly LightningDatabase _storageDb;
+
+    private LmdbFlatBackend(LightningEnvironment env, LightningDatabase accountDb, LightningDatabase storageDb)
+    {
+        _env = env;
+        _accountDb = accountDb;
+        _storageDb = storageDb;
+    }
+
+    public static LmdbFlatBackend OpenWrite(string dir, long mapSize) =>
+        Open(dir, mapSize, EnvironmentOpenFlags.None, new DatabaseConfiguration { Flags = DatabaseOpenFlags.Create });
+
+    public static LmdbFlatBackend OpenRead(string dir, long mapSize) =>
+        Open(dir, mapSize,
+            EnvironmentOpenFlags.ReadOnly | EnvironmentOpenFlags.NoThreadLocalStorage | EnvironmentOpenFlags.NoReadAhead,
+            new DatabaseConfiguration());
+
+    private static LmdbFlatBackend Open(string dir, long mapSize, EnvironmentOpenFlags flags, DatabaseConfiguration dbConfig)
+    {
+        Directory.CreateDirectory(dir);
+        LightningEnvironment env = new(dir, new EnvironmentConfiguration
+        {
+            MapSize = mapSize,
+            MaxDatabases = 2,
+            MaxReaders = 512,
+        });
+        env.Open(flags);
+
+        using LightningTransaction tx = env.BeginTransaction(
+            flags.HasFlag(EnvironmentOpenFlags.ReadOnly) ? TransactionBeginFlags.ReadOnly : TransactionBeginFlags.None);
+        LightningDatabase accountDb = tx.OpenDatabase("account", dbConfig);
+        LightningDatabase storageDb = tx.OpenDatabase("storage", dbConfig);
+        Check(tx.Commit());
+        return new LmdbFlatBackend(env, accountDb, storageDb);
+    }
+
+    /// <summary>Bulk-load one shard. Keys must be sorted ascending and follow all previously written
+    /// keys of the database (<see cref="PutOptions.AppendData"/>). One transaction per shard keeps the
+    /// dirty-page list bounded on the full-scale dataset.</summary>
+    public void PutShard(bool storage, byte[][] keys, byte[][] values, int count)
+    {
+        using LightningTransaction tx = _env.BeginTransaction();
+        LightningDatabase db = storage ? _storageDb : _accountDb;
+        for (int i = 0; i < count; i++)
+            Check(tx.Put(db, keys[i], values[i], PutOptions.AppendData));
+        Check(tx.Commit());
+    }
+
+    public IFlatReadSession BeginSession() => new Session(this);
+
+    public void Dispose()
+    {
+        _accountDb.Dispose();
+        _storageDb.Dispose();
+        _env.Dispose();
+    }
+
+    private static void Check(MDBResultCode resultCode)
+    {
+        if (resultCode != MDBResultCode.Success)
+            throw new InvalidOperationException($"LMDB operation failed: {resultCode}");
+    }
+
+    private sealed class Session(LmdbFlatBackend backend) : IFlatReadSession
+    {
+        private readonly LmdbFlatBackend _backend = backend;
+        private readonly LightningTransaction _tx = backend._env.BeginTransaction(TransactionBeginFlags.ReadOnly);
+
+        public int GetAccount(ReadOnlySpan<byte> key20, Span<byte> valueOut) =>
+            Get(_backend._accountDb, key20, valueOut);
+
+        public int GetSlot(ReadOnlySpan<byte> key52, Span<byte> valueOut) =>
+            Get(_backend._storageDb, key52, valueOut);
+
+        private int Get(LightningDatabase db, ReadOnlySpan<byte> key, Span<byte> valueOut)
+        {
+            (MDBResultCode resultCode, MDBValue _, MDBValue value) = _tx.Get(db, key);
+            if (resultCode != MDBResultCode.Success) return 0;
+
+            ReadOnlySpan<byte> span = value.AsSpan();
+            span.CopyTo(valueOut);
+            return span.Length;
+        }
+
+        public void Dispose() => _tx.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/README.md
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/README.md
@@ -1,0 +1,90 @@
+# Flat-base point-read benchmark (Phase 0 gate)
+
+Standalone micro-benchmark comparing cold/warm uniform-random point reads across three storage
+backends holding **byte-identical** synthetic state data:
+
+| Backend | What it is |
+| --- | --- |
+| `RocksDb` | Production flat layout: `ColumnsDb<FlatDbColumns>` with the default `DbConfig` `FlatDb`/`FlatAccountDb`/`FlatStorageDb` option strings and dedicated HyperClockCaches (300 MiB Account / 700 MiB Storage — the 30/70 split of the 1 GiB flat budget applied by `FlatRocksDbConfigAdjuster`). |
+| `SortedArena` | Prototype "MDBX-like" flat base: one mmap'd arena file per kind (`ArenaFile`, `MADV_RANDOM` on Linux) holding one `SortedTable` (see `Nethermind.State.Flat/PersistedSnapshots/Sorted/FORMAT.md`) per key-prefix shard (256 shards), plus a tiny in-memory shard directory. A point read is an index-block seek + one 4 KiB data-page seek. |
+| `Lmdb` | LMDB via the `LightningDB` package (benchmark-only dependency), bulk-loaded in key order with `MDB_APPEND`; read with `MDB_NOTLS | MDB_NORDAHEAD`. |
+
+Keys and values replicate the production flat encodings (`BaseFlatPersistence`): accounts are 20-byte
+truncated address hashes mapping to ~70–90-byte slim-RLP account values; slots are 52-byte split keys
+(`[4B addrHash | 32B slotHash | 16B addrHash]`) mapping to 32-byte values. All values derive
+deterministically from the generation counter, and every benchmark setup re-validates 1000 sampled
+keys byte-for-byte on the selected backend — a mismatch fails the run.
+
+## Dataset
+
+Built once and reused across runs (a `dataset.marker` file records the parameters; changing scale or
+format rebuilds). Controlled by environment variables:
+
+- `NETH_FLATBENCH_DIR` — dataset root (default: `<temp>/neth-flatbench`). Put it on the disk you want
+  to measure.
+- `NETH_FLATBENCH_SCALE`:
+  - `smoke` (default): 100k accounts / 500k slots. CI/local friendly (~100 MB per backend); the smoke
+    numbers are **indicative only** — everything fits in cache.
+  - `full`: 300M accounts / 1.2B slots (≥ 100 GB per backend). Build takes hours and needs a large
+    disk plus tens of GB of RAM headroom for the RocksDB bulk load/compaction. Run it on purpose, on
+    the target Linux box only.
+
+```bash
+NETH_FLATBENCH_SCALE=full NETH_FLATBENCH_DIR=/mnt/nvme/flatbench \
+  dotnet run -c release --project src/Nethermind/Nethermind.Benchmark.Runner -- \
+  -f '*FlatBasePointRead*'
+```
+
+The first benchmark process builds the dataset (spill → per-shard sorted bulk-load of all three
+backends → validation); subsequent processes reuse it.
+
+## Running
+
+Parameters: backend × {hit, guaranteed-miss} × reader threads {1, 8, 32}. Each invocation performs
+8192 reads split across the workers; results are reported per read.
+
+- **Warm**: just run the filter above. In-process caches (RocksDB block cache, OS page cache for the
+  mmap/LMDB) are hot after warmup.
+- **Cold** (the decision numbers): cold means *page-cache-cold*. On Linux, before **each** measured
+  pass:
+
+  ```bash
+  sync; echo 3 | sudo tee /proc/sys/vm/drop_caches
+  ```
+
+  and run a short single-shot job so warmup does not re-warm the cache, one parameter combination at
+  a time, e.g.:
+
+  ```bash
+  dotnet run -c release --project src/Nethermind/Nethermind.Benchmark.Runner -- \
+    -f '*FlatBasePointRead*' --warmupCount 0 --iterationCount 1 --invocationCount 1 --unrollFactor 1
+  ```
+
+  Repeat (drop caches → run) ≥ 5 times per combination and aggregate manually.
+
+## Metrics to record
+
+- p50/p99 per-read latency and reads/s per (backend, hit/miss, threads) — from the per-read means of
+  the repeated cold passes (BDN's in-run percentiles are meaningless for single-shot cold runs).
+- IOPS per read: run `iostat -x 1` on the dataset device during the pass; `r/s ÷ reads/s` gives
+  physical reads per lookup (the arena's core claim is ~1 data-page read per hit; RocksDB pays
+  index/filter misses on top).
+- Peak RSS per backend (cache budget accounting: RocksDB holds a 1 GiB block cache; the arena and
+  LMDB rely on the page cache).
+
+## Go/no-go thresholds (from planning)
+
+On cold uniform-random reads at the `full` scale (≥ 100 GB per backend):
+
+- **Go** if the arena is ≥ **1.8× RocksDB** on cold random hits **and** ≥ **0.85× LMDB**;
+- miss cost must be ≤ **1.2× LMDB** (the arena has no bloom filters — misses still binary-search a
+  shard; if this fails, Phase 1 adds a per-shard filter before any production work);
+- otherwise **no-go**: stop the flat-base workstream and record the numbers.
+
+## Implementation notes
+
+- `Sorted/` contains verbatim copies of the internal `SortedTable` machinery from
+  `Nethermind.State.Flat/PersistedSnapshots/Sorted/` (no `InternalsVisibleTo` for benchmarks; copying
+  beats widening production visibility). Keep them in sync with the originals.
+- `LightningDB` is referenced **only** by `Nethermind.Benchmark` — never add it to shipping projects.
+- Zero production code was changed for this benchmark.

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/RocksDbFlatBackend.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/RocksDbFlatBackend.cs
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using Nethermind.Core;
+using Nethermind.Core.Test;
+using Nethermind.Db;
+using Nethermind.Db.Rocks;
+using Nethermind.Db.Rocks.Config;
+using Nethermind.Logging;
+using Nethermind.State.Flat;
+
+namespace Nethermind.Benchmarks.State.FlatBase;
+
+/// <summary>
+/// The production-tuned RocksDB flat store: a <see cref="ColumnsDb{T}"/> over
+/// <see cref="FlatDbColumns"/> opened with the default <see cref="DbConfig"/> Flat/FlatAccount/FlatStorage
+/// option strings, plus dedicated HyperClockCaches for the Account (300 MiB) and Storage (700 MiB)
+/// columns — the same 30/70 split of the 1 GiB flat block-cache budget that
+/// <c>Nethermind.Init.Modules.FlatRocksDbConfigAdjuster</c> applies (that adjuster is internal, so its
+/// two-column cache wiring is mirrored here). Reads go through a DB snapshot, like
+/// <c>RocksDbPersistence.CreateReader</c>.
+/// </summary>
+internal sealed class RocksDbFlatBackend : IFlatPointReadBackend
+{
+    private const double AccountCacheShare = 0.3;
+    private const double StorageCacheShare = 0.7;
+    private const ulong BlockCacheBudget = 1024UL * 1024 * 1024;
+
+    private readonly HyperClockCacheWrapper _accountCache;
+    private readonly HyperClockCacheWrapper _storageCache;
+    private readonly ColumnsDb<FlatDbColumns> _db;
+    private readonly Lock _snapshotLock = new();
+    private IColumnDbSnapshot<FlatDbColumns> _snapshot;
+    private IReadOnlyKeyValueStore _accountColumn;
+    private IReadOnlyKeyValueStore _storageColumn;
+
+    public RocksDbFlatBackend(string basePath)
+    {
+        _accountCache = new HyperClockCacheWrapper((ulong)(BlockCacheBudget * AccountCacheShare));
+        _storageCache = new HyperClockCacheWrapper((ulong)(BlockCacheBudget * StorageCacheShare));
+
+        DbConfig dbConfig = new();
+        RocksDbConfigFactory baseFactory = new(
+            dbConfig, new PruningConfig(), new TestHardwareInfo(), NullLogManager.Instance);
+        CacheInjectingConfigFactory factory = new(baseFactory, _accountCache, _storageCache);
+
+        _db = new ColumnsDb<FlatDbColumns>(
+            basePath, new DbSettings("Flat", "flat"), dbConfig, factory, NullLogManager.Instance,
+            Enum.GetValues<FlatDbColumns>());
+    }
+
+    public void WriteShard(FlatDbColumns column, byte[][] keys, byte[][] values, int count)
+    {
+        using IColumnsWriteBatch<FlatDbColumns> batch = _db.StartWriteBatch();
+        IWriteBatch columnBatch = batch.GetColumnBatch(column);
+        for (int i = 0; i < count; i++)
+            columnBatch.PutSpan(keys[i], values[i], WriteFlags.DisableWAL);
+    }
+
+    /// <summary>Materialize the bulk load: flush memtables to SSTs and run a full compaction so
+    /// benchmark reads see the steady-state LSM shape rather than a pile of L0 files.</summary>
+    public void FinishWrites()
+    {
+        _db.Flush();
+        _db.Compact();
+        _db.Flush();
+    }
+
+    public IFlatReadSession BeginSession()
+    {
+        // Sessions are opened concurrently by the benchmark's reader threads; guard the one-time
+        // snapshot creation (reads through the snapshot columns are thread-safe).
+        lock (_snapshotLock)
+        {
+            if (_snapshot is null)
+            {
+                _snapshot = ((IColumnsDb<FlatDbColumns>)_db).CreateSnapshot();
+                _accountColumn = _snapshot.GetColumn(FlatDbColumns.Account);
+                _storageColumn = _snapshot.GetColumn(FlatDbColumns.Storage);
+            }
+        }
+
+        return new Session(this);
+    }
+
+    public void Dispose()
+    {
+        _snapshot?.Dispose();
+        _db.Dispose();
+        _accountCache.Dispose();
+        _storageCache.Dispose();
+    }
+
+    private sealed class Session(RocksDbFlatBackend backend) : IFlatReadSession
+    {
+        public int GetAccount(ReadOnlySpan<byte> key20, Span<byte> valueOut) =>
+            backend._accountColumn.Get(key20, valueOut);
+
+        public int GetSlot(ReadOnlySpan<byte> key52, Span<byte> valueOut) =>
+            backend._storageColumn.Get(key52, valueOut);
+
+        public void Dispose() { }
+    }
+
+    /// <summary>Mirror of the internal <c>FlatRocksDbConfigAdjuster</c>: hand the Account and Storage
+    /// columns their dedicated HyperClockCaches, leaving every other option to the production
+    /// <see cref="DbConfig"/> strings resolved by the wrapped factory.</summary>
+    private sealed class CacheInjectingConfigFactory(
+        IRocksDbConfigFactory inner,
+        HyperClockCacheWrapper accountCache,
+        HyperClockCacheWrapper storageCache) : IRocksDbConfigFactory
+    {
+        public IRocksDbConfig GetForDatabase(string databaseName, string columnName)
+        {
+            IRocksDbConfig config = inner.GetForDatabase(databaseName, columnName);
+            IntPtr? cacheHandle = columnName switch
+            {
+                nameof(FlatDbColumns.Account) => accountCache.Handle,
+                nameof(FlatDbColumns.Storage) => storageCache.Handle,
+                _ => null,
+            };
+
+            return cacheHandle is null
+                ? config
+                : new AdjustedRocksdbConfig(config, "", config.WriteBufferSize.GetValueOrDefault(), cacheHandle);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/ShardedSortedTableArena.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/ShardedSortedTableArena.cs
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using Nethermind.Benchmarks.State.FlatBase.Sorted;
+using Nethermind.State.Flat;
+using Nethermind.State.Flat.Io;
+using Nethermind.State.Flat.PersistedSnapshots.Storage;
+
+namespace Nethermind.Benchmarks.State.FlatBase;
+
+/// <summary>
+/// Prototype "flat base" store: one append-only arena file holding one <see cref="Sorted.SortedTable"/>
+/// per key-prefix shard, plus a tiny sidecar directory file mapping shard → table bound. Reads go
+/// through the production <see cref="ArenaFile"/> mmap (MADV_RANDOM on Linux); a point read is a
+/// two-level table seek — typically one index-block touch and one 4 KiB data-page touch.
+/// </summary>
+/// <remarks>
+/// The shard of a key is its top byte's high bits (<c>key[0] &gt;&gt; (8 − log2(shardCount))</c>), so
+/// shards cover contiguous key ranges and writing shards 0..N-1 in order keeps the whole arena
+/// ascending. Each table is started on a 4 KiB boundary so the table-relative block alignment holds
+/// absolutely. Directory sidecar format: <c>[shardCount i32][offset i64, length i64] × shardCount</c>.
+/// </remarks>
+internal static class ShardedSortedTableArena
+{
+    internal const string AccountArenaFile = "account.arena";
+    internal const string AccountDirFile = "account.dir";
+    internal const string StorageArenaFile = "storage.arena";
+    internal const string StorageDirFile = "storage.dir";
+
+    internal static int ShardOf(ReadOnlySpan<byte> key, int shardShift) => key[0] >> shardShift;
+
+    internal static int ShardShift(int shardCount)
+    {
+        if (shardCount is < 1 or > 256 || (shardCount & (shardCount - 1)) != 0)
+            throw new ArgumentOutOfRangeException(nameof(shardCount), shardCount, "Shard count must be a power of two in [1, 256]");
+        return 8 - System.Numerics.BitOperations.Log2((uint)shardCount);
+    }
+}
+
+/// <summary>Buffered <see cref="IByteBufferWriter"/> over a <see cref="FileStream"/> for streaming
+/// <see cref="Sorted.SortedTableBuilder{TWriter}"/> output to disk during dataset build.</summary>
+internal sealed class FileByteBufferWriter(FileStream stream) : IByteBufferWriter, IDisposable
+{
+    private readonly byte[] _buffer = new byte[1 << 20];
+    private int _position;
+
+    public long Written { get; private set; }
+
+    // The stream starts at offset 0 of the arena file, which is 4 KiB-aligned by definition.
+    public long FirstOffset => 0;
+
+    public Span<byte> GetSpan(int sizeHint)
+    {
+        if (_position + sizeHint > _buffer.Length) FlushBuffer();
+        return _buffer.AsSpan(_position);
+    }
+
+    public void Advance(int count)
+    {
+        _position += count;
+        Written += count;
+    }
+
+    private void FlushBuffer()
+    {
+        stream.Write(_buffer, 0, _position);
+        _position = 0;
+    }
+
+    public void Dispose()
+    {
+        FlushBuffer();
+        stream.Flush();
+    }
+}
+
+/// <summary>
+/// Pointer-backed <see cref="IByteReader{TPin}"/> over the arena's mmap — the production
+/// <c>ArenaByteReader</c> minus the reservation/residency tracking, which the benchmark store
+/// does not have.
+/// </summary>
+internal readonly unsafe struct PointerByteReader(byte* basePtr, long length) : IByteReader<NoOpPin>
+{
+    public long Length => length;
+
+    public bool TryRead(long offset, scoped Span<byte> output)
+    {
+        if ((ulong)offset + (ulong)output.Length > (ulong)length) return false;
+        // Safety: the bounds check above keeps [offset, offset + output.Length) within the mmap
+        // region [basePtr, basePtr + length) owned by the ArenaFile the caller keeps alive.
+        new ReadOnlySpan<byte>(basePtr + offset, output.Length).CopyTo(output);
+        return true;
+    }
+
+    public NoOpPin PinBuffer(Bound bound)
+    {
+        if ((ulong)bound.Offset + (ulong)bound.Length > (ulong)length)
+            throw new ArgumentOutOfRangeException(nameof(bound));
+        // Safety: same in-bounds guarantee as TryRead; the span never outlives the mmap because the
+        // NoOpPin is consumed within the seek call while the backend holds the ArenaFile open.
+        return new NoOpPin(new ReadOnlySpan<byte>(basePtr + bound.Offset, checked((int)bound.Length)));
+    }
+}
+
+/// <summary>Streams one sorted table per shard into an arena file and records the shard directory.
+/// Shards must be written in ascending shard order with keys sorted ascending within each shard.</summary>
+internal sealed class ShardedArenaWriter : IDisposable
+{
+    private readonly FileStream _stream;
+    private FileByteBufferWriter _writer;
+    private readonly Bound[] _tables;
+    private readonly string _dirPath;
+
+    public ShardedArenaWriter(string arenaPath, string dirPath, int shardCount)
+    {
+        _stream = new FileStream(arenaPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1);
+        _writer = new FileByteBufferWriter(_stream);
+        _tables = new Bound[shardCount];
+        _dirPath = dirPath;
+    }
+
+    public void WriteShard(int shard, byte[][] keys, byte[][] values, int count)
+    {
+        PadToPageBoundary();
+        long start = _writer.Written;
+        SortedTableBuilder<FileByteBufferWriter> builder = new(ref _writer);
+        try
+        {
+            for (int i = 0; i < count; i++)
+                builder.Add(keys[i], values[i]);
+            builder.Build();
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+
+        _tables[shard] = new Bound(start, _writer.Written - start);
+    }
+
+    private void PadToPageBoundary()
+    {
+        long pad = (-_writer.Written) & (PageLayout.PageSize - 1);
+        while (pad > 0)
+        {
+            int chunk = (int)Math.Min(pad, 256);
+            _writer.GetSpan(chunk)[..chunk].Clear();
+            _writer.Advance(chunk);
+            pad -= chunk;
+        }
+    }
+
+    public void Dispose()
+    {
+        _writer.Dispose();
+        _stream.Dispose();
+
+        byte[] dir = new byte[sizeof(int) + _tables.Length * 2 * sizeof(long)];
+        BinaryPrimitives.WriteInt32LittleEndian(dir, _tables.Length);
+        for (int i = 0; i < _tables.Length; i++)
+        {
+            BinaryPrimitives.WriteInt64LittleEndian(dir.AsSpan(sizeof(int) + i * 2 * sizeof(long)), _tables[i].Offset);
+            BinaryPrimitives.WriteInt64LittleEndian(dir.AsSpan(sizeof(int) + i * 2 * sizeof(long) + sizeof(long)), _tables[i].Length);
+        }
+
+        File.WriteAllBytes(_dirPath, dir);
+    }
+}
+
+/// <summary>Point-read side of a sharded arena: mmaps the arena via the production
+/// <see cref="ArenaFile"/> and seeks the shard's table selected by the key prefix.</summary>
+internal sealed unsafe class ShardedArenaReader : IDisposable
+{
+    private readonly ArenaFile _file;
+    private readonly Bound[] _tables;
+    private readonly int _shardShift;
+
+    private ShardedArenaReader(ArenaFile file, Bound[] tables)
+    {
+        _file = file;
+        _tables = tables;
+        _shardShift = ShardedSortedTableArena.ShardShift(tables.Length);
+    }
+
+    public static ShardedArenaReader Open(string arenaPath, string dirPath)
+    {
+        byte[] dir = File.ReadAllBytes(dirPath);
+        int shardCount = BinaryPrimitives.ReadInt32LittleEndian(dir);
+        Bound[] tables = new Bound[shardCount];
+        for (int i = 0; i < shardCount; i++)
+        {
+            long offset = BinaryPrimitives.ReadInt64LittleEndian(dir.AsSpan(sizeof(int) + i * 2 * sizeof(long)));
+            long length = BinaryPrimitives.ReadInt64LittleEndian(dir.AsSpan(sizeof(int) + i * 2 * sizeof(long) + sizeof(long)));
+            tables[i] = new Bound(offset, length);
+        }
+
+        ArenaFile file = new(id: 0, arenaPath, new FileInfo(arenaPath).Length);
+        // ArenaFile deletes its backing file when the last lease drops unless told otherwise; the
+        // benchmark dataset must survive across runs.
+        file.PersistOnShutdown();
+        return new ShardedArenaReader(file, tables);
+    }
+
+    public bool TryGet(ReadOnlySpan<byte> key, Span<byte> valueOut, out int length)
+    {
+        Bound table = _tables[ShardedSortedTableArena.ShardOf(key, _shardShift)];
+        PointerByteReader reader = new(_file.BasePtr, _file.MappedSize);
+        if (!SortedTableReader.TrySeek<PointerByteReader, NoOpPin>(in reader, table, key, out Bound value))
+        {
+            length = 0;
+            return false;
+        }
+
+        length = (int)value.Length;
+        // Safety: TrySeek only returns bounds inside the reader's [0, MappedSize) region.
+        new ReadOnlySpan<byte>(_file.BasePtr + value.Offset, length).CopyTo(valueOut);
+        return true;
+    }
+
+    public void Dispose() => _file.Dispose();
+}
+
+/// <summary>The sharded-arena <see cref="IFlatPointReadBackend"/>: one arena for accounts, one for slots.</summary>
+internal sealed class SortedArenaBackend : IFlatPointReadBackend
+{
+    private readonly ShardedArenaReader _accounts;
+    private readonly ShardedArenaReader _storage;
+
+    private SortedArenaBackend(ShardedArenaReader accounts, ShardedArenaReader storage)
+    {
+        _accounts = accounts;
+        _storage = storage;
+    }
+
+    public static SortedArenaBackend OpenRead(string dir) => new(
+        ShardedArenaReader.Open(
+            Path.Combine(dir, ShardedSortedTableArena.AccountArenaFile),
+            Path.Combine(dir, ShardedSortedTableArena.AccountDirFile)),
+        ShardedArenaReader.Open(
+            Path.Combine(dir, ShardedSortedTableArena.StorageArenaFile),
+            Path.Combine(dir, ShardedSortedTableArena.StorageDirFile)));
+
+    public IFlatReadSession BeginSession() => new Session(this);
+
+    public void Dispose()
+    {
+        _accounts.Dispose();
+        _storage.Dispose();
+    }
+
+    private sealed class Session(SortedArenaBackend backend) : IFlatReadSession
+    {
+        public int GetAccount(ReadOnlySpan<byte> key20, Span<byte> valueOut) =>
+            backend._accounts.TryGet(key20, valueOut, out int length) ? length : 0;
+
+        public int GetSlot(ReadOnlySpan<byte> key52, Span<byte> valueOut) =>
+            backend._storage.TryGet(key52, valueOut, out int length) ? length : 0;
+
+        public void Dispose() { }
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/Block.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/Block.cs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Verbatim copy of Nethermind.State.Flat/PersistedSnapshots/Sorted/Block.cs (internal in
+// Nethermind.State.Flat, which has no InternalsVisibleTo for benchmarks). Benchmark-scoped
+// prototype code — keep in sync with the original; do not diverge.
+
+using System.Runtime.InteropServices;
+
+namespace Nethermind.Benchmarks.State.FlatBase.Sorted;
+
+/// <summary>
+/// A single, self-describing, binary-searchable block of key/value records with front-coded keys — the shared
+/// unit of both the data blocks and the top-level index of a <see cref="SortedTable"/>.
+/// </summary>
+internal static class Block
+{
+    // On-disk header flag selecting the block's role and thereby its offset width. A data Block is
+    // capped at BlockSize (well under 64 KiB) so it uses 2-byte offsets; the Index can be multi-MB
+    // and uses 4-byte offsets — one format serves both.
+    internal const byte FlagBlock = 1;   // 2-byte offsets
+    internal const byte FlagIndex = 2;   // 4-byte offsets
+
+    /// <summary>Offset width in bytes for <paramref name="flag"/>, or 0 if it is neither
+    /// <see cref="FlagBlock"/> nor <see cref="FlagIndex"/>.</summary>
+    internal static int WidthFromFlag(byte flag) => flag switch
+    {
+        FlagBlock => 2,
+        FlagIndex => 4,
+        _ => 0,
+    };
+
+    /// <summary>Block-relative byte offset of the first record, given the offset width and restart count.</summary>
+    internal static long RecordsStart(int width, long numRestarts) => 1 + 2L * width + (long)width * numRestarts;
+
+    /// <summary>Fixed 3-byte prefix of a data record: the key's common-prefix length with the previous
+    /// record, the length of the key suffix that follows, and the inline value's length. Layout
+    /// <c>[cp][suffixLen][valueLen][keySuffix][value]</c>, so the prefix is read in one blit and the key
+    /// then value are sliced from the bytes after it. Single-byte fields, so endianness-independent.</summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal readonly record struct DataRecordHeader(byte CommonPrefix, byte SuffixLength, byte ValueLength);
+
+    /// <summary>Fixed 3-byte prefix of an index record: the front-coded key (cp, suffixLen) then the
+    /// number of little-endian low-order value bytes stored in <see cref="ValueChangedLength"/>. Layout
+    /// <c>[cp][suffixLen][valChangedLen][keySuffix][valChanged]</c>; the value (a data-block byte offset)
+    /// keeps the high bytes of the previous record's value and overwrites only its low bytes, reset against
+    /// 0 at a <c>cp == 0</c> restart (see <see cref="BlockBuilder.AddChangedPrefixValue"/>).</summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal readonly record struct IndexRecordHeader(byte CommonPrefix, byte SuffixLength, byte ValueChangedLength);
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/BlockBuilder.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/BlockBuilder.cs
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Verbatim copy of Nethermind.State.Flat/PersistedSnapshots/Sorted/BlockBuilder.cs (internal in
+// Nethermind.State.Flat, which has no InternalsVisibleTo for benchmarks). Benchmark-scoped
+// prototype code — keep in sync with the original; do not diverge.
+
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Nethermind.Core.Collections;
+using Nethermind.State.Flat;
+using Nethermind.State.Flat.Io;
+
+namespace Nethermind.Benchmarks.State.FlatBase.Sorted;
+
+/// <summary>
+/// Builds one <see cref="Block"/>: records are added in ascending key order, front-coded and
+/// restart-tracked off-heap, then emitted to a writer at <see cref="Finish"/> under the caller's
+/// <see cref="Block.FlagBlock"/>/<see cref="Block.FlagIndex"/> role flag, which fixes the offset width.
+/// </summary>
+internal sealed class BlockBuilder(int restartInterval, int expectedBytes = 4096) : IDisposable
+{
+    private readonly NativeMemoryList<byte> _body = new(Math.Max(64, expectedBytes));
+    private readonly NativeMemoryList<int> _restarts = new(64);
+    private readonly NativeMemoryList<byte> _prevKey = new(256);
+    // Previous index value; only used by AddChangedPrefixValue to find which low bytes changed.
+    private ulong _prevValue;
+    private int _recordCount;
+
+    public int RecordCount => _recordCount;
+
+    /// <summary>Append a data record <c>[cp][suffixLen][valueLen][keySuffix][value]</c>. Keys must arrive
+    /// in ascending order; key and value lengths ≤ 255.</summary>
+    public void Add(scoped ReadOnlySpan<byte> key, scoped ReadOnlySpan<byte> value)
+    {
+        int cp = StartRecord(key);
+        Block.DataRecordHeader h = new((byte)cp, (byte)(key.Length - cp), (byte)value.Length);
+        _body.AddRange(MemoryMarshal.AsBytes(new Span<Block.DataRecordHeader>(ref h)));
+        _body.AddRange(key[cp..]);
+        _body.AddRange(value);
+        EndRecord(key);
+    }
+
+    /// <summary>Append an index record whose value is a non-negative 48-bit integer (a data-block byte
+    /// offset). Only the low little-endian bytes that differ from the previous record's value are stored —
+    /// <c>[cp][suffixLen][valChangedLen][keySuffix][valChanged]</c> — and the reader keeps the unchanged
+    /// high bytes. At a key restart (<c>cp == 0</c>) the value is coded against 0 (fully restated) so a
+    /// seek can begin there.</summary>
+    /// <remarks>Offsets ascend, so the high bytes rarely change and the stored low-byte prefix stays short;
+    /// the little-endian layout lets <see cref="IndexBlockReader.SeekCeiling"/> copy those bytes straight
+    /// onto the low end of a running value.</remarks>
+    public void AddChangedPrefixValue(scoped ReadOnlySpan<byte> key, long value)
+    {
+        Debug.Assert((ulong)value >> 48 == 0, "index value must fit in 48 bits");
+        int cp = StartRecord(key);
+
+        // Number of low (little-endian) bytes that differ from the previous value (against 0 at a restart):
+        // the byte index of the highest-order change plus one; value/diff 0 ⇒ nothing stored.
+        ulong v = (ulong)value;
+        ulong diff = v ^ (cp == 0 ? 0UL : _prevValue);
+        int changedLen = diff == 0 ? 0 : BitOperations.Log2(diff) / 8 + 1;
+
+        Block.IndexRecordHeader h = new((byte)cp, (byte)(key.Length - cp), (byte)changedLen);
+        _body.AddRange(MemoryMarshal.AsBytes(new Span<Block.IndexRecordHeader>(ref h)));
+        _body.AddRange(key[cp..]);
+        _body.AddRange(MemoryMarshal.AsBytes(new Span<ulong>(ref v))[..changedLen]);
+
+        _prevValue = v;
+        EndRecord(key);
+    }
+
+    /// <summary>Determine the record's key common-prefix length and record a restart-table entry at every
+    /// <c>cp == 0</c>. A record is a <em>restart</em> when <c>cp == 0</c> (it stores a full key): forced
+    /// every <c>restartInterval</c> records to bound scan length, and arising naturally wherever the key
+    /// shares no leading byte with its predecessor.</summary>
+    private int StartRecord(scoped ReadOnlySpan<byte> key)
+    {
+        int cp = _recordCount % restartInterval == 0
+            ? 0
+            : ((ReadOnlySpan<byte>)_prevKey.AsSpan()).CommonPrefixLength(key);
+        if (cp == 0)
+            _restarts.Add(_body.Count);
+        return cp;
+    }
+
+    /// <summary>Advance the previous-key and record-count state after a record's bytes have been written.</summary>
+    private void EndRecord(scoped ReadOnlySpan<byte> key)
+    {
+        _prevKey.Clear();
+        _prevKey.AddRange(key);
+        _recordCount++;
+    }
+
+    /// <summary>Whether adding a record of the given key/value lengths would push the finished block
+    /// (assuming the 2-byte width that any ≤ 64 KiB block uses) across a 4 KiB page. Used by the data-block
+    /// size cap so each block stays within one page; the index block is never capped.</summary>
+    public bool WouldCrossPage(int keyLen, int valueLen)
+    {
+        // The next record may be a restart (cp == 0), which adds a restart-table entry; count it.
+        long header = Block.RecordsStart(2, _restarts.Count + 1);
+        int recordMax = Unsafe.SizeOf<Block.DataRecordHeader>() + keyLen + valueLen;
+        return header + _body.Count + recordMax > PageLayout.PageSize;
+    }
+
+    /// <summary>Emit the finished block under <paramref name="formatFlag"/>
+    /// (<see cref="Block.FlagBlock"/> for a data block, <see cref="Block.FlagIndex"/> for the index)
+    /// to <paramref name="writer"/>; returns the bytes written. The flag fixes the offset width — a
+    /// data block is capped well under 64 KiB so its 2-byte offsets always fit.</summary>
+    public long Finish<TWriter>(ref TWriter writer, byte formatFlag) where TWriter : IByteBufferWriter
+    {
+        int width = Block.WidthFromFlag(formatFlag);
+        int n = _restarts.Count;
+        int bodyLen = _body.Count;
+        long recordsStart = Block.RecordsStart(width, n);
+        long recordsEnd = recordsStart + bodyLen;
+
+        long start = writer.Written;
+        writer.GetSpan(1)[0] = formatFlag;
+        writer.Advance(1);
+        WriteOffset(ref writer, width, recordsEnd);
+        WriteOffset(ref writer, width, n);
+        Span<int> rs = _restarts.AsSpan();
+        for (int k = 0; k < n; k++)
+            WriteOffset(ref writer, width, recordsStart + rs[k]);
+        IByteBufferWriter.Copy(ref writer, _body.AsSpan());
+        return writer.Written - start;
+    }
+
+    public void Reset()
+    {
+        _body.Clear();
+        _restarts.Clear();
+        _prevKey.Clear();
+        _prevValue = 0;
+        _recordCount = 0;
+    }
+
+    public void Dispose()
+    {
+        _body.Dispose();
+        _restarts.Dispose();
+        _prevKey.Dispose();
+    }
+
+    private static void WriteOffset<TWriter>(ref TWriter writer, int width, long value) where TWriter : IByteBufferWriter
+    {
+        Span<byte> dst = writer.GetSpan(width);
+        if (width == 2) BinaryPrimitives.WriteUInt16LittleEndian(dst, checked((ushort)value));
+        else BinaryPrimitives.WriteUInt32LittleEndian(dst, checked((uint)value));
+        writer.Advance(width);
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/DataBlockReader.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/DataBlockReader.cs
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Verbatim copy of Nethermind.State.Flat/PersistedSnapshots/Sorted/DataBlockReader.cs (internal in
+// Nethermind.State.Flat, which has no InternalsVisibleTo for benchmarks). Benchmark-scoped
+// prototype code — keep in sync with the original; do not diverge. The TryReadRecordRange helper
+// (only used by the production enumerator, which is not copied) is omitted.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Nethermind.State.Flat.Io;
+
+namespace Nethermind.Benchmarks.State.FlatBase.Sorted;
+
+/// <summary>Read-side search and header parsing for a <see cref="Block"/>'s data records, whose values
+/// are plain inline bytes. The index block's changed-prefix-coded values are read separately by
+/// <see cref="IndexBlockReader"/>.</summary>
+internal static class DataBlockReader
+{
+    /// <summary>Data-block header (<see cref="Block.FlagBlock"/>, 2-byte offsets): the role flag then
+    /// the block-relative records-end and restart count. Read by reinterpreting the leading bytes (the
+    /// <c>u16</c> fields are little-endian on disk, matching the host on supported targets).</summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    private readonly struct Header
+    {
+        internal readonly byte Flag;
+        internal readonly ushort RecordsEnd;
+        internal readonly ushort NumRestarts;
+    }
+
+    /// <summary>
+    /// Position at the first record whose key ≥ <paramref name="target"/> (the ceiling) in the data block
+    /// at <paramref name="blockStart"/>: restart binary search then a forward scan to <c>recordsEnd</c>.
+    /// On a hit copies the ceiling key into <paramref name="keyBuf"/> and returns its value
+    /// <see cref="Bound"/>. Returns <c>false</c> when the block is empty or every key is
+    /// &lt; <paramref name="target"/>.
+    /// </summary>
+    /// <remarks>A data block normally fits within one <see cref="SortedTable.BlockSize"/> page, so the page
+    /// is pinned once and the search runs over a <see cref="SpanByteReader"/> on the pinned span — a
+    /// copy-on-pin reader does a single read instead of one per record and field. A block whose records
+    /// reach past the pinned page (not expected for a well-formed data block) is searched straight through
+    /// <paramref name="reader"/> instead, so it is still read in full.</remarks>
+    internal static bool SeekCeiling<TReader, TPin>(scoped in TReader reader, long blockStart,
+        scoped ReadOnlySpan<byte> target, scoped Span<byte> keyBuf, out int keyLen, out Bound value)
+        where TPin : struct, IBufferPin, allows ref struct
+        where TReader : IByteReader<TPin>, allows ref struct
+    {
+        keyLen = 0;
+        value = default;
+
+        long remaining = reader.Length - blockStart;
+        if (remaining <= 0) return false;
+        long pageLen = remaining < SortedTable.BlockSize ? remaining : SortedTable.BlockSize;
+
+        using TPin pagePin = reader.PinBuffer(new Bound(blockStart, pageLen));
+        SpanByteReader page = new(pagePin.Buffer);
+
+        // Read and validate the header once from the pinned page; the core search reuses it.
+        Header header = default;
+        if (!page.TryRead(0, MemoryMarshal.AsBytes(new Span<Header>(ref header)))) return false;
+        if (header.Flag != Block.FlagBlock || header.NumRestarts == 0) return false;
+
+        // Whole block in the pinned page ⇒ search the span; otherwise fall back to the original reader.
+        if (header.RecordsEnd <= pageLen)
+        {
+            if (!SeekCeilingCore<SpanByteReader, NoOpPin>(in page, 0, in header, target, keyBuf, out keyLen, out Bound local))
+                return false;
+            // local.Offset is page-relative; lift it back to reader-absolute for the caller.
+            value = new Bound(blockStart + local.Offset, local.Length);
+            return true;
+        }
+
+        return SeekCeilingCore<TReader, TPin>(in reader, blockStart, in header, target, keyBuf, out keyLen, out value);
+    }
+
+    /// <summary>Restart binary search then forward scan over the data block at <paramref name="blockStart"/>
+    /// described by the already-parsed <paramref name="header"/> (<see cref="Block.FlagBlock"/>,
+    /// <c>NumRestarts &gt; 0</c>), reading through <paramref name="reader"/>. The returned value
+    /// <see cref="Bound"/> is in <paramref name="reader"/> coordinates.</summary>
+    private static bool SeekCeilingCore<TReader, TPin>(scoped in TReader reader, long blockStart, in Header header,
+        scoped ReadOnlySpan<byte> target, scoped Span<byte> keyBuf, out int keyLen, out Bound value)
+        where TPin : struct, IBufferPin, allows ref struct
+        where TReader : IByteReader<TPin>, allows ref struct
+    {
+        keyLen = 0;
+        value = default;
+
+        long restartTableStart = blockStart + Unsafe.SizeOf<Header>();
+        long end = blockStart + header.RecordsEnd;
+
+        // Pin the whole restart-offset table once and index it in place, instead of reading each offset.
+        long offsetsBytes = (long)header.NumRestarts * sizeof(ushort);
+        if (restartTableStart + offsetsBytes > reader.Length) return false;
+        using TPin offsetsPin = reader.PinBuffer(new Bound(restartTableStart, offsetsBytes));
+        ReadOnlySpan<ushort> offsets = MemoryMarshal.Cast<byte, ushort>(offsetsPin.Buffer);
+        Block.DataRecordHeader rec = default;
+
+        // Restart offsets are block-relative record starts; a corrupt one must land within the records region
+        // [recordsStart, RecordsEnd), not in the header/restart table or past the block.
+        int recordsStart = Unsafe.SizeOf<Header>() + (int)offsetsBytes;
+
+        // Rightmost restart whose first key <= target (cp == 0 there, so the suffix is the full key).
+        int lo = 0;
+        int hi = header.NumRestarts - 1;
+        int found = -1;
+        while (lo <= hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            long recStart = blockStart + CheckRestartOffset(offsets[mid], recordsStart, header.RecordsEnd);
+            if (!reader.TryRead(recStart, MemoryMarshal.AsBytes(new Span<Block.DataRecordHeader>(ref rec)))) return false;
+            using TPin keyPin = reader.PinBuffer(new Bound(recStart + Unsafe.SizeOf<Block.DataRecordHeader>(), rec.SuffixLength));
+            if (keyPin.Buffer.SequenceCompareTo(target) <= 0) { found = mid; lo = mid + 1; }
+            else hi = mid - 1;
+        }
+
+        // target < firstKey ⇒ ceiling is the very first record; clamp the scan start to restart 0.
+        int scanRestart = found < 0 ? 0 : found;
+        long pos = blockStart + CheckRestartOffset(offsets[scanRestart], recordsStart, header.RecordsEnd);
+
+        // Scan forward across restart boundaries (cp = 0 self-corrects) for the first key >= target. The
+        // 3-byte prefix blit carries the value length, so the value is just a Bound past the key.
+        int prevKeyLen = 0;
+        while (pos < end)
+        {
+            if (!reader.TryRead(pos, MemoryMarshal.AsBytes(new Span<Block.DataRecordHeader>(ref rec)))) return false;
+            int cp = rec.CommonPrefix;
+            int suffixLen = rec.SuffixLength;
+            // Front-coding keeps keyBuf[0..cp) from the previous record; a cp beyond the previous key length
+            // would rebuild the key from stale bytes (a silent wrong key). A restart record (cp == 0) always
+            // passes and resets the running key.
+            if (cp > prevKeyLen)
+                SortedTable.ThrowCorrupt($"data record at byte {pos} declares common-prefix {cp} exceeding the previous key length {prevKeyLen}");
+            if (cp + suffixLen > keyBuf.Length)
+                SortedTable.ThrowCorrupt($"data record at byte {pos} declares key length {cp}+{suffixLen} exceeding the {keyBuf.Length}-byte reader buffer");
+            long keyStart = pos + Unsafe.SizeOf<Block.DataRecordHeader>();
+            if (!reader.TryRead(keyStart, keyBuf.Slice(cp, suffixLen))) return false; // keep [0..cp) from prev
+            int kLen = cp + suffixLen;
+            prevKeyLen = kLen;
+            long valueStart = keyStart + suffixLen;
+
+            if (target.SequenceCompareTo(keyBuf[..kLen]) <= 0)
+            {
+                keyLen = kLen;
+                value = new Bound(valueStart, rec.ValueLength);
+                return true;
+            }
+            pos = valueStart + rec.ValueLength;
+        }
+        return false;
+    }
+
+    /// <summary>Validate a block-relative restart offset lands within the records region
+    /// <c>[recordsStart, recordsEnd)</c> before it is dereferenced; throws (wipe-and-resync) otherwise.</summary>
+    private static ushort CheckRestartOffset(ushort offset, int recordsStart, ushort recordsEnd)
+    {
+        if (offset < recordsStart || offset >= recordsEnd)
+            SortedTable.ThrowCorrupt($"data block restart offset {offset} is outside the records region [{recordsStart}, {recordsEnd})");
+        return offset;
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/IndexBlockReader.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/IndexBlockReader.cs
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Verbatim copy of Nethermind.State.Flat/PersistedSnapshots/Sorted/IndexBlockReader.cs (internal in
+// Nethermind.State.Flat, which has no InternalsVisibleTo for benchmarks). Benchmark-scoped
+// prototype code — keep in sync with the original; do not diverge. The TryReadRecordRange helper
+// (only used by the production enumerator, which is not copied) is omitted.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Nethermind.State.Flat.Io;
+
+namespace Nethermind.Benchmarks.State.FlatBase.Sorted;
+
+/// <summary>
+/// Read-side ceiling search over a <see cref="SortedTable"/> index block, whose record values are u48 byte
+/// offsets stored little-endian as only the low bytes that changed from the previous value (the high bytes
+/// carry over), reset at every restart (see <see cref="BlockBuilder.AddChangedPrefixValue"/>). The restart
+/// binary search and forward scan are its own, since the index scan reconstructs the offset where the
+/// data-block scan (<see cref="DataBlockReader.SeekCeiling"/>) returns a value <see cref="Bound"/>.
+/// </summary>
+internal static class IndexBlockReader
+{
+    /// <summary>Index-block header (<see cref="Block.FlagIndex"/>, 4-byte offsets): the role flag then
+    /// the block-relative records-end and restart count. Read by reinterpreting the leading bytes (the
+    /// <c>u32</c> fields are little-endian on disk, matching the host on supported targets).</summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    private readonly struct Header
+    {
+        internal readonly byte Flag;
+        internal readonly uint RecordsEnd;
+        internal readonly uint NumRestarts;
+    }
+
+    /// <summary>
+    /// Position at the first separator ≥ <paramref name="target"/> (the ceiling) in the index block at
+    /// <paramref name="blockStart"/> and return the reconstructed absolute byte offset
+    /// <paramref name="byteOffset"/> of its data block, copying the ceiling separator into
+    /// <paramref name="keyBuf"/>. Returns <c>false</c> when the index is empty or every separator is
+    /// &lt; <paramref name="target"/>.
+    /// </summary>
+    /// <remarks>
+    /// The binary search picks the rightmost restart whose first key ≤ <paramref name="target"/>, so the
+    /// scan starts at a restart record (<c>cp == 0</c>) that resets the running value to 0; each later
+    /// record overwrites only its low <c>valChangedLen</c> bytes, keeping the unchanged high bytes.
+    /// </remarks>
+    internal static bool SeekCeiling<TReader, TPin>(scoped in TReader reader, long blockStart,
+        scoped ReadOnlySpan<byte> target, scoped Span<byte> keyBuf,
+        out int keyLen, out long byteOffset, out long ceilingRecordEnd)
+        where TPin : struct, IBufferPin, allows ref struct
+        where TReader : IByteReader<TPin>, allows ref struct
+    {
+        keyLen = 0;
+        byteOffset = 0;
+        ceilingRecordEnd = 0;
+
+        Header header = default;
+        if (!reader.TryRead(blockStart, MemoryMarshal.AsBytes(new Span<Header>(ref header)))) return false;
+        if (header.Flag != Block.FlagIndex || header.NumRestarts == 0) return false;
+
+        long restartTableStart = blockStart + Unsafe.SizeOf<Header>();
+        long end = blockStart + header.RecordsEnd;
+
+        // The index block stays well under 2 GiB (≈ 60 MiB even for a 12 GiB snapshot), so its restart
+        // count fits int and the restart indices below cannot overflow. The offset table can be large, so
+        // each binary-search step reads just the one restart offset it needs rather than pinning the table.
+        Block.IndexRecordHeader rec = default;
+
+        // Restart offsets are block-relative record starts; a corrupt one must land within the records region
+        // [recordsStart, RecordsEnd), not in the header/restart table or past the block.
+        long recordsStart = Unsafe.SizeOf<Header>() + (long)header.NumRestarts * sizeof(uint);
+        long recordsEnd = header.RecordsEnd;
+
+        // Rightmost restart whose first key <= target (cp == 0 there, so the suffix is the full key).
+        int lo = 0;
+        int hi = (int)header.NumRestarts - 1;
+        int found = -1;
+        while (lo <= hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            uint offset = 0;
+            if (!reader.TryRead(restartTableStart + (long)mid * sizeof(uint), MemoryMarshal.AsBytes(new Span<uint>(ref offset)))) return false;
+            long recStart = blockStart + CheckRestartOffset(offset, recordsStart, recordsEnd);
+            if (!reader.TryRead(recStart, MemoryMarshal.AsBytes(new Span<Block.IndexRecordHeader>(ref rec)))) return false;
+            using TPin keyPin = reader.PinBuffer(new Bound(recStart + Unsafe.SizeOf<Block.IndexRecordHeader>(), rec.SuffixLength));
+            if (keyPin.Buffer.SequenceCompareTo(target) <= 0) { found = mid; lo = mid + 1; }
+            else hi = mid - 1;
+        }
+
+        // target < firstKey ⇒ ceiling is the very first record; clamp the scan start to restart 0.
+        int scanRestart = found < 0 ? 0 : found;
+        uint scanOffset = 0;
+        if (!reader.TryRead(restartTableStart + (long)scanRestart * sizeof(uint), MemoryMarshal.AsBytes(new Span<uint>(ref scanOffset)))) return false;
+        long pos = blockStart + CheckRestartOffset(scanOffset, recordsStart, recordsEnd);
+
+        // The value (a u48 byte offset) is stored little-endian as only the low bytes that changed from the
+        // previous record; a restart (cp == 0) drops the previous high bytes by resetting to 0. Each record
+        // overwrites the running value's low valChangedLen bytes in place — a direct copy, no decode.
+        long runningValue = 0;
+
+        // Scan forward across restart boundaries (cp = 0 self-corrects) for the first key >= target.
+        int prevKeyLen = 0;
+        while (pos < end)
+        {
+            if (!reader.TryRead(pos, MemoryMarshal.AsBytes(new Span<Block.IndexRecordHeader>(ref rec)))) return false;
+            int cp = rec.CommonPrefix;
+            int suffixLen = rec.SuffixLength;
+            int valChangedLen = rec.ValueChangedLength;
+            if (valChangedLen > 6)
+                SortedTable.ThrowCorrupt($"index record at byte {pos} declares value-changed length {valChangedLen} exceeding the u48 maximum of 6");
+            // Front-coding keeps keyBuf[0..cp) from the previous record; reject a cp beyond the previous key
+            // length (would rebuild the key from stale bytes). A restart (cp == 0) always passes.
+            if (cp > prevKeyLen)
+                SortedTable.ThrowCorrupt($"index record at byte {pos} declares common-prefix {cp} exceeding the previous key length {prevKeyLen}");
+            if (cp + suffixLen > keyBuf.Length)
+                SortedTable.ThrowCorrupt($"index record at byte {pos} declares key length {cp}+{suffixLen} exceeding the {keyBuf.Length}-byte reader buffer");
+
+            long keyStart = pos + Unsafe.SizeOf<Block.IndexRecordHeader>();
+            if (!reader.TryRead(keyStart, keyBuf.Slice(cp, suffixLen))) return false; // keep [0..cp) from prev
+            int kLen = cp + suffixLen;
+            prevKeyLen = kLen;
+            long valueStart = keyStart + suffixLen;
+
+            if (cp == 0) runningValue = 0;
+            if (valChangedLen > 0 &&
+                !reader.TryRead(valueStart, MemoryMarshal.AsBytes(new Span<long>(ref runningValue))[..valChangedLen])) return false;
+
+            if (target.SequenceCompareTo(keyBuf[..kLen]) <= 0)
+            {
+                keyLen = kLen;
+                byteOffset = runningValue;
+                // Index position just past the ceiling record, so a resuming cursor keeps walking the
+                // index from the next record with `runningValue` as its carried-over high bytes.
+                ceilingRecordEnd = valueStart + valChangedLen;
+                return true;
+            }
+            pos = valueStart + valChangedLen;
+        }
+        return false;
+    }
+
+    /// <summary>Validate a block-relative restart offset lands within the records region
+    /// <c>[recordsStart, recordsEnd)</c> before it is dereferenced; throws (wipe-and-resync) otherwise.</summary>
+    private static uint CheckRestartOffset(uint offset, long recordsStart, long recordsEnd)
+    {
+        if (offset < recordsStart || offset >= recordsEnd)
+            SortedTable.ThrowCorrupt($"index block restart offset {offset} is outside the records region [{recordsStart}, {recordsEnd})");
+        return offset;
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/SortedTable.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/SortedTable.cs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Verbatim copy of Nethermind.State.Flat/PersistedSnapshots/Sorted/SortedTable.cs (internal in
+// Nethermind.State.Flat, which has no InternalsVisibleTo for benchmarks). Benchmark-scoped
+// prototype code — keep in sync with the original; do not diverge.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Nethermind.State.Flat;
+using Nethermind.State.Flat.Io;
+
+namespace Nethermind.Benchmarks.State.FlatBase.Sorted;
+
+/// <summary>
+/// Shared wire-format constants and footer helper for the two-level sorted table that backs a
+/// persisted snapshot's metadata blob. It is an ascending byte-sorted map of fully-materialized keys
+/// to small inline values, laid out as a run of 4 KiB-aligned <see cref="Block">data blocks</see>
+/// located by table-relative byte offset, followed by a single index block (separator → byte offset)
+/// and a footer.
+/// </summary>
+internal static class SortedTable
+{
+    /// <summary>Data-block size and alignment — every data block but the last is zero-padded to this 4 KiB
+    /// page, so block <c>i</c> sits at <c>i · BlockSize</c> and the index records its byte offset directly.</summary>
+    internal const int BlockSize = PageLayout.PageSize;
+
+    /// <summary>Default front-coding restart interval (records per restart run).</summary>
+    internal const int DefaultRestartInterval = 8;
+
+    /// <summary>Fixed footer: index-block byte offset (i64), version (u8).</summary>
+    internal const int FooterSize = sizeof(long) + 1;
+
+    /// <summary>On-disk footer layout: index-block byte offset then version. Read by reinterpreting the
+    /// trailing bytes (the <c>i64</c> field is little-endian on disk, matching the host on supported
+    /// targets). <see cref="FooterSize"/> equals <c>Unsafe.SizeOf&lt;FooterBytes&gt;()</c>.</summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    private readonly struct FooterBytes
+    {
+        internal readonly long IndexOffset;
+        internal readonly byte Version;
+    }
+
+    internal const byte FormatVersion = 1;
+
+    /// <summary>Footer-resolved table geometry: the table-relative byte offset of the (unaligned) index
+    /// block. The index values need no stored restart interval — a restart is any <c>cp == 0</c> record
+    /// (see <see cref="Block"/>).</summary>
+    internal readonly record struct Footer(long IndexOffset);
+
+    /// <summary>Reader-absolute start of the index block.</summary>
+    internal static long IndexBlockStart(Bound table, in Footer footer) => table.Offset + footer.IndexOffset;
+
+    /// <summary>Reader-absolute start of the data block at table-relative <paramref name="byteOffset"/>.</summary>
+    internal static long DataBlockStart(Bound table, long byteOffset) => table.Offset + byteOffset;
+
+    /// <summary>Read the footer of the table occupying <paramref name="table"/> and resolve the
+    /// index-block offset.</summary>
+    /// <returns><c>false</c> when the bound is too small, unreadable, or carries an unknown version.</returns>
+    internal static bool TryReadFooter<TReader, TPin>(scoped in TReader reader, Bound table, out Footer footer)
+        where TPin : struct, IBufferPin, allows ref struct
+        where TReader : IByteReader<TPin>, allows ref struct
+    {
+        footer = default;
+        if (table.Length < FooterSize) return false;
+
+        FooterBytes bytes = default;
+        if (!reader.TryRead(table.Offset + table.Length - FooterSize, MemoryMarshal.AsBytes(new Span<FooterBytes>(ref bytes)))) return false;
+        if (bytes.Version != FormatVersion) return false;
+
+        long indexOffset = bytes.IndexOffset;
+        // Bound the offset by the actual table size so a corrupt footer cannot address outside the
+        // bound: data blocks live in [0, indexOffset) and the index block + footer fill the tail.
+        if (indexOffset < 0) return false;
+        if (indexOffset > table.Length - FooterSize) return false;
+
+        footer = new Footer(indexOffset);
+        return true;
+    }
+
+    /// <summary>Signals unrecoverable corruption in an on-disk table — an impossible length or offset read
+    /// off a torn/malformed record. Loud by design: a persisted-snapshot read fails fast here rather than
+    /// silently returning a miss, which would surface downstream as wrong state.</summary>
+    [DoesNotReturn]
+    internal static void ThrowCorrupt(string detail) =>
+        throw new InvalidOperationException(
+            $"Corrupt persisted-snapshot SortedTable: {detail}. The persistedSnapshot/ directory is corrupted — wipe and resync.");
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/SortedTableBuilder.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/SortedTableBuilder.cs
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Verbatim copy of Nethermind.State.Flat/PersistedSnapshots/Sorted/SortedTableBuilder.cs (internal in
+// Nethermind.State.Flat, which has no InternalsVisibleTo for benchmarks). Benchmark-scoped
+// prototype code — keep in sync with the original; do not diverge.
+
+using System;
+using System.Buffers.Binary;
+using Nethermind.Core.Collections;
+using Nethermind.State.Flat.Io;
+
+namespace Nethermind.Benchmarks.State.FlatBase.Sorted;
+
+/// <summary>
+/// Builds a <see cref="SortedTable"/> by streaming: records must be <see cref="Add"/>ed in strictly
+/// ascending key order and are written straight into 4 KiB-aligned data blocks as they arrive — no
+/// record buffer, so the table size is bounded by the data region (256 TiB) rather than by an in-memory
+/// buffer. The index (separator → data-block byte offset) accrues one entry per flushed data block; at
+/// <see cref="Build"/> the final data block and the single index block are emitted, followed by the footer.
+/// </summary>
+internal ref struct SortedTableBuilder<TWriter> where TWriter : IByteBufferWriter
+{
+    private ref TWriter _writer;
+    private readonly long _tableStart;
+    private readonly BlockBuilder _dataBlock;
+    private readonly BlockBuilder _indexBlock;
+    // Last key Added overall — also the last key of the current data block, used to enforce ascending
+    // order and to derive the separator when a block flushes. Keys are ≤ 255 bytes.
+    private readonly NativeMemoryList<byte> _prevKey;
+    // Records Added so far; only its non-zero-ness is consulted, to skip the ascending check on the first.
+    private long _count;
+
+    public SortedTableBuilder(ref TWriter writer, int restartInterval = SortedTable.DefaultRestartInterval)
+    {
+        _writer = ref writer;
+        _tableStart = writer.Written;
+        _dataBlock = new BlockBuilder(restartInterval, SortedTable.BlockSize);
+        _indexBlock = new BlockBuilder(restartInterval);
+        _prevKey = new NativeMemoryList<byte>(256);
+    }
+
+    /// <summary>Stream one record. Keys must arrive in strictly ascending order and be unique; key and
+    /// value lengths must each be ≤ 255.</summary>
+    /// <exception cref="ArgumentException">The key is not strictly greater than the previous key.</exception>
+    public void Add(scoped ReadOnlySpan<byte> key, scoped ReadOnlySpan<byte> value)
+    {
+        if (_count > 0 && ((ReadOnlySpan<byte>)_prevKey.AsSpan()).SequenceCompareTo(key) >= 0)
+            throw new ArgumentException("Keys must be added in strictly ascending order.", nameof(key));
+
+        if (_dataBlock.RecordCount > 0 && _dataBlock.WouldCrossPage(key.Length, value.Length))
+            FlushDataBlock(key);
+
+        _dataBlock.Add(key, value);
+        _prevKey.Clear();
+        _prevKey.AddRange(key);
+        _count++;
+    }
+
+    /// <summary>Emit the final data block, the index block, and the footer.</summary>
+    public void Build()
+    {
+        if (_dataBlock.RecordCount > 0) FlushDataBlock(nextFirstKey: default);
+
+        // The index block begins right after the last (unpadded) data block; record its offset so the
+        // reader can locate it directly without recomputing it from the block count.
+        long indexOffset = _writer.Written - _tableStart;
+        _indexBlock.Finish(ref _writer, Block.FlagIndex);
+
+        Span<byte> footer = _writer.GetSpan(SortedTable.FooterSize);
+        BinaryPrimitives.WriteInt64LittleEndian(footer, indexOffset);
+        footer[sizeof(long)] = SortedTable.FormatVersion;
+        _writer.Advance(SortedTable.FooterSize);
+    }
+
+    /// <summary>Emit the current data block (4 KiB-padding it unless it is the final block) and record
+    /// its separator → table-relative byte offset in the index. The separator is the shortest key in
+    /// <c>[lastKey, nextFirstKey)</c>; the final block (<paramref name="nextFirstKey"/> empty) uses its
+    /// own last key.</summary>
+    private void FlushDataBlock(scoped ReadOnlySpan<byte> nextFirstKey)
+    {
+        // The data block is written here, so its table-relative start is the current writer position.
+        long blockOffset = _writer.Written - _tableStart;
+        _dataBlock.Finish(ref _writer, Block.FlagBlock);
+        bool isLast = nextFirstKey.IsEmpty;
+        if (!isLast) PadZeros((-(_writer.Written - _tableStart)) & (SortedTable.BlockSize - 1));
+
+        Span<byte> sepBuf = stackalloc byte[256];
+        ReadOnlySpan<byte> lastKey = _prevKey.AsSpan();
+        int sepLen;
+        if (isLast)
+        {
+            lastKey.CopyTo(sepBuf);
+            sepLen = lastKey.Length;
+        }
+        else
+        {
+            sepLen = FindShortestSeparator(lastKey, nextFirstKey, sepBuf);
+        }
+
+        _indexBlock.AddChangedPrefixValue(sepBuf[..sepLen], blockOffset);
+        _dataBlock.Reset();
+    }
+
+    private void PadZeros(long count)
+    {
+        while (count > 0)
+        {
+            int chunk = (int)Math.Min(count, 256);
+            _writer.GetSpan(chunk)[..chunk].Clear();
+            _writer.Advance(chunk);
+            count -= chunk;
+        }
+    }
+
+    /// <summary>Shortest key <c>S</c> with <paramref name="a"/> ≤ <c>S</c> &lt; <paramref name="b"/>
+    /// (caller guarantees <paramref name="a"/> &lt; <paramref name="b"/>), written to
+    /// <paramref name="dst"/>; returns its length. Falls back to <paramref name="a"/> when it cannot be
+    /// shortened.</summary>
+    private static int FindShortestSeparator(scoped ReadOnlySpan<byte> a, scoped ReadOnlySpan<byte> b, scoped Span<byte> dst)
+    {
+        int min = Math.Min(a.Length, b.Length);
+        int l = 0;
+        while (l < min && a[l] == b[l]) l++;
+        if (l < min && a[l] + 1 < b[l])
+        {
+            a[..l].CopyTo(dst);
+            dst[l] = (byte)(a[l] + 1);
+            return l + 1;
+        }
+        a.CopyTo(dst);
+        return a.Length;
+    }
+
+    public void Dispose()
+    {
+        _dataBlock.Dispose();
+        _indexBlock.Dispose();
+        _prevKey.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/SortedTableReader.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBase/Sorted/SortedTableReader.cs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Verbatim copy of Nethermind.State.Flat/PersistedSnapshots/Sorted/SortedTableReader.cs (internal in
+// Nethermind.State.Flat, which has no InternalsVisibleTo for benchmarks). Benchmark-scoped
+// prototype code — keep in sync with the original; do not diverge.
+
+using System;
+using Nethermind.State.Flat.Io;
+
+namespace Nethermind.Benchmarks.State.FlatBase.Sorted;
+
+/// <summary>
+/// Lookup over a <see cref="SortedTable"/>: a ceiling search of the index block
+/// (<see cref="IndexBlockReader.SeekCeiling"/>) selects a data block by byte offset, then a ceiling
+/// search of that data block (<see cref="DataBlockReader.SeekCeiling"/>) resolves the exact key. Wire
+/// layout: <see cref="SortedTable"/>.
+/// </summary>
+internal static class SortedTableReader
+{
+    /// <summary>
+    /// Seek <paramref name="key"/> in the table occupying <paramref name="table"/>. On a hit returns
+    /// the reader-absolute <see cref="Bound"/> of the matching record's value.
+    /// </summary>
+    internal static bool TrySeek<TReader, TPin>(scoped in TReader reader, Bound table, scoped ReadOnlySpan<byte> key, out Bound value)
+        where TPin : struct, IBufferPin, allows ref struct
+        where TReader : IByteReader<TPin>, allows ref struct
+    {
+        value = default;
+        // An empty table has an empty index block (no restarts), so the stage-1 ceiling below returns
+        // false — no separate empty check needed.
+        if (!SortedTable.TryReadFooter<TReader, TPin>(in reader, table, out SortedTable.Footer footer))
+            return false;
+
+        // Stage 1: ceiling over the index block — first separator ≥ target → its data block's table-relative
+        // byte offset (index values are changed-prefix coded, reconstructed by IndexBlockReader).
+        Span<byte> sepBuf = stackalloc byte[256];
+        if (!IndexBlockReader.SeekCeiling<TReader, TPin>(in reader, SortedTable.IndexBlockStart(table, footer), key, sepBuf, out _, out long byteOffset, out _))
+            return false;
+
+        // Stage 2: ceiling over the data block; a hit requires the ceiling key to equal the target.
+        Span<byte> keyBuf = stackalloc byte[256];
+        if (!DataBlockReader.SeekCeiling<TReader, TPin>(in reader, SortedTable.DataBlockStart(table, byteOffset), key, keyBuf, out int keyLen, out Bound v))
+            return false;
+        if (!key.SequenceEqual(keyBuf[..keyLen])) return false;
+
+        value = v;
+        return true;
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBaseBenchmarkDatasetBuilder.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBaseBenchmarkDatasetBuilder.cs
@@ -1,0 +1,365 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Threading.Tasks;
+using Nethermind.Benchmarks.State.FlatBase;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Int256;
+using Nethermind.Serialization.Rlp;
+using Nethermind.State.Flat;
+
+namespace Nethermind.Benchmarks.State;
+
+/// <summary>
+/// Parameters and on-disk layout of the flat-base point-read dataset. Resolved from
+/// <c>NETH_FLATBENCH_SCALE</c> (<c>smoke</c> — default, 100k accounts / 500k slots — or <c>full</c>,
+/// 300M accounts / 1.2B slots) and <c>NETH_FLATBENCH_DIR</c> (dataset root, defaults to a temp dir).
+/// </summary>
+public sealed class FlatBaseDatasetSpec
+{
+    public const string SmokeScale = "smoke";
+    public const string FullScale = "full";
+    private const int FormatVersion = 1;
+
+    public string Scale { get; private init; }
+    public long AccountCount { get; private init; }
+    public int SlotsPerAccount { get; private init; }
+    public int ShardCount { get; private init; }
+    public string Root { get; private init; }
+
+    public long SlotCount => AccountCount * SlotsPerAccount;
+    public string DatasetDir => Path.Combine(Root, Scale);
+    public string RocksDbDir => Path.Combine(DatasetDir, "rocksdb");
+    public string ArenaDir => Path.Combine(DatasetDir, "arena");
+    public string LmdbDir => Path.Combine(DatasetDir, "lmdb");
+    public string MarkerPath => Path.Combine(DatasetDir, "dataset.marker");
+
+    public string MarkerText =>
+        $"flatbase v{FormatVersion} scale={Scale} accounts={AccountCount} slotsPerAccount={SlotsPerAccount} shards={ShardCount}";
+
+    /// <summary>Upper bound for the LMDB memory map. Virtual (sparse) on Linux; on Windows LMDB
+    /// materializes the data file at this size, so it scales with the dataset instead of a fixed cap.</summary>
+    public long LmdbMapSize => Math.Max(1L << 30, 2 * (AccountCount * 160 + SlotCount * 128));
+
+    public static FlatBaseDatasetSpec FromEnvironment()
+    {
+        string scale = Environment.GetEnvironmentVariable("NETH_FLATBENCH_SCALE") ?? SmokeScale;
+        string root = Environment.GetEnvironmentVariable("NETH_FLATBENCH_DIR")
+                      ?? Path.Combine(Path.GetTempPath(), "neth-flatbench");
+
+        return scale switch
+        {
+            SmokeScale => new FlatBaseDatasetSpec
+            {
+                Scale = scale,
+                AccountCount = 100_000,
+                SlotsPerAccount = 5,
+                ShardCount = 256,
+                Root = root,
+            },
+            FullScale => new FlatBaseDatasetSpec
+            {
+                Scale = scale,
+                AccountCount = 300_000_000,
+                SlotsPerAccount = 4,
+                ShardCount = 256,
+                Root = root,
+            },
+            _ => throw new NotSupportedException($"Unknown NETH_FLATBENCH_SCALE '{scale}' (expected '{SmokeScale}' or '{FullScale}')"),
+        };
+    }
+}
+
+/// <summary>
+/// Deterministic synthetic dataset generator for the flat-base point-read benchmark: N accounts
+/// (keccak(counter)-derived 20-byte keys, ~70-byte slim-RLP values) and N×slotsPerAccount storage
+/// slots (52-byte production split keys, 32-byte values), written byte-identically to all three
+/// backends (RocksDB flat columns, sharded sorted-table arena, LMDB). Built once per
+/// scale under the dataset root and reused across runs via a parameter marker file.
+/// </summary>
+/// <remarks>
+/// Key layouts replicate <c>BaseFlatPersistence</c>: accounts are keyed by the truncated 20-byte
+/// address hash; slots by <c>[4B addrHash | 32B slotHash | 16B addrHash]</c>. Values derive from the
+/// generation counter via SplitMix64, so a validation read can recompute the expected bytes.
+/// Generation runs in three phases: (1) spill (counter, key) records per key-prefix shard,
+/// (2) per shard: sort and bulk-load all three backends in globally ascending key order,
+/// (3) byte-for-byte validation of sampled keys on every backend.
+/// </remarks>
+public static class FlatBaseBenchmarkDatasetBuilder
+{
+    public const int AccountKeyLength = 20;
+    public const int StorageKeyLength = 52;
+    public const int SlotValueLength = 32;
+    private const int StoragePrefixLength = 4;
+    private const int SpillRecordLength = sizeof(long) + AccountKeyLength;
+
+    private const ulong NonceSalt = 0x5FD3_91C7_0A2B_11EFUL;
+    private const ulong BalanceSalt = 0x9A64_2E85_77D0_43B1UL;
+    private const ulong StorageRootSalt = 0x1B3C_58F2_D944_6E07UL;
+    private const ulong CodeHashSalt = 0xC0DE_C0DE_1234_5678UL;
+    private const ulong SlotHashSalt = 0x5107_4A5B_88ED_2C93UL;
+    private const ulong SlotValueSalt = 0x5107_7A1E_0F66_B4D5UL;
+
+    /// <summary>Build the dataset for the environment-selected spec unless a marker with matching
+    /// parameters already exists; returns the spec either way.</summary>
+    public static FlatBaseDatasetSpec EnsureBuilt()
+    {
+        FlatBaseDatasetSpec spec = FlatBaseDatasetSpec.FromEnvironment();
+        if (File.Exists(spec.MarkerPath) && File.ReadAllText(spec.MarkerPath) == spec.MarkerText)
+            return spec;
+
+        if (Directory.Exists(spec.DatasetDir))
+            Directory.Delete(spec.DatasetDir, recursive: true);
+        Directory.CreateDirectory(spec.DatasetDir);
+
+        Console.WriteLine($"[FlatBase] Building dataset: {spec.MarkerText} under {spec.DatasetDir}");
+        Build(spec);
+        File.WriteAllText(spec.MarkerPath, spec.MarkerText);
+        Console.WriteLine("[FlatBase] Dataset build complete");
+        return spec;
+    }
+
+    private static void Build(FlatBaseDatasetSpec spec)
+    {
+        string spillDir = Path.Combine(spec.DatasetDir, "spill");
+        SpillAccountKeys(spec, spillDir);
+
+        Directory.CreateDirectory(spec.ArenaDir);
+        using (ShardedArenaWriter accountArena = new(
+                   Path.Combine(spec.ArenaDir, ShardedSortedTableArena.AccountArenaFile),
+                   Path.Combine(spec.ArenaDir, ShardedSortedTableArena.AccountDirFile),
+                   spec.ShardCount))
+        using (ShardedArenaWriter storageArena = new(
+                   Path.Combine(spec.ArenaDir, ShardedSortedTableArena.StorageArenaFile),
+                   Path.Combine(spec.ArenaDir, ShardedSortedTableArena.StorageDirFile),
+                   spec.ShardCount))
+        using (LmdbFlatBackend lmdb = LmdbFlatBackend.OpenWrite(spec.LmdbDir, spec.LmdbMapSize))
+        using (RocksDbFlatBackend rocks = new(spec.RocksDbDir))
+        {
+            for (int shard = 0; shard < spec.ShardCount; shard++)
+            {
+                LoadShard(spillDir, shard, out byte[][] accountKeys, out long[] counters);
+                int accountCount = accountKeys.Length;
+                Array.Sort(accountKeys, counters, Bytes.Comparer);
+
+                byte[][] accountValues = new byte[accountCount][];
+                Parallel.For(0, accountCount, i => accountValues[i] = AccountValue(counters[i]));
+
+                accountArena.WriteShard(shard, accountKeys, accountValues, accountCount);
+                lmdb.PutShard(storage: false, accountKeys, accountValues, accountCount);
+                rocks.WriteShard(FlatDbColumns.Account, accountKeys, accountValues, accountCount);
+
+                int slotCount = accountCount * spec.SlotsPerAccount;
+                byte[][] slotKeys = new byte[slotCount][];
+                byte[][] slotValues = new byte[slotCount][];
+                Parallel.For(0, accountCount, i =>
+                {
+                    Span<byte> slotHash = stackalloc byte[32];
+                    for (int k = 0; k < spec.SlotsPerAccount; k++)
+                    {
+                        int index = i * spec.SlotsPerAccount + k;
+                        byte[] key = new byte[StorageKeyLength];
+                        WriteSlotHash(counters[i], k, slotHash);
+                        WriteStorageKey(accountKeys[i], slotHash, key);
+                        slotKeys[index] = key;
+
+                        byte[] value = new byte[SlotValueLength];
+                        WriteSlotValue(counters[i], k, value);
+                        slotValues[index] = value;
+                    }
+                });
+                Array.Sort(slotKeys, slotValues, Bytes.Comparer);
+
+                storageArena.WriteShard(shard, slotKeys, slotValues, slotCount);
+                lmdb.PutShard(storage: true, slotKeys, slotValues, slotCount);
+                rocks.WriteShard(FlatDbColumns.Storage, slotKeys, slotValues, slotCount);
+
+                if ((shard & 31) == 31)
+                    Console.WriteLine($"[FlatBase] Loaded shard {shard + 1}/{spec.ShardCount}");
+            }
+
+            Console.WriteLine("[FlatBase] Flushing and compacting RocksDB");
+            rocks.FinishWrites();
+        }
+
+        Directory.Delete(spillDir, recursive: true);
+
+        Console.WriteLine("[FlatBase] Validating backends");
+        using (RocksDbFlatBackend rocks = new(spec.RocksDbDir))
+            Validate(spec, rocks, sampleCount: 1000);
+        using (SortedArenaBackend arena = SortedArenaBackend.OpenRead(spec.ArenaDir))
+            Validate(spec, arena, sampleCount: 1000);
+        using (LmdbFlatBackend lmdb = LmdbFlatBackend.OpenRead(spec.LmdbDir, spec.LmdbMapSize))
+            Validate(spec, lmdb, sampleCount: 1000);
+    }
+
+    /// <summary>Phase 1: stream all account counters, hash them (in parallel chunks) and append
+    /// <c>[counter i64 LE][key 20B]</c> records to one spill file per key-prefix shard.</summary>
+    private static void SpillAccountKeys(FlatBaseDatasetSpec spec, string spillDir)
+    {
+        Directory.CreateDirectory(spillDir);
+        int shardShift = ShardedSortedTableArena.ShardShift(spec.ShardCount);
+        FileStream[] spills = new FileStream[spec.ShardCount];
+        try
+        {
+            for (int shard = 0; shard < spec.ShardCount; shard++)
+                spills[shard] = new FileStream(SpillPath(spillDir, shard), FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1 << 16);
+
+            const int ChunkSize = 1 << 16;
+            byte[] chunkKeys = new byte[ChunkSize * AccountKeyLength];
+            byte[] record = new byte[SpillRecordLength];
+            for (long chunkStart = 0; chunkStart < spec.AccountCount; chunkStart += ChunkSize)
+            {
+                int chunkCount = (int)Math.Min(ChunkSize, spec.AccountCount - chunkStart);
+                Parallel.For(0, chunkCount, i =>
+                    WriteAccountKey(chunkStart + i, chunkKeys.AsSpan(i * AccountKeyLength, AccountKeyLength)));
+
+                for (int i = 0; i < chunkCount; i++)
+                {
+                    ReadOnlySpan<byte> key = chunkKeys.AsSpan(i * AccountKeyLength, AccountKeyLength);
+                    BinaryPrimitives.WriteInt64LittleEndian(record, chunkStart + i);
+                    key.CopyTo(record.AsSpan(sizeof(long)));
+                    spills[ShardedSortedTableArena.ShardOf(key, shardShift)].Write(record);
+                }
+            }
+        }
+        finally
+        {
+            foreach (FileStream spill in spills)
+                spill?.Dispose();
+        }
+    }
+
+    private static void LoadShard(string spillDir, int shard, out byte[][] keys, out long[] counters)
+    {
+        byte[] data = File.ReadAllBytes(SpillPath(spillDir, shard));
+        int count = data.Length / SpillRecordLength;
+        keys = new byte[count][];
+        counters = new long[count];
+        for (int i = 0; i < count; i++)
+        {
+            ReadOnlySpan<byte> record = data.AsSpan(i * SpillRecordLength, SpillRecordLength);
+            counters[i] = BinaryPrimitives.ReadInt64LittleEndian(record);
+            keys[i] = record[sizeof(long)..].ToArray();
+        }
+    }
+
+    private static string SpillPath(string spillDir, int shard) => Path.Combine(spillDir, $"shard-{shard:D3}.spill");
+
+    /// <summary>Read <paramref name="sampleCount"/> known account and slot keys plus a handful of
+    /// guaranteed-miss keys and compare byte-for-byte against the recomputed expected values,
+    /// throwing on any mismatch.</summary>
+    public static void Validate(FlatBaseDatasetSpec spec, IFlatPointReadBackend backend, int sampleCount)
+    {
+        using IFlatReadSession session = backend.BeginSession();
+        Span<byte> accountKey = stackalloc byte[AccountKeyLength];
+        Span<byte> slotHash = stackalloc byte[32];
+        Span<byte> storageKey = stackalloc byte[StorageKeyLength];
+        Span<byte> slotExpected = stackalloc byte[SlotValueLength];
+        Span<byte> buffer = stackalloc byte[256];
+
+        for (int i = 0; i < sampleCount; i++)
+        {
+            long counter = (long)(SplitMix64((ulong)i) % (ulong)spec.AccountCount);
+            WriteAccountKey(counter, accountKey);
+            byte[] expected = AccountValue(counter);
+            int length = session.GetAccount(accountKey, buffer);
+            if (length != expected.Length || !buffer[..length].SequenceEqual(expected))
+                throw new InvalidOperationException(
+                    $"{backend.GetType().Name}: account {counter} mismatch — expected {expected.Length} bytes, read {length}");
+
+            int slotIndex = (int)(SplitMix64((ulong)i ^ SlotHashSalt) % (ulong)spec.SlotsPerAccount);
+            WriteSlotHash(counter, slotIndex, slotHash);
+            WriteStorageKey(accountKey, slotHash, storageKey);
+            WriteSlotValue(counter, slotIndex, slotExpected);
+            length = session.GetSlot(storageKey, buffer);
+            if (length != SlotValueLength || !buffer[..length].SequenceEqual(slotExpected))
+                throw new InvalidOperationException(
+                    $"{backend.GetType().Name}: slot ({counter}, {slotIndex}) mismatch — expected {SlotValueLength} bytes, read {length}");
+        }
+
+        // Guaranteed misses: account counters ≥ AccountCount and slot indices ≥ SlotsPerAccount are never written.
+        for (int i = 0; i < 16; i++)
+        {
+            WriteAccountKey(spec.AccountCount + i, accountKey);
+            if (session.GetAccount(accountKey, buffer) != 0)
+                throw new InvalidOperationException($"{backend.GetType().Name}: miss account {spec.AccountCount + i} returned a value");
+
+            WriteAccountKey(i, accountKey);
+            WriteSlotHash(i, spec.SlotsPerAccount + 1 + i, slotHash);
+            WriteStorageKey(accountKey, slotHash, storageKey);
+            if (session.GetSlot(storageKey, buffer) != 0)
+                throw new InvalidOperationException($"{backend.GetType().Name}: miss slot ({i}, {spec.SlotsPerAccount + 1 + i}) returned a value");
+        }
+    }
+
+    // --- Deterministic key/value derivations, shared with the benchmark ---
+
+    /// <summary>Account key: keccak(8-byte BE counter) truncated to 20 bytes — the flat layout's
+    /// truncated address hash. Counters ≥ <see cref="FlatBaseDatasetSpec.AccountCount"/> are never
+    /// written, so they yield guaranteed-miss keys.</summary>
+    public static void WriteAccountKey(long counter, Span<byte> key20)
+    {
+        Span<byte> input = stackalloc byte[sizeof(long)];
+        BinaryPrimitives.WriteInt64BigEndian(input, counter);
+        ValueHash256 hash = ValueKeccak.Compute(input);
+        hash.Bytes[..AccountKeyLength].CopyTo(key20);
+    }
+
+    /// <summary>Production split storage key: <c>[4B addrHash | 32B slotHash | 16B addrHash]</c>
+    /// (see <c>BaseFlatPersistence</c>) — both address parts come from the truncated 20-byte account key.</summary>
+    public static void WriteStorageKey(ReadOnlySpan<byte> accountKey20, ReadOnlySpan<byte> slotHash32, Span<byte> key52)
+    {
+        accountKey20[..StoragePrefixLength].CopyTo(key52);
+        slotHash32.CopyTo(key52[StoragePrefixLength..]);
+        accountKey20[StoragePrefixLength..].CopyTo(key52[(StoragePrefixLength + 32)..]);
+    }
+
+    /// <summary>Slot hash for (account counter, slot index). Slot indices ≥
+    /// <see cref="FlatBaseDatasetSpec.SlotsPerAccount"/> are never written, so they yield
+    /// guaranteed-miss keys on a live account.</summary>
+    public static void WriteSlotHash(long accountCounter, long slotIndex, Span<byte> hash32) =>
+        Fill32(SplitMix64((ulong)accountCounter ^ SlotHashSalt) ^ (ulong)slotIndex, hash32);
+
+    public static void WriteSlotValue(long accountCounter, long slotIndex, Span<byte> value32)
+    {
+        Fill32(SplitMix64((ulong)accountCounter ^ SlotValueSalt) ^ (ulong)slotIndex, value32);
+        // A nonzero leading byte keeps the stored value at the full 32 bytes on every backend,
+        // sidestepping leading-zero stripping concerns.
+        value32[0] |= 0x10;
+    }
+
+    /// <summary>Slim-RLP account value (~70-90 bytes): nonce, balance, and non-empty storage root and
+    /// code hash (contract-shaped, per the flat Account column's dominant size class).</summary>
+    public static byte[] AccountValue(long counter)
+    {
+        ulong seed = (ulong)counter;
+        ulong nonce = SplitMix64(seed ^ NonceSalt) & 0xFFFF;
+        UInt256 balance = new(SplitMix64(seed ^ BalanceSalt), SplitMix64(seed ^ (BalanceSalt + 1)) & 0xFF);
+        Span<byte> hash = stackalloc byte[32];
+        Fill32(seed ^ StorageRootSalt, hash);
+        Hash256 storageRoot = new(new ValueHash256(hash));
+        Fill32(seed ^ CodeHashSalt, hash);
+        Hash256 codeHash = new(new ValueHash256(hash));
+        return AccountDecoder.Slim.EncodeAsBytes(new Account(nonce, balance, storageRoot, codeHash));
+    }
+
+    public static ulong SplitMix64(ulong x)
+    {
+        x += 0x9E3779B97F4A7C15UL;
+        x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9UL;
+        x = (x ^ (x >> 27)) * 0x94D049BB133111EBUL;
+        return x ^ (x >> 31);
+    }
+
+    private static void Fill32(ulong seed, Span<byte> output32)
+    {
+        for (int i = 0; i < 4; i++)
+            BinaryPrimitives.WriteUInt64LittleEndian(output32[(i * sizeof(ulong))..], SplitMix64(seed + (ulong)i));
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/State/FlatBasePointReadBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/FlatBasePointReadBenchmark.cs
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Benchmarks.State.FlatBase;
+
+namespace Nethermind.Benchmarks.State;
+
+/// <summary>
+/// Phase-0 go/no-go micro-benchmark for the "MDBX-like flat persistence" workstream: uniform-random
+/// point reads (account 20-byte keys, storage-slot 52-byte keys; hits and guaranteed misses; 1/8/32
+/// reader threads) over three backends holding byte-identical data — production-tuned RocksDB flat
+/// columns, the sharded <c>SortedTable</c> arena prototype, and LMDB. See
+/// <c>State/FlatBase/README.md</c> for the full-scale dataset procedure, cold-run methodology
+/// (dropping the OS page cache), metrics to record, and the go/no-go thresholds.
+/// </summary>
+/// <remarks>
+/// The dataset is built once by <see cref="FlatBaseBenchmarkDatasetBuilder"/> (scale/location via
+/// <c>NETH_FLATBENCH_SCALE</c>/<c>NETH_FLATBENCH_DIR</c>) and validated byte-for-byte on every setup.
+/// Each invocation performs <see cref="TotalReads"/> reads split evenly across
+/// <see cref="Threads"/> workers, walking pre-generated key pools; results are per-read
+/// (<c>OperationsPerInvoke</c>). Warm in-process numbers are indicative only — the decision numbers
+/// come from cold runs at the <c>full</c> scale on Linux.
+/// </remarks>
+[MemoryDiagnoser]
+[WarmupCount(2)]
+[MinIterationCount(3)]
+[MaxIterationCount(10)]
+public class FlatBasePointReadBenchmark
+{
+    public enum BackendKind
+    {
+        RocksDb,
+        SortedArena,
+        Lmdb,
+    }
+
+    private const int TotalReads = 8192;
+    private const int PoolSize = 1 << 15;
+    private const int PoolMask = PoolSize - 1;
+    private const ulong AccountPickSalt = 0xACC0_0517_BEEF_F00DUL;
+    private const ulong SlotPickSalt = 0x510C_C817_1234_ABCDUL;
+
+    [Params(BackendKind.RocksDb, BackendKind.SortedArena, BackendKind.Lmdb)]
+    public BackendKind Backend;
+
+    [Params(false, true)]
+    public bool Miss;
+
+    [Params(1, 8, 32)]
+    public int Threads;
+
+    private FlatBaseDatasetSpec _spec;
+    private IFlatPointReadBackend _backend;
+    private byte[] _accountKeys;
+    private byte[] _slotKeys;
+    private long[] _threadSums;
+    private long _cursor;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _spec = FlatBaseBenchmarkDatasetBuilder.EnsureBuilt();
+        _backend = Backend switch
+        {
+            BackendKind.RocksDb => new RocksDbFlatBackend(_spec.RocksDbDir),
+            BackendKind.SortedArena => SortedArenaBackend.OpenRead(_spec.ArenaDir),
+            BackendKind.Lmdb => LmdbFlatBackend.OpenRead(_spec.LmdbDir, _spec.LmdbMapSize),
+            _ => throw new ArgumentOutOfRangeException(nameof(Backend)),
+        };
+
+        // Correctness gate: every backend must return byte-identical values for known keys.
+        FlatBaseBenchmarkDatasetBuilder.Validate(_spec, _backend, sampleCount: 1000);
+
+        BuildKeyPools();
+        _threadSums = new long[Threads];
+
+        // A hit pool read must return data and a miss pool read must not — fail loudly, not measure garbage.
+        using IFlatReadSession session = _backend.BeginSession();
+        Span<byte> buffer = stackalloc byte[256];
+        int length = session.GetAccount(_accountKeys.AsSpan(0, FlatBaseBenchmarkDatasetBuilder.AccountKeyLength), buffer);
+        if (Miss ? length != 0 : length == 0)
+            throw new InvalidOperationException($"Key pool sanity check failed: Miss={Miss}, first account read returned {length} bytes");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _backend?.Dispose();
+
+    /// <summary>Pre-generate uniform-random key pools. Hits pick written counters/slot indices;
+    /// misses pick counters ≥ AccountCount (accounts) or slot indices ≥ SlotsPerAccount on live
+    /// accounts (slots) — domains the builder never writes.</summary>
+    private void BuildKeyPools()
+    {
+        const int accountKeyLength = FlatBaseBenchmarkDatasetBuilder.AccountKeyLength;
+        const int storageKeyLength = FlatBaseBenchmarkDatasetBuilder.StorageKeyLength;
+        _accountKeys = new byte[PoolSize * accountKeyLength];
+        _slotKeys = new byte[PoolSize * storageKeyLength];
+
+        long accountCount = _spec.AccountCount;
+        int slotsPerAccount = _spec.SlotsPerAccount;
+        bool miss = Miss;
+        byte[] accountKeys = _accountKeys;
+        byte[] slotKeys = _slotKeys;
+        Parallel.For(0, PoolSize, i =>
+        {
+            ulong pick = FlatBaseBenchmarkDatasetBuilder.SplitMix64((ulong)i ^ AccountPickSalt);
+            long counter = (long)(pick % (ulong)accountCount) + (miss ? accountCount : 0);
+            FlatBaseBenchmarkDatasetBuilder.WriteAccountKey(counter, accountKeys.AsSpan(i * accountKeyLength, accountKeyLength));
+
+            // Slot misses target live accounts with absent slots — the realistic miss shape.
+            ulong slotPick = FlatBaseBenchmarkDatasetBuilder.SplitMix64((ulong)i ^ SlotPickSalt);
+            long slotAccount = (long)(slotPick % (ulong)accountCount);
+            long slotIndex = (long)(FlatBaseBenchmarkDatasetBuilder.SplitMix64(slotPick) % (ulong)slotsPerAccount)
+                             + (miss ? slotsPerAccount : 0);
+
+            Span<byte> slotAccountKey = stackalloc byte[accountKeyLength];
+            Span<byte> slotHash = stackalloc byte[32];
+            FlatBaseBenchmarkDatasetBuilder.WriteAccountKey(slotAccount, slotAccountKey);
+            FlatBaseBenchmarkDatasetBuilder.WriteSlotHash(slotAccount, slotIndex, slotHash);
+            FlatBaseBenchmarkDatasetBuilder.WriteStorageKey(
+                slotAccountKey, slotHash, slotKeys.AsSpan(i * storageKeyLength, storageKeyLength));
+        });
+    }
+
+    [Benchmark(OperationsPerInvoke = TotalReads)]
+    public long AccountPointRead() => Run(slots: false);
+
+    [Benchmark(OperationsPerInvoke = TotalReads)]
+    public long SlotPointRead() => Run(slots: true);
+
+    private long Run(bool slots)
+    {
+        long start = _cursor;
+        _cursor += TotalReads;
+
+        if (Threads == 1)
+        {
+            using IFlatReadSession session = _backend.BeginSession();
+            return ReadRange(session, start, TotalReads, slots);
+        }
+
+        int perThread = TotalReads / Threads;
+        long[] sums = _threadSums;
+        Parallel.For(0, Threads, t =>
+        {
+            using IFlatReadSession session = _backend.BeginSession();
+            sums[t] = ReadRange(session, start + t * perThread, perThread, slots);
+        });
+
+        long total = 0;
+        foreach (long sum in sums)
+            total += sum;
+        return total;
+    }
+
+    private long ReadRange(IFlatReadSession session, long start, int count, bool slots)
+    {
+        const int accountKeyLength = FlatBaseBenchmarkDatasetBuilder.AccountKeyLength;
+        const int storageKeyLength = FlatBaseBenchmarkDatasetBuilder.StorageKeyLength;
+        Span<byte> buffer = stackalloc byte[256];
+        long sum = 0;
+        if (slots)
+        {
+            byte[] keys = _slotKeys;
+            for (int i = 0; i < count; i++)
+            {
+                int index = (int)((start + i) & PoolMask);
+                sum += session.GetSlot(keys.AsSpan(index * storageKeyLength, storageKeyLength), buffer);
+            }
+        }
+        else
+        {
+            byte[] keys = _accountKeys;
+            for (int i = 0; i < count; i++)
+            {
+                int index = (int)((start + i) & PoolMask);
+                sum += session.GetAccount(keys.AsSpan(index * accountKeyLength, accountKeyLength), buffer);
+            }
+        }
+
+        return sum;
+    }
+}


### PR DESCRIPTION
## Changes

Phase 0 gate for evaluating an mmap-based (MDBX-like) base tier for flat state: a standalone micro-benchmark comparing **cold/warm random point reads** across three backends, before committing to any production backend work.

- `FlatBaseBenchmarkDatasetBuilder`: deterministic synthetic dataset (keccak(counter) keys, realistic slim-RLP account values, 52-byte split-key slots) built once and reused via marker files. Scale via `NETH_FLATBENCH_SCALE`: `smoke` (100k accounts / 500k slots, local-friendly) or `full` (300M / 1.2B, ≥100 GB, for a Linux box). Root dir via `NETH_FLATBENCH_DIR`.
- `FlatBasePointReadBenchmark`: BenchmarkDotNet, backend × {hit, guaranteed-miss} × threads {1, 8, 32}, account (20B) and slot (52B) reads, zero per-read allocations.
- Backends (benchmark-scoped only, zero production-code changes):
  - **RocksDB** with the production `DbConfig` Flat* option strings and 300/700 MiB HyperClockCaches mirroring `FlatRocksDbConfigAdjuster` — the honest baseline;
  - **ShardedSortedTableArena**: 256-shard prototype of the in-repo `SortedTable` format over production `ArenaFile` mmap (the candidate base-tier design);
  - **LMDB** via `LightningDB` (added to CPM, referenced only by Nethermind.Benchmark) — the reth-configuration control.
- README documents the full-scale build, the Linux cold-read procedure (`drop_caches` per pass), the metrics to record, and the go/no-go thresholds: arena ≥1.8× RocksDB on cold hits at ≥100 GB AND ≥0.85× LMDB; miss cost ≤1.2× LMDB.
- Every dataset build and benchmark setup runs a byte-for-byte validation pass (1000 sampled keys per backend + guaranteed-miss checks).

Indicative warm smoke numbers on Windows (mean ns/read, account hits, 1 thread): RocksDB ~1700, arena ~420, LMDB ~230; at 32 threads: 224 / 43 / 49. The decision numbers require the documented cold full-scale Linux run.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [x] Other: Benchmark infrastructure (no shipping-code changes)

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Smoke scale ran end-to-end locally: all 36 benchmark cases completed; built-in correctness validation (byte-for-byte compare + miss checks) passed for all three backends at build time and in every benchmark setup.
- `Benchmarks.slnx` release build: 0 warnings.
- Note: the 7 `Sorted/*` files are verbatim copies of internal `Nethermind.State.Flat` sorted-table machinery (header-noted) — copied rather than widening production visibility with `InternalsVisibleTo`. If reviewers prefer `InternalsVisibleTo`, happy to switch.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Part of the BAL benchmark performance workstream (#12681, #12682, #12683). Next step: run the `full` scale cold procedure on a Linux benchmark host; the thresholds above decide whether the sorted-arena base tier (or an LMDB/libmdbx backend behind the same `IPersistence` seam) proceeds to a production prototype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)