### PR TITLE
Improve comment quality and flag comment slop during review

### DIFF
--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -164,6 +164,8 @@ Only flag when it genuinely affects correctness or usability:
 - A comment or doc that **contradicts the code** — misleading docs are worse than no docs
 - A non-obvious consensus rule or algorithm applied with no reference to the EIP or Yellow Paper section — link it so future reviewers can verify
 - Config keys whose units or defaults are ambiguous (e.g., is it milliseconds or seconds?)
+- An **added** comment that adds nothing beyond the code it sits on — it restates the adjacent statement (`// increment counter` over `i++`), narrates an obviously-named call (`// create the writer` over `new Writer()`), or an XML `<summary>` that just repeats the member name. Per AGENTS.md, "comments that merely restate the code are noise" — flag it for deletion. Hold the >80% bar: flag only clearly-redundant comments, never a terse one that explains *why*, cites a spec/EIP, states an invariant, or warns the caller.
+- An **added** comment carrying author uncertainty or generation residue — `// not sure how to handle this`, `// maybe this should be X`, `// AI generated`, `// as requested`, or a bare `// TODO` with no actionable detail. These should be resolved or moved to a tracked issue, not merged.
 
 ---
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -135,6 +135,7 @@ jobs:
             - Security implications
             - Performance (this is a hot-path Ethereum execution client)
             - Adherence to repo rules in CONTRIBUTING.md and .agents/rules/
+            - Comment quality (Low severity): flag *added* comments that merely restate the adjacent code, tautological XML docs, or generation residue ("AI generated", "as requested", "not sure how to handle this"). Per AGENTS.md, comments that restate the code are noise. Only flag clear cases — a comment that explains *why*, cites a spec/EIP, states an invariant, or warns the caller is good and must NOT be flagged.
 
             Categorize each finding by severity:
             - **Critical**: blocks merge, likely production impact

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -373,7 +373,6 @@ public sealed partial class KeccakHash
         // Obtain the state data in the desired (hash) size we want.
         _hash = output;
 
-        // Return the result.
         return output;
     }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnDb.cs
@@ -127,12 +127,11 @@ public class ColumnDb : IDb, ISortedKeyValueStore, IMergeableKeyValueStore, IKey
         _rocksDb.CompactRange(Keccak.Zero.BytesToArray(), Keccak.MaxValue.BytesToArray(), _columnFamily);
 
     /// <summary>
-    /// Not sure how to handle delete of the columns DB
+    /// Clearing a single column family is not supported; it shares the underlying database with the other columns.
     /// </summary>
-    /// <exception cref="NotSupportedException"></exception>
+    /// <exception cref="NotSupportedException">Always thrown; clearing a single column family is not supported.</exception>
     public void Clear() => throw new NotSupportedException();
 
-    // Maybe it should be column-specific metric?
     public IDbMeta.DbMetric GatherMetric() => _mainDb.GatherMetric();
 
     public void SetWriteBuffer(long sizeBytes)

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -31,16 +31,13 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     // it save a decent amount of CPU.
     private readonly ConcurrentDictionary<StateId, ReadOnlySnapshotBundle> _readonlySnapshotBundleCache = new();
 
-    // First it go to here
     private readonly Task _compactorTask;
     private readonly Channel<StateId> _compactorJobs;
 
-    // And here in parallel.
     // The node cache is kinda important for performance, so we want it populated as quickly as possible.
     private readonly Task _populateTrieNodeCacheTask;
     private readonly Channel<TransientResource> _populateTrieNodeCacheJobs;
 
-    // Then eventually a compacted snapshot will be sent here where this will decide what to persist exactly
     private readonly Task _persistenceTask;
     private readonly Channel<StateId> _persistenceJobs;
 

--- a/src/Nethermind/Nethermind.State.Flat/Persistence/BloomFilter/BloomFilter.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Persistence/BloomFilter/BloomFilter.cs
@@ -13,7 +13,7 @@ namespace Nethermind.State.Flat.Persistence.BloomFilter;
 /// Pure in-memory cache-local (64B / 512-bit) Bloom filter.
 /// Owns its memory and supports atomic adds + AVX2-optimized queries.
 /// Optimized for Linux Transparent Huge Pages (THP).
-/// AI-generated based on RocksDB's bloom filter implementation.
+/// Based on RocksDB's bloom filter implementation.
 /// </summary>
 public sealed unsafe class BloomFilter : IDisposable
 {

--- a/src/Nethermind/Nethermind.State.Flat/SpmcRingBuffer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SpmcRingBuffer.cs
@@ -7,7 +7,7 @@ using Nethermind.Core.Threading;
 namespace Nethermind.State.Flat;
 
 /// <summary>
-/// AI generated single producer multiple consumer ring buffer. If called by multiple producers, it will hang.
+/// Single producer, multiple consumer ring buffer. If called by multiple producers, it will hang.
 /// See <see cref="MpmcRingBuffer{T}"/> for multiple producer variant.
 /// The selection of <see cref="T"/> is important. It should be ideally a struct of size no more than 64 bytes
 /// or 32 bytes if possible.


### PR DESCRIPTION
## Motivation

Following internal feedback that AI-generated comment slop is creeping into the codebase, this does two things: cleans up a small focal set of low-value comments, and — more importantly — closes the gap that let them land by giving the automated review a comment-quality dimension.

This is grounded in our own rule (AGENTS.md):

> Comments that merely restate the code are noise — don't add them, and remove them when you encounter them.

## What this changes

### Cleanup (7 comments across 5 files)
- **`SpmcRingBuffer` / `BloomFilter`** — drop the `AI generated` / `AI-generated` attribution, keep the substantive notes (the "will hang if called by multiple producers" warning and the RocksDB provenance).
- **`FlatDbManager`** — delete stream-of-consciousness narration (`// First it go to here`, `// And here in parallel.`, `// Then eventually...`); keep the real performance note.
- **`ColumnDb`** — replace `// Not sure how to handle...` / `// Maybe it should be...` musings with an actual explanation, and fill the empty `<exception>` doc.
- **`KeccakHash`** — delete `// Return the result.` sitting above `return output;`.

### Review steering (the durable part)
- **`.agents/skills/review/SKILL.md`** — the review skill now flags *added* comments that restate adjacent code, are tautological XML docs, or carry author uncertainty / generation residue (`// AI generated`, `// not sure how to handle this`, `// as requested`, bare `// TODO`). Held to the skill's existing **>80% confidence bar**, with an explicit do-**not**-flag list: comments that explain *why*, cite a spec/EIP, state an invariant, or warn the caller are good and must not be touched.
- **`.github/workflows/claude-review.yml`** — mirrors the rule as a **Low-severity** focus item. Low is deliberate: the `mergeable` gate only trips on Critical/High/Medium, so comment-quality notes surface as inline advice **without blocking merges**.

## Why prevention over a big cleanup

An audit of the existing comment corpus came back essentially clean (~0.15% flag rate; the single biggest cluster is 2019-era human legacy, not AI). The corpus barely needs scrubbing — what needs controlling is *new inflow*, and the review bot was previously configured to only flag comments that **contradict** code, so restating/narration/residue passed straight through. This flips that.

## Scope / safety
- Comment-only edits in the 5 source files — no behavioural change.
- The workflow edit is purely additive prose inside the existing `prompt:` block: no new `run:` step, no untrusted-input interpolation. YAML validated.
- Framed as comment **quality**, not "AI vs human" — enforceable regardless of authorship and no detector involved.

## Deliberately not included (open for discussion)
- `.github/copilot-instructions.md` / Cursor rules to cover non-Claude AI entry points.
- A deterministic `slop-lint` CI check (ripgrep → reviewdog, added-lines-only) for the few near-zero-FP patterns.
- Empty-XML-tag cleanup (~28 `<param></param>`/`<returns></returns>` tags) — fill-vs-delete is a per-member judgement call.