### PR TITLE
Surface EIP-2780 runtime OOG from eth_call

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -558,6 +558,56 @@ public class BlockProcessorTests
         processor.TransactionsExecuted -= handler;
     }
 
+    // Regression: a top-frame EIP-8037 state-gas OOG tx halts before EVM dispatch but is a valid,
+    // executed transaction — a block must include it between successful txs with a failed receipt.
+    [Test]
+    public async Task Block_with_top_frame_state_gas_oog_tx_processes_with_failed_receipt()
+    {
+        TestSpecProvider specProvider = new(Amsterdam.Instance) { AllowTestChainOverride = false };
+        using BasicTestBlockchain chain = await BasicTestBlockchain.Create(builder => builder
+            .AddSingleton<ISpecProvider>(specProvider));
+
+        IReleaseSpec spec = Amsterdam.Instance;
+        Address freshRecipient = Address.FromNumber(0x8037);
+
+        // Senders B and C only: A has code at genesis and Amsterdam enforces EIP-3607.
+        Transaction okTx1 = Build.A.Transaction
+            .WithTo(TestItem.AddressB)
+            .WithValue(1.Wei)
+            .WithNonce(0)
+            .WithGasLimit(100_000)
+            .SignedAndResolved(TestItem.PrivateKeyC, spec.IsEip155Enabled)
+            .TestObject;
+        Transaction oogTx = Build.A.Transaction
+            .WithTo(freshRecipient)
+            .WithValue(1.Wei)
+            .WithNonce(0)
+            .SignedAndResolved(TestItem.PrivateKeyB, spec.IsEip155Enabled)
+            .TestObject;
+        oogTx.GasLimit = IntrinsicGasCalculator.Calculate(oogTx, spec).Standard + (ulong)GasCostOf.NewAccountState - 1;
+        Transaction okTx2 = Build.A.Transaction
+            .WithTo(TestItem.AddressB)
+            .WithValue(1.Wei)
+            .WithNonce(1)
+            .WithGasLimit(100_000)
+            .SignedAndResolved(TestItem.PrivateKeyC, spec.IsEip155Enabled)
+            .TestObject;
+
+        Block block = await chain.AddBlock(okTx1, oogTx, okTx2);
+
+        TxReceipt[] receipts = chain.ReceiptStorage.Get(block);
+        int failedIndex = Array.FindIndex(receipts, r => r.TxHash == oogTx.Hash);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(block.Transactions, Has.Length.EqualTo(3), "all txs, including the halted one, must be included");
+            Assert.That(receipts, Has.Length.EqualTo(3));
+            Assert.That(failedIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(receipts[failedIndex].StatusCode, Is.EqualTo(StatusCode.Failure));
+            Assert.That(receipts[failedIndex].GasUsed, Is.EqualTo(oogTx.GasLimit), "the halted tx burns its full gas limit");
+            Assert.That(Array.FindAll(receipts, r => r.TxHash != oogTx.Hash && r.StatusCode == StatusCode.Success), Has.Length.EqualTo(2));
+        }
+    }
+
     [Test]
     public void BlockProductionTransactionPicker_validates_block_length_using_proper_tx_form()
     {

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.SimpleTransfer.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.SimpleTransfer.cs
@@ -238,8 +238,9 @@ public partial class TransactionProcessorTests
         IReleaseSpec spec = _specProvider.GetSpec(block.Header);
         EthereumIntrinsicGas intrinsicGas = IntrinsicGasCalculator.Calculate(transaction, spec);
         transaction.GasLimit = intrinsicGas.Standard + (ulong)GasCostOf.NewAccountState - 1;
+        SimpleTransferActionTracer tracer = new();
 
-        TransactionResult result = transactionProcessor.Execute(transaction, new BlockExecutionContext(block.Header, spec), NullTxTracer.Instance);
+        TransactionResult result = transactionProcessor.Execute(transaction, new BlockExecutionContext(block.Header, spec), tracer);
 
         using (Assert.EnterMultipleScope())
         {
@@ -247,6 +248,10 @@ public partial class TransactionProcessorTests
             Assert.That(result.EvmExceptionType, Is.EqualTo(EvmExceptionType.OutOfGas));
             Assert.That(virtualMachine.ExecuteTransactionCalls, Is.EqualTo(0));
             Assert.That(_stateProvider.GetBalance(deadRecipient), Is.EqualTo(UInt256.Zero));
+            Assert.That(tracer.ActionCalls, Is.EqualTo(1));
+            Assert.That(tracer.ActionGas, Is.EqualTo((ulong)GasCostOf.NewAccountState - 1));
+            Assert.That(tracer.ActionErrorCalls, Is.EqualTo(1));
+            Assert.That(tracer.ActionErrorType, Is.EqualTo(EvmExceptionType.OutOfGas));
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.SimpleTransfer.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.SimpleTransfer.cs
@@ -84,6 +84,7 @@ public partial class TransactionProcessorTests
             Assert.That(tracer.ActionEndCalls, Is.EqualTo(1));
             Assert.That(tracer.ActionGas, Is.EqualTo(tx.GasLimit - GasCostOf.Transaction));
             Assert.That(tracer.ActionEndGas, Is.EqualTo(tx.GasLimit - GasCostOf.Transaction));
+            Assert.That(tracer.ActionErrorCalls, Is.EqualTo(0));
             Assert.That(tracer.ActionValue, Is.EqualTo((UInt256)7.Wei));
             Assert.That(tracer.ActionFrom, Is.EqualTo(TestItem.AddressA));
             Assert.That(tracer.ActionTo, Is.EqualTo(recipient));
@@ -91,6 +92,37 @@ public partial class TransactionProcessorTests
             Assert.That(tracer.ActionType, Is.EqualTo(ExecutionType.TRANSACTION));
             Assert.That(tracer.IsPrecompileCall, Is.False);
             Assert.That(tracer.ActionOutput, Is.Empty);
+        }
+    }
+
+    [Test]
+    public void Eip8037_simple_transfer_reports_runtime_out_of_gas_to_action_trace()
+    {
+        IReleaseSpec spec = Amsterdam.Instance;
+        ISpecProvider specProvider = new TestSpecProvider(spec);
+        _stateProvider.Commit(spec);
+        _stateProvider.CommitTree(0);
+
+        (CountingVirtualMachine virtualMachine, EthereumTransactionProcessor transactionProcessor) = CreateProcessor(specProvider);
+
+        Address deadRecipient = Address.FromNumber((UInt256)2103);
+        Transaction tx = BuildSimpleTransfer(deadRecipient, 1.Wei, withAuthorizationList: false, gasLimit: 1_000_000);
+        EthereumIntrinsicGas intrinsicGas = IntrinsicGasCalculator.Calculate(tx, spec);
+        tx.GasLimit = intrinsicGas.Standard + (ulong)GasCostOf.NewAccountState - 1;
+        Block block = BuildAmsterdamBlock(tx);
+        SimpleTransferActionTracer tracer = new();
+
+        TransactionResult result = transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, spec), tracer);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(result.EvmExceptionType, Is.EqualTo(EvmExceptionType.OutOfGas));
+            Assert.That(virtualMachine.ExecuteTransactionCalls, Is.EqualTo(0));
+            Assert.That(tracer.ActionCalls, Is.EqualTo(1));
+            Assert.That(tracer.ActionEndCalls, Is.EqualTo(0));
+            Assert.That(tracer.ActionErrorCalls, Is.EqualTo(1));
+            Assert.That(tracer.ActionErrorType, Is.EqualTo(EvmExceptionType.OutOfGas));
         }
     }
 
@@ -397,6 +429,8 @@ public partial class TransactionProcessorTests
         public override bool IsTracingActions { get; protected set; } = true;
         public int ActionCalls { get; private set; }
         public int ActionEndCalls { get; private set; }
+        public int ActionErrorCalls { get; private set; }
+        public EvmExceptionType ActionErrorType { get; private set; }
         public ulong ActionGas { get; private set; }
         public ulong ActionEndGas { get; private set; }
         public UInt256 ActionValue { get; private set; }
@@ -424,6 +458,12 @@ public partial class TransactionProcessorTests
             ActionEndCalls++;
             ActionEndGas = gas;
             ActionOutput = output.ToArray();
+        }
+
+        public override void ReportActionError(EvmExceptionType evmExceptionType)
+        {
+            ActionErrorCalls++;
+            ActionErrorType = evmExceptionType;
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.SimpleTransfer.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionProcessorTests.SimpleTransfer.cs
@@ -195,6 +195,29 @@ public partial class TransactionProcessorTests
         }
     }
 
+    [Test]
+    public void Eip8037_evm_path_value_transfer_to_dead_recipient_reports_runtime_out_of_gas()
+    {
+        (CountingVirtualMachine virtualMachine, EthereumTransactionProcessor transactionProcessor) = CreateProcessor(_specProvider);
+
+        Address deadRecipient = Address.FromNumber((UInt256)2102);
+        Transaction transaction = BuildSetCodeTransfer(deadRecipient, 1.Wei, TestItem.PrivateKeyA, TestItem.PrivateKeyD, 0);
+        Block block = BuildAmsterdamBlock(transaction);
+        IReleaseSpec spec = _specProvider.GetSpec(block.Header);
+        EthereumIntrinsicGas intrinsicGas = IntrinsicGasCalculator.Calculate(transaction, spec);
+        transaction.GasLimit = intrinsicGas.Standard + (ulong)GasCostOf.NewAccountState - 1;
+
+        TransactionResult result = transactionProcessor.Execute(transaction, new BlockExecutionContext(block.Header, spec), NullTxTracer.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(result.EvmExceptionType, Is.EqualTo(EvmExceptionType.OutOfGas));
+            Assert.That(virtualMachine.ExecuteTransactionCalls, Is.EqualTo(0));
+            Assert.That(_stateProvider.GetBalance(deadRecipient), Is.EqualTo(UInt256.Zero));
+        }
+    }
+
     // Regression: an empty precompile pays NEW_ACCOUNT like any other dead recipient.
     [Test]
     public void Eip8037_value_transfer_to_dead_precompile_charges_new_account_state_gas()

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
@@ -291,6 +291,10 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
             Assert.That(tracer.GasConsumedResult.SpentGas, Is.EqualTo(transaction.GasLimit));
             Assert.That(TestState.GetBalance(Sender), Is.EqualTo(senderBalanceBefore - transaction.GasLimit));
             Assert.That(TestState.AccountExists(contractAddress), Is.False);
+            Assert.That(tracer.Actions, Has.Count.EqualTo(1));
+            Assert.That(tracer.Actions[0].CallType, Is.EqualTo(ExecutionType.CREATE));
+            Assert.That(tracer.Actions[0].Gas, Is.EqualTo((ulong)GasCostOf.CreateState - 1));
+            Assert.That(tracer.ReportedActionErrors, Is.EqualTo(new[] { EvmExceptionType.OutOfGas }));
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -442,6 +442,7 @@ namespace Nethermind.Evm.TransactionProcessing
             bool hasValueTransfer = !value.IsZero;
             bool senderIsRecipient = tx.SenderAddress == recipient;
             bool isTracingActions = tracer.IsTracingActions;
+            TGasPolicy actionGasBeforeNewAccountCharge = gasAvailable;
 
             // EIP-8037: a value transfer materialising a new (dead) recipient — including an empty
             // precompile — pays NEW_ACCOUNT state gas; if uncovered, no value moves and all gas is forfeit.
@@ -460,11 +461,6 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 if (hasValueTransfer) PayValue(tx, spec, opts);
                 WorldState.AddToBalanceAndCreateIfNotExists(recipient, in hasValueTransfer ? ref value : ref UInt256.Zero, spec);
-            }
-
-            if (isTracingActions)
-            {
-                TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in gasAvailable);
             }
 
             JournalCollection<LogEntry>? logs = null;
@@ -489,10 +485,12 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 if (newAccountOutOfGas)
                 {
+                    TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in actionGasBeforeNewAccountCharge);
                     tracer.ReportActionError(EvmExceptionType.OutOfGas);
                 }
                 else
                 {
+                    TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in gasAvailable);
                     tracer.ReportActionEnd(TGasPolicy.GetRemainingGas(in gasAvailable), default);
                 }
             }
@@ -528,6 +526,23 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 tracer.ReportByteCode(default);
             }
+        }
+
+        private static void TraceHaltedTopFrameAction(Transaction tx, ExecutionEnvironment env, ITxTracer tracer, in TGasPolicy gasAvailable)
+        {
+            if (!tracer.IsTracingActions) return;
+
+            bool isContractCreation = tx.IsContractCreation;
+            tracer.ReportAction(
+                TGasPolicy.GetRemainingGas(in gasAvailable),
+                env.Value,
+                env.Caller,
+                env.CodeSource ?? env.ExecutingAccount,
+                isContractCreation ? env.CodeInfo.Code : env.InputData,
+                isContractCreation ? ExecutionType.CREATE : ExecutionType.TRANSACTION);
+
+            if (tracer.IsTracingCode) tracer.ReportByteCode(env.CodeInfo.Code);
+            tracer.ReportActionError(EvmExceptionType.OutOfGas);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1305,6 +1320,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (topFrameOutOfGas)
             {
+                TraceHaltedTopFrameAction(tx, env, tracer, in gasAvailable);
                 substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracing);
                 TGasPolicy.SetOutOfGas(ref gasAvailable);
                 TGasPolicy oogIntrinsicGasStandard = gas.Standard;
@@ -1353,6 +1369,7 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 if (spec.IsEip8037Enabled && topLevelCreateStateGasCharged && !TGasPolicy.ConsumeCreateStateGas(ref state.Gas))
                 {
+                    TraceHaltedTopFrameAction(tx, env, tracer, in gasAvailable);
                     substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracing);
                     gasAvailable = state.Gas;
                     TGasPolicy.SetOutOfGas(ref gasAvailable);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -482,6 +482,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 logs: logs,
                 shouldRevert: false,
                 isTracerConnected: false, // safe: the ctor reads this only when shouldRevert is true
+                evmExceptionType: newAccountOutOfGas ? EvmExceptionType.OutOfGas : EvmExceptionType.None,
                 logger: Logger);
 
             if (isTracingActions)
@@ -1292,6 +1293,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (topFrameOutOfGas)
             {
+                substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracing);
                 TGasPolicy.SetOutOfGas(ref gasAvailable);
                 TGasPolicy oogIntrinsicGasStandard = gas.Standard;
                 gasConsumed = CompleteEip8037Halt(tx, spec, opts, ref gasAvailable, VirtualMachine.TxExecutionContext.GasPrice, in oogIntrinsicGasStandard, floorGasLong, postIntrinsicStateReservoir);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -481,13 +481,20 @@ namespace Nethermind.Evm.TransactionProcessing
                 destroyList: null,
                 logs: logs,
                 shouldRevert: false,
-                isTracerConnected: false, // safe: the ctor reads this only when shouldRevert is true
+                isTracerConnected: false, // Keep IsError false: this is a valid transaction-level halt; EvmExceptionType is surfaced separately.
                 evmExceptionType: newAccountOutOfGas ? EvmExceptionType.OutOfGas : EvmExceptionType.None,
                 logger: Logger);
 
             if (isTracingActions)
             {
-                tracer.ReportActionEnd(TGasPolicy.GetRemainingGas(in gasAvailable), default);
+                if (newAccountOutOfGas)
+                {
+                    tracer.ReportActionError(EvmExceptionType.OutOfGas);
+                }
+                else
+                {
+                    tracer.ReportActionEnd(TGasPolicy.GetRemainingGas(in gasAvailable), default);
+                }
             }
 
             TGasPolicy floorGas = intrinsicGas.FloorGas;
@@ -644,7 +651,12 @@ namespace Nethermind.Evm.TransactionProcessing
                 if (statusCode == StatusCode.Failure)
                 {
                     byte[] output = substate.ShouldRevert ? substate.Output.AsReadOnlyArray() : [];
-                    tracer.MarkAsFailed(executingAccount, spentGas, output, substate.Error, stateRoot);
+                    string? error = substate.Error;
+                    if (error is null && substate.EvmExceptionType is not EvmExceptionType.None)
+                    {
+                        error = substate.EvmExceptionType.FastToString();
+                    }
+                    tracer.MarkAsFailed(executingAccount, spentGas, output, error, stateRoot);
                 }
                 else
                 {
@@ -1341,6 +1353,7 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 if (spec.IsEip8037Enabled && topLevelCreateStateGasCharged && !TGasPolicy.ConsumeCreateStateGas(ref state.Gas))
                 {
+                    substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracing);
                     gasAvailable = state.Gas;
                     TGasPolicy.SetOutOfGas(ref gasAvailable);
                     WorldState.Restore(snapshot);

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -463,6 +463,11 @@ namespace Nethermind.Evm.TransactionProcessing
                 WorldState.AddToBalanceAndCreateIfNotExists(recipient, in hasValueTransfer ? ref value : ref UInt256.Zero, spec);
             }
 
+            if (isTracingActions && !newAccountOutOfGas)
+            {
+                TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in gasAvailable);
+            }
+
             JournalCollection<LogEntry>? logs = null;
             if (spec.IsEip7708Enabled && hasValueTransfer && !senderIsRecipient && !newAccountOutOfGas)
             {
@@ -490,7 +495,6 @@ namespace Nethermind.Evm.TransactionProcessing
                 }
                 else
                 {
-                    TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in gasAvailable);
                     tracer.ReportActionEnd(TGasPolicy.GetRemainingGas(in gasAvailable), default);
                 }
             }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -442,7 +442,6 @@ namespace Nethermind.Evm.TransactionProcessing
             bool hasValueTransfer = !value.IsZero;
             bool senderIsRecipient = tx.SenderAddress == recipient;
             bool isTracingActions = tracer.IsTracingActions;
-            TGasPolicy actionGasBeforeNewAccountCharge = gasAvailable;
 
             // EIP-8037: a value transfer materialising a new (dead) recipient — including an empty
             // precompile — pays NEW_ACCOUNT state gas; if uncovered, no value moves and all gas is forfeit.
@@ -451,8 +450,6 @@ namespace Nethermind.Evm.TransactionProcessing
                 && WorldState.IsDeadAccount(recipient))
             {
                 newAccountOutOfGas = !TGasPolicy.ConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost());
-                if (newAccountOutOfGas)
-                    TGasPolicy.Consume(ref gasAvailable, TGasPolicy.GetRemainingGas(in gasAvailable));
             }
 
             // Self-send: sender account is already touched/warmed by gas charging and any
@@ -463,10 +460,14 @@ namespace Nethermind.Evm.TransactionProcessing
                 WorldState.AddToBalanceAndCreateIfNotExists(recipient, in hasValueTransfer ? ref value : ref UInt256.Zero, spec);
             }
 
-            if (isTracingActions && !newAccountOutOfGas)
+            if (isTracingActions)
             {
                 TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in gasAvailable);
             }
+
+            // Forfeit after the action start is traced: a halted frame reports the gas it would have received.
+            if (newAccountOutOfGas)
+                TGasPolicy.Consume(ref gasAvailable, TGasPolicy.GetRemainingGas(in gasAvailable));
 
             JournalCollection<LogEntry>? logs = null;
             if (spec.IsEip7708Enabled && hasValueTransfer && !senderIsRecipient && !newAccountOutOfGas)
@@ -481,8 +482,10 @@ namespace Nethermind.Evm.TransactionProcessing
                 refund: 0,
                 destroyList: null,
                 logs: logs,
+                // shouldRevert: false keeps IsError false — Refund and CalculateSpentGasAndRefund branch on
+                // IsError, so this halt must surface via EvmExceptionType only, or gas accounting changes.
                 shouldRevert: false,
-                isTracerConnected: false, // Keep IsError false: this is a valid transaction-level halt; EvmExceptionType is surfaced separately.
+                isTracerConnected: false, // safe: the ctor reads this only when shouldRevert is true
                 evmExceptionType: newAccountOutOfGas ? EvmExceptionType.OutOfGas : EvmExceptionType.None,
                 logger: Logger);
 
@@ -490,7 +493,6 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 if (newAccountOutOfGas)
                 {
-                    TraceSimpleTransferActionStart(tx, recipient, tracer, in value, in actionGasBeforeNewAccountCharge);
                     tracer.ReportActionError(EvmExceptionType.OutOfGas);
                 }
                 else
@@ -532,6 +534,7 @@ namespace Nethermind.Evm.TransactionProcessing
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void TraceHaltedTopFrameAction(Transaction tx, ExecutionEnvironment env, ITxTracer tracer, in TGasPolicy gasAvailable)
         {
             if (!tracer.IsTracingActions) return;
@@ -1343,6 +1346,7 @@ namespace Nethermind.Evm.TransactionProcessing
                     {
                         if (Logger.IsTrace) Logger.Trace("Restoring state from before transaction");
                         WorldState.Restore(snapshot);
+                        substate = new TransactionSubstate(EvmExceptionType.TransactionCollision, tracer.IsTracing);
                         TGasPolicy collisionIntrinsicGasStandard = gas.Standard;
                         gasConsumed = RefundOnContractCollision(
                             tx,
@@ -1451,6 +1455,13 @@ namespace Nethermind.Evm.TransactionProcessing
             goto Complete;
         FailContractCreate:
             if (Logger.IsTrace) Logger.Trace("Restoring state from before transaction");
+            // Surface the deployment failure to RPC while keeping Error null — IsError must stay
+            // false because Refund and CalculateSpentGasAndRefund branch on it for gas accounting.
+            EvmExceptionType deployException = CodeDepositHandler.CodeIsInvalid(spec, substate.Output)
+                ? EvmExceptionType.InvalidCode
+                : EvmExceptionType.OutOfGas;
+            substate = new(substate.Output, substate.Refund, substate.DestroyList, substate.Logs,
+                shouldRevert: false, isTracerConnected: false, evmExceptionType: deployException, logger: Logger);
             if (spec.ChargeForTopLevelCreate)
             {
                 TGasPolicy.SetOutOfGas(ref gasAvailable);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -31,8 +31,12 @@ namespace Nethermind.JsonRpc.Test.Modules.Eth;
 
 public partial class EthRpcModuleTests
 {
-    private const ulong Eip2780NewAccountTransferGas = 204600;
-    private const string Eip2780FreshRecipient = "0xc278000000000000000000000000000000000000";
+    private const ulong Eip8037NewAccountTransferGas = GasCostOf.TransactionEip2780
+        + Eip8038Constants.ColdAccountAccess
+        + GasCostOf.TxValueCostEip2780
+        + GasCostOf.TransferLogEip2780
+        + (ulong)GasCostOf.NewAccountState;
+    private const string FreshRecipientAddress = "0xc278000000000000000000000000000000000000";
 
     [Test]
     public async Task Eth_call_web3_sample()
@@ -255,13 +259,13 @@ public partial class EthRpcModuleTests
             Does.Contain("intrinsic gas too low"));
     }
 
-    [TestCase(Eip2780NewAccountTransferGas - 1, true)]
-    [TestCase(Eip2780NewAccountTransferGas, false)]
+    [TestCase(Eip8037NewAccountTransferGas - 1, true)]
+    [TestCase(Eip8037NewAccountTransferGas, false)]
     public async Task Eth_call_value_transfer_to_fresh_account_reports_runtime_out_of_gas(ulong gasLimit, bool expectedError)
     {
         using Context ctx = await Context.CreateWithAmsterdamEnabled();
         LegacyTransactionForRpc transaction = ctx.Test.JsonSerializer.Deserialize<LegacyTransactionForRpc>(
-            $$"""{"from":"{{SecondaryTestAddress}}","to":"{{Eip2780FreshRecipient}}","value":"0x1","gas":"0x{{gasLimit:X}}"}""");
+            $$"""{"from":"{{SecondaryTestAddress}}","to":"{{FreshRecipientAddress}}","value":"0x1","gas":"0x{{gasLimit:X}}"}""");
         object stateOverride = JsonSerializer.Deserialize<object>(
             $"{{\"{SecondaryTestAddress}\":{{\"balance\":\"0xde0b6b3a7640000\"}}}}")!;
 
@@ -655,6 +659,33 @@ public partial class EthRpcModuleTests
 
         Assert.That(
             serialized, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":\"0x\",\"id\":67}"));
+    }
+
+    [Test]
+    public async Task Eth_call_contract_creation_reports_runtime_out_of_gas()
+    {
+        using Context ctx = await Context.CreateWithAmsterdamEnabled();
+        byte[] code = Prepare.EvmCode
+            .Op(Instruction.STOP)
+            .Done;
+        Transaction tx = Build.A.Transaction
+            .WithData(code)
+            .WithGasLimit(1_000_000)
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+        EthereumIntrinsicGas intrinsicGas = IntrinsicGasCalculator.Calculate(tx, Amsterdam.Instance);
+        tx.GasLimit = intrinsicGas.Standard + (ulong)GasCostOf.CreateState - 1;
+        LegacyTransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
+        transaction.To = null;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction);
+        JToken response = JToken.Parse(serialized);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response["error"]!["code"]!.Value<int>(), Is.EqualTo(-32000));
+            Assert.That(response["error"]!["message"]!.Value<string>(), Is.EqualTo("out of gas"));
+        }
     }
 
     [TestCase(null)]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -31,6 +31,9 @@ namespace Nethermind.JsonRpc.Test.Modules.Eth;
 
 public partial class EthRpcModuleTests
 {
+    private const ulong Eip2780NewAccountTransferGas = 204600;
+    private const string Eip2780FreshRecipient = "0xc278000000000000000000000000000000000000";
+
     [Test]
     public async Task Eth_call_web3_sample()
     {
@@ -250,6 +253,33 @@ public partial class EthRpcModuleTests
         Assert.That(
             JToken.Parse(serialized)["error"]!["message"]!.Value<string>(),
             Does.Contain("intrinsic gas too low"));
+    }
+
+    [TestCase(Eip2780NewAccountTransferGas - 1, true)]
+    [TestCase(Eip2780NewAccountTransferGas, false)]
+    public async Task Eth_call_value_transfer_to_fresh_account_reports_runtime_out_of_gas(ulong gasLimit, bool expectedError)
+    {
+        using Context ctx = await Context.CreateWithAmsterdamEnabled();
+        LegacyTransactionForRpc transaction = ctx.Test.JsonSerializer.Deserialize<LegacyTransactionForRpc>(
+            $$"""{"from":"{{SecondaryTestAddress}}","to":"{{Eip2780FreshRecipient}}","value":"0x1","gas":"0x{{gasLimit:X}}"}""");
+        object stateOverride = JsonSerializer.Deserialize<object>(
+            $"{{\"{SecondaryTestAddress}\":{{\"balance\":\"0xde0b6b3a7640000\"}}}}")!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction, "latest", stateOverride);
+        JToken response = JToken.Parse(serialized);
+
+        if (expectedError)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(response["error"]!["code"]!.Value<int>(), Is.EqualTo(-32000));
+                Assert.That(response["error"]!["message"]!.Value<string>(), Is.EqualTo("out of gas"));
+            }
+        }
+        else
+        {
+            Assert.That(response["result"]!.Value<string>(), Is.EqualTo("0x"));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -688,6 +688,95 @@ public partial class EthRpcModuleTests
         }
     }
 
+    [Test]
+    public async Task Eth_call_contract_creation_reports_code_deposit_out_of_gas()
+    {
+        using Context ctx = await Context.CreateWithCancunEnabled();
+        byte[] code = Prepare.EvmCode
+            .PushData(32) // size
+            .PushData(0) // offset
+            .Op(Instruction.RETURN) // returns 32 zero bytes; deposit costs 32 * GasCostOf.CodeDeposit
+            .Done;
+        Transaction tx = Build.A.Transaction
+            .WithData(code)
+            .WithGasLimit(1_000_000)
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+        tx.To = null;
+        EthereumIntrinsicGas intrinsicGas = IntrinsicGasCalculator.Calculate(tx, Cancun.Instance);
+        // Covers intrinsic and initcode execution but not the 6,400 gas code deposit.
+        tx.GasLimit = intrinsicGas.Standard + 1_000;
+        LegacyTransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
+
+        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction);
+        JToken response = JToken.Parse(serialized);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response["error"]!["code"]!.Value<int>(), Is.EqualTo(-32000));
+            Assert.That(response["error"]!["message"]!.Value<string>(), Is.EqualTo("out of gas"));
+        }
+    }
+
+    [Test]
+    public async Task Eth_call_contract_creation_reports_ef_prefix_invalid_code()
+    {
+        using Context ctx = await Context.CreateWithCancunEnabled();
+        byte[] code = Prepare.EvmCode
+            .PushData(new byte[] { 0xEF, 0x00 })
+            .PushData(0)
+            .Op(Instruction.MSTORE)
+            .PushData(2)
+            .PushData(30)
+            .Op(Instruction.RETURN) // returns 0xEF00, rejected by EIP-3541
+            .Done;
+        Transaction tx = Build.A.Transaction
+            .WithData(code)
+            .WithGasLimit(1_000_000)
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+        LegacyTransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
+        transaction.To = null;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction);
+        JToken response = JToken.Parse(serialized);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response["error"]!["code"]!.Value<int>(), Is.EqualTo(-32000));
+            Assert.That(response["error"]!["message"]!.Value<string>(), Is.EqualTo("invalid code: must not begin with 0xef"));
+        }
+    }
+
+    [Test]
+    public async Task Eth_call_contract_creation_reports_address_collision()
+    {
+        using Context ctx = await Context.CreateWithCancunEnabled();
+        byte[] code = Prepare.EvmCode
+            .Op(Instruction.STOP)
+            .Done;
+        Transaction tx = Build.A.Transaction
+            .WithData(code)
+            .WithGasLimit(1_000_000)
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+        LegacyTransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
+        transaction.To = null;
+
+        Address collisionAddress = ContractAddress.From(TestItem.AddressA, 0);
+        object stateOverride = JsonSerializer.Deserialize<object>(
+            $"{{\"{TestItem.AddressA}\":{{\"nonce\":\"0x0\"}},\"{collisionAddress}\":{{\"code\":\"0x6000\"}}}}")!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_call", transaction, "latest", stateOverride);
+        JToken response = JToken.Parse(serialized);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response["error"]!["code"]!.Value<int>(), Is.EqualTo(-32000));
+            Assert.That(response["error"]!["message"]!.Value<string>(), Is.EqualTo("contract address collision"));
+        }
+    }
+
     [TestCase(null)]
     [TestCase(new byte[0])]
     public async Task Eth_call_to_is_null_and_not_contract_creation(byte[]? data)


### PR DESCRIPTION
## Changes

- Propagate EIP-2780/EIP-8037 runtime out-of-gas results through both simple-transfer and EVM execution paths so `eth_call` reports the failure.
- Preserve valid transaction execution and failed receipt semantics while exposing the JSON-RPC `-32000` / `out of gas` error.
- Add gas-boundary regressions at 204,599 and 204,600 gas. See [EIP-2780](https://eips.ethereum.org/EIPS/eip-2780).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `Eth_call_value_transfer_to_fresh_account_reports_runtime_out_of_gas`: 2 passed.
- `Eip8037_evm_path_value_transfer_to_dead_recipient_reports_runtime_out_of_gas`: 2 passed.
- Existing EIP-8037 regressions: 4 Blockchain tests and 1 EVM test passed.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
