### PR TITLE
Flush flat state on shutdown and survive a missing arena on load

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/ArenaMetricsTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ArenaMetricsTests.cs
@@ -124,7 +124,7 @@ public class ArenaMetricsTests
     }
 
     [Test]
-    public void Initialize_DropsCatalogEntriesWhoseArenaFileIsGone()
+    public void Initialize_ReportsCatalogEntriesWhoseArenaFileIsGone()
     {
         string arenaDir = Path.Combine(_testDir, "arena");
         using ArenaManager arena = new(arenaDir, new FlatDbConfig
@@ -150,9 +150,11 @@ public class ArenaMetricsTests
             PersistedSnapshotArenaPageCacheBytes = 0,
             ArenaFileSizeBytes = 64 * 1024,
         }, LimboLogs.Instance);
-        reopened.Initialize(entries);
+        IReadOnlySet<int> missingArenas = reopened.Initialize(entries);
 
-        // The orphan is unreadable — Open would throw and take startup down with it.
-        Assert.That(entries, Is.EqualTo(new[] { live }));
+        // The orphan is unreadable — the loader filters it before Open, which would otherwise take
+        // startup down with it. Initialization itself does not mutate the caller's catalog list.
+        Assert.That(missingArenas, Is.EquivalentTo(new[] { 65 }));
+        Assert.That(entries, Is.EqualTo(new[] { live, orphan }));
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/ArenaMetricsTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ArenaMetricsTests.cs
@@ -21,6 +21,31 @@ public class ArenaMetricsTests
 {
     private string _testDir = null!;
 
+    private static ArenaManager CreateArenaManager(string arenaDir) => new(arenaDir, new FlatDbConfig
+    {
+        PersistedSnapshotArenaPageCacheBytes = 0,
+        ArenaFileSizeBytes = 64 * 1024,
+    }, LimboLogs.Instance);
+
+    private static SnapshotLocation WritePersistedArena(ArenaManager arena, int size = 4096)
+    {
+        using ArenaWriter writer = arena.CreateWriter(size);
+        writer.GetWriter().GetSpan(size).Clear();
+        writer.GetWriter().Advance(size);
+        (SnapshotLocation location, ArenaReservation reservation) = writer.Complete();
+        using (reservation)
+        {
+            reservation.PersistOnShutdown();
+        }
+        return location;
+    }
+
+    private static void PreserveArena(ArenaManager arena, in SnapshotLocation location)
+    {
+        using ArenaReservation reservation = arena.Open(location);
+        reservation.PersistOnShutdown();
+    }
+
     [SetUp]
     public void SetUp()
     {
@@ -124,37 +149,50 @@ public class ArenaMetricsTests
     }
 
     [Test]
-    public void Initialize_ReportsCatalogEntriesWhoseArenaFileIsGone()
+    public void Initialize_ReportsMissingArenaEntriesWithoutReusingTheirIds()
     {
         string arenaDir = Path.Combine(_testDir, "arena");
-        using ArenaManager arena = new(arenaDir, new FlatDbConfig
+        SnapshotLocation liveLocation;
+        using (ArenaManager arena = CreateArenaManager(arenaDir))
         {
-            PersistedSnapshotArenaPageCacheBytes = 0,
-            ArenaFileSizeBytes = 64 * 1024,
-        }, LimboLogs.Instance);
-
-        // Materialise arena 0 so one entry stays serviceable.
-        using (ArenaWriter writer = arena.CreateWriter(4096))
-        {
-            writer.GetWriter().GetSpan(4096).Clear();
-            writer.GetWriter().Advance(4096);
-            writer.Complete();
+            liveLocation = WritePersistedArena(arena);
         }
 
-        CatalogEntry live = new(default, default, new SnapshotLocation(0, 0, 4096), SnapshotTier.PersistedBase);
-        CatalogEntry orphan = new(default, default, new SnapshotLocation(65, 0, 4096), SnapshotTier.PersistedBase);
-        List<CatalogEntry> entries = [live, orphan];
+        CatalogEntry live = new(default, default, liveLocation, SnapshotTier.PersistedBase);
+        CatalogEntry orphan = new(default, default,
+            new SnapshotLocation(liveLocation.ArenaId + 1, 0, liveLocation.Size), SnapshotTier.PersistedBase);
+        CatalogEntry maxIdOrphan = new(default, default,
+            new SnapshotLocation(int.MaxValue, 0, liveLocation.Size), SnapshotTier.PersistedBase);
+        List<CatalogEntry> catalogEntries = [live, orphan, maxIdOrphan];
+        List<CatalogEntry> firstLoad = [.. catalogEntries];
+        SnapshotLocation replacementLocation;
 
-        using ArenaManager reopened = new(arenaDir, new FlatDbConfig
+        using (ArenaManager reopened = CreateArenaManager(arenaDir))
         {
-            PersistedSnapshotArenaPageCacheBytes = 0,
-            ArenaFileSizeBytes = 64 * 1024,
-        }, LimboLogs.Instance);
-        IReadOnlySet<int> missingArenas = reopened.Initialize(entries);
+            IReadOnlySet<int> missingArenas = reopened.Initialize(firstLoad);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(missingArenas, Is.EquivalentTo(new[] { orphan.Location.ArenaId, int.MaxValue }));
+                Assert.That(firstLoad, Is.EqualTo(catalogEntries));
+            }
 
-        // The orphan is unreadable — the loader filters it before Open, which would otherwise take
-        // startup down with it. Initialization itself does not mutate the caller's catalog list.
-        Assert.That(missingArenas, Is.EquivalentTo(new[] { 65 }));
-        Assert.That(entries, Is.EqualTo(new[] { live, orphan }));
+            PreserveArena(reopened, liveLocation);
+            replacementLocation = WritePersistedArena(reopened);
+        }
+
+        Assert.That(replacementLocation.ArenaId, Is.GreaterThan(orphan.Location.ArenaId));
+
+        CatalogEntry replacement = new(default, default, replacementLocation, SnapshotTier.PersistedBase);
+        catalogEntries.Add(replacement);
+        List<CatalogEntry> secondLoad = [.. catalogEntries];
+
+        using ArenaManager restarted = CreateArenaManager(arenaDir);
+        IReadOnlySet<int> missingAfterRestart = restarted.Initialize(secondLoad);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(missingAfterRestart, Is.EquivalentTo(new[] { orphan.Location.ArenaId, int.MaxValue }));
+            Assert.That(secondLoad, Is.EqualTo(catalogEntries));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/ArenaMetricsTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ArenaMetricsTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Nethermind.Db;
 using Nethermind.Logging;
@@ -120,5 +121,38 @@ public class ArenaMetricsTests
         // Arena gauges stay flat — blob writes never touch them.
         Assert.That(Metrics.ArenaAllocatedBytes, Is.EqualTo(arenaBytesBefore));
         Assert.That(Metrics.ArenaFileCount, Is.EqualTo(arenaCountBefore));
+    }
+
+    [Test]
+    public void Initialize_DropsCatalogEntriesWhoseArenaFileIsGone()
+    {
+        string arenaDir = Path.Combine(_testDir, "arena");
+        using ArenaManager arena = new(arenaDir, new FlatDbConfig
+        {
+            PersistedSnapshotArenaPageCacheBytes = 0,
+            ArenaFileSizeBytes = 64 * 1024,
+        }, LimboLogs.Instance);
+
+        // Materialise arena 0 so one entry stays serviceable.
+        using (ArenaWriter writer = arena.CreateWriter(4096))
+        {
+            writer.GetWriter().GetSpan(4096).Clear();
+            writer.GetWriter().Advance(4096);
+            writer.Complete();
+        }
+
+        CatalogEntry live = new(default, default, new SnapshotLocation(0, 0, 4096), SnapshotTier.PersistedBase);
+        CatalogEntry orphan = new(default, default, new SnapshotLocation(65, 0, 4096), SnapshotTier.PersistedBase);
+        List<CatalogEntry> entries = [live, orphan];
+
+        using ArenaManager reopened = new(arenaDir, new FlatDbConfig
+        {
+            PersistedSnapshotArenaPageCacheBytes = 0,
+            ArenaFileSizeBytes = 64 * 1024,
+        }, LimboLogs.Instance);
+        reopened.Initialize(entries);
+
+        // The orphan is unreadable — Open would throw and take startup down with it.
+        Assert.That(entries, Is.EqualTo(new[] { live }));
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -98,6 +98,28 @@ public class FlatDbManagerTests
         return new StateId(blockNumber, new ValueHash256(bytes));
     }
 
+    private (FlatDbManager Manager, StateId SnapshotTo) CreateManagerWithQueuedSnapshot(
+        bool processExitAlreadyCancelled = false)
+    {
+        _config = new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 4, InlineCompaction = false };
+        StateId snapshotFrom = CreateStateId(10);
+        StateId snapshotTo = CreateStateId(11);
+        _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(5));
+        _snapshotRepository.TryAdd(Arg.Any<Snapshot>(), SnapshotTier.InMemoryBase).Returns(true);
+        _persistenceManager.AddToPersistence(snapshotTo).Returns(Task.CompletedTask);
+
+        if (processExitAlreadyCancelled) _cts.Cancel();
+
+        ResourcePool realResourcePool = new(_config);
+        Snapshot snapshot = realResourcePool.CreateSnapshot(
+            snapshotFrom, snapshotTo, ResourcePool.Usage.MainBlockProcessing);
+        TransientResource transientResource = realResourcePool.GetCachedResource(ResourcePool.Usage.MainBlockProcessing);
+
+        FlatDbManager manager = CreateManager();
+        manager.AddSnapshot(snapshot, transientResource);
+        return (manager, snapshotTo);
+    }
+
     [Test]
     public async Task HasStateForBlock_FoundInRepository_ReturnsTrue()
     {
@@ -137,50 +159,76 @@ public class FlatDbManagerTests
         Assert.That(result, Is.False);
     }
 
-    [Test]
-    public async Task DisposeAsync_FlushesInMemoryStateToPersistence()
+    [TestCase(1)]
+    [TestCase(2)]
+    public async Task DisposeAsync_CallsFlushOnce(int disposeCalls)
     {
         _persistenceManager.FlushToPersistence().Returns(CreateStateId(10));
 
         FlatDbManager manager = CreateManager();
-        await manager.DisposeAsync();
+        for (int i = 0; i < disposeCalls; i++) await manager.DisposeAsync();
 
         _persistenceManager.Received(1).FlushToPersistence();
     }
 
-    [Test]
-    public async Task DisposeAsync_CalledTwice_FlushesOnce()
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task AddSnapshot_QueuedCompactionAndPersistence_AreDrainedBeforeFlushOnDispose(
+        bool processExitAlreadyCancelled)
     {
-        _persistenceManager.FlushToPersistence().Returns(CreateStateId(10));
+        (FlatDbManager manager, StateId snapshotTo) =
+            CreateManagerWithQueuedSnapshot(processExitAlreadyCancelled);
+        _persistenceManager.FlushToPersistence().Returns(snapshotTo);
 
-        FlatDbManager manager = CreateManager();
-        await manager.DisposeAsync();
         await manager.DisposeAsync();
 
+        _snapshotRepository.Received(1).AddStateId(snapshotTo);
+        await _persistenceManager.Received(1).AddToPersistence(snapshotTo);
         _persistenceManager.Received(1).FlushToPersistence();
+        Received.InOrder(() =>
+        {
+            _snapshotRepository.AddStateId(snapshotTo);
+            _ = _persistenceManager.AddToPersistence(snapshotTo);
+            _persistenceManager.FlushToPersistence();
+        });
     }
 
     [Test]
-    public async Task AddSnapshot_QueuedCompaction_IsDrainedAndFlushedOnDispose()
+    public async Task DisposeAsync_FlushThrows_AwaitsWorkerCleanup()
     {
-        _config = new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 4, InlineCompaction = false };
-        _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(5));
-        _snapshotRepository.TryAdd(Arg.Any<Snapshot>(), SnapshotTier.InMemoryBase).Returns(true);
-        _persistenceManager.FlushToPersistence().Returns(CreateStateId(11));
+        TaskCompletionSource populateStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releasePopulate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource flushAttempted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        InvalidOperationException flushFailure = new("Flush failed");
+        _trieNodeCache.When(cache => cache.Add(Arg.Any<TransientResource>())).Do(_ =>
+        {
+            populateStarted.TrySetResult();
+            releasePopulate.Task.GetAwaiter().GetResult();
+        });
 
-        ResourcePool realResourcePool = new(_config);
-        Snapshot snapshot = realResourcePool.CreateSnapshot(
-            CreateStateId(10), CreateStateId(11), ResourcePool.Usage.MainBlockProcessing);
-        TransientResource transientResource = realResourcePool.GetCachedResource(ResourcePool.Usage.MainBlockProcessing);
+        (FlatDbManager manager, _) = CreateManagerWithQueuedSnapshot();
+        _persistenceManager.FlushToPersistence().Returns(_ =>
+        {
+            flushAttempted.TrySetResult();
+            throw flushFailure;
+        });
 
-        FlatDbManager manager = CreateManager();
-        manager.AddSnapshot(snapshot, transientResource);
-        await manager.DisposeAsync();
+        await populateStarted.Task;
+        Task disposeTask = manager.DisposeAsync().AsTask();
+        await flushAttempted.Task;
+        await Task.Yield();
 
-        // The compactor feeds the persistence queue, so a snapshot queued right before shutdown only
-        // reaches persistence if both drain before the flush.
-        _snapshotRepository.Received(1).AddStateId(Arg.Any<StateId>());
-        _persistenceManager.Received(1).FlushToPersistence();
+        try
+        {
+            Assert.That(disposeTask.IsCompleted, Is.False);
+        }
+        finally
+        {
+            releasePopulate.TrySetResult();
+        }
+
+        await Assert.ThatAsync(async () => await disposeTask,
+            Throws.TypeOf<InvalidOperationException>().With.Message.EqualTo(flushFailure.Message));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -138,6 +138,52 @@ public class FlatDbManagerTests
     }
 
     [Test]
+    public async Task DisposeAsync_FlushesInMemoryStateToPersistence()
+    {
+        _persistenceManager.FlushToPersistence().Returns(CreateStateId(10));
+
+        FlatDbManager manager = CreateManager();
+        await manager.DisposeAsync();
+
+        _persistenceManager.Received(1).FlushToPersistence();
+    }
+
+    [Test]
+    public async Task DisposeAsync_CalledTwice_FlushesOnce()
+    {
+        _persistenceManager.FlushToPersistence().Returns(CreateStateId(10));
+
+        FlatDbManager manager = CreateManager();
+        await manager.DisposeAsync();
+        await manager.DisposeAsync();
+
+        _persistenceManager.Received(1).FlushToPersistence();
+    }
+
+    [Test]
+    public async Task AddSnapshot_QueuedCompaction_IsDrainedAndFlushedOnDispose()
+    {
+        _config = new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 4, InlineCompaction = false };
+        _persistenceManager.GetCurrentPersistedStateId().Returns(CreateStateId(5));
+        _snapshotRepository.TryAdd(Arg.Any<Snapshot>(), SnapshotTier.InMemoryBase).Returns(true);
+        _persistenceManager.FlushToPersistence().Returns(CreateStateId(11));
+
+        ResourcePool realResourcePool = new(_config);
+        Snapshot snapshot = realResourcePool.CreateSnapshot(
+            CreateStateId(10), CreateStateId(11), ResourcePool.Usage.MainBlockProcessing);
+        TransientResource transientResource = realResourcePool.GetCachedResource(ResourcePool.Usage.MainBlockProcessing);
+
+        FlatDbManager manager = CreateManager();
+        manager.AddSnapshot(snapshot, transientResource);
+        await manager.DisposeAsync();
+
+        // The compactor feeds the persistence queue, so a snapshot queued right before shutdown only
+        // reaches persistence if both drain before the flush.
+        _snapshotRepository.Received(1).AddStateId(Arg.Any<StateId>());
+        _persistenceManager.Received(1).FlushToPersistence();
+    }
+
+    [Test]
     public async Task AddSnapshot_BlockBelowPersistedState_ReturnsEarlyAndLogsWarning()
     {
         StateId persistedStateId = CreateStateId(100);

--- a/src/Nethermind/Nethermind.State.Flat.Test/PageResidencyTrackerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PageResidencyTrackerTests.cs
@@ -70,7 +70,7 @@ public class PageResidencyTrackerTests
         public PageResidencyTracker PageTracker => tracker;
         public void QueueEviction(int arenaId, uint pageIdx) => handler.OnPageEvicted(arenaId, (int)pageIdx);
         public ArenaWriter CreateWriter(long estimatedSize, bool small = false) => throw new NotSupportedException();
-        public void Initialize(IReadOnlyList<CatalogEntry> entries) => throw new NotSupportedException();
+        public void Initialize(List<CatalogEntry> entries) => throw new NotSupportedException();
         public ArenaReservation Open(in SnapshotLocation location) => throw new NotSupportedException();
         // No-op so reservation disposal doesn't blow up in tests.
         public bool MarkDead(ArenaFile file, long deadSize) => false;

--- a/src/Nethermind/Nethermind.State.Flat.Test/PageResidencyTrackerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PageResidencyTrackerTests.cs
@@ -70,7 +70,7 @@ public class PageResidencyTrackerTests
         public PageResidencyTracker PageTracker => tracker;
         public void QueueEviction(int arenaId, uint pageIdx) => handler.OnPageEvicted(arenaId, (int)pageIdx);
         public ArenaWriter CreateWriter(long estimatedSize, bool small = false) => throw new NotSupportedException();
-        public void Initialize(List<CatalogEntry> entries) => throw new NotSupportedException();
+        public IReadOnlySet<int> Initialize(IReadOnlyList<CatalogEntry> entries) => throw new NotSupportedException();
         public ArenaReservation Open(in SnapshotLocation location) => throw new NotSupportedException();
         // No-op so reservation disposal doesn't blow up in tests.
         public bool MarkDead(ArenaFile file, long deadSize) => false;

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotLoaderTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotLoaderTests.cs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nethermind.Db;
+using Nethermind.Logging;
+using Nethermind.State.Flat.PersistedSnapshots;
+using Nethermind.State.Flat.PersistedSnapshots.Storage;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.Test;
+
+[TestFixture]
+public class PersistedSnapshotLoaderTests
+{
+    private string _testDir = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"nm_persisted_loader_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_testDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Test]
+    public void Load_FiltersEntriesReferencingMissingArenasBeforeOpen()
+    {
+        CatalogEntry orphan = new(default, default, new SnapshotLocation(65, 0, 4096), SnapshotTier.PersistedBase);
+        IArenaManager arena = Substitute.For<IArenaManager>();
+        arena.Initialize(Arg.Any<IReadOnlyList<CatalogEntry>>()).Returns(new HashSet<int> { 65 });
+
+        ISnapshotCatalog catalog = Substitute.For<ISnapshotCatalog>();
+        catalog.Load().Returns(new[] { orphan });
+
+        using BlobArenaManager blobs = new(Path.Combine(_testDir, "blobs"), 64 * 1024);
+        using PersistedSnapshotLoader loader = new(
+            Substitute.For<ISnapshotRepository>(),
+            arena,
+            blobs,
+            catalog,
+            new FlatDbConfig { PersistedSnapshotBloomBitsPerKey = 0 },
+            LimboLogs.Instance);
+
+        loader.Load();
+
+        arena.DidNotReceive().Open(Arg.Any<SnapshotLocation>());
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -52,6 +52,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
     // For debugging. Do the compaction synchronously
     private readonly bool _inlineCompaction;
+    private readonly CancellationToken _processExitToken;
     private readonly CancellationTokenSource _cancelTokenSource;
     private int _isDisposed = 0;
     private readonly bool _enableDetailedMetrics;
@@ -90,10 +91,10 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         _compactorStallTimeout = TimeSpan.FromSeconds(0.5 * blocksConfig.SecondsPerSlot * _compactSize);
         _inlineCompaction = config.InlineCompaction;
 
-        // Created after the throwing setup above: a ctor throw never constructs the linked CTS (whose
-        // registration on the long-lived ProcessExitSource would otherwise leak, since Autofac does not
-        // dispose a failed-ctor instance).
-        _cancelTokenSource = CancellationTokenSource.CreateLinkedTokenSource(processExitSource.Token);
+        // Keep worker cancellation under this manager's control so process-exit cancellation cannot
+        // preempt the ordered channel drain in DisposeAsync. Producer-side waits still observe process exit.
+        _processExitToken = processExitSource.Token;
+        _cancelTokenSource = new();
 
         _compactorJobs = Channel.CreateBounded<StateId>(config.MaxInFlightCompactJob);
         _populateTrieNodeCacheJobs = Channel.CreateBounded<TransientResource>(1);
@@ -371,7 +372,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
         if (_inlineCompaction)
         {
-            RunCompactJobSync(endBlock, transientResource, _cancelTokenSource.Token).Wait();
+            RunCompactJobSync(endBlock, transientResource, _processExitToken).Wait();
         }
         else
         {
@@ -383,7 +384,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
             if (!_compactorJobs.Writer.TryWrite(endBlock))
             {
-                if (_cancelTokenSource.Token.IsCancellationRequested) return; // When cancelled the queue stop
+                if (_processExitToken.IsCancellationRequested) return; // When cancelled the queue stop
 
                 // Block processing is now stalled waiting for the compactor to drain the queue; measure how long.
                 long stallStart = Stopwatch.GetTimestamp();
@@ -394,7 +395,8 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
                 while (true)
                 {
-                    using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(_cancelTokenSource.Token);
+                    using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(
+                        _processExitToken, _cancelTokenSource.Token);
                     cts.CancelAfter(delay);
 
                     try
@@ -402,7 +404,9 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
                         _compactorJobs.Writer.WriteAsync(endBlock, cts.Token).AsTask().Wait();
                         break;
                     }
-                    catch (AggregateException ex) when (ex.InnerException is OperationCanceledException && !_cancelTokenSource.Token.IsCancellationRequested)
+                    catch (AggregateException ex) when (ex.InnerException is OperationCanceledException
+                        && !_processExitToken.IsCancellationRequested
+                        && !_cancelTokenSource.Token.IsCancellationRequested)
                     {
                         delay = TimeSpan.FromSeconds(5);
                         if (_logger.IsWarn) _logger.Warn("Compactor job stall! Persistence is too slow for the network.");
@@ -477,23 +481,39 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     {
         if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 1) return;
 
-        ClearReadOnlyBundleCache();
+        try
+        {
+            ClearReadOnlyBundleCache();
 
-        _compactorJobs.Writer.Complete();
-        await _compactorTask;
+            _compactorJobs.Writer.TryComplete();
+            await _compactorTask;
 
-        _persistenceJobs.Writer.Complete();
-        await _persistenceTask;
+            _persistenceJobs.Writer.TryComplete();
+            await _persistenceTask;
 
-        FlushCache(CancellationToken.None);
+            FlushCache(CancellationToken.None);
+        }
+        finally
+        {
+            _compactorJobs.Writer.TryComplete();
+            _persistenceJobs.Writer.TryComplete();
+            _populateTrieNodeCacheJobs.Writer.TryComplete();
+            _cancelTokenSource.Cancel();
 
-        _cancelTokenSource.Cancel();
-
-        _populateTrieNodeCacheJobs.Writer.Complete();
-
-        await _populateTrieNodeCacheTask;
-        await _clearBundleCacheTask;
-
-        _cancelTokenSource.Dispose();
+            try
+            {
+                await Task.WhenAll(
+                    _compactorTask,
+                    _persistenceTask,
+                    _populateTrieNodeCacheTask,
+                    _clearBundleCacheTask);
+            }
+            finally
+            {
+                while (_populateTrieNodeCacheJobs.Reader.TryRead(out TransientResource? cachedResource))
+                    cachedResource.ReleaseLease();
+                _cancelTokenSource.Dispose();
+            }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -462,20 +462,36 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         return false;
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Persists the in-memory tier before tearing the workers down, so the flat state on disk matches
+    /// the block tree. Without it the process exits with the state up to <c>MinReorgDepth</c> blocks
+    /// behind the last committed block, and the next start has to re-run that branch from the persisted
+    /// base — a path that only survives as far as the next compaction boundary.
+    ///
+    /// The queues are completed in feed order — the compactor writes into the persistence queue, so it
+    /// has to drain first — and both are drained before the flush, so nothing still in flight is lost.
+    /// Cancellation comes after, otherwise it would abort the very work being drained.
+    /// </remarks>
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 1) return;
 
         ClearReadOnlyBundleCache();
-        _cancelTokenSource.Cancel();
 
         _compactorJobs.Writer.Complete();
-        _populateTrieNodeCacheJobs.Writer.Complete();
-        _persistenceJobs.Writer.Complete();
-
         await _compactorTask;
-        await _populateTrieNodeCacheTask;
+
+        _persistenceJobs.Writer.Complete();
         await _persistenceTask;
+
+        FlushCache(CancellationToken.None);
+
+        _cancelTokenSource.Cancel();
+
+        _populateTrieNodeCacheJobs.Writer.Complete();
+
+        await _populateTrieNodeCacheTask;
         await _clearBundleCacheTask;
 
         _cancelTokenSource.Dispose();

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotLoader.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotLoader.cs
@@ -61,7 +61,9 @@ public sealed class PersistedSnapshotLoader(
         // Can be millions of entries on a long-running node — materialised once and shared by the
         // arena init and the parallel load below.
         List<CatalogEntry> entries = [.. _catalog.Load()];
-        arena.Initialize(entries);
+        IReadOnlySet<int> missingArenas = arena.Initialize(entries);
+        if (missingArenas.Count != 0)
+            entries.RemoveAll(e => missingArenas.Contains(e.Location.ArenaId));
 
         LoadSnapshotsParallel(entries);
 

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
@@ -77,9 +77,16 @@ public sealed class ArenaManager : IArenaManager
 
     /// <summary>
     /// Initialize from existing arena files and catalog entries.
-    /// Computes allocation frontiers and dead bytes per arena.
+    /// Computes allocation frontiers and dead bytes per arena, and removes from
+    /// <paramref name="entries"/> those that reference an arena with no on-disk file.
     /// </summary>
-    public void Initialize(IReadOnlyList<CatalogEntry> entries)
+    /// <remarks>
+    /// The caller shares this list with the snapshot load that follows, so the drop has to happen
+    /// here rather than being applied to this manager's bookkeeping alone: an entry left in the list
+    /// would reach <c>Open</c>, which throws for an arena that was never registered, and take the whole
+    /// startup down over a slice that is unreadable either way.
+    /// </remarks>
+    public void Initialize(List<CatalogEntry> entries)
     {
         using Lock.Scope scope = _lock.EnterScope();
         // Open existing arena files. Defer the per-file metric push until after frontier
@@ -130,6 +137,8 @@ public sealed class ArenaManager : IArenaManager
             liveSizes.TryGetValue(aid, out long live);
             liveSizes[aid] = live + entry.Location.Size;
         }
+
+        if (missingArenas.Count > 0) entries.RemoveAll(e => missingArenas.Contains(e.Location.ArenaId));
 
         // Now that frontiers reflect the catalog's high-water mark, push the per-file count + bytes
         // gauges in one go (seeds ReportedFrontier).

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
@@ -119,6 +119,10 @@ public sealed class ArenaManager : IArenaManager
         foreach (CatalogEntry entry in entries)
         {
             int aid = entry.Location.ArenaId;
+            // The catalog is not rewritten by this recovery path, so reserve every id with a
+            // representable successor; reusing one would make stale entries appear serviceable.
+            if (aid >= _nextArenaId && aid < int.MaxValue)
+                _nextArenaId = aid + 1;
             if (!_arenas.TryGetValue(aid, out ArenaFile? arena))
             {
                 if (missingArenas.Add(aid) && _logger.IsWarn)

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/ArenaManager.cs
@@ -77,16 +77,10 @@ public sealed class ArenaManager : IArenaManager
 
     /// <summary>
     /// Initialize from existing arena files and catalog entries.
-    /// Computes allocation frontiers and dead bytes per arena, and removes from
-    /// <paramref name="entries"/> those that reference an arena with no on-disk file.
+    /// Computes allocation frontiers and dead bytes per arena, and returns the ids of
+    /// arenas referenced by the catalog for which no on-disk file exists.
     /// </summary>
-    /// <remarks>
-    /// The caller shares this list with the snapshot load that follows, so the drop has to happen
-    /// here rather than being applied to this manager's bookkeeping alone: an entry left in the list
-    /// would reach <c>Open</c>, which throws for an arena that was never registered, and take the whole
-    /// startup down over a slice that is unreadable either way.
-    /// </remarks>
-    public void Initialize(List<CatalogEntry> entries)
+    public IReadOnlySet<int> Initialize(IReadOnlyList<CatalogEntry> entries)
     {
         using Lock.Scope scope = _lock.EnterScope();
         // Open existing arena files. Defer the per-file metric push until after frontier
@@ -138,8 +132,6 @@ public sealed class ArenaManager : IArenaManager
             liveSizes[aid] = live + entry.Location.Size;
         }
 
-        if (missingArenas.Count > 0) entries.RemoveAll(e => missingArenas.Contains(e.Location.ArenaId));
-
         // Now that frontiers reflect the catalog's high-water mark, push the per-file count + bytes
         // gauges in one go (seeds ReportedFrontier).
         foreach (KeyValuePair<int, ArenaFile> kv in _arenas)
@@ -148,6 +140,8 @@ public sealed class ArenaManager : IArenaManager
             kv.Value.DeadBytes = kv.Value.Frontier - live;
             kv.Value.ReportAdded();
         }
+
+        return missingArenas;
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/IArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/IArenaManager.cs
@@ -6,11 +6,10 @@ namespace Nethermind.State.Flat.PersistedSnapshots.Storage;
 public unsafe interface IArenaManager : IDisposable
 {
     /// <summary>
-    /// Rehydrate the arena pool from the on-disk files and <paramref name="entries"/>, and drop from
-    /// <paramref name="entries"/> any that reference an arena with no file — those slices cannot be
-    /// served, and the list is shared with the snapshot load that follows.
+    /// Rehydrate the arena pool from the on-disk files and <paramref name="entries"/> and return the
+    /// arena ids referenced by entries for which no on-disk file exists.
     /// </summary>
-    void Initialize(List<CatalogEntry> entries);
+    IReadOnlySet<int> Initialize(IReadOnlyList<CatalogEntry> entries);
 
     /// <summary>
     /// Create an <see cref="ArenaWriter"/> for a new snapshot slice.

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/IArenaManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/Storage/IArenaManager.cs
@@ -5,7 +5,12 @@ namespace Nethermind.State.Flat.PersistedSnapshots.Storage;
 
 public unsafe interface IArenaManager : IDisposable
 {
-    void Initialize(IReadOnlyList<CatalogEntry> entries);
+    /// <summary>
+    /// Rehydrate the arena pool from the on-disk files and <paramref name="entries"/>, and drop from
+    /// <paramref name="entries"/> any that reference an arena with no file — those slices cannot be
+    /// served, and the list is shared with the snapshot load that follows.
+    /// </summary>
+    void Initialize(List<CatalogEntry> entries);
 
     /// <summary>
     /// Create an <see cref="ArenaWriter"/> for a new snapshot slice.


### PR DESCRIPTION
FlatDbManager.DisposeAsync tore the workers down without persisting the in-memory tier. FlushCache -> FlushToPersistence existed but GenesisLoader was its only non-test caller, so every clean exit left the flat state up to MinReorgDepth blocks behind the block tree, and the next start had to re-run that branch from the persisted base.

Drain the queues in feed order (the compactor writes into the persistence queue) and flush before cancelling, so nothing in flight is lost and the cancellation does not abort the work being drained. Flushing 989 blocks takes ~1s, well inside a normal SIGTERM grace period.

Second, ArenaManager.Initialize dropped catalog entries whose arena file is gone, but only from its own bookkeeping. PersistedSnapshotLoader walks the same shared list and calls Open on them, which throws "Arena N is not registered with this manager" and takes the whole startup down over a slice that is unreadable either way. Remove those entries from the shared list so the drop the manager already decided on actually applies.