### PR TITLE
fix(txpool): gate frame transactions on their full gas budget

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -7,6 +7,7 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
@@ -444,6 +445,42 @@ namespace Nethermind.Blockchain.Test
 
             Assert.That(args.Action, Is.EqualTo(expectedSkipReason is null ? BlockProcessor.TxAction.Add : BlockProcessor.TxAction.Skip));
             if (expectedSkipReason is not null) Assert.That(args.Reason, Is.EqualTo(expectedSkipReason));
+        }
+
+        // EIP-8141: a frame transaction's GasLimit is only the sum of its frame gas limits, so the picker must gate on
+        // max_gas or the produced block exceeds its own gas limit. The mandatory cost of the single frame below is
+        // FRAME_TX_INTRINSIC_COST + FRAME_TX_PER_FRAME_COST = 15,475, and each non-zero calldata byte adds 16 to the
+        // standard cost against 40 to the EIP-7623 floor, so the last case fits the block on its standard cost alone.
+        [TestCase(100_000UL, 0, false)]
+        [TestCase(115_000UL, 0, true)]
+        [TestCase(10_000UL, 4000, true)]
+        public void Frame_transaction_is_gated_on_its_max_gas(ulong frameGasLimit, int frameDataLength, bool expectedSkipped)
+        {
+            IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+            using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+            stateProvider.CreateAccount(TestItem.AddressA, 1.Ether);
+
+            byte[] frameData = Enumerable.Repeat((byte)1, frameDataLength).ToArray();
+            Transaction frameTx = new()
+            {
+                Type = TxType.FrameTx,
+                Nonce = 0,
+                SenderAddress = TestItem.AddressA,
+                Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, frameGasLimit, UInt256.Zero, frameData)],
+                FrameSignatures = [],
+                GasLimit = frameGasLimit,
+                GasPrice = 1,
+                DecodedMaxFeePerGas = 1,
+            };
+            frameTx.Hash = frameTx.CalculateHash();
+
+            Block block = Build.A.Block.WithGasLimit(130_000).WithTransactions([frameTx]).TestObject;
+            ISpecProvider specProvider = new TestSingleReleaseSpecProvider(Bogota.Instance);
+            BlockProcessor.BlockProductionTransactionPicker picker = new(specProvider);
+
+            BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(block, frameTx, new HashSet<Transaction>(), stateProvider);
+
+            Assert.That(args.Action == BlockProcessor.TxAction.Skip && args.Reason.StartsWith("Not enough gas in block"), Is.EqualTo(expectedSkipped));
         }
 
         private static Transaction[] RunBlockProduction(

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -480,7 +480,15 @@ namespace Nethermind.Blockchain.Test
 
             BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(block, frameTx, new HashSet<Transaction>(), stateProvider);
 
-            Assert.That(args.Action == BlockProcessor.TxAction.Skip && args.Reason.StartsWith("Not enough gas in block"), Is.EqualTo(expectedSkipped));
+            if (expectedSkipped)
+            {
+                Assert.That(args.Action, Is.EqualTo(BlockProcessor.TxAction.Skip));
+                Assert.That(args.Reason, Does.StartWith("Not enough gas in block"));
+            }
+            else
+            {
+                Assert.That(args.Action, Is.EqualTo(BlockProcessor.TxAction.Add), args.Reason);
+            }
         }
 
         private static Transaction[] RunBlockProduction(

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -58,9 +58,16 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, "Null sender");
                 }
 
-                if (currentTx.GasLimit > gasRemaining)
+                // A frame transaction's GasLimit is only the sum of its frame gas limits, so gating on it alone would
+                // let the produced block exceed its own gas limit.
+                ulong txGasBudget = currentTx.SupportsFrames
+                        && FrameTxValidation.TryCalculateGasBudget(currentTx, _specProvider.GetSpec(block.Header), out _, out _, out ulong frameTxMaxGas)
+                    ? frameTxMaxGas
+                    : currentTx.GasLimit;
+
+                if (txGasBudget > gasRemaining)
                 {
-                    return args.Set(TxAction.Skip, $"Not enough gas in block, gas limit {currentTx.GasLimit} > {gasRemaining}");
+                    return args.Set(TxAction.Skip, $"Not enough gas in block, gas limit {txGasBudget} > {gasRemaining}");
                 }
 
                 if (transactionsInBlock.Contains(currentTx))

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -58,12 +58,15 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, "Null sender");
                 }
 
+                IReleaseSpec spec = _specProvider.GetSpec(block.Header);
+
                 // A frame transaction's GasLimit is only the sum of its frame gas limits, so gating on it alone would
-                // let the produced block exceed its own gas limit.
-                ulong txGasBudget = currentTx.SupportsFrames
-                        && FrameTxValidation.TryCalculateGasBudget(currentTx, _specProvider.GetSpec(block.Header), out _, out _, out ulong frameTxMaxGas)
-                    ? frameTxMaxGas
-                    : currentTx.GasLimit;
+                // let the produced block exceed its own gas limit. A transaction that cannot be priced never fits.
+                ulong txGasBudget = !currentTx.SupportsFrames
+                    ? currentTx.GasLimit
+                    : FrameTxValidation.TryCalculateGasBudget(currentTx, spec, out _, out _, out ulong frameTxMaxGas)
+                        ? frameTxMaxGas
+                        : ulong.MaxValue;
 
                 if (txGasBudget > gasRemaining)
                 {
@@ -75,7 +78,6 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, "Transaction already in block");
                 }
 
-                IReleaseSpec spec = _specProvider.GetSpec(block.Header);
                 if (currentTx.IsAboveInitCode(spec))
                 {
                     return args.Set(TxAction.Skip, TransactionResult.TransactionSizeOverMaxInitCodeSize.ErrorDescription);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -60,6 +60,11 @@ namespace Nethermind.Consensus.Processing
 
                 IReleaseSpec spec = _specProvider.GetSpec(block.Header);
 
+                if (transactionsInBlock.Contains(currentTx))
+                {
+                    return args.Set(TxAction.Skip, "Transaction already in block");
+                }
+
                 // A frame transaction's GasLimit is only the sum of its frame gas limits, so gating on it alone would
                 // let the produced block exceed its own gas limit. A transaction that cannot be priced never fits.
                 ulong txGasBudget = !currentTx.SupportsFrames
@@ -71,11 +76,6 @@ namespace Nethermind.Consensus.Processing
                 if (txGasBudget > gasRemaining)
                 {
                     return args.Set(TxAction.Skip, $"Not enough gas in block, gas limit {txGasBudget} > {gasRemaining}");
-                }
-
-                if (transactionsInBlock.Contains(currentTx))
-                {
-                    return args.Set(TxAction.Skip, "Transaction already in block");
                 }
 
                 if (currentTx.IsAboveInitCode(spec))

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Buffers.Binary;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 
 namespace Nethermind.Core;
 
@@ -310,6 +312,101 @@ public static class FrameTxValidation
 
     private static bool IsPay(TxFrame frame) =>
         frame.Mode == TxFrame.ModeVerify && frame.Flags == TxFrame.ApprovePayment;
+
+    /// <summary>
+    /// Calculates the gas an EIP-8141 frame transaction reserves: <c>max_gas</c>, the greater of its intrinsic cost
+    /// plus the sum of the frame gas limits and its EIP-7623 calldata floor.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Transaction.GasLimit"/> of a frame transaction carries only the sum of the frame gas limits, so any
+    /// consumer gating on a gas budget (mempool admission, block production, execution) must price the transaction
+    /// through this method or it under-counts by at least <see cref="Eip8141Constants.IntrinsicGasCost"/>.
+    /// The intrinsic cost is FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST + the calldata cost of the
+    /// frame data and signature fields + the per-scheme signature verification cost. The rate and token weighting
+    /// behind <paramref name="floorGas"/> are resolved from the spec, as
+    /// <c>IntrinsicGasCalculator.CalculateFloorCost</c> does, so a frame transaction's floor cannot diverge from an
+    /// ordinary transaction's under the same fork. A transaction whose frames reserve less than the floor raises its
+    /// reservation rather than becoming invalid; the headroom is reserved and refunded, never spendable.
+    /// </remarks>
+    /// <param name="transaction">The frame transaction to price.</param>
+    /// <param name="spec">The release spec supplying the calldata token pricing.</param>
+    /// <param name="intrinsicGas">The intrinsic cost, charged before any frame runs.</param>
+    /// <param name="floorGas">The minimum chargeable gas, or 0 when floor pricing is not active.</param>
+    /// <param name="maxGas">The gas reserved against the payer's balance and the block gas limit.</param>
+    /// <returns><c>false</c> if the frame gas limits or the resulting budget overflow <see cref="ulong"/>.</returns>
+    public static bool TryCalculateGasBudget(Transaction transaction, IReleaseSpec spec, out ulong intrinsicGas, out ulong floorGas, out ulong maxGas)
+    {
+        intrinsicGas = 0;
+        floorGas = 0;
+        maxGas = 0;
+
+        TxFrame[]? frames = transaction.Frames;
+        if (frames is null)
+        {
+            return false;
+        }
+
+        ulong tokens = 0;
+        ulong dataLength = 0;
+        ulong totalFrameGas = 0;
+        foreach (TxFrame frame in frames)
+        {
+            tokens += CountCalldataTokens(frame.Data.Span, spec);
+            dataLength += (ulong)frame.Data.Length;
+
+            ulong accumulated = totalFrameGas + frame.GasLimit;
+            if (accumulated < totalFrameGas)
+            {
+                return false;
+            }
+
+            totalFrameGas = accumulated;
+        }
+
+        ulong signatureVerificationCost = 0;
+        TxFrameSignature[]? signatures = transaction.FrameSignatures;
+        if (signatures is not null)
+        {
+            foreach (TxFrameSignature signature in signatures)
+            {
+                tokens += signature.Signer is null ? 0 : CountCalldataTokens(signature.Signer.Bytes, spec);
+                tokens += CountCalldataTokens(signature.Msg.Span, spec);
+                tokens += CountCalldataTokens(signature.Signature.Span, spec);
+                dataLength += (ulong)(signature.Signer is null ? 0 : Address.Size)
+                              + (ulong)signature.Msg.Length
+                              + (ulong)signature.Signature.Length;
+                signatureVerificationCost += signature.Scheme switch
+                {
+                    TxFrameSignature.SchemeArbitrary => Eip8141Constants.ArbitraryVerificationGasCost,
+                    TxFrameSignature.SchemeSecp256k1 => Eip8141Constants.Secp256k1VerificationGasCost,
+                    TxFrameSignature.SchemeP256 => Eip8141Constants.P256VerificationGasCost,
+                    _ => 0,
+                };
+            }
+        }
+
+        ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost
+                             + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
+                             + signatureVerificationCost;
+        ulong floorTokens = spec.IsEip7976Enabled ? dataLength * spec.GasCosts.TxDataNonZeroMultiplier : tokens;
+        floorGas = spec.IsEip7623Enabled ? mandatoryGas + floorTokens * spec.GasCosts.TotalCostFloorPerToken : 0;
+        intrinsicGas = mandatoryGas + tokens * GasCostOf.TxDataZero;
+
+        ulong standardGas = intrinsicGas + totalFrameGas;
+        if (standardGas < intrinsicGas)
+        {
+            return false;
+        }
+
+        maxGas = Math.Max(standardGas, floorGas);
+        return true;
+    }
+
+    private static ulong CountCalldataTokens(ReadOnlySpan<byte> data, IReleaseSpec spec)
+    {
+        int zeros = data.CountZeros();
+        return (ulong)zeros + (ulong)(data.Length - zeros) * spec.GasCosts.TxDataNonZeroMultiplier;
+    }
 
     /// <summary>
     /// Reads the EIP-8141 expiry deadline (Unix seconds) from the expiry-verifier VERIFY frame, if present.

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Threading;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 
@@ -321,20 +322,34 @@ public static class FrameTxValidation
     /// <see cref="Transaction.GasLimit"/> of a frame transaction carries only the sum of the frame gas limits, so any
     /// consumer gating on a gas budget (mempool admission, block production, execution) must price the transaction
     /// through this method or it under-counts by at least <see cref="Eip8141Constants.IntrinsicGasCost"/>.
-    /// The intrinsic cost is FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST + the calldata cost of the
-    /// frame data and signature fields + the per-scheme signature verification cost. The rate and token weighting
-    /// behind <paramref name="floorGas"/> are resolved from the spec, as
-    /// <c>IntrinsicGasCalculator.CalculateFloorCost</c> does, so a frame transaction's floor cannot diverge from an
-    /// ordinary transaction's under the same fork. A transaction whose frames reserve less than the floor raises its
-    /// reservation rather than becoming invalid; the headroom is reserved and refunded, never spendable.
+    /// A transaction whose frames reserve less than the floor raises its reservation rather than becoming invalid;
+    /// the headroom is reserved and refunded, never spendable.
+    /// The result is memoized on <see cref="Transaction.IntrinsicGasMemo"/>, which a frame transaction otherwise
+    /// leaves unused, and is keyed on the spec reference as <c>EthereumGasPolicy</c> keys its own memo.
     /// </remarks>
     /// <param name="transaction">The frame transaction to price.</param>
     /// <param name="spec">The release spec supplying the calldata token pricing.</param>
     /// <param name="intrinsicGas">The intrinsic cost, charged before any frame runs.</param>
     /// <param name="floorGas">The minimum chargeable gas, or 0 when floor pricing is not active.</param>
     /// <param name="maxGas">The gas reserved against the payer's balance and the block gas limit.</param>
-    /// <returns><c>false</c> if the frame gas limits or the resulting budget overflow <see cref="ulong"/>.</returns>
+    /// <returns><c>false</c> if the transaction carries no frames, or if the frame gas limits or the resulting budget
+    /// overflow <see cref="ulong"/>. In every failure case the outputs are 0 and the transaction cannot be priced.</returns>
     public static bool TryCalculateGasBudget(Transaction transaction, IReleaseSpec spec, out ulong intrinsicGas, out ulong floorGas, out ulong maxGas)
+    {
+        if (Volatile.Read(ref transaction.IntrinsicGasMemo) is FrameGasBudgetMemo memo && ReferenceEquals(memo.Spec, spec))
+        {
+            (intrinsicGas, floorGas, maxGas) = (memo.IntrinsicGas, memo.FloorGas, memo.MaxGas);
+            return memo.Priced;
+        }
+
+        bool priced = CalculateGasBudget(transaction, spec, out intrinsicGas, out floorGas, out maxGas);
+        Volatile.Write(ref transaction.IntrinsicGasMemo, new FrameGasBudgetMemo(spec, priced, intrinsicGas, floorGas, maxGas));
+        return priced;
+    }
+
+    private sealed record FrameGasBudgetMemo(IReleaseSpec Spec, bool Priced, ulong IntrinsicGas, ulong FloorGas, ulong MaxGas) : IIntrinsicGasMemo;
+
+    private static bool CalculateGasBudget(Transaction transaction, IReleaseSpec spec, out ulong intrinsicGas, out ulong floorGas, out ulong maxGas)
     {
         intrinsicGas = 0;
         floorGas = 0;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -4,7 +4,6 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.Precompiles;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -57,24 +57,11 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 $"max fee per gas less than block base fee: address {tx.SenderAddress?.ToString(withEip55Checksum: true) ?? "unknown"}, maxFeePerGas: {tx.MaxFeePerGas}, baseFee: {header.BaseFeePerGas}");
         }
 
-        // Spec gas: tx_gas_limit = intrinsic + per-frame + calldata + signature verification
-        // + sum(frame.gas_limit); the sum is overflow-checked so the processor does not depend
-        // on static validation having run.
-        ulong intrinsicGas = CalculateFrameTxIntrinsicGas(tx, frames, spec, out ulong floorGas);
-        ulong totalFrameGas = 0;
+        // Enforced here, not only in static validation, so unvalidated entry points (e.g. eth_call)
+        // cannot mint ETH: EIP-8141 forbids approval scope on a frame belonging to an atomic batch.
         bool prevIsAtomicBatch = false;
         foreach (TxFrame frame in frames)
         {
-            ulong accumulated = totalFrameGas + frame.GasLimit;
-            if (accumulated < totalFrameGas)
-            {
-                return TransactionResult.ErrorType.MalformedTransaction.WithDetail("total frame gas overflows");
-            }
-
-            totalFrameGas = accumulated;
-
-            // Enforced here, not only in static validation, so unvalidated entry points (e.g. eth_call)
-            // cannot mint ETH: EIP-8141 forbids approval scope on a frame belonging to an atomic batch.
             if ((frame.IsAtomicBatch || prevIsAtomicBatch) && frame.AllowedApproveScope != 0)
             {
                 return TransactionResult.ErrorType.MalformedTransaction.WithDetail("approval scope on atomic batch frame");
@@ -83,15 +70,12 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             prevIsAtomicBatch = frame.IsAtomicBatch;
         }
 
-        ulong txGasLimit = intrinsicGas + totalFrameGas;
-        if (txGasLimit < intrinsicGas)
+        // The frame gas sum is overflow-checked so the processor does not depend on static validation
+        // having run.
+        if (!FrameTxValidation.TryCalculateGasBudget(tx, spec, out ulong intrinsicGas, out ulong floorGas, out ulong txGasLimit))
         {
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction gas limit overflows");
         }
-
-        // max_gas: frames reserving less than the calldata floor raise the reservation rather than
-        // invalidate the transaction. The headroom is reserved and refunded, never spendable.
-        txGasLimit = Math.Max(txGasLimit, floorGas);
 
         // max_cost is defined at basefee=max (TXPARAM 0x06): the payer solvency gate reserves at
         // max_fee_per_gas plus blob cost, not the effective price, so it is not under-reserved.
@@ -424,53 +408,28 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     }
 
     /// <summary>
-    /// FRAME_TX_INTRINSIC_COST + frames × FRAME_TX_PER_FRAME_COST + calldata cost of frame data
-    /// and signature fields + per-scheme signature verification cost.
+    /// The transaction log set: the frame-order concatenation of the per-frame receipt logs.
     /// </summary>
-    /// <remarks>
-    /// The rate and token weighting behind <paramref name="floorGas"/> are resolved from the spec, as
-    /// <see cref="IntrinsicGasCalculator.CalculateFloorCost"/> does, so a frame transaction's floor
-    /// cannot diverge from an ordinary transaction's under the same fork.
-    /// </remarks>
-    /// <param name="floorGas">The minimum chargeable gas, or 0 when floor pricing is not active.</param>
-    private static ulong CalculateFrameTxIntrinsicGas(Transaction tx, TxFrame[] frames, IReleaseSpec spec, out ulong floorGas)
+    private static LogEntry[] ConcatFrameLogs(TxFrameReceipt[] frameReceipts)
     {
-        ulong tokens = 0;
-        ulong dataLength = 0;
-        foreach (TxFrame frame in frames)
+        int total = 0;
+        foreach (TxFrameReceipt frameReceipt in frameReceipts)
         {
-            tokens += CountCalldataTokens(frame.Data.Span, spec);
-            dataLength += (ulong)frame.Data.Length;
+            total += frameReceipt.Logs.Length;
         }
 
-        ulong signatureVerificationCost = 0;
-        TxFrameSignature[]? signatures = tx.FrameSignatures;
-        if (signatures is not null)
+        if (total == 0) return [];
+
+        LogEntry[] logs = new LogEntry[total];
+        int offset = 0;
+        foreach (TxFrameReceipt frameReceipt in frameReceipts)
         {
-            foreach (TxFrameSignature signature in signatures)
-            {
-                tokens += signature.Signer is null ? 0 : CountCalldataTokens(signature.Signer.Bytes, spec);
-                tokens += CountCalldataTokens(signature.Msg.Span, spec);
-                tokens += CountCalldataTokens(signature.Signature.Span, spec);
-                dataLength += (ulong)(signature.Signer is null ? 0 : Address.Size)
-                              + (ulong)signature.Msg.Length
-                              + (ulong)signature.Signature.Length;
-                signatureVerificationCost += FrameTxValidation.SignatureVerificationGas(signature.Scheme);
-            }
+            LogEntry[] frameLogs = frameReceipt.Logs;
+            frameLogs.CopyTo(logs, offset);
+            offset += frameLogs.Length;
         }
 
-        ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost
-                             + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
-                             + signatureVerificationCost;
-        ulong floorTokens = spec.IsEip7976Enabled ? dataLength * spec.GasCosts.TxDataNonZeroMultiplier : tokens;
-        floorGas = spec.IsEip7623Enabled ? mandatoryGas + floorTokens * spec.GasCosts.TotalCostFloorPerToken : 0;
-        return mandatoryGas + tokens * GasCostOf.TxDataZero;
-    }
-
-    private static ulong CountCalldataTokens(ReadOnlySpan<byte> data, IReleaseSpec spec)
-    {
-        int zeros = data.CountZeros();
-        return (ulong)zeros + (ulong)(data.Length - zeros) * spec.GasCosts.TxDataNonZeroMultiplier;
+        return logs;
     }
 
     private TransactionSubstate ExecuteFrame(TxFrame frame, Address resolvedTarget, Address caller, bool isStatic, FrameTxContext frameContext, in StackAccessTracker accessTracker, IReleaseSpec spec, ITxTracer tracer, out ulong gasUsed)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2078,6 +2078,41 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        // EIP-8141: a frame transaction's GasLimit is only the sum of its frame gas limits, so the pool must gate on
+        // max_gas or it admits transactions that can never fit in a block. The mandatory cost of the single frame below
+        // is FRAME_TX_INTRINSIC_COST + FRAME_TX_PER_FRAME_COST = 15,475, and each non-zero calldata byte adds 16 to the
+        // standard cost against 40 to the EIP-7623 floor, so the last case is admissible on its standard cost alone.
+        [TestCase(100_000UL, 0, true)]
+        [TestCase(115_000UL, 0, false)]
+        [TestCase(10_000UL, 4000, false)]
+        public void SubmitTx_FrameTransaction_IsGatedOnMaxGas(ulong frameGasLimit, int frameDataLength, bool expectedAccepted)
+        {
+            _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
+            _headInfo.BlockGasLimit = 130_000;
+
+            byte[] frameData = Enumerable.Repeat((byte)1, frameDataLength).ToArray();
+            Transaction frameTx = new()
+            {
+                Type = TxType.FrameTx,
+                ChainId = _specProvider.ChainId,
+                Nonce = 0,
+                SenderAddress = TestItem.PrivateKeyA.Address,
+                Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, frameGasLimit, UInt256.Zero, frameData)],
+                FrameSignatures = [],
+                GasLimit = frameGasLimit,
+                GasPrice = 1.GWei,
+                DecodedMaxFeePerGas = 1.GWei,
+            };
+            frameTx.Hash = frameTx.CalculateHash();
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+
+            Assert.That(result, expectedAccepted
+                ? Is.EqualTo(AcceptTxResult.Accepted)
+                : Is.EqualTo(AcceptTxResult.GasLimitExceeded));
+        }
+
         // EIP-8141: expired frame txs must be evicted on the new head; deadline == timestamp is still valid
         // (the predeploy reverts only on strictly greater-than).
         [TestCase(1_000UL, 1_500UL, 0, TestName = "deadline in the past is dropped")]

--- a/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
@@ -21,11 +21,12 @@ namespace Nethermind.TxPool.Filters
             ulong gasLimit = Math.Min(chainHeadInfoProvider.BlockGasLimit ?? ulong.MaxValue, _configuredGasLimit);
 
             // A frame transaction's GasLimit is only the sum of its frame gas limits, so gating on it alone would
-            // admit transactions whose reservation can never fit in a block.
-            ulong txGasBudget = tx.SupportsFrames
-                    && FrameTxValidation.TryCalculateGasBudget(tx, chainHeadInfoProvider.SpecProvider.GetCurrentHeadSpec(), out _, out _, out ulong frameTxMaxGas)
-                ? frameTxMaxGas
-                : tx.GasLimit;
+            // admit transactions whose reservation can never fit in a block. One that cannot be priced never fits.
+            ulong txGasBudget = !tx.SupportsFrames
+                ? tx.GasLimit
+                : FrameTxValidation.TryCalculateGasBudget(tx, chainHeadInfoProvider.SpecProvider.GetCurrentHeadSpec(), out _, out _, out ulong frameTxMaxGas)
+                    ? frameTxMaxGas
+                    : ulong.MaxValue;
 
             if (txGasBudget > gasLimit)
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
@@ -19,7 +19,15 @@ namespace Nethermind.TxPool.Filters
         public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
         {
             ulong gasLimit = Math.Min(chainHeadInfoProvider.BlockGasLimit ?? ulong.MaxValue, _configuredGasLimit);
-            if (tx.GasLimit > gasLimit)
+
+            // A frame transaction's GasLimit is only the sum of its frame gas limits, so gating on it alone would
+            // admit transactions whose reservation can never fit in a block.
+            ulong txGasBudget = tx.SupportsFrames
+                    && FrameTxValidation.TryCalculateGasBudget(tx, chainHeadInfoProvider.SpecProvider.GetCurrentHeadSpec(), out _, out _, out ulong frameTxMaxGas)
+                ? frameTxMaxGas
+                : tx.GasLimit;
+
+            if (txGasBudget > gasLimit)
             {
                 Metrics.PendingTransactionsGasLimitTooHigh++;
 
@@ -31,7 +39,7 @@ namespace Nethermind.TxPool.Filters
                 bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0;
                 return isNotLocal ?
                     AcceptTxResult.GasLimitExceeded :
-                    AcceptTxResult.GasLimitExceeded.WithMessage($"Gas limit: {gasLimit}, gas limit of rejected tx: {tx.GasLimit}");
+                    AcceptTxResult.GasLimitExceeded.WithMessage($"Gas limit: {gasLimit}, gas limit of rejected tx: {txGasBudget}");
             }
 
             return AcceptTxResult.Accepted;


### PR DESCRIPTION
A frame transaction's `GasLimit` carries only the sum of its frame gas limits, as the decoder states. The gas actually reserved is `max_gas`, the greater of `intrinsic + sum(frame.gas_limit)` and the EIP-7623 calldata floor, so every consumer that gates on `GasLimit` alone under-counts by at least `FRAME_TX_INTRINSIC_COST` plus the per-frame, calldata and signature verification costs.

Two consumers did that. `GasLimitTxFilter` admitted frame transactions whose reservation cannot fit in any block, and those were then broadcast to peers. `BlockProductionTransactionPicker` could select a frame transaction with less room left in the block than its reservation, producing a block over its own gas limit; the `GasUsed > GasLimit` check in the transactions executor runs only under `shouldValidate`, so nothing catches it on the production path.

The calculation now lives in `FrameTxValidation.TryCalculateGasBudget`, which returns the intrinsic cost, the calldata floor and `max_gas`, and reports overflow. The private copy in `TransactionProcessorBase.FrameTx` is gone and the processor calls the shared helper, which also removes the duplicated `CountCalldataTokens` and the signature-scheme switch that existed on both sides.

Based on #12594, which introduced the floor in the processor.

Three regression cases on each side, verified red before the fix: the pool and the picker each reject a frame transaction whose reservation exceeds the available gas and accept one that fits, including a case that fits on its standard cost but not once the calldata floor raises the reservation.

Out of scope: the picker's solvency gate still asks the sender for the full cost, while a frame transaction is paid by the payer approved during execution. That is unreachable today because the pool's balance filters drop such transactions earlier, and closing it needs the payer to be known to both layers. The spec side of that gap is https://github.com/ethereum/EIPs/pull/12091.
