### PR TITLE
fix(flat): stop the trie warmer poisoning reads with a cached Unknown

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
@@ -73,27 +73,24 @@ public class SnapshotBundleWarmerTests
         // from them, so afterwards they are reachable only through the path the warmer must not take.
         bundle.CollectAndApplySnapshot(StateId.PreGenesis, new StateId(1, TestItem.KeccakA), returnSnapshot: false);
 
-        // Read normally first: the warmer caches its own Unknown result into the transient, which a later
-        // normal read would then serve.
-        TrieNode normalStateRead = bundle.FindStateNodeOrUnknown(committedPath, TestItem.KeccakA);
-        TrieNode normalStorageRead = bundle.FindStorageNodeOrUnknown(storageAddress, committedStoragePath, TestItem.KeccakA);
         TrieNode warmedCommittedState = bundle.FindStateNodeOrUnknownForTrieWarmer(committedPath, TestItem.KeccakA);
         TrieNode warmedCommittedStorage = bundle.FindStorageNodeOrUnknownTrieWarmer(storageAddress, committedStoragePath, TestItem.KeccakA);
         TrieNode warmedPersistedState = bundle.FindStateNodeOrUnknownForTrieWarmer(persistedPath, TestItem.KeccakB);
         TrieNode warmedPersistedStorage = bundle.FindStorageNodeOrUnknownTrieWarmer(storageAddress, persistedStoragePath, TestItem.KeccakB);
 
+        TrieNode normalStateRead = bundle.FindStateNodeOrUnknown(committedPath, TestItem.KeccakA);
+        TrieNode normalStorageRead = bundle.FindStorageNodeOrUnknown(storageAddress, committedStoragePath, TestItem.KeccakA);
+
         using (Assert.EnterMultipleScope())
         {
-            // The committed nodes really are reachable, so the warmer's Unknown below is a genuine miss.
-            Assert.That(normalStateRead, Is.SameAs(committedNode));
-            Assert.That(normalStorageRead, Is.SameAs(committedStorageNode));
-
             Assert.That(warmedCommittedState.NodeType, Is.EqualTo(NodeType.Unknown));
             Assert.That(warmedCommittedStorage.NodeType, Is.EqualTo(NodeType.Unknown));
 
-            // The warmer still returns nodes that are in persistence (state and storage).
             Assert.That(warmedPersistedState, Is.SameAs(persistedNode));
             Assert.That(warmedPersistedStorage, Is.SameAs(persistedStorageNode));
+
+            Assert.That(normalStateRead, Is.SameAs(committedNode));
+            Assert.That(normalStorageRead, Is.SameAs(committedStorageNode));
         }
     }
 
@@ -128,49 +125,6 @@ public class SnapshotBundleWarmerTests
         finally
         {
             bundle.ReleaseReadOnlyBundleLease();
-        }
-    }
-
-    [Test]
-    public void Warmer_miss_is_not_cached_so_a_later_normal_read_still_sees_the_committed_node()
-    {
-        TreePath committedPath = TreePath.FromHexString("12");
-        TrieNode committedNode = Leaf(0x82);
-        Hash256 warmHash = TestItem.KeccakA;
-
-        using SnapshotBundle bundle = NewBundle();
-        bundle.SetStateNode(committedPath, committedNode);
-        bundle.CollectAndApplySnapshot(StateId.PreGenesis, new StateId(1, TestItem.KeccakA), returnSnapshot: false);
-
-        TrieNode warmed = bundle.FindStateNodeOrUnknownForTrieWarmer(committedPath, warmHash);
-        TrieNode normalRead = bundle.FindStateNodeOrUnknown(committedPath, warmHash);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(warmed.NodeType, Is.EqualTo(NodeType.Unknown));
-            Assert.That(normalRead, Is.SameAs(committedNode));
-        }
-    }
-
-    [Test]
-    public void Warmer_storage_miss_is_not_cached_so_a_later_normal_read_still_sees_the_committed_node()
-    {
-        Hash256 storageAddress = TestItem.KeccakC;
-        TreePath committedStoragePath = TreePath.FromHexString("34");
-        TrieNode committedStorageNode = Leaf(0x83);
-        Hash256 warmHash = TestItem.KeccakA;
-
-        using SnapshotBundle bundle = NewBundle();
-        bundle.SetStorageNode(storageAddress, committedStoragePath, committedStorageNode);
-        bundle.CollectAndApplySnapshot(StateId.PreGenesis, new StateId(1, TestItem.KeccakA), returnSnapshot: false);
-
-        TrieNode warmed = bundle.FindStorageNodeOrUnknownTrieWarmer(storageAddress, committedStoragePath, warmHash);
-        TrieNode normalRead = bundle.FindStorageNodeOrUnknown(storageAddress, committedStoragePath, warmHash);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(warmed.NodeType, Is.EqualTo(NodeType.Unknown));
-            Assert.That(normalRead, Is.SameAs(committedStorageNode));
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
@@ -131,6 +131,49 @@ public class SnapshotBundleWarmerTests
         }
     }
 
+    [Test]
+    public void Warmer_miss_is_not_cached_so_a_later_normal_read_still_sees_the_committed_node()
+    {
+        TreePath committedPath = TreePath.FromHexString("12");
+        TrieNode committedNode = Leaf(0x82);
+        Hash256 warmHash = TestItem.KeccakA;
+
+        using SnapshotBundle bundle = NewBundle();
+        bundle.SetStateNode(committedPath, committedNode);
+        bundle.CollectAndApplySnapshot(StateId.PreGenesis, new StateId(1, TestItem.KeccakA), returnSnapshot: false);
+
+        TrieNode warmed = bundle.FindStateNodeOrUnknownForTrieWarmer(committedPath, warmHash);
+        TrieNode normalRead = bundle.FindStateNodeOrUnknown(committedPath, warmHash);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warmed.NodeType, Is.EqualTo(NodeType.Unknown));
+            Assert.That(normalRead, Is.SameAs(committedNode));
+        }
+    }
+
+    [Test]
+    public void Warmer_storage_miss_is_not_cached_so_a_later_normal_read_still_sees_the_committed_node()
+    {
+        Hash256 storageAddress = TestItem.KeccakC;
+        TreePath committedStoragePath = TreePath.FromHexString("34");
+        TrieNode committedStorageNode = Leaf(0x83);
+        Hash256 warmHash = TestItem.KeccakA;
+
+        using SnapshotBundle bundle = NewBundle();
+        bundle.SetStorageNode(storageAddress, committedStoragePath, committedStorageNode);
+        bundle.CollectAndApplySnapshot(StateId.PreGenesis, new StateId(1, TestItem.KeccakA), returnSnapshot: false);
+
+        TrieNode warmed = bundle.FindStorageNodeOrUnknownTrieWarmer(storageAddress, committedStoragePath, warmHash);
+        TrieNode normalRead = bundle.FindStorageNodeOrUnknown(storageAddress, committedStoragePath, warmHash);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warmed.NodeType, Is.EqualTo(NodeType.Unknown));
+            Assert.That(normalRead, Is.SameAs(committedStorageNode));
+        }
+    }
+
     private sealed record ChurnEpoch(SnapshotBundle Bundle, TrieNode Node);
 
     // Regression for the warmer recycle-under-reader race. Warmer-shaped readers hold only a

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -207,16 +207,12 @@ public sealed class SnapshotBundle : IDisposable
         if (transientResource.TryGetStateNode(path, hash, out TrieNode? node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
-        }
-        else
-        {
-            node = transientResource.GetOrAddStateNode(path,
-                TryFindStateNodeInPersistence(path, hash, out node)
-                    ? node
-                    : new TrieNode(NodeType.Unknown, hash));
+            return node;
         }
 
-        return node;
+        return TryFindStateNodeInPersistence(path, hash, out node)
+            ? transientResource.GetOrAddStateNode(path, node)
+            : new TrieNode(NodeType.Unknown, hash);
     }
 
     // Returns a leased transient, or null once the bundle is being torn down. A stale read can acquire a
@@ -337,16 +333,12 @@ public sealed class SnapshotBundle : IDisposable
         if (transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out TrieNode? node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
-        }
-        else
-        {
-            node = transientResource.GetOrAddStorageNode((Hash256AsKey)address, path,
-                TryFindStorageNodeInPersistence(address, path, hash, out node) && node is not null
-                    ? node
-                    : new TrieNode(NodeType.Unknown, hash));
+            return node;
         }
 
-        return node;
+        return TryFindStorageNodeInPersistence(address, path, hash, out node) && node is not null
+            ? transientResource.GetOrAddStorageNode((Hash256AsKey)address, path, node)
+            : new TrieNode(NodeType.Unknown, hash);
     }
 
     private bool TryFindStorageNodeInPersistence(Hash256 address, in TreePath path, Hash256 hash, out TrieNode? node)

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -313,7 +313,7 @@ public sealed class SnapshotBundle : IDisposable
         TransientResource? transientResource = TryLeaseTransientResource();
         if (transientResource is null)
         {
-            return TryFindStorageNodeInPersistence(address, path, hash, out TrieNode? node) && node is not null
+            return TryFindStorageNodeInPersistence(address, path, hash, out TrieNode? node)
                 ? node
                 : new TrieNode(NodeType.Unknown, hash);
         }
@@ -336,12 +336,12 @@ public sealed class SnapshotBundle : IDisposable
             return node;
         }
 
-        return TryFindStorageNodeInPersistence(address, path, hash, out node) && node is not null
+        return TryFindStorageNodeInPersistence(address, path, hash, out node)
             ? transientResource.GetOrAddStorageNode((Hash256AsKey)address, path, node)
             : new TrieNode(NodeType.Unknown, hash);
     }
 
-    private bool TryFindStorageNodeInPersistence(Hash256 address, in TreePath path, Hash256 hash, out TrieNode? node)
+    private bool TryFindStorageNodeInPersistence(Hash256 address, in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node)
     {
         if (_trieNodeCache.TryGet(address, path, hash, out node))
         {


### PR DESCRIPTION
## Changes

Regression from #12429. That PR correctly stopped the trie warmer reading the recyclable in-memory `_snapshots` tier (closing a recycle-under-reader race), but the warmer still wrote the result of its now-narrower lookup — **including a miss** — into the shared `_transientResource` via `GetOrAdd`.

A node that lives only in `_snapshots` (recent, not-yet-persisted blocks) is not in persistence or the trie node cache, so the warmer resolved it to `new TrieNode(Unknown, hash)` and cached that Unknown under its path. A normal read consults `_transientResource` **before** `_snapshots`, and the transient cache matches on `Keccak == hash`, so the poisoned Unknown was served instead of the real node. The subtree read as empty and the state root diverged.

Observed on Flat sync, block `25681470`: `InvalidStateRoot: Expected 0xe6a4b280…ba748, got 0xd3a9f4b3…fd50`.

- `WarmUpStateNode` / `WarmUpStorageNode`: cache **only a real persistence hit** into the transient; on a miss return an unshared `Unknown` so a normal read falls through to `_snapshots`.
- The recycle-race fix is preserved — the warmer still never reads `_snapshots`. In-memory nodes are already hot and do not need warming.
- Regression tests (state + storage): warm a committed (in-memory-only) node's path, then assert a subsequent normal read of the same path/hash still resolves the committed node rather than the warmer's `Unknown`. Both fail on current `master` (return `Unknown`) and pass with this fix.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Nethermind.State.Flat.Test` passes locally. Positive control: both new tests fail on `master` (`normalRead` returns `Unknown`) and pass with the fix. The one unrelated local failure (`ArenaWriter_…FrontierDelta`, a global static metric gauge) reproduces on a clean `master` checkout with none of these changes.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No