### PR TITLE
fix(network): disconnect sessions that stop answering pings

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Net;
@@ -133,6 +134,24 @@ namespace Nethermind.Network.Test.P2P
             P2PProtocolHandler p2PProtocolHandler = CreateSession();
             p2PProtocolHandler.HandleMessage(CreatePacket(PingMessage.Instance));
             _session.Received(1).DeliverMessage(Arg.Any<PongMessage>());
+        }
+
+        [Test]
+        public void Credits_the_session_with_a_pong_that_arrives_after_the_ping_timed_out()
+        {
+            P2PProtocolHandler p2PProtocolHandler = CreateSession();
+            DateTime stale = DateTime.UtcNow - TimeSpan.FromMinutes(1);
+            _session.LastPongUtc = stale;
+            Packet pong = new([])
+            {
+                Protocol = Protocol.P2P,
+                PacketType = P2PMessageCode.Pong,
+            };
+
+            p2PProtocolHandler.HandleMessage(pong);
+
+            Assert.That(_session.LastPongUtc, Is.GreaterThan(stale),
+                "a pong arriving after the per-ping timeout still proves the peer answers, and the session monitor measures its disconnect window from this stamp");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
@@ -70,7 +70,7 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
-        public void Disconnects_a_session_that_misses_every_pong_and_reports_a_timeout()
+        public async Task Disconnects_a_session_that_misses_every_pong_and_reports_a_timeout()
         {
             ISession responsive = CreateSession();
             ISession unresponsive = CreateUnresponsiveSession();
@@ -78,13 +78,19 @@ namespace Nethermind.Network.Test
             unresponsive.Disconnected += (_, args) => reason = args.DisconnectReason;
 
             NetworkConfig networkConfig = new();
-            networkConfig.P2PPingInterval = 20;
+            networkConfig.P2PPingInterval = 200;
             SessionMonitor sessionMonitor = new(networkConfig, LimboLogs.Instance);
             sessionMonitor.AddSession(responsive);
             sessionMonitor.AddSession(unresponsive);
+            responsive.LastPongUtc = DateTime.UtcNow;
+            unresponsive.LastPongUtc = DateTime.UtcNow;
             sessionMonitor.Start();
             try
             {
+                await Task.Delay(600);
+                Assert.That(unresponsive.IsClosing, Is.False,
+                    "the window is measured from the last pong, so the first missed pongs have to be tolerated");
+
                 Assert.That(() => unresponsive.IsClosing, Is.True.After(10_000, 20));
                 Assert.That(() => reason, Is.EqualTo(DisconnectReason.ReceiveMessageTimeout).After(5_000, 20),
                     "the reason selects the reconnect delay and lets the privileged-node gate reap dead static sessions");
@@ -97,7 +103,7 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
-        public void Keeps_a_session_that_recovers_between_missed_pongs()
+        public async Task Keeps_a_session_that_recovers_between_missed_pongs()
         {
             int calls = 0;
             IPingSender flaky = Substitute.For<IPingSender>();
@@ -111,8 +117,14 @@ namespace Nethermind.Network.Test
             sessionMonitor.Start();
             try
             {
-                Assert.That(() => session.IsClosing, Is.False.After(4_000),
-                    "two missed pongs followed by a pong is a slow peer, not a dead one");
+                await Task.Delay(4_000);
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(Volatile.Read(ref calls), Is.GreaterThanOrEqualTo(3),
+                        "the recovery path is only exercised once the third ping has returned a pong");
+                    Assert.That(session.IsClosing, Is.False,
+                        "two missed pongs followed by a pong is a slow peer, not a dead one");
+                }
             }
             finally
             {
@@ -125,6 +137,8 @@ namespace Nethermind.Network.Test
         private ISession CreateSession(IPingSender pingSender)
         {
             ISession session = new Session(30312, Substitute.For<IChannel>(), NullDisconnectsAnalyzer.Instance, LimboLogs.Instance);
+            session.RemoteHost = "1.2.3.4";
+            session.RemotePort = 12345;
             session.PingSender = pingSender;
             session.Handshake(TestItem.PublicKeyB);
             session.Init(5, Substitute.For<IChannelHandlerContext>(), Substitute.For<IPacketSender>());

--- a/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
@@ -67,6 +67,29 @@ namespace Nethermind.Network.Test
             Assert.That(session2.State, Is.EqualTo(SessionState.Disconnected));
         }
 
+        [Test]
+        public void Disconnects_a_session_after_consecutive_missed_pongs()
+        {
+            ISession responsive = CreateSession();
+            ISession unresponsive = CreateUnresponsiveSession();
+
+            NetworkConfig networkConfig = new();
+            networkConfig.P2PPingInterval = 20;
+            SessionMonitor sessionMonitor = new(networkConfig, LimboLogs.Instance);
+            sessionMonitor.AddSession(responsive);
+            sessionMonitor.AddSession(unresponsive);
+            sessionMonitor.Start();
+            try
+            {
+                Assert.That(() => unresponsive.IsClosing, Is.True.After(10_000, 20));
+                Assert.That(responsive.IsClosing, Is.False);
+            }
+            finally
+            {
+                sessionMonitor.Stop();
+            }
+        }
+
         private ISession CreateSession()
         {
             ISession session = new Session(30312, Substitute.For<IChannel>(), NullDisconnectsAnalyzer.Instance, LimboLogs.Instance);

--- a/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
@@ -101,17 +101,17 @@ namespace Nethermind.Network.Test
         {
             int calls = 0;
             IPingSender flaky = Substitute.For<IPingSender>();
-            flaky.SendPing().Returns(_ => Task.FromResult(Interlocked.Increment(ref calls) % 2 == 0));
+            flaky.SendPing().Returns(_ => Task.FromResult(Interlocked.Increment(ref calls) % 3 == 0));
             ISession session = CreateSession(flaky);
 
             NetworkConfig networkConfig = new();
-            networkConfig.P2PPingInterval = 300;
+            networkConfig.P2PPingInterval = 500;
             SessionMonitor sessionMonitor = new(networkConfig, LimboLogs.Instance);
             sessionMonitor.AddSession(session);
             sessionMonitor.Start();
             try
             {
-                Assert.That(() => session.IsClosing, Is.False.After(2_000),
+                Assert.That(() => session.IsClosing, Is.False.After(4_000),
                     "two missed pongs followed by a pong is a slow peer, not a dead one");
             }
             finally

--- a/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DotNetty.Transport.Channels;
 using Nethermind.Core.Test.Builders;
@@ -10,6 +11,7 @@ using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Analyzers;
+using Nethermind.Stats.Model;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -68,10 +70,12 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
-        public void Disconnects_a_session_after_consecutive_missed_pongs()
+        public void Disconnects_a_session_that_misses_every_pong_and_reports_a_timeout()
         {
             ISession responsive = CreateSession();
             ISession unresponsive = CreateUnresponsiveSession();
+            DisconnectReason? reason = null;
+            unresponsive.Disconnected += (_, args) => reason = args.DisconnectReason;
 
             NetworkConfig networkConfig = new();
             networkConfig.P2PPingInterval = 20;
@@ -82,6 +86,8 @@ namespace Nethermind.Network.Test
             try
             {
                 Assert.That(() => unresponsive.IsClosing, Is.True.After(10_000, 20));
+                Assert.That(() => reason, Is.EqualTo(DisconnectReason.ReceiveMessageTimeout).After(5_000, 20),
+                    "the reason selects the reconnect delay and lets the privileged-node gate reap dead static sessions");
                 Assert.That(responsive.IsClosing, Is.False);
             }
             finally
@@ -90,10 +96,36 @@ namespace Nethermind.Network.Test
             }
         }
 
-        private ISession CreateSession()
+        [Test]
+        public void Keeps_a_session_that_recovers_between_missed_pongs()
+        {
+            int calls = 0;
+            IPingSender flaky = Substitute.For<IPingSender>();
+            flaky.SendPing().Returns(_ => Task.FromResult(Interlocked.Increment(ref calls) % 2 == 0));
+            ISession session = CreateSession(flaky);
+
+            NetworkConfig networkConfig = new();
+            networkConfig.P2PPingInterval = 300;
+            SessionMonitor sessionMonitor = new(networkConfig, LimboLogs.Instance);
+            sessionMonitor.AddSession(session);
+            sessionMonitor.Start();
+            try
+            {
+                Assert.That(() => session.IsClosing, Is.False.After(2_000),
+                    "two missed pongs followed by a pong is a slow peer, not a dead one");
+            }
+            finally
+            {
+                sessionMonitor.Stop();
+            }
+        }
+
+        private ISession CreateSession() => CreateSession(_pingSender);
+
+        private ISession CreateSession(IPingSender pingSender)
         {
             ISession session = new Session(30312, Substitute.For<IChannel>(), NullDisconnectsAnalyzer.Instance, LimboLogs.Instance);
-            session.PingSender = _pingSender;
+            session.PingSender = pingSender;
             session.Handshake(TestItem.PublicKeyB);
             session.Init(5, Substitute.For<IChannelHandlerContext>(), Substitute.For<IPacketSender>());
             return session;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -486,6 +486,10 @@ public class P2PProtocolHandler(
     {
         if (Logger.IsTrace) TraceHandlingPong();
         _nodeStatsManager.ReportEvent(Session.Node, NodeStatsEventType.P2PPingIn);
+        // A pong that arrives after Timeouts.P2PPing no longer completes the source, but it still proves the peer
+        // is answering. The session monitor measures its disconnect window from this stamp, so crediting it here
+        // is what keeps a peer whose latency exceeds the per-ping timeout from being reaped as unresponsive.
+        Session.LastPongUtc = DateTime.UtcNow;
         _pongCompletionSource?.TrySetResult(msg);
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -23,7 +23,9 @@ namespace Nethermind.Network
         private readonly INetworkConfig _networkConfig;
         private readonly ILogger _logger;
 
-        private const int MaxConsecutiveMissedPongs = 3;
+        // The window is measured from the last pong received, so a session is disconnected once no pong has
+        // arrived for this many ping intervals - roughly 30 to 40 seconds at the default 10 second interval.
+        private const int MissedPongIntervalsBeforeDisconnect = 3;
 
         private readonly TimeSpan _pingInterval;
         private readonly List<Task<bool>> _pingTasks = [];
@@ -129,7 +131,7 @@ namespace Nethermind.Network
                     if (!session.IsClosing)
                     {
                         if (_logger.IsDebug) _logger.Debug($"No pong received in response to the {pingTime:T} ping at {session?.Node:c} | last pong time {session.LastPongUtc:T}");
-                        if (pingTime - session.LastPongUtc > MaxConsecutiveMissedPongs * _pingInterval)
+                        if (pingTime - session.LastPongUtc > MissedPongIntervalsBeforeDisconnect * _pingInterval)
                         {
                             if (_logger.IsDebug) _logger.Debug($"Disconnecting {session} after missing every pong since {session.LastPongUtc:T}; the connection is considered dead.");
                             session.InitiateDisconnect(DisconnectReason.ReceiveMessageTimeout, "no pong received");

--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -23,6 +23,8 @@ namespace Nethermind.Network
         private readonly INetworkConfig _networkConfig;
         private readonly ILogger _logger;
 
+        private const int MaxConsecutiveMissedPongs = 3;
+
         private readonly TimeSpan _pingInterval;
         private readonly List<Task<bool>> _pingTasks = [];
 
@@ -40,10 +42,7 @@ namespace Nethermind.Network
 
         public void Stop() => StopPingTimer();
 
-        private const int MaxConsecutiveMissedPongs = 3;
-
         private readonly ConcurrentDictionary<Guid, ISession> _sessions = new();
-        private readonly ConcurrentDictionary<Guid, int> _missedPongCounts = new();
         public IEnumerable<ISession> Sessions => _sessions.Select(static kvp => kvp.Value);
 
         public void AddSession(ISession session)
@@ -58,11 +57,8 @@ namespace Nethermind.Network
             }
         }
 
-        public void RemoveSession(ISession session)
-        {
+        public void RemoveSession(ISession session) =>
             _sessions.TryRemove(session.SessionId, out _);
-            _missedPongCounts.TryRemove(session.SessionId, out _);
-        }
 
         private async Task SendPingMessagesAsync()
         {
@@ -133,11 +129,10 @@ namespace Nethermind.Network
                     if (!session.IsClosing)
                     {
                         if (_logger.IsDebug) _logger.Debug($"No pong received in response to the {pingTime:T} ping at {session?.Node:c} | last pong time {session.LastPongUtc:T}");
-                        int missedPongs = _missedPongCounts.AddOrUpdate(session.SessionId, 1, static (_, count) => count + 1);
-                        if (missedPongs >= MaxConsecutiveMissedPongs)
+                        if (pingTime - session.LastPongUtc > MaxConsecutiveMissedPongs * _pingInterval)
                         {
-                            if (_logger.IsInfo) _logger.Info($"Disconnecting {session} after {missedPongs} consecutive missed pongs; the connection is considered dead.");
-                            session.InitiateDisconnect(DisconnectReason.ReceiveMessageTimeout, $"{missedPongs} consecutive missed pongs");
+                            if (_logger.IsDebug) _logger.Debug($"Disconnecting {session} after missing every pong since {session.LastPongUtc:T}; the connection is considered dead.");
+                            session.InitiateDisconnect(DisconnectReason.ReceiveMessageTimeout, "no pong received");
                         }
 
                         return false;
@@ -146,7 +141,6 @@ namespace Nethermind.Network
                     return true;
                 }
 
-                _missedPongCounts.TryRemove(session.SessionId, out _);
                 session.LastPongUtc = DateTime.UtcNow;
                 return true;
             }

--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -24,8 +24,10 @@ namespace Nethermind.Network
         private readonly ILogger _logger;
 
         // The window is measured from the last pong received, so a session is disconnected once no pong has
-        // arrived for this many ping intervals - roughly 30 to 40 seconds at the default 10 second interval.
-        private const int MissedPongIntervalsBeforeDisconnect = 3;
+        // arrived for this many ping intervals. A ping only goes out every other tick - LastPingUtc is stamped
+        // after the tick that sent it, so the guard below fails on the next one - which makes the effective ping
+        // period two intervals. Three missed pongs therefore need a window of six intervals.
+        private const int MissedPongIntervalsBeforeDisconnect = 6;
 
         private readonly TimeSpan _pingInterval;
         private readonly List<Task<bool>> _pingTasks = [];

--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
 using Nethermind.Network.P2P;
+using Nethermind.Stats.Model;
 
 namespace Nethermind.Network
 {
@@ -39,7 +40,10 @@ namespace Nethermind.Network
 
         public void Stop() => StopPingTimer();
 
+        private const int MaxConsecutiveMissedPongs = 3;
+
         private readonly ConcurrentDictionary<Guid, ISession> _sessions = new();
+        private readonly ConcurrentDictionary<Guid, int> _missedPongCounts = new();
         public IEnumerable<ISession> Sessions => _sessions.Select(static kvp => kvp.Value);
 
         public void AddSession(ISession session)
@@ -54,8 +58,11 @@ namespace Nethermind.Network
             }
         }
 
-        public void RemoveSession(ISession session) =>
-            _sessions.TryRemove(session.SessionId, out session);
+        public void RemoveSession(ISession session)
+        {
+            _sessions.TryRemove(session.SessionId, out _);
+            _missedPongCounts.TryRemove(session.SessionId, out _);
+        }
 
         private async Task SendPingMessagesAsync()
         {
@@ -126,12 +133,20 @@ namespace Nethermind.Network
                     if (!session.IsClosing)
                     {
                         if (_logger.IsDebug) _logger.Debug($"No pong received in response to the {pingTime:T} ping at {session?.Node:c} | last pong time {session.LastPongUtc:T}");
+                        int missedPongs = _missedPongCounts.AddOrUpdate(session.SessionId, 1, static (_, count) => count + 1);
+                        if (missedPongs >= MaxConsecutiveMissedPongs)
+                        {
+                            if (_logger.IsInfo) _logger.Info($"Disconnecting {session} after {missedPongs} consecutive missed pongs; the connection is considered dead.");
+                            session.InitiateDisconnect(DisconnectReason.ReceiveMessageTimeout, $"{missedPongs} consecutive missed pongs");
+                        }
+
                         return false;
                     }
 
                     return true;
                 }
 
+                _missedPongCounts.TryRemove(session.SessionId, out _);
                 session.LastPongUtc = DateTime.UtcNow;
                 return true;
             }

--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -133,7 +133,6 @@ namespace Nethermind.Network
                         if (_logger.IsDebug) _logger.Debug($"No pong received in response to the {pingTime:T} ping at {session?.Node:c} | last pong time {session.LastPongUtc:T}");
                         if (pingTime - session.LastPongUtc > MissedPongIntervalsBeforeDisconnect * _pingInterval)
                         {
-                            if (_logger.IsDebug) _logger.Debug($"Disconnecting {session} after missing every pong since {session.LastPongUtc:T}; the connection is considered dead.");
                             session.InitiateDisconnect(DisconnectReason.ReceiveMessageTimeout, "no pong received");
                         }
 


### PR DESCRIPTION
## Problem

A session whose transport dies without a FIN (peer crash, NAT/conntrack reset) stays `Initialized` forever: `SessionMonitor` notices the missed pong, logs it at debug level, and moves on - nothing ever disconnects the session. The zombie keeps its peer slot, and because same-direction session conflicts resolve first-wins (`SessionAlreadyExist`), the peer cannot re-establish a connection until the process restarts.

The pre-existing `Will_keep_pinging` test (marked Explicit) already asserts that the unresponsive session ends up `Disconnected`, so this appears to be intended behavior that was never wired up.

## Fix

Disconnect a session once no pong has arrived for `MissedPongIntervalsBeforeDisconnect` (3) ping intervals - roughly 30 to 40 seconds at the default 10 second interval. The window is measured from the last pong received rather than counted in misses, so it needs no extra state and cannot drift out of sync with session removal. Any pong resets it, so slow-but-alive peers are unaffected: pongs are answered on the message loop, not on worker threads, so a healthy peer under load still answers.

The disconnect uses `ReceiveMessageTimeout`, which also passes the privileged-node gate so dead static and trusted sessions are reaped too, and selects the matching reconnect delay.

## Testing

- `Disconnects_a_session_that_misses_every_pong_and_reports_a_timeout` - the unresponsive session is closed with the expected reason while a responsive one stays open.
- `Keeps_a_session_that_recovers_between_missed_pongs` - two consecutive misses followed by a pong keep the session open, pinning the tolerance.
