### PR TITLE
fix(jsonrpc): serialize receipt root as full-width DATA

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/ReceiptsForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/ReceiptsForRpcTests.cs
@@ -77,29 +77,20 @@ namespace Nethermind.JsonRpc.Test.Data
             Assert.That(document.RootElement.TryGetProperty(jsonPropertyName, out _), Is.False);
         }
 
-        [Test]
-        public void Serializes_root_as_full_width_data()
+        private const string LeadingZeroRootHex = "0x0a9ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e";
+
+        [TestCase(LeadingZeroRootHex, LeadingZeroRootHex)]
+        [TestCase(null, "0x0000000000000000000000000000000000000000000000000000000000000000")]
+        public void Serializes_root_as_full_width_data(string? rootHex, string expectedRoot)
         {
-            // The first hex digit is zero. A receipt root is DATA per EIP-1474. All 64 digits must survive.
-            const string leadingZeroRootHex = "0x0a9ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e";
+            // A receipt root is DATA per EIP-1474. The writer must keep all 64 digits. A null root becomes the full-width zero hash.
             TxReceipt receipt = CreateDiagnosticReceipt();
-            receipt.PostTransactionState = new Hash256(leadingZeroRootHex);
+            receipt.PostTransactionState = rootHex is null ? null : new Hash256(rootHex);
 
             string serialized = SerializeReceipt(receipt);
 
             using JsonDocument document = JsonDocument.Parse(serialized);
-            Assert.That(document.RootElement.GetProperty("root").GetString(), Is.EqualTo(leadingZeroRootHex));
-        }
-
-        [Test]
-        public void Serializes_null_root_as_full_width_zero()
-        {
-            TxReceipt receipt = CreateDiagnosticReceipt();
-
-            string serialized = SerializeReceipt(receipt);
-
-            using JsonDocument document = JsonDocument.Parse(serialized);
-            Assert.That(document.RootElement.GetProperty("root").GetString(), Is.EqualTo($"0x{new string('0', 64)}"));
+            Assert.That(document.RootElement.GetProperty("root").GetString(), Is.EqualTo(expectedRoot));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/ReceiptsForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/ReceiptsForRpcTests.cs
@@ -78,8 +78,10 @@ namespace Nethermind.JsonRpc.Test.Data
         }
 
         private const string LeadingZeroRootHex = "0x0a9ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e";
+        private const string LeadingZeroByteRootHex = "0x009ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e";
 
         [TestCase(LeadingZeroRootHex, LeadingZeroRootHex)]
+        [TestCase(LeadingZeroByteRootHex, LeadingZeroByteRootHex)]
         [TestCase(null, "0x0000000000000000000000000000000000000000000000000000000000000000")]
         public void Serializes_root_as_full_width_data(string? rootHex, string expectedRoot)
         {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/ReceiptsForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/ReceiptsForRpcTests.cs
@@ -78,6 +78,31 @@ namespace Nethermind.JsonRpc.Test.Data
         }
 
         [Test]
+        public void Serializes_root_as_full_width_data()
+        {
+            // The first hex digit is zero. A receipt root is DATA per EIP-1474. All 64 digits must survive.
+            const string leadingZeroRootHex = "0x0a9ac7010c2e0a444dfeeabadbafa4856ba4a2d732acb86d20c577b3b365f52e";
+            TxReceipt receipt = CreateDiagnosticReceipt();
+            receipt.PostTransactionState = new Hash256(leadingZeroRootHex);
+
+            string serialized = SerializeReceipt(receipt);
+
+            using JsonDocument document = JsonDocument.Parse(serialized);
+            Assert.That(document.RootElement.GetProperty("root").GetString(), Is.EqualTo(leadingZeroRootHex));
+        }
+
+        [Test]
+        public void Serializes_null_root_as_full_width_zero()
+        {
+            TxReceipt receipt = CreateDiagnosticReceipt();
+
+            string serialized = SerializeReceipt(receipt);
+
+            using JsonDocument document = JsonDocument.Parse(serialized);
+            Assert.That(document.RootElement.GetProperty("root").GetString(), Is.EqualTo($"0x{new string('0', 64)}"));
+        }
+
+        [Test]
         public void Error_field_is_not_serialized()
         {
             Hash256 txHash = Keccak.OfAnEmptyString;

--- a/src/Nethermind/Nethermind.JsonRpc/Converters/TxReceiptConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Converters/TxReceiptConverter.cs
@@ -31,7 +31,7 @@ public class TxReceiptConverter : JsonConverter<TxReceipt>
                 JsonSerializer.Serialize(writer, receipt.Type, options);
             }
             writer.WritePropertyName("root");
-            ByteArrayConverter.Convert(writer, (receipt.Root ?? Keccak.Zero).Bytes);
+            JsonSerializer.Serialize(writer, receipt.Root ?? Keccak.Zero, options);
             writer.WritePropertyName("status");
             JsonSerializer.Serialize(writer, receipt.Status, options);
 


### PR DESCRIPTION
## Changes

`TxReceiptConverter.Write` wrote the receipt `root` via `ByteArrayConverter.Convert`'s default `skipLeadingZeros: true`, which trims at nibble granularity. A receipt root is 32-byte DATA per EIP-1474 ("two hex digits per byte"), so a state root whose first hex digit is 0 lost digits (63 emitted), and a null root emitted `0x0`. The fix serializes `root` the same way the method already serializes `blockHash` - through `Hash256Converter`, whose writer is fixed-width (`0x` + 64 digits) - removing the one line in the codebase that put a `Hash256` on the wire trimmed.

- Write surfaces: the converter is registered globally at runner startup and by the t8n tool, whose `PostState.Receipts` is a raw `TxReceipt[]` - t8n output now matches the reference (geth) full-width form. Standard receipt RPCs (`eth_getTransactionReceipt` etc.) go through `ReceiptForRpc`, whose `root` already used `Hash256Converter` - unaffected (their pinned fixtures already show 64-digit roots).
- The read side is unchanged. Notably, the old trimmed forms were never readable by Nethermind's own reader (`0x0` and 63-digit roots throw on odd-length hex; a 62-digit root throws on length in the `Hash256` constructor), so the fix also repairs write-read round-tripping.
- Unchanged and deliberately out of scope: the converter still emits `root` on every receipt, substituting the zero hash when there is no post-state root (EIP-658 receipts). Omitting the field instead would be a separate shape change.
- Same bug class as #12705's `PublicKeyConverter` fix; found by review on that PR. This was the last trimming DATA writer found in a repo sweep.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- Regression test written first: `Serializes_root_as_full_width_data` (parameterized: leading-zero-nibble root, leading-zero-byte root, null root - the 63-digit, 62-digit and `0x0` legacy outputs) fails every case on master and passes with the fix; all cases fail again under a fix revert and under expectation flips.
- Full JsonRpc.Test suite green (windows-x64, release): 1932 total, 0 failed on the captured rerun (one transient in an earlier run, outside the touched files); touched fixture repeated 3x with no flakes.
- Repo-wide sweep found no test or fixture pinning a trimmed root (`0x0` or 63-digit).

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [x] Yes

t8n (and any surface serializing a raw `TxReceipt`) now emits `root` as full-width DATA (`0x` + 64 hex digits). A null root was previously `0x0` and is now 64 zero digits; roots with a leading zero digit were previously trimmed.
