### PR TITLE
fix(simulate): default a no-gas eth_simulateV1 call to the block gas budget (#12692)

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
 using Nethermind.Core.Exceptions;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Threading;
@@ -81,12 +82,16 @@ public partial class BlockProcessor
             for (uint i = 0; i < block.Transactions.Length; i++)
             {
                 Transaction currentTx = block.Transactions[i];
+                ITransactionProcessorAdapter txProcessor = balManager.GetTxProcessor(i + 1);
                 if (shouldValidate)
                 {
+                    // A simulate no-gas call defaults to GasCap, which the inclusion check would reject;
+                    // resolve it to the remaining block budget (state dimension too) before that check runs.
+                    txProcessor.PrepareForInclusionCheck(currentTx, block.Header.GasLimit.SaturatingSub(totalStateGas));
                     BlockAccessListManager.CheckPerTxInclusion(block, (int)i, currentTx, spec, totalExecutionGas, totalStateGas);
                 }
 
-                ProcessTransaction(balManager.GetTxProcessor(i + 1), stateProvider, block, currentTx, (int)i, receiptsTracer, processingOptions, inner);
+                ProcessTransaction(txProcessor, stateProvider, block, currentTx, (int)i, receiptsTracer, processingOptions, inner);
                 totalExecutionGas = receiptsTracer.CumulativeExecutionGasUsed;
                 totalStateGas = receiptsTracer.BlockStateGasUsed;
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/ITransactionProcessorAdapter.cs
@@ -11,5 +11,12 @@ namespace Nethermind.Evm.TransactionProcessing
         TransactionResult Execute(Transaction transaction, ITxTracer txTracer);
 
         void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext);
+
+        /// <summary>
+        /// Resolves an implicit gas limit to the value execution will use, ahead of the EIP-8037 per-tx
+        /// inclusion check. No-op unless the adapter defaults gas (simulate, for calls that omit <c>gas</c>).
+        /// </summary>
+        /// <param name="stateGasAvailable">Remaining EIP-8037 state-dimension budget, so the limit fits that dimension too.</param>
+        void PrepareForInclusionCheck(Transaction transaction, ulong stateGasAvailable) { }
     }
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateBridgeHelper.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateBridgeHelper.cs
@@ -152,6 +152,7 @@ public class SimulateBridgeHelper(IBlocksConfig blocksConfig, ISpecProvider spec
 
                 (BlockHeader callHeader, IReleaseSpec spec) = GetCallHeader(env.SpecProvider, blockCall, parent, payload.Validation);
                 env.SimulateRequestState.BlockGasLeft = callHeader.GasLimit;
+                env.SimulateRequestState.BlockStateGasLeft = callHeader.GasLimit;
                 callHeader.Hash = callHeader.CalculateHash();
 
                 TransactionWithSourceDetails[] calls = blockCall.Calls ?? [];

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateRequestState.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateRequestState.cs
@@ -12,6 +12,9 @@ public class SimulateRequestState : IBlobBaseFeeOverrideProvider
     public UInt256? BlobBaseFeeOverride { get; set; }
     public ulong TotalGasLeft { get; set; }
     public ulong BlockGasLeft { get; set; }
+
+    /// <summary>Remaining EIP-8037 state-dimension block budget, mirroring <see cref="BlockGasLeft"/> (execution).</summary>
+    public ulong BlockStateGasLeft { get; set; }
     public bool[] TxsWithExplicitGas { get; private set; } = [];
 
     public void SetTxsWithExplicitGas(TransactionWithSourceDetails[] calls)

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateTransactionProcessorAdapter.cs
@@ -22,16 +22,9 @@ public class SimulateTransactionProcessorAdapter(ITransactionProcessor transacti
     private int _currentTxIndex = 0;
     public TransactionResult Execute(Transaction transaction, ITxTracer txTracer)
     {
-        // The gas limit per tx go down as the block is processed.
-        if (!simulateRequestState.TxsWithExplicitGas[_currentTxIndex])
-        {
-            transaction.GasLimit = Math.Min(simulateRequestState.BlockGasLeft, simulateRequestState.TotalGasLeft);
-        }
-
-        if (simulateRequestState.TotalGasLeft < transaction.GasLimit)
-        {
-            transaction.GasLimit = simulateRequestState.TotalGasLeft;
-        }
+        // The non-BAL / validation:false paths never run the block executor's pre-check, so resolve the gas
+        // here; on the BAL path this repeats it with the same budget, leaving the accepted limit unchanged.
+        PrepareForInclusionCheck(transaction, simulateRequestState.BlockStateGasLeft);
         transaction.Hash = transaction.CalculateHash();
 
         TransactionResult result = simulateRequestState.Validate ? transactionProcessor.Execute(transaction, txTracer) : transactionProcessor.Trace(transaction, txTracer);
@@ -49,5 +42,24 @@ public class SimulateTransactionProcessorAdapter(ITransactionProcessor transacti
     {
         _currentTxIndex = 0;
         transactionProcessor.SetBlockExecutionContext(in blockExecutionContext);
+    }
+
+    /// <inheritdoc/>
+    public void PrepareForInclusionCheck(Transaction transaction, ulong stateGasAvailable)
+    {
+        simulateRequestState.BlockStateGasLeft = stateGasAvailable;
+
+        // The per-dimension budgets shrink as the block is processed.
+        if (!simulateRequestState.TxsWithExplicitGas[_currentTxIndex])
+        {
+            transaction.GasLimit = Math.Min(
+                Math.Min(simulateRequestState.BlockGasLeft, stateGasAvailable),
+                simulateRequestState.TotalGasLeft);
+        }
+
+        if (simulateRequestState.TotalGasLeft < transaction.GasLimit)
+        {
+            transaction.GasLimit = simulateRequestState.TotalGasLeft;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -1064,6 +1064,116 @@ public class EthSimulateTestsBlocksAndTransactions
     }
 
     /// <summary>
+    /// #12692 (item 1): a no-gas call must default to the block budget, not GasCap (100M) — which the EIP-8037
+    /// inclusion check rejects (ExecutionDimensionExceeded on a small block, StateDimensionExceeded below the cap).
+    /// </summary>
+    [TestCase(5_000_000ul, TestName = "no-gas call fits a small block's gas budget (execution dimension)")]
+    [TestCase(30_000_000ul, TestName = "no-gas call fits a realistic block's gas budget (state dimension)")]
+    public async Task eth_simulateV1_defaults_missing_gas_to_block_limit_on_bal_path(ulong blockGasLimit)
+    {
+        TestRpcBlockchain chain = await BuildAmsterdamBalChain();
+
+        SimulatePayload<TransactionForRpc> payload = new()
+        {
+            BlockStateCalls =
+            [
+                new()
+                {
+                    BlockOverrides = new BlockOverride { GasLimit = blockGasLimit },
+                    StateOverrides = new Dictionary<Address, AccountOverride>
+                    {
+                        { TestItem.AddressA, new AccountOverride { Balance = 1.Ether } }
+                    },
+                    Calls =
+                    [
+                        new LegacyTransactionForRpc { From = TestItem.AddressA, To = TestItem.AddressB, Value = 0, GasPrice = UInt256.Zero }
+                    ]
+                }
+            ],
+            Validation = true
+        };
+
+        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
+            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
+
+        Assert.That(result.Result.ResultType, Is.EqualTo(Core.ResultType.Success));
+        Assert.That(result.Data![0].Calls.First().Error, Is.Null);
+    }
+
+    /// <summary>
+    /// #12692 (item 1): the no-gas default tracks the running budget, so multiple gas-less calls in one block all fit.
+    /// </summary>
+    [Test]
+    public async Task eth_simulateV1_defaults_missing_gas_for_multiple_calls_on_bal_path()
+    {
+        TestRpcBlockchain chain = await BuildAmsterdamBalChain();
+
+        SimulatePayload<TransactionForRpc> payload = new()
+        {
+            BlockStateCalls =
+            [
+                new()
+                {
+                    StateOverrides = new Dictionary<Address, AccountOverride>
+                    {
+                        { TestItem.AddressA, new AccountOverride { Balance = 1.Ether } }
+                    },
+                    Calls =
+                    [
+                        new LegacyTransactionForRpc { From = TestItem.AddressA, To = TestItem.AddressB, Value = 0, GasPrice = UInt256.Zero },
+                        new LegacyTransactionForRpc { From = TestItem.AddressA, To = TestItem.AddressB, Value = 0, GasPrice = UInt256.Zero }
+                    ]
+                }
+            ],
+            Validation = true
+        };
+
+        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
+            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
+
+        Assert.That(result.Result.ResultType, Is.EqualTo(Core.ResultType.Success));
+        Assert.That(result.Data![0].Calls.All(static c => c.Error is null), Is.True);
+    }
+
+    /// <summary>
+    /// #12692 (item 1, state dimension): a storage write costs far more state gas than execution gas, so a
+    /// following no-gas call must clamp to the state budget too, else StateDimensionExceeded.
+    /// </summary>
+    [Test]
+    public async Task eth_simulateV1_no_gas_call_after_state_write_fits_state_dimension()
+    {
+        TestRpcBlockchain chain = await BuildAmsterdamBalChain();
+
+        SimulatePayload<TransactionForRpc> payload = new()
+        {
+            BlockStateCalls =
+            [
+                new()
+                {
+                    StateOverrides = new Dictionary<Address, AccountOverride>
+                    {
+                        { TestItem.AddressA, new AccountOverride { Balance = 1.Ether } },
+                        // runtime code PUSH1 1, PUSH1 0, SSTORE: writes a new slot → large EIP-8037 state gas
+                        { TestItem.AddressC, new AccountOverride { Code = Bytes.FromHexString("0x6001600055") } }
+                    },
+                    Calls =
+                    [
+                        new LegacyTransactionForRpc { From = TestItem.AddressA, To = TestItem.AddressC, Gas = 200_000, GasPrice = UInt256.Zero },
+                        new LegacyTransactionForRpc { From = TestItem.AddressA, To = TestItem.AddressB, Value = 0, GasPrice = UInt256.Zero }
+                    ]
+                }
+            ],
+            Validation = true
+        };
+
+        ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result =
+            chain.EthRpcModule.eth_simulateV1(payload, BlockParameter.Latest);
+
+        Assert.That(result.Result.ResultType, Is.EqualTo(Core.ResultType.Success));
+        Assert.That(result.Data![0].Calls.All(static c => c.Error is null), Is.True);
+    }
+
+    /// <summary>
     /// Regression test: blob tx rejected when <c>maxFeePerBlobGas</c> is below the <c>blobBaseFee</c>
     /// block override. The decorated calculator must be used for validation, not the static
     /// <c>BlobGasCalculator.TryCalculateFeePerBlobGas</c> which reads from the raw header.


### PR DESCRIPTION
Part of #12692 (item 1). **Stacked on #12721** (needs the simulate adapter on the EIP-7928 BAL path); rebase onto `master` once that merges.

## Changes

Under EIP-7928 + EIP-8037, `eth_simulateV1` rejected any call that omits `gas`. A no-gas call is defaulted to `JsonRpc.GasCap` (100M) at parse time, and the EIP-8037 per-tx inclusion check runs **before** execution:

- On a small block it fails `ExecutionDimensionExceeded` (`min(EIP-7825 cap 16.7M, 100M)` exceeds the execution budget).
- On **any** block whose gas limit is below the cap it fails `StateDimensionExceeded`, because the state dimension reserves the full, **uncapped** tx gas (`txGas > stateAvailable`) — so a 100M default is rejected even on a 30M block.

Fix: the simulate adapter already resolves a no-gas call to the running block budget (`min(BlockGasLeft, TotalGasLeft)`), but only inside `Execute`, which runs *after* the inclusion check. Expose that adjustment through a new `ITransactionProcessorAdapter.PrepareForInclusionCheck(tx)` hook (default no-op) and call it from the sequential BAL executor immediately before `CheckPerTxInclusion`. Because the budget decreases per tx, this is correct for **multiple** gas-less calls in one block, not just the first — the common `eth_simulateV1` shape.

- No other execution path is affected: `PrepareForInclusionCheck` is a no-op on every adapter except the simulate one, and only the sequential BAL path calls it (real block production/validation gets the default `ExecuteTransactionProcessorAdapter`, whose hook does nothing).
- Replaces the earlier `SimulateBridgeHelper` assembly-time default (which only fixed the first call per block, per review), and shares the gas-adjust logic between `Execute` and the new hook.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

- [x] Requires testing — [x] tests written

`eth_simulateV1_defaults_missing_gas_to_block_limit_on_bal_path` — a single no-gas Amsterdam call under a 5M block (execution dimension) and a 30M block (state dimension). `eth_simulateV1_defaults_missing_gas_for_multiple_calls_on_bal_path` — two gas-less calls in one block, which only pass when the default tracks the running budget. All fail without the fix and pass with it. Simulate suite 114/114; BAL/BlockProcessor/Eip8037 green.

## Documentation

- [ ] Requires documentation update — [x] No
- [ ] Requires Release Notes — [x] No
