### PR TITLE
fix(evm): report a frame transaction's state gas in the block's state dimension

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using Nethermind.State;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// EIP-7778 block-gas accounting for EIP-8141 frame transactions.
+/// </summary>
+[TestFixture]
+public class FrameTxBlockGasTests
+{
+    private ISpecProvider _specProvider;
+    private ITransactionProcessor _processor;
+    private IWorldState _state;
+    private IDisposable _closer;
+    private IReleaseSpec Spec => _specProvider.GenesisSpec;
+
+    private static readonly Address Sender = TestItem.AddressA;
+    private static readonly Address Writer = TestItem.AddressB;
+    private static readonly Address Inert = TestItem.AddressC;
+
+    [SetUp]
+    public void Setup()
+    {
+        _specProvider = new TestSpecProvider(new OverridableReleaseSpec(Eip8141Prototype.Instance));
+        _state = TestWorldStateFactory.CreateForTest();
+        _closer = _state.BeginScope(IWorldState.PreGenesis);
+        EthereumCodeInfoRepository codeInfoRepository = new(_state);
+        EthereumVirtualMachine vm = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        _processor = new EthereumTransactionProcessor(BlobBaseFeeCalculator.Instance, _specProvider, _state, vm, codeInfoRepository, LimboLogs.Instance);
+    }
+
+    [TearDown]
+    public void TearDown() => _closer?.Dispose();
+
+    [Test]
+    public void Execute_PayloadFrameWritesFreshSlot_ReportsTheChargeInTheStateDimension()
+    {
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        Deploy(Inert, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        TestAllTracerWithOutput writing = new();
+        TestAllTracerWithOutput inert = new();
+        Assert.That(Process(FrameTx(nonce: 0, Writer), writing).TransactionExecuted, Is.True);
+        Assert.That(Process(FrameTx(nonce: 1, Inert), inert).TransactionExecuted, Is.True);
+
+        const ulong stateCharge = (ulong)GasCostOf.SSetState;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(inert.GasConsumedResult.BlockStateGas, Is.Zero,
+                "a frame that creates no state owes no state gas");
+            Assert.That(writing.GasConsumedResult.BlockStateGas, Is.EqualTo(stateCharge),
+                "the fresh slot's state-growth charge belongs to the state dimension");
+            Assert.That(writing.GasConsumedResult.EffectiveBlockGas,
+                Is.EqualTo(writing.GasConsumedResult.SpentGas - stateCharge),
+                "the state charge leaves the regular dimension; counting it in both bills the block twice");
+        }
+    }
+
+    [Test]
+    public void Execute_PayloadFrameReverts_OwesNoStateGas()
+    {
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode
+            .PushData(1).PushData(0).Op(Instruction.SSTORE)
+            .PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        TestAllTracerWithOutput tracer = new();
+        Assert.That(Process(FrameTx(nonce: 0, Writer), tracer).TransactionExecuted, Is.True);
+
+        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero,
+            "a reverted frame commits no state, so it grows none");
+    }
+
+    /// <summary>An atomic batch whose later frame fails gives back the state gas its earlier frame owed.</summary>
+    /// <remarks>
+    /// The unroll restores the pre-batch state, so the fresh slot the first frame wrote never reaches the
+    /// block; charging the block's state dimension for it would price state that does not exist.
+    /// </remarks>
+    [Test]
+    public void Execute_AtomicBatchUnrolls_GivesBackTheStateGasOfTheRolledBackFrames()
+    {
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        Deploy(Inert, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        TestAllTracerWithOutput tracer = new();
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, TxFrame.AtomicBatchFlag, Writer, gasLimit: 400_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, Inert, gasLimit: 400_000, UInt256.Zero, default));
+
+        Assert.That(Process(tx, tracer).TransactionExecuted, Is.True);
+
+        Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero,
+            "the batch was rolled back, so the slot its first frame wrote never grew the state");
+    }
+
+    private static byte[] ApproveCode(byte scope) =>
+        Prepare.EvmCode.PushData(scope).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
+
+    private void Deploy(Address address, byte[] code, UInt256 balance = default)
+    {
+        _state.CreateAccount(address, balance);
+        _state.InsertCode(address, code, Spec);
+        _state.Commit(Spec);
+        _state.CommitTree(0);
+    }
+
+    private static Transaction FrameTx(ulong nonce, Address target) =>
+        FrameTx(nonce,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, target, gasLimit: 400_000, UInt256.Zero, default));
+
+    private static Transaction FrameTx(ulong nonce, params TxFrame[] frames) =>
+        new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            Nonce = nonce,
+            SenderAddress = Sender,
+            Frames = frames,
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+
+    private TransactionResult Process(Transaction tx, ITxTracer tracer)
+    {
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+        return _processor.Execute(tx, new BlockExecutionContext(block.Header, Spec), tracer);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -346,6 +346,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         ulong grossGas = intrinsicGas + totalFrameGasUsed;
         ulong spentGas = Math.Max(grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)refundCounter, spec), floorGas);
         ulong blockStateGas = (ulong)totalFrameStateGasUsed;
+        // blockStateGas <= grossGas by the reservoir-0 invariant: each frame rents an empty state-gas
+        // reservoir, so every state charge is already counted inside totalFrameGasUsed (hence grossGas),
+        // which is what makes the SaturatingSub in CalculateBlockRegularGas sound.
         ulong blockRegularGas = Eip8037BlockGasInclusionCheck.CalculateBlockRegularGas(grossGas, blockStateGas, floorGas);
         // Block-level gas accounting reads Transaction.BlockGasUsed, whose getter otherwise falls back
         // to tx.GasLimit (the frame-gas sum, not the gas actually spent). Set it explicitly like the
@@ -502,6 +505,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         ulong remainingGas = substate.IsError ? 0 : TGasPolicy.GetRemainingGas(in state.Gas);
         gasUsed = frame.GasLimit - remainingGas;
+        // Clamp rather than assert: unlike the standard path, this also runs for reverted or errored
+        // frames, where the state-gas value carries no non-negativity guarantee.
         stateGasUsed = Math.Max(0, TGasPolicy.GetStateGasUsed(in state.Gas));
 
         if (substate.ShouldRevert || substate.IsError)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -6,6 +6,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
@@ -107,6 +108,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         TxFrameReceipt[] frameReceipts = new TxFrameReceipt[frames.Length];
         ulong totalFrameGasUsed = 0;
+        long totalFrameStateGasUsed = 0;
         // EIP-3529 storage refunds accumulate into a single transaction-scoped counter (ethereum/EIPs#11940).
         long refundCounter = 0;
 
@@ -133,6 +135,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         StackAccessTracker batchTracker = default;
         int batchStartIndex = 0;
         long batchStartRefund = 0;
+        long batchStartStateGas = 0;
 
         Snapshot prefixEndSnapshot = txSnapshot;
         int prefixEndIndex = -1;
@@ -153,6 +156,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 batchTracker.TakeSnapshot();
                 batchStartIndex = i;
                 batchStartRefund = refundCounter;
+                batchStartStateGas = totalFrameStateGasUsed;
             }
 
             // Transient storage (TSTORE/TLOAD) is discarded between frames (spec: Cross-frame
@@ -176,12 +180,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
             // The shared journal accumulates logs across frames; this frame's own logs start here.
             int frameLogStart = accessTracker.Logs.Count;
-            TransactionSubstate substate = ExecuteFrame(frame, resolvedTarget, caller, isStatic, frameContext, in accessTracker, spec, tracer, out ulong frameGasUsed);
+            TransactionSubstate substate = ExecuteFrame(frame, resolvedTarget, caller, isStatic, frameContext, in accessTracker, spec, tracer, out ulong frameGasUsed, out long frameStateGas);
             totalFrameGasUsed += frameGasUsed;
 
             bool frameSucceeded = !substate.ShouldRevert && !substate.IsError;
             if (frameSucceeded)
             {
+                totalFrameStateGasUsed += frameStateGas;
                 frameContext.MarkFrameSucceeded(i);
                 // A reverted frame's refunds are discarded with its state; only successful frames
                 // contribute (ethereum/EIPs#11940). An in-batch contribution is unwound below.
@@ -292,6 +297,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                             frameReceipts[s] = new TxFrameReceipt(earlier.Status, earlier.GasUsed, []);
                         }
                     }
+
+                    // The unrolled frames' writes are gone with the snapshot, so their state charges
+                    // are not owed either; the counter only grows, so the batch-start value undoes them.
+                    totalFrameStateGasUsed = batchStartStateGas;
                     // Refunds from the reverted batch are discarded with its state, so roll the counter back.
                     // No payer/sender_approved rollback is needed: EIP-8141 forbids approval scope on batch frames.
                     refundCounter = batchStartRefund;
@@ -336,11 +345,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // the net charge from below.
         ulong grossGas = intrinsicGas + totalFrameGasUsed;
         ulong spentGas = Math.Max(grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)refundCounter, spec), floorGas);
+        ulong blockStateGas = (ulong)totalFrameStateGasUsed;
+        ulong blockRegularGas = Eip8037BlockGasInclusionCheck.CalculateBlockRegularGas(grossGas, blockStateGas, floorGas);
         // Block-level gas accounting reads Transaction.BlockGasUsed, whose getter otherwise falls back
         // to tx.GasLimit (the frame-gas sum, not the gas actually spent). Set it explicitly like the
         // regular path so parallel block validation (BlockAccessListManager) accumulates the frame
-        // tx's real spent gas into the header.
-        tx.BlockGasUsed = spentGas;
+        // tx's real regular gas into the header.
+        tx.BlockGasUsed = blockRegularGas;
         Address payer = frameContext.Payer;
 
         // The payer was charged the max cost at payment approval; refund the unused remainder and
@@ -392,7 +403,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             // Derive the tx log set from the per-frame receipts rather than maintaining a parallel
             // union, so the two can't diverge: an unrolled batch clears its frames' logs above.
             LogEntry[] txLogs = TxFrameReceipt.ConcatLogs(frameReceipts);
-            GasConsumed gasConsumed = new(spentGas, spentGas, spentGas);
+            GasConsumed gasConsumed = new(spentGas, spentGas, blockRegularGas, blockStateGas, spentGas);
             if (postTxReverted)
             {
                 tracer.MarkAsFailed(Eip8141Constants.EntryPointAddress, in gasConsumed, [], "POST_TX frame reverted");
@@ -431,8 +442,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         return logs;
     }
 
-    private TransactionSubstate ExecuteFrame(TxFrame frame, Address resolvedTarget, Address caller, bool isStatic, FrameTxContext frameContext, in StackAccessTracker accessTracker, IReleaseSpec spec, ITxTracer tracer, out ulong gasUsed)
+    private TransactionSubstate ExecuteFrame(TxFrame frame, Address resolvedTarget, Address caller, bool isStatic, FrameTxContext frameContext, in StackAccessTracker accessTracker, IReleaseSpec spec, ITxTracer tracer, out ulong gasUsed, out long stateGasUsed)
     {
+        stateGasUsed = 0;
+
         // As with an ordinary CALL, a caller unable to fund the value transfer reverts the frame.
         UInt256 value = frame.Value;
         if (!value.IsZero && WorldState.GetBalance(caller) < value)
@@ -489,6 +502,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         ulong remainingGas = substate.IsError ? 0 : TGasPolicy.GetRemainingGas(in state.Gas);
         gasUsed = frame.GasLimit - remainingGas;
+        stateGasUsed = Math.Max(0, TGasPolicy.GetStateGasUsed(in state.Gas));
 
         if (substate.ShouldRevert || substate.IsError)
         {


### PR DESCRIPTION
A frame transaction reported all of its gas in the block's regular dimension, so the EIP-8037 state gas its frames spent was counted twice: once inside the regular sum and once in the state sum. EIP-7778 accumulates the two dimensions separately and takes the larger, so a payload frame that writes storage inflates the header's `gasUsed`.

On a two-client devnet this is a chain split. A frame transaction whose payload frame writes two fresh slots produced `gasUsed` 510292 here against 314452 elsewhere, and every block carrying it was rejected with `HeaderGasUsedMismatch`.

`ExecuteFrame` now reports the state gas its frame drew alongside the regular gas. A frame starts with an empty state reservoir, so its state charges spill into the frame's own gas and are already inside `totalFrameGasUsed`; the new value only says how much of that total was state. Only committed state counts, so a reverted frame contributes nothing, and a frame unrolled with its atomic batch has its contribution taken back with the rest of its effects. The transaction then reports the two dimensions through `GasConsumed` the way the ordinary path does, with the regular one computed by the same `Eip8037BlockGasInclusionCheck` helper so the calldata floor keeps binding it.

`FrameTxBlockGasTests` pins both halves: a payload frame writing one fresh slot puts `STATE_BYTES_PER_STORAGE_SET * COST_PER_STATE_BYTE` into the state dimension and keeps it out of the regular one, and a frame that writes nothing reports no state gas. On the unfixed processor the first case reports 0 state gas.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Tests added
- 78 `FrameTx` tests pass.
