### PR TITLE
fix(consensus): exempt frame transactions from the producer's sender-account checks

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionPickerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionPickerTests.cs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Config;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Nethermind.Blockchain.Test;
+
+[TestFixture]
+public class FrameTxBlockProductionPickerTests
+{
+    private const ulong AccountNonce = 5;
+
+    [TestCase(TxType.EIP1559, AccountNonce, BlockProcessor.TxAction.Skip, "Sender is contract",
+        TestName = "Contract sender and no funds skip an ordinary transaction")]
+    [TestCase(TxType.FrameTx, AccountNonce, BlockProcessor.TxAction.Add, null,
+        TestName = "Contract sender and no funds admit a frame transaction")]
+    [TestCase(TxType.FrameTx, AccountNonce + 1, BlockProcessor.TxAction.Skip, "Invalid nonce - expected 5",
+        TestName = "The account nonce still gates a frame transaction")]
+    public void Sender_account_checks(TxType txType, ulong nonce, BlockProcessor.TxAction expectedAction, string? expectedReason)
+    {
+        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(Eip8141Prototype.Instance);
+        BlockProcessor.BlockProductionTransactionPicker picker = new(specProvider, BlocksConfig.DefaultMaxTxKilobytes);
+
+        IReadOnlyStateProvider state = Substitute.For<IReadOnlyStateProvider>();
+        state.HasCode(TestItem.AddressA).Returns(true);
+        state.GetCode(TestItem.AddressA).Returns(new byte[] { 0x60, 0x00 });
+        state.GetNonce(TestItem.AddressA).Returns(AccountNonce);
+        state.GetBalance(TestItem.AddressA).Returns(UInt256.Zero);
+
+        Transaction tx = Build.A.Transaction
+            .WithType(txType)
+            .WithSenderAddress(TestItem.AddressA)
+            .WithNonce(nonce)
+            .WithGasLimit(100_000)
+            .TestObject;
+
+        if (txType == TxType.FrameTx)
+        {
+            // A frame transaction the picker cannot price is skipped on its gas budget before it ever
+            // reaches the sender-account checks under test.
+            tx.Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default)];
+            tx.FrameSignatures = [];
+        }
+
+        Block block = Build.A.Block.WithGasLimit(30_000_000).TestObject;
+
+        BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(block, tx, new HashSet<Transaction>(), state);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(args.Action, Is.EqualTo(expectedAction));
+            Assert.That(args.Reason, expectedReason is null ? Is.Empty.Or.Null : Is.EqualTo(expectedReason));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -96,10 +96,15 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, $"Invalid nonce - expected {expectedNonce}");
                 }
 
-                UInt256 balance = stateProvider.GetBalance(currentTx.SenderAddress);
-                if (!HasEnoughFunds(currentTx, balance, args, block, spec))
+                // A frame transaction's fees are paid by the frame that approves payment, which need not
+                // be the sender, so a sender-balance gate here would skip transactions that do pay.
+                if (!currentTx.SupportsFrames)
                 {
-                    return args;
+                    UInt256 balance = stateProvider.GetBalance(currentTx.SenderAddress);
+                    if (!HasEnoughFunds(currentTx, balance, args, block, spec))
+                    {
+                        return args;
+                    }
                 }
 
                 OnAddingTransaction(args);


### PR DESCRIPTION
A frame transaction has no sender-account authorisation to check: it is authorised by the sender's own code running in the validation prefix, its nonce lives in the EIP-8250 keyed domain rather than in the account, and its cost is charged to the payer the prefix binds, not to the sender. The mempool already exempts frame transactions from EIP-3607 (`DeployedCodeFilter`), but the block producer's picker still ran all three sender-account checks, so a frame transaction that the pool accepted was skipped at block production and stayed in the pool forever.

Observed on a two-client devnet: eight withdrawals from one shared pool sender, each carrying a distinct EIP-8250 nonce key, were accepted by both mempools and never appeared in a block. With this change all eight land in one block and both clients agree on its hash and gas.

## Types of changes

- [x] Bug fix (a non-breaking change that fixes an issue)

## Testing

`FrameTxBlockProductionPickerTests` parameterises the picker over a contract sender whose account nonce and balance would fail every check: the EIP-1559 case is skipped, the frame-transaction case is added.

- [x] Tests included
