### PR TITLE
Treat a null header answer as the block being absent

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -73,7 +73,14 @@ public class SyncPeerPoolTests
 
         public Task<IOwnedReadOnlyList<BlockHeader>?> GetBlockHeaders(Hash256 startHash, int maxBlocks, int skip, CancellationToken token) =>
             Task.FromResult<IOwnedReadOnlyList<BlockHeader>?>(
-                HeaderToReturn is null ? ArrayPoolList<BlockHeader>.Empty() : new ArrayPoolList<BlockHeader>([HeaderToReturn]));
+                AnswersWithEmptyHeader ? new ArrayPoolList<BlockHeader>([null!])
+                    : HeaderToReturn is null ? ArrayPoolList<BlockHeader>.Empty()
+                        : new ArrayPoolList<BlockHeader>([HeaderToReturn]));
+
+        /// <summary>
+        /// Makes the peer answer with a single null header, which is how an empty list item decodes off the wire.
+        /// </summary>
+        public bool AnswersWithEmptyHeader { get; set; }
 
         /// <summary>
         /// Header this peer answers header requests with, whatever hash was asked for. When unset, head-header
@@ -812,6 +819,22 @@ public class SyncPeerPoolTests
         await ctx.Pool.FetchHeaderFromPeer(requested.Hash!);
 
         Assert.That(peers[0].DisconnectRequested, Is.EqualTo(shouldReport));
+    }
+
+    [Test]
+    public async Task Fetch_header_treats_a_null_header_answer_as_the_block_being_absent()
+    {
+        await using Context ctx = new();
+        SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 1);
+
+        BlockHeader requested = Build.A.BlockHeader.WithNumber(10).TestObject;
+        peers[0].HeadHeaderUnavailable = true;
+        peers[0].AnswersWithEmptyHeader = true;
+
+        BlockHeader? result = await ctx.Pool.FetchHeaderFromPeer(requested.Hash!);
+
+        Assert.That(result, Is.Null);
+        Assert.That(peers[0].DisconnectRequested, Is.False);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -73,14 +73,9 @@ public class SyncPeerPoolTests
 
         public Task<IOwnedReadOnlyList<BlockHeader>?> GetBlockHeaders(Hash256 startHash, int maxBlocks, int skip, CancellationToken token) =>
             Task.FromResult<IOwnedReadOnlyList<BlockHeader>?>(
-                AnswersWithEmptyHeader ? new ArrayPoolList<BlockHeader>([null!])
+                AnswersWithNullHeader ? new ArrayPoolList<BlockHeader>([null!])
                     : HeaderToReturn is null ? ArrayPoolList<BlockHeader>.Empty()
                         : new ArrayPoolList<BlockHeader>([HeaderToReturn]));
-
-        /// <summary>
-        /// Makes the peer answer with a single null header, which is how an empty list item decodes off the wire.
-        /// </summary>
-        public bool AnswersWithEmptyHeader { get; set; }
 
         /// <summary>
         /// Header this peer answers header requests with, whatever hash was asked for. When unset, head-header
@@ -92,6 +87,11 @@ public class SyncPeerPoolTests
         /// Makes the peer answer head-header requests with nothing, as a peer that does not have the block does.
         /// </summary>
         public bool HeadHeaderUnavailable { get; set; }
+
+        /// <summary>
+        /// Makes the peer answer with a single null header, which is how an empty list item decodes off the wire.
+        /// </summary>
+        public bool AnswersWithNullHeader { get; set; }
 
         public async Task<BlockHeader?> GetHeadBlockHeader(Hash256? hash, CancellationToken token)
         {
@@ -829,7 +829,7 @@ public class SyncPeerPoolTests
 
         BlockHeader requested = Build.A.BlockHeader.WithNumber(10).TestObject;
         peers[0].HeadHeaderUnavailable = true;
-        peers[0].AnswersWithEmptyHeader = true;
+        peers[0].AnswersWithNullHeader = true;
 
         BlockHeader? result = await ctx.Pool.FetchHeaderFromPeer(requested.Hash!);
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -202,8 +202,7 @@ namespace Nethermind.Synchronization.Peers
             {
                 try
                 {
-                    BlockHeader? header = await peer.SyncPeer.GetHeadBlockHeader(headerHash, token);
-                    return header is null ? null : Validate(syncPeerPool, peer, header, headerHash);
+                    return Validate(syncPeerPool, peer, await peer.SyncPeer.GetHeadBlockHeader(headerHash, token), headerHash);
                 }
                 catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
                 {
@@ -211,8 +210,10 @@ namespace Nethermind.Synchronization.Peers
                 }
             }
 
-            static BlockHeader? Validate(ISyncPeerPool syncPeerPool, PeerInfo peer, BlockHeader header, Hash256 headerHash)
+            // A peer without the block answers with an empty list, or with an item that decodes to a null header.
+            static BlockHeader? Validate(ISyncPeerPool syncPeerPool, PeerInfo peer, BlockHeader? header, Hash256 headerHash)
             {
+                if (header is null) return null;
                 if (header.Hash == headerHash) return header;
 
                 syncPeerPool.ReportBreachOfProtocol(peer, DisconnectReason.UnexpectedHeaderHash, "header hash inconsistent with request");


### PR DESCRIPTION
Follow-up to #12730, which landed just before this was spotted.

## Changes

- `FetchHeaderFromPeer`'s allocated-peer fallback passed the first element of the response straight into the hash comparison. That element can be `null`: `HeaderDecoder.DecodeInternal` maps an RLP empty list item (`0xc0`) to `null` and `Rlp.DecodeArrayPool` keeps it in the list, so a peer can answer a single-header request with one null entry and make the comparison throw.
- Handled in `Validate`, which lets the head-header path drop its own null check.

Nulls in header responses are expected elsewhere in the codebase — `HeadersSyncFeed` types its response `ReadOnlySpan<BlockHeader?>`, and `BlockTree.FindHeaders` returns an all-`null` list for an unknown start hash. Before #12730 the same bytes produced a `null` header that callers null-checked; the hash comparison introduced the dereference.

`FetchHeaderFromPeer` only catches cancellation and timeouts, so the exception escapes to its caller in `ForkchoiceUpdatedHandler` — i.e. out of `engine_forkchoiceUpdated`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `Fetch_header_treats_a_null_header_answer_as_the_block_being_absent`, with an `AnswersWithEmptyHeader` switch on `SimpleSyncPeerMock`. It asserts the result is `null` and the peer is not disconnected — a peer saying it does not have the block is not misbehaving. Reverting the null handling fails it with the `NullReferenceException`.

Full `Nethermind.Synchronization.Test` passes (2095).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No