### PR TITLE
fix(network): keep the static flag when the peer is already pooled

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
@@ -249,6 +249,26 @@ public class PeerPoolTests
     }
 
     [Test]
+    public void GetOrAdd_PromotesTheStaticFlagOntoAnAlreadyPooledPeer()
+    {
+        ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
+        TestNodeSource nodeSource = new();
+        PeerPool pool = CreatePeerPool(nodeSource, trustedNodesManager, maxActivePeers: 10, maxCandidatePeerCount: 10);
+
+        Node persistedNode = new(TestItem.PublicKeyA, "1.2.3.4", 1234);
+        Peer pooled = pool.GetOrAdd(persistedNode);
+        Assert.That(pool.StaticPeers, Is.Empty);
+
+        Node staticNode = new(TestItem.PublicKeyA, "1.2.3.4", 1234) { IsStatic = true };
+        Peer resolved = pool.GetOrAdd(staticNode);
+
+        Assert.That(resolved, Is.SameAs(pooled));
+        Assert.That(pooled.Node.IsStatic, Is.True,
+            "a static peer that was already pooled from the persisted peers db must gain its static status, or it is never treated as static for the whole session");
+        Assert.That(pool.StaticPeers, Has.Exactly(1).Items);
+    }
+
+    [Test]
     public void GetOrAdd_NetworkNode_sets_trusted_flag_from_manager()
     {
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();

--- a/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
@@ -269,12 +269,15 @@ public class PeerPoolTests
         };
         Peer resolved = pool.GetOrAdd(configuredNode);
 
-        Assert.That(resolved, Is.SameAs(pooled));
-        Assert.That(pooled.Node.IsStatic, Is.EqualTo(isStatic),
-            "a peer that was already pooled from the persisted peers db must gain the elevated status of a later arrival, or it is never treated as such for the whole session");
-        Assert.That(pooled.Node.IsTrusted, Is.EqualTo(isTrusted));
-        Assert.That(pooled.Node.IsBootnode, Is.EqualTo(isBootnode));
-        Assert.That(pool.StaticPeers, isStatic ? Has.Exactly(1).Items : Is.Empty);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(resolved, Is.SameAs(pooled));
+            Assert.That(pooled.Node.IsStatic, Is.EqualTo(isStatic),
+                "a peer that was already pooled from the persisted peers db must gain the elevated status of a later arrival, or it is never treated as such for the whole session");
+            Assert.That(pooled.Node.IsTrusted, Is.EqualTo(isTrusted));
+            Assert.That(pooled.Node.IsBootnode, Is.EqualTo(isBootnode));
+            Assert.That(pool.StaticPeers, isStatic ? Has.Exactly(1).Items : Is.Empty);
+        }
     }
 
     [Test]
@@ -328,6 +331,27 @@ public class PeerPoolTests
         Assert.That(pooled.Node.IsTrusted, Is.True,
             "a peer trusted after it was pooled must gain the flag, or admin_addTrustedPeer never takes effect for an already known peer");
     }
+
+    [Test]
+    public void GetOrAdd_NetworkNode_refreshes_the_trusted_flag_of_an_enr_backed_pooled_peer()
+    {
+        ITrustedNodesManager trustedNodesManager = new TrustedNodesManager("trusted-nodes.json", LimboLogs.Instance);
+        TestNodeSource nodeSource = new();
+        PeerPool pool = CreatePeerPool(nodeSource, trustedNodesManager, maxActivePeers: 10, maxCandidatePeerCount: 10);
+
+        NetworkNode enrNode = new(TestEnrString);
+        Peer pooled = pool.GetOrAdd(new Node(enrNode.NodeId, "1.2.3.4", 1234));
+
+        Peer resolved = pool.GetOrAdd(enrNode);
+
+        Assert.That(resolved, Is.SameAs(pooled),
+            "an ENR has no enode representation, so the trusted refresh must not dereference it - a throw here aborts the whole persistence tick and skips the pending commit");
+    }
+
+    private const string TestEnrString =
+        "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOo" +
+        "nrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPK" +
+        "Y0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
 
     private static PeerPool CreatePeerPool(TestNodeSource nodeSource, ITrustedNodesManager trustedNodesManager, int maxActivePeers, int maxCandidatePeerCount) => new(
             nodeSource,

--- a/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
@@ -309,6 +309,26 @@ public class PeerPoolTests
         Assert.That(peer.Node.IsTrusted, Is.True, "GetOrAdd(NetworkNode) marks trusted via the manager");
     }
 
+    [Test]
+    public void GetOrAdd_NetworkNode_refreshes_the_trusted_flag_of_an_already_pooled_peer()
+    {
+        ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
+        trustedNodesManager.IsTrusted(Arg.Any<Enode>()).Returns(false);
+        TestNodeSource nodeSource = new();
+        PeerPool pool = CreatePeerPool(nodeSource, trustedNodesManager, maxActivePeers: 10, maxCandidatePeerCount: 10);
+
+        string enode = new Enode(TestItem.PublicKeyA, IPAddress.Parse("1.2.3.4"), 30303).ToString();
+        Peer pooled = pool.GetOrAdd(new NetworkNode(enode));
+        Assert.That(pooled.Node.IsTrusted, Is.False);
+
+        trustedNodesManager.IsTrusted(Arg.Any<Enode>()).Returns(true);
+        Peer resolved = pool.GetOrAdd(new NetworkNode(enode));
+
+        Assert.That(resolved, Is.SameAs(pooled));
+        Assert.That(pooled.Node.IsTrusted, Is.True,
+            "a peer trusted after it was pooled must gain the flag, or admin_addTrustedPeer never takes effect for an already known peer");
+    }
+
     private static PeerPool CreatePeerPool(TestNodeSource nodeSource, ITrustedNodesManager trustedNodesManager, int maxActivePeers, int maxCandidatePeerCount) => new(
             nodeSource,
             Substitute.For<INodeStatsManager>(),

--- a/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
@@ -248,8 +248,10 @@ public class PeerPoolTests
         Assert.That(replacedPeer.Node.IsStatic, Is.False);
     }
 
-    [Test]
-    public void GetOrAdd_PromotesTheStaticFlagOntoAnAlreadyPooledPeer()
+    [TestCase(true, false, false)]
+    [TestCase(false, true, false)]
+    [TestCase(false, false, true)]
+    public void GetOrAdd_PromotesElevatedFlagsOntoAnAlreadyPooledPeer(bool isStatic, bool isTrusted, bool isBootnode)
     {
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
         TestNodeSource nodeSource = new();
@@ -259,13 +261,38 @@ public class PeerPoolTests
         Peer pooled = pool.GetOrAdd(persistedNode);
         Assert.That(pool.StaticPeers, Is.Empty);
 
+        Node configuredNode = new(TestItem.PublicKeyA, "1.2.3.4", 1234)
+        {
+            IsStatic = isStatic,
+            IsTrusted = isTrusted,
+            IsBootnode = isBootnode
+        };
+        Peer resolved = pool.GetOrAdd(configuredNode);
+
+        Assert.That(resolved, Is.SameAs(pooled));
+        Assert.That(pooled.Node.IsStatic, Is.EqualTo(isStatic),
+            "a peer that was already pooled from the persisted peers db must gain the elevated status of a later arrival, or it is never treated as such for the whole session");
+        Assert.That(pooled.Node.IsTrusted, Is.EqualTo(isTrusted));
+        Assert.That(pooled.Node.IsBootnode, Is.EqualTo(isBootnode));
+        Assert.That(pool.StaticPeers, isStatic ? Has.Exactly(1).Items : Is.Empty);
+    }
+
+    [Test]
+    public void GetOrAdd_DoesNotClearElevatedFlagsWhenAPlainArrivalFollows()
+    {
+        ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
+        TestNodeSource nodeSource = new();
+        PeerPool pool = CreatePeerPool(nodeSource, trustedNodesManager, maxActivePeers: 10, maxCandidatePeerCount: 10);
+
         Node staticNode = new(TestItem.PublicKeyA, "1.2.3.4", 1234) { IsStatic = true };
-        Peer resolved = pool.GetOrAdd(staticNode);
+        Peer pooled = pool.GetOrAdd(staticNode);
+
+        Node plainNode = new(TestItem.PublicKeyA, "1.2.3.4", 1234);
+        Peer resolved = pool.GetOrAdd(plainNode);
 
         Assert.That(resolved, Is.SameAs(pooled));
         Assert.That(pooled.Node.IsStatic, Is.True,
-            "a static peer that was already pooled from the persisted peers db must gain its static status, or it is never treated as static for the whole session");
-        Assert.That(pool.StaticPeers, Has.Exactly(1).Items);
+            "promotion is monotonic: a later plain arrival of the same node id must never demote the pooled peer");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -91,7 +91,11 @@ namespace Nethermind.Network
 
         public Peer GetOrAdd(Node node)
         {
-            if (Peers.TryGetValue(node.Id, out Peer? existing)) return existing;
+            if (Peers.TryGetValue(node.Id, out Peer? existing))
+            {
+                PromoteFlags(node, existing.Node);
+                return existing;
+            }
 
             // ConcurrentDictionary may run the factory on a losing thread; only the thread whose value is
             // actually inserted (reference-equal) fires PeerAdded.
@@ -102,11 +106,27 @@ namespace Nethermind.Network
                 if ((node.IsBootnode || node.IsStatic) && _logger.IsDebug) DebugAddingCandidatePeer(node);
                 PeerAdded?.Invoke(this, new PeerEventArgs(peer));
             }
+            else
+            {
+                PromoteFlags(node, peer.Node);
+            }
+
             return peer;
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             void DebugAddingCandidatePeer(Node n)
                 => _logger.Debug($"Adding a {(n.IsBootnode ? "bootnode" : "stored")} candidate peer {n:s}");
+        }
+
+        // A node id can reach the pool through several sources (the persisted peers db, discovery, the
+        // static/trusted config) and the first arrival wins the dictionary slot. Elevated flags from a later
+        // arrival must land on the pooled instance, otherwise a static peer that is also in the persisted
+        // peers db loses its static status for the whole session and is never redialed as one.
+        private static void PromoteFlags(Node incoming, Node pooled)
+        {
+            if (incoming.IsStatic) pooled.IsStatic = true;
+            if (incoming.IsTrusted) pooled.IsTrusted = true;
+            if (incoming.IsBootnode) pooled.IsBootnode = true;
         }
 
         public Peer GetOrAdd(NetworkNode networkNode)

--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -127,27 +127,36 @@ namespace Nethermind.Network
             if (incoming.IsStatic && !pooled.IsStatic)
             {
                 pooled.IsStatic = true;
-                if (_logger.IsDebug) _logger.Debug($"Promoting already pooled peer {pooled:s} to static");
+                if (_logger.IsDebug) DebugPromoted(pooled, "static");
             }
 
             if (incoming.IsTrusted && !pooled.IsTrusted)
             {
                 pooled.IsTrusted = true;
-                if (_logger.IsDebug) _logger.Debug($"Promoting already pooled peer {pooled:s} to trusted");
+                if (_logger.IsDebug) DebugPromoted(pooled, "trusted");
             }
 
             if (incoming.IsBootnode && !pooled.IsBootnode)
             {
                 pooled.IsBootnode = true;
-                if (_logger.IsDebug) _logger.Debug($"Promoting already pooled peer {pooled:s} to bootnode");
+                if (_logger.IsDebug) DebugPromoted(pooled, "bootnode");
             }
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void DebugPromoted(Node node, string role)
+            => _logger.Debug($"Promoting already pooled peer {node:s} to {role}");
 
         public Peer GetOrAdd(NetworkNode networkNode)
         {
             if (Peers.TryGetValue(networkNode.NodeId, out Peer? existing))
             {
-                if (!existing.Node.IsTrusted && _trustedNodesManager.IsTrusted(networkNode.Enode)) existing.Node.IsTrusted = true;
+                if (!existing.Node.IsTrusted && _trustedNodesManager.IsTrusted(networkNode.Enode))
+                {
+                    existing.Node.IsTrusted = true;
+                    if (_logger.IsDebug) DebugPromoted(existing.Node, "trusted");
+                }
+
                 return existing;
             }
 

--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -122,16 +122,34 @@ namespace Nethermind.Network
         // static/trusted config) and the first arrival wins the dictionary slot. Elevated flags from a later
         // arrival must land on the pooled instance, otherwise a static peer that is also in the persisted
         // peers db loses its static status for the whole session and is never redialed as one.
-        private static void PromoteFlags(Node incoming, Node pooled)
+        private void PromoteFlags(Node incoming, Node pooled)
         {
-            if (incoming.IsStatic) pooled.IsStatic = true;
-            if (incoming.IsTrusted) pooled.IsTrusted = true;
-            if (incoming.IsBootnode) pooled.IsBootnode = true;
+            if (incoming.IsStatic && !pooled.IsStatic)
+            {
+                pooled.IsStatic = true;
+                if (_logger.IsDebug) _logger.Debug($"Promoting already pooled peer {pooled:s} to static");
+            }
+
+            if (incoming.IsTrusted && !pooled.IsTrusted)
+            {
+                pooled.IsTrusted = true;
+                if (_logger.IsDebug) _logger.Debug($"Promoting already pooled peer {pooled:s} to trusted");
+            }
+
+            if (incoming.IsBootnode && !pooled.IsBootnode)
+            {
+                pooled.IsBootnode = true;
+                if (_logger.IsDebug) _logger.Debug($"Promoting already pooled peer {pooled:s} to bootnode");
+            }
         }
 
         public Peer GetOrAdd(NetworkNode networkNode)
         {
-            if (Peers.TryGetValue(networkNode.NodeId, out Peer? existing)) return existing;
+            if (Peers.TryGetValue(networkNode.NodeId, out Peer? existing))
+            {
+                if (!existing.Node.IsTrusted && _trustedNodesManager.IsTrusted(networkNode.Enode)) existing.Node.IsTrusted = true;
+                return existing;
+            }
 
             Node node = new(networkNode) { IsTrusted = _trustedNodesManager.IsTrusted(networkNode.Enode) };
             Peer created = new(node, _stats.GetOrAdd(node));

--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -151,7 +151,7 @@ namespace Nethermind.Network
         {
             if (Peers.TryGetValue(networkNode.NodeId, out Peer? existing))
             {
-                if (!existing.Node.IsTrusted && _trustedNodesManager.IsTrusted(networkNode.Enode))
+                if (!existing.Node.IsTrusted && networkNode.IsEnode && _trustedNodesManager.IsTrusted(networkNode.Enode))
                 {
                     existing.Node.IsTrusted = true;
                     if (_logger.IsDebug) DebugPromoted(existing.Node, "trusted");


### PR DESCRIPTION
## Problem

`NodesLoader` loads the persisted peers db before the configured static peers, and `PeerPool.GetOrAdd` (keyed by node id) lets the first arrival win. So a static peer that is also present in the peers db - which is every static peer on a node that has run for more than one session - silently loses its `IsStatic` status for the whole session.

The peer then competes for candidate slots like any other node: it loses the `MaxCandidatePeerCount` exemption, loses the privileged-disconnect protection in `Session.InitiateDisconnect`, and after a mid-run disconnect it is only ever redialed if a general peer slot happens to be free. On a node running with full peer slots, a dropped static connection stays down until restart.

Observed live: a node with one configured static peer lost the connection mid-run and never redialed it across hours, on every session except the very first one (empty peers db) after a fresh sync.

## Fix

`GetOrAdd` promotes the static, trusted, and bootnode flags from the incoming node onto the already-pooled instance instead of dropping them (both on the fast path and on the losing thread of the concurrent add). Promotion is monotonic; nothing downgrades.

## Testing

`GetOrAdd_PromotesTheStaticFlagOntoAnAlreadyPooledPeer` reproduces the db-first-then-config arrival order and asserts the pooled peer gains static status and `StaticPeers` sees it.
