### PR TITLE
Snap sync: reject storage range responses with unmatched slot lists

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
@@ -124,10 +124,13 @@ public class SnapProviderTests
         Assert.That(progressTracker.IsSnapGetRangesFinished(), Is.False);
     }
 
-    [TestCase(1, 2)]
-    [TestCase(2, 3)]
-    [TestCase(4, 64)]
-    public void AddStorageRange_ResponseHasMoreSlotListsThanRequestedAccounts_ReturnsOutOfBounds(int accountCount, int slotListCount)
+    [TestCase(1, 2, AddRangeResult.OutOfBounds)]
+    [TestCase(2, 3, AddRangeResult.OutOfBounds)]
+    [TestCase(4, 64, AddRangeResult.OutOfBounds)]
+    [TestCase(1, 1, AddRangeResult.EmptyRange)]
+    [TestCase(4, 4, AddRangeResult.EmptyRange)]
+    [TestCase(4, 2, AddRangeResult.EmptyRange)]
+    public void AddStorageRange_RejectsResponseOnlyWhenSlotListsExceedRequestedAccounts(int accountCount, int slotListCount, AddRangeResult expected)
     {
         using IContainer container = CreateContainer();
 
@@ -136,7 +139,7 @@ public class SnapProviderTests
         using StorageRange request = CreateStorageRange(accountCount);
         using SlotsAndProofs response = CreateEmptySlotsResponse(slotListCount);
 
-        Assert.That(snapProvider.AddStorageRange(request, response), Is.EqualTo(AddRangeResult.OutOfBounds));
+        Assert.That(snapProvider.AddStorageRange(request, response), Is.EqualTo(expected));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
@@ -124,6 +124,60 @@ public class SnapProviderTests
         Assert.That(progressTracker.IsSnapGetRangesFinished(), Is.False);
     }
 
+    [TestCase(1, 2)]
+    [TestCase(2, 3)]
+    [TestCase(4, 64)]
+    public void AddStorageRange_ResponseHasMoreSlotListsThanRequestedAccounts_ReturnsOutOfBounds(int accountCount, int slotListCount)
+    {
+        using IContainer container = CreateContainer();
+
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+
+        using StorageRange request = CreateStorageRange(accountCount);
+        using SlotsAndProofs response = CreateEmptySlotsResponse(slotListCount);
+
+        Assert.That(snapProvider.AddStorageRange(request, response), Is.EqualTo(AddRangeResult.OutOfBounds));
+    }
+
+    [Test]
+    public void AddStorageRange_ResponseHasMoreSlotListsThanRequestedAccounts_KeepsRangePhaseCompletable()
+    {
+        using IContainer container = CreateContainerBuilder(new TestSyncConfig()
+        {
+            SnapSyncAccountRangePartitionCount = 1
+        })
+            .WithSuggestedHeaderOfStateRoot(Keccak.EmptyTreeHash)
+            .Build();
+
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+        ProgressTracker progressTracker = container.Resolve<ProgressTracker>();
+
+        PathWithAccount account = new(TestItem.ValueKeccaks[0], Account.TotallyEmpty);
+        progressTracker.EnqueueAccountStorage(account);
+
+        // Drain the account range partition so that the storage request is the only outstanding work.
+        progressTracker.IsFinished(out SnapSyncBatch? accountBatch);
+        ValueHash256 partitionLimit = accountBatch!.AccountRangeRequest!.LimitHash!.Value;
+        progressTracker.UpdateAccountRangePartitionProgress(partitionLimit, Keccak.MaxValue, false);
+        progressTracker.ReportAccountRangePartitionFinished(partitionLimit);
+        accountBatch.Dispose();
+
+        progressTracker.IsFinished(out SnapSyncBatch? storageBatch);
+        using (SlotsAndProofs response = CreateEmptySlotsResponse(storageBatch!.StorageRangeRequest!.Accounts.Count + 1))
+        {
+            Assert.That(snapProvider.AddStorageRange(storageBatch.StorageRangeRequest, response), Is.EqualTo(AddRangeResult.OutOfBounds));
+        }
+        storageBatch.Dispose();
+
+        progressTracker.IsFinished(out SnapSyncBatch? retryBatch);
+        Assert.That(retryBatch!.StorageRangeRequest!.Accounts.AsSpan()[0].Path, Is.EqualTo(account.Path));
+
+        progressTracker.ReportFullStorageRequestFinished(retryBatch.StorageRangeRequest.Accounts.Count);
+        retryBatch.Dispose();
+
+        Assert.That(progressTracker.IsSnapGetRangesFinished(), Is.True);
+    }
+
     [Test]
     public void AddStorageRange_ShouldPersistEntries()
     {
@@ -305,6 +359,28 @@ public class SnapProviderTests
         List<string> Paths,
         List<string> Accounts
     );
+
+    private static StorageRange CreateStorageRange(int accountCount)
+    {
+        ArrayPoolList<PathWithAccount> accounts = new(accountCount);
+        for (int i = 0; i < accountCount; i++)
+        {
+            accounts.Add(new PathWithAccount(TestItem.ValueKeccaks[i], Account.TotallyEmpty));
+        }
+
+        return new StorageRange { Accounts = accounts, StartingHash = Keccak.Zero };
+    }
+
+    private static SlotsAndProofs CreateEmptySlotsResponse(int slotListCount)
+    {
+        ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>> pathsAndSlots = new(slotListCount);
+        for (int i = 0; i < slotListCount; i++)
+        {
+            pathsAndSlots.Add(new ArrayPoolList<PathWithStorageSlot>(0));
+        }
+
+        return new SlotsAndProofs { PathsAndSlots = pathsAndSlots, Proofs = EmptyByteArrayList.Instance };
+    }
 
     private static (ISnapStateServer, Hash256) BuildSnapServerFromEntries((Hash256, Account)[] entries)
     {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -146,6 +146,16 @@ namespace Nethermind.Synchronization.SnapSync
 
                 int requestLength = request.Accounts.Count;
 
+                if (responses.Length > requestLength)
+                {
+                    if (_logger.IsTrace) _logger.Trace($"SNAP - GetStorageRange - got {responses.Length} slot lists for {requestLength} accounts, RootHash:{request.RootHash}");
+
+                    _progressTracker.RetryStorageRange(request.Copy());
+                    Metrics.SnapRangeResult.Increment(new SnapRangeResult(isStorage: true, result: AddRangeResult.OutOfBounds));
+
+                    return AddRangeResult.OutOfBounds;
+                }
+
                 for (int i = 0; i < responses.Length; i++)
                 {
                     // only the last can have proofs


### PR DESCRIPTION
## Changes

- `SnapProvider.AddStorageRange` looped over the number of slot lists in the `StorageRanges` response and used that index to look up the account in the original request. A response containing more slot lists than the request had accounts read past the end of `StorageRange.Accounts`, throwing `IndexOutOfRangeException` before any accounting ran.
- The response is now rejected as `OutOfBounds` and the range retried via `ProgressTracker.RetryStorageRange`, matching how the expired-root-hash case is already handled. This re-queues the accounts and balances `_activeStorageRequests`, so `IsSnapGetRangesFinished` can still become true and the range download phase completes.
- Returning a result instead of throwing also lets `SnapSyncFeed.AnalyzeResponsePerPeer` account for the response, which an escaping exception skipped.

The response length was previously only checked in the other direction (fewer lists than accounts, handled just below the loop). The message deserializer bounds the outer list at `MaxRequestAccounts` rather than the actual request size, so the counts are not correlated before this point.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Two regression tests in `SnapProviderTests`, both of which fail on `master` with `IndexOutOfRangeException`:

- `AddStorageRange_ResponseHasMoreSlotListsThanRequestedAccounts_ReturnsOutOfBounds` — parameterized over several account/slot-list count combinations.
- `AddStorageRange_ResponseHasMoreSlotListsThanRequestedAccounts_KeepsRangePhaseCompletable` — drives a request through `ProgressTracker`, feeds it an over-long response, and asserts the accounts are re-queued and `IsSnapGetRangesFinished()` becomes true once the retried range is reported finished.

Full `Nethermind.Synchronization.Test` suite passes (2080 passed, 0 failed).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
