### PR TITLE
EIP-8141: statically reject approval scope on atomic-batch frames

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -91,9 +91,8 @@ public class FrameTxValidationTests
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: TxFrame.AtomicBatchFlag), Frame(mode: TxFrame.ModeVerify)],
             FrameTxValidation.AtomicBatchFollowedByVerifyFrame);
 
-        // ethereum/EIPs#12109: frames belonging to an atomic batch must not carry approval scope,
-        // where "belongs" means the frame is flagged or its predecessor is (covering the terminating
-        // frame). Both APPROVE_PAYMENT and APPROVE_EXECUTION are forbidden.
+        // EIP-8141: a frame belonging to an atomic batch (flagged, or the terminating frame following
+        // a flagged one) must not carry approval scope.
         yield return Case("ApprovePaymentOnBatchFrame_ApprovalScopeInAtomicBatch",
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: (byte)(TxFrame.ApprovePayment | TxFrame.AtomicBatchFlag)), DefaultModeFrame()],
             FrameTxValidation.ApprovalScopeInAtomicBatch);

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -91,6 +91,22 @@ public class FrameTxValidationTests
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: TxFrame.AtomicBatchFlag), Frame(mode: TxFrame.ModeVerify)],
             FrameTxValidation.AtomicBatchFollowedByVerifyFrame);
 
+        // ethereum/EIPs#12109: frames belonging to an atomic batch must not carry approval scope,
+        // where "belongs" means the frame is flagged or its predecessor is (covering the terminating
+        // frame). Both APPROVE_PAYMENT and APPROVE_EXECUTION are forbidden.
+        yield return Case("ApprovePaymentOnBatchFrame_ApprovalScopeInAtomicBatch",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: (byte)(TxFrame.ApprovePayment | TxFrame.AtomicBatchFlag)), DefaultModeFrame()],
+            FrameTxValidation.ApprovalScopeInAtomicBatch);
+        yield return Case("ApproveExecutionOnBatchFrame_ApprovalScopeInAtomicBatch",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: (byte)(TxFrame.ApproveExecution | TxFrame.AtomicBatchFlag)), DefaultModeFrame()],
+            FrameTxValidation.ApprovalScopeInAtomicBatch);
+        yield return Case("ApprovalOnBatchTerminatingFrame_ApprovalScopeInAtomicBatch",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: TxFrame.AtomicBatchFlag), Frame(flags: TxFrame.ApprovePayment)],
+            FrameTxValidation.ApprovalScopeInAtomicBatch);
+        yield return Case("BatchWithoutApprovalScope_Valid",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: TxFrame.AtomicBatchFlag), DefaultModeFrame()],
+            null);
+
         // total_frame_gas accumulated across frames must not overflow 2^64 - 1
         yield return Case("TotalFrameGasOverflows_FrameGasOverflow",
             static tx => tx.Frames = [Frame(gasLimit: ulong.MaxValue), Frame(gasLimit: 1)],

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -104,8 +104,8 @@ public static class FrameTxValidation
                 }
             }
 
-            // EIP-8141 (ethereum/EIPs#12109): a frame belonging to an atomic batch must not carry approval
-            // scope. A frame belongs when it is flagged, or its predecessor is (the terminating frame).
+            // EIP-8141: the terminating frame (the one after the last flagged frame) also belongs to the
+            // batch, so approval scope is forbidden on it as well as on flagged frames.
             if (((frame.Flags & TxFrame.AtomicBatchFlag) != 0 || (i > 0 && (frames[i - 1].Flags & TxFrame.AtomicBatchFlag) != 0))
                 && (frame.Flags & TxFrame.ApproveScopeMask) != 0)
             {

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -22,6 +22,7 @@ public static class FrameTxValidation
     public const string AtomicBatchOnLastFrame = "the last frame must not have the atomic batch flag set";
     public const string AtomicBatchOnVerifyFrame = "the atomic batch flag must not be set on a VERIFY frame";
     public const string AtomicBatchFollowedByVerifyFrame = "an atomic batch frame must not be followed by a VERIFY frame";
+    public const string ApprovalScopeInAtomicBatch = "frames belonging to an atomic batch must not carry approval scope";
     public const string FrameGasOverflow = "total frame gas must not exceed 2^64 - 1";
     public const string InvalidExpiryFrame = "expiry verifier frame must have zero flags, zero value, and 8-byte data";
     public const string MultipleExpiryFrames = "at most one expiry verifier frame is allowed";
@@ -101,6 +102,16 @@ public static class FrameTxValidation
                     error = AtomicBatchFollowedByVerifyFrame;
                     return false;
                 }
+            }
+
+            // EIP-8141 (ethereum/EIPs#12109): a frame belonging to an atomic batch must not carry
+            // approval scope. A frame belongs to a batch when it is flagged, or its predecessor is —
+            // covering the batch's non-flagged terminating frame and back-to-back batches.
+            if (((frame.Flags & TxFrame.AtomicBatchFlag) != 0 || (i > 0 && (frames[i - 1].Flags & TxFrame.AtomicBatchFlag) != 0))
+                && (frame.Flags & TxFrame.ApproveScopeMask) != 0)
+            {
+                error = ApprovalScopeInAtomicBatch;
+                return false;
             }
 
             if (frame.Mode == TxFrame.ModeVerify && frame.Target == Eip8141Constants.ExpiryVerifierAddress)

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -104,9 +104,8 @@ public static class FrameTxValidation
                 }
             }
 
-            // EIP-8141 (ethereum/EIPs#12109): a frame belonging to an atomic batch must not carry
-            // approval scope. A frame belongs to a batch when it is flagged, or its predecessor is —
-            // covering the batch's non-flagged terminating frame and back-to-back batches.
+            // EIP-8141 (ethereum/EIPs#12109): a frame belonging to an atomic batch must not carry approval
+            // scope. A frame belongs when it is flagged, or its predecessor is (the terminating frame).
             if (((frame.Flags & TxFrame.AtomicBatchFlag) != 0 || (i > 0 && (frames[i - 1].Flags & TxFrame.AtomicBatchFlag) != 0))
                 && (frame.Flags & TxFrame.ApproveScopeMask) != 0)
             {

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -104,10 +104,7 @@ public static class FrameTxValidation
                 }
             }
 
-            // EIP-8141: the terminating frame (the one after the last flagged frame) also belongs to the
-            // batch, so approval scope is forbidden on it as well as on flagged frames.
-            if (((frame.Flags & TxFrame.AtomicBatchFlag) != 0 || (i > 0 && (frames[i - 1].Flags & TxFrame.AtomicBatchFlag) != 0))
-                && (frame.Flags & TxFrame.ApproveScopeMask) != 0)
+            if (BelongsToAtomicBatch(frames, i) && (frame.Flags & TxFrame.ApproveScopeMask) != 0)
             {
                 error = ApprovalScopeInAtomicBatch;
                 return false;
@@ -182,6 +179,12 @@ public static class FrameTxValidation
         }
 
         return true;
+
+        // EIP-8141: a frame belongs to a batch when flagged, or when it is the terminating frame
+        // immediately after a flagged one (approval scope is forbidden on either).
+        static bool BelongsToAtomicBatch(TxFrame[] frames, int i) =>
+            (frames[i].Flags & TxFrame.AtomicBatchFlag) != 0
+            || (i > 0 && (frames[i - 1].Flags & TxFrame.AtomicBatchFlag) != 0);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
@@ -544,29 +545,46 @@ public class FrameTxProcessorTests
         Assert.That(_stateProvider.GetBalance(sponsor), Is.LessThan(1.Ether), "the sponsor paid for it");
     }
 
-    [Test]
-    public void Execute_AtomicBatch_PaymentApprovalInsideFailedBatch_UnrollsPayerAndInvalidatesTransaction()
+    [TestCaseSource(nameof(AtomicBatchApprovalScopeCases))]
+    public void IsWellFormed_ApprovalScopeOnAtomicBatchFrame_IsStaticallyRejected(TxFrame[] frames, string? expectedError)
     {
-        // ethereum/EIPs#11955: a failed batch unrolls ALL effects of an APPROVE it contained. The
-        // payer debit and sender nonce are reverted by Restore, and the payer/sender_approved context
-        // is rolled back to its pre-batch value too, so the payer never survives an uncollected charge.
-        // Payment was only approved inside the batch, so after the unroll payer == None and the
-        // terminal payer gate rejects the whole transaction — the sponsor is not charged.
-        DeploySmartSender(ApproveCode(TxFrame.ApproveExecution));
-        DeployContract(Observer, ApproveCode(TxFrame.ApprovePayment), 1.Ether);
-        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+        // ethereum/EIPs#12109: approval scope on a frame belonging to an atomic batch (the flagged
+        // frame, a mid-batch frame, or the batch's non-flagged terminating frame) is now a static
+        // validation failure — it replaces the old runtime batch-unroll of the approval context.
+        Transaction tx = FrameTx(nonce: 0, frames);
 
-        Transaction tx = FrameTx(nonce: 0,
-            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 200_000, UInt256.Zero, default),
-            Frame(TxFrame.ModeDefault, flags: (byte)(TxFrame.ApprovePayment | TxFrame.AtomicBatchFlag), target: Observer),
-            Frame(TxFrame.ModeSender, target: Recipient));
+        bool wellFormed = FrameTxValidation.IsWellFormed(tx, out string? error);
 
-        TransactionResult result = Process(tx);
+        Assert.That(wellFormed, Is.EqualTo(expectedError is null));
+        Assert.That(error, Is.EqualTo(expectedError));
+    }
 
-        Assert.That(result.TransactionExecuted, Is.False);
-        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
-        Assert.That(_stateProvider.GetBalance(Observer), Is.EqualTo(1.Ether), "the sponsor is not charged when the batch unrolls its payment approval");
-        Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0UL), "the sender nonce is not consumed");
+    private static IEnumerable<TestCaseData> AtomicBatchApprovalScopeCases()
+    {
+        // Payment approval on the flagged batch frame itself.
+        yield return new TestCaseData(
+            new[] { SelfVerifyFrame(), Frame(TxFrame.ModeDefault, flags: (byte)(TxFrame.ApprovePayment | TxFrame.AtomicBatchFlag)), Frame(TxFrame.ModeSender) },
+            FrameTxValidation.ApprovalScopeInAtomicBatch).SetName("IsWellFormed_PaymentApprovalOnBatchFrame_Rejected");
+
+        // Approval on a mid-batch frame (a batch spanning two flagged frames).
+        yield return new TestCaseData(
+            new[] { SelfVerifyFrame(), Frame(TxFrame.ModeDefault, flags: TxFrame.AtomicBatchFlag), Frame(TxFrame.ModeDefault, flags: (byte)(TxFrame.ApprovePayment | TxFrame.AtomicBatchFlag)), Frame(TxFrame.ModeSender) },
+            FrameTxValidation.ApprovalScopeInAtomicBatch).SetName("IsWellFormed_ApprovalOnMiddleBatchFrame_Rejected");
+
+        // Approval on the batch's non-flagged terminating frame (belongs to the batch via its predecessor).
+        yield return new TestCaseData(
+            new[] { SelfVerifyFrame(), Frame(TxFrame.ModeDefault, flags: TxFrame.AtomicBatchFlag), Frame(TxFrame.ModeSender, flags: TxFrame.ApprovePayment) },
+            FrameTxValidation.ApprovalScopeInAtomicBatch).SetName("IsWellFormed_ApprovalOnTerminatingFrame_Rejected");
+
+        // Execution approval (not just payment) is equally rejected; target null resolves to the sender.
+        yield return new TestCaseData(
+            new[] { SelfVerifyFrame(), Frame(TxFrame.ModeDefault, flags: (byte)(TxFrame.ApproveExecution | TxFrame.AtomicBatchFlag)), Frame(TxFrame.ModeSender) },
+            FrameTxValidation.ApprovalScopeInAtomicBatch).SetName("IsWellFormed_ExecutionApprovalOnBatchFrame_Rejected");
+
+        // A batch carrying no approval scope on any of its frames stays valid.
+        yield return new TestCaseData(
+            new[] { SelfVerifyFrame(), Frame(TxFrame.ModeDefault, flags: TxFrame.AtomicBatchFlag), Frame(TxFrame.ModeSender) },
+            null).SetName("IsWellFormed_BatchWithoutApprovalScope_Valid");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -547,9 +547,8 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_AtomicBatch_ApprovalScopeOnBatchFrame_ReturnsMalformedTransaction()
     {
-        // ethereum/EIPs#12109: approval scope on an atomic-batch frame is rejected before any frame runs
-        // (replacing the old runtime batch-unroll), so the sponsor is not charged and the nonce is intact.
-        // The processor enforces this itself: it is reachable without a static validator (e.g. eth_call).
+        // EIP-8141: approval scope on an atomic-batch frame is rejected before any frame runs. The processor
+        // enforces this itself since it is reachable without static validation (e.g. eth_call).
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecution));
         DeployContract(Observer, ApproveCode(TxFrame.ApprovePayment), 1.Ether);
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
@@ -545,46 +544,26 @@ public class FrameTxProcessorTests
         Assert.That(_stateProvider.GetBalance(sponsor), Is.LessThan(1.Ether), "the sponsor paid for it");
     }
 
-    [TestCaseSource(nameof(AtomicBatchApprovalScopeCases))]
-    public void IsWellFormed_ApprovalScopeOnAtomicBatchFrame_IsStaticallyRejected(TxFrame[] frames, string? expectedError)
+    [Test]
+    public void Execute_AtomicBatch_ApprovalScopeOnBatchFrame_ReturnsMalformedTransaction()
     {
-        // ethereum/EIPs#12109: approval scope on a frame belonging to an atomic batch (the flagged
-        // frame, a mid-batch frame, or the batch's non-flagged terminating frame) is now a static
-        // validation failure — it replaces the old runtime batch-unroll of the approval context.
-        Transaction tx = FrameTx(nonce: 0, frames);
+        // ethereum/EIPs#12109: approval scope on an atomic-batch frame is rejected before any frame runs
+        // (replacing the old runtime batch-unroll), so the sponsor is not charged and the nonce is intact.
+        // The processor enforces this itself: it is reachable without a static validator (e.g. eth_call).
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecution));
+        DeployContract(Observer, ApproveCode(TxFrame.ApprovePayment), 1.Ether);
 
-        bool wellFormed = FrameTxValidation.IsWellFormed(tx, out string? error);
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            Frame(TxFrame.ModeDefault, flags: (byte)(TxFrame.ApprovePayment | TxFrame.AtomicBatchFlag), target: Observer),
+            Frame(TxFrame.ModeSender, target: Recipient));
 
-        Assert.That(wellFormed, Is.EqualTo(expectedError is null));
-        Assert.That(error, Is.EqualTo(expectedError));
-    }
+        TransactionResult result = Process(tx);
 
-    private static IEnumerable<TestCaseData> AtomicBatchApprovalScopeCases()
-    {
-        // Payment approval on the flagged batch frame itself.
-        yield return new TestCaseData(
-            new[] { SelfVerifyFrame(), Frame(TxFrame.ModeDefault, flags: (byte)(TxFrame.ApprovePayment | TxFrame.AtomicBatchFlag)), Frame(TxFrame.ModeSender) },
-            FrameTxValidation.ApprovalScopeInAtomicBatch).SetName("IsWellFormed_PaymentApprovalOnBatchFrame_Rejected");
-
-        // Approval on a mid-batch frame (a batch spanning two flagged frames).
-        yield return new TestCaseData(
-            new[] { SelfVerifyFrame(), Frame(TxFrame.ModeDefault, flags: TxFrame.AtomicBatchFlag), Frame(TxFrame.ModeDefault, flags: (byte)(TxFrame.ApprovePayment | TxFrame.AtomicBatchFlag)), Frame(TxFrame.ModeSender) },
-            FrameTxValidation.ApprovalScopeInAtomicBatch).SetName("IsWellFormed_ApprovalOnMiddleBatchFrame_Rejected");
-
-        // Approval on the batch's non-flagged terminating frame (belongs to the batch via its predecessor).
-        yield return new TestCaseData(
-            new[] { SelfVerifyFrame(), Frame(TxFrame.ModeDefault, flags: TxFrame.AtomicBatchFlag), Frame(TxFrame.ModeSender, flags: TxFrame.ApprovePayment) },
-            FrameTxValidation.ApprovalScopeInAtomicBatch).SetName("IsWellFormed_ApprovalOnTerminatingFrame_Rejected");
-
-        // Execution approval (not just payment) is equally rejected; target null resolves to the sender.
-        yield return new TestCaseData(
-            new[] { SelfVerifyFrame(), Frame(TxFrame.ModeDefault, flags: (byte)(TxFrame.ApproveExecution | TxFrame.AtomicBatchFlag)), Frame(TxFrame.ModeSender) },
-            FrameTxValidation.ApprovalScopeInAtomicBatch).SetName("IsWellFormed_ExecutionApprovalOnBatchFrame_Rejected");
-
-        // A batch carrying no approval scope on any of its frames stays valid.
-        yield return new TestCaseData(
-            new[] { SelfVerifyFrame(), Frame(TxFrame.ModeDefault, flags: TxFrame.AtomicBatchFlag), Frame(TxFrame.ModeSender) },
-            null).SetName("IsWellFormed_BatchWithoutApprovalScope_Valid");
+        Assert.That(result.TransactionExecuted, Is.False);
+        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+        Assert.That(_stateProvider.GetBalance(Observer), Is.EqualTo(1.Ether), "the sponsor is not charged");
+        Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0UL), "the sender nonce is not consumed");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -73,8 +73,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
             totalFrameGas = accumulated;
 
-            // ethereum/EIPs#12109: a frame belonging to an atomic batch (flagged, or following a flagged
-            // frame) must not carry approval scope; enforced here so unvalidated entry points cannot mint ETH.
+            // Enforced here, not only in static validation, so unvalidated entry points (e.g. eth_call)
+            // cannot mint ETH: EIP-8141 forbids approval scope on a frame belonging to an atomic batch.
             if ((frame.IsAtomicBatch || prevIsAtomicBatch) && frame.AllowedApproveScope != 0)
             {
                 return TransactionResult.ErrorType.MalformedTransaction.WithDetail("approval scope on atomic batch frame");
@@ -262,10 +262,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                             frameReceipts[s] = new TxFrameReceipt(earlier.Status, earlier.GasUsed, []);
                         }
                     }
-                    // A batch frame's successful EIP-3529 refunds are discarded with its state, so the
-                    // refund counter rolls back to its pre-batch value. The approval context (payer,
-                    // sender_approved) needs no rollback: ethereum/EIPs#12109 forbids approval scope on
-                    // batch frames, rejected before execution, so no in-batch frame can have set it.
+                    // Refunds from the reverted batch are discarded with its state, so roll the counter back.
+                    // No payer/sender_approved rollback is needed: EIP-8141 forbids approval scope on batch frames.
                     refundCounter = batchStartRefund;
 
                     int terminal = i;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -135,8 +135,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         Snapshot batchStartSnapshot = default;
         StackAccessTracker batchTracker = default;
         int batchStartIndex = 0;
-        Address? batchStartPayer = null;
-        bool batchStartSenderApproved = false;
         long batchStartRefund = 0;
 
         for (int i = 0; i < frames.Length; i++)
@@ -152,8 +150,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 batchTracker = accessTracker;
                 batchTracker.TakeSnapshot();
                 batchStartIndex = i;
-                batchStartPayer = frameContext.Payer;
-                batchStartSenderApproved = frameContext.SenderApproved;
                 batchStartRefund = refundCounter;
             }
 
@@ -256,15 +252,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                             frameReceipts[s] = new TxFrameReceipt(earlier.Status, earlier.GasUsed, []);
                         }
                     }
-                    // EIP-8141 (ethereum/EIPs#11955): a failed batch unrolls ALL effects of any APPROVE
-                    // it contained. Restore reverts the payer debit and sender nonce (world state); the
-                    // approval context (payer, sender_approved) and refund counter are not world state,
-                    // so roll them back to their pre-batch values too. Without this, the payer field
-                    // would survive a reverted charge and the terminal gate would refund uncollected
-                    // funds. If the payer was only set inside the batch, it is now unset again and the
-                    // gate below rejects the transaction.
-                    frameContext.Payer = batchStartPayer;
-                    frameContext.SenderApproved = batchStartSenderApproved;
+                    // A batch frame's successful EIP-3529 refunds are discarded with its state, so the
+                    // refund counter rolls back to its pre-batch value. The approval context (payer,
+                    // sender_approved) needs no rollback: ethereum/EIPs#12109 statically forbids approval
+                    // scope on batch frames (FrameTxValidation), so no in-batch frame can have set it.
                     refundCounter = batchStartRefund;
 
                     int terminal = i;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -62,6 +62,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // on static validation having run.
         ulong intrinsicGas = CalculateFrameTxIntrinsicGas(tx, frames, spec);
         ulong totalFrameGas = 0;
+        bool prevIsAtomicBatch = false;
         foreach (TxFrame frame in frames)
         {
             ulong accumulated = totalFrameGas + frame.GasLimit;
@@ -71,6 +72,15 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             }
 
             totalFrameGas = accumulated;
+
+            // ethereum/EIPs#12109: a frame belonging to an atomic batch (flagged, or following a flagged
+            // frame) must not carry approval scope; enforced here so unvalidated entry points cannot mint ETH.
+            if ((frame.IsAtomicBatch || prevIsAtomicBatch) && frame.AllowedApproveScope != 0)
+            {
+                return TransactionResult.ErrorType.MalformedTransaction.WithDetail("approval scope on atomic batch frame");
+            }
+
+            prevIsAtomicBatch = frame.IsAtomicBatch;
         }
 
         ulong txGasLimit = intrinsicGas + totalFrameGas;
@@ -254,8 +264,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                     }
                     // A batch frame's successful EIP-3529 refunds are discarded with its state, so the
                     // refund counter rolls back to its pre-batch value. The approval context (payer,
-                    // sender_approved) needs no rollback: ethereum/EIPs#12109 statically forbids approval
-                    // scope on batch frames (FrameTxValidation), so no in-batch frame can have set it.
+                    // sender_approved) needs no rollback: ethereum/EIPs#12109 forbids approval scope on
+                    // batch frames, rejected before execution, so no in-batch frame can have set it.
                     refundCounter = batchStartRefund;
 
                     int terminal = i;


### PR DESCRIPTION
Matches the updated spec PR ethereum/EIPs#12109, which replaces the runtime batch-unroll rollback of the approval context with a static ban: a frame transaction is rejected at validation if any frame belonging to an atomic batch carries approval scope. A frame "belongs to a batch" when it has `ATOMIC_BATCH_FLAG` or its predecessor does (covering the batch's non-flagged terminating frame and consecutive batches). Both `APPROVE_EXECUTION` and `APPROVE_PAYMENT` are forbidden.

## Changes
- `FrameTxValidation.IsWellFormed`: new static check with reason `ApprovalScopeInAtomicBatch`, matching the spec pseudocode (frame or predecessor flagged ⇒ `flags & APPROVE_SCOPE_MASK == 0`).
- `TransactionProcessorBase.FrameTx`: removed the now-dead batch-unroll rollback of the transaction-scoped approval context (`payer`/`sender_approved`) — an in-batch APPROVE can no longer occur. The batch world-state restore and the refund-counter rollback are kept, as is the frame-level discard of approval effects on an individual frame revert (independent of batches).
- Tests: constraint-matrix cases in `FrameTxValidationTests`; reworked the former runtime-unroll test in `FrameTxProcessorTests` into an `IsWellFormed` matrix (approval on the flagged frame, a mid-batch frame, the terminating frame, `APPROVE_EXECUTION`; a no-approval batch stays valid).