### PR TITLE
Handle failed sender recovery

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Receipts/ReceiptsRegenerator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Receipts/ReceiptsRegenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
@@ -58,7 +59,19 @@ public sealed class ReceiptsRegenerator(
         if (parent is null) return false;
 
         foreach (Transaction tx in block.Transactions)
-            tx.SenderAddress ??= ecdsa.RecoverAddress(tx, !spec.ValidateChainId);
+        {
+            if (tx.SenderAddress is not null)
+            {
+                continue;
+            }
+
+            if (!ecdsa.TryRecoverAddress(tx, out Address? senderAddress, !spec.ValidateChainId))
+            {
+                return FailUnrecoverableSender(block, tx);
+            }
+
+            tx.SenderAddress = senderAddress;
+        }
 
         // Re-execute on a throwaway copy: block processing writes back the resolved state root, account-change
         // buffers, and generated access list, and this runs on RPC threads against the shared block-tree instance —
@@ -110,5 +123,12 @@ public sealed class ReceiptsRegenerator(
             // defensively so a pooled buffer can never outlive this call regardless of where regeneration runs.
             isolated.DisposeAccountChanges();
         }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool FailUnrecoverableSender(Block block, Transaction tx)
+    {
+        if (_logger.IsWarn) _logger.Warn($"Could not regenerate receipts for block {block.Number} ({block.Hash}): transaction {tx.Hash} sender address is not recoverable.");
+        return false;
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/Crypto/EthereumEcdsaTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Crypto/EthereumEcdsaTests.cs
@@ -25,6 +25,14 @@ namespace Nethermind.Core.Test.Crypto
             ecdsa.Verify(testCase.Tx.SenderAddress!, testCase.Tx);
         }
 
+        [Test]
+        public void Verify_returns_false_for_unsigned_transaction()
+        {
+            EthereumEcdsa ecdsa = new(BlockchainIds.Sepolia);
+            Transaction tx = Build.A.Transaction.TestObject;
+
+            Assert.That(ecdsa.Verify(TestItem.AddressA, tx), Is.False);
+        }
 
         [TestCase(true)]
         [TestCase(false)]
@@ -36,6 +44,38 @@ namespace Nethermind.Core.Test.Crypto
             ecdsa.Sign(key, tx, eip155);
             Address? address = ecdsa.RecoverAddress(tx);
             Assert.That(address, Is.EqualTo(key.Address));
+        }
+
+        [Test]
+        public void TryRecoverAddress_recovers_sender_for_signed_transaction()
+        {
+            EthereumEcdsa ecdsa = new(BlockchainIds.Sepolia);
+            PrivateKey key = Build.A.PrivateKey.TestObject;
+            Transaction tx = Build.A.Transaction.TestObject;
+            ecdsa.Sign(key, tx);
+
+            bool result = ecdsa.TryRecoverAddress(tx, out Address? address);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.True);
+                Assert.That(address, Is.EqualTo(key.Address));
+            }
+        }
+
+        [Test]
+        public void TryRecoverAddress_returns_false_for_unsigned_transaction()
+        {
+            EthereumEcdsa ecdsa = new(BlockchainIds.Sepolia);
+            Transaction tx = Build.A.Transaction.TestObject;
+
+            bool result = ecdsa.TryRecoverAddress(tx, out Address? address);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.False);
+                Assert.That(address, Is.Null);
+            }
         }
 
         [TestCase(true)]

--- a/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
+++ b/src/Nethermind/Nethermind.Crypto/EthereumEcdsaExtensions.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Nethermind.Core;
 using Nethermind.Core.Caching;
@@ -59,11 +60,8 @@ public static class EthereumEcdsaExtensions
     /// <param name="sender"></param>
     /// <param name="tx"></param>
     /// <returns></returns>
-    public static bool Verify(this IEthereumEcdsa ecdsa, Address sender, Transaction tx)
-    {
-        Address? recovered = ecdsa.RecoverAddress(tx);
-        return recovered?.Equals(sender) ?? false;
-    }
+    public static bool Verify(this IEthereumEcdsa ecdsa, Address sender, Transaction tx) =>
+        ecdsa.TryRecoverAddress(tx, out Address? recovered) && recovered.Equals(sender);
 
     /// <summary>
     /// Recovers the address that signed the transaction.
@@ -77,6 +75,31 @@ public static class EthereumEcdsaExtensions
         Signature signature = tx.Signature
             ?? throw new InvalidDataException("Cannot recover sender address from a transaction without a signature.");
 
+        return RecoverAddress(ecdsa, tx, signature, useSignatureChainId);
+    }
+
+    /// <summary>
+    /// Tries to recover the address that signed the transaction.
+    /// </summary>
+    /// <param name="ecdsa">The ECDSA implementation used for recovery.</param>
+    /// <param name="tx">The transaction whose signature should be recovered.</param>
+    /// <param name="address">The recovered address when recovery succeeds.</param>
+    /// <param name="useSignatureChainId">Whether to use the chain id encoded in a legacy EIP-155 signature.</param>
+    /// <returns><see langword="true"/> when the transaction has a recoverable sender address; otherwise <see langword="false"/>.</returns>
+    public static bool TryRecoverAddress(this IEthereumEcdsa ecdsa, Transaction tx, [NotNullWhen(true)] out Address? address, bool useSignatureChainId = false)
+    {
+        if (tx.Signature is not { } signature)
+        {
+            address = null;
+            return false;
+        }
+
+        address = RecoverAddress(ecdsa, tx, signature, useSignatureChainId);
+        return address is not null;
+    }
+
+    private static Address? RecoverAddress(IEthereumEcdsa ecdsa, Transaction tx, Signature signature, bool useSignatureChainId)
+    {
         bool cacheable = tx.Type != TxType.Legacy && tx.Hash is not null;
         if (cacheable && _senderCache.TryGet(tx.Hash!.ValueHash256, out Address cached))
         {

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -561,7 +561,8 @@ namespace Nethermind.Facade
         public Hash256[] GetPendingTransactionFilterChanges(int filterId) =>
             filterManager.PollPendingTransactionHashes(filterId);
 
-        public Address? RecoverTxSender(Transaction tx) => ecdsa.RecoverAddress(tx);
+        public Address? RecoverTxSender(Transaction tx) =>
+            ecdsa.TryRecoverAddress(tx, out Address? senderAddress) ? senderAddress : null;
 
         public void RunTreeVisitor<TCtx>(ITreeVisitor<TCtx> treeVisitor, BlockHeader? baseBlock, VisitingStats? diagnostics = null) where TCtx : struct, INodeContext<TCtx>
             => stateReader.RunTreeVisitor(treeVisitor, baseBlock, diagnostics: diagnostics);

--- a/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateSubmissionHandler.cs
+++ b/src/Nethermind/Nethermind.Flashbots/Handlers/ValidateSubmissionHandler.cs
@@ -198,7 +198,11 @@ public class ValidateSubmissionHandler(
         IWorldState worldState = scope.Component.WorldState;
         IBlockProcessor blockProcessor = scope.Component.BlockProcessor;
 
-        RecoverSenderAddress(block, releaseSpec);
+        if (!RecoverSenderAddress(block, releaseSpec, out error))
+        {
+            return false;
+        }
+
         UInt256 feeRecipientBalanceBefore = worldState.HasStateForBlock(parentHeader) ? (worldState.AccountExists(feeRecipient) ? worldState.GetBalance(feeRecipient) : UInt256.Zero) : UInt256.Zero;
 
         BlockReceiptsTracer blockReceiptsTracer = new();
@@ -249,12 +253,26 @@ public class ValidateSubmissionHandler(
         return true;
     }
 
-    private void RecoverSenderAddress(Block block, IReleaseSpec spec)
+    private bool RecoverSenderAddress(Block block, IReleaseSpec spec, out string? error)
     {
         foreach (Transaction tx in block.Transactions)
         {
-            tx.SenderAddress ??= _ethereumEcdsa.RecoverAddress(tx, !spec.ValidateChainId);
+            if (tx.SenderAddress is not null)
+            {
+                continue;
+            }
+
+            if (!_ethereumEcdsa.TryRecoverAddress(tx, out Address? senderAddress, !spec.ValidateChainId))
+            {
+                error = $"Transaction {tx.Hash} sender address is not recoverable";
+                return false;
+            }
+
+            tx.SenderAddress = senderAddress;
         }
+
+        error = null;
+        return true;
     }
 
     private bool ValidateBlockMetadata(Block block, ulong registerGasLimit, BlockHeader parentHeader, IReleaseSpec releaseSpec, out string? error)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -97,6 +97,20 @@ public partial class EthRpcModuleTests
 
     private static void AssertAccountDoesNotExist(Context ctx, Address account) => Assert.That(ctx.Test.ReadOnlyState.AccountExists(account), Is.False);
 
+    private sealed class NoRecoveryEthereumEcdsa(IEthereumEcdsa signer) : IEthereumEcdsa
+    {
+        public ulong ChainId => signer.ChainId;
+
+        public Signature Sign(PrivateKey privateKey, in ValueHash256 message) => signer.Sign(privateKey, in message);
+
+        public PublicKey? RecoverPublicKey(Signature signature, in ValueHash256 message) => signer.RecoverPublicKey(signature, in message);
+
+        public CompressedPublicKey? RecoverCompressedPublicKey(Signature signature, in ValueHash256 message) =>
+            signer.RecoverCompressedPublicKey(signature, in message);
+
+        public Address? RecoverAddress(Signature signature, in ValueHash256 message) => null;
+    }
+
     [TestCase("earliest", "0x3635c9adc5dea00000")]
     [TestCase("latest", "0x3635c9adc5de9f09e5")]
     [TestCase("pending", "0x3635c9adc5de9f09e5")]
@@ -2031,6 +2045,19 @@ public partial class EthRpcModuleTests
         string serialized = await ctx.Test.TestEthRpc("eth_sendRawTransaction", "c0");
 
         Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"Invalid RLP.\"},\"id\":67}"));
+    }
+
+    [Test]
+    public async Task Send_raw_transaction_returns_failed_to_recover_sender_when_sender_recovery_fails()
+    {
+        IEthereumEcdsa signingEcdsa = new EthereumEcdsa(TestBlockchainIds.ChainId);
+        using TestRpcBlockchain test = await TestRpcBlockchain.ForTest(SealEngineType.NethDev)
+            .Build(builder => builder.AddSingleton<IEthereumEcdsa>(new NoRecoveryEthereumEcdsa(signingEcdsa)));
+        Transaction tx = Build.A.Transaction.Signed(signingEcdsa, TestItem.PrivateKeyA).TestObject;
+
+        string serialized = await test.TestEthRpc("eth_sendRawTransaction", Rlp.Encode(tx, RlpBehaviors.None).Bytes.ToHexString());
+
+        Assert.That(serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"failed to recover sender\"},\"id\":67}"));
     }
 
     [TestCaseSource(nameof(SendRawTransactionSyncFailureCases))]

--- a/src/Nethermind/Nethermind.Optimism.Test/Rpc/OptimismEthRpcModuleTest.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/Rpc/OptimismEthRpcModuleTest.cs
@@ -10,7 +10,9 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.History;
 using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db.LogIndex;
@@ -18,6 +20,7 @@ using Nethermind.Evm;
 using Nethermind.Facade;
 using Nethermind.Facade.Eth;
 using Nethermind.Facade.Eth.RpcTransaction;
+using Nethermind.JsonRpc;
 using Nethermind.JsonRpc.Client;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.JsonRpc.Modules.Eth.FeeHistory;
@@ -73,6 +76,33 @@ public class OptimismEthRpcModuleTest
                 opSpecHelper: Substitute.For<IOptimismSpecHelper>())
             .Build();
 
+    private sealed class NoRecoveryEthereumEcdsa(IEthereumEcdsa signer) : IEthereumEcdsa
+    {
+        public ulong ChainId => signer.ChainId;
+
+        public Signature Sign(PrivateKey privateKey, in ValueHash256 message) => signer.Sign(privateKey, in message);
+
+        public PublicKey? RecoverPublicKey(Signature signature, in ValueHash256 message) => signer.RecoverPublicKey(signature, in message);
+
+        public CompressedPublicKey? RecoverCompressedPublicKey(Signature signature, in ValueHash256 message) =>
+            signer.RecoverCompressedPublicKey(signature, in message);
+
+        public Address? RecoverAddress(Signature signature, in ValueHash256 message) => null;
+    }
+
+    private sealed class NullSenderTransactionForRpc(Transaction transaction) : SignableTransactionForRpc
+    {
+        public override Result<Transaction> ToTransaction(bool validateUserInput = false, ulong? gasCap = null, IReleaseSpec? spec = null)
+        {
+            Transaction tx = new();
+            transaction.CopyTo(tx);
+            tx.SenderAddress = null;
+            return tx;
+        }
+
+        public override bool ShouldSetBaseFee() => false;
+    }
+
     [Test]
     public async Task Sequencer_send_transaction_with_signature_will_not_try_to_sign()
     {
@@ -101,6 +131,38 @@ public class OptimismEthRpcModuleTest
 
         await txSender.Received().SendTransaction(tx: Arg.Any<Transaction>(), txHandlingOptions: TxHandlingOptions.PersistentBroadcast);
         Assert.That(serialized, Is.EqualTo($$"""{"jsonrpc":"2.0","result":"{{TestItem.KeccakA.Bytes.ToHexString(withZeroX: true)}}","id":67}"""));
+    }
+
+    [Test]
+    public async Task Send_transaction_returns_failed_to_recover_sender_when_sender_recovery_fails()
+    {
+        IBlockchainBridge bridge = Substitute.For<IBlockchainBridge>();
+        ITxSealer sealer = Substitute.For<ITxSealer>();
+        EthereumEcdsa signingEcdsa = new(chainId: TestBlockchainIds.ChainId);
+        TestRpcBlockchain rpcBlockchain = await TestRpcBlockchain
+            .ForTest(sealEngineType: SealEngineType.Optimism)
+            .WithBlockchainBridge(bridge)
+            .WithOptimismEthRpcModule(
+                sequencerRpcClient: null /* explicitly using null to behave as Sequencer */,
+                accountStateProvider: Substitute.For<IAccountStateProvider>(),
+                ecdsa: new NoRecoveryEthereumEcdsa(signingEcdsa),
+                sealer: sealer,
+                opSpecHelper: Substitute.For<IOptimismSpecHelper>())
+            .Build();
+
+        Transaction tx = Build.A.Transaction
+            .Signed(ecdsa: signingEcdsa, privateKey: TestItem.PrivateKeyA)
+            .TestObject;
+        SignableTransactionForRpc rpcTx = new NullSenderTransactionForRpc(tx);
+
+        ResultWrapper<Hash256> result = await rpcBlockchain.EthRpcModule.eth_sendTransaction(rpcTx);
+
+        sealer.DidNotReceive().TrySeal(Arg.Any<Transaction>(), Arg.Any<TxHandlingOptions>());
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.TransactionRejected));
+            Assert.That(result.Result.Error, Is.EqualTo(TxPoolErrorMessages.FailedToRecoverSender));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthRpcModule.cs
+++ b/src/Nethermind/Nethermind.Optimism/Rpc/OptimismEthRpcModule.cs
@@ -126,11 +126,14 @@ public class OptimismEthRpcModule(
         }
 
         tx.ChainId = _blockchainBridge.GetChainId();
-        tx.SenderAddress ??= ecdsa.RecoverAddress(tx);
-
         if (tx.SenderAddress is null)
         {
-            return ResultWrapper<Hash256>.Fail("Failed to recover sender");
+            if (!ecdsa.TryRecoverAddress(tx, out Address? senderAddress))
+            {
+                return ResultWrapper<Hash256>.Fail(TxPoolErrorMessages.FailedToRecoverSender, ErrorCodes.TransactionRejected);
+            }
+
+            tx.SenderAddress = senderAddress;
         }
 
         if (!sealer.TrySeal(tx, TxHandlingOptions.None))

--- a/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterTxLoader.cs
@@ -14,7 +14,6 @@ using Nethermind.Shutter.Contracts;
 using Nethermind.Shutter.Config;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
-using System.IO;
 using Nethermind.Abi;
 using Nethermind.Facade.Find;
 using System.Runtime.CompilerServices;
@@ -182,18 +181,19 @@ public class ShutterTxLoader(
         {
             _logger.DebugError("Could not recover Shutter transaction sender address", e);
         }
-        catch (InvalidDataException e)
-        {
-            _logger.DebugError("Decrypted Shutter transaction had no signature", e);
-        }
-
         return null;
     }
 
-    private Transaction DecodeTransaction(ReadOnlySpan<byte> encoded)
+    private Transaction? DecodeTransaction(ReadOnlySpan<byte> encoded)
     {
         Transaction tx = TxRlpDecoder.DecodeCompleteNotNull(encoded, RlpBehaviors.SkipTypedWrapping);
-        tx.SenderAddress = ecdsa.RecoverAddress(tx, true);
+        if (!ecdsa.TryRecoverAddress(tx, out Address? senderAddress, true))
+        {
+            if (_logger.IsDebug) _logger.Debug("Decrypted Shutter transaction sender address is not recoverable.");
+            return null;
+        }
+
+        tx.SenderAddress = senderAddress;
         return tx;
     }
 

--- a/src/Nethermind/Nethermind.Taiko/TaikoBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoBlockValidator.cs
@@ -113,12 +113,14 @@ public class TaikoBlockValidator(
 
         // We don't set the tx.SenderAddress here, as it will stop the rest of the transactions in the block
         // from getting their sender address recovered
-        Address? senderAddress = tx.SenderAddress ?? ecdsa.RecoverAddress(tx);
-
+        Address? senderAddress = tx.SenderAddress;
         if (senderAddress is null)
         {
-            errorMessage = "Anchor transaction sender address is not recoverable";
-            return false;
+            if (!ecdsa.TryRecoverAddress(tx, out senderAddress))
+            {
+                errorMessage = "Anchor transaction sender address is not recoverable";
+                return false;
+            }
         }
 
         if (!senderAddress.Equals(GoldenTouchAccount))

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -735,6 +735,46 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public async Task should_count_reorganized_blob_txs_with_unrecoverable_sender()
+        {
+            const ulong blockNumber = 358;
+
+            Transaction blobTx = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields()
+                .WithHash(TestItem.KeccakA)
+                .TestObject;
+
+            IBlobTxStorage blobTxStorage = Substitute.For<IBlobTxStorage>();
+            blobTxStorage.TryGetBlobTransactionsFromBlock(blockNumber, out Arg.Any<Transaction[]>())
+                .Returns(callInfo =>
+                {
+                    callInfo[1] = new[] { blobTx };
+                    return true;
+                });
+
+            ITxPoolConfig txPoolConfig = new TxPoolConfig()
+            {
+                Size = 128,
+                BlobsSupport = BlobsSupportMode.StorageWithReorgs
+            };
+            _txPool = CreatePool(txPoolConfig, GetCancunSpecProvider(), txStorage: blobTxStorage);
+
+            long unresolvableSenderBefore = Metrics.PendingTransactionsUnresolvableSender;
+
+            Block blockA = Build.A.Block.WithNumber(blockNumber).TestObject;
+            Block blockB = Build.A.Block.WithNumber(blockNumber).TestObject;
+            await RaiseBlockAddedToMainAndWaitForNewHead(blockB, blockA);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(Metrics.PendingTransactionsUnresolvableSender, Is.GreaterThanOrEqualTo(unresolvableSenderBefore + 1));
+                Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(0));
+            }
+
+            blobTxStorage.Received().DeleteBlobTransactionsFromBlock(blockNumber);
+        }
+
+        [Test]
         public void should_index_blobs_when_adding_txs([Values(true, false)] bool isPersistentStorage, [Values(true, false)] bool uniqueBlobs)
         {
             const int poolSize = 10;

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -37,13 +37,13 @@ namespace Nethermind.TxPool.Filters
             Metrics.PendingTransactionsWithExpensiveFiltering++;
             if (tx.SenderAddress is null)
             {
-                tx.SenderAddress = ecdsa.RecoverAddress(tx);
-                if (tx.SenderAddress is null)
+                if (!ecdsa.TryRecoverAddress(tx, out Address? senderAddress))
                 {
                     Metrics.PendingTransactionsUnresolvableSender++;
                     if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, no sender.");
                     return AcceptTxResult.FailedToResolveSender;
                 }
+                tx.SenderAddress = senderAddress;
             }
 
             // An unresolved sender is conservatively priced as non-self, so only a rejected

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -348,7 +348,16 @@ namespace Nethermind.TxPool
                     {
                         if (_logger.IsTrace) _logger.Trace($"Readded tx {blobTx.Hash} from reorged block {previousBlock.Number} (hash {previousBlock.Hash}) to blob pool");
                         _hashCache.Delete(blobTx.Hash!);
-                        blobTx.SenderAddress ??= _ecdsa.RecoverAddress(blobTx);
+                        if (blobTx.SenderAddress is null)
+                        {
+                            if (!_ecdsa.TryRecoverAddress(blobTx, out Address? senderAddress))
+                            {
+                                RecordUnrecoverableReorgedBlobTx(blobTx, previousBlock);
+                                continue;
+                            }
+
+                            blobTx.SenderAddress = senderAddress;
+                        }
                         SubmitTx(blobTx, isEip155Enabled ? TxHandlingOptions.None : TxHandlingOptions.PreEip155Signing);
                     }
                     if (_logger.IsTrace) _logger.Trace($"Readded txs from reorged block {previousBlock.Number} (hash {previousBlock.Hash}) to blob pool");
@@ -356,6 +365,13 @@ namespace Nethermind.TxPool
                     _blobTxStorage.DeleteBlobTransactionsFromBlock(previousBlock.Number);
                 }
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void RecordUnrecoverableReorgedBlobTx(Transaction blobTx, Block previousBlock)
+        {
+            Metrics.PendingTransactionsUnresolvableSender++;
+            if (_logger.IsDebug) _logger.Debug($"Skipped readding tx {blobTx.Hash} from reorged block {previousBlock.Number} (hash {previousBlock.Hash}) to blob pool: sender address is not recoverable");
         }
 
         private void RemoveProcessedTransactions(Block block)

--- a/src/Nethermind/Nethermind.TxPool/TxPoolSender.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolSender.cs
@@ -19,9 +19,15 @@ namespace Nethermind.TxPool
         public ValueTask<(Hash256, AcceptTxResult?)> SendTransaction(Transaction tx, TxHandlingOptions txHandlingOptions)
         {
             bool manageNonce = (txHandlingOptions & TxHandlingOptions.ManagedNonce) == TxHandlingOptions.ManagedNonce;
-            tx.SenderAddress ??= _ecdsa.RecoverAddress(tx);
+
             if (tx.SenderAddress is null)
-                throw new ArgumentNullException(nameof(tx.SenderAddress));
+            {
+                if (!_ecdsa.TryRecoverAddress(tx, out Address? senderAddress))
+                {
+                    return new((tx.Hash!, AcceptTxResult.FailedToResolveSender));
+                }
+                tx.SenderAddress = senderAddress;
+            }
 
             AcceptTxResult result = manageNonce
                 ? SubmitTxWithManagedNonce(tx, txHandlingOptions)


### PR DESCRIPTION
## Changes

- Added a `TryRecoverAddress` transaction sender recovery helper so untrusted transaction input can be handled without exception control flow.
- Updated tx-pool sender recovery paths to return `failed to recover sender` when recovery is not possible.
- Switched nullable/error-return sender recovery paths in Facade, Optimism, Taiko, Flashbots, Shutter, blob reorg re-add, and receipt regeneration to the non-throwing helper.
- Addressed PR review feedback by moving cold sender-recovery logs out of loop bodies, aligning Optimism sender-recovery RPC rejection with tx-pool rejection code/text, and counting unrecoverable blob reorg re-adds in the tx-pool unresolved-sender metric.
- Added crypto, JSON-RPC, TxPool, and Optimism regression coverage for failed sender recovery.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Targeted Core, JSON-RPC, TxPool, Optimism, Taiko, Flashbots, and Shutter checks passed locally.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Sender recovery failure could reach tx-pool submission as a null `SenderAddress`, leaking exception text and logging ERROR-level failures instead of returning the canonical `failed to recover sender` transaction rejection.
