### PR TITLE
ci: run orphaned Nethermind test projects in the test matrix

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -53,9 +53,12 @@ jobs:
           - ubuntu-24.04-arm
         project:
           - Nethermind.Abi.Test
+          - Nethermind.Analyzers.Test
           - Nethermind.Api.Test
           - Nethermind.AuRa.Test
+          - Nethermind.BalRecorder.Test
           - Nethermind.Blockchain.Test
+          - Nethermind.CensorshipDetector.Plugin.Test
           - Nethermind.Clique.Test
           - Nethermind.Config.Test
           - Nethermind.Consensus.Test
@@ -83,15 +86,19 @@ jobs:
           - Nethermind.Network.Dns.Test
           - Nethermind.Network.Enr.Test
           - Nethermind.Network.Test
+          - Nethermind.OpcodeTracing.Plugin.Test
           - Nethermind.Optimism.Test
           - Nethermind.Runner.Test
           - Nethermind.Serialization.Ssz.Test
+          - Nethermind.Serialization.SszGenerator.Test
           - Nethermind.Shutter.Test
           - Nethermind.Sockets.Test
           - Nethermind.Specs.Test
+          - Nethermind.State.Flat.History.Test
           - Nethermind.State.Flat.Test
           - Nethermind.State.Test
           - Nethermind.State.Test.Runner.Test
+          - Nethermind.StateDiffsWriter.Test
           - Nethermind.Synchronization.Test
           - Nethermind.Taiko.Test
           - Nethermind.Trie.Test

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -383,9 +383,9 @@ jobs:
           # Intentional exclusions:
           # - Nethermind.Precompiles.Benchmark.Test: lives in Benchmarks.slnx only, not built by the test artifact
           # - Ethereum.Blockchain.Pyspec.Test: the fixture shards are superseded by the nethtest job
-          #   (see run-nethtest.yml). The assembly also holds plain unit tests (StatelessSchemaTests,
-          #   CiSentinelTests) that remain unwired: test discovery loads the full pyspec fixture sets,
-          #   so a matrix run exceeds the job timeout. Wiring those tests needs a project move.
+          #   (see run-nethtest.yml). The assembly also holds plain unit tests (StatelessSchemaTests)
+          #   that remain unwired: test discovery loads the full pyspec fixture sets, so a matrix
+          #   run exceeds the job timeout. Wiring those tests needs a project move.
           allowlist="Nethermind.Precompiles.Benchmark.Test Ethereum.Blockchain.Pyspec.Test"
           missing=0
           for dir in src/Nethermind/*.Test; do

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -382,7 +382,10 @@ jobs:
         run: |
           # Intentional exclusions:
           # - Nethermind.Precompiles.Benchmark.Test: lives in Benchmarks.slnx only, not built by the test artifact
-          # - Ethereum.Blockchain.Pyspec.Test: superseded by the nethtest job (see run-nethtest.yml)
+          # - Ethereum.Blockchain.Pyspec.Test: the fixture shards are superseded by the nethtest job
+          #   (see run-nethtest.yml). The assembly also holds plain unit tests (StatelessSchemaTests,
+          #   CiSentinelTests) that remain unwired: test discovery loads the full pyspec fixture sets,
+          #   so a matrix run exceeds the job timeout. Wiring those tests needs a project move.
           allowlist="Nethermind.Precompiles.Benchmark.Test Ethereum.Blockchain.Pyspec.Test"
           missing=0
           for dir in src/Nethermind/*.Test; do
@@ -409,7 +412,8 @@ jobs:
             "${{ needs.tests.result }}" == "success" && \
             "${{ needs.tests-spec.result }}" == "success" && \
             "${{ needs.tests-chunked.result }}" == "success" && \
-            "${{ needs.nethtest.result }}" == "success" \
+            "${{ needs.nethtest.result }}" == "success" && \
+            "${{ needs.matrix-guard.result }}" == "success" \
           ]]
 
   codecov-upload:

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -217,6 +217,7 @@ jobs:
           - Ethereum.Legacy.VM.Test
           - Ethereum.PoW.Test
           - Ethereum.Rlp.Test
+          - Ethereum.Ssz.Test
           - Ethereum.Transaction.Test
           - Ethereum.Trie.Test
         chunk: ['']
@@ -370,9 +371,35 @@ jobs:
       test_types: engineTest,blockTest,stateTest,syncTest,txTest,zkevmTest
       setup_group: sequential
 
+  matrix-guard:
+    name: Check test project matrix is exhaustive
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Check every test project has a matrix entry
+        run: |
+          # Intentional exclusions:
+          # - Nethermind.Precompiles.Benchmark.Test: lives in Benchmarks.slnx only, not built by the test artifact
+          # - Ethereum.Blockchain.Pyspec.Test: superseded by the nethtest job (see run-nethtest.yml)
+          allowlist="Nethermind.Precompiles.Benchmark.Test Ethereum.Blockchain.Pyspec.Test"
+          missing=0
+          for dir in src/Nethermind/*.Test; do
+            project=$(basename "$dir")
+            [[ -f "$dir/$project.csproj" ]] || continue
+            [[ " $allowlist " == *" $project "* ]] && continue
+            esc=$(printf '%s' "$project" | sed 's/\./\\./g')
+            if ! grep -qE "^ +- ${esc}\$|project: ${esc}[,} ]" .github/workflows/nethermind-tests.yml; then
+              echo "::error::$project runs in no CI matrix - add it to a matrix in nethermind-tests.yml or to the allowlist in this step"
+              missing=1
+            fi
+          done
+          exit $missing
+
   tests-summary:
     name: Tests summary
-    needs: [tests, tests-spec, tests-chunked, nethtest]
+    needs: [tests, tests-spec, tests-chunked, nethtest, matrix-guard]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/src/Nethermind/Nethermind.OpcodeTracing.Plugin.Test/OpcodeTraceRecorderTests.cs
+++ b/src/Nethermind/Nethermind.OpcodeTracing.Plugin.Test/OpcodeTraceRecorderTests.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;

--- a/src/Nethermind/Nethermind.OpcodeTracing.Plugin.Test/OpcodeTraceRecorderTests.cs
+++ b/src/Nethermind/Nethermind.OpcodeTracing.Plugin.Test/OpcodeTraceRecorderTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.IO;
-using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core.Specs;

--- a/src/Nethermind/Nethermind.OpcodeTracing.Plugin.Test/OpcodeTracingModuleTests.cs
+++ b/src/Nethermind/Nethermind.OpcodeTracing.Plugin.Test/OpcodeTracingModuleTests.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Nethermind/Nethermind.OpcodeTracing.Plugin.Test/OpcodeTracingModuleTests.cs
+++ b/src/Nethermind/Nethermind.OpcodeTracing.Plugin.Test/OpcodeTracingModuleTests.cs
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Autofac;
 using Autofac.Core;
 using Nethermind.Api.Steps;

--- a/src/Nethermind/Nethermind.slnx
+++ b/src/Nethermind/Nethermind.slnx
@@ -16,6 +16,7 @@
     <Project Path="Nethermind.CensorshipDetector.Plugin/Nethermind.CensorshipDetector.Plugin.csproj" />
   </Folder>
   <Folder Name="/Plugins/OpcodeTracing/">
+    <Project Path="Nethermind.OpcodeTracing.Plugin.Test/Nethermind.OpcodeTracing.Plugin.Test.csproj" />
     <Project Path="Nethermind.OpcodeTracing.Plugin/Nethermind.OpcodeTracing.Plugin.csproj" />
   </Folder>
   <Folder Name="/Plugins/Hive/">


### PR DESCRIPTION
## Changes

How to review this fast: three commits (base change, then two review/lint follow-ups), +36/-8 across 4 files - new matrix entries and a guard job in `nethermind-tests.yml`, one missing project entry in `Nethermind.slnx`, and redundant usings removed from the newly built test project. No product code changed.

- Seven `Nethermind.*` test projects were absent from every test workflow (`nethermind-tests.yml`, `-flat`, `-checked`), so their tests never ran in CI: **Analyzers.Test, BalRecorder.Test, CensorshipDetector.Plugin.Test, OpcodeTracing.Plugin.Test, Serialization.SszGenerator.Test, State.Flat.History.Test, StateDiffsWriter.Test**. This adds them to the `tests` job matrix.
- `Nethermind.OpcodeTracing.Plugin.Test` was also missing from `Nethermind.slnx` (only the plugin itself was listed), so the shared test-artifact build produced no binaries for it; added to the solution.
- `Nethermind.Precompiles.Benchmark.Test` is deliberately **not** wired in: it lives in `Benchmarks.slnx` only, and the test-artifact build compiles only `Nethermind.slnx` + `EthereumTests.slnx`; pulling the BenchmarkDotNet-dependent benchmark project into the main solution for its single test seemed disproportionate.

From review feedback:

- A `matrix-guard` job now fails CI when a `src/Nethermind/*.Test` directory has no matrix entry, so projects cannot silently fall out of CI again (allowlist: `Nethermind.Precompiles.Benchmark.Test`, `Ethereum.Blockchain.Pyspec.Test`). It is wired into `tests-summary` so branch protection sees it.
- `Ethereum.Ssz.Test` was in `EthereumTests.slnx` but in no matrix; added to `tests-spec`.
- The two OpcodeTracing test files shed usings covered by `ImplicitUsings` (flagged by lint once the project actually built in the solution).

This is the first PR of a test-hygiene effort (fixing tests that cannot meaningfully fail); a test suite that never runs is the limiting case, so it goes first.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] No

#### Notes on testing

All 7 projects were run locally on windows-x64 (release, sequential): Analyzers 96, BalRecorder 24, CensorshipDetector 7, OpcodeTracing 16, SszGenerator 61, State.Flat.History 100, StateDiffsWriter 36 - 340 tests, 0 failed, 0 skipped. The real verification is this PR's own checks: the 7 new matrix jobs must appear and pass on ubuntu x64/arm64.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No
