### PR TITLE
fix(evm): restore instead of commit for a frame tx CallAndRestore

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Tracing;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
@@ -979,6 +980,36 @@ public class FrameTxProcessorTests
         Assert.That(Process(tx, tracer: tracer).TransactionExecuted, Is.True);
         Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Failure));
         AssertStorage(Observer, 0, UInt256.Zero, "a failure in the second assertion unwinds the body the first one passed on");
+    }
+
+    // eth_estimateGas runs one probe plus a binary search of CallAndRestore calls against a single
+    // world state, so a frame transaction's CallAndRestore has to leave nothing behind: a surviving
+    // nonce bump makes the next iteration fail the nonce pre-check and the estimate comes back as an
+    // error instead of a gas figure.
+    [Test]
+    public void CallAndRestore_RepeatedForGasEstimation_LeavesNoStateAndEstimates()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Recipient));
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithGasLimit(30_000_000).TestObject;
+
+        EstimateGasTracer gasTracer = new();
+        _transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, Spec));
+        TransactionResult probe = _transactionProcessor.CallAndRestore(tx, gasTracer);
+        Assert.That(probe.TransactionExecuted, Is.True, probe.ErrorDescription ?? probe.Error.ToString());
+
+        GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
+        ulong estimate = estimator.Estimate(tx, header, gasTracer, out string? error);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(error, Is.Null);
+            Assert.That(estimate, Is.GreaterThan(0ul));
+            Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0ul), "the estimation loop committed a nonce bump");
+            Assert.That(_stateProvider.GetBalance(Sender) == 1.Ether, Is.True, "the estimation loop committed a payer charge");
+        }
     }
 
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -982,10 +982,12 @@ public class FrameTxProcessorTests
         AssertStorage(Observer, 0, UInt256.Zero, "a failure in the second assertion unwinds the body the first one passed on");
     }
 
-    // eth_estimateGas runs one probe plus a binary search of CallAndRestore calls against a single
-    // world state, so a frame transaction's CallAndRestore has to leave nothing behind: a surviving
-    // nonce bump makes the next iteration fail the nonce pre-check and the estimate comes back as an
-    // error instead of a gas figure.
+    /// <summary>A frame transaction's <c>CallAndRestore</c> must leave nothing behind.</summary>
+    /// <remarks>
+    /// <c>eth_estimateGas</c> runs one probe plus a binary search of <c>CallAndRestore</c> calls against a single
+    /// world state, so a surviving nonce bump makes the next iteration fail the nonce pre-check and the estimate
+    /// comes back as an error instead of a gas figure.
+    /// </remarks>
     [Test]
     public void CallAndRestore_RepeatedForGasEstimation_LeavesNoStateAndEstimates()
     {
@@ -1006,9 +1008,9 @@ public class FrameTxProcessorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(error, Is.Null);
-            Assert.That(estimate, Is.GreaterThan(0ul));
+            Assert.That(estimate, Is.GreaterThan((ulong)GasCostOf.Transaction), "the estimate collapsed to the regular-path lower bound");
             Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0ul), "the estimation loop committed a nonce bump");
-            Assert.That(_stateProvider.GetBalance(Sender) == 1.Ether, Is.True, "the estimation loop committed a payer charge");
+            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether), "the estimation loop committed a payer charge");
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -379,10 +379,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         UInt256 fees = premiumPerGas * (UInt256)spentGas;
         WorldState.AddToBalanceAndCreateIfNotExists(header.GasBeneficiary!, fees, spec);
 
-        // CommitAndRestore asks for both, and a commit clears the journals the snapshot indexes into,
-        // so restoring after it would revert nothing. The frame path keeps the whole transaction in
-        // the journal until here, so the restore alone returns the state the caller started with —
-        // which is what lets a gas-estimation loop run repeated CallAndRestore calls on one world state.
+        // CommitAndRestore asks for both, and a commit clears the journals the snapshot indexes into, so restoring
+        // after it would revert nothing. The frame path keeps the whole transaction in the journal until here, so the
+        // restore alone returns the state the caller started with.
         if (opts.HasFlag(ExecutionOptions.Restore))
         {
             WorldState.Restore(txSnapshot);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -379,15 +379,17 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         UInt256 fees = premiumPerGas * (UInt256)spentGas;
         WorldState.AddToBalanceAndCreateIfNotExists(header.GasBeneficiary!, fees, spec);
 
-        bool commit = opts.HasFlag(ExecutionOptions.Commit);
-        if (commit)
-        {
-            WorldState.Commit(spec, commitRoots: false);
-        }
-
+        // CommitAndRestore asks for both, and a commit clears the journals the snapshot indexes into,
+        // so restoring after it would revert nothing. The frame path keeps the whole transaction in
+        // the journal until here, so the restore alone returns the state the caller started with —
+        // which is what lets a gas-estimation loop run repeated CallAndRestore calls on one world state.
         if (opts.HasFlag(ExecutionOptions.Restore))
         {
             WorldState.Restore(txSnapshot);
+        }
+        else if (opts.HasFlag(ExecutionOptions.Commit))
+        {
+            WorldState.Commit(spec, commitRoots: false);
         }
 
         if (tracer.IsTracingFees)


### PR DESCRIPTION
Raised by @wurdum in review of #12593 and tracked separately as out of scope there.

On the frame path settlement ran `Commit` and then `Restore`. A commit clears the journals the entry snapshot indexes into, so the restore reverted nothing, which is exactly the combination `CommitAndRestore` (`eth_call`, `eth_estimateGas`, `trace_call`) asks for.

The visible effect is gas estimation. `GasEstimator` runs a probe plus a binary search of `CallAndRestore` calls against a single world state, so the first iteration's committed nonce bump and payer charge survive into the next one, which then fails the nonce pre-check. Estimation for a frame transaction came back as an error instead of a gas figure. The regular path does not have this because it never commits inside the estimate loop without unwinding afterwards.

The frame path keeps the whole transaction in the journal until settlement, so the restore on its own returns the state the caller started with. Commit now runs only when the caller did not ask for a restore.

Regression test: `FrameTxProcessorTests.CallAndRestore_RepeatedForGasEstimation_LeavesNoStateAndEstimates` drives `GasEstimator` over a frame transaction and asserts a non-zero estimate with no error, plus an unchanged sender nonce and balance afterwards. Without the fix it reports estimate 0, nonce 1 and a charged balance.

Tests: `Nethermind.Evm.Test` 5081 passed / 8 skipped / 0 failed; `Nethermind.Blockchain.Test` TransactionProcessorTests 116 passed.
