### PR TITLE
fix(network): reject connections to and from this node's own identity

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -253,19 +253,31 @@ namespace Nethermind.Network.Test.P2P
                 P2PVersion = 5,
             };
 
-            using DisposableByteBuffer data = _serializer.ZeroSerialize(message).AsDisposable();
-            data.ReadByte();
-
-            Packet packet = new(data.ReadAllBytesAsArray())
-            {
-                Protocol = message.Protocol,
-                PacketType = (byte)message.PacketType,
-            };
-
-            p2PProtocolHandler.HandleMessage(packet);
+            p2PProtocolHandler.HandleMessage(CreateP2PPacket(message));
 
             _session.Received(1).InitiateDisconnect(DisconnectReason.IdentitySameAsSelf, Arg.Any<string>());
             _session.DidNotReceive().InitiateDisconnect(DisconnectReason.NoCapabilityMatched, Arg.Any<string>());
+        }
+
+        [Test]
+        public void On_hello_from_a_session_authenticated_as_this_node_disconnects()
+        {
+            _session.RemoteNodeId.Returns(TestItem.PublicKeyA);
+            P2PProtocolHandler p2PProtocolHandler = CreateSession();
+            p2PProtocolHandler.AddSupportedCapability(new Capability(Protocol.Eth, 68));
+
+            using HelloMessage message = new()
+            {
+                Capabilities = new ArrayPoolList<Capability>(1) { new(Protocol.Eth, 68) },
+                NodeId = TestItem.PublicKeyB,
+                ClientId = "Nethermind/v1.0",
+                ListenPort = 30303,
+                P2PVersion = 5,
+            };
+
+            p2PProtocolHandler.HandleMessage(CreateP2PPacket(message));
+
+            _session.Received(1).InitiateDisconnect(DisconnectReason.IdentitySameAsSelf, Arg.Any<string>());
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -108,7 +108,7 @@ namespace Nethermind.Network.Test.P2P
             using HelloMessage message = new()
             {
                 Capabilities = new ArrayPoolList<Capability>(1) { new(Protocol.Eth, 63) },
-                NodeId = TestItem.PublicKeyA,
+                NodeId = TestItem.PublicKeyB,
             };
 
             using DisposableByteBuffer data = _serializer.ZeroSerialize(message).AsDisposable();
@@ -218,7 +218,7 @@ namespace Nethermind.Network.Test.P2P
             using HelloMessage message = new()
             {
                 Capabilities = new ArrayPoolList<Capability>(1) { new(Protocol.Eth, 68) },
-                NodeId = TestItem.PublicKeyA,
+                NodeId = TestItem.PublicKeyB,
                 ClientId = "Nethermind/v1.0",
                 ListenPort = 30303,
                 P2PVersion = 5,
@@ -236,6 +236,36 @@ namespace Nethermind.Network.Test.P2P
             p2PProtocolHandler.HandleMessage(packet);
 
             _session.DidNotReceive().InitiateDisconnect(DisconnectReason.MessageLimitsBreached, Arg.Any<string>());
+        }
+
+        [Test]
+        public void On_hello_carrying_this_nodes_own_identity_disconnects()
+        {
+            P2PProtocolHandler p2PProtocolHandler = CreateSession();
+            p2PProtocolHandler.AddSupportedCapability(new Capability(Protocol.Eth, 68));
+
+            using HelloMessage message = new()
+            {
+                Capabilities = new ArrayPoolList<Capability>(1) { new(Protocol.Eth, 68) },
+                NodeId = TestItem.PublicKeyA,
+                ClientId = "Nethermind/v1.0",
+                ListenPort = 30303,
+                P2PVersion = 5,
+            };
+
+            using DisposableByteBuffer data = _serializer.ZeroSerialize(message).AsDisposable();
+            data.ReadByte();
+
+            Packet packet = new(data.ReadAllBytesAsArray())
+            {
+                Protocol = message.Protocol,
+                PacketType = (byte)message.PacketType,
+            };
+
+            p2PProtocolHandler.HandleMessage(packet);
+
+            _session.Received(1).InitiateDisconnect(DisconnectReason.IdentitySameAsSelf, Arg.Any<string>());
+            _session.DidNotReceive().InitiateDisconnect(DisconnectReason.NoCapabilityMatched, Arg.Any<string>());
         }
 
         [Test]
@@ -277,7 +307,7 @@ namespace Nethermind.Network.Test.P2P
                     new(Protocol.Eth, 70),
                     new(Protocol.Eth, 71),
                 },
-                NodeId = TestItem.PublicKeyA,
+                NodeId = TestItem.PublicKeyB,
             };
 
             p2PProtocolHandler.HandleMessage(CreateP2PPacket(message));

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerFilteringIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerFilteringIntegrationTests.cs
@@ -93,6 +93,28 @@ public class PeerManagerFilteringIntegrationTests
     }
 
     [Test]
+    public async Task OwnRecord_IsRejectedBeforeTheIpFilterSeesIt()
+    {
+        await using Context ctx = new();
+        Node self = new(TestItem.PublicKeyA, "203.0.113.50", 30303);
+        Node other = new(new PrivateKeyGenerator().Generate().PublicKey, "198.51.100.7", 30303) { IsStatic = true };
+
+        ctx.TestNodeSource.AddNode(self);
+        ctx.TestNodeSource.AddNode(other);
+
+        ctx.PeerPool.Start();
+        ctx.PeerManager.Start();
+
+        await ctx.RlpxMock.FirstConnect.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.That(ctx.RlpxMock.CallsToShouldContact, Does.Contain(other.Address.Address),
+            "the dial of the other peer has to reach the filter, otherwise the assertion below passes for the wrong reason");
+        Assert.That(ctx.RlpxMock.CallsToShouldContact, Does.Not.Contain(self.Address.Address),
+            "the IP filter records every address it accepts, so our own record must be rejected before it reaches the filter - otherwise it keeps re-arming it for our own subnet and locks out real peers there");
+        Assert.That(ctx.RlpxMock.ConnectedNodeIds, Does.Not.Contain(self.Id));
+    }
+
+    [Test]
     public async Task RegularPeer_BlockedByIpFilter()
     {
         await using Context ctx = new();
@@ -178,9 +200,14 @@ public class PeerManagerFilteringIntegrationTests
     private class FilterRejectingRlpxMock : IRlpxHost
     {
         public ConcurrentBag<PublicKey> ConnectedNodeIds { get; } = [];
+        public ConcurrentBag<IPAddress> CallsToShouldContact { get; } = [];
         public TaskCompletionSource<Node> FirstConnect { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public bool ShouldContact(IPAddress ip, bool exactOnly = false) => exactOnly;
+        public bool ShouldContact(IPAddress ip, bool exactOnly = false)
+        {
+            CallsToShouldContact.Add(ip);
+            return exactOnly;
+        }
 
         public Task<bool> ConnectAsync(Node node)
         {

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerFilteringIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerFilteringIntegrationTests.cs
@@ -108,7 +108,7 @@ public class PeerManagerFilteringIntegrationTests
         await ctx.RlpxMock.FirstConnect.Task.WaitAsync(TimeSpan.FromSeconds(30));
 
         Assert.That(ctx.RlpxMock.CallsToShouldContact, Does.Contain(other.Address.Address),
-            "the dial of the other peer has to reach the filter, otherwise the assertion below passes for the wrong reason");
+            "the dial of the other peer has to reach the filter, otherwise the assertion below passes for the wrong reason - the peer is static because this mock filter only accepts privileged dials");
         Assert.That(ctx.RlpxMock.CallsToShouldContact, Does.Not.Contain(self.Address.Address),
             "the IP filter records every address it accepts, so our own record must be rejected before it reaches the filter - otherwise it keeps re-arming it for our own subnet and locks out real peers there");
         Assert.That(ctx.RlpxMock.ConnectedNodeIds, Does.Not.Contain(self.Id));

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -413,7 +413,7 @@ namespace Nethermind.Network.Test
 
             ctx.TestNodeSource.AddNode(new Node(TestItem.PublicKeyA, "1.2.3.4", 30303));
 
-            Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(0).After(500),
+            Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(0).After(_delay),
                 "a discovered node carrying the local identity is a hairpinned self-dial and must never be attempted");
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -353,8 +353,8 @@ namespace Nethermind.Network.Test
             session1.RemotePort = 12345;
             session1.RemoteNodeId =
                 (firstDirection == ConnectionDirection.In)
-                    ? (shouldLose ? TestItem.PublicKeyA : TestItem.PublicKeyC)
-                    : (shouldLose ? TestItem.PublicKeyC : TestItem.PublicKeyA);
+                    ? (shouldLose ? TestItem.PublicKeyB : TestItem.PublicKeyC)
+                    : (shouldLose ? TestItem.PublicKeyC : TestItem.PublicKeyB);
 
             void EnsureSession(ISession? session)
             {
@@ -403,6 +403,19 @@ namespace Nethermind.Network.Test
         }
 
         private void HandshakeOnCreate(object sender, SessionEventArgs e) => e.Session.Handshake(e.Session.RemoteNodeId);
+
+        [Test]
+        public async Task Will_not_dial_a_node_carrying_this_nodes_own_identity()
+        {
+            await using Context ctx = new();
+            ctx.PeerPool.Start();
+            ctx.PeerManager.Start();
+
+            ctx.TestNodeSource.AddNode(new Node(TestItem.PublicKeyA, "1.2.3.4", 30303));
+
+            Assert.That(() => ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(0).After(500),
+                "a discovered node carrying the local identity is a hairpinned self-dial and must never be attempted");
+        }
 
         [Test]
         public async Task Will_fill_up_on_disconnects()

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -418,6 +418,24 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
+        public async Task Will_not_select_a_static_node_carrying_this_nodes_own_identity()
+        {
+            await using Context ctx = new();
+            ctx.RlpxPeer.MakeItFail();
+            const long neverRanked = -424242;
+            Node self = new(TestItem.PublicKeyA, "1.2.3.4", 30303) { IsStatic = true, CurrentReputation = neverRanked };
+            ctx.PeerPool.Start();
+            ctx.PeerManager.Start();
+
+            ctx.TestNodeSource.AddNode(new Node(new PrivateKeyGenerator().Generate().PublicKey, "5.6.7.8", 30303));
+            ctx.TestNodeSource.AddNode(self);
+            await Task.Delay(_delayLonger);
+
+            Assert.That(self.CurrentReputation, Is.EqualTo(neverRanked),
+                "a static peer bypasses the pre-candidate filters, so the local identity has to be dropped from the static projection too - otherwise it is selected every round, discarded again at dial time without taking a slot, and the update loop never reaches its idle delay");
+        }
+
+        [Test]
         public async Task Will_fill_up_on_disconnects()
         {
             await using Context ctx = new();

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -266,9 +266,9 @@ public class P2PProtocolHandler(
 
         if (Logger.IsTrace) TraceReceivedHello();
 
-        if (hello.NodeId == _localNodeId)
+        if (hello.NodeId == _localNodeId || Session.RemoteNodeId == _localNodeId)
         {
-            if (Logger.IsInfo) Logger.Info($"Disconnecting {Session}: the remote identity is this node's own identity, so the connection loops back to this node.");
+            if (Logger.IsDebug) Logger.Debug($"Disconnecting {Session}: remote identity is this node's own identity");
             Session.InitiateDisconnect(DisconnectReason.IdentitySameAsSelf, "connection to self");
             return;
         }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -266,6 +266,13 @@ public class P2PProtocolHandler(
 
         if (Logger.IsTrace) TraceReceivedHello();
 
+        if (hello.NodeId == _localNodeId)
+        {
+            if (Logger.IsInfo) Logger.Info($"Disconnecting {Session}: the remote identity is this node's own identity, so the connection loops back to this node.");
+            Session.InitiateDisconnect(DisconnectReason.IdentitySameAsSelf, "connection to self");
+            return;
+        }
+
         if (!hello.NodeId.Equals(Session.RemoteNodeId))
         {
             if (Logger.IsDebug) DebugInconsistentNodeId(hello, isInbound);

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -547,7 +547,7 @@ namespace Nethermind.Network
                 // Also dropped at dial time, but a candidate that can never be dialed and never records a stat
                 // stays eligible for every future round, and the loop re-runs immediately whenever a slot is
                 // still free - so leaving it in the selection spins this loop with no delay between rounds.
-                if (peer.Node.Id == _enode.PublicKey)
+                if (IsSelf(peer))
                 {
                     continue;
                 }
@@ -558,7 +558,7 @@ namespace Nethermind.Network
             bool hasOnlyStaticNodes = false;
             if (_currentSelection.PreCandidates.Count == 0)
             {
-                _currentSelection.Candidates.AddRange(_peerPool.StaticPeers.Where(sn => !_peerPool.ActivePeers.ContainsKey(sn.Node.Id)));
+                _currentSelection.Candidates.AddRange(_peerPool.StaticPeers.Where(sn => !IsSelf(sn) && !_peerPool.ActivePeers.ContainsKey(sn.Node.Id)));
                 hasOnlyStaticNodes = _currentSelection.PreCandidates.Count > 0;
             }
 
@@ -602,7 +602,7 @@ namespace Nethermind.Network
 
             if (!hasOnlyStaticNodes)
             {
-                _currentSelection.Candidates.AddRange(_peerPool.StaticPeers.Where(sn => !_peerPool.ActivePeers.ContainsKey(sn.Node.Id)));
+                _currentSelection.Candidates.AddRange(_peerPool.StaticPeers.Where(sn => !IsSelf(sn) && !_peerPool.ActivePeers.ContainsKey(sn.Node.Id)));
             }
 
             foreach (Peer peer in _currentSelection.Candidates)
@@ -954,8 +954,10 @@ namespace Nethermind.Network
         /// peer-added - pass through here.
         /// </remarks>
         private bool ShouldContactPeer(Peer peer)
-            => peer.Node.Id != _enode.PublicKey
+            => !IsSelf(peer)
                && _rlpxHost.ShouldContact(peer.Node.Address.Address, exactOnly: peer.Node.IsStatic || peer.Node.IsBootnode);
+
+        private bool IsSelf(Peer peer) => peer.Node.Id == _enode.PublicKey;
 
         /// <summary>
         /// Fast-path guard for the peer-added event: checks throttle before the IP filter

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -771,7 +771,12 @@ namespace Nethermind.Network
         [Todo(Improve.MissingFunctionality, "Add cancellation support for the peer connection (so it does not wait for the 10sec timeout")]
         private async Task SetupOutgoingPeerConnection(Peer peer, bool cancelIfThrottled = false)
         {
-            if (peer.Node.Id == _enode.PublicKey) return;
+            // A hairpinned NAT or a discovery record echoing our own ENR would otherwise dial ourselves
+            if (peer.Node.Id == _enode.PublicKey)
+            {
+                if (_logger.IsTrace) _logger.Trace($"Skipping outgoing connection to self: {peer.Node.Id}");
+                return;
+            }
 
             if (cancelIfThrottled && _outgoingConnectionRateLimiter.IsThrottled()) return;
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -771,13 +771,6 @@ namespace Nethermind.Network
         [Todo(Improve.MissingFunctionality, "Add cancellation support for the peer connection (so it does not wait for the 10sec timeout")]
         private async Task SetupOutgoingPeerConnection(Peer peer, bool cancelIfThrottled = false)
         {
-            // A hairpinned NAT or a discovery record echoing our own ENR would otherwise dial ourselves
-            if (peer.Node.Id == _enode.PublicKey)
-            {
-                if (_logger.IsTrace) _logger.Trace($"Skipping outgoing connection to self: {peer.Node.Id}");
-                return;
-            }
-
             if (cancelIfThrottled && _outgoingConnectionRateLimiter.IsThrottled()) return;
 
             await _outgoingConnectionRateLimiter.WaitAsync(_cancellationTokenSource.Token);
@@ -943,8 +936,12 @@ namespace Nethermind.Network
                 => _logger.Trace($"Initiating disconnect with {session} {DisconnectReason.HardLimitTooManyPeers} {DisconnectType.Local}");
         }
 
+        // Sits ahead of the recent-IP filter on purpose: that filter records every address it accepts, so letting
+        // our own record through would keep re-arming it for our own subnet and lock out real peers sharing it.
+        // Both dial paths - the update loop's workers and the quick-connect on peer-added - pass through here.
         private bool ShouldContactPeer(Peer peer)
-            => _rlpxHost.ShouldContact(peer.Node.Address.Address, exactOnly: peer.Node.IsStatic || peer.Node.IsBootnode);
+            => peer.Node.Id != _enode.PublicKey
+               && _rlpxHost.ShouldContact(peer.Node.Address.Address, exactOnly: peer.Node.IsStatic || peer.Node.IsBootnode);
 
         /// <summary>
         /// Fast-path guard for the peer-added event: checks throttle before the IP filter

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -544,11 +544,6 @@ namespace Nethermind.Network
                     continue;
                 }
 
-                if (peer.Node.Id == _enode.PublicKey)
-                {
-                    continue;
-                }
-
                 _currentSelection.PreCandidates.Add(peer);
             }
 
@@ -776,6 +771,8 @@ namespace Nethermind.Network
         [Todo(Improve.MissingFunctionality, "Add cancellation support for the peer connection (so it does not wait for the 10sec timeout")]
         private async Task SetupOutgoingPeerConnection(Peer peer, bool cancelIfThrottled = false)
         {
+            if (peer.Node.Id == _enode.PublicKey) return;
+
             if (cancelIfThrottled && _outgoingConnectionRateLimiter.IsThrottled()) return;
 
             await _outgoingConnectionRateLimiter.WaitAsync(_cancellationTokenSource.Token);

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -544,6 +544,14 @@ namespace Nethermind.Network
                     continue;
                 }
 
+                // Also dropped at dial time, but a candidate that can never be dialed and never records a stat
+                // stays eligible for every future round, and the loop re-runs immediately whenever a slot is
+                // still free - so leaving it in the selection spins this loop with no delay between rounds.
+                if (peer.Node.Id == _enode.PublicKey)
+                {
+                    continue;
+                }
+
                 _currentSelection.PreCandidates.Add(peer);
             }
 
@@ -936,9 +944,15 @@ namespace Nethermind.Network
                 => _logger.Trace($"Initiating disconnect with {session} {DisconnectReason.HardLimitTooManyPeers} {DisconnectType.Local}");
         }
 
-        // Sits ahead of the recent-IP filter on purpose: that filter records every address it accepts, so letting
-        // our own record through would keep re-arming it for our own subnet and lock out real peers sharing it.
-        // Both dial paths - the update loop's workers and the quick-connect on peer-added - pass through here.
+        /// <summary>
+        /// Whether an outbound dial to <paramref name="peer"/> should be attempted.
+        /// </summary>
+        /// <remarks>
+        /// The self-identity check deliberately precedes the recent-IP filter: that filter records every address
+        /// it accepts, so letting our own record through would keep re-arming it for our own subnet and lock out
+        /// real peers sharing it. Both dial paths - the update loop's workers and the quick-connect on
+        /// peer-added - pass through here.
+        /// </remarks>
         private bool ShouldContactPeer(Peer peer)
             => peer.Node.Id != _enode.PublicKey
                && _rlpxHost.ShouldContact(peer.Node.Address.Address, exactOnly: peer.Node.IsStatic || peer.Node.IsBootnode);

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -544,6 +544,11 @@ namespace Nethermind.Network
                     continue;
                 }
 
+                if (peer.Node.Id == _enode.PublicKey)
+                {
+                    continue;
+                }
+
                 _currentSelection.PreCandidates.Add(peer);
             }
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -544,9 +544,6 @@ namespace Nethermind.Network
                     continue;
                 }
 
-                // Also dropped at dial time, but a candidate that can never be dialed and never records a stat
-                // stays eligible for every future round, and the loop re-runs immediately whenever a slot is
-                // still free - so leaving it in the selection spins this loop with no delay between rounds.
                 if (IsSelf(peer))
                 {
                     continue;
@@ -944,15 +941,6 @@ namespace Nethermind.Network
                 => _logger.Trace($"Initiating disconnect with {session} {DisconnectReason.HardLimitTooManyPeers} {DisconnectType.Local}");
         }
 
-        /// <summary>
-        /// Whether an outbound dial to <paramref name="peer"/> should be attempted.
-        /// </summary>
-        /// <remarks>
-        /// The self-identity check deliberately precedes the recent-IP filter: that filter records every address
-        /// it accepts, so letting our own record through would keep re-arming it for our own subnet and lock out
-        /// real peers sharing it. Both dial paths - the update loop's workers and the quick-connect on
-        /// peer-added - pass through here.
-        /// </remarks>
         private bool ShouldContactPeer(Peer peer)
             => !IsSelf(peer)
                && _rlpxHost.ShouldContact(peer.Node.Address.Address, exactOnly: peer.Node.IsStatic || peer.Node.IsBootnode);


### PR DESCRIPTION
## Problem

Nothing in the network stack checks the remote identity against the local one. A node can dial its own enode (discovery can hand a node its own record back, and a hairpinned NAT completes the loop) and end up holding a fully initialized session with itself - wasting two peer slots and polluting node stats. Observed live behind a Docker bridge: an inbound session from the node's own external IP completed the full handshake and protocol negotiation with itself.

`DisconnectReason.IdentitySameAsSelf` exists in the enum but was never used anywhere.

## Fix

Two independent guards:
- `P2PProtocolHandler.HandleHello` rejects a hello carrying the local public key with `IdentitySameAsSelf`, covering both directions and any peer that echoes our identity.
- Peer candidate selection drops candidates carrying the local identity, so the self-dial is not even attempted.

## Testing

`On_hello_carrying_this_nodes_own_identity_disconnects` asserts the hello-level rejection; existing tests that sent hellos from the local test identity were switched to a distinct remote key.
