### PR TITLE
test: give state/evm smoke tests real assertions

### DIFF
--- a/src/Nethermind/Nethermind.Api.Test/SinglePluginLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Api.Test/SinglePluginLoaderTests.cs
@@ -10,9 +10,6 @@ namespace Nethermind.Api.Test;
 public class SinglePluginLoaderTests
 {
     [Test]
-    public void Can_load() => SinglePluginLoader<TestPlugin>.Instance.Load();
-
-    [Test]
     public void Returns_correct_plugin() =>
         Assert.That(SinglePluginLoader<TestPlugin>.Instance.PluginTypes.FirstOrDefault(), Is.EqualTo(typeof(TestPlugin)));
 }

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
@@ -1,27 +1,33 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Api;
-using Nethermind.Api.Extensions;
+using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using Nethermind.Api.Steps;
 using Nethermind.EthStats.Configs;
-using Nethermind.Runner.Test.Ethereum;
 using NUnit.Framework;
 
 namespace Nethermind.EthStats.Test;
 
 public class EthStatsPluginTests
 {
-    private NethermindApi _context = null!;
-    private INethermindPlugin _plugin = null!;
+    [Test]
+    public void Enabled_reflects_config([Values] bool enabled)
+    {
+        EthStatsPlugin plugin = new(new EthStatsConfig { Enabled = enabled });
 
-    [SetUp]
-    public void Setup() => _context = Build.ContextWithMocks();
+        Assert.That(plugin.Enabled, Is.EqualTo(enabled));
+    }
 
     [Test]
-    public void Init_eth_stats_plugin_does_not_throw_exception([Values] bool enabled)
+    public void Module_registers_the_eth_stats_step()
     {
-        _plugin = new EthStatsPlugin(new EthStatsConfig() { Enabled = enabled });
+        ContainerBuilder builder = new();
+        builder.RegisterModule(new EthStatsPlugin(new EthStatsConfig()).Module);
+        using IContainer container = builder.Build();
 
-        Assert.DoesNotThrow(() => _plugin.InitTxTypesAndRlpDecoders(_context));
+        Assert.That(container.Resolve<IEnumerable<StepInfo>>().Select(static s => s.StepType),
+            Does.Contain(typeof(EthStatsStep)));
     }
 }

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsPluginTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
-using System.Linq;
 using Autofac;
 using Nethermind.Api.Steps;
 using Nethermind.EthStats.Configs;
@@ -27,7 +26,7 @@ public class EthStatsPluginTests
         builder.RegisterModule(new EthStatsPlugin(new EthStatsConfig()).Module);
         using IContainer container = builder.Build();
 
-        Assert.That(container.Resolve<IEnumerable<StepInfo>>().Select(static s => s.StepType),
-            Does.Contain(typeof(EthStatsStep)));
+        Assert.That(container.Resolve<IEnumerable<StepInfo>>(),
+            Has.Some.Matches<StepInfo>(static s => s.StepType == typeof(EthStatsStep)));
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/VmStateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VmStateTests.cs
@@ -224,23 +224,21 @@ namespace Nethermind.Evm.Test
         }
 
         [Test]
-        public void Can_dispose_without_init()
-        {
-            VmStateScope scope = CreateEvmStateScope();
-
-            // Dispose must accept a state whose stacks were never initialized.
-            Assert.DoesNotThrow(scope.Dispose);
-        }
+        public void Can_dispose_without_init() =>
+            Assert.DoesNotThrow(static () =>
+            {
+                // Dispose must accept a state whose stacks were never initialized.
+                using VmStateScope _ = CreateEvmStateScope();
+            });
 
         [Test]
-        public void Can_dispose_after_init()
-        {
-            VmStateScope scope = CreateEvmStateScope();
-            scope.VmState.InitializeStacks(default, out EvmStack _);
-
-            // Dispose must return the initialized stacks to the pool without an error.
-            Assert.DoesNotThrow(scope.Dispose);
-        }
+        public void Can_dispose_after_init() =>
+            Assert.DoesNotThrow(static () =>
+            {
+                // Dispose must return the initialized stacks to the pool without an error.
+                using VmStateScope scope = CreateEvmStateScope();
+                scope.VmState.InitializeStacks(default, out EvmStack _);
+            });
 
         private static VmStateScope CreateEvmStateScope(VmState<EthereumGasPolicy> parentVmState = null) =>
             new(parentVmState is null

--- a/src/Nethermind/Nethermind.Evm.Test/VmStateTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VmStateTests.cs
@@ -63,15 +63,35 @@ namespace Nethermind.Evm.Test
         public void Nothing_to_commit()
         {
             using VmStateScope parent = CreateEvmStateScope();
-            using VmStateScope child = CreateEvmStateScope(parent.VmState);
-            child.VmState.CommitToParent(parent.VmState);
+            using (VmStateScope child = CreateEvmStateScope(parent.VmState))
+            {
+                child.VmState.CommitToParent(parent.VmState);
+            }
+
+            AssertParentIsUntouched(parent.VmState);
         }
 
         [Test]
         public void Nothing_to_restore()
         {
             using VmStateScope parent = CreateEvmStateScope();
-            using VmStateScope _ = CreateEvmStateScope(parent.VmState);
+            using (VmStateScope _ = CreateEvmStateScope(parent.VmState))
+            {
+            }
+
+            AssertParentIsUntouched(parent.VmState);
+        }
+
+        // An empty commit or restore must not corrupt the parent state.
+        private static void AssertParentIsUntouched(VmState<EthereumGasPolicy> parent)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parent.Refund, Is.EqualTo(0));
+                Assert.That(parent.AccessTracker.Logs, Is.Empty);
+                Assert.That(parent.AccessTracker.DestroyList, Is.Empty);
+                Assert.That(parent.AccessTracker.IsCold(TestItem.AddressA), Is.True);
+            }
         }
 
         [Test]
@@ -206,14 +226,20 @@ namespace Nethermind.Evm.Test
         [Test]
         public void Can_dispose_without_init()
         {
-            using VmStateScope scope = CreateEvmStateScope();
+            VmStateScope scope = CreateEvmStateScope();
+
+            // Dispose must accept a state whose stacks were never initialized.
+            Assert.DoesNotThrow(scope.Dispose);
         }
 
         [Test]
         public void Can_dispose_after_init()
         {
-            using VmStateScope scope = CreateEvmStateScope();
+            VmStateScope scope = CreateEvmStateScope();
             scope.VmState.InitializeStacks(default, out EvmStack _);
+
+            // Dispose must return the initialized stacks to the pool without an error.
+            Assert.DoesNotThrow(scope.Dispose);
         }
 
         private static VmStateScope CreateEvmStateScope(VmState<EthereumGasPolicy> parentVmState = null) =>

--- a/src/Nethermind/Nethermind.State.Test/NodeTest.cs
+++ b/src/Nethermind/Nethermind.State.Test/NodeTest.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core.Buffers;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
@@ -15,81 +16,102 @@ namespace Nethermind.Store.Test
     [TestFixture, Parallelizable(ParallelScope.Children)]
     public class NodeTest
     {
-        private (ITrieNodeResolver tree, TrieNode decoded) CreateBranchAndDecode()
+        private static (ITrieNodeResolver tree, TrieNode decoded, byte[] originalRlp) CreateBranchAndDecode()
         {
             TrieNode node = new(NodeType.Branch);
             node.SetChild(0, new TrieNode(NodeType.Leaf, TestItem.KeccakA));
             node.SetChild(1, new TrieNode(NodeType.Leaf, TestItem.KeccakB));
-            ITrieNodeResolver tree = BuildATreeFromNode(node);
+            (ITrieNodeResolver tree, byte[] originalRlp) = BuildATreeFromNode(node);
             TrieNode decoded = new(NodeType.Unknown, node.Keccak);
             decoded.ResolveNode(tree, TreePath.Empty);
-            return (tree, decoded);
+            return (tree, decoded, originalRlp);
+        }
+
+        private static byte[] Encode(ITrieNodeResolver tree, TrieNode node)
+        {
+            TreePath emptyPath = TreePath.Empty;
+            return node.RlpEncode(tree, ref emptyPath).ToArray();
+        }
+
+        // A fresh node built with the same children is the encoding oracle for the
+        // decode-then-mutate paths.
+        private static byte[] EncodeFreshBranch(params (int index, Hash256 child)[] children)
+        {
+            TrieNode node = new(NodeType.Branch);
+            foreach ((int index, Hash256 child) in children)
+            {
+                node.SetChild(index, new TrieNode(NodeType.Leaf, child));
+            }
+
+            TreePath emptyPath = TreePath.Empty;
+            return node.RlpEncode(null, ref emptyPath).ToArray();
+        }
+
+        private static void AssertEncodesLikeFreshBranch(
+            byte[] encoded, byte[] originalRlp, params (int index, Hash256 child)[] expectedChildren)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(encoded, Is.EqualTo(EncodeFreshBranch(expectedChildren)),
+                    "a mutated clone must encode like a fresh node with the same children");
+                Assert.That(encoded, Is.Not.EqualTo(originalRlp), "the mutation must change the encoding");
+            }
         }
 
         [Test]
         public void Two_children_store_encode()
         {
-            (ITrieNodeResolver tree, TrieNode decoded) = CreateBranchAndDecode();
-            TreePath emptyPath = TreePath.Empty;
-            decoded.RlpEncode(tree, ref emptyPath);
+            (ITrieNodeResolver tree, TrieNode decoded, byte[] originalRlp) = CreateBranchAndDecode();
+
+            Assert.That(Encode(tree, decoded), Is.EqualTo(originalRlp),
+                "a decoded node must re-encode to the stored bytes");
         }
 
-        [Test]
-        public void Two_children_store_resolve_encode()
+        [TestCase(0, TestName = "Two_children_store_resolve_get_existing_child_encode")]
+        [TestCase(3, TestName = "Two_children_store_resolve_get_null_child_encode")]
+        public void Two_children_store_resolve_get_encode(int childIndex)
         {
-            (ITrieNodeResolver tree, TrieNode decoded) = CreateBranchAndDecode();
+            (ITrieNodeResolver tree, TrieNode decoded, byte[] originalRlp) = CreateBranchAndDecode();
             TreePath emptyPath = TreePath.Empty;
-            decoded.RlpEncode(tree, ref emptyPath);
-        }
+            _ = decoded.GetChild(tree, ref emptyPath, childIndex);
 
-        [Test]
-        public void Two_children_store_resolve_get1_encode()
-        {
-            (ITrieNodeResolver tree, TrieNode decoded) = CreateBranchAndDecode();
-            TreePath emptyPath = TreePath.Empty;
-            _ = decoded.GetChild(tree, ref emptyPath, 0);
-            decoded.RlpEncode(tree, ref emptyPath);
-        }
-
-        [Test]
-        public void Two_children_store_resolve_getnull_encode()
-        {
-            (ITrieNodeResolver tree, TrieNode decoded) = CreateBranchAndDecode();
-            TreePath emptyPath = TreePath.Empty;
-            _ = decoded.GetChild(tree, ref emptyPath, 3);
-            decoded.RlpEncode(tree, ref emptyPath);
+            Assert.That(Encode(tree, decoded), Is.EqualTo(originalRlp),
+                "a child read must not change the encoding");
         }
 
         [Test]
         public void Two_children_store_resolve_update_encode()
         {
-            (ITrieNodeResolver tree, TrieNode decoded) = CreateBranchAndDecode();
+            (ITrieNodeResolver tree, TrieNode decoded, byte[] originalRlp) = CreateBranchAndDecode();
             decoded = decoded.Clone();
             decoded.SetChild(0, new TrieNode(NodeType.Leaf, TestItem.KeccakC));
-            TreePath emptyPath = TreePath.Empty;
-            decoded.RlpEncode(tree, ref emptyPath);
+
+            AssertEncodesLikeFreshBranch(Encode(tree, decoded), originalRlp,
+                (0, TestItem.KeccakC), (1, TestItem.KeccakB));
         }
 
         [Test]
         public void Two_children_store_resolve_update_null_encode()
         {
-            (ITrieNodeResolver tree, TrieNode decoded) = CreateBranchAndDecode();
+            (ITrieNodeResolver tree, TrieNode decoded, byte[] originalRlp) = CreateBranchAndDecode();
             decoded = decoded.Clone();
             decoded.SetChild(4, new TrieNode(NodeType.Leaf, TestItem.KeccakC));
             decoded.SetChild(5, new TrieNode(NodeType.Leaf, TestItem.KeccakD));
-            TreePath emptyPath = TreePath.Empty;
-            decoded.RlpEncode(tree, ref emptyPath);
+
+            AssertEncodesLikeFreshBranch(Encode(tree, decoded), originalRlp,
+                (0, TestItem.KeccakA), (1, TestItem.KeccakB), (4, TestItem.KeccakC), (5, TestItem.KeccakD));
         }
 
         [Test]
         public void Two_children_store_resolve_delete_and_add_encode()
         {
-            (ITrieNodeResolver tree, TrieNode decoded) = CreateBranchAndDecode();
+            (ITrieNodeResolver tree, TrieNode decoded, byte[] originalRlp) = CreateBranchAndDecode();
             decoded = decoded.Clone();
             decoded.SetChild(0, null);
             decoded.SetChild(4, new TrieNode(NodeType.Leaf, TestItem.KeccakC));
-            TreePath emptyPath = TreePath.Empty;
-            decoded.RlpEncode(tree, ref emptyPath);
+
+            AssertEncodesLikeFreshBranch(Encode(tree, decoded), originalRlp,
+                (1, TestItem.KeccakB), (4, TestItem.KeccakC));
         }
 
         [Test]
@@ -97,14 +119,15 @@ namespace Nethermind.Store.Test
         {
             TrieNode node = new(NodeType.Branch);
             node.SetChild(0, new TrieNode(NodeType.Leaf, TestItem.KeccakA));
-            ITrieNodeResolver tree = BuildATreeFromNode(node);
+            (ITrieNodeResolver tree, byte[] originalRlp) = BuildATreeFromNode(node);
             TrieNode decoded = new(NodeType.Unknown, node.Keccak);
             decoded.ResolveNode(tree, TreePath.Empty);
-            TreePath emptyPath = TreePath.Empty;
-            decoded.RlpEncode(tree, ref emptyPath);
+
+            Assert.That(Encode(tree, decoded), Is.EqualTo(originalRlp),
+                "a decoded node must re-encode to the stored bytes");
         }
 
-        private static ITrieNodeResolver BuildATreeFromNode(TrieNode node)
+        private static (ITrieNodeResolver tree, byte[] originalRlp) BuildATreeFromNode(TrieNode node)
         {
             TreePath emptyPath = TreePath.Empty;
             CappedArray<byte> rlp = node.RlpEncode(null, ref emptyPath);
@@ -113,8 +136,7 @@ namespace Nethermind.Store.Test
             MemDb memDb = new();
             memDb[NodeStorage.GetHalfPathNodeStoragePath(null, TreePath.Empty, node.Keccak)] = rlp.ToArray();
 
-            // ITrieNodeResolver tree = new PatriciaTree(memDb, node.Keccak, false, true);
-            return TestTrieStoreFactory.Build(memDb, NullLogManager.Instance).GetTrieStore(null);
+            return (TestTrieStoreFactory.Build(memDb, NullLogManager.Instance).GetTrieStore(null), rlp.ToArray());
         }
     }
 }

--- a/src/Nethermind/Nethermind.State.Test/NodeTest.cs
+++ b/src/Nethermind/Nethermind.State.Test/NodeTest.cs
@@ -133,10 +133,13 @@ namespace Nethermind.Store.Test
             CappedArray<byte> rlp = node.RlpEncode(null, ref emptyPath);
             node.ResolveKey(null, ref emptyPath);
 
+            byte[] rlpBytes = rlp.ToArray();
             MemDb memDb = new();
-            memDb[NodeStorage.GetHalfPathNodeStoragePath(null, TreePath.Empty, node.Keccak)] = rlp.ToArray();
+            memDb[NodeStorage.GetHalfPathNodeStoragePath(null, TreePath.Empty, node.Keccak)] = rlpBytes;
 
-            return (TestTrieStoreFactory.Build(memDb, NullLogManager.Instance).GetTrieStore(null), rlp.ToArray());
+            // The oracle is an independent copy. A write into the stored buffer must fail
+            // the compare, not silently update the expectation.
+            return (TestTrieStoreFactory.Build(memDb, NullLogManager.Instance).GetTrieStore(null), [.. rlpBytes]);
         }
     }
 }


### PR DESCRIPTION
## Changes

How to review this fast: five commits, one concern each (the fifth addresses review feedback); 4 files, all under `*.Test` projects (verified: no non-test file in the diff); +113/-62.

These tests ran product code and asserted nothing. Each now has a real oracle, or is deleted where the product method is literally empty.

- `NodeTest.cs` (Nethermind.State.Test): all eight trie-node tests ended in an un-asserted `RlpEncode`. Decode and child-read paths now assert the node re-encodes to the stored bytes; the expected-bytes oracle is an independent copy of the stored buffer, so an in-place write to the stored bytes cannot pass the compare. Clone-and-mutate paths assert the encoding equals a fresh-built branch with the same children and differs from the original - the two sides take different encode paths in `TrieNode` (rlp-copy vs data-driven), so the comparison is not self-referential. One byte-identical duplicate test is deleted; the two get-child variants fold into `[TestCase(0)]`/`[TestCase(3)]`.
- `VmStateTests.cs` (Nethermind.Evm.Test): `Nothing_to_commit` / `Nothing_to_restore` now assert the parent state is untouched (refund, logs, destroy list, address coldness). The two dispose tests construct and dispose inside `Assert.DoesNotThrow`, so a failure anywhere in the rent-init-dispose path surfaces and nothing leaks when init throws. Note: the `DataStack is not null` guard in `VmState.Dispose` is not coverable from these tests by design - removing it does not throw at dispose time, it enqueues a null stack that poisons the pool for a later renter; the guard is what prevents that.
- `SinglePluginLoaderTests.cs`: `Can_load` deleted - `SinglePluginLoader<T>.Load()` is an empty method body, so the test could not fail under any change.
- `EthStatsPluginTests.cs`: the project's only test asserted `DoesNotThrow` on an empty interface default method (`InitTxTypesAndRlpDecoders`). Rewritten against the plugin's real surface: `Enabled` reflects the config, and the plugin module registers `EthStatsStep`. This also drops the mocked-API context dependency.

Part of the test-hygiene series (#12689, #12690, #12693).

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- Mutation-checked (each deliberate break made its strengthened test fail, then was reverted): corrupting the trie rlp-copy path fails all 7 NodeTest cases; dropping `InitRlp` from `TrieNode.Clone` fails the 3 mutate-path cases; corrupting the null-node write fails the null-child cases; a refund off-by-one fails `Nothing_to_commit`; negating `Enabled` and dropping the step registration fail both EthStats tests; a throwing `Dispose` fails both dispose tests.
- Full local suites green (windows-x64, release): State.Test 1183, Evm.Test 5005, Api.Test 7, EthStats.Test 23 - zero failures; strengthened fixtures repeated 3x with no flakes.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No
