### PR TITLE
fix(sync): format SyncMode flags

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugBridge.cs
@@ -199,7 +199,7 @@ public class DebugBridge : IDebugBridge
 
     public SyncReportSummary GetCurrentSyncStage() => new()
     {
-        CurrentStage = _syncModeSelector.Current.ToString()
+        CurrentStage = _syncModeSelector.Current.ToFlagsString()
     };
 
     public bool HaveNotSyncedHeadersYet() => _syncModeSelector.Current.HaveNotSyncedHeadersYet();

--- a/src/Nethermind/Nethermind.OpcodeTracing.Plugin/Tracing/OpcodeTraceRecorder.cs
+++ b/src/Nethermind/Nethermind.OpcodeTracing.Plugin/Tracing/OpcodeTraceRecorder.cs
@@ -216,7 +216,7 @@ public sealed class OpcodeTraceRecorder(
         if (isSyncing && _logger.IsWarn)
         {
             _logger.Warn(
-                $"RealTime opcode tracing is enabled, but the node is currently syncing (SyncMode={syncMode}). " +
+                $"RealTime opcode tracing is enabled, but the node is currently syncing (SyncMode={syncMode.ToFlagsString()}). " +
                 "RealTime mode only captures opcodes from NEW blocks processed at the chain tip AFTER sync completes. " +
                 "Blocks downloaded during sync do NOT execute the EVM and will NOT be traced. " +
                 "For tracing historical blocks during sync, use Retrospective mode instead: --OpcodeTracing.Mode Retrospective");
@@ -224,7 +224,7 @@ public sealed class OpcodeTraceRecorder(
         }
         else if (!isSyncing && !_syncCompleteLogged && _logger.IsInfo)
         {
-            _logger.Info($"Node sync complete (SyncMode={syncMode}). RealTime opcode tracing is now active for new blocks.");
+            _logger.Info($"Node sync complete (SyncMode={syncMode.ToFlagsString()}). RealTime opcode tracing is now active for new blocks.");
             _syncCompleteLogged = true;
         }
     }
@@ -240,19 +240,19 @@ public sealed class OpcodeTraceRecorder(
             // Use the actual range from the tracer (which may have been recalculated at attach time)
             BlockRange? range = _realTimeTracer?.Range;
             _logger.Info(
-                $"Sync state changed to {args.Current}. " +
+                $"Sync state changed to {args.Current.ToFlagsString()}. " +
                 $"RealTime opcode tracing is now waiting for new blocks in range {range?.StartBlock ?? _traceConfig?.EffectiveStartBlock}-{range?.EndBlock ?? _traceConfig?.EffectiveEndBlock}.");
             _waitingForBlockLogged = true;
         }
 
         if (args.Current.NotSyncing() && !_syncCompleteLogged && _logger.IsInfo)
         {
-            _logger.Info($"Node sync complete (SyncMode={args.Current}). RealTime opcode tracing is now active for new blocks.");
+            _logger.Info($"Node sync complete (SyncMode={args.Current.ToFlagsString()}). RealTime opcode tracing is now active for new blocks.");
             _syncCompleteLogged = true;
         }
         else if (!args.Current.NotSyncing() && !_syncModeWarningLogged && _logger.IsWarn)
         {
-            _logger.Warn($"Node entered sync mode (SyncMode={args.Current}). RealTime opcode tracing paused - only new blocks at chain tip are traced.");
+            _logger.Warn($"Node entered sync mode (SyncMode={args.Current.ToFlagsString()}). RealTime opcode tracing paused - only new blocks at chain tip are traced.");
             _syncModeWarningLogged = true;
         }
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncModeExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncModeExtensionsTests.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Synchronization.ParallelSync;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.ParallelSync
+{
+    [Parallelizable(ParallelScope.All)]
+    [TestFixture]
+    public class SyncModeExtensionsTests
+    {
+        [TestCase(SyncMode.None, "None")]
+        [TestCase(SyncMode.FastSync | SyncMode.StateNodes | SyncMode.FastHeaders, "FastHeaders, StateNodes, FastSync")]
+        [TestCase(SyncMode.FastBodies | SyncMode.FastBlockAccessLists | SyncMode.Full, "FastBlockAccessLists, FastBodies, Full")]
+        [TestCase(SyncMode.BeaconHeaders | SyncMode.FastBlockAccessLists | SyncMode.FastBodies, "BeaconHeaders, FastBlockAccessLists, FastBodies")]
+        [TestCase(SyncMode.StateNodes | (SyncMode)64, "StateNodes, unknown: 64")]
+        [TestCase((SyncMode)64, "unknown: 64")]
+        public void Formats_flags_by_name_without_falling_back_to_a_number(SyncMode syncMode, string expected) =>
+            Assert.That(syncMode.ToFlagsString(), Is.EqualTo(expected));
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncModeExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncModeExtensionsTests.cs
@@ -4,19 +4,20 @@
 using Nethermind.Synchronization.ParallelSync;
 using NUnit.Framework;
 
-namespace Nethermind.Synchronization.Test.ParallelSync
+namespace Nethermind.Synchronization.Test.ParallelSync;
+
+[Parallelizable(ParallelScope.All)]
+[TestFixture]
+public class SyncModeExtensionsTests
 {
-    [Parallelizable(ParallelScope.All)]
-    [TestFixture]
-    public class SyncModeExtensionsTests
-    {
-        [TestCase(SyncMode.None, "None")]
-        [TestCase(SyncMode.FastSync | SyncMode.StateNodes | SyncMode.FastHeaders, "FastHeaders, StateNodes, FastSync")]
-        [TestCase(SyncMode.FastBodies | SyncMode.FastBlockAccessLists | SyncMode.Full, "FastBlockAccessLists, FastBodies, Full")]
-        [TestCase(SyncMode.BeaconHeaders | SyncMode.FastBlockAccessLists | SyncMode.FastBodies, "BeaconHeaders, FastBlockAccessLists, FastBodies")]
-        [TestCase(SyncMode.StateNodes | (SyncMode)64, "StateNodes, unknown: 64")]
-        [TestCase((SyncMode)64, "unknown: 64")]
-        public void Formats_flags_by_name_without_falling_back_to_a_number(SyncMode syncMode, string expected) =>
-            Assert.That(syncMode.ToFlagsString(), Is.EqualTo(expected));
-    }
+    [TestCase(SyncMode.None, "None")]
+    [TestCase(SyncMode.All, "All")]
+    [TestCase(SyncMode.FastHeaders, "FastHeaders")]
+    [TestCase(SyncMode.FastSync | SyncMode.StateNodes | SyncMode.FastHeaders, "FastHeaders, StateNodes, FastSync")]
+    [TestCase(SyncMode.FastBodies | SyncMode.FastBlockAccessLists | SyncMode.Full, "FastBlockAccessLists, FastBodies, Full")]
+    [TestCase(SyncMode.BeaconHeaders | SyncMode.FastBlockAccessLists | SyncMode.FastBodies, "BeaconHeaders, FastBlockAccessLists, FastBodies")]
+    [TestCase(SyncMode.StateNodes | (SyncMode)64, "StateNodes, unknown: 0x40")]
+    [TestCase((SyncMode)64, "unknown: 0x40")]
+    public void Formats_flags_by_name_without_falling_back_to_a_number(SyncMode syncMode, string expected) =>
+        Assert.That(syncMode.ToFlagsString(), Is.EqualTo(expected));
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -189,7 +189,6 @@ namespace Nethermind.Synchronization.ParallelSync
                             {
                                 if (_logger.IsInfo)
                                     _logger.Info($"Changing sync {current.ToFlagsString()} to {newModes.ToFlagsString()} at {BuildStateString(best)}");
-
                             }
                         }
                         catch (InvalidAsynchronousStateException)

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -188,7 +188,8 @@ namespace Nethermind.Synchronization.ParallelSync
                             if (IsTheModeSwitchWorthMentioning(current, newModes))
                             {
                                 if (_logger.IsInfo)
-                                    _logger.Info($"Changing sync {current} to {newModes} at {BuildStateString(best)}");
+                                    _logger.Info($"Changing sync {current.ToFlagsString()} to {newModes.ToFlagsString()} at {BuildStateString(best)}");
+
                             }
                         }
                         catch (InvalidAsynchronousStateException)
@@ -221,7 +222,7 @@ namespace Nethermind.Synchronization.ParallelSync
         {
             if (_logger.IsTrace)
             {
-                _logger.Trace($"Changing state to {newModes} | {reason}");
+                _logger.Trace($"Changing state to {newModes.ToFlagsString()} | {reason}");
             }
 
             SyncMode previous = Current;

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncMode.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncMode.cs
@@ -116,7 +116,16 @@ namespace Nethermind.Synchronization.ParallelSync
             syncMode.HasFlag(SyncMode.StateNodes) ||
             syncMode.HasFlag(SyncMode.UpdatingPivot);
 
-        internal static string ToFlagsString(this SyncMode syncMode)
+        /// <summary>
+        /// Formats the flags in <paramref name="syncMode"/> by name.
+        /// </summary>
+        /// <remarks>
+        /// The default flags formatting falls back to printing a raw number when two or more flags that share a
+        /// bit are combined, so this checks each flag independently instead, walking from the largest value down
+        /// and skipping a flag once its bits are already covered by one already printed. Bits that match no defined
+        /// flag are reported as unknown instead of being silently dropped.
+        /// </remarks>
+        public static string ToFlagsString(this SyncMode syncMode)
         {
             if (syncMode == SyncMode.None)
             {

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncMode.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncMode.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Text;
 
 namespace Nethermind.Synchronization.ParallelSync
 {
@@ -105,5 +106,53 @@ namespace Nethermind.Synchronization.ParallelSync
             syncMode.HasFlag(SyncMode.FastSync) ||
             syncMode.HasFlag(SyncMode.StateNodes) ||
             syncMode.HasFlag(SyncMode.UpdatingPivot);
+
+        private static readonly SyncMode[] s_flagsDescending = CreateDescendingFlags();
+
+        private static SyncMode[] CreateDescendingFlags()
+        {
+            SyncMode[] flags = Enum.GetValues<SyncMode>();
+            Array.Reverse(flags);
+            return flags;
+        }
+
+        public static string ToFlagsString(this SyncMode syncMode)
+        {
+            if (syncMode == SyncMode.None)
+            {
+                return nameof(SyncMode.None);
+            }
+
+            StringBuilder builder = new();
+            SyncMode printed = SyncMode.None;
+            foreach (SyncMode flag in s_flagsDescending)
+            {
+                if ((syncMode & flag) != flag || (printed & flag) == flag)
+                {
+                    continue;
+                }
+
+                if (builder.Length > 0)
+                {
+                    builder.Append(", ");
+                }
+
+                builder.Append(flag);
+                printed |= flag;
+            }
+
+            SyncMode unknown = syncMode & ~printed;
+            if (unknown != SyncMode.None)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(", ");
+                }
+
+                builder.Append("unknown: ").Append((int)unknown);
+            }
+
+            return builder.ToString();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncMode.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncMode.cs
@@ -132,7 +132,7 @@ namespace Nethermind.Synchronization.ParallelSync
                 return nameof(SyncMode.None);
             }
 
-            StringBuilder builder = new();
+            StringBuilder builder = new(64);
             SyncMode printed = SyncMode.None;
             foreach (SyncMode flag in FlagsDescending)
             {

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncMode.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncMode.cs
@@ -70,6 +70,15 @@ namespace Nethermind.Synchronization.ParallelSync
 
     public static class SyncModeExtensions
     {
+        private static readonly SyncMode[] FlagsDescending = CreateDescendingFlags();
+
+        private static SyncMode[] CreateDescendingFlags()
+        {
+            SyncMode[] flags = Enum.GetValues<SyncMode>();
+            Array.Reverse(flags);
+            return flags;
+        }
+
         public static bool NotSyncing(this SyncMode syncMode) => syncMode is SyncMode.WaitingForBlock or SyncMode.Disconnected;
 
         public static bool HaveNotSyncedBodiesYet(this SyncMode syncMode) =>
@@ -107,16 +116,7 @@ namespace Nethermind.Synchronization.ParallelSync
             syncMode.HasFlag(SyncMode.StateNodes) ||
             syncMode.HasFlag(SyncMode.UpdatingPivot);
 
-        private static readonly SyncMode[] s_flagsDescending = CreateDescendingFlags();
-
-        private static SyncMode[] CreateDescendingFlags()
-        {
-            SyncMode[] flags = Enum.GetValues<SyncMode>();
-            Array.Reverse(flags);
-            return flags;
-        }
-
-        public static string ToFlagsString(this SyncMode syncMode)
+        internal static string ToFlagsString(this SyncMode syncMode)
         {
             if (syncMode == SyncMode.None)
             {
@@ -125,7 +125,7 @@ namespace Nethermind.Synchronization.ParallelSync
 
             StringBuilder builder = new();
             SyncMode printed = SyncMode.None;
-            foreach (SyncMode flag in s_flagsDescending)
+            foreach (SyncMode flag in FlagsDescending)
             {
                 if ((syncMode & flag) != flag || (printed & flag) == flag)
                 {
@@ -137,7 +137,7 @@ namespace Nethermind.Synchronization.ParallelSync
                     builder.Append(", ");
                 }
 
-                builder.Append(flag);
+                builder.Append(flag.ToString());
                 printed |= flag;
             }
 
@@ -149,7 +149,7 @@ namespace Nethermind.Synchronization.ParallelSync
                     builder.Append(", ");
                 }
 
-                builder.Append("unknown: ").Append((int)unknown);
+                builder.Append("unknown: 0x").Append(((uint)unknown).ToString("X"));
             }
 
             return builder.ToString();

--- a/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Reporting/SyncReport.cs
@@ -85,7 +85,7 @@ namespace Nethermind.Synchronization.Reporting
             if (e.Previous != e.Current)
             {
                 // Repeat of "Changing state" so only output as confirm in debug
-                if (_logger.IsDebug) _logger.Debug($"Sync mode changed from {e.Previous} to {e.Current}");
+                if (_logger.IsDebug) _logger.Debug($"Sync mode changed from {e.Previous.ToFlagsString()} to {e.Current.ToFlagsString()}");
             }
         }
 


### PR DESCRIPTION
## Changes

- Add `SyncModeExtensions.ToFlagsString()`, which formats a `SyncMode` value by checking each defined flag independently instead of relying on `Enum.ToString()`'s flags algorithm.
- Use it in the two `MultiSyncModeSelector` log lines that previously interpolated `SyncMode` directly.
- Add regression tests covering the two real combinations observed in a devnet log that reproduced the bug.

## Why

`FastHeaders`, `FastBodies`, `FastReceipts` and `FastBlockAccessLists` all OR in the same `FastBlocks` bit. `Enum.ToString()`'s flags algorithm can only consume that shared bit once when decomposing a value; if two or more of these flags are combined, the bit gets consumed by whichever is tried first, leaving the other's remaining bit unrepresentable — so the whole decomposition fails and it prints the raw number instead of names, e.g.:
```
Changing sync StateNodes to 2596 at pivot: ...
Changing sync 2596 to 6660 at pivot: ...
```
After this fix, the same transitions log as:
```
Changing sync StateNodes to FastBlockAccessLists, FastBodies, Full at pivot: ...
Changing sync FastBlockAccessLists, FastBodies, Full to BeaconHeaders, FastBlockAccessLists, FastBodies at pivot: ...
```

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
