### PR TITLE
EIP-8141: align SIGPARAM copy operand order with CALLDATACOPY

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -469,7 +469,7 @@ public class FrameTxProcessorTests
     {
         // signature bytes[i] == i; copy 8 bytes from dataOffset 4 into memOffset 0, then MLOAD(0).
         // Operand order (top to bottom) is memOffset, dataOffset, length — matching CALLDATACOPY and
-        // FRAMEDATACOPY (ethereum/EIPs#12042). Asymmetric operands catch a reversed pop order.
+        // FRAMEDATACOPY. Asymmetric operands catch a reversed pop order.
         byte[] signatureBytes = new byte[32];
         for (int i = 0; i < signatureBytes.Length; i++) signatureBytes[i] = (byte)i;
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -416,6 +416,34 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_FrameDataCopy_UsesMemOffsetDataOffsetLengthFrameIndexOrder()
+    {
+        // frameData[i] == i; copy 8 bytes from dataOffset 4 into memOffset 0, then MLOAD(0).
+        // Operand order (top to bottom) is memOffset, dataOffset, length, frameIndex — matching
+        // CALLDATACOPY plus the trailing frameIndex. Asymmetric operands catch a reversed pop order.
+        byte[] frameData = new byte[32];
+        for (int i = 0; i < frameData.Length; i++) frameData[i] = (byte)i;
+
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData(1).PushData(8).PushData(4).PushData(0) // frameIndex, length, dataOffset, memOffset (deepest to top)
+            .Op(Instruction.FRAMEDATACOPY)
+            .PushData(0).Op(Instruction.MLOAD).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeDefault, target: Recipient, data: frameData),
+            Frame(TxFrame.ModeDefault, target: Observer));
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        byte[] expected = new byte[32];
+        frameData.AsSpan(4, 8).CopyTo(expected); // copied bytes land in the high-order end of the word
+        AssertStorage(Observer, 0, new UInt256(expected, isBigEndian: true));
+    }
+
+    [Test]
     public void Execute_SigParam_ReadsArbitrarySignatureMetadata()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -437,6 +437,33 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_SigParamCopy_UsesMemOffsetDataOffsetLengthOrder()
+    {
+        // signature bytes[i] == i; copy 8 bytes from dataOffset 4 into memOffset 0, then MLOAD(0).
+        // Operand order (top to bottom) is memOffset, dataOffset, length — matching CALLDATACOPY and
+        // FRAMEDATACOPY (ethereum/EIPs#12042). Asymmetric operands catch a reversed pop order.
+        byte[] signatureBytes = new byte[32];
+        for (int i = 0; i < signatureBytes.Length; i++) signatureBytes[i] = (byte)i;
+
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData(8).PushData(4).PushData(0)   // length, dataOffset, memOffset (deepest to top)
+            .PushData(0x04).PushData(0)            // param (copy form), signatureIndex on top
+            .Op(Instruction.SIGPARAM)
+            .PushData(0).Op(Instruction.MLOAD).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeArbitrary, null, default, signatureBytes)];
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        byte[] expected = new byte[32];
+        signatureBytes.AsSpan(4, 8).CopyTo(expected); // copied bytes land in the high-order end of the word
+        AssertStorage(Observer, 0, new UInt256(expected, isBigEndian: true));
+    }
+
+    [Test]
     public void Execute_SigParamResolvedSignerOfArbitraryEntry_ExceptionallyHalts()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
@@ -37,8 +37,8 @@ public static partial class EvmInstructions
     }
 
     /// <summary>
-    /// Copy-to-memory core with operands already popped, for instructions whose stack layout
-    /// differs from the CODECOPY/CALLDATACOPY order.
+    /// Copy-to-memory core with the three copy operands (destination offset, source offset, length)
+    /// already popped, for callers that pop preceding operands first (e.g. SIGPARAM and FRAMEDATACOPY).
     /// </summary>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -217,10 +217,9 @@ public static unsafe partial class EvmInstructions
         if (param.u0 == 0x04)
         {
             if (signature.Scheme != TxFrameSignature.SchemeArbitrary) return EvmExceptionType.BadInstruction;
-            // Spec stack order after signatureIndex/param: length, dataOffset, memOffset.
-            // EIP8141-ISSUE: this is the reverse of the CALLDATACOPY operand order — likely a spec
-            // oversight worth pinning with an explicit stack table; implemented as written.
-            if (!stack.PopUInt256(out UInt256 length, out UInt256 dataOffset, out UInt256 memOffset))
+            // Spec stack order after signatureIndex/param: memOffset, dataOffset, length —
+            // matching CALLDATACOPY/CODECOPY/RETURNDATACOPY and the sibling FRAMEDATACOPY (ethereum/EIPs#12042).
+            if (!stack.PopUInt256(out UInt256 memOffset, out UInt256 dataOffset, out UInt256 length))
                 return EvmExceptionType.StackUnderflow;
             return DataCopyCore<TGasPolicy, TTracingInst>(vm, ref gas, in memOffset, in dataOffset, in length, signature.Signature.Span);
         }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -119,8 +119,7 @@ public static unsafe partial class EvmInstructions
         if (ctx is null) return EvmExceptionType.BadInstruction;
 
         TGasPolicy.Consume<VeryLowGasCost>(ref gas);
-        // EIP8141-ISSUE: no explicit stack table (audit L-8); the prose lists offset, frameIndex —
-        // read top-to-bottom, so offset is on top (matching CALLDATALOAD).
+        // Spec stack order: offset on top, frameIndex second (matching CALLDATALOAD).
         if (!stack.PopUInt256(out UInt256 offset, out UInt256 frameIndex)) return EvmExceptionType.StackUnderflow;
         if (frameIndex >= (UInt256)ctx.Frames.Length) return EvmExceptionType.BadInstruction;
 
@@ -146,8 +145,7 @@ public static unsafe partial class EvmInstructions
         FrameTxContext? ctx = vm.TxExecutionContext.FrameTxContext;
         if (ctx is null) return EvmExceptionType.BadInstruction;
 
-        // EIP8141-ISSUE: no explicit stack table (audit L-8); the prose lists memOffset, dataOffset,
-        // length, frameIndex — read top-to-bottom like the SIGPARAM copy list, so frameIndex is deepest.
+        // Spec stack order: memOffset, dataOffset, length, frameIndex (top to bottom, matching CALLDATACOPY).
         if (!stack.PopUInt256(out UInt256 memOffset, out UInt256 dataOffset, out UInt256 length, out UInt256 frameIndex))
             return EvmExceptionType.StackUnderflow;
         if (frameIndex >= (UInt256)ctx.Frames.Length) return EvmExceptionType.BadInstruction;
@@ -217,8 +215,6 @@ public static unsafe partial class EvmInstructions
         if (param.u0 == 0x04)
         {
             if (signature.Scheme != TxFrameSignature.SchemeArbitrary) return EvmExceptionType.BadInstruction;
-            // Spec stack order after signatureIndex/param: memOffset, dataOffset, length —
-            // matching CALLDATACOPY/CODECOPY/RETURNDATACOPY and the sibling FRAMEDATACOPY (ethereum/EIPs#12042).
             if (!stack.PopUInt256(out UInt256 memOffset, out UInt256 dataOffset, out UInt256 length))
                 return EvmExceptionType.StackUnderflow;
             return DataCopyCore<TGasPolicy, TTracingInst>(vm, ref gas, in memOffset, in dataOffset, in length, signature.Signature.Span);


### PR DESCRIPTION
Impl follow-up to the merged spec change ethereum/EIPs#12042. Swaps the SIGPARAM copy (`param == 0x04`) operands to `memOffset, dataOffset, length` so they match `CALLDATACOPY`/`CODECOPY`/`RETURNDATACOPY` and the sibling `FRAMEDATACOPY`, which already used memOffset-first. Adds a regression test that pins the new order with asymmetric operands.