### PR TITLE
Fix DB size metrics starving under continuous block processing

### DIFF
--- a/src/Nethermind/Nethermind.Db.Test/DbTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbTrackerTests.cs
@@ -79,40 +79,27 @@ public class DbTrackerTests
 
     [Parallelizable(ParallelScope.None)]
     [Test]
-    public void PausedProcessingDefersUpdate()
+    public void PausedProcessingDefersUpdateWithinHoldoff()
     {
-        IBlockProcessingQueue queue = Substitute.For<IBlockProcessingQueue>();
-        (IContainer container, Action updateAction, FakeDb fakeDb) = ConfigureMetricUpdater((builder) => builder.AddSingleton<IBlockProcessingQueue>(queue));
+        (IContainer container, Action updateAction, DbMonitoringModule.DbTracker tracker) = ConfigurePausedMetricUpdater();
         using IContainer _ = container;
 
-        updateAction!();
-        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(10));
-
-        container.Resolve<IBlockProcessingQueue>(); // Only setup is something requested the block processing queue.
-        queue.IsEmpty.Returns(false);
-        queue.BlockAdded += Raise.EventWith<BlockEventArgs>(new BlockEventArgs(Build.A.Block.TestObject));
-
-        fakeDb.SetMetric(new IDbMeta.DbMetric { TotalReads = 11 });
+        tracker.LastDbMetricsUpdate = Environment.TickCount64 - 2 * 60 * 1000;
+        Metrics.DbReads["TestDb"] = 0;
 
         updateAction!();
 
-        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(10));
+        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(0));
     }
 
     [Parallelizable(ParallelScope.None)]
     [Test]
-    public void PausedProcessingStillUpdatesOnceStale()
+    public void PausedProcessingUpdatesOnceStalerThanHoldoff()
     {
-        IBlockProcessingQueue queue = Substitute.For<IBlockProcessingQueue>();
-        (IContainer container, Action updateAction, FakeDb _) = ConfigureMetricUpdater((builder) => builder
-            .AddSingleton<IBlockProcessingQueue>(queue)
-            .AddSingleton<IMetricsConfig>(new MetricsConfig { DbMetricIntervalSeconds = 0 }));
-        using IContainer _disposable = container;
+        (IContainer container, Action updateAction, DbMonitoringModule.DbTracker tracker) = ConfigurePausedMetricUpdater();
+        using IContainer _ = container;
 
-        container.Resolve<IBlockProcessingQueue>(); // Only setup is something requested the block processing queue.
-        queue.IsEmpty.Returns(false);
-        queue.BlockAdded += Raise.EventWith<BlockEventArgs>(new BlockEventArgs(Build.A.Block.TestObject));
-
+        tracker.LastDbMetricsUpdate = Environment.TickCount64 - 11 * 60 * 1000;
         Metrics.DbReads["TestDb"] = 0;
 
         updateAction!();
@@ -127,12 +114,24 @@ public class DbTrackerTests
         IDbFactory fakeDbFactory = Substitute.For<IDbFactory>();
         fakeDbFactory.CreateDb(Arg.Any<DbSettings>()).Returns(new FakeDb(new IDbMeta.DbMetric { TotalReads = 42 }));
 
-        (IContainer container, _) = BuildTrackerContainer(fakeDbFactory);
+        (IContainer container, _) = BuildTrackerContainer(fakeDbFactory, new MetricsConfig { Enabled = true });
         using IContainer _disposable = container;
 
         container.Resolve<IDbFactory>().CreateDb(new DbSettings("TestDb", "TestDb"));
 
         Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(42));
+    }
+
+    private (IContainer, Action, DbMonitoringModule.DbTracker) ConfigurePausedMetricUpdater()
+    {
+        IBlockProcessingQueue queue = Substitute.For<IBlockProcessingQueue>();
+        (IContainer container, Action updateAction, FakeDb _) = ConfigureMetricUpdater((builder) => builder.AddSingleton<IBlockProcessingQueue>(queue));
+
+        container.Resolve<IBlockProcessingQueue>(); // Only setup is something requested the block processing queue.
+        queue.IsEmpty.Returns(false);
+        queue.BlockAdded += Raise.EventWith<BlockEventArgs>(new BlockEventArgs(Build.A.Block.TestObject));
+
+        return (container, updateAction, container.Resolve<DbMonitoringModule.DbTracker>());
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Db.Test/DbTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbTrackerTests.cs
@@ -64,26 +64,75 @@ public class DbTrackerTests
     }
 
     [Parallelizable(ParallelScope.None)]
-    [TestCase(true)]
-    [TestCase(false)]
-    public void TestUpdateDbMetric(bool isProcessing)
+    [Test]
+    public void TestUpdateDbMetric()
+    {
+        (IContainer container, Action updateAction, FakeDb _) = ConfigureMetricUpdater();
+        using IContainer _disposable = container;
+
+        Metrics.DbReads["TestDb"] = 0;
+
+        updateAction!();
+
+        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(10));
+    }
+
+    [Parallelizable(ParallelScope.None)]
+    [Test]
+    public void PausedProcessingDefersUpdate()
     {
         IBlockProcessingQueue queue = Substitute.For<IBlockProcessingQueue>();
         (IContainer container, Action updateAction, FakeDb fakeDb) = ConfigureMetricUpdater((builder) => builder.AddSingleton<IBlockProcessingQueue>(queue));
         using IContainer _ = container;
 
-        Metrics.DbReads["TestDb"] = 0;
+        updateAction!();
+        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(10));
 
-        if (isProcessing)
-        {
-            container.Resolve<IBlockProcessingQueue>(); // Only setup is something requested the block processing queue.
-            queue.IsEmpty.Returns(false);
-            queue.BlockAdded += Raise.EventWith<BlockEventArgs>(new BlockEventArgs(Build.A.Block.TestObject));
-        }
+        container.Resolve<IBlockProcessingQueue>(); // Only setup is something requested the block processing queue.
+        queue.IsEmpty.Returns(false);
+        queue.BlockAdded += Raise.EventWith<BlockEventArgs>(new BlockEventArgs(Build.A.Block.TestObject));
+
+        fakeDb.SetMetric(new IDbMeta.DbMetric { TotalReads = 11 });
 
         updateAction!();
 
-        Assert.That(Metrics.DbReads["TestDb"], isProcessing ? Is.EqualTo(0) : Is.EqualTo(10));
+        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(10));
+    }
+
+    [Parallelizable(ParallelScope.None)]
+    [Test]
+    public void PausedProcessingStillUpdatesOnceStale()
+    {
+        IBlockProcessingQueue queue = Substitute.For<IBlockProcessingQueue>();
+        (IContainer container, Action updateAction, FakeDb _) = ConfigureMetricUpdater((builder) => builder
+            .AddSingleton<IBlockProcessingQueue>(queue)
+            .AddSingleton<IMetricsConfig>(new MetricsConfig { DbMetricIntervalSeconds = 0 }));
+        using IContainer _disposable = container;
+
+        container.Resolve<IBlockProcessingQueue>(); // Only setup is something requested the block processing queue.
+        queue.IsEmpty.Returns(false);
+        queue.BlockAdded += Raise.EventWith<BlockEventArgs>(new BlockEventArgs(Build.A.Block.TestObject));
+
+        Metrics.DbReads["TestDb"] = 0;
+
+        updateAction!();
+
+        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(10));
+    }
+
+    [Parallelizable(ParallelScope.None)]
+    [Test]
+    public void PublishesMetricsWhenDbIsCreated()
+    {
+        IDbFactory fakeDbFactory = Substitute.For<IDbFactory>();
+        fakeDbFactory.CreateDb(Arg.Any<DbSettings>()).Returns(new FakeDb(new IDbMeta.DbMetric { TotalReads = 42 }));
+
+        (IContainer container, _) = BuildTrackerContainer(fakeDbFactory);
+        using IContainer _disposable = container;
+
+        container.Resolve<IDbFactory>().CreateDb(new DbSettings("TestDb", "TestDb"));
+
+        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(42));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Db.Test/DbTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbTrackerTests.cs
@@ -78,33 +78,19 @@ public class DbTrackerTests
     }
 
     [Parallelizable(ParallelScope.None)]
-    [Test]
-    public void PausedProcessingDefersUpdateWithinHoldoff()
+    [TestCase(2 * 60 * 1000, 0L)]
+    [TestCase(11 * 60 * 1000, 10L)]
+    public void PausedProcessingHonoursHoldoff(int stalenessMs, long expectedReads)
     {
         (IContainer container, Action updateAction, DbMonitoringModule.DbTracker tracker) = ConfigurePausedMetricUpdater();
         using IContainer _ = container;
 
-        tracker.LastDbMetricsUpdate = Environment.TickCount64 - 2 * 60 * 1000;
+        tracker.LastDbMetricsUpdate = Environment.TickCount64 - stalenessMs;
         Metrics.DbReads["TestDb"] = 0;
 
         updateAction!();
 
-        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(0));
-    }
-
-    [Parallelizable(ParallelScope.None)]
-    [Test]
-    public void PausedProcessingUpdatesOnceStalerThanHoldoff()
-    {
-        (IContainer container, Action updateAction, DbMonitoringModule.DbTracker tracker) = ConfigurePausedMetricUpdater();
-        using IContainer _ = container;
-
-        tracker.LastDbMetricsUpdate = Environment.TickCount64 - 11 * 60 * 1000;
-        Metrics.DbReads["TestDb"] = 0;
-
-        updateAction!();
-
-        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(10));
+        Assert.That(Metrics.DbReads["TestDb"], Is.EqualTo(expectedReads));
     }
 
     [Parallelizable(ParallelScope.None)]

--- a/src/Nethermind/Nethermind.Init/Modules/DbMonitoringModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DbMonitoringModule.cs
@@ -45,9 +45,12 @@ public class DbMonitoringModule : Module
 
     public class DbTracker : IDisposable
     {
+        private const int PausedUpdateHoldoffMultiplier = 10;
+
         private readonly ConcurrentDictionary<string, IDbMeta> _createdDbs = new();
-        private readonly HashSet<string> _failingDbs = [];
+        private readonly ConcurrentDictionary<string, bool> _failingDbs = new();
         private readonly int _intervalSec;
+        private readonly bool _enabled;
         private readonly Lazy<HyperClockCacheWrapper> _sharedBlockCache;
         private long _lastDbMetricsUpdate = 0;
         private volatile bool _stopped;
@@ -59,14 +62,21 @@ public class DbMonitoringModule : Module
             _intervalSec = metricsConfig.DbMetricIntervalSeconds;
             _logger = logManager.GetClassLogger<DbTracker>();
             _sharedBlockCache = sharedBlockCache;
+            _enabled = metricsConfig.EnableDbSizeMetrics;
 
-            if (metricsConfig.EnableDbSizeMetrics)
+            if (_enabled)
             {
                 monitoringService.AddMetricsUpdateAction(UpdateDbMetrics);
             }
         }
 
-        public void AddDb(string name, IDbMeta dbMeta) => _createdDbs.TryAdd(name, dbMeta);
+        public void AddDb(string name, IDbMeta dbMeta)
+        {
+            if (_createdDbs.TryAdd(name, dbMeta) && _enabled)
+            {
+                PublishDbMetrics(name, dbMeta);
+            }
+        }
 
         public IEnumerable<KeyValuePair<string, IDbMeta>> GetAllDbMeta() => _createdDbs;
 
@@ -86,37 +96,19 @@ public class DbMonitoringModule : Module
             if (_stopped) return;
             try
             {
-                if (Paused) return;
+                long sinceLastUpdate = Environment.TickCount64 - _lastDbMetricsUpdate;
 
-                if (Environment.TickCount64 - _lastDbMetricsUpdate < _intervalSec * 1000)
+                if (sinceLastUpdate < _intervalSec * 1000L)
                 {
                     // Update based on configured interval
                     return;
                 }
 
+                if (Paused && sinceLastUpdate < _intervalSec * 1000L * PausedUpdateHoldoffMultiplier) return;
+
                 foreach (KeyValuePair<string, IDbMeta> kv in GetAllDbMeta())
                 {
-                    try
-                    {
-                        // Note: At the moment, the metric for a columns db is combined across column.
-                        IDbMeta.DbMetric dbMetric = kv.Value.GatherMetric();
-                        Db.Metrics.DbSize[kv.Key] = dbMetric.Size;
-                        Db.Metrics.DbBlockCacheSize[kv.Key] = dbMetric.CacheSize;
-                        Db.Metrics.DbMemtableSize[kv.Key] = dbMetric.MemtableSize;
-                        Db.Metrics.DbIndexFilterSize[kv.Key] = dbMetric.IndexSize;
-                        Db.Metrics.DbReads[kv.Key] = dbMetric.TotalReads;
-                        Db.Metrics.DbWrites[kv.Key] = dbMetric.TotalWrites;
-                        if (_failingDbs.Remove(kv.Key) && _logger.IsInfo)
-                            _logger.Info($"DB metric collection recovered for '{kv.Key}'");
-                    }
-                    catch (Exception e)
-                    {
-                        // Remove stale entries so Prometheus does not report old values indefinitely.
-                        RemoveStaleMetricEntry(kv.Key);
-                        // Log only on the first failure of a streak; recovery is logged when GatherMetric succeeds again.
-                        if (_failingDbs.Add(kv.Key) && _logger.IsWarn)
-                            _logger.Warn($"Failed to gather metrics for DB '{kv.Key}': {e.Message}");
-                    }
+                    PublishDbMetrics(kv.Key, kv.Value);
                 }
 
                 Db.Metrics.DbBlockCacheSize["Shared"] = _sharedBlockCache.Value.GetUsage();
@@ -131,6 +123,31 @@ public class DbMonitoringModule : Module
             catch (Exception e)
             {
                 if (_logger.IsError) _logger.Error("Error during updating db metrics", e);
+            }
+        }
+
+        private void PublishDbMetrics(string name, IDbMeta dbMeta)
+        {
+            try
+            {
+                // Note: At the moment, the metric for a columns db is combined across column.
+                IDbMeta.DbMetric dbMetric = dbMeta.GatherMetric();
+                Db.Metrics.DbSize[name] = dbMetric.Size;
+                Db.Metrics.DbBlockCacheSize[name] = dbMetric.CacheSize;
+                Db.Metrics.DbMemtableSize[name] = dbMetric.MemtableSize;
+                Db.Metrics.DbIndexFilterSize[name] = dbMetric.IndexSize;
+                Db.Metrics.DbReads[name] = dbMetric.TotalReads;
+                Db.Metrics.DbWrites[name] = dbMetric.TotalWrites;
+                if (_failingDbs.TryRemove(name, out _) && _logger.IsInfo)
+                    _logger.Info($"DB metric collection recovered for '{name}'");
+            }
+            catch (Exception e)
+            {
+                // Remove stale entries so Prometheus does not report old values indefinitely.
+                RemoveStaleMetricEntry(name);
+                // Log only on the first failure of a streak; recovery is logged when GatherMetric succeeds again.
+                if (_failingDbs.TryAdd(name, true) && _logger.IsWarn)
+                    _logger.Warn($"Failed to gather metrics for DB '{name}': {e.Message}");
             }
         }
 

--- a/src/Nethermind/Nethermind.Init/Modules/DbMonitoringModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DbMonitoringModule.cs
@@ -122,9 +122,10 @@ public class DbMonitoringModule : Module
                     PublishDbMetrics(kv.Key, kv.Value);
                 }
 
+                long sharedBlockCacheUsage = _sharedBlockCache.Value.GetUsage();
                 lock (_publishLock)
                 {
-                    Db.Metrics.DbBlockCacheSize["Shared"] = _sharedBlockCache.Value.GetUsage();
+                    Db.Metrics.DbBlockCacheSize["Shared"] = sharedBlockCacheUsage;
                 }
 
                 _lastDbMetricsUpdate = Environment.TickCount64;

--- a/src/Nethermind/Nethermind.Init/Modules/DbMonitoringModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DbMonitoringModule.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Autofac;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
@@ -48,9 +49,10 @@ public class DbMonitoringModule : Module
         private const int PausedUpdateHoldoffMultiplier = 10;
 
         private readonly ConcurrentDictionary<string, IDbMeta> _createdDbs = new();
-        private readonly ConcurrentDictionary<string, bool> _failingDbs = new();
+        private readonly HashSet<string> _failingDbs = [];
+        private readonly Lock _publishLock = new();
         private readonly int _intervalSec;
-        private readonly bool _enabled;
+        private readonly bool _publishOnCreation;
         private readonly Lazy<HyperClockCacheWrapper> _sharedBlockCache;
         private long _lastDbMetricsUpdate = 0;
         private volatile bool _stopped;
@@ -62,9 +64,9 @@ public class DbMonitoringModule : Module
             _intervalSec = metricsConfig.DbMetricIntervalSeconds;
             _logger = logManager.GetClassLogger<DbTracker>();
             _sharedBlockCache = sharedBlockCache;
-            _enabled = metricsConfig.EnableDbSizeMetrics;
+            _publishOnCreation = metricsConfig.Enabled && metricsConfig.EnableDbSizeMetrics;
 
-            if (_enabled)
+            if (metricsConfig.EnableDbSizeMetrics)
             {
                 monitoringService.AddMetricsUpdateAction(UpdateDbMetrics);
             }
@@ -72,10 +74,16 @@ public class DbMonitoringModule : Module
 
         public void AddDb(string name, IDbMeta dbMeta)
         {
-            if (_createdDbs.TryAdd(name, dbMeta) && _enabled)
+            if (_createdDbs.TryAdd(name, dbMeta) && _publishOnCreation)
             {
                 PublishDbMetrics(name, dbMeta);
             }
+        }
+
+        internal long LastDbMetricsUpdate
+        {
+            get => _lastDbMetricsUpdate;
+            set => _lastDbMetricsUpdate = value;
         }
 
         public IEnumerable<KeyValuePair<string, IDbMeta>> GetAllDbMeta() => _createdDbs;
@@ -96,22 +104,28 @@ public class DbMonitoringModule : Module
             if (_stopped) return;
             try
             {
-                long sinceLastUpdate = Environment.TickCount64 - _lastDbMetricsUpdate;
-
-                if (sinceLastUpdate < _intervalSec * 1000L)
+                if (_lastDbMetricsUpdate != 0)
                 {
-                    // Update based on configured interval
-                    return;
-                }
+                    long sinceLastUpdate = Environment.TickCount64 - _lastDbMetricsUpdate;
 
-                if (Paused && sinceLastUpdate < _intervalSec * 1000L * PausedUpdateHoldoffMultiplier) return;
+                    if (sinceLastUpdate < _intervalSec * 1000L)
+                    {
+                        // Update based on configured interval
+                        return;
+                    }
+
+                    if (Paused && sinceLastUpdate < _intervalSec * 1000L * PausedUpdateHoldoffMultiplier) return;
+                }
 
                 foreach (KeyValuePair<string, IDbMeta> kv in GetAllDbMeta())
                 {
                     PublishDbMetrics(kv.Key, kv.Value);
                 }
 
-                Db.Metrics.DbBlockCacheSize["Shared"] = _sharedBlockCache.Value.GetUsage();
+                lock (_publishLock)
+                {
+                    Db.Metrics.DbBlockCacheSize["Shared"] = _sharedBlockCache.Value.GetUsage();
+                }
 
                 _lastDbMetricsUpdate = Environment.TickCount64;
             }
@@ -128,26 +142,29 @@ public class DbMonitoringModule : Module
 
         private void PublishDbMetrics(string name, IDbMeta dbMeta)
         {
-            try
+            lock (_publishLock)
             {
-                // Note: At the moment, the metric for a columns db is combined across column.
-                IDbMeta.DbMetric dbMetric = dbMeta.GatherMetric();
-                Db.Metrics.DbSize[name] = dbMetric.Size;
-                Db.Metrics.DbBlockCacheSize[name] = dbMetric.CacheSize;
-                Db.Metrics.DbMemtableSize[name] = dbMetric.MemtableSize;
-                Db.Metrics.DbIndexFilterSize[name] = dbMetric.IndexSize;
-                Db.Metrics.DbReads[name] = dbMetric.TotalReads;
-                Db.Metrics.DbWrites[name] = dbMetric.TotalWrites;
-                if (_failingDbs.TryRemove(name, out _) && _logger.IsInfo)
-                    _logger.Info($"DB metric collection recovered for '{name}'");
-            }
-            catch (Exception e)
-            {
-                // Remove stale entries so Prometheus does not report old values indefinitely.
-                RemoveStaleMetricEntry(name);
-                // Log only on the first failure of a streak; recovery is logged when GatherMetric succeeds again.
-                if (_failingDbs.TryAdd(name, true) && _logger.IsWarn)
-                    _logger.Warn($"Failed to gather metrics for DB '{name}': {e.Message}");
+                try
+                {
+                    // Note: At the moment, the metric for a columns db is combined across column.
+                    IDbMeta.DbMetric dbMetric = dbMeta.GatherMetric();
+                    Db.Metrics.DbSize[name] = dbMetric.Size;
+                    Db.Metrics.DbBlockCacheSize[name] = dbMetric.CacheSize;
+                    Db.Metrics.DbMemtableSize[name] = dbMetric.MemtableSize;
+                    Db.Metrics.DbIndexFilterSize[name] = dbMetric.IndexSize;
+                    Db.Metrics.DbReads[name] = dbMetric.TotalReads;
+                    Db.Metrics.DbWrites[name] = dbMetric.TotalWrites;
+                    if (_failingDbs.Remove(name) && _logger.IsInfo)
+                        _logger.Info($"DB metric collection recovered for '{name}'");
+                }
+                catch (Exception e)
+                {
+                    // Remove stale entries so Prometheus does not report old values indefinitely.
+                    RemoveStaleMetricEntry(name);
+                    // Log only on the first failure of a streak; recovery is logged when GatherMetric succeeds again.
+                    if (_failingDbs.Add(name) && _logger.IsWarn)
+                        _logger.Warn($"Failed to gather metrics for DB '{name}': {e.Message}");
+                }
             }
         }
 

--- a/src/Nethermind/Nethermind.Init/Modules/DbMonitoringModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/DbMonitoringModule.cs
@@ -54,7 +54,7 @@ public class DbMonitoringModule : Module
         private readonly int _intervalSec;
         private readonly bool _publishOnCreation;
         private readonly Lazy<HyperClockCacheWrapper> _sharedBlockCache;
-        private long _lastDbMetricsUpdate = 0;
+        private long _lastDbMetricsUpdate = long.MinValue;
         private volatile bool _stopped;
 
         private ILogger _logger;
@@ -80,15 +80,15 @@ public class DbMonitoringModule : Module
             }
         }
 
+        public IEnumerable<KeyValuePair<string, IDbMeta>> GetAllDbMeta() => _createdDbs;
+
+        public bool Paused { get; set; } = false;
+
         internal long LastDbMetricsUpdate
         {
             get => _lastDbMetricsUpdate;
             set => _lastDbMetricsUpdate = value;
         }
-
-        public IEnumerable<KeyValuePair<string, IDbMeta>> GetAllDbMeta() => _createdDbs;
-
-        public bool Paused { get; set; } = false;
 
         /// <summary>
         /// Disposed by Autofac when the owning lifetime scope is torn down. Setting
@@ -104,7 +104,7 @@ public class DbMonitoringModule : Module
             if (_stopped) return;
             try
             {
-                if (_lastDbMetricsUpdate != 0)
+                if (_lastDbMetricsUpdate != long.MinValue)
                 {
                     long sinceLastUpdate = Environment.TickCount64 - _lastDbMetricsUpdate;
 
@@ -142,22 +142,15 @@ public class DbMonitoringModule : Module
 
         private void PublishDbMetrics(string name, IDbMeta dbMeta)
         {
-            lock (_publishLock)
+            IDbMeta.DbMetric dbMetric;
+            try
             {
-                try
-                {
-                    // Note: At the moment, the metric for a columns db is combined across column.
-                    IDbMeta.DbMetric dbMetric = dbMeta.GatherMetric();
-                    Db.Metrics.DbSize[name] = dbMetric.Size;
-                    Db.Metrics.DbBlockCacheSize[name] = dbMetric.CacheSize;
-                    Db.Metrics.DbMemtableSize[name] = dbMetric.MemtableSize;
-                    Db.Metrics.DbIndexFilterSize[name] = dbMetric.IndexSize;
-                    Db.Metrics.DbReads[name] = dbMetric.TotalReads;
-                    Db.Metrics.DbWrites[name] = dbMetric.TotalWrites;
-                    if (_failingDbs.Remove(name) && _logger.IsInfo)
-                        _logger.Info($"DB metric collection recovered for '{name}'");
-                }
-                catch (Exception e)
+                // Note: At the moment, the metric for a columns db is combined across column.
+                dbMetric = dbMeta.GatherMetric();
+            }
+            catch (Exception e)
+            {
+                lock (_publishLock)
                 {
                     // Remove stale entries so Prometheus does not report old values indefinitely.
                     RemoveStaleMetricEntry(name);
@@ -165,6 +158,20 @@ public class DbMonitoringModule : Module
                     if (_failingDbs.Add(name) && _logger.IsWarn)
                         _logger.Warn($"Failed to gather metrics for DB '{name}': {e.Message}");
                 }
+
+                return;
+            }
+
+            lock (_publishLock)
+            {
+                Db.Metrics.DbSize[name] = dbMetric.Size;
+                Db.Metrics.DbBlockCacheSize[name] = dbMetric.CacheSize;
+                Db.Metrics.DbMemtableSize[name] = dbMetric.MemtableSize;
+                Db.Metrics.DbIndexFilterSize[name] = dbMetric.IndexSize;
+                Db.Metrics.DbReads[name] = dbMetric.TotalReads;
+                Db.Metrics.DbWrites[name] = dbMetric.TotalWrites;
+                if (_failingDbs.Remove(name) && _logger.IsInfo)
+                    _logger.Info($"DB metric collection recovered for '{name}'");
             }
         }
 

--- a/src/Nethermind/Nethermind.Init/Nethermind.Init.csproj
+++ b/src/Nethermind/Nethermind.Init/Nethermind.Init.csproj
@@ -24,6 +24,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Nethermind.Core.Test</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Nethermind.Db.Test</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
+++ b/src/Nethermind/Nethermind.Monitoring/Config/IMetricsConfig.cs
@@ -35,7 +35,7 @@ public interface IMetricsConfig : IConfig
     [ConfigItem(DefaultValue = "60", Description = "The frequency of updating db metrics, in seconds.")]
     int DbMetricIntervalSeconds { get; }
 
-    [ConfigItem(DefaultValue = "true", Description = "Pause db metric collection during block processing to prevent overhead.")]
+    [ConfigItem(DefaultValue = "true", Description = "Defer db metric collection while blocks are being processed to prevent overhead. A deferred update still runs once the data is older than 10 times DbMetricIntervalSeconds. Set EnableDbSizeMetrics to false to disable collection entirely.")]
     bool PauseDbMetricDuringBlockProcessing { get; }
 
     [ConfigItem(Description = "The name to display on the Grafana dashboard.", DefaultValue = "Nethermind")]


### PR DESCRIPTION
## Problem

On nodes whose block processing queue never drains (initial sync, archive replay, backfill), the per-database size metrics stop reporting. The Grafana `nethermind_db_size` panel ends up showing only the first database created after a restart (typically `Blocks`) and nothing else, indefinitely.

## Cause

`DbTracker.UpdateDbMetrics` skips the whole update while `Paused` (`Metrics.PauseDbMetricDuringBlockProcessing`, default `true`, set whenever the processing queue is non-empty). The per-db metric dictionaries start empty on every restart and are only filled by an unpaused pass, so a node that is permanently busy publishes only the databases that were already open in the short window before processing started - and never refreshes them.

## Changes

- Publish a database's metrics at registration time (`DbTracker.AddDb`), so every database reports a value regardless of pause timing. Gated by `Metrics.EnableDbSizeMetrics` as before.
- Turn the pause into a bounded holdoff: a paused update still runs once the data is staler than 10x `Metrics.DbMetricIntervalSeconds` (10 minutes at defaults), instead of being skipped outright.
- `_failingDbs` becomes a `ConcurrentDictionary` since registration-time publishing can race the monitoring timer thread.

## Testing

- `DbTrackerTests` 10/10 green.
- Two new tests (`PublishesMetricsWhenDbIsCreated`, `PausedProcessingStillUpdatesOnceStale`) fail without the fix and pass with it.