### PR TITLE
test: add hand-derived golden tests for eth/71 and snap serializers

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/BlockAccessListsMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/BlockAccessListsMessageSerializerTests.cs
@@ -146,7 +146,7 @@ public class GetBlockAccessListsMessageSerializerTests
                 })),
                 "e364e1a00000000000000000000000000000000000000000000000000000000000000000")
             .SetName("Roundtrip_single_hash");
-        // The hashes are Keccak.Zero, keccak("A"), and keccak("B").
+        // The last two 32-byte literals in the expectation are keccak("A") and keccak("B").
         yield return new TestCaseData(
                 new Func<GetBlockAccessListsMessage>(() => new GetBlockAccessListsMessage(101, new ArrayPoolList<Hash256>(3)
                 {

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/BlockAccessListsMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V71/BlockAccessListsMessageSerializerTests.cs
@@ -18,7 +18,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V71;
 public class BlockAccessListsMessageSerializerTests
 {
     [TestCaseSource(nameof(BlockAccessListsRoundtripCases))]
-    public void Roundtrip(Func<BlockAccessListsMessage> buildMessage, string? expectedData)
+    public void Roundtrip(Func<BlockAccessListsMessage> buildMessage, string expectedData)
     {
         BlockAccessListsMessageSerializer serializer = new();
         using BlockAccessListsMessage msg = buildMessage();
@@ -35,11 +35,7 @@ public class BlockAccessListsMessageSerializerTests
         buffer.SetReaderIndex(0);
         string allHex = buffer.ReadAllHex();
         Assert.That(buffer2.ReadAllHex(), Is.EqualTo(allHex), "test zero");
-
-        if (expectedData is not null)
-        {
-            Assert.That(allHex, Is.EqualTo(expectedData));
-        }
+        Assert.That(allHex, Is.EqualTo(expectedData));
     }
 
     [TestCaseSource(nameof(BlockAccessListsRejectionCases))]
@@ -55,7 +51,7 @@ public class BlockAccessListsMessageSerializerTests
     {
         yield return new TestCaseData(
                 new Func<BlockAccessListsMessage>(() => BuildMessage(42)),
-                null)
+                "c22ac0")
             .SetName("Roundtrip_empty");
         yield return new TestCaseData(
                 new Func<BlockAccessListsMessage>(() => BuildMessage(43, (byte[]?)null)),
@@ -69,9 +65,10 @@ public class BlockAccessListsMessageSerializerTests
                 new Func<BlockAccessListsMessage>(() => BuildMessage(45, [0xc1, 0x80], [0xc2, 0x01, 0x02], null)),
                 "c82dc6c180c2010280")
             .SetName("Roundtrip_multiple_bals");
+        // A negative request id encodes as its unsigned two's-complement value.
         yield return new TestCaseData(
                 new Func<BlockAccessListsMessage>(() => BuildMessage(-1)),
-                null)
+                "ca88ffffffffffffffffc0")
             .SetName("Roundtrip_negative_request_id");
     }
 
@@ -128,31 +125,36 @@ public class BlockAccessListsMessageSerializerTests
 public class GetBlockAccessListsMessageSerializerTests
 {
     [TestCaseSource(nameof(GetBlockAccessListsRoundtripCases))]
-    public void Roundtrip(Func<GetBlockAccessListsMessage> buildMessage)
+    public void Roundtrip(Func<GetBlockAccessListsMessage> buildMessage, string expectedData)
     {
         GetBlockAccessListsMessageSerializer serializer = new();
         using GetBlockAccessListsMessage msg = buildMessage();
-        SerializerTester.TestZero(serializer, msg);
+        SerializerTester.TestZero(serializer, msg, expectedData);
     }
 
     private static IEnumerable<TestCaseData> GetBlockAccessListsRoundtripCases()
     {
         yield return new TestCaseData(
-                new Func<GetBlockAccessListsMessage>(() => new GetBlockAccessListsMessage(99, ArrayPoolList<Hash256>.Empty())))
+                new Func<GetBlockAccessListsMessage>(() => new GetBlockAccessListsMessage(99, ArrayPoolList<Hash256>.Empty())),
+                "c263c0")
             .SetName("Roundtrip_empty_hashes");
+        // Each hash encodes as 0xa0 + 32 bytes.
         yield return new TestCaseData(
                 new Func<GetBlockAccessListsMessage>(() => new GetBlockAccessListsMessage(100, new ArrayPoolList<Hash256>(1)
                 {
                     Keccak.Zero
-                })))
+                })),
+                "e364e1a00000000000000000000000000000000000000000000000000000000000000000")
             .SetName("Roundtrip_single_hash");
+        // The hashes are Keccak.Zero, keccak("A"), and keccak("B").
         yield return new TestCaseData(
                 new Func<GetBlockAccessListsMessage>(() => new GetBlockAccessListsMessage(101, new ArrayPoolList<Hash256>(3)
                 {
                     Keccak.Zero,
                     TestItem.KeccakA,
                     TestItem.KeccakB
-                })))
+                })),
+                "f86665f863a00000000000000000000000000000000000000000000000000000000000000000a003783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760a01f675bff07515f5df96737194ea945c36c41e7b4fcef307b7cd4d0e602a69111")
             .SetName("Roundtrip_multiple_hashes");
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/ByteCodesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/ByteCodesMessageSerializerTests.cs
@@ -15,6 +15,20 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
         {
             ArrayPoolList<byte[]> data = new(2) { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed } };
 
+            ByteCodesMessage message = new(new ByteArrayListAdapter(data)) { RequestId = 1 };
+
+            ByteCodesMessageSerializer serializer = new();
+
+            // The message encodes as [requestId, codes].
+            SerializerTester.TestZero(serializer, message, "ca01c884deadc0de82feed");
+        }
+
+        [Test]
+        public void Roundtrip_random_request_id()
+        {
+            ArrayPoolList<byte[]> data = new(2) { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed } };
+
+            // The constructor assigns a random request id; it must roundtrip unchanged.
             ByteCodesMessage message = new(new ByteArrayListAdapter(data));
 
             ByteCodesMessageSerializer serializer = new();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/ByteCodesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/ByteCodesMessageSerializerTests.cs
@@ -10,30 +10,18 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
     [TestFixture, Parallelizable(ParallelScope.All)]
     public class ByteCodesMessageSerializerTests
     {
-        [Test]
-        public void Roundtrip()
+        [TestCase(1L, "ca01c884deadc0de82feed")]
+        [TestCase(long.MaxValue, "d2887fffffffffffffffc884deadc0de82feed")]
+        public void Roundtrip(long requestId, string expectedData)
         {
             ArrayPoolList<byte[]> data = new(2) { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed } };
 
-            ByteCodesMessage message = new(new ByteArrayListAdapter(data)) { RequestId = 1 };
+            using ByteCodesMessage message = new(new ByteArrayListAdapter(data)) { RequestId = requestId };
 
             ByteCodesMessageSerializer serializer = new();
 
             // The message encodes as [requestId, codes].
-            SerializerTester.TestZero(serializer, message, "ca01c884deadc0de82feed");
-        }
-
-        [Test]
-        public void Roundtrip_random_request_id()
-        {
-            ArrayPoolList<byte[]> data = new(2) { new byte[] { 0xde, 0xad, 0xc0, 0xde }, new byte[] { 0xfe, 0xed } };
-
-            // The constructor assigns a random request id; it must roundtrip unchanged.
-            ByteCodesMessage message = new(new ByteArrayListAdapter(data));
-
-            ByteCodesMessageSerializer serializer = new();
-
-            SerializerTester.TestZero(serializer, message);
+            SerializerTester.TestZero(serializer, message, expectedData);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetAccountRangeMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetAccountRangeMessageSerializerTests.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
         {
             GetAccountRangeMessage msg = new()
             {
-                RequestId = 1111,
+                RequestId = SnapSerializerGoldens.RequestId1111,
                 AccountRange = new(Keccak.OfAnEmptyString, SnapSerializerGoldens.RangeStart, SnapSerializerGoldens.RangeLimit),
                 ResponseBytes = 10
             };
@@ -24,12 +24,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
             byte[] bytes = serializer.Serialize(msg);
             GetAccountRangeMessage deserializedMsg = serializer.Deserialize(bytes);
 
-            Assert.That(deserializedMsg.RequestId, Is.EqualTo(msg.RequestId));
-            Assert.That(deserializedMsg.PacketType, Is.EqualTo(msg.PacketType));
-            Assert.That(deserializedMsg.AccountRange.RootHash, Is.EqualTo(msg.AccountRange.RootHash));
-            Assert.That(deserializedMsg.AccountRange.StartingHash, Is.EqualTo(msg.AccountRange.StartingHash));
-            Assert.That(deserializedMsg.AccountRange.LimitHash, Is.EqualTo(msg.AccountRange.LimitHash));
-            Assert.That(deserializedMsg.ResponseBytes, Is.EqualTo(msg.ResponseBytes));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(deserializedMsg.RequestId, Is.EqualTo(msg.RequestId));
+                Assert.That(deserializedMsg.PacketType, Is.EqualTo(msg.PacketType));
+                Assert.That(deserializedMsg.AccountRange.RootHash, Is.EqualTo(msg.AccountRange.RootHash));
+                Assert.That(deserializedMsg.AccountRange.StartingHash, Is.EqualTo(msg.AccountRange.StartingHash));
+                Assert.That(deserializedMsg.AccountRange.LimitHash, Is.EqualTo(msg.AccountRange.LimitHash));
+                Assert.That(deserializedMsg.ResponseBytes, Is.EqualTo(msg.ResponseBytes));
+            }
 
             // The message encodes as [requestId, rootHash, startingHash, limitHash, responseBytes].
             SerializerTester.TestZero(serializer, msg,
@@ -54,8 +57,11 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
             byte[] bytes = serializer.Serialize(msg);
             GetAccountRangeMessage deserializedMsg = serializer.Deserialize(bytes);
 
-            Assert.That(deserializedMsg.AccountRange.LimitHash, Is.EqualTo(Keccak.MaxValue));
-            Assert.That(deserializedMsg.ResponseBytes, Is.EqualTo(1000_000));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(deserializedMsg.AccountRange.LimitHash, Is.EqualTo(Keccak.MaxValue));
+                Assert.That(deserializedMsg.ResponseBytes, Is.EqualTo(1000_000));
+            }
 
             // A null limit hash goes on the wire as Keccak.MaxValue; response bytes 0 as 1000000.
             SerializerTester.TestZero(serializer, msg,

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetAccountRangeMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetAccountRangeMessageSerializerTests.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
             GetAccountRangeMessage msg = new()
             {
                 RequestId = 1111,
-                AccountRange = new(Keccak.OfAnEmptyString, new Hash256("0x15d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), new Hash256("0x20d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")),
+                AccountRange = new(Keccak.OfAnEmptyString, SnapSerializerGoldens.RangeStart, SnapSerializerGoldens.RangeLimit),
                 ResponseBytes = 10
             };
             GetAccountRangeMessageSerializer serializer = new();
@@ -33,10 +33,10 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
 
             // The message encodes as [requestId, rootHash, startingHash, limitHash, responseBytes].
             SerializerTester.TestZero(serializer, msg,
-                "f867" + "820457" +
-                "a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
-                "a015d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
-                "a020d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                "f867" + SnapSerializerGoldens.RequestId1111Rlp +
+                SnapSerializerGoldens.EmptyStringKeccakRlp +
+                SnapSerializerGoldens.RangeStartRlp +
+                SnapSerializerGoldens.RangeLimitRlp +
                 "0a");
         }
 
@@ -60,7 +60,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
             // A null limit hash goes on the wire as Keccak.MaxValue; response bytes 0 as 1000000.
             SerializerTester.TestZero(serializer, msg,
                 "f870" + "887fffffffffffffff" +
-                "a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                SnapSerializerGoldens.EmptyStringKeccakRlp +
                 "a00000000000000000000000000000000000000000000000000000000000000000" +
                 "a0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
                 "830f4240");

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetAccountRangeMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetAccountRangeMessageSerializerTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core.Crypto;
-using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Subprotocols.Snap.V1.Messages;
 using NUnit.Framework;
 
@@ -16,7 +15,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
         {
             GetAccountRangeMessage msg = new()
             {
-                RequestId = MessageConstants.Random.NextLong(),
+                RequestId = 1111,
                 AccountRange = new(Keccak.OfAnEmptyString, new Hash256("0x15d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"), new Hash256("0x20d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")),
                 ResponseBytes = 10
             };
@@ -32,7 +31,13 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
             Assert.That(deserializedMsg.AccountRange.LimitHash, Is.EqualTo(msg.AccountRange.LimitHash));
             Assert.That(deserializedMsg.ResponseBytes, Is.EqualTo(msg.ResponseBytes));
 
-            SerializerTester.TestZero(serializer, msg);
+            // The message encodes as [requestId, rootHash, startingHash, limitHash, responseBytes].
+            SerializerTester.TestZero(serializer, msg,
+                "f867" + "820457" +
+                "a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                "a015d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                "a020d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                "0a");
         }
 
         [Test]
@@ -40,7 +45,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
         {
             GetAccountRangeMessage msg = new()
             {
-                RequestId = MessageConstants.Random.NextLong(),
+                // long.MaxValue also pins the eight-byte request-id encoding.
+                RequestId = long.MaxValue,
                 AccountRange = new(Keccak.OfAnEmptyString, Keccak.Zero)
             };
             GetAccountRangeMessageSerializer serializer = new();
@@ -51,7 +57,13 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
             Assert.That(deserializedMsg.AccountRange.LimitHash, Is.EqualTo(Keccak.MaxValue));
             Assert.That(deserializedMsg.ResponseBytes, Is.EqualTo(1000_000));
 
-            SerializerTester.TestZero(serializer, msg);
+            // A null limit hash goes on the wire as Keccak.MaxValue; response bytes 0 as 1000000.
+            SerializerTester.TestZero(serializer, msg,
+                "f870" + "887fffffffffffffff" +
+                "a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                "a00000000000000000000000000000000000000000000000000000000000000000" +
+                "a0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+                "830f4240");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetByteCodesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetByteCodesMessageSerializerTests.cs
@@ -37,7 +37,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
         {
             GetByteCodesMessage msg = new()
             {
-                RequestId = 1111,
+                RequestId = SnapSerializerGoldens.RequestId1111,
                 Hashes = ArrayPoolList<ValueHash256>.Empty(),
                 Bytes = 10
             };

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetByteCodesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetByteCodesMessageSerializerTests.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
             GetByteCodesMessageSerializer serializer = new();
 
             // The message encodes as [requestId, hashes, bytes].
-            SerializerTester.TestZero(serializer, msg, "c5820457c00a");
+            SerializerTester.TestZero(serializer, msg, "c5" + SnapSerializerGoldens.RequestId1111Rlp + "c0" + "0a");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetByteCodesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetByteCodesMessageSerializerTests.cs
@@ -37,14 +37,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
         {
             GetByteCodesMessage msg = new()
             {
-                RequestId = MessageConstants.Random.NextLong(),
+                RequestId = 1111,
                 Hashes = ArrayPoolList<ValueHash256>.Empty(),
                 Bytes = 10
             };
 
             GetByteCodesMessageSerializer serializer = new();
 
-            SerializerTester.TestZero(serializer, msg);
+            // The message encodes as [requestId, hashes, bytes].
+            SerializerTester.TestZero(serializer, msg, "c5820457c00a");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetStorageRangesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetStorageRangesMessageSerializerTests.cs
@@ -28,8 +28,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
                 {
                     RootHash = TestItem.KeccakA,
                     Accounts = TestItem.Keccaks.Select(static k => new PathWithAccount(k, null)).ToPooledList(TestItem.Keccaks.Length),
-                    StartingHash = new Hash256("0x15d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"),
-                    LimitHash = new Hash256("0x20d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+                    StartingHash = SnapSerializerGoldens.RangeStart,
+                    LimitHash = SnapSerializerGoldens.RangeLimit
                 },
                 ResponseBytes = 1000
             };
@@ -49,8 +49,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
                 {
                     RootHash = Keccak.OfAnEmptyString,
                     Accounts = ArrayPoolList<PathWithAccount>.Empty(),
-                    StartingHash = new Hash256("0x15d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"),
-                    LimitHash = new Hash256("0x20d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+                    StartingHash = SnapSerializerGoldens.RangeStart,
+                    LimitHash = SnapSerializerGoldens.RangeLimit
                 },
                 ResponseBytes = 1000
             };
@@ -58,11 +58,11 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
 
             // The message encodes as [requestId, rootHash, accountPaths, startingHash, limitHash, responseBytes].
             SerializerTester.TestZero(serializer, msg,
-                "f86a" + "820457" +
-                "a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                "f86a" + SnapSerializerGoldens.RequestId1111Rlp +
+                SnapSerializerGoldens.EmptyStringKeccakRlp +
                 "c0" +
-                "a015d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
-                "a020d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                SnapSerializerGoldens.RangeStartRlp +
+                SnapSerializerGoldens.RangeLimitRlp +
                 "8203e8");
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetStorageRangesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetStorageRangesMessageSerializerTests.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
         {
             GetStorageRangeMessage msg = new()
             {
-                RequestId = 1111,
+                RequestId = SnapSerializerGoldens.RequestId1111,
                 StorageRange = new()
                 {
                     RootHash = Keccak.OfAnEmptyString,

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetStorageRangesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetStorageRangesMessageSerializerTests.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
         {
             GetStorageRangeMessage msg = new()
             {
-                RequestId = MessageConstants.Random.NextLong(),
+                RequestId = 1111,
                 StorageRange = new()
                 {
                     RootHash = Keccak.OfAnEmptyString,
@@ -56,7 +56,14 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
             };
             GetStorageRangesMessageSerializer serializer = new();
 
-            SerializerTester.TestZero(serializer, msg);
+            // The message encodes as [requestId, rootHash, accountPaths, startingHash, limitHash, responseBytes].
+            SerializerTester.TestZero(serializer, msg,
+                "f86a" + "820457" +
+                "a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                "c0" +
+                "a015d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                "a020d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470" +
+                "8203e8");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/SnapSerializerGoldens.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/SnapSerializerGoldens.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages;
+
+/// <summary>
+/// Shared inputs and hand-derived RLP fragments for the snap serializer goldens.
+/// </summary>
+/// <remarks>
+/// Each golden fragment and its input come from one hex constant, so the
+/// expectation cannot drift from the input. The values are verified with an
+/// independent encoder (pyrlp + pycryptodome keccak).
+/// </remarks>
+internal static class SnapSerializerGoldens
+{
+    private const string EmptyStringKeccakHex = "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
+    private const string RangeStartHex = "15d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
+    private const string RangeLimitHex = "20d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
+
+    /// <summary>Request id 1111 as an RLP item: 0x82 length prefix + 0x0457.</summary>
+    public const string RequestId1111Rlp = "820457";
+
+    /// <summary>keccak("") as an RLP item: 0xa0 + 32 bytes.</summary>
+    public const string EmptyStringKeccakRlp = "a0" + EmptyStringKeccakHex;
+
+    /// <summary><see cref="RangeStart"/> as an RLP item.</summary>
+    public const string RangeStartRlp = "a0" + RangeStartHex;
+
+    /// <summary><see cref="RangeLimit"/> as an RLP item.</summary>
+    public const string RangeLimitRlp = "a0" + RangeLimitHex;
+
+    /// <summary>The starting hash the range request tests use.</summary>
+    public static readonly Hash256 RangeStart = new(RangeStartHex);
+
+    /// <summary>The limit hash the range request tests use.</summary>
+    public static readonly Hash256 RangeLimit = new(RangeLimitHex);
+}

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/SnapSerializerGoldens.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/SnapSerializerGoldens.cs
@@ -9,9 +9,11 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages;
 /// Shared inputs and hand-derived RLP fragments for the snap serializer goldens.
 /// </summary>
 /// <remarks>
-/// Each golden fragment and its input come from one hex constant, so the
-/// expectation cannot drift from the input. The values are verified with an
-/// independent encoder (pyrlp + pycryptodome keccak).
+/// The range fragments and their <see cref="Hash256"/> inputs come from one hex
+/// constant each, so those expectations cannot drift from the inputs.
+/// <see cref="EmptyStringKeccakRlp"/> is a deliberately independent literal: the
+/// tests feed <c>Keccak.OfAnEmptyString</c>, so the fragment also pins keccak("").
+/// The values are verified with an independent encoder (pyrlp + pycryptodome keccak).
 /// </remarks>
 internal static class SnapSerializerGoldens
 {
@@ -19,7 +21,10 @@ internal static class SnapSerializerGoldens
     private const string RangeStartHex = "15d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
     private const string RangeLimitHex = "20d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
 
-    /// <summary>Request id 1111 as an RLP item: 0x82 length prefix + 0x0457.</summary>
+    /// <summary>The request id the golden request tests use.</summary>
+    public const long RequestId1111 = 1111;
+
+    /// <summary><see cref="RequestId1111"/> as an RLP item: 0x82 length prefix + 0x0457.</summary>
     public const string RequestId1111Rlp = "820457";
 
     /// <summary>keccak("") as an RLP item: 0xa0 + 32 bytes.</summary>


### PR DESCRIPTION
## Changes

How to review this fast: three commits - the golden tests, a user-requested constants hoist, then review-feedback fixes; 6 files, all under `Nethermind.Network.Test` (verified: no non-test file in the diff); +113/-39.

Rule for this chunk: every serializer test file in Eth V68/V69/V71 and Snap/V1 asserts an exact wire encoding somewhere. These encodings are consensus-observable, so no expected value was captured from Nethermind's own output - each was hand-derived from the RLP rules and independently verified with pyrlp (the ethereum reference RLP implementation) plus pycryptodome keccak.

Most files in these directories already had golden tests (V68, V69 Status/BlockRangeUpdate/Receipts with Geth-sourced vectors, Snap AccountRange/StorageRanges/TrieNodes/GetTrieNodes). The gaps:

- **V71 `BlockAccessListsMessageSerializerTests`**: the two roundtrip cases that passed a null expectation now pin `c22ac0` (empty) and `ca88ff...c0` (a negative request id encodes as its unsigned two's-complement value); the now-unreachable null guard is gone and the expectation parameter is non-nullable. The `GetBlockAccessLists` fixture had no exact-encoding assert at all; its three roundtrip cases now carry hand-derived expected values.
- **Snap `GetAccountRangeMessageSerializerTests`**: both tests pinned. `Roundtrip` (request id 1111) pins the flat `[requestId, rootHash, startingHash, limitHash, responseBytes]` layout. `Roundtrip_Defaults` pins `RequestId = long.MaxValue` - keeping the eight-byte-id encode path deterministically covered - and wire-pins the serializer's normalizations: a null limit hash goes out as `Keccak.MaxValue` and response bytes 0 as 1,000,000.
- **Snap `GetByteCodes` / `GetStorageRanges`**: the empty-variant roundtrips pin their layouts; expected values are split at field boundaries so a reviewer can map segment to field.
- **Snap `ByteCodesMessageSerializerTests`**: the roundtrip is parameterized over two pinned ids - `1` (`ca01c884deadc0de82feed`) and `long.MaxValue` (`d288...`), which covers the eight-byte-id path deterministically. The constructor assigns a random id by default - a first golden attempt caught that live.
- Random request ids (`MessageConstants.Random.NextLong()`) are pinned only in tests that assert exact bytes; the other roundtrips keep them.
- **`SnapSerializerGoldens`** (second commit): the repeated fragments - request id 1111, keccak("") item, range start/limit items - live once; each golden fragment and its `Hash256` test input are built from the same hex constant, so the expectation cannot drift from the input.

Derivations (each re-derived byte-for-byte by two independent reviews): request ids per the RLP integer rules (including `-1` -> eight `0xff` bytes and `long.MaxValue` -> `887fffffffffffffff`); hash items as `0xa0` + 32 bytes with keccak("") = `c5d246...` (cross-checked against the existing V62 GetBlockHeaders golden test), keccak("A")/("B") matching the values pinned in #12696; framing lengths verified by frame arithmetic and pyrlp.

Deliberately untouched: V68 and the anchored V69/Snap files above; the V71 keccak hex duplicates a constant #12696 adds (`EthSerializerGoldens`) - folding it in is a post-merge follow-up since that branch is not an ancestor. V69 `ReceiptMessageDecoder69Tests` does not pin the eth/69 bloom-absence on the wire; it is a decoder test outside this rule's wording and is tracked for a later chunk.

Part of the test-hygiene series (#12689, #12690, #12693, #12694, #12696).

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- Mutation-checked, 5/5 detected (each deliberate break made the golden tests fail, then was reverted): `requestId ^ 1` in the shared eth/66 serializer base fails 15 V71 tests including all five new expected values; swapping starting/limit hash in GetAccountRange fails both of its golden tests; per-serializer request-id mutations fail each snap golden test (ByteCodes fails all three tests including the pre-existing fixed vector). The constants hoist landed after the mutation pass; the reassembled values were machine-verified byte-identical, and all fixtures re-ran green.
- Full local suite green (windows-x64, release): Nethermind.Network.Test 1289 total, 0 failed, 8 skipped (pre-existing discovery/rlpx skips, none in touched files). Subprotocol fixtures (546 tests) repeated 3x with no flakes.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No
