### PR TITLE
fix(cache): preserve live entries during racing AssociativeCache Clear()

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Caching/AssociativeCacheTestsBase.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/AssociativeCacheTestsBase.cs
@@ -228,6 +228,35 @@ public abstract class AssociativeCacheTestsBase
     }
 
     [Test]
+    public void Concurrent_clears_preserve_live_entries_and_exact_count()
+    {
+        // Regression: Clear()'s reference-release pass captured its epoch and nulled every entry
+        // whose epoch differed. When Clear() calls raced, a stale pass would null entries written
+        // after a LATER Clear (a newer epoch) — dropping live entries and orphaning their count.
+        // Capacity keys collide into few 8-way sets (forcing eviction) and frequent concurrent
+        // Clears reproduce the race. Each round ends quiescent, so Count must equal the number of
+        // retrievable entries; a dropped live entry or an orphaned count breaks that equality.
+        for (int round = 0; round < 1000; round++)
+        {
+            CreateCache(Capacity);
+
+            Parallel.For(0, Environment.ProcessorCount * 4, iter =>
+            {
+                for (int i = 0; i < Capacity; i++)
+                    Set(in _keys[i], i);
+                if (iter % 2 == 0)
+                    Clear();
+            });
+
+            int live = 0;
+            for (int i = 0; i < Capacity; i++)
+                if (Get(in _keys[i])) live++;
+
+            Assert.That(GetCount(), Is.EqualTo(live), $"round {round}: Count disagrees with retrievable entries");
+        }
+    }
+
+    [Test]
     public void Concurrent_delete_and_clear_keeps_count_non_negative()
     {
         // Stress test: concurrent Delete + Clear should never produce negative count.

--- a/src/Nethermind/Nethermind.Core/Caching/AssociativeCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/AssociativeCache.cs
@@ -349,24 +349,25 @@ public sealed class AssociativeCache<TKey, TValue>
     {
         if (_setCount != 0)
         {
-            long currentEpoch = ClearEpochAndCount(ref _epochAndCount);
+            ClearEpochAndCount(ref _epochAndCount);
 
             if (releaseReferences)
             {
-                ClearEntries(currentEpoch);
+                ClearEntries();
             }
         }
     }
 
     /// <remarks>
-    /// If a concurrent Clear() bumps the epoch again while this scan is in progress,
-    /// entries from our epoch (N+1) that were written between the two bumps will be
-    /// skipped by both scans (neither N+1 nor N+2 matches the other's snapshot).
-    /// Those entries are logically dead (invisible to readers) but remain GC-rooted
-    /// until overwritten by new inserts. This is benign — not a safety issue.
+    /// Preserves entries live in the latest epoch and nulls only stale ones (older epoch).
+    /// The latest epoch is re-read per set under the gate rather than captured at Clear() time:
+    /// a concurrent Clear() may bump the epoch again, and entries written after that later bump
+    /// are live — comparing against a stale snapshot would wrongly null them, dropping live
+    /// entries and corrupting the count. Stale entries left behind by an interrupted pass remain
+    /// GC-rooted until a later pass or an overwriting insert reclaims them; this is benign.
     /// </remarks>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void ClearEntries(long currentEpoch)
+    private void ClearEntries()
     {
         ref Entry entries = ref MemoryMarshal.GetArrayDataReference(_entries);
         ref int gates = ref MemoryMarshal.GetArrayDataReference(_setGates);
@@ -377,15 +378,20 @@ public sealed class AssociativeCache<TKey, TValue>
             AcquireGate(ref gate);
             try
             {
+                // Re-read the latest epoch under the gate: a concurrent Clear() may have bumped
+                // it since this pass started, so entries from that newer epoch are live and must
+                // be preserved. Comparing against a snapshot taken at Clear() time would null them.
+                long latestEpoch = ReadEpoch(ref _epochAndCount);
+
                 int baseIdx = s << WayShift;
                 for (int i = 0; i < Ways; i++)
                 {
                     ref Entry e = ref Unsafe.Add(ref entries, baseIdx + i);
                     long h = Volatile.Read(ref e.Header);
 
-                    // Skip empty entries and entries written after the epoch bump
+                    // Skip empty entries and entries live in the latest epoch; null only stale ones.
                     if ((h & OccupiedBit) == 0) continue;
-                    if ((h & EpochMask) == currentEpoch) continue;
+                    if ((h & EpochMask) == latestEpoch) continue;
 
                     // Seqlock write: lock → null fields → unlock (clears OccupiedBit)
                     long newSeq = ((h & SeqMask) + SeqInc) & SeqMask;

--- a/src/Nethermind/Nethermind.Core/Caching/AssociativeKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/AssociativeKeyCache.cs
@@ -264,23 +264,25 @@ public sealed class AssociativeKeyCache<TKey>
     {
         if (_setCount != 0)
         {
-            long currentEpoch = ClearEpochAndCount(ref _epochAndCount);
+            ClearEpochAndCount(ref _epochAndCount);
 
             if (releaseReferences && RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
             {
-                ClearEntries(currentEpoch);
+                ClearEntries();
             }
         }
     }
 
     /// <remarks>
-    /// If a concurrent Clear() bumps the epoch again while this scan is in progress,
-    /// entries from our epoch that were written between the two bumps will be skipped
-    /// by both scans. Those entries are logically dead but remain GC-rooted until
-    /// overwritten by new inserts. This is benign — not a safety issue.
+    /// Preserves entries live in the latest epoch and nulls only stale ones (older epoch).
+    /// The latest epoch is re-read per set under the gate rather than captured at Clear() time:
+    /// a concurrent Clear() may bump the epoch again, and entries written after that later bump
+    /// are live — comparing against a stale snapshot would wrongly null them, dropping live
+    /// entries and corrupting the count. Stale entries left behind by an interrupted pass remain
+    /// GC-rooted until a later pass or an overwriting insert reclaims them; this is benign.
     /// </remarks>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void ClearEntries(long currentEpoch)
+    private void ClearEntries()
     {
         ref Entry entries = ref MemoryMarshal.GetArrayDataReference(_entries);
         ref int gates = ref MemoryMarshal.GetArrayDataReference(_setGates);
@@ -291,15 +293,20 @@ public sealed class AssociativeKeyCache<TKey>
             AcquireGate(ref gate);
             try
             {
+                // Re-read the latest epoch under the gate: a concurrent Clear() may have bumped
+                // it since this pass started, so entries from that newer epoch are live and must
+                // be preserved. Comparing against a snapshot taken at Clear() time would null them.
+                long latestEpoch = ReadEpoch(ref _epochAndCount);
+
                 int baseIdx = s << WayShift;
                 for (int i = 0; i < Ways; i++)
                 {
                     ref Entry e = ref Unsafe.Add(ref entries, baseIdx + i);
                     long h = Volatile.Read(ref e.Header);
 
-                    // Skip empty entries and entries written after the epoch bump
+                    // Skip empty entries and entries live in the latest epoch; null only stale ones.
                     if ((h & OccupiedBit) == 0) continue;
-                    if ((h & EpochMask) == currentEpoch) continue;
+                    if ((h & EpochMask) == latestEpoch) continue;
 
                     // Seqlock write: lock → null Key → unlock (clears OccupiedBit)
                     long newSeq = ((h & SeqMask) + SeqInc) & SeqMask;


### PR DESCRIPTION
## Changes

Fixes an intermittent, load-sensitive failure in `AssociativeCacheTests` / `AssociativeKeyCacheTests` that surfaced on the `[no-intrinsics]` CI variant as evicted/absent cache entries (`AssertValue` presence failures) and, on other timings, a `Count` exceeding capacity.

**Root cause — a real concurrency bug in `AssociativeCache`/`AssociativeKeyCache`, not a flaky assumption.** `Clear()` bumps the epoch (O(1) invalidation) and then `ClearEntries()` walks each set under its gate to null out `Key`/`Value` fields so the GC can reclaim them. `ClearEntries` captured the epoch bumped by *its own* `Clear()` and preserved only entries whose epoch matched it (`== currentEpoch`), nulling everything else. When two `Clear()` calls raced, an earlier (now-stale) release pass ran with a stale captured epoch: entries written after the *later* `Clear()` carry a *newer* epoch, so the stale pass nulled them — destroying **live** entries. This dropped keys (presence loss) and orphaned their count contributions (`Count` drifting above the live set, e.g. `48` reported vs `16` live). Commit `366067da33` handled preserving the same clear's epoch but not entries from a subsequent concurrent clear.

**Fix.** `ClearEntries` now re-reads the latest epoch per set under the gate and nulls only stale entries (`epoch != latestEpoch`). Since epochs are monotonic and no entry can carry an epoch newer than the global counter, `epoch != latest` is exactly "stale", so live (latest-epoch) entries are never nulled. The gate guarantees no new-epoch entry can be written into a set while its release pass holds the gate. Applied symmetrically to both `AssociativeCache` and `AssociativeKeyCache`.

- `AssociativeCache.ClearEntries` / `AssociativeKeyCache.ClearEntries`: re-read latest epoch per set; drop the now-unused `currentEpoch` parameter; update the `<remarks>`.
- Add `Concurrent_clears_preserve_live_entries_and_exact_count` regression test (runs for both cache types via the shared base). After a quiescent round of concurrent `Set` + racing `Clear`, `Count` must equal the number of retrievable entries.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

The new regression test reliably fails on the pre-fix code in both fixtures (mirroring the CI's 2-assertion failure) and passes after the fix. Verified with the full `Nethermind.Core.Test` suite green on both the default and `[no-intrinsics]` (`DOTNET_EnableHWIntrinsic=0`) variants, and stressed ~30 full-namespace runs under parallel load (≈30k race rounds) with no failures. `dotnet format whitespace` clean; code-style build (`-p:EnforceCodeStyleInBuild=true`) reports no new warnings.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
