### PR TITLE
Implement GetEpochSwitchInfoBetween for subnet chains

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/SubnetEpochSwitchManagerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/SubnetEpochSwitchManagerTests.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Linq;
 using Nethermind.Blockchain;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Xdc.Spec;
@@ -129,4 +131,103 @@ internal class SubnetEpochSwitchManagerTests
         Assert.That(() => _epochSwitchManager.GetEpochSwitchInfo(header), Throws.InstanceOf<ArgumentException>());
     }
 
+    private const ulong EpochLength = 10;
+
+    /// <summary>
+    /// Registers an epoch switch block with the substituted tree and snapshot manager.
+    /// </summary>
+    /// <param name="withQuorumCertificate">
+    /// When <see langword="false"/>, models the switch block: no consensus data, so no parent block info.
+    /// </param>
+    private XdcSubnetBlockHeader SetupEpochSwitchBlock(ulong number, bool withQuorumCertificate = true)
+    {
+        Address[] masterNodes = [TestItem.AddressA, TestItem.AddressB];
+
+        XdcSubnetBlockHeaderBuilder builder = Build.A.XdcSubnetBlockHeader();
+        builder.WithNumber(number);
+        builder.WithHash(Keccak.Compute($"epoch-switch-{number}"));
+        builder.WithValidators(masterNodes);
+        if (withQuorumCertificate)
+        {
+            builder.WithExtraConsensusData(new ExtraFieldsV2(number, Build.A.QuorumCertificate().TestObject));
+        }
+        XdcSubnetBlockHeader header = builder.TestObject;
+
+        _tree.FindHeader(number).Returns(header);
+        _snapshotManager.GetSnapshotByBlockNumber(number, Arg.Any<IXdcReleaseSpec>())
+            .Returns(new SubnetSnapshot(number, header.Hash!, [.. masterNodes], []));
+
+        return header;
+    }
+
+    private void SetupSpec(ulong switchBlock = 0) =>
+        _config.GetSpec(Arg.Any<ForkActivation>()).Returns(new XdcReleaseSpec
+        {
+            EpochLength = EpochLength,
+            Gap = 5,
+            SwitchBlock = switchBlock,
+            GenesisMasterNodes = [TestItem.AddressA, TestItem.AddressB],
+            V2Configs = [new V2ConfigParams()]
+        });
+
+    private XdcSubnetBlockHeader PlainHeader(ulong number)
+    {
+        XdcSubnetBlockHeaderBuilder builder = Build.A.XdcSubnetBlockHeader();
+        builder.WithNumber(number);
+        return builder.TestObject;
+    }
+
+    [TestCase(5UL, 35UL, new ulong[] { 10, 20, 30 }, TestName = "spans partial epochs at both ends")]
+    [TestCase(10UL, 30UL, new ulong[] { 10, 20, 30 }, TestName = "includes both exact boundaries")]
+    [TestCase(11UL, 29UL, new ulong[] { 20 }, TestName = "excludes boundaries outside the range")]
+    [TestCase(11UL, 19UL, new ulong[] { }, TestName = "no epoch switch in range")]
+    [TestCase(20UL, 20UL, new ulong[] { }, TestName = "empty range")]
+    [TestCase(30UL, 20UL, new ulong[] { }, TestName = "end before start")]
+    public void GetEpochSwitchInfoBetween_ReturnsEpochSwitchesInRange(ulong start, ulong end, ulong[] expected)
+    {
+        SetupSpec();
+        for (ulong number = EpochLength; number <= 40; number += EpochLength)
+        {
+            SetupEpochSwitchBlock(number);
+        }
+
+        EpochSwitchInfo[]? result = _epochSwitchManager.GetEpochSwitchInfoBetween(PlainHeader(start), PlainHeader(end));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Select(static i => i.EpochSwitchBlockInfo.BlockNumber), Is.EqualTo(expected).AsCollection);
+    }
+
+    [Test]
+    public void GetEpochSwitchInfoBetween_ExcludesSwitchBlockWithoutQuorumCertificate()
+    {
+        SetupSpec();
+        SetupEpochSwitchBlock(0, withQuorumCertificate: false);
+        SetupEpochSwitchBlock(10);
+        SetupEpochSwitchBlock(20);
+
+        EpochSwitchInfo[]? result = _epochSwitchManager.GetEpochSwitchInfoBetween(PlainHeader(0), PlainHeader(20));
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Select(static i => i.EpochSwitchBlockInfo.BlockNumber), Is.EqualTo(new ulong[] { 10, 20 }).AsCollection);
+    }
+
+    [Test]
+    public void GetEpochSwitchInfoBetween_MissingHeader_ReturnsNull()
+    {
+        SetupSpec();
+        SetupEpochSwitchBlock(10);
+        _tree.FindHeader(20UL).Returns((BlockHeader?)null);
+
+        Assert.That(_epochSwitchManager.GetEpochSwitchInfoBetween(PlainHeader(5), PlainHeader(25)), Is.Null);
+    }
+
+    [Test]
+    public void GetEpochSwitchInfoBetween_MissingSnapshot_ReturnsNull()
+    {
+        SetupSpec();
+        XdcSubnetBlockHeader header = SetupEpochSwitchBlock(10);
+        _snapshotManager.GetSnapshotByBlockNumber(header.Number, Arg.Any<IXdcReleaseSpec>()).Returns((Snapshot?)null);
+
+        Assert.That(_epochSwitchManager.GetEpochSwitchInfoBetween(PlainHeader(5), PlainHeader(15)), Is.Null);
+    }
 }

--- a/src/Nethermind/Nethermind.Xdc.Test/SubnetEpochSwitchManagerTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/SubnetEpochSwitchManagerTests.cs
@@ -17,6 +17,8 @@ namespace Nethermind.Xdc.Test;
 
 internal class SubnetEpochSwitchManagerTests
 {
+    private const ulong EpochLength = 10;
+
     private IEpochSwitchManager _epochSwitchManager;
     private IBlockTree _tree;
     private ISpecProvider _config;
@@ -30,6 +32,16 @@ internal class SubnetEpochSwitchManagerTests
         _snapshotManager = Substitute.For<ISnapshotManager>();
         _epochSwitchManager = new SubnetEpochSwitchManager(_config, _tree, _snapshotManager);
     }
+
+    private void SetupSpec() =>
+        _config.GetSpec(Arg.Any<ForkActivation>()).Returns(new XdcReleaseSpec
+        {
+            EpochLength = EpochLength,
+            Gap = 5,
+            SwitchBlock = 0,
+            GenesisMasterNodes = [TestItem.AddressA, TestItem.AddressB],
+            V2Configs = [new V2ConfigParams()]
+        });
 
     [TestCase(20UL, 10UL, true)]
     [TestCase(5UL, 10UL, false)]
@@ -77,15 +89,7 @@ internal class SubnetEpochSwitchManagerTests
         Address[] headerPenalties = [TestItem.AddressD]; // deliberately different
         Address[] masterNodes = [TestItem.AddressA, TestItem.AddressB];
 
-        XdcReleaseSpec releaseSpec = new()
-        {
-            EpochLength = 10,
-            Gap = 5,
-            SwitchBlock = 0,
-            GenesisMasterNodes = masterNodes,
-            V2Configs = [new V2ConfigParams()]
-        };
-        _config.GetSpec(Arg.Any<ForkActivation>()).Returns(releaseSpec);
+        SetupSpec();
 
         // Block 0 is an epoch switch (0 % 10 == 0), so no parent-walk needed
         XdcSubnetBlockHeaderBuilder builder = Build.A.XdcSubnetBlockHeader();
@@ -110,15 +114,7 @@ internal class SubnetEpochSwitchManagerTests
     {
         Address[] masterNodes = [TestItem.AddressA, TestItem.AddressB];
 
-        XdcReleaseSpec releaseSpec = new()
-        {
-            EpochLength = 10,
-            Gap = 5,
-            SwitchBlock = 0,
-            GenesisMasterNodes = masterNodes,
-            V2Configs = [new V2ConfigParams()]
-        };
-        _config.GetSpec(Arg.Any<ForkActivation>()).Returns(releaseSpec);
+        SetupSpec();
 
         XdcSubnetBlockHeaderBuilder builder = Build.A.XdcSubnetBlockHeader();
         builder.WithNumber(0);
@@ -130,8 +126,6 @@ internal class SubnetEpochSwitchManagerTests
 
         Assert.That(() => _epochSwitchManager.GetEpochSwitchInfo(header), Throws.InstanceOf<ArgumentException>());
     }
-
-    private const ulong EpochLength = 10;
 
     /// <summary>
     /// Registers an epoch switch block with the substituted tree and snapshot manager.
@@ -159,16 +153,6 @@ internal class SubnetEpochSwitchManagerTests
 
         return header;
     }
-
-    private void SetupSpec(ulong switchBlock = 0) =>
-        _config.GetSpec(Arg.Any<ForkActivation>()).Returns(new XdcReleaseSpec
-        {
-            EpochLength = EpochLength,
-            Gap = 5,
-            SwitchBlock = switchBlock,
-            GenesisMasterNodes = [TestItem.AddressA, TestItem.AddressB],
-            V2Configs = [new V2ConfigParams()]
-        });
 
     private XdcSubnetBlockHeader PlainHeader(ulong number)
     {

--- a/src/Nethermind/Nethermind.Xdc/IEpochSwitchManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/IEpochSwitchManager.cs
@@ -42,5 +42,18 @@ public interface IEpochSwitchManager
     /// Returns the epoch switch block info for the given epoch number, or null if not found.
     /// </summary>
     BlockRoundInfo? GetBlockByEpochNumber(ulong epochNumber);
+
+    /// <summary>
+    /// Returns the epoch switch infos between two blocks, in ascending block order.
+    /// </summary>
+    /// <remarks>
+    /// The switch block itself is never reported: it carries no quorum certificate, so it has no parent block info.
+    /// </remarks>
+    /// <param name="start">Lower bound of the range; an epoch switch on this block is included.</param>
+    /// <param name="end">Upper bound of the range; the most recent epoch switch at or before it is included.</param>
+    /// <returns>
+    /// The epoch switch infos in range; empty when <paramref name="end"/> is not after <paramref name="start"/>;
+    /// <see langword="null"/> when a header or snapshot needed to resolve the range is unavailable.
+    /// </returns>
     EpochSwitchInfo[]? GetEpochSwitchInfoBetween(XdcBlockHeader start, XdcBlockHeader end);
 }

--- a/src/Nethermind/Nethermind.Xdc/SubnetEpochSwitchManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/SubnetEpochSwitchManager.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -59,6 +60,36 @@ internal class SubnetEpochSwitchManager(
         return epochSwitchInfo.EpochSwitchBlockInfo;
     }
 
-    public override EpochSwitchInfo[]? GetEpochSwitchInfoBetween(XdcBlockHeader start, XdcBlockHeader end) =>
-        throw new NotImplementedException("GetEpochSwitchInfoBetween is not implemented for subnet epoch switch manager.");
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Subnet epoch switches sit on exact multiples of the epoch length, so the blocks in range are computed directly
+    /// instead of walking the chain as <see cref="EpochSwitchManager"/> does.
+    /// </remarks>
+    public override EpochSwitchInfo[]? GetEpochSwitchInfoBetween(XdcBlockHeader start, XdcBlockHeader end)
+    {
+        if (end.Number <= start.Number) return [];
+
+        ulong epochLength = XdcSpecProvider.GetXdcSpec(end).EpochLength;
+        ulong offset = start.Number % epochLength;
+        ulong first = offset == 0 ? start.Number : start.Number + (epochLength - offset);
+        ulong last = end.Number - end.Number % epochLength;
+        if (first > last) return [];
+
+        List<EpochSwitchInfo> epochSwitchInfos = [];
+        for (ulong number = first; number <= last; number += epochLength)
+        {
+            if (Tree.FindHeader(number) is not XdcBlockHeader header) return null;
+
+            EpochSwitchInfo? epochSwitchInfo = GetEpochSwitchInfo(header);
+            if (epochSwitchInfo is null) return null;
+
+            // The switch block carries no quorum certificate, so it has no parent block info. EpochSwitchManager
+            // stops its backward walk there rather than reporting it, and callers expect the same set.
+            if (epochSwitchInfo.EpochSwitchParentBlockInfo is null) continue;
+
+            epochSwitchInfos.Add(epochSwitchInfo);
+        }
+
+        return epochSwitchInfos.ToArray();
+    }
 }

--- a/src/Nethermind/Nethermind.Xdc/SubnetEpochSwitchManager.cs
+++ b/src/Nethermind/Nethermind.Xdc/SubnetEpochSwitchManager.cs
@@ -63,7 +63,9 @@ internal class SubnetEpochSwitchManager(
     /// <inheritdoc/>
     /// <remarks>
     /// Subnet epoch switches sit on exact multiples of the epoch length, so the blocks in range are computed directly
-    /// instead of walking the chain as <see cref="EpochSwitchManager"/> does.
+    /// instead of walking the chain as <see cref="EpochSwitchManager"/> does. Resolution is therefore canonical by
+    /// block number: the branch <paramref name="start"/> and <paramref name="end"/> sit on is not honoured, so a
+    /// non-canonical header yields canonical results rather than that branch's ancestors.
     /// </remarks>
     public override EpochSwitchInfo[]? GetEpochSwitchInfoBetween(XdcBlockHeader start, XdcBlockHeader end)
     {


### PR DESCRIPTION
## Changes

`SubnetEpochSwitchManager` left `GetEpochSwitchInfoBetween` throwing `NotImplementedException`. `XDPoS_getEpochNumbersBetween` and `XDPoS_getRewardByAccount` are its only callers and neither guards it, so on a subnet node **every** call to either RPC answered `-32603 "Internal error"` with a .NET stack trace in `data`, and wrote an `_logger.Error` line on the node. Nothing about the request had to be unusual — the earlier guards all pass, so it failed on any valid range.

- Implemented the override by arithmetic: subnet epoch switches sit on exact multiples of the epoch length, so the epoch switch blocks in a range are computed directly rather than walked.
- Documented the contract on `IEpochSwitchManager.GetEpochSwitchInfoBetween`, previously the one undocumented member on that interface.
- No change to `XdcRpcModule` — both RPCs now return real data through the path they already had.

### Correctness

The arithmetic matches how the upstream XDC-Subnet client resolves epochs — `consensus/XDPoS/engines/engine_v2/epochSwitch.go`:

```go
func (x *XDPoS_v2) GetCurrentEpochSwitchBlock(chain consensus.ChainReader, blockNum *big.Int) (uint64, uint64, error) {
	// in subnet, epoch switch block is whose block num % Epoch == 0
	num := blockNum.Uint64()
	currentCheckpointNumber := num - num%x.config.Epoch
	epochNum := num / x.config.Epoch
	return currentCheckpointNumber, epochNum, nil
}
```

Upstream subnet resolves epochs by closed-form arithmetic everywhere and never walks the chain for it. `EpochLength` is safe to use across an arbitrary range because it is chain-wide, not fork-varying: `XdcChainSpecBasedSpecProvider.CreateReleaseSpec` assigns `chainSpecEngineParameters.Epoch` into every release spec regardless of `releaseStartBlock`.

Result semantics mirror `EpochSwitchManager` (itself a faithful port of mainnet Go's `GetEpochSwitchInfoBetween`): ascending order, an epoch switch on `start` included, the upper bound being the most recent epoch switch at or before `end`, empty when `end` is not after `start`, `null` when a header or snapshot is missing, and the switch block excluded — it carries no quorum certificate, so its epoch switch info has no parent block info, and mainnet's backward walk stops there rather than reporting it.

**Known contract divergence:** resolution is canonical by block number. `EpochSwitchManager` walks back from `end.Hash` through quorum-certificate parent hashes, so its results are provably ancestors of `end`; this override reads only the block *numbers*, so a non-canonical header yields canonical results rather than that branch's ancestors. Not reachable from either RPC — both resolve their headers via `tree.FindHeader(number)`, which is canonical — and `GetBlockByEpochNumber` already has the same property. Documented in the `<remarks>` on the override.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Nine cases in `SubnetEpochSwitchManagerTests`: range boundaries (partial epochs at both ends, exact boundaries included, boundaries outside the range excluded), no epoch switch in range, empty range, end before start, switch-block exclusion, missing header, missing snapshot.

Verified by mutation rather than only by passing — each of these breaks the suite:

| Mutation | Failures |
|---|---|
| Drop the switch-block exclusion | 1 |
| Upper bound `<=` → `<` | 6 |
| Missing header `return null` → `continue` | 1 |

All 561 tests in `Nethermind.Xdc.Test` pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

`XDPoS_getEpochNumbersBetween` and `XDPoS_getRewardByAccount` now work on subnet chains; previously both returned an internal error.

## Remarks

1. **Supersedes #12768.** That PR made the same two RPCs fail cleanly (`return null` → a generic error message) rather than fault. This makes them work instead, so it should be closed if this lands.

2. **This is a Nethermind superset, not upstream parity.** A whole-repo grep of XDC-Subnet finds no `GetEpochNumbersBetween`, `GetEpochSwitchInfoBetween`, `GetBlockByEpochNumber`, `GetBlockInfoByEpochNum`, or `GetRewardByAccount` — its XDPoS API surface is 11 methods and none of these are among them. Nethermind exposes them on subnet because `XdcSubnetModule` inherits `RegisterSingletonJsonRpcModule<IXdcRpcModule, XdcRpcModule>()` from `XdcModule` wholesale. There is precedent for filling these in rather than removing them: `SubnetEpochSwitchManager.GetBlockByEpochNumber` is already implemented with exactly this arithmetic despite having no upstream counterpart. Worth a maintainer decision on whether the subnet RPC surface should be trimmed to match upstream instead.

3. **These two RPCs can still fault, just not on the common path.** `GetEpochSwitchInfo` throws `InvalidOperationException` when `ValidatorsAddress` is null on an epoch-switch block, and `ResolvePenalties` throws `ArgumentException` for a non-`SubnetSnapshot`; neither caller wraps the call, unlike `XDPoS_getMissedRoundsInEpochByBlockNum`. So this removes the guaranteed internal error, not every possible one. The same applies to sibling subnet paths reachable from `XDPoS_getMasternodesByNumber` / `XDPoS_getBlockInfoByV2EpochNum` — the `(XdcBlockHeader?)` casts in `GetBlockByEpochNumber` throw `InvalidCastException` on a non-XDC header. Not addressed here; the new code uses a type-test pattern rather than a cast for that reason.

4. **No end-to-end RPC test.** `RpcModuleTests` substitutes `IEpochSwitchManager`, so it cannot exercise the real subnet manager through `XdcRpcModule`. The coverage here is at the manager level; the RPC-level path from a populated result was already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
