### PR TITLE
perf: experiment with SVE2 Keccak on ARM64

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -7,8 +7,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Init.Steps;
+using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
@@ -20,6 +24,8 @@ namespace Nethermind.Core.Test
         public const string KeccakOfAnEmptyString = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
         public const string KeccakZero = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
         private const string ExperimentalSve2KeccakEnvironmentVariable = "NETHERMIND_EXPERIMENTAL_SVE2_KECCAK";
+        private const string ExperimentalSve2KeccakChildMarker = "NETHERMIND_SVE2_KECCAK_CHILD_EXECUTED";
+        private static readonly TimeSpan ExperimentalSve2KeccakChildTimeout = TimeSpan.FromMinutes(1);
 
         [TestCase(true, "0xc5d246...85a470")]
         [TestCase(false, "c5d246...85a470")]
@@ -193,10 +199,9 @@ namespace Nethermind.Core.Test
         }
 
         [Test]
-        public void Experimental_sve2_opt_in_on_unsupported_host_does_not_poison_KeccakHash()
+        public async Task Experimental_sve2_opt_in_initializes_and_logs_in_child_process()
         {
-            if (KeccakHash.IsSve2KeccakSupported())
-                Assert.Ignore("SVE2 SHA3 is supported on this platform.");
+            bool sve2Supported = KeccakHash.IsSve2KeccakSupported();
 
             string resultsDirectory = Path.Combine(Path.GetTempPath(), $"Nethermind.KeccakTests.{Guid.NewGuid():N}");
             try
@@ -211,21 +216,52 @@ namespace Nethermind.Core.Test
                 };
                 startInfo.ArgumentList.Add(typeof(KeccakTests).Assembly.Location);
                 startInfo.ArgumentList.Add("--filter");
-                startInfo.ArgumentList.Add($"FullyQualifiedName~{nameof(Experimental_sve2_opt_in_child_computes_known_hash)}");
+                startInfo.ArgumentList.Add($"FullyQualifiedName~{nameof(Experimental_sve2_opt_in_child_initializes_and_logs)}");
                 startInfo.ArgumentList.Add("--results-directory");
                 startInfo.ArgumentList.Add(resultsDirectory);
                 startInfo.ArgumentList.Add("--no-ansi");
                 startInfo.ArgumentList.Add("--progress");
                 startInfo.ArgumentList.Add("off");
+                startInfo.ArgumentList.Add("--output");
+                startInfo.ArgumentList.Add("Detailed");
+                startInfo.ArgumentList.Add("--show-stdout");
+                startInfo.ArgumentList.Add("All");
                 startInfo.Environment[ExperimentalSve2KeccakEnvironmentVariable] = "1";
 
                 using Process process = Process.Start(startInfo)
                     ?? throw new InvalidOperationException("Could not start the Keccak child test process.");
-                string standardOutput = process.StandardOutput.ReadToEnd();
-                string standardError = process.StandardError.ReadToEnd();
-                process.WaitForExit();
+                Task<string> standardOutputTask = process.StandardOutput.ReadToEndAsync();
+                Task<string> standardErrorTask = process.StandardError.ReadToEndAsync();
+                using CancellationTokenSource timeout = new(ExperimentalSve2KeccakChildTimeout);
 
-                Assert.That(process.ExitCode, Is.Zero, $"{standardOutput}{Environment.NewLine}{standardError}");
+                try
+                {
+                    await process.WaitForExitAsync(timeout.Token);
+                }
+                catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+                {
+                    if (!process.HasExited)
+                        process.Kill(entireProcessTree: true);
+
+                    await process.WaitForExitAsync();
+                    string timedOutStandardOutput = await standardOutputTask;
+                    string timedOutStandardError = await standardErrorTask;
+                    Assert.Fail($"The Keccak child test process timed out after {ExperimentalSve2KeccakChildTimeout}.{Environment.NewLine}{timedOutStandardOutput}{Environment.NewLine}{timedOutStandardError}");
+                }
+
+                string standardOutput = await standardOutputTask;
+                string standardError = await standardErrorTask;
+                string childOutput = $"{standardOutput}{Environment.NewLine}{standardError}";
+                string expectedDiagnostic = sve2Supported
+                    ? "Experimental SVE2 Keccak permutation enabled."
+                    : "Experimental SVE2 Keccak permutation was requested but is unsupported; falling back to the existing Keccak implementation.";
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(process.ExitCode, Is.Zero, childOutput);
+                    Assert.That(standardOutput, Does.Contain(ExperimentalSve2KeccakChildMarker), childOutput);
+                    Assert.That(childOutput, Does.Contain(expectedDiagnostic), childOutput);
+                }
             }
             finally
             {
@@ -234,12 +270,21 @@ namespace Nethermind.Core.Test
         }
 
         [Test]
-        public void Experimental_sve2_opt_in_child_computes_known_hash()
+        public async Task Experimental_sve2_opt_in_child_initializes_and_logs()
         {
             if (Environment.GetEnvironmentVariable(ExperimentalSve2KeccakEnvironmentVariable) != "1")
                 Assert.Ignore("This test is executed by the isolated opt-in regression test.");
 
+            bool sve2Supported = KeccakHash.IsSve2KeccakSupported();
+            KeccakHash.ExperimentalSve2KeccakStatus expectedState = sve2Supported
+                ? KeccakHash.ExperimentalSve2KeccakStatus.Enabled
+                : KeccakHash.ExperimentalSve2KeccakStatus.Unsupported;
+
+            Assert.That(KeccakHash.ExperimentalSve2KeccakState, Is.EqualTo(expectedState));
             Assert.That(Keccak.Compute([]).ToString(), Is.EqualTo(KeccakOfAnEmptyString));
+
+            await new LogHardwareInfo(new TestLogManager(LogLevel.Info)).Execute(CancellationToken.None);
+            TestContext.Out.WriteLine(ExperimentalSve2KeccakChildMarker);
         }
 
         [TestCase("0x", "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")]

--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -17,6 +19,7 @@ namespace Nethermind.Core.Test
     {
         public const string KeccakOfAnEmptyString = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
         public const string KeccakZero = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
+        private const string ExperimentalSve2KeccakEnvironmentVariable = "NETHERMIND_EXPERIMENTAL_SVE2_KECCAK";
 
         [TestCase(true, "0xc5d246...85a470")]
         [TestCase(false, "c5d246...85a470")]
@@ -166,6 +169,77 @@ namespace Nethermind.Core.Test
                 Assert.That(Keccak.Compute(byteArray.AsSpan()), Is.EqualTo(expected));
                 Assert.That(Keccak.Compute(byteArray), Is.EqualTo(expected));
             }
+        }
+
+        [Test]
+        public void Sve2_permutation_matches_scalar()
+        {
+            if (!KeccakHash.IsSve2KeccakSupported())
+                Assert.Ignore("SVE2 SHA3 is not supported on this platform.");
+
+            Span<ulong> scalarState = stackalloc ulong[25];
+            scalarState.Clear();
+            AssertSve2PermutationMatchesScalar(scalarState);
+
+            scalarState.Fill(ulong.MaxValue);
+            AssertSve2PermutationMatchesScalar(scalarState);
+
+            for (int lane = 0; lane < scalarState.Length; lane++)
+            {
+                scalarState[lane] = (ulong)(lane + 1) * 0x9E3779B97F4A7C15UL ^ 0xD1B54A32D192ED03UL;
+            }
+
+            AssertSve2PermutationMatchesScalar(scalarState);
+        }
+
+        [Test]
+        public void Experimental_sve2_opt_in_on_unsupported_host_does_not_poison_KeccakHash()
+        {
+            if (KeccakHash.IsSve2KeccakSupported())
+                Assert.Ignore("SVE2 SHA3 is supported on this platform.");
+
+            string resultsDirectory = Path.Combine(Path.GetTempPath(), $"Nethermind.KeccakTests.{Guid.NewGuid():N}");
+            try
+            {
+                ProcessStartInfo startInfo = new()
+                {
+                    FileName = "dotnet",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+                startInfo.ArgumentList.Add(typeof(KeccakTests).Assembly.Location);
+                startInfo.ArgumentList.Add("--filter");
+                startInfo.ArgumentList.Add($"FullyQualifiedName~{nameof(Experimental_sve2_opt_in_child_computes_known_hash)}");
+                startInfo.ArgumentList.Add("--results-directory");
+                startInfo.ArgumentList.Add(resultsDirectory);
+                startInfo.ArgumentList.Add("--no-ansi");
+                startInfo.ArgumentList.Add("--progress");
+                startInfo.ArgumentList.Add("off");
+                startInfo.Environment[ExperimentalSve2KeccakEnvironmentVariable] = "1";
+
+                using Process process = Process.Start(startInfo)
+                    ?? throw new InvalidOperationException("Could not start the Keccak child test process.");
+                string standardOutput = process.StandardOutput.ReadToEnd();
+                string standardError = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+
+                Assert.That(process.ExitCode, Is.Zero, $"{standardOutput}{Environment.NewLine}{standardError}");
+            }
+            finally
+            {
+                TryDeleteDirectory(resultsDirectory);
+            }
+        }
+
+        [Test]
+        public void Experimental_sve2_opt_in_child_computes_known_hash()
+        {
+            if (Environment.GetEnvironmentVariable(ExperimentalSve2KeccakEnvironmentVariable) != "1")
+                Assert.Ignore("This test is executed by the isolated opt-in regression test.");
+
+            Assert.That(Keccak.Compute([]).ToString(), Is.EqualTo(KeccakOfAnEmptyString));
         }
 
         [TestCase("0x", "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")]
@@ -1271,6 +1345,34 @@ namespace Nethermind.Core.Test
         ["0x34925cc5cf6ece6759f008716fd59af2a3fa41d384bfa1e5402e9842c384cc14aac1913d459679b3876584e5184c998723372a19341501e4647883ad062e7253592fe1ec699bee515601cf041f08350dcbbb5e8fde60074bba669fc2e27f4c2192a1c2d737f336d199ba309555bff182d22d5bf6a06e0d7fa789aa4dcc06b29419da41512b72eb3cbfb017d099e88d9f478b3e9694e0805e239647e32d7c795183453a976a32b8743a9c5ca563f8904d2ab671ac49e5ef8bf2f2e8580557523e7e2ce236ed08437de83357e595700759e8f8c9c09d91079ad3e6d4bf3d0e337db5eb312d0bd34242e02cbfa391a7c20e793483d9c8084f3ca40a6981bdc7e096b1cdce3c51f90a3767517be6b13ffd34ae2a5900e75b177f224eb8a083ba6690dcde5a252e1321e54d8687453b9cfb247a746c3ac7a74a259cab8b328b4cdc7d8600c6276929eaed5cb39e099c5881399483ef15c2cbebf912b7eab736d07d5784a15f7414f3678ad8a967d94ec10e85756610f3e60b2b42f3f8e92153784f52bf87ca5ba752826195ec907125a998b5a4b4a6dc3778c696cdc6e300dcfd09a01a0437da5a9112fba4c932f6b07bf8a98f56d709f439024447ba8836c8d3bac22e7e3bb88166560a2f50a2f9dab9e044fb261bb2d30d0e23cfdc35ad5efce9b47697209d73c02a55a76a779e47b675d7ab8e1a99bcad4b213ec164d25c108","52e42cc6e8ec4884dfd0682c3a055305894e6e822d31fb9c96fdd253382702e0"],
         ["0x1a625bc90b1e3a18b6a9c82fe4a755d787fef103c9042f5cc2dd7b5214112834390812a442f20ffdaf9f634f1d317eaccaef8495f4ec92d04bf3ff913dded21d1d7f5f603b5d3f86a95905b1274154b8d14d4efa33ea54dd85f239e804ea86756917b46332b1dc32c6b6881fef6443b419fc1639dea9f4956d7c3d3846b231767d8fe1e59d5944ce37281ea1fa5a87aa42257a20699a7ac9cd344aee895f933d3374152f86ad7948c1fa87388e879156a7bacbc0cc585a3117a62a0439282cf36022678bf2a22e7830bafc8f624d2785335f183526adeea543840e18d4c8442909ed6114b34f688ce7e9af31c8f13bee056be8e16ea9a967a10704130eb8a6662d21c125ae962ffbbc63dfb14d015244b3f92fed61e679cae4d2e90d43634e917dcecbb4cc8d60a6d8383e1e0bc6d76358ecc8418466c4a185042a69436154b6498615ba325b5c28545f6f791aeee9e00918fbcd9c1898485971ff9bfc7ad371d25245d2fb25727fed73de3c20b617719525a69f207192bb6badfe4047035041bdadefa314e34bf6a2c0a72c92dc392f3b3f31d96fa8e7f04f6854243bac757c6913a9bd043e58d5bd09ce2bcbd446bdea4ce442d4a27afdaca5b9c13fd02e93baf71ed019150a1db050f4499c65d0caddcb59071727c0b9adc3b4981d8d7e63e06257ffccdc15ceffbfb71190f037406254e98854338c4d02c0af79fa3a3e","7f849b09a7ead26acc15eaf80f9c5656098249dd70b7ddeed53e9f6bb8f5ed5f"],
             };
+
+        private static void AssertSve2PermutationMatchesScalar(Span<ulong> scalarState)
+        {
+            Span<ulong> sveState = stackalloc ulong[scalarState.Length];
+            scalarState.CopyTo(sveState);
+
+            KeccakHash.KeccakF1600Scalar(scalarState);
+            KeccakHash.KeccakF1600Sve2(sveState);
+
+            Assert.That(sveState.SequenceEqual(scalarState), Is.True);
+        }
+
+        private static void TryDeleteDirectory(string path)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                    Directory.Delete(path, recursive: true);
+            }
+            catch (IOException exception)
+            {
+                TestContext.Out.WriteLine($"Could not delete child test results directory '{path}': {exception.Message}");
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                TestContext.Out.WriteLine($"Could not delete child test results directory '{path}': {exception.Message}");
+            }
+        }
 
         private static byte[] EncodeItems(byte[][] items)
         {

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.std.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.std.cs
@@ -33,25 +33,49 @@ public sealed partial class KeccakHash
         0x8000000000008080UL, 0x0000000080000001UL, 0x8000000080008008UL
     ];
 
-#pragma warning disable SYSLIB5003
-    // .NET 10 lacks a FEAT_SVE_SHA3-specific probe, so explicit opt-in is required.
-    private static readonly bool ExperimentalSve2KeccakEnabled = GetExperimentalSve2KeccakEnabled();
-
-    private static bool GetExperimentalSve2KeccakEnabled()
+    private enum ExperimentalSve2KeccakStatus
     {
-        if (Environment.GetEnvironmentVariable("NETHERMIND_EXPERIMENTAL_SVE2_KECCAK") != "1")
+        Disabled,
+        Unsupported,
+        VerificationFailed,
+        Enabled,
+    }
+
+    // .NET 10 lacks a FEAT_SVE_SHA3-specific probe, so explicit opt-in is required.
+    private static readonly ExperimentalSve2KeccakStatus ExperimentalSve2Keccak = GetExperimentalSve2KeccakStatus();
+
+    private static ExperimentalSve2KeccakStatus GetExperimentalSve2KeccakStatus()
+    {
+        try
+        {
+            if (Environment.GetEnvironmentVariable("NETHERMIND_EXPERIMENTAL_SVE2_KECCAK") != "1")
+                return ExperimentalSve2KeccakStatus.Disabled;
+
+            if (!IsSve2KeccakSupported())
+                return ExperimentalSve2KeccakStatus.Unsupported;
+
+            return VerifySve2Keccak() ? ExperimentalSve2KeccakStatus.Enabled : ExperimentalSve2KeccakStatus.VerificationFailed;
+        }
+        catch (Exception)
+        {
+            return ExperimentalSve2KeccakStatus.VerificationFailed;
+        }
+    }
+
+#pragma warning disable SYSLIB5003
+    internal static bool IsSve2KeccakSupported()
+    {
+        try
+        {
+            return OperatingSystem.IsLinux()
+                && RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                && Sve2.IsSupported
+                && (GetAuxiliaryValue(AT_HWCAP2) & HWCAP2_SVESHA3) != 0;
+        }
+        catch (Exception)
+        {
             return false;
-
-        if (!OperatingSystem.IsLinux() || RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
-            throw new PlatformNotSupportedException("NETHERMIND_EXPERIMENTAL_SVE2_KECCAK=1 requires Linux ARM64.");
-
-        if (!Sve2.IsSupported)
-            throw new PlatformNotSupportedException("NETHERMIND_EXPERIMENTAL_SVE2_KECCAK=1 requires SVE2, but .NET did not expose SVE2 support on this platform.");
-
-        if ((GetAuxiliaryValue(AT_HWCAP2) & HWCAP2_SVESHA3) == 0)
-            throw new PlatformNotSupportedException("NETHERMIND_EXPERIMENTAL_SVE2_KECCAK=1 requires Linux HWCAP2_SVESHA3 support.");
-
-        return true;
+        }
     }
 
     [DllImport("libc", EntryPoint = "getauxval")]
@@ -61,15 +85,19 @@ public sealed partial class KeccakHash
     // update the state with given number of rounds
     private static partial void KeccakF(Span<ulong> st)
     {
+        if (ExperimentalSve2Keccak == ExperimentalSve2KeccakStatus.Enabled)
+        {
+            KeccakF1600Sve2(st);
+            return;
+        }
+
         if (Avx512F.IsSupported)
             KeccakF1600Avx512F(st);
-        else if (ExperimentalSve2KeccakEnabled)
-            KeccakF1600Sve2(st);
         else
-            KeccakF1600(st);
+            KeccakF1600Scalar(st);
     }
 
-    private static void KeccakF1600(Span<ulong> st)
+    internal static void KeccakF1600Scalar(Span<ulong> st)
     {
         Debug.Assert(st.Length == 25);
 
@@ -281,79 +309,248 @@ public sealed partial class KeccakHash
         st[0] = aba;
     }
 
+    private static bool VerifySve2Keccak()
+    {
+        Span<ulong> scalarState = stackalloc ulong[25];
+        Span<ulong> sveState = stackalloc ulong[25];
+
+        scalarState.Clear();
+        if (!VerifySve2KeccakState(scalarState, sveState))
+            return false;
+
+        scalarState.Fill(ulong.MaxValue);
+        if (!VerifySve2KeccakState(scalarState, sveState))
+            return false;
+
+        for (int lane = 0; lane < scalarState.Length; lane++)
+        {
+            scalarState[lane] = (ulong)(lane + 1) * 0x9E3779B97F4A7C15UL ^ 0xD1B54A32D192ED03UL;
+        }
+
+        return VerifySve2KeccakState(scalarState, sveState);
+    }
+
+    private static bool VerifySve2KeccakState(Span<ulong> scalarState, Span<ulong> sveState)
+    {
+        scalarState.CopyTo(sveState);
+        KeccakF1600Scalar(scalarState);
+        KeccakF1600Sve2(sveState);
+        return scalarState.SequenceEqual(sveState);
+    }
+
 #pragma warning disable SYSLIB5003
-    private static void KeccakF1600Sve2(Span<ulong> st)
+    [SkipLocalsInit]
+    internal static void KeccakF1600Sve2(Span<ulong> st)
     {
         Debug.Assert(st.Length == 25);
 
-        Span<Vector<ulong>> a = stackalloc Vector<ulong>[25];
-        Span<Vector<ulong>> b = stackalloc Vector<ulong>[25];
-        Span<Vector<ulong>> c = stackalloc Vector<ulong>[5];
-        Span<Vector<ulong>> d = stackalloc Vector<ulong>[5];
+        Vector<ulong> aba, abe, abi, abo, abu;
+        Vector<ulong> aga, age, agi, ago, agu;
+        Vector<ulong> aka, ake, aki, ako, aku;
+        Vector<ulong> ama, ame, ami, amo, amu;
+        Vector<ulong> asa, ase, asi, aso, asu;
+        Vector<ulong> bCa, bCe, bCi, bCo, bCu;
+        Vector<ulong> da, de, di, @do, du;
+        Vector<ulong> eba, ebe, ebi, ebo, ebu;
+        Vector<ulong> ega, ege, egi, ego, egu;
+        Vector<ulong> eka, eke, eki, eko, eku;
+        Vector<ulong> ema, eme, emi, emo, emu;
+        Vector<ulong> esa, ese, esi, eso, esu;
 
-        for (int i = 0; i < 25; i++)
-            a[i] = new Vector<ulong>(st[i]);
+        asu = new Vector<ulong>(st[24]);
+        aso = new Vector<ulong>(st[23]);
+        asi = new Vector<ulong>(st[22]);
+        ase = new Vector<ulong>(st[21]);
+        asa = new Vector<ulong>(st[20]);
+        amu = new Vector<ulong>(st[19]);
+        amo = new Vector<ulong>(st[18]);
+        ami = new Vector<ulong>(st[17]);
+        ame = new Vector<ulong>(st[16]);
+        ama = new Vector<ulong>(st[15]);
+        aku = new Vector<ulong>(st[14]);
+        ako = new Vector<ulong>(st[13]);
+        aki = new Vector<ulong>(st[12]);
+        ake = new Vector<ulong>(st[11]);
+        aka = new Vector<ulong>(st[10]);
+        agu = new Vector<ulong>(st[9]);
+        ago = new Vector<ulong>(st[8]);
+        agi = new Vector<ulong>(st[7]);
+        age = new Vector<ulong>(st[6]);
+        aga = new Vector<ulong>(st[5]);
+        abu = new Vector<ulong>(st[4]);
+        abo = new Vector<ulong>(st[3]);
+        abi = new Vector<ulong>(st[2]);
+        abe = new Vector<ulong>(st[1]);
+        aba = new Vector<ulong>(st[0]);
 
-        for (int round = 0; round < ROUNDS; round++)
+        for (int round = 0; round < ROUNDS; round += 2)
         {
-            c[0] = Sve2.Xor(Sve2.Xor(a[0], a[5], a[10]), a[15], a[20]);
-            c[1] = Sve2.Xor(Sve2.Xor(a[1], a[6], a[11]), a[16], a[21]);
-            c[2] = Sve2.Xor(Sve2.Xor(a[2], a[7], a[12]), a[17], a[22]);
-            c[3] = Sve2.Xor(Sve2.Xor(a[3], a[8], a[13]), a[18], a[23]);
-            c[4] = Sve2.Xor(Sve2.Xor(a[4], a[9], a[14]), a[19], a[24]);
+            bCa = Sve2.Xor(Sve2.Xor(aba, aga, aka), ama, asa);
+            bCe = Sve2.Xor(Sve2.Xor(abe, age, ake), ame, ase);
+            bCi = Sve2.Xor(Sve2.Xor(abi, agi, aki), ami, asi);
+            bCo = Sve2.Xor(Sve2.Xor(abo, ago, ako), amo, aso);
+            bCu = Sve2.Xor(Sve2.Xor(abu, agu, aku), amu, asu);
 
-            d[0] = Vector.Xor(c[4], Vector.BitwiseOr(Vector.ShiftLeft(c[1], 1), Vector.ShiftRightLogical(c[1], 63)));
-            d[1] = Vector.Xor(c[0], Vector.BitwiseOr(Vector.ShiftLeft(c[2], 1), Vector.ShiftRightLogical(c[2], 63)));
-            d[2] = Vector.Xor(c[1], Vector.BitwiseOr(Vector.ShiftLeft(c[3], 1), Vector.ShiftRightLogical(c[3], 63)));
-            d[3] = Vector.Xor(c[2], Vector.BitwiseOr(Vector.ShiftLeft(c[4], 1), Vector.ShiftRightLogical(c[4], 63)));
-            d[4] = Vector.Xor(c[3], Vector.BitwiseOr(Vector.ShiftLeft(c[0], 1), Vector.ShiftRightLogical(c[0], 63)));
+            da = Vector.Xor(bCu, RotateLeftOne(bCe));
+            de = Vector.Xor(bCa, RotateLeftOne(bCi));
+            di = Vector.Xor(bCe, RotateLeftOne(bCo));
+            @do = Vector.Xor(bCi, RotateLeftOne(bCu));
+            du = Vector.Xor(bCo, RotateLeftOne(bCa));
 
-            b[0] = Vector.Xor(a[0], d[0]);
-            b[10] = Sve2.XorRotateRight(a[1], d[1], (byte)63);
-            b[20] = Sve2.XorRotateRight(a[2], d[2], (byte)2);
-            b[5] = Sve2.XorRotateRight(a[3], d[3], (byte)36);
-            b[15] = Sve2.XorRotateRight(a[4], d[4], (byte)37);
+            bCa = Vector.Xor(aba, da);
+            bCe = Sve2.XorRotateRight(age, de, (byte)20);
+            bCi = Sve2.XorRotateRight(aki, di, (byte)21);
+            eba = Vector.Xor(Sve2.BitwiseClearXor(bCa, bCi, bCe), new Vector<ulong>(RoundConstants[round]));
+            bCo = Sve2.XorRotateRight(amo, @do, (byte)43);
+            ebe = Sve2.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sve2.XorRotateRight(asu, du, (byte)50);
+            ebi = Sve2.BitwiseClearXor(bCi, bCu, bCo);
+            ebo = Sve2.BitwiseClearXor(bCo, bCa, bCu);
+            ebu = Sve2.BitwiseClearXor(bCu, bCe, bCa);
 
-            b[16] = Sve2.XorRotateRight(a[5], d[0], (byte)28);
-            b[1] = Sve2.XorRotateRight(a[6], d[1], (byte)20);
-            b[11] = Sve2.XorRotateRight(a[7], d[2], (byte)58);
-            b[21] = Sve2.XorRotateRight(a[8], d[3], (byte)9);
-            b[6] = Sve2.XorRotateRight(a[9], d[4], (byte)44);
+            bCa = Sve2.XorRotateRight(abo, @do, (byte)36);
+            bCe = Sve2.XorRotateRight(agu, du, (byte)44);
+            bCi = Sve2.XorRotateRight(aka, da, (byte)61);
+            ega = Sve2.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sve2.XorRotateRight(ame, de, (byte)19);
+            ege = Sve2.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sve2.XorRotateRight(asi, di, (byte)3);
+            egi = Sve2.BitwiseClearXor(bCi, bCu, bCo);
+            ego = Sve2.BitwiseClearXor(bCo, bCa, bCu);
+            egu = Sve2.BitwiseClearXor(bCu, bCe, bCa);
 
-            b[7] = Sve2.XorRotateRight(a[10], d[0], (byte)61);
-            b[17] = Sve2.XorRotateRight(a[11], d[1], (byte)54);
-            b[2] = Sve2.XorRotateRight(a[12], d[2], (byte)21);
-            b[12] = Sve2.XorRotateRight(a[13], d[3], (byte)39);
-            b[22] = Sve2.XorRotateRight(a[14], d[4], (byte)25);
+            bCa = Sve2.XorRotateRight(abe, de, (byte)63);
+            bCe = Sve2.XorRotateRight(agi, di, (byte)58);
+            bCi = Sve2.XorRotateRight(ako, @do, (byte)39);
+            eka = Sve2.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sve2.XorRotateRight(amu, du, (byte)56);
+            eke = Sve2.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sve2.XorRotateRight(asa, da, (byte)46);
+            eki = Sve2.BitwiseClearXor(bCi, bCu, bCo);
+            eko = Sve2.BitwiseClearXor(bCo, bCa, bCu);
+            eku = Sve2.BitwiseClearXor(bCu, bCe, bCa);
 
-            b[23] = Sve2.XorRotateRight(a[15], d[0], (byte)23);
-            b[8] = Sve2.XorRotateRight(a[16], d[1], (byte)19);
-            b[18] = Sve2.XorRotateRight(a[17], d[2], (byte)49);
-            b[3] = Sve2.XorRotateRight(a[18], d[3], (byte)43);
-            b[13] = Sve2.XorRotateRight(a[19], d[4], (byte)56);
+            bCa = Sve2.XorRotateRight(abu, du, (byte)37);
+            bCe = Sve2.XorRotateRight(aga, da, (byte)28);
+            bCi = Sve2.XorRotateRight(ake, de, (byte)54);
+            ema = Sve2.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sve2.XorRotateRight(ami, di, (byte)49);
+            eme = Sve2.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sve2.XorRotateRight(aso, @do, (byte)8);
+            emi = Sve2.BitwiseClearXor(bCi, bCu, bCo);
+            emo = Sve2.BitwiseClearXor(bCo, bCa, bCu);
+            emu = Sve2.BitwiseClearXor(bCu, bCe, bCa);
 
-            b[14] = Sve2.XorRotateRight(a[20], d[0], (byte)46);
-            b[24] = Sve2.XorRotateRight(a[21], d[1], (byte)62);
-            b[9] = Sve2.XorRotateRight(a[22], d[2], (byte)3);
-            b[19] = Sve2.XorRotateRight(a[23], d[3], (byte)8);
-            b[4] = Sve2.XorRotateRight(a[24], d[4], (byte)50);
+            bCa = Sve2.XorRotateRight(abi, di, (byte)2);
+            bCe = Sve2.XorRotateRight(ago, @do, (byte)9);
+            bCi = Sve2.XorRotateRight(aku, du, (byte)25);
+            esa = Sve2.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sve2.XorRotateRight(ama, da, (byte)23);
+            ese = Sve2.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sve2.XorRotateRight(ase, de, (byte)62);
+            esi = Sve2.BitwiseClearXor(bCi, bCu, bCo);
+            eso = Sve2.BitwiseClearXor(bCo, bCa, bCu);
+            esu = Sve2.BitwiseClearXor(bCu, bCe, bCa);
 
-            for (int y = 0; y < 25; y += 5)
-            {
-                a[y] = Sve2.BitwiseClearXor(b[y], b[y + 2], b[y + 1]);
-                a[y + 1] = Sve2.BitwiseClearXor(b[y + 1], b[y + 3], b[y + 2]);
-                a[y + 2] = Sve2.BitwiseClearXor(b[y + 2], b[y + 4], b[y + 3]);
-                a[y + 3] = Sve2.BitwiseClearXor(b[y + 3], b[y], b[y + 4]);
-                a[y + 4] = Sve2.BitwiseClearXor(b[y + 4], b[y + 1], b[y]);
-            }
+            bCe = Sve2.Xor(Sve2.Xor(ebe, ege, eke), eme, ese);
+            bCu = Sve2.Xor(Sve2.Xor(ebu, egu, eku), emu, esu);
 
-            a[0] = Vector.Xor(a[0], new Vector<ulong>(RoundConstants[round]));
+            da = Vector.Xor(bCu, RotateLeftOne(bCe));
+            bCa = Sve2.Xor(Sve2.Xor(eba, ega, eka), ema, esa);
+            bCi = Sve2.Xor(Sve2.Xor(ebi, egi, eki), emi, esi);
+            de = Vector.Xor(bCa, RotateLeftOne(bCi));
+            bCo = Sve2.Xor(Sve2.Xor(ebo, ego, eko), emo, eso);
+            di = Vector.Xor(bCe, RotateLeftOne(bCo));
+            @do = Vector.Xor(bCi, RotateLeftOne(bCu));
+            du = Vector.Xor(bCo, RotateLeftOne(bCa));
+
+            bCi = Sve2.XorRotateRight(eki, di, (byte)21);
+            bCe = Sve2.XorRotateRight(ege, de, (byte)20);
+            bCa = Vector.Xor(eba, da);
+            aba = Vector.Xor(Sve2.BitwiseClearXor(bCa, bCi, bCe), new Vector<ulong>(RoundConstants[round + 1]));
+            bCo = Sve2.XorRotateRight(emo, @do, (byte)43);
+            abe = Sve2.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sve2.XorRotateRight(esu, du, (byte)50);
+            abi = Sve2.BitwiseClearXor(bCi, bCu, bCo);
+            abo = Sve2.BitwiseClearXor(bCo, bCa, bCu);
+            abu = Sve2.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sve2.XorRotateRight(ebo, @do, (byte)36);
+            bCe = Sve2.XorRotateRight(egu, du, (byte)44);
+            bCi = Sve2.XorRotateRight(eka, da, (byte)61);
+            aga = Sve2.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sve2.XorRotateRight(eme, de, (byte)19);
+            age = Sve2.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sve2.XorRotateRight(esi, di, (byte)3);
+            agi = Sve2.BitwiseClearXor(bCi, bCu, bCo);
+            ago = Sve2.BitwiseClearXor(bCo, bCa, bCu);
+            agu = Sve2.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sve2.XorRotateRight(ebe, de, (byte)63);
+            bCe = Sve2.XorRotateRight(egi, di, (byte)58);
+            bCi = Sve2.XorRotateRight(eko, @do, (byte)39);
+            aka = Sve2.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sve2.XorRotateRight(emu, du, (byte)56);
+            ake = Sve2.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sve2.XorRotateRight(esa, da, (byte)46);
+            aki = Sve2.BitwiseClearXor(bCi, bCu, bCo);
+            ako = Sve2.BitwiseClearXor(bCo, bCa, bCu);
+            aku = Sve2.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sve2.XorRotateRight(ebu, du, (byte)37);
+            bCe = Sve2.XorRotateRight(ega, da, (byte)28);
+            bCi = Sve2.XorRotateRight(eke, de, (byte)54);
+            ama = Sve2.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sve2.XorRotateRight(emi, di, (byte)49);
+            ame = Sve2.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sve2.XorRotateRight(eso, @do, (byte)8);
+            ami = Sve2.BitwiseClearXor(bCi, bCu, bCo);
+            amo = Sve2.BitwiseClearXor(bCo, bCa, bCu);
+            amu = Sve2.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sve2.XorRotateRight(ebi, di, (byte)2);
+            bCe = Sve2.XorRotateRight(ego, @do, (byte)9);
+            bCi = Sve2.XorRotateRight(eku, du, (byte)25);
+            asa = Sve2.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sve2.XorRotateRight(ema, da, (byte)23);
+            ase = Sve2.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sve2.XorRotateRight(ese, de, (byte)62);
+            asi = Sve2.BitwiseClearXor(bCi, bCu, bCo);
+            aso = Sve2.BitwiseClearXor(bCo, bCa, bCu);
+            asu = Sve2.BitwiseClearXor(bCu, bCe, bCa);
         }
 
-        for (int i = 0; i < 25; i++)
-            st[i] = a[i][0];
+        st[24] = asu[0];
+        st[23] = aso[0];
+        st[22] = asi[0];
+        st[21] = ase[0];
+        st[20] = asa[0];
+        st[19] = amu[0];
+        st[18] = amo[0];
+        st[17] = ami[0];
+        st[16] = ame[0];
+        st[15] = ama[0];
+        st[14] = aku[0];
+        st[13] = ako[0];
+        st[12] = aki[0];
+        st[11] = ake[0];
+        st[10] = aka[0];
+        st[9] = agu[0];
+        st[8] = ago[0];
+        st[7] = agi[0];
+        st[6] = age[0];
+        st[5] = aga[0];
+        st[4] = abu[0];
+        st[3] = abo[0];
+        st[2] = abi[0];
+        st[1] = abe[0];
+        st[0] = aba[0];
     }
 #pragma warning restore SYSLIB5003
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector<ulong> RotateLeftOne(Vector<ulong> value)
+        => Vector.BitwiseOr(Vector.ShiftLeft(value, 1), Vector.ShiftRightLogical(value, LANE_BITS - 1));
 
     [SkipLocalsInit]
     public static void KeccakF1600Avx512F(Span<ulong> state)

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.std.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.std.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 using static System.Numerics.BitOperations;
@@ -17,6 +19,8 @@ public sealed partial class KeccakHash
     private const int ROUNDS = 24;
     private const int LANE_BITS = 8 * 8;
     private const int TEMP_BUFF_SIZE = 144;
+    private const ulong AT_HWCAP2 = 26;
+    private const ulong HWCAP2_SVESHA3 = 1UL << 5;
     private static readonly ulong[] RoundConstants =
     [
         0x0000000000000001UL, 0x0000000000008082UL, 0x800000000000808aUL,
@@ -29,11 +33,38 @@ public sealed partial class KeccakHash
         0x8000000000008080UL, 0x0000000080000001UL, 0x8000000080008008UL
     ];
 
+#pragma warning disable SYSLIB5003
+    // .NET 10 lacks a FEAT_SVE_SHA3-specific probe, so explicit opt-in is required.
+    private static readonly bool ExperimentalSve2KeccakEnabled = GetExperimentalSve2KeccakEnabled();
+
+    private static bool GetExperimentalSve2KeccakEnabled()
+    {
+        if (Environment.GetEnvironmentVariable("NETHERMIND_EXPERIMENTAL_SVE2_KECCAK") != "1")
+            return false;
+
+        if (!OperatingSystem.IsLinux() || RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            throw new PlatformNotSupportedException("NETHERMIND_EXPERIMENTAL_SVE2_KECCAK=1 requires Linux ARM64.");
+
+        if (!Sve2.IsSupported)
+            throw new PlatformNotSupportedException("NETHERMIND_EXPERIMENTAL_SVE2_KECCAK=1 requires SVE2, but .NET did not expose SVE2 support on this platform.");
+
+        if ((GetAuxiliaryValue(AT_HWCAP2) & HWCAP2_SVESHA3) == 0)
+            throw new PlatformNotSupportedException("NETHERMIND_EXPERIMENTAL_SVE2_KECCAK=1 requires Linux HWCAP2_SVESHA3 support.");
+
+        return true;
+    }
+
+    [DllImport("libc", EntryPoint = "getauxval")]
+    private static extern ulong GetAuxiliaryValue(ulong type);
+#pragma warning restore SYSLIB5003
+
     // update the state with given number of rounds
     private static partial void KeccakF(Span<ulong> st)
     {
         if (Avx512F.IsSupported)
             KeccakF1600Avx512F(st);
+        else if (ExperimentalSve2KeccakEnabled)
+            KeccakF1600Sve2(st);
         else
             KeccakF1600(st);
     }
@@ -249,6 +280,80 @@ public sealed partial class KeccakHash
         st[1] = abe;
         st[0] = aba;
     }
+
+#pragma warning disable SYSLIB5003
+    private static void KeccakF1600Sve2(Span<ulong> st)
+    {
+        Debug.Assert(st.Length == 25);
+
+        Span<Vector<ulong>> a = stackalloc Vector<ulong>[25];
+        Span<Vector<ulong>> b = stackalloc Vector<ulong>[25];
+        Span<Vector<ulong>> c = stackalloc Vector<ulong>[5];
+        Span<Vector<ulong>> d = stackalloc Vector<ulong>[5];
+
+        for (int i = 0; i < 25; i++)
+            a[i] = new Vector<ulong>(st[i]);
+
+        for (int round = 0; round < ROUNDS; round++)
+        {
+            c[0] = Sve2.Xor(Sve2.Xor(a[0], a[5], a[10]), a[15], a[20]);
+            c[1] = Sve2.Xor(Sve2.Xor(a[1], a[6], a[11]), a[16], a[21]);
+            c[2] = Sve2.Xor(Sve2.Xor(a[2], a[7], a[12]), a[17], a[22]);
+            c[3] = Sve2.Xor(Sve2.Xor(a[3], a[8], a[13]), a[18], a[23]);
+            c[4] = Sve2.Xor(Sve2.Xor(a[4], a[9], a[14]), a[19], a[24]);
+
+            d[0] = Vector.Xor(c[4], Vector.BitwiseOr(Vector.ShiftLeft(c[1], 1), Vector.ShiftRightLogical(c[1], 63)));
+            d[1] = Vector.Xor(c[0], Vector.BitwiseOr(Vector.ShiftLeft(c[2], 1), Vector.ShiftRightLogical(c[2], 63)));
+            d[2] = Vector.Xor(c[1], Vector.BitwiseOr(Vector.ShiftLeft(c[3], 1), Vector.ShiftRightLogical(c[3], 63)));
+            d[3] = Vector.Xor(c[2], Vector.BitwiseOr(Vector.ShiftLeft(c[4], 1), Vector.ShiftRightLogical(c[4], 63)));
+            d[4] = Vector.Xor(c[3], Vector.BitwiseOr(Vector.ShiftLeft(c[0], 1), Vector.ShiftRightLogical(c[0], 63)));
+
+            b[0] = Vector.Xor(a[0], d[0]);
+            b[10] = Sve2.XorRotateRight(a[1], d[1], (byte)63);
+            b[20] = Sve2.XorRotateRight(a[2], d[2], (byte)2);
+            b[5] = Sve2.XorRotateRight(a[3], d[3], (byte)36);
+            b[15] = Sve2.XorRotateRight(a[4], d[4], (byte)37);
+
+            b[16] = Sve2.XorRotateRight(a[5], d[0], (byte)28);
+            b[1] = Sve2.XorRotateRight(a[6], d[1], (byte)20);
+            b[11] = Sve2.XorRotateRight(a[7], d[2], (byte)58);
+            b[21] = Sve2.XorRotateRight(a[8], d[3], (byte)9);
+            b[6] = Sve2.XorRotateRight(a[9], d[4], (byte)44);
+
+            b[7] = Sve2.XorRotateRight(a[10], d[0], (byte)61);
+            b[17] = Sve2.XorRotateRight(a[11], d[1], (byte)54);
+            b[2] = Sve2.XorRotateRight(a[12], d[2], (byte)21);
+            b[12] = Sve2.XorRotateRight(a[13], d[3], (byte)39);
+            b[22] = Sve2.XorRotateRight(a[14], d[4], (byte)25);
+
+            b[23] = Sve2.XorRotateRight(a[15], d[0], (byte)23);
+            b[8] = Sve2.XorRotateRight(a[16], d[1], (byte)19);
+            b[18] = Sve2.XorRotateRight(a[17], d[2], (byte)49);
+            b[3] = Sve2.XorRotateRight(a[18], d[3], (byte)43);
+            b[13] = Sve2.XorRotateRight(a[19], d[4], (byte)56);
+
+            b[14] = Sve2.XorRotateRight(a[20], d[0], (byte)46);
+            b[24] = Sve2.XorRotateRight(a[21], d[1], (byte)62);
+            b[9] = Sve2.XorRotateRight(a[22], d[2], (byte)3);
+            b[19] = Sve2.XorRotateRight(a[23], d[3], (byte)8);
+            b[4] = Sve2.XorRotateRight(a[24], d[4], (byte)50);
+
+            for (int y = 0; y < 25; y += 5)
+            {
+                a[y] = Sve2.BitwiseClearXor(b[y], b[y + 2], b[y + 1]);
+                a[y + 1] = Sve2.BitwiseClearXor(b[y + 1], b[y + 3], b[y + 2]);
+                a[y + 2] = Sve2.BitwiseClearXor(b[y + 2], b[y + 4], b[y + 3]);
+                a[y + 3] = Sve2.BitwiseClearXor(b[y + 3], b[y], b[y + 4]);
+                a[y + 4] = Sve2.BitwiseClearXor(b[y + 4], b[y + 1], b[y]);
+            }
+
+            a[0] = Vector.Xor(a[0], new Vector<ulong>(RoundConstants[round]));
+        }
+
+        for (int i = 0; i < 25; i++)
+            st[i] = a[i][0];
+    }
+#pragma warning restore SYSLIB5003
 
     [SkipLocalsInit]
     public static void KeccakF1600Avx512F(Span<ulong> state)

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.std.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.std.cs
@@ -21,6 +21,7 @@ public sealed partial class KeccakHash
     private const int TEMP_BUFF_SIZE = 144;
     private const ulong AT_HWCAP2 = 26;
     private const ulong HWCAP2_SVESHA3 = 1UL << 5;
+    // Resolution verifies the SVE2 permutation, so RoundConstants must initialize first.
     private static readonly ulong[] RoundConstants =
     [
         0x0000000000000001UL, 0x0000000000008082UL, 0x800000000000808aUL,
@@ -33,7 +34,7 @@ public sealed partial class KeccakHash
         0x8000000000008080UL, 0x0000000080000001UL, 0x8000000080008008UL
     ];
 
-    private enum ExperimentalSve2KeccakStatus
+    internal enum ExperimentalSve2KeccakStatus
     {
         Disabled,
         Unsupported,
@@ -41,36 +42,37 @@ public sealed partial class KeccakHash
         Enabled,
     }
 
-    // .NET 10 lacks a FEAT_SVE_SHA3-specific probe, so explicit opt-in is required.
-    private static readonly ExperimentalSve2KeccakStatus ExperimentalSve2Keccak = GetExperimentalSve2KeccakStatus();
+    private static readonly (ExperimentalSve2KeccakStatus Status, Exception? Failure) s_experimentalSve2Keccak = ResolveExperimentalSve2Keccak();
 
-    private static ExperimentalSve2KeccakStatus GetExperimentalSve2KeccakStatus()
+    internal static ExperimentalSve2KeccakStatus ExperimentalSve2KeccakState => s_experimentalSve2Keccak.Status;
+
+    internal static Exception? ExperimentalSve2KeccakFailure => s_experimentalSve2Keccak.Failure;
+
+    private static (ExperimentalSve2KeccakStatus Status, Exception? Failure) ResolveExperimentalSve2Keccak()
     {
         try
         {
             if (Environment.GetEnvironmentVariable("NETHERMIND_EXPERIMENTAL_SVE2_KECCAK") != "1")
-                return ExperimentalSve2KeccakStatus.Disabled;
+                return (ExperimentalSve2KeccakStatus.Disabled, null);
 
-            if (!IsSve2KeccakSupported())
-                return ExperimentalSve2KeccakStatus.Unsupported;
+            if (!IsSve2KeccakSupportedCore())
+                return (ExperimentalSve2KeccakStatus.Unsupported, null);
 
-            return VerifySve2Keccak() ? ExperimentalSve2KeccakStatus.Enabled : ExperimentalSve2KeccakStatus.VerificationFailed;
+            return VerifySve2Keccak()
+                ? (ExperimentalSve2KeccakStatus.Enabled, null)
+                : (ExperimentalSve2KeccakStatus.VerificationFailed, null);
         }
-        catch (Exception)
+        catch (Exception exception)
         {
-            return ExperimentalSve2KeccakStatus.VerificationFailed;
+            return (ExperimentalSve2KeccakStatus.VerificationFailed, exception);
         }
     }
 
-#pragma warning disable SYSLIB5003
     internal static bool IsSve2KeccakSupported()
     {
         try
         {
-            return OperatingSystem.IsLinux()
-                && RuntimeInformation.ProcessArchitecture == Architecture.Arm64
-                && Sve2.IsSupported
-                && (GetAuxiliaryValue(AT_HWCAP2) & HWCAP2_SVESHA3) != 0;
+            return IsSve2KeccakSupportedCore();
         }
         catch (Exception)
         {
@@ -78,14 +80,24 @@ public sealed partial class KeccakHash
         }
     }
 
+    private static bool IsSve2KeccakSupportedCore()
+    {
+        if (!OperatingSystem.IsLinux() || RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            return false;
+
+#pragma warning disable SYSLIB5003
+        bool sve2Supported = Sve2.IsSupported;
+#pragma warning restore SYSLIB5003
+        return sve2Supported && (GetAuxiliaryValue(AT_HWCAP2) & HWCAP2_SVESHA3) != 0;
+    }
+
     [DllImport("libc", EntryPoint = "getauxval")]
     private static extern ulong GetAuxiliaryValue(ulong type);
-#pragma warning restore SYSLIB5003
 
     // update the state with given number of rounds
     private static partial void KeccakF(Span<ulong> st)
     {
-        if (ExperimentalSve2Keccak == ExperimentalSve2KeccakStatus.Enabled)
+        if (s_experimentalSve2Keccak.Status == ExperimentalSve2KeccakStatus.Enabled)
         {
             KeccakF1600Sve2(st);
             return;

--- a/src/Nethermind/Nethermind.Core/InternalsVisibility.cs
+++ b/src/Nethermind/Nethermind.Core/InternalsVisibility.cs
@@ -6,4 +6,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Nethermind.Core.Test")]
 [assembly: InternalsVisibleTo("Nethermind.Blockchain.Test")]
 [assembly: InternalsVisibleTo("Nethermind.Clique.Test")]
+[assembly: InternalsVisibleTo("Nethermind.Init")]
 [assembly: InternalsVisibleTo("Nethermind.Precompiles.Benchmark")]

--- a/src/Nethermind/Nethermind.Core/InternalsVisibility.cs
+++ b/src/Nethermind/Nethermind.Core/InternalsVisibility.cs
@@ -6,3 +6,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Nethermind.Core.Test")]
 [assembly: InternalsVisibleTo("Nethermind.Blockchain.Test")]
 [assembly: InternalsVisibleTo("Nethermind.Clique.Test")]
+[assembly: InternalsVisibleTo("Nethermind.Precompiles.Benchmark")]

--- a/src/Nethermind/Nethermind.Init/Steps/LogHardwareInfo.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/LogHardwareInfo.cs
@@ -1,10 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api.Steps;
 using Nethermind.Core.Cpu;
+#if !ZK_EVM
+using Nethermind.Core.Crypto;
+#endif
 using Nethermind.Logging;
 using ILogger = Nethermind.Logging.ILogger;
 
@@ -18,6 +22,9 @@ public class LogHardwareInfo(ILogManager logManager) : IStep
 
     public Task Execute(CancellationToken cancellationToken)
     {
+#if !ZK_EVM
+        LogExperimentalSve2KeccakStatus();
+#endif
         if (!_logger.IsInfo) return Task.CompletedTask;
 
         try
@@ -33,4 +40,26 @@ public class LogHardwareInfo(ILogManager logManager) : IStep
 
         return Task.CompletedTask;
     }
+
+#if !ZK_EVM
+    private void LogExperimentalSve2KeccakStatus()
+    {
+        switch (KeccakHash.ExperimentalSve2KeccakState)
+        {
+            case KeccakHash.ExperimentalSve2KeccakStatus.Enabled when _logger.IsInfo:
+                _logger.Info("Experimental SVE2 Keccak permutation enabled.");
+                break;
+            case KeccakHash.ExperimentalSve2KeccakStatus.Unsupported when _logger.IsWarn:
+                _logger.Warn("Experimental SVE2 Keccak permutation was requested but is unsupported; falling back to the existing Keccak implementation.");
+                break;
+            case KeccakHash.ExperimentalSve2KeccakStatus.VerificationFailed when _logger.IsError:
+                Exception? failure = KeccakHash.ExperimentalSve2KeccakFailure;
+                if (failure is null)
+                    _logger.Error("Experimental SVE2 Keccak permutation did not match scalar verification; falling back to the existing Keccak implementation.");
+                else
+                    _logger.Error("Experimental SVE2 Keccak permutation verification failed; falling back to the existing Keccak implementation.", failure);
+                break;
+        }
+    }
+#endif
 }

--- a/src/Nethermind/Nethermind.Precompiles.Benchmark/KeccakBenchmark.cs
+++ b/src/Nethermind/Nethermind.Precompiles.Benchmark/KeccakBenchmark.cs
@@ -4,15 +4,15 @@
 using System;
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Precompiles.Benchmark
 {
-    [MemoryDiagnoser]
     public class KeccakBenchmark
     {
-        private readonly byte[] _output = new byte[32];
-
         public readonly struct Param
         {
             private static readonly Random _random = new(42);
@@ -44,8 +44,51 @@ namespace Nethermind.Precompiles.Benchmark
 
         [Benchmark(Baseline = true)]
         public Span<byte> Baseline() => ValueKeccak.Compute(Input.Bytes).BytesAsSpan;
+    }
+
+    [Config(typeof(InProcessConfig))]
+    [MemoryDiagnoser]
+    public class KeccakPermutationBenchmark
+    {
+        private sealed class InProcessConfig : ManualConfig
+        {
+            public InProcessConfig()
+            {
+                WithUnionRule(ConfigUnionRule.AlwaysUseLocal);
+                AddJob(Job.MediumRun.WithToolchain(InProcessNoEmitToolchain.Instance));
+            }
+        }
+
+        private const int LaneCount = 25;
+        private const ulong InitialLaneMultiplier = 0x9E3779B97F4A7C15UL;
+        private const ulong InitialLaneXor = 0xD1B54A32D192ED03UL;
+
+        private readonly ulong[] _scalarState = new ulong[LaneCount];
+        private readonly ulong[] _sveState = new ulong[LaneCount];
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            if (!KeccakHash.IsSve2KeccakSupported())
+                throw new PlatformNotSupportedException("KeccakPermutationBenchmark requires SVE2 SHA3 support.");
+
+            for (int lane = 0; lane < LaneCount; lane++)
+            {
+                _scalarState[lane] = (ulong)(lane + 1) * InitialLaneMultiplier ^ InitialLaneXor;
+            }
+
+            _scalarState.AsSpan().CopyTo(_sveState);
+            KeccakHash.KeccakF1600Scalar(_scalarState);
+            KeccakHash.KeccakF1600Sve2(_sveState);
+
+            if (!_scalarState.AsSpan().SequenceEqual(_sveState))
+                throw new InvalidOperationException("SVE2 Keccak does not match the scalar permutation.");
+        }
+
+        [Benchmark(Baseline = true)]
+        public void Scalar() => KeccakHash.KeccakF1600Scalar(_scalarState);
 
         [Benchmark]
-        public void ComputeHash() => KeccakHash.ComputeHash(Input.Bytes, _output);
+        public void Sve2() => KeccakHash.KeccakF1600Sve2(_sveState);
     }
 }

--- a/src/Nethermind/Nethermind.Precompiles.Benchmark/KeccakBenchmark.cs
+++ b/src/Nethermind/Nethermind.Precompiles.Benchmark/KeccakBenchmark.cs
@@ -8,8 +8,11 @@ using Nethermind.Core.Crypto;
 
 namespace Nethermind.Precompiles.Benchmark
 {
+    [MemoryDiagnoser]
     public class KeccakBenchmark
     {
+        private readonly byte[] _output = new byte[32];
+
         public readonly struct Param
         {
             private static readonly Random _random = new(42);
@@ -41,5 +44,8 @@ namespace Nethermind.Precompiles.Benchmark
 
         [Benchmark(Baseline = true)]
         public Span<byte> Baseline() => ValueKeccak.Compute(Input.Bytes).BytesAsSpan;
+
+        [Benchmark]
+        public void ComputeHash() => KeccakHash.ComputeHash(Input.Bytes, _output);
     }
 }

--- a/src/Nethermind/Nethermind.Precompiles.Benchmark/KeccakBenchmark.cs
+++ b/src/Nethermind/Nethermind.Precompiles.Benchmark/KeccakBenchmark.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 using Nethermind.Core.Crypto;
@@ -56,6 +57,8 @@ namespace Nethermind.Precompiles.Benchmark
             {
                 WithUnionRule(ConfigUnionRule.AlwaysUseLocal);
                 AddJob(Job.MediumRun.WithToolchain(InProcessNoEmitToolchain.Instance));
+                AddFilter(new SimpleFilter(static benchmarkCase =>
+                    benchmarkCase.Descriptor.Type != typeof(KeccakPermutationBenchmark) || KeccakHash.IsSve2KeccakSupported()));
             }
         }
 
@@ -63,15 +66,13 @@ namespace Nethermind.Precompiles.Benchmark
         private const ulong InitialLaneMultiplier = 0x9E3779B97F4A7C15UL;
         private const ulong InitialLaneXor = 0xD1B54A32D192ED03UL;
 
+        // Keccak's data-independent permutation keeps evolving benchmark states representative.
         private readonly ulong[] _scalarState = new ulong[LaneCount];
         private readonly ulong[] _sveState = new ulong[LaneCount];
 
         [GlobalSetup]
         public void Setup()
         {
-            if (!KeccakHash.IsSve2KeccakSupported())
-                throw new PlatformNotSupportedException("KeccakPermutationBenchmark requires SVE2 SHA3 support.");
-
             for (int lane = 0; lane < LaneCount; lane++)
             {
                 _scalarState[lane] = (ulong)(lane + 1) * InitialLaneMultiplier ^ InitialLaneXor;


### PR DESCRIPTION
## Changes

- Add an experimental Linux ARM64 Keccak-f[1600] path using SVE2 SHA3 instructions (`EOR3`, `XAR`, and `BCAX`) with named vector locals and no vector-backed stack arrays.
- Keep it disabled by default; enable only with exact `NETHERMIND_EXPERIMENTAL_SVE2_KECCAK=1`, .NET SVE2 support, Linux `HWCAP2_SVESHA3`, and a successful scalar-equivalence self-test.
- Fall back safely to the existing AVX-512/scalar path when the platform probe or self-test fails.
- Add a direct, same-process scalar/SVE permutation benchmark.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `dotnet test Nethermind.Core.Test/Nethermind.Core.Test.csproj -c Release --no-restore --filter FullyQualifiedName~Keccak` — 1,066 passed; two expected skips on unsupported x64.
- Fresh-process forced-opt-in fallback regression — passed on x64.
- `dotnet build Nethermind.Precompiles.Benchmark/Nethermind.Precompiles.Benchmark.csproj -c Release --no-restore` — passed with zero warnings and errors.
- Linux ARM64 correctness, generated-code inspection, and performance validation on c9gd remain required.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This remains a controlled benchmark experiment. Target acceptance requires the full Keccak suite with the opt-in enabled, the direct scalar/SVE benchmark, and disassembly confirming `EOR3`, `XAR`, and `BCAX` without excessive spill traffic.
