### PR TITLE
fix(xdc): resolve XDPoS committed/finalized state from the block tree, not the highest QC

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RpcModuleTests.cs
@@ -583,7 +583,6 @@ public class RpcModuleTests
     [Test]
     public void GetMasternodesByNumber_ShouldResolveFinalizedBlock_FromTheCommittedTip()
     {
-        // Arrange
         XdcBlockHeader finalizedHeader = ArrangeChainWithFinalizedTip()[FinalizedBlockNumber];
 
         IXdcReleaseSpec spec = CreateDummyXdcReleaseSpec(switchEpoch: 5, epochLength: 10, configsCount: 200);
@@ -598,10 +597,8 @@ public class RpcModuleTests
 
         _epochSwitchManager.GetEpochSwitchInfo(finalizedHeader).Returns(epochSwitchInfo);
 
-        // Act
         ResultWrapper<MasternodesStatus> result = _rpcModule.XDPoS_getMasternodesByNumber(BlockParameter.Finalized);
 
-        // Assert
         Assert.That(result.Result, Is.EqualTo(Result.Success));
         Assert.That(result.Data, Is.Not.Null);
         using (Assert.EnterMultipleScope())
@@ -615,13 +612,10 @@ public class RpcModuleTests
     [Test]
     public void GetMasternodesByNumber_ShouldReturnFail_WhenFinalizedBlockNotFound()
     {
-        // Arrange
         _blockTree.FinalizedHash.Returns((Hash256?)null);
 
-        // Act
         ResultWrapper<MasternodesStatus> result = _rpcModule.XDPoS_getMasternodesByNumber(BlockParameter.Finalized);
 
-        // Assert
         Assert.That(result.Result, Is.Not.EqualTo(Result.Success));
         Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.InternalError));
     }
@@ -699,14 +693,11 @@ public class RpcModuleTests
     [TestCase(97UL, true)]
     public void GetV2BlockByNumber_ShouldReportCommitted_OnlyUpToFinalizedBlock(ulong? blockNumber, bool expectedCommitted)
     {
-        // Arrange
         ArrangeChainWithFinalizedTip();
 
-        // Act
         ResultWrapper<V2BlockInfo> result = _rpcModule.XDPoS_getV2BlockByNumber(
             blockNumber is null ? BlockParameter.Latest : new BlockParameter(blockNumber.Value));
 
-        // Assert
         AssertCommitted(result, expectedCommitted);
     }
 
@@ -715,28 +706,22 @@ public class RpcModuleTests
     [TestCase(98UL, true)]
     public void GetV2BlockByHash_ShouldReportCommitted_OnlyUpToFinalizedBlock(ulong? blockNumber, bool expectedCommitted)
     {
-        // Arrange
         Dictionary<ulong, XdcBlockHeader> headers = ArrangeChainWithFinalizedTip();
 
-        // Act
         ResultWrapper<V2BlockInfo> result = _rpcModule.XDPoS_getV2BlockByHash(
             blockNumber is null ? BlockParameter.Latest : new BlockParameter(headers[blockNumber.Value].Hash!));
 
-        // Assert
         AssertCommitted(result, expectedCommitted);
     }
 
     [Test]
     public void GetV2BlockByNumber_ShouldReturnError_WhenNoFinalizedBlock()
     {
-        // Arrange
         ArrangeChainWithFinalizedTip();
         _blockTree.FinalizedHash.Returns((Hash256?)null);
 
-        // Act
         ResultWrapper<V2BlockInfo> result = _rpcModule.XDPoS_getV2BlockByNumber(BlockParameter.Latest);
 
-        // Assert
         Assert.That(result.Result, Is.EqualTo(Result.Success));
         Assert.That(result.Data, Is.Not.Null);
         using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RpcModuleTests.cs
@@ -693,6 +693,70 @@ public class RpcModuleTests
     }
 
 
+    [TestCase(null, false)]
+    [TestCase(99UL, false)]
+    [TestCase(98UL, true)]
+    public void GetV2BlockByNumber_ShouldReportCommitted_OnlyUpToFinalizedBlock(ulong? blockNumber, bool expectedCommitted)
+    {
+        // Arrange
+        XdcBlockHeader committedHeader = BuildHeader(98);
+        XdcBlockHeader uncommittedHeader = BuildHeader(99);
+        XdcBlockHeader headHeader = BuildHeader(100);
+
+        _blockTree.Head.Returns(Build.A.Block.WithHeader(headHeader).TestObject);
+        _blockTree.FindHeader(98).Returns(committedHeader);
+        _blockTree.FindHeader(99).Returns(uncommittedHeader);
+        _blockTree.FindFinalizedHeader().Returns(committedHeader);
+
+        // The highest known QC certifies the head, two rounds ahead of the commit, so it must not drive the flag
+        _quorumCertificateManager.HighestKnownCertificate.Returns(
+            new QuorumCertificate(new BlockRoundInfo(headHeader.Hash!, 100, 100), null, 100));
+
+        // Act
+        ResultWrapper<V2BlockInfo> result = _rpcModule.XDPoS_getV2BlockByNumber(
+            blockNumber is null ? BlockParameter.Latest : new BlockParameter(blockNumber.Value));
+
+        // Assert
+        Assert.That(result.Result, Is.EqualTo(Result.Success));
+        Assert.That(result.Data, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Data!.Committed, Is.EqualTo(expectedCommitted));
+            Assert.That(result.Data.Error, Is.Null);
+        }
+
+        static XdcBlockHeader BuildHeader(ulong number) =>
+            Build.A.XdcBlockHeader()
+                .WithNumber(number)
+                .WithExtraConsensusData(new ExtraFieldsV2(number, Build.A.QuorumCertificate().TestObject))
+                .TestObject;
+    }
+
+    [Test]
+    public void GetV2BlockByNumber_ShouldReturnError_WhenNoFinalizedBlock()
+    {
+        // Arrange
+        XdcBlockHeader headHeader = Build.A.XdcBlockHeader()
+            .WithNumber(100)
+            .WithExtraConsensusData(new ExtraFieldsV2(100, Build.A.QuorumCertificate().TestObject))
+            .TestObject;
+
+        _blockTree.Head.Returns(Build.A.Block.WithHeader(headHeader).TestObject);
+        _blockTree.FindFinalizedHeader().Returns((BlockHeader?)null);
+
+        // Act
+        ResultWrapper<V2BlockInfo> result = _rpcModule.XDPoS_getV2BlockByNumber(BlockParameter.Latest);
+
+        // Assert
+        Assert.That(result.Result, Is.EqualTo(Result.Success));
+        Assert.That(result.Data, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Data!.Committed, Is.False);
+            Assert.That(result.Data.Error, Is.Not.Null);
+        }
+    }
+
     [Test]
     public void GetSigners_ShouldReturnSuccess_WithLatestBlockParameter()
     {

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RpcModuleTests.cs
@@ -694,55 +694,45 @@ public class RpcModuleTests
 
 
     [TestCase(null, false)]
+    [TestCase(100UL, false)]
     [TestCase(99UL, false)]
     [TestCase(98UL, true)]
+    [TestCase(97UL, true)]
     public void GetV2BlockByNumber_ShouldReportCommitted_OnlyUpToFinalizedBlock(ulong? blockNumber, bool expectedCommitted)
     {
         // Arrange
-        XdcBlockHeader committedHeader = BuildHeader(98);
-        XdcBlockHeader uncommittedHeader = BuildHeader(99);
-        XdcBlockHeader headHeader = BuildHeader(100);
-
-        _blockTree.Head.Returns(Build.A.Block.WithHeader(headHeader).TestObject);
-        _blockTree.FindHeader(98).Returns(committedHeader);
-        _blockTree.FindHeader(99).Returns(uncommittedHeader);
-        _blockTree.FindFinalizedHeader().Returns(committedHeader);
-
-        // The highest known QC certifies the head, two rounds ahead of the commit, so it must not drive the flag
-        _quorumCertificateManager.HighestKnownCertificate.Returns(
-            new QuorumCertificate(new BlockRoundInfo(headHeader.Hash!, 100, 100), null, 100));
+        ArrangeChainWithFinalizedTip();
 
         // Act
         ResultWrapper<V2BlockInfo> result = _rpcModule.XDPoS_getV2BlockByNumber(
             blockNumber is null ? BlockParameter.Latest : new BlockParameter(blockNumber.Value));
 
         // Assert
-        Assert.That(result.Result, Is.EqualTo(Result.Success));
-        Assert.That(result.Data, Is.Not.Null);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.Data!.Committed, Is.EqualTo(expectedCommitted));
-            Assert.That(result.Data.Error, Is.Null);
-        }
+        AssertCommitted(result, expectedCommitted);
+    }
 
-        static XdcBlockHeader BuildHeader(ulong number) =>
-            Build.A.XdcBlockHeader()
-                .WithNumber(number)
-                .WithExtraConsensusData(new ExtraFieldsV2(number, Build.A.QuorumCertificate().TestObject))
-                .TestObject;
+    [TestCase(null, false)]
+    [TestCase(99UL, false)]
+    [TestCase(98UL, true)]
+    public void GetV2BlockByHash_ShouldReportCommitted_OnlyUpToFinalizedBlock(ulong? blockNumber, bool expectedCommitted)
+    {
+        // Arrange
+        Dictionary<ulong, XdcBlockHeader> headers = ArrangeChainWithFinalizedTip();
+
+        // Act
+        ResultWrapper<V2BlockInfo> result = _rpcModule.XDPoS_getV2BlockByHash(
+            blockNumber is null ? BlockParameter.Latest : new BlockParameter(headers[blockNumber.Value].Hash!));
+
+        // Assert
+        AssertCommitted(result, expectedCommitted);
     }
 
     [Test]
     public void GetV2BlockByNumber_ShouldReturnError_WhenNoFinalizedBlock()
     {
         // Arrange
-        XdcBlockHeader headHeader = Build.A.XdcBlockHeader()
-            .WithNumber(100)
-            .WithExtraConsensusData(new ExtraFieldsV2(100, Build.A.QuorumCertificate().TestObject))
-            .TestObject;
-
-        _blockTree.Head.Returns(Build.A.Block.WithHeader(headHeader).TestObject);
-        _blockTree.FindFinalizedHeader().Returns((BlockHeader?)null);
+        ArrangeChainWithFinalizedTip();
+        _blockTree.FinalizedHash.Returns((Hash256?)null);
 
         // Act
         ResultWrapper<V2BlockInfo> result = _rpcModule.XDPoS_getV2BlockByNumber(BlockParameter.Latest);
@@ -754,6 +744,49 @@ public class RpcModuleTests
         {
             Assert.That(result.Data!.Committed, Is.False);
             Assert.That(result.Data.Error, Is.Not.Null);
+        }
+    }
+
+    /// <summary>
+    /// Sets up a chain whose head is two rounds ahead of the committed (finalized) tip, as the XDPoS 2.0 commit rule
+    /// leaves it, and stubs the highest known QC on the head so it cannot be mistaken for the committed block.
+    /// </summary>
+    /// <returns>The headers of the chain, keyed by block number.</returns>
+    private Dictionary<ulong, XdcBlockHeader> ArrangeChainWithFinalizedTip()
+    {
+        const ulong finalizedNumber = 98;
+        const ulong headNumber = 100;
+
+        Dictionary<ulong, XdcBlockHeader> headers = [];
+        for (ulong number = finalizedNumber - 1; number <= headNumber; number++)
+        {
+            XdcBlockHeader header = Build.A.XdcBlockHeader()
+                .WithNumber(number)
+                .WithExtraConsensusData(new ExtraFieldsV2(number, Build.A.QuorumCertificate().TestObject))
+                .TestObject;
+
+            headers[number] = header;
+            _blockTree.FindHeader(number).Returns(header);
+            _blockTree.FindHeader(header.Hash!).Returns(header);
+        }
+
+        _blockTree.Head.Returns(Build.A.Block.WithHeader(headers[headNumber]).TestObject);
+        _blockTree.FinalizedHash.Returns(headers[finalizedNumber].Hash);
+        _blockTree.LastFinalizedBlockLevel.Returns(finalizedNumber);
+        _quorumCertificateManager.HighestKnownCertificate.Returns(
+            new QuorumCertificate(new BlockRoundInfo(headers[headNumber].Hash!, headNumber, (long)headNumber), null, headNumber));
+
+        return headers;
+    }
+
+    private static void AssertCommitted(ResultWrapper<V2BlockInfo> result, bool expectedCommitted)
+    {
+        Assert.That(result.Result, Is.EqualTo(Result.Success));
+        Assert.That(result.Data, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Data!.Committed, Is.EqualTo(expectedCommitted));
+            Assert.That(result.Data.Error, Is.Null);
         }
     }
 

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RpcModuleTests.cs
@@ -22,10 +22,12 @@ namespace Nethermind.Xdc.Test.ModuleTests;
 [TestFixture, NonParallelizable]
 public class RpcModuleTests
 {
+    private const ulong FinalizedBlockNumber = 98;
+    private const ulong HeadBlockNumber = 100;
+
     private IBlockTree _blockTree;
     private ISnapshotManager _snapshotManager;
     private ISpecProvider _specProvider;
-    private IQuorumCertificateManager _quorumCertificateManager;
     private IEpochSwitchManager _epochSwitchManager;
     private IVotesManager _votesManager;
     private ITimeoutCertificateManager _timeoutCertificateManager;
@@ -147,7 +149,6 @@ public class RpcModuleTests
         _blockTree = Substitute.For<IBlockTree>();
         _snapshotManager = Substitute.For<ISnapshotManager>();
         _specProvider = Substitute.For<ISpecProvider>();
-        _quorumCertificateManager = Substitute.For<IQuorumCertificateManager>();
         _epochSwitchManager = Substitute.For<IEpochSwitchManager>();
         _votesManager = Substitute.For<IVotesManager>();
         _timeoutCertificateManager = Substitute.For<ITimeoutCertificateManager>();
@@ -158,7 +159,6 @@ public class RpcModuleTests
             _blockTree,
             _snapshotManager,
             _specProvider,
-            _quorumCertificateManager,
             _epochSwitchManager,
             _votesManager,
             _timeoutCertificateManager,
@@ -581,17 +581,10 @@ public class RpcModuleTests
     }
 
     [Test]
-    public void GetMasternodesByNumber_ShouldReturnSuccess_WithFinalizedBlockParameter()
+    public void GetMasternodesByNumber_ShouldResolveFinalizedBlock_FromTheCommittedTip()
     {
         // Arrange
-        XdcBlockHeader header = Build.A.XdcBlockHeader().TestObject;
-        header.Number = 100;
-        BlockRoundInfo proposedBlock = new(header.Hash!, 50, 100);
-        QuorumCertificate qc = new(proposedBlock, null, 50);
-        header.ExtraConsensusData = new ExtraFieldsV2(50, qc);
-
-        _quorumCertificateManager.HighestKnownCertificate.Returns(qc);
-        _blockTree.FindHeader(header.Hash!).Returns(header);
+        XdcBlockHeader finalizedHeader = ArrangeChainWithFinalizedTip()[FinalizedBlockNumber];
 
         IXdcReleaseSpec spec = CreateDummyXdcReleaseSpec(switchEpoch: 5, epochLength: 10, configsCount: 200);
         _specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
@@ -601,9 +594,9 @@ public class RpcModuleTests
             masternodes,
             Array.Empty<Address>(),
             Array.Empty<Address>(),
-            new BlockRoundInfo(TestItem.KeccakA, 50, 100));
+            new BlockRoundInfo(finalizedHeader.Hash!, FinalizedBlockNumber, (long)FinalizedBlockNumber));
 
-        _epochSwitchManager.GetEpochSwitchInfo(header).Returns(epochSwitchInfo);
+        _epochSwitchManager.GetEpochSwitchInfo(finalizedHeader).Returns(epochSwitchInfo);
 
         // Act
         ResultWrapper<MasternodesStatus> result = _rpcModule.XDPoS_getMasternodesByNumber(BlockParameter.Finalized);
@@ -611,13 +604,19 @@ public class RpcModuleTests
         // Assert
         Assert.That(result.Result, Is.EqualTo(Result.Success));
         Assert.That(result.Data, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Data!.Number, Is.EqualTo(FinalizedBlockNumber));
+            Assert.That(result.Data.Round, Is.EqualTo((UInt256)FinalizedBlockNumber));
+            Assert.That(result.Data.Masternodes, Is.EquivalentTo(masternodes));
+        }
     }
 
     [Test]
     public void GetMasternodesByNumber_ShouldReturnFail_WhenFinalizedBlockNotFound()
     {
         // Arrange
-        _quorumCertificateManager.HighestKnownCertificate.Returns((QuorumCertificate?)null);
+        _blockTree.FinalizedHash.Returns((Hash256?)null);
 
         // Act
         ResultWrapper<MasternodesStatus> result = _rpcModule.XDPoS_getMasternodesByNumber(BlockParameter.Finalized);
@@ -749,16 +748,13 @@ public class RpcModuleTests
 
     /// <summary>
     /// Sets up a chain whose head is two rounds ahead of the committed (finalized) tip, as the XDPoS 2.0 commit rule
-    /// leaves it, and stubs the highest known QC on the head so it cannot be mistaken for the committed block.
+    /// leaves it. Each header carries its own block number as its round.
     /// </summary>
     /// <returns>The headers of the chain, keyed by block number.</returns>
     private Dictionary<ulong, XdcBlockHeader> ArrangeChainWithFinalizedTip()
     {
-        const ulong finalizedNumber = 98;
-        const ulong headNumber = 100;
-
         Dictionary<ulong, XdcBlockHeader> headers = [];
-        for (ulong number = finalizedNumber - 1; number <= headNumber; number++)
+        for (ulong number = FinalizedBlockNumber - 1; number <= HeadBlockNumber; number++)
         {
             XdcBlockHeader header = Build.A.XdcBlockHeader()
                 .WithNumber(number)
@@ -768,13 +764,12 @@ public class RpcModuleTests
             headers[number] = header;
             _blockTree.FindHeader(number).Returns(header);
             _blockTree.FindHeader(header.Hash!).Returns(header);
+            _blockTree.FindHeader(header.Hash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(header);
         }
 
-        _blockTree.Head.Returns(Build.A.Block.WithHeader(headers[headNumber]).TestObject);
-        _blockTree.FinalizedHash.Returns(headers[finalizedNumber].Hash);
-        _blockTree.LastFinalizedBlockLevel.Returns(finalizedNumber);
-        _quorumCertificateManager.HighestKnownCertificate.Returns(
-            new QuorumCertificate(new BlockRoundInfo(headers[headNumber].Hash!, headNumber, (long)headNumber), null, headNumber));
+        _blockTree.Head.Returns(Build.A.Block.WithHeader(headers[HeadBlockNumber]).TestObject);
+        _blockTree.FinalizedHash.Returns(headers[FinalizedBlockNumber].Hash);
+        _blockTree.LastFinalizedBlockLevel.Returns(FinalizedBlockNumber);
 
         return headers;
     }

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/RpcModuleTests.cs
@@ -715,6 +715,25 @@ public class RpcModuleTests
     }
 
     [Test]
+    public void GetV2BlockByHash_ShouldNotReportCommitted_ForBlockOffTheCanonicalChain()
+    {
+        ArrangeChainWithFinalizedTip();
+
+        XdcBlockHeader forkHeader = Build.A.XdcBlockHeader()
+            .WithNumber(FinalizedBlockNumber)
+            .WithParentHash(TestItem.KeccakA)
+            .WithExtraConsensusData(new ExtraFieldsV2(FinalizedBlockNumber, Build.A.QuorumCertificate().TestObject))
+            .TestObject;
+
+        _blockTree.FindHeader(forkHeader.Hash!).Returns(forkHeader);
+        _blockTree.IsMainChain(forkHeader).Returns(false);
+
+        ResultWrapper<V2BlockInfo> result = _rpcModule.XDPoS_getV2BlockByHash(new BlockParameter(forkHeader.Hash!));
+
+        AssertCommitted(result, false);
+    }
+
+    [Test]
     public void GetV2BlockByNumber_ShouldReturnError_WhenNoFinalizedBlock()
     {
         ArrangeChainWithFinalizedTip();
@@ -750,6 +769,7 @@ public class RpcModuleTests
             _blockTree.FindHeader(number).Returns(header);
             _blockTree.FindHeader(header.Hash!).Returns(header);
             _blockTree.FindHeader(header.Hash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(header);
+            _blockTree.IsMainChain(header).Returns(true);
         }
 
         _blockTree.Head.Returns(Build.A.Block.WithHeader(headers[HeadBlockNumber]).TestObject);

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
@@ -536,8 +536,6 @@ internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, I
             return ResultWrapper<V2BlockInfo>.Fail("Header is not an XDC block header");
         }
 
-        // A block is committed only once the three-consecutive-round rule fires, which the block tree tracks as the
-        // finalized block. The highest known QC merely certifies a block, so it runs two rounds ahead of the commit.
         if (tree.FinalizedHash is null)
         {
             return ResultWrapper<V2BlockInfo>.Success(new V2BlockInfo

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
@@ -545,7 +545,7 @@ internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, I
             });
         }
 
-        bool committed = header.Number <= tree.LastFinalizedBlockLevel;
+        bool committed = tree.IsMainChain(header) && header.Number <= tree.LastFinalizedBlockLevel;
 
         // Get round number from extra consensus data
         ulong round = 0;

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
@@ -539,8 +539,9 @@ internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, I
             return ResultWrapper<V2BlockInfo>.Fail("Header is not an XDC block header");
         }
 
-        bool committed = false;
-        BlockRoundInfo latestCommittedBlock = quorumCertificateManager.HighestKnownCertificate?.ProposedBlockInfo;
+        // A block is committed only once the three-consecutive-round rule fires, which the block tree tracks as the
+        // finalized block. The highest known QC merely certifies a block, so it runs two rounds ahead of the commit.
+        BlockHeader? latestCommittedBlock = tree.FindFinalizedHeader();
 
         if (latestCommittedBlock is null)
         {
@@ -551,10 +552,7 @@ internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, I
             });
         }
 
-        if (header.Number <= latestCommittedBlock.BlockNumber)
-        {
-            committed = true;
-        }
+        bool committed = header.Number <= latestCommittedBlock.Number;
 
         // Get round number from extra consensus data
         ulong round = 0;

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
@@ -176,8 +176,6 @@ internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, I
                 return ResultWrapper<MasternodesStatus>.Fail("No finalized block found from consensus");
             }
 
-            // Only the header contents are read here, so skip the total difficulty lookup, which creates the chain
-            // level when it is missing and would turn this read-only path into a write
             header = tree.FindHeader(tree.FinalizedHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
         }
         else if (blockNumber.BlockNumber is null)

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
@@ -541,9 +541,7 @@ internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, I
 
         // A block is committed only once the three-consecutive-round rule fires, which the block tree tracks as the
         // finalized block. The highest known QC merely certifies a block, so it runs two rounds ahead of the commit.
-        BlockHeader? latestCommittedBlock = tree.FindFinalizedHeader();
-
-        if (latestCommittedBlock is null)
+        if (tree.FinalizedHash is null)
         {
             return ResultWrapper<V2BlockInfo>.Success(new V2BlockInfo
             {
@@ -552,7 +550,7 @@ internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, I
             });
         }
 
-        bool committed = header.Number <= latestCommittedBlock.Number;
+        bool committed = header.Number <= tree.LastFinalizedBlockLevel;
 
         // Get round number from extra consensus data
         ulong round = 0;

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
@@ -545,7 +545,7 @@ internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, I
             });
         }
 
-        bool committed = tree.IsMainChain(header) && header.Number <= tree.LastFinalizedBlockLevel;
+        bool committed = header.Number <= tree.LastFinalizedBlockLevel && tree.IsMainChain(header);
 
         // Get round number from extra consensus data
         ulong round = 0;

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
@@ -17,7 +17,7 @@ using Nethermind.Xdc.RLP;
 
 namespace Nethermind.Xdc.RPC;
 
-internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, ISpecProvider specProvider, IQuorumCertificateManager quorumCertificateManager, IEpochSwitchManager epochSwitchManager, IVotesManager voteManager, ITimeoutCertificateManager timeoutCertificateManager, ISyncInfoManager syncInfoManager, IRewardsStore rewardsStore) : IXdcRpcModule
+internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, ISpecProvider specProvider, IEpochSwitchManager epochSwitchManager, IVotesManager voteManager, ITimeoutCertificateManager timeoutCertificateManager, ISyncInfoManager syncInfoManager, IRewardsStore rewardsStore) : IXdcRpcModule
 {
     public ResultWrapper<EpochNumInfo> XDPoS_calculateBlockInfoByV1EpochNum(ulong targetEpochNum) =>
         ResultWrapper<EpochNumInfo>.Fail("V1 epoch is not supported");
@@ -171,15 +171,14 @@ internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, I
         }
         else if (blockNumber.Type == BlockParameterType.Finalized)
         {
-            BlockRoundInfo latestCommittedBlock = quorumCertificateManager.HighestKnownCertificate?.ProposedBlockInfo;
-            if (latestCommittedBlock != null)
-            {
-                header = tree.FindHeader(latestCommittedBlock.Hash);
-            }
-            else
+            if (tree.FinalizedHash is null)
             {
                 return ResultWrapper<MasternodesStatus>.Fail("No finalized block found from consensus");
             }
+
+            // Only the header contents are read here, so skip the total difficulty lookup, which creates the chain
+            // level when it is missing and would turn this read-only path into a write
+            header = tree.FindHeader(tree.FinalizedHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
         }
         else if (blockNumber.BlockNumber is null)
         {


### PR DESCRIPTION
## Changes

- `XdcRpcModule.BuildV2BlockInfo` (backing `XDPoS_getV2BlockByNumber` / `XDPoS_getV2BlockByHash`) now derives the committed tip from the block tree's `FinalizedHash` / `LastFinalizedBlockLevel` instead of `IQuorumCertificateManager.HighestKnownCertificate.ProposedBlockInfo`, and gates `committed` on the block being canonical.
- `XDPoS_getMasternodesByNumber("finalized")` resolves the finalized header the same way, so `finalized` no longer means two different blocks inside one RPC module.
- `IQuorumCertificateManager` is no longer used by the module and was dropped from its constructor.
- Regression tests for both entry points, plus `XDPoS_getV2BlockByHash` coverage.

### Why

The `committed` flag and the `finalized` block parameter were computed from the highest *known QC*. A QC only certifies a block — under XDPoS 2.0 a block is committed when three consecutive rounds are seen, which `TryCommitBlock` records as the grandparent of the QC's proposed block. Once a quorum of votes for the head forms (`VotesManager` → `CommitCertificate`), the highest QC proposes the head itself, so `header.Number <= highestQc.ProposedBlockInfo.BlockNumber` held for the head and `XDPoS_getV2BlockByNumber("latest")` returned `committed: true` for a block two rounds away from being committed. In the brief window before that QC forms the same call returned `false`, so the flag also flip-flopped for a fixed block. `XDPoS_getMasternodesByNumber("finalized")` had the same off-by-two-rounds error and returned the head's masternode set.

`XdcBlockTree`'s finalized block is only ever advanced from `QuorumCertificateManager.TryCommitBlock` → `ForkChoiceUpdated(grandParent, grandParent)`, so it is exactly `HighestCommitBlock` — and it is persisted to the metadata DB and reloaded on startup. Using it keeps the fix free of new interfaces or public methods and matches go-XDC, which compares against `EngineV2.GetLatestCommittedBlockInfo()`.

The commit level is a number, so a block resolved by hash on a discarded fork at or below that level would still compare as committed even though it never can be. `committed` is therefore gated on `IsMainChain` before the level comparison — a deliberate divergence from go-XDC, which compares numbers only.

### On the lookup used

`BuildV2BlockInfo` only needs the committed *number*, so it reads the in-memory `LastFinalizedBlockLevel` and keeps `FinalizedHash is null` as the "nothing committed yet" probe (the level alone conflates that with a finalized genesis). `XDPoS_getMasternodesByNumber` needs the header itself, so it looks it up with `BlockTreeLookupOptions.TotalDifficultyNotNeeded`: the default option set requires total difficulty, which makes `BlockTree.FindHeader` create the chain level when it is missing — a DB write from a read-only RPC path. `FindFinalizedHeader()` / `FindFinalizedBlock()` both use the default options and so carry that cost; `FindFinalizedBlock()` additionally loads the block body, which no caller here needs.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`GetV2BlockByNumber_ShouldReportCommitted_OnlyUpToFinalizedBlock` and `GetV2BlockByHash_…` run head / head−1 / finalized / below-finalized against a chain whose head sits two rounds past the committed tip; 8 of their 9 cases fail on the pre-fix code. `GetV2BlockByHash_ShouldNotReportCommitted_ForBlockOffTheCanonicalChain` covers a fork block at the finalized level. `GetMasternodesByNumber_ShouldResolveFinalizedBlock_FromTheCommittedTip` asserts the returned number, round and masternode set belong to the finalized block, not the head — it fails if the finalized branch resolves any other block. Full `Nethermind.Xdc.Test` suite passes (562 tests).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
