### PR TITLE
fix(evm): charge a frame for resolving its target's delegation

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -327,39 +327,52 @@ public class FrameTxProcessorTests
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         Address identityPrecompile = Address.FromNumber(4);
         Assert.That(Spec.IsPrecompile(identityPrecompile), Is.True);
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
 
-        CallOutputTracer precompileTracer = new();
-        Assert.That(Process(FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: identityPrecompile)),
-            tracer: precompileTracer).TransactionExecuted, Is.True);
-
-        CallOutputTracer coldTracer = new();
-        Assert.That(Process(FrameTx(nonce: 1, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Recipient)),
-            tracer: coldTracer).TransactionExecuted, Is.True);
-
-        Assert.That(coldTracer.GasSpent - precompileTracer.GasSpent,
+        Assert.That(EntryGasDelta(Recipient, identityPrecompile),
             Is.EqualTo((long)(Eip8038Constants.ColdAccountAccess - Eip8038Constants.WarmAccess)),
             "a precompile target must pay warm entry access where a cold account pays cold");
     }
 
-    [Test]
-    public void Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess()
+    [TestCase(false, TestName = "Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess(contract designation)")]
+    [TestCase(true, TestName = "Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess(precompile designation)")]
+    public void Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess(bool designatePrecompile)
     {
         // create_evm_from_frame resolves the EIP-7702 designation at frame entry, an access of the
-        // designated address charged on top of the target's own.
+        // designated address charged on top of the target's own; a designated precompile is warm.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        Address designated = designatePrecompile ? Address.FromNumber(4) : Recipient;
+        DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. designated.Bytes]);
+
+        ulong expected = designatePrecompile ? Eip8038Constants.WarmAccess : Eip8038Constants.ColdAccountAccess;
+
+        Assert.That(EntryGasDelta(Observer, Recipient), Is.EqualTo((long)expected),
+            "resolving the designation must charge the access of the designated address");
+    }
+
+    [Test]
+    public void Execute_FrameGasCoveringOnlyTheTargetAccess_FailsOnTheDelegateAccess()
+    {
+        // The designation access is charged after the target's own, so a frame that affords one but
+        // not both fails at entry with its whole gas limit consumed.
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
         DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. Recipient.Bytes]);
 
-        CallOutputTracer delegatedTracer = new();
-        Assert.That(Process(FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer)),
-            tracer: delegatedTracer).TransactionExecuted, Is.True);
+        TxFrame frame = new(TxFrame.ModeDefault, flags: 0, Observer,
+            gasLimit: Eip8038Constants.ColdAccountAccess, UInt256.Zero, default);
+        FrameReceiptTracer tracer = new();
 
-        CallOutputTracer directTracer = new();
-        Assert.That(Process(FrameTx(nonce: 1, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Recipient)),
-            tracer: directTracer).TransactionExecuted, Is.True);
+        Assert.That(Process(FrameTx(nonce: 0, SelfVerifyFrame(), frame), tracer: tracer).TransactionExecuted, Is.True);
 
-        Assert.That(delegatedTracer.GasSpent - directTracer.GasSpent, Is.EqualTo((long)Eip8038Constants.ColdAccountAccess),
-            "resolving the designation must charge the cold access of the designated address");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure),
+                "gas covering only the target access must not reach the designated code");
+            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(Eip8038Constants.ColdAccountAccess),
+                "a frame failing at entry consumes its whole gas limit");
+        }
     }
 
     [Test]
@@ -1199,6 +1212,28 @@ public class FrameTxProcessorTests
 
     private UInt256 ExpectedBlobFee(ulong excessBlobGas, int blobCount) =>
         FeePerBlobGas(excessBlobGas) * BlobGasCalculator.CalculateBlobGas(blobCount);
+
+    private sealed class FrameReceiptTracer : CallOutputTracer, IFrameTxReceiptTracer
+    {
+        public TxFrameReceipt[]? FrameReceipts { get; private set; }
+
+        public void ReportFrameTxReceipt(Address payer, TxFrameReceipt[] frameReceipts) => FrameReceipts = frameReceipts;
+    }
+
+    /// <summary>Frame gas of a <c>DEFAULT</c> frame targeting <paramref name="target"/> less the same
+    /// frame targeting <paramref name="baseline"/>, isolating what the two entry charges differ by.</summary>
+    private long EntryGasDelta(Address target, Address baseline)
+    {
+        CallOutputTracer targetTracer = new();
+        Assert.That(Process(FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: target)),
+            tracer: targetTracer).TransactionExecuted, Is.True);
+
+        CallOutputTracer baselineTracer = new();
+        Assert.That(Process(FrameTx(nonce: 1, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: baseline)),
+            tracer: baselineTracer).TransactionExecuted, Is.True);
+
+        return (long)targetTracer.GasSpent - (long)baselineTracer.GasSpent;
+    }
 
     private void DeploySmartSender(byte[] code) => DeployContract(Sender, code, 1.Ether);
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -384,11 +384,7 @@ public class FrameTxProcessorTests
         DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
         DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. Recipient.Bytes]);
 
-        TracedAccessWorldState tracedState = new(_stateProvider, parallel: false);
-        tracedState.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
-        EthereumCodeInfoRepository codeInfoRepository = new(tracedState);
-        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
-        EthereumTransactionProcessor tracedProcessor = new(BlobBaseFeeCalculator.Instance, _specProvider, tracedState, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+        (EthereumTransactionProcessor tracedProcessor, TracedAccessWorldState tracedState) = TracedProcessor();
 
         TxFrame frame = new(TxFrame.ModeDefault, flags: 0, Observer,
             gasLimit: Eip8038Constants.ColdAccountAccess, UInt256.Zero, default);
@@ -408,6 +404,31 @@ public class FrameTxProcessorTests
             Assert.That(bal.GetAccountChanges(Recipient), Is.Null,
                 "a frame that cannot pay the designation access must not read the designated account");
         }
+    }
+
+    [Test]
+    public void Execute_FrameTargetDesignatesAPrecompile_RecordsThePrecompileInTheBal()
+    {
+        // EIP-7928: the designation is resolved by accessing the designated account, and the
+        // precompile branch asks the repository for nothing, so only the explicit read records it.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Address identityPrecompile = Address.FromNumber(4);
+        DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. identityPrecompile.Bytes]);
+
+        (EthereumTransactionProcessor tracedProcessor, TracedAccessWorldState tracedState) = TracedProcessor();
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+
+        Assert.That(tracedProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance).TransactionExecuted, Is.True);
+
+        BlockAccessListAtIndex bal = tracedState.GetGeneratingBlockAccessList()!;
+        Assert.That(bal.GetAccountChanges(identityPrecompile), Is.Not.Null,
+            "resolving a designation accesses the designated precompile");
     }
 
     [Test]
@@ -931,11 +952,7 @@ public class FrameTxProcessorTests
         _stateProvider.Commit(Spec);
         _stateProvider.CommitTree(0);
 
-        TracedAccessWorldState tracedState = new(_stateProvider, parallel: false);
-        tracedState.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
-        EthereumCodeInfoRepository codeInfoRepository = new(tracedState);
-        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
-        EthereumTransactionProcessor tracedProcessor = new(BlobBaseFeeCalculator.Instance, _specProvider, tracedState, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+        (EthereumTransactionProcessor tracedProcessor, TracedAccessWorldState tracedState) = TracedProcessor();
 
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
         tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, new byte[TxFrameSignature.Secp256k1SignatureLength])];
@@ -971,11 +988,7 @@ public class FrameTxProcessorTests
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         Address beneficiary = TestItem.AddressF;
 
-        TracedAccessWorldState tracedState = new(_stateProvider, parallel: false);
-        tracedState.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
-        EthereumCodeInfoRepository codeInfoRepository = new(tracedState);
-        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
-        EthereumTransactionProcessor tracedProcessor = new(BlobBaseFeeCalculator.Instance, _specProvider, tracedState, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+        (EthereumTransactionProcessor tracedProcessor, TracedAccessWorldState tracedState) = TracedProcessor();
 
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
         tx.GasPrice = 0; // max_priority_fee_per_gas - zero premium, so the beneficiary credit is zero
@@ -1268,6 +1281,17 @@ public class FrameTxProcessorTests
             tracer: baselineTracer).TransactionExecuted, Is.True);
 
         return (long)targetTracer.GasSpent - (long)baselineTracer.GasSpent;
+    }
+
+    /// <summary>A processor over a <see cref="TracedAccessWorldState"/> that generates a block access list.</summary>
+    private (EthereumTransactionProcessor Processor, TracedAccessWorldState State) TracedProcessor()
+    {
+        TracedAccessWorldState tracedState = new(_stateProvider, parallel: false);
+        tracedState.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
+        EthereumCodeInfoRepository codeInfoRepository = new(tracedState);
+        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        return (new EthereumTransactionProcessor(BlobBaseFeeCalculator.Instance, _specProvider, tracedState,
+            virtualMachine, codeInfoRepository, LimboLogs.Instance), tracedState);
     }
 
     private void DeploySmartSender(byte[] code) => DeployContract(Sender, code, 1.Ether);

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -342,6 +342,27 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess()
+    {
+        // create_evm_from_frame resolves the EIP-7702 designation at frame entry, an access of the
+        // designated address charged on top of the target's own.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. Recipient.Bytes]);
+
+        CallOutputTracer delegatedTracer = new();
+        Assert.That(Process(FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer)),
+            tracer: delegatedTracer).TransactionExecuted, Is.True);
+
+        CallOutputTracer directTracer = new();
+        Assert.That(Process(FrameTx(nonce: 1, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Recipient)),
+            tracer: directTracer).TransactionExecuted, Is.True);
+
+        Assert.That(delegatedTracer.GasSpent - directTracer.GasSpent, Is.EqualTo((long)Eip8038Constants.ColdAccountAccess),
+            "resolving the designation must charge the cold access of the designated address");
+    }
+
+    [Test]
     public void Execute_MaxFeeTimesGasLimitOverflows_RejectedWithoutCreditingBeneficiary()
     {
         // max_fee = max_priority = 2^255 with an even tx gas limit (415_950 here) wraps maxCost to

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -338,8 +338,7 @@ public class FrameTxProcessorTests
     [TestCase(true, TestName = "Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess(precompile designation)")]
     public void Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess(bool designatePrecompile)
     {
-        // create_evm_from_frame resolves the EIP-7702 designation at frame entry, an access of the
-        // designated address charged on top of the target's own; a designated precompile is warm.
+        // create_evm_from_frame charges the designated address's access on top of the target's own.
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
         Address designated = designatePrecompile ? Address.FromNumber(4) : Recipient;
@@ -354,8 +353,6 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_FrameGasCoveringOnlyTheTargetAccess_FailsOnTheDelegateAccess()
     {
-        // The designation access is charged after the target's own, so a frame that affords one but
-        // not both fails at entry with its whole gas limit consumed.
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
         DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. Recipient.Bytes]);
@@ -378,8 +375,7 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_FrameGasCoveringOnlyTheTargetAccess_LeavesTheDesignatedAccountOutOfTheBal()
     {
-        // EIP-7928: the designated code is read only once its access is paid for, so a frame that
-        // cannot afford the charge leaves no BAL entry for the designated account.
+        // EIP-7928: the designated code is read only once its access is paid for.
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
         DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. Recipient.Bytes]);
@@ -409,8 +405,7 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_FrameTargetDesignatesAPrecompile_RecordsThePrecompileInTheBal()
     {
-        // EIP-7928: the designation is resolved by accessing the designated account, and the
-        // precompile branch asks the repository for nothing, so only the explicit read records it.
+        // EIP-7928: the precompile branch asks the repository for nothing, so only the explicit read records it.
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         Address identityPrecompile = Address.FromNumber(4);
         DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. identityPrecompile.Bytes]);
@@ -1268,8 +1263,7 @@ public class FrameTxProcessorTests
         public void ReportFrameTxReceipt(Address payer, TxFrameReceipt[] frameReceipts) => FrameReceipts = frameReceipts;
     }
 
-    /// <summary>Frame gas of a <c>DEFAULT</c> frame targeting <paramref name="target"/> less the same
-    /// frame targeting <paramref name="baseline"/>, isolating what the two entry charges differ by.</summary>
+    /// <summary>Difference in frame gas between two <c>DEFAULT</c> frames, isolating their entry charges.</summary>
     private long EntryGasDelta(Address target, Address baseline)
     {
         CallOutputTracer targetTracer = new();

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -376,6 +376,41 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_FrameGasCoveringOnlyTheTargetAccess_LeavesTheDesignatedAccountOutOfTheBal()
+    {
+        // EIP-7928: the designated code is read only once its access is paid for, so a frame that
+        // cannot afford the charge leaves no BAL entry for the designated account.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. Recipient.Bytes]);
+
+        TracedAccessWorldState tracedState = new(_stateProvider, parallel: false);
+        tracedState.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
+        EthereumCodeInfoRepository codeInfoRepository = new(tracedState);
+        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        EthereumTransactionProcessor tracedProcessor = new(BlobBaseFeeCalculator.Instance, _specProvider, tracedState, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+
+        TxFrame frame = new(TxFrame.ModeDefault, flags: 0, Observer,
+            gasLimit: Eip8038Constants.ColdAccountAccess, UInt256.Zero, default);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), frame);
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+
+        Assert.That(tracedProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance).TransactionExecuted, Is.True);
+
+        BlockAccessListAtIndex bal = tracedState.GetGeneratingBlockAccessList()!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(bal.GetAccountChanges(Observer), Is.Not.Null, "the target is read to find the designation");
+            Assert.That(bal.GetAccountChanges(Recipient), Is.Null,
+                "a frame that cannot pay the designation access must not read the designated account");
+        }
+    }
+
+    [Test]
     public void Execute_MaxFeeTimesGasLimitOverflows_RejectedWithoutCreditingBeneficiary()
     {
         // max_fee = max_priority = 2^255 with an even tx gas limit (415_950 here) wraps maxCost to

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -518,8 +518,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         }
 
         CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, spec, out Address? delegation);
-        // resolve_delegated_code_address: following the designation accesses the designated address,
-        // charged at frame entry like the target's own access.
+        // resolve_delegated_code_address: following the designation accesses the designated address.
+        // The target is charged just above and counts as accessed, so a self-designation is warm.
         if (delegation is not null && spec.UseHotAndColdStorage)
         {
             entryCharge += delegation != resolvedTarget && accessTracker.IsCold(delegation) && !spec.IsPrecompile(delegation)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -519,22 +519,22 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         }
 
         CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, followDelegation: false, spec, out Address? delegation);
-        // resolve_delegated_code_address: following the designation accesses the designated address.
-        // The target is charged just above and counts as accessed, so a self-designation is warm.
-        if (delegation is not null && spec.UseHotAndColdStorage)
-        {
-            entryCharge += delegation != resolvedTarget && accessTracker.IsCold(delegation) && !spec.IsPrecompile(delegation)
-                ? TGasPolicy.GetColdAccountAccessCost(spec)
-                : Eip8038Constants.WarmAccess;
-            if (entryCharge > frame.GasLimit)
-            {
-                gasUsed = frame.GasLimit;
-                return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
-            }
-        }
-
         if (delegation is not null)
         {
+            // resolve_delegated_code_address: following the designation accesses the designated address.
+            // The target is charged just above and counts as accessed, so a self-designation is warm.
+            if (spec.UseHotAndColdStorage)
+            {
+                entryCharge += delegation != resolvedTarget && accessTracker.IsCold(delegation) && !spec.IsPrecompile(delegation)
+                    ? TGasPolicy.GetColdAccountAccessCost(spec)
+                    : Eip8038Constants.WarmAccess;
+                if (entryCharge > frame.GasLimit)
+                {
+                    gasUsed = frame.GasLimit;
+                    return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+                }
+            }
+
             // create_evm_from_frame reads the designated code only once its access is paid for, so a
             // frame failing that charge never touches the account. EIP-7702: no dispatch to a precompile.
             WorldState.AddAccountRead(delegation);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -517,7 +517,21 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return DefaultCodeSuccess();
         }
 
-        CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, spec, out _);
+        CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, spec, out Address? delegation);
+        // resolve_delegated_code_address: following the designation accesses the designated address,
+        // charged at frame entry like the target's own access.
+        if (delegation is not null && spec.UseHotAndColdStorage)
+        {
+            entryCharge += delegation != resolvedTarget && accessTracker.IsCold(delegation) && !spec.IsPrecompile(delegation)
+                ? TGasPolicy.GetColdAccountAccessCost(spec)
+                : Eip8038Constants.WarmAccess;
+            if (entryCharge > frame.GasLimit)
+            {
+                gasUsed = frame.GasLimit;
+                return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+            }
+        }
+
         ReadOnlyMemory<byte> inputData = frame.Data;
 
         ExecutionEnvironment env = ExecutionEnvironment.Rent(
@@ -544,6 +558,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         if (spec.UseHotAndColdStorage)
         {
             frameTracker.WarmUp(resolvedTarget);
+            if (delegation is not null) frameTracker.WarmUp(delegation);
         }
 
         // The reservoir starts empty, so the VM cannot draw the entry state gas back out of it.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -465,6 +465,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         stateGasUsed = 0;
         gasUsed = 0;
         // As with an ordinary CALL, a caller unable to fund the value transfer reverts the frame.
+        // execute_frame tests funding before building the EVM, so the frame pays no entry charge.
         UInt256 value = frame.Value;
         if (!value.IsZero && WorldState.GetBalance(caller) < value)
         {
@@ -517,7 +518,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return DefaultCodeSuccess();
         }
 
-        CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, spec, out Address? delegation);
+        CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, followDelegation: false, spec, out Address? delegation);
         // resolve_delegated_code_address: following the designation accesses the designated address.
         // The target is charged just above and counts as accessed, so a self-designation is warm.
         if (delegation is not null && spec.UseHotAndColdStorage)
@@ -530,6 +531,16 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 gasUsed = frame.GasLimit;
                 return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
             }
+        }
+
+        if (delegation is not null)
+        {
+            // create_evm_from_frame reads the designated code only once its access is paid for, so a
+            // frame failing that charge never touches the account. EIP-7702: no dispatch to a precompile.
+            WorldState.AddAccountRead(delegation);
+            codeInfo = spec.IsPrecompile(delegation)
+                ? CodeInfo.Empty
+                : _codeInfoRepository.GetCachedCodeInfoNoDelegation(delegation, spec);
         }
 
         ReadOnlyMemory<byte> inputData = frame.Data;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -521,8 +521,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, followDelegation: false, spec, out Address? delegation);
         if (delegation is not null)
         {
-            // resolve_delegated_code_address: following the designation accesses the designated address.
-            // The target is charged just above and counts as accessed, so a self-designation is warm.
+            // resolve_delegated_code_address: the target counts as accessed by now, so a self-designation is warm.
             if (spec.UseHotAndColdStorage)
             {
                 entryCharge += delegation != resolvedTarget && accessTracker.IsCold(delegation) && !spec.IsPrecompile(delegation)
@@ -535,8 +534,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 }
             }
 
-            // create_evm_from_frame reads the designated code only once its access is paid for, so a
-            // frame failing that charge never touches the account. EIP-7702: no dispatch to a precompile.
+            // create_evm_from_frame reads the designated code only after its access is paid for.
+            // EIP-7702: a precompile must not execute via delegation.
             WorldState.AddAccountRead(delegation);
             codeInfo = spec.IsPrecompile(delegation)
                 ? CodeInfo.Empty


### PR DESCRIPTION
## Changes

- Charge a frame the access of its target's EIP-7702 designated address at frame entry.

The frame entry charge covered the target's own access and the EIP-8037 `NEW_ACCOUNT` state cost, but not the access that resolving a designation performs. `create_evm_from_frame` charges it alongside the target's: `resolve_delegated_code_address` reads the target's code and, when it is a designation, charges warm or cold for the designated address and warms it. A frame targeting a delegated account was therefore following the designation for free.

The designated code is also read only after that charge succeeds, mirroring the top-level path: `create_evm_from_frame` resolves the designation before it loads the code, so a frame that cannot afford the access must leave the designated account untouched — and out of the block access list. Following the designation now goes through the same `IsPrecompile` guard the `CALL` path uses, which is required once the code is fetched separately, since the repository would otherwise dispatch a precompile through a designation.

Direction: gas moves **up** for a frame whose target is delegated — by `COLD_ACCOUNT_ACCESS` when the designated address is cold, or `WARM_ACCESS` when an earlier frame already touched it (a designation pointing at a precompile is warm, since EIP-2929 seeds the precompiles). Every other frame is unaffected. The charge is applied after the target's own, so a frame that cannot afford it fails with its gas limit consumed, matching the order the reference implementation charges in; the designated address is warmed into the frame's tracker so a reverting frame discards it with the rest of its accesses.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Three cases in `FrameTxProcessorTests`, all failing before the change:

- `Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess` compares a frame targeting a delegated account against one targeting the designated contract directly, parameterised over a contract designation (**3000**, was 0) and a precompile designation (**100**, was 0 — pinning the warm disjunct).
- `Execute_FrameGasCoveringOnlyTheTargetAccess_FailsOnTheDelegateAccess` gives the frame exactly the target's own cold access, the window the second entry check opens: the frame now fails with its whole limit consumed, where before it succeeded.
- `Execute_FrameGasCoveringOnlyTheTargetAccess_LeavesTheDesignatedAccountOutOfTheBal` covers the read-ordering half of the same case, which status and gas cannot see: the designated account is absent from the block access list, where reading it before the charge recorded it.

`Nethermind.Evm.Test`: 5125 passed, 8 skipped, 0 failed. `dotnet format whitespace` clean, and a build with the lint workflow's `NoWarn` set reports no `IDE`/`CA` warnings.

Also verified against fixtures: with this change, the frame transaction suite's delegated-target entry-charge cases (cold and warm designated address) and the designation-to-precompile case pass, where all three failed before. No regression in the rest of the suite.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
