### PR TITLE
refactor: bundle EIP-7928 BAL per-tx processor construction into BalTxProcessorFactory

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -197,7 +197,7 @@ namespace Nethermind.AuRa.Test
             IBlockTree blockTree = Build.A.BlockTree(GnosisSpecProvider.Instance).TestObject;
             ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
             IBlockhashProvider blockhashProvider = Substitute.For<IBlockhashProvider>();
-            BlockAccessListManager balManager = new(stateProvider, GnosisSpecProvider.Instance, blockhashProvider, LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), static worldState => new EthereumCodeInfoRepository(worldState), static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor));
+            BlockAccessListManager balManager = new(stateProvider, LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), new BalTxProcessorFactory(blockhashProvider, GnosisSpecProvider.Instance, LimboLogs.Instance, static worldState => new EthereumCodeInfoRepository(worldState)));
             ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
             IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.ParallelBlockValidationTransactionsExecutor(
                 new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider),

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessListSequentialValidationTests.cs
@@ -168,13 +168,11 @@ public class BlockAccessListSequentialValidationTests
         TestSingleReleaseSpecProvider specProvider = new(Amsterdam.Instance);
         BlockAccessListManager balManager = new(
             stateProvider,
-            specProvider,
-            Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = false },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            static worldState => new EthereumCodeInfoRepository(worldState),
-            static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor));
+            new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), specProvider, LimboLogs.Instance,
+                static worldState => new EthereumCodeInfoRepository(worldState)));
         return (stateProvider, balManager);
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BlockAccessListManagerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockAccessLists/BlockAccessListManagerTests.cs
@@ -32,13 +32,11 @@ public class BlockAccessListManagerTests
 
         public Harness() => Manager = new BlockAccessListManager(
             WorldState,
-            Substitute.For<ISpecProvider>(),
-            Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
             new BlocksConfig(), // ParallelExecution / ParallelExecutionBatchRead default to true
             Substitute.For<IWithdrawalProcessorFactory>(),
-            static worldState => new EthereumCodeInfoRepository(worldState),
-            static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor),
+            new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), Substitute.For<ISpecProvider>(), LimboLogs.Instance,
+                static worldState => new EthereumCodeInfoRepository(worldState)),
             // Enables parallel execution (and thus BAL read warmup), mirroring the production DI path.
             readOnlyTxProcessingEnvFactory: Substitute.For<IReadOnlyTxProcessingEnvFactory>());
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -124,13 +124,11 @@ public class BlockProcessorTests
         TrackingReadOnlyTxProcessingEnvFactory parentReaderFactory = new();
         using BlockAccessListManager balManager = new(
             stateProvider,
-            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
-            Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = true },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            static worldState => new EthereumCodeInfoRepository(worldState),
-            static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor),
+            new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), new TestSingleReleaseSpecProvider(Amsterdam.Instance), LimboLogs.Instance,
+                static worldState => new EthereumCodeInfoRepository(worldState)),
             readOnlyTxProcessingEnvFactory: parentReaderFactory);
 
         Transaction firstTx = Build.A.Transaction.WithNonce(0).TestObject;
@@ -196,13 +194,11 @@ public class BlockProcessorTests
         TrackingReadOnlyTxProcessingEnvFactory parentReaderFactory = new();
         using BlockAccessListManager balManager = new(
             stateProvider,
-            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
-            Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = true },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            static worldState => new EthereumCodeInfoRepository(worldState),
-            static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor),
+            new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), new TestSingleReleaseSpecProvider(Amsterdam.Instance), LimboLogs.Instance,
+                static worldState => new EthereumCodeInfoRepository(worldState)),
             readOnlyTxProcessingEnvFactory: parentReaderFactory);
 
         Transaction tx = Build.A.Transaction.WithNonce(0).TestObject;
@@ -261,7 +257,7 @@ public class BlockProcessorTests
     {
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
         ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
-        BlockAccessListManager balManager = new(stateProvider, HoodiSpecProvider.Instance, Substitute.For<IBlockhashProvider>(), LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), static worldState => new EthereumCodeInfoRepository(worldState), static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor));
+        BlockAccessListManager balManager = new(stateProvider, LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), HoodiSpecProvider.Instance, LimboLogs.Instance, static worldState => new EthereumCodeInfoRepository(worldState)));
         ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
         IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.ParallelBlockValidationTransactionsExecutor(
             new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider),
@@ -688,13 +684,11 @@ public class BlockProcessorTests
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
         BlockAccessListManager balManager = new(
             stateProvider,
-            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
-            Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = false },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            static worldState => new EthereumCodeInfoRepository(worldState),
-            static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor));
+            new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), new TestSingleReleaseSpecProvider(Amsterdam.Instance), LimboLogs.Instance,
+                static worldState => new EthereumCodeInfoRepository(worldState)));
 
         // Prepare with a block that has gasUsed = gasRemaining (sets _gasRemaining)
         ReadOnlyBlockAccessList suggestedBal = Build.A.BlockAccessList
@@ -734,13 +728,11 @@ public class BlockProcessorTests
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
         BlockAccessListManager balManager = new(
             stateProvider,
-            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
-            Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = false },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            static worldState => new EthereumCodeInfoRepository(worldState),
-            static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor));
+            new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), new TestSingleReleaseSpecProvider(Amsterdam.Instance), LimboLogs.Instance,
+                static worldState => new EthereumCodeInfoRepository(worldState)));
 
         Address lowAddress = TestItem.AddressA;
         Address highAddress = TestItem.AddressB;
@@ -1282,13 +1274,11 @@ public class BlockProcessorTests
     private static BlockAccessListManager CreateAmsterdamBalManager(IWorldState stateProvider) =>
         new(
             stateProvider,
-            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
-            Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = true },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            static worldState => new EthereumCodeInfoRepository(worldState),
-            static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor),
+            new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), new TestSingleReleaseSpecProvider(Amsterdam.Instance), LimboLogs.Instance,
+                static worldState => new EthereumCodeInfoRepository(worldState)),
             readOnlyTxProcessingEnvFactory: Substitute.For<IReadOnlyTxProcessingEnvFactory>());
 
     private static void WithScopedAmsterdamBalManager(Action<BlockAccessListManager> action)

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockhashProviderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockhashProviderTests.cs
@@ -365,13 +365,11 @@ public class BlockhashProviderTests
         TestSingleReleaseSpecProvider specProvider = new(spec);
         BlockAccessListManager balManager = new(
             balWorldState,
-            specProvider,
-            Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = false },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            static worldState => new EthereumCodeInfoRepository(worldState),
-            static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor));
+            new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), specProvider, LimboLogs.Instance,
+                static worldState => new EthereumCodeInfoRepository(worldState)));
         balManager.PrepareForProcessing(current, spec, ProcessingOptions.None);
         balManager.SetBlockExecutionContext(new BlockExecutionContext(current.Header, spec));
         balManager.Setup(current);

--- a/src/Nethermind/Nethermind.Blockchain.Test/Eip8037BlockGasIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Eip8037BlockGasIntegrationTests.cs
@@ -42,13 +42,11 @@ public class Eip8037BlockGasIntegrationTests
         IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
         return new(
             stateProvider,
-            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
-            Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = true },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            static worldState => new EthereumCodeInfoRepository(worldState),
-            static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor));
+            new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), new TestSingleReleaseSpecProvider(Amsterdam.Instance), LimboLogs.Instance,
+                static worldState => new EthereumCodeInfoRepository(worldState)));
     }
 
     private static (BlockAccessListManager, Block) BuildAmsterdamBlock(ulong blockGasLimit, params Transaction[] txs)
@@ -209,13 +207,11 @@ public class Eip8037BlockGasIntegrationTests
         TestSingleReleaseSpecProvider specProvider = new(Amsterdam.Instance);
         BlockAccessListManager balManager = new(
             stateProvider,
-            specProvider,
-            Substitute.For<IBlockhashProvider>(),
             LimboLogs.Instance,
             new BlocksConfig { ParallelExecution = false },
             new WithdrawalProcessorFactory(LimboLogs.Instance),
-            static worldState => new EthereumCodeInfoRepository(worldState),
-            static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor));
+            new BalTxProcessorFactory(Substitute.For<IBlockhashProvider>(), specProvider, LimboLogs.Instance,
+                static worldState => new EthereumCodeInfoRepository(worldState)));
 
         ulong blockGasLimit = Eip7825Constants.DefaultTxGasLimitCap + 100ul;
         Transaction tx = Build.A.Transaction.WithHash(TestItem.KeccakA)

--- a/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/ReorgTests.cs
@@ -90,7 +90,7 @@ public class ReorgTests
             new EthereumCodeInfoRepository(stateProvider),
             LimboLogs.Instance);
 
-        BlockAccessListManager balManager = new(stateProvider, specProvider, blockhashProvider, LimboLogs.Instance, new BlocksConfig() { ParallelExecution = false }, new WithdrawalProcessorFactory(LimboLogs.Instance), static worldState => new EthereumCodeInfoRepository(worldState), static txProcessor => new ExecuteTransactionProcessorAdapter(txProcessor));
+        BlockAccessListManager balManager = new(stateProvider, LimboLogs.Instance, new BlocksConfig() { ParallelExecution = false }, new WithdrawalProcessorFactory(LimboLogs.Instance), new BalTxProcessorFactory(blockhashProvider, specProvider, LimboLogs.Instance, static worldState => new EthereumCodeInfoRepository(worldState)));
         BlockProcessor blockProcessor = new(
             MainnetSpecProvider.Instance,
             Always.Valid,

--- a/src/Nethermind/Nethermind.Consensus/Processing/BalTxProcessorFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BalTxProcessorFactory.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Specs;
+using Nethermind.Evm;
+using Nethermind.Evm.GasPolicy;
+using Nethermind.Evm.State;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Logging;
+
+namespace Nethermind.Consensus.Processing;
+
+/// <summary>
+/// Builds the per-world-state tx processor and its adapter for the EIP-7928 block-access-list pool.
+/// </summary>
+/// <remarks>
+/// Bundles everything <see cref="BlockAccessListManager"/>'s pool needs to construct a processor so the
+/// manager takes one collaborator instead of five. <paramref name="adapterFactory"/> and
+/// <paramref name="processorFactory"/> default to the standard Execute adapter / Ethereum gas policy for
+/// manual construction (stateless envs, tests); container resolution fills them from the scope so the
+/// scoped <see cref="ITransactionProcessorAdapter"/> and the pool's per-worker adapters stay on one axis.
+/// </remarks>
+public class BalTxProcessorFactory(
+    IBlockhashProvider blockHashProvider,
+    ISpecProvider specProvider,
+    ILogManager logManager,
+    CodeInfoRepositoryFactory codeInfoRepositoryFactory,
+    TransactionProcessorAdapterFactory? adapterFactory = null,
+    ITransactionProcessorFactory? processorFactory = null)
+{
+    private readonly TransactionProcessorAdapterFactory _adapterFactory = adapterFactory ?? CreateExecuteAdapter;
+    private readonly ITransactionProcessorFactory _processorFactory = processorFactory ?? new TransactionProcessorFactory<EthereumGasPolicy>();
+
+    public (ITransactionProcessor Processor, ITransactionProcessorAdapter Adapter) Create(IWorldState worldState, bool parallel)
+    {
+        VirtualMachine virtualMachine = new(blockHashProvider, specProvider, logManager);
+        ICodeInfoRepository codeInfoRepository = codeInfoRepositoryFactory(worldState);
+        ITransactionProcessor processor = _processorFactory.Create(
+            BlobBaseFeeCalculator.Instance, specProvider, worldState, virtualMachine, codeInfoRepository, logManager, parallel);
+        return (processor, _adapterFactory(processor));
+    }
+
+    private static ITransactionProcessorAdapter CreateExecuteAdapter(ITransactionProcessor transactionProcessor)
+        => new ExecuteTransactionProcessorAdapter(transactionProcessor);
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
@@ -79,35 +79,23 @@ public partial class BlockAccessListManager
 
         // processors are not shared statically between BAL managers
         private readonly ConcurrentQueue<TxProcessorWithWorldState> _processors = [];
-        private readonly IBlockhashProvider _blockHashProvider;
-        private readonly ISpecProvider _specProvider;
         private readonly IWorldState _stateProvider;
         private readonly ILogManager _logManager;
-        private readonly ITransactionProcessorFactory _txProcessorFactory;
+        private readonly BalTxProcessorFactory _txProcessorFactory;
         private readonly ObjectPool<IReadOnlyTxProcessorSource>? _parentReaderEnvPool;
         private int _processorCount;
-        private readonly CodeInfoRepositoryFactory _codeInfoRepositoryFactory;
-        private readonly TransactionProcessorAdapterFactory _adapterFactory;
 
         public ParallelTxProcessorWithWorldStateManager(
-            IBlockhashProvider blockHashProvider,
-            ISpecProvider specProvider,
             IWorldState stateProvider,
             ILogManager logManager,
             PrewarmerEnvFactory? prewarmerEnvFactory,
             PreBlockCaches? preBlockCaches,
             IReadOnlyTxProcessingEnvFactory? readOnlyTxProcessingEnvFactory,
-            ITransactionProcessorFactory txProcessorFactory,
-            CodeInfoRepositoryFactory codeInfoRepositoryFactory,
-            TransactionProcessorAdapterFactory adapterFactory)
+            BalTxProcessorFactory txProcessorFactory)
         {
-            _blockHashProvider = blockHashProvider;
-            _specProvider = specProvider;
             _stateProvider = stateProvider;
             _logManager = logManager;
             _txProcessorFactory = txProcessorFactory;
-            _codeInfoRepositoryFactory = codeInfoRepositoryFactory;
-            _adapterFactory = adapterFactory;
             _parentReaderEnvPool = CreateParentReaderEnvPool(prewarmerEnvFactory, preBlockCaches, readOnlyTxProcessingEnvFactory);
             for (int i = 0; i < ProcessorPoolSize; i++)
             {
@@ -233,7 +221,7 @@ public partial class BlockAccessListManager
             => (int)uint.Min(balIndex, (uint)_lastBalIndex);
 
         private TxProcessorWithWorldState NewProcessor()
-            => new(true, _blockHashProvider, _specProvider, _stateProvider, _logManager, _txProcessorFactory, _codeInfoRepositoryFactory, _adapterFactory);
+            => new(true, _stateProvider, _logManager, _txProcessorFactory);
 
         private TxProcessorWithWorldState RentProcessor()
         {
@@ -336,15 +324,11 @@ public partial class BlockAccessListManager
         private readonly TxProcessorWithWorldState _txProcessorWithWorldState;
 
         public SequentialTxProcessorWithWorldStateManager(
-            IBlockhashProvider blockHashProvider,
-            ISpecProvider specProvider,
             IWorldState stateProvider,
             ILogManager logManager,
-            ITransactionProcessorFactory txProcessorFactory,
-            CodeInfoRepositoryFactory codeInfoRepositoryFactory,
-            TransactionProcessorAdapterFactory adapterFactory)
+            BalTxProcessorFactory txProcessorFactory)
         {
-            _txProcessorWithWorldState = new(false, blockHashProvider, specProvider, stateProvider, logManager, txProcessorFactory, codeInfoRepositoryFactory, adapterFactory);
+            _txProcessorWithWorldState = new(false, stateProvider, logManager, txProcessorFactory);
             _txProcessorWithWorldState.WorldState.SetGeneratingBlockAccessList(new());
         }
 
@@ -382,16 +366,10 @@ public partial class BlockAccessListManager
 
         public TxProcessorWithWorldState(
             bool parallel,
-            IBlockhashProvider blockHashProvider,
-            ISpecProvider specProvider,
             IWorldState stateProvider,
             ILogManager logManager,
-            ITransactionProcessorFactory txProcessorFactory,
-            CodeInfoRepositoryFactory codeInfoRepositoryFactory,
-            TransactionProcessorAdapterFactory adapterFactory)
+            BalTxProcessorFactory txProcessorFactory)
         {
-
-            VirtualMachine virtualMachine = new(blockHashProvider, specProvider, logManager);
             IWorldState worldState = stateProvider;
             if (parallel)
             {
@@ -399,9 +377,7 @@ public partial class BlockAccessListManager
                 worldState = _balWorldState;
             }
             WorldState = new TracedAccessWorldState(worldState, parallel);
-            ICodeInfoRepository codeInfoRepository = codeInfoRepositoryFactory(WorldState);
-            TxProcessor = txProcessorFactory.Create(BlobBaseFeeCalculator.Instance, specProvider, WorldState, virtualMachine, codeInfoRepository, logManager, parallel);
-            TxProcessorAdapter = adapterFactory(TxProcessor);
+            (TxProcessor, TxProcessorAdapter) = txProcessorFactory.Create(WorldState, parallel);
         }
 
         public void Setup(Block block, BlockExecutionContext blockExecutionContext, uint balIndex, ParentReaderLease? parentReader)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -15,7 +15,6 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
-using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Logging;
@@ -41,17 +40,13 @@ namespace Nethermind.Consensus.Processing;
 /// </remarks>
 public partial class BlockAccessListManager(
     IWorldState stateProvider,
-    ISpecProvider specProvider,
-    IBlockhashProvider blockHashProvider,
     ILogManager logManager,
     IBlocksConfig blocksConfig,
     IWithdrawalProcessorFactory withdrawalProcessorFactory,
-    CodeInfoRepositoryFactory codeInfoRepositoryFactory,
-    TransactionProcessorAdapterFactory txProcessorAdapterFactory,
+    BalTxProcessorFactory txProcessorFactory,
     PrewarmerEnvFactory? prewarmerEnvFactory = null,
     PreBlockCaches? preBlockCaches = null,
     IReadOnlyTxProcessingEnvFactory? readOnlyTxProcessingEnvFactory = null,
-    ITransactionProcessorFactory? transactionProcessorFactory = null,
     IExecutionRequestsProcessorFactory? executionRequestsProcessorFactory = null)
     : IBlockAccessListManager, IDisposable
 {
@@ -60,11 +55,9 @@ public partial class BlockAccessListManager(
     private ITxProcessorWithWorldStateManager? _txProcessorWithWorldStateManager;
     private Task? _balWarmupTask;
     private readonly Lazy<ParallelTxProcessorWithWorldStateManager> _parallelTxProcessorWithWorldStateManager =
-        new(() => new(blockHashProvider, specProvider, stateProvider, logManager, prewarmerEnvFactory, preBlockCaches, readOnlyTxProcessingEnvFactory,
-            transactionProcessorFactory ?? new TransactionProcessorFactory<EthereumGasPolicy>(), codeInfoRepositoryFactory, txProcessorAdapterFactory));
+        new(() => new(stateProvider, logManager, prewarmerEnvFactory, preBlockCaches, readOnlyTxProcessingEnvFactory, txProcessorFactory));
     private readonly Lazy<SequentialTxProcessorWithWorldStateManager> _sequentialTxProcessorWithWorldStateManager =
-        new(() => new(blockHashProvider, specProvider, stateProvider, logManager,
-            transactionProcessorFactory ?? new TransactionProcessorFactory<EthereumGasPolicy>(), codeInfoRepositoryFactory, txProcessorAdapterFactory));
+        new(() => new(stateProvider, logManager, txProcessorFactory));
     private const int GasValidationChunkSize = 8;
     private ulong? _gasRemaining;
     private bool _isBuilding;

--- a/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
@@ -50,8 +50,6 @@ public class StatelessBlockProcessingEnv(
         EthereumTransactionProcessor txProcessor = CreateTransactionProcessor(WorldState, blockhashProvider);
         BlockAccessListManager blockAccessListManager = new(
             WorldState,
-            specProvider,
-            blockhashProvider,
             logManager,
             new BlocksConfig()
             {
@@ -59,8 +57,8 @@ public class StatelessBlockProcessingEnv(
                 ParallelExecutionBatchRead = false
             },
             new WithdrawalProcessorFactory(logManager),
-            codeInfoRepositoryFactory: static state => new CacheCodeInfoRepository(state, new EthereumPrecompileProvider(), NoopCodeCache.Instance),
-            txProcessorAdapterFactory: static p => new ExecuteTransactionProcessorAdapter(p),
+            new BalTxProcessorFactory(blockhashProvider, specProvider, logManager,
+                static state => new CacheCodeInfoRepository(state, new EthereumPrecompileProvider(), NoopCodeCache.Instance)),
             executionRequestsProcessorFactory: StatelessExecutionRequestsProcessorFactory.Instance
         );
         BlockProcessor.ParallelBlockValidationTransactionsExecutor txExecutor = new(

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessCapturingBlockProcessingEnv.cs
@@ -87,14 +87,10 @@ public sealed class WitnessCapturingBlockProcessingEnv(
             .AddScoped<ICodeCache>(NoopCodeCache.Instance)
             .AddScoped<IBlockAccessListManager>(ctx => new BlockAccessListManager(
                 ctx.Resolve<IWorldState>(),
-                ctx.Resolve<ISpecProvider>(),
-                ctx.Resolve<IBlockhashProvider>(),
                 ctx.Resolve<ILogManager>(),
                 ctx.Resolve<IBlocksConfig>(),
                 ctx.Resolve<IWithdrawalProcessorFactory>(),
-                codeInfoRepositoryFactory: ctx.Resolve<CodeInfoRepositoryFactory>(),
-                txProcessorAdapterFactory: ctx.Resolve<TransactionProcessorAdapterFactory>(),
-                transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
+                ctx.Resolve<BalTxProcessorFactory>()))
             // Validation tx executor; everything else is inherited from root and re-resolved against the overridden world state.
             .AddModule(validationModules));
 

--- a/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/WitnessGeneratingBlockProcessingEnvFactory.cs
@@ -94,14 +94,10 @@ public class WitnessGeneratingBlockProcessingEnvFactory(
             .AddScoped<ICodeCache>(NoopCodeCache.Instance)
             .AddScoped<IBlockAccessListManager>(ctx => new BlockAccessListManager(
                 ctx.Resolve<IWorldState>(),
-                ctx.Resolve<ISpecProvider>(),
-                ctx.Resolve<IBlockhashProvider>(),
                 ctx.Resolve<ILogManager>(),
                 ctx.Resolve<IBlocksConfig>(),
                 ctx.Resolve<IWithdrawalProcessorFactory>(),
-                codeInfoRepositoryFactory: ctx.Resolve<CodeInfoRepositoryFactory>(),
-                txProcessorAdapterFactory: ctx.Resolve<TransactionProcessorAdapterFactory>(),
-                transactionProcessorFactory: ctx.Resolve<ITransactionProcessorFactory>()))
+                ctx.Resolve<BalTxProcessorFactory>()))
             .AddModule(validationModules)
             .AddScoped<IWitnessGeneratingBlockProcessingEnv, WitnessGeneratingBlockProcessingEnv>());
 

--- a/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BlockProcessingModule.cs
@@ -80,6 +80,7 @@ public class BlockProcessingModule(IInitConfig initConfig, IBlocksConfig blocksC
             .AddScoped<TransactionProcessorAdapterFactory>(CreateExecuteAdapter)
             .AddScoped<ITransactionProcessorAdapter, ITransactionProcessor, TransactionProcessorAdapterFactory>(
                 static (transactionProcessor, adapterFactory) => adapterFactory(transactionProcessor))
+            .AddScoped<BalTxProcessorFactory>()
             .AddScoped<IBlockAccessListManager, BlockAccessListManager>()
 
             .AddScoped<IProcessingStats, ProcessingStats>()


### PR DESCRIPTION
Follow-up to #12721 (LukaszRozmej's step 2). **Stacked on #12721** — rebase onto `master` once that merges.

## Changes

`BlockAccessListManager`'s `blockHashProvider`, `specProvider`, `codeInfoRepositoryFactory`, `transactionProcessorFactory`, and the tx-adapter factory were only ever used together — in `TxProcessorWithWorldState`'s ctor — to build one processor next to a `VirtualMachine`. This bundles that into a new `BalTxProcessorFactory`:

```csharp
(ITransactionProcessor Processor, ITransactionProcessorAdapter Adapter) Create(IWorldState worldState, bool parallel)
```

- `BlockAccessListManager` drops **five** ctor params for **one** (`BalTxProcessorFactory`); the pool managers and the pooled leaf shrink to `(stateProvider, logManager, factory)`.
- `BalTxProcessorFactory`'s adapter/processor factories **default** to `ExecuteTransactionProcessorAdapter` / `TransactionProcessorFactory<EthereumGasPolicy>` for the manual construction sites (stateless env, test harnesses); container resolution fills them from the scope, so the single-axis wiring from #12721 is preserved and the scoped adapter / BAL-pool adapters still agree.
- Witness envs now resolve the registered `BalTxProcessorFactory` instead of threading the individual collaborators.

Net **−15 lines** despite the new type — the bundling removes more plumbing than it adds.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [x] Refactoring

## Testing

- [x] Requires testing — [x] existing coverage

No behaviour change (pure construction re-shaping). Green locally: Blockchain BAL/BlockProcessor/Producer/Eip8037/Reorg/Blockhash 269, JsonRpc simulate/trace/proof/debug 402, Merge.Plugin payload/production 885; full solution builds clean.

## Documentation

- [ ] Requires documentation update — [x] No
- [ ] Requires Release Notes — [x] No