### PR TITLE
test: anchor crypto and RLP tests to independent expectations

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
@@ -178,6 +178,7 @@ public class BlockDecoderTests
         // that decodes canonical wire, like Can_do_roundtrip_regression, can find that class.
         Assert.That(decoded, Is.Not.Null);
         Assert.That(decoded!.Transactions, Has.Length.EqualTo(block.Transactions.Length));
+        Assert.That(decoded.Uncles, Has.Length.EqualTo(block.Uncles.Length));
         using (Assert.EnterMultipleScope())
         {
             Assert.That(encoded2.Bytes.ToHexString(), Is.EqualTo(encoded.Bytes.ToHexString()));
@@ -215,7 +216,11 @@ public class BlockDecoderTests
                 Assert.That(decoded.Transactions[i].Hash, Is.EqualTo(block.Transactions[i].Hash), $"transaction {i}");
             }
 
-            Assert.That(decoded.Uncles.Length, Is.EqualTo(block.Uncles.Length));
+            for (int i = 0; i < block.Uncles.Length; i++)
+            {
+                Assert.That(decoded.Uncles[i].Hash, Is.EqualTo(block.Uncles[i].Hash), $"uncle {i}");
+            }
+
             Assert.That(decoded.Withdrawals?.Length, Is.EqualTo(block.Withdrawals?.Length));
         }
     }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -137,14 +136,23 @@ public class BlockDecoderTests
         RlpReader ctx = new(encoded.Bytes);
         Block? decoded = decoder.Decode(ref ctx);
         Rlp encoded2 = decoder.Encode(decoded);
-        Assert.That(encoded2.Bytes.ToHexString(), Is.EqualTo(encoded.Bytes.ToHexString()));
-    }
 
-    [TestCase("0xf902cef9025ba055870e2f3ef77a9e6163ee5c005dc51d648a2eead382b9044b1a5ad2ee69b0c6a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa0b77e3b74c6c8af85408677375183385a2e55446bd071bf193a4958f7417dc8fba056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800188016345785d8a0000800c80a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a0cc3b10b54dc4e97c01f1df20e8b95874cd5fe83bf6eae64935a16cb08db85fa98080a00000000000000000000000000000000000000000000000000000000000000000a0e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855c0c0f86ce08080946389e7f33ce3b1e94e4325ef02829cd12297ef7188ffffffffffffffffd80180948a0a19589531694250d570040a0c4b74576919b801d8028094000000000000000000000000000000000000100080d8038094a94f5374fce5edbc8e2a8697c15331677e6ebf0b80")]
-    [Ignore("The test is useful for debugging hive - shouldn't be executed on CI")]
-    public void Write_rlp_of_blocks_to_file(string rlp) =>
-        // the test is useful for debugging hive
-        File.WriteAllBytes("chains\\block1.rlp".GetApplicationResourcePath(), Bytes.FromHexString(rlp));
+        // A re-encode comparison alone cannot see a symmetric decode error. Compare the decoded block to the original as well.
+        Assert.That(decoded, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(encoded2.Bytes.ToHexString(), Is.EqualTo(encoded.Bytes.ToHexString()));
+            Assert.That(decoded!.Hash, Is.EqualTo(block.Hash));
+            Assert.That(decoded.Transactions.Length, Is.EqualTo(block.Transactions.Length));
+            for (int i = 0; i < block.Transactions.Length; i++)
+            {
+                Assert.That(decoded.Transactions[i].Hash, Is.EqualTo(block.Transactions[i].Hash), $"transaction {i}");
+            }
+
+            Assert.That(decoded.Uncles.Length, Is.EqualTo(block.Uncles.Length));
+            Assert.That(decoded.Withdrawals?.Length, Is.EqualTo(block.Withdrawals?.Length));
+        }
+    }
 
     [Test]
     public void Encode_with_pre_encoded_transactions_produces_same_rlp(

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
@@ -124,7 +124,23 @@ public class BlockDecoderTests
         RlpReader ctx = new(bytes);
         Block? decoded = decoder.Decode(ref ctx);
         Rlp encoded = decoder.Encode(decoded);
-        Assert.That(encoded.Bytes.ToHexString(), Is.EqualTo(bytes.ToHexString()));
+
+        // The expected values come from an independent pyrlp decode of the fixed bytes.
+        // This is the one test that decodes canonical wire, so only its field asserts can catch a self-canceling encode/decode error.
+        Assert.That(decoded, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(encoded.Bytes.ToHexString(), Is.EqualTo(bytes.ToHexString()));
+            Assert.That(decoded!.Number, Is.EqualTo(5644));
+            Assert.That(decoded.Header.GasLimit, Is.EqualTo(8_000_000L));
+            Assert.That(decoded.Header.GasUsed, Is.EqualTo(21_000L));
+            Assert.That(decoded.Header.Timestamp, Is.EqualTo(1549034638UL));
+            Assert.That(decoded.Header.StateRoot, Is.EqualTo(new Hash256("0xfe77dd4ad7c2a3fa4c11868a00e4d728adcdfef8d2e3c13b256b06cbdbb02ec9")));
+            Assert.That(decoded.Transactions, Has.Length.EqualTo(1));
+            Assert.That(decoded.Transactions[0].Nonce, Is.EqualTo(0UL));
+            Assert.That(decoded.Transactions[0].Value, Is.EqualTo(UInt256.Parse("100000000000000000000000")));
+            Assert.That(decoded.Uncles, Is.Empty);
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
@@ -94,6 +94,21 @@ public class BlockDecoderTests
                 .WithBlobGasUsed(ulong.MaxValue)
                 .WithExcessBlobGas(ulong.MaxValue)
                 .WithMixHash(Keccak.EmptyTreeHash)
+                .TestObject,
+            // Every optional tail field is set, with a distinct value per field. This makes the field comparisons discriminating.
+            Build.A.Block.WithNumber(1)
+                .WithBaseFeePerGas(1)
+                .WithTransactions(transactions)
+                .WithUncles(uncles)
+                .WithWithdrawals(8)
+                .WithBloom(new Bloom(new[] { Build.A.LogEntry.TestObject }))
+                .WithBlobGasUsed(1)
+                .WithExcessBlobGas(2)
+                .WithParentBeaconBlockRoot(TestItem.KeccakA)
+                .WithRequestsHash(TestItem.KeccakB)
+                .WithBlockAccessListHash(TestItem.KeccakC)
+                .WithSlotNumber(7)
+                .WithMixHash(Keccak.EmptyTreeHash)
                 .TestObject
         ];
     }
@@ -158,13 +173,15 @@ public class BlockDecoderTests
         Block? decoded = decoder.Decode(ref ctx);
         Rlp encoded2 = decoder.Encode(decoded);
 
-        // A re-encode comparison alone cannot find a symmetric encode/decode error. The hash values also derive
-        // from the encoded bytes. Only direct field comparisons can find such an error.
+        // A re-encode comparison cannot find a decode error that the matching encode hides. The field
+        // comparisons below can. A fully self-canceling encode/decode pair passes both; only the
+        // canonical-wire regression test can find that class.
         Assert.That(decoded, Is.Not.Null);
         Assert.That(decoded!.Transactions, Has.Length.EqualTo(block.Transactions.Length));
         using (Assert.EnterMultipleScope())
         {
             Assert.That(encoded2.Bytes.ToHexString(), Is.EqualTo(encoded.Bytes.ToHexString()));
+            // The hash pins the embedded header bytes against the standalone header encoding. It cannot find decode errors.
             Assert.That(decoded.Hash, Is.EqualTo(block.Hash));
 
             BlockHeader actual = decoded.Header;
@@ -175,6 +192,7 @@ public class BlockDecoderTests
             Assert.That(actual.StateRoot, Is.EqualTo(expected.StateRoot));
             Assert.That(actual.TxRoot, Is.EqualTo(expected.TxRoot));
             Assert.That(actual.ReceiptsRoot, Is.EqualTo(expected.ReceiptsRoot));
+            Assert.That(actual.Bloom, Is.EqualTo(expected.Bloom));
             Assert.That(actual.Difficulty, Is.EqualTo(expected.Difficulty));
             Assert.That(actual.Number, Is.EqualTo(expected.Number));
             Assert.That(actual.GasLimit, Is.EqualTo(expected.GasLimit));
@@ -187,6 +205,10 @@ public class BlockDecoderTests
             Assert.That(actual.BlobGasUsed, Is.EqualTo(expected.BlobGasUsed));
             Assert.That(actual.ExcessBlobGas, Is.EqualTo(expected.ExcessBlobGas));
             Assert.That(actual.MixHash, Is.EqualTo(expected.MixHash));
+            Assert.That(actual.ParentBeaconBlockRoot, Is.EqualTo(expected.ParentBeaconBlockRoot));
+            Assert.That(actual.RequestsHash, Is.EqualTo(expected.RequestsHash));
+            Assert.That(actual.BlockAccessListHash, Is.EqualTo(expected.BlockAccessListHash));
+            Assert.That(actual.SlotNumber, Is.EqualTo(expected.SlotNumber));
 
             for (int i = 0; i < block.Transactions.Length; i++)
             {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
@@ -95,13 +95,13 @@ public class BlockDecoderTests
                 .WithExcessBlobGas(ulong.MaxValue)
                 .WithMixHash(Keccak.EmptyTreeHash)
                 .TestObject,
-            // Every optional tail field is set, with a distinct value per field. This makes the field comparisons discriminating.
+            // This scenario sets every optional tail field, with a distinct value per field. This makes the field comparisons discriminating.
             Build.A.Block.WithNumber(1)
-                .WithBaseFeePerGas(1)
+                .WithBaseFeePerGas(3)
                 .WithTransactions(transactions)
                 .WithUncles(uncles)
                 .WithWithdrawals(8)
-                .WithBloom(new Bloom(new[] { Build.A.LogEntry.TestObject }))
+                .WithBloom(new Bloom([Build.A.LogEntry.TestObject]))
                 .WithBlobGasUsed(1)
                 .WithExcessBlobGas(2)
                 .WithParentBeaconBlockRoot(TestItem.KeccakA)
@@ -174,8 +174,8 @@ public class BlockDecoderTests
         Rlp encoded2 = decoder.Encode(decoded);
 
         // A re-encode comparison cannot find a decode error that the matching encode hides. The field
-        // comparisons below can. A fully self-canceling encode/decode pair passes both; only the
-        // canonical-wire regression test can find that class.
+        // comparisons below can. A fully self-canceling encode/decode pair passes both; only a test
+        // that decodes canonical wire, like Can_do_roundtrip_regression, can find that class.
         Assert.That(decoded, Is.Not.Null);
         Assert.That(decoded!.Transactions, Has.Length.EqualTo(block.Transactions.Length));
         using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
@@ -138,11 +138,30 @@ public class BlockDecoderTests
         Rlp encoded2 = decoder.Encode(decoded);
 
         // A re-encode comparison alone cannot see a symmetric decode error. Compare the decoded block to the original as well.
+        // Hashes derive from the wire bytes, so only direct field comparisons can catch a symmetric field swap.
         Assert.That(decoded, Is.Not.Null);
         using (Assert.EnterMultipleScope())
         {
             Assert.That(encoded2.Bytes.ToHexString(), Is.EqualTo(encoded.Bytes.ToHexString()));
             Assert.That(decoded!.Hash, Is.EqualTo(block.Hash));
+
+            BlockHeader actual = decoded.Header;
+            BlockHeader expected = block.Header;
+            Assert.That(actual.ParentHash, Is.EqualTo(expected.ParentHash));
+            Assert.That(actual.UnclesHash, Is.EqualTo(expected.UnclesHash));
+            Assert.That(actual.Beneficiary, Is.EqualTo(expected.Beneficiary));
+            Assert.That(actual.StateRoot, Is.EqualTo(expected.StateRoot));
+            Assert.That(actual.TxRoot, Is.EqualTo(expected.TxRoot));
+            Assert.That(actual.ReceiptsRoot, Is.EqualTo(expected.ReceiptsRoot));
+            Assert.That(actual.Number, Is.EqualTo(expected.Number));
+            Assert.That(actual.GasLimit, Is.EqualTo(expected.GasLimit));
+            Assert.That(actual.GasUsed, Is.EqualTo(expected.GasUsed));
+            Assert.That(actual.Timestamp, Is.EqualTo(expected.Timestamp));
+            Assert.That(actual.BaseFeePerGas, Is.EqualTo(expected.BaseFeePerGas));
+            Assert.That(actual.BlobGasUsed, Is.EqualTo(expected.BlobGasUsed));
+            Assert.That(actual.ExcessBlobGas, Is.EqualTo(expected.ExcessBlobGas));
+            Assert.That(actual.MixHash, Is.EqualTo(expected.MixHash));
+
             Assert.That(decoded.Transactions.Length, Is.EqualTo(block.Transactions.Length));
             for (int i = 0; i < block.Transactions.Length; i++)
             {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
@@ -9,7 +9,6 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Int256;
-using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
@@ -125,20 +124,27 @@ public class BlockDecoderTests
         Block? decoded = decoder.Decode(ref ctx);
         Rlp encoded = decoder.Encode(decoded);
 
-        // The expected values come from an independent pyrlp decode of the fixed bytes.
-        // This is the one test that decodes canonical wire, so only its field asserts can catch a self-canceling encode/decode error.
+        // An independent pyrlp decode of the fixed bytes produced the expected values.
+        // Only this test decodes canonical wire. Only these asserts can find a self-canceling encode/decode error.
         Assert.That(decoded, Is.Not.Null);
+        Assert.That(decoded!.Transactions, Has.Length.EqualTo(1));
+        Transaction tx = decoded.Transactions[0];
         using (Assert.EnterMultipleScope())
         {
             Assert.That(encoded.Bytes.ToHexString(), Is.EqualTo(bytes.ToHexString()));
-            Assert.That(decoded!.Number, Is.EqualTo(5644));
-            Assert.That(decoded.Header.GasLimit, Is.EqualTo(8_000_000L));
-            Assert.That(decoded.Header.GasUsed, Is.EqualTo(21_000L));
+            Assert.That(decoded.Header.Number, Is.EqualTo(5644UL));
+            Assert.That(decoded.Header.Difficulty, Is.EqualTo(UInt256.One));
+            Assert.That(decoded.Header.Beneficiary, Is.EqualTo(Address.Zero));
+            Assert.That(decoded.Header.GasLimit, Is.EqualTo(8_000_000UL));
+            Assert.That(decoded.Header.GasUsed, Is.EqualTo(21_000UL));
             Assert.That(decoded.Header.Timestamp, Is.EqualTo(1549034638UL));
+            Assert.That(decoded.Header.Nonce, Is.EqualTo(0UL));
             Assert.That(decoded.Header.StateRoot, Is.EqualTo(new Hash256("0xfe77dd4ad7c2a3fa4c11868a00e4d728adcdfef8d2e3c13b256b06cbdbb02ec9")));
-            Assert.That(decoded.Transactions, Has.Length.EqualTo(1));
-            Assert.That(decoded.Transactions[0].Nonce, Is.EqualTo(0UL));
-            Assert.That(decoded.Transactions[0].Value, Is.EqualTo(UInt256.Parse("100000000000000000000000")));
+            Assert.That(tx.Nonce, Is.EqualTo(0UL));
+            Assert.That(tx.GasPrice, Is.EqualTo((UInt256)1_000_000_000));
+            Assert.That(tx.GasLimit, Is.EqualTo(21_000L));
+            Assert.That(tx.To, Is.EqualTo(new Address("0x22ea9f6b28db76a7162054c05ed812deb2f519cd")));
+            Assert.That(tx.Value, Is.EqualTo(UInt256.Parse("100000000000000000000000")));
             Assert.That(decoded.Uncles, Is.Empty);
         }
     }
@@ -153,13 +159,13 @@ public class BlockDecoderTests
         Block? decoded = decoder.Decode(ref ctx);
         Rlp encoded2 = decoder.Encode(decoded);
 
-        // A re-encode comparison alone cannot see a symmetric decode error. Compare the decoded block to the original as well.
-        // Hashes derive from the wire bytes, so only direct field comparisons can catch a symmetric field swap.
+        // A re-encode comparison alone cannot find a symmetric decode error. Compare the decoded block with the original.
         Assert.That(decoded, Is.Not.Null);
+        Assert.That(decoded!.Transactions.Length, Is.EqualTo(block.Transactions.Length));
         using (Assert.EnterMultipleScope())
         {
             Assert.That(encoded2.Bytes.ToHexString(), Is.EqualTo(encoded.Bytes.ToHexString()));
-            Assert.That(decoded!.Hash, Is.EqualTo(block.Hash));
+            Assert.That(decoded.Hash, Is.EqualTo(block.Hash));
 
             BlockHeader actual = decoded.Header;
             BlockHeader expected = block.Header;
@@ -169,16 +175,19 @@ public class BlockDecoderTests
             Assert.That(actual.StateRoot, Is.EqualTo(expected.StateRoot));
             Assert.That(actual.TxRoot, Is.EqualTo(expected.TxRoot));
             Assert.That(actual.ReceiptsRoot, Is.EqualTo(expected.ReceiptsRoot));
+            Assert.That(actual.Difficulty, Is.EqualTo(expected.Difficulty));
             Assert.That(actual.Number, Is.EqualTo(expected.Number));
             Assert.That(actual.GasLimit, Is.EqualTo(expected.GasLimit));
             Assert.That(actual.GasUsed, Is.EqualTo(expected.GasUsed));
             Assert.That(actual.Timestamp, Is.EqualTo(expected.Timestamp));
+            Assert.That(actual.ExtraData, Is.EqualTo(expected.ExtraData));
+            Assert.That(actual.Nonce, Is.EqualTo(expected.Nonce));
             Assert.That(actual.BaseFeePerGas, Is.EqualTo(expected.BaseFeePerGas));
+            Assert.That(actual.WithdrawalsRoot, Is.EqualTo(expected.WithdrawalsRoot));
             Assert.That(actual.BlobGasUsed, Is.EqualTo(expected.BlobGasUsed));
             Assert.That(actual.ExcessBlobGas, Is.EqualTo(expected.ExcessBlobGas));
             Assert.That(actual.MixHash, Is.EqualTo(expected.MixHash));
 
-            Assert.That(decoded.Transactions.Length, Is.EqualTo(block.Transactions.Length));
             for (int i = 0; i < block.Transactions.Length; i++)
             {
                 Assert.That(decoded.Transactions[i].Hash, Is.EqualTo(block.Transactions[i].Hash), $"transaction {i}");

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockDecoderTests.cs
@@ -138,11 +138,10 @@ public class BlockDecoderTests
             Assert.That(decoded.Header.GasLimit, Is.EqualTo(8_000_000UL));
             Assert.That(decoded.Header.GasUsed, Is.EqualTo(21_000UL));
             Assert.That(decoded.Header.Timestamp, Is.EqualTo(1549034638UL));
-            Assert.That(decoded.Header.Nonce, Is.EqualTo(0UL));
             Assert.That(decoded.Header.StateRoot, Is.EqualTo(new Hash256("0xfe77dd4ad7c2a3fa4c11868a00e4d728adcdfef8d2e3c13b256b06cbdbb02ec9")));
             Assert.That(tx.Nonce, Is.EqualTo(0UL));
             Assert.That(tx.GasPrice, Is.EqualTo((UInt256)1_000_000_000));
-            Assert.That(tx.GasLimit, Is.EqualTo(21_000L));
+            Assert.That(tx.GasLimit, Is.EqualTo(21_000UL));
             Assert.That(tx.To, Is.EqualTo(new Address("0x22ea9f6b28db76a7162054c05ed812deb2f519cd")));
             Assert.That(tx.Value, Is.EqualTo(UInt256.Parse("100000000000000000000000")));
             Assert.That(decoded.Uncles, Is.Empty);
@@ -159,9 +158,10 @@ public class BlockDecoderTests
         Block? decoded = decoder.Decode(ref ctx);
         Rlp encoded2 = decoder.Encode(decoded);
 
-        // A re-encode comparison alone cannot find a symmetric decode error. Compare the decoded block with the original.
+        // A re-encode comparison alone cannot find a symmetric encode/decode error. The hash values also derive
+        // from the encoded bytes. Only direct field comparisons can find such an error.
         Assert.That(decoded, Is.Not.Null);
-        Assert.That(decoded!.Transactions.Length, Is.EqualTo(block.Transactions.Length));
+        Assert.That(decoded!.Transactions, Has.Length.EqualTo(block.Transactions.Length));
         using (Assert.EnterMultipleScope())
         {
             Assert.That(encoded2.Bytes.ToHexString(), Is.EqualTo(encoded.Bytes.ToHexString()));

--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -159,7 +159,13 @@ namespace Nethermind.Core.Test
                 byteArray[i] = (byte)(i % 256);
             }
 
-            Assert.That(Keccak.Compute(byteArray.AsSpan()), Is.EqualTo(Keccak.Compute(byteArray)));
+            // The expected hash comes from an independent keccak-256 implementation (pycryptodome).
+            Hash256 expected = new("0x5902e53903be0d0f9656bdbd5b9f0d8c2d815f865645d629eef77f5185f6cd7f");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Keccak.Compute(byteArray.AsSpan()), Is.EqualTo(expected));
+                Assert.That(Keccak.Compute(byteArray), Is.EqualTo(expected));
+            }
         }
 
         [TestCase("0x", "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")]

--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -151,7 +151,7 @@ namespace Nethermind.Core.Test
         public void CompareSameInstance() => Assert.That(Keccak.Zero.CompareTo(Keccak.Zero), Is.EqualTo(0));
 
         [Test]
-        public void Span()
+        public void Computes_known_hash_for_span_and_array()
         {
             byte[] byteArray = new byte[1024];
             for (int i = 0; i < byteArray.Length; i++)

--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -159,7 +159,7 @@ namespace Nethermind.Core.Test
                 byteArray[i] = (byte)(i % 256);
             }
 
-            // The expected hash comes from an independent keccak-256 implementation (pycryptodome).
+            // An independent keccak-256 implementation (pycryptodome) produced the expected hash.
             Hash256 expected = new("0x5902e53903be0d0f9656bdbd5b9f0d8c2d815f865645d629eef77f5185f6cd7f");
             using (Assert.EnterMultipleScope())
             {

--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -293,9 +293,9 @@ namespace Nethermind.Core.Test
 
         /// <summary>Computes the RLP length of an unsigned integer.</summary>
         /// <remarks>
-        /// Transcribed from Yellow Paper appendix B: a value below 0x80 uses one byte; larger values use
+        /// Yellow Paper appendix B gives the length. A value below 0x80 uses one byte. Larger values use
         /// one prefix byte plus the minimal big-endian bytes. The loop shape is deliberately different from
-        /// the production implementation so both cannot share one defect.
+        /// the production implementation. This prevents a defect shared with the production code.
         /// </remarks>
         private static int SpecLengthOf(ulong value)
         {

--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -291,7 +291,12 @@ namespace Nethermind.Core.Test
             }
         }
 
-        // RLP integer length per Yellow Paper appendix B: one byte below 0x80, else one prefix byte plus the minimal big-endian bytes.
+        /// <summary>Computes the RLP length of an unsigned integer.</summary>
+        /// <remarks>
+        /// Transcribed from Yellow Paper appendix B: a value below 0x80 uses one byte; larger values use
+        /// one prefix byte plus the minimal big-endian bytes. The loop shape is deliberately different from
+        /// the production implementation so both cannot share one defect.
+        /// </remarks>
         private static int SpecLengthOf(ulong value)
         {
             if (value < 0x80)

--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -281,7 +281,32 @@ namespace Nethermind.Core.Test
         }
 
         [Test]
-        public void Length_of_ulong_same_as_uint256([ValueSource(nameof(ULongValues))] ulong value) => Assert.That(Rlp.LengthOf(value), Is.EqualTo(Rlp.LengthOf((UInt256)value)));
+        public void Length_of_ulong_matches_spec([ValueSource(nameof(ULongValues))] ulong value)
+        {
+            int expected = SpecLengthOf(value);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Rlp.LengthOf(value), Is.EqualTo(expected), "ulong");
+                Assert.That(Rlp.LengthOf((UInt256)value), Is.EqualTo(expected), "UInt256");
+            }
+        }
+
+        // RLP integer length per Yellow Paper appendix B: one byte below 0x80, else one prefix byte plus the minimal big-endian bytes.
+        private static int SpecLengthOf(ulong value)
+        {
+            if (value < 0x80)
+            {
+                return 1;
+            }
+
+            int byteCount = 0;
+            for (ulong rest = value; rest != 0; rest >>= 8)
+            {
+                byteCount++;
+            }
+
+            return 1 + byteCount;
+        }
 
         [Test]
         public void Single_byte_encoding_decoding()


### PR DESCRIPTION
## Changes

Part of the test-hygiene series (#12689, #12690 - merged, #12693, #12694, #12696 - merged, #12699, #12705, #12710, #12711): tests that cannot meaningfully fail get real expectations. Rule for this chunk: an expectation must not come from the code under test. Three files in `Nethermind.Core.Test`; no product code changed (verified).

- **`KeccakTests.Span`**: compared the Span overload against the array overload of the same function - both could be wrong identically. Both overloads now assert an independent vector: keccak-256 of the 1024-byte `i % 256` pattern, derived with pycryptodome.
- **`RlpTests`**: `Length_of_ulong_same_as_uint256` compared two `Rlp.LengthOf` overloads against each other over a pow2-boundary sweep - a shared wrong boundary passes. Renamed `Length_of_ulong_matches_spec`: both overloads now assert a spec-derived expected (Yellow Paper appendix B: one byte below `0x80`, else one prefix byte plus the minimal big-endian bytes), keeping the sweep and the cross-overload agreement transitively.
- **`BlockDecoderTests`**:
  - `Can_do_roundtrip_scenarios` (encode-decode-encode) never looked at the original block; it now also compares the decoded block to the original: block hash, fourteen header fields, the transaction-hash sequence, and uncle/withdrawal counts.
  - `Can_do_roundtrip_regression` is the only test that decodes canonical fixed wire, which makes it the only place a *self-canceling* encode/decode error is observable. It now asserts field values derived from the fixed hex with an independent RLP decoder (pyrlp): number, gas limit, gas used, timestamp, state root, the single transaction's nonce and value, and the empty uncle list.
  - The `[Ignore]`d `Write_rlp_of_blocks_to_file` is deleted: a permanently ignored, assert-free hive-debugging utility (resurrectable from git history).

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Every strengthened assertion was mutation-checked (deliberate product break, confirm red, revert). The two headline mutations target exactly the blindness this chunk removes:

- A *coordinated* boundary shift in both `Rlp.LengthOf` overloads (`< 128` to `< 127` in the `ulong` and `UInt256` paths) keeps the overloads agreeing - the old cross-overload test stays logically satisfied - but fails the spec anchor at exactly value 127.
- A *fully self-canceling* `GasLimit`/`GasUsed` swap in `HeaderDecoder` (decode and encode) passes every byte-roundtrip, hash, and scenario-field assert in the file - the decoded object is correct because the two swaps cancel; only the wire layout is wrong - and fails exactly the two pyrlp-anchored asserts in the canonical-wire regression test.
- A coordinated transaction-order reversal (decode and the live encode loop) is caught by the existing pre-encoded-transactions comparison tests (verified live, 7 failures), so the wire-order class is covered at fixture level.
- Expectation flips (vector nibble, spec-helper threshold) confirmed red.

Full local suite green (windows-x64, release): Core.Test 5984 total, 0 failed (the skip count drops by one - the deleted `[Ignore]`d case).

Golden derivations: the keccak vector and the regression-block field values were derived with pycryptodome and pyrlp respectively; the spec-length helper transcribes Yellow Paper appendix B and is structurally different from the product implementation (loop vs `LeadingZeroCount`).

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No
