### PR TITLE
test: Db tests assert stored state instead of smoke-calling empty methods

### DIFF
--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -564,7 +564,7 @@ namespace Nethermind.Db.Test
         };
 
         [Test]
-        public void Can_get_all_on_empty() => _ = _db.GetAll().ToList();
+        public void Can_get_all_on_empty() => Assert.That(_db.GetAll(), Is.Empty);
 
         [Test]
         public void Smoke_test_iterator()

--- a/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
@@ -31,8 +31,9 @@ namespace Nethermind.Db.Test
         {
             MemDb memDb = new(10, 10);
             memDb.Set(TestItem.KeccakA, new byte[] { 1, 2, 3 });
-            memDb.Get(TestItem.KeccakA);
-            _ = memDb[new[] { TestItem.KeccakA.BytesToArray() }];
+            Assert.That(memDb.Get(TestItem.KeccakA), Is.EqualTo(new byte[] { 1, 2, 3 }));
+            KeyValuePair<byte[], byte[]>[] result = memDb[new[] { TestItem.KeccakA.BytesToArray() }];
+            Assert.That(result[0].Value, Is.EqualTo(new byte[] { 1, 2, 3 }));
         }
 
         [Test]
@@ -49,7 +50,7 @@ namespace Nethermind.Db.Test
         {
             MemDb memDb = new();
             memDb.Set(TestItem.KeccakA, new byte[] { 1, 2, 3 });
-            memDb.Get(TestItem.KeccakA);
+            Assert.That(memDb.Get(TestItem.KeccakA), Is.EqualTo(new byte[] { 1, 2, 3 }));
         }
 
         [Test]
@@ -131,20 +132,6 @@ namespace Nethermind.Db.Test
             memDb.Set(TestItem.KeccakA, _sampleValue);
             memDb.Set(TestItem.KeccakB, _sampleValue);
             Assert.That(memDb.Values, Has.Count.EqualTo(2));
-        }
-
-        [Test]
-        public void Dispose_does_not_cause_trouble()
-        {
-            MemDb memDb = new();
-            memDb.Dispose();
-        }
-
-        [Test]
-        public void Flush_does_not_cause_trouble()
-        {
-            MemDb memDb = new();
-            memDb.Flush();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/MemDbTests.cs
@@ -31,9 +31,13 @@ namespace Nethermind.Db.Test
         {
             MemDb memDb = new(10, 10);
             memDb.Set(TestItem.KeccakA, new byte[] { 1, 2, 3 });
-            Assert.That(memDb.Get(TestItem.KeccakA), Is.EqualTo(new byte[] { 1, 2, 3 }));
-            KeyValuePair<byte[], byte[]>[] result = memDb[new[] { TestItem.KeccakA.BytesToArray() }];
-            Assert.That(result[0].Value, Is.EqualTo(new byte[] { 1, 2, 3 }));
+            byte[]? direct = memDb.Get(TestItem.KeccakA);
+            KeyValuePair<byte[], byte[]>[] batch = memDb[new[] { TestItem.KeccakA.BytesToArray() }];
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(direct, Is.EqualTo(new byte[] { 1, 2, 3 }));
+                Assert.That(batch[0].Value, Is.EqualTo(new byte[] { 1, 2, 3 }));
+            }
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Db.Test/ReadOnlyDbProviderTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ReadOnlyDbProviderTests.cs
@@ -36,7 +36,11 @@ namespace Nethermind.Db.Test
 
             dbProvider.ClearTempChanges();
 
-            Assert.That(readOnlyDb.Get(TestItem.KeccakB), Is.Null, "the in-memory overlay must be dropped");
+            if (localChanges)
+            {
+                Assert.That(readOnlyDb.Get(TestItem.KeccakB), Is.Null, "the in-memory overlay must be dropped");
+            }
+
             Assert.That(readOnlyDb.Get(TestItem.KeccakA), Is.EqualTo(new byte[] { 1, 2, 3 }), "the wrapped db must be untouched");
         }
     }

--- a/src/Nethermind/Nethermind.Db.Test/ReadOnlyDbProviderTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ReadOnlyDbProviderTests.cs
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -13,8 +16,28 @@ namespace Nethermind.Db.Test
         [TestCase(false)]
         public void Can_clear(bool localChanges)
         {
-            ReadOnlyDbProvider dbProvider = new(Substitute.For<IDbProvider>(), localChanges);
+            MemDb wrappedDb = new();
+            wrappedDb.Set(TestItem.KeccakA, [1, 2, 3]);
+            IDbProvider wrappedProvider = Substitute.For<IDbProvider>();
+            wrappedProvider.GetDb<IDb>("test").Returns(wrappedDb);
+
+            ReadOnlyDbProvider dbProvider = new(wrappedProvider, localChanges);
+            IDb readOnlyDb = dbProvider.GetDb<IDb>("test");
+
+            if (localChanges)
+            {
+                readOnlyDb.Set(TestItem.KeccakB, [4, 5, 6]);
+                Assert.That(readOnlyDb.Get(TestItem.KeccakB), Is.EqualTo(new byte[] { 4, 5, 6 }));
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => readOnlyDb.Set(TestItem.KeccakB, [4, 5, 6]));
+            }
+
             dbProvider.ClearTempChanges();
+
+            Assert.That(readOnlyDb.Get(TestItem.KeccakB), Is.Null, "the in-memory overlay must be dropped");
+            Assert.That(readOnlyDb.Get(TestItem.KeccakA), Is.EqualTo(new byte[] { 1, 2, 3 }), "the wrapped db must be untouched");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Test/ReadOnlyDbProviderTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ReadOnlyDbProviderTests.cs
@@ -36,12 +36,15 @@ namespace Nethermind.Db.Test
 
             dbProvider.ClearTempChanges();
 
-            if (localChanges)
+            using (Assert.EnterMultipleScope())
             {
-                Assert.That(readOnlyDb.Get(TestItem.KeccakB), Is.Null, "the in-memory overlay must be dropped");
-            }
+                if (localChanges)
+                {
+                    Assert.That(readOnlyDb.Get(TestItem.KeccakB), Is.Null, "the in-memory overlay must be dropped");
+                }
 
-            Assert.That(readOnlyDb.Get(TestItem.KeccakA), Is.EqualTo(new byte[] { 1, 2, 3 }), "the wrapped db must be untouched");
+                Assert.That(readOnlyDb.Get(TestItem.KeccakA), Is.EqualTo(new byte[] { 1, 2, 3 }), "the wrapped db must be untouched");
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Db.Test/SnapshotableMemColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/SnapshotableMemColumnsDbTests.cs
@@ -157,20 +157,6 @@ namespace Nethermind.Db.Test
         }
 
         [Test]
-        public void Flush_does_not_cause_trouble()
-        {
-            SnapshotableMemColumnsDb<TestColumns> columnsDb = new();
-            columnsDb.Flush();
-        }
-
-        [Test]
-        public void Dispose_does_not_cause_trouble()
-        {
-            SnapshotableMemColumnsDb<TestColumns> columnsDb = new();
-            columnsDb.Dispose();
-        }
-
-        [Test]
         public void ColumnKeys_returns_all_columns()
         {
             SnapshotableMemColumnsDb<TestColumns> columnsDb = new();

--- a/src/Nethermind/Nethermind.Db.Test/SnapshotableMemDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/SnapshotableMemDbTests.cs
@@ -191,20 +191,6 @@ namespace Nethermind.Db.Test
         }
 
         [Test]
-        public void Dispose_does_not_cause_trouble()
-        {
-            SnapshotableMemDb memDb = new();
-            memDb.Dispose();
-        }
-
-        [Test]
-        public void Flush_does_not_cause_trouble()
-        {
-            SnapshotableMemDb memDb = new();
-            memDb.Flush();
-        }
-
-        [Test]
         public void Can_clear()
         {
             SnapshotableMemDb memDb = new();


### PR DESCRIPTION
## Changes

How to review this fast: four commits, one concern each; 5 files, all under `Nethermind.Db.Test` (no product code changed); net -23 lines.

- Deletes the six `*_does_not_cause_trouble` tests: `MemDb.Flush`/`Dispose` and the `SnapshotableMemDb` variants are empty method bodies (`MemDb.cs:83,100`), and `SnapshotableMemColumnsDb.Flush`/`Dispose` only loop over those empty bodies - the tests could not fail under any code change, because there is no behavior to cover.
- `MemDbTests.Can_create_with_delays` / `Can_create_without_arguments` had no assertions; they now verify the written value round-trips through `Get` and the batch indexer (grouped in `Assert.EnterMultipleScope`).
- `ReadOnlyDbProviderTests.Can_clear` called `ClearTempChanges()` on a provider with an empty registry - no db was ever registered, so the method body was a no-op loop. It now registers a real `MemDb`-backed `ReadOnlyDb` through a substituted `IDbProvider` and asserts: the in-memory overlay is dropped by `ClearTempChanges` while the wrapped db stays intact (`localChanges: true`), and `Set` throws `InvalidOperationException` when writes are not expected (`localChanges: false`).
- `DbOnTheRocksDbTests.Can_get_all_on_empty` discarded the enumeration; it now asserts `Is.Empty` on the per-test fresh db (both `useColumnDb` fixture variants).

Part of the test-hygiene series (#12689, #12690): tests that cannot meaningfully fail get real assertions or are removed where nothing exists to cover.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- Full `Nethermind.Db.Test` suite green locally (windows-x64, release): 1091 total, 0 failed (544 skipped are pre-existing fixture-mode guards).
- Mutation-checked: making `ReadOnlyDb.ClearTempChanges` a no-op fails `Can_clear(true)`; perturbed expectations fail the strengthened MemDb test and both `Can_get_all_on_empty` fixture variants. All mutations reverted.
- The deleted tests' subjects were independently verified as empty method bodies; the columns variants remain exercised indirectly via `MemDbFactory.CreateColumnsDb` and `PseudoNethermindModule`.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No