### PR TITLE
Only accept the requested header in FetchHeaderFromPeer

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -72,7 +72,13 @@ public class SyncPeerPoolTests
             Task.FromResult<IOwnedReadOnlyList<BlockHeader>?>(ArrayPoolList<BlockHeader>.Empty());
 
         public Task<IOwnedReadOnlyList<BlockHeader>?> GetBlockHeaders(Hash256 startHash, int maxBlocks, int skip, CancellationToken token) =>
-            Task.FromResult<IOwnedReadOnlyList<BlockHeader>?>(ArrayPoolList<BlockHeader>.Empty());
+            Task.FromResult<IOwnedReadOnlyList<BlockHeader>?>(
+                HeaderToReturn is null ? ArrayPoolList<BlockHeader>.Empty() : new ArrayPoolList<BlockHeader>([HeaderToReturn]));
+
+        /// <summary>
+        /// Header this peer answers header requests with, whatever hash was asked for. Defaults to an arbitrary one.
+        /// </summary>
+        public BlockHeader? HeaderToReturn { get; set; }
 
         public async Task<BlockHeader?> GetHeadBlockHeader(Hash256? hash, CancellationToken token)
         {
@@ -92,7 +98,7 @@ public class SyncPeerPoolTests
             }
 
             IsInitialized = true;
-            return await Task.FromResult(Build.A.BlockHeader.TestObject);
+            return await Task.FromResult(HeaderToReturn ?? Build.A.BlockHeader.TestObject);
         }
 
         public void NotifyOfNewBlock(Block block, SendBlockMode mode)
@@ -738,6 +744,35 @@ public class SyncPeerPoolTests
         SyncPeerAllocation r2 = await w2;
         Assert.That(r1.HasPeer, Is.True);
         Assert.That(r2.HasPeer, Is.True);
+    }
+
+    /// <summary>
+    /// Every peer answers with a header, but only <paramref name="peerWithRequestedBlock"/> answers with the one
+    /// that was asked for (-1 when no peer has it). The rest stand in for peers serving some other block.
+    /// </summary>
+    [TestCase(0, 0, true, TestName = "Fetch_header_accepts_the_requested_block")]
+    [TestCase(-1, 0, false, TestName = "Fetch_header_rejects_a_different_block")]
+    [TestCase(1, 100, true, TestName = "Fetch_header_waits_past_a_peer_answering_with_a_different_block")]
+    public async Task Fetch_header_only_accepts_the_requested_block(int peerWithRequestedBlock, int responseDelay, bool shouldFind)
+    {
+        await using Context ctx = new();
+        SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 2);
+
+        BlockHeader requested = Build.A.BlockHeader.WithNumber(10).TestObject;
+        for (int i = 0; i < peers.Length; i++)
+        {
+            peers[i].HeaderToReturn = Build.A.BlockHeader.WithNumber(20 + i).TestObject;
+        }
+
+        if (peerWithRequestedBlock >= 0)
+        {
+            peers[peerWithRequestedBlock].HeaderToReturn = requested;
+            peers[peerWithRequestedBlock].SetHeaderResponseTime(responseDelay);
+        }
+
+        BlockHeader? result = await ctx.Pool.FetchHeaderFromPeer(requested.Hash!);
+
+        Assert.That(result?.Hash, Is.EqualTo(shouldFind ? requested.Hash : null));
     }
 
     private async Task<SimpleSyncPeerMock[]> SetupPeers(Context ctx, int count)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -782,6 +782,20 @@ public class SyncPeerPoolTests
     }
 
     [Test]
+    public async Task Fetch_header_reports_a_peer_answering_with_a_different_block()
+    {
+        await using Context ctx = new();
+        SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 1);
+
+        BlockHeader requested = Build.A.BlockHeader.WithNumber(10).TestObject;
+        peers[0].HeaderToReturn = Build.A.BlockHeader.WithNumber(20).TestObject;
+
+        await ctx.Pool.FetchHeaderFromPeer(requested.Hash!);
+
+        Assert.That(peers[0].DisconnectRequested, Is.True);
+    }
+
+    [Test]
     public async Task Fetch_header_falls_back_to_an_allocated_peer_when_no_head_header_is_returned()
     {
         await using Context ctx = new();

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -781,18 +781,37 @@ public class SyncPeerPoolTests
         Assert.That(result, Is.SameAs(shouldFind ? requested : null));
     }
 
-    [Test]
-    public async Task Fetch_header_reports_a_peer_answering_with_a_different_block()
+    public enum PeerAnswer { RequestedBlock, DifferentBlock, Nothing }
+
+    /// <summary>
+    /// Substituting another block is a protocol breach and costs the peer its connection, but not having the
+    /// block is the normal answer while a head is unknown and must leave the peer alone.
+    /// </summary>
+    [TestCase(PeerAnswer.RequestedBlock, false)]
+    [TestCase(PeerAnswer.DifferentBlock, true)]
+    [TestCase(PeerAnswer.Nothing, false)]
+    public async Task Fetch_header_only_reports_a_peer_answering_with_a_different_block(PeerAnswer answer, bool shouldReport)
     {
         await using Context ctx = new();
         SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 1);
 
         BlockHeader requested = Build.A.BlockHeader.WithNumber(10).TestObject;
-        peers[0].HeaderToReturn = Build.A.BlockHeader.WithNumber(20).TestObject;
+        switch (answer)
+        {
+            case PeerAnswer.RequestedBlock:
+                peers[0].HeaderToReturn = requested;
+                break;
+            case PeerAnswer.DifferentBlock:
+                peers[0].HeaderToReturn = Build.A.BlockHeader.WithNumber(20).TestObject;
+                break;
+            case PeerAnswer.Nothing:
+                peers[0].HeadHeaderUnavailable = true;
+                break;
+        }
 
         await ctx.Pool.FetchHeaderFromPeer(requested.Hash!);
 
-        Assert.That(peers[0].DisconnectRequested, Is.True);
+        Assert.That(peers[0].DisconnectRequested, Is.EqualTo(shouldReport));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -76,9 +76,15 @@ public class SyncPeerPoolTests
                 HeaderToReturn is null ? ArrayPoolList<BlockHeader>.Empty() : new ArrayPoolList<BlockHeader>([HeaderToReturn]));
 
         /// <summary>
-        /// Header this peer answers header requests with, whatever hash was asked for. Defaults to an arbitrary one.
+        /// Header this peer answers header requests with, whatever hash was asked for. When unset, head-header
+        /// requests are answered with an arbitrary header and by-hash requests with an empty list.
         /// </summary>
         public BlockHeader? HeaderToReturn { get; set; }
+
+        /// <summary>
+        /// Makes the peer answer head-header requests with nothing, as a peer that does not have the block does.
+        /// </summary>
+        public bool HeadHeaderUnavailable { get; set; }
 
         public async Task<BlockHeader?> GetHeadBlockHeader(Hash256? hash, CancellationToken token)
         {
@@ -98,7 +104,7 @@ public class SyncPeerPoolTests
             }
 
             IsInitialized = true;
-            return await Task.FromResult(HeaderToReturn ?? Build.A.BlockHeader.TestObject);
+            return await Task.FromResult(HeadHeaderUnavailable ? null : HeaderToReturn ?? Build.A.BlockHeader.TestObject);
         }
 
         public void NotifyOfNewBlock(Block block, SendBlockMode mode)
@@ -772,7 +778,25 @@ public class SyncPeerPoolTests
 
         BlockHeader? result = await ctx.Pool.FetchHeaderFromPeer(requested.Hash!);
 
-        Assert.That(result?.Hash, Is.EqualTo(shouldFind ? requested.Hash : null));
+        Assert.That(result, Is.SameAs(shouldFind ? requested : null));
+    }
+
+    [Test]
+    public async Task Fetch_header_falls_back_to_an_allocated_peer_when_no_head_header_is_returned()
+    {
+        await using Context ctx = new();
+        SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 2);
+
+        BlockHeader requested = Build.A.BlockHeader.WithNumber(10).TestObject;
+        foreach (SimpleSyncPeerMock peer in peers)
+        {
+            peer.HeaderToReturn = requested;
+            peer.HeadHeaderUnavailable = true;
+        }
+
+        BlockHeader? result = await ctx.Pool.FetchHeaderFromPeer(requested.Hash!);
+
+        Assert.That(result, Is.SameAs(requested));
     }
 
     private async Task<SimpleSyncPeerMock[]> SetupPeers(Context ctx, int count)

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -144,6 +144,13 @@ namespace Nethermind.Synchronization.Peers
         }
 
 
+        /// <summary>
+        /// Asks the connected peers for the header of <paramref name="hash"/>.
+        /// </summary>
+        /// <returns>
+        /// The header whose hash is <paramref name="hash"/>, or <c>null</c> if no peer supplied it in time.
+        /// A response for any other block is discarded, so the result never depends on which peer answered.
+        /// </returns>
         public static async Task<BlockHeader?> FetchHeaderFromPeer(this ISyncPeerPool syncPeerPool, Hash256 hash, CancellationToken cancellationToken = default)
         {
             try
@@ -187,14 +194,15 @@ namespace Nethermind.Synchronization.Peers
                     token);
 
                 ReadOnlySpan<BlockHeader> headersSpan = headers is null ? [] : headers.AsSpan();
-                return headersSpan.Length == 1 ? headersSpan[0] : null;
+                return headersSpan.Length == 1 && headersSpan[0].Hash == headerHash ? headersSpan[0] : null;
             }
 
             static async Task<BlockHeader?> FetchHeader(PeerInfo peer, Hash256 headerHash, CancellationToken token)
             {
                 try
                 {
-                    return await peer.SyncPeer.GetHeadBlockHeader(headerHash, token);
+                    BlockHeader? header = await peer.SyncPeer.GetHeadBlockHeader(headerHash, token);
+                    return header?.Hash == headerHash ? header : null;
                 }
                 catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
                 {

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -161,7 +161,7 @@ namespace Nethermind.Synchronization.Peers
                 List<Task<BlockHeader?>> requests = new(syncPeerPool.InitializedPeersCount);
                 foreach (PeerInfo peer in syncPeerPool.InitializedPeers)
                 {
-                    requests.Add(FetchHeader(peer, hash, cts.Token));
+                    requests.Add(FetchHeader(syncPeerPool, peer, hash, cts.Token));
                 }
 
                 while (requests.Count > 0)
@@ -185,29 +185,38 @@ namespace Nethermind.Synchronization.Peers
                 return null;
             }
 
-            static async Task<BlockHeader?> FetchAllocatedHeader(ISyncPeerPool syncPeerPool, Hash256 headerHash, CancellationToken token)
-            {
-                using IOwnedReadOnlyList<BlockHeader>? headers = await syncPeerPool.AllocateAndRun(
-                    peer => peer.GetBlockHeaders(headerHash, 1, 0, token),
+            static Task<BlockHeader?> FetchAllocatedHeader(ISyncPeerPool syncPeerPool, Hash256 headerHash, CancellationToken token) =>
+                syncPeerPool.AllocateAndRun(
+                    async (PeerInfo peer) =>
+                    {
+                        using IOwnedReadOnlyList<BlockHeader>? headers = await peer.SyncPeer.GetBlockHeaders(headerHash, 1, 0, token);
+
+                        ReadOnlySpan<BlockHeader> headersSpan = headers is null ? [] : headers.AsSpan();
+                        return headersSpan.Length == 1 ? Validate(syncPeerPool, peer, headersSpan[0], headerHash) : null;
+                    },
                     BySpeedStrategy.FastestHeader,
                     AllocationContexts.Headers,
                     token);
 
-                ReadOnlySpan<BlockHeader> headersSpan = headers is null ? [] : headers.AsSpan();
-                return headersSpan.Length == 1 && headersSpan[0].Hash == headerHash ? headersSpan[0] : null;
-            }
-
-            static async Task<BlockHeader?> FetchHeader(PeerInfo peer, Hash256 headerHash, CancellationToken token)
+            static async Task<BlockHeader?> FetchHeader(ISyncPeerPool syncPeerPool, PeerInfo peer, Hash256 headerHash, CancellationToken token)
             {
                 try
                 {
                     BlockHeader? header = await peer.SyncPeer.GetHeadBlockHeader(headerHash, token);
-                    return header?.Hash == headerHash ? header : null;
+                    return header is null ? null : Validate(syncPeerPool, peer, header, headerHash);
                 }
                 catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
                 {
                     return null;
                 }
+            }
+
+            static BlockHeader? Validate(ISyncPeerPool syncPeerPool, PeerInfo peer, BlockHeader header, Hash256 headerHash)
+            {
+                if (header.Hash == headerHash) return header;
+
+                syncPeerPool.ReportBreachOfProtocol(peer, DisconnectReason.UnexpectedHeaderHash, "header hash inconsistent with request");
+                return null;
             }
         }
     }


### PR DESCRIPTION
## Changes

- `FetchHeaderFromPeer` now compares the hash of a peer-supplied header against the hash that was requested, and ignores the response when they differ. Previously it queried every initialized peer in parallel and returned the first non-null response as-is, so a peer answering with a header for some other block had it accepted — the result depended on which peer replied first rather than on what was asked for.
- Applied on both response paths: the parallel fan-out and the `FetchAllocatedHeader` fallback.
- A non-matching response is treated like a missing one rather than a hard failure, so the peers still in flight can supply the requested header instead of the whole lookup returning null.
- Documented the return contract on the method.
- The equivalent lookups in `StartingSyncPivotUpdater` and `PeerRefresher` already validate this way; `FetchHeaderFromPeer` was the one that did not.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `Fetch_header_only_accepts_the_requested_block` to `SyncPeerPoolTests`, covering three cases: the requested block is returned when a peer has it, `null` when no peer does, and the requested header is still found when another peer answers first with a different block. The last two fail on master and pass with this change. `SimpleSyncPeerMock` gained a `HeaderToReturn` property so a peer can be configured to answer with a specific header; it defaults to the previous behaviour, so existing tests are unaffected.

Full `Nethermind.Synchronization.Test` (2079 passed) and `Nethermind.Merge.Plugin.Test` (1681 passed) suites pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No