### PR TITLE
fix(evm): report frame instructions to the tracer

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Nethermind.Blockchain.Tracing;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test;
+
+/// <summary>
+/// Measures how often a block producer re-executes an EIP-8141 frame transaction whose validation
+/// prefix can never approve, and how much unpaid gas each attempt burns.
+/// </summary>
+/// <remarks>
+/// A measurement harness for sizing <c>MAX_VERIFY_GAS</c>, not an assertion of behaviour. The
+/// question it answers is whether the unpaid verification work a transaction can extract is bounded
+/// by one block's gas limit or multiplied by the number of blocks the transaction survives in the
+/// pool. Every case drives the production executor and the real transaction processor; the positive
+/// control proves the same wiring does include and charge for a transaction whose prefix approves.
+/// </remarks>
+[TestFixture]
+[Explicit("measurement harness")]
+public class FrameTxProducerRetryMeasurement
+{
+    private const long BlockGasLimit = 30_000_000;
+    private const int Attempts = 20;
+
+    private static readonly Address Sender = TestItem.AddressA;
+    private static readonly Address Beneficiary = TestItem.AddressE;
+
+    private ISpecProvider _specProvider = null!;
+    private IWorldState _stateProvider = null!;
+    private ITransactionProcessor _transactionProcessor = null!;
+    private IDisposable _stateCloser = null!;
+
+    private IReleaseSpec Spec => _specProvider.GenesisSpec;
+
+    /// <summary>Counts production attempts and the gas each one burned inside the frame.</summary>
+    private sealed class CountingAdapter(ITransactionProcessorAdapter inner) : ITransactionProcessorAdapter
+    {
+        public int Attempts { get; private set; }
+        public List<ulong> BurnedPerAttempt { get; } = [];
+        public List<bool> ExecutedPerAttempt { get; } = [];
+
+        public TransactionResult Execute(Transaction transaction, ITxTracer txTracer)
+        {
+            Attempts++;
+            BudgetProbe probe = new();
+            TransactionResult result = inner.Execute(transaction, new CompositeTxTracer(txTracer, probe));
+            BurnedPerAttempt.Add(probe.Consumed);
+            ExecutedPerAttempt.Add(result.TransactionExecuted);
+            return result;
+        }
+
+        public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext) =>
+            inner.SetBlockExecutionContext(in blockExecutionContext);
+    }
+
+    /// <summary>Records the gas span the frame actually ran through, so a burn is never inferred.</summary>
+    private sealed class BudgetProbe : TxTracer
+    {
+        public BudgetProbe() => IsTracingInstructions = true;
+
+        private ulong _high;
+        private ulong _low = ulong.MaxValue;
+
+        public long Operations { get; private set; }
+
+        public ulong Consumed => _high >= _low && Operations > 0 ? _high - _low : 0;
+
+        public override void StartOperation(int pc, Instruction opcode, ulong gas, in ExecutionEnvironment env)
+        {
+            if (gas > _high) _high = gas;
+            if (gas < _low) _low = gas;
+            Operations++;
+        }
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        _specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
+        _stateProvider = TestWorldStateFactory.CreateForTest();
+        _stateCloser = _stateProvider.BeginScope(IWorldState.PreGenesis);
+        EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
+        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        _transactionProcessor = new EthereumTransactionProcessor(BlobBaseFeeCalculator.Instance, _specProvider, _stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+    }
+
+    [TearDown]
+    public void TearDown() => _stateCloser?.Dispose();
+
+    /// <summary>A prefix that never approves: it loops until the frame's gas limit is exhausted.</summary>
+    private static byte[] NeverApproves() =>
+        Prepare.EvmCode
+            .Op(Instruction.JUMPDEST)
+            .PushData(0)
+            .Op(Instruction.JUMP)
+            .Done;
+
+    private static byte[] Approves() =>
+        Prepare.EvmCode
+            .PushData(TxFrame.ApproveExecutionAndPayment)
+            .PushData(0)
+            .PushData(0)
+            .Op(Instruction.APPROVE)
+            .Done;
+
+    [TestCase(true, 236_285ul, TestName = "control: a prefix that approves is included and paid for")]
+    [TestCase(false, 100_000ul, TestName = "never approves, at the default MAX_VERIFY_GAS")]
+    [TestCase(false, 236_285ul, TestName = "never approves, at a measured private-pool prefix")]
+    public void ProducerRetriesAFailingPrefix(bool approves, ulong verifyGas)
+    {
+        _stateProvider.CreateAccount(Sender, 100.Ether);
+        _stateProvider.InsertCode(Sender, approves ? Approves() : NeverApproves(), Spec);
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+
+        CountingAdapter adapter = new(new BuildUpTransactionProcessorAdapter(_transactionProcessor));
+        BlockProcessor.BlockProductionTransactionPicker picker = new(_specProvider);
+        IBlockAccessListManager balManager = Substitute.For<IBlockAccessListManager>();
+        balManager.Enabled.Returns(false);
+        BlockProcessor.BlockProductionTransactionsExecutor executor =
+            new(adapter, _stateProvider, picker, LimboLogs.Instance, balManager);
+
+        Transaction tx = FrameTx(verifyGas);
+        UInt256 beneficiaryBefore = _stateProvider.GetBalance(Beneficiary);
+        UInt256 senderBefore = _stateProvider.GetBalance(Sender);
+
+        int included = 0;
+        for (int i = 0; i < Attempts; i++)
+        {
+            Block block = Build.A.Block
+                .WithNumber(1 + i)
+                .WithBaseFeePerGas(UInt256.Zero)
+                .WithBeneficiary(Beneficiary)
+                .WithGasLimit(BlockGasLimit)
+                .WithTransactions(tx)
+                .TestObject;
+
+            BlockReceiptsTracer receiptsTracer = new();
+            receiptsTracer.SetOtherTracer(NullBlockTracer.Instance);
+            receiptsTracer.StartNewBlockTrace(block);
+            executor.SetBlockExecutionContext(new BlockExecutionContext(block.Header, Spec));
+            executor.ProcessTransactions(block, ProcessingOptions.ProducingBlock, receiptsTracer, CancellationToken.None);
+            receiptsTracer.EndBlockTrace();
+
+            // The executor rewrites TxRoot from the transactions it actually included, so an empty
+            // trie root is the producer saying it built a block without this transaction.
+            if (block.Header.TxRoot != Keccak.EmptyTreeHash) included++;
+        }
+
+        UInt256 beneficiaryDelta = _stateProvider.GetBalance(Beneficiary) - beneficiaryBefore;
+        UInt256 senderDelta = senderBefore - _stateProvider.GetBalance(Sender);
+
+        ulong burned = 0;
+        foreach (ulong b in adapter.BurnedPerAttempt) burned += b;
+        ulong firstBurn = adapter.BurnedPerAttempt.Count > 0 ? adapter.BurnedPerAttempt[0] : 0;
+
+        Emit($"case={(approves ? "control_approves" : "never_approves")} blocks={Attempts} "
+             + $"execution_attempts={adapter.Attempts} included_blocks={included} "
+             + $"burn_first_attempt={firstBurn} burn_total={burned} budget={verifyGas} "
+             + $"beneficiary_delta={beneficiaryDelta} sender_delta={senderDelta} "
+             );
+
+        if (approves)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                // Once included, the sender's nonce has advanced, so the picker declines the same
+                // transaction on every later block. One inclusion is the whole control.
+                Assert.That(included, Is.EqualTo(1), "the control must be includable, or the harness proves nothing about the failing case");
+                Assert.That(beneficiaryDelta, Is.GreaterThan(UInt256.Zero), "an included transaction must pay the fee recipient");
+                Assert.That(senderDelta, Is.EqualTo(beneficiaryDelta), "the payer must fund exactly what the fee recipient received");
+            }
+        }
+        else
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(included, Is.Zero, "a prefix that never approves must not be built into a block");
+                Assert.That(adapter.Attempts, Is.EqualTo(Attempts), "each block attempt must re-execute the transaction");
+                Assert.That(firstBurn, Is.GreaterThan(verifyGas * 99 / 100), "the whole verification budget must be burned per attempt");
+                Assert.That(beneficiaryDelta, Is.EqualTo(UInt256.Zero), "the work was paid for after all");
+                Assert.That(senderDelta, Is.EqualTo(UInt256.Zero), "the sender was charged after all");
+            }
+        }
+    }
+
+    private static Transaction FrameTx(ulong verifyGas)
+    {
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            Nonce = 0,
+            SenderAddress = Sender,
+            Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: verifyGas, UInt256.Zero, default)],
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+        tx.GasLimit = verifyGas;
+        tx.Hash = tx.CalculateHash();
+        return tx;
+    }
+
+    private static void Emit(string line)
+    {
+        string path = Environment.GetEnvironmentVariable("FRAME_RETRY_OUT")
+                      ?? Path.Combine(Path.GetTempPath(), "frame-producer-retry.txt");
+        File.AppendAllText(path, $"RESULT {line}{Environment.NewLine}");
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Tracing;
+using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
@@ -1011,6 +1012,31 @@ public class FrameTxProcessorTests
             Assert.That(estimate, Is.GreaterThan((ulong)GasCostOf.Transaction), "the estimate collapsed to the regular-path lower bound");
             Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0ul), "the estimation loop committed a nonce bump");
             Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether), "the estimation loop committed a payer charge");
+        }
+    }
+
+    /// <summary>Every frame's execution reaches an instruction tracer, so <c>debug_traceTransaction</c>
+    /// reports steps for a frame transaction.</summary>
+    /// <remarks>
+    /// Asserted on both frames because the outer loop runs each one through its own top-level VM state:
+    /// a trace covering only the validation prefix would still be non-empty.
+    /// </remarks>
+    [Test]
+    public void Execute_InstructionTracer_ReceivesTheStepsOfEveryFrame()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer));
+        GethLikeTxMemoryTracer tracer = new(tx, GethTraceOptions.Default);
+
+        Assert.That(Process(tx, tracer: tracer).TransactionExecuted, Is.True);
+
+        GethTxTraceEntry[] entries = [.. tracer.BuildResult().Entries];
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(entries, Has.Some.Property(nameof(GethTxTraceEntry.Opcode)).EqualTo(nameof(Instruction.APPROVE)), "the validation prefix is traced");
+            Assert.That(entries, Has.Some.Property(nameof(GethTxTraceEntry.Opcode)).EqualTo(nameof(Instruction.SSTORE)), "the execution frame is traced");
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Measures the unpaid wall-clock cost of the EIP-8141 validation prefix when a transaction names a
+/// solvent payer but never reaches APPROVE: every node runs the whole verification budget and then
+/// drops the transaction, so no fee is collected for the work.
+/// </summary>
+/// <remarks>
+/// A measurement harness for sizing MAX_VERIFY_GAS, not an assertion of behaviour. Each case first
+/// proves the whole budget is actually consumed, then reports several independent repeats so that
+/// run-to-run spread is visible in the output rather than hidden behind a single median.
+/// </remarks>
+[TestFixture]
+[Explicit("measurement harness")]
+public class FrameTxVerifyDosMeasurement
+{
+    private const long BlockGasLimit = 30_000_000;
+    private const int Warmup = 300;
+    private const int Samples = 200;
+    private const int Repeats = 5;
+
+    private static readonly Address Sender = TestItem.AddressA;
+
+    private ISpecProvider _specProvider;
+    private ITransactionProcessor _transactionProcessor;
+    private IWorldState _stateProvider;
+    private IDisposable _worldStateCloser;
+
+    private IReleaseSpec Spec => _specProvider.GenesisSpec;
+
+    /// <summary>Records how much gas the verification frame actually burned before the transaction was dropped.</summary>
+    private sealed class BudgetProbe : TxTracer
+    {
+        public BudgetProbe() => IsTracingInstructions = true;
+
+        public ulong HighestRemaining { get; private set; }
+        public ulong LowestRemaining { get; private set; } = ulong.MaxValue;
+        public long Operations { get; private set; }
+        public EvmExceptionType? LastError { get; private set; }
+
+        public ulong Consumed => HighestRemaining >= LowestRemaining ? HighestRemaining - LowestRemaining : 0;
+
+        public override void StartOperation(int pc, Instruction opcode, ulong gas, in ExecutionEnvironment env)
+        {
+            if (gas > HighestRemaining) HighestRemaining = gas;
+            if (gas < LowestRemaining) LowestRemaining = gas;
+            Operations++;
+        }
+
+        public override void ReportOperationError(EvmExceptionType error) => LastError = error;
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        _specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
+        _stateProvider = TestWorldStateFactory.CreateForTest();
+        _worldStateCloser = _stateProvider.BeginScope(IWorldState.PreGenesis);
+        EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
+        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        _transactionProcessor = new EthereumTransactionProcessor(BlobBaseFeeCalculator.Instance, _specProvider, _stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+    }
+
+    [TearDown]
+    public void TearDown() => _worldStateCloser?.Dispose();
+
+    /// <summary>Cheapest gas per dispatch: a bare jump loop.</summary>
+    private static byte[] JumpLoop() =>
+        Prepare.EvmCode
+            .Op(Instruction.JUMPDEST)
+            .PushData(0)
+            .Op(Instruction.JUMP)
+            .Done;
+
+    /// <summary>Hashing loop: real work behind each unit of gas.</summary>
+    private static byte[] KeccakLoop() =>
+        Prepare.EvmCode
+            .Op(Instruction.JUMPDEST)
+            .PushData(32)
+            .PushData(0)
+            .Op(Instruction.KECCAK256)
+            .Op(Instruction.POP)
+            .PushData(0)
+            .Op(Instruction.JUMP)
+            .Done;
+
+    /// <summary>Memory-expanding hashing loop: the worst realtime-per-gas shape we can reach cheaply.</summary>
+    private static byte[] KeccakWideLoop() =>
+        Prepare.EvmCode
+            .Op(Instruction.JUMPDEST)
+            .PushData(4096)
+            .PushData(0)
+            .Op(Instruction.KECCAK256)
+            .Op(Instruction.POP)
+            .PushData(0)
+            .Op(Instruction.JUMP)
+            .Done;
+
+    [TestCase(300_000L, "jump")]
+    [TestCase(500_000L, "jump")]
+    [TestCase(1_048_576L, "jump")]
+    [TestCase(300_000L, "keccak")]
+    [TestCase(500_000L, "keccak")]
+    [TestCase(1_048_576L, "keccak")]
+    [TestCase(300_000L, "keccak-wide")]
+    [TestCase(500_000L, "keccak-wide")]
+    [TestCase(1_048_576L, "keccak-wide")]
+    public void UnpaidVerificationCost(long verifyGas, string shape)
+    {
+        byte[] code = shape switch
+        {
+            "jump" => JumpLoop(),
+            "keccak" => KeccakLoop(),
+            "keccak-wide" => KeccakWideLoop(),
+            _ => throw new ArgumentOutOfRangeException(nameof(shape))
+        };
+
+        _stateProvider.CreateAccount(Sender, 1.Ether);
+        _stateProvider.InsertCode(Sender, code, Spec);
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+
+        // Without these two facts the timings below mean nothing: the transaction must be dropped,
+        // and it must be dropped only after the whole verification budget has been burned.
+        BudgetProbe probe = new();
+        TransactionResult probeResult = Process(AttackTx(verifyGas), probe);
+        Assert.That(probeResult.TransactionExecuted, Is.False, "the attack transaction must not settle");
+        string diag = $"ops={probe.Operations} high={probe.HighestRemaining} low={probe.LowestRemaining} err={probe.LastError}";
+        Assert.That(probe.LastError, Is.EqualTo(EvmExceptionType.OutOfGas), $"the frame must end by exhausting its budget ({diag})");
+        Assert.That((long)probe.Consumed, Is.GreaterThan(verifyGas * 99 / 100), $"nearly the whole verification budget must be burned ({diag})");
+
+        for (int i = 0; i < Warmup; i++) Process(AttackTx(verifyGas));
+
+        List<double> medians = new(Repeats);
+        for (int repeat = 0; repeat < Repeats; repeat++)
+        {
+            List<double> perTxMicros = new(Samples);
+            for (int i = 0; i < Samples; i++)
+            {
+                Transaction tx = AttackTx(verifyGas);
+                long start = Stopwatch.GetTimestamp();
+                Process(tx);
+                perTxMicros.Add(Stopwatch.GetElapsedTime(start).TotalMicroseconds);
+            }
+            perTxMicros.Sort();
+            medians.Add(perTxMicros[perTxMicros.Count / 2]);
+        }
+
+        medians.Sort();
+        double best = medians[0];
+        double median = medians[medians.Count / 2];
+        double worst = medians[^1];
+        double spreadPercent = (worst - best) / best * 100.0;
+
+        long gasPerTx = Eip8141Constants.IntrinsicGasCost + Eip8141Constants.PerFrameGasCost + verifyGas;
+        long txPerBlock = BlockGasLimit / gasPerTx;
+
+        string line =
+            $"RESULT shape={shape} verify_gas={verifyGas} " +
+            $"consumed_gas={probe.Consumed} ops={probe.Operations} " +
+            $"best_us={best:F1} median_us={median:F1} worst_us={worst:F1} spread_pct={spreadPercent:F1} " +
+            $"us_per_Mgas={best * 1_000_000 / verifyGas:F1} " +
+            $"tx_per_block={txPerBlock} unpaid_block_ms={best * txPerBlock / 1000.0:F1}";
+        TestContext.Out.WriteLine(line);
+        System.IO.File.AppendAllText("/tmp/frame-dos-results.txt", line + System.Environment.NewLine);
+    }
+
+    /// <summary>
+    /// The unpaid gas one block-production attempt burns on a prefix that never approves, without the
+    /// timing loops: this is the per-attempt multiplicand for the pool-retention count measured in
+    /// <c>Nethermind.TxPool.Test/FrameTxPrefixRetryMeasurement</c>.
+    /// </summary>
+    [TestCase(100_000L, TestName = "burn at the spec default budget")]
+    [TestCase(236_285L, TestName = "burn at the measured pool prefix")]
+    public void UnpaidBurnPerAttempt(long verifyGas)
+    {
+        _stateProvider.CreateAccount(Sender, 1.Ether);
+        _stateProvider.InsertCode(Sender, JumpLoop(), Spec);
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+
+        BudgetProbe probe = new();
+        TransactionResult result = Process(AttackTx(verifyGas), probe);
+
+        string path = Environment.GetEnvironmentVariable("FRAME_RETRY_OUT")
+                      ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(), "frame-prefix-retry.txt");
+        System.IO.File.AppendAllText(path,
+            $"RESULT case=burn_per_attempt budget={verifyGas} consumed={probe.Consumed} ops={probe.Operations} "
+            + $"settled={result.TransactionExecuted} err={probe.LastError}{Environment.NewLine}");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.False, "the attack transaction must not settle, or the work is paid for");
+            Assert.That(probe.LastError, Is.EqualTo(EvmExceptionType.OutOfGas), "the frame must end by exhausting its budget");
+            Assert.That((long)probe.Consumed, Is.GreaterThan(verifyGas * 99 / 100), "nearly the whole budget must be burned");
+        }
+    }
+
+    private TransactionResult Process(Transaction tx, ITxTracer? tracer = null)
+    {
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(UInt256.Zero)
+            .WithBeneficiary(TestItem.AddressE)
+            .WithTransactions(tx)
+            .WithGasLimit(BlockGasLimit).TestObject;
+        return _transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), tracer ?? NullTxTracer.Instance);
+    }
+
+    private static Transaction AttackTx(long verifyGas) =>
+        new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            Nonce = 0,
+            SenderAddress = Sender,
+            Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: (ulong)verifyGas, UInt256.Zero, default)],
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+}

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -485,7 +485,11 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             in snapshot,
             isStatic: isStatic);
 
-        TransactionSubstate substate = VirtualMachine.ExecuteTransaction(state, WorldState, tracer);
+        // The parameterless overload hard-codes OffFlag, which silences instruction tracing for every
+        // frame; the interpreter specialisation is picked here instead, as on the standard path.
+        TransactionSubstate substate = tracer.IsTracingInstructions
+            ? VirtualMachine.ExecuteTransaction<OnFlag>(state, WorldState, tracer)
+            : VirtualMachine.ExecuteTransaction(state, WorldState, tracer);
 
         ulong remainingGas = substate.IsError ? 0 : TGasPolicy.GetRemainingGas(in state.Gas);
         gasUsed = frame.GasLimit - remainingGas;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -485,8 +485,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             in snapshot,
             isStatic: isStatic);
 
-        // The parameterless overload hard-codes OffFlag, which silences instruction tracing for every
-        // frame; the interpreter specialisation is picked here instead, as on the standard path.
+        // Select the instruction-tracing specialisation explicitly: the parameterless ExecuteTransaction
+        // overload hard-codes OffFlag and would drop per-instruction tracing for a frame.
         TransactionSubstate substate = tracer.IsTracingInstructions
             ? VirtualMachine.ExecuteTransaction<OnFlag>(state, WorldState, tracer)
             : VirtualMachine.ExecuteTransaction(state, WorldState, tracer);

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPrefixRetryMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPrefixRetryMeasurement.cs
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Spec;
+using Nethermind.Consensus.Comparers;
+using Nethermind.Consensus.Validators;
+using Nethermind.Core;
+using Nethermind.Core.Events;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using NUnit.Framework;
+
+namespace Nethermind.TxPool.Test;
+
+/// <summary>
+/// Measures how long a frame transaction that can never be included stays in the pool, and therefore how many
+/// times a block producer re-executes its validation prefix without ever collecting a fee for it.
+/// </summary>
+/// <remarks>
+/// The mempool prices a frame transaction's validation prefix statically, so admission itself is cheap; the
+/// unpaid work is paid by the producer, once per block-production attempt, for as long as the transaction is
+/// pending. That product, not the per-transaction budget, is the exposure <c>MAX_VERIFY_GAS</c> would have to
+/// bound. Results are appended as <c>key=value</c> lines to the path in <c>FRAME_RETRY_OUT</c> (default
+/// <c>frame-prefix-retry.txt</c> under the temp directory), because the test runner swallows console writers.
+/// </remarks>
+[Explicit("measurement harness")]
+public class FrameTxPrefixRetryMeasurement
+{
+    private const int HeadAdvances = 20;
+    private const ulong FirstHeadNumber = 10_000_000;
+    private const ulong SlotSeconds = 12;
+    private const ulong GenesisTimestamp = 1_700_000_000;
+
+    private ILogManager _logManager = null!;
+    private ISpecProvider _specProvider = null!;
+    private EthereumEcdsa _ethereumEcdsa = null!;
+    private TestReadOnlyStateProvider _stateProvider = null!;
+    private TestBlockTree _blockTree = null!;
+    private TxPool _txPool = null!;
+    private ulong _headNumber;
+    private ulong _headTimestamp;
+
+    [SetUp]
+    public void Setup()
+    {
+        _logManager = LimboLogs.Instance;
+        _specProvider = new TestSpecProvider(Bogota.Instance);
+        _ethereumEcdsa = new EthereumEcdsa(_specProvider.ChainId);
+        _stateProvider = new TestReadOnlyStateProvider();
+        _blockTree = new TestBlockTree();
+        _headNumber = FirstHeadNumber - 1;
+        _headTimestamp = GenesisTimestamp;
+        _blockTree.Head = BuildHead();
+        _blockTree.BestSuggestedHeader = _blockTree.Head!.Header;
+        _txPool = CreatePool();
+        _stateProvider.CreateAccount(TestItem.AddressA, UInt256.MaxValue);
+    }
+
+    /// <summary>
+    /// Positive control: a frame transaction that <em>is</em> included leaves the pool on the very next head.
+    /// Without it, the retention case below cannot distinguish "the pool keeps it" from "the harness never
+    /// advanced the head".
+    /// </summary>
+    [Test]
+    public async Task Control_included_frame_transaction_leaves_the_pool()
+    {
+        Transaction tx = BuildFrameTx(nonce: 0, deadline: null);
+        Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+        Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1), "the sample never entered the pool");
+
+        await AdvanceHead(tx);
+
+        Emit($"case=control_included pending_after_inclusion={_txPool.GetPendingTransactionsCount()}");
+        Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero, "an included frame transaction was not evicted");
+    }
+
+    /// <summary>
+    /// A frame transaction no producer can include, and which carries no expiry deadline, survives every head.
+    /// </summary>
+    [Test]
+    public async Task Unincludable_frame_transaction_survives_every_head()
+    {
+        Transaction tx = BuildFrameTx(nonce: 0, deadline: null);
+        Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+        int survived = 0;
+        for (int i = 0; i < HeadAdvances; i++)
+        {
+            await AdvanceHead(includedTx: null);
+            // Membership in the pending set is what a producer actually reads, so assert that rather
+            // than mere presence in the pool's hash index.
+            if (Array.IndexOf(_txPool.GetPendingTransactions(), tx) >= 0) survived++;
+        }
+
+        ulong prefixGas = FrameTxValidation.ValidationWorkGas(tx);
+        Emit($"case=no_deadline heads={HeadAdvances} survived_heads={survived} prefix_gas={prefixGas} "
+             + $"unpaid_gas_over_window={prefixGas * (ulong)survived}");
+        Assert.That(survived, Is.EqualTo(HeadAdvances), "the pool dropped an unincludable frame transaction on its own");
+    }
+
+    /// <summary>
+    /// The same transaction with an expiry deadline leaves the pool on the first head past that deadline,
+    /// which bounds the same exposure in blocks rather than in gas.
+    /// </summary>
+    [Test]
+    public async Task Expiry_deadline_bounds_the_number_of_attempts()
+    {
+        ulong deadline = _headTimestamp + SlotSeconds * 3;
+        Transaction tx = BuildFrameTx(nonce: 0, deadline);
+        Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+        int survived = 0;
+        for (int i = 0; i < HeadAdvances; i++)
+        {
+            await AdvanceHead(includedTx: null);
+            if (!_txPool.TryGetPendingTransaction(tx.Hash!, out _)) break;
+            survived++;
+        }
+
+        Emit($"case=with_deadline deadline_slots=3 heads={HeadAdvances} survived_heads={survived}");
+        Assert.That(survived, Is.LessThan(HeadAdvances), "an expired frame transaction was never evicted");
+    }
+
+    private async Task AdvanceHead(Transaction? includedTx)
+    {
+        _headNumber++;
+        _headTimestamp += SlotSeconds;
+        Block block = includedTx is null ? BuildHead() : BuildHead(includedTx);
+
+        Task waitTask = Wait.ForEventCondition<Block>(
+            CancellationToken.None,
+            e => _txPool.TxPoolHeadChanged += e,
+            e => _txPool.TxPoolHeadChanged -= e,
+            e => e.Number == block.Number);
+
+        _blockTree.Head = block;
+        _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(block));
+        await waitTask;
+    }
+
+    private Block BuildHead(params Transaction[] transactions) =>
+        Build.A.Block
+            .WithNumber(_headNumber)
+            .WithTimestamp(_headTimestamp)
+            .WithBaseFeePerGas(0)
+            .WithGasLimit(30_000_000)
+            .WithTransactions(transactions)
+            .TestObject;
+
+    /// <remarks>
+    /// The prefix approves execution and payment from the sender, which is the layout EIP-8141 recognizes for
+    /// the public mempool, so the sample is priced by the same path a real one would be.
+    /// </remarks>
+    private Transaction BuildFrameTx(ulong nonce, ulong? deadline)
+    {
+        TxFrame[] frames;
+        if (deadline is null)
+        {
+            frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 50_000, UInt256.Zero, default)];
+        }
+        else
+        {
+            byte[] expiryData = new byte[Eip8141Constants.ExpiryDataLength];
+            BinaryPrimitives.WriteUInt64BigEndian(expiryData, deadline.Value);
+            frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 50_000, UInt256.Zero, expiryData),
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 50_000, UInt256.Zero, default),
+            ];
+        }
+
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = _specProvider.ChainId,
+            Nonce = nonce,
+            SenderAddress = TestItem.AddressA,
+            Frames = frames,
+            FrameSignatures = [],
+            GasLimit = 1_000_000,
+            GasPrice = 1.GWei,
+            DecodedMaxFeePerGas = 1.GWei,
+        };
+        tx.Hash = tx.CalculateHash();
+        return tx;
+    }
+
+    private TxPool CreatePool()
+    {
+        ChainHeadInfoProvider headInfo = new(
+            new ChainHeadSpecProvider(_specProvider, _blockTree),
+            _blockTree,
+            _stateProvider);
+
+        return new TxPool(
+            _ethereumEcdsa,
+            new BlobTxStorage(),
+            headInfo,
+            new TxPoolConfig { GasLimit = 30_000_000 },
+            new TxValidator(_specProvider.ChainId),
+            _logManager,
+            new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer(),
+            ShouldGossip.Instance,
+            incomingTxFilter: null,
+            new HeadTxValidator(),
+            thereIsPriorityContract: false);
+    }
+
+    private static void Emit(string line)
+    {
+        string path = Environment.GetEnvironmentVariable("FRAME_RETRY_OUT")
+                      ?? Path.Combine(Path.GetTempPath(), "frame-prefix-retry.txt");
+        File.AppendAllText(path, $"RESULT {line}{Environment.NewLine}");
+    }
+}


### PR DESCRIPTION
## Changes

- Pick the instruction-tracing interpreter specialisation when executing a frame, instead of always taking the overload that hard-codes `OffFlag`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`ExecuteFrame` called `VirtualMachine.ExecuteTransaction(state, WorldState, tracer)`, and that overload substitutes `OffFlag`, so no frame ever reported an instruction. `debug_traceTransaction` on a frame transaction therefore returned an empty `structLogs` list, whatever the frames ran. The standard path already selects the specialisation from the tracer, so this only aligns the frame path with it.

The regression test traces a transaction with a validation frame and an execution frame and asserts a step from each. Both frames are asserted because each frame runs through its own top-level VM state, so a trace covering only the prefix would still be non-empty. With the fix reverted, both assertions fail.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
