### PR TITLE
test: make can-never-fail tests assert what their names claim

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/McsLockTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/McsLockTests.cs
@@ -101,8 +101,8 @@ public class McsLockTests
     [Test]
     public void ReacquireAfterReleaseSucceeds()
     {
-        // Run on a worker so a broken release surfaces as a fast, explicit failure
-        // instead of the second Acquire deadlocking the test host.
+        // Run on a worker thread. A broken release then causes a fast, explicit
+        // failure instead of a deadlocked test host.
         Task reacquisitions = Task.Run(() =>
         {
             for (int i = 0; i < 3; i++)

--- a/src/Nethermind/Nethermind.Core.Test/McsLockTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/McsLockTests.cs
@@ -20,17 +20,6 @@ public class McsLockTests
     public void Setup() => mcsLock = new McsLock();
 
     [Test]
-    public void SingleThreadAcquireRelease()
-    {
-        using (McsLock.Disposable handle = mcsLock.EnterScope())
-        {
-            Thread.Sleep(10);
-        }
-
-        Assert.Pass(); // Test passes if no deadlock or exception occurs.
-    }
-
-    [Test]
     public void MultipleThreads()
     {
         int counter = 0;
@@ -112,12 +101,17 @@ public class McsLockTests
     [Test]
     public void ReacquireAfterReleaseSucceeds()
     {
-        for (int i = 0; i < 3; i++)
+        // Run on a worker so a broken release surfaces as a fast, explicit failure
+        // instead of the second Acquire deadlocking the test host.
+        Task reacquisitions = Task.Run(() =>
         {
-            using McsLock.Disposable handle = mcsLock.Acquire();
-        }
+            for (int i = 0; i < 3; i++)
+            {
+                using McsLock.Disposable handle = mcsLock.Acquire();
+            }
+        });
 
-        Assert.Pass();
+        Assert.That(reacquisitions.Wait(TimeSpan.FromSeconds(10)), Is.True, "a released lock could not be re-acquired");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
@@ -101,40 +101,6 @@ public class NewPayloadHandlerRaceConditionTests : BaseEngineModuleTests
     }
 
     [Test]
-    public async Task ValidateBlockAndProcess_does_not_accumulate_completions_across_repeated_timeouts()
-    {
-        Block block = Build.A.Block
-            .WithParentHash(TestItem.KeccakA)
-            .WithNumber(1)
-            .WithDifficulty(0)
-            .WithNonce(0)
-            .TestObject;
-        block.Header.IsPostMerge = true;
-
-        IBlockProcessingQueue processingQueue = Substitute.For<IBlockProcessingQueue>();
-        processingQueue
-            .Enqueue(Arg.Any<Block>(), Arg.Any<ProcessingOptions>())
-            .Returns(_ => ValueTask.CompletedTask);
-
-        using NewPayloadHandler handler = CreateHandler(
-            block,
-            suggestBlockResult: AddBlockResult.Added,
-            wasProcessed: false,
-            validateSuggestedBlock: true,
-            processingQueue: processingQueue,
-            timeoutMs: 100);
-
-        for (int i = 0; i < 5; i++)
-        {
-            ResultWrapper<PayloadStatusV1> result = await handler.HandleAsync(ExecutionPayload.Create(block));
-            Assert.That(result.Data.Status, Is.EqualTo(PayloadStatus.Syncing));
-        }
-
-        Assert.That(GetPendingValidationTaskCount(handler), Is.EqualTo(0),
-            "repeated timed-out payloads must not accumulate stale completion sources");
-    }
-
-    [Test]
     public async Task ValidateBlockAndProcess_cleans_up_completion_when_block_tree_rejects_before_enqueue()
     {
         Block block = Build.A.Block

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/NewPayloadHandlerRaceConditionTests.cs
@@ -101,100 +101,37 @@ public class NewPayloadHandlerRaceConditionTests : BaseEngineModuleTests
     }
 
     [Test]
-    public async Task NewPayloadV1_EventHandler_Cleanup_Should_Prevent_Memory_Leaks()
+    public async Task ValidateBlockAndProcess_does_not_accumulate_completions_across_repeated_timeouts()
     {
-        // This test verifies that event handlers are properly cleaned up
-        // even when exceptions occur during processing
-
-        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 100 // Short timeout to trigger timeout scenarios
-        });
-
-        // Create an invalid block that will cause processing to fail or timeout
-        Block invalidBlock = Build.A.Block
-            .WithNumber(999999) // Very high number to trigger validation failures
-            .WithParentHash(TestItem.KeccakA) // Non-existent parent
-            .WithDifficulty(0)
-            .WithNonce(0)
-            .TestObject;
-
-        ExecutionPayload invalidPayload = ExecutionPayload.Create(invalidBlock);
-
-        // Process multiple invalid payloads that will fail or timeout
-        for (int i = 0; i < 5; i++)
-        {
-            try
-            {
-                ResultWrapper<PayloadStatusV1> result = await chain.EngineRpcModule.engine_newPayloadV1(invalidPayload);
-                // Even if processing fails, it should not throw exceptions due to event handler issues
-            }
-            catch (Exception ex)
-            {
-                // We expect some processing failures, but not event handler related exceptions
-                Assert.That(ex, Is.Not.TypeOf<InvalidOperationException>(), "Event handler race conditions should be fixed");
-                Assert.That(ex, Is.Not.TypeOf<ObjectDisposedException>(), "Event handler cleanup should be proper");
-            }
-        }
-
-        // After processing, event handlers should be properly cleaned up
-        // This is a conceptual test - the main verification is that no exceptions are thrown
-        // In the actual implementation, the fix ensures event handlers are always unsubscribed
-        // in the finally block using Interlocked.CompareExchange to prevent double unsubscription
-
-        // If we reach here without exceptions, the event handler cleanup is working correctly
-        Assert.Pass("Event handlers were properly cleaned up without race condition exceptions");
-    }
-
-    [Test]
-    public async Task NewPayloadV1_TaskCompletionSource_TrySet_Should_Not_Throw_On_Double_Completion()
-    {
-        // This test specifically targets the TrySetResult/TrySetException fix
-        // where the original code used SetResult/SetException which would throw if already completed
-
-        using MergeTestBlockchain chain = await CreateBlockchain(mergeConfig: new MergeConfig()
-        {
-            NewPayloadBlockProcessingTimeout = 1000
-        });
-
-        // Create a block that will trigger event processing
         Block block = Build.A.Block
+            .WithParentHash(TestItem.KeccakA)
             .WithNumber(1)
-            .WithParent(chain.BlockTree.Head!)
             .WithDifficulty(0)
             .WithNonce(0)
-            .WithExtraData(new byte[32])
             .TestObject;
+        block.Header.IsPostMerge = true;
 
-        ExecutionPayload payload = ExecutionPayload.Create(block);
+        IBlockProcessingQueue processingQueue = Substitute.For<IBlockProcessingQueue>();
+        processingQueue
+            .Enqueue(Arg.Any<Block>(), Arg.Any<ProcessingOptions>())
+            .Returns(_ => ValueTask.CompletedTask);
 
-        List<Task> concurrentTasks = [];
+        using NewPayloadHandler handler = CreateHandler(
+            block,
+            suggestBlockResult: AddBlockResult.Added,
+            wasProcessed: false,
+            validateSuggestedBlock: true,
+            processingQueue: processingQueue,
+            timeoutMs: 100);
 
-        // Launch multiple concurrent operations that might try to complete the same task
         for (int i = 0; i < 5; i++)
         {
-            concurrentTasks.Add(Task.Run(async () =>
-            {
-                try
-                {
-                    await chain.EngineRpcModule.engine_newPayloadV1(payload);
-                }
-                catch (OperationCanceledException)
-                {
-                    // This is expected due to cancellation
-                }
-                catch (InvalidOperationException ex) when (ex.Message.Contains("already completed"))
-                {
-                    // This should NOT happen with the fix - TrySetResult/TrySetException prevent this
-                    Assert.Fail($"TaskCompletionSource double completion exception: {ex.Message}");
-                }
-            }));
+            ResultWrapper<PayloadStatusV1> result = await handler.HandleAsync(ExecutionPayload.Create(block));
+            Assert.That(result.Data.Status, Is.EqualTo(PayloadStatus.Syncing));
         }
 
-        await Task.WhenAll(concurrentTasks);
-
-        // If we reach here, the TrySetResult/TrySetException fix is working correctly
-        Assert.Pass("TaskCompletionSource race condition handling works correctly");
+        Assert.That(GetPendingValidationTaskCount(handler), Is.EqualTo(0),
+            "repeated timed-out payloads must not accumulate stale completion sources");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Synchronization/BeaconHeadersSyncTests.cs
@@ -215,7 +215,7 @@ public class BeaconHeadersSyncTests
     }
 
     [Test]
-    public void Feed_able_to_sync_when_new_pivot_is_set()
+    public async Task Feed_able_to_sync_when_new_pivot_is_set()
     {
         BlockTree syncedBlockTree = Build.A.BlockTree().OfChainLength(1000).TestObject;
         Block genesisBlock = syncedBlockTree.FindBlock(syncedBlockTree.GenesisHash, BlockTreeLookupOptions.None)!;
@@ -233,19 +233,19 @@ public class BeaconHeadersSyncTests
 
         Context ctx = new() { BlockTree = blockTree, SyncConfig = syncConfig, BeaconPivot = pivot };
 
-        BuildAndProcessHeaderSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 0UL, 501UL);
+        await BuildAndProcessHeaderSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 0UL, 501UL);
 
         // move best pointers forward as proxy for chain merge
         Block highestBlock = syncedBlockTree.FindBlock(700, BlockTreeLookupOptions.None)!;
         blockTree.Insert(highestBlock, BlockTreeInsertBlockOptions.SaveHeader);
 
         pivot.EnsurePivot(syncedBlockTree.FindHeader(900, BlockTreeLookupOptions.None));
-        BuildAndProcessHeaderSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 700UL, 701UL);
+        await BuildAndProcessHeaderSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 700UL, 701UL);
 
         highestBlock = syncedBlockTree.FindBlock(900, BlockTreeLookupOptions.None)!;
         blockTree.Insert(highestBlock, BlockTreeInsertBlockOptions.SaveHeader);
         pivot.EnsurePivot(syncedBlockTree.FindHeader(999, BlockTreeLookupOptions.None));
-        BuildAndProcessHeaderSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 900UL, 901UL);
+        await BuildAndProcessHeaderSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 900UL, 901UL);
     }
 
     [Test]
@@ -272,7 +272,7 @@ public class BeaconHeadersSyncTests
 
         Assert.That(ctx.BeaconSync.ShouldBeInBeaconHeaders(), Is.True);
         Assert.That(blockTree.BestKnownNumber, Is.EqualTo(6));
-        BuildHeadersSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 2);
+        await BuildHeadersSyncBatches(ctx, blockTree, syncedBlockTree, pivot, 2);
         using HeadersSyncBatch? result = await ctx.Feed.PrepareRequest();
         Assert.That(result, Is.Null);
         Assert.That(blockTree.BestKnownNumber, Is.EqualTo(6));
@@ -400,7 +400,7 @@ public class BeaconHeadersSyncTests
         Assert.That(request, Is.Null);
     }
 
-    private async void BuildAndProcessHeaderSyncBatches(
+    private async Task BuildAndProcessHeaderSyncBatches(
         Context ctx,
         BlockTree blockTree,
         BlockTree syncedBlockTree,
@@ -420,7 +420,7 @@ public class BeaconHeadersSyncTests
             Assert.That(blockTree.LowestInsertedBeaconHeader?.Number, Is.EqualTo(pivotHeader?.Number));
         }
 
-        BuildHeadersSyncBatches(ctx, blockTree, syncedBlockTree, pivot, endLowestBeaconHeader);
+        await BuildHeadersSyncBatches(ctx, blockTree, syncedBlockTree, pivot, endLowestBeaconHeader);
 
         HeadersSyncBatch? result = await ctx.Feed.PrepareRequest();
         using (Assert.EnterMultipleScope())
@@ -437,7 +437,7 @@ public class BeaconHeadersSyncTests
         }
     }
 
-    private async void BuildHeadersSyncBatches(
+    private async Task BuildHeadersSyncBatches(
         Context ctx,
         BlockTree blockTree,
         BlockTree syncedBlockTree,

--- a/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectsAnalyzerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectsAnalyzerTests.cs
@@ -28,21 +28,21 @@ namespace Nethermind.Network.Test.P2P
             {
                 ILogManager logManager = Substitute.For<ILogManager>();
                 logManager.GetClassLogger<DisconnectsAnalyzer>().Returns(new ILogger(_logger));
-                // The default 10s interval keeps the first flush far away, so reports recorded
-                // before TriggerFlushes cannot straddle a flush boundary.
+                // The constructor arms the flush timer at 10 s. Reports recorded before
+                // TriggerFlushes() shortens the interval cannot race a flush.
                 DisconnectsAnalyzer = new DisconnectsAnalyzer(logManager);
             }
 
             public void TriggerFlushes() => DisconnectsAnalyzer.WithIntervalOverride(10);
 
-            public void ShouldEventuallyReport(string pattern, int times = 1) =>
-                Assert.That(PollUntil(() => _logger.CountMatches(pattern) >= times), Is.True,
-                    () => $"expected {times} flush report(s) matching '{pattern}'; got: {_logger.Dump()}");
+            public void ShouldEventuallyReport(string pattern) =>
+                Assert.That(PollUntil(() => _logger.CountMatches(pattern) >= 1), Is.True,
+                    () => $"expected a flush report matching '{pattern}'; got: {_logger.Dump()}");
 
             public void ShouldStayAt(string pattern, int times)
             {
-                // The analyzer double-buffers its counters, so a lost clear resurfaces stale
-                // categories in every other flush; watch a few more flushes to rule that out.
+                // The analyzer double-buffers its counters. A lost clear makes a stale
+                // category appear again in every other flush. Watch more flushes to detect that.
                 int flushesSeen = _logger.FlushCount;
                 Assert.That(PollUntil(() => _logger.FlushCount >= flushesSeen + 4), Is.True,
                     "flush timer stopped ticking");
@@ -70,9 +70,9 @@ namespace Nethermind.Network.Test.P2P
 
                 public int FlushCount => _flushes.Count;
 
-                // Assertions match the report's column format (Type PadRight(8), Reason
-                // PadRight(24), count PadLeft(4)); a format change in DisconnectsAnalyzer
-                // surfaces here as a wait timeout.
+                // Assertions match the report's column format: Type PadRight(8), Reason
+                // PadRight(24), count PadLeft(4). A format change in DisconnectsAnalyzer
+                // causes a wait timeout here.
                 public int CountMatches(string pattern)
                 {
                     int count = 0;
@@ -141,9 +141,9 @@ namespace Nethermind.Network.Test.P2P
             ctx.TriggerFlushes();
             ctx.ShouldEventuallyReport(@"Local\s+TooManyPeers\s+1\b");
 
-            // No second report is issued (it could race the flush's enumerate-then-clear
-            // window): a lost clear is observable on its own, because the stale count
-            // resurfaces in later flushes - the category must appear exactly once.
+            // Do not send a second report: it can race the flush's enumerate-then-clear
+            // window. A lost clear is visible on its own, because the stale count appears
+            // again in later flushes. The category must appear exactly one time.
             ctx.ShouldStayAt(@"Local\s+TooManyPeers\s+1\b", times: 1);
         }
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectsAnalyzerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectsAnalyzerTests.cs
@@ -35,34 +35,27 @@ namespace Nethermind.Network.Test.P2P
 
             public void TriggerFlushes() => DisconnectsAnalyzer.WithIntervalOverride(10);
 
-            public void ShouldEventuallyReport(string pattern) =>
-                Assert.That(PollUntil(() => _logger.CountMatches(pattern) >= 1), Is.True,
+            public void ShouldEventuallyReport(string pattern)
+            {
+                // A flush can land in SpinUntil's final sleep tick. Re-check once after a timeout.
+                Func<bool> reported = () => _logger.CountMatches(pattern) >= 1;
+                Assert.That(SpinWait.SpinUntil(reported, WaitLimit) || reported(), Is.True,
                     () => $"expected a flush report matching '{pattern}'; got: {_logger.Dump()}");
+            }
 
             public void ShouldStayAt(string pattern, int times)
             {
                 // The analyzer double-buffers its counters. A lost clear makes a stale
                 // category appear again in every other flush. Watch more flushes to detect that.
                 int flushesSeen = _logger.FlushCount;
-                Assert.That(PollUntil(() => _logger.FlushCount >= flushesSeen + 4), Is.True,
+                Func<bool> flushed = () => _logger.FlushCount >= flushesSeen + 4;
+                Assert.That(SpinWait.SpinUntil(flushed, WaitLimit) || flushed(), Is.True,
                     "flush timer stopped ticking");
                 Assert.That(_logger.CountMatches(pattern), Is.EqualTo(times),
                     () => $"a cleared category resurfaced in a later flush; got: {_logger.Dump()}");
             }
 
             public void Dispose() => DisconnectsAnalyzer.Dispose();
-
-            private static bool PollUntil(Func<bool> condition)
-            {
-                long deadline = Environment.TickCount64 + (long)WaitLimit.TotalMilliseconds;
-                while (Environment.TickCount64 < deadline)
-                {
-                    if (condition()) return true;
-                    Thread.Sleep(1);
-                }
-
-                return condition();
-            }
 
             private sealed class FlushCapturingLogger : InterfaceLogger
             {

--- a/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectsAnalyzerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectsAnalyzerTests.cs
@@ -16,6 +16,8 @@ namespace Nethermind.Network.Test.P2P
     [TestFixture, Parallelizable(ParallelScope.All)]
     public class DisconnectsAnalyzerTests
     {
+        private static readonly TimeSpan WaitLimit = TimeSpan.FromSeconds(10);
+
         private sealed class Context : IDisposable
         {
             private readonly FlushCapturingLogger _logger = new();
@@ -33,29 +35,34 @@ namespace Nethermind.Network.Test.P2P
 
             public void TriggerFlushes() => DisconnectsAnalyzer.WithIntervalOverride(10);
 
-            public void ShouldEventuallyReport(string pattern, int times = 1)
-            {
-                bool Matches() => _logger.CountMatches(pattern) >= times;
-                Assert.That(SpinWait.SpinUntil(Matches, TimeSpan.FromSeconds(10)), Is.True,
+            public void ShouldEventuallyReport(string pattern, int times = 1) =>
+                Assert.That(PollUntil(() => _logger.CountMatches(pattern) >= times), Is.True,
                     () => $"expected {times} flush report(s) matching '{pattern}'; got: {_logger.Dump()}");
-            }
-
-            public void ShouldNeverHaveReported(string pattern) =>
-                Assert.That(_logger.CountMatches(pattern), Is.Zero,
-                    () => $"unexpected flush report matching '{pattern}'; got: {_logger.Dump()}");
 
             public void ShouldStayAt(string pattern, int times)
             {
                 // The analyzer double-buffers its counters, so a lost clear resurfaces stale
                 // categories in every other flush; watch a few more flushes to rule that out.
                 int flushesSeen = _logger.FlushCount;
-                Assert.That(SpinWait.SpinUntil(() => _logger.FlushCount >= flushesSeen + 4, TimeSpan.FromSeconds(10)),
-                    Is.True, "flush timer stopped ticking");
+                Assert.That(PollUntil(() => _logger.FlushCount >= flushesSeen + 4), Is.True,
+                    "flush timer stopped ticking");
                 Assert.That(_logger.CountMatches(pattern), Is.EqualTo(times),
                     () => $"a cleared category resurfaced in a later flush; got: {_logger.Dump()}");
             }
 
             public void Dispose() => DisconnectsAnalyzer.Dispose();
+
+            private static bool PollUntil(Func<bool> condition)
+            {
+                long deadline = Environment.TickCount64 + (long)WaitLimit.TotalMilliseconds;
+                while (Environment.TickCount64 < deadline)
+                {
+                    if (condition()) return true;
+                    Thread.Sleep(1);
+                }
+
+                return condition();
+            }
 
             private sealed class FlushCapturingLogger : InterfaceLogger
             {
@@ -63,6 +70,9 @@ namespace Nethermind.Network.Test.P2P
 
                 public int FlushCount => _flushes.Count;
 
+                // Assertions match the report's column format (Type PadRight(8), Reason
+                // PadRight(24), count PadLeft(4)); a format change in DisconnectsAnalyzer
+                // surfaces here as a wait timeout.
                 public int CountMatches(string pattern)
                 {
                     int count = 0;
@@ -131,12 +141,10 @@ namespace Nethermind.Network.Test.P2P
             ctx.TriggerFlushes();
             ctx.ShouldEventuallyReport(@"Local\s+TooManyPeers\s+1\b");
 
-            // The first report was flushed and cleared above, so this one must show up as
-            // a fresh count of 1 in a later flush - a 2 means the clear was lost.
-            ctx.DisconnectsAnalyzer.ReportDisconnect(DisconnectReason.TooManyPeers, DisconnectType.Local, null);
-            ctx.ShouldEventuallyReport(@"Local\s+TooManyPeers\s+1\b", times: 2);
-            ctx.ShouldNeverHaveReported(@"Local\s+TooManyPeers\s+2\b");
-            ctx.ShouldStayAt(@"Local\s+TooManyPeers\s+1\b", times: 2);
+            // No second report is issued (it could race the flush's enumerate-then-clear
+            // window): a lost clear is observable on its own, because the stale count
+            // resurfaces in later flushes - the category must appear exactly once.
+            ctx.ShouldStayAt(@"Local\s+TooManyPeers\s+1\b", times: 1);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectsAnalyzerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/DisconnectsAnalyzerTests.cs
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
 using System.Threading;
-using Nethermind.Core.Test;
 using Nethermind.Logging;
 using Nethermind.Network.P2P.Analyzers;
 using Nethermind.Stats.Model;
@@ -14,61 +16,127 @@ namespace Nethermind.Network.Test.P2P
     [TestFixture, Parallelizable(ParallelScope.All)]
     public class DisconnectsAnalyzerTests
     {
-        private class Context
+        private sealed class Context : IDisposable
         {
+            private readonly FlushCapturingLogger _logger = new();
+
             public DisconnectsAnalyzer DisconnectsAnalyzer { get; }
-            public TestLogger TestLogger { get; }
 
             public Context()
             {
-                TestLogger = new TestLogger();
                 ILogManager logManager = Substitute.For<ILogManager>();
-                logManager.GetClassLogger<DisconnectsAnalyzer>().Returns(new ILogger(TestLogger));
-                DisconnectsAnalyzer = new DisconnectsAnalyzer(logManager).WithIntervalOverride(10);
+                logManager.GetClassLogger<DisconnectsAnalyzer>().Returns(new ILogger(_logger));
+                // The default 10s interval keeps the first flush far away, so reports recorded
+                // before TriggerFlushes cannot straddle a flush boundary.
+                DisconnectsAnalyzer = new DisconnectsAnalyzer(logManager);
+            }
+
+            public void TriggerFlushes() => DisconnectsAnalyzer.WithIntervalOverride(10);
+
+            public void ShouldEventuallyReport(string pattern, int times = 1)
+            {
+                bool Matches() => _logger.CountMatches(pattern) >= times;
+                Assert.That(SpinWait.SpinUntil(Matches, TimeSpan.FromSeconds(10)), Is.True,
+                    () => $"expected {times} flush report(s) matching '{pattern}'; got: {_logger.Dump()}");
+            }
+
+            public void ShouldNeverHaveReported(string pattern) =>
+                Assert.That(_logger.CountMatches(pattern), Is.Zero,
+                    () => $"unexpected flush report matching '{pattern}'; got: {_logger.Dump()}");
+
+            public void ShouldStayAt(string pattern, int times)
+            {
+                // The analyzer double-buffers its counters, so a lost clear resurfaces stale
+                // categories in every other flush; watch a few more flushes to rule that out.
+                int flushesSeen = _logger.FlushCount;
+                Assert.That(SpinWait.SpinUntil(() => _logger.FlushCount >= flushesSeen + 4, TimeSpan.FromSeconds(10)),
+                    Is.True, "flush timer stopped ticking");
+                Assert.That(_logger.CountMatches(pattern), Is.EqualTo(times),
+                    () => $"a cleared category resurfaced in a later flush; got: {_logger.Dump()}");
+            }
+
+            public void Dispose() => DisconnectsAnalyzer.Dispose();
+
+            private sealed class FlushCapturingLogger : InterfaceLogger
+            {
+                private readonly ConcurrentQueue<string> _flushes = new();
+
+                public int FlushCount => _flushes.Count;
+
+                public int CountMatches(string pattern)
+                {
+                    int count = 0;
+                    foreach (string flush in _flushes)
+                    {
+                        if (Regex.IsMatch(flush, pattern)) count++;
+                    }
+
+                    return count;
+                }
+
+                public string Dump() => string.Join(" | ", _flushes);
+
+                public void Info(string text) => _flushes.Enqueue(text);
+                public void Warn(string text) { }
+                public void Debug(string text) { }
+                public void Trace(string text) { }
+                public void Error(string text, Exception? ex = null) { }
+
+                public bool IsInfo => true;
+                public bool IsWarn => true;
+                public bool IsDebug => true;
+                public bool IsTrace => true;
+                public bool IsError => true;
             }
         }
 
         [Test]
         public void Can_pass_null_details()
         {
-            Context ctx = new();
+            using Context ctx = new();
             ctx.DisconnectsAnalyzer.ReportDisconnect(DisconnectReason.TooManyPeers, DisconnectType.Local, null);
+            ctx.TriggerFlushes();
+
+            ctx.ShouldEventuallyReport(@"Local\s+TooManyPeers\s+1\b");
         }
 
         [Test]
         public void Will_add_of_same_type()
         {
-            Context ctx = new();
+            using Context ctx = new();
             ctx.DisconnectsAnalyzer.ReportDisconnect(DisconnectReason.TooManyPeers, DisconnectType.Local, null);
             ctx.DisconnectsAnalyzer.ReportDisconnect(DisconnectReason.TooManyPeers, DisconnectType.Local, null);
+            ctx.TriggerFlushes();
 
-            // GitHub actions not handling these tests well
-            // Assert.That(ctx.TestLogger.LogList.Any(l => l.Contains("Local")), Is.True, string.Join(", ", ctx.TestLogger.LogList));
+            ctx.ShouldEventuallyReport(@"Local\s+TooManyPeers\s+2\b");
         }
 
         [Test]
         public void Will_add_of_different_types()
         {
-            Context ctx = new();
+            using Context ctx = new();
             ctx.DisconnectsAnalyzer.ReportDisconnect(DisconnectReason.TooManyPeers, DisconnectType.Local, null);
             ctx.DisconnectsAnalyzer.ReportDisconnect(DisconnectReason.TooManyPeers, DisconnectType.Remote, null);
-            Thread.Sleep(15);
+            ctx.TriggerFlushes();
 
-            // GitHub actions not handling these tests well
-            // Assert.That(ctx.TestLogger.LogList.Any(l => l.Contains("Remote")), Is.True, string.Join(", ", ctx.TestLogger.LogList));
-            // Assert.That(ctx.TestLogger.LogList.Any(l => l.Contains("Local")), Is.True, string.Join(", ", ctx.TestLogger.LogList));
+            ctx.ShouldEventuallyReport(@"Local\s+TooManyPeers\s+1\b");
+            ctx.ShouldEventuallyReport(@"Remote\s+TooManyPeers\s+1\b");
         }
 
         [Test]
         public void Will_clear_after_report()
         {
-            Context ctx = new();
+            using Context ctx = new();
             ctx.DisconnectsAnalyzer.ReportDisconnect(DisconnectReason.TooManyPeers, DisconnectType.Local, null);
-            Thread.Sleep(15);
-            ctx.DisconnectsAnalyzer.ReportDisconnect(DisconnectReason.TooManyPeers, DisconnectType.Local, null);
-            Thread.Sleep(15);
+            ctx.TriggerFlushes();
+            ctx.ShouldEventuallyReport(@"Local\s+TooManyPeers\s+1\b");
 
-            // GitHub actions not handling these tests well
+            // The first report was flushed and cleared above, so this one must show up as
+            // a fresh count of 1 in a later flush - a 2 means the clear was lost.
+            ctx.DisconnectsAnalyzer.ReportDisconnect(DisconnectReason.TooManyPeers, DisconnectType.Local, null);
+            ctx.ShouldEventuallyReport(@"Local\s+TooManyPeers\s+1\b", times: 2);
+            ctx.ShouldNeverHaveReported(@"Local\s+TooManyPeers\s+2\b");
+            ctx.ShouldStayAt(@"Local\s+TooManyPeers\s+1\b", times: 2);
         }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerPersistedTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerPersistedTests.cs
@@ -50,28 +50,6 @@ public class FlatDbManagerPersistedTests
     }
 
     [Test]
-    public async Task ConstructorAcceptsPersistedRepository()
-    {
-        using FlatTestContainer tier = new(arenaFileSizeBytes: 4096);
-        SnapshotRepository repo = tier.Repository;
-
-        await using FlatDbManager manager = new(
-            Substitute.For<IResourcePool>(),
-            _processExitSource,
-            Substitute.For<ITrieNodeCache>(),
-            Substitute.For<ISnapshotCompactor>(),
-            repo,
-            Substitute.For<IPersistenceManager>(),
-            Substitute.For<IPersistedSnapshotLoader>(),
-            _config,
-            new BlocksConfig(),
-            LimboLogs.Instance,
-            enableDetailedMetrics: false);
-
-        Assert.That(manager, Is.Not.Null);
-    }
-
-    [Test]
     public async Task GatherReadOnlySnapshotBundle_IncludesPersistedSnapshots()
     {
         StateId s0 = new(0, Keccak.EmptyTreeHash);
@@ -116,7 +94,7 @@ public class FlatDbManagerPersistedTests
     }
 
     [Test]
-    public async Task DisposeAsync_DisposesPersistedRepository()
+    public async Task DisposeAsync_CompletesPromptlyAndIsIdempotent()
     {
         using FlatTestContainer tier = new(arenaFileSizeBytes: 4096);
         SnapshotRepository repo = tier.Repository;
@@ -140,8 +118,11 @@ public class FlatDbManagerPersistedTests
             LimboLogs.Instance,
             enableDetailedMetrics: false);
 
-        await manager.DisposeAsync();
+        // A hang here means the worker-channel drain deadlocked; the timeout turns that
+        // into a fast failure instead of stalling the test host.
+        await manager.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
 
-        Assert.Pass("Dispose completed without error");
+        // Repeated disposal must be a no-op - completing an already-completed channel throws.
+        await manager.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerPersistedTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerPersistedTests.cs
@@ -120,11 +120,11 @@ public class FlatDbManagerPersistedTests
             LimboLogs.Instance,
             enableDetailedMetrics: false);
 
-        // WaitAsync bounds only the wait, not the drain itself: a wedged worker-channel
-        // drain surfaces as a fast TimeoutException here instead of stalling the test host.
+        // WaitAsync bounds only the wait, not the drain. A wedged worker-channel drain
+        // causes a fast TimeoutException here instead of a stalled test host.
         Assert.DoesNotThrowAsync(async () => await manager.DisposeAsync().AsTask().WaitAsync(DisposeWaitLimit));
 
-        // Repeated disposal must be a no-op - completing an already-completed channel throws.
+        // A second disposal must be a no-op. A completed channel throws on Complete().
         Assert.DoesNotThrowAsync(async () => await manager.DisposeAsync().AsTask().WaitAsync(DisposeWaitLimit));
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerPersistedTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerPersistedTests.cs
@@ -22,6 +22,8 @@ namespace Nethermind.State.Flat.Test;
 [TestFixture]
 public class FlatDbManagerPersistedTests
 {
+    private static readonly TimeSpan DisposeWaitLimit = TimeSpan.FromSeconds(10);
+
     private string _testDir = null!;
     private ResourcePool _pool = null!;
     private IProcessExitSource _processExitSource = null!;
@@ -94,7 +96,7 @@ public class FlatDbManagerPersistedTests
     }
 
     [Test]
-    public async Task DisposeAsync_CompletesPromptlyAndIsIdempotent()
+    public void DisposeAsync_CompletesPromptlyAndIsIdempotent()
     {
         using FlatTestContainer tier = new(arenaFileSizeBytes: 4096);
         SnapshotRepository repo = tier.Repository;
@@ -118,11 +120,11 @@ public class FlatDbManagerPersistedTests
             LimboLogs.Instance,
             enableDetailedMetrics: false);
 
-        // A hang here means the worker-channel drain deadlocked; the timeout turns that
-        // into a fast failure instead of stalling the test host.
-        await manager.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        // WaitAsync bounds only the wait, not the drain itself: a wedged worker-channel
+        // drain surfaces as a fast TimeoutException here instead of stalling the test host.
+        Assert.DoesNotThrowAsync(async () => await manager.DisposeAsync().AsTask().WaitAsync(DisposeWaitLimit));
 
         // Repeated disposal must be a no-op - completing an already-completed channel throws.
-        await manager.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.DoesNotThrowAsync(async () => await manager.DisposeAsync().AsTask().WaitAsync(DisposeWaitLimit));
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BloomFilter/BloomFilterTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BloomFilter/BloomFilterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -62,7 +63,9 @@ public class BloomFilterTests
     [Test]
     public void Add_ConcurrentWithMightContain_ShouldWork()
     {
-        using Bloom bloom = NewBloom(capacity: 10000);
+        // Sized well above the 30k added keys: a saturated filter's false-positive rate
+        // would mask a single lost write, defeating the postcondition below.
+        using Bloom bloom = NewBloom(capacity: 100_000);
         const int iterationsPerThread = 10000;
 
         Task[] writerTasks = Enumerable.Range(0, 3).Select(threadId => Task.Run(() =>
@@ -87,15 +90,18 @@ public class BloomFilterTests
 
         // A bloom filter never reports false negatives, so every added hash must be
         // found afterwards - a miss means a write was lost to a concurrent-access race.
+        List<ulong> lost = [];
         for (int threadId = 0; threadId < 3; threadId++)
         {
             ulong hash = (ulong)(threadId * 1000000);
             for (int i = 0; i < iterationsPerThread; i++)
             {
-                Assert.That(bloom.MightContain(hash), Is.True, $"hash {hash} was lost during concurrent add");
+                if (!bloom.MightContain(hash)) lost.Add(hash);
                 hash++;
             }
         }
+
+        Assert.That(lost, Is.Empty, "hashes lost during concurrent add");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BloomFilter/BloomFilterTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BloomFilter/BloomFilterTests.cs
@@ -85,7 +85,17 @@ public class BloomFilterTests
 
         Task.WaitAll(writerTasks.Concat(readerTasks).ToArray());
 
-        Assert.Pass("Concurrent operations completed without exceptions");
+        // A bloom filter never reports false negatives, so every added hash must be
+        // found afterwards - a miss means a write was lost to a concurrent-access race.
+        for (int threadId = 0; threadId < 3; threadId++)
+        {
+            ulong hash = (ulong)(threadId * 1000000);
+            for (int i = 0; i < iterationsPerThread; i++)
+            {
+                Assert.That(bloom.MightContain(hash), Is.True, $"hash {hash} was lost during concurrent add");
+                hash++;
+            }
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BloomFilter/BloomFilterTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Persistence/BloomFilter/BloomFilterTests.cs
@@ -63,8 +63,8 @@ public class BloomFilterTests
     [Test]
     public void Add_ConcurrentWithMightContain_ShouldWork()
     {
-        // Sized well above the 30k added keys: a saturated filter's false-positive rate
-        // would mask a single lost write, defeating the postcondition below.
+        // The capacity is far above the 30k added keys. A saturated filter's
+        // false-positive rate masks a single lost write and defeats the check below.
         using Bloom bloom = NewBloom(capacity: 100_000);
         const int iterationsPerThread = 10000;
 
@@ -88,8 +88,8 @@ public class BloomFilterTests
 
         Task.WaitAll(writerTasks.Concat(readerTasks).ToArray());
 
-        // A bloom filter never reports false negatives, so every added hash must be
-        // found afterwards - a miss means a write was lost to a concurrent-access race.
+        // A bloom filter never returns a false negative. Every added hash must be found
+        // afterwards. A miss means a concurrent-access race lost a write.
         List<ulong> lost = [];
         for (int threadId = 0; threadId < 3; threadId++)
         {

--- a/src/Nethermind/Nethermind.Xdc.Test/SpecialTransactionsTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/SpecialTransactionsTests.cs
@@ -214,8 +214,6 @@ internal class SpecialTransactionsTests
                 onlyEncounteredSpecialTx = false;
             }
         }
-
-        Assert.Pass();
     }
 
     [TestCase(false, false)]


### PR DESCRIPTION
## Changes

How to review this fast: commits are one concern each; 7 files, all under `*.Test` projects (verified: `git diff --name-only origin/master...HEAD | grep -v .Test` is empty); net -30 lines. No product code changed.

These tests passed unconditionally - assertions only inside `catch` blocks, `Assert.Pass()` endings, assertion-free bodies, or `async void` helpers whose assertions raced the test body. Each now asserts the thing its name claims, or is deleted where a retained test strictly subsumes it.

- `SpecialTransactionsTests`: drop the redundant trailing `Assert.Pass()` (real asserts precede it).
- `McsLockTests`: delete `SingleThreadAcquireRelease` (no asserts; subsumed by `ReacquireAfterReleaseSucceeds`), which now runs on a worker with a 10s bound so a broken release fails fast instead of hanging the run.
- `BloomFilterTests`: the concurrent add/read test now verifies every added hash is found afterwards (a bloom filter never returns a false negative, so a miss means a lost write). Capacity is 100k so saturation false-positives cannot mask a single lost write; misses are collected into one `Is.Empty` assertion.
- `FlatDbManagerPersistedTests`: `DisposeAsync_DisposesPersistedRepository` renamed to `DisposeAsync_CompletesPromptlyAndIsIdempotent` - `FlatDbManager.DisposeAsync` does not dispose the repository (the container owns it), so the old name asserted a contract that does not exist; it now asserts bounded worker-drain completion and an idempotent second dispose via `Assert.DoesNotThrowAsync`. The `Not.Null`-on-fresh-object constructor test is deleted.
- `NewPayloadHandlerRaceConditionTests`: two tests deleted. The memory-leak test asserted only inside `catch` and ended with `Assert.Pass`; the retained `..._when_timeout_happens_before_block_removed` test already covers the `finally`-block cleanup it aimed at, and iterating adds nothing (`_blockValidationTasks` is keyed by block hash, so resubmitting one block can never push the count above 1). The TrySet double-completion test was a strictly weaker duplicate of the concurrent-calls test above it (same scenario, but swallowing `OperationCanceledException` and keying `Assert.Fail` on exception message text).
- `BeaconHeadersSyncTests`: two `async void` helpers were invoked without awaiting - including one un-awaited call inside the other - so ~20 assertions raced the test body. Now `async Task` and awaited; all pass, so no latent failure was being masked.
- `DisconnectsAnalyzerTests`: all four tests had their assertions commented out as CI-flaky, leaving zero live assertions. Rewritten deterministically: reports are recorded while the constructor's 10s flush interval is in effect, and only then is the interval shortened, so a report can never race a flush. The clear test sends no second report at all (`Timer.Stop` does not drain a queued `Elapsed` callback, so no test-side quiesce is airtight); instead it relies on the analyzer's double-buffering - a lost clear resurfaces the stale count in later flushes, so the category must appear in exactly one flush across several more. `TestLogger.LogList` (a plain `List` written from the timer thread) is replaced by a `ConcurrentQueue` capture, and the previously leaked timer is disposed.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- Mutation-checked: deliberate breaks (McsLock release no-op, BloomFilter.Add skipping bit writes, FlatDbManager dispose-guard bypass, NewPayloadHandler cleanup removal, DisconnectsAnalyzer clear removal, a perturbed BeaconHeaders expectation) each made the strengthened test fail, then were reverted. The clear-removal mutation was re-verified against the final single-report arrangement.
- Measured, not modelled: at the old `capacity: 10000` the bloom filter's false-positive rate (~34%) masked a single lost write one time in three; at `100_000` it is ~4e-5.
- Flake smoke: 0 failures across repeat runs (timing-sensitive fixtures 10-15x, others 3-6x, windows-x64 release).
- Full local suites green: Core.Test 5985, Merge.Plugin.Test, Network.Test, Xdc.Test. State.Flat.Test has 14 pre-existing `StorageLayerTests` failures on Windows only (identical on pristine master; `TearDown` deletes a directory while mmap views are live) - unrelated to this diff and invisible in CI, where the project runs on ubuntu.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No