### PR TITLE
Green devnet7 CI: pin SSH.NET past the advisory, drop unused usings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,6 +90,7 @@
     <PackageVersion Include="SmartFormat" Version="3.6.1" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.10" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.10" />

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
@@ -20,7 +20,6 @@ using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using NSubstitute;

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
@@ -15,7 +15,6 @@ using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
-using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
@@ -17,7 +17,6 @@ using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
-using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;


### PR DESCRIPTION
## Changes

CI is red across every open frame-tx PR for two reasons that live on this integration branch, not in any child diff:

- **Restore fails repo-wide.** NuGetAudit now flags the transitive `SSH.NET` 2024.1.0 (GHSA-q939-rpr3-3284, high severity) as a warning-as-error, so `Nethermind.IntegrationTests` restore fails and every downstream build with it. Pin `SSH.NET` to the patched `2026.0.0`, the same version already on `master`. Transitive pinning is enabled, so this overrides the version pulled in through `Testcontainers`.
- **Lint fails on three unused usings.** `IDE0005` trips on `FrameTxBlockGasTests`, `FrameTxVerifyDosMeasurement`, and `FrameTxProducerRetryMeasurement`. Remove the dead directives.

Merging this greens the whole cascade at once.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

Restore of `Nethermind.IntegrationTests` succeeds with no `NU1903`. `Nethermind.Evm.Test` and `Nethermind.Blockchain.Test` build clean (0 errors) after the usings are dropped.
