### PR TITLE
fix(simulate): relax EIP-3607 via execution flag, not spec wrapping

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
@@ -87,6 +87,7 @@ public partial class BlockAccessListManager
         private readonly ObjectPool<IReadOnlyTxProcessorSource>? _parentReaderEnvPool;
         private int _processorCount;
         private readonly CodeInfoRepositoryFactory _codeInfoRepositoryFactory;
+        private readonly ExecutionOptions _additionalTxExecutionOptions;
 
         public ParallelTxProcessorWithWorldStateManager(
             IBlockhashProvider blockHashProvider,
@@ -97,7 +98,8 @@ public partial class BlockAccessListManager
             PreBlockCaches? preBlockCaches,
             IReadOnlyTxProcessingEnvFactory? readOnlyTxProcessingEnvFactory,
             ITransactionProcessorFactory txProcessorFactory,
-            CodeInfoRepositoryFactory codeInfoRepositoryFactory)
+            CodeInfoRepositoryFactory codeInfoRepositoryFactory,
+            ExecutionOptions additionalTxExecutionOptions = ExecutionOptions.None)
         {
             _blockHashProvider = blockHashProvider;
             _specProvider = specProvider;
@@ -105,6 +107,7 @@ public partial class BlockAccessListManager
             _logManager = logManager;
             _txProcessorFactory = txProcessorFactory;
             _codeInfoRepositoryFactory = codeInfoRepositoryFactory;
+            _additionalTxExecutionOptions = additionalTxExecutionOptions;
             _parentReaderEnvPool = CreateParentReaderEnvPool(prewarmerEnvFactory, preBlockCaches, readOnlyTxProcessingEnvFactory);
             for (int i = 0; i < ProcessorPoolSize; i++)
             {
@@ -230,7 +233,7 @@ public partial class BlockAccessListManager
             => (int)uint.Min(balIndex, (uint)_lastBalIndex);
 
         private TxProcessorWithWorldState NewProcessor()
-            => new(true, _blockHashProvider, _specProvider, _stateProvider, _logManager, _txProcessorFactory, _codeInfoRepositoryFactory);
+            => new(true, _blockHashProvider, _specProvider, _stateProvider, _logManager, _txProcessorFactory, _codeInfoRepositoryFactory, _additionalTxExecutionOptions);
 
         private TxProcessorWithWorldState RentProcessor()
         {
@@ -338,9 +341,10 @@ public partial class BlockAccessListManager
             IWorldState stateProvider,
             ILogManager logManager,
             ITransactionProcessorFactory txProcessorFactory,
-            CodeInfoRepositoryFactory codeInfoRepositoryFactory)
+            CodeInfoRepositoryFactory codeInfoRepositoryFactory,
+            ExecutionOptions additionalTxExecutionOptions = ExecutionOptions.None)
         {
-            _txProcessorWithWorldState = new(false, blockHashProvider, specProvider, stateProvider, logManager, txProcessorFactory, codeInfoRepositoryFactory);
+            _txProcessorWithWorldState = new(false, blockHashProvider, specProvider, stateProvider, logManager, txProcessorFactory, codeInfoRepositoryFactory, additionalTxExecutionOptions);
             _txProcessorWithWorldState.WorldState.SetGeneratingBlockAccessList(new());
         }
 
@@ -383,7 +387,8 @@ public partial class BlockAccessListManager
             IWorldState stateProvider,
             ILogManager logManager,
             ITransactionProcessorFactory txProcessorFactory,
-            CodeInfoRepositoryFactory codeInfoRepositoryFactory)
+            CodeInfoRepositoryFactory codeInfoRepositoryFactory,
+            ExecutionOptions additionalTxExecutionOptions = ExecutionOptions.None)
         {
 
             VirtualMachine virtualMachine = new(blockHashProvider, specProvider, logManager);
@@ -396,7 +401,7 @@ public partial class BlockAccessListManager
             WorldState = new TracedAccessWorldState(worldState, parallel);
             ICodeInfoRepository codeInfoRepository = codeInfoRepositoryFactory(WorldState);
             TxProcessor = txProcessorFactory.Create(BlobBaseFeeCalculator.Instance, specProvider, WorldState, virtualMachine, codeInfoRepository, logManager, parallel);
-            TxProcessorAdapter = new(TxProcessor);
+            TxProcessorAdapter = new(TxProcessor, additionalTxExecutionOptions);
         }
 
         public void Setup(Block block, BlockExecutionContext blockExecutionContext, uint balIndex, ParentReaderLease? parentReader)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -51,7 +51,8 @@ public partial class BlockAccessListManager(
     PreBlockCaches? preBlockCaches = null,
     IReadOnlyTxProcessingEnvFactory? readOnlyTxProcessingEnvFactory = null,
     ITransactionProcessorFactory? transactionProcessorFactory = null,
-    IExecutionRequestsProcessorFactory? executionRequestsProcessorFactory = null)
+    IExecutionRequestsProcessorFactory? executionRequestsProcessorFactory = null,
+    BlockAccessListTxExecutionOptions? txExecutionOptions = null)
     : IBlockAccessListManager, IDisposable
 {
     private readonly ILogger _logger = logManager.GetClassLogger<BlockAccessListManager>();
@@ -60,10 +61,12 @@ public partial class BlockAccessListManager(
     private Task? _balWarmupTask;
     private readonly Lazy<ParallelTxProcessorWithWorldStateManager> _parallelTxProcessorWithWorldStateManager =
         new(() => new(blockHashProvider, specProvider, stateProvider, logManager, prewarmerEnvFactory, preBlockCaches, readOnlyTxProcessingEnvFactory,
-            transactionProcessorFactory ?? new TransactionProcessorFactory<EthereumGasPolicy>(), codeInfoRepositoryFactory));
+            transactionProcessorFactory ?? new TransactionProcessorFactory<EthereumGasPolicy>(), codeInfoRepositoryFactory,
+            (txExecutionOptions ?? BlockAccessListTxExecutionOptions.None).AdditionalOptions));
     private readonly Lazy<SequentialTxProcessorWithWorldStateManager> _sequentialTxProcessorWithWorldStateManager =
         new(() => new(blockHashProvider, specProvider, stateProvider, logManager,
-            transactionProcessorFactory ?? new TransactionProcessorFactory<EthereumGasPolicy>(), codeInfoRepositoryFactory));
+            transactionProcessorFactory ?? new TransactionProcessorFactory<EthereumGasPolicy>(), codeInfoRepositoryFactory,
+            (txExecutionOptions ?? BlockAccessListTxExecutionOptions.None).AdditionalOptions));
     private const int GasValidationChunkSize = 8;
     private ulong? _gasRemaining;
     private bool _isBuilding;

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListTxExecutionOptions.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListTxExecutionOptions.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Evm.TransactionProcessing;
+
+namespace Nethermind.Consensus.Processing;
+
+/// <summary>
+/// Extra <see cref="ExecutionOptions"/> OR-ed into every transaction the <see cref="BlockAccessListManager"/>
+/// runs through its own tx processors (the EIP-7928 BAL path, which bypasses the normal adapter).
+/// </summary>
+/// <remarks>
+/// Registered in the <c>eth_simulateV1</c> scope with <see cref="ExecutionOptions.SkipSenderCodeCheck"/> so a
+/// state-overridden contract can be the sender on the BAL path too, without wrapping (and type-erasing) the
+/// release spec. Absent (or <see cref="None"/>) everywhere else, so real block production keeps EIP-3607 enforced.
+/// </remarks>
+public sealed record BlockAccessListTxExecutionOptions(ExecutionOptions AdditionalOptions)
+{
+    public static readonly BlockAccessListTxExecutionOptions None = new(ExecutionOptions.None);
+}

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecuteTransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecuteTransactionProcessorAdapter.cs
@@ -6,11 +6,11 @@ using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Evm.TransactionProcessing
 {
-    public class ExecuteTransactionProcessorAdapter(ITransactionProcessor transactionProcessor)
+    public class ExecuteTransactionProcessorAdapter(ITransactionProcessor transactionProcessor, ExecutionOptions additionalOptions = ExecutionOptions.None)
         : ITransactionProcessorAdapter
     {
         public TransactionResult Execute(Transaction transaction, ITxTracer txTracer) =>
-            transactionProcessor.Execute(transaction, txTracer);
+            transactionProcessor.Process(transaction, txTracer, ExecutionOptions.Commit | additionalOptions);
 
         public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
             => transactionProcessor.SetBlockExecutionContext(in blockExecutionContext);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ExecutionOptions.cs
@@ -39,6 +39,17 @@ public enum ExecutionOptions
     BuildUp = 16,
 
     /// <summary>
+    /// Skip the EIP-3607 sender-has-code check, letting a contract address act as the transaction sender.
+    /// </summary>
+    /// <remarks>
+    /// Used by <c>eth_simulateV1</c> for state-overridden contract senders. Carried as an execution-policy
+    /// flag rather than by wrapping the release spec, so the spec's concrete runtime type (and any
+    /// chain-specific interfaces such as <c>ITaikoReleaseSpec</c>/<c>IXdcReleaseSpec</c>) survives on the
+    /// tx-processor path.
+    /// </remarks>
+    SkipSenderCodeCheck = 32,
+
+    /// <summary>
     /// Skip potential fail checks and commit state after execution
     /// </summary>
     SkipValidationAndCommit = Commit | SkipValidation,

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1021,7 +1021,9 @@ namespace Nethermind.Evm.TransactionProcessing
         {
             bool validate = !opts.HasFlag(ExecutionOptions.SkipValidation);
 
-            if (validate && WorldState.IsInvalidContractSender(spec, tx.SenderAddress!))
+            if (validate
+                && !opts.HasFlag(ExecutionOptions.SkipSenderCodeCheck)
+                && WorldState.IsInvalidContractSender(spec, tx.SenderAddress!))
             {
                 TraceLogInvalidTx(tx, "SENDER_IS_CONTRACT");
                 return TransactionResult.SenderHasDeployedCode;

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateBlockValidationTransactionsExecutor.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
-using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.State.Proofs;
 
@@ -16,24 +15,18 @@ public class SimulateBlockValidationTransactionsExecutor(
     SimulateRequestState simulateState)
     : IBlockProcessor.IBlockTransactionsExecutor
 {
-    public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
-    {
-        // Relax EIP-3607 on the block execution context so a state-overridden contract can be the tx
-        // sender. Done here (not at the spec-provider level) so it reaches both the main tx processor and
-        // the EIP-7928 BAL manager — ParallelBlockValidationTransactionsExecutor sets this context on both —
-        // while BlockProcessor still receives the unwrapped spec, preserving chain-specific spec interfaces.
-        IReleaseSpec spec = blockExecutionContext.Spec.WithoutEip3607();
-
-        // This is now the single context-rebuild funnel for the simulate scope, so relax nothing but the spec:
-        // forward the incoming PrevRandao and BlobBaseFee verbatim rather than re-deriving them from the header.
-        // A BlockProcessor subclass (e.g. XdcBlockProcessor) may have supplied non-default values that the
-        // default derivation would otherwise discard. A blobBaseFee block override still takes precedence.
+    // Apply only the simulate blobBaseFee override here; EIP-3607 relaxation for state-overridden
+    // contract senders is handled by the SkipSenderCodeCheck execution-policy flag on the tx processors
+    // (both the main adapter and the EIP-7928 BAL path), so the spec keeps its concrete runtime type and
+    // chain-specific interfaces (ITaikoReleaseSpec/IXdcReleaseSpec) survive. Forward the incoming
+    // PrevRandao and BlobBaseFee verbatim rather than re-deriving them from the header — a BlockProcessor
+    // subclass (e.g. XdcBlockProcessor) may have supplied non-default values. The override still wins.
+    public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext) =>
         baseTransactionExecutor.SetBlockExecutionContext(BlockExecutionContext.WithPrevRandaoAndBlobBaseFee(
             blockExecutionContext.Header,
-            spec,
+            blockExecutionContext.Spec,
             blockExecutionContext.PrevRandao,
             simulateState.BlobBaseFeeOverride ?? blockExecutionContext.BlobBaseFee.ToUInt256()));
-    }
 
     public TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions, BlockReceiptsTracer receiptsTracer,
         CancellationToken token = default)

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
@@ -62,6 +62,10 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
             .AddDecorator<IBlockValidator, SimulateBlockValidatorProxy>()
             .AddDecorator<ITransactionProcessor.IBlobBaseFeeCalculator, BlobBaseFeeOverrideCalculatorDecorator>()
             .AddDecorator<IBlockProcessor.IBlockTransactionsExecutor, SimulateBlockValidationTransactionsExecutor>()
+            // Relax EIP-3607 on the EIP-7928 BAL path too (it builds its own tx processors), so a
+            // state-overridden contract can be the sender. Done via an execution-policy flag rather than
+            // by wrapping the spec, keeping the spec's runtime type intact for chain-specific processors.
+            .AddSingleton(new BlockAccessListTxExecutionOptions(ExecutionOptions.SkipSenderCodeCheck))
             .AddSingleton<ITransactionProcessorAdapter, SimulateTransactionProcessorAdapter>()
             .AddSingleton<IReceiptStorage>(NullReceiptStorage.Instance)
             .AddScoped<SimulateRequestState>()

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
@@ -27,7 +27,10 @@ public class SimulateTransactionProcessorAdapter(ITransactionProcessor transacti
         }
         transaction.Hash = transaction.CalculateHash();
 
-        TransactionResult result = simulateRequestState.Validate ? transactionProcessor.Execute(transaction, txTracer) : transactionProcessor.Trace(transaction, txTracer);
+        // SkipSenderCodeCheck relaxes EIP-3607 so a state-overridden contract can be the sender (mirrors the
+        // BAL path, which gets the same flag via BlockAccessListTxExecutionOptions).
+        ExecutionOptions options = (simulateRequestState.Validate ? ExecutionOptions.Commit : ExecutionOptions.SkipValidationAndCommit) | ExecutionOptions.SkipSenderCodeCheck;
+        TransactionResult result = transactionProcessor.Process(transaction, txTracer, options);
 
         // Keep track of gas left
         ulong blockGasUsed = transaction.BlockGasUsed;
@@ -41,8 +44,6 @@ public class SimulateTransactionProcessorAdapter(ITransactionProcessor transacti
     public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
     {
         _currentTxIndex = 0;
-        // EIP-3607 is relaxed on the block execution context by SimulateBlockValidationTransactionsExecutor
-        // (which reaches both this processor and the EIP-7928 BAL manager), so the spec here is already relaxed.
         transactionProcessor.SetBlockExecutionContext(in blockExecutionContext);
     }
 }

--- a/src/Nethermind/Nethermind.Taiko.Test/TransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TransactionProcessorTests.cs
@@ -88,6 +88,37 @@ public class TransactionProcessorTests
         });
     }
 
+    [Test]
+    public void Contract_sender_executes_and_pays_fees_when_sender_code_check_skipped()
+    {
+        // Regression for the eth_simulateV1 spec type-erasure (follow-up to the EIP-3607/BAL fix): relaxing
+        // EIP-3607 via the SkipSenderCodeCheck execution-policy flag keeps the concrete ITaikoReleaseSpec, so
+        // PayFees can still cast it. The earlier spec-wrapping relaxation replaced it with a NoEip3607Spec
+        // (plain IReleaseSpec) and this cast threw InvalidCastException.
+        _spec.IsEip3607Enabled = true;
+        _stateProvider!.InsertCode(TestItem.AddressA, Bytes.FromHexString("0x600060"), _spec);
+        _stateProvider!.Commit(_spec);
+
+        ulong gasLimit = 100000;
+        Transaction tx = Build.A.Transaction
+            .WithValue(1)
+            .WithGasPrice(1)
+            .WithGasLimit(gasLimit)
+            .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+
+        Block block = Build.A.Block.WithNumber(1).WithTransactions(tx)
+            .WithBaseFeePerGas(1)
+            .WithExtraData(new byte[32])
+            .WithBeneficiary(TestItem.AddressC).WithGasLimit(gasLimit).TestObject;
+
+        _transactionProcessor!.SetBlockExecutionContext(new BlockExecutionContext(block.Header, _specProvider.GetSpec(block.Header)));
+
+        TransactionResult result = _transactionProcessor.Process(tx, NullTxTracer.Instance,
+            ExecutionOptions.Commit | ExecutionOptions.SkipSenderCodeCheck);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+    }
+
     public static IEnumerable FeesDistributionTests
     {
         get


### PR DESCRIPTION
## Summary

Follow-up to #12691, addressing the residual **spec type-erasure** raised in its review (and tracked on #12692).

#12691 relaxes EIP-3607 for `eth_simulateV1` contract senders by wrapping the block-execution-context spec with `WithoutEip3607()`, which returns a `NoEip3607Spec` decorator that implements only `IReleaseSpec`. The tx processors read their spec from that context (`TransactionProcessor.GetSpec => BlockExecutionContext.Spec`), so the decorator reaches **chain-specific** processors that hard-cast it:

- `TaikoTransactionProcessor.PayFees` → `(ITaikoReleaseSpec)spec` → `InvalidCastException`
- `XdcTransactionProcessor` → `(IXdcReleaseSpec)spec` on **every** tx → `InvalidOperationException`

`Eip3607Transition` defaults to `0`, so the wrap is always active on those chains — `eth_simulateV1` throws an unhandled exception instead of returning a JSON-RPC result. Pre-existing on `master` (the old `SimulateTransactionProcessorAdapter` wrapped identically); this closes it.

## Approach

Relax EIP-3607 via a dedicated **execution-policy flag** (`ExecutionOptions.SkipSenderCodeCheck`) gated in `ValidateSender`, instead of mutating the spec. The spec keeps its concrete runtime type on every path.

- **Main path**: `SimulateTransactionProcessorAdapter` ORs the flag into its `Process` call.
- **EIP-7928 BAL path** (builds its own tx processors, so it doesn't see the main adapter): a small `BlockAccessListTxExecutionOptions` is injected into `BlockAccessListManager` and threaded to its `ExecuteTransactionProcessorAdapter`. Registered with the flag only in the simulate scope, so real block production keeps EIP-3607 enforced.
- Drops the `WithoutEip3607()` wrap from `SimulateBlockValidationTransactionsExecutor` (the context now carries the real, typed spec).

## Tests

- `Nethermind.Taiko.Test` — a code-bearing sender run through `TaikoTransactionProcessor.PayFees`: **passes** with the flag, and I verified it **throws `InvalidCastException` under the old spec-wrapping** (so it genuinely guards the regression).
- The existing `eth_simulateV1` BAL-path contract-sender test and the full simulate suite (107) stay green.

## @claude — question on the approach

This reaches the BAL path by threading a policy object through `BlockAccessListManager → TxProcessorPool → ExecuteTransactionProcessorAdapter` (shared `Nethermind.Consensus` code). I considered but rejected:
1. **Decorator-holds-original / unwrap at cast sites** — C# casts aren't interceptable; would require every chain-specific cast site to unwrap, and any new cast silently reintroduces the crash.
2. **Flag on `BlockExecutionContext`** — flows to both paths for free (they share the context) and avoids the BAL threading, but parks a validation-policy flag on the block-environment struct.

Is there a cleaner way to relax EIP-3607 on both the main and EIP-7928 BAL execution paths without either the spec wrapping (type erasure) or threading a flag through the shared BAL construction? Would a `BlockExecutionContext` field be preferable to the `ExecutionOptions` + BAL-injection route here?
