### PR TITLE
Optimize EVM stream execution for common fused operations

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
@@ -539,6 +539,48 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         };
     }
 
+    private static IEnumerable<TestCaseData> FixedGasPairOpCodeCountCases()
+    {
+        yield return FixedGasPairOpCodeCountCase(
+            "PopPopSuccess",
+            [(byte)Instruction.PUSH0, (byte)Instruction.PUSH0, (byte)Instruction.POP, (byte)Instruction.POP, (byte)Instruction.STOP],
+            FusedOpcode.PopPop,
+            5);
+        yield return FixedGasPairOpCodeCountCase(
+            "PopPopFirstOperationUnderflow",
+            [(byte)Instruction.POP, (byte)Instruction.POP, (byte)Instruction.STOP],
+            FusedOpcode.PopPop,
+            1);
+        yield return FixedGasPairOpCodeCountCase(
+            "PopPopSecondOperationUnderflow",
+            [(byte)Instruction.PUSH0, (byte)Instruction.POP, (byte)Instruction.POP, (byte)Instruction.STOP],
+            FusedOpcode.PopPop,
+            3);
+        yield return FixedGasPairOpCodeCountCase(
+            "SwapPopSuccess",
+            [(byte)Instruction.PUSH0, (byte)Instruction.PUSH0, (byte)Instruction.SWAP1, (byte)Instruction.POP, (byte)Instruction.STOP],
+            FusedOpcode.SwapPop,
+            5);
+        yield return FixedGasPairOpCodeCountCase(
+            "SwapPopFirstOperationUnderflow",
+            [(byte)Instruction.PUSH0, (byte)Instruction.SWAP1, (byte)Instruction.POP, (byte)Instruction.STOP],
+            FusedOpcode.SwapPop,
+            2);
+        yield return FixedGasPairOpCodeCountCase(
+            "AndIsZeroSuccess",
+            [(byte)Instruction.PUSH0, (byte)Instruction.PUSH0, (byte)Instruction.SWAP1, (byte)Instruction.AND, (byte)Instruction.ISZERO, (byte)Instruction.STOP],
+            FusedOpcode.AndIsZero,
+            6);
+        yield return FixedGasPairOpCodeCountCase(
+            "AndIsZeroFirstOperationUnderflow",
+            [(byte)Instruction.PUSH0, (byte)Instruction.JUMPDEST, (byte)Instruction.AND, (byte)Instruction.ISZERO, (byte)Instruction.STOP],
+            FusedOpcode.AndIsZero,
+            3);
+    }
+
+    private static TestCaseData FixedGasPairOpCodeCountCase(string name, byte[] code, byte expectedFusedOpcode, int expectedOpCodeCount)
+        => new(code, expectedFusedOpcode, expectedOpCodeCount) { TestName = name };
+
     private static byte[] BuildSwapPopCode(int swapDepth, bool succeeds)
     {
         List<byte> code = [];
@@ -655,6 +697,27 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         }
     }
 
+    [TestCaseSource(nameof(FixedGasPairOpCodeCountCases))]
+    public void StreamInterpreter_FusedFixedGasPair_OpCodeCountMatchesByteCodeLoop(byte[] code, byte expectedFusedOpcode, int expectedOpCodeCount)
+    {
+        AssertFusedOpcode(code, expectedFusedOpcode);
+
+        RunWithInterpreter(code, useStream: false);
+        int byteCodeOpCodeCount = Machine.OpCodeCount;
+
+        Setup();
+        long framesBefore = StreamInterpreter.FramesExecuted;
+        RunWithInterpreter(code, useStream: true);
+        int streamOpCodeCount = Machine.OpCodeCount;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(byteCodeOpCodeCount, Is.EqualTo(expectedOpCodeCount), "the bytecode loop precondition must count exactly the completed operations");
+            Assert.That(StreamInterpreter.FramesExecuted, Is.GreaterThan(framesBefore), "the stream interpreter did not engage for the opcode-count differential");
+            Assert.That(streamOpCodeCount, Is.EqualTo(byteCodeOpCodeCount), "the fused pair must count exactly the operations the bytecode loop completed");
+        }
+    }
+
     [TestCaseSource(nameof(FusedPairCancellationCases))]
     public void StreamInterpreter_FusedPair_PreservesCancellationCadence(Instruction first, Instruction second, int stackDepth, bool shouldCancel, byte expectedFusedOpcode)
     {
@@ -662,12 +725,12 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         AssertFusedOpcode(code, expectedFusedOpcode);
 
         PollingCancellationTracer byteCodeTracer = new();
-        AssertCancellationOutcome(code, useStream: false, shouldCancel, byteCodeTracer);
+        int byteCodeOpCodeCount = AssertCancellationOutcome(code, useStream: false, shouldCancel, byteCodeTracer);
 
         Setup();
         long framesBefore = StreamInterpreter.FramesExecuted;
         PollingCancellationTracer streamTracer = new();
-        AssertCancellationOutcome(code, useStream: true, shouldCancel, streamTracer);
+        int streamOpCodeCount = AssertCancellationOutcome(code, useStream: true, shouldCancel, streamTracer);
 
         using (Assert.EnterMultipleScope())
         {
@@ -677,6 +740,10 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
                 "the stream interpreter did not engage — this cancellation regression proved nothing");
             Assert.That(streamTracer.CancellationPollCount, Is.EqualTo(shouldCancel ? 2 : 1),
                 "the fused pair must preserve the bytecode loop's cancellation-poll ordering");
+            Assert.That(byteCodeOpCodeCount, Is.EqualTo(shouldCancel ? 0 : 1024),
+                "the bytecode loop must publish completed operations unless cancellation interrupts the frame");
+            Assert.That(streamOpCodeCount, Is.EqualTo(byteCodeOpCodeCount),
+                "the stream must retain the bytecode loop's externally visible cancellation count");
         }
     }
 
@@ -707,12 +774,14 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         return code;
     }
 
-    private void AssertCancellationOutcome(byte[] code, bool useStream, bool shouldCancel, Evm.Tracing.ITxTracer tracer)
+    private int AssertCancellationOutcome(byte[] code, bool useStream, bool shouldCancel, Evm.Tracing.ITxTracer tracer)
     {
         if (shouldCancel)
             Assert.Throws<OperationCanceledException>(() => RunWithInterpreter(code, useStream, tracer: tracer));
         else
             Assert.DoesNotThrow(() => RunWithInterpreter(code, useStream, tracer: tracer));
+
+        return Machine.OpCodeCount;
     }
 
     private static void AssertFusedOpcode(byte[] code, byte expectedFusedOpcode)

--- a/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
 using Nethermind.Specs;
 using NUnit.Framework;
 
@@ -179,6 +180,34 @@ public class InstructionStreamTests
     public void TryBuild_EmptyCode_ReturnsNull()
         => Assert.That(InstructionStream.TryBuild(ReadOnlySpan<byte>.Empty), Is.Null);
 
+    [Test]
+    public void TryBuild_AdjacentPops_FusesGasAndPcMap()
+    {
+        byte[] code =
+        [
+            (byte)Instruction.PUSH1, 0x2A,
+            (byte)Instruction.POP,
+            (byte)Instruction.POP,
+            (byte)Instruction.STOP,
+        ];
+
+        InstructionStream stream = InstructionStream.TryBuild(code)!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(stream.BlockGas, Has.Length.EqualTo(1));
+            Assert.That(stream.BlockGas[0], Is.EqualTo(GasCostOf.VeryLow + 2 * GasCostOf.Base), "both POP costs stay in the precharged block");
+            Assert.That(stream.Ops, Has.Length.EqualTo(3));
+            Assert.That(stream.Ops[1].Opcode, Is.EqualTo(FusedOpcode.PopPop));
+            Assert.That(stream.Ops[1].Kind, Is.EqualTo(StreamOpKind.FusedInBlock));
+            Assert.That(stream.Ops[1].Pc, Is.EqualTo(2));
+            Assert.That(stream.Ops[1].Advance, Is.EqualTo(2));
+            Assert.That(stream.PcToEntry[2], Is.EqualTo(1), "the first POP remains an entry start");
+            Assert.That(stream.PcToEntry[3], Is.EqualTo(InstructionStream.InvalidEntry), "nothing can land on the second POP");
+            Assert.That(stream.PcToEntry[4], Is.EqualTo(2), "the boundary after the pair stays reachable");
+        }
+    }
+
     [TestCase(Instruction.ADD, GasCostOf.VeryLow, TestName = "Add")]
     [TestCase(Instruction.MUL, GasCostOf.Low, TestName = "Mul")]
     [TestCase(Instruction.SDIV, GasCostOf.Low, TestName = "SDiv")]
@@ -296,6 +325,13 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         .PushData(32).PushData(0).Op(Instruction.RETURN)
         .Done;
 
+    private static readonly byte[] PopPopWithSurvivingValue = Prepare.EvmCode
+        .PushData(42).PushData(17).PushData(19)
+        .Op(Instruction.POP).Op(Instruction.POP)
+        .PushData(0).Op(Instruction.MSTORE)
+        .PushData(32).PushData(0).Op(Instruction.RETURN)
+        .Done;
+
     private static readonly byte[] FullStackStaticJump = BuildFullStackJump(Instruction.JUMP);
     private static readonly byte[] FullStackStaticJumpI = BuildFullStackJump(Instruction.JUMPI);
 
@@ -364,6 +400,56 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         yield return new TestCaseData(BuildOutOfGasMidBlock()) { TestName = "OutOfGasInsideMeteredBlock" };
     }
 
+    private static IEnumerable<TestCaseData> FusedConstOutputCases()
+    {
+        yield return FusedConstOutputCase("Add", Instruction.ADD, FusedOpcode.Add, 37, 19);
+        yield return FusedConstOutputCase("Sub", Instruction.SUB, FusedOpcode.Sub, 17, 43);
+        yield return FusedConstOutputCase("Mul", Instruction.MUL, FusedOpcode.Mul, 11, 13);
+        yield return FusedConstOutputCase("Div", Instruction.DIV, FusedOpcode.Div, 7, 91);
+        yield return FusedConstOutputCase("SDiv", Instruction.SDIV, FusedOpcode.SDiv, 7, 91);
+        yield return FusedConstOutputCase("Mod", Instruction.MOD, FusedOpcode.Mod, 11, 97);
+        yield return FusedConstOutputCase("SMod", Instruction.SMOD, FusedOpcode.SMod, 11, 97);
+        yield return FusedConstOutputCase("Lt", Instruction.LT, FusedOpcode.Lt, 79, 23);
+        yield return FusedConstOutputCase("Gt", Instruction.GT, FusedOpcode.Gt, 23, 79);
+        yield return FusedConstOutputCase("SLt", Instruction.SLT, FusedOpcode.SLt, 79, 23);
+        yield return FusedConstOutputCase("SGt", Instruction.SGT, FusedOpcode.SGt, 23, 79);
+        yield return FusedConstOutputCase("Shl255", Instruction.SHL, FusedOpcode.Shl, UInt256.One, 255);
+        yield return FusedConstOutputCase("Shl256", Instruction.SHL, FusedOpcode.Shl, UInt256.One, 256, new byte[] { 0, 1, 0 });
+        yield return FusedConstOutputCase("Shr255", Instruction.SHR, FusedOpcode.Shr, UInt256.One << 255, 255);
+        yield return FusedConstOutputCase("Shr256", Instruction.SHR, FusedOpcode.Shr, UInt256.One << 255, 256, new byte[] { 0, 1, 0 });
+    }
+
+    private static TestCaseData FusedConstOutputCase(string name, Instruction instruction, byte fusedOpcode, UInt256 stackValue, UInt256 constant, byte[]? encodedConstant = null)
+    {
+        Prepare code = Prepare.EvmCode.PushData(stackValue);
+        if (encodedConstant is null)
+            code.PushData(constant);
+        else
+            code.PushData(encodedConstant);
+
+        byte[] bytecode = code
+            .Op(instruction)
+            .PushData(0).Op(Instruction.MSTORE)
+            .PushData(32).PushData(0).Op(Instruction.RETURN)
+            .Done;
+
+        return new TestCaseData(bytecode, fusedOpcode) { TestName = name };
+    }
+
+    private static IEnumerable<TestCaseData> PopPopCases()
+    {
+        yield return new TestCaseData(PopPopWithSurvivingValue, (byte)Evm.StatusCode.Success, WordWithLowByte(42)) { TestName = "SuccessReturnsSurvivingValue" };
+        yield return new TestCaseData(new byte[] { (byte)Instruction.POP, (byte)Instruction.POP, (byte)Instruction.STOP }, (byte)Evm.StatusCode.Failure, Array.Empty<byte>()) { TestName = "UnderflowAtDepthZero" };
+        yield return new TestCaseData(Prepare.EvmCode.PushData(1).Op(Instruction.POP).Op(Instruction.POP).Op(Instruction.STOP).Done, (byte)Evm.StatusCode.Failure, Array.Empty<byte>()) { TestName = "UnderflowAtDepthOne" };
+    }
+
+    private static byte[] WordWithLowByte(byte value)
+    {
+        byte[] word = new byte[32];
+        word[^1] = value;
+        return word;
+    }
+
     [Test]
     public void Activation_IsShanghaiOrLater_SoStreamEngages() =>
         Assert.That(
@@ -394,6 +480,60 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
             Assert.That(streamed.GasSpent, Is.EqualTo(baseline.GasSpent), "gas must match to the unit");
             Assert.That(streamed.Output, Is.EqualTo(baseline.Output), "return data must match");
         }
+    }
+
+    [TestCaseSource(nameof(FusedConstOutputCases))]
+    public void StreamInterpreter_FusedConstOps_ReturnedOutputMatchesByteCodeLoop(byte[] code, byte expectedFusedOpcode)
+    {
+        AssertFusedOpcode(code, expectedFusedOpcode);
+        AssertStreamMatchesByteCodeLoop(code);
+    }
+
+    [TestCaseSource(nameof(PopPopCases))]
+    public void StreamInterpreter_FusedPopPop_MatchesByteCodeLoop(byte[] code, byte expectedStatus, byte[] expectedOutput)
+    {
+        AssertFusedOpcode(code, FusedOpcode.PopPop);
+        ReceiptCaptureTracer streamed = AssertStreamMatchesByteCodeLoop(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(streamed.StatusCode, Is.EqualTo(expectedStatus), "the fused pair must preserve the expected success or underflow status");
+            Assert.That(streamed.Output, Is.EqualTo(expectedOutput), "the fused pair must preserve the surviving stack value or empty failure output");
+        }
+    }
+
+    private static void AssertFusedOpcode(byte[] code, byte expectedFusedOpcode)
+    {
+        InstructionStream? stream = InstructionStream.TryBuild(code);
+        Assert.That(stream, Is.Not.Null, "test bytecode must build a stream");
+
+        foreach (StreamOp entry in stream!.Ops)
+        {
+            if (entry.Opcode == expectedFusedOpcode)
+                return;
+        }
+
+        Assert.Fail($"expected fused opcode 0x{expectedFusedOpcode:X2} was not emitted");
+    }
+
+    private ReceiptCaptureTracer AssertStreamMatchesByteCodeLoop(byte[] code)
+    {
+        ReceiptCaptureTracer baseline = RunWithInterpreter(code, useStream: false);
+        Setup();
+
+        long framesBefore = StreamInterpreter.FramesExecuted;
+        ReceiptCaptureTracer streamed = RunWithInterpreter(code, useStream: true);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(StreamInterpreter.FramesExecuted, Is.GreaterThan(framesBefore),
+                "the stream interpreter did not engage â€” this differential proved nothing");
+            Assert.That(streamed.StatusCode, Is.EqualTo(baseline.StatusCode), "success/failure must match");
+            Assert.That(streamed.GasSpent, Is.EqualTo(baseline.GasSpent), "gas must match to the unit");
+            Assert.That(streamed.Output, Is.EqualTo(baseline.Output), "return data must match");
+        }
+
+        return streamed;
     }
 
     // Guards that the executor's in-block switch covers exactly the TryGetInBlockCost set:

--- a/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
@@ -466,6 +466,7 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
     private static IEnumerable<TestCaseData> FusedConstOutputCases()
     {
         yield return FusedConstOutputCase("Add", Instruction.ADD, FusedOpcode.Add, 37, 19);
+        yield return FusedConstOutputCase("AddPush32MaxValue", Instruction.ADD, FusedOpcode.Add, UInt256.One, UInt256.MaxValue);
         yield return FusedConstOutputCase("Sub", Instruction.SUB, FusedOpcode.Sub, 17, 43);
         yield return FusedConstOutputCase("Mul", Instruction.MUL, FusedOpcode.Mul, 11, 13);
         yield return FusedConstOutputCase("Div", Instruction.DIV, FusedOpcode.Div, 7, 91);
@@ -478,6 +479,7 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         yield return FusedConstOutputCase("SGt", Instruction.SGT, FusedOpcode.SGt, 23, 79);
         yield return FusedConstOutputCase("Shl255", Instruction.SHL, FusedOpcode.Shl, UInt256.One, 255);
         yield return FusedConstOutputCase("Shl256", Instruction.SHL, FusedOpcode.Shl, UInt256.One, 256, new byte[] { 0, 1, 0 });
+        yield return FusedConstOutputCase("ShlHighLimbAmount", Instruction.SHL, FusedOpcode.Shl, UInt256.One, UInt256.One << 64);
         yield return FusedConstOutputCase("Shr255", Instruction.SHR, FusedOpcode.Shr, UInt256.One << 255, 255);
         yield return FusedConstOutputCase("Shr256", Instruction.SHR, FusedOpcode.Shr, UInt256.One << 255, 256, new byte[] { 0, 1, 0 });
     }

--- a/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
@@ -502,6 +502,54 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         }
     }
 
+    [TestCase(0, false, TestName = "DepthZeroUnderflowsBeforeSkippedCancellationPoll")]
+    [TestCase(1, true, TestName = "DepthOnePollsBeforeSecondPopUnderflow")]
+    [TestCase(1023, true, TestName = "FullStackPollsAtFusedSecondPopBoundary")]
+    public void StreamInterpreter_FusedPopPop_PreservesCancellationCadence(int stackDepth, bool shouldCancel)
+    {
+        byte[] code = BuildPopPopAtCancellationBoundary(stackDepth);
+        AssertFusedOpcode(code, FusedOpcode.PopPop);
+
+        PollingCancellationTracer byteCodeTracer = new();
+        AssertCancellationOutcome(code, useStream: false, shouldCancel, byteCodeTracer);
+
+        Setup();
+        long framesBefore = StreamInterpreter.FramesExecuted;
+        PollingCancellationTracer streamTracer = new();
+        AssertCancellationOutcome(code, useStream: true, shouldCancel, streamTracer);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(byteCodeTracer.CancellationPollCount, Is.EqualTo(shouldCancel ? 2 : 1),
+                "the bytecode loop must poll before the second POP only after the first succeeds");
+            Assert.That(StreamInterpreter.FramesExecuted, Is.GreaterThan(framesBefore),
+                "the stream interpreter did not engage — this cancellation regression proved nothing");
+            Assert.That(streamTracer.CancellationPollCount, Is.EqualTo(shouldCancel ? 2 : 1),
+                "the fused pair must preserve the bytecode loop's cancellation-poll ordering");
+        }
+    }
+
+    private static byte[] BuildPopPopAtCancellationBoundary(int stackDepth)
+    {
+        const int instructionsBeforePair = 1023;
+        byte[] code = new byte[instructionsBeforePair + 3];
+        int jumpDestCount = instructionsBeforePair - stackDepth;
+        code.AsSpan(0, jumpDestCount).Fill((byte)Instruction.JUMPDEST);
+        code.AsSpan(jumpDestCount, stackDepth).Fill((byte)Instruction.PUSH0);
+        code[instructionsBeforePair] = (byte)Instruction.POP;
+        code[instructionsBeforePair + 1] = (byte)Instruction.POP;
+        code[instructionsBeforePair + 2] = (byte)Instruction.STOP;
+        return code;
+    }
+
+    private void AssertCancellationOutcome(byte[] code, bool useStream, bool shouldCancel, Evm.Tracing.ITxTracer tracer)
+    {
+        if (shouldCancel)
+            Assert.Throws<OperationCanceledException>(() => RunWithInterpreter(code, useStream, tracer: tracer));
+        else
+            Assert.DoesNotThrow(() => RunWithInterpreter(code, useStream, tracer: tracer));
+    }
+
     private static void AssertFusedOpcode(byte[] code, byte expectedFusedOpcode)
     {
         InstructionStream? stream = InstructionStream.TryBuild(code);
@@ -602,7 +650,7 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         }
     }
 
-    private ReceiptCaptureTracer RunWithInterpreter(byte[] code, bool useStream, ulong gasLimit = 8_000_000)
+    private ReceiptCaptureTracer RunWithInterpreter(byte[] code, bool useStream, ulong gasLimit = 8_000_000, Evm.Tracing.ITxTracer? tracer = null)
     {
         TestState.CreateAccount(CalleeAddress, 1000000);
         TestState.InsertCode(CalleeAddress, CalleeCode, Spec);
@@ -631,9 +679,9 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
                     Assert.Fail("the stream did not build within the timeout");
             }
 
-            ReceiptCaptureTracer tracer = new();
-            _processor.Execute(transaction, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
-            return tracer;
+            ReceiptCaptureTracer receiptTracer = new();
+            _processor.Execute(transaction, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer ?? receiptTracer);
+            return receiptTracer;
         }
         finally
         {
@@ -641,6 +689,15 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
             StreamInterpreter.BuildThreshold = thresholdBefore;
             StreamInterpreter.ForceAllContexts = forceBefore;
         }
+    }
+
+    private sealed class PollingCancellationTracer : Evm.Tracing.TxTracer, Evm.Tracing.ITxTracer
+    {
+        private int _cancellationPollCount;
+
+        public int CancellationPollCount => _cancellationPollCount;
+        public bool IsCancelable => true;
+        public bool IsCancelled => _cancellationPollCount++ > 0;
     }
 
     private sealed class ReceiptCaptureTracer : Evm.Tracing.TxTracer

--- a/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeAnalysis/InstructionStreamTests.cs
@@ -208,6 +208,69 @@ public class InstructionStreamTests
         }
     }
 
+    [TestCaseSource(nameof(FixedGasPairAnalyzerCases))]
+    public void TryBuild_FixedGasPair_FusesGasAndPcMap(Instruction first, Instruction second, byte expectedOpcode, ulong expectedOperand, bool hasPrefix)
+    {
+        byte[] code = hasPrefix
+            ? [(byte)Instruction.PUSH0, (byte)first, (byte)second, (byte)Instruction.STOP]
+            : [(byte)first, (byte)second, (byte)Instruction.STOP];
+        int pairPc = hasPrefix ? 1 : 0;
+        int pairEntry = hasPrefix ? 1 : 0;
+        ulong pairGas = second == Instruction.POP
+            ? GasCostOf.VeryLow + GasCostOf.Base
+            : 2 * GasCostOf.VeryLow;
+
+        InstructionStream stream = InstructionStream.TryBuild(code)!;
+        StreamOp pair = stream.Ops[pairEntry];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(stream.BlockGas, Has.Length.EqualTo(1));
+            Assert.That(stream.BlockGas[0], Is.EqualTo(pairGas + (hasPrefix ? GasCostOf.Base : 0)),
+                "both fixed-gas operations remain in their precharged block");
+            Assert.That(pair.Opcode, Is.EqualTo(expectedOpcode));
+            Assert.That(pair.Operand, Is.EqualTo(expectedOperand));
+            Assert.That(pair.Kind, Is.EqualTo(hasPrefix ? StreamOpKind.FusedInBlock : StreamOpKind.FusedBlockFirst));
+            Assert.That(pair.Pc, Is.EqualTo(pairPc));
+            Assert.That(pair.BlockIndex, Is.EqualTo(0));
+            Assert.That(pair.Advance, Is.EqualTo(2));
+            Assert.That(stream.PcToEntry[pairPc], Is.EqualTo(pairEntry), "the first operation remains an entry start");
+            Assert.That(stream.PcToEntry[pairPc + 1], Is.EqualTo(InstructionStream.InvalidEntry), "nothing can land on the fused second operation");
+            Assert.That(stream.PcToEntry[pairPc + 2], Is.EqualTo(pairEntry + 1), "the boundary after the pair stays reachable");
+            Assert.That(stream.Ops[pairEntry + 1].Kind, Is.EqualTo(StreamOpKind.Boundary));
+        }
+    }
+
+    private static IEnumerable<TestCaseData> FixedGasPairAnalyzerCases()
+    {
+        yield return FixedGasPairAnalyzerCase("Swap1BlockFirst", Instruction.SWAP1, Instruction.POP, FusedOpcode.SwapPop, 2, hasPrefix: false);
+        yield return FixedGasPairAnalyzerCase("Swap1InBlock", Instruction.SWAP1, Instruction.POP, FusedOpcode.SwapPop, 2, hasPrefix: true);
+        yield return FixedGasPairAnalyzerCase("Swap3BlockFirst", Instruction.SWAP3, Instruction.POP, FusedOpcode.SwapPop, 4, hasPrefix: false);
+        yield return FixedGasPairAnalyzerCase("Swap3InBlock", Instruction.SWAP3, Instruction.POP, FusedOpcode.SwapPop, 4, hasPrefix: true);
+        yield return FixedGasPairAnalyzerCase("Swap8BlockFirst", Instruction.SWAP8, Instruction.POP, FusedOpcode.SwapPop, 9, hasPrefix: false);
+        yield return FixedGasPairAnalyzerCase("Swap8InBlock", Instruction.SWAP8, Instruction.POP, FusedOpcode.SwapPop, 9, hasPrefix: true);
+        yield return FixedGasPairAnalyzerCase("AndIsZeroBlockFirst", Instruction.AND, Instruction.ISZERO, FusedOpcode.AndIsZero, 0, hasPrefix: false);
+        yield return FixedGasPairAnalyzerCase("AndIsZeroInBlock", Instruction.AND, Instruction.ISZERO, FusedOpcode.AndIsZero, 0, hasPrefix: true);
+    }
+
+    private static TestCaseData FixedGasPairAnalyzerCase(string name, Instruction first, Instruction second, byte expectedOpcode, ulong expectedOperand, bool hasPrefix)
+        => new(first, second, expectedOpcode, expectedOperand, hasPrefix) { TestName = name };
+
+    [Test]
+    public void TryBuild_AndIsZero_DoesNotConsumePrecedingFusedConstAnd()
+    {
+        byte[] code = [(byte)Instruction.PUSH1, 0x00, (byte)Instruction.AND, (byte)Instruction.ISZERO, (byte)Instruction.STOP];
+
+        InstructionStream stream = InstructionStream.TryBuild(code)!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(stream.Ops[0].Opcode, Is.EqualTo(FusedOpcode.And), "precondition: the preceding PUSH1; AND is already fused");
+            Assert.That(stream.Ops[1].Opcode, Is.EqualTo((byte)Instruction.ISZERO), "a fixed-gas pair cannot consume an already-fused entry");
+            Assert.That(stream.Ops[1].Kind, Is.EqualTo(StreamOpKind.InBlock));
+        }
+    }
+
     [TestCase(Instruction.ADD, GasCostOf.VeryLow, TestName = "Add")]
     [TestCase(Instruction.MUL, GasCostOf.Low, TestName = "Mul")]
     [TestCase(Instruction.SDIV, GasCostOf.Low, TestName = "SDiv")]
@@ -443,6 +506,83 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         yield return new TestCaseData(Prepare.EvmCode.PushData(1).Op(Instruction.POP).Op(Instruction.POP).Op(Instruction.STOP).Done, (byte)Evm.StatusCode.Failure, Array.Empty<byte>()) { TestName = "UnderflowAtDepthOne" };
     }
 
+    private static IEnumerable<TestCaseData> FixedGasPairCases()
+    {
+        for (int swapDepth = 1; swapDepth <= 8; swapDepth++)
+        {
+            byte expectedTop = (byte)(swapDepth + 1);
+            yield return new TestCaseData(BuildSwapPopCode(swapDepth, succeeds: true), FusedOpcode.SwapPop, (byte)Evm.StatusCode.Success, WordWithLowByte(expectedTop))
+            {
+                TestName = $"Swap{swapDepth}PopSuccess",
+            };
+            yield return new TestCaseData(BuildSwapPopCode(swapDepth, succeeds: false), FusedOpcode.SwapPop, (byte)Evm.StatusCode.Failure, Array.Empty<byte>())
+            {
+                TestName = $"Swap{swapDepth}PopUnderflow",
+            };
+        }
+
+        yield return new TestCaseData(BuildAndIsZeroCode(0xF0, 0x0F), FusedOpcode.AndIsZero, (byte)Evm.StatusCode.Success, WordWithLowByte(1))
+        {
+            TestName = "AndIsZeroConjunctionIsZero",
+        };
+        yield return new TestCaseData(BuildAndIsZeroCode(0xF0, 0x30), FusedOpcode.AndIsZero, (byte)Evm.StatusCode.Success, WordWithLowByte(0))
+        {
+            TestName = "AndIsZeroConjunctionIsNonZero",
+        };
+        yield return new TestCaseData(new byte[] { (byte)Instruction.AND, (byte)Instruction.ISZERO, (byte)Instruction.STOP }, FusedOpcode.AndIsZero, (byte)Evm.StatusCode.Failure, Array.Empty<byte>())
+        {
+            TestName = "AndIsZeroUnderflowAtDepthZero",
+        };
+        yield return new TestCaseData(new byte[] { (byte)Instruction.PUSH0, (byte)Instruction.JUMPDEST, (byte)Instruction.AND, (byte)Instruction.ISZERO, (byte)Instruction.STOP }, FusedOpcode.AndIsZero, (byte)Evm.StatusCode.Failure, Array.Empty<byte>())
+        {
+            TestName = "AndIsZeroUnderflowAtDepthOne",
+        };
+    }
+
+    private static byte[] BuildSwapPopCode(int swapDepth, bool succeeds)
+    {
+        List<byte> code = [];
+        int stackDepth = succeeds ? swapDepth + 1 : swapDepth;
+        for (int value = 1; value <= stackDepth; value++)
+        {
+            code.Add((byte)Instruction.PUSH1);
+            code.Add((byte)value);
+        }
+
+        code.Add((byte)((byte)Instruction.SWAP1 + swapDepth - 1));
+        code.Add((byte)Instruction.POP);
+        if (!succeeds)
+        {
+            code.Add((byte)Instruction.STOP);
+            return code.ToArray();
+        }
+
+        if (swapDepth > 1)
+            code.Add((byte)((byte)Instruction.SWAP1 + swapDepth - 2));
+        code.Add((byte)Instruction.PUSH0);
+        code.Add((byte)Instruction.MSTORE);
+        code.Add((byte)Instruction.PUSH1);
+        code.Add(32);
+        code.Add((byte)Instruction.PUSH0);
+        code.Add((byte)Instruction.RETURN);
+        return code.ToArray();
+    }
+
+    private static byte[] BuildAndIsZeroCode(byte first, byte second)
+        =>
+        [
+            (byte)Instruction.PUSH1, first,
+            (byte)Instruction.PUSH1, second,
+            (byte)Instruction.SWAP1,
+            (byte)Instruction.AND,
+            (byte)Instruction.ISZERO,
+            (byte)Instruction.PUSH0,
+            (byte)Instruction.MSTORE,
+            (byte)Instruction.PUSH1, 32,
+            (byte)Instruction.PUSH0,
+            (byte)Instruction.RETURN,
+        ];
+
     private static byte[] WordWithLowByte(byte value)
     {
         byte[] word = new byte[32];
@@ -502,13 +642,24 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         }
     }
 
-    [TestCase(0, false, TestName = "DepthZeroUnderflowsBeforeSkippedCancellationPoll")]
-    [TestCase(1, true, TestName = "DepthOnePollsBeforeSecondPopUnderflow")]
-    [TestCase(1023, true, TestName = "FullStackPollsAtFusedSecondPopBoundary")]
-    public void StreamInterpreter_FusedPopPop_PreservesCancellationCadence(int stackDepth, bool shouldCancel)
+    [TestCaseSource(nameof(FixedGasPairCases))]
+    public void StreamInterpreter_FusedFixedGasPair_MatchesByteCodeLoop(byte[] code, byte expectedFusedOpcode, byte expectedStatus, byte[] expectedOutput)
     {
-        byte[] code = BuildPopPopAtCancellationBoundary(stackDepth);
-        AssertFusedOpcode(code, FusedOpcode.PopPop);
+        AssertFusedOpcode(code, expectedFusedOpcode);
+        ReceiptCaptureTracer streamed = AssertStreamMatchesByteCodeLoop(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(streamed.StatusCode, Is.EqualTo(expectedStatus), "the fused pair must preserve the expected success or underflow status");
+            Assert.That(streamed.Output, Is.EqualTo(expectedOutput), "the fused pair must preserve the expected stack result");
+        }
+    }
+
+    [TestCaseSource(nameof(FusedPairCancellationCases))]
+    public void StreamInterpreter_FusedPair_PreservesCancellationCadence(Instruction first, Instruction second, int stackDepth, bool shouldCancel, byte expectedFusedOpcode)
+    {
+        byte[] code = BuildFusedPairAtCancellationBoundary(first, second, stackDepth);
+        AssertFusedOpcode(code, expectedFusedOpcode);
 
         PollingCancellationTracer byteCodeTracer = new();
         AssertCancellationOutcome(code, useStream: false, shouldCancel, byteCodeTracer);
@@ -529,15 +680,29 @@ public class StreamInterpreterDifferentialTests : VirtualMachineTestsBase
         }
     }
 
-    private static byte[] BuildPopPopAtCancellationBoundary(int stackDepth)
+    private static IEnumerable<TestCaseData> FusedPairCancellationCases()
+    {
+        yield return FusedPairCancellationCase("PopPopDepthZeroUnderflowsBeforeSkippedPoll", Instruction.POP, Instruction.POP, 0, shouldCancel: false, expectedFusedOpcode: FusedOpcode.PopPop);
+        yield return FusedPairCancellationCase("PopPopDepthOnePollsBeforeSecondUnderflow", Instruction.POP, Instruction.POP, 1, shouldCancel: true, expectedFusedOpcode: FusedOpcode.PopPop);
+        yield return FusedPairCancellationCase("PopPopFullStackPollsAtSecondBoundary", Instruction.POP, Instruction.POP, 1023, shouldCancel: true, expectedFusedOpcode: FusedOpcode.PopPop);
+        yield return FusedPairCancellationCase("Swap8PopUnderflowWinsBeforeSkippedPoll", Instruction.SWAP8, Instruction.POP, 8, shouldCancel: false, expectedFusedOpcode: FusedOpcode.SwapPop);
+        yield return FusedPairCancellationCase("Swap8PopPollsBeforeSecondPop", Instruction.SWAP8, Instruction.POP, 9, shouldCancel: true, expectedFusedOpcode: FusedOpcode.SwapPop);
+        yield return FusedPairCancellationCase("AndIsZeroDepthOneUnderflowWinsBeforeSkippedPoll", Instruction.AND, Instruction.ISZERO, 1, shouldCancel: false, expectedFusedOpcode: FusedOpcode.AndIsZero);
+        yield return FusedPairCancellationCase("AndIsZeroPollsBeforeSecondOperation", Instruction.AND, Instruction.ISZERO, 2, shouldCancel: true, expectedFusedOpcode: FusedOpcode.AndIsZero);
+    }
+
+    private static TestCaseData FusedPairCancellationCase(string name, Instruction first, Instruction second, int stackDepth, bool shouldCancel, byte expectedFusedOpcode)
+        => new(first, second, stackDepth, shouldCancel, expectedFusedOpcode) { TestName = name };
+
+    private static byte[] BuildFusedPairAtCancellationBoundary(Instruction first, Instruction second, int stackDepth)
     {
         const int instructionsBeforePair = 1023;
         byte[] code = new byte[instructionsBeforePair + 3];
         int jumpDestCount = instructionsBeforePair - stackDepth;
         code.AsSpan(0, jumpDestCount).Fill((byte)Instruction.JUMPDEST);
         code.AsSpan(jumpDestCount, stackDepth).Fill((byte)Instruction.PUSH0);
-        code[instructionsBeforePair] = (byte)Instruction.POP;
-        code[instructionsBeforePair + 1] = (byte)Instruction.POP;
+        code[instructionsBeforePair] = (byte)first;
+        code[instructionsBeforePair + 1] = (byte)second;
         code[instructionsBeforePair + 2] = (byte)Instruction.STOP;
         return code;
     }

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
@@ -26,8 +26,9 @@ internal enum StreamOpKind : byte
 
 /// <summary>
 /// Virtual opcodes for fused instruction sequences use undefined EVM byte values: the 0x0C..0x0F
-/// and 0x21..0x2F gaps, plus <c>PopPop</c> at currently undefined 0x4D above SLOTNUM. The fingerprint
-/// gate keeps new forks (which might define one of these) off the stream until reviewed.
+/// and 0x21..0x2F gaps, plus <c>AndIsZero</c>, <c>PopPop</c>, and <c>SwapPop</c> in the currently
+/// undefined 0x4C..0x4E range above SLOTNUM. The fingerprint gate keeps new forks (which might define
+/// one of these) off the stream until reviewed.
 /// </summary>
 internal static class FusedOpcode
 {
@@ -48,7 +49,9 @@ internal static class FusedOpcode
     public const byte Xor = 0x2B;
     public const byte Shl = 0x2C;
     public const byte Shr = 0x2D;
+    public const byte AndIsZero = 0x4C;
     public const byte PopPop = 0x4D;
+    public const byte SwapPop = 0x4E;
     public const byte StaticJump = 0x2E;
     public const byte StaticJumpI = 0x2F;
 
@@ -190,15 +193,14 @@ internal sealed class InstructionStream
             else if (GetInBlockCost(instruction) is ulong cost && cost != NotInBlock && pc + immediates < code.Length)
             {
                 if (openBlock >= 0
-                    && instruction == Instruction.POP
-                    && TryTakePrecedingPop(ops, out StreamOp pop))
+                    && TryTakePrecedingFixedGasPair(ops, instruction, out byte pairOpcode, out ulong pairOperand, out StreamOp first))
                 {
                     blockGas[openBlock] += cost;
                     pcToEntry[pc] = InvalidEntry;
-                    StreamOpKind fusedKind = pop.Kind == StreamOpKind.BlockFirst
+                    StreamOpKind fusedKind = first.Kind == StreamOpKind.BlockFirst
                         ? StreamOpKind.FusedBlockFirst
                         : StreamOpKind.FusedInBlock;
-                    ops[^1] = new StreamOp(FusedOpcode.PopPop, fusedKind, pop.Pc, pop.BlockIndex, (byte)(pop.Advance + size), 0);
+                    ops[^1] = new StreamOp(pairOpcode, fusedKind, first.Pc, first.BlockIndex, (byte)(first.Advance + size), pairOperand);
                 }
                 else if (openBlock >= 0
                     && FusedOpcode.TryMap(instruction, out byte fusedOpcode)
@@ -345,18 +347,45 @@ internal sealed class InstructionStream
         return true;
     }
 
-    private static bool TryTakePrecedingPop(List<StreamOp> ops, out StreamOp pop)
+    private static bool TryTakePrecedingFixedGasPair(List<StreamOp> ops, Instruction second, out byte fusedOpcode, out ulong operand, out StreamOp first)
     {
-        pop = default;
+        fusedOpcode = 0;
+        operand = 0;
+        first = default;
         if (ops.Count == 0)
             return false;
 
         StreamOp last = ops[^1];
-        if (last.Kind is not (StreamOpKind.BlockFirst or StreamOpKind.InBlock)
-            || last.Opcode != (byte)Instruction.POP)
+        if (last.Kind is not (StreamOpKind.BlockFirst or StreamOpKind.InBlock))
             return false;
 
-        pop = last;
+        Instruction firstInstruction = (Instruction)last.Opcode;
+        if (second == Instruction.POP)
+        {
+            if (firstInstruction == Instruction.POP)
+            {
+                fusedOpcode = FusedOpcode.PopPop;
+            }
+            else if (firstInstruction is >= Instruction.SWAP1 and <= Instruction.SWAP8)
+            {
+                fusedOpcode = FusedOpcode.SwapPop;
+                operand = (ulong)(firstInstruction - Instruction.SWAP1 + 2);
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else if (firstInstruction == Instruction.AND && second == Instruction.ISZERO)
+        {
+            fusedOpcode = FusedOpcode.AndIsZero;
+        }
+        else
+        {
+            return false;
+        }
+
+        first = last;
         return true;
     }
 

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/InstructionStream.cs
@@ -25,9 +25,9 @@ internal enum StreamOpKind : byte
 }
 
 /// <summary>
-/// Virtual opcodes for fused PUSH+op pairs, placed in byte values the EVM does not define
-/// (0x0C..0x0F and 0x21..0x2F gaps). The fingerprint gate keeps new forks (which might define
-/// one of these) off the stream until reviewed.
+/// Virtual opcodes for fused instruction sequences use undefined EVM byte values: the 0x0C..0x0F
+/// and 0x21..0x2F gaps, plus <c>PopPop</c> at currently undefined 0x4D above SLOTNUM. The fingerprint
+/// gate keeps new forks (which might define one of these) off the stream until reviewed.
 /// </summary>
 internal static class FusedOpcode
 {
@@ -48,6 +48,7 @@ internal static class FusedOpcode
     public const byte Xor = 0x2B;
     public const byte Shl = 0x2C;
     public const byte Shr = 0x2D;
+    public const byte PopPop = 0x4D;
     public const byte StaticJump = 0x2E;
     public const byte StaticJumpI = 0x2F;
 
@@ -189,6 +190,17 @@ internal sealed class InstructionStream
             else if (GetInBlockCost(instruction) is ulong cost && cost != NotInBlock && pc + immediates < code.Length)
             {
                 if (openBlock >= 0
+                    && instruction == Instruction.POP
+                    && TryTakePrecedingPop(ops, out StreamOp pop))
+                {
+                    blockGas[openBlock] += cost;
+                    pcToEntry[pc] = InvalidEntry;
+                    StreamOpKind fusedKind = pop.Kind == StreamOpKind.BlockFirst
+                        ? StreamOpKind.FusedBlockFirst
+                        : StreamOpKind.FusedInBlock;
+                    ops[^1] = new StreamOp(FusedOpcode.PopPop, fusedKind, pop.Pc, pop.BlockIndex, (byte)(pop.Advance + size), 0);
+                }
+                else if (openBlock >= 0
                     && FusedOpcode.TryMap(instruction, out byte fusedOpcode)
                     && TryTakePrecedingPush(ops, out StreamOp push))
                 {
@@ -330,6 +342,21 @@ internal sealed class InstructionStream
             return false;
 
         push = last;
+        return true;
+    }
+
+    private static bool TryTakePrecedingPop(List<StreamOp> ops, out StreamOp pop)
+    {
+        pop = default;
+        if (ops.Count == 0)
+            return false;
+
+        StreamOp last = ops[^1];
+        if (last.Kind is not (StreamOpKind.BlockFirst or StreamOpKind.InBlock)
+            || last.Opcode != (byte)Instruction.POP)
+            return false;
+
+        pop = last;
         return true;
     }
 

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -2212,6 +2212,56 @@ public ref struct EvmStack
         return EvmExceptionType.None;
     }
 
+    /// <summary>Fuses <c>SWAPn; POP</c> by replacing the swap partner with the original top word and dropping the top; requires <c>Head &gt;= depth</c>.</summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal EvmExceptionType SwapPop(int depth)
+    {
+        int head = Head;
+        if (head < depth)
+        {
+            return EvmExceptionType.StackUnderflow;
+        }
+
+        ref byte bytes = ref _stack;
+        nuint headOffset = (nuint)(uint)head << 5;
+
+        ref byte partner = ref Unsafe.Add(ref bytes, headOffset - ((nuint)(uint)depth << 5));
+        ref byte top = ref Unsafe.Add(ref bytes, headOffset - WordSize);
+
+        Unsafe.WriteUnaligned(ref partner, Unsafe.ReadUnaligned<EvmWord>(ref top));
+        Head = head - 1;
+        return EvmExceptionType.None;
+    }
+
+    /// <summary>Fuses <c>AND; ISZERO</c> over two stack words, writing canonical zero or one to the second slot.</summary>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal EvmExceptionType AndIsZero()
+    {
+        int head = Head;
+        if (head < 2)
+        {
+            return EvmExceptionType.StackUnderflow;
+        }
+
+        ref byte bytes = ref _stack;
+        nuint headOffset = (nuint)(uint)head << 5;
+
+        ref byte top = ref Unsafe.Add(ref bytes, headOffset - WordSize);
+        ref byte second = ref Unsafe.Add(ref bytes, headOffset - (WordSize * 2));
+        bool isZero = (Unsafe.ReadUnaligned<EvmWord>(ref top) & Unsafe.ReadUnaligned<EvmWord>(ref second)) == default;
+
+        Unsafe.WriteUnaligned(ref second, default(EvmWord));
+        if (isZero)
+        {
+            Unsafe.Add(ref second, WordSize - 1) = 1;
+        }
+
+        Head = head - 1;
+        return EvmExceptionType.None;
+    }
+
     public readonly bool EnsureDepth(int depth)
         => Head >= depth;
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
@@ -57,6 +57,19 @@ public static partial class EvmInstructions
     }
 
     /// <summary>
+    /// Fuses <c>POP; POP</c>; its single <c>Head &lt; 2</c> check preserves sequential execution's exact underflow condition.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType FusedPopPopCore(ref EvmStack stack)
+    {
+        if (stack.Head < 2)
+            return EvmExceptionType.StackUnderflow;
+
+        stack.Head -= 2;
+        return EvmExceptionType.None;
+    }
+
+    /// <summary>
     /// Fused <c>PUSH const; bitwise-op</c> over the stack-representation pool: one vector load per
     /// operand, no limb conversion.
     /// </summary>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FusedConst.cs
@@ -16,7 +16,7 @@ public static partial class EvmInstructions
     /// </summary>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.NoInlining)]
-    internal static EvmExceptionType FusedConstBinaryCore<TOpMath>(ref EvmStack stack, UInt256 a)
+    internal static EvmExceptionType FusedConstBinaryCore<TOpMath>(ref EvmStack stack, in UInt256 a)
         where TOpMath : struct, IOpMath2Param
     {
         if (stack.Head == EvmStack.MaxStackSize - 1)
@@ -34,7 +34,7 @@ public static partial class EvmInstructions
     /// <summary>Fused <c>PUSH shift-amount; SHL/SHR</c>, mirroring <see cref="ShiftCore{TOpShift, TTracingInst}"/>.</summary>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.NoInlining)]
-    internal static EvmExceptionType FusedConstShiftCore<TOpShift>(ref EvmStack stack, UInt256 a)
+    internal static EvmExceptionType FusedConstShiftCore<TOpShift>(ref EvmStack stack, in UInt256 a)
         where TOpShift : struct, IOpShift
     {
         if (stack.Head == EvmStack.MaxStackSize - 1)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -163,6 +163,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                         case (Instruction)FusedOpcode.Shr:
                             exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShr>(ref stack, in constants[(int)entry.Operand]);
                             break;
+                        case (Instruction)FusedOpcode.PopPop:
+                            exceptionType = EvmInstructions.FusedPopPopCore(ref stack);
+                            break;
                         case Instruction.ADD:
                             exceptionType = EvmInstructions.Math2ParamCore<EvmInstructions.OpAdd, OffFlag>(ref stack);
                             break;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -171,6 +171,25 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                                 ThrowStreamOperationCanceledException();
                             exceptionType = EvmInstructions.FusedPopPopCore(ref stack);
                             break;
+                        case (Instruction)FusedOpcode.SwapPop:
+                        {
+                            int depth = (int)entry.Operand;
+                            if (TCancelable.IsActive
+                                && stack.Head >= depth
+                                && ((opCodeCount - 1) & CancellationCheckMask) == 0
+                                && _txTracer.IsCancelled)
+                                ThrowStreamOperationCanceledException();
+                            exceptionType = stack.SwapPop(depth);
+                            break;
+                        }
+                        case (Instruction)FusedOpcode.AndIsZero:
+                            if (TCancelable.IsActive
+                                && stack.Head >= 2
+                                && ((opCodeCount - 1) & CancellationCheckMask) == 0
+                                && _txTracer.IsCancelled)
+                                ThrowStreamOperationCanceledException();
+                            exceptionType = stack.AndIsZero();
+                            break;
                         case Instruction.ADD:
                             exceptionType = EvmInstructions.Math2ParamCore<EvmInstructions.OpAdd, OffFlag>(ref stack);
                             break;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -164,30 +164,42 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                             exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShr>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.PopPop:
-                            if (TCancelable.IsActive
-                                && stack.Head >= 1
-                                && ((opCodeCount - 1) & CancellationCheckMask) == 0
-                                && _txTracer.IsCancelled)
-                                ThrowStreamOperationCanceledException();
+                            opCodeCount--;
+                            if (stack.Head >= 1)
+                            {
+                                if (TCancelable.IsActive
+                                    && (opCodeCount & CancellationCheckMask) == 0
+                                    && _txTracer.IsCancelled)
+                                    ThrowStreamOperationCanceledException();
+                                opCodeCount++;
+                            }
                             exceptionType = EvmInstructions.FusedPopPopCore(ref stack);
                             break;
                         case (Instruction)FusedOpcode.SwapPop:
                         {
                             int depth = (int)entry.Operand;
-                            if (TCancelable.IsActive
-                                && stack.Head >= depth
-                                && ((opCodeCount - 1) & CancellationCheckMask) == 0
-                                && _txTracer.IsCancelled)
-                                ThrowStreamOperationCanceledException();
+                            opCodeCount--;
+                            if (stack.Head >= depth)
+                            {
+                                if (TCancelable.IsActive
+                                    && (opCodeCount & CancellationCheckMask) == 0
+                                    && _txTracer.IsCancelled)
+                                    ThrowStreamOperationCanceledException();
+                                opCodeCount++;
+                            }
                             exceptionType = stack.SwapPop(depth);
                             break;
                         }
                         case (Instruction)FusedOpcode.AndIsZero:
-                            if (TCancelable.IsActive
-                                && stack.Head >= 2
-                                && ((opCodeCount - 1) & CancellationCheckMask) == 0
-                                && _txTracer.IsCancelled)
-                                ThrowStreamOperationCanceledException();
+                            opCodeCount--;
+                            if (stack.Head >= 2)
+                            {
+                                if (TCancelable.IsActive
+                                    && (opCodeCount & CancellationCheckMask) == 0
+                                    && _txTracer.IsCancelled)
+                                    ThrowStreamOperationCanceledException();
+                                opCodeCount++;
+                            }
                             exceptionType = stack.AndIsZero();
                             break;
                         case Instruction.ADD:

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -164,6 +164,11 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                             exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShr>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.PopPop:
+                            if (TCancelable.IsActive
+                                && stack.Head >= 1
+                                && ((opCodeCount - 1) & CancellationCheckMask) == 0
+                                && _txTracer.IsCancelled)
+                                ThrowStreamOperationCanceledException();
                             exceptionType = EvmInstructions.FusedPopPopCore(ref stack);
                             break;
                         case Instruction.ADD:

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -176,20 +176,20 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                             exceptionType = EvmInstructions.FusedPopPopCore(ref stack);
                             break;
                         case (Instruction)FusedOpcode.SwapPop:
-                        {
-                            int depth = (int)entry.Operand;
-                            opCodeCount--;
-                            if (stack.Head >= depth)
                             {
-                                if (TCancelable.IsActive
-                                    && (opCodeCount & CancellationCheckMask) == 0
-                                    && _txTracer.IsCancelled)
-                                    ThrowStreamOperationCanceledException();
-                                opCodeCount++;
+                                int depth = (int)entry.Operand;
+                                opCodeCount--;
+                                if (stack.Head >= depth)
+                                {
+                                    if (TCancelable.IsActive
+                                        && (opCodeCount & CancellationCheckMask) == 0
+                                        && _txTracer.IsCancelled)
+                                        ThrowStreamOperationCanceledException();
+                                    opCodeCount++;
+                                }
+                                exceptionType = stack.SwapPop(depth);
+                                break;
                             }
-                            exceptionType = stack.SwapPop(depth);
-                            break;
-                        }
                         case (Instruction)FusedOpcode.AndIsZero:
                             opCodeCount--;
                             if (stack.Head >= 2)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -113,37 +113,37 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                     switch (instruction)
                     {
                         case (Instruction)FusedOpcode.Add:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpAdd>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpAdd>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.Sub:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpSub>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpSub>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.Mul:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpMul>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpMul>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.Div:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpDiv>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpDiv>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.SDiv:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpSDiv>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpSDiv>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.Mod:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpMod>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpMod>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.SMod:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpSMod>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpSMod>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.Lt:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpLt>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpLt>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.Gt:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpGt>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpGt>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.SLt:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpSLt>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpSLt>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.SGt:
-                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpSGt>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstBinaryCore<EvmInstructions.OpSGt>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.Eq:
                             exceptionType = EvmInstructions.FusedConstBitwiseCore<EvmInstructions.OpBitwiseEq>(ref stack, ref constantBytes[(int)entry.Operand * 32]);
@@ -158,10 +158,10 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                             exceptionType = EvmInstructions.FusedConstBitwiseCore<EvmInstructions.OpBitwiseXor>(ref stack, ref constantBytes[(int)entry.Operand * 32]);
                             break;
                         case (Instruction)FusedOpcode.Shl:
-                            exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShl>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShl>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case (Instruction)FusedOpcode.Shr:
-                            exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShr>(ref stack, constants[(int)entry.Operand]);
+                            exceptionType = EvmInstructions.FusedConstShiftCore<EvmInstructions.OpShr>(ref stack, in constants[(int)entry.Operand]);
                             break;
                         case Instruction.ADD:
                             exceptionType = EvmInstructions.Math2ParamCore<EvmInstructions.OpAdd, OffFlag>(ref stack);


### PR DESCRIPTION
## Changes

- pass fused `UInt256` constants by readonly reference to avoid hot-path value copies
- fuse common fixed-gas stream pairs: `POP; POP`, `SWAP1..8; POP`, and `AND; ISZERO`
- preserve gas, program-counter metadata, stack-underflow ordering, cancellation cadence, and public opcode counts
- add analyzer and bytecode-vs-stream differential coverage for results, underflows, cancellation, opcode counts, and full-width constants

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Release `Nethermind.Evm` and test-project builds: 0 warnings, 0 errors
- focused `InstructionStreamTests|StreamInterpreterDifferentialTests`: 174 passed
- full `Nethermind.Evm.Test`: 5,061 passed, 8 intentional skips, 0 failed
- whitespace verification passed for both affected projects
- [final 30-second A/B run](https://github.com/NethermindEth/nethermind/actions/runs/30916322691):
  - candidate p50 261.47 ms vs master 282.38 ms: 7.40% faster
  - candidate average 266.96 ms vs master 288.90 ms: 7.60% faster
  - candidate p90 268.77 ms vs master 286.79 ms: 6.28% faster
  - candidate p95 274.50 ms vs master 313.90 ms: 12.55% faster
  - 31/31 requests passed on each side; exact response parity, clean error scans, normal shutdown, unchanged DB manifests
- [runtime configuration sweep](https://github.com/NethermindEth/nethermind/actions/runs/30906385415) found no toggle worth retaining

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Reth was captured once, as requested, at 195.83 ms p50 in [run 30908140459](https://github.com/NethermindEth/nethermind/actions/runs/30908140459) and was not repeated. Compared with that cached reference, the final candidate remains about 65.64 ms (33.5%) slower. The short-run sample count is modest, but multiple independent candidate/master iterations were consistently positive.
