### PR TITLE
EIP-8141: blob-pool routing, sidecar, and production budget for blob-carrying frame transactions

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -494,8 +494,10 @@ namespace Nethermind.Blockchain.Test
         [Test]
         public void CanAddTransaction_skips_blob_carrying_frame_transaction()
         {
-            // EIP8141: block production does not yet meter blob-carrying frame txs against the block
-            // blob budget, so the picker excludes them conservatively to avoid self-invalidating a block.
+            // EIP8141: blob-carrying frame txs are routed to the blob pool and metered against the block
+            // blob budget by the blob-selection path, so they do not reach this normal-pool picker in the
+            // standard flow. The picker still excludes any that arrive here (defense in depth): without a
+            // resolvable EIP-7594 sidecar they cannot be produced with a complete blobs bundle.
             IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
             using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
             stateProvider.CreateAccount(TestItem.AddressA, 1.Ether);

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -152,9 +152,10 @@ public class TxPoolSourceTests
         Assert.That(result, Is.EqualTo(new[] { highPriorityBlobTx, lowerPriorityRegularTx }).UsingTransactionComparer());
     }
 
-    // EIP-8141: a blob-carrying frame tx (type 6) routed to the blob pool is produced through the same
-    // blob-budget selection path as a type-3 tx. It is metered against the block blob budget: selected
-    // when within budget, excluded when it would overflow it, so a produced block never exceeds the budget.
+    // EIP-8141: validates the tx-source selection/metering groundwork only — end-to-end production of
+    // blob-frame txs is deferred (the production picker deliberately skips them). A blob-carrying frame tx
+    // routed to the blob pool is metered against the block blob budget like a type-3 tx: selected when
+    // within budget, excluded when it would overflow it. Does not assert the tx is producible.
     [TestCase(3, 6, true)]
     [TestCase(3, 2, false)]
     public void GetTransactions_meters_blob_carrying_frame_tx_against_blob_budget(int blobCount, int blobLimit, bool expectSelected)

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -19,6 +19,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.TxPool.Comparison;
 
@@ -149,5 +150,80 @@ public class TxPoolSourceTests
 
         // Assert: High priority blob tx should come BEFORE lower priority regular tx
         Assert.That(result, Is.EqualTo(new[] { highPriorityBlobTx, lowerPriorityRegularTx }).UsingTransactionComparer());
+    }
+
+    // EIP-8141: a blob-carrying frame tx (type 6) routed to the blob pool is produced through the same
+    // blob-budget selection path as a type-3 tx. It is metered against the block blob budget: selected
+    // when within budget, excluded when it would overflow it, so a produced block never exceeds the budget.
+    [TestCase(3, 6, true)]
+    [TestCase(3, 2, false)]
+    public void GetTransactions_meters_blob_carrying_frame_tx_against_blob_budget(int blobCount, int blobLimit, bool expectSelected)
+    {
+        TestSingleReleaseSpecProvider specProvider = new(Cancun.Instance);
+        TransactionComparerProvider transactionComparerProvider = new(specProvider, Build.A.BlockTree().TestObject);
+
+        Transaction frameBlobTx = BuildFrameBlobTxWithSidecar(senderByte: 1, blobCount: blobCount);
+
+        ITxPool txPool = Substitute.For<ITxPool>();
+        txPool.GetPendingTransactions().Returns([]);
+        txPool.GetPendingLightBlobTransactionsBySender()
+            .Returns(new Dictionary<AddressAsKey, Transaction[]> { { frameBlobTx.SenderAddress!, [frameBlobTx] } });
+        txPool.SupportsBlobs.Returns(true);
+
+        ITxFilterPipeline txFilterPipeline = Substitute.For<ITxFilterPipeline>();
+        txFilterPipeline.Execute(Arg.Any<Transaction>(), Arg.Any<BlockHeader>(), Arg.Any<IReleaseSpec>()).Returns(true);
+
+        TxPoolTxSource txSource = new(txPool, specProvider, transactionComparerProvider, LimboLogs.Instance,
+            txFilterPipeline, new BlocksConfig { SecondsPerSlot = 12, BlockProductionBlobLimit = blobLimit });
+
+        BlockHeader parent = Build.A.BlockHeader.WithNumber(0).WithExcessBlobGas(0).TestObject;
+        Transaction[] result = txSource.GetTransactions(parent, long.MaxValue).ToArray();
+
+        ulong selectedBlobs = result.Aggregate(0UL, (sum, tx) => sum + (ulong)tx.GetBlobCount());
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Contains(frameBlobTx), Is.EqualTo(expectSelected));
+            Assert.That(selectedBlobs, Is.EqualTo(expectSelected ? (ulong)blobCount : 0UL));
+            Assert.That(selectedBlobs, Is.LessThanOrEqualTo((ulong)Cancun.Instance.MaxProductionBlobCount(blobLimit)));
+        }
+    }
+
+    private static Transaction BuildFrameBlobTxWithSidecar(byte senderByte, int blobCount)
+    {
+        byte[][] versionedHashes = new byte[blobCount][];
+        byte[][] blobs = new byte[blobCount][];
+        byte[][] commitments = new byte[blobCount][];
+        byte[][] proofs = new byte[blobCount][];
+        for (int i = 0; i < blobCount; i++)
+        {
+            byte[] hash = new byte[Eip4844Constants.BytesPerBlobVersionedHash];
+            hash[0] = KzgPolynomialCommitments.KzgBlobHashVersionV1;
+            hash[1] = (byte)i;
+            versionedHashes[i] = hash;
+            blobs[i] = [];
+            commitments[i] = [];
+            proofs[i] = [];
+        }
+
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            SenderAddress = new Address(new byte[19].Concat(new[] { senderByte }).ToArray()),
+            Nonce = 0,
+            GasLimit = 1_000_000,
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 100.GWei,
+            MaxFeePerBlobGas = 1000,
+            Frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default),
+            ],
+            FrameSignatures = [],
+            BlobVersionedHashes = versionedHashes,
+            NetworkWrapper = new ShardBlobNetworkWrapper(blobs, commitments, proofs, ProofVersion.V0),
+        };
+        tx.Hash = tx.CalculateHash();
+        return tx;
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Comparers/BlobTxPriorityComparer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Comparers/BlobTxPriorityComparer.cs
@@ -25,7 +25,7 @@ public sealed class BlobTxPriorityComparer : IComparer<Transaction>
         if (x is null) return TxComparisonResult.XFirst;
         if (y is null) return TxComparisonResult.YFirst;
 
-        return x.SupportsBlobs == y.SupportsBlobs ? TxComparisonResult.Equal :
-            x.SupportsBlobs ? TxComparisonResult.XFirst : TxComparisonResult.YFirst;
+        return x.CarriesBlobs == y.CarriesBlobs ? TxComparisonResult.Equal :
+            x.CarriesBlobs ? TxComparisonResult.XFirst : TxComparisonResult.YFirst;
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -65,12 +65,8 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, "Transaction already in block");
                 }
 
-                // EIP8141: blob-carrying frame transactions are routed to the blob pool and metered against
-                // the block blob budget by the blob-selection path in TxPoolTxSource (like type-3), so they
-                // never reach this normal-pool picker in the standard flow. This guard stays as defense in
-                // depth: a frame tx arriving here still carries no resolvable EIP-7594 sidecar, so producing
-                // it would count towards header.BlobGasUsed yet leave the block's blobs bundle incomplete.
-                // Exclude it until the sidecar wire format lands and its blob data can be published.
+                // EIP-8141: defense in depth — a blob-carrying frame tx here has no resolvable EIP-7594
+                // sidecar, so producing it would leave the block's blobs bundle incomplete.
                 if (currentTx.Type == TxType.FrameTx && currentTx.CarriesBlobs)
                 {
                     return args.Set(TxAction.Skip, "Blob-carrying frame transaction not yet supported in block production");

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -71,7 +71,7 @@ namespace Nethermind.Consensus.Processing
                 // depth: a frame tx arriving here still carries no resolvable EIP-7594 sidecar, so producing
                 // it would count towards header.BlobGasUsed yet leave the block's blobs bundle incomplete.
                 // Exclude it until the sidecar wire format lands and its blob data can be published.
-                if (currentTx.Type == TxType.FrameTx && currentTx.BlobVersionedHashes is { Length: > 0 })
+                if (currentTx.Type == TxType.FrameTx && currentTx.CarriesBlobs)
                 {
                     return args.Set(TxAction.Skip, "Blob-carrying frame transaction not yet supported in block production");
                 }
@@ -138,7 +138,7 @@ namespace Nethermind.Consensus.Processing
                         return false;
                     }
 
-                    if (transaction.BlobVersionedHashes is { Length: > 0 } && (
+                    if (transaction.CarriesBlobs && (
                         !BlobGasCalculator.TryCalculateBlobBaseFee(block.Header, transaction, releaseSpec.BlobBaseFeeUpdateFraction, out UInt256 blobBaseFee) ||
                         senderBalance < (maxFee += blobBaseFee)))
                     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -65,8 +65,12 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, "Transaction already in block");
                 }
 
-                // EIP-8141: block production does not yet meter blob-carrying frame txs against the block
-                // blob budget, so exclude them conservatively rather than risk exceeding MaxBlobGasPerBlock.
+                // EIP8141: blob-carrying frame transactions are routed to the blob pool and metered against
+                // the block blob budget by the blob-selection path in TxPoolTxSource (like type-3), so they
+                // never reach this normal-pool picker in the standard flow. This guard stays as defense in
+                // depth: a frame tx arriving here still carries no resolvable EIP-7594 sidecar, so producing
+                // it would count towards header.BlobGasUsed yet leave the block's blobs bundle incomplete.
+                // Exclude it until the sidecar wire format lands and its blob data can be published.
                 if (currentTx.Type == TxType.FrameTx && currentTx.BlobVersionedHashes is { Length: > 0 })
                 {
                     return args.Set(TxAction.Skip, "Blob-carrying frame transaction not yet supported in block production");

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -66,7 +66,8 @@ namespace Nethermind.Consensus.Processing
                 }
 
                 // EIP-8141: defense in depth — a blob-carrying frame tx here has no resolvable EIP-7594
-                // sidecar, so producing it would leave the block's blobs bundle incomplete.
+                // sidecar, and the blobs-bundle builders filter on SupportsBlobs (type-6 excluded), so
+                // producing it would leave the block's blobs bundle incomplete.
                 if (currentTx.Type == TxType.FrameTx && currentTx.CarriesBlobs)
                 {
                     return args.Set(TxAction.Skip, "Blob-carrying frame transaction not yet supported in block production");

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -65,12 +65,11 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, "Transaction already in block");
                 }
 
-                // EIP-8141: defense in depth — a blob-carrying frame tx here has no resolvable EIP-7594
-                // sidecar, and the blobs-bundle builders filter on SupportsBlobs (type-6 excluded), so
-                // producing it would leave the block's blobs bundle incomplete.
+                // EIP-8141: blob-frame production is deferred — deliberately skip until a follow-up wires
+                // picker admission together with type-6 support in the blobs-bundle builders.
                 if (currentTx.Type == TxType.FrameTx && currentTx.CarriesBlobs)
                 {
-                    return args.Set(TxAction.Skip, "Blob-carrying frame transaction not yet supported in block production");
+                    return args.Set(TxAction.Skip, "Blob-carrying frame transaction production is deferred");
                 }
 
                 // A frame transaction's GasLimit is only the sum of its frame gas limits, so gating on it alone would

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -348,8 +348,9 @@ public class BlockValidator(
         {
             Transaction transaction = transactions[txIndex];
 
-            // EIP-8141: gate on blob hashes, not the type-3-only SupportsBlobs, so blob-carrying frame txs also count.
-            if (transaction.BlobVersionedHashes is not { Length: > 0 })
+            // EIP-8141: a blob-carrying frame transaction (type 6) follows EIP-4844 too, so gate on the
+            // instance-level blob predicate rather than the type-level SupportsBlobs (which is type-3 only).
+            if (!transaction.CarriesBlobs)
             {
                 continue;
             }

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -348,8 +348,6 @@ public class BlockValidator(
         {
             Transaction transaction = transactions[txIndex];
 
-            // EIP-8141: a blob-carrying frame transaction (type 6) follows EIP-4844 too, so gate on the
-            // instance-level blob predicate rather than the type-level SupportsBlobs (which is type-3 only).
             if (!transaction.CarriesBlobs)
             {
                 continue;

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -87,10 +87,9 @@ public sealed class TxValidator : ITxValidator
         // Frame transactions have no envelope ECDSA signature (explicit sender, protocol-validated
         // signature list) — signature/intrinsic-gas validators do not apply; per-frame gas and
         // signature validation happen during processing.
-        // EIP8141: a blob-carrying frame tx currently has no EIP-7594 sidecar network wrapper, so no
-        // sidecar/proof validator is registered here (a wrapper on a frame tx is rejected as malformed
-        // by NonBlobFieldsTxValidator's absence + the network-form gates). When the type-6 sidecar wire
-        // format lands, add a MempoolBlobTxValidator-equivalent (and proof-version validator) to this chain.
+        // EIP8141: FrameTxDecoder never decodes a network wrapper for a type-6 tx, so no sidecar/proof
+        // validator is registered and no mempool form is required yet. Add a blob-sidecar and proof-version
+        // validator here once the type-6 sidecar wire format lands.
         RegisterValidator(TxType.FrameTx, new CompositeTxValidator([
             new ReleaseSpecTxValidator(static spec => spec.IsEip8141Enabled),
             NonceCapTxValidator.Instance,

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -87,6 +87,10 @@ public sealed class TxValidator : ITxValidator
         // Frame transactions have no envelope ECDSA signature (explicit sender, protocol-validated
         // signature list) — signature/intrinsic-gas validators do not apply; per-frame gas and
         // signature validation happen during processing.
+        // EIP8141: a blob-carrying frame tx currently has no EIP-7594 sidecar network wrapper, so no
+        // sidecar/proof validator is registered here (a wrapper on a frame tx is rejected as malformed
+        // by NonBlobFieldsTxValidator's absence + the network-form gates). When the type-6 sidecar wire
+        // format lands, add a MempoolBlobTxValidator-equivalent (and proof-version validator) to this chain.
         RegisterValidator(TxType.FrameTx, new CompositeTxValidator([
             new ReleaseSpecTxValidator(static spec => spec.IsEip8141Enabled),
             NonceCapTxValidator.Instance,

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -87,9 +87,8 @@ public sealed class TxValidator : ITxValidator
         // Frame transactions have no envelope ECDSA signature (explicit sender, protocol-validated
         // signature list) — signature/intrinsic-gas validators do not apply; per-frame gas and
         // signature validation happen during processing.
-        // EIP8141: FrameTxDecoder never decodes a network wrapper for a type-6 tx, so no sidecar/proof
-        // validator is registered and no mempool form is required yet. Add a blob-sidecar and proof-version
-        // validator here once the type-6 sidecar wire format lands.
+        // EIP-8141: no type-6 network wrapper is decoded yet, so no sidecar/proof validator is registered.
+        // Add a blob-sidecar and proof-version validator here once the sidecar wire format lands.
         RegisterValidator(TxType.FrameTx, new CompositeTxValidator([
             new ReleaseSpecTxValidator(static spec => spec.IsEip8141Enabled),
             NonceCapTxValidator.Instance,

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -55,6 +55,17 @@ namespace Nethermind.Core
         public bool SupportsBlobs => Type.SupportsBlobs();
         public bool SupportsAuthorizationList => Type.SupportsAuthorizationList();
         public bool SupportsFrames => Type.SupportsFrames();
+
+        /// <summary>
+        /// EIP-8141: whether this transaction is blob-carrying for pool routing and blob-gas accounting —
+        /// a type-3 (EIP-4844) blob tx or a blob-carrying frame tx (type 6 with versioned hashes).
+        /// </summary>
+        /// <remarks>
+        /// Instance-level gate distinct from the type-level <see cref="SupportsBlobs"/>, which networking
+        /// and decode paths key on. Mirrors the accounting predicate used in block validation and the blob
+        /// gas calculator so a blob-carrying frame tx counts towards the block blob budget like a type-3 tx.
+        /// </remarks>
+        public bool CarriesBlobs => BlobVersionedHashes is { Length: > 0 };
         public ulong GasLimit { get; set; }
         private ulong _spentGas;
         private ulong _blockGasUsed;

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -57,14 +57,9 @@ namespace Nethermind.Core
         public bool SupportsFrames => Type.SupportsFrames();
 
         /// <summary>
-        /// EIP-8141: whether this transaction is blob-carrying for pool routing and blob-gas accounting —
-        /// a type-3 (EIP-4844) blob tx or a blob-carrying frame tx (type 6 with versioned hashes).
+        /// EIP-8141: whether this transaction carries blobs (a type-3 blob tx or a blob-carrying type-6 frame tx)
+        /// for pool routing and blob-gas accounting; the instance-level counterpart to <see cref="SupportsBlobs"/>.
         /// </summary>
-        /// <remarks>
-        /// Instance-level gate distinct from the type-level <see cref="SupportsBlobs"/>, which networking
-        /// and decode paths key on. Mirrors the accounting predicate used in block validation and the blob
-        /// gas calculator so a blob-carrying frame tx counts towards the block blob budget like a type-3 tx.
-        /// </remarks>
         public bool CarriesBlobs => BlobVersionedHashes is { Length: > 0 };
         public ulong GasLimit { get; set; }
         private ulong _spentGas;

--- a/src/Nethermind/Nethermind.Evm/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionExtensions.cs
@@ -20,7 +20,7 @@ namespace Nethermind.Evm
             UInt256 effectiveGasPrice = tx.CalculateEffectiveGasPrice(spec.IsEip1559Enabled, header.BaseFeePerGas);
 
             // EIP-8141: gate on blob presence, not the type-3-only SupportsBlobs, so frame-blob txs report blob gas.
-            if (tx.GetBlobCount() > 0)
+            if (tx.CarriesBlobs)
             {
                 if (header.ExcessBlobGas is null)
                 {

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -196,7 +196,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         protected virtual void SendNewTransactionCore(Transaction tx)
         {
-            if (!tx.SupportsBlobs) //additional protection from sending full tx with blob
+            if (!tx.CarriesBlobs) //additional protection from sending full tx with blob (incl. blob-carrying frame txs)
             {
                 SendMessage(new ArrayPoolList<Transaction>(1) { tx });
             }
@@ -231,7 +231,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
                     packetSizeLeft = TransactionsMessage.MaxPacketSize;
                 }
 
-                if (tx.Hash is not null && !tx.SupportsBlobs) //additional protection from sending full tx with blob
+                if (tx.Hash is not null && !tx.CarriesBlobs) //additional protection from sending full tx with blob (incl. blob-carrying frame txs)
                 {
                     txsToSend.Add(tx);
                     packetSizeLeft -= txSize;

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers.Binary;
 using CkzgLib;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
@@ -1476,9 +1477,61 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        // EIP-8141: a blob-carrying frame tx lives in the blob pool, so the on-head expiry pass must scan it there
+        // (the blob pool's Inserted/Removed feed the same expiry counter as the normal pool).
+        [Test]
+        public async Task Expired_blob_carrying_frame_tx_is_evicted_from_blob_pool_on_new_head()
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.InMemory };
+            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider());
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            Transaction tx = BuildBlobFrameTx(nonce: 0, blobCount: 1, deadline: 1_000);
+            Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(1_500).TestObject);
+
+            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(0),
+                "an expired blob-carrying frame tx must be evicted from the blob pool on a new head");
+        }
+
+        // EIP-8141: with blobs disabled the blob-pool routing has zero capacity, so a blob-carrying frame tx must be
+        // rejected as an unsupported type at ingress rather than silently dropped as too-low-fee.
+        [Test]
+        public void Blob_carrying_frame_tx_is_rejected_when_blobs_disabled()
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.Disabled };
+            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider());
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            AcceptTxResult result = _txPool.SubmitTx(BuildBlobFrameTx(nonce: 0, blobCount: 1), TxHandlingOptions.None);
+
+            Assert.That(result, Is.EqualTo(AcceptTxResult.NotSupportedTxType));
+        }
+
+        // EIP-8141: a blob-carrying frame tx counts against the per-sender blob limit (MaxPendingBlobTxsPerSender),
+        // not the unlimited normal-pool default, so a nonce beyond that window is rejected as too far in the future.
+        [Test]
+        public void Blob_carrying_frame_tx_respects_per_sender_blob_limit()
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.InMemory, MaxPendingBlobTxsPerSender = 2 };
+            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider());
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            using (Assert.EnterMultipleScope())
+            {
+                // Consecutive nonces within the window [current, current + 2] are admitted; the first beyond it is not.
+                Assert.That(_txPool.SubmitTx(BuildBlobFrameTx(nonce: 0, blobCount: 1), TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+                Assert.That(_txPool.SubmitTx(BuildBlobFrameTx(nonce: 1, blobCount: 1), TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+                Assert.That(_txPool.SubmitTx(BuildBlobFrameTx(nonce: 2, blobCount: 1), TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+                Assert.That(_txPool.SubmitTx(BuildBlobFrameTx(nonce: 3, blobCount: 1), TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.NonceTooFarInFuture));
+            }
+        }
+
         private static ISpecProvider GetBogotaSpecProvider() => new TestSpecProvider(Bogota.Instance);
 
-        private Transaction BuildBlobFrameTx(ulong nonce, int blobCount)
+        private Transaction BuildBlobFrameTx(ulong nonce, int blobCount, ulong? deadline = null)
         {
             byte[][] versionedHashes = null;
             if (blobCount > 0)
@@ -1493,6 +1546,17 @@ namespace Nethermind.TxPool.Test
                 }
             }
 
+            List<TxFrame> frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default),
+            ];
+            if (deadline is not null)
+            {
+                byte[] expiryData = new byte[Eip8141Constants.ExpiryDataLength];
+                BinaryPrimitives.WriteUInt64BigEndian(expiryData, deadline.Value);
+                frames.Add(new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 50_000, UInt256.Zero, expiryData));
+            }
+
             Transaction tx = new()
             {
                 Type = TxType.FrameTx,
@@ -1503,10 +1567,7 @@ namespace Nethermind.TxPool.Test
                 GasPrice = 1,
                 DecodedMaxFeePerGas = 1.GWei,
                 MaxFeePerBlobGas = blobCount > 0 ? 1.GWei : UInt256.Zero,
-                Frames =
-                [
-                    new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default),
-                ],
+                Frames = [.. frames],
                 FrameSignatures = [],
                 BlobVersionedHashes = versionedHashes,
             };

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -1410,5 +1410,108 @@ namespace Nethermind.TxPool.Test
                 Assert.That(proofs[1].Length, Is.EqualTo(Ckzg.CellsPerExtBlob));
             }
         }
+
+        // EIP-8141: a blob-carrying frame tx (type 6 with versioned hashes) is routed to the blob pool,
+        // mirroring type-3 routing, so it is subject to blob-pool rules. A plain frame tx and a type-3
+        // blob tx must route unchanged.
+        [Test]
+        public void blob_carrying_frame_tx_is_routed_to_blob_pool()
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.InMemory };
+            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider());
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            Transaction frameBlobTx = BuildBlobFrameTx(nonce: 0, blobCount: 1);
+
+            AcceptTxResult result = _txPool.SubmitTx(frameBlobTx, TxHandlingOptions.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
+                Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(0));
+            }
+        }
+
+        [Test]
+        public void non_blob_frame_tx_is_routed_to_normal_pool()
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.InMemory };
+            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider());
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            Transaction frameTx = BuildBlobFrameTx(nonce: 0, blobCount: 0);
+
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+                Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(0));
+            }
+        }
+
+        [Test]
+        public void type3_blob_tx_routing_is_unchanged_alongside_frame_txs()
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.InMemory };
+            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider());
+            EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
+
+            Transaction type3Tx = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(1, spec: new ReleaseSpec() { IsEip7594Enabled = true })
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .WithNonce(0)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyB).TestObject;
+
+            AcceptTxResult result = _txPool.SubmitTx(type3Tx, TxHandlingOptions.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
+                Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(0));
+            }
+        }
+
+        private static ISpecProvider GetBogotaSpecProvider() => new TestSpecProvider(Bogota.Instance);
+
+        private Transaction BuildBlobFrameTx(ulong nonce, int blobCount)
+        {
+            byte[][] versionedHashes = null;
+            if (blobCount > 0)
+            {
+                versionedHashes = new byte[blobCount][];
+                for (int i = 0; i < blobCount; i++)
+                {
+                    byte[] hash = new byte[Eip4844Constants.BytesPerBlobVersionedHash];
+                    hash[0] = KzgPolynomialCommitments.KzgBlobHashVersionV1;
+                    hash[1] = (byte)i;
+                    versionedHashes[i] = hash;
+                }
+            }
+
+            Transaction tx = new()
+            {
+                Type = TxType.FrameTx,
+                ChainId = _specProvider.ChainId,
+                SenderAddress = TestItem.AddressA,
+                Nonce = nonce,
+                GasLimit = 1_000_000,
+                GasPrice = 1,
+                DecodedMaxFeePerGas = 1.GWei,
+                MaxFeePerBlobGas = blobCount > 0 ? 1.GWei : UInt256.Zero,
+                Frames =
+                [
+                    new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default),
+                ],
+                FrameSignatures = [],
+                BlobVersionedHashes = versionedHashes,
+            };
+            tx.Hash = tx.CalculateHash();
+            return tx;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -1453,6 +1453,26 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        // EIP-8141: a blob-carrying frame tx must clear the same blob-pool fee floor as a type-3 tx, so one priced
+        // below the current blob base fee is rejected as FeeTooLow rather than admitted via the SupportsBlobs gate.
+        [Test]
+        public void Blob_carrying_frame_tx_below_current_blob_base_fee_is_rejected()
+        {
+            ISpecProvider specProvider = GetBogotaSpecProvider();
+            ChainHeadInfoProvider chainHeadInfoProvider = new(new ChainHeadSpecProvider(specProvider, _blockTree), _blockTree, _stateProvider)
+            {
+                CurrentFeePerBlobGas = 100
+            };
+
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.InMemory, CurrentBlobBaseFeeRequired = true };
+            _txPool = CreatePool(config: txPoolConfig, specProvider: specProvider, chainHeadInfoProvider: chainHeadInfoProvider);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            Transaction tx = BuildBlobFrameTx(nonce: 0, blobCount: 1, maxFeePerBlobGas: 99);
+
+            Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.FeeTooLow));
+        }
+
         [Test]
         public void type3_blob_tx_routing_is_unchanged_alongside_frame_txs()
         {
@@ -1478,7 +1498,9 @@ namespace Nethermind.TxPool.Test
         }
 
         // EIP-8141: a blob-carrying frame tx lives in the blob pool, so the on-head expiry pass must scan it there
-        // (the blob pool's Inserted/Removed feed the same expiry counter as the normal pool).
+        // (the blob pool's Inserted/Removed feed the same expiry counter as the normal pool). This holds only under
+        // BlobsSupportMode.InMemory: persistent storage's LightTransaction hard-codes TxType.Blob (SupportsFrames
+        // false), so it cannot be evicted until the light record carries the tx type.
         [Test]
         public async Task Expired_blob_carrying_frame_tx_is_evicted_from_blob_pool_on_new_head()
         {
@@ -1531,7 +1553,7 @@ namespace Nethermind.TxPool.Test
 
         private static ISpecProvider GetBogotaSpecProvider() => new TestSpecProvider(Bogota.Instance);
 
-        private Transaction BuildBlobFrameTx(ulong nonce, int blobCount, ulong? deadline = null)
+        private Transaction BuildBlobFrameTx(ulong nonce, int blobCount, ulong? deadline = null, UInt256? maxFeePerBlobGas = null)
         {
             byte[][] versionedHashes = null;
             if (blobCount > 0)
@@ -1566,7 +1588,7 @@ namespace Nethermind.TxPool.Test
                 GasLimit = 1_000_000,
                 GasPrice = 1,
                 DecodedMaxFeePerGas = 1.GWei,
-                MaxFeePerBlobGas = blobCount > 0 ? 1.GWei : UInt256.Zero,
+                MaxFeePerBlobGas = blobCount > 0 ? (maxFeePerBlobGas ?? 1.GWei) : null,
                 Frames = [.. frames],
                 FrameSignatures = [],
                 BlobVersionedHashes = versionedHashes,

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -1532,6 +1532,26 @@ namespace Nethermind.TxPool.Test
             Assert.That(result, Is.EqualTo(AcceptTxResult.NotSupportedTxType));
         }
 
+        // EIP-8141: a persistent blob pool would store a blob-carrying frame tx via the frame RLP decoder, which drops
+        // the sidecar and reloads a wrapper-less, unproducible LightTransaction. Such txs are therefore rejected at
+        // ingress under the persistent modes and admitted only under BlobsSupportMode.InMemory, where the full tx is kept.
+        [TestCase(BlobsSupportMode.Storage)]
+        [TestCase(BlobsSupportMode.StorageWithReorgs)]
+        public void Blob_carrying_frame_tx_is_rejected_under_persistent_blob_pool(BlobsSupportMode blobsSupport)
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = blobsSupport };
+            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider());
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            AcceptTxResult result = _txPool.SubmitTx(BuildBlobFrameTx(nonce: 0, blobCount: 1), TxHandlingOptions.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(AcceptTxResult.NotSupportedTxType));
+                Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(0));
+            }
+        }
+
         // EIP-8141: a blob-carrying frame tx counts against the per-sender blob limit (MaxPendingBlobTxsPerSender),
         // not the unlimited normal-pool default, so a nonce beyond that window is rejected as too far in the future.
         [Test]

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -36,7 +36,7 @@ namespace Nethermind.TxPool.Filters
             UInt256 balance = account.Balance;
 
             BucketBalanceState bucketBalanceState = new(account.Nonce, tx.Nonce);
-            TxDistinctSortedPool pool = tx.SupportsBlobs ? _blobTxs : _txs;
+            TxDistinctSortedPool pool = tx.CarriesBlobs ? _blobTxs : _txs;
             // tx.SenderAddress! as unknownSenderFilter will run before this one
             pool.VisitBucket(tx.SenderAddress!, ref bucketBalanceState, static (Transaction otherTx, ref BucketBalanceState bucketState) =>
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FeeTooLowFilter.cs
@@ -41,7 +41,7 @@ namespace Nethermind.TxPool.Filters
                 return AcceptTxResult.FeeTooLow;
             }
 
-            TxDistinctSortedPool relevantPool = (tx.SupportsBlobs ? _blobTxs : _txs);
+            TxDistinctSortedPool relevantPool = (tx.CarriesBlobs ? _blobTxs : _txs);
             if (relevantPool.IsFull() && relevantPool.TryGetLast(out Transaction? lastTx)
                 && affordableGasPrice <= lastTx?.GasBottleneck)
             {

--- a/src/Nethermind/Nethermind.TxPool/Filters/FutureNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FutureNonceFilter.cs
@@ -12,7 +12,7 @@ public class FutureNonceFilter(ITxPoolConfig txPoolConfig) : IIncomingTxFilter
 
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        int relevantMaxPendingTxsPerSender = (tx.SupportsBlobs
+        int relevantMaxPendingTxsPerSender = (tx.CarriesBlobs
             ? _txPoolConfig.MaxPendingBlobTxsPerSender
             : _txPoolConfig.MaxPendingTxsPerSender);
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
@@ -21,12 +21,12 @@ namespace Nethermind.TxPool.Filters
         {
             bool isLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) != 0;
             bool nonceGapsAllowed = isLocal || !_txs.IsFull();
-            if (nonceGapsAllowed && !tx.SupportsBlobs)
+            if (nonceGapsAllowed && !tx.CarriesBlobs)
             {
                 return AcceptTxResult.Accepted;
             }
 
-            int numberOfSenderTxsInPending = tx.SupportsBlobs
+            int numberOfSenderTxsInPending = tx.CarriesBlobs
                 ? _blobTxs.GetBucketCount(tx.SenderAddress!)
                 : _txs.GetBucketCount(tx.SenderAddress!); // since unknownSenderFilter will run before this one
             ulong currentNonce = state.SenderAccount.Nonce;

--- a/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
@@ -18,7 +18,7 @@ internal sealed class NotSupportedTxFilter(ITxPoolConfig txPoolConfig, IChainHea
 
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        if (_txPoolConfig.BlobsSupport.IsDisabled() && tx.SupportsBlobs)
+        if (_txPoolConfig.BlobsSupport.IsDisabled() && tx.CarriesBlobs)
         {
             Metrics.PendingTransactionsNotSupportedTxType++;
             if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, blob transactions are not supported.");

--- a/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
@@ -25,6 +25,16 @@ internal sealed class NotSupportedTxFilter(ITxPoolConfig txPoolConfig, IChainHea
             return AcceptTxResult.NotSupportedTxType;
         }
 
+        // EIP-8141: a persistent blob pool stores a blob-carrying frame tx via the frame RLP decoder, which
+        // has no network-wrapper handling and drops the sidecar, reloading a wrapper-less LightTransaction that
+        // is unproducible and unservable. Only BlobsSupportMode.InMemory keeps the full tx intact, so admit it there only.
+        if (tx.SupportsFrames && tx.CarriesBlobs && _txPoolConfig.BlobsSupport.IsPersistentStorage())
+        {
+            Metrics.PendingTransactionsNotSupportedTxType++;
+            if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, blob-carrying frame transactions require in-memory blob support.");
+            return AcceptTxResult.NotSupportedTxType;
+        }
+
         // EIP8141-GAP (devnet only): frame txs are admitted while the fork is unscheduled on public networks.
         // The public-mempool DoS rules (validation-prefix simulation, MAX_VERIFY_GAS, paymaster reservation,
         // failed-APPROVE replay bound, payer-exposure accounting, dependency-set revalidation/eviction ordering)

--- a/src/Nethermind/Nethermind.TxPool/Filters/PriorityFeeTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/PriorityFeeTooLowFilter.cs
@@ -15,7 +15,7 @@ public class PriorityFeeTooLowFilter(IChainHeadInfoProvider chainHeadInfoProvide
 
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions handlingOptions)
     {
-        if (!tx.SupportsBlobs)
+        if (!tx.CarriesBlobs)
         {
             return AcceptTxResult.Accepted;
         }

--- a/src/Nethermind/Nethermind.TxPool/Filters/SizeTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/SizeTxFilter.cs
@@ -16,7 +16,7 @@ internal sealed class SizeTxFilter(ITxPoolConfig txPoolConfig, ILogger logger) :
 
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        long maxSize = tx.SupportsBlobs ? _configuredMaxBlobTxSize : _configuredMaxTxSize;
+        long maxSize = tx.CarriesBlobs ? _configuredMaxBlobTxSize : _configuredMaxTxSize;
 
         if (tx.GetLength(shouldCountBlobs: false) > maxSize)
         {

--- a/src/Nethermind/Nethermind.TxPool/Filters/TxTypeTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/TxTypeTxFilter.cs
@@ -13,8 +13,6 @@ public class TxTypeTxFilter(TxDistinctSortedPool txs, TxDistinctSortedPool blobT
 {
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        // EIP-8141: route on the instance-level blob gate so a blob-carrying frame tx is treated as a
-        // blob-pool member (conflicts with the sender's normal-pool txs), mirroring type-3 routing.
         TxDistinctSortedPool otherTxTypePool = tx.CarriesBlobs ? txs : blobTxs;
         if (otherTxTypePool.ContainsBucket(tx.SenderAddress!)) // as unknownSenderFilter will run before this one
         {

--- a/src/Nethermind/Nethermind.TxPool/Filters/TxTypeTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/TxTypeTxFilter.cs
@@ -13,7 +13,9 @@ public class TxTypeTxFilter(TxDistinctSortedPool txs, TxDistinctSortedPool blobT
 {
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        TxDistinctSortedPool otherTxTypePool = tx.SupportsBlobs ? txs : blobTxs;
+        // EIP-8141: route on the instance-level blob gate so a blob-carrying frame tx is treated as a
+        // blob-pool member (conflicts with the sender's normal-pool txs), mirroring type-3 routing.
+        TxDistinctSortedPool otherTxTypePool = tx.CarriesBlobs ? txs : blobTxs;
         if (otherTxTypePool.ContainsBucket(tx.SenderAddress!)) // as unknownSenderFilter will run before this one
         {
             Metrics.PendingTransactionsConflictingTxType++;

--- a/src/Nethermind/Nethermind.TxPool/SpecDrivenTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/SpecDrivenTxGossipPolicy.cs
@@ -10,9 +10,8 @@ public class SpecDrivenTxGossipPolicy(IChainHeadInfoProvider chainHeadInfoProvid
     private IChainHeadInfoProvider ChainHeadInfoProvider { get; } = chainHeadInfoProvider;
 
     public bool ShouldGossipTransaction(Transaction tx) =>
-        // EIP8141: a blob-carrying frame tx (type 6) has no EIP-7594 sidecar network wrapper yet, so it
-        // cannot participate in the announce-by-hash / serve-with-sidecar blob gossip protocol. Withhold
-        // it from gossip until that wire format lands, rather than leaking it in bare consensus form.
+        // EIP-8141: a blob-carrying frame tx has no EIP-7594 sidecar wrapper yet, so withhold it from
+        // gossip rather than leak it in bare consensus form.
         tx.SupportsBlobs
             ? tx.GetProofVersion() == ChainHeadInfoProvider.CurrentProofVersion
             : !tx.CarriesBlobs;

--- a/src/Nethermind/Nethermind.TxPool/SpecDrivenTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/SpecDrivenTxGossipPolicy.cs
@@ -13,7 +13,7 @@ public class SpecDrivenTxGossipPolicy(IChainHeadInfoProvider chainHeadInfoProvid
         // EIP8141: a blob-carrying frame tx (type 6) has no EIP-7594 sidecar network wrapper yet, so it
         // cannot participate in the announce-by-hash / serve-with-sidecar blob gossip protocol. Withhold
         // it from gossip until that wire format lands, rather than leaking it in bare consensus form.
-        tx.CarriesBlobs && !tx.SupportsBlobs
-            ? false
-            : !tx.SupportsBlobs || tx.GetProofVersion() == ChainHeadInfoProvider.CurrentProofVersion;
+        tx.SupportsBlobs
+            ? tx.GetProofVersion() == ChainHeadInfoProvider.CurrentProofVersion
+            : !tx.CarriesBlobs;
 }

--- a/src/Nethermind/Nethermind.TxPool/SpecDrivenTxGossipPolicy.cs
+++ b/src/Nethermind/Nethermind.TxPool/SpecDrivenTxGossipPolicy.cs
@@ -10,5 +10,10 @@ public class SpecDrivenTxGossipPolicy(IChainHeadInfoProvider chainHeadInfoProvid
     private IChainHeadInfoProvider ChainHeadInfoProvider { get; } = chainHeadInfoProvider;
 
     public bool ShouldGossipTransaction(Transaction tx) =>
-        !tx.SupportsBlobs || tx.GetProofVersion() == ChainHeadInfoProvider.CurrentProofVersion;
+        // EIP8141: a blob-carrying frame tx (type 6) has no EIP-7594 sidecar network wrapper yet, so it
+        // cannot participate in the announce-by-hash / serve-with-sidecar blob gossip protocol. Withhold
+        // it from gossip until that wire format lands, rather than leaking it in bare consensus form.
+        tx.CarriesBlobs && !tx.SupportsBlobs
+            ? false
+            : !tx.SupportsBlobs || tx.GetProofVersion() == ChainHeadInfoProvider.CurrentProofVersion;
 }

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -75,11 +75,13 @@ namespace Nethermind.TxPool
             overflow |= UInt256.AddOverflow(currentCost, maxTxCost, out cumulativeCost);
             overflow |= UInt256.AddOverflow(cumulativeCost, (UInt256)tx.Value, out cumulativeCost);
 
-            // EIP-8141: gate on blob hashes, not the type-3-only SupportsBlobs, so blob-carrying frame txs
-            // reserve the blob fee too; priced at max_fee_per_blob_gas, an upper bound on the processor's escrow.
-            if (tx.BlobVersionedHashes is { Length: > 0 })
+            // EIP-8141: a blob-carrying frame transaction (type 6) also reserves the blob fee, so gate
+            // on the instance-level blob predicate rather than the type-level SupportsBlobs (type-3 only).
+            // Priced at max_fee_per_blob_gas, an upper bound on the processor's escrow, so mempool
+            // affordability never admits a tx the processor cannot charge.
+            if (tx.CarriesBlobs)
             {
-                overflow |= UInt256.MultiplyOverflow(Eip4844Constants.GasPerBlob, (UInt256)tx.BlobVersionedHashes.Length, out UInt256 blobGas);
+                overflow |= UInt256.MultiplyOverflow(Eip4844Constants.GasPerBlob, (UInt256)tx.GetBlobCount(), out UInt256 blobGas);
                 overflow |= UInt256.MultiplyOverflow(blobGas, tx.MaxFeePerBlobGas ?? UInt256.MaxValue, out UInt256 blobGasCost);
                 overflow |= UInt256.AddOverflow(cumulativeCost, blobGasCost, out cumulativeCost);
             }

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -20,9 +20,9 @@ namespace Nethermind.TxPool
 
         public static bool CanPayBaseFee(this Transaction tx, UInt256 currentBaseFee) => (UInt256)tx.MaxFeePerGas >= currentBaseFee;
 
-        public static bool CanPayForBlobGas(this Transaction tx, UInt256 currentPricePerBlobGas) => !tx.SupportsBlobs || tx.MaxFeePerBlobGas >= currentPricePerBlobGas;
+        public static bool CanPayForBlobGas(this Transaction tx, UInt256 currentPricePerBlobGas) => !tx.CarriesBlobs || tx.MaxFeePerBlobGas >= currentPricePerBlobGas;
 
-        public static bool CanBeBroadcast(this Transaction tx) => !tx.SupportsBlobs && tx.GetLength() <= MaxSizeOfTxForBroadcast;
+        public static bool CanBeBroadcast(this Transaction tx) => !tx.CarriesBlobs && tx.GetLength() <= MaxSizeOfTxForBroadcast;
 
         internal static UInt256 CalculateGasPrice(this Transaction tx, bool eip1559Enabled, in UInt256 baseFee)
         {

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -75,10 +75,8 @@ namespace Nethermind.TxPool
             overflow |= UInt256.AddOverflow(currentCost, maxTxCost, out cumulativeCost);
             overflow |= UInt256.AddOverflow(cumulativeCost, (UInt256)tx.Value, out cumulativeCost);
 
-            // EIP-8141: a blob-carrying frame transaction (type 6) also reserves the blob fee, so gate
-            // on the instance-level blob predicate rather than the type-level SupportsBlobs (type-3 only).
-            // Priced at max_fee_per_blob_gas, an upper bound on the processor's escrow, so mempool
-            // affordability never admits a tx the processor cannot charge.
+            // EIP-8141: blob fee priced at max_fee_per_blob_gas, an upper bound on the processor's escrow,
+            // so mempool affordability never admits a tx the processor cannot charge.
             if (tx.CarriesBlobs)
             {
                 overflow |= UInt256.MultiplyOverflow(Eip4844Constants.GasPerBlob, (UInt256)tx.GetBlobCount(), out UInt256 blobGas);

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -649,7 +649,7 @@ namespace Nethermind.TxPool
                 // null-assignment (which would be missing the just-added tx).
                 if (accepted)
                 {
-                    if (tx.SupportsBlobs)
+                    if (tx.CarriesBlobs)
                         _blobTransactionSnapshot = null;
                     else
                         _transactionSnapshot = null;
@@ -706,7 +706,7 @@ namespace Nethermind.TxPool
         {
             bool eip1559Enabled = _specProvider.GetCurrentHeadSpec().IsEip1559Enabled;
             UInt256 effectiveGasPrice = tx.CalculateEffectiveGasPrice(eip1559Enabled, _headInfo.CurrentBaseFee);
-            TxDistinctSortedPool relevantPool = (tx.SupportsBlobs ? _blobTransactions : _transactions);
+            TxDistinctSortedPool relevantPool = (tx.CarriesBlobs ? _blobTransactions : _transactions);
 
             relevantPool.TryGetBucketsWorstValue(tx.SenderAddress!, out Transaction? worstTx);
             tx.GasBottleneck = (worstTx is null || effectiveGasPrice <= worstTx.GasBottleneck)
@@ -726,7 +726,7 @@ namespace Nethermind.TxPool
             if (tx.Hash == removed?.Hash)
             {
                 // it means it was added and immediately evicted - pool was full of better txs
-                if (!isPersistentBroadcast || tx.SupportsBlobs || !_broadcaster.Broadcast(tx, true))
+                if (!isPersistentBroadcast || tx.CarriesBlobs || !_broadcaster.Broadcast(tx, true))
                 {
                     // we are adding only to persistent broadcast - not good enough for standard pool,
                     // but can be good enough for TxBroadcaster pool - for local txs only
@@ -743,7 +743,7 @@ namespace Nethermind.TxPool
             Interlocked.Increment(ref Metrics.PendingTransactionsAdded);
             Interlocked.Increment(ref _pendingTransactionsAdded);
             if (tx.Supports1559) { Metrics.Pending1559TransactionsAdded++; }
-            if (tx.SupportsBlobs) { Metrics.PendingBlobTransactionsAdded++; }
+            if (tx.CarriesBlobs) { Metrics.PendingBlobTransactionsAdded++; }
 
             if (removed is not null)
             {
@@ -881,7 +881,7 @@ namespace Nethermind.TxPool
                 if (allowLaterPoolReentrance) _hashCache.DeleteFromLongTerm(tx.Hash!);
                 updateTx(transactions, tx, null, lastElement);
                 // evict all following txs to prevent nonce gaps between blob tx
-                evictNextTxs |= tx.SupportsBlobs;
+                evictNextTxs |= tx.CarriesBlobs;
             }
         }
 
@@ -968,7 +968,11 @@ namespace Nethermind.TxPool
 
         public bool ContainsTx(Hash256 hash, TxType txType) => txType == TxType.Blob
             ? _blobTransactions.ContainsKey(hash)
-            : _transactions.ContainsKey(hash) || _broadcaster.ContainsTx(hash);
+            // EIP-8141: a blob-carrying frame tx lives in the blob pool; a plain frame tx in the normal
+            // pool. Without the instance we cannot tell them apart by type alone, so check both for type 6.
+            : _transactions.ContainsKey(hash)
+                || (txType == TxType.FrameTx && _blobTransactions.ContainsKey(hash))
+                || _broadcaster.ContainsTx(hash);
 
         public bool TryGetPendingTransaction(Hash256 hash, [NotNullWhen(true)] out Transaction? transaction) =>
             _transactions.TryGetValue(hash, out transaction)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -151,8 +151,8 @@ namespace Nethermind.TxPool
             _blobTransactions = txPoolConfig.BlobsSupport.IsPersistentStorage()
                 ? new PersistentBlobTxDistinctSortedPool(blobTxStorage, _txPoolConfig, comparer, logManager)
                 : new BlobTxDistinctSortedPool(txPoolConfig.BlobsSupport == BlobsSupportMode.InMemory ? _txPoolConfig.InMemoryBlobPoolSize : 0, comparer, logManager);
-            // EIP8141: blob-carrying frame txs live in the blob pool, so its inserts/removals must feed the
-            // same delegation and frame-expiry bookkeeping as the normal pool.
+            // EIP-8141: blob-carrying frame txs live in the blob pool, so it needs the same insert/removal
+            // bookkeeping (delegations, frame expiry) as the normal pool.
             _blobTransactions.Inserted += OnInsertedTx;
             _blobTransactions.Removed += OnRemovedTx;
             if (_blobTransactions.Count > 0)
@@ -499,7 +499,6 @@ namespace Nethermind.TxPool
             }
 
             ulong timestamp = block.Timestamp;
-            // Blob-carrying frame txs live in the blob pool, so both pools are scanned.
             EvictExpiredFrameTransactions(_transactions.GetSnapshot(), timestamp);
             EvictExpiredFrameTransactions(_blobTransactions.GetSnapshot(), timestamp);
         }
@@ -978,8 +977,7 @@ namespace Nethermind.TxPool
 
         public bool ContainsTx(Hash256 hash, TxType txType) => txType == TxType.Blob
             ? _blobTransactions.ContainsKey(hash)
-            // EIP-8141: a blob-carrying frame tx lives in the blob pool; a plain frame tx in the normal
-            // pool. Without the instance we cannot tell them apart by type alone, so check both for type 6.
+            // EIP-8141: a type-6 frame tx may carry blobs (blob pool) or not (normal pool), so check both.
             : _transactions.ContainsKey(hash)
                 || (txType == TxType.FrameTx && _blobTransactions.ContainsKey(hash))
                 || _broadcaster.ContainsTx(hash);

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -151,6 +151,10 @@ namespace Nethermind.TxPool
             _blobTransactions = txPoolConfig.BlobsSupport.IsPersistentStorage()
                 ? new PersistentBlobTxDistinctSortedPool(blobTxStorage, _txPoolConfig, comparer, logManager)
                 : new BlobTxDistinctSortedPool(txPoolConfig.BlobsSupport == BlobsSupportMode.InMemory ? _txPoolConfig.InMemoryBlobPoolSize : 0, comparer, logManager);
+            // EIP8141: blob-carrying frame txs live in the blob pool, so its inserts/removals must feed the
+            // same delegation and frame-expiry bookkeeping as the normal pool.
+            _blobTransactions.Inserted += OnInsertedTx;
+            _blobTransactions.Removed += OnRemovedTx;
             if (_blobTransactions.Count > 0)
                 _blobTransactions.UpdatePool(_accounts, _updateBucket);
 
@@ -360,7 +364,7 @@ namespace Nethermind.TxPool
                 for (int i = 0; i < txs.Length; i++)
                 {
                     Transaction tx = txs[i];
-                    if (tx.SupportsBlobs)
+                    if (tx.CarriesBlobs)
                     {
                         continue;
                     }
@@ -413,7 +417,7 @@ namespace Nethermind.TxPool
                     eip7702Txs++;
                 }
 
-                if (blockTx.SupportsBlobs)
+                if (blockTx.CarriesBlobs)
                 {
                     blobTxs++;
                     blobs += (long)blockTx.GetBlobCount();
@@ -495,7 +499,13 @@ namespace Nethermind.TxPool
             }
 
             ulong timestamp = block.Timestamp;
-            Transaction[] snapshot = _transactions.GetSnapshot();
+            // Blob-carrying frame txs live in the blob pool, so both pools are scanned.
+            EvictExpiredFrameTransactions(_transactions.GetSnapshot(), timestamp);
+            EvictExpiredFrameTransactions(_blobTransactions.GetSnapshot(), timestamp);
+        }
+
+        private void EvictExpiredFrameTransactions(Transaction[] snapshot, ulong timestamp)
+        {
             for (int i = 0; i < snapshot.Length; i++)
             {
                 Transaction tx = snapshot[i];
@@ -1061,6 +1071,8 @@ namespace Nethermind.TxPool
             _headBlocksChannel.Writer.Complete();
             _transactions.Inserted -= OnInsertedTx;
             _transactions.Removed -= OnRemovedTx;
+            _blobTransactions.Inserted -= OnInsertedTx;
+            _blobTransactions.Removed -= OnRemovedTx;
 
             await _retryCache.DisposeAsync();
             await _headProcessing;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -151,8 +151,10 @@ namespace Nethermind.TxPool
             _blobTransactions = txPoolConfig.BlobsSupport.IsPersistentStorage()
                 ? new PersistentBlobTxDistinctSortedPool(blobTxStorage, _txPoolConfig, comparer, logManager)
                 : new BlobTxDistinctSortedPool(txPoolConfig.BlobsSupport == BlobsSupportMode.InMemory ? _txPoolConfig.InMemoryBlobPoolSize : 0, comparer, logManager);
-            // EIP-8141: blob-carrying frame txs live in the blob pool, so it needs the same insert/removal
-            // bookkeeping (delegations, frame expiry) as the normal pool.
+            // EIP-8141: blob-carrying frame txs live in the blob pool, so it wires the same insert/removal
+            // bookkeeping (delegations, frame expiry) as the normal pool. Frame expiry only takes effect
+            // under BlobsSupportMode.InMemory: persistent storage keeps a LightTransaction whose Type is
+            // hard-coded TxType.Blob, so SupportsFrames is false until the light record carries the tx type.
             _blobTransactions.Inserted += OnInsertedTx;
             _blobTransactions.Removed += OnRemovedTx;
             if (_blobTransactions.Count > 0)
@@ -322,6 +324,8 @@ namespace Nethermind.TxPool
 
                         ReAddReorganisedTransactions(args.PreviousBlock);
                         RemoveProcessedTransactions(args.Block);
+                        // EIP-8141: for blob-carrying frame txs this evicts only under BlobsSupportMode.InMemory,
+                        // since persistent storage's LightTransaction hard-codes TxType.Blob (SupportsFrames false).
                         RemoveExpiredFrameTransactions(args.Block);
 
                         if (!_headInfo.IsSyncing || AcceptTxWhenNotSynced || args.PreviousBlock is not null)


### PR DESCRIPTION
## Changes

Non-consensus blob layer for EIP-8141 blob-carrying frame transactions (type 6), building on the now-merged consensus blob accounting (#12701). Resolves the `EIP8141:` deferral markers #12701 left.

- **Blob-pool routing** — a new instance-level `Transaction.CarriesBlobs` gate (blob versioned hashes present); the pool routes on it so a blob-carrying frame tx lands in the blob pool exactly like a type-3 tx. The type-level `SupportsBlobs()` that networking/decode paths key on is left untouched, so type-3 routing is unchanged. The same gate drives `TxTypeTxFilter` conflict detection, snapshot invalidation, eviction cascade, metrics, and `ContainsTx`.
- **Persistent-pool ingress guard** — a persistent blob pool stores a blob tx through the frame RLP decoder, which has no network-wrapper handling and would drop the sidecar, reloading a wrapper-less, unproducible `LightTransaction`. So a blob-carrying frame tx is rejected at ingress under the persistent modes (`Storage`/`StorageWithReorgs`) and admitted only under `BlobsSupportMode.InMemory`, where the full tx is kept intact.
- **Blob-budget metering groundwork** — because frame-blob txs sit in the blob pool, they flow through the blob-selection path in `TxPoolTxSource` and are metered against the block blob budget (`MaxBlobGasPerBlock` / `MaxProductionBlobCount`) during selection. This is groundwork only: end-to-end production of blob-frame txs is deferred — the production picker deliberately skips them (and the blobs bundle excludes type-6) until a follow-up wires picker admission together with type-6 bundle support.
- **Gossip (conservative)** — blob-carrying frame txs are withheld from gossip (`SpecDrivenTxGossipPolicy`) until the sidecar wire format lands, rather than leaking them in bare consensus form.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

A blob-carrying frame tx routes to the blob pool under `InMemory`; a plain frame tx and a type-3 tx route unchanged (regression). Under the persistent modes (`Storage`/`StorageWithReorgs`) a blob-carrying frame tx is rejected at ingress rather than silently persisted without its sidecar. A frame-blob tx carrying a sidecar is metered and selected within the block blob budget, and excluded when it would overflow it — this covers the selection/metering groundwork only, not end-to-end production (deferred).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The EIP-7594 sidecar / network-wrapper wire format for type 6 is out of scope here — it was deferred with documented `EIP8141:` markers and is implemented in the follow-up #12758. End-to-end production of blob-frame txs is also deferred to a follow-up: the picker skips them and the blobs bundle excludes type-6, so the metering/selection logic here is groundwork that a later PR wires into producible blocks (picker admission + type-6 bundle support).
