### PR TITLE
Align debug_traceCall base fee with Geth

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTraceOptions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTraceOptions.cs
@@ -38,6 +38,12 @@ public record GethTraceOptions
     public BlockOverride? BlockOverrides { get; set; }
 
     /// <summary>
+    /// Uses a zero base fee when tracing a call without gas pricing.
+    /// </summary>
+    [JsonIgnore]
+    public bool NoBaseFee { get; init; }
+
+    /// <summary>
     /// When set, overrides <c>JsonRpc.EnableTracingStreamMode</c> for this single call.
     /// </summary>
     public bool? StreamMode { get; init; }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTraceOptions.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethTraceOptions.cs
@@ -37,9 +37,6 @@ public record GethTraceOptions
 
     public BlockOverride? BlockOverrides { get; set; }
 
-    /// <summary>
-    /// Uses a zero base fee when tracing a call without gas pricing.
-    /// </summary>
     [JsonIgnore]
     public bool NoBaseFee { get; init; }
 

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -26,6 +26,7 @@ using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.JavaScript;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native;
 using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Consensus.Tracing;
@@ -64,7 +65,8 @@ public class GethStyleTracer(
 
         try
         {
-            return TraceImpl(block, tx.Hash, cancellationToken, options, ProcessingOptions.TraceTransactions, writer, pipeWriter);
+            return TraceImpl(block, tx.Hash, cancellationToken, options, ProcessingOptions.TraceTransactions, writer, pipeWriter,
+                zeroBaseFeeForUnpricedCall: tx.MaxFeePerGas.IsZero);
         }
         finally
         {
@@ -176,7 +178,8 @@ public class GethStyleTracer(
     }
 
     private GethLikeTxTrace? TraceImpl(Block block, Hash256? txHash, CancellationToken cancellationToken, GethTraceOptions options,
-        ProcessingOptions processingOptions = ProcessingOptions.Trace, Utf8JsonWriter? writer = null, PipeWriter? pipeWriter = null)
+        ProcessingOptions processingOptions = ProcessingOptions.Trace, Utf8JsonWriter? writer = null, PipeWriter? pipeWriter = null,
+        bool zeroBaseFeeForUnpricedCall = false)
     {
         ArgumentNullException.ThrowIfNull(txHash);
 
@@ -189,6 +192,11 @@ public class GethStyleTracer(
             : block.Header;
 
         options.BlockOverrides?.ApplyOverrides(block.Header);
+        if (zeroBaseFeeForUnpricedCall)
+        {
+            // EIP-1559 requires the base fee to be below the fee cap; match geth for unpriced calls.
+            block.Header.BaseFeePerGas = UInt256.Zero;
+        }
         using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(baseBlockHeader, options.StateOverrides);
 
         GethTraceOptions filtered = options with { TxHash = txHash };

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -185,7 +185,6 @@ public class GethStyleTracer(
         // which is set by the `BranchProcessor`, which mean the state override probably does not take affect.
         // However, when it is `TraceTransaction`, it applies `ForceSameBlock` to `BlockchainProcessor`, which will send the same
         // block as the baseBlock, which is important as the stateroot of the baseblock is modified in `BuildAndOverride`.
-        // Most callers pass a block owned by the block tree, so clone before mutating its header below.
         if (options.BlockOverrides is not null || options.NoBaseFee)
         {
             block = block.WithReplacedBodyCloned(block.Body);
@@ -198,7 +197,6 @@ public class GethStyleTracer(
         options.BlockOverrides?.ApplyOverrides(block.Header);
         if (options.NoBaseFee)
         {
-            // Geth applies block overrides before resetting the base fee for an unpriced call.
             block.Header.BaseFeePerGas = UInt256.Zero;
         }
         using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(baseBlockHeader, options.StateOverrides);

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -185,6 +185,12 @@ public class GethStyleTracer(
         // which is set by the `BranchProcessor`, which mean the state override probably does not take affect.
         // However, when it is `TraceTransaction`, it applies `ForceSameBlock` to `BlockchainProcessor`, which will send the same
         // block as the baseBlock, which is important as the stateroot of the baseblock is modified in `BuildAndOverride`.
+        // Most callers pass a block owned by the block tree, so clone before mutating its header below.
+        if (options.BlockOverrides is not null || options.NoBaseFee)
+        {
+            block = block.WithReplacedBodyCloned(block.Body);
+        }
+
         BlockHeader baseBlockHeader = (processingOptions & ProcessingOptions.ForceSameBlock) == 0
             ? FindParent(block)
             : block.Header;

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -65,8 +65,7 @@ public class GethStyleTracer(
 
         try
         {
-            return TraceImpl(block, tx.Hash, cancellationToken, options, ProcessingOptions.TraceTransactions, writer, pipeWriter,
-                zeroBaseFeeForUnpricedCall: tx.MaxFeePerGas.IsZero);
+            return TraceImpl(block, tx.Hash, cancellationToken, options, ProcessingOptions.TraceTransactions, writer, pipeWriter);
         }
         finally
         {
@@ -178,8 +177,7 @@ public class GethStyleTracer(
     }
 
     private GethLikeTxTrace? TraceImpl(Block block, Hash256? txHash, CancellationToken cancellationToken, GethTraceOptions options,
-        ProcessingOptions processingOptions = ProcessingOptions.Trace, Utf8JsonWriter? writer = null, PipeWriter? pipeWriter = null,
-        bool zeroBaseFeeForUnpricedCall = false)
+        ProcessingOptions processingOptions = ProcessingOptions.Trace, Utf8JsonWriter? writer = null, PipeWriter? pipeWriter = null)
     {
         ArgumentNullException.ThrowIfNull(txHash);
 
@@ -192,9 +190,9 @@ public class GethStyleTracer(
             : block.Header;
 
         options.BlockOverrides?.ApplyOverrides(block.Header);
-        if (zeroBaseFeeForUnpricedCall)
+        if (options.NoBaseFee)
         {
-            // EIP-1559 requires the base fee to be below the fee cap; match geth for unpriced calls.
+            // Geth applies block overrides before resetting the base fee for an unpriced call.
             block.Header.BaseFeePerGas = UInt256.Zero;
         }
         using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(baseBlockHeader, options.StateOverrides);

--- a/src/Nethermind/Nethermind.Evm/BlockOverride.cs
+++ b/src/Nethermind/Nethermind.Evm/BlockOverride.cs
@@ -45,8 +45,7 @@ public class BlockOverride
         // (and for simulate via IBlobBaseFeeOverrideProvider) instead.
     }
 
-    /// <summary>Returns a shallow copy with the base fee replaced by <paramref name="baseFee"/>.</summary>
-    public BlockOverride WithBaseFee(in UInt256 baseFee)
+    public BlockOverride WithBaseFee(UInt256 baseFee)
     {
         BlockOverride copy = (BlockOverride)MemberwiseClone();
         copy.BaseFeePerGas = baseFee;

--- a/src/Nethermind/Nethermind.Evm/BlockOverride.cs
+++ b/src/Nethermind/Nethermind.Evm/BlockOverride.cs
@@ -44,4 +44,12 @@ public class BlockOverride
         // EIP-4844 formula. The override is applied via BlobBaseFeeOverrideCalculatorDecorator
         // (and for simulate via IBlobBaseFeeOverrideProvider) instead.
     }
+
+    /// <summary>Returns a shallow copy with the base fee replaced by <paramref name="baseFee"/>.</summary>
+    public BlockOverride WithBaseFee(in UInt256 baseFee)
+    {
+        BlockOverride copy = (BlockOverride)MemberwiseClone();
+        copy.BaseFeePerGas = baseFee;
+        return copy;
+    }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceTransaction.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.TraceTransaction.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm;
+using Nethermind.Int256;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.FourByte;
@@ -32,6 +33,29 @@ public partial class DebugRpcModuleTests
         string response = await RpcTest.TestSerializedRequest(context.DebugRpcModule, "debug_traceTransaction", transaction.Hash, options);
 
         Assert.That(JToken.Parse(response), Is.EqualTo(JToken.Parse(expected)).Using(JToken.EqualityComparer));
+    }
+
+    [Test]
+    public async Task Debug_traceTransaction_with_block_override_does_not_mutate_cached_header()
+    {
+        using Context context = await Context.Create();
+
+        Transaction transaction = Build.A.Transaction
+            .WithNonce(context.Blockchain.ReadOnlyState.GetNonce(TestItem.AddressA))
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+        await context.Blockchain.AddBlock(transaction);
+
+        BlockHeader header = context.Blockchain.BlockTree.Head!.Header;
+        UInt256 baseFee = header.BaseFeePerGas;
+
+        GethTraceOptions options = new()
+        {
+            BlockOverrides = new BlockOverride { BaseFeePerGas = baseFee + UInt256.One }
+        };
+        await RpcTest.TestSerializedRequest(context.DebugRpcModule, "debug_traceTransaction", transaction.Hash, options);
+
+        Assert.That(header.BaseFeePerGas, Is.EqualTo(baseFee), "block override must not write into the block-tree-cached header");
     }
 
     [TestCaseSource(nameof(TraceTransactionTransferSource))]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
@@ -107,30 +107,52 @@ public partial class DebugRpcModuleTests
         RpcTest.AssertSuccess(response);
     }
 
-    [Test]
-    public async Task Debug_traceCall_without_gas_pricing_uses_zero_base_fee()
+    [TestCase(false, false, false, TestName = "Debug_traceCall_without_gas_pricing_uses_zero_base_fee")]
+    [TestCase(false, false, true, TestName = "Debug_traceCall_without_gas_pricing_ignores_base_fee_override")]
+    [TestCase(true, true, false, TestName = "Debug_traceCall_with_max_fee_uses_live_base_fee")]
+    [TestCase(true, true, true, TestName = "Debug_traceCall_with_max_fee_uses_base_fee_override")]
+    public async Task Debug_traceCall_uses_expected_base_fee(bool includeMaxFeePerGas, bool includeMaxPriorityFeePerGas, bool overrideBaseFee)
     {
         OverridableReleaseSpec releaseSpec = new(London.Instance) { Eip1559TransitionBlock = 1 };
         using Context ctx = await Context.Create(new TestSpecProvider(releaseSpec));
 
-        Assert.That(ctx.Blockchain.BlockTree.Head!.Header.BaseFeePerGas, Is.Not.EqualTo(UInt256.Zero));
+        UInt256 baseFee = ctx.Blockchain.BlockTree.Head!.Header.BaseFeePerGas;
+        Assert.That(baseFee, Is.Not.EqualTo(UInt256.Zero));
+
+        Address sender = Build.An.Address.TestObject;
+        Dictionary<string, object?> transaction = new()
+        {
+            ["from"] = $"{sender}",
+            ["data"] = "0x4860005260206000f3"
+        };
+        if (includeMaxFeePerGas)
+            transaction["maxFeePerGas"] = "0x100000000";
+        if (includeMaxPriorityFeePerGas)
+            transaction["maxPriorityFeePerGas"] = "0x1";
+
+        object stateOverride = JsonSerializer.Deserialize<object>(
+            "{\"" + sender + "\":{\"balance\":\"0x56BC75E2D63100000\"}}")!;
+        object? options = overrideBaseFee
+            ? new
+            {
+                stateOverrides = stateOverride,
+                blockOverrides = new { baseFeePerGas = "0x100" }
+            }
+            : new { stateOverrides = stateOverride };
 
         string response = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
-            new { data = "0x4860005260206000f3" });
-        string overriddenResponse = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
-            new { data = "0x4860005260206000f3" }, null, new
-            {
-                blockOverrides = new { baseFeePerGas = "0x100" }
-            });
+            transaction, null, options);
 
         JToken result = JToken.Parse(response)["result"]!;
-        JToken overriddenResult = JToken.Parse(overriddenResponse)["result"]!;
+        UInt256 expectedBaseFee = !includeMaxFeePerGas && !includeMaxPriorityFeePerGas
+            ? UInt256.Zero
+            : overrideBaseFee
+                ? (UInt256)0x100
+                : baseFee;
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result["failed"]?.Value<bool>(), Is.False);
-            Assert.That(result["returnValue"]?.Value<string>(), Is.EqualTo("0x0000000000000000000000000000000000000000000000000000000000000000"));
-            Assert.That(overriddenResult["failed"]?.Value<bool>(), Is.False);
-            Assert.That(overriddenResult["returnValue"]?.Value<string>(), Is.EqualTo("0x0000000000000000000000000000000000000000000000000000000000000000"));
+            Assert.That(ParseReturnValue(response).ToUInt256(), Is.EqualTo(expectedBaseFee));
         }
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.cs
@@ -14,6 +14,9 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using Nethermind.JsonRpc.Modules.DebugModule;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -102,6 +105,33 @@ public partial class DebugRpcModuleTests
         );
 
         RpcTest.AssertSuccess(response);
+    }
+
+    [Test]
+    public async Task Debug_traceCall_without_gas_pricing_uses_zero_base_fee()
+    {
+        OverridableReleaseSpec releaseSpec = new(London.Instance) { Eip1559TransitionBlock = 1 };
+        using Context ctx = await Context.Create(new TestSpecProvider(releaseSpec));
+
+        Assert.That(ctx.Blockchain.BlockTree.Head!.Header.BaseFeePerGas, Is.Not.EqualTo(UInt256.Zero));
+
+        string response = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
+            new { data = "0x4860005260206000f3" });
+        string overriddenResponse = await RpcTest.TestSerializedRequest(ctx.DebugRpcModule, "debug_traceCall",
+            new { data = "0x4860005260206000f3" }, null, new
+            {
+                blockOverrides = new { baseFeePerGas = "0x100" }
+            });
+
+        JToken result = JToken.Parse(response)["result"]!;
+        JToken overriddenResult = JToken.Parse(overriddenResponse)["result"]!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result["failed"]?.Value<bool>(), Is.False);
+            Assert.That(result["returnValue"]?.Value<string>(), Is.EqualTo("0x0000000000000000000000000000000000000000000000000000000000000000"));
+            Assert.That(overriddenResult["failed"]?.Value<bool>(), Is.False);
+            Assert.That(overriddenResult["returnValue"]?.Value<string>(), Is.EqualTo("0x0000000000000000000000000000000000000000000000000000000000000000"));
+        }
     }
 
     [TestCase(

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -219,6 +219,27 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Estimate_gas_feeless_with_positive_blockOverride_baseFeePerGas_uses_zero_base_fee()
+    {
+        // Scenario: caller sends no fee fields (fee-less call) but blockOverride.baseFeePerGas > 0.
+        // The code reverts when BASEFEE is non-zero, so a successful estimate proves the base fee
+        // override was dropped — matching eth_call's behaviour for the same request body.
+        using Context ctx = await Context.CreateWithLondonEnabled();
+
+        const string revertOnNonZeroBaseFee = "0x4860095760006000f35b60006000fd";
+        object? transaction = JsonSerializer.Deserialize<object>(
+            $"{{\"from\":\"{SecondaryTestAddress}\",\"to\":\"{SecondaryTestAddress}\",\"data\":\"{revertOnNonZeroBaseFee}\"}}");
+        object? stateOverride = JsonSerializer.Deserialize<object>(
+            $"{{\"{SecondaryTestAddress}\":{{\"code\":\"{revertOnNonZeroBaseFee}\"}}}}");
+        object? blockOverride = JsonSerializer.Deserialize<object>("""{"baseFeePerGas":"0x100"}""");
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest", stateOverride, blockOverride);
+
+        Assert.That(JToken.Parse(serialized)["error"], Is.Null, "unpriced estimate must zero the base fee override instead of reverting");
+        Assert.That(JToken.Parse(serialized)["result"], Is.Not.Null);
+    }
+
+    [Test]
     public async Task Estimate_gas_with_revert()
     {
         using Context ctx = await Context.CreateWithLondonEnabled();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -221,9 +221,6 @@ public partial class EthRpcModuleTests
     [Test]
     public async Task Estimate_gas_feeless_with_positive_blockOverride_baseFeePerGas_uses_zero_base_fee()
     {
-        // Scenario: caller sends no fee fields (fee-less call) but blockOverride.baseFeePerGas > 0.
-        // The code reverts when BASEFEE is non-zero, so a successful estimate proves the base fee
-        // override was dropped — matching eth_call's behaviour for the same request body.
         using Context ctx = await Context.CreateWithLondonEnabled();
 
         const string revertOnNonZeroBaseFee = "0x4860095760006000f35b60006000fd";

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -902,18 +902,20 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
-    public async Task Eth_call_feeless_with_positive_blockOverride_baseFeePerGas_succeeds()
+    public async Task Eth_call_feeless_with_positive_blockOverride_baseFeePerGas_uses_zero_base_fee()
     {
         // Scenario: caller sends no fee fields (fee-less call) but blockOverride.baseFeePerGas > 0.
         using Context ctx = await Context.CreateWithLondonEnabled();
 
         object? transaction = JsonSerializer.Deserialize<object>(
-            $"{{\"from\":\"{SecondaryTestAddress}\",\"to\":\"0xc200000000000000000000000000000000000000\"}}");
+            $"{{\"from\":\"{SecondaryTestAddress}\",\"to\":\"{SecondaryTestAddress}\",\"data\":\"{BaseFeeReturnCode.ToHexString(true)}\"}}");
+        object? stateOverride = JsonSerializer.Deserialize<object>(
+            $"{{\"{SecondaryTestAddress}\":{{\"code\":\"{BaseFeeReturnCode.ToHexString(true)}\"}}}}");
         object? blockOverride = JsonSerializer.Deserialize<object>("""{"baseFeePerGas":"0x100"}""");
 
-        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction, "latest", null, blockOverride);
+        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction, "latest", stateOverride, blockOverride);
 
-        Assert.That(JToken.Parse(serialized)["error"], Is.Null, "fee-less call must succeed even when blockOverride.baseFeePerGas > 0");
+        Assert.That(JToken.Parse(serialized)["result"]?.Value<string>(), Is.EqualTo("0x0000000000000000000000000000000000000000000000000000000000000000"));
     }
 
     [TestCase(

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -120,9 +120,13 @@ public class DebugRpcModule(
             return ResultWrapper<GethLikeTxTrace>.Fail(error, ErrorCodes.InvalidInput);
         }
 
+        GethTraceOptions effective = (options ?? GethTraceOptions.Default) with
+        {
+            NoBaseFee = !call.ShouldSetBaseFee()
+        };
+
         if (CanStreamStructLogs(options))
         {
-            GethTraceOptions effective = options ?? GethTraceOptions.Default;
             return ResultWrapper<GethLikeTxTrace>.Success(BuildStreamingResult(
                 (writer, pipeWriter, token) =>
                     debugBridge.GetTransactionTrace(tx, blockParameter, token, effective, writer, pipeWriter)));
@@ -134,7 +138,7 @@ public class DebugRpcModule(
         GethLikeTxTrace? transactionTrace;
         try
         {
-            transactionTrace = debugBridge.GetTransactionTrace(tx, blockParameter, cancellationToken, options);
+            transactionTrace = debugBridge.GetTransactionTrace(tx, blockParameter, cancellationToken, effective);
         }
         catch (InsufficientBalanceException ex)
         {

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
@@ -22,7 +22,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
         private abstract class TxExecutor<TResult>(IBlockchainBridge blockchainBridge, IBlockFinder blockFinder, IJsonRpcConfig rpcConfig, ISpecProvider specProvider)
             : ExecutorBase<TResult, TransactionForRpc, Transaction>(blockchainBridge, blockFinder, rpcConfig)
         {
-            private bool NoBaseFee { get; set; }
+            protected bool NoBaseFee { get; private set; }
             private BlockOverride? _blockOverride;
             protected BlockOverride? BlockOverride => _blockOverride;
             protected UInt256? BlobBaseFeeOverride => _blockOverride?.BlobBaseFee;
@@ -123,7 +123,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
         {
             protected override ResultWrapper<HexBytes> ExecuteTx(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, CancellationToken token)
             {
-                CallOutput result = _blockchainBridge.Call(header, tx, stateOverride, BlobBaseFeeOverride, BlockOverride, token);
+                CallOutput result = _blockchainBridge.Call(header, tx, stateOverride, BlobBaseFeeOverride, GetBlockOverrideForExecution(), token);
 
                 if (!result.ExecutionReverted && result.Error is not null)
                 {
@@ -135,6 +135,23 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
                 HexBytes outputData = result.OutputData is null ? default : new HexBytes(result.OutputData);
                 return CreateResultWrapper(result.InputError, result.Error, outputData, result.ExecutionReverted, result.OutputData);
+            }
+
+            private BlockOverride? GetBlockOverrideForExecution()
+            {
+                if (!NoBaseFee || BlockOverride?.BaseFeePerGas is null)
+                    return BlockOverride;
+
+                return new BlockOverride
+                {
+                    Number = BlockOverride.Number,
+                    PrevRandao = BlockOverride.PrevRandao,
+                    Time = BlockOverride.Time,
+                    GasLimit = BlockOverride.GasLimit,
+                    FeeRecipient = BlockOverride.FeeRecipient,
+                    BaseFeePerGas = UInt256.Zero,
+                    BlobBaseFee = BlockOverride.BlobBaseFee
+                };
             }
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.TransactionExecutor.cs
@@ -27,6 +27,11 @@ namespace Nethermind.JsonRpc.Modules.Eth
             protected BlockOverride? BlockOverride => _blockOverride;
             protected UInt256? BlobBaseFeeOverride => _blockOverride?.BlobBaseFee;
 
+            protected BlockOverride? BlockOverrideForExecution =>
+                !NoBaseFee || _blockOverride?.BaseFeePerGas is null
+                    ? _blockOverride
+                    : _blockOverride.WithBaseFee(UInt256.Zero);
+
             protected IReleaseSpec GetSpec(BlockHeader header) => specProvider.GetSpec(header);
 
             protected override Result<Transaction> Prepare(TransactionForRpc call, BlockHeader header)
@@ -123,7 +128,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
         {
             protected override ResultWrapper<HexBytes> ExecuteTx(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, CancellationToken token)
             {
-                CallOutput result = _blockchainBridge.Call(header, tx, stateOverride, BlobBaseFeeOverride, GetBlockOverrideForExecution(), token);
+                CallOutput result = _blockchainBridge.Call(header, tx, stateOverride, BlobBaseFeeOverride, BlockOverrideForExecution, token);
 
                 if (!result.ExecutionReverted && result.Error is not null)
                 {
@@ -135,23 +140,6 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
                 HexBytes outputData = result.OutputData is null ? default : new HexBytes(result.OutputData);
                 return CreateResultWrapper(result.InputError, result.Error, outputData, result.ExecutionReverted, result.OutputData);
-            }
-
-            private BlockOverride? GetBlockOverrideForExecution()
-            {
-                if (!NoBaseFee || BlockOverride?.BaseFeePerGas is null)
-                    return BlockOverride;
-
-                return new BlockOverride
-                {
-                    Number = BlockOverride.Number,
-                    PrevRandao = BlockOverride.PrevRandao,
-                    Time = BlockOverride.Time,
-                    GasLimit = BlockOverride.GasLimit,
-                    FeeRecipient = BlockOverride.FeeRecipient,
-                    BaseFeePerGas = UInt256.Zero,
-                    BlobBaseFee = BlockOverride.BlobBaseFee
-                };
             }
         }
 
@@ -186,7 +174,7 @@ namespace Nethermind.JsonRpc.Modules.Eth
 
             protected override ResultWrapper<UInt256?> ExecuteTx(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride> stateOverride, CancellationToken token)
             {
-                CallOutput result = _blockchainBridge.EstimateGas(header, tx, _errorMargin, stateOverride, BlobBaseFeeOverride, BlockOverride, token);
+                CallOutput result = _blockchainBridge.EstimateGas(header, tx, _errorMargin, stateOverride, BlobBaseFeeOverride, BlockOverrideForExecution, token);
 
                 string? errorMessage = result.Error;
                 if (!result.ExecutionReverted && !result.InputError && errorMessage is not null)


### PR DESCRIPTION
## Changes

- Align `debug_traceCall` with Geth by using a zero base fee when the call has no gas pricing.
- Apply the zeroing after block overrides so an unpriced call remains unpriced even when an override supplies a base fee.
- Add a regression test covering both the default and overridden base-fee paths.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- The focused `debug_traceCall_without_gas_pricing_uses_zero_base_fee` regression test passed.
- The release solution build completed with warnings treated as errors.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Geth lowers the base fee to zero for unpriced `debug_traceCall` requests. Without that behavior, BASEFEE-dependent calls can diverge from Geth or fail in the trace context when the live block base fee is non-zero.
