### PR TITLE
refactor(evm): drop the unused EIP-8272 native recent-root write path

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -16,10 +16,12 @@ namespace Nethermind.Evm.Test;
 [TestFixture]
 public class RecentRootStoreTests
 {
-    private static readonly Address Source = TestItem.AddressA;
-    private static readonly ValueHash256 Salt = TestItem.KeccakA.ValueHash256;
+    private static readonly ValueHash256 SourceId = TestItem.KeccakD.ValueHash256;
+    private static readonly ValueHash256 OtherSourceId = TestItem.KeccakE.ValueHash256;
     private static readonly ValueHash256 Root = TestItem.KeccakB.ValueHash256;
     private static readonly ValueHash256 OtherRoot = TestItem.KeccakC.ValueHash256;
+    private static readonly Address Source = TestItem.AddressA;
+    private static readonly ValueHash256 Salt = TestItem.KeccakA.ValueHash256;
 
     // Every concatenation in EIP-8272 is fixed-width, and an address is 20 bytes there, so the
     // preimage is 52 bytes. Left-padding the address to a word changes every source id, which is
@@ -37,37 +39,29 @@ public class RecentRootStoreTests
     [Test]
     public void EntryHash_is_deterministic_and_distinct_per_input()
     {
-        ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
-        ValueHash256 otherSource = RecentRootStore.SourceId(TestItem.AddressB, Salt);
-        ValueHash256 baseline = RecentRootStore.EntryHash(sourceId, 100, Root);
+        ValueHash256 baseline = RecentRootStore.EntryHash(SourceId, 100, Root);
 
-        Assert.That(RecentRootStore.EntryHash(sourceId, 100, Root), Is.EqualTo(baseline));
-        Assert.That(RecentRootStore.EntryHash(sourceId, 101, Root), Is.Not.EqualTo(baseline));
-        Assert.That(RecentRootStore.EntryHash(sourceId, 100, OtherRoot), Is.Not.EqualTo(baseline));
-        Assert.That(RecentRootStore.EntryHash(otherSource, 100, Root), Is.Not.EqualTo(baseline));
+        Assert.That(RecentRootStore.EntryHash(SourceId, 100, Root), Is.EqualTo(baseline));
+        Assert.That(RecentRootStore.EntryHash(SourceId, 101, Root), Is.Not.EqualTo(baseline));
+        Assert.That(RecentRootStore.EntryHash(SourceId, 100, OtherRoot), Is.Not.EqualTo(baseline));
+        Assert.That(RecentRootStore.EntryHash(OtherSourceId, 100, Root), Is.Not.EqualTo(baseline));
     }
 
     [Test]
     public void StorageKey_is_deterministic_and_distinct_per_input()
     {
-        ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
-        ValueHash256 otherSource = RecentRootStore.SourceId(TestItem.AddressB, Salt);
-        ValueHash256 baseline = RecentRootStore.StorageKey(sourceId, 5);
+        ValueHash256 baseline = RecentRootStore.StorageKey(SourceId, 5);
 
-        Assert.That(RecentRootStore.StorageKey(sourceId, 5), Is.EqualTo(baseline));
-        Assert.That(RecentRootStore.StorageKey(sourceId, 6), Is.Not.EqualTo(baseline));
-        Assert.That(RecentRootStore.StorageKey(otherSource, 5), Is.Not.EqualTo(baseline));
+        Assert.That(RecentRootStore.StorageKey(SourceId, 5), Is.EqualTo(baseline));
+        Assert.That(RecentRootStore.StorageKey(SourceId, 6), Is.Not.EqualTo(baseline));
+        Assert.That(RecentRootStore.StorageKey(OtherSourceId, 5), Is.Not.EqualTo(baseline));
     }
 
     [Test]
-    public void EntryHash_and_StorageKey_use_distinct_domains()
-    {
-        ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
-
+    public void EntryHash_and_StorageKey_use_distinct_domains() =>
         Assert.That(
-            RecentRootStore.EntryHash(sourceId, 5, Root),
-            Is.Not.EqualTo(RecentRootStore.StorageKey(sourceId, 5)));
-    }
+            RecentRootStore.EntryHash(SourceId, 5, Root),
+            Is.Not.EqualTo(RecentRootStore.StorageKey(SourceId, 5)));
 
     [Test]
     public void Reference_validity_window_boundaries()
@@ -76,16 +70,15 @@ public class RecentRootStoreTests
         using (scope)
         {
             const ulong writeSlot = 100_000;
-            Write(state, Source, Salt, Root, writeSlot);
-            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            Write(state, SourceId, Root, writeSlot);
 
-            Assert.That(RecentRootStore.IsReferenceValid(state, sourceId, writeSlot, Root, writeSlot + 1), Is.True);
-            Assert.That(RecentRootStore.IsReferenceValid(state, sourceId, writeSlot, Root, writeSlot), Is.False);
+            Assert.That(RecentRootStore.IsReferenceValid(state, SourceId, writeSlot, Root, writeSlot + 1), Is.True);
+            Assert.That(RecentRootStore.IsReferenceValid(state, SourceId, writeSlot, Root, writeSlot), Is.False);
             Assert.That(
-                RecentRootStore.IsReferenceValid(state, sourceId, writeSlot, Root, writeSlot + Eip8272Constants.RecentRootUsableWindow),
+                RecentRootStore.IsReferenceValid(state, SourceId, writeSlot, Root, writeSlot + Eip8272Constants.RecentRootUsableWindow),
                 Is.True);
             Assert.That(
-                RecentRootStore.IsReferenceValid(state, sourceId, writeSlot, Root, writeSlot + Eip8272Constants.RecentRootUsableWindow + 1),
+                RecentRootStore.IsReferenceValid(state, SourceId, writeSlot, Root, writeSlot + Eip8272Constants.RecentRootUsableWindow + 1),
                 Is.False);
         }
     }
@@ -98,10 +91,9 @@ public class RecentRootStoreTests
         {
             const ulong writeSlot = 1000;
             const ulong currentSlot = 1001;
-            Write(state, Source, Salt, Root, writeSlot);
-            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            Write(state, SourceId, Root, writeSlot);
 
-            Assert.That(RecentRootStore.IsReferenceValid(state, sourceId, writeSlot, Root, currentSlot), Is.True);
+            Assert.That(RecentRootStore.IsReferenceValid(state, SourceId, writeSlot, Root, currentSlot), Is.True);
         }
     }
 
@@ -113,13 +105,11 @@ public class RecentRootStoreTests
         {
             const ulong writeSlot = 1000;
             const ulong currentSlot = 1001;
-            Write(state, Source, Salt, Root, writeSlot);
-            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
-            ValueHash256 wrongSource = RecentRootStore.SourceId(TestItem.AddressB, Salt);
+            Write(state, SourceId, Root, writeSlot);
 
-            Assert.That(RecentRootStore.IsReferenceValid(state, sourceId, writeSlot, OtherRoot, currentSlot), Is.False);
-            Assert.That(RecentRootStore.IsReferenceValid(state, sourceId, writeSlot - 1, Root, currentSlot), Is.False);
-            Assert.That(RecentRootStore.IsReferenceValid(state, wrongSource, writeSlot, Root, currentSlot), Is.False);
+            Assert.That(RecentRootStore.IsReferenceValid(state, SourceId, writeSlot, OtherRoot, currentSlot), Is.False);
+            Assert.That(RecentRootStore.IsReferenceValid(state, SourceId, writeSlot - 1, Root, currentSlot), Is.False);
+            Assert.That(RecentRootStore.IsReferenceValid(state, OtherSourceId, writeSlot, Root, currentSlot), Is.False);
         }
     }
 
@@ -131,15 +121,13 @@ public class RecentRootStoreTests
         {
             const ulong writtenSlot = 5;
             ulong aliasedSlot = writtenSlot + Eip8272Constants.RecentRootLength;
-            Write(state, Source, Salt, Root, writtenSlot);
-            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            Write(state, SourceId, Root, writtenSlot);
 
             Assert.That(
-                RecentRootStore.StorageKey(sourceId, aliasedSlot % Eip8272Constants.RecentRootLength),
-                Is.EqualTo(RecentRootStore.StorageKey(sourceId, writtenSlot % Eip8272Constants.RecentRootLength)));
+                RecentRootStore.StorageKey(SourceId, aliasedSlot % Eip8272Constants.RecentRootLength),
+                Is.EqualTo(RecentRootStore.StorageKey(SourceId, writtenSlot % Eip8272Constants.RecentRootLength)));
 
-            // The stored entry commits to writtenSlot, so a reference to the aliased slot cannot match.
-            Assert.That(RecentRootStore.IsReferenceValid(state, sourceId, aliasedSlot, Root, aliasedSlot + 1), Is.False);
+            Assert.That(RecentRootStore.IsReferenceValid(state, SourceId, aliasedSlot, Root, aliasedSlot + 1), Is.False);
         }
     }
 
@@ -160,14 +148,13 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            Write(state, Source, Salt, Root, 100);
-            Write(state, Source, Salt, OtherRoot, 150);
-            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            Write(state, SourceId, Root, 100);
+            Write(state, SourceId, OtherRoot, 150);
 
             (ValueHash256, ulong, ValueHash256)[] references =
             [
-                (sourceId, 100UL, Root),
-                (sourceId, 150UL, OtherRoot)
+                (SourceId, 100UL, Root),
+                (SourceId, 150UL, OtherRoot)
             ];
             Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
         }
@@ -179,13 +166,12 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            Write(state, Source, Salt, Root, 100);
-            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            Write(state, SourceId, Root, 100);
 
             (ValueHash256, ulong, ValueHash256)[] references =
             [
-                (sourceId, 100UL, Root),
-                (sourceId, 100UL, OtherRoot)
+                (SourceId, 100UL, Root),
+                (SourceId, 100UL, OtherRoot)
             ];
             Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.False);
         }
@@ -197,13 +183,12 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            Write(state, Source, Salt, Root, 100);
-            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
+            Write(state, SourceId, Root, 100);
 
             (ValueHash256, ulong, ValueHash256)[] references =
             [
-                (sourceId, 100UL, Root),
-                (sourceId, 100UL, Root)
+                (SourceId, 100UL, Root),
+                (SourceId, 100UL, Root)
             ];
             Assert.That(RecentRootStore.AreReferencesValid(state, references, currentSlot: 200), Is.True);
         }
@@ -216,22 +201,19 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
-            // every reference is individually valid, so only the count decides the result
             (ValueHash256, ulong, ValueHash256)[] references = new (ValueHash256, ulong, ValueHash256)[Eip8272Constants.MaxRecentRootReferences + overCap];
             for (int i = 0; i < references.Length; i++)
             {
                 ulong slot = (ulong)(100 + i);
-                Write(state, Source, Salt, Root, slot);
-                references[i] = (sourceId, slot, Root);
+                Write(state, SourceId, Root, slot);
+                references[i] = (SourceId, slot, Root);
             }
             return RecentRootStore.AreReferencesValid(state, references, currentSlot: 500);
         }
     }
 
-    private static void Write(IWorldState state, Address source, in ValueHash256 salt, in ValueHash256 root, ulong slot)
+    private static void Write(IWorldState state, in ValueHash256 sourceId, in ValueHash256 root, ulong slot)
     {
-        ValueHash256 sourceId = RecentRootStore.SourceId(source, salt);
         StorageCell cell = new(
             Eip8272Constants.RecentRootAddress,
             RecentRootStore.StorageKey(sourceId, slot % Eip8272Constants.RecentRootLength).ToUInt256());

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -4,12 +4,11 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
-using Nethermind.Specs.Forks;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;
@@ -21,17 +20,6 @@ public class RecentRootStoreTests
     private static readonly ValueHash256 Salt = TestItem.KeccakA.ValueHash256;
     private static readonly ValueHash256 Root = TestItem.KeccakB.ValueHash256;
     private static readonly ValueHash256 OtherRoot = TestItem.KeccakC.ValueHash256;
-    private static readonly IReleaseSpec Spec = Amsterdam.Instance;
-
-    [Test]
-    public void SourceId_is_deterministic_and_distinct_per_input()
-    {
-        ValueHash256 baseline = RecentRootStore.SourceId(Source, Salt);
-
-        Assert.That(RecentRootStore.SourceId(Source, Salt), Is.EqualTo(baseline));
-        Assert.That(RecentRootStore.SourceId(TestItem.AddressB, Salt), Is.Not.EqualTo(baseline));
-        Assert.That(RecentRootStore.SourceId(Source, OtherRoot), Is.Not.EqualTo(baseline));
-    }
 
     // Every concatenation in EIP-8272 is fixed-width, and an address is 20 bytes there, so the
     // preimage is 52 bytes. Left-padding the address to a word changes every source id, which is
@@ -88,7 +76,7 @@ public class RecentRootStoreTests
         using (scope)
         {
             const ulong writeSlot = 100_000;
-            RecentRootStore.Write(state, Source, Salt, Root, writeSlot, Spec);
+            Write(state, Source, Salt, Root, writeSlot);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             Assert.That(RecentRootStore.IsReferenceValid(state, sourceId, writeSlot, Root, writeSlot + 1), Is.True);
@@ -110,7 +98,7 @@ public class RecentRootStoreTests
         {
             const ulong writeSlot = 1000;
             const ulong currentSlot = 1001;
-            RecentRootStore.Write(state, Source, Salt, Root, writeSlot, Spec);
+            Write(state, Source, Salt, Root, writeSlot);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             Assert.That(RecentRootStore.IsReferenceValid(state, sourceId, writeSlot, Root, currentSlot), Is.True);
@@ -125,7 +113,7 @@ public class RecentRootStoreTests
         {
             const ulong writeSlot = 1000;
             const ulong currentSlot = 1001;
-            RecentRootStore.Write(state, Source, Salt, Root, writeSlot, Spec);
+            Write(state, Source, Salt, Root, writeSlot);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
             ValueHash256 wrongSource = RecentRootStore.SourceId(TestItem.AddressB, Salt);
 
@@ -143,7 +131,7 @@ public class RecentRootStoreTests
         {
             const ulong writtenSlot = 5;
             ulong aliasedSlot = writtenSlot + Eip8272Constants.RecentRootLength;
-            RecentRootStore.Write(state, Source, Salt, Root, writtenSlot, Spec);
+            Write(state, Source, Salt, Root, writtenSlot);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             Assert.That(
@@ -172,8 +160,8 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
-            RecentRootStore.Write(state, Source, Salt, OtherRoot, 150, Spec);
+            Write(state, Source, Salt, Root, 100);
+            Write(state, Source, Salt, OtherRoot, 150);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             (ValueHash256, ulong, ValueHash256)[] references =
@@ -191,7 +179,7 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            Write(state, Source, Salt, Root, 100);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             (ValueHash256, ulong, ValueHash256)[] references =
@@ -209,7 +197,7 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            Write(state, Source, Salt, Root, 100);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             (ValueHash256, ulong, ValueHash256)[] references =
@@ -234,11 +222,20 @@ public class RecentRootStoreTests
             for (int i = 0; i < references.Length; i++)
             {
                 ulong slot = (ulong)(100 + i);
-                RecentRootStore.Write(state, Source, Salt, Root, slot, Spec);
+                Write(state, Source, Salt, Root, slot);
                 references[i] = (sourceId, slot, Root);
             }
             return RecentRootStore.AreReferencesValid(state, references, currentSlot: 500);
         }
+    }
+
+    private static void Write(IWorldState state, Address source, in ValueHash256 salt, in ValueHash256 root, ulong slot)
+    {
+        ValueHash256 sourceId = RecentRootStore.SourceId(source, salt);
+        StorageCell cell = new(
+            Eip8272Constants.RecentRootAddress,
+            RecentRootStore.StorageKey(sourceId, slot % Eip8272Constants.RecentRootLength).ToUInt256());
+        state.Set(cell, RecentRootStore.EntryHash(sourceId, slot, root).Bytes.WithoutLeadingZeros().ToArray());
     }
 
     private static IWorldState CreateState(out IDisposable scope)

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -6,12 +6,12 @@ using System.Buffers.Binary;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
 
 namespace Nethermind.Evm;
 
 /// <summary>Key/commitment derivations and the pre-state reference check for <see href="https://eips.ethereum.org/EIPS/eip-8272">EIP-8272</see> recent roots.</summary>
+/// <remarks>Recent-root storage is written by the <c>RECENT_ROOT_ADDRESS</c> predeploy bytecode during ordinary execution, not by the client, so this type only derives keys and validates references against already-written state.</remarks>
 public static class RecentRootStore
 {
     private const int HashLength = 32;
@@ -64,14 +64,6 @@ public static class RecentRootStore
         Span<byte> padded = stackalloc byte[HashLength];
         stored.CopyTo(padded.Slice(HashLength - stored.Length));
         return new ValueHash256(padded) == EntryHash(sourceId, slot, root);
-    }
-
-    public static void Write(IWorldState state, Address sourceAddress, in ValueHash256 salt, in ValueHash256 root, ulong currentSlot, IReleaseSpec spec)
-    {
-        ValueHash256 sourceId = SourceId(sourceAddress, salt);
-        StorageCell cell = RingBufferCell(sourceId, currentSlot % Eip8272Constants.RecentRootLength);
-        ValueHash256 entryHash = EntryHash(sourceId, currentSlot, root);
-        state.Set(cell, entryHash.Bytes.WithoutLeadingZeros().ToArray());
     }
 
     public static bool AreReferencesValid(IWorldState state, ReadOnlySpan<(ValueHash256 SourceId, ulong Slot, ValueHash256 Root)> references, ulong currentSlot)

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers.Binary;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Evm.State;
 
 namespace Nethermind.Evm;


### PR DESCRIPTION
## Changes

- Remove `RecentRootStore.Write` and its private helper `SourceId`, plus the test-only convenience overload they served.

Recent-root storage (EIP-8272) is written by the `RECENT_ROOT_ADDRESS` predeploy bytecode during ordinary execution, not by the client. `RecentRootStore.Write` was a leftover native-write path from before the predeploy approach and had no production caller on any branch: the only references were in its own unit tests. The SSTORE is performed by the EVM executing the predeploy code, so there is no C# write hook and there should not be one. `SourceId` was reachable only from `Write`, so it goes with it.

The read path (`EntryHash`, `StorageKey`, `IsReferenceValid`) stays because it is consumed by the EIP-8272 stack, not by this branch. This PR is based on `master`, where the read path has no caller, so it makes no such claim here; the consumers are one and two hops up the stack:

- the predeploy is installed at activation by `PredeployInstaller` — #12732, [`PredeployInstaller.cs#L37`](https://github.com/NethermindEth/nethermind/blob/0375133949d8c4dee44ed705e081137a75399752/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs#L37).
- `IsReferenceValid` is called by the frame-transaction pre-state check `RecentRootReferences.Validate` — #12743, [`RecentRootReferences.cs#L89`](https://github.com/NethermindEth/nethermind/blob/85ae4f9b92241d9af4733da9487c4366d76b5497/src/Nethermind/Nethermind.Evm/RecentRootReferences.cs#L89), wired at [`TransactionProcessorBase.FrameTx.cs#L134`](https://github.com/NethermindEth/nethermind/blob/85ae4f9b92241d9af4733da9487c4366d76b5497/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs#L134).
- reference count/reader opcode `0x0F` — #12659, [`EvmInstructions.FrameTx.cs#L110`](https://github.com/NethermindEth/nethermind/blob/50fc85dbd2fdea180fc2ca8453b99ef1228a9580/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs#L110).

The `SourceId` derivation moves into the test file as a private helper using `source_id = keccak256(source_address || salt)` with the unpadded 20-byte `source_address` (EIP-8272 fixed-length encoding, spec L56/L73), matching the canonical `SourceId` on the stack.

## Types of changes

- [x] Refactoring (removing dead code)

## Testing

- [x] Yes

`RecentRootStoreTests` rewritten against the read path; `dotnet test Nethermind.Evm.Test --filter RecentRootStoreTests` passes 7/7.
