### PR TITLE
feat(eip-2780): fold EIP-7708 transfer log cost into TX_VALUE_COST

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorEip7702Tests.cs
@@ -141,7 +141,7 @@ internal class TransactionProcessorEip7702Tests
         // Applying a valid authorization writes the authority leaf once; state charges are direct
         // top-frame charges and are not refunded.
         ulong intrinsicExecutionGas = GasCostOf.TransactionEip2780 + Eip8038Constants.ColdAccountAccess
-            + GasCostOf.TransferLogEip2780 + GasCostOf.TxValueCostEip2780 + Eip8038Constants.PerAuthBaseExecution;
+            + GasCostOf.TxValueCostEip2780 + Eip8038Constants.PerAuthBaseExecution;
         ulong topFrameExecutionGas = Eip8038Constants.AccountWrite;
         ulong topFrameStateGas = (ulong)expectedTopFrameStateGas;
         ulong expectedSpentGas = intrinsicExecutionGas + topFrameExecutionGas + topFrameStateGas;

--- a/src/Nethermind/Nethermind.Core/GasCostOf.cs
+++ b/src/Nethermind/Nethermind.Core/GasCostOf.cs
@@ -94,7 +94,6 @@ namespace Nethermind.Core
 
         // eip-2780: reduce intrinsic transaction gas and reprice state-touching primitives.
         public const ulong TransactionEip2780 = 12000; // TX_BASE_COST: ECDSA recovery + sender account access + sender account write
-        public const ulong TxValueCostEip2780 = 4244; // recipient balance write for a value-bearing transfer (non-create)
-        public const ulong TransferLogEip2780 = 1756; // eip-7708 LOG3 transfer event cost
+        public const ulong TxValueCostEip2780 = 6000; // TX_VALUE_COST: recipient balance write + folded eip-7708 transfer log for a value-bearing transfer (non-create)
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip2780Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip2780Tests.cs
@@ -53,8 +53,8 @@ public class Eip2780Tests
             new TestSpecProvider(new OverridableReleaseSpec(Prague.Instance) { IsEip2780Enabled = true, IsEip7708Enabled = true })));
 
     // Whole-transaction totals; recipient existence is irrelevant (state-independent intrinsic).
-    [TestCase(false, 1ul, GasCostOf.TransactionEip2780 + GasCostOf.ColdAccountAccess + GasCostOf.TxValueCostEip2780 + GasCostOf.TransferLogEip2780, TestName = "value transfer to existing EOA (20600)")]
-    [TestCase(true, 1ul, GasCostOf.TransactionEip2780 + GasCostOf.ColdAccountAccess + GasCostOf.TxValueCostEip2780 + GasCostOf.TransferLogEip2780, TestName = "value transfer to new account (20600)")]
+    [TestCase(false, 1ul, GasCostOf.TransactionEip2780 + GasCostOf.ColdAccountAccess + GasCostOf.TxValueCostEip2780, TestName = "value transfer to existing EOA (20600)")]
+    [TestCase(true, 1ul, GasCostOf.TransactionEip2780 + GasCostOf.ColdAccountAccess + GasCostOf.TxValueCostEip2780, TestName = "value transfer to new account (20600)")]
     [TestCase(false, 0ul, GasCostOf.TransactionEip2780 + GasCostOf.ColdAccountAccess, TestName = "no-transfer to existing EOA (14600)")]
     [TestCase(true, 0ul, GasCostOf.TransactionEip2780 + GasCostOf.ColdAccountAccess, TestName = "no-transfer to empty account (14600)")]
     public async Task Simple_transfer_spends_eip2780_total_gas(bool recipientIsNew, ulong value, ulong expectedGas)

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
@@ -164,8 +164,8 @@ public class Eip8037Tests : VirtualMachineTestsBase
         IntrinsicGas<EthereumGasPolicy> splitIntrinsicGas = EthereumGasPolicy.CalculateIntrinsicGas(tx, Amsterdam.Instance);
         EthereumIntrinsicGas intrinsicGas = IntrinsicGasCalculator.Calculate(tx, Amsterdam.Instance);
         // Access-list entries repriced to the cold costs; the value-bearing recipient touch
-        // adds COLD_ACCOUNT_ACCESS + TRANSFER_LOG + TX_VALUE.
-        ulong recipientExecution = Eip8038Constants.ColdAccountAccess + GasCostOf.TransferLogEip2780 + GasCostOf.TxValueCostEip2780;
+        // adds COLD_ACCOUNT_ACCESS + TX_VALUE (transfer log folded into TX_VALUE).
+        ulong recipientExecution = Eip8038Constants.ColdAccountAccess + GasCostOf.TxValueCostEip2780;
         ulong accessListBaseCost = Eip8038Constants.AccessListAddressCost + 3 * Eip8038Constants.AccessListStorageKeyCost;
         ulong accessListFloorTokens = (20ul + 3ul * 32ul) * Amsterdam.Instance.GasCosts.TxDataNonZeroMultiplier;
         ulong accessListFloorCost = accessListFloorTokens * Amsterdam.Instance.GasCosts.TotalCostFloorPerToken;

--- a/src/Nethermind/Nethermind.Evm.Test/IntrinsicGasCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/IntrinsicGasCalculatorTests.cs
@@ -316,18 +316,21 @@ namespace Nethermind.Evm.Test
             Assert.That(actual, Is.EqualTo(TxBaseEip2780 + GasCostOf.AccessAccountListEntry + ColdAccess + TxValueCost));
         }
 
-        [Test]
-        public void Eip2780_intrinsic_gas_for_create_is_value_independent()
+        [TestCase(false, TestName = "Eip2780_create_value_independent_pre8038")]
+        [TestCase(true, TestName = "Eip2780_create_value_independent_8038")]
+        public void Eip2780_intrinsic_gas_for_create_is_value_independent(bool eip8038Enabled)
         {
-            OverridableReleaseSpec spec = new(Prague.Instance) { IsEip2780Enabled = true, IsEip7708Enabled = true };
+            OverridableReleaseSpec spec = new(Prague.Instance) { IsEip2780Enabled = true, IsEip7708Enabled = true, IsEip8038Enabled = eip8038Enabled };
 
             Transaction createZero = Build.A.Transaction.WithValue(0).WithCode(Array.Empty<byte>())
                 .SignedAndResolved(TestItem.PrivateKeyA).TestObject;
             Transaction createValue = Build.A.Transaction.WithValue(1).WithCode(Array.Empty<byte>())
                 .SignedAndResolved(TestItem.PrivateKeyA).TestObject;
 
-            // The recipient balance write is already covered by CREATE_ACCESS, so a value endowment adds nothing.
-            ulong expected = TxBaseEip2780 + GasCostOf.TxCreate;
+            // The create charge (CREATE_ACCESS under EIP-8038) already covers the recipient balance write,
+            // so a value endowment adds nothing — create-with-value equals create-with-zero-value.
+            ulong createCharge = eip8038Enabled ? Eip8038Constants.CreateAccess : GasCostOf.TxCreate;
+            ulong expected = TxBaseEip2780 + createCharge;
             Assert.That(IntrinsicGasCalculator.Calculate(createZero, spec).Standard, Is.EqualTo(expected));
             Assert.That(IntrinsicGasCalculator.Calculate(createValue, spec).Standard, Is.EqualTo(expected));
         }

--- a/src/Nethermind/Nethermind.Evm.Test/IntrinsicGasCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/IntrinsicGasCalculatorTests.cs
@@ -234,8 +234,8 @@ namespace Nethermind.Evm.Test
                 .TestObject;
             IntrinsicGas<EthereumGasPolicy> intrinsicGas = EthereumGasPolicy.CalculateIntrinsicGas(tx, Amsterdam.Instance);
 
-            // Recipient touch: COLD + TRANSFER_LOG + TX_VALUE; authorization: state-independent base.
-            ulong recipientExecution = Eip8038Constants.ColdAccountAccess + GasCostOf.TransferLogEip2780 + GasCostOf.TxValueCostEip2780;
+            // Recipient touch: COLD + TX_VALUE (transfer log folded into TX_VALUE); authorization: state-independent base.
+            ulong recipientExecution = Eip8038Constants.ColdAccountAccess + GasCostOf.TxValueCostEip2780;
             Assert.That(intrinsicGas.Standard.Value, Is.EqualTo(GasCostOf.TransactionEip2780 + recipientExecution + Eip8038Constants.PerAuthBaseExecution));
             Assert.That(intrinsicGas.Standard.StateReservoir, Is.Zero);
         }
@@ -248,8 +248,8 @@ namespace Nethermind.Evm.Test
                 .TestObject;
             EthereumIntrinsicGas gas = IntrinsicGasCalculator.Calculate(tx, Amsterdam.Instance);
 
-            // Create execution = CREATE_ACCESS + TRANSFER_LOG (value endowment); NEW_ACCOUNT is top-frame state gas.
-            ulong expectedExecution = GasCostOf.TransactionEip2780 + Eip8038Constants.CreateAccess + GasCostOf.TransferLogEip2780;
+            // Create execution = CREATE_ACCESS (value endowment adds nothing); NEW_ACCOUNT is top-frame state gas.
+            ulong expectedExecution = GasCostOf.TransactionEip2780 + Eip8038Constants.CreateAccess;
             Assert.That(gas.Standard, Is.EqualTo(expectedExecution));
             Assert.That(gas.MinimalGas, Is.EqualTo(Math.Max(gas.Standard, gas.FloorGas)));
         }
@@ -262,7 +262,7 @@ namespace Nethermind.Evm.Test
                 .TestObject;
             EthereumIntrinsicGas gas = IntrinsicGasCalculator.Calculate(tx, Amsterdam.Instance);
 
-            ulong recipientExecution = Eip8038Constants.ColdAccountAccess + GasCostOf.TransferLogEip2780 + GasCostOf.TxValueCostEip2780;
+            ulong recipientExecution = Eip8038Constants.ColdAccountAccess + GasCostOf.TxValueCostEip2780;
             ulong expectedExecution = GasCostOf.TransactionEip2780 + recipientExecution + Eip8038Constants.PerAuthBaseExecution;
             Assert.That(gas.Standard, Is.EqualTo(expectedExecution));
         }
@@ -276,18 +276,17 @@ namespace Nethermind.Evm.Test
                 .TestObject;
             EthereumIntrinsicGas gas = IntrinsicGasCalculator.Calculate(tx, Amsterdam.Instance);
 
-            ulong execution = GasCostOf.TransactionEip2780 + Eip8038Constants.CreateAccess + GasCostOf.TransferLogEip2780;
+            ulong execution = GasCostOf.TransactionEip2780 + Eip8038Constants.CreateAccess;
             Assert.That(gas.MinimalGas, Is.GreaterThanOrEqualTo(execution));
         }
 
         // EIP-2780 fixed-cost vectors: the intrinsic is state-independent, so the recipient
         // touch and value-move costs are flat for every non-self recipient.
         private const ulong TxBaseEip2780 = GasCostOf.TransactionEip2780;
-        private const ulong TransferLogEip2780 = GasCostOf.TransferLogEip2780;
         private const ulong ColdAccess = GasCostOf.ColdAccountAccess;
         private const ulong TxValueCost = GasCostOf.TxValueCostEip2780;
 
-        [TestCase(false, 1ul, TxBaseEip2780 + ColdAccess + TxValueCost + TransferLogEip2780, TestName = "Eip2780_intrinsic_value_transfer_20600")]
+        [TestCase(false, 1ul, TxBaseEip2780 + ColdAccess + TxValueCost, TestName = "Eip2780_intrinsic_value_transfer_20600")]
         [TestCase(true, 1ul, TxBaseEip2780, TestName = "Eip2780_intrinsic_self_transfer_12000")]
         [TestCase(false, 0ul, TxBaseEip2780 + ColdAccess, TestName = "Eip2780_intrinsic_no_transfer_14600")]
         [TestCase(true, 0ul, TxBaseEip2780, TestName = "Eip2780_intrinsic_self_no_transfer_12000")]
@@ -314,11 +313,11 @@ namespace Nethermind.Evm.Test
 
             ulong actual = IntrinsicGasCalculator.Calculate(tx, spec).Standard;
 
-            Assert.That(actual, Is.EqualTo(TxBaseEip2780 + GasCostOf.AccessAccountListEntry + ColdAccess + TxValueCost + TransferLogEip2780));
+            Assert.That(actual, Is.EqualTo(TxBaseEip2780 + GasCostOf.AccessAccountListEntry + ColdAccess + TxValueCost));
         }
 
         [Test]
-        public void Eip2780_intrinsic_gas_for_create_charges_transfer_log_only_when_value_positive()
+        public void Eip2780_intrinsic_gas_for_create_is_value_independent()
         {
             OverridableReleaseSpec spec = new(Prague.Instance) { IsEip2780Enabled = true, IsEip7708Enabled = true };
 
@@ -327,11 +326,10 @@ namespace Nethermind.Evm.Test
             Transaction createValue = Build.A.Transaction.WithValue(1).WithCode(Array.Empty<byte>())
                 .SignedAndResolved(TestItem.PrivateKeyA).TestObject;
 
-            Assert.That(IntrinsicGasCalculator.Calculate(createZero, spec).Standard,
-                Is.EqualTo(TxBaseEip2780 + GasCostOf.TxCreate));
-            // CREATE endows a fresh, sender-distinct address, so value > 0 pays the transfer log.
-            Assert.That(IntrinsicGasCalculator.Calculate(createValue, spec).Standard,
-                Is.EqualTo(TxBaseEip2780 + GasCostOf.TxCreate + TransferLogEip2780));
+            // The recipient balance write is already covered by CREATE_ACCESS, so a value endowment adds nothing.
+            ulong expected = TxBaseEip2780 + GasCostOf.TxCreate;
+            Assert.That(IntrinsicGasCalculator.Calculate(createZero, spec).Standard, Is.EqualTo(expected));
+            Assert.That(IntrinsicGasCalculator.Calculate(createValue, spec).Standard, Is.EqualTo(expected));
         }
 
         [TestCase(false, GasCostOf.ColdAccountAccess)]

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -669,14 +669,14 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     /// <remarks>
     /// State-independent by design: a flat cold touch for a non-self recipient, plus TX_VALUE_COST on
     /// value transfers (the EIP-7708 transfer log is folded into TX_VALUE_COST). Contract creation's
-    /// recipient charge is fully covered by CREATE_ACCESS, so it adds nothing here even with value.
-    /// New-account and delegation costs are charged elsewhere.
+    /// recipient balance write is already covered by the create charge (CREATE_ACCESS under EIP-8038),
+    /// so it adds nothing here even with value. New-account and delegation costs are charged elsewhere.
     /// </remarks>
     private static ulong Eip2780ExtraGas(Transaction tx, IReleaseSpec spec)
     {
         if (!spec.IsEip2780Enabled) return 0;
 
-        // Contract creation is fully priced by CREATE_ACCESS; a value endowment adds no further charge.
+        // The create charge (CREATE_ACCESS under EIP-8038) already covers the recipient balance write; a value endowment adds nothing.
         if (tx.IsContractCreation) return 0;
 
         // Self-transfers coalesce into the sender leaf write already priced into TX_BASE_COST.

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -667,24 +667,24 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     /// EIP-2780 recipient charge on top of TX_BASE_COST.
     /// </summary>
     /// <remarks>
-    /// State-independent by design: a flat cold touch for a non-self recipient, plus transfer-log and
-    /// value-move costs on value transfers. New-account and delegation costs are charged elsewhere.
+    /// State-independent by design: a flat cold touch for a non-self recipient, plus TX_VALUE_COST on
+    /// value transfers (the EIP-7708 transfer log is folded into TX_VALUE_COST). Contract creation's
+    /// recipient charge is fully covered by CREATE_ACCESS, so it adds nothing here even with value.
+    /// New-account and delegation costs are charged elsewhere.
     /// </remarks>
     private static ulong Eip2780ExtraGas(Transaction tx, IReleaseSpec spec)
     {
         if (!spec.IsEip2780Enabled) return 0;
 
-        bool hasValue = !tx.Value.IsZero;
-
-        if (tx.IsContractCreation)
-            return hasValue ? GasCostOf.TransferLogEip2780 : 0;
+        // Contract creation is fully priced by CREATE_ACCESS; a value endowment adds no further charge.
+        if (tx.IsContractCreation) return 0;
 
         // Self-transfers coalesce into the sender leaf write already priced into TX_BASE_COST.
         if (tx.SenderAddress == tx.To) return 0;
 
         ulong cost = ColdAccountAccessCost(spec);
-        if (hasValue)
-            cost += GasCostOf.TransferLogEip2780 + GasCostOf.TxValueCostEip2780;
+        if (!tx.Value.IsZero)
+            cost += GasCostOf.TxValueCostEip2780;
 
         return cost;
     }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -635,8 +635,7 @@ public partial class EthRpcModuleTests
 
         ulong eip2780ValueTransferBase = GasCostOf.TransactionEip2780
             + Eip8038Constants.ColdAccountAccess
-            + GasCostOf.TxValueCostEip2780
-            + GasCostOf.TransferLogEip2780;
+            + GasCostOf.TxValueCostEip2780;
 
         // EIP-7981: access list with 1 address, no calldata - standard wins.
         ulong eip7981Standard = eip2780ValueTransferBase + Eip8038Constants.AccessListAddressCost


### PR DESCRIPTION
Part of #12599 — EIP-2780 spec update for glamsterdam devnet-8 (breaks devnet-7 intrinsic gas).

## Changes

Folds the EIP-7708 transfer-log cost into `TX_VALUE_COST` instead of charging it as a separate intrinsic primitive:

- `GasCostOf.TxValueCostEip2780`: **4244 → 6000** (absorbs the 1756 transfer-log cost).
- Removes the now-redundant `GasCostOf.TransferLogEip2780` constant — it was only ever used in intrinsic-gas accounting, never at runtime.
- `EthereumGasPolicy.Eip2780ExtraGas`: contract creation adds **no** recipient charge even with a value endowment (the recipient balance write is already covered by `CREATE_ACCESS`). Create-with-value and create-with-zero-value now have identical intrinsic cost.
- Updates the affected unit tests to the new model.

**Effect on totals:** a plain value transfer is unchanged (4244 + 1756 re-labeled to a single 6000); **create-with-value drops by 1756**, matching the EIP-2780 devnet-8 reference table where create `value = 0` and create `value > 0` are equal.

## Types of changes

- [x] Breaking change (a change that causes existing functionality not to work as expected)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Updated `Eip2780Tests`, `IntrinsicGasCalculatorTests` (incl. rewriting the create-with-value test, now `Eip2780_intrinsic_gas_for_create_is_value_independent`), `Eip8037Tests`, `TransactionProcessorEip7702Tests`, and `EthRpcModuleTests.EstimateGas`. All green: Evm.Test (214), Blockchain.Test EIP-7702 (51), JsonRpc.Test estimateGas floor cost (6).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
