### PR TITLE
Specify the EIP-8272 RECENT_ROOT_CODE predeploy body

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -313,8 +313,6 @@ public class BlockProcessorTests
             .SetName("Installs_eip8141_expiry_verifier_predeploy_once_and_captures_it_in_bal");
         yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode.ToArray())
             .SetName("Installs_eip8250_nonce_manager_predeploy_once_and_captures_it_in_bal");
-        // A storage namespace with empty canonical code: its activation update is the nonce alone, so a
-        // code-only idempotency probe would never fire it.
         yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8272Enabled = true }, Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode.ToArray())
             .SetName("Installs_eip8272_recent_root_predeploy_once_and_captures_it_in_bal");
     }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -313,6 +313,10 @@ public class BlockProcessorTests
             .SetName("Installs_eip8141_expiry_verifier_predeploy_once_and_captures_it_in_bal");
         yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode.ToArray())
             .SetName("Installs_eip8250_nonce_manager_predeploy_once_and_captures_it_in_bal");
+        // A storage namespace with empty canonical code: its activation update is the nonce alone, so a
+        // code-only idempotency probe would never fire it.
+        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8272Enabled = true }, Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode.ToArray())
+            .SetName("Installs_eip8272_recent_root_predeploy_once_and_captures_it_in_bal");
     }
 
     [TestCaseSource(nameof(PredeployInstallCases)), MaxTime(Timeout.MaxTestTime)]
@@ -344,8 +348,12 @@ public class BlockProcessorTests
         Assert.That(installChanges, Is.Not.Null, "predeploy install must be captured in the BAL");
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(installChanges!.CodeChanges, Has.Count.EqualTo(1));
-            Assert.That(installChanges.CodeChanges[0].Code, Is.EqualTo(code));
+            Assert.That(installChanges!.CodeChanges, Has.Count.EqualTo(code.Length == 0 ? 0 : 1));
+            if (code.Length != 0)
+            {
+                Assert.That(installChanges.CodeChanges[0].Code, Is.EqualTo(code));
+            }
+
             Assert.That(installChanges.NonceChanges, Has.Count.EqualTo(1));
             Assert.That(installChanges.NonceChanges[0].Value, Is.EqualTo(1ul));
         }
@@ -358,47 +366,6 @@ public class BlockProcessorTests
         Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(1ul));
         Assert.That(processed2.GeneratedBlockAccessList!.GetAccountChanges(predeploy), Is.Null,
             "a re-install must not churn state or the BAL once the code is already present");
-    }
-
-    /// <summary>
-    /// The EIP-8272 predeploy is a storage namespace with empty canonical code, so its activation
-    /// account update is the nonce alone. A code-only idempotency probe would never fire it.
-    /// </summary>
-    [Test, MaxTime(Timeout.MaxTestTime)]
-    public void Installs_eip8272_recent_root_namespace_predeploy_once_and_captures_it_in_bal()
-    {
-        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8272Enabled = true });
-        (BlockProcessor processor, _, IWorldState stateProvider) = CreateProcessorAndBranch(specProvider: specProvider);
-        IReleaseSpec spec = specProvider.GetSpec((ForkActivation)1);
-
-        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
-        InstallExecutionRequestPredeploys(stateProvider, spec);
-        stateProvider.Commit(spec);
-        stateProvider.CommitTree(0);
-
-        Block block1 = Build.A.Block.WithNumber(1).WithAuthor(TestItem.AddressD).TestObject;
-        (Block processed1, _) = processor.ProcessOne(block1, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(stateProvider.GetNonce(Eip8272Constants.RecentRootAddress), Is.EqualTo(1ul));
-            Assert.That(stateProvider.GetCode(Eip8272Constants.RecentRootAddress), Is.Empty);
-        }
-
-        GeneratedAccountChanges? installChanges = processed1.GeneratedBlockAccessList!.GetAccountChanges(Eip8272Constants.RecentRootAddress);
-        Assert.That(installChanges, Is.Not.Null, "predeploy install must be captured in the BAL");
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(installChanges!.NonceChanges, Has.Count.EqualTo(1));
-            Assert.That(installChanges.NonceChanges[0].Value, Is.EqualTo(1ul));
-            Assert.That(installChanges.CodeChanges, Is.Empty);
-        }
-
-        Block block2 = Build.A.Block.WithNumber(2).WithAuthor(TestItem.AddressD).TestObject;
-        (Block processed2, _) = processor.ProcessOne(block2, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
-
-        Assert.That(processed2.GeneratedBlockAccessList!.GetAccountChanges(Eip8272Constants.RecentRootAddress), Is.Null,
-            "a re-install must not churn state or the BAL once the nonce is already present");
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -360,6 +360,47 @@ public class BlockProcessorTests
             "a re-install must not churn state or the BAL once the code is already present");
     }
 
+    /// <summary>
+    /// The EIP-8272 predeploy is a storage namespace with empty canonical code, so its activation
+    /// account update is the nonce alone. A code-only idempotency probe would never fire it.
+    /// </summary>
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Installs_eip8272_recent_root_namespace_predeploy_once_and_captures_it_in_bal()
+    {
+        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8272Enabled = true });
+        (BlockProcessor processor, _, IWorldState stateProvider) = CreateProcessorAndBranch(specProvider: specProvider);
+        IReleaseSpec spec = specProvider.GetSpec((ForkActivation)1);
+
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        InstallExecutionRequestPredeploys(stateProvider, spec);
+        stateProvider.Commit(spec);
+        stateProvider.CommitTree(0);
+
+        Block block1 = Build.A.Block.WithNumber(1).WithAuthor(TestItem.AddressD).TestObject;
+        (Block processed1, _) = processor.ProcessOne(block1, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(stateProvider.GetNonce(Eip8272Constants.RecentRootAddress), Is.EqualTo(1ul));
+            Assert.That(stateProvider.GetCode(Eip8272Constants.RecentRootAddress), Is.Empty);
+        }
+
+        GeneratedAccountChanges? installChanges = processed1.GeneratedBlockAccessList!.GetAccountChanges(Eip8272Constants.RecentRootAddress);
+        Assert.That(installChanges, Is.Not.Null, "predeploy install must be captured in the BAL");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(installChanges!.NonceChanges, Has.Count.EqualTo(1));
+            Assert.That(installChanges.NonceChanges[0].Value, Is.EqualTo(1ul));
+            Assert.That(installChanges.CodeChanges, Is.Empty);
+        }
+
+        Block block2 = Build.A.Block.WithNumber(2).WithAuthor(TestItem.AddressD).TestObject;
+        (Block processed2, _) = processor.ProcessOne(block2, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
+
+        Assert.That(processed2.GeneratedBlockAccessList!.GetAccountChanges(Eip8272Constants.RecentRootAddress), Is.Null,
+            "a re-install must not churn state or the BAL once the nonce is already present");
+    }
+
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Prepared_block_contains_author_field()
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
@@ -22,18 +22,19 @@ namespace Nethermind.Consensus.Processing;
 /// each predeploy's activation and none afterwards. The nonce probe is what carries a predeploy whose
 /// canonical code is empty — a protocol-managed storage namespace such as EIP-8272's — since its code
 /// matches from the start. The predeploy nonce is 1, matching the EIP-2935/4788/7002/7251 predeploy
-/// convention, and an existing higher nonce is preserved rather than lowered, so the resulting state
-/// root and the EIP-7928 block-level access list agree across clients.
+/// convention, so the resulting state root and the EIP-7928 block-level access list agree across
+/// clients. Whether an existing higher nonce is preserved or overwritten is per-predeploy, because
+/// only EIP-8272 specifies <c>max(existing_nonce, 1)</c>.
 /// </remarks>
 public static class PredeployInstaller
 {
-    private readonly record struct Predeploy(Address Address, ReadOnlyMemory<byte> Code, ulong Nonce, Func<IReleaseSpec, bool> IsActive);
+    private readonly record struct Predeploy(Address Address, ReadOnlyMemory<byte> Code, ulong Nonce, Func<IReleaseSpec, bool> IsActive, bool PreservesHigherNonce = false);
 
     private static readonly Predeploy[] Predeploys =
     [
         new(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, 1, static spec => spec.IsEip8141Enabled),
         new(Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode, 1, static spec => spec.IsEip8250Enabled),
-        new(Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode, 1, static spec => spec.IsEip8272Enabled),
+        new(Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode, 1, static spec => spec.IsEip8272Enabled, PreservesHigherNonce: true),
     ];
 
     /// <summary>
@@ -82,8 +83,12 @@ public static class PredeployInstaller
             }
 
             writeState.CreateAccountIfNotExists(predeploy.Address, UInt256.Zero);
-            writeState.InsertCode(predeploy.Address, code, spec);
-            writeState.SetNonce(predeploy.Address, Math.Max(nonce, predeploy.Nonce));
+            if (!code.IsEmpty)
+            {
+                writeState.InsertCode(predeploy.Address, code, spec);
+            }
+
+            writeState.SetNonce(predeploy.Address, predeploy.PreservesHigherNonce ? Math.Max(nonce, predeploy.Nonce) : predeploy.Nonce);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
@@ -17,10 +17,13 @@ namespace Nethermind.Consensus.Processing;
 /// Each predeploy is described as data — address, runtime code, nonce, and the fork gate that
 /// activates it — so a new predeploy (e.g. a keyed-nonce or recent-roots manager) is added as a list
 /// entry rather than another installer and interface method. The install is idempotent: code + nonce
-/// are written only when the account's current code differs from the canonical bytecode, so exactly
-/// one account update is produced at the first block after each predeploy's activation and none
-/// afterwards. The predeploy nonce is 1, matching the EIP-2935/4788/7002/7251 predeploy convention,
-/// so the resulting state root and the EIP-7928 block-level access list agree across clients.
+/// are written only when the account's current code differs from the canonical bytecode or its nonce
+/// is below the predeploy nonce, so exactly one account update is produced at the first block after
+/// each predeploy's activation and none afterwards. The nonce probe is what carries a predeploy whose
+/// canonical code is empty — a protocol-managed storage namespace such as EIP-8272's — since its code
+/// matches from the start. The predeploy nonce is 1, matching the EIP-2935/4788/7002/7251 predeploy
+/// convention, and an existing higher nonce is preserved rather than lowered, so the resulting state
+/// root and the EIP-7928 block-level access list agree across clients.
 /// </remarks>
 public static class PredeployInstaller
 {
@@ -30,6 +33,7 @@ public static class PredeployInstaller
     [
         new(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, 1, static spec => spec.IsEip8141Enabled),
         new(Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode, 1, static spec => spec.IsEip8250Enabled),
+        new(Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode, 1, static spec => spec.IsEip8272Enabled),
     ];
 
     /// <summary>
@@ -71,14 +75,15 @@ public static class PredeployInstaller
             }
 
             ReadOnlyMemory<byte> code = predeploy.Code;
-            if (readState.GetCode(predeploy.Address).AsSpan().SequenceEqual(code.Span))
+            ulong nonce = readState.GetNonce(predeploy.Address);
+            if (readState.GetCode(predeploy.Address).AsSpan().SequenceEqual(code.Span) && nonce >= predeploy.Nonce)
             {
                 continue;
             }
 
             writeState.CreateAccountIfNotExists(predeploy.Address, UInt256.Zero);
             writeState.InsertCode(predeploy.Address, code, spec);
-            writeState.SetNonce(predeploy.Address, predeploy.Nonce);
+            writeState.SetNonce(predeploy.Address, Math.Max(nonce, predeploy.Nonce));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -92,7 +92,8 @@ public sealed class TxValidator : ITxValidator
             NonceCapTxValidator.Instance,
             expectedChainIdTxValidator,
             GasFieldsTxValidator.Instance,
-            FrameTxFieldsTxValidator.Instance
+            FrameTxFieldsTxValidator.Instance,
+            FrameTxEnvelopeTxValidator.Instance
         ]));
     }
 
@@ -191,6 +192,34 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
         FrameTxValidation.IsWellFormed(transaction, out string? error) ? ValidationResult.Success : error!;
+}
+
+/// <summary>Admits the frame-transaction envelope extensions only on forks that define them.</summary>
+/// <remarks>
+/// The RLP decoder tells the envelope shapes apart without fork context, so the fork that admits each
+/// one is decided here. The reference cap is re-checked because a transaction can reach validation
+/// without passing through the decoder at all — <c>eth_call</c>, <c>eth_estimateGas</c> and block
+/// building all construct one directly.
+/// </remarks>
+public sealed class FrameTxEnvelopeTxValidator : ITxValidator
+{
+    public static readonly FrameTxEnvelopeTxValidator Instance = new();
+    private FrameTxEnvelopeTxValidator() { }
+
+    public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
+    {
+        RecentRootReference[]? references = transaction.RecentRootReferences;
+        if (references is null)
+        {
+            return ValidationResult.Success;
+        }
+
+        return releaseSpec.IsEip8272Enabled
+            ? references.Length <= Eip8272Constants.MaxRecentRootReferences
+                ? ValidationResult.Success
+                : "too many recent root references"
+            : "recent root references are not enabled";
+    }
 }
 
 public sealed class ContractSizeTxValidator : ITxValidator

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -31,6 +31,7 @@ public class FrameTxDecoderTests
         Assert.That(decoded.ChainId, Is.EqualTo(tx.ChainId));
         Assert.That(decoded.Nonce, Is.EqualTo(tx.Nonce));
         Assert.That(decoded.NonceKeys, Is.EqualTo(tx.NonceKeys));
+        AssertReferencesEqual(decoded.RecentRootReferences, tx.RecentRootReferences);
         // The sender is explicit in the payload — no envelope signature, no ECDSA recovery.
         Assert.That(decoded.SenderAddress, Is.EqualTo(tx.SenderAddress));
         Assert.That(decoded.GasPrice, Is.EqualTo(tx.GasPrice));
@@ -125,6 +126,45 @@ public class FrameTxDecoderTests
         {
             Assert.That(FrameTxSigHash.ComputeValue(legacyKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacy)));
             Assert.That(FrameTxSigHash.ComputeValue(otherKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacyKey)));
+    // The reference list is part of the signing payload, and an absent list is a different envelope
+    // from an empty one, so neither may reuse the other's hash.
+    [Test]
+    public void ComputeSigHash_RecentRootReferencesChange_HashChanges()
+    {
+        Transaction none = CreateFrameTx();
+        Transaction empty = CreateFrameTx();
+        empty.RecentRootReferences = [];
+        Transaction referencing = CreateFrameTx();
+        referencing.RecentRootReferences = [Reference(slot: 7)];
+        Transaction otherSlot = CreateFrameTx();
+        otherSlot.RecentRootReferences = [Reference(slot: 8)];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(FrameTxSigHash.ComputeValue(empty), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(none)));
+            Assert.That(FrameTxSigHash.ComputeValue(referencing), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(empty)));
+            Assert.That(FrameTxSigHash.ComputeValue(otherSlot), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(referencing)));
+        }
+    }
+
+    private static RecentRootReference Reference(ulong slot) =>
+        new(TestItem.KeccakA.ValueHash256, slot, TestItem.KeccakB.ValueHash256);
+
+    private static void AssertReferencesEqual(RecentRootReference[]? actual, RecentRootReference[]? expected)
+    {
+        if (expected is null)
+        {
+            Assert.That(actual, Is.Null);
+            return;
+        }
+
+        Assert.That(actual, Is.Not.Null);
+        Assert.That(actual!.Length, Is.EqualTo(expected.Length));
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.That(actual[i].SourceId, Is.EqualTo(expected[i].SourceId));
+            Assert.That(actual[i].Slot, Is.EqualTo(expected[i].Slot));
+            Assert.That(actual[i].Root, Is.EqualTo(expected[i].Root));
         }
     }
 
@@ -156,6 +196,13 @@ public class FrameTxDecoderTests
         multiKeyed.NonceKeys = [1, UInt256.MaxValue];
         multiKeyed.Nonce = 42;
         yield return new TestCaseData(multiKeyed).SetName("Roundtrip_KeyedNonceEnvelope_MultipleKeys");
+        Transaction emptyReferences = CreateFrameTx();
+        emptyReferences.RecentRootReferences = [];
+        yield return new TestCaseData(emptyReferences).SetName("Roundtrip_EmptyRecentRootReferenceList");
+
+        Transaction referencing = CreateFrameTx();
+        referencing.RecentRootReferences = [Reference(slot: 0), Reference(slot: ulong.MaxValue)];
+        yield return new TestCaseData(referencing).SetName("Roundtrip_RecentRootReferences");
 
         Transaction blobCarrying = CreateFrameTx();
         blobCarrying.MaxFeePerBlobGas = 7;

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -30,6 +30,7 @@ public class FrameTxDecoderTests
         Assert.That(decoded.Type, Is.EqualTo(TxType.FrameTx));
         Assert.That(decoded.ChainId, Is.EqualTo(tx.ChainId));
         Assert.That(decoded.Nonce, Is.EqualTo(tx.Nonce));
+        Assert.That(decoded.NonceKeys, Is.EqualTo(tx.NonceKeys));
         // The sender is explicit in the payload — no envelope signature, no ECDSA recovery.
         Assert.That(decoded.SenderAddress, Is.EqualTo(tx.SenderAddress));
         Assert.That(decoded.GasPrice, Is.EqualTo(tx.GasPrice));
@@ -109,6 +110,24 @@ public class FrameTxDecoderTests
         Assert.That(FrameTxSigHash.ComputeValue(second), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(first)));
     }
 
+    // The keyed envelope is part of the signing payload, so selecting different keys — or none at all,
+    // which is a different envelope rather than the key 0 — must not reuse another transaction's hash.
+    [Test]
+    public void ComputeSigHash_NonceKeysChange_HashChanges()
+    {
+        Transaction legacy = CreateFrameTx();
+        Transaction legacyKey = CreateFrameTx();
+        legacyKey.NonceKeys = [UInt256.Zero];
+        Transaction otherKey = CreateFrameTx();
+        otherKey.NonceKeys = [1];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(FrameTxSigHash.ComputeValue(legacyKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacy)));
+            Assert.That(FrameTxSigHash.ComputeValue(otherKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacyKey)));
+        }
+    }
+
     private static IEnumerable<TestCaseData> RoundtripCases()
     {
         yield return new TestCaseData(CreateFrameTx()).SetName("Roundtrip_MinimalSingleFrame");
@@ -128,6 +147,15 @@ public class FrameTxDecoderTests
             new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, TestItem.AddressC, FilledBytes(32, 0xab), FilledBytes(TxFrameSignature.Secp256k1SignatureLength, 0x22)),
             new TxFrameSignature(TxFrameSignature.SchemeP256, TestItem.AddressD, default, FilledBytes(TxFrameSignature.P256SignatureLength, 0x33)),
         ])).SetName("Roundtrip_AllSignatureSchemes");
+
+        Transaction keyed = CreateFrameTx();
+        keyed.NonceKeys = [UInt256.Zero];
+        yield return new TestCaseData(keyed).SetName("Roundtrip_KeyedNonceEnvelope_LegacyKeyOnly");
+
+        Transaction multiKeyed = CreateFrameTx();
+        multiKeyed.NonceKeys = [1, UInt256.MaxValue];
+        multiKeyed.Nonce = 42;
+        yield return new TestCaseData(multiKeyed).SetName("Roundtrip_KeyedNonceEnvelope_MultipleKeys");
 
         Transaction blobCarrying = CreateFrameTx();
         blobCarrying.MaxFeePerBlobGas = 7;

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -126,6 +126,9 @@ public class FrameTxDecoderTests
         {
             Assert.That(FrameTxSigHash.ComputeValue(legacyKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacy)));
             Assert.That(FrameTxSigHash.ComputeValue(otherKey), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(legacyKey)));
+        }
+    }
+
     // The reference list is part of the signing payload, and an absent list is a different envelope
     // from an empty one, so neither may reuse the other's hash.
     [Test]

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
@@ -149,6 +150,46 @@ public class FrameTxDecoderTests
             Assert.That(FrameTxSigHash.ComputeValue(otherSlot), Is.Not.EqualTo(FrameTxSigHash.ComputeValue(referencing)));
         }
     }
+
+    // Every rejection the reference list introduces: a tuple that is not three well-sized elements is
+    // not a reference, and a list longer than the cap is not decodable at all — both must throw rather
+    // than yield a transaction some other client would read differently.
+    [TestCaseSource(nameof(MalformedReferenceListCases))]
+    public void Decode_MalformedRecentRootReferenceList_Throws(Rlp references)
+    {
+        Rlp sequence = Rlp.Encode(
+            Rlp.Encode(TestBlockchainIds.ChainId),
+            Rlp.Encode(0L),
+            Rlp.Encode(TestItem.AddressA.Bytes),
+            Rlp.Encode(Array.Empty<Rlp>()),
+            Rlp.Encode(Array.Empty<Rlp>()),
+            Rlp.Encode(0L),
+            Rlp.Encode(0L),
+            Rlp.Encode(0L),
+            Rlp.Encode(Array.Empty<Rlp>()),
+            references);
+
+        byte[] payload = new byte[1 + sequence.Length];
+        payload[0] = (byte)TxType.FrameTx;
+        sequence.Bytes.CopyTo(payload, 1);
+
+        Assert.That(() => { RlpReader reader = new(payload); _txDecoder.Decode(ref reader); }, Throws.InstanceOf<RlpException>());
+    }
+
+    private static IEnumerable<TestCaseData> MalformedReferenceListCases()
+    {
+        Rlp wellFormed = EncodeReference(TestItem.KeccakA.BytesToArray(), 7, TestItem.KeccakB.BytesToArray());
+
+        yield return new TestCaseData(Rlp.Encode(EncodeReference(new byte[31], 7, TestItem.KeccakB.BytesToArray())))
+            .SetName("Decode_ReferenceWithUndersizedSourceId_Throws");
+        yield return new TestCaseData(Rlp.Encode(Rlp.Encode(new[] { Rlp.Encode(TestItem.KeccakA.BytesToArray()), Rlp.Encode(7L) })))
+            .SetName("Decode_ReferenceMissingRoot_Throws");
+        yield return new TestCaseData(Rlp.Encode(Enumerable.Repeat(wellFormed, Eip8272Constants.MaxRecentRootReferences + 1).ToArray()))
+            .SetName("Decode_MoreReferencesThanTheCap_Throws");
+    }
+
+    private static Rlp EncodeReference(byte[] sourceId, ulong slot, byte[] root) =>
+        Rlp.Encode(new[] { Rlp.Encode(sourceId), Rlp.Encode(slot), Rlp.Encode(root) });
 
     private static RecentRootReference Reference(ulong slot) =>
         new(TestItem.KeccakA.ValueHash256, slot, TestItem.KeccakB.ValueHash256);

--- a/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Core;
@@ -19,4 +20,12 @@ public static class Eip8272Constants
 
     // Provisional: spec address is TBD; mirrors the only existing implementation.
     public static readonly Address RecentRootAddress = new("0x0000000000000000000000000000000000008272");
+
+    /// <summary>The runtime code installed at <see cref="RecentRootAddress"/> when EIP-8272 activates.</summary>
+    /// <remarks>
+    /// The spec leaves <c>RECENT_ROOT_CODE</c> TBD, and the predeploy is only ever a protocol-managed
+    /// storage namespace: recent-root entries are written natively and no call ever enters the account.
+    /// Empty code keeps the activation account state minimal and matches the only existing implementation.
+    /// </remarks>
+    public static ReadOnlyMemory<byte> RecentRootCode { get; } = ReadOnlyMemory<byte>.Empty;
 }

--- a/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 
 namespace Nethermind.Core;
 
@@ -23,11 +24,11 @@ public static class Eip8272Constants
 
     /// <summary>The runtime code installed at <see cref="RecentRootAddress"/> when EIP-8272 activates.</summary>
     /// <remarks>
-    /// Provisional: <c>RECENT_ROOT_CODE</c> is TBD in the spec's constants table, and unlike the address
-    /// there is no reference implementation value to mirror.
-    /// The predeploy is only ever a protocol-managed
-    /// storage namespace: recent-root entries are written natively and no call ever enters the account.
-    /// Empty code keeps the activation account state minimal and matches the only existing implementation.
+    /// Provisional: <c>RECENT_ROOT_CODE</c> is TBD in the spec's constants table, so this is the candidate
+    /// proposed in ethereum/EIPs#12131 — the specified write operation assembled verbatim, reading the
+    /// current slot through the <see href="https://eips.ethereum.org/EIPS/eip-7843">EIP-7843</see>
+    /// <c>SLOTNUM</c> opcode.
     /// </remarks>
-    public static ReadOnlyMemory<byte> RecentRootCode { get; } = ReadOnlyMemory<byte>.Empty;
+    public static ReadOnlyMemory<byte> RecentRootCode { get; } = Bytes.FromHexString(
+        "0x341536604014166100105760006000fd5b33600052602060006020376034600c20807f8f42481679c8e6fefa040974b3c905e0ce3f2e464ba93acdb074a41181617efc6040524b606852606052602060206088376068604020817fbdc897da2177d260ff5f4be5d4b2aad43f89c3347a305b584fa5a2546d053daa60a852611fff4b1660d05260c852604860a8205500");
 }

--- a/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8272Constants.cs
@@ -23,7 +23,9 @@ public static class Eip8272Constants
 
     /// <summary>The runtime code installed at <see cref="RecentRootAddress"/> when EIP-8272 activates.</summary>
     /// <remarks>
-    /// The spec leaves <c>RECENT_ROOT_CODE</c> TBD, and the predeploy is only ever a protocol-managed
+    /// Provisional: <c>RECENT_ROOT_CODE</c> is TBD in the spec's constants table, and unlike the address
+    /// there is no reference implementation value to mirror.
+    /// The predeploy is only ever a protocol-managed
     /// storage namespace: recent-root entries are written natively and no call ever enters the account.
     /// Empty code keeps the activation account state minimal and matches the only existing implementation.
     /// </remarks>

--- a/src/Nethermind/Nethermind.Core/RecentRootReference.cs
+++ b/src/Nethermind/Nethermind.Core/RecentRootReference.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Core;
+
+/// <summary>
+/// A recent-root reference declared by a frame transaction: <c>[source_id, slot, root]</c>.
+/// https://eips.ethereum.org/EIPS/eip-8272
+/// </summary>
+/// <remarks>The root is opaque to consensus — applications bind its meaning. The slot is a beacon slot number.</remarks>
+public class RecentRootReference(in ValueHash256 sourceId, ulong slot, in ValueHash256 root)
+{
+    public ValueHash256 SourceId { get; } = sourceId;
+    public ulong Slot { get; } = slot;
+    public ValueHash256 Root { get; } = root;
+}

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -331,6 +331,11 @@ namespace Nethermind.Core.Specs
         bool IsEip8250Enabled { get; }
 
         /// <summary>
+        /// EIP-8272: recent roots for frame transactions.
+        /// </summary>
+        bool IsEip8272Enabled { get; }
+
+        /// <summary>
         /// EIP-8038: State-access gas cost update
         /// </summary>
         bool IsEip8038Enabled { get; }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -83,6 +83,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual bool IsEip8282Enabled => spec.IsEip8282Enabled;
     public virtual bool IsEip8141Enabled => spec.IsEip8141Enabled;
     public virtual bool IsEip8250Enabled => spec.IsEip8250Enabled;
+    public virtual bool IsEip8272Enabled => spec.IsEip8272Enabled;
     public virtual bool IsEip7702Enabled => spec.IsEip7702Enabled;
     public virtual bool IsEip7823Enabled => spec.IsEip7823Enabled;
     public virtual bool IsEip7825Enabled => spec.IsEip7825Enabled;

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -221,6 +221,8 @@ namespace Nethermind.Core
         /// <remarks><see langword="null"/> for the EIP-8141 envelope, whose single nonce is the sender's
         /// linear account nonce — the same domain EIP-8250 addresses as the key <c>0</c>.</remarks>
         public UInt256[]? NonceKeys { get; set; }
+
+        /// <summary>
         /// Recent-root references declared by a frame transaction.
         /// https://eips.ethereum.org/EIPS/eip-8272
         /// </summary>

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -221,6 +221,12 @@ namespace Nethermind.Core
         /// <remarks><see langword="null"/> for the EIP-8141 envelope, whose single nonce is the sender's
         /// linear account nonce — the same domain EIP-8250 addresses as the key <c>0</c>.</remarks>
         public UInt256[]? NonceKeys { get; set; }
+        /// Recent-root references declared by a frame transaction.
+        /// https://eips.ethereum.org/EIPS/eip-8272
+        /// </summary>
+        /// <remarks><see langword="null"/> for an envelope that predates EIP-8272, which is a different
+        /// signing payload from one carrying an empty reference list.</remarks>
+        public RecentRootReference[]? RecentRootReferences { get; set; }
 
         /// <summary>
         /// Service transactions are free. The field added to handle baseFee validation after 1559
@@ -342,6 +348,7 @@ namespace Nethermind.Core
                 obj.Frames = default;
                 obj.FrameSignatures = default;
                 obj.NonceKeys = default;
+                obj.RecentRootReferences = default;
 
                 return true;
             }
@@ -377,6 +384,7 @@ namespace Nethermind.Core
             tx.Frames = Frames;
             tx.FrameSignatures = FrameSignatures;
             tx.NonceKeys = NonceKeys;
+            tx.RecentRootReferences = RecentRootReferences;
         }
 
         public virtual ProofVersion? GetProofVersion() =>

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -215,6 +215,14 @@ namespace Nethermind.Core
         public TxFrameSignature[]? FrameSignatures { get; set; }
 
         /// <summary>
+        /// Nonce keys selected by a frame transaction, sharing the sequence number held by <see cref="Nonce"/>.
+        /// https://eips.ethereum.org/EIPS/eip-8250
+        /// </summary>
+        /// <remarks><see langword="null"/> for the EIP-8141 envelope, whose single nonce is the sender's
+        /// linear account nonce — the same domain EIP-8250 addresses as the key <c>0</c>.</remarks>
+        public UInt256[]? NonceKeys { get; set; }
+
+        /// <summary>
         /// Service transactions are free. The field added to handle baseFee validation after 1559
         /// </summary>
         /// <remarks>Used for AuRa consensus.</remarks>
@@ -333,6 +341,7 @@ namespace Nethermind.Core
                 obj.AuthorizationList = default;
                 obj.Frames = default;
                 obj.FrameSignatures = default;
+                obj.NonceKeys = default;
 
                 return true;
             }
@@ -367,6 +376,7 @@ namespace Nethermind.Core
             tx.AuthorizationList = AuthorizationList;
             tx.Frames = Frames;
             tx.FrameSignatures = FrameSignatures;
+            tx.NonceKeys = NonceKeys;
         }
 
         public virtual ProofVersion? GetProofVersion() =>

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8272RecentRootCodeTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8272RecentRootCodeTests.cs
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// Executes <see cref="Eip8272Constants.RecentRootCode"/> as ordinary EVM code and checks the commitment it
+/// leaves in storage against the derivations the reference check reads.
+/// </summary>
+[TestFixture]
+public class Eip8272RecentRootCodeTests : VirtualMachineTestsBase
+{
+    protected override ulong BlockNumber => MainnetSpecProvider.ParisBlockNumber;
+    protected override ulong Timestamp => MainnetSpecProvider.AmsterdamBlockTimestamp;
+
+    private const ulong SlotNumber = 12_345;
+
+    private static readonly ValueHash256 Salt = TestItem.KeccakA.ValueHash256;
+    private static readonly ValueHash256 Root = TestItem.KeccakB.ValueHash256;
+
+    [Test]
+    public void Commits_the_entry_a_reference_to_the_written_slot_reads()
+    {
+        TestAllTracerWithOutput result = Write(Bytes.Concat(Salt.Bytes, Root.Bytes));
+
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
+        Assert.That(Stored(SlotNumber), Is.EqualTo(ExpectedEntryHash()));
+    }
+
+    /// <remarks>
+    /// The ring index is the slot modulo <see cref="Eip8272Constants.RecentRootLength"/>, while the entry commits
+    /// to the unaliased slot — writing to one index and reading from another would silently validate stale roots.
+    /// </remarks>
+    [Test]
+    public void Commits_under_the_ring_index_of_the_current_slot()
+    {
+        Write(Bytes.Concat(Salt.Bytes, Root.Bytes));
+
+        Assert.That(
+            RecentRootStore.StorageKey(SourceId, SlotNumber % Eip8272Constants.RecentRootLength),
+            Is.Not.EqualTo(RecentRootStore.StorageKey(SourceId, SlotNumber)));
+        Assert.That(StoredAt(RecentRootStore.StorageKey(SourceId, SlotNumber)), Is.EqualTo(UInt256.Zero));
+    }
+
+    [TestCase(63, 0ul, TestName = "calldata shorter than a (salt, root) pair")]
+    [TestCase(65, 0ul, TestName = "calldata longer than a (salt, root) pair")]
+    [TestCase(64, 1ul, TestName = "value transferred with the write")]
+    public void Refuses_a_call_the_write_operation_does_not_define(int calldataLength, ulong value)
+    {
+        byte[] calldata = Bytes.Concat(Salt.Bytes, Root.Bytes);
+        Array.Resize(ref calldata, calldataLength);
+
+        TestAllTracerWithOutput result = Write(calldata, value);
+
+        Assert.That(result.Error, Is.EqualTo(EvmExceptionType.Revert.ToString()).IgnoreCase,
+            "the entry check is an explicit REVERT, so a halt for any other reason means the guard was not what stopped the write");
+        Assert.That(Stored(SlotNumber), Is.EqualTo(UInt256.Zero));
+    }
+
+    /// <remarks>
+    /// The body carries the derivation constants as literals, so nothing in the source shows that they still agree
+    /// with the values <see cref="RecentRootStore"/> derives from. Pinning them here is what makes the 144 bytes
+    /// auditable: a domain string or a ring length changed on one side alone fails this before it can diverge
+    /// between the write and the reference check.
+    /// </remarks>
+    [Test]
+    public void Embeds_the_derivation_constants_the_reference_check_uses()
+    {
+        ReadOnlySpan<byte> code = Eip8272Constants.RecentRootCode.Span;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(code.IndexOf(Eip8272Constants.RecentRootEntryDomain.Bytes), Is.GreaterThanOrEqualTo(0),
+                "the entry-hash domain separator");
+            Assert.That(code.IndexOf(Eip8272Constants.RecentRootStorageDomain.Bytes), Is.GreaterThanOrEqualTo(0),
+                "the storage-key domain separator");
+            Assert.That(code.IndexOf((ReadOnlySpan<byte>)[0x61, .. ((ushort)(Eip8272Constants.RecentRootLength - 1)).ToBigEndianByteArray()]), Is.GreaterThanOrEqualTo(0),
+                "PUSH2 of the ring-index mask");
+        }
+    }
+
+    private static ValueHash256 SourceId => RecentRootStore.SourceId(Sender, Salt);
+
+    private static UInt256 ExpectedEntryHash() =>
+        new(RecentRootStore.EntryHash(SourceId, SlotNumber, Root).Bytes, isBigEndian: true);
+
+    private UInt256 Stored(ulong slot) => StoredAt(RecentRootStore.StorageKey(SourceId, slot % Eip8272Constants.RecentRootLength));
+
+    private UInt256 StoredAt(in ValueHash256 storageKey) =>
+        new(TestState.Get(new StorageCell(Recipient, storageKey.ToUInt256())), isBigEndian: true);
+
+    private TestAllTracerWithOutput Write(byte[] calldata, ulong value = 0)
+    {
+        Transaction transaction = Build.A.Transaction
+            .WithGasLimit(200_000)
+            .WithGasPrice(1UL)
+            .WithData(calldata)
+            .WithValue(value)
+            .To(Recipient)
+            .SignedAndResolved(SenderKey)
+            .TestObject;
+
+        (Block block, Transaction prepared) = PrepareTx(
+            Activation,
+            200_000,
+            Eip8272Constants.RecentRootCode.ToArray(),
+            slotNumber: SlotNumber,
+            transaction: transaction);
+
+        TestAllTracerWithOutput tracer = CreateTracer();
+        _processor.Execute(prepared, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+        return tracer;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -792,9 +792,10 @@ public class FrameTxProcessorTests
 
     // Asserted through a sentinel stored after the opcode: a silent zero push would also leave slot 0
     // at zero, and it would read as a real reference committing to the zero root.
-    [TestCase(1, 0, TestName = "Execute_RecentRootRefLoad_IndexPastTheDeclaredList_Halts")]
-    [TestCase(0, 3, TestName = "Execute_RecentRootRefLoad_UndefinedField_Halts")]
-    public void Execute_RecentRootRefLoad_OutOfRange_ExceptionallyHalts(int index, int field)
+    [TestCase(0, 0, 1, TestName = "Execute_RecentRootRefLoad_InRange_Continues")]
+    [TestCase(1, 0, 0, TestName = "Execute_RecentRootRefLoad_IndexPastTheDeclaredList_Halts")]
+    [TestCase(0, 3, 0, TestName = "Execute_RecentRootRefLoad_UndefinedField_Halts")]
+    public void Execute_RecentRootRefLoad_OutOfRange_ExceptionallyHalts(int index, int field, int expectedSentinel)
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Observer, Prepare.EvmCode
@@ -805,7 +806,7 @@ public class FrameTxProcessorTests
         tx.RecentRootReferences = [CommitReference(ReferencedSlot)];
 
         Assert.That(Process(tx, slotNumber: HeadSlot).TransactionExecuted, Is.True);
-        AssertStorage(Observer, 0, UInt256.Zero);
+        AssertStorage(Observer, 0, (UInt256)expectedSentinel);
     }
 
     [TestCase(0, TestName = "Execute_TxParamReferenceCount_WithoutReferences")]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -20,6 +20,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using Nethermind.State;
 using NUnit.Framework;
 
@@ -36,6 +37,7 @@ namespace Nethermind.Evm.Test;
 public class FrameTxProcessorTests
 {
     private ISpecProvider _specProvider;
+    private OverridableReleaseSpec _spec;
     private ITransactionProcessor _transactionProcessor;
     private IWorldState _stateProvider;
     private IDisposable _worldStateCloser;
@@ -49,7 +51,10 @@ public class FrameTxProcessorTests
     [SetUp]
     public void Setup()
     {
-        _specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
+        // The prototype fork carries EIP-8141 only; the later frame-transaction EIPs are switched on
+        // here so a test can turn one back off and assert the fork gate rather than the feature.
+        _spec = new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip8250Enabled = true, IsEip8272Enabled = true };
+        _specProvider = new TestSpecProvider(_spec);
         _stateProvider = TestWorldStateFactory.CreateForTest();
         _worldStateCloser = _stateProvider.BeginScope(IWorldState.PreGenesis);
         EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
@@ -785,6 +790,10 @@ public class FrameTxProcessorTests
         Assert.That(referencing.TransactionExecuted, Is.EqualTo(expectedExecuted));
         if (!expectedExecuted)
         {
+            // Pinned to the reference check specifically: every other rejection in the outer loop also
+            // leaves TransactionExecuted false, so the weaker assertion would survive an unrelated break.
+            Assert.That(referencing.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+            Assert.That(referencing.ErrorDescription, Does.Contain("recent root reference"));
             return;
         }
 
@@ -794,6 +803,27 @@ public class FrameTxProcessorTests
         Assert.That(unreferencing.TransactionExecuted, Is.True);
         Assert.That(referencingTracer.GasSpent, Is.GreaterThan(plainTracer.GasSpent),
             "the reference's calldata and prepaid accesses must be charged");
+    }
+
+    // An empty reference list is a different envelope from an absent one and still occupies a byte on
+    // the wire, so it is priced: EIP-8272 short-circuits the per-reference term at zero references, not
+    // the calldata term over `rlp(recent_root_references)`.
+    [Test]
+    public void Execute_EmptyRecentRootReferenceList_IsPricedAsTheBytesItAdds()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+
+        Transaction empty = FrameTx(nonce: 0, SelfVerifyFrame());
+        empty.RecentRootReferences = [];
+        CallOutputTracer emptyTracer = new();
+        CallOutputTracer absentTracer = new();
+
+        Assert.That(Process(empty, tracer: emptyTracer).TransactionExecuted, Is.True);
+        Assert.That(Process(FrameTx(nonce: 1, SelfVerifyFrame()), tracer: absentTracer).TransactionExecuted, Is.True);
+
+        // rlp([]) is the single non-zero byte 0xc0, which is TxDataNonZeroMultiplier tokens.
+        Assert.That(emptyTracer.GasSpent - absentTracer.GasSpent,
+            Is.EqualTo((long)(Spec.GasCosts.TxDataNonZeroMultiplier * GasCostOf.TxDataZero)));
     }
 
     private static TxFrame SelfVerifyFrame() =>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -764,6 +764,104 @@ public class FrameTxProcessorTests
         // APPROVE stack order (top to bottom): offset, length, scope.
         Prepare.EvmCode.PushData(scope).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
 
+    // RECENTROOTREFLOAD reads the signed envelope, so each field must come back exactly as declared —
+    // application validation logic binds the proof's public inputs to this tuple.
+    [TestCase((byte)0, TestName = "Execute_RecentRootRefLoad_SourceId")]
+    [TestCase((byte)1, TestName = "Execute_RecentRootRefLoad_Slot")]
+    [TestCase((byte)2, TestName = "Execute_RecentRootRefLoad_Root")]
+    public void Execute_RecentRootRefLoad_ReadsTheDeclaredReferenceField(byte field)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        // Spec stack order: field on top, index second.
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData(0).PushData(field).Op(Instruction.RECENTROOTREFLOAD).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        RecentRootReference reference = CommitReference(ReferencedSlot);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        tx.RecentRootReferences = [reference];
+
+        TransactionResult r = Process(tx, slotNumber: HeadSlot);
+        Assert.That(r.TransactionExecuted, Is.True, r.ErrorDescription ?? r.Error.ToString());
+        AssertStorage(Observer, 0, field switch
+        {
+            0 => new UInt256(reference.SourceId.Bytes, isBigEndian: true),
+            1 => (UInt256)reference.Slot,
+            _ => new UInt256(reference.Root.Bytes, isBigEndian: true),
+        });
+    }
+
+    // Both out-of-range conditions the spec makes exceptional. A silent zero would let validation logic
+    // read an absent reference as a real one committing to the zero root.
+    [TestCase(1, 0, TestName = "Execute_RecentRootRefLoad_IndexPastTheDeclaredList_Halts")]
+    [TestCase(0, 3, TestName = "Execute_RecentRootRefLoad_UndefinedField_Halts")]
+    public void Execute_RecentRootRefLoad_OutOfRange_ExceptionallyHalts(int index, int field)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData((UInt256)index).PushData((UInt256)field).Op(Instruction.RECENTROOTREFLOAD).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        RecentRootReference reference = CommitReference(ReferencedSlot);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        tx.RecentRootReferences = [reference];
+
+        // The halting frame is a DEFAULT one, so the transaction still executes; its writes are discarded.
+        Assert.That(Process(tx, slotNumber: HeadSlot).TransactionExecuted, Is.True);
+        AssertStorage(Observer, 0, UInt256.Zero);
+    }
+
+    [TestCase(0, TestName = "Execute_TxParamReferenceCount_WithoutReferences")]
+    [TestCase(2, TestName = "Execute_TxParamReferenceCount_WithReferences")]
+    public void Execute_TxParam_ReportsTheReferenceCount(int referenceCount)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData(0x0F).Op(Instruction.TXPARAM).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        RecentRootReference[] references = new RecentRootReference[referenceCount];
+        for (int i = 0; i < referenceCount; i++) references[i] = CommitReference(ReferencedSlot - (ulong)i);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        tx.RecentRootReferences = references;
+
+        Assert.That(Process(tx, slotNumber: HeadSlot).TransactionExecuted, Is.True);
+        AssertStorage(Observer, 0, (UInt256)referenceCount);
+    }
+
+    // The fork gate on the new TXPARAM index. Asserted through a sentinel rather than the value itself:
+    // an ungated read of a transaction declaring nothing returns 0, which is also what a halted frame
+    // leaves behind, so storing the count would pass with the gate removed.
+    [TestCase(true, ExpectedResult = 0UL, TestName = "Execute_ReferenceCountTxParamBeforeTheFork_Halts")]
+    [TestCase(false, ExpectedResult = 1UL, TestName = "Execute_ReferenceCountTxParamAfterTheFork_Reads")]
+    public ulong Execute_ReferenceCountTxParam_IsGatedOnTheFork(bool beforeTheFork)
+    {
+        _spec.IsEip8272Enabled = !beforeTheFork;
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData(0x0F).Op(Instruction.TXPARAM).Op(Instruction.POP)
+            .PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+
+        Assert.That(Process(tx, slotNumber: HeadSlot).TransactionExecuted, Is.True);
+        return (ulong)_stateProvider.Get(new StorageCell(Observer, 0)).ToUnsignedBigInteger();
+    }
+
+    private const ulong HeadSlot = 1_001;
+    private const ulong ReferencedSlot = 1_000;
+
+    /// <summary>Commits a recent root for <paramref name="slot"/> so a reference to it validates.</summary>
+    private RecentRootReference CommitReference(ulong slot)
+    {
+        ValueHash256 sourceId = RecentRootStore.SourceId(Observer, TestItem.KeccakA.ValueHash256);
+        ValueHash256 root = TestItem.KeccakB.ValueHash256;
+        _stateProvider.Set(RecentRootStore.ReferenceCell(sourceId, slot),
+            RecentRootStore.EntryHash(sourceId, slot, root).Bytes.WithoutLeadingZeros().ToArray());
+        _stateProvider.Commit(Spec);
+        return new RecentRootReference(sourceId, slot, root);
+    }
+
     // EIP-8272: a declared reference is only satisfied by the commitment the predeploy actually holds
     // for that slot, so an uncommitted or out-of-window reference invalidates the transaction. The
     // committed case also proves the reference's intrinsic gas is charged, since the transaction pays
@@ -773,7 +871,6 @@ public class FrameTxProcessorTests
     [TestCase(9_193UL, false, TestName = "a reference older than the usable window has been overwritten")]
     public void Execute_RecentRootReference_IsCheckedAgainstTheCommittedEntry(ulong committedSlot, bool expectedExecuted)
     {
-        const ulong HeadSlot = 1_001;
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         ValueHash256 sourceId = RecentRootStore.SourceId(Observer, TestItem.KeccakA.ValueHash256);
         ValueHash256 root = TestItem.KeccakB.ValueHash256;

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -726,12 +726,13 @@ public class FrameTxProcessorTests
         }
     }
 
-    private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)
+    private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null, ulong? slotNumber = null)
     {
         Block block = Build.A.Block.WithNumber(1)
             .WithBaseFeePerGas(baseFeePerGas)
             .WithBeneficiary(Beneficiary)
             .WithTransactions(tx)
+            .WithSlotNumber(slotNumber)
             .WithGasLimit(30_000_000).TestObject;
         return _transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), tracer ?? NullTxTracer.Instance);
     }
@@ -757,6 +758,43 @@ public class FrameTxProcessorTests
     private static byte[] ApproveCode(byte scope) =>
         // APPROVE stack order (top to bottom): offset, length, scope.
         Prepare.EvmCode.PushData(scope).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
+
+    // EIP-8272: a declared reference is only satisfied by the commitment the predeploy actually holds
+    // for that slot, so an uncommitted or out-of-window reference invalidates the transaction. The
+    // committed case also proves the reference's intrinsic gas is charged, since the transaction pays
+    // more than the same transaction declaring nothing.
+    [TestCase(1_000UL, true, TestName = "a committed reference inside the window executes")]
+    [TestCase(1_001UL, false, TestName = "a reference to the current slot is not yet referenceable")]
+    [TestCase(9_193UL, false, TestName = "a reference older than the usable window has been overwritten")]
+    public void Execute_RecentRootReference_IsCheckedAgainstTheCommittedEntry(ulong committedSlot, bool expectedExecuted)
+    {
+        const ulong HeadSlot = 1_001;
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        ValueHash256 sourceId = RecentRootStore.SourceId(Observer, TestItem.KeccakA.ValueHash256);
+        ValueHash256 root = TestItem.KeccakB.ValueHash256;
+        _stateProvider.Set(RecentRootStore.ReferenceCell(sourceId, committedSlot),
+            RecentRootStore.EntryHash(sourceId, committedSlot, root).Bytes.WithoutLeadingZeros().ToArray());
+        _stateProvider.Commit(Spec);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.RecentRootReferences = [new RecentRootReference(sourceId, committedSlot, root)];
+
+        CallOutputTracer referencingTracer = new();
+        TransactionResult referencing = Process(tx, tracer: referencingTracer, slotNumber: HeadSlot);
+
+        Assert.That(referencing.TransactionExecuted, Is.EqualTo(expectedExecuted));
+        if (!expectedExecuted)
+        {
+            return;
+        }
+
+        CallOutputTracer plainTracer = new();
+        TransactionResult unreferencing = Process(FrameTx(nonce: 1, SelfVerifyFrame()), tracer: plainTracer, slotNumber: HeadSlot);
+
+        Assert.That(unreferencing.TransactionExecuted, Is.True);
+        Assert.That(referencingTracer.GasSpent, Is.GreaterThan(plainTracer.GasSpent),
+            "the reference's calldata and prepaid accesses must be charged");
+    }
 
     private static TxFrame SelfVerifyFrame() =>
         new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default);

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -764,8 +764,7 @@ public class FrameTxProcessorTests
         // APPROVE stack order (top to bottom): offset, length, scope.
         Prepare.EvmCode.PushData(scope).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
 
-    // RECENTROOTREFLOAD reads the signed envelope, so each field must come back exactly as declared —
-    // application validation logic binds the proof's public inputs to this tuple.
+    // Application validation logic binds a proof's public inputs to this tuple.
     [TestCase((byte)0, TestName = "Execute_RecentRootRefLoad_SourceId")]
     [TestCase((byte)1, TestName = "Execute_RecentRootRefLoad_Slot")]
     [TestCase((byte)2, TestName = "Execute_RecentRootRefLoad_Root")]
@@ -791,22 +790,20 @@ public class FrameTxProcessorTests
         });
     }
 
-    // Both out-of-range conditions the spec makes exceptional. A silent zero would let validation logic
-    // read an absent reference as a real one committing to the zero root.
+    // Asserted through a sentinel stored after the opcode: a silent zero push would also leave slot 0
+    // at zero, and it would read as a real reference committing to the zero root.
     [TestCase(1, 0, TestName = "Execute_RecentRootRefLoad_IndexPastTheDeclaredList_Halts")]
     [TestCase(0, 3, TestName = "Execute_RecentRootRefLoad_UndefinedField_Halts")]
     public void Execute_RecentRootRefLoad_OutOfRange_ExceptionallyHalts(int index, int field)
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Observer, Prepare.EvmCode
-            .PushData((UInt256)index).PushData((UInt256)field).Op(Instruction.RECENTROOTREFLOAD).PushData(0).Op(Instruction.SSTORE)
-            .Op(Instruction.STOP).Done);
-        RecentRootReference reference = CommitReference(ReferencedSlot);
+            .PushData((UInt256)index).PushData((UInt256)field).Op(Instruction.RECENTROOTREFLOAD).Op(Instruction.POP)
+            .PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
 
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
-        tx.RecentRootReferences = [reference];
+        tx.RecentRootReferences = [CommitReference(ReferencedSlot)];
 
-        // The halting frame is a DEFAULT one, so the transaction still executes; its writes are discarded.
         Assert.That(Process(tx, slotNumber: HeadSlot).TransactionExecuted, Is.True);
         AssertStorage(Observer, 0, UInt256.Zero);
     }
@@ -829,9 +826,7 @@ public class FrameTxProcessorTests
         AssertStorage(Observer, 0, (UInt256)referenceCount);
     }
 
-    // The fork gate on the new TXPARAM index. Asserted through a sentinel rather than the value itself:
-    // an ungated read of a transaction declaring nothing returns 0, which is also what a halted frame
-    // leaves behind, so storing the count would pass with the gate removed.
+    // Asserted through a sentinel: an ungated read returns 0, which is also what a halted frame leaves.
     [TestCase(true, ExpectedResult = 0UL, TestName = "Execute_ReferenceCountTxParamBeforeTheFork_Halts")]
     [TestCase(false, ExpectedResult = 1UL, TestName = "Execute_ReferenceCountTxParamAfterTheFork_Reads")]
     public ulong Execute_ReferenceCountTxParam_IsGatedOnTheFork(bool beforeTheFork)
@@ -862,24 +857,17 @@ public class FrameTxProcessorTests
         return new RecentRootReference(sourceId, slot, root);
     }
 
-    // EIP-8272: a declared reference is only satisfied by the commitment the predeploy actually holds
-    // for that slot, so an uncommitted or out-of-window reference invalidates the transaction. The
-    // committed case also proves the reference's intrinsic gas is charged, since the transaction pays
-    // more than the same transaction declaring nothing.
+    // A declared reference is only satisfied by the commitment the predeploy holds for that slot. The
+    // committed case also proves the reference's intrinsic gas is charged.
     [TestCase(1_000UL, true, TestName = "a committed reference inside the window executes")]
     [TestCase(1_001UL, false, TestName = "a reference to the current slot is not yet referenceable")]
     [TestCase(9_193UL, false, TestName = "a reference older than the usable window has been overwritten")]
     public void Execute_RecentRootReference_IsCheckedAgainstTheCommittedEntry(ulong committedSlot, bool expectedExecuted)
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
-        ValueHash256 sourceId = RecentRootStore.SourceId(Observer, TestItem.KeccakA.ValueHash256);
-        ValueHash256 root = TestItem.KeccakB.ValueHash256;
-        _stateProvider.Set(RecentRootStore.ReferenceCell(sourceId, committedSlot),
-            RecentRootStore.EntryHash(sourceId, committedSlot, root).Bytes.WithoutLeadingZeros().ToArray());
-        _stateProvider.Commit(Spec);
 
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
-        tx.RecentRootReferences = [new RecentRootReference(sourceId, committedSlot, root)];
+        tx.RecentRootReferences = [CommitReference(committedSlot)];
 
         CallOutputTracer referencingTracer = new();
         TransactionResult referencing = Process(tx, tracer: referencingTracer, slotNumber: HeadSlot);
@@ -887,8 +875,7 @@ public class FrameTxProcessorTests
         Assert.That(referencing.TransactionExecuted, Is.EqualTo(expectedExecuted));
         if (!expectedExecuted)
         {
-            // Pinned to the reference check specifically: every other rejection in the outer loop also
-            // leaves TransactionExecuted false, so the weaker assertion would survive an unrelated break.
+            // Every other rejection in the outer loop also leaves TransactionExecuted false.
             Assert.That(referencing.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
             Assert.That(referencing.ErrorDescription, Does.Contain("recent root reference"));
             return;

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -768,10 +768,11 @@ public class FrameTxProcessorTests
     // for that slot, so an uncommitted or out-of-window reference invalidates the transaction. The
     // committed case also proves the reference's intrinsic gas is charged, since the transaction pays
     // more than the same transaction declaring nothing.
-    [TestCase(1_000UL, true, TestName = "a committed reference inside the window executes")]
-    [TestCase(1_001UL, false, TestName = "a reference to the current slot is not yet referenceable")]
-    [TestCase(9_193UL, false, TestName = "a reference older than the usable window has been overwritten")]
-    public void Execute_RecentRootReference_IsCheckedAgainstTheCommittedEntry(ulong committedSlot, bool expectedExecuted)
+    [TestCase(1_000UL, false, true, TestName = "a committed reference inside the window executes")]
+    [TestCase(1_001UL, false, false, TestName = "a reference to the current slot is not yet referenceable")]
+    [TestCase(9_193UL, false, false, TestName = "a reference older than the usable window has been overwritten")]
+    [TestCase(1_000UL, true, false, TestName = "a reference to a different root at a committed slot fails")]
+    public void Execute_RecentRootReference_IsCheckedAgainstTheCommittedEntry(ulong committedSlot, bool declareOtherRoot, bool expectedExecuted)
     {
         const ulong HeadSlot = 1_001;
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
@@ -782,7 +783,8 @@ public class FrameTxProcessorTests
         _stateProvider.Commit(Spec);
 
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
-        tx.RecentRootReferences = [new RecentRootReference(sourceId, committedSlot, root)];
+        tx.RecentRootReferences = [new RecentRootReference(sourceId, committedSlot,
+            declareOtherRoot ? TestItem.KeccakC.ValueHash256 : root)];
 
         CallOutputTracer referencingTracer = new();
         TransactionResult referencing = Process(tx, tracer: referencingTracer, slotNumber: HeadSlot);

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -142,6 +142,65 @@ public class RecentRootStoreTests
         }
     }
 
+    [Test]
+    public void AreReferencesValid_true_for_empty_set()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            (ValueHash256, ulong, ValueHash256)[] references = [];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+        }
+    }
+
+    [Test]
+    public void AreReferencesValid_true_when_every_reference_is_valid()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            RecentRootStore.Write(state, Source, Salt, OtherRoot, 150, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+
+            (ValueHash256, ulong, ValueHash256)[] references =
+            [
+                (sourceId, 100UL, Root),
+                (sourceId, 150UL, OtherRoot)
+            ];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+        }
+    }
+
+    [Test]
+    public void AreReferencesValid_false_when_a_reference_is_invalid()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+
+            (ValueHash256, ulong, ValueHash256)[] references =
+            [
+                (sourceId, 100UL, Root),
+                (sourceId, 100UL, OtherRoot)
+            ];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
+        }
+    }
+
+    [Test]
+    public void AreReferencesValid_false_over_the_reference_cap()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + 1];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
+        }
+    }
+
     private static IWorldState CreateState(out IDisposable scope)
     {
         IWorldState state = TestWorldStateFactory.CreateForTest();

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -201,6 +201,24 @@ public class RecentRootStoreTests
         }
     }
 
+    [Test]
+    public void AreReferencesValid_true_at_the_reference_cap()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences];
+            for (int i = 0; i < references.Length; i++)
+            {
+                ulong slot = (ulong)(100 + i);
+                RecentRootStore.Write(state, Source, Salt, Root, slot, Spec);
+                references[i] = (sourceId, slot, Root);
+            }
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 500), Is.True);
+        }
+    }
+
     private static IWorldState CreateState(out IDisposable scope)
     {
         IWorldState state = TestWorldStateFactory.CreateForTest();

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -33,6 +33,19 @@ public class RecentRootStoreTests
         Assert.That(RecentRootStore.SourceId(Source, OtherRoot), Is.Not.EqualTo(baseline));
     }
 
+    // Every concatenation in EIP-8272 is fixed-width, and an address is 20 bytes there, so the
+    // preimage is 52 bytes. Left-padding the address to a word changes every source id, which is
+    // consensus-visible on the first reference-carrying transaction.
+    [Test]
+    public void SourceId_hashes_the_address_unpadded()
+    {
+        Span<byte> preimage = stackalloc byte[Address.Size + ValueHash256.MemorySize];
+        Source.Bytes.CopyTo(preimage);
+        Salt.Bytes.CopyTo(preimage[Address.Size..]);
+
+        Assert.That(RecentRootStore.SourceId(Source, Salt), Is.EqualTo(ValueKeccak.Compute(preimage)));
+    }
+
     [Test]
     public void EntryHash_is_deterministic_and_distinct_per_input()
     {

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -191,6 +191,24 @@ public class RecentRootStoreTests
     }
 
     [Test]
+    public void AreReferencesValid_true_for_duplicate_valid_references()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+
+            (ValueHash256, ulong, ValueHash256)[] references =
+            [
+                (sourceId, 100UL, Root),
+                (sourceId, 100UL, Root)
+            ];
+            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+        }
+    }
+
+    [Test]
     public void AreReferencesValid_false_over_the_reference_cap()
     {
         IWorldState state = CreateState(out IDisposable scope);

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -208,32 +208,23 @@ public class RecentRootStoreTests
         }
     }
 
-    [Test]
-    public void AreReferencesValid_false_over_the_reference_cap()
-    {
-        IWorldState state = CreateState(out IDisposable scope);
-        using (scope)
-        {
-            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + 1];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
-        }
-    }
-
-    [Test]
-    public void AreReferencesValid_true_at_the_reference_cap()
+    [TestCase(0, ExpectedResult = true)]
+    [TestCase(1, ExpectedResult = false)]
+    public bool AreReferencesValid_enforces_the_reference_cap(int overCap)
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
-            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences];
+            // every reference is individually valid, so only the count decides the result
+            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + overCap];
             for (int i = 0; i < references.Length; i++)
             {
                 ulong slot = (ulong)(100 + i);
                 RecentRootStore.Write(state, Source, Salt, Root, slot, Spec);
                 references[i] = (sourceId, slot, Root);
             }
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 500), Is.True);
+            return RecentRootStore.AreReferencesValid(state, references, currentSlot: 500);
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -155,19 +155,25 @@ public class RecentRootStoreTests
         }
     }
 
+    // The consensus check the processor runs: a set is admissible only when every reference matches
+    // the commitment the predeploy holds, and only up to the reference cap.
     [Test]
-    public void AreReferencesValid_true_for_empty_set()
+    public void Validate_true_for_an_absent_and_an_empty_set()
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            (ValueHash256, ulong, ValueHash256)[] references = [];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+            using StackAccessTracker accessTracker = new(false);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(RecentRootReferences.Validate(state, null, currentSlot: 200, in accessTracker), Is.True);
+                Assert.That(RecentRootReferences.Validate(state, [], currentSlot: 200, in accessTracker), Is.True);
+            }
         }
     }
 
     [Test]
-    public void AreReferencesValid_true_when_every_reference_is_valid()
+    public void Validate_true_when_every_reference_is_committed()
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
@@ -176,17 +182,12 @@ public class RecentRootStoreTests
             RecentRootStore.Write(state, Source, Salt, OtherRoot, 150, Spec);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
-            (ValueHash256, ulong, ValueHash256)[] references =
-            [
-                (sourceId, 100UL, Root),
-                (sourceId, 150UL, OtherRoot)
-            ];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+            Assert.That(Validate(state, [new(sourceId, 100, Root), new(sourceId, 150, OtherRoot)]), Is.True);
         }
     }
 
     [Test]
-    public void AreReferencesValid_false_when_a_reference_is_invalid()
+    public void Validate_false_when_a_reference_names_a_root_the_slot_does_not_hold()
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
@@ -194,17 +195,12 @@ public class RecentRootStoreTests
             RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
-            (ValueHash256, ulong, ValueHash256)[] references =
-            [
-                (sourceId, 100UL, Root),
-                (sourceId, 100UL, OtherRoot)
-            ];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
+            Assert.That(Validate(state, [new(sourceId, 100, Root), new(sourceId, 100, OtherRoot)]), Is.False);
         }
     }
 
     [Test]
-    public void AreReferencesValid_true_for_duplicate_valid_references()
+    public void Validate_true_for_a_repeated_committed_reference()
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
@@ -212,33 +208,50 @@ public class RecentRootStoreTests
             RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
-            (ValueHash256, ulong, ValueHash256)[] references =
-            [
-                (sourceId, 100UL, Root),
-                (sourceId, 100UL, Root)
-            ];
-            Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
+            Assert.That(Validate(state, [new(sourceId, 100, Root), new(sourceId, 100, Root)]), Is.True);
+        }
+    }
+
+    // A header without a slot number cannot place a reference in the window, so it admits none.
+    [Test]
+    public void Validate_false_without_a_slot_number()
+    {
+        IWorldState state = CreateState(out IDisposable scope);
+        using (scope)
+        {
+            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            using StackAccessTracker accessTracker = new(false);
+
+            Assert.That(RecentRootReferences.Validate(state, [new(sourceId, 100, Root)], currentSlot: null, in accessTracker), Is.False);
         }
     }
 
     [TestCase(0, ExpectedResult = true)]
     [TestCase(1, ExpectedResult = false)]
-    public bool AreReferencesValid_enforces_the_reference_cap(int overCap)
+    public bool Validate_enforces_the_reference_cap(int overCap)
     {
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
             // every reference is individually valid, so only the count decides the result
-            (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + overCap];
+            RecentRootReference[] references = new RecentRootReference[Eip8272Constants.MaxRecentRootReferences + overCap];
             for (int i = 0; i < references.Length; i++)
             {
                 ulong slot = (ulong)(100 + i);
                 RecentRootStore.Write(state, Source, Salt, Root, slot, Spec);
-                references[i] = (sourceId, slot, Root);
+                references[i] = new RecentRootReference(sourceId, slot, Root);
             }
-            return RecentRootStore.AreReferencesValid(state, references, currentSlot: 500);
+
+            return Validate(state, references, currentSlot: 500);
         }
+    }
+
+    private static bool Validate(IWorldState state, RecentRootReference[] references, ulong currentSlot = 200)
+    {
+        using StackAccessTracker accessTracker = new(false);
+        return RecentRootReferences.Validate(state, references, currentSlot, in accessTracker);
     }
 
     private static IWorldState CreateState(out IDisposable scope)

--- a/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
+++ b/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
@@ -25,7 +25,7 @@ public sealed class FrameTxContext(
     in UInt256 maxPriorityFeePerGas,
     in UInt256 maxFeePerGas,
     in UInt256 maxFeePerBlobGas,
-    RecentRootReference[]? recentRootReferences = null)
+    RecentRootReference[]? recentRootReferences)
 {
     public Address Sender { get; } = sender;
     public ulong Nonce { get; } = nonce;
@@ -38,10 +38,7 @@ public sealed class FrameTxContext(
     public UInt256 MaxFeePerBlobGas { get; } = maxFeePerBlobGas;
 
     /// <summary>The EIP-8272 recent-root references of the signed envelope, empty when it carries none.</summary>
-    /// <remarks>
-    /// <c>RECENTROOTREFLOAD</c> reads the envelope, never the predeploy's storage, so the absent and the
-    /// empty list are indistinguishable to executing code even though they are different envelopes.
-    /// </remarks>
+    /// <remarks>The absent and the empty list are different envelopes but indistinguishable to executing code.</remarks>
     public RecentRootReference[] RecentRootReferences { get; } = recentRootReferences ?? [];
 
     /// <summary>Index of the frame currently executing; set by the outer loop before each frame.</summary>

--- a/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
+++ b/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
@@ -24,7 +24,8 @@ public sealed class FrameTxContext(
     in UInt256 maxCost,
     in UInt256 maxPriorityFeePerGas,
     in UInt256 maxFeePerGas,
-    in UInt256 maxFeePerBlobGas)
+    in UInt256 maxFeePerBlobGas,
+    RecentRootReference[]? recentRootReferences = null)
 {
     public Address Sender { get; } = sender;
     public ulong Nonce { get; } = nonce;
@@ -35,6 +36,13 @@ public sealed class FrameTxContext(
     public UInt256 MaxPriorityFeePerGas { get; } = maxPriorityFeePerGas;
     public UInt256 MaxFeePerGas { get; } = maxFeePerGas;
     public UInt256 MaxFeePerBlobGas { get; } = maxFeePerBlobGas;
+
+    /// <summary>The EIP-8272 recent-root references of the signed envelope, empty when it carries none.</summary>
+    /// <remarks>
+    /// <c>RECENTROOTREFLOAD</c> reads the envelope, never the predeploy's storage, so the absent and the
+    /// empty list are indistinguishable to executing code even though they are different envelopes.
+    /// </remarks>
+    public RecentRootReference[] RecentRootReferences { get; } = recentRootReferences ?? [];
 
     /// <summary>Index of the frame currently executing; set by the outer loop before each frame.</summary>
     public int CurrentFrameIndex { get; set; }

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -167,6 +167,9 @@ public enum Instruction : byte
     FRAMEPARAM = 0xb3,
     SIGPARAM = 0xb4,
 
+    // EIP-8272 recent roots
+    RECENTROOTREFLOAD = 0xb5,
+
     DUPN = 0xe6,
     SWAPN = 0xe7,
     EXCHANGE = 0xe8,

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -11,9 +11,9 @@ using Nethermind.Int256;
 namespace Nethermind.Evm;
 
 /// <summary>
-/// EIP-8141 frame transaction introspection and approval opcodes. All six are registered only when
-/// <c>IsEip8141Enabled</c>; each exceptional-halts when executed outside a frame transaction (i.e.
-/// when the transaction-scoped <see cref="FrameTxContext"/> is absent).
+/// EIP-8141 frame transaction introspection and approval opcodes, plus the EIP-8272 reference reader,
+/// which is additionally gated on <c>IsEip8272Enabled</c>. Each exceptional-halts when executed outside
+/// a frame transaction (i.e. when the transaction-scoped <see cref="FrameTxContext"/> is absent).
 /// https://eips.ethereum.org/EIPS/eip-8141
 /// </summary>
 public static unsafe partial class EvmInstructions
@@ -114,9 +114,8 @@ public static unsafe partial class EvmInstructions
 
     /// <summary>RECENTROOTREFLOAD (0xb5): read one field of a declared recent-root reference.</summary>
     /// <remarks>
-    /// Reads the signed envelope, not the predeploy's storage — the references were checked against the
-    /// pre-state before any frame ran, so no state access is needed here and the opcode is legal in every
-    /// frame mode, <c>VERIFY</c> included.
+    /// Reads the signed envelope, not the predeploy's storage: the references were checked against the
+    /// pre-state before any frame ran, so the opcode is legal in every frame mode, <c>VERIFY</c> included.
     /// </remarks>
     [SkipLocalsInit]
     public static EvmExceptionType InstructionRecentRootRefLoad<TGasPolicy, TTracingInst>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
@@ -127,6 +126,7 @@ public static unsafe partial class EvmInstructions
         if (ctx is null) return EvmExceptionType.BadInstruction;
 
         TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        // Spec stack order: field on top, index second — the reverse of FRAMEPARAM and SIGPARAM.
         if (!stack.PopUInt256(out UInt256 field, out UInt256 index)) return EvmExceptionType.StackUnderflow;
         if (index >= (UInt256)ctx.RecentRootReferences.Length || field > 2) return EvmExceptionType.BadInstruction;
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -78,17 +78,19 @@ public static unsafe partial class EvmInstructions
     }
 
     /// <summary>TXPARAM (0xb0): read a transaction-scoped field.</summary>
+    /// <typeparam name="TEip8272">Whether the fork defines the recent-root reference count at index 0x0F.</typeparam>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionTxParam<TGasPolicy, TTracingInst>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+    public static EvmExceptionType InstructionTxParam<TGasPolicy, TTracingInst, TEip8272>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
+        where TEip8272 : struct, IFlag
     {
         FrameTxContext? ctx = vm.TxExecutionContext.FrameTxContext;
         if (ctx is null) return EvmExceptionType.BadInstruction;
 
         TGasPolicy.Consume<BaseGasCost>(ref gas);
         if (!stack.PopUInt256(out UInt256 param)) return EvmExceptionType.StackUnderflow;
-        if (param > 0x0B) return EvmExceptionType.BadInstruction;
+        if (param > (TEip8272.IsActive ? 0x0FU : 0x0BU)) return EvmExceptionType.BadInstruction;
 
         byte[][]? blobHashes = vm.TxExecutionContext.BlobVersionedHashes;
         return param.u0 switch
@@ -105,7 +107,35 @@ public static unsafe partial class EvmInstructions
             0x09 => stack.PushUInt256<TTracingInst>((UInt256)ctx.Frames.Length),
             0x0A => stack.PushUInt256<TTracingInst>((UInt256)ctx.CurrentFrameIndex),
             0x0B => stack.PushUInt256<TTracingInst>((UInt256)ctx.Signatures.Length),
+            0x0F => stack.PushUInt256<TTracingInst>((UInt256)ctx.RecentRootReferences.Length),
             _ => EvmExceptionType.BadInstruction,
+        };
+    }
+
+    /// <summary>RECENTROOTREFLOAD (0xb5): read one field of a declared recent-root reference.</summary>
+    /// <remarks>
+    /// Reads the signed envelope, not the predeploy's storage — the references were checked against the
+    /// pre-state before any frame ran, so no state access is needed here and the opcode is legal in every
+    /// frame mode, <c>VERIFY</c> included.
+    /// </remarks>
+    [SkipLocalsInit]
+    public static EvmExceptionType InstructionRecentRootRefLoad<TGasPolicy, TTracingInst>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        where TTracingInst : struct, IFlag
+    {
+        FrameTxContext? ctx = vm.TxExecutionContext.FrameTxContext;
+        if (ctx is null) return EvmExceptionType.BadInstruction;
+
+        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!stack.PopUInt256(out UInt256 field, out UInt256 index)) return EvmExceptionType.StackUnderflow;
+        if (index >= (UInt256)ctx.RecentRootReferences.Length || field > 2) return EvmExceptionType.BadInstruction;
+
+        RecentRootReference reference = ctx.RecentRootReferences[(int)index.u0];
+        return field.u0 switch
+        {
+            0 => stack.PushBytes<TTracingInst>(reference.SourceId.BytesAsSpan),
+            1 => stack.PushUInt256<TTracingInst>((UInt256)reference.Slot),
+            _ => stack.PushBytes<TTracingInst>(reference.Root.BytesAsSpan),
         };
     }
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -131,7 +131,9 @@ public static unsafe partial class EvmInstructions
         if (spec.IsEip8141Enabled)
         {
             lookup[(int)Instruction.APPROVE] = &InstructionApprove;
-            lookup[(int)Instruction.TXPARAM] = &InstructionTxParam<TGasPolicy, TTracingInst>;
+            lookup[(int)Instruction.TXPARAM] = spec.IsEip8272Enabled
+                ? &InstructionTxParam<TGasPolicy, TTracingInst, OnFlag>
+                : &InstructionTxParam<TGasPolicy, TTracingInst, OffFlag>;
             lookup[(int)Instruction.FRAMEDATALOAD] = &InstructionFrameDataLoad<TGasPolicy, TTracingInst>;
             lookup[(int)Instruction.FRAMEDATACOPY] = &InstructionFrameDataCopy<TGasPolicy, TTracingInst>;
             lookup[(int)Instruction.FRAMEPARAM] = &InstructionFrameParam<TGasPolicy, TTracingInst>;
@@ -144,6 +146,10 @@ public static unsafe partial class EvmInstructions
         if (spec.IsEip7843Enabled)
         {
             lookup[(int)Instruction.SLOTNUM] = &InstructionSlotNum<TGasPolicy, TTracingInst>;
+        }
+        if (spec.IsEip8272Enabled)
+        {
+            lookup[(int)Instruction.RECENTROOTREFLOAD] = &InstructionRecentRootRefLoad<TGasPolicy, TTracingInst>;
         }
 
         // Gap: opcodes 0x4c to 0x4f are unassigned.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -147,7 +147,7 @@ public static unsafe partial class EvmInstructions
         {
             lookup[(int)Instruction.SLOTNUM] = &InstructionSlotNum<TGasPolicy, TTracingInst>;
         }
-        if (spec.IsEip8272Enabled)
+        if (spec.IsEip8141Enabled && spec.IsEip8272Enabled)
         {
             lookup[(int)Instruction.RECENTROOTREFLOAD] = &InstructionRecentRootRefLoad<TGasPolicy, TTracingInst>;
         }

--- a/src/Nethermind/Nethermind.Evm/RecentRootReferences.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootReferences.cs
@@ -14,11 +14,16 @@ namespace Nethermind.Evm;
 /// </summary>
 public static class RecentRootReferences
 {
-    /// <summary>The <c>recent_root_calldata</c> the references add to the payload, priced as frame data is.</summary>
-    /// <remarks>Empty for a transaction that declares no reference, so its gas is exactly the EIP-8141 figure.</remarks>
+    /// <summary>
+    /// The <c>recent_root_calldata</c> the references add to the payload, priced as frame data is.
+    /// </summary>
+    /// <remarks>
+    /// Only an absent list is free: a present-but-empty list still encodes as <c>0xc0</c>, and EIP-8272
+    /// short-circuits the per-reference intrinsic term at zero references but not the calldata term.
+    /// </remarks>
     public static byte[] Calldata(RecentRootReference[]? references)
     {
-        if (references is null || references.Length == 0)
+        if (references is null)
         {
             return [];
         }
@@ -79,8 +84,9 @@ public static class RecentRootReferences
         accessTracker.WarmUp(Eip8272Constants.RecentRootAddress);
         foreach (RecentRootReference reference in references)
         {
-            accessTracker.WarmUp(RecentRootStore.ReferenceCell(reference.SourceId, reference.Slot));
-            if (!RecentRootStore.IsReferenceValid(state, reference.SourceId, reference.Slot, reference.Root, slot))
+            StorageCell cell = RecentRootStore.ReferenceCell(reference.SourceId, reference.Slot);
+            accessTracker.WarmUp(cell);
+            if (!RecentRootStore.IsReferenceValid(state, in cell, reference.SourceId, reference.Slot, reference.Root, slot))
             {
                 return false;
             }

--- a/src/Nethermind/Nethermind.Evm/RecentRootReferences.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootReferences.cs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.Evm;
+
+/// <summary>
+/// Gas and pre-state validity of the <see href="https://eips.ethereum.org/EIPS/eip-8272">EIP-8272</see>
+/// recent-root references declared by a frame transaction.
+/// </summary>
+public static class RecentRootReferences
+{
+    /// <summary>The <c>recent_root_calldata</c> the references add to the payload, priced as frame data is.</summary>
+    /// <remarks>Empty for a transaction that declares no reference, so its gas is exactly the EIP-8141 figure.</remarks>
+    public static byte[] Calldata(RecentRootReference[]? references)
+    {
+        if (references is null || references.Length == 0)
+        {
+            return [];
+        }
+
+        byte[] bytes = new byte[RecentRootReferenceDecoder.Instance.GetArrayLength(references)];
+        RlpWriter writer = new(bytes);
+        RecentRootReferenceDecoder.Instance.EncodeArray(ref writer, references);
+        return bytes;
+    }
+
+    /// <summary>
+    /// The <c>recent_root_reference_intrinsic_gas</c> that prepays warming the predeploy and each derived
+    /// storage key, plus the two Keccak computations deriving the key and the committed entry hash.
+    /// </summary>
+    /// <remarks>
+    /// A mandatory cost charged outside the EIP-7623 floored term. The access-list rates are resolved from
+    /// the spec, so a reference cannot be priced against a fork the transaction does not execute under.
+    /// </remarks>
+    public static ulong IntrinsicGas(RecentRootReference[]? references, IReleaseSpec spec)
+    {
+        if (references is null || references.Length == 0)
+        {
+            return 0;
+        }
+
+        ulong addressCost = spec.IsEip8038Enabled ? Eip8038Constants.AccessListAddressCost : GasCostOf.AccessAccountListEntry;
+        ulong storageKeyCost = spec.IsEip8038Enabled ? Eip8038Constants.AccessListStorageKeyCost : GasCostOf.AccessStorageListEntry;
+        ulong perReference = storageKeyCost + 2 * GasCostOf.Sha3 + 7 * GasCostOf.Sha3Word;
+        return addressCost + (ulong)references.Length * perReference;
+    }
+
+    /// <summary>
+    /// Checks every declared reference against the pre-state commitment in <c>RECENT_ROOT_ADDRESS</c> and
+    /// warms the predeploy and the keys read, which the intrinsic gas has already paid for.
+    /// </summary>
+    /// <remarks>
+    /// A reference at or ahead of <paramref name="currentSlot"/> is not yet referenceable and one older than
+    /// the usable window has been overwritten by ring-buffer aliasing; both fail, as does a commitment that
+    /// does not match. The reads are real predeploy reads rather than declared access-list entries, so they
+    /// belong in the block access list once the whole pass succeeds — a failed reference invalidates the
+    /// transaction and the block carrying it.
+    /// </remarks>
+    /// <returns><see langword="true"/> when every reference is committed and in range.</returns>
+    public static bool Validate(IWorldState state, RecentRootReference[]? references, ulong? currentSlot, in StackAccessTracker accessTracker)
+    {
+        if (references is null || references.Length == 0)
+        {
+            return true;
+        }
+
+        // References are anchored to slots, so a header that carries no slot number cannot place them
+        // in the window at all.
+        if (currentSlot is not { } slot || references.Length > Eip8272Constants.MaxRecentRootReferences)
+        {
+            return false;
+        }
+
+        accessTracker.WarmUp(Eip8272Constants.RecentRootAddress);
+        foreach (RecentRootReference reference in references)
+        {
+            accessTracker.WarmUp(RecentRootStore.ReferenceCell(reference.SourceId, reference.Slot));
+            if (!RecentRootStore.IsReferenceValid(state, reference.SourceId, reference.Slot, reference.Root, slot))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -75,6 +75,24 @@ public static class RecentRootStore
         state.Set(cell, entryHash.Bytes.WithoutLeadingZeros().ToArray());
     }
 
+    public static bool AreReferencesValid(IWorldState state, ReadOnlySpan<(ValueHash256 SourceId, ulong Slot, ValueHash256 Root)> references, ulong currentSlot)
+    {
+        if (references.Length > Eip8272Constants.MaxRecentRootReferences)
+        {
+            return false;
+        }
+
+        foreach ((ValueHash256 sourceId, ulong slot, ValueHash256 root) in references)
+        {
+            if (!IsReferenceValid(state, sourceId, slot, root, currentSlot))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private static StorageCell RingBufferCell(in ValueHash256 sourceId, ulong ringIndex) =>
         new(Eip8272Constants.RecentRootAddress, StorageKey(sourceId, ringIndex).ToUInt256());
 }

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -45,7 +45,14 @@ public static class RecentRootStore
         return ValueKeccak.Compute(input);
     }
 
-    public static bool IsReferenceValid(IWorldState state, in ValueHash256 sourceId, ulong slot, in ValueHash256 root, ulong currentSlot)
+    public static bool IsReferenceValid(IWorldState state, in ValueHash256 sourceId, ulong slot, in ValueHash256 root, ulong currentSlot) =>
+        IsReferenceValid(state, ReferenceCell(sourceId, slot), sourceId, slot, root, currentSlot);
+
+    /// <summary>
+    /// Checks a reference against the commitment held in <paramref name="cell"/>, which the caller has
+    /// already derived — the ring-buffer key costs a Keccak the gas schedule pays for once per reference.
+    /// </summary>
+    public static bool IsReferenceValid(IWorldState state, in StorageCell cell, in ValueHash256 sourceId, ulong slot, in ValueHash256 root, ulong currentSlot)
     {
         ulong age = currentSlot - slot; // unsigned: a future or same slot underflows and is rejected below
         if (age is 0 || age > Eip8272Constants.RecentRootUsableWindow)
@@ -53,7 +60,6 @@ public static class RecentRootStore
             return false;
         }
 
-        StorageCell cell = RingBufferCell(sourceId, slot % Eip8272Constants.RecentRootLength);
         ReadOnlySpan<byte> stored = state.Get(cell);
         if (stored.Length > HashLength)
         {
@@ -72,24 +78,6 @@ public static class RecentRootStore
         StorageCell cell = RingBufferCell(sourceId, currentSlot % Eip8272Constants.RecentRootLength);
         ValueHash256 entryHash = EntryHash(sourceId, currentSlot, root);
         state.Set(cell, entryHash.Bytes.WithoutLeadingZeros().ToArray());
-    }
-
-    public static bool AreReferencesValid(IWorldState state, ReadOnlySpan<(ValueHash256 SourceId, ulong Slot, ValueHash256 Root)> references, ulong currentSlot)
-    {
-        if (references.Length > Eip8272Constants.MaxRecentRootReferences)
-        {
-            return false;
-        }
-
-        foreach ((ValueHash256 sourceId, ulong slot, ValueHash256 root) in references)
-        {
-            if (!IsReferenceValid(state, sourceId, slot, root, currentSlot))
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /// <summary>The predeploy storage cell a reference to <paramref name="slot"/> reads.</summary>

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -92,6 +92,10 @@ public static class RecentRootStore
         return true;
     }
 
+    /// <summary>The predeploy storage cell a reference to <paramref name="slot"/> reads.</summary>
+    public static StorageCell ReferenceCell(in ValueHash256 sourceId, ulong slot) =>
+        RingBufferCell(sourceId, slot % Eip8272Constants.RecentRootLength);
+
     private static StorageCell RingBufferCell(in ValueHash256 sourceId, ulong ringIndex) =>
         new(Eip8272Constants.RecentRootAddress, StorageKey(sourceId, ringIndex).ToUInt256());
 }

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -18,12 +18,11 @@ public static class RecentRootStore
     private const int AddressLength = Address.Size;
     private const int SlotLength = sizeof(ulong);
 
-    // Consensus-critical, spec-ambiguous: 32-byte-padded address matches the only existing implementation (spec text says 20 bytes).
     public static ValueHash256 SourceId(Address sourceAddress, in ValueHash256 salt)
     {
-        Span<byte> input = stackalloc byte[HashLength + HashLength];
-        sourceAddress.Bytes.CopyTo(input.Slice(HashLength - AddressLength, AddressLength));
-        salt.Bytes.CopyTo(input.Slice(HashLength));
+        Span<byte> input = stackalloc byte[AddressLength + HashLength];
+        sourceAddress.Bytes.CopyTo(input);
+        salt.Bytes.CopyTo(input.Slice(AddressLength));
         return ValueKeccak.Compute(input);
     }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -106,7 +106,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             in maxCost,
             in tx.MaxPriorityFeePerGas,
             tx.DecodedMaxFeePerGas,
-            tx.MaxFeePerBlobGas.GetValueOrDefault());
+            tx.MaxFeePerBlobGas.GetValueOrDefault(),
+            tx.RecentRootReferences);
 
         TxFrameReceipt[] frameReceipts = new TxFrameReceipt[frames.Length];
         ulong totalFrameGasUsed = 0;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -128,6 +128,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             accessTracker.WarmUp(sender);
         }
 
+        // EIP-8272: every declared reference must match the commitment RECENT_ROOT_ADDRESS holds in the
+        // pre-state, so the transaction is invalid — and the block carrying it with it — when one does not.
+        if (!RecentRootReferences.Validate(WorldState, tx.RecentRootReferences, header.SlotNumber, in accessTracker))
+        {
+            return TransactionResult.ErrorType.MalformedTransaction.WithDetail("recent root reference is not committed or out of range");
+        }
+
         // Atomic batch state: a maximal contiguous run [i, j] where i..j-1 have ATOMIC_BATCH_FLAG
         // and j does not. On any failure inside the run, state rolls back to before the run began
         // and the remaining frames are skipped (spec: Behavior, atomic batch).
@@ -417,10 +424,15 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             }
         }
 
+        // EIP-8272 prices the bytes its reference list adds to the payload exactly as EIP-8141 prices
+        // frame and signature data, and prepays the predeploy and storage-key accesses the checks make.
+        tokens += CountCalldataTokens(RecentRootReferences.Calldata(tx.RecentRootReferences), spec);
+
         return (ulong)Eip8141Constants.IntrinsicGasCost
                + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
                + tokens * GasCostOf.TxDataZero
-               + signatureVerificationCost;
+               + signatureVerificationCost
+               + RecentRootReferences.IntrinsicGas(tx.RecentRootReferences, spec);
     }
 
     private static ulong CountCalldataTokens(ReadOnlySpan<byte> data, IReleaseSpec spec)

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
@@ -23,6 +23,8 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
 
     public FrameSignatureForRpc[]? Signatures { get; set; }
 
+    public RecentRootReferenceForRpc[]? RecentRootReferences { get; set; }
+
     [JsonConstructor]
     public FrameTransactionForRpc() { }
 
@@ -31,6 +33,7 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
     {
         Frames = FrameForRpc.FromFrames(transaction.Frames);
         Signatures = FrameSignatureForRpc.FromSignatures(transaction.FrameSignatures);
+        RecentRootReferences = RecentRootReferenceForRpc.FromReferences(transaction.RecentRootReferences);
     }
 
     public override Result<Transaction> ToTransaction(bool validateUserInput = false, ulong? gasCap = null, IReleaseSpec? spec = null)
@@ -41,6 +44,7 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
         Transaction tx = baseResult.Data;
         tx.Frames = FrameForRpc.ToFrames(Frames);
         tx.FrameSignatures = FrameSignatureForRpc.ToSignatures(Signatures);
+        tx.RecentRootReferences = RecentRootReferenceForRpc.ToReferences(RecentRootReferences);
         return tx;
     }
 

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/RecentRootReferenceForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/RecentRootReferenceForRpc.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Linq;
+using System.Text.Json.Serialization;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Facade.Eth.RpcTransaction;
+
+/// <summary>
+/// JSON-RPC view of an EIP-8272 recent-root reference <c>[source_id, slot, root]</c>.
+/// </summary>
+/// <remarks>
+/// The reference list is part of the signing payload, so an absent list and an empty one are different
+/// transactions; the mapping preserves that distinction rather than collapsing both to <c>null</c>.
+/// </remarks>
+public class RecentRootReferenceForRpc
+{
+    public Hash256 SourceId { get; set; } = Keccak.Zero;
+    public ulong Slot { get; set; }
+    public Hash256 Root { get; set; } = Keccak.Zero;
+
+    [JsonConstructor]
+    public RecentRootReferenceForRpc() { }
+
+    public RecentRootReferenceForRpc(in RecentRootReference reference)
+    {
+        SourceId = new Hash256(reference.SourceId);
+        Slot = reference.Slot;
+        Root = new Hash256(reference.Root);
+    }
+
+    public RecentRootReference ToReference() => new(SourceId.ValueHash256, Slot, Root.ValueHash256);
+
+    public static RecentRootReferenceForRpc[]? FromReferences(RecentRootReference[]? references) =>
+        references?.Select(static r => new RecentRootReferenceForRpc(r)).ToArray();
+
+    public static RecentRootReference[]? ToReferences(RecentRootReferenceForRpc[]? references) =>
+        references?.Select(static r => r.ToReference()).ToArray();
+}

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RecentRootReferenceDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RecentRootReferenceDecoder.cs
@@ -38,15 +38,9 @@ public sealed class RecentRootReferenceDecoder : RlpDecoder<RecentRootReference>
         writer.Encode(item.Root);
     }
 
-    public void EncodeArray<TWriter>(ref TWriter writer, RecentRootReference[]? items)
+    public void EncodeArray<TWriter>(ref TWriter writer, RecentRootReference[] items)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
     {
-        if (items is null)
-        {
-            writer.WriteByte(Rlp.EmptyListByte);
-            return;
-        }
-
         writer.StartSequence(GetArrayContentLength(items));
         for (int i = 0; i < items.Length; i++)
         {
@@ -56,7 +50,7 @@ public sealed class RecentRootReferenceDecoder : RlpDecoder<RecentRootReference>
 
     public override int GetLength(RecentRootReference item, RlpBehaviors rlpBehaviors) => Rlp.LengthOfSequence(GetContentLength(item));
 
-    public int GetArrayLength(RecentRootReference[]? items) => items is null ? 1 : Rlp.LengthOfSequence(GetArrayContentLength(items));
+    public int GetArrayLength(RecentRootReference[] items) => Rlp.LengthOfSequence(GetArrayContentLength(items));
 
     private int GetArrayContentLength(RecentRootReference[] items)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RecentRootReferenceDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RecentRootReferenceDecoder.cs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Serialization.Rlp;
+
+/// <summary>Decodes the EIP-8272 recent-root reference tuple <c>[source_id, slot, root]</c>.</summary>
+public sealed class RecentRootReferenceDecoder : RlpDecoder<RecentRootReference>
+{
+    public static readonly RecentRootReferenceDecoder Instance = new();
+
+    protected override RecentRootReference DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    {
+        int length = decoderContext.ReadSequenceLength();
+        int check = length + decoderContext.Position;
+
+        ValueHash256 sourceId = decoderContext.DecodeValueKeccak() ?? ThrowMissingHash();
+        ulong slot = decoderContext.DecodeULong();
+        ValueHash256 root = decoderContext.DecodeValueKeccak() ?? ThrowMissingHash();
+
+        if (!rlpBehaviors.HasFlag(RlpBehaviors.AllowExtraBytes))
+        {
+            decoderContext.Check(check);
+        }
+
+        return new RecentRootReference(sourceId, slot, root);
+    }
+
+    public override void Encode<TWriter>(ref TWriter writer, RecentRootReference item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    {
+        writer.StartSequence(GetContentLength(item));
+        writer.Encode(item.SourceId);
+        writer.Encode(item.Slot);
+        writer.Encode(item.Root);
+    }
+
+    public void EncodeArray<TWriter>(ref TWriter writer, RecentRootReference[]? items)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct
+    {
+        if (items is null)
+        {
+            writer.WriteByte(Rlp.EmptyListByte);
+            return;
+        }
+
+        writer.StartSequence(GetArrayContentLength(items));
+        for (int i = 0; i < items.Length; i++)
+        {
+            Encode(ref writer, items[i]);
+        }
+    }
+
+    public override int GetLength(RecentRootReference item, RlpBehaviors rlpBehaviors) => Rlp.LengthOfSequence(GetContentLength(item));
+
+    public int GetArrayLength(RecentRootReference[]? items) => items is null ? 1 : Rlp.LengthOfSequence(GetArrayContentLength(items));
+
+    private int GetArrayContentLength(RecentRootReference[] items)
+    {
+        int length = 0;
+        for (int i = 0; i < items.Length; i++)
+        {
+            length += GetLength(items[i], RlpBehaviors.None);
+        }
+
+        return length;
+    }
+
+    [DoesNotReturn, StackTraceHidden]
+    private static ValueHash256 ThrowMissingHash() => throw new RlpException("recent root reference source id and root must be 32-byte hashes");
+
+    private static int GetContentLength(RecentRootReference item) =>
+        Rlp.LengthOf(item.SourceId)
+        + Rlp.LengthOf(item.Slot)
+        + Rlp.LengthOf(item.Root);
+}

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -15,6 +15,8 @@ namespace Nethermind.Serialization.Rlp.TxDecoders;
 /// <c>[chain_id, nonce, sender, frames, signatures, max_priority_fee_per_gas, max_fee_per_gas,
 /// max_fee_per_blob_gas, blob_versioned_hashes]</c>, or its EIP-8250 form, which replaces
 /// <c>nonce</c> with <c>nonce_keys, nonce_seq</c>.
+/// max_fee_per_blob_gas, blob_versioned_hashes]</c>, optionally followed by the EIP-8272
+/// <c>recent_root_references</c> list.
 /// The sender is explicit in the payload — there is no envelope ECDSA signature and no recovery.
 /// Encoding with <c>forSigning</c> produces the <c>compute_sig_hash</c> form: the raw signature
 /// bytes of canonical-hash (empty msg) entries are elided.
@@ -33,7 +35,50 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     // EIP8141-GAP: the spec does not bound blob_versioned_hashes; mirrors the blob tx decode cap.
     private static readonly RlpLimit BlobVersionedHashesCountLimit = RlpLimit.For<Transaction>(128, nameof(Transaction.BlobVersionedHashes));
 
+    private static readonly RlpLimit ReferencesCountLimit = RlpLimit.For<Transaction>(Eip8272Constants.MaxRecentRootReferences, nameof(Transaction.RecentRootReferences));
+
     private static readonly byte[][] EmptyVersionedHashes = [];
+
+    private readonly Func<T> _newTransaction = transactionFactory ?? (static () => new T());
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// A frame transaction carries no envelope signature — the sender is explicit — so what follows the
+    /// EIP-8141 fields is the optional EIP-8272 reference list rather than a trailing <c>[v, r, s]</c>.
+    /// A non-list element there is padding and is rejected: accepting it would decode a spurious
+    /// signature that strict clients drop, diverging on the transaction hash.
+    /// </remarks>
+    public override void Decode(ref Transaction? transaction, int txSequenceStart, ReadOnlySpan<byte> transactionSequence,
+        ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    {
+        transaction ??= _newTransaction();
+        transaction.Type = Type;
+
+        int payloadLength = decoderContext.ReadSequenceLength();
+        int lastCheck = decoderContext.Position + payloadLength;
+
+        DecodePayload(transaction, ref decoderContext, rlpBehaviors);
+
+        if (decoderContext.Position < lastCheck)
+        {
+            if (!decoderContext.IsSequenceNext())
+            {
+                ThrowTrailingSignature();
+            }
+
+            transaction.RecentRootReferences = decoderContext.DecodeArray(RecentRootReferenceDecoder.Instance, limit: ReferencesCountLimit);
+        }
+
+        if ((rlpBehaviors & RlpBehaviors.AllowExtraBytes) == 0)
+        {
+            decoderContext.Check(lastCheck);
+        }
+
+        if ((rlpBehaviors & RlpBehaviors.ExcludeHashes) == 0)
+        {
+            CalculateHash(transaction, txSequenceStart, transactionSequence, ref decoderContext);
+        }
+    }
 
     protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,
         RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -115,6 +160,10 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         writer.Encode(transaction.DecodedMaxFeePerGas);
         writer.Encode(transaction.MaxFeePerBlobGas.GetValueOrDefault());
         writer.Encode(transaction.BlobVersionedHashes ?? EmptyVersionedHashes);
+        if (transaction.RecentRootReferences is { } references)
+        {
+            RecentRootReferenceDecoder.Instance.EncodeArray(ref writer, references);
+        }
     }
 
     protected override int GetContentLength(Transaction transaction, RlpBehaviors rlpBehaviors, bool forSigning,
@@ -128,7 +177,8 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         + Rlp.LengthOf(transaction.GasPrice)
         + Rlp.LengthOf(transaction.DecodedMaxFeePerGas)
         + Rlp.LengthOf(transaction.MaxFeePerBlobGas.GetValueOrDefault())
-        + Rlp.LengthOf(transaction.BlobVersionedHashes ?? EmptyVersionedHashes);
+        + Rlp.LengthOf(transaction.BlobVersionedHashes ?? EmptyVersionedHashes)
+        + (transaction.RecentRootReferences is { } references ? RecentRootReferenceDecoder.Instance.GetArrayLength(references) : 0);
 
     protected override int GetSignatureLength(Signature? signature, bool forSigning, bool isEip155Enabled = false, ulong chainId = 0) => 0;
 
@@ -137,12 +187,8 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     {
     }
 
-    // The payload is exactly 9 fields with no envelope signature (the sender is explicit). The base
-    // decoder reads a trailing [v, r, s] whenever elements remain after the payload; reject that so a
-    // padded encoding is not silently accepted with a spurious signature (which strict clients drop,
-    // diverging on the transaction hash).
-    protected override Signature? DecodeSignature(ulong v, ReadOnlySpan<byte> rBytes, ReadOnlySpan<byte> sBytes, Signature? fallbackSignature = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None) =>
-        throw new RlpException("frame transaction must not carry a trailing signature");
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowTrailingSignature() => throw new RlpException("frame transaction must not carry a trailing signature");
 
     private static int NonceKeysContentLength(UInt256[] nonceKeys)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -6,13 +6,15 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Int256;
 
 namespace Nethermind.Serialization.Rlp.TxDecoders;
 
 /// <summary>
 /// Decodes the EIP-8141 frame transaction payload
 /// <c>[chain_id, nonce, sender, frames, signatures, max_priority_fee_per_gas, max_fee_per_gas,
-/// max_fee_per_blob_gas, blob_versioned_hashes]</c>.
+/// max_fee_per_blob_gas, blob_versioned_hashes]</c>, or its EIP-8250 form, which replaces
+/// <c>nonce</c> with <c>nonce_keys, nonce_seq</c>.
 /// The sender is explicit in the payload — there is no envelope ECDSA signature and no recovery.
 /// Encoding with <c>forSigning</c> produces the <c>compute_sig_hash</c> form: the raw signature
 /// bytes of canonical-hash (empty msg) entries are elided.
@@ -27,6 +29,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 
     private static readonly RlpLimit FramesCountLimit = RlpLimit.For<Transaction>(Eip8141Constants.MaxFrames, nameof(Transaction.Frames));
     private static readonly RlpLimit SignaturesCountLimit = RlpLimit.For<Transaction>(SignaturesDecodeCap, nameof(Transaction.FrameSignatures));
+    private static readonly RlpLimit NonceKeysCountLimit = RlpLimit.For<Transaction>(Eip8250Constants.MaxNonceKeys, nameof(Transaction.NonceKeys));
     // EIP8141-GAP: the spec does not bound blob_versioned_hashes; mirrors the blob tx decode cap.
     private static readonly RlpLimit BlobVersionedHashesCountLimit = RlpLimit.For<Transaction>(128, nameof(Transaction.BlobVersionedHashes));
 
@@ -38,6 +41,12 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         // EIP8141-DEVIATION: the spec allows chain_id < 2^256; decoded as u64 like every other
         // Nethermind transaction type (codebase-wide ChainId width).
         transaction.ChainId = decoderContext.DecodeULong();
+        // EIP-8250 replaces `nonce` with `nonce_keys, nonce_seq`. The two shapes are self-describing —
+        // `nonce` is an integer and `nonce_keys` a list — so the payload is read without fork context and
+        // the fork that admits each shape is enforced where the spec is available, in validation.
+        transaction.NonceKeys = decoderContext.IsSequenceNext()
+            ? decoderContext.DecodeArray(static (ref RlpReader ctx) => ctx.DecodeUInt256(), limit: NonceKeysCountLimit)
+            : null;
         transaction.Nonce = decoderContext.DecodeULong();
         transaction.SenderAddress = decoderContext.DecodeAddress() ?? ThrowMissingSender();
         transaction.Frames = decoderContext.DecodeArray(TxFrameDecoder.Instance, limit: FramesCountLimit);
@@ -90,6 +99,14 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
     {
         writer.Encode(transaction.ChainId ?? 0);
+        if (transaction.NonceKeys is { } nonceKeys)
+        {
+            writer.StartSequence(NonceKeysContentLength(nonceKeys));
+            foreach (UInt256 nonceKey in nonceKeys)
+            {
+                writer.Encode(nonceKey);
+            }
+        }
         writer.Encode(transaction.Nonce);
         writer.Encode(transaction.SenderAddress);
         TxFrameDecoder.Instance.EncodeArray(ref writer, transaction.Frames);
@@ -103,6 +120,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     protected override int GetContentLength(Transaction transaction, RlpBehaviors rlpBehaviors, bool forSigning,
         bool isEip155Enabled = false, ulong chainId = 0) =>
         Rlp.LengthOf(transaction.ChainId ?? 0)
+        + (transaction.NonceKeys is { } nonceKeys ? Rlp.LengthOfSequence(NonceKeysContentLength(nonceKeys)) : 0)
         + Rlp.LengthOf(transaction.Nonce)
         + Rlp.LengthOf(transaction.SenderAddress)
         + TxFrameDecoder.Instance.GetArrayLength(transaction.Frames)
@@ -125,6 +143,17 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     // diverging on the transaction hash).
     protected override Signature? DecodeSignature(ulong v, ReadOnlySpan<byte> rBytes, ReadOnlySpan<byte> sBytes, Signature? fallbackSignature = null, RlpBehaviors rlpBehaviors = RlpBehaviors.None) =>
         throw new RlpException("frame transaction must not carry a trailing signature");
+
+    private static int NonceKeysContentLength(UInt256[] nonceKeys)
+    {
+        int contentLength = 0;
+        foreach (UInt256 nonceKey in nonceKeys)
+        {
+            contentLength += Rlp.LengthOf(nonceKey);
+        }
+
+        return contentLength;
+    }
 
     [DoesNotReturn, StackTraceHidden]
     private static Address ThrowMissingSender() => throw new RlpException("frame transaction sender must be a 20-byte address");

--- a/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/OverridableReleaseSpec.cs
@@ -97,6 +97,7 @@ namespace Nethermind.Specs.Test
         public bool IsEip8282Enabled { get; set; } = spec.IsEip8282Enabled;
         public bool IsEip8141Enabled { get; set; } = spec.IsEip8141Enabled;
         public bool IsEip8250Enabled { get; set; } = spec.IsEip8250Enabled;
+        public bool IsEip8272Enabled { get; set; } = spec.IsEip8272Enabled;
         public bool IsEip4788Enabled { get; set; } = spec.IsEip4788Enabled;
         public bool IsEip4844FeeCollectorEnabled { get; set; } = spec.IsEip4844FeeCollectorEnabled;
         public Address? Eip4788ContractAddress { get; set; } = spec.Eip4788ContractAddress;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainParameters.cs
@@ -192,6 +192,8 @@ public class ChainParameters
     public ulong? Eip8282TransitionTimestamp { get; set; }
     public ulong? Eip8141TransitionTimestamp { get; set; }
     public ulong? Eip8250TransitionTimestamp { get; set; }
+
+    public ulong? Eip8272TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip2780TransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecBasedSpecProvider.cs
@@ -343,6 +343,7 @@ namespace Nethermind.Specs.ChainSpecStyle
             releaseSpec.IsEip8282Enabled = (chainSpec.Parameters.Eip8282TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip8141Enabled = (chainSpec.Parameters.Eip8141TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
             releaseSpec.IsEip8250Enabled = (chainSpec.Parameters.Eip8250TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
+            releaseSpec.IsEip8272Enabled = (chainSpec.Parameters.Eip8272TransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;
 
             bool eip1559FeeCollector = releaseSpec.IsEip1559Enabled && BlockOf(chainSpec.Parameters.Eip1559FeeCollectorTransition) <= block;
             bool eip4844FeeCollector = releaseSpec.IsEip4844Enabled && (chainSpec.Parameters.Eip4844FeeCollectorTransitionTimestamp ?? ulong.MaxValue) <= releaseStartTimestamp;

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -221,6 +221,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             Eip8282TransitionTimestamp = chainSpecJson.Params.Eip8282TransitionTimestamp,
             Eip8141TransitionTimestamp = chainSpecJson.Params.Eip8141TransitionTimestamp,
             Eip8250TransitionTimestamp = chainSpecJson.Params.Eip8250TransitionTimestamp,
+            Eip8272TransitionTimestamp = chainSpecJson.Params.Eip8272TransitionTimestamp,
             Eip7843TransitionTimestamp = chainSpecJson.Params.Eip7843TransitionTimestamp,
             Eip7954TransitionTimestamp = chainSpecJson.Params.Eip7954TransitionTimestamp,
             Eip2780TransitionTimestamp = chainSpecJson.Params.Eip2780TransitionTimestamp,

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/ChainSpecParamsJson.cs
@@ -199,6 +199,8 @@ public class ChainSpecParamsJson : IHasNamedForks
     public ulong? Eip8282TransitionTimestamp { get; set; }
     public ulong? Eip8141TransitionTimestamp { get; set; }
     public ulong? Eip8250TransitionTimestamp { get; set; }
+
+    public ulong? Eip8272TransitionTimestamp { get; set; }
     public ulong? Eip7843TransitionTimestamp { get; set; }
     public ulong? Eip7954TransitionTimestamp { get; set; }
     public ulong? Eip2780TransitionTimestamp { get; set; }

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -93,6 +93,7 @@ public class ReleaseSpec : IReleaseSpec
     public bool IsEip8282Enabled { get; set; }
     public bool IsEip8141Enabled { get; set; }
     public bool IsEip8250Enabled { get; set; }
+    public bool IsEip8272Enabled { get; set; }
     public bool IsEip4788Enabled { get; set; }
     public bool IsEip7702Enabled { get; set; }
     public bool IsEip7823Enabled { get; set; }


### PR DESCRIPTION
EIP-8272 leaves `RECENT_ROOT_CODE` as TBD in its constants table, so the predeploy has been installed here with an empty body. That makes the write operation the spec describes unreachable: a call to `RECENT_ROOT_ADDRESS` is a transfer to a codeless account, nothing is committed, and the reference check then refuses every reference the caller believed it had published.

This installs the candidate body proposed in https://github.com/ethereum/EIPs/pull/12131 — the write operation assembled from the spec text, reading the current slot through the EIP-7843 `SLOTNUM` opcode. It is the same 144 bytes as in that PR.

The write is ordinary EVM execution rather than a native handler, so what a caller commits, and the gas it pays for committing it, are whatever the bytecode does. `Eip8272RecentRootCodeTests` runs the code and checks the storage it leaves against `RecentRootStore`, which is where every other EIP-8272 test and the transaction-level reference check take their expectations from. It also covers the three cases the operation refuses: calldata shorter than a `(salt, root)` pair, longer than one, and a non-zero value.

Verified on a two-client devnet before proposing the value: the committed entry hash and its storage key match what the spec prescribes, and with this body preloaded both clients agree byte for byte on the predeploy account.

The constant stays marked provisional until the EIP merges the value.
