### PR TITLE
test(flat): make the arena allocated-bytes assertion page-size portable

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/ArenaMetricsTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ArenaMetricsTests.cs
@@ -64,7 +64,7 @@ public class ArenaMetricsTests
     {
         // Use a delta from the baseline so parallel-running tests don't interfere.
         const long maxArenaSize = 64 * 1024;  // 64 KiB sparse arena file
-        const int payloadBytes = 4096;
+        int payloadBytes = Environment.SystemPageSize;
 
         long arenaBytesBefore = Metrics.ArenaAllocatedBytes;
         long arenaCountBefore = Metrics.ArenaFileCount;

--- a/src/Nethermind/Nethermind.State.Flat.Test/ArenaMetricsTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ArenaMetricsTests.cs
@@ -63,7 +63,7 @@ public class ArenaMetricsTests
     public void ArenaWriter_Complete_AdvancesAllocatedBytes_ByFrontierDelta_NotMappedSize()
     {
         // Use a delta from the baseline so parallel-running tests don't interfere.
-        const long maxArenaSize = 64 * 1024;  // 64 KiB sparse arena file
+        long maxArenaSize = Math.Max(64 * 1024, 4L * Environment.SystemPageSize);
         int payloadBytes = Environment.SystemPageSize;
 
         long arenaBytesBefore = Metrics.ArenaAllocatedBytes;


### PR DESCRIPTION
## Changes

- `ArenaMetricsTests.ArenaWriter_Complete_AdvancesAllocatedBytes_ByFrontierDelta_NotMappedSize` sized its payload to a hard-coded 4096 bytes and expected the `ArenaAllocatedBytes` gauge to advance by exactly 4096. `ArenaWriter.Complete` pads a shared arena's frontier up to an OS page, so the gauge advances by one page, not the logical write. On 4 KiB-page hosts (Linux CI) the two coincide; on 16 KiB-page hosts (Apple Silicon) the gauge advanced by 16384 and the assertion failed locally.
- Size the payload to `Environment.SystemPageSize` so the delta equals exactly one page on any platform, still proving the gauge tracks the written frontier and not the 64 KiB mapped size.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] No

#### Notes on testing

`Nethermind.State.Flat.Test` was red locally on arm64 macOS on this one case and is green after the change (961 passed / 10 skipped / 0 failed). Unaffected on 4 KiB Linux CI.
