### PR TITLE
test: add JSON converter golden tests and fix public-key DATA width

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Json/AddressConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/AddressConverterTests.cs
@@ -18,6 +18,20 @@ public class AddressConverterTests : ConverterTestBase<Address>
     [TestCaseSource(nameof(AddressTestCases))]
     public void Test_roundtrip(Address? value) => TestConverter(value!, static (address, address1) => address == address1, converter);
 
+    [TestCaseSource(nameof(SerializationCases))]
+    public void Serializes_as_prefixed_lowercase_hex(Address value, string expectedJson) => TestConverter(
+        value,
+        expectedJson,
+        converter,
+        static (address, address1) => address == address1);
+
+    static IEnumerable<TestCaseData> SerializationCases =
+    [
+        new TestCaseData(TestItem.AddressA, "\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\"").SetName("testItemA"),
+        // The zero address keeps its full width: an address is DATA, not a QUANTITY.
+        new TestCaseData(Address.Zero, "\"0x0000000000000000000000000000000000000000\"").SetName("zero"),
+    ];
+
     [TestCase("\"0xc94770007dda54cf92009bff0de90c06f603a09\"", TestName = "Rejects_39_hex_odd_short")]
     [TestCase("\"0xc94770007dda54cf92009bff0de90c06f603a09f1\"", TestName = "Rejects_41_hex_odd_long")]
     public void Rejects_odd_length_hex(string json)
@@ -68,10 +82,9 @@ public class AddressConverterTests : ConverterTestBase<Address>
         }
     }
 
+    // The non-null roundtrips live in Serializes_as_prefixed_lowercase_hex.
     static IEnumerable<TestCaseData> AddressTestCases =
     [
         new TestCaseData(null).SetName("null"),
-        new TestCaseData(Address.Zero).SetName("zero"),
-        new TestCaseData(TestItem.AddressA).SetName("testItemA"),
     ];
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/Base64ConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/Base64ConverterTests.cs
@@ -24,4 +24,13 @@ public class Base64ConverterTests : ConverterTestBase<byte[]?>
             value,
             static (before, after) => (before is null && after is null) || (before is not null && after is not null && before.SequenceEqual(after)),
             new Base64Converter());
+
+    [TestCase(new byte[0], "\"\"")]
+    [TestCase(new byte[] { 1 }, "\"AQ==\"")]
+    [TestCase(new byte[] { 0, 0, 255 }, "\"AAD/\"")]
+    public void Serializes_as_base64(byte[] value, string expectedJson) => TestConverter(
+            value,
+            expectedJson,
+            new Base64Converter(),
+            static (before, after) => (before is null && after is null) || (before is not null && after is not null && before.SequenceEqual(after)));
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/BigIntegerConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/BigIntegerConverterTests.cs
@@ -19,10 +19,9 @@ public class BigIntegerConverterTests : ConverterTestBase<BigInteger>
     [TestCaseSource(nameof(RoundtripTestCases))]
     public void Test_roundtrip(BigInteger value) => TestConverter(value, static (a, b) => a.Equals(b), converter);
 
+    // The int.MaxValue roundtrip lives in Serializes_as_decimal_string.
     static IEnumerable<TestCaseData> RoundtripTestCases =
     [
-        new TestCaseData((BigInteger)int.MaxValue)
-            .SetName("int.MaxValue"),
         new TestCaseData(BigInteger.One)
             .SetName("One"),
         new TestCaseData(BigInteger.Zero)
@@ -36,4 +35,8 @@ public class BigIntegerConverterTests : ConverterTestBase<BigInteger>
         BigInteger result = JsonSerializer.Deserialize<BigInteger>(json, options);
         Assert.That(result, Is.EqualTo(BigInteger.Parse(expected)));
     }
+
+    [Test]
+    public void Serializes_as_decimal_string() =>
+        TestConverter((BigInteger)int.MaxValue, "\"2147483647\"", converter, static (a, b) => a.Equals(b));
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/BloomConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/BloomConverterTests.cs
@@ -25,10 +25,17 @@ public class BloomConverterTests : ConverterTestBase<Bloom>
         Assert.That(() => JsonSerializer.Deserialize<Bloom>(json, options), Throws.InstanceOf<FormatException>());
     }
 
+    [Test]
+    public void Serializes_as_full_width_prefixed_hex() => TestConverter(
+        Bloom.Empty,
+        $"\"0x{new string('0', 512)}\"",
+        converter,
+        static (a, b) => a is null ? b is null : a.Equals(b));
+
+    // The empty-bloom roundtrip lives in Serializes_as_full_width_prefixed_hex.
     static IEnumerable<TestCaseData> BloomTestCases =
     [
         new TestCaseData(null).SetName("null"),
-        new TestCaseData(Bloom.Empty).SetName("empty"),
         new TestCaseData(new Bloom(Enumerable.Range(0, 255).Select(static i => (byte)i).ToArray())).SetName("range_0_to_254"),
     ];
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/Bytes32ConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/Bytes32ConverterTests.cs
@@ -21,5 +21,13 @@ namespace Nethermind.Core.Test.Json
                 values,
                 static (before, after) => Bytes.AreEqual(before.WithoutLeadingZeros(), after.WithoutLeadingZeros()),
                 new Bytes32Converter());
+
+        [TestCase(new byte[] { 1 }, "\"0x0000000000000000000000000000000000000000000000000000000000000001\"")]
+        [TestCase(new byte[] { 0, 1 }, "\"0x0000000000000000000000000000000000000000000000000000000000000001\"")]
+        public void Serializes_as_padded_prefixed_hex(byte[] value, string expectedJson) => TestConverter(
+                value,
+                expectedJson,
+                new Bytes32Converter(),
+                static (before, after) => Bytes.AreEqual(before.WithoutLeadingZeros(), after.WithoutLeadingZeros()));
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/ConverterTestBase.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/ConverterTestBase.cs
@@ -16,17 +16,33 @@ public class ConverterTestBase<T>
 
     protected void TestConverter<TItem>(TItem? item, JsonConverter<T> converter, Func<TItem, TItem, bool>? equalityComparer = null)
     {
-        JsonSerializerOptions options = new()
-        {
-            Converters =
-            {
-                converter
-            }
-        };
+        JsonSerializerOptions options = BuildOptions(converter);
+
+        AssertRoundtrip(item, JsonSerializer.Serialize(item, options), options, equalityComparer);
+    }
+
+    /// <summary>Asserts the exact serialized JSON before the roundtrip check.</summary>
+    protected void TestConverter<TItem>(TItem? item, string expectedJson, JsonConverter<T> converter, Func<TItem, TItem, bool>? equalityComparer = null)
+    {
+        JsonSerializerOptions options = BuildOptions(converter);
 
         string result = JsonSerializer.Serialize(item, options);
+        Assert.That(result, Is.EqualTo(expectedJson), result.Replace("\"", "\\\""));
 
-        TItem? deserialized = JsonSerializer.Deserialize<TItem>(result, options);
+        AssertRoundtrip(item, result, options, equalityComparer);
+    }
+
+    private static JsonSerializerOptions BuildOptions(JsonConverter<T> converter) => new()
+    {
+        Converters =
+        {
+            converter
+        }
+    };
+
+    private static void AssertRoundtrip<TItem>(TItem? item, string json, JsonSerializerOptions options, Func<TItem, TItem, bool>? equalityComparer)
+    {
+        TItem? deserialized = JsonSerializer.Deserialize<TItem>(json, options);
 
 #pragma warning disable CS8604
         if (equalityComparer is not null)

--- a/src/Nethermind/Nethermind.Core.Test/Json/NullableBigIntegerConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/NullableBigIntegerConverterTests.cs
@@ -35,4 +35,8 @@ public class NullableBigIntegerConverterTests : ConverterTestBase<BigInteger?>
         BigInteger? result = JsonSerializer.Deserialize<BigInteger?>(json, options);
         Assert.That(result, Is.EqualTo(expected is null ? null : BigInteger.Parse(expected)));
     }
+
+    [Test]
+    public void Serializes_as_decimal_string() =>
+        TestConverter((BigInteger?)int.MaxValue, "\"2147483647\"", converter, static (a, b) => a.Equals(b));
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/NullableLongConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/NullableLongConverterTests.cs
@@ -22,6 +22,11 @@ public class NullableLongConverterTests : ConverterTestBase<long?>
     [TestCase(0L)]
     public void Test_roundtrip(long value) => TestConverter((long?)value, static (a, b) => a.Equals(b), converter);
 
+    [TestCase(10485760L, "\"0xa00000\"")]
+    [TestCase(0L, "\"0x0\"")]
+    public void Writes_correct_hex(long value, string expectedJson) =>
+        TestConverter((long?)value, expectedJson, converter, static (a, b) => a.Equals(b));
+
     [TestCase("\"0xa00000\"", 10485760L)]
     [TestCase("\"0x0\"", 0L)]
     [TestCase("0", 0L)]

--- a/src/Nethermind/Nethermind.Core.Test/Json/NullableLongConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/NullableLongConverterTests.cs
@@ -24,7 +24,7 @@ public class NullableLongConverterTests : ConverterTestBase<long?>
 
     [TestCase(10485760L, "\"0xa00000\"")]
     [TestCase(0L, "\"0x0\"")]
-    public void Writes_correct_hex(long value, string expectedJson) =>
+    public void Serializes_as_hex_quantity(long value, string expectedJson) =>
         TestConverter((long?)value, expectedJson, converter, static (a, b) => a.Equals(b));
 
     [TestCase("\"0xa00000\"", 10485760L)]

--- a/src/Nethermind/Nethermind.Core.Test/Json/NullableUInt256ConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/NullableUInt256ConverterTests.cs
@@ -37,4 +37,8 @@ public class NullableUInt256ConverterTests : ConverterTestBase<UInt256?>
         UInt256? result = JsonSerializer.Deserialize<UInt256?>(json, options);
         Assert.That(result, Is.EqualTo(UInt256.Parse(expected)));
     }
+
+    [Test]
+    public void Serializes_as_hex_quantity() =>
+        TestConverter((UInt256?)10485760, "\"0xa00000\"", converter, static (a, b) => a.Equals(b));
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/PublicKeyConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/PublicKeyConverterTests.cs
@@ -17,15 +17,22 @@ public class PublicKeyConverterTests : ConverterTestBase<PublicKey>
     [TestCaseSource(nameof(PublicKeyTestCases))]
     public void Test_roundtrip(PublicKey? value) => TestConverter(value!, static (key, publicKey) => key == publicKey, converter);
 
-    [Test]
-    public void Serializes_as_prefixed_hex() => TestConverter(
-        TestItem.PublicKeyA,
-        "\"0xa49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92\"",
+    [TestCaseSource(nameof(FullWidthCases))]
+    public void Serializes_as_full_width_prefixed_hex(PublicKey value, string expectedJson) => TestConverter(
+        value,
+        expectedJson,
         converter,
         static (key, publicKey) => key == publicKey);
 
     static IEnumerable<TestCaseData> PublicKeyTestCases =
     [
         new TestCaseData(null).SetName("null"),
+    ];
+
+    static IEnumerable<TestCaseData> FullWidthCases =
+    [
+        // A public key is DATA per EIP-1474: two hex digits per byte, all 64 bytes kept.
+        new TestCaseData(new PublicKey(new byte[64]), $"\"0x{new string('0', 128)}\"").SetName("full_width_zero"),
+        new TestCaseData(TestItem.PublicKeyA, "\"0xa49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92\"").SetName("full_width_testItemA"),
     ];
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/PublicKeyConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/PublicKeyConverterTests.cs
@@ -24,15 +24,6 @@ public class PublicKeyConverterTests : ConverterTestBase<PublicKey>
         converter,
         static (key, publicKey) => key == publicKey);
 
-    // Known deviation: a public key is fixed-width DATA (parity_getTransaction), but the
-    // writer drops leading zeros. The reader pads the value back to 64 bytes.
-    [Test]
-    public void Serializes_zero_key_without_leading_zeros() => TestConverter(
-        new PublicKey(new byte[64]),
-        "\"0x0\"",
-        converter,
-        static (key, publicKey) => key == publicKey);
-
     static IEnumerable<TestCaseData> PublicKeyTestCases =
     [
         new TestCaseData(null).SetName("null"),

--- a/src/Nethermind/Nethermind.Core.Test/Json/PublicKeyConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/PublicKeyConverterTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Serialization.Json;
 using NUnit.Framework;
 
@@ -16,9 +17,24 @@ public class PublicKeyConverterTests : ConverterTestBase<PublicKey>
     [TestCaseSource(nameof(PublicKeyTestCases))]
     public void Test_roundtrip(PublicKey? value) => TestConverter(value!, static (key, publicKey) => key == publicKey, converter);
 
+    [Test]
+    public void Serializes_as_prefixed_hex() => TestConverter(
+        TestItem.PublicKeyA,
+        "\"0xa49ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365fdaeb0a70ce47f890cf2f9fca562a7ed784f76eb870a2c75c0f2ab476a70ccb67e92\"",
+        converter,
+        static (key, publicKey) => key == publicKey);
+
+    // Known deviation: a public key is fixed-width DATA (parity_getTransaction), but the
+    // writer drops leading zeros. The reader pads the value back to 64 bytes.
+    [Test]
+    public void Serializes_zero_key_without_leading_zeros() => TestConverter(
+        new PublicKey(new byte[64]),
+        "\"0x0\"",
+        converter,
+        static (key, publicKey) => key == publicKey);
+
     static IEnumerable<TestCaseData> PublicKeyTestCases =
     [
         new TestCaseData(null).SetName("null"),
-        new TestCaseData(new PublicKey(new byte[64])).SetName("zero"),
     ];
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/TxTypeConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/TxTypeConverterTests.cs
@@ -12,5 +12,15 @@ namespace Nethermind.Core.Test.Json
     {
         [TestCaseSource(typeof(TxTypeSource), nameof(TxTypeSource.Any))]
         public void Test_roundtrip(TxType arg) => TestConverter(arg, static (before, after) => before.Equals(after), new TxTypeConverter());
+
+        [TestCase(TxType.Legacy, "\"0x0\"")]
+        [TestCase(TxType.AccessList, "\"0x1\"")]
+        [TestCase(TxType.EIP1559, "\"0x2\"")]
+        [TestCase(TxType.Blob, "\"0x3\"")]
+        [TestCase(TxType.SetCode, "\"0x4\"")]
+        [TestCase((TxType)16, "\"0x10\"")]
+        [TestCase(TxType.DepositTx, "\"0x7e\"")]
+        public void Serializes_as_hex_quantity(TxType type, string expectedJson) =>
+            TestConverter(type, expectedJson, new TxTypeConverter(), static (before, after) => before.Equals(after));
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Json/UInt256ConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/UInt256ConverterTests.cs
@@ -25,9 +25,17 @@ public class UInt256ConverterTests : ConverterTestBase<UInt256>
     [TestCase(NumberConversion.Raw)]
     public void Test_roundtrip(NumberConversion numberConversion)
     {
-        TestConverter(int.MaxValue, static (integer, bigInteger) => integer.Equals(bigInteger), converter);
-        TestConverter(UInt256.One, static (integer, bigInteger) => integer.Equals(bigInteger), converter);
-        TestConverter(UInt256.Zero, static (integer, bigInteger) => integer.Equals(bigInteger), converter);
+        ForcedNumberConversion.Value = numberConversion;
+        try
+        {
+            TestConverter(int.MaxValue, static (integer, bigInteger) => integer.Equals(bigInteger), converter);
+            TestConverter(UInt256.One, static (integer, bigInteger) => integer.Equals(bigInteger), converter);
+            TestConverter(UInt256.Zero, static (integer, bigInteger) => integer.Equals(bigInteger), converter);
+        }
+        finally
+        {
+            ForcedNumberConversion.Value = NumberConversion.Hex;
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core.Test/Json/ValueHash256ConverterTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Json/ValueHash256ConverterTests.cs
@@ -28,7 +28,11 @@ public class ValueHash256ConverterTests
         string json = JsonSerializer.Serialize(hash, _options);
         ValueHash256 deserialized = JsonSerializer.Deserialize<ValueHash256>(json, _options);
 
-        Assert.That(deserialized, Is.EqualTo(hash));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(json, Is.EqualTo("\"" + ValidHex + "\""));
+            Assert.That(deserialized, Is.EqualTo(hash));
+        }
     }
 
     [TestCase("\"0x01\"", false, TestName = "Rejects_one_byte_hex_at_root")]

--- a/src/Nethermind/Nethermind.Core/Crypto/PublicKeyConverter.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/PublicKeyConverter.cs
@@ -35,5 +35,5 @@ public class PublicKeyConverter : JsonConverter<PublicKey>
     public override void Write(
         Utf8JsonWriter writer,
         PublicKey publicKey,
-        JsonSerializerOptions options) => ByteArrayConverter.Convert(writer, publicKey.Bytes);
+        JsonSerializerOptions options) => ByteArrayConverter.Convert(writer, publicKey.Bytes, skipLeadingZeros: false);
 }

--- a/src/Nethermind/Nethermind.Flashbots.Test/BidTraceSerializationTests.cs
+++ b/src/Nethermind/Nethermind.Flashbots.Test/BidTraceSerializationTests.cs
@@ -47,14 +47,17 @@ namespace Nethermind.Flashbots.Test
         public void BidTrace_WithLeadingZeroPublicKeys_SerializesFullWidth()
         {
             // The first hex digit is zero. A public key is DATA per EIP-1474. All 128 digits must survive.
-            const string leadingZeroKey = "0a9ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e5a8728693008d97ae83d51194f273455acf1a30e6f3926aefaede484c07d8ec3";
-            PublicKey publicKey = new(leadingZeroKey);
-            BidTrace trace = new(12345, Hash256.Zero, Hash256.Zero, publicKey, publicKey, Address.Zero, 0, 0, UInt256.Zero);
+            const string builderKey = "0a9ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e5a8728693008d97ae83d51194f273455acf1a30e6f3926aefaede484c07d8ec3";
+            const string proposerKey = "0b9ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e5a8728693008d97ae83d51194f273455acf1a30e6f3926aefaede484c07d8ec4";
+            BidTrace trace = new(12345, Hash256.Zero, Hash256.Zero, new PublicKey(builderKey), new PublicKey(proposerKey), Address.Zero, 0, 0, UInt256.Zero);
 
             string json = _serializer.Serialize(trace);
 
-            Assert.That(json, Does.Contain($"\"builder_public_key\":\"0x{leadingZeroKey}\""));
-            Assert.That(json, Does.Contain($"\"proposer_public_key\":\"0x{leadingZeroKey}\""));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(json, Does.Contain($"\"builder_public_key\":\"0x{builderKey}\""));
+                Assert.That(json, Does.Contain($"\"proposer_public_key\":\"0x{proposerKey}\""));
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Flashbots.Test/BidTraceSerializationTests.cs
+++ b/src/Nethermind/Nethermind.Flashbots.Test/BidTraceSerializationTests.cs
@@ -1,8 +1,11 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Flashbots.Data;
+using Nethermind.Int256;
 using Nethermind.Serialization.Json;
 using NUnit.Framework;
 
@@ -38,6 +41,20 @@ namespace Nethermind.Flashbots.Test
             Assert.That(trace.ProposerPublicKey.Bytes.Length, Is.EqualTo(64));
             Assert.That(trace.BuilderPublicKey.Bytes, Is.EqualTo(builderKeyBytes));
             Assert.That(trace.ProposerPublicKey.Bytes, Is.EqualTo(proposerKeyBytes));
+        }
+
+        [Test]
+        public void BidTrace_WithLeadingZeroPublicKeys_SerializesFullWidth()
+        {
+            // The first hex digit is zero. A public key is DATA per EIP-1474. All 128 digits must survive.
+            const string leadingZeroKey = "0a9ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e5a8728693008d97ae83d51194f273455acf1a30e6f3926aefaede484c07d8ec3";
+            PublicKey publicKey = new(leadingZeroKey);
+            BidTrace trace = new(12345, Hash256.Zero, Hash256.Zero, publicKey, publicKey, Address.Zero, 0, 0, UInt256.Zero);
+
+            string json = _serializer.Serialize(trace);
+
+            Assert.That(json, Does.Contain($"\"builder_public_key\":\"0x{leadingZeroKey}\""));
+            Assert.That(json, Does.Contain($"\"proposer_public_key\":\"0x{leadingZeroKey}\""));
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/AddressConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/AddressConverterTests.cs
@@ -12,5 +12,9 @@ namespace Nethermind.JsonRpc.Test.Data
     {
         [Test]
         public void Can_do_roundtrip() => TestRoundtrip(TestItem.AddressA);
+
+        [Test]
+        public void Serializes_as_prefixed_lowercase_hex() =>
+            TestToJson(TestItem.AddressA, "\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\"");
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/DictionaryConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/DictionaryConverterTests.cs
@@ -37,5 +37,16 @@ namespace Nethermind.JsonRpc.Test.Data
 
             TestRoundtrip(dictionary);
         }
+
+        // One entry keeps the expectation free of dictionary ordering.
+        [Test]
+        public void Serializes_address_key_as_prefixed_hex() =>
+            TestToJson(new Dictionary<Address, string> { { TestItem.AddressA, "A" } },
+                "{\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\":\"A\"}");
+
+        [Test]
+        public void Serializes_address_as_key_type_as_prefixed_hex() =>
+            TestToJson(new Dictionary<AddressAsKey, string> { { TestItem.AddressA, "A" } },
+                "{\"0xb7705ae4c6f81b66cdb323c65f4e8133690fc099\":\"A\"}");
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/IdConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/IdConverterTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Numerics;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Nethermind.Int256;
@@ -33,7 +34,14 @@ namespace Nethermind.JsonRpc.Test.Data
         public void Can_handle_int()
         {
             IdConverter converter = new();
-            converter.Write(new Utf8JsonWriter(new MemoryStream()), 1, null);
+            using MemoryStream stream = new();
+            using (Utf8JsonWriter writer = new(stream))
+            {
+                converter.Write(writer, 1, null!);
+                writer.Flush();
+            }
+
+            Assert.That(Encoding.UTF8.GetString(stream.ToArray()), Is.EqualTo("1"));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/KeccakConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/KeccakConverterTests.cs
@@ -12,5 +12,9 @@ namespace Nethermind.JsonRpc.Test.Data
     {
         [Test]
         public void Can_do_roundtrip() => TestRoundtrip(TestItem.KeccakA);
+
+        [Test]
+        public void Serializes_as_prefixed_hex() =>
+            TestToJson(TestItem.KeccakA, "\"0x03783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760\"");
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/UInt256ConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/UInt256ConverterTests.cs
@@ -15,5 +15,13 @@ namespace Nethermind.JsonRpc.Test.Data
 
         [Test]
         public void Can_do_roundtrip_big() => TestRoundtrip(UInt256.Parse("1321312414124781461278412647816487146817246816418746187246187468714681"));
+
+        [Test]
+        public void Serializes_as_hex_quantity() => TestToJson((UInt256)123456789, "\"0x75bcd15\"");
+
+        [Test]
+        public void Serializes_big_value_as_hex_quantity() => TestToJson(
+            UInt256.Parse("1321312414124781461278412647816487146817246816418746187246187468714681"),
+            "\"0x31029c8dfe1bb525f0e013a68e2cdcfc562b27e9e16d9b0fb8044672b9\"");
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
@@ -393,5 +393,17 @@ namespace Nethermind.JsonRpc.Test.Modules
             Assert.That(tx.PublicKey.Bytes.Length, Is.EqualTo(64));
             Assert.That(tx.PublicKey.Bytes, Is.EqualTo(fullPublicKeyBytes));
         }
+
+        [Test]
+        public void ParityTransaction_WithLeadingZeroPublicKey_SerializesFullWidth()
+        {
+            // The first hex digit is zero. A public key is DATA per EIP-1474, so all 128 digits must survive.
+            const string leadingZeroKeyHex = "049ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e5a8728693008d97ae83d51194f273455acf1a30e6f3926aefaede484c07d8ec3";
+            ParityTransaction tx = new() { PublicKey = new PublicKey(leadingZeroKeyHex) };
+
+            string json = new EthereumJsonSerializer().Serialize(tx);
+
+            Assert.That(json, Does.Contain($"\"publicKey\":\"0x{leadingZeroKeyHex}\""));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
@@ -397,8 +397,8 @@ namespace Nethermind.JsonRpc.Test.Modules
         [Test]
         public void ParityTransaction_WithLeadingZeroPublicKey_SerializesFullWidth()
         {
-            // The first hex digit is zero. A public key is DATA per EIP-1474, so all 128 digits must survive.
-            const string leadingZeroKeyHex = "049ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e5a8728693008d97ae83d51194f273455acf1a30e6f3926aefaede484c07d8ec3";
+            // The first hex digit is zero. A public key is DATA per EIP-1474. All 128 digits must survive.
+            const string leadingZeroKeyHex = "0a9ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e5a8728693008d97ae83d51194f273455acf1a30e6f3926aefaede484c07d8ec3";
             ParityTransaction tx = new() { PublicKey = new PublicKey(leadingZeroKeyHex) };
 
             string json = new EthereumJsonSerializer().Serialize(tx);


### PR DESCRIPTION
## Changes

How to review this fast: seven commits, one concern each - no-op test fixes, golden tests, a zero-key handoff, the product fix the golden tests surfaced, then three re-review-feedback commits (wire-level fixtures + a golden rename + fixture hardening); 21 files, one product file (`PublicKeyConverter.cs`, one line).

Part 1 - test hygiene (JSON converter suites in `Nethermind.JsonRpc.Test/Data` and `Nethermind.Core.Test/Json`):

- **Tests that could not fail, fixed**: `IdConverterTests.Can_handle_int` wrote to a `MemoryStream` and asserted nothing - it now asserts the written text. The core `UInt256ConverterTests.Test_roundtrip` received a `NumberConversion` parameter it never applied, so its three cases ran identically - it now forces the conversion mode like its sibling tests.
- **Golden tests added**: converter test files whose only serialization checks were self-consistency roundtrips (serialize-deserialize-compare, JSON text never pinned) now assert the exact JSON somewhere: Address (incl. full-width zero), Keccak, UInt256 (hex quantities), Dictionary (single-entry, to stay free of ordering), Base64, Bytes32 (left-padding pinned), TxType (`0x0`-`0x4` plus the two-nibble `0x10`/`0x7e` path), BigInteger and NullableBigInteger (decimal-string format), NullableLong, NullableUInt256, ValueHash256, PublicKey. `ConverterTestBase` gains an expected-JSON overload; roundtrip cases the golden tests fully subsume are removed.
- Expected values are hand-derived (python hex/base64; the `PublicKeyA` value via from-scratch secp256k1, cross-checked against the `parity_enode` expectation), never captured from Nethermind output.

Part 2 - the fix those golden tests surfaced:

`PublicKeyConverter.Write` used `ByteArrayConverter.Convert`'s default `skipLeadingZeros: true`, which trims at nibble granularity. A public key is DATA per EIP-1474 ("two hex digits per byte"), so the trimmed form was invalid whenever a key's first hex digit is 0 (~1 in 16 keys emit 127 digits; a zero key emits `0x0`). The fix passes `skipLeadingZeros: false`, matching the other DATA converters (Address, Bloom, Bytes32).

- The only affected wire surface is `parity_pendingTransactions` `publicKey` (`ParityTransaction` is the sole write-side user; `EthereumJsonSerializer` registers `PublicKeyHashedConverter` first, so unattributed `PublicKey` properties - e.g. `admin_peers` ids - are untouched; Flashbots `BidTrace` uses the converter read-side only in production).
- The read side is unchanged and still pads short inputs, so previously emitted trimmed values remain accepted.
- Regression test written first: the zero-key case fails without the fix (`0x0`) and passes with it; the `TestItem.PublicKeyA` case (no leading zeros) passes on both sides, pinning the fix's scope to leading-zero keys.

Re-review feedback (both attribute-level guards the converter unit tests cannot give):

- Wire-level fixtures for a leading-zero key on both `[JsonConverter(typeof(PublicKeyConverter))]` sites: `ParityTransaction` and Flashbots `BidTrace` now each serialize through a real `EthereumJsonSerializer` and pin the exact full-width field. Swapping or dropping the attribute falls back to `PublicKeyHashedConverter` (unprefixed keccak) and fails the assert.
- One new golden renamed to the PR's `Serializes_as_*` convention. Sibling files (`LongConverterTests`, `NullableULongConverterTests`, `Hash256ConverterTests`) keep their pre-existing `Writes_correct_hex` names - untouched master code, not an oversight.

Part of the test-hygiene series (#12689, #12690 - merged, #12693, #12694, #12696, #12699).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- Red-green verified on this branch: reverting the one-line fix makes `Serializes_as_full_width_prefixed_hex(full_width_zero)` fail, and also fails both new wire-level tests (`ParityTransaction_WithLeadingZeroPublicKey_SerializesFullWidth`, `BidTrace_WithLeadingZeroPublicKeys_SerializesFullWidth`).
- Mutation-checked, 12/12 detected for the golden tests (deliberate breaks, each reverted): the TxType Legacy special case, the Bytes32 padding flag, and a BigInteger value change each fail exactly their golden tests; 9 expectation flips each fail exactly their consumers. The two wire-level tests each verified red under a fix revert and an expectation flip.
- Full local suites green (windows-x64, release): Core.Test 6002 total 0 failed, JsonRpc.Test 1936 total 0 failed (one unreproducible transient in an earlier run, outside the touched files), ParityRpcModuleTests 13/13 (their pinned `publicKey` starts with a non-zero digit, so expectations are unchanged), Flashbots.Test 7/7. Touched fixtures repeated with no flakes.
- Repo-wide sweep found no test or fixture pinning a trimmed public key.

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [x] Yes

`parity_pendingTransactions` now returns `publicKey` as full-width DATA (0x + 128 hex digits). Keys whose first hex digit is zero were previously returned with the leading zeros trimmed.
