### PR TITLE
test(eip8141): map the frame-format exception for transaction tests

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
+++ b/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
@@ -26,9 +26,10 @@ namespace Ethereum.Test.Base;
 /// themselves.
 /// </para>
 /// <para>
-/// Only <c>BlockchainTestBase</c> consumes this today; the transaction-test table gains its
-/// <c>TYPE_6_INVALID_FRAME_FORMAT</c> entry with #12788, which should point at <see cref="Format"/> rather
-/// than repeat the fragments.
+/// <c>BlockchainTestBase</c> maps all three labels. <c>TransactionTestBase</c> maps only
+/// <c>TYPE_6_INVALID_FRAME_FORMAT</c>, from <see cref="Format"/> and <see cref="Decode"/>: it stops at
+/// <c>TxValidator.IsWellFormed</c>, which runs neither the signature validator nor the transaction
+/// processor, so no <see cref="Signature"/> or <see cref="Execution"/> message can reach it.
 /// </para>
 /// </remarks>
 public static class FrameExceptionFragments

--- a/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
+++ b/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
@@ -69,6 +69,9 @@ public static class FrameExceptionFragments
         // does not verify as a signature failure.
         FrameTxSignatureValidator.InvalidSecp256k1Signer,
         FrameTxSignatureValidator.InvalidP256Signer,
+        // A decoder literal, no constant to reference: the trailing element is present but is not
+        // the recent-root-reference sequence. Thrown before any rule runs, so no rule names it.
+        "frame transaction must not carry a trailing signature",
     ];
 
     /// <summary>Signature verification — the spec <c>validate_signature</c> step.</summary>

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -138,8 +138,7 @@ public abstract class TransactionTestBase
         ["TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH"] = ["InvalidBlobVersionedHashVersion"],
         ["TransactionException.TYPE_3_TX_CONTRACT_CREATION"] = ["blob transaction of type create"],
         ["TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS"] = ["max fee per blob gas less than block blob gas fee"],
-        // EIP-8141 static frame rules: most messages name a frame, so new rules match without an entry
-        // here; the five that do not are taken from the constants themselves rather than copied.
+        // EIP-8141 static frame rules: most messages name a frame, so new rules match without an entry here.
         ["TransactionException.TYPE_6_INVALID_FRAME_FORMAT"] =
         [
             "frame",

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -138,15 +138,16 @@ public abstract class TransactionTestBase
         ["TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH"] = ["InvalidBlobVersionedHashVersion"],
         ["TransactionException.TYPE_3_TX_CONTRACT_CREATION"] = ["blob transaction of type create"],
         ["TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS"] = ["max fee per blob gas less than block blob gas fee"],
-        // EIP-8141 static frame rules: most messages name a frame, the rest are the signature-entry
-        // and blob-field rules of FrameTxValidation.
+        // EIP-8141 static frame rules: most messages name a frame, so new rules match without an entry
+        // here; the five that do not are taken from the constants themselves rather than copied.
         ["TransactionException.TYPE_6_INVALID_FRAME_FORMAT"] =
         [
             "frame",
-            "signature scheme",
-            "signature msg",
-            "signatures must not name a signer",
-            "max fee per blob gas must be 0",
+            FrameTxValidation.InvalidSignatureScheme,
+            FrameTxValidation.ArbitrarySignatureWithSigner,
+            FrameTxValidation.InvalidMsgLength,
+            FrameTxValidation.ZeroDigestMsg,
+            FrameTxValidation.BlobFeeWithoutBlobs,
             .. s_rlpDecodeFragments
         ],
     };

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -144,5 +144,8 @@ public abstract class TransactionTestBase
         ["TransactionException.RLP_LEADING_ZEROS_NONCE"] = ["Non-canonical integer"],
         ["TransactionException.RLP_LEADING_ZEROS_NONCE_SIZE"] = ["Non-canonical integer", .. s_rlpDecodeFragments],
         ["TransactionException.RLP_INVALID_NONCE"] = [.. s_rlpDecodeFragments],
+        // Not s_rlpDecodeFragments: its "Invalid signature" fragment also matches the frame
+        // signature failures, which the fixtures file under a separate label.
+        ["TransactionException.TYPE_6_INVALID_FRAME_FORMAT"] = [.. FrameExceptionFragments.Format, .. FrameExceptionFragments.Decode],
     };
 }

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -138,6 +138,17 @@ public abstract class TransactionTestBase
         ["TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH"] = ["InvalidBlobVersionedHashVersion"],
         ["TransactionException.TYPE_3_TX_CONTRACT_CREATION"] = ["blob transaction of type create"],
         ["TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS"] = ["max fee per blob gas less than block blob gas fee"],
+        // EIP-8141 static frame rules: most messages name a frame, the rest are the signature-entry
+        // and blob-field rules of FrameTxValidation.
+        ["TransactionException.TYPE_6_INVALID_FRAME_FORMAT"] =
+        [
+            "frame",
+            "signature scheme",
+            "signature msg",
+            "signatures must not name a signer",
+            "max fee per blob gas must be 0",
+            .. s_rlpDecodeFragments
+        ],
     };
 }
 


### PR DESCRIPTION
## Changes

- Map `TransactionException.TYPE_6_INVALID_FRAME_FORMAT` in the transaction-test exception table to the shared `FrameExceptionFragments` sets.

The table in `TransactionTestBase` carries no `TYPE_6_*` entry, so a transaction-test fixture naming that exception could never match: the runner reported `Expected 'TransactionException.TYPE_6_INVALID_FRAME_FORMAT' but got '<message>'` even when the transaction had been correctly rejected for exactly the right reason. Any frame transaction test was red regardless of behaviour, which is the failure mode that trains people to ignore a suite.

`FrameExceptionFragments` already holds the canonical fragment sets and is already consumed by `BlockchainTestBase`, so the entry references `Format` and `Decode` rather than repeating them. One source of truth: a newly added frame rule is picked up by both tables at once.

### Why only this one label

`TYPE_6_INVALID_FRAME_FORMAT` is the only `TYPE_6_*` label this path can produce, so the other two are deliberately absent rather than overlooked. `RunTest` does `Rlp.Decode<Transaction>` then `TxValidator.IsWellFormed`, and nothing else:

- **`TYPE_6_INVALID_FRAME_EXECUTION`** — all three `Execution` fragments are produced in `TransactionProcessorBase.FrameTx.cs`. No transaction is executed here.
- **`TYPE_6_INVALID_SIGNATURE`** — all five `Signature` messages are produced only inside `FrameTxSignatureValidator`, whose sole callers are the transaction processor and the mempool signature filter. `TxValidator`'s `TxType.FrameTx` composite does not include it, and none of those literals appear anywhere else, decoder included.

### Why `Decode` and not the neighbouring `s_rlpDecodeFragments`

They are not equivalent. `s_rlpDecodeFragments` is strictly broader — it matches all four `Decode` fragments (via `"RLP"`, `"Collection count"`, `"expected length"`) plus nine more — and two of those extras break the entry:

- its `"Invalid signature"` fragment matches `"frame transaction has an invalid signature"`, which the fixtures file under `TYPE_6_INVALID_SIGNATURE`, so a format fixture would pass on a signature rejection;
- the same fragment matches `TxErrorMessages.InvalidAuthoritySignature`, so the entry would no longer be discriminating against non-frame validation messages.

`s_rlpDecodeFragments` stays as-is for the existing `TYPE_4`/RLP entries; only the new entry uses the shared set.

For the same reason the entry adds no bare `"frame"` fragment: it would match every `Signature` message and two of three `Execution` messages, which is precisely what `FrameExceptionFragments`' pairwise-disjointness note warns against.

`Format` also gains one decoder wording, `"frame transaction must not carry a trailing signature"`, raised in review. It is reachable on exactly this path — appending a trailing scalar to a valid frame transaction produces it — and it arrived verbatim at the comparison while matching no existing fragment. The decoder has no constant to reference for it (`FrameTxDecoder<T>` is generic with no non-generic sibling), so it is listed as a literal, as `Decode`'s four already are.

Two adjacent findings from the same review are filed separately rather than folded in: the decoder's `"sender must be a 20-byte address"` message is unreachable dead code (`DecodeAddress()` returns non-nullable and throws instead), and the frame gas-cap message needs its own `GAS_LIMIT_EXCEEDS_MAXIMUM` row, which is a different exception label.

The class doc on `FrameExceptionFragments` is updated: it previously described this entry as a future change.

Test-only: nothing outside `Ethereum.Test.Base` changes, and no consensus behaviour is affected. No `transactionTest` lane is wired in CI on this branch, so this gates nothing today — it is groundwork so that the lane is usable when it is added.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: test infrastructure

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

`Ethereum.Test.Base` and every project referencing it build clean in release (0 errors, 0 warnings), and the lint flags (`EnforceCodeStyleInBuild`, `GenerateDocumentationFile`) are clean on the touched project — positive-controlled by injecting an unused `using` and confirming `IDE0005` fires. `Ethereum.Transaction.Test` passes.

The mapping itself was driven directly against the built table over every real client message. With this diff: the label matches all 29 `Format` and all 4 `Decode` fragments, and matches none of the 5 `Signature` messages, none of the 3 `Execution` messages, and none of the 31 `TxErrorMessages` messages. Reinstating the previous approach (`"frame"` plus `s_rlpDecodeFragments`) turns 9 of those checks red, including all 5 signature messages and the authorization-list signature error.

Reachability of the added decoder wording was confirmed by round-tripping a real frame transaction through the decoder rather than by inspection: `06de…c0` decodes clean, and the same payload with a trailing scalar appended yields the mapped message.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
