### PR TITLE
Back off idle random-walk discovery once the routing table is full

### DIFF
--- a/src/Nethermind/Nethermind.Kademlia/IRoutingTable.cs
+++ b/src/Nethermind/Nethermind.Kademlia/IRoutingTable.cs
@@ -17,5 +17,10 @@ public interface IRoutingTable<TNode, TKadKey>
     void LogDebugInfo();
     event EventHandler<TNode>? OnNodeAdded;
     event EventHandler<TNode>? OnNodeRemoved;
-    int Size { get; }
+
+    /// <summary>
+    /// Returns how many nodes the table holds and how many slots its current buckets provide.
+    /// </summary>
+    /// <remarks>Implementations may walk every bucket, so this is not meant for hot paths.</remarks>
+    RoutingTableOccupancy GetOccupancy();
 }

--- a/src/Nethermind/Nethermind.Kademlia/KBucketTree.cs
+++ b/src/Nethermind/Nethermind.Kademlia/KBucketTree.cs
@@ -448,29 +448,28 @@ public class KBucketTree<TNode, TKadKey> : IRoutingTable<TNode, TKadKey>
     public event EventHandler<TNode>? OnNodeAdded;
     public event EventHandler<TNode>? OnNodeRemoved;
 
-    public int Size
+    public RoutingTableOccupancy GetOccupancy()
     {
-        get
+        int nodeCount = 0;
+        int bucketCount = 0;
+        lock (_lock)
         {
-            int total = 0;
-            lock (_lock)
-            {
-                CountNodes(_root);
-            }
-
-            return total;
-
-            void CountNodes(TreeNode node)
-            {
-                if (node.IsLeaf)
-                {
-                    total += node.Bucket.Count;
-                    return;
-                }
-
-                CountNodes(node.Left!);
-                CountNodes(node.Right!);
-            }
+            CountOccupancy(_root, ref nodeCount, ref bucketCount);
         }
+
+        return new RoutingTableOccupancy(nodeCount, bucketCount * _k);
+    }
+
+    private static void CountOccupancy(TreeNode node, ref int nodeCount, ref int bucketCount)
+    {
+        if (node.IsLeaf)
+        {
+            nodeCount += node.Bucket.Count;
+            bucketCount++;
+            return;
+        }
+
+        CountOccupancy(node.Left!, ref nodeCount, ref bucketCount);
+        CountOccupancy(node.Right!, ref nodeCount, ref bucketCount);
     }
 }

--- a/src/Nethermind/Nethermind.Kademlia/README.md
+++ b/src/Nethermind/Nethermind.Kademlia/README.md
@@ -54,11 +54,13 @@ ILookupAlgo<MyNode, MyKadKey> lookup =
 IKademlia<MyKey, MyNode> kademlia =
     new Kademlia<MyKey, MyNode, MyKadKey>(keyOperator, sender, routingTable, lookup, healthTracker, config, loggerFactory);
 IKademliaDiscovery<MyKey, MyNode> discovery =
-    new RandomWalkKademliaDiscovery<MyKey, MyNode, MyKadKey>(kademlia, keyOperator, distance, config, loggerFactory);
+    new RandomWalkKademliaDiscovery<MyKey, MyNode, MyKadKey>(kademlia, routingTable, keyOperator, distance, config, loggerFactory);
 ```
 
 Call `AddOrRefresh` when an authenticated node sends a valid protocol message, and call `Remove` when a node must be dropped from the table. Start periodic bootstrap and bucket refresh with `Run(token)`.
 
 Use `LookupNodesClosest(key, token)` when the caller needs the final closest set. Use `LookupNodes(key, token, maxResults)` or `IKademliaDiscovery<TKey, TNode>.DiscoverNodes(...)` when the caller wants candidates streamed as soon as lookups find them.
+
+`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled or lookups keep admitting nodes, and backs off exponentially up to 30 minutes once a filled table stops learning anything new.
 
 Dispose `NodeHealthTracker<TKey, TNode, TKadKey>` when the host shuts down, or let the dependency-injection container that owns it dispose it.

--- a/src/Nethermind/Nethermind.Kademlia/README.md
+++ b/src/Nethermind/Nethermind.Kademlia/README.md
@@ -61,6 +61,6 @@ Call `AddOrRefresh` when an authenticated node sends a valid protocol message, a
 
 Use `LookupNodesClosest(key, token)` when the caller needs the final closest set. Use `LookupNodes(key, token, maxResults)` or `IKademliaDiscovery<TKey, TNode>.DiscoverNodes(...)` when the caller wants candidates streamed as soon as lookups find them.
 
-`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled or lookups keep admitting nodes, and backs off exponentially up to 30 minutes once a filled table stops learning anything new.
+`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled or lookups keep admitting nodes, and backs off exponentially up to five minutes once a filled table stops learning anything new.
 
 Dispose `NodeHealthTracker<TKey, TNode, TKadKey>` when the host shuts down, or let the dependency-injection container that owns it dispose it.

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -30,7 +30,18 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     where TKadKey : notnull
 {
     private static readonly TimeSpan MinimumIterationDuration = TimeSpan.FromSeconds(1);
-    private static readonly TimeSpan MaximumIterationDuration = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Longest interval an idle job backs off to.
+    /// </summary>
+    /// <remarks>
+    /// The lookup rate is inversely proportional to this cap, so almost all of the saving is already banked by the
+    /// first few doublings: a one-minute cap removes 98% of the one-second crawl rate and this one removes 99.7%,
+    /// while a half-hour cap would buy a further 0.3% at six times the worst-case delay. Because a reset only
+    /// applies to the next iteration and never wakes a sleeping job, this cap alone bounds how long a job can go
+    /// without looking up, whatever else happens in the table meanwhile.
+    /// </remarks>
+    private static readonly TimeSpan MaximumIterationDuration = TimeSpan.FromMinutes(5);
 
     /// <summary>
     /// Reciprocal of the bucket-slot fill ratio the table must reach before idle lookups may slow down.

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -114,10 +114,12 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     private async Task RunDiscoveryJob(ChannelWriter<TNode> writer, int lookupResultLimit, AdmissionCounter admissions, CancellationToken token)
     {
         TimeSpan iterationDuration = MinimumIterationDuration;
+        // Carried across iterations so that the window covers the paced wait as well as the lookup; a job at the
+        // maximum interval is asleep for nearly all of its iteration, and admissions made then must still reset it.
+        long admissionsSeen = admissions.Count;
         while (!token.IsCancellationRequested)
         {
             long iterationStart = _timeProvider.GetTimestamp();
-            long admissionsBefore = admissions.Count;
             try
             {
                 int targetDistance = Random.Shared.Next(_maxDistance) + 1;
@@ -142,7 +144,9 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
                 _logger.LogError(ex, "Random Kademlia discovery lookup failed.");
             }
 
-            iterationDuration = NextIterationDuration(iterationDuration, admissions.Count != admissionsBefore);
+            long admissionsNow = admissions.Count;
+            iterationDuration = NextIterationDuration(iterationDuration, admissionsNow != admissionsSeen);
+            admissionsSeen = admissionsNow;
 
             TimeSpan elapsed = _timeProvider.GetElapsedTime(iterationStart);
             if (elapsed < iterationDuration)
@@ -163,7 +167,7 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     /// Returns the pace for the next iteration, resetting it when the last lookup was worth running.
     /// </summary>
     /// <param name="current">Pace the finished iteration ran at.</param>
-    /// <param name="admittedNodes">Whether the routing table admitted a node while the iteration ran.</param>
+    /// <param name="admittedNodes">Whether the routing table admitted a node since the previous iteration decided its pace.</param>
     private TimeSpan NextIterationDuration(TimeSpan current, bool admittedNodes)
     {
         if (admittedNodes || IsUnderfilled())
@@ -185,10 +189,10 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     /// one that only re-confirmed nodes it already knew or whose results a full bucket rejected.
     /// </summary>
     /// <remarks>
-    /// Jobs compare this counter around their own lookup, which also catches admissions made by a concurrent job or
-    /// by inbound traffic in that window. Attributing an admission to the lookup that caused it would mean threading
-    /// a lookup identity through every protocol adapter, and the imprecision is one-sided: an admission this job did
-    /// not cause still means the table is changing, and reading it as productive only keeps discovery eager.
+    /// Jobs compare this counter across their whole iteration, so admissions made by a concurrent job or by inbound
+    /// traffic count too. Attributing an admission to the lookup that caused it would mean threading a lookup
+    /// identity through every protocol adapter, and the imprecision is one-sided: an admission this job did not
+    /// cause still means the table is changing, and reading it as productive only keeps discovery eager.
     /// </remarks>
     private sealed class AdmissionCounter
     {

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
@@ -12,30 +11,51 @@ namespace Nethermind.Kademlia;
 /// <summary>
 /// Runs active random Kademlia lookups and streams discovered nodes.
 /// </summary>
+/// <remarks>
+/// Jobs iterate at <see cref="MinimumIterationDuration"/> while the routing table is still underfilled or while
+/// lookups keep admitting nodes into it. Once the table is filled and a lookup admits nothing, the job doubles its
+/// interval up to <see cref="MaximumIterationDuration"/>, so a node with a healthy table stops behaving like a
+/// crawler. Periodic bootstrap and bucket refresh in <see cref="IKademlia{TKey,TNode}.Run"/> are unaffected.
+/// </remarks>
 public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     IKademlia<TKey, TNode> kademlia,
+    IRoutingTable<TNode, TKadKey> routingTable,
     IKeyOperator<TKey, TNode, TKadKey> keyOperator,
     IKademliaDistance<TKadKey> distance,
     KademliaConfig<TNode> kademliaConfig,
-    ILoggerFactory loggerFactory)
+    ILoggerFactory loggerFactory,
+    TimeProvider? timeProvider = null)
     : IKademliaDiscovery<TKey, TNode>
     where TNode : notnull
     where TKadKey : notnull
 {
     private static readonly TimeSpan MinimumIterationDuration = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan MaximumIterationDuration = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Reciprocal of the bucket-slot fill ratio the table must reach before idle lookups may slow down.
+    /// </summary>
+    /// <remarks>
+    /// Buckets only split once they overflow, so a table that saturated its reachable neighbourhood settles above
+    /// 90% of its slots. A table holding only a handful of contacts, such as one still bootstrapping or one whose
+    /// peers were just evicted for being unresponsive, stays below this ratio and keeps discovering at full speed.
+    /// </remarks>
+    private const int HealthyOccupancyDivisor = 3;
 
     public RandomWalkKademliaDiscovery(
         IKademlia<TKey, TNode> kademlia,
+        IRoutingTable<TNode, TKadKey> routingTable,
         IKeyOperator<TKey, TNode, TKadKey> keyOperator,
         IKademliaDistance<TKadKey> distance,
         KademliaConfig<TNode> kademliaConfig)
-        : this(kademlia, keyOperator, distance, kademliaConfig, NullLoggerFactory.Instance)
+        : this(kademlia, routingTable, keyOperator, distance, kademliaConfig, NullLoggerFactory.Instance)
     {
     }
 
     private readonly ILogger _logger = loggerFactory.CreateLogger<RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>>();
     private readonly TKadKey _currentNodeHash = keyOperator.GetNodeHash(kademliaConfig.CurrentNodeId);
     private readonly int _maxDistance = distance.MaxDistance;
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
     /// <inheritdoc/>
     public IAsyncEnumerable<TNode> DiscoverNodes(int concurrentDiscoveryJobs, int lookupResultLimit, CancellationToken token)
@@ -59,11 +79,13 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
         using CancellationTokenSource disposeCts = CancellationTokenSource.CreateLinkedTokenSource(token);
         CancellationToken discoveryToken = disposeCts.Token;
         Channel<TNode> channel = Channel.CreateBounded<TNode>(lookupResultLimit);
+        AdmissionCounter admissions = new();
 
+        routingTable.OnNodeAdded += admissions.OnNodeAdded;
         Task[] discoverTasks = new Task[concurrentDiscoveryJobs];
         for (int i = 0; i < discoverTasks.Length; i++)
         {
-            discoverTasks[i] = Task.Run(() => RunDiscoveryJob(channel.Writer, lookupResultLimit, discoveryToken));
+            discoverTasks[i] = Task.Run(() => RunDiscoveryJob(channel.Writer, lookupResultLimit, admissions, discoveryToken));
         }
 
         Task discoverTask = Task.WhenAll(discoverTasks);
@@ -78,6 +100,7 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
         {
             await disposeCts.CancelAsync();
             channel.Writer.TryComplete();
+            routingTable.OnNodeAdded -= admissions.OnNodeAdded;
             try
             {
                 await discoverTask;
@@ -88,11 +111,13 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
         }
     }
 
-    private async Task RunDiscoveryJob(ChannelWriter<TNode> writer, int lookupResultLimit, CancellationToken token)
+    private async Task RunDiscoveryJob(ChannelWriter<TNode> writer, int lookupResultLimit, AdmissionCounter admissions, CancellationToken token)
     {
+        TimeSpan iterationDuration = MinimumIterationDuration;
         while (!token.IsCancellationRequested)
         {
-            Stopwatch iterationTime = Stopwatch.StartNew();
+            long iterationStart = _timeProvider.GetTimestamp();
+            long admissionsBefore = admissions.Count;
             try
             {
                 int targetDistance = Random.Shared.Next(_maxDistance) + 1;
@@ -117,12 +142,14 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
                 _logger.LogError(ex, "Random Kademlia discovery lookup failed.");
             }
 
-            TimeSpan elapsed = iterationTime.Elapsed;
-            if (elapsed < MinimumIterationDuration)
+            iterationDuration = NextIterationDuration(iterationDuration, admissions.Count != admissionsBefore);
+
+            TimeSpan elapsed = _timeProvider.GetElapsedTime(iterationStart);
+            if (elapsed < iterationDuration)
             {
                 try
                 {
-                    await Task.Delay(MinimumIterationDuration - elapsed, token);
+                    await Task.Delay(iterationDuration - elapsed, _timeProvider, token);
                 }
                 catch (OperationCanceledException) when (token.IsCancellationRequested)
                 {
@@ -130,5 +157,45 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Returns the pace for the next iteration, resetting it when the last lookup was worth running.
+    /// </summary>
+    /// <param name="current">Pace the finished iteration ran at.</param>
+    /// <param name="admittedNodes">Whether the routing table admitted a node while the iteration ran.</param>
+    private TimeSpan NextIterationDuration(TimeSpan current, bool admittedNodes)
+    {
+        if (admittedNodes || IsUnderfilled())
+        {
+            return MinimumIterationDuration;
+        }
+
+        return TimeSpan.FromTicks(Math.Min(current.Ticks * 2, MaximumIterationDuration.Ticks));
+    }
+
+    private bool IsUnderfilled()
+    {
+        RoutingTableOccupancy occupancy = routingTable.GetOccupancy();
+        return occupancy.NodeCount * HealthyOccupancyDivisor < occupancy.Capacity;
+    }
+
+    /// <summary>
+    /// Counts nodes newly admitted into the routing table, so that a job can tell a lookup that grew the table from
+    /// one that only re-confirmed nodes it already knew or whose results a full bucket rejected.
+    /// </summary>
+    /// <remarks>
+    /// Jobs compare this counter around their own lookup, which also catches admissions made by a concurrent job or
+    /// by inbound traffic in that window. Attributing an admission to the lookup that caused it would mean threading
+    /// a lookup identity through every protocol adapter, and the imprecision is one-sided: an admission this job did
+    /// not cause still means the table is changing, and reading it as productive only keeps discovery eager.
+    /// </remarks>
+    private sealed class AdmissionCounter
+    {
+        private long _count;
+
+        public long Count => Interlocked.Read(ref _count);
+
+        public void OnNodeAdded(object? sender, TNode node) => Interlocked.Increment(ref _count);
     }
 }

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -81,7 +81,6 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
         Channel<TNode> channel = Channel.CreateBounded<TNode>(lookupResultLimit);
         AdmissionCounter admissions = new();
 
-        routingTable.OnNodeAdded += admissions.OnNodeAdded;
         Task[] discoverTasks = new Task[concurrentDiscoveryJobs];
         for (int i = 0; i < discoverTasks.Length; i++)
         {
@@ -91,6 +90,7 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
         Task discoverTask = Task.WhenAll(discoverTasks);
         try
         {
+            routingTable.OnNodeAdded += admissions.OnNodeAdded;
             await foreach (TNode node in channel.Reader.ReadAllAsync(token))
             {
                 yield return node;
@@ -98,9 +98,9 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
         }
         finally
         {
+            routingTable.OnNodeAdded -= admissions.OnNodeAdded;
             await disposeCts.CancelAsync();
             channel.Writer.TryComplete();
-            routingTable.OnNodeAdded -= admissions.OnNodeAdded;
             try
             {
                 await discoverTask;

--- a/src/Nethermind/Nethermind.Kademlia/RoutingTableOccupancy.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RoutingTableOccupancy.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Kademlia;
+
+/// <summary>
+/// Summary of how filled a routing table is.
+/// </summary>
+/// <param name="NodeCount">Number of nodes held across all buckets.</param>
+/// <param name="Capacity">Number of node slots the current buckets provide, that is bucket count times k.</param>
+public readonly record struct RoutingTableOccupancy(int NodeCount, int Capacity);

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/KBucketTreeTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/KBucketTreeTests.cs
@@ -58,6 +58,21 @@ public class KBucketTreeTests
         Assert.That(result.All(expectedCandidates.Contains), Is.True);
     }
 
+    [Test]
+    public void GetOccupancy_should_track_node_count_and_capacity_across_splits()
+    {
+        KBucketTree<int, int> tree = CreateTree(k: 2, beta: 0);
+        Assert.That(tree.GetOccupancy(), Is.EqualTo(new RoutingTableOccupancy(0, 2)));
+
+        Add(tree, KeyAtDistance(31, 0x10));
+        Add(tree, KeyAtDistance(31, 0x11));
+        Assert.That(tree.GetOccupancy(), Is.EqualTo(new RoutingTableOccupancy(2, 2)));
+
+        // The bucket is full, so admitting a node at another distance splits it and grows the reported capacity.
+        Add(tree, KeyAtDistance(30, 0x20));
+        Assert.That(tree.GetOccupancy(), Is.EqualTo(new RoutingTableOccupancy(3, 6)));
+    }
+
     private static int KeyAtDistance(int distance, int suffix)
         => Int32KademliaDistance.Instance.SetBit(suffix, Int32KademliaDistance.Instance.MaxDistance - distance);
 }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/KademliaTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/KademliaTests.cs
@@ -77,6 +77,17 @@ public class KademliaTests
         Assert.That(nodeRemovedTriggered, Is.EqualTo(1));
     }
 
+    /// <summary>Guards the wiring both discv4 and discv5 rely on, as they share this module.</summary>
+    [Test]
+    public void ShouldResolveRandomWalkDiscovery()
+    {
+        using IContainer container = CreateKadContainer(new KademliaConfig<ValueHash256>());
+
+        Assert.That(
+            container.Resolve<IKademliaDiscovery<ValueHash256, ValueHash256>>(),
+            Is.InstanceOf<RandomWalkKademliaDiscovery<ValueHash256, ValueHash256, Hash256>>());
+    }
+
     [Test]
     public void ShouldSeedBootnodes()
     {

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/NodeHealthTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/NodeHealthTrackerTests.cs
@@ -226,12 +226,6 @@ public class NodeHealthTrackerTests
             remove { }
         }
 
-        public int Size
-        {
-            get
-            {
-                lock (AddCalls) return AddCalls.Count;
-            }
-        }
+        public RoutingTableOccupancy GetOccupancy() => throw new NotSupportedException();
     }
 }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -132,11 +132,24 @@ public class RandomWalkKademliaDiscoveryTests
     }
 
     /// <summary>
-    /// Asserts that the first iterations waited for the expected paces, allowing for the lookup time that each
-    /// iteration subtracts from its pace.
+    /// A backed-off job spends nearly all of its iteration waiting, so an admission arriving from inbound traffic or
+    /// another job while it waits has to reset it just as one during its own lookup does.
     /// </summary>
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_reset_pace_when_a_node_is_admitted_while_waiting(CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 5, token,
+            onDelayRequested: wait => { if (wait == 2) routingTable.RaiseNodeAdded(42); });
+
+        AssertPacedBy(delays, [TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), OneSecond, TimeSpan.FromSeconds(2)]);
+    }
+
+    /// <summary>Asserts that the first iterations waited for exactly the expected paces.</summary>
     private static void AssertPacedBy(TimeSpan[] delays, TimeSpan[] expected) =>
-        Assert.That(delays.Take(expected.Length).ToArray(), Is.EqualTo(expected).Within(TimeSpan.FromMilliseconds(250)));
+        Assert.That(delays.Take(expected.Length).ToArray(), Is.EqualTo(expected));
 
     private static RandomWalkKademliaDiscovery<int, int, int> CreateDiscovery(
         TestKademlia kademlia,
@@ -157,9 +170,14 @@ public class RandomWalkKademliaDiscoveryTests
     /// Delays are requested before the wait starts, so consuming the nodes of iteration n guarantees that the delays
     /// of every earlier iteration have been recorded.
     /// </remarks>
-    private static async Task<TimeSpan[]> RunIterations(TestKademlia kademlia, RoutingTableStub routingTable, int iterations, CancellationToken token)
+    private static async Task<TimeSpan[]> RunIterations(
+        TestKademlia kademlia,
+        RoutingTableStub routingTable,
+        int iterations,
+        CancellationToken token,
+        Action<int>? onDelayRequested = null)
     {
-        NoWaitTimeProvider timeProvider = new();
+        NoWaitTimeProvider timeProvider = new() { OnDelayRequested = onDelayRequested };
         RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, routingTable, timeProvider);
 
         await discovery.DiscoverNodes(1, NodesPerLookup, token).Take(iterations * NodesPerLookup).ToListAsync(token);
@@ -167,16 +185,28 @@ public class RandomWalkKademliaDiscoveryTests
         return timeProvider.RequestedDelays;
     }
 
-    /// <summary>Runs timers immediately while recording the delay that was asked for.</summary>
+    /// <summary>
+    /// Runs timers immediately while recording the delay that was asked for, on a clock that never advances.
+    /// </summary>
+    /// <remarks>
+    /// Freezing <see cref="GetTimestamp"/> makes the measured lookup time zero, so a job asks for exactly the pace it
+    /// chose rather than the pace minus however long the test machine took.
+    /// </remarks>
     private sealed class NoWaitTimeProvider : TimeProvider
     {
         private readonly ConcurrentQueue<TimeSpan> _requestedDelays = new();
 
         public TimeSpan[] RequestedDelays => _requestedDelays.ToArray();
 
+        /// <summary>Called as a job starts waiting, with the one-based ordinal of that wait.</summary>
+        public Action<int>? OnDelayRequested { get; init; }
+
+        public override long GetTimestamp() => 0;
+
         public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
         {
             _requestedDelays.Enqueue(dueTime);
+            OnDelayRequested?.Invoke(_requestedDelays.Count);
             return System.CreateTimer(callback, state, TimeSpan.Zero, period);
         }
     }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -108,14 +108,13 @@ public class RandomWalkKademliaDiscoveryTests
     {
         RoutingTableStub routingTable = new() { Occupancy = FilledTable };
 
-        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 13, token);
+        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 11, token);
 
         AssertPacedBy(delays, [
             TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(16),
             TimeSpan.FromSeconds(32), TimeSpan.FromSeconds(64), TimeSpan.FromSeconds(128), TimeSpan.FromSeconds(256),
-            TimeSpan.FromSeconds(512), TimeSpan.FromSeconds(1024),
             // Doubling stops at the cap.
-            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(30)
+            TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5)
         ]);
     }
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 using Nethermind.Kademlia;
 using NUnit.Framework;
 
@@ -15,16 +17,19 @@ namespace Nethermind.Network.Discovery.Test.Kademlia;
 
 public class RandomWalkKademliaDiscoveryTests
 {
+    private const int NodesPerLookup = 2;
+
+    private static readonly TimeSpan OneSecond = TimeSpan.FromSeconds(1);
+
+    /// <summary>A table whose buckets are filled well past the ratio that lets idle lookups back off.</summary>
+    private static readonly RoutingTableOccupancy FilledTable = new(16, 16);
+
     [Test]
     [CancelAfter(10000)]
     public async Task DiscoverNodes_should_stream_nodes_from_random_lookup(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = new(
-            kademlia,
-            IntKeyOperator.Instance,
-            Int32KademliaDistance.Instance,
-            new KademliaConfig<int> { CurrentNodeId = 0 });
+        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
 
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(2).ToListAsync(token);
 
@@ -38,14 +43,26 @@ public class RandomWalkKademliaDiscoveryTests
 
     [Test]
     [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_not_run_any_job_when_disabled(CancellationToken token)
+    {
+        TestKademlia kademlia = new();
+        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+
+        List<int> nodes = await discovery.DiscoverNodes(0, 2, token).ToListAsync(token);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(nodes, Is.Empty);
+            Assert.That(kademlia.LookupNodesCalls, Is.Zero);
+        }
+    }
+
+    [Test]
+    [CancelAfter(10000)]
     public async Task DiscoverNodes_should_pace_iterations_to_minimum_iteration_duration(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = new(
-            kademlia,
-            IntKeyOperator.Instance,
-            Int32KademliaDistance.Instance,
-            new KademliaConfig<int> { CurrentNodeId = 0 });
+        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
 
         Stopwatch stopwatch = Stopwatch.StartNew();
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(4).ToListAsync(token);
@@ -62,11 +79,7 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_not_delay_when_lookup_exceeds_minimum_iteration_duration(CancellationToken token)
     {
         TestKademlia kademlia = new() { LookupDelay = TimeSpan.FromMilliseconds(1100) };
-        RandomWalkKademliaDiscovery<int, int, int> discovery = new(
-            kademlia,
-            IntKeyOperator.Instance,
-            Int32KademliaDistance.Instance,
-            new KademliaConfig<int> { CurrentNodeId = 0 });
+        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
 
         Stopwatch stopwatch = Stopwatch.StartNew();
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(3).ToListAsync(token);
@@ -78,14 +91,142 @@ public class RandomWalkKademliaDiscoveryTests
         }
     }
 
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_keep_minimum_pace_while_table_is_underfilled(CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(5, 16) };
+
+        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 4, token);
+
+        AssertPacedBy(delays, [OneSecond, OneSecond, OneSecond]);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_back_off_when_filled_table_admits_nothing(CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 13, token);
+
+        AssertPacedBy(delays, [
+            TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32), TimeSpan.FromSeconds(64), TimeSpan.FromSeconds(128), TimeSpan.FromSeconds(256),
+            TimeSpan.FromSeconds(512), TimeSpan.FromSeconds(1024),
+            // Doubling stops at the cap.
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(30)
+        ]);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_reset_pace_when_lookup_admits_a_node(CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+        TestKademlia kademlia = new() { OnLookup = lookup => { if (lookup == 3) routingTable.RaiseNodeAdded(42); } };
+
+        TimeSpan[] delays = await RunIterations(kademlia, routingTable, iterations: 5, token);
+
+        AssertPacedBy(delays, [TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), OneSecond, TimeSpan.FromSeconds(2)]);
+    }
+
+    /// <summary>
+    /// Asserts that the first iterations waited for the expected paces, allowing for the lookup time that each
+    /// iteration subtracts from its pace.
+    /// </summary>
+    private static void AssertPacedBy(TimeSpan[] delays, TimeSpan[] expected) =>
+        Assert.That(delays.Take(expected.Length).ToArray(), Is.EqualTo(expected).Within(TimeSpan.FromMilliseconds(250)));
+
+    private static RandomWalkKademliaDiscovery<int, int, int> CreateDiscovery(
+        TestKademlia kademlia,
+        RoutingTableStub routingTable,
+        TimeProvider? timeProvider = null) =>
+        new(kademlia,
+            routingTable,
+            IntKeyOperator.Instance,
+            Int32KademliaDistance.Instance,
+            new KademliaConfig<int> { CurrentNodeId = 0 },
+            NullLoggerFactory.Instance,
+            timeProvider);
+
+    /// <summary>
+    /// Runs the requested number of lookup iterations and returns the paced delays each of them asked for.
+    /// </summary>
+    /// <remarks>
+    /// Delays are requested before the wait starts, so consuming the nodes of iteration n guarantees that the delays
+    /// of every earlier iteration have been recorded.
+    /// </remarks>
+    private static async Task<TimeSpan[]> RunIterations(TestKademlia kademlia, RoutingTableStub routingTable, int iterations, CancellationToken token)
+    {
+        NoWaitTimeProvider timeProvider = new();
+        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, routingTable, timeProvider);
+
+        await discovery.DiscoverNodes(1, NodesPerLookup, token).Take(iterations * NodesPerLookup).ToListAsync(token);
+
+        return timeProvider.RequestedDelays;
+    }
+
+    /// <summary>Runs timers immediately while recording the delay that was asked for.</summary>
+    private sealed class NoWaitTimeProvider : TimeProvider
+    {
+        private readonly ConcurrentQueue<TimeSpan> _requestedDelays = new();
+
+        public TimeSpan[] RequestedDelays => _requestedDelays.ToArray();
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            _requestedDelays.Enqueue(dueTime);
+            return System.CreateTimer(callback, state, TimeSpan.Zero, period);
+        }
+    }
+
+    private sealed class RoutingTableStub : IRoutingTable<int, int>
+    {
+        public RoutingTableOccupancy Occupancy { get; init; } = new(0, 16);
+
+        public RoutingTableOccupancy GetOccupancy() => Occupancy;
+
+        public void RaiseNodeAdded(int node) => OnNodeAdded?.Invoke(this, node);
+
+        public event EventHandler<int>? OnNodeAdded;
+
+        public event EventHandler<int>? OnNodeRemoved
+        {
+            add { }
+            remove { }
+        }
+
+        public BucketAddResult TryAddOrRefresh(in int hash, int item, out int toRefresh) => throw new NotSupportedException();
+
+        public bool Remove(in int hash) => throw new NotSupportedException();
+
+        public int[] GetKNearestNeighbour(int hash, bool excludeSelf = false) => throw new NotSupportedException();
+
+        public int[] GetKNearestNeighbourExcluding(int hash, int exclude, bool excludeSelf = false) => throw new NotSupportedException();
+
+        public int[] GetAllAtDistance(int i) => throw new NotSupportedException();
+
+        public IEnumerable<RoutingTableBucket<int, int>> IterateBuckets() => throw new NotSupportedException();
+
+        public int GetByHash(int nodeId) => throw new NotSupportedException();
+
+        public void LogDebugInfo() => throw new NotSupportedException();
+    }
+
     private sealed class TestKademlia : IKademlia<int, int>
     {
+        private int _lookupNodesCalls;
+
         public event EventHandler<int>? OnNodeAdded { add { } remove { } }
         public event EventHandler<int>? OnNodeRemoved { add { } remove { } }
 
-        public int LookupNodesCalls { get; private set; }
+        public int LookupNodesCalls => _lookupNodesCalls;
         public int? LastMaxResults { get; private set; }
         public TimeSpan LookupDelay { get; set; }
+
+        /// <summary>Called with the one-based ordinal of each started lookup.</summary>
+        public Action<int>? OnLookup { get; init; }
 
         public void AddOrRefresh(int node) => throw new NotSupportedException();
 
@@ -99,8 +240,9 @@ public class RandomWalkKademliaDiscoveryTests
 
         public IAsyncEnumerable<int> LookupNodes(int key, CancellationToken token, int? maxResults = null)
         {
-            LookupNodesCalls++;
             LastMaxResults = maxResults;
+            int lookup = Interlocked.Increment(ref _lookupNodesCalls);
+            OnLookup?.Invoke(lookup);
             return CreateAsyncEnumerable(LookupDelay, token, 1, 2);
         }
 


### PR DESCRIPTION
## Changes

Both discv4 and discv5 node sources run `DiscoveryConfig.ConcurrentDiscoveryJob` (default 10) random-walk lookups through the shared `RandomWalkKademliaDiscovery`, and every job kept iterating at the one-second minimum even when the routing table was full and the lookups admitted nothing. A node with a healthy table behaved like a crawler, wasting UDP traffic and CPU.

- Each random-walk job now keeps its own iteration interval. It stays at the existing one second while the routing table is underfilled or while a node was admitted during the iteration, and otherwise doubles up to a five-minute cap (9 idle iterations, ~8.5 minutes, to reach it).
- Admissions are observed through `IRoutingTable.OnNodeAdded`, which `KBucketTree` raises only for `BucketAddResult.Added`. A lookup that merely re-confirms known nodes, or whose results a full bucket rejects, does not count as productive. Jobs compare the counter across their whole iteration, so an admission made by a concurrent job or by inbound traffic while a job waits also counts; attributing an admission to the lookup that caused it would mean threading a lookup identity through every protocol adapter, and the imprecision is one-sided since it can only keep discovery eager, never silence it.
- New `RoutingTableOccupancy(NodeCount, Capacity)` and `IRoutingTable.GetOccupancy()` report both numbers from a single lock acquisition, so the fill ratio is never computed across a bucket split. This replaces `IRoutingTable.Size`, which was implemented but read nowhere.
- "Underfilled" is `NodeCount * 3 < Capacity`. Buckets only split once they overflow, so a saturated table sits far above that threshold while a bootstrapping table, or one whose peers were just evicted for being unresponsive, sits below it and keeps discovering at full speed.
- The cap is five minutes rather than the half hour first proposed. Lookup rate is inversely proportional to the cap, so the early doublings bank almost all of the saving: a one-minute cap removes 98% of the one-second crawl rate and five minutes removes 99.7%, while half an hour buys a further 0.3% at six times the worst-case delay. Since a reset only applies to a job's next iteration and never wakes a sleeping job, this cap is what actually bounds how long a job can go without looking up.

Unchanged on purpose: `Kademlia.Run` still bootstraps and refreshes stale buckets on its own schedule (`DiscoveryInterval`, 30 s by default; `BucketRefreshInterval`, 1 h), discv4 persisted-node loading is untouched, and `ConcurrentDiscoveryJob = 0` still short-circuits before any job starts.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Pacing is driven through an injected `TimeProvider` whose clock is frozen and whose timers fire immediately, so the back-off tests assert the exact requested delay sequence, with no tolerance and no real waiting.

- `DiscoverNodes_should_back_off_when_filled_table_admits_nothing` asserts the full 2 s to 256 s to 5 min sequence including the cap.
- `DiscoverNodes_should_reset_pace_when_lookup_admits_a_node` covers a productive lookup resetting the pace.
- `DiscoverNodes_should_keep_minimum_pace_while_table_is_underfilled` covers an underfilled table staying aggressive.
- `DiscoverNodes_should_not_run_any_job_when_disabled` covers `ConcurrentDiscoveryJob = 0`.
- `KademliaTests.ShouldResolveRandomWalkDiscovery` resolves the discovery service from the module both protocols share, guarding the wiring against the added constructor dependency.
- `DiscoverNodes_should_reset_pace_when_a_node_is_admitted_while_waiting` covers an admission arriving during the back-off wait rather than during a lookup.
- `KBucketTreeTests.GetOccupancy_should_track_node_count_and_capacity_across_splits` covers occupancy accounting across a bucket split.

The occupancy threshold was picked from measurements on a production-shaped table (256-bit key space, `beta=2`, random node IDs). At the default `k=16`, 20 inserted nodes give a 0.625 fill ratio, 100 give 0.773, 1 000 give 0.902, 5 000 give 0.956 and 20 000 give 0.946, so a saturated table clears the one-third threshold with wide margin.

`Discovery.BucketSize` is configurable, so the same measurement was repeated at larger `k` to confirm the back-off still engages: `k=64` settles at 0.880 / 0.859 / 0.915 for 1 000 / 5 000 / 20 000 nodes, and `k=256` at 0.797 / 0.871 for 5 000 / 20 000. The one case that reads as underfilled is `k=64` holding only 20 nodes (0.312), which is the intended answer for a table that thin.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

A node whose Kademlia routing table is full and no longer learning new peers now slows its active discovery lookups from once per second per job down to once per five minutes, and returns to the fast pace as soon as the table admits a node again. Peer discovery while the table is still filling is unaffected.

## Remarks

**Breaking change scope.** `IRoutingTable` is part of the `Nethermind.Kademlia` package surface. `Size` is removed rather than kept alongside `GetOccupancy().NodeCount`; it had no callers in the repo, but an out-of-tree implementation of the interface would need the new member. `RandomWalkKademliaDiscovery`'s constructors also gain an `IRoutingTable` parameter, resolved automatically for anyone composing it through `KademliaModule`.

**Known trade-off: the discv5 candidate stream thins once the table saturates.** `Discv5.Kademlia.NodeSource` forwards every node the random walk yields straight into its peer-candidate channel, whereas `Discv4.Kademlia.NodeSource` discards the stream and publishes candidates from bonding instead, so discv4 keeps a walk-independent source and discv5 does not. A saturated routing table returns `BucketAddResult.Full` for nodes it has never seen, so those nodes never raise `OnNodeAdded` even though they are exactly the fresh candidates `PeerPool` wants -- the back-off's reset signal and discv5's candidate supply diverge on precisely that case. Routing-table occupancy measures UDP-liveness knowledge, not peering health, so a node with a full, stable table but a hungry peer pool receives roughly ten lookups' worth of candidates per five minutes instead of ten per second. The same mechanism slows eclipse recovery, since a table full of attacker-controlled contacts produces no admissions either.

This is what set the cap. Since a reset never wakes a sleeping job, no choice of reset signal can shorten the blind spot -- only the cap can -- which is why the cap absorbed the fix rather than the productivity condition. `OnNodeRemoved` was considered as a second reset trigger and rejected: `KBucket.RemoveAndReplace` promotes a replacement the instant an active node is evicted, so the event routinely fires while `NodeCount` is unchanged and the table needs nothing, and wiring it would erode the saving on exactly the healthy nodes this targets.

The residual window is bounded rather than a cliff: `PeerPool.FeedFromNodeSource` already throttles itself while it has enough peers, discv5 still emits the routing table on subscription and pushes every `OnNodeAdded`, and any admission -- including one from inbound traffic -- re-arms the whole fleet to the one-second pace on its next iteration.


