### PR TITLE
Detect Geth genesis format independent of property order

### DIFF
--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
@@ -397,6 +397,31 @@ public class GethGenesisLoaderTests
     }
 
     [Test]
+    public void AutoDetectingLoader_detects_geth_format_when_config_is_after_detection_buffer()
+    {
+        string padding = new('a', 8192);
+        string gethGenesis = $$"""
+        {
+          "nonce": "0x0",
+          "padding": "{{padding}}",
+          "config": {
+            "chainId": 12345,
+            "homesteadBlock": 0,
+            "eip150Block": 0,
+            "eip155Block": 0,
+            "eip158Block": 0
+          },
+          "difficulty": "0x1",
+          "gasLimit": "0x8000000",
+          "alloc": {}
+        }
+        """;
+
+        ChainSpec chainSpec = LoadAutoDetecting(gethGenesis);
+        Assert.That(chainSpec.ChainId, Is.EqualTo(12345));
+    }
+
+    [Test]
     public void AutoDetectingLoader_detects_parity_format()
     {
         const string parityChainspec = """

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
@@ -69,8 +69,41 @@ public class GethGenesisLoaderTests
         return new AutoDetectingChainSpecLoader(new EthereumJsonSerializer(), LimboLogs.Instance).Load(stream);
     }
 
+    private static ChainSpec LoadAutoDetectingNonSeekable(string json)
+    {
+        using NonSeekableStream stream = new(Encoding.UTF8.GetBytes(json));
+        return new AutoDetectingChainSpecLoader(new EthereumJsonSerializer(), LimboLogs.Instance).Load(stream);
+    }
+
     private static ChainSpec LoadHoodiChainSpec() => LoadChainSpec(
         Path.Combine(TestContext.CurrentContext.WorkDirectory, "../../../../", "Chains/hoodi.json"));
+
+    private sealed class NonSeekableStream(byte[] data) : Stream
+    {
+        private readonly MemoryStream _inner = new(data, writable: false);
+
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override int Read(Span<byte> buffer) => _inner.Read(buffer);
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
 
     /// <summary>
     /// Builds a standard geth genesis JSON with homesteadBlock/eip150Block/eip155Block/eip158Block all set to 0.
@@ -415,6 +448,43 @@ public class GethGenesisLoaderTests
     public void AutoDetectingLoader_detects_geth_format_regardless_of_config_position(string gethGenesis)
     {
         ChainSpec chainSpec = LoadAutoDetecting(gethGenesis);
+        Assert.That(chainSpec.ChainId, Is.EqualTo(12345));
+    }
+
+    [Test]
+    public void AutoDetectingLoader_loads_geth_format_from_non_seekable_stream()
+    {
+        ChainSpec chainSpec = LoadAutoDetectingNonSeekable(BuildStandardGethGenesisJson(chainId: 12345));
+
+        Assert.That(chainSpec.ChainId, Is.EqualTo(12345));
+    }
+
+    [Test]
+    public void AutoDetectingLoader_uses_serializer_maximum_json_depth()
+    {
+        StringBuilder nestedValue = new();
+        nestedValue.Append('[', 70);
+        nestedValue.Append('0');
+        nestedValue.Append(']', 70);
+
+        string gethGenesis = $$"""
+            {
+              "config": {
+                "chainId": 12345,
+                "homesteadBlock": 0,
+                "eip150Block": 0,
+                "eip155Block": 0,
+                "eip158Block": 0
+              },
+              "nested": {{nestedValue}},
+              "difficulty": "0x1",
+              "gasLimit": "0x8000000",
+              "alloc": {}
+            }
+            """;
+
+        ChainSpec chainSpec = LoadAutoDetecting(gethGenesis);
+
         Assert.That(chainSpec.ChainId, Is.EqualTo(12345));
     }
 

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
@@ -371,7 +371,7 @@ public class GethGenesisLoaderTests
         get
         {
             yield return new TestCaseData(BuildStandardGethGenesisJson(chainId: 12345))
-                { TestName = "Geth_config_is_first" };
+                .SetName("Geth_config_is_first");
 
             yield return new TestCaseData("""
                 {
@@ -388,7 +388,7 @@ public class GethGenesisLoaderTests
                   "alloc": {}
                 }
                 """)
-                { TestName = "Geth_config_follows_nonce" };
+                .SetName("Geth_config_follows_nonce");
 
             string padding = new('a', 8192);
             yield return new TestCaseData($$"""
@@ -407,7 +407,7 @@ public class GethGenesisLoaderTests
                   "alloc": {}
                 }
                 """)
-                { TestName = "Geth_config_follows_large_value" };
+                .SetName("Geth_config_follows_large_value");
         }
     }
 

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
@@ -374,6 +374,29 @@ public class GethGenesisLoaderTests
     }
 
     [Test]
+    public void AutoDetectingLoader_detects_geth_format_when_config_is_not_first()
+    {
+        const string gethGenesis = """
+        {
+          "nonce": "0x0",
+          "config": {
+            "chainId": 12345,
+            "homesteadBlock": 0,
+            "eip150Block": 0,
+            "eip155Block": 0,
+            "eip158Block": 0
+          },
+          "difficulty": "0x1",
+          "gasLimit": "0x8000000",
+          "alloc": {}
+        }
+        """;
+
+        ChainSpec chainSpec = LoadAutoDetecting(gethGenesis);
+        Assert.That(chainSpec.ChainId, Is.EqualTo(12345));
+    }
+
+    [Test]
     public void AutoDetectingLoader_detects_parity_format()
     {
         const string parityChainspec = """

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
@@ -422,6 +422,36 @@ public class GethGenesisLoaderTests
     }
 
     [Test]
+    public void AutoDetectingLoader_preserves_parity_format_with_top_level_config()
+    {
+        const string parityChainspec = """
+        {
+          "config": { "chainId": 12345 },
+          "engine": { "Ethash": {} },
+          "params": {
+            "chainID": "0x1",
+            "terminalPoWBlockNumber": "0x64",
+            "terminalTotalDifficulty": "0xA"
+          },
+          "genesis": {
+            "difficulty": "0x1",
+            "gasLimit": "0x1388"
+          },
+          "accounts": {}
+        }
+        """;
+
+        ChainSpec chainSpec = LoadAutoDetecting(parityChainspec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(chainSpec.ChainId, Is.EqualTo(1));
+            Assert.That(chainSpec.TerminalPoWBlockNumber, Is.EqualTo(100));
+            Assert.That(chainSpec.TerminalTotalDifficulty, Is.EqualTo((UInt256)10));
+        }
+    }
+
+    [Test]
     public void AutoDetectingLoader_detects_parity_format()
     {
         const string parityChainspec = """

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
@@ -366,57 +366,54 @@ public class GethGenesisLoaderTests
         }
     }
 
-    [Test]
-    public void AutoDetectingLoader_detects_geth_format()
+    public static IEnumerable<TestCaseData> GethGenesisDetectionCases
     {
-        ChainSpec chainSpec = LoadAutoDetecting(BuildStandardGethGenesisJson(chainId: 12345));
-        Assert.That(chainSpec.ChainId, Is.EqualTo(12345));
+        get
+        {
+            yield return new TestCaseData(BuildStandardGethGenesisJson(chainId: 12345))
+                { TestName = "Geth_config_is_first" };
+
+            yield return new TestCaseData("""
+                {
+                  "nonce": "0x0",
+                  "config": {
+                    "chainId": 12345,
+                    "homesteadBlock": 0,
+                    "eip150Block": 0,
+                    "eip155Block": 0,
+                    "eip158Block": 0
+                  },
+                  "difficulty": "0x1",
+                  "gasLimit": "0x8000000",
+                  "alloc": {}
+                }
+                """)
+                { TestName = "Geth_config_follows_nonce" };
+
+            string padding = new('a', 8192);
+            yield return new TestCaseData($$"""
+                {
+                  "nonce": "0x0",
+                  "padding": "{{padding}}",
+                  "config": {
+                    "chainId": 12345,
+                    "homesteadBlock": 0,
+                    "eip150Block": 0,
+                    "eip155Block": 0,
+                    "eip158Block": 0
+                  },
+                  "difficulty": "0x1",
+                  "gasLimit": "0x8000000",
+                  "alloc": {}
+                }
+                """)
+                { TestName = "Geth_config_follows_large_value" };
+        }
     }
 
-    [Test]
-    public void AutoDetectingLoader_detects_geth_format_when_config_is_not_first()
+    [TestCaseSource(nameof(GethGenesisDetectionCases))]
+    public void AutoDetectingLoader_detects_geth_format_regardless_of_config_position(string gethGenesis)
     {
-        const string gethGenesis = """
-        {
-          "nonce": "0x0",
-          "config": {
-            "chainId": 12345,
-            "homesteadBlock": 0,
-            "eip150Block": 0,
-            "eip155Block": 0,
-            "eip158Block": 0
-          },
-          "difficulty": "0x1",
-          "gasLimit": "0x8000000",
-          "alloc": {}
-        }
-        """;
-
-        ChainSpec chainSpec = LoadAutoDetecting(gethGenesis);
-        Assert.That(chainSpec.ChainId, Is.EqualTo(12345));
-    }
-
-    [Test]
-    public void AutoDetectingLoader_detects_geth_format_when_config_is_after_detection_buffer()
-    {
-        string padding = new('a', 8192);
-        string gethGenesis = $$"""
-        {
-          "nonce": "0x0",
-          "padding": "{{padding}}",
-          "config": {
-            "chainId": 12345,
-            "homesteadBlock": 0,
-            "eip150Block": 0,
-            "eip155Block": 0,
-            "eip158Block": 0
-          },
-          "difficulty": "0x1",
-          "gasLimit": "0x8000000",
-          "alloc": {}
-        }
-        """;
-
         ChainSpec chainSpec = LoadAutoDetecting(gethGenesis);
         Assert.That(chainSpec.ChainId, Is.EqualTo(12345));
     }

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/AutoDetectingChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/AutoDetectingChainSpecLoader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.IO;
 using System.Text.Json;
+using Nethermind.Core.Resettables;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
 
@@ -26,10 +27,16 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
     {
         if (!streamData.CanSeek)
         {
-            using MemoryStream bufferedStream = new();
-            streamData.CopyTo(bufferedStream);
+            using Stream bufferedStream = RecyclableStream.GetStream(nameof(AutoDetectingChainSpecLoader));
+            GenesisFormat format;
+            using (CapturingStream detectionStream = new(streamData, bufferedStream))
+            {
+                format = DetectFormat(detectionStream);
+            }
+
             bufferedStream.Position = 0;
-            return LoadSeekable(bufferedStream);
+            using PrefixedStream replayStream = new(bufferedStream, streamData);
+            return LoadDetected(format, replayStream);
         }
 
         return LoadSeekable(streamData);
@@ -41,12 +48,14 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
         GenesisFormat format = DetectFormat(streamData);
         streamData.Position = startPosition;
 
-        return format switch
-        {
-            GenesisFormat.Geth => _gethLoader.Load(streamData),
-            _ => _parityLoader.Load(streamData),
-        };
+        return LoadDetected(format, streamData);
     }
+
+    private ChainSpec LoadDetected(GenesisFormat format, Stream streamData) => format switch
+    {
+        GenesisFormat.Geth => _gethLoader.Load(streamData),
+        _ => _parityLoader.Load(streamData),
+    };
 
     /// <summary>
     /// Geth genesis contains a top-level <c>"config"</c> property, while Parity-style chainspecs
@@ -61,7 +70,11 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
         {
             int bytesInBuffer = 0;
             bool hasGethConfig = false;
-            JsonReaderState readerState = new(new JsonReaderOptions { AllowTrailingCommas = true });
+            JsonReaderState readerState = new(new JsonReaderOptions
+            {
+                AllowTrailingCommas = true,
+                MaxDepth = EthereumJsonSerializer.DefaultMaxDepth,
+            });
 
             while (true)
             {
@@ -131,6 +144,99 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
 
         if (_logger.IsWarn) _logger.Warn("Failed to detect genesis file format, assuming Parity-like style.");
         return GenesisFormat.Unknown;
+    }
+
+    private sealed class CapturingStream(Stream inner, Stream capture) : Stream
+    {
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int bytesRead = inner.Read(buffer, offset, count);
+            if (bytesRead > 0)
+            {
+                capture.Write(buffer, offset, bytesRead);
+            }
+
+            return bytesRead;
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            int bytesRead = inner.Read(buffer);
+            if (bytesRead > 0)
+            {
+                capture.Write(buffer[..bytesRead]);
+            }
+
+            return bytesRead;
+        }
+
+        public override int ReadByte()
+        {
+            int value = inner.ReadByte();
+            if (value >= 0)
+            {
+                capture.WriteByte((byte)value);
+            }
+
+            return value;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class PrefixedStream(Stream prefix, Stream inner) : Stream
+    {
+        private bool _prefixExhausted;
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (!_prefixExhausted)
+            {
+                int bytesRead = prefix.Read(buffer, offset, count);
+                if (bytesRead > 0)
+                {
+                    return bytesRead;
+                }
+
+                _prefixExhausted = true;
+            }
+
+            return inner.Read(buffer, offset, count);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            if (!_prefixExhausted)
+            {
+                int bytesRead = prefix.Read(buffer);
+                if (bytesRead > 0)
+                {
+                    return bytesRead;
+                }
+
+                _prefixExhausted = true;
+            }
+
+            return inner.Read(buffer);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     private enum GenesisFormat

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/AutoDetectingChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/AutoDetectingChainSpecLoader.cs
@@ -49,7 +49,9 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
     }
 
     /// <summary>
-    /// Geth genesis contains a top-level <c>"config"</c> property; parity chainspecs do not.
+    /// Geth genesis contains a top-level <c>"config"</c> property, while Parity-style chainspecs
+    /// are identified by their top-level <c>"engine"</c>, <c>"params"</c>, <c>"genesis"</c>, or
+    /// <c>"accounts"</c> properties.
     /// </summary>
     private GenesisFormat DetectFormat(Stream streamData)
     {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/AutoDetectingChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/AutoDetectingChainSpecLoader.cs
@@ -21,43 +21,41 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
 
     public ChainSpec Load(Stream streamData)
     {
-        static Stream RewindStream(Stream streamData, long startPosition)
+        if (!streamData.CanSeek)
         {
-            streamData.Position = startPosition;
-            return streamData;
+            using MemoryStream bufferedStream = new();
+            streamData.CopyTo(bufferedStream);
+            bufferedStream.Position = 0;
+            return LoadSeekable(bufferedStream);
         }
 
-        Span<byte> header = stackalloc byte[256];
-        long startPosition = streamData.CanSeek ? streamData.Position : -1;
-        int headerLength = streamData.ReadAtLeast(header, 1, throwOnEndOfStream: false);
-        header = header[..headerLength];
-        GenesisFormat format = DetectFormat(header);
+        return LoadSeekable(streamData);
+    }
 
-        Stream stream = streamData.CanSeek
-            ? RewindStream(streamData, startPosition)
-            : new PrefixedStream(header.ToArray(), streamData);
+    private ChainSpec LoadSeekable(Stream streamData)
+    {
+        long startPosition = streamData.Position;
+        GenesisFormat format = DetectFormat(streamData);
+        streamData.Position = startPosition;
 
         return format switch
         {
-            GenesisFormat.Geth => _gethLoader.Load(stream),
-            _ => _parityLoader.Load(stream),
+            GenesisFormat.Geth => _gethLoader.Load(streamData),
+            _ => _parityLoader.Load(streamData),
         };
     }
 
     /// <summary>
-    /// Geth genesis always starts with <c>"config"</c> as the first property; parity chainspecs never do.
+    /// Geth genesis contains a top-level <c>"config"</c> property; parity chainspecs do not.
     /// </summary>
-    private GenesisFormat DetectFormat(ReadOnlySpan<byte> data)
+    private GenesisFormat DetectFormat(Stream streamData)
     {
         try
         {
-            Utf8JsonReader reader = new(data, new JsonReaderOptions { AllowTrailingCommas = true });
-
-            while (reader.Read())
-            {
-                if (reader.TokenType is JsonTokenType.PropertyName && !reader.ValueTextEquals("$schema"u8))
-                    return reader.ValueTextEquals("config"u8) ? GenesisFormat.Geth : GenesisFormat.Parity;
-            }
+            using JsonDocument document = JsonDocument.Parse(streamData, new JsonDocumentOptions { AllowTrailingCommas = true });
+            return document.RootElement.ValueKind is JsonValueKind.Object && document.RootElement.TryGetProperty("config", out _)
+                ? GenesisFormat.Geth
+                : GenesisFormat.Parity;
         }
         catch (JsonException e)
         {
@@ -66,51 +64,6 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
 
         if (_logger.IsWarn) _logger.Warn("Failed to detect genesis file format, assuming Parity-like style.");
         return GenesisFormat.Unknown;
-    }
-
-    /// <summary>
-    /// A read-only stream that replays a prefix byte buffer before delegating to the inner stream.
-    /// Avoids copying the entire inner stream to a MemoryStream just for format detection.
-    /// </summary>
-    private sealed class PrefixedStream(ReadOnlyMemory<byte> prefix, Stream inner) : Stream
-    {
-        private int _prefixPosition;
-
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            if (_prefixPosition < prefix.Length)
-            {
-                int toCopy = Math.Min(count, prefix.Length - _prefixPosition);
-                prefix.Span.Slice(_prefixPosition, toCopy).CopyTo(buffer.AsSpan(offset, toCopy));
-                _prefixPosition += toCopy;
-                return toCopy;
-            }
-
-            return inner.Read(buffer, offset, count);
-        }
-
-        public override int Read(Span<byte> buffer)
-        {
-            if (_prefixPosition < prefix.Length)
-            {
-                int toCopy = Math.Min(buffer.Length, prefix.Length - _prefixPosition);
-                prefix.Span.Slice(_prefixPosition, toCopy).CopyTo(buffer);
-                _prefixPosition += toCopy;
-                return toCopy;
-            }
-
-            return inner.Read(buffer);
-        }
-
-        public override bool CanRead => true;
-        public override bool CanSeek => false;
-        public override bool CanWrite => false;
-        public override long Length => throw new NotSupportedException();
-        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
-        public override void Flush() { }
-        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-        public override void SetLength(long value) => throw new NotSupportedException();
-        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     private enum GenesisFormat

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/AutoDetectingChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/AutoDetectingChainSpecLoader.cs
@@ -58,6 +58,7 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
         try
         {
             int bytesInBuffer = 0;
+            bool hasGethConfig = false;
             JsonReaderState readerState = new(new JsonReaderOptions { AllowTrailingCommas = true });
 
             while (true)
@@ -79,7 +80,7 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
                 {
                     if (reader.TokenType is JsonTokenType.EndObject && reader.CurrentDepth == 0)
                     {
-                        return GenesisFormat.Parity;
+                        return hasGethConfig ? GenesisFormat.Geth : GenesisFormat.Parity;
                     }
 
                     if (reader.TokenType is not JsonTokenType.PropertyName || reader.CurrentDepth != 1)
@@ -87,10 +88,15 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
                         continue;
                     }
 
-                    if (reader.ValueTextEquals("config"u8))
+                    if (reader.ValueTextEquals("engine"u8) ||
+                        reader.ValueTextEquals("params"u8) ||
+                        reader.ValueTextEquals("genesis"u8) ||
+                        reader.ValueTextEquals("accounts"u8))
                     {
-                        return GenesisFormat.Geth;
+                        return GenesisFormat.Parity;
                     }
+
+                    hasGethConfig |= reader.ValueTextEquals("config"u8);
 
                     if (!reader.Read() || !reader.TrySkip())
                     {

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/AutoDetectingChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/AutoDetectingChainSpecLoader.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Text.Json;
 using Nethermind.Logging;
@@ -15,6 +16,8 @@ namespace Nethermind.Specs.ChainSpecStyle;
 /// </summary>
 public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManager logManager) : IChainSpecLoader
 {
+    private const int DetectionBufferSize = 4096;
+
     private readonly ILogger _logger = logManager.GetClassLogger<AutoDetectingChainSpecLoader>();
     private readonly ChainSpecLoader _parityLoader = new(serializer, logManager);
     private readonly GethGenesisLoader _gethLoader = new(serializer);
@@ -50,16 +53,72 @@ public class AutoDetectingChainSpecLoader(IJsonSerializer serializer, ILogManage
     /// </summary>
     private GenesisFormat DetectFormat(Stream streamData)
     {
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(DetectionBufferSize);
+
         try
         {
-            using JsonDocument document = JsonDocument.Parse(streamData, new JsonDocumentOptions { AllowTrailingCommas = true });
-            return document.RootElement.ValueKind is JsonValueKind.Object && document.RootElement.TryGetProperty("config", out _)
-                ? GenesisFormat.Geth
-                : GenesisFormat.Parity;
+            int bytesInBuffer = 0;
+            JsonReaderState readerState = new(new JsonReaderOptions { AllowTrailingCommas = true });
+
+            while (true)
+            {
+                if (bytesInBuffer == buffer.Length)
+                {
+                    byte[] largerBuffer = ArrayPool<byte>.Shared.Rent(checked(buffer.Length * 2));
+                    buffer.AsSpan(0, bytesInBuffer).CopyTo(largerBuffer);
+                    ArrayPool<byte>.Shared.Return(buffer);
+                    buffer = largerBuffer;
+                }
+
+                int bytesRead = streamData.Read(buffer.AsSpan(bytesInBuffer));
+                bytesInBuffer += bytesRead;
+                bool isFinalBlock = bytesRead == 0;
+
+                Utf8JsonReader reader = new(buffer.AsSpan(0, bytesInBuffer), isFinalBlock, readerState);
+                while (reader.Read())
+                {
+                    if (reader.TokenType is JsonTokenType.EndObject && reader.CurrentDepth == 0)
+                    {
+                        return GenesisFormat.Parity;
+                    }
+
+                    if (reader.TokenType is not JsonTokenType.PropertyName || reader.CurrentDepth != 1)
+                    {
+                        continue;
+                    }
+
+                    if (reader.ValueTextEquals("config"u8))
+                    {
+                        return GenesisFormat.Geth;
+                    }
+
+                    if (!reader.Read() || !reader.TrySkip())
+                    {
+                        break;
+                    }
+                }
+
+                readerState = reader.CurrentState;
+                int bytesConsumed = checked((int)reader.BytesConsumed);
+                if (bytesConsumed > 0)
+                {
+                    buffer.AsSpan(bytesConsumed, bytesInBuffer - bytesConsumed).CopyTo(buffer);
+                    bytesInBuffer -= bytesConsumed;
+                }
+
+                if (isFinalBlock)
+                {
+                    break;
+                }
+            }
         }
         catch (JsonException e)
         {
             if (_logger.IsError) _logger.Error("Error parsing specification", e);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
         }
 
         if (_logger.IsWarn) _logger.Warn("Failed to detect genesis file format, assuming Parity-like style.");


### PR DESCRIPTION
## Changes

- Make Geth genesis auto-detection order-independent by checking for a top-level `config` property while preserving Parity-style files that also contain `config` alongside `engine`, `params`, `genesis`, or `accounts`.
- Scan with a pooled incremental JSON reader, skip nested values, and avoid materializing a JSON document.
- Preserve Parity fallback and support non-seekable input streams.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Parameterized regression coverage uses one test source for Geth `config` in its normal position, after `nonce`, and after a value larger than the initial detection buffer; separate coverage protects Parity chainspecs with a top-level `config`. Existing Merge/TTD tests also pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
