### PR TITLE
fix(rpc): estimate a frame transaction against the budget its frames fix

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -77,7 +77,7 @@ public class GasEstimator(
         tx.SenderAddress ??= Address.Zero;
 
         if (tx.SupportsFrames)
-            return EstimateFrameTx(tx, header, spec, gasTracer);
+            return EstimateFrameTx(tx, header, spec);
 
         UInt256 senderBalance = stateProvider.GetBalance(tx.SenderAddress!);
 
@@ -99,18 +99,15 @@ public class GasEstimator(
         return BinarySearchEstimate(tx, header, spec, gasTracer, bounds, errorMargin, token);
     }
 
-    /// <summary>The gas an EIP-8141 frame transaction reserves, or the probe's failure.</summary>
+    /// <summary>The gas an EIP-8141 frame transaction reserves, or a failure when that budget is unestimable.</summary>
     /// <remarks>
     /// A frame transaction has no <c>gas_limit</c> to search: the processor derives the budget from the
     /// signed per-frame limits and ignores <see cref="Transaction.GasLimit"/>. Affordability gates are
     /// skipped because the payer is frame-chosen rather than the sender; the tracer's out-of-gas and
     /// revert flags are not consulted because each frame runs as its own top-level action.
     /// </remarks>
-    private static EstimationResult EstimateFrameTx(Transaction tx, BlockHeader header, IReleaseSpec spec, EstimateGasTracer gasTracer)
+    private static EstimationResult EstimateFrameTx(Transaction tx, BlockHeader header, IReleaseSpec spec)
     {
-        if (gasTracer.StatusCode != StatusCode.Success)
-            return EstimationResult.Failure(GetError(gasTracer));
-
         if (!FrameTxValidation.TryCalculateGasBudget(tx, spec, out _, out _, out ulong maxGas))
             return EstimationResult.Failure(FrameTxGasLimitOverflows);
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -100,15 +100,10 @@ public class GasEstimator(
 
     /// <summary>The gas an EIP-8141 frame transaction reserves, or the probe's failure.</summary>
     /// <remarks>
-    /// A frame transaction has no <c>gas_limit</c> field: its budget is the intrinsic cost plus the
-    /// per-frame limits it signs over, so a caller cannot lower it and there is nothing to search for.
-    /// Binary search would also be blind here, since the processor derives the budget from the frames
-    /// and ignores <see cref="Transaction.GasLimit"/> — every probe succeeds regardless of the value
-    /// under test. The affordability gates are skipped for the same reason they would be wrong: the
-    /// frames choose the payer, which need not be the sender, and a payer too poor to cover the
-    /// reservation already fails the probe. The tracer's per-action out-of-gas and revert flags are not
-    /// consulted: each frame runs as its own top-level action, so they describe the last frame rather than
-    /// the transaction, and a frame that fails still reserves the same budget.
+    /// A frame transaction has no <c>gas_limit</c> to search: the processor derives the budget from the
+    /// signed per-frame limits and ignores <see cref="Transaction.GasLimit"/>. Affordability gates are
+    /// skipped because the payer is frame-chosen rather than the sender; the tracer's out-of-gas and
+    /// revert flags are not consulted because each frame runs as its own top-level action.
     /// </remarks>
     private static EstimationResult EstimateFrameTx(Transaction tx, BlockHeader header, IReleaseSpec spec, EstimateGasTracer gasTracer)
     {

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -45,7 +45,8 @@ public class GasEstimator(
     private static readonly string InvalidErrorMarginTooHigh = $"Invalid error margin, must be lower than {MaxErrorMargin}.";
     private const string GasEstimationOutOfGas = "Gas estimation failed due to out of gas";
     private const string TransactionExecutionFails = "Transaction execution fails";
-    private const string CannotEstimateGasExceeded = "Cannot estimate gas, gas spent exceeded transaction and block gas limit or transaction gas limit cap";
+    /// <summary>Error emitted when the required gas exceeds the transaction and block gas limits, or the transaction gas limit cap.</summary>
+    public const string CannotEstimateGasExceeded = "Cannot estimate gas, gas spent exceeded transaction and block gas limit or transaction gas limit cap";
     private const string ExecutionReverted = "execution reverted";
     private const string FrameTxGasLimitOverflows = "frame transaction gas limit overflows";
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -47,6 +47,7 @@ public class GasEstimator(
     private const string TransactionExecutionFails = "Transaction execution fails";
     private const string CannotEstimateGasExceeded = "Cannot estimate gas, gas spent exceeded transaction and block gas limit or transaction gas limit cap";
     private const string ExecutionReverted = "execution reverted";
+    private const string FrameTxGasLimitOverflows = "frame transaction gas limit overflows";
 
     public ulong Estimate(
         Transaction tx,
@@ -74,6 +75,9 @@ public class GasEstimator(
         IReleaseSpec spec = specProvider.GetSpec(header.Number + 1, header.Timestamp + blocksConfig.SecondsPerSlot);
         tx.SenderAddress ??= Address.Zero;
 
+        if (tx.SupportsFrames)
+            return EstimateFrameTx(tx, header, spec, gasTracer);
+
         UInt256 senderBalance = stateProvider.GetBalance(tx.SenderAddress!);
 
         if (CheckFunds(tx, spec, gasTracer, senderBalance, out UInt256 available) is { } fundsResult)
@@ -92,6 +96,31 @@ public class GasEstimator(
         EstimationBounds bounds = CapByAllowance(new EstimationBounds(leftBound, rightBound, intrinsicGas), available, feeCap);
 
         return BinarySearchEstimate(tx, header, spec, gasTracer, bounds, errorMargin, token);
+    }
+
+    /// <summary>The gas an EIP-8141 frame transaction reserves, or the probe's failure.</summary>
+    /// <remarks>
+    /// A frame transaction has no <c>gas_limit</c> field: its budget is the intrinsic cost plus the
+    /// per-frame limits it signs over, so a caller cannot lower it and there is nothing to search for.
+    /// Binary search would also be blind here, since the processor derives the budget from the frames
+    /// and ignores <see cref="Transaction.GasLimit"/> — every probe succeeds regardless of the value
+    /// under test. The affordability gates are skipped for the same reason they would be wrong: the
+    /// frames choose the payer, which need not be the sender, and a payer too poor to cover the
+    /// reservation already fails the probe. The tracer's per-action out-of-gas and revert flags are not
+    /// consulted: each frame runs as its own top-level action, so they describe the last frame rather than
+    /// the transaction, and a frame that fails still reserves the same budget.
+    /// </remarks>
+    private static EstimationResult EstimateFrameTx(Transaction tx, BlockHeader header, IReleaseSpec spec, EstimateGasTracer gasTracer)
+    {
+        if (gasTracer.StatusCode != StatusCode.Success)
+            return EstimationResult.Failure(GetError(gasTracer));
+
+        if (!FrameTxValidation.TryCalculateGasBudget(tx, spec, out _, out _, out ulong maxGas))
+            return EstimationResult.Failure(FrameTxGasLimitOverflows);
+
+        return maxGas > Math.Min(header.GasLimit, spec.GetTxGasLimitCap())
+            ? EstimationResult.Failure(CannotEstimateGasExceeded)
+            : EstimationResult.Success(maxGas);
     }
 
     private static EstimationResult? ValidateErrorMargin(ulong errorMargin) =>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -701,6 +701,40 @@ public class FrameTxProcessorTests
         Assert.That(error, Is.EqualTo(GasEstimator.CannotEstimateGasExceeded));
     }
 
+    /// <summary>A reverting POST_TX frame fails the probe's status but keeps the transaction valid and
+    /// its frame budget well-defined, so the estimate is returned rather than reported as a failure.</summary>
+    [Test]
+    public void EstimateGas_FrameTxWithARevertingPostTxFrame_StillReturnsTheFrameBudget()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, target: Observer),
+            Frame(TxFrame.ModePostTx, target: Recipient));
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithGasLimit(30_000_000).TestObject;
+
+        EstimateGasTracer gasTracer = new();
+        _transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, Spec));
+        TransactionResult probe = _transactionProcessor.CallAndRestore(tx, gasTracer);
+
+        Assert.That(probe.TransactionExecuted, Is.True, probe.ErrorDescription ?? probe.Error.ToString());
+        Assert.That(gasTracer.StatusCode, Is.EqualTo(StatusCode.Failure), "a reverting POST_TX frame fails the probe status");
+
+        GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
+        ulong estimate = estimator.Estimate(tx, header, gasTracer, out string? error);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(error, Is.Null, "a reverting POST_TX frame must not fail a frame-budget estimate");
+            Assert.That(estimate, Is.GreaterThan(0UL));
+        }
+    }
+
     [Test]
     public void Execute_CodelessSenderSelfVerify_WithoutSignature_TransactionInvalid()
     {

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -698,7 +698,7 @@ public class FrameTxProcessorTests
         GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
         estimator.Estimate(tx, header, gasTracer, out string? error);
 
-        Assert.That(error, Is.Not.Null);
+        Assert.That(error, Is.EqualTo(GasEstimator.CannotEstimateGasExceeded));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -638,6 +638,69 @@ public class FrameTxProcessorTests
         Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0UL), "the sender nonce is not consumed");
     }
 
+    /// <summary>A sponsored frame transaction estimates against the budget its frames fix, not against
+    /// the sender's balance.</summary>
+    /// <remarks>
+    /// The regular estimation path bounds the search by what the sender can afford at the fee cap, which
+    /// is zero here, and searches over a gas limit the frame processor never reads. Both are wrong for a
+    /// frame transaction: the payer is chosen by the frames, and the budget is fixed by them.
+    /// </remarks>
+    [Test]
+    public void EstimateGas_SponsoredFrameTx_ReturnsTheFrameBudgetForAZeroBalanceSender()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecution));
+        DeployContract(Observer, ApproveCode(TxFrame.ApprovePayment), 1.Ether);
+
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApprovePayment, Observer, gasLimit: 200_000, UInt256.Zero, default),
+            Frame(TxFrame.ModeSender, target: Recipient));
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithGasLimit(30_000_000).TestObject;
+
+        EstimateGasTracer gasTracer = new();
+        _transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, Spec));
+        TransactionResult probe = _transactionProcessor.CallAndRestore(tx, gasTracer);
+        Assert.That(probe.TransactionExecuted, Is.True, probe.ErrorDescription ?? probe.Error.ToString());
+
+        GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
+        ulong estimate = estimator.Estimate(tx, header, gasTracer, out string? error);
+
+        const ulong frameGasSum = 3 * 200_000;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(error, Is.Null, "a zero-balance sender must not cap a sponsored estimate");
+            Assert.That(estimate, Is.GreaterThanOrEqualTo(
+                frameGasSum + (ulong)Eip8141Constants.IntrinsicGasCost + 3 * (ulong)Eip8141Constants.PerFrameGasCost),
+                "every frame's own limit is reserved on top of the transaction's intrinsic cost");
+        }
+    }
+
+    /// <remarks>
+    /// The frames fix the budget, so a transaction reserving more than the block can hold is not estimable —
+    /// returning the reservation would hand the caller a figure no block can include.
+    /// </remarks>
+    [Test]
+    public void EstimateGas_FrameTxReservingMoreThanTheBlock_ReportsTheBudgetAsUnestimable()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Recipient));
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithGasLimit(100_000).TestObject;
+
+        EstimateGasTracer gasTracer = new();
+        _transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, Spec));
+        _transactionProcessor.CallAndRestore(tx, gasTracer);
+
+        GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
+        estimator.Estimate(tx, header, gasTracer, out string? error);
+
+        Assert.That(error, Is.Not.Null);
+    }
+
     [Test]
     public void Execute_CodelessSenderSelfVerify_WithoutSignature_TransactionInvalid()
     {

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -222,6 +222,19 @@ namespace Nethermind.Facade
             return RunEstimateGas(components.StateReader, components.TransactionProcessor, components.WorldState, header, tx, errorMargin, blobBaseFeeOverride, cancellationToken);
         }
 
+        /// <summary>Whether the sender's balance bounds <paramref name="tx"/>'s gas limit, and what is left for gas after its value.</summary>
+        /// <remarks>
+        /// False for an EIP-8141 frame transaction: its gas limit is derived from the frames rather than
+        /// chosen, and the reservation is owed by the frame-approved payer rather than by the sender.
+        /// </remarks>
+        private static bool IsCappedBySenderAllowance(Transaction tx, in UInt256 senderBalance, in UInt256 feeCap, out UInt256 availableForGas)
+        {
+            availableForGas = UInt256.Zero;
+            return !tx.SupportsFrames
+                && feeCap > UInt256.Zero
+                && !UInt256.SubtractUnderflow(senderBalance, tx.ValueRef, out availableForGas);
+        }
+
         private CallOutput RunEstimateGas(IStateReader nonceReader, ITransactionProcessor txProcessor, IWorldState worldState, BlockHeader header, Transaction tx, int errorMargin, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
         {
             // Cap tx.GasLimit to the sender's affordable allowance before the initial probe,
@@ -230,9 +243,7 @@ namespace Nethermind.Facade
             IReleaseSpec spec = specProvider.GetSpec(header.Number + 1, header.Timestamp + blocksConfig.SecondsPerSlot);
             UInt256 senderBalance = worldState.GetBalance(tx.SenderAddress ?? Address.Zero);
             UInt256 feeCap = tx.CalculateFeeCap();
-            // A frame transaction is exempt: its gas limit is derived from the frames rather than chosen,
-            // and the reservation is owed by the frame-approved payer rather than by the sender.
-            if (!tx.SupportsFrames && feeCap > UInt256.Zero && !UInt256.SubtractUnderflow(senderBalance, tx.ValueRef, out UInt256 availableForGas))
+            if (IsCappedBySenderAllowance(tx, in senderBalance, in feeCap, out UInt256 availableForGas))
             {
                 if (!BlobGasCalculator.TrySubtractBlobFee(spec, tx, ref availableForGas))
                     availableForGas = UInt256.Zero;

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -230,7 +230,9 @@ namespace Nethermind.Facade
             IReleaseSpec spec = specProvider.GetSpec(header.Number + 1, header.Timestamp + blocksConfig.SecondsPerSlot);
             UInt256 senderBalance = worldState.GetBalance(tx.SenderAddress ?? Address.Zero);
             UInt256 feeCap = tx.CalculateFeeCap();
-            if (feeCap > UInt256.Zero && !UInt256.SubtractUnderflow(senderBalance, tx.ValueRef, out UInt256 availableForGas))
+            // A frame transaction is exempt: its gas limit is derived from the frames rather than chosen,
+            // and the reservation is owed by the frame-approved payer rather than by the sender.
+            if (!tx.SupportsFrames && feeCap > UInt256.Zero && !UInt256.SubtractUnderflow(senderBalance, tx.ValueRef, out UInt256 availableForGas))
             {
                 if (!BlobGasCalculator.TrySubtractBlobFee(spec, tx, ref availableForGas))
                     availableForGas = UInt256.Zero;


### PR DESCRIPTION
A frame transaction has no `gas_limit` field. `FrameTxDecoder` synthesises `tx.GasLimit` from the frame gas sum and the processor derives its own budget from the frames, so `GasEstimator`'s binary search was searching over a value nothing reads: every probe succeeded regardless of the limit under test.

The affordability gates were wrong for a different reason. They measure the sender's balance, but a frame transaction is funded by the frame-approved payer, which is the sponsorship case EIP-8141 exists for. A zero-balance sender gave `allowance = 0`, so a sponsored transaction was reported as exceeding an allowance it never owed.

Estimation for a frame transaction now returns the budget the frames fix, and the sender-balance pre-cap in `BlockchainBridge` is skipped for one. Regression test: a sponsored transaction from a zero-balance sender estimates to its frame budget instead of erroring. Depends on #12687 for `TryCalculateGasBudget`.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

- [x] Tests added
