### PR TITLE
chore: record the TxPool precompile dependency in the lock file

### DIFF
--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -1258,6 +1258,7 @@
           "Nethermind.Crypto": "[1.40.0-unstable, )",
           "Nethermind.Db": "[1.40.0-unstable, )",
           "Nethermind.Evm": "[1.40.0-unstable, )",
+          "Nethermind.Evm.Precompiles": "[1.40.0-unstable, )",
           "Nethermind.Network.Contract": "[1.40.0-unstable, )",
           "Nethermind.State": "[1.40.0-unstable, )",
           "NonBlocking": "[2.1.2, )"


### PR DESCRIPTION
## Changes

- Record `Nethermind.Evm.Precompiles` as a `Nethermind.TxPool` dependency in the runner's lock file

`Nethermind.TxPool` took the dependency when frame-transaction signatures started being verified at pool ingress, but the lock file was not regenerated, so `dotnet restore --locked-mode` fails on this branch:

```
error NU1004: The project references nethermind.txpool whose dependencies has changed.
The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode.
```

That is the restore the Dockerfile runs, so any image built from this branch fails. Regenerated with `dotnet restore src/Nethermind/Nethermind.Runner --force-evaluate`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

`docker build` from this branch reaches the publish step; without the change it stops at restore.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
