### PR TITLE
Return only the requested header from GetHeadBlockHeader

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncPeer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncPeer.cs
@@ -37,6 +37,13 @@ namespace Nethermind.Blockchain.Synchronization
         Task<OwnedBlockBodies> GetBlockBodies(IReadOnlyList<Hash256> blockHashes, CancellationToken token);
         Task<IOwnedReadOnlyList<BlockHeader>?> GetBlockHeaders(ulong number, int maxBlocks, int skip, CancellationToken token);
         Task<IOwnedReadOnlyList<BlockHeader>?> GetBlockHeaders(Hash256 startHash, int maxBlocks, int skip, CancellationToken token);
+        /// <summary>
+        /// Asks the peer for the header of <paramref name="hash"/>, or of its announced head when null.
+        /// </summary>
+        /// <returns>
+        /// The header of the requested block, or <c>null</c> if the peer does not have it. A peer answering with
+        /// any other block is disconnected, so callers never need to re-check the hash of the result.
+        /// </returns>
         Task<BlockHeader?> GetHeadBlockHeader(Hash256? hash, CancellationToken token);
         void NotifyOfNewBlock(Block block, SendBlockMode mode);
         void NotifyOfNewRange(BlockHeader earliest, BlockHeader latest) { }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Synchronization/StartingSyncPivotUpdater.cs
@@ -175,12 +175,8 @@ public class StartingSyncPivotUpdater(
     }
 
     protected async Task<ulong?> TryGetFromPeers(Hash256? hash, CancellationToken cancellationToken, string type = Pivot) =>
-        (await TryGetFromPeers(hash, cancellationToken, static async (peer, hash256, token) =>
-        {
-            BlockHeader? header = await peer.GetHeadBlockHeader(hash256, token);
-            // Only accept a header that is actually the requested block; a peer must not substitute another.
-            return header is not null && header.Hash == hash256 ? header : null;
-        }, type))?.Number;
+        (await TryGetFromPeers(hash, cancellationToken,
+            static (peer, hash256, token) => peer.GetHeadBlockHeader(hash256, token), type))?.Number;
 
     protected async Task<BlockHeader?> TryGetFromPeers<T>(T id, CancellationToken cancellationToken,
         Func<ISyncPeer, T, CancellationToken, Task<BlockHeader?>> getHeader, string? type = Pivot)

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -846,15 +846,16 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _session.Received(messagesCount).DeliverMessage(Arg.Is<TransactionsMessage>(m => m.Transactions.Count == numberOfTxsInOneMsg || m.Transactions.Count == nonFullMsgTxsCount));
         }
 
-        public enum HeadHeaderAnswer { RequestedBlock, DifferentBlock, Nothing }
+        public enum HeadHeaderAnswer { RequestedBlock, DifferentBlock, Nothing, EmptyHeader }
 
         /// <summary>
-        /// Answering with an empty list is how a peer says it does not have the block and must not cost it the
-        /// connection, but substituting another block is a protocol breach.
+        /// Saying "I don't have it" — an empty list, or an empty list item that decodes to a null header — must
+        /// not cost the peer its connection, but substituting another block is a protocol breach.
         /// </summary>
         [TestCase(HeadHeaderAnswer.RequestedBlock, false)]
         [TestCase(HeadHeaderAnswer.DifferentBlock, true)]
         [TestCase(HeadHeaderAnswer.Nothing, false)]
+        [TestCase(HeadHeaderAnswer.EmptyHeader, false)]
         public async Task Head_block_header_is_only_returned_for_the_requested_block(HeadHeaderAnswer answer, bool shouldDisconnect)
         {
             BlockHeader requested = Build.A.BlockHeader.WithNumber(10).TestObject;
@@ -862,6 +863,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             {
                 HeadHeaderAnswer.RequestedBlock => [requested],
                 HeadHeaderAnswer.DifferentBlock => [Build.A.BlockHeader.WithNumber(20).TestObject],
+                HeadHeaderAnswer.EmptyHeader => [null!],
                 _ => [],
             };
 
@@ -873,8 +875,15 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
 
             BlockHeader? result = await request;
 
-            bool shouldFind = answer == HeadHeaderAnswer.RequestedBlock;
-            Assert.That(result?.Hash, Is.EqualTo(shouldFind ? requested.Hash : null));
+            if (answer == HeadHeaderAnswer.RequestedBlock)
+            {
+                Assert.That(result?.Hash, Is.EqualTo(requested.Hash));
+            }
+            else
+            {
+                Assert.That(result, Is.Null);
+            }
+
             _session.Received(shouldDisconnect ? 1 : 0)
                 .InitiateDisconnect(DisconnectReason.UnexpectedHeaderHash, Arg.Any<string>());
         }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -846,6 +846,39 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _session.Received(messagesCount).DeliverMessage(Arg.Is<TransactionsMessage>(m => m.Transactions.Count == numberOfTxsInOneMsg || m.Transactions.Count == nonFullMsgTxsCount));
         }
 
+        public enum HeadHeaderAnswer { RequestedBlock, DifferentBlock, Nothing }
+
+        /// <summary>
+        /// Answering with an empty list is how a peer says it does not have the block and must not cost it the
+        /// connection, but substituting another block is a protocol breach.
+        /// </summary>
+        [TestCase(HeadHeaderAnswer.RequestedBlock, false)]
+        [TestCase(HeadHeaderAnswer.DifferentBlock, true)]
+        [TestCase(HeadHeaderAnswer.Nothing, false)]
+        public async Task Head_block_header_is_only_returned_for_the_requested_block(HeadHeaderAnswer answer, bool shouldDisconnect)
+        {
+            BlockHeader requested = Build.A.BlockHeader.WithNumber(10).TestObject;
+            BlockHeader[] answered = answer switch
+            {
+                HeadHeaderAnswer.RequestedBlock => [requested],
+                HeadHeaderAnswer.DifferentBlock => [Build.A.BlockHeader.WithNumber(20).TestObject],
+                _ => [],
+            };
+
+            HandleIncomingStatusMessage();
+
+            Task<BlockHeader?> request = ((ISyncPeer)_handler).GetHeadBlockHeader(requested.Hash, CancellationToken.None);
+            using BlockHeadersMessage response = new(answered.ToPooledList());
+            HandleZeroMessage(response, Eth62MessageCode.BlockHeaders);
+
+            BlockHeader? result = await request;
+
+            bool shouldFind = answer == HeadHeaderAnswer.RequestedBlock;
+            Assert.That(result?.Hash, Is.EqualTo(shouldFind ? requested.Hash : null));
+            _session.Received(shouldDisconnect ? 1 : 0)
+                .InitiateDisconnect(DisconnectReason.UnexpectedHeaderHash, Arg.Any<string>());
+        }
+
         private void HandleZeroMessage<T>(T msg, int messageCode) where T : MessageBase
         {
             using DisposableByteBuffer getBlockHeadersPacket = _svc.ZeroSerialize(msg).AsDisposable();

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -150,7 +150,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         async Task<BlockHeader?> ISyncPeer.GetHeadBlockHeader(Hash256? hash, CancellationToken token)
         {
-            Hash256 requestedHash = hash ?? _remoteHeadBlockHash;
+            Hash256? requestedHash = hash ?? _remoteHeadBlockHash;
 
             GetBlockHeadersMessage msg = new();
             msg.StartBlockHash = requestedHash;
@@ -160,9 +160,11 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
             using IOwnedReadOnlyList<BlockHeader> headers = await SendRequest(msg, token);
             ReadOnlySpan<BlockHeader> headersSpan = headers.AsSpan();
-            if (headersSpan.Length == 0) return null;
 
-            BlockHeader header = headersSpan[0];
+            // A peer without the block answers with an empty list, or with an item that decodes to a null header.
+            BlockHeader? header = headersSpan.Length == 0 ? null : headersSpan[0];
+            if (header is null) return null;
+
             if (requestedHash is not null && header.Hash != requestedHash)
             {
                 Disconnect(DisconnectReason.UnexpectedHeaderHash, "header hash inconsistent with request");

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -151,6 +151,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
         async Task<BlockHeader?> ISyncPeer.GetHeadBlockHeader(Hash256? hash, CancellationToken token)
         {
             Hash256? requestedHash = hash ?? _remoteHeadBlockHash;
+            if (requestedHash is null) return null;
 
             GetBlockHeadersMessage msg = new();
             msg.StartBlockHash = requestedHash;
@@ -165,7 +166,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
             BlockHeader? header = headersSpan.Length == 0 ? null : headersSpan[0];
             if (header is null) return null;
 
-            if (requestedHash is not null && header.Hash != requestedHash)
+            if (header.Hash != requestedHash)
             {
                 Disconnect(DisconnectReason.UnexpectedHeaderHash, "header hash inconsistent with request");
                 return null;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/SyncPeerProtocolHandlerBase.cs
@@ -150,15 +150,26 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         async Task<BlockHeader?> ISyncPeer.GetHeadBlockHeader(Hash256? hash, CancellationToken token)
         {
+            Hash256 requestedHash = hash ?? _remoteHeadBlockHash;
+
             GetBlockHeadersMessage msg = new();
-            msg.StartBlockHash = hash ?? _remoteHeadBlockHash;
+            msg.StartBlockHash = requestedHash;
             msg.MaxHeaders = 1;
             msg.Reverse = 0;
             msg.Skip = 0;
 
             using IOwnedReadOnlyList<BlockHeader> headers = await SendRequest(msg, token);
             ReadOnlySpan<BlockHeader> headersSpan = headers.AsSpan();
-            return headersSpan.Length > 0 ? headersSpan[0] : null;
+            if (headersSpan.Length == 0) return null;
+
+            BlockHeader header = headersSpan[0];
+            if (requestedHash is not null && header.Hash != requestedHash)
+            {
+                Disconnect(DisconnectReason.UnexpectedHeaderHash, "header hash inconsistent with request");
+                return null;
+            }
+
+            return header;
         }
 
         async Task<IOwnedReadOnlyList<BlockHeader>> ISyncPeer.GetBlockHeaders(Hash256 startHash, int maxBlocks, int skip, CancellationToken token)


### PR DESCRIPTION
Follow-up to #12730, per [this review comment](https://github.com/NethermindEth/nethermind/pull/12730#discussion_r3735899739) — moving the guarantee into `GetHeadBlockHeader` itself rather than leaving each caller to re-check. Independent of #12730; the two touch different files and can merge in either order.

## Changes

- `SyncPeerProtocolHandlerBase.GetHeadBlockHeader` now compares the returned header against the hash it asked for, and disconnects a peer that answers with a different block (`DisconnectReason.UnexpectedHeaderHash`, as `HeadersSyncFeed` already does for the same situation). A peer that simply does not have the block answers with an empty list, which is the normal response while a head is unknown and still returns `null` with no penalty.
- Documented the guarantee on `ISyncPeer.GetHeadBlockHeader` so callers can rely on it.
- Removed the now-redundant hash check in `StartingSyncPivotUpdater`, whose lambda existed only to perform it.
- This also closes a gap in `SyncPeerPool.ExecuteRefreshTask`, which only ran `HeaderValidator.ValidateHash` — that checks a header is internally consistent (`Hash == CalculateHash()`), not that it is the block that was requested. Peer init and total-difficulty refresh would otherwise accept a substituted header and record the wrong head number and TD against that peer.

The comparison is meaningful because `HeaderDecoder` sets `Hash = Keccak.Compute(headerRlp)` over the received bytes, so a peer cannot claim a hash it did not send bytes for.

### Note on `PeerRefresher`

I said in #12730 that both hand-rolled checks could go. On implementation I kept `PeerRefresher`'s: that method validates its head/parent response locally regardless, because it arrives via `GetBlockHeaders`, which carries no such guarantee. Removing only the finalized-header check would leave one response in the method validated and the other trusted, which reads as an inconsistency rather than a simplification — and it would have meant rewriting an existing test that covers it.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `Head_block_header_is_only_returned_for_the_requested_block` to `Eth62ProtocolHandlerTests`, driving a real request/response round-trip through the handler across three answer shapes: the requested block (returned, peer kept), a different block (`null`, peer disconnected), and an empty list (`null`, peer kept). Reverting the production change fails the middle case and leaves the other two green.

Full suites pass: `Nethermind.Network.Test` (1285), `Nethermind.Merge.Plugin.Test` (1681), `Nethermind.Synchronization.Test` (2087).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No