### PR TITLE
fix(evm): trace instructions inside EIP-8141 frames

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Linq;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Tracing;
+using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
@@ -806,6 +808,20 @@ public class FrameTxProcessorTests
             .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done);
 
         return Process(FrameTx(nonce: 0, SelfVerifyFrame())).TransactionExecuted;
+    }
+
+    [Test]
+    public void Execute_TracingInstructions_RecordsFrameOpcodes()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.PushData(1).PushData(2).Op(Instruction.ADD).Op(Instruction.POP).Done);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Recipient));
+
+        GethLikeTxMemoryTracer tracer = new(tx, GethTraceOptions.Default);
+        TransactionResult result = Process(tx, tracer: tracer);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(tracer.BuildResult().Entries.Select(static e => e.Opcode), Does.Contain(nameof(Instruction.ADD)));
     }
 
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -498,7 +498,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             in snapshot,
             isStatic: isStatic);
 
-        TransactionSubstate substate = VirtualMachine.ExecuteTransaction(state, WorldState, tracer);
+        TransactionSubstate substate = tracer.IsTracingInstructions
+            ? VirtualMachine.ExecuteTransaction<OnFlag>(state, WorldState, tracer)
+            : VirtualMachine.ExecuteTransaction(state, WorldState, tracer);
 
         ulong remainingGas = substate.IsError ? 0 : TGasPolicy.GetRemainingGas(in state.Gas);
         gasUsed = frame.GasLimit - remainingGas;


### PR DESCRIPTION
Every EVM frame of an EIP-8141 frame transaction runs through the non-generic `IVirtualMachine.ExecuteTransaction` overload, which defaults to `OffFlag`, so instruction tracing is off for the whole transaction regardless of what the tracer asks for. The regular transaction path picks the overload from its `TTracingInst` flag; the frame path never did.

The visible effect is `debug_traceTransaction` on a frame transaction returning a correct `gas` and an empty `structLogs`. There is no error, so the caller has no signal that the trace is incomplete.

## Types of changes

- [x] Bug fix (a non-breaking change that fixes an issue)

## Testing

`Execute_TracingInstructions_RecordsFrameOpcodes` traces a frame transaction whose payload frame executes `ADD` and asserts the opcode reaches the trace. It fails on the base branch and passes with this change.

- [x] Tests included
