### PR TITLE
docs(core): drop the provisional note on the pinned EIP-8250 and EIP-8272 addresses

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8250Constants.cs
@@ -12,7 +12,6 @@ public static class Eip8250Constants
     public const ulong MaxNonceSeq = ulong.MaxValue;
     public const long KeyedNonceFirstUseGas = 20_000;
 
-    // Provisional: spec address is TBD; mirrors the only existing implementation.
     public static readonly Address NonceManagerAddress = new("0x0000000000000000000000000000000000008250");
 
     // Spec-pinned revert(0, 0): a storage namespace only, never callable. Exposed as memory rather

--- a/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
@@ -17,6 +17,5 @@ public static class Eip8272Constants
     public static readonly ValueHash256 RecentRootEntryDomain = ValueKeccak.Compute("RECENT_ROOT_ENTRY");
     public static readonly ValueHash256 RecentRootStorageDomain = ValueKeccak.Compute("RECENT_ROOT_STORAGE");
 
-    // Provisional: spec address is TBD; mirrors the only existing implementation.
     public static readonly Address RecentRootAddress = new("0x0000000000000000000000000000000000008272");
 }


### PR DESCRIPTION
The NONCE_MANAGER and RECENT_ROOT_ADDRESS values are no longer provisional. EIP-8250 pins `NONCE_MANAGER` to `0x...8250` and EIP-8272 pins `RECENT_ROOT_ADDRESS` to `0x...8272` on master, so the comments saying the spec address is TBD and that the value mirrors an existing implementation are wrong.

Comment-only change, no behaviour difference.
