### PR TITLE
fix(xdc): relay timeouts even when the local epoch lookup fails

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/TimeoutCertificateManagerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/TimeoutCertificateManagerTests.cs
@@ -272,6 +272,84 @@ public class TimeoutCertificateManagerTests
         Assert.That(tcManager.FilterTimeout(timeout), Is.EqualTo(expected));
     }
 
+    [TestCase(99UL, 0, 0L, TestName = "StaleRound_NeitherRelayedNorPooled")]
+    [TestCase(100UL, 1, 1L, TestName = "CurrentRound_RelayedAndPooled")]
+    [TestCase(101UL, 0, 0L, TestName = "FutureRound_NeitherRelayedNorPooled")]
+    public async Task OnReceiveTimeout_DifferentRounds_RelaysAndPoolsAsExpected(ulong timeoutRound, int expectedRelays, long expectedPooled)
+    {
+        PrivateKey[] keys = XdcTestHelper.GeneratePrivateKeys(3);
+        Address[] masternodes = keys.Select(k => k.Address).ToArray();
+        (TimeoutCertificateManager manager, ISyncPeerPool syncPeerPool) = BuildManagerForReceivedTimeouts(masternodes);
+
+        Timeout timeout = XdcTestHelper.BuildSignedTimeout(keys[0], timeoutRound, Gap);
+        await manager.OnReceiveTimeout(timeout);
+
+        _ = syncPeerPool.Received(expectedRelays).AllPeers;
+        Assert.That(manager.GetTimeoutsCount(timeout), Is.EqualTo(expectedPooled));
+    }
+
+    [Test]
+    public async Task OnReceiveTimeout_EpochSwitchInfoUnavailable_StillRelaysTimeout()
+    {
+        PrivateKey[] keys = XdcTestHelper.GeneratePrivateKeys(3);
+        Address[] masternodes = keys.Select(k => k.Address).ToArray();
+
+        IEpochSwitchManager epochSwitchManager = Substitute.For<IEpochSwitchManager>();
+        epochSwitchManager.GetEpochSwitchInfo(Arg.Any<XdcBlockHeader>()).Returns((EpochSwitchInfo?)null);
+
+        (TimeoutCertificateManager manager, ISyncPeerPool syncPeerPool) =
+            BuildManagerForReceivedTimeouts(masternodes, epochSwitchManager);
+
+        Timeout timeout = XdcTestHelper.BuildSignedTimeout(keys[0], CurrentRound, Gap);
+        await manager.OnReceiveTimeout(timeout);
+
+        _ = syncPeerPool.Received(1).AllPeers;
+        Assert.That(manager.GetTimeoutsCount(timeout), Is.EqualTo(1L));
+    }
+
+    private const ulong CurrentRound = 100;
+    private const ulong Gap = 0;
+
+    private static (TimeoutCertificateManager Manager, ISyncPeerPool SyncPeerPool) BuildManagerForReceivedTimeouts(
+        Address[] masternodes,
+        IEpochSwitchManager? epochSwitchManager = null)
+    {
+        XdcBlockHeader header = Build.A.XdcBlockHeader().TestObject;
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(new Block(header, new BlockBody()));
+
+        ISnapshotManager snapshotManager = Substitute.For<ISnapshotManager>();
+        snapshotManager.GetSnapshotByGapNumber(Gap).Returns(new Snapshot(0, Hash256.Zero, masternodes));
+
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        IXdcReleaseSpec spec = Substitute.For<IXdcReleaseSpec>();
+        spec.EpochLength.Returns(900UL);
+        spec.CertificateThreshold.Returns(0.667);
+        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
+
+        if (epochSwitchManager is null)
+        {
+            epochSwitchManager = Substitute.For<IEpochSwitchManager>();
+            epochSwitchManager.GetEpochSwitchInfo(Arg.Any<XdcBlockHeader>())
+                .Returns(new EpochSwitchInfo(masternodes, [], [], new BlockRoundInfo(header.Hash!, CurrentRound, header.Number)));
+        }
+
+        ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
+
+        TimeoutCertificateManager manager = new(
+            new XdcConsensusContext { CurrentRound = CurrentRound },
+            Substitute.For<ITimeoutTimer>(),
+            syncPeerPool,
+            snapshotManager,
+            epochSwitchManager,
+            specProvider,
+            blockTree,
+            Substitute.For<ISigner>(),
+            NullLogManager.Instance);
+
+        return (manager, syncPeerPool);
+    }
+
     private TimeoutCertificateManager BuildTimeoutCertificateManager(XdcConsensusContext? ctx = null) =>
         new(
             ctx ?? new XdcConsensusContext(),

--- a/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/TimeoutCertificateManager.cs
@@ -75,6 +75,8 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
         _timeouts.Add(timeout);
         IReadOnlyCollection<Timeout> collectedTimeouts = _timeouts.GetItemsByKey(timeout);
 
+        BroadcastTimeout(timeout);
+
         XdcBlockHeader xdcHeader = _blockTree.Head?.Header as XdcBlockHeader;
         EpochSwitchInfo epochSwitchInfo = _epochSwitchManager.GetEpochSwitchInfo(xdcHeader);
         if (epochSwitchInfo is null)
@@ -82,8 +84,6 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
             // Failed to get epoch switch info, cannot process timeout
             return Task.CompletedTask;
         }
-
-        BroadcastTimeout(timeout);
 
         IXdcReleaseSpec spec = _specProvider.GetXdcSpec(xdcHeader, timeout.Round);
         double requiredTimeouts = epochSwitchInfo.Masternodes.Length * spec.CertificateThreshold;
@@ -254,7 +254,6 @@ public class TimeoutCertificateManager : ITimeoutCertificateManager
 
         if (FilterTimeout(timeout))
         {
-            //TODO: Broadcast Timeout
             return HandleTimeoutVote(timeout);
         }
         return Task.CompletedTask;


### PR DESCRIPTION
## Changes

- Move `BroadcastTimeout` above the `epochSwitchInfo is null` check in `TimeoutCertificateManager.HandleTimeoutVote`, so relaying a current-round timeout no longer depends on this node being able to resolve its own epoch.
- Drop the stale `//TODO: Broadcast Timeout` in `OnReceiveTimeout` (see below — relaying received timeouts already happens, and extending it to future rounds is deliberately not done).
- Add regression tests for the relay/pool behaviour by round, and for the epoch-lookup-unavailable case.

### Why

`_timeouts.Add` sits above the epoch lookup but the broadcast sat below it, so a node that cannot resolve its epoch keeps accumulating timeouts locally while going silent towards its peers. Those peers are at the same round and need exactly those timeouts to reach `masternodes × CertificateThreshold` and build a TC.

That condition is not always transient: `GetEpochSwitchInfo` returns null when the gap-block snapshot is missing, and `TryRecoverSnapshot` requires the gap block to be both processed and to have state available, so a freshly synced or state-pruned node can remain in it for a whole epoch. Subnets feel it more sharply — a 3–5 validator set needs 2-of-3 or 3-of-4 for a TC, so one silent node is 20–33% of the quorum rather than statistical noise.

Relay stays restricted to the current round, so the set of messages this node will forward is unchanged. Only the dependency on local epoch resolution is removed.

### Why not also relay future-round timeouts

An earlier revision of this PR hoisted the relay all the way into `OnReceiveTimeout`, which additionally forwarded timeouts for rounds this node has not reached. That has been dropped.

Upstream XDPoSChain does relay those — `eth/bft/bft_handler.go` does `verify → broadcastCh <- timeout → timeoutHandler`, and `VerifyTimeoutMessage` bounds only `round < currentRound`, with no forward cap — so the wider version was at parity with the Go client. But upstream also drops duplicates at a **node-global** `knownTimeouts` LRU before verification (`eth/handler.go:869`), and this client has no equivalent: `Handle(TimeoutMsg)` goes straight to `OnReceiveTimeout`, so every arrival costs a fresh `ecrecover` in `FilterTimeout`. Copying upstream's relay breadth without upstream's dedup imports the cost and not the mitigation.

Concretely: `FilterTimeout` rejects only `round < CurrentRound`, so any key in `snapshot.NextEpochCandidates` can sign `Timeout(CurrentRound + K, validGap)` for arbitrary `K`. Each `K` is a distinct `Timeout.Hash`, so the per-peer `_notifiedTimeouts` cache dedups repeats but not a varying stream — one inbound message becomes N outbound at every hop, and no node at a lower round can pool those rounds, so there is no liveness gain to offset it. The benefit only exists for peers a few rounds ahead, which the originator's own all-peers broadcast, the per-`TimeoutPeriod` re-emission, and `SyncInfo` already cover.

Suggested follow-ups, in order: add a node-global receive-side dedup for votes and timeouts matching upstream's `knownTimeouts` (a win independent of any of this), then revisit forward-round relay behind a forward bound mirroring `VotesManager._maxRoundDistance`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`OnReceiveTimeout_EpochSwitchInfoUnavailable_StillRelaysTimeout` covers the fix. `OnReceiveTimeout_DifferentRounds_RelaysAndPoolsAsExpected` is a guardrail pinning the stale / current / future relay-and-pool matrix, including that a future-round timeout is *not* relayed — so a future change in that direction has to be deliberate.

Verified the fix is a genuine regression: with `TimeoutCertificateManager.cs` reset to the branch base, exactly one case fails — `OnReceiveTimeout_EpochSwitchInfoUnavailable_StillRelaysTimeout` ("Expected to receive exactly 1 call… Actually received no matching calls"). The three round cases pass on the base too, as guardrails should.

Full `Nethermind.Xdc.Test` suite: 556 passed, 0 failed. `dotnet format whitespace --verify-no-changes` clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
