### PR TITLE
EIP-8141: support blob-carrying frame transactions (validate correctly, produce conservatively)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -491,6 +491,39 @@ namespace Nethermind.Blockchain.Test
             }
         }
 
+        [Test]
+        public void CanAddTransaction_skips_blob_carrying_frame_transaction()
+        {
+            // EIP8141: block production does not yet meter blob-carrying frame txs against the block
+            // blob budget, so the picker excludes them conservatively to avoid self-invalidating a block.
+            IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+            using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+            stateProvider.CreateAccount(TestItem.AddressA, 1.Ether);
+
+            ISpecProvider specProvider = new TestSingleReleaseSpecProvider(Eip8141Prototype.Instance);
+
+            Transaction frameBlobTx = Build.A.Transaction
+                .WithType(TxType.FrameTx)
+                .WithBlobVersionedHashes(1)
+                .WithSenderAddress(TestItem.AddressA)
+                .WithNonce(0)
+                .WithGasLimit(GasCostOf.Transaction)
+                .TestObject;
+
+            Block block = Build.A.Block
+                .WithNumber(1)
+                .WithExcessBlobGas(0)
+                .WithGasLimit(30_000_000)
+                .TestObject;
+
+            BlockProcessor.BlockProductionTransactionPicker picker = new(specProvider);
+            BlockProcessor.AddingTxEventArgs args =
+                picker.CanAddTransaction(block, frameBlobTx, new HashSet<Transaction>(), stateProvider);
+
+            Assert.That(args.Action, Is.EqualTo(BlockProcessor.TxAction.Skip));
+            Assert.That(args.Reason, Does.Contain("frame"));
+        }
+
         private static Transaction[] RunBlockProduction(
             ITransactionProcessorAdapter transactionProcessor,
             IWorldState stateProvider,

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -891,6 +891,19 @@ public class TxValidatorTests
         Assert.That(result.Error, Is.EqualTo(TxErrorMessages.InvalidBlobVersionedHashVersion));
     }
 
+    [Test]
+    public void IsWellFormed_FrameTxWithoutMaxFeePerBlobGas_ReturnFalse()
+    {
+        Transaction tx = BuildBlobFrameTx(blobCount: 1);
+        tx.MaxFeePerBlobGas = null;
+        TxValidator txValidator = new(TestBlockchainIds.ChainId);
+
+        ValidationResult result = txValidator.IsWellFormed(tx, Bogota.Instance);
+
+        Assert.That(result.AsBool(), Is.False);
+        Assert.That(result.Error, Is.EqualTo(TxErrorMessages.BlobTxMissingMaxFeePerBlobGas));
+    }
+
     private static Transaction BuildBlobFrameTx(int blobCount, byte versionByte = KzgPolynomialCommitments.KzgBlobHashVersionV1)
     {
         byte[][] versionedHashes = new byte[blobCount][];

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -848,13 +848,12 @@ public class TxValidatorTests
         }
     }
 
-    // EIP-7594 (ethereum/EIPs#11985): a blob-carrying frame tx (EIP-8141) is bound by the same per-tx
-    // blob-count limit (BLOB_COUNT_LIMIT = 6) and versioned-hash version byte (0x01) as a type-3 blob tx,
-    // matching EELS validate_frame_transaction.
+    // EIP-7594/EIP-8141: a blob-carrying frame tx is bound by the same per-tx blob-count limit and
+    // versioned-hash version byte (0x01) as a type-3 blob tx.
     private static IEnumerable<int> FrameTxWithinBlobCountLimitCases()
     {
         yield return 1;
-        yield return (int)Bogota.Instance.MaxBlobsPerTx; // BLOB_COUNT_LIMIT
+        yield return (int)Bogota.Instance.MaxBlobsPerTx;
     }
 
     [TestCaseSource(nameof(FrameTxWithinBlobCountLimitCases))]

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -847,6 +847,71 @@ public class TxValidatorTests
             };
         }
     }
+
+    // EIP-7594 (ethereum/EIPs#11985): a blob-carrying frame tx (EIP-8141) is bound by the same per-tx
+    // blob-count limit (BLOB_COUNT_LIMIT = 6) and versioned-hash version byte (0x01) as a type-3 blob tx,
+    // matching EELS validate_frame_transaction.
+    [Test]
+    public void IsWellFormed_FrameTxWithSingleValidBlob_ReturnTrue()
+    {
+        Transaction tx = BuildBlobFrameTx(blobCount: 1);
+        TxValidator txValidator = new(TestBlockchainIds.ChainId);
+
+        Assert.That(txValidator.IsWellFormed(tx, Bogota.Instance).AsBool(), Is.True);
+    }
+
+    [Test]
+    public void IsWellFormed_FrameTxAtBlobCountLimit_ReturnTrue()
+    {
+        Transaction tx = BuildBlobFrameTx(blobCount: (int)Bogota.Instance.MaxBlobsPerTx);
+        TxValidator txValidator = new(TestBlockchainIds.ChainId);
+
+        Assert.That(txValidator.IsWellFormed(tx, Bogota.Instance).AsBool(), Is.True);
+    }
+
+    [Test]
+    public void IsWellFormed_FrameTxExceedsBlobCountLimit_ReturnFalse()
+    {
+        Transaction tx = BuildBlobFrameTx(blobCount: (int)Bogota.Instance.MaxBlobsPerTx + 1);
+        TxValidator txValidator = new(TestBlockchainIds.ChainId);
+
+        Assert.That(txValidator.IsWellFormed(tx, Bogota.Instance).AsBool(), Is.False);
+    }
+
+    [Test]
+    public void IsWellFormed_FrameTxWithWrongVersionedHashVersionByte_ReturnFalse()
+    {
+        Transaction tx = BuildBlobFrameTx(blobCount: 1, versionByte: 0x02);
+        TxValidator txValidator = new(TestBlockchainIds.ChainId);
+
+        ValidationResult result = txValidator.IsWellFormed(tx, Bogota.Instance);
+
+        Assert.That(result.AsBool(), Is.False);
+        Assert.That(result.Error, Is.EqualTo(TxErrorMessages.InvalidBlobVersionedHashVersion));
+    }
+
+    private static Transaction BuildBlobFrameTx(int blobCount, byte versionByte = KzgPolynomialCommitments.KzgBlobHashVersionV1)
+    {
+        byte[][] versionedHashes = new byte[blobCount][];
+        for (int i = 0; i < blobCount; i++)
+        {
+            byte[] hash = new byte[Eip4844Constants.BytesPerBlobVersionedHash];
+            hash[0] = versionByte;
+            versionedHashes[i] = hash;
+        }
+
+        return new Transaction
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            SenderAddress = TestItem.AddressA,
+            Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default)],
+            FrameSignatures = [],
+            DecodedMaxFeePerGas = 100_000,
+            MaxFeePerBlobGas = 1,
+            BlobVersionedHashes = versionedHashes,
+        };
+    }
 }
 
 /// <summary>The EIP-7906 fork gate on the <c>POST_TX</c> frame mode.</summary>

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -851,31 +851,33 @@ public class TxValidatorTests
     // EIP-7594 (ethereum/EIPs#11985): a blob-carrying frame tx (EIP-8141) is bound by the same per-tx
     // blob-count limit (BLOB_COUNT_LIMIT = 6) and versioned-hash version byte (0x01) as a type-3 blob tx,
     // matching EELS validate_frame_transaction.
-    [Test]
-    public void IsWellFormed_FrameTxWithSingleValidBlob_ReturnTrue()
+    private static IEnumerable<int> FrameTxWithinBlobCountLimitCases()
     {
-        Transaction tx = BuildBlobFrameTx(blobCount: 1);
+        yield return 1;
+        yield return (int)Bogota.Instance.MaxBlobsPerTx; // BLOB_COUNT_LIMIT
+    }
+
+    [TestCaseSource(nameof(FrameTxWithinBlobCountLimitCases))]
+    public void IsWellFormed_FrameTxWithinBlobCountLimit_ReturnTrue(int blobCount)
+    {
+        Transaction tx = BuildBlobFrameTx(blobCount);
         TxValidator txValidator = new(TestBlockchainIds.ChainId);
 
         Assert.That(txValidator.IsWellFormed(tx, Bogota.Instance).AsBool(), Is.True);
     }
 
     [Test]
-    public void IsWellFormed_FrameTxAtBlobCountLimit_ReturnTrue()
+    public void IsWellFormed_FrameTxExceedsBlobCountLimit_ReturnBlobGasLimitExceeded()
     {
-        Transaction tx = BuildBlobFrameTx(blobCount: (int)Bogota.Instance.MaxBlobsPerTx);
+        int blobCount = (int)Bogota.Instance.MaxBlobsPerTx + 1;
+        Transaction tx = BuildBlobFrameTx(blobCount);
         TxValidator txValidator = new(TestBlockchainIds.ChainId);
 
-        Assert.That(txValidator.IsWellFormed(tx, Bogota.Instance).AsBool(), Is.True);
-    }
+        ValidationResult result = txValidator.IsWellFormed(tx, Bogota.Instance);
 
-    [Test]
-    public void IsWellFormed_FrameTxExceedsBlobCountLimit_ReturnFalse()
-    {
-        Transaction tx = BuildBlobFrameTx(blobCount: (int)Bogota.Instance.MaxBlobsPerTx + 1);
-        TxValidator txValidator = new(TestBlockchainIds.ChainId);
-
-        Assert.That(txValidator.IsWellFormed(tx, Bogota.Instance).AsBool(), Is.False);
+        Assert.That(result.AsBool(), Is.False);
+        Assert.That(result.Error, Is.EqualTo(TxErrorMessages.BlobTxGasLimitExceeded(
+            (ulong)blobCount * Eip4844Constants.GasPerBlob, Bogota.Instance.GasCosts.MaxBlobGasPerTx)));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -137,7 +137,7 @@ namespace Nethermind.Consensus.Processing
                         return false;
                     }
 
-                    if (transaction.SupportsBlobs && (
+                    if (transaction.BlobVersionedHashes is { Length: > 0 } && (
                         !BlobGasCalculator.TryCalculateBlobBaseFee(block.Header, transaction, releaseSpec.BlobBaseFeeUpdateFraction, out UInt256 blobBaseFee) ||
                         senderBalance < (maxFee += blobBaseFee)))
                     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -78,6 +78,16 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, $"Not enough gas in block, gas limit {txGasBudget} > {gasRemaining}");
                 }
 
+                // EIP8141: blob-carrying frame transactions sit in the normal pool and are not yet
+                // metered against the block blob budget during production (deferred: blob-pool routing
+                // and blob-budget selection). Now that they count towards header.BlobGasUsed, an
+                // unguarded producer could exceed MaxBlobGasPerBlock and self-invalidate the block.
+                // Exclude them conservatively until block production tracks their blob gas.
+                if (currentTx.Type == TxType.FrameTx && currentTx.BlobVersionedHashes is { Length: > 0 })
+                {
+                    return args.Set(TxAction.Skip, "Blob-carrying frame transaction not yet supported in block production");
+                }
+
                 if (currentTx.IsAboveInitCode(spec))
                 {
                     return args.Set(TxAction.Skip, TransactionResult.TransactionSizeOverMaxInitCodeSize.ErrorDescription);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -65,6 +65,13 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, "Transaction already in block");
                 }
 
+                // EIP-8141: block production does not yet meter blob-carrying frame txs against the block
+                // blob budget, so exclude them conservatively rather than risk exceeding MaxBlobGasPerBlock.
+                if (currentTx.Type == TxType.FrameTx && currentTx.BlobVersionedHashes is { Length: > 0 })
+                {
+                    return args.Set(TxAction.Skip, "Blob-carrying frame transaction not yet supported in block production");
+                }
+
                 // A frame transaction's GasLimit is only the sum of its frame gas limits, so gating on it alone would
                 // let the produced block exceed its own gas limit. A transaction that cannot be priced never fits.
                 ulong txGasBudget = !currentTx.SupportsFrames
@@ -76,13 +83,6 @@ namespace Nethermind.Consensus.Processing
                 if (txGasBudget > gasRemaining)
                 {
                     return args.Set(TxAction.Skip, $"Not enough gas in block, gas limit {txGasBudget} > {gasRemaining}");
-                }
-
-                // EIP-8141: block production does not yet meter blob-carrying frame txs against the block
-                // blob budget, so exclude them conservatively rather than risk exceeding MaxBlobGasPerBlock.
-                if (currentTx.Type == TxType.FrameTx && currentTx.BlobVersionedHashes is { Length: > 0 })
-                {
-                    return args.Set(TxAction.Skip, "Blob-carrying frame transaction not yet supported in block production");
                 }
 
                 if (currentTx.IsAboveInitCode(spec))

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -78,11 +78,8 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, $"Not enough gas in block, gas limit {txGasBudget} > {gasRemaining}");
                 }
 
-                // EIP8141: blob-carrying frame transactions sit in the normal pool and are not yet
-                // metered against the block blob budget during production (deferred: blob-pool routing
-                // and blob-budget selection). Now that they count towards header.BlobGasUsed, an
-                // unguarded producer could exceed MaxBlobGasPerBlock and self-invalidate the block.
-                // Exclude them conservatively until block production tracks their blob gas.
+                // EIP-8141: block production does not yet meter blob-carrying frame txs against the block
+                // blob budget, so exclude them conservatively rather than risk exceeding MaxBlobGasPerBlock.
                 if (currentTx.Type == TxType.FrameTx && currentTx.BlobVersionedHashes is { Length: > 0 })
                 {
                     return args.Set(TxAction.Skip, "Blob-carrying frame transaction not yet supported in block production");

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -348,8 +348,7 @@ public class BlockValidator(
         {
             Transaction transaction = transactions[txIndex];
 
-            // EIP-8141: a blob-carrying frame transaction (type 6) follows EIP-4844 too, so gate on the
-            // presence of blob hashes rather than the type-level SupportsBlobs (which is type-3 only).
+            // EIP-8141: gate on blob hashes, not the type-3-only SupportsBlobs, so blob-carrying frame txs also count.
             if (transaction.BlobVersionedHashes is not { Length: > 0 })
             {
                 continue;

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -348,7 +348,9 @@ public class BlockValidator(
         {
             Transaction transaction = transactions[txIndex];
 
-            if (!transaction.SupportsBlobs)
+            // EIP-8141: a blob-carrying frame transaction (type 6) follows EIP-4844 too, so gate on the
+            // presence of blob hashes rather than the type-level SupportsBlobs (which is type-3 only).
+            if (transaction.BlobVersionedHashes is not { Length: > 0 })
             {
                 continue;
             }

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -202,6 +202,11 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
         byte[]?[]? blobVersionedHashes = transaction.BlobVersionedHashes;
         if (blobVersionedHashes is { Length: > 0 })
         {
+            if (transaction.MaxFeePerBlobGas is null)
+            {
+                return TxErrorMessages.BlobTxMissingMaxFeePerBlobGas;
+            }
+
             ValidationResult blobGasLimitResult = BlobFieldsTxValidator.ValidateBlobGasLimits(blobVersionedHashes.Length, releaseSpec);
             return !blobGasLimitResult ? blobGasLimitResult : BlobFieldsTxValidator.ValidateBlobVersionedHashes(blobVersionedHashes);
         }
@@ -282,7 +287,7 @@ public sealed class BlobFieldsTxValidator : ITxValidator
     /// Validates that every blob versioned hash is present, 32 bytes, and carries the KZG version byte
     /// (EIP-4844 <c>VERSIONED_HASH_VERSION_KZG = 0x01</c>).
     /// </summary>
-    public static ValidationResult ValidateBlobVersionedHashes(byte[]?[] blobVersionedHashes)
+    internal static ValidationResult ValidateBlobVersionedHashes(byte[]?[] blobVersionedHashes)
     {
         foreach (byte[]? versionedHash in blobVersionedHashes)
         {

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -182,17 +182,32 @@ public sealed class GasFieldsTxValidator : ITxValidator
 }
 
 /// <summary>
-/// EIP-8141 static constraints (frame modes, flags, atomic batch shape, signature schemes).
+/// EIP-8141 static constraints (frame modes, flags, atomic batch shape, signature schemes) plus the
+/// EIP-7594 blob constraints for a blob-carrying frame transaction.
 /// </summary>
 public sealed class FrameTxFieldsTxValidator : ITxValidator
 {
     public static readonly FrameTxFieldsTxValidator Instance = new();
     private FrameTxFieldsTxValidator() { }
 
-    public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
-        FrameTxValidation.IsWellFormed(transaction, releaseSpec.IsEip7906Enabled, out string? error)
-            ? ValidationResult.Success
-            : error!;
+    public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
+    {
+        if (!FrameTxValidation.IsWellFormed(transaction, releaseSpec.IsEip7906Enabled, out string? error))
+        {
+            return error!;
+        }
+
+        // EIP-7594: a blob-carrying frame tx is bound by the same per-tx blob-count
+        // limit and versioned-hash version byte as a type-3 blob tx.
+        byte[]?[]? blobVersionedHashes = transaction.BlobVersionedHashes;
+        if (blobVersionedHashes is { Length: > 0 })
+        {
+            ValidationResult blobGasLimitResult = BlobFieldsTxValidator.ValidateBlobGasLimits(blobVersionedHashes.Length, releaseSpec);
+            return !blobGasLimitResult ? blobGasLimitResult : BlobFieldsTxValidator.ValidateBlobVersionedHashes(blobVersionedHashes);
+        }
+
+        return ValidationResult.Success;
+    }
 }
 
 public sealed class ContractSizeTxValidator : ITxValidator
@@ -260,13 +275,22 @@ public sealed class BlobFieldsTxValidator : ITxValidator
             return blobPerTxLimitValidationResult;
         }
 
-        for (int i = 0; i < blobCount; i++)
+        return ValidateBlobVersionedHashes(transaction.BlobVersionedHashes!);
+    }
+
+    /// <summary>
+    /// Validates that every blob versioned hash is present, 32 bytes, and carries the KZG version byte
+    /// (EIP-4844 <c>VERSIONED_HASH_VERSION_KZG = 0x01</c>).
+    /// </summary>
+    public static ValidationResult ValidateBlobVersionedHashes(byte[]?[] blobVersionedHashes)
+    {
+        foreach (byte[]? versionedHash in blobVersionedHashes)
         {
-            switch (transaction.BlobVersionedHashes[i])
+            switch (versionedHash)
             {
                 case null: return TxErrorMessages.MissingBlobVersionedHash;
                 case { Length: not Eip4844Constants.BytesPerBlobVersionedHash }: return TxErrorMessages.InvalidBlobVersionedHashSize;
-                case { Length: Eip4844Constants.BytesPerBlobVersionedHash } when transaction.BlobVersionedHashes[i][0] != KzgPolynomialCommitments.KzgBlobHashVersionV1: return TxErrorMessages.InvalidBlobVersionedHashVersion;
+                case { Length: Eip4844Constants.BytesPerBlobVersionedHash } when versionedHash[0] != KzgPolynomialCommitments.KzgBlobHashVersionV1: return TxErrorMessages.InvalidBlobVersionedHashVersion;
             }
         }
 

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -197,8 +197,8 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
             return error!;
         }
 
-        // EIP-7594: a blob-carrying frame tx is bound by the same per-tx blob-count
-        // limit and versioned-hash version byte as a type-3 blob tx.
+        // EIP-7594: a blob-carrying frame tx is bound by the same per-tx blob-count limit and
+        // versioned-hash version byte as a type-3 blob tx.
         byte[]?[]? blobVersionedHashes = transaction.BlobVersionedHashes;
         if (blobVersionedHashes is { Length: > 0 })
         {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -109,6 +109,30 @@ public class FrameTxDecoderTests
         Assert.That(FrameTxSigHash.ComputeValue(second), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(first)));
     }
 
+    [Test]
+    public void ComputeSigHash_MaxFeePerBlobGasChanges_HashChanges()
+    {
+        // The blob fields are the last two elements of the signing preimage (matching EELS #3047's
+        // FrameTransaction layout); the signature must commit to them.
+        Transaction first = CreateFrameTx();
+        first.MaxFeePerBlobGas = 7;
+        Transaction second = CreateFrameTx();
+        second.MaxFeePerBlobGas = 8;
+
+        Assert.That(FrameTxSigHash.ComputeValue(second), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(first)));
+    }
+
+    [Test]
+    public void ComputeSigHash_BlobVersionedHashesChange_HashChanges()
+    {
+        Transaction first = CreateFrameTx();
+        first.BlobVersionedHashes = [FilledBytes(32, 0x01)];
+        Transaction second = CreateFrameTx();
+        second.BlobVersionedHashes = [FilledBytes(32, 0x02)];
+
+        Assert.That(FrameTxSigHash.ComputeValue(second), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(first)));
+    }
+
     private static IEnumerable<TestCaseData> RoundtripCases()
     {
         yield return new TestCaseData(CreateFrameTx()).SetName("Roundtrip_MinimalSingleFrame");

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -112,8 +112,7 @@ public class FrameTxDecoderTests
     [Test]
     public void ComputeSigHash_MaxFeePerBlobGasChanges_HashChanges()
     {
-        // The blob fields are the last two elements of the signing preimage (matching EELS #3047's
-        // FrameTransaction layout); the signature must commit to them.
+        // The blob fields are part of the signing preimage, so the signature must commit to them.
         Transaction first = CreateFrameTx();
         first.MaxFeePerBlobGas = 7;
         Transaction second = CreateFrameTx();

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -217,11 +217,9 @@ public static class FrameTxValidation
             return false;
         }
 
-        // EIP8141: the per-transaction blob-count limit (EIP-7594) and the versioned-hash-version
-        // check that EELS #3047 validate_frame_transaction applies to blob-carrying frame txs are not
-        // enforced here yet — deferred with the rest of the EIP-7594 slice. A blob-carrying frame tx
-        // is still bounded by the block-level MaxBlobGasPerBlock check in BlockValidator, so it cannot
-        // over-fill a block; the gap is only that a single tx may carry more blobs than EELS allows.
+        // The per-transaction blob-count limit (EIP-7594) and the versioned-hash version byte that EELS
+        // validate_frame_transaction applies to blob-carrying frame txs require the release spec, so they
+        // are enforced by FrameTxFieldsTxValidator rather than in this stateless check.
 
         return true;
 

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -217,6 +217,12 @@ public static class FrameTxValidation
             return false;
         }
 
+        // EIP8141: the per-transaction blob-count limit (EIP-7594) and the versioned-hash-version
+        // check that EELS #3047 validate_frame_transaction applies to blob-carrying frame txs are not
+        // enforced here yet — deferred with the rest of the EIP-7594 slice. A blob-carrying frame tx
+        // is still bounded by the block-level MaxBlobGasPerBlock check in BlockValidator, so it cannot
+        // over-fill a block; the gap is only that a single tx may carry more blobs than EELS allows.
+
         return true;
 
         // EIP-8141: a frame belongs to a batch when flagged, or when it is the terminating frame

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -217,10 +217,8 @@ public static class FrameTxValidation
             return false;
         }
 
-        // The per-transaction blob-count limit (EIP-7594) and the versioned-hash version byte that EELS
-        // validate_frame_transaction applies to blob-carrying frame txs require the release spec, so they
+        // The EIP-7594 blob-count limit and versioned-hash version byte need the release spec, so they
         // are enforced by FrameTxFieldsTxValidator rather than in this stateless check.
-
         return true;
 
         // EIP-8141: a frame belongs to a batch when flagged, or when it is the terminating frame

--- a/src/Nethermind/Nethermind.Evm.Test/BlobGasCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BlobGasCalculatorTests.cs
@@ -53,6 +53,21 @@ public class BlobGasCalculatorTests
         Assert.That(blobBaseFee, Is.EqualTo(UInt256.MaxValue));
     }
 
+    [Test]
+    public void CalculateBlobGas_counts_blob_carrying_frame_txs_alongside_type3()
+    {
+        // EIP-8141: a frame tx (type 6) with blob hashes contributes to the block's blob gas exactly
+        // like a type-3 blob tx; a frame tx without blobs and non-blob txs contribute nothing.
+        Transaction type3 = Build.A.Transaction.WithType(TxType.Blob).WithBlobVersionedHashes(2).TestObject;
+        Transaction frameWithBlobs = Build.A.Transaction.WithType(TxType.FrameTx).WithBlobVersionedHashes(3).TestObject;
+        Transaction frameNoBlobs = Build.A.Transaction.WithType(TxType.FrameTx).TestObject;
+        Transaction legacy = Build.A.Transaction.TestObject;
+
+        ulong blobGas = BlobGasCalculator.CalculateBlobGas([type3, frameWithBlobs, frameNoBlobs, legacy]);
+
+        Assert.That(blobGas, Is.EqualTo(BlobGasCalculator.CalculateBlobGas(2 + 3)));
+    }
+
     private static IEnumerable<TestCaseData> GenerateTestCases()
     {
         (IReleaseSpec Instance, bool)[] specs =

--- a/src/Nethermind/Nethermind.Evm.Test/BlobGasCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BlobGasCalculatorTests.cs
@@ -56,8 +56,6 @@ public class BlobGasCalculatorTests
     [Test]
     public void CalculateBlobGas_counts_blob_carrying_frame_txs_alongside_type3()
     {
-        // EIP-8141: a frame tx (type 6) with blob hashes contributes to the block's blob gas exactly
-        // like a type-3 blob tx; a frame tx without blobs and non-blob txs contribute nothing.
         Transaction type3 = Build.A.Transaction.WithType(TxType.Blob).WithBlobVersionedHashes(2).TestObject;
         Transaction frameWithBlobs = Build.A.Transaction.WithType(TxType.FrameTx).WithBlobVersionedHashes(3).TestObject;
         Transaction frameNoBlobs = Build.A.Transaction.WithType(TxType.FrameTx).TestObject;

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
@@ -89,6 +89,35 @@ public class FrameTxBlockReceiptsTests
         }
     }
 
+    // A blob-carrying frame tx pays the blob fee and counts towards the block's blob gas, so its receipt
+    // must report blobGasUsed/blobGasPrice; a blobless frame tx reports neither.
+    [Test]
+    public void GetGasInfo_BlobCarryingFrameTx_ReportsBlobGas()
+    {
+        IReleaseSpec spec = Eip8141Prototype.Instance;
+        BlockHeader header = Build.A.BlockHeader.WithBaseFee(0).WithExcessBlobGas(0).TestObject;
+
+        Transaction blobFrameTx = new()
+        {
+            Type = TxType.FrameTx,
+            BlobVersionedHashes = [new byte[32]],
+            MaxFeePerBlobGas = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+        TxGasInfo blobInfo = blobFrameTx.GetGasInfo(spec, header);
+
+        Transaction bloblessFrameTx = new() { Type = TxType.FrameTx, DecodedMaxFeePerGas = 1 };
+        TxGasInfo bloblessInfo = bloblessFrameTx.GetGasInfo(spec, header);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(blobInfo.BlobGasUsed, Is.EqualTo(BlobGasCalculator.CalculateBlobGas(blobFrameTx)), "blob frame tx reports its blob gas");
+            Assert.That(blobInfo.BlobGasPrice, Is.Not.Null);
+            Assert.That(bloblessInfo.BlobGasUsed, Is.Null, "a blobless frame tx reports no blob gas");
+            Assert.That(bloblessInfo.BlobGasPrice, Is.Null);
+        }
+    }
+
     /// <summary>
     /// Runs a two-frame transaction (self-verify, then a SENDER frame calling <paramref name="observerCode"/>)
     /// through the real receipts tracer and returns the single receipt it produced.

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
@@ -89,8 +89,6 @@ public class FrameTxBlockReceiptsTests
         }
     }
 
-    // A blob-carrying frame tx pays the blob fee and counts towards the block's blob gas, so its receipt
-    // must report blobGasUsed/blobGasPrice; a blobless frame tx reports neither.
     [Test]
     public void GetGasInfo_BlobCarryingFrameTx_ReportsBlobGas()
     {

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -147,6 +147,56 @@ public class FrameTxProcessorTests
         Assert.That(balance, Is.GreaterThan(1.Ether - (UInt256)frame.GasLimit), "unused gas refunded");
     }
 
+    [Test]
+    public void Execute_BlobCarryingFrameTx_ChargesAndBurnsBlobFee()
+    {
+        // EIP-8141 (spec ~L492-499): a blob-carrying frame tx follows EIP-4844 — the payer covers the
+        // blob fee, which is burned. With base fee 0 the whole gas premium goes to the beneficiary, so
+        // the only value that leaves the payer for good is the burned blob fee. Parity: EELS #3047.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.BlobVersionedHashes = [new byte[32]];
+        tx.MaxFeePerBlobGas = 1000;
+
+        CallOutputTracer tracer = new();
+        TransactionResult result = ProcessWithBlobHeader(tx, excessBlobGas: 0, tracer: tracer);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        UInt256 spentGas = (UInt256)tracer.GasSpent;
+        UInt256 blobFee = ExpectedBlobFee(excessBlobGas: 0, blobCount: 1);
+        Assert.That(blobFee, Is.GreaterThan(UInt256.Zero), "blob fee is nonzero at the minimum blob base fee");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_stateProvider.GetBalance(Beneficiary), Is.EqualTo(spentGas), "beneficiary gets the gas premium only");
+            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - spentGas - blobFee), "payer pays the spent gas and the blob fee");
+            Assert.That(_stateProvider.GetBalance(Sender) + _stateProvider.GetBalance(Beneficiary),
+                Is.EqualTo(1.Ether - blobFee), "the blob fee is burned, not paid to the beneficiary");
+        }
+    }
+
+    [Test]
+    public void Execute_BlobFrameTx_MaxFeePerBlobGasBelowBlobBaseFee_Invalid()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.BlobVersionedHashes = [new byte[32]];
+
+        const ulong excessBlobGas = 50_000_000;
+        UInt256 feePerBlobGas = FeePerBlobGas(excessBlobGas);
+        Assert.That(feePerBlobGas, Is.GreaterThan(UInt256.One), "excess chosen so the blob base fee exceeds 1");
+        tx.MaxFeePerBlobGas = feePerBlobGas - 1;
+
+        TransactionResult result = ProcessWithBlobHeader(tx, excessBlobGas);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.False);
+            Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.InsufficientMaxFeePerGasForSenderBalance));
+            Assert.That(_stateProvider.GetBalance(Beneficiary), Is.EqualTo(UInt256.Zero), "beneficiary not credited");
+            Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0UL), "nonce not consumed");
+        }
+    }
+
     [TestCase(7ul, 2ul, 10ul, 2ul, TestName = "Execute_NonZeroBaseFee_PremiumIsTheRequestedPriorityFee")]
     [TestCase(7ul, 5ul, 8ul, 1ul, TestName = "Execute_NonZeroBaseFee_PremiumCappedByMaxFeeMinusBaseFee")]
     public void Execute_NonZeroBaseFee_PaysBeneficiaryThePremiumAndBurnsTheBaseFee(
@@ -1023,6 +1073,27 @@ public class FrameTxProcessorTests
             .WithGasLimit(30_000_000).TestObject;
         return _transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), tracer ?? NullTxTracer.Instance);
     }
+
+    private TransactionResult ProcessWithBlobHeader(Transaction tx, ulong excessBlobGas, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)
+    {
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(baseFeePerGas)
+            .WithBeneficiary(Beneficiary)
+            .WithExcessBlobGas(excessBlobGas)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+        return _transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), tracer ?? NullTxTracer.Instance);
+    }
+
+    private UInt256 FeePerBlobGas(ulong excessBlobGas)
+    {
+        BlockHeader header = Build.A.BlockHeader.WithExcessBlobGas(excessBlobGas).TestObject;
+        BlobGasCalculator.TryCalculateFeePerBlobGas(header, Spec.BlobBaseFeeUpdateFraction, out UInt256 feePerBlobGas);
+        return feePerBlobGas;
+    }
+
+    private UInt256 ExpectedBlobFee(ulong excessBlobGas, int blobCount) =>
+        FeePerBlobGas(excessBlobGas) * BlobGasCalculator.CalculateBlobGas(blobCount);
 
     private void DeploySmartSender(byte[] code) => DeployContract(Sender, code, 1.Ether);
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -49,6 +49,9 @@ public class FrameTxProcessorTests
     private static readonly Address Recipient = TestItem.AddressC;
     private static readonly Address Beneficiary = TestItem.AddressE;
 
+    // The gas leg of max_cost (TXPARAM 0x06) for a SelfVerify + one DEFAULT frame at max fee 1, blob-free.
+    private const ulong BlobFreeMaxCost = 415_950;
+
     [SetUp]
     public void Setup()
     {
@@ -174,6 +177,43 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_BlobCarryingFrameTx_OnFeeCollectorChain_CollectsBaseFeeAndBlobFee()
+    {
+        // Regression: on a fee-collector chain that also enables EIP-4844 fee collection (e.g. Gnosis),
+        // both the EIP-1559 base-fee share and the blob fee must be routed to the collector, exactly as
+        // PayFees does on the regular path. A nonzero base fee makes the 1559 leg observable: the fix
+        // credits it to the collector rather than burning it, so nothing is destroyed.
+        Address feeCollector = TestItem.AddressF;
+        _spec.FeeCollector = feeCollector;
+        _spec.IsEip4844FeeCollectorEnabled = true;
+
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.BlobVersionedHashes = [new byte[32]];
+        tx.MaxFeePerBlobGas = 1000;
+        tx.GasPrice = 1;                 // max_priority_fee_per_gas
+        tx.DecodedMaxFeePerGas = 10;
+
+        const ulong baseFee = 7;
+        CallOutputTracer tracer = new();
+        TransactionResult result = ProcessWithBlobHeader(tx, excessBlobGas: 0, baseFeePerGas: baseFee, tracer: tracer);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        UInt256 spentGas = (UInt256)tracer.GasSpent;
+        UInt256 blobFee = ExpectedBlobFee(excessBlobGas: 0, blobCount: 1);
+        Assert.That(blobFee, Is.GreaterThan(UInt256.Zero), "blob fee is nonzero at the minimum blob base fee");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_stateProvider.GetBalance(Beneficiary), Is.EqualTo(spentGas), "beneficiary gets the 1-wei premium only");
+            Assert.That(_stateProvider.GetBalance(feeCollector), Is.EqualTo(baseFee * spentGas + blobFee),
+                "the collector receives both the base-fee share and the blob fee");
+            Assert.That(
+                _stateProvider.GetBalance(Sender) + _stateProvider.GetBalance(Beneficiary) + _stateProvider.GetBalance(feeCollector),
+                Is.EqualTo(1.Ether), "no value is burned - both burned legs go to the collector");
+        }
+    }
+
+    [Test]
     public void Execute_BlobFrameTx_MaxFeePerBlobGasBelowBlobBaseFee_Invalid()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
@@ -212,10 +252,10 @@ public class FrameTxProcessorTests
         TransactionResult result = ProcessWithBlobHeader(tx, excessBlobGas: 0);
 
         Assert.That(result.TransactionExecuted, Is.True);
-        // Gas leg is the same 415_950 the blobless Execute_TxParam_MaxCost case observes (max fee 1).
-        UInt256 expectedMaxCost = 415_950 + ExpectedBlobFee(excessBlobGas: 0, blobCount: 1);
+        // Gas leg is the blobless Execute_TxParam_MaxCost value the same frame shape observes (max fee 1).
+        UInt256 expectedMaxCost = BlobFreeMaxCost + ExpectedBlobFee(excessBlobGas: 0, blobCount: 1);
         AssertStorage(Observer, 0, expectedMaxCost);
-        UInt256 maxFeePricedMaxCost = 415_950 + tx.MaxFeePerBlobGas.Value * BlobGasCalculator.CalculateBlobGas(1);
+        UInt256 maxFeePricedMaxCost = BlobFreeMaxCost + tx.MaxFeePerBlobGas.Value * BlobGasCalculator.CalculateBlobGas(1);
         Assert.That(expectedMaxCost, Is.LessThan(maxFeePricedMaxCost),
             "max_cost priced below the max_fee_per_blob_gas reservation, i.e. at the blob base fee");
     }
@@ -396,7 +436,7 @@ public class FrameTxProcessorTests
     [TestCase((byte)0x04, 1UL, TestName = "Execute_TxParam_MaxFee")]
     [TestCase((byte)0x05, 0UL, TestName = "Execute_TxParam_MaxBlobFee")]
     // Max cost = sum(frame gas) 400000 + intrinsic 15000 + per-frame 475×2 (no calldata/sig).
-    [TestCase((byte)0x06, 415_950UL, TestName = "Execute_TxParam_MaxCost")]
+    [TestCase((byte)0x06, BlobFreeMaxCost, TestName = "Execute_TxParam_MaxCost")]
     [TestCase((byte)0x07, 0UL, TestName = "Execute_TxParam_BlobHashCount")]
     [TestCase((byte)0x09, 2UL, TestName = "Execute_TxParam_FrameCount")]
     [TestCase((byte)0x0A, 1UL, TestName = "Execute_TxParam_CurrentFrameIndex")]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -150,9 +150,8 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_BlobCarryingFrameTx_ChargesAndBurnsBlobFee()
     {
-        // EIP-8141 (spec ~L492-499): a blob-carrying frame tx follows EIP-4844 — the payer covers the
-        // blob fee, which is burned. With base fee 0 the whole gas premium goes to the beneficiary, so
-        // the only value that leaves the payer for good is the burned blob fee. Parity: EELS #3047.
+        // EIP-8141/EIP-4844: the payer covers the burned blob fee. With base fee 0 the whole gas premium
+        // goes to the beneficiary, so the only value that leaves the payer for good is the burned blob fee.
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
         tx.BlobVersionedHashes = [new byte[32]];
@@ -200,9 +199,8 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_TxParamMaxCost_BlobCarryingFrameTx_ReservesBlobLegAtBlobBaseFeeNotMaxFee()
     {
-        // TXPARAM 0x06 (max_cost) is consensus-visible mid-transaction and also gates payer solvency.
-        // For a blob-carrying frame tx the blob leg of max_cost is reserved at the actual blob_base_fee,
-        // not max_fee_per_blob_gas, so it must equal the blobless gas leg plus blob_gas × blob_base_fee.
+        // The blob leg of max_cost (TXPARAM 0x06) is reserved at the actual blob_base_fee, not
+        // max_fee_per_blob_gas, so it equals the gas leg plus blob_gas × blob_base_fee.
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Observer, Prepare.EvmCode
             .PushData(0x06).Op(Instruction.TXPARAM).PushData(0).Op(Instruction.SSTORE)

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -191,10 +191,35 @@ public class FrameTxProcessorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.TransactionExecuted, Is.False);
-            Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.InsufficientMaxFeePerGasForSenderBalance));
+            Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.InsufficientSenderBalance));
             Assert.That(_stateProvider.GetBalance(Beneficiary), Is.EqualTo(UInt256.Zero), "beneficiary not credited");
             Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0UL), "nonce not consumed");
         }
+    }
+
+    [Test]
+    public void Execute_TxParamMaxCost_BlobCarryingFrameTx_ReservesBlobLegAtBlobBaseFeeNotMaxFee()
+    {
+        // TXPARAM 0x06 (max_cost) is consensus-visible mid-transaction and also gates payer solvency.
+        // For a blob-carrying frame tx the blob leg of max_cost is reserved at the actual blob_base_fee,
+        // not max_fee_per_blob_gas, so it must equal the blobless gas leg plus blob_gas × blob_base_fee.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData(0x06).Op(Instruction.TXPARAM).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        tx.BlobVersionedHashes = [new byte[32]];
+        tx.MaxFeePerBlobGas = 1000;
+
+        TransactionResult result = ProcessWithBlobHeader(tx, excessBlobGas: 0);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        // Gas leg is the same 415_950 the blobless Execute_TxParam_MaxCost case observes (max fee 1).
+        UInt256 expectedMaxCost = 415_950 + ExpectedBlobFee(excessBlobGas: 0, blobCount: 1);
+        AssertStorage(Observer, 0, expectedMaxCost);
+        UInt256 maxFeePricedMaxCost = 415_950 + tx.MaxFeePerBlobGas.Value * BlobGasCalculator.CalculateBlobGas(1);
+        Assert.That(expectedMaxCost, Is.LessThan(maxFeePricedMaxCost),
+            "max_cost priced below the max_fee_per_blob_gas reservation, i.e. at the blob base fee");
     }
 
     [TestCase(7ul, 2ul, 10ul, 2ul, TestName = "Execute_NonZeroBaseFee_PremiumIsTheRequestedPriorityFee")]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxSignatureValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxSignatureValidatorTests.cs
@@ -52,8 +52,6 @@ public class FrameTxSignatureValidatorTests
     [Test]
     public void Validate_Secp256k1BlobCarryingTx_ReturnsTrueAndResolvesSigner()
     {
-        // A blob-carrying frame tx: the blob fields are in the sig-hash preimage (EIP-8141 /
-        // EELS #3047), so a signature computed over that hash validates and resolves the signer.
         Transaction tx = CreateFrameTx();
         tx.MaxFeePerBlobGas = 3;
         tx.BlobVersionedHashes = [BlobVersionedHash(0x01), BlobVersionedHash(0x02)];
@@ -66,8 +64,7 @@ public class FrameTxSignatureValidatorTests
     [Test]
     public void Validate_BlobFieldTamperedAfterSigning_ReturnsFalse()
     {
-        // The signature commits to the blob fields; mutating one after signing must invalidate it,
-        // proving the sig-hash preimage covers max_fee_per_blob_gas and blob_versioned_hashes.
+        // Mutating a blob field after signing must invalidate the signature, proving the preimage covers it.
         Transaction tx = CreateFrameTx();
         tx.MaxFeePerBlobGas = 3;
         tx.BlobVersionedHashes = [BlobVersionedHash(0x01)];

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxSignatureValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxSignatureValidatorTests.cs
@@ -50,6 +50,36 @@ public class FrameTxSignatureValidatorTests
     }
 
     [Test]
+    public void Validate_Secp256k1BlobCarryingTx_ReturnsTrueAndResolvesSigner()
+    {
+        // A blob-carrying frame tx: the blob fields are in the sig-hash preimage (EIP-8141 /
+        // EELS #3047), so a signature computed over that hash validates and resolves the signer.
+        Transaction tx = CreateFrameTx();
+        tx.MaxFeePerBlobGas = 3;
+        tx.BlobVersionedHashes = [BlobVersionedHash(0x01), BlobVersionedHash(0x02)];
+        tx.FrameSignatures = [Secp256k1Entry(tx, TestItem.PrivateKeyB, signer: TestItem.PrivateKeyB.Address)];
+
+        Assert.That(Validate(tx, out string? error), Is.True);
+        Assert.That(error, Is.Null);
+    }
+
+    [Test]
+    public void Validate_BlobFieldTamperedAfterSigning_ReturnsFalse()
+    {
+        // The signature commits to the blob fields; mutating one after signing must invalidate it,
+        // proving the sig-hash preimage covers max_fee_per_blob_gas and blob_versioned_hashes.
+        Transaction tx = CreateFrameTx();
+        tx.MaxFeePerBlobGas = 3;
+        tx.BlobVersionedHashes = [BlobVersionedHash(0x01)];
+        tx.FrameSignatures = [Secp256k1Entry(tx, TestItem.PrivateKeyB, signer: TestItem.PrivateKeyB.Address)];
+
+        tx.BlobVersionedHashes = [BlobVersionedHash(0x02)];
+
+        Assert.That(Validate(tx, out string? error), Is.False);
+        Assert.That(error, Is.EqualTo(FrameTxSignatureValidator.InvalidSignature));
+    }
+
+    [Test]
     public void Validate_Secp256k1WithAbsentSigner_ResolvesToTxSender()
     {
         // "If absent, tx.sender is used" — the sender key must have produced the signature.
@@ -325,6 +355,13 @@ public class FrameTxSignatureValidatorTests
         bytes[0] = signature.RecoveryId; // strict yParity encoding (0/1)
         signature.Bytes.CopyTo(bytes.AsSpan(1));
         return bytes;
+    }
+
+    private static byte[] BlobVersionedHash(byte fill)
+    {
+        byte[] hash = new byte[Hash256.Size];
+        hash.AsSpan().Fill(fill);
+        return hash;
     }
 
     private static byte[] Pad32(byte[] value)

--- a/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
@@ -46,8 +46,7 @@ public static class BlobGasCalculator
         ulong blobCount = 0UL;
         foreach (Transaction tx in transactions)
         {
-            // EIP-8141: blob-carrying frame transactions (type 6) count towards the block's blob gas too,
-            // so the count comes from the blob hashes rather than the type-level SupportsBlobs.
+            // EIP-8141: count from blob hashes, not the type-3-only SupportsBlobs, so blob-carrying frame txs also count.
             blobCount += (ulong)tx.GetBlobCount();
         }
 

--- a/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
@@ -46,12 +46,9 @@ public static class BlobGasCalculator
         ulong blobCount = 0UL;
         foreach (Transaction tx in transactions)
         {
-            // EIP-8141: include blob-carrying frame transactions (type 6), not just type-3, in the
-            // block's blob gas — gate on blob hashes instead of the type-level SupportsBlobs.
-            if (tx.BlobVersionedHashes is { Length: > 0 })
-            {
-                blobCount += (ulong)tx.GetBlobCount();
-            }
+            // EIP-8141: blob-carrying frame transactions (type 6) count towards the block's blob gas too,
+            // so the count comes from the blob hashes rather than the type-level SupportsBlobs.
+            blobCount += (ulong)tx.GetBlobCount();
         }
 
         return CalculateBlobGas(blobCount);

--- a/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
@@ -46,7 +46,9 @@ public static class BlobGasCalculator
         ulong blobCount = 0UL;
         foreach (Transaction tx in transactions)
         {
-            if (tx.SupportsBlobs)
+            // EIP-8141: include blob-carrying frame transactions (type 6), not just type-3, in the
+            // block's blob gas — gate on blob hashes instead of the type-level SupportsBlobs.
+            if (tx.BlobVersionedHashes is { Length: > 0 })
             {
                 blobCount += (ulong)tx.GetBlobCount();
             }

--- a/src/Nethermind/Nethermind.Evm/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionExtensions.cs
@@ -19,8 +19,7 @@ namespace Nethermind.Evm
         {
             UInt256 effectiveGasPrice = tx.CalculateEffectiveGasPrice(spec.IsEip1559Enabled, header.BaseFeePerGas);
 
-            // EIP-8141: report blob gas from blob presence, not the type-3-only SupportsBlobs, so a
-            // blob-carrying frame tx's receipt shows blobGasUsed/blobGasPrice.
+            // EIP-8141: gate on blob presence, not the type-3-only SupportsBlobs, so frame-blob txs report blob gas.
             if (tx.GetBlobCount() > 0)
             {
                 if (header.ExcessBlobGas is null)

--- a/src/Nethermind/Nethermind.Evm/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionExtensions.cs
@@ -19,7 +19,9 @@ namespace Nethermind.Evm
         {
             UInt256 effectiveGasPrice = tx.CalculateEffectiveGasPrice(spec.IsEip1559Enabled, header.BaseFeePerGas);
 
-            if (tx.SupportsBlobs)
+            // EIP-8141: report blob gas from blob presence, not the type-3-only SupportsBlobs, so a
+            // blob-carrying frame tx's receipt shows blobGasUsed/blobGasPrice.
+            if (tx.GetBlobCount() > 0)
             {
                 if (header.ExcessBlobGas is null)
                 {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -4,6 +4,8 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.Precompiles;
@@ -77,18 +79,36 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         }
 
         // max_cost is defined at basefee=max (TXPARAM 0x06): the payer solvency gate reserves at
-        // max_fee_per_gas plus blob cost, not the effective price, so it is not under-reserved.
-        // Settlement below still charges the effective price, so the payer's net cost is unchanged.
-        // EIP8141-DEVIATION: blob gas is reserved here but never settled — a blob-carrying frame tx
-        // would have its blob reservation fully refunded (blobs go uncharged) and BlobGasUsed is not
-        // set. Blob support is deferred pending the upstream blob-semantics spec; devnets do not send
-        // blob frame txs. Charge blob gas (and reject or account it) once that lands.
+        // max_fee_per_gas plus the blob fee, not the effective price, so it is not under-reserved.
+        // Settlement below still charges the effective price, so the payer's net gas cost is unchanged.
         // Overflow-checked like BuyGas: premium <= max fee and spentGas <= txGasLimit, so bounding
         // this product also bounds the settlement products (spentCost, fees) below.
-        ulong blobGas = (ulong)(tx.BlobVersionedHashes?.Length ?? 0) * Eip4844Constants.GasPerBlob;
+        //
+        // EIP-8141 (spec ~L492-499, ethereum/EIPs#11985): a blob-carrying frame tx follows EIP-4844 —
+        // the payer covers blob_gas × blob_base_fee, which is charged and burned (never refunded).
+        // Parity with EELS #3047: the blob leg of max_cost is priced at the actual blob_base_fee, not
+        // max_fee_per_blob_gas. The escrow the payer sees mid-transaction must match EELS, and the
+        // burned blob fee cancels against this term in the refund below.
+        UInt256 blobFee = UInt256.Zero;
+        if (tx.BlobVersionedHashes is { Length: > 0 })
+        {
+            if (!_blobBaseFeeCalculator.TryCalculateBlobFees(header, tx, spec.BlobBaseFeeUpdateFraction, out UInt256 feePerBlobGas, out blobFee))
+            {
+                TraceLogInvalidTx(tx, "BLOB_BASE_FEE_OVERFLOW");
+                return RequiredBalanceExceeds256Bits(tx);
+            }
+
+            // EIP-4844: max_fee_per_blob_gas must cover the current blob base fee, else the tx is invalid.
+            if (tx.MaxFeePerBlobGas.GetValueOrDefault() < feePerBlobGas)
+            {
+                TraceLogInvalidTx(tx, "INSUFFICIENT_MAX_FEE_PER_BLOB_GAS");
+                return TransactionResult.ErrorType.InsufficientMaxFeePerGasForSenderBalance.WithDetail(
+                    BlockErrorMessages.InsufficientMaxFeePerBlobGas(tx.SenderAddress, tx.MaxFeePerBlobGas, feePerBlobGas));
+            }
+        }
+
         if (UInt256.MultiplyOverflow((UInt256)txGasLimit, tx.DecodedMaxFeePerGas, out UInt256 maxCost)
-            || UInt256.MultiplyOverflow((UInt256)blobGas, tx.MaxFeePerBlobGas.GetValueOrDefault(), out UInt256 maxBlobCost)
-            || UInt256.AddOverflow(maxCost, maxBlobCost, out maxCost))
+            || UInt256.AddOverflow(maxCost, blobFee, out maxCost))
         {
             TraceLogInvalidTx(tx, "INSUFFICIENT_MAX_FEE_PER_GAS_FOR_SENDER_BALANCE");
             return RequiredBalanceExceeds256Bits(tx);
@@ -345,10 +365,22 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         // The payer was charged the max cost at payment approval; refund the unused remainder and
         // pay the beneficiary premium. The base-fee share stays deducted (burned).
+        // EIP-8141/EIP-4844: the blob fee (blob_gas × blob_base_fee) is also charged and burned — it
+        // is excluded from the refund regardless of frame outcome. Both charged legs are bounded by
+        // max_cost (spentCost <= txGasLimit × maxFeePerGas, blobFee is max_cost's blob leg), so the
+        // subtraction cannot underflow.
         UInt256 spentCost = (UInt256)spentGas * effectiveGasPrice;
-        if (maxCost > spentCost)
+        UInt256 chargedCost = spentCost + blobFee;
+        if (maxCost > chargedCost)
         {
-            WorldState.AddToBalance(payer, maxCost - spentCost, spec);
+            WorldState.AddToBalance(payer, maxCost - chargedCost, spec);
+        }
+
+        // EIP-4844 fee-collector chains (e.g. Gnosis) collect the burned blob fee instead of losing
+        // it, consistent with the regular path's PayFees; elsewhere the fee is simply burned.
+        if (!blobFee.IsZero && spec.IsEip4844FeeCollectorEnabled && spec.FeeCollector is not null)
+        {
+            WorldState.AddToBalanceAndCreateIfNotExists(spec.FeeCollector, blobFee, spec);
         }
 
         // EIP-1559/EIP-7928: fee accounting touches the beneficiary regardless of premium, so the
@@ -377,9 +409,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         if (tracer.IsTracingFees)
         {
             // As in PayFees, the burnt half is capped at the effective price paid so validation-off
-            // runs with max fee below base fee do not over-report.
+            // runs with max fee below base fee do not over-report; the burned blob fee is added in.
             UInt256 effectiveBaseFee = UInt256.Min(header.BaseFeePerGas, effectiveGasPrice);
-            tracer.ReportFees(fees, effectiveBaseFee * spentGas);
+            tracer.ReportFees(fees, effectiveBaseFee * spentGas + blobFee);
         }
 
         if (tracer.IsTracingReceipt)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -78,17 +78,16 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction gas limit overflows");
         }
 
-        // max_cost is defined at basefee=max (TXPARAM 0x06): the payer solvency gate reserves at
-        // max_fee_per_gas plus the blob fee, not the effective price, so it is not under-reserved.
-        // Settlement below still charges the effective price, so the payer's net gas cost is unchanged.
-        // Overflow-checked like BuyGas: premium <= max fee and spentGas <= txGasLimit, so bounding
-        // this product also bounds the settlement products (spentCost, fees) below.
-        //
-        // EIP-8141 (spec ~L492-499, ethereum/EIPs#11985): a blob-carrying frame tx follows EIP-4844 —
-        // the payer covers blob_gas × blob_base_fee, which is charged and burned (never refunded).
-        // Parity with EELS #3047: the blob leg of max_cost is priced at the actual blob_base_fee, not
-        // max_fee_per_blob_gas. The escrow the payer sees mid-transaction must match EELS, and the
-        // burned blob fee cancels against this term in the refund below.
+        // max_gas: frames reserving less than the calldata floor raise the reservation rather than
+        // invalidate the transaction. The headroom is reserved and refunded, never spendable.
+        txGasLimit = Math.Max(txGasLimit, floorGas);
+
+        // max_cost (TXPARAM 0x06) reserves at max_fee_per_gas plus the blob fee, not the effective
+        // price, so it is not under-reserved; settlement below charges the effective price. Bounded
+        // like BuyGas: premium <= max fee and spentGas <= txGasLimit, so this product also bounds the
+        // settlement products (spentCost, fees) below.
+        // EIP-8141/EIP-4844: the blob leg is priced at the actual blob_base_fee (not max_fee_per_blob_gas)
+        // so the mid-tx escrow the payer sees is correct; the burned blob fee cancels in the refund below.
         UInt256 blobFee = UInt256.Zero;
         if (tx.BlobVersionedHashes is { Length: > 0 })
         {
@@ -365,10 +364,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         // The payer was charged the max cost at payment approval; refund the unused remainder and
         // pay the beneficiary premium. The base-fee share stays deducted (burned).
-        // EIP-8141/EIP-4844: the blob fee (blob_gas × blob_base_fee) is also charged and burned — it
-        // is excluded from the refund regardless of frame outcome. Both charged legs are bounded by
-        // max_cost (spentCost <= txGasLimit × maxFeePerGas, blobFee is max_cost's blob leg), so the
-        // subtraction cannot underflow.
+        // EIP-8141/EIP-4844: the blob fee is also charged and burned, excluded from the refund. Both
+        // legs are bounded by max_cost (spentCost <= gas leg, blobFee is the blob leg), so no underflow.
         UInt256 spentCost = (UInt256)spentGas * effectiveGasPrice;
         UInt256 chargedCost = spentCost + blobFee;
         if (maxCost > chargedCost)
@@ -376,10 +373,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             WorldState.AddToBalance(payer, maxCost - chargedCost, spec);
         }
 
-        // EIP-4844 fee-collector chains (e.g. Gnosis) collect the burned blob fee instead of losing
-        // it, consistent with the regular path's PayFees; elsewhere the fee is simply burned.
-        // The EIP-1559 base-fee share of a frame tx is not routed to the collector (only burned); no
-        // chain enables both frame txs and the fee collector, so this stays deferred.
+        // EIP-4844 fee-collector chains (e.g. Gnosis) collect the burned blob fee, as in PayFees;
+        // elsewhere it is burned. The base-fee share stays burned as no chain enables both features.
         if (!blobFee.IsZero && spec.IsEip4844FeeCollectorEnabled && spec.FeeCollector is not null)
         {
             WorldState.AddToBalanceAndCreateIfNotExists(spec.FeeCollector, blobFee, spec);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -77,10 +77,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction gas limit overflows");
         }
 
-        // max_gas: frames reserving less than the calldata floor raise the reservation rather than
-        // invalidate the transaction. The headroom is reserved and refunded, never spendable.
-        txGasLimit = Math.Max(txGasLimit, floorGas);
-
         // max_cost (TXPARAM 0x06) reserves at max_fee_per_gas plus the blob fee, not the effective
         // price, so it is not under-reserved; settlement below charges the effective price. Bounded
         // like BuyGas: premium <= max fee and spentGas <= txGasLimit, so this product also bounds the

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -4,7 +4,6 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -102,7 +102,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             if (tx.MaxFeePerBlobGas.GetValueOrDefault() < feePerBlobGas)
             {
                 TraceLogInvalidTx(tx, "INSUFFICIENT_MAX_FEE_PER_BLOB_GAS");
-                return TransactionResult.ErrorType.InsufficientMaxFeePerGasForSenderBalance.WithDetail(
+                return TransactionResult.ErrorType.InsufficientSenderBalance.WithDetail(
                     BlockErrorMessages.InsufficientMaxFeePerBlobGas(tx.SenderAddress, tx.MaxFeePerBlobGas, feePerBlobGas));
             }
         }
@@ -378,6 +378,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         // EIP-4844 fee-collector chains (e.g. Gnosis) collect the burned blob fee instead of losing
         // it, consistent with the regular path's PayFees; elsewhere the fee is simply burned.
+        // The EIP-1559 base-fee share of a frame tx is not routed to the collector (only burned); no
+        // chain enables both frame txs and the fee collector, so this stays deferred.
         if (!blobFee.IsZero && spec.IsEip4844FeeCollectorEnabled && spec.FeeCollector is not null)
         {
             WorldState.AddToBalanceAndCreateIfNotExists(spec.FeeCollector, blobFee, spec);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -373,11 +373,17 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             WorldState.AddToBalance(payer, maxCost - chargedCost, spec);
         }
 
-        // EIP-4844 fee-collector chains (e.g. Gnosis) collect the burned blob fee, as in PayFees;
-        // elsewhere it is burned. The base-fee share stays burned as no chain enables both features.
-        if (!blobFee.IsZero && spec.IsEip4844FeeCollectorEnabled && spec.FeeCollector is not null)
+        // Fee-collector chains (e.g. Gnosis) collect the otherwise-burned legs, exactly as PayFees does:
+        // the EIP-1559 base-fee share and, when EIP-4844 fee collection is enabled, the blob fee.
+        UInt256 effectiveBaseFee = UInt256.Min(header.BaseFeePerGas, effectiveGasPrice);
+        UInt256 collectedFees = spec.IsEip1559Enabled ? effectiveBaseFee * (UInt256)spentGas : UInt256.Zero;
+        if (spec.IsEip4844FeeCollectorEnabled)
         {
-            WorldState.AddToBalanceAndCreateIfNotExists(spec.FeeCollector, blobFee, spec);
+            collectedFees += blobFee;
+        }
+        if (spec.FeeCollector is not null && !collectedFees.IsZero)
+        {
+            WorldState.AddToBalanceAndCreateIfNotExists(spec.FeeCollector, collectedFees, spec);
         }
 
         // EIP-1559/EIP-7928: fee accounting touches the beneficiary regardless of premium, so the
@@ -405,9 +411,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         if (tracer.IsTracingFees)
         {
-            // As in PayFees, the burnt half is capped at the effective price paid so validation-off
-            // runs with max fee below base fee do not over-report; the burned blob fee is added in.
-            UInt256 effectiveBaseFee = UInt256.Min(header.BaseFeePerGas, effectiveGasPrice);
+            // As in PayFees, the burnt/collected half is capped at the effective price paid so
+            // validation-off runs with max fee below base fee do not over-report; blob fee added in.
             tracer.ReportFees(fees, effectiveBaseFee * spentGas + blobFee);
         }
 

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -75,10 +75,13 @@ namespace Nethermind.TxPool
             overflow |= UInt256.AddOverflow(currentCost, maxTxCost, out cumulativeCost);
             overflow |= UInt256.AddOverflow(cumulativeCost, (UInt256)tx.Value, out cumulativeCost);
 
-            if (tx.SupportsBlobs)
+            // EIP-8141: a blob-carrying frame transaction (type 6) also reserves the blob fee, so gate
+            // on the presence of blob hashes rather than the type-level SupportsBlobs (type-3 only).
+            // Priced at max_fee_per_blob_gas, an upper bound on the processor's escrow, so mempool
+            // affordability never admits a tx the processor cannot charge.
+            if (tx.BlobVersionedHashes is { Length: > 0 })
             {
-                // if tx.SupportsBlobs and has BlobVersionedHashes = null, it will throw on earlier step of validation, in TxValidator
-                overflow |= UInt256.MultiplyOverflow(Eip4844Constants.GasPerBlob, (UInt256)tx.BlobVersionedHashes!.Length, out UInt256 blobGas);
+                overflow |= UInt256.MultiplyOverflow(Eip4844Constants.GasPerBlob, (UInt256)tx.BlobVersionedHashes.Length, out UInt256 blobGas);
                 overflow |= UInt256.MultiplyOverflow(blobGas, tx.MaxFeePerBlobGas ?? UInt256.MaxValue, out UInt256 blobGasCost);
                 overflow |= UInt256.AddOverflow(cumulativeCost, blobGasCost, out cumulativeCost);
             }

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -75,10 +75,8 @@ namespace Nethermind.TxPool
             overflow |= UInt256.AddOverflow(currentCost, maxTxCost, out cumulativeCost);
             overflow |= UInt256.AddOverflow(cumulativeCost, (UInt256)tx.Value, out cumulativeCost);
 
-            // EIP-8141: a blob-carrying frame transaction (type 6) also reserves the blob fee, so gate
-            // on the presence of blob hashes rather than the type-level SupportsBlobs (type-3 only).
-            // Priced at max_fee_per_blob_gas, an upper bound on the processor's escrow, so mempool
-            // affordability never admits a tx the processor cannot charge.
+            // EIP-8141: gate on blob hashes, not the type-3-only SupportsBlobs, so blob-carrying frame txs
+            // reserve the blob fee too; priced at max_fee_per_blob_gas, an upper bound on the processor's escrow.
             if (tx.BlobVersionedHashes is { Length: > 0 })
             {
                 overflow |= UInt256.MultiplyOverflow(Eip4844Constants.GasPerBlob, (UInt256)tx.BlobVersionedHashes.Length, out UInt256 blobGas);


### PR DESCRIPTION
Aligns blob accounting for EIP-8141 frame transactions with the spec (`eip-8141.md` ~L492-499, ethereum/EIPs#11985) and EELS #3047.

## Changes
- **Instance-level blob gate at the two block accounting sites** — `BlockValidator.ValidateEip4844Fields` and `BlobGasCalculator.CalculateBlobGas(Transaction[])` now gate on `BlobVersionedHashes.Length > 0` instead of the type-level `SupportsBlobs` (type-3 only). A blob-carrying frame tx (type 6) now contributes to `header.BlobGasUsed` and the per-block blob budget, exactly like a type-3 tx. `TxTypeExtensions.SupportsBlobs()` is deliberately left unchanged so networking/wrapper/decode paths are unaffected.
- **Blob-fee charge + burn in the frame processor** — the payer covers `blob_gas × blob_base_fee`, charged and burned (never refunded, regardless of frame outcome); `max_fee_per_blob_gas >= blob_base_fee` is enforced (invalid otherwise). The `max_cost` blob leg is priced at the **actual** `blob_base_fee`, matching EELS #3047 — this keeps both the payer escrow observed mid-transaction and the EVM-observable `TXPARAM_MAX_COST (0x06)` in parity. On EIP-4844 fee-collector chains the blob fee is routed to the collector, consistent with the regular path's `PayFees`.
- **Mempool max-cost** — the blob term is added to the frame-tx affordability check.
- **Conservative production guard** — the block-production picker skips blob-carrying frame txs until they are metered against the block blob budget, so a produced block cannot exceed `MaxBlobGasPerBlock` and self-invalidate.

## Tests
- Blob-carrying frame tx: charges + burns the blob fee (payer/beneficiary balances asserted); `max_fee_per_blob_gas < blob_base_fee` → invalid.
- `BlobGasCalculator` counts blob-carrying frame txs alongside type-3.
- Block production skips a blob-carrying frame tx.
- Frame-tx, 4844/blob, BlockValidator and TxPool suites remain green (type-3 unchanged).