### PR TITLE
Expose EIP-8282 builder contracts in eth_config

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip8282Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8282Constants.cs
@@ -9,6 +9,9 @@ namespace Nethermind.Core;
 /// </summary>
 public static class Eip8282Constants
 {
+    public const string BuilderDepositContractAddressKey = "BUILDER_DEPOSIT_CONTRACT_ADDRESS";
+    public const string BuilderExitContractAddressKey = "BUILDER_EXIT_CONTRACT_ADDRESS";
+
     public static readonly Address BuilderDepositRequestPredeployAddress = new("0x0000BFF46984E3725691FA540A8C7589300D8282");
 
     public static readonly Address BuilderExitRequestPredeployAddress = new("0x000064D678505AD48F8CCB093BC65613800E8282");

--- a/src/Nethermind/Nethermind.Evm.Precompiles/Extensions.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/Extensions.cs
@@ -66,6 +66,11 @@ public static class Extensions
         OrderedDictionary<string, Address> systemContracts = [];
 
         if (spec.IsBeaconBlockRootAvailable) systemContracts[Eip4788Constants.ContractAddressKey] = Eip4788Constants.BeaconRootsAddress;
+        if (spec.BuilderRequestsEnabled)
+        {
+            systemContracts[Eip8282Constants.BuilderDepositContractAddressKey] = Eip8282Constants.BuilderDepositRequestPredeployAddress;
+            systemContracts[Eip8282Constants.BuilderExitContractAddressKey] = Eip8282Constants.BuilderExitRequestPredeployAddress;
+        }
         if (spec.ConsolidationRequestsEnabled) systemContracts[Eip7251Constants.ContractAddressKey] = Eip7251Constants.ConsolidationRequestPredeployAddress;
         if (spec.DepositsEnabled) systemContracts[Eip6110Constants.ContractAddressKey] = spec.DepositContractAddress!;
         if (spec.IsEip2935Enabled) systemContracts[Eip2935Constants.ContractAddressKey] = Eip2935Constants.BlockHashHistoryAddress;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -264,6 +264,22 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
+    public async Task Eth_config_includes_builder_request_contracts()
+    {
+        using Context ctx = await Context.CreateWithAmsterdamEnabled();
+        string serialized = await ctx.Test.TestEthRpc("eth_config");
+        JToken result = JToken.Parse(serialized);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.SelectToken("result.current.systemContracts.BUILDER_DEPOSIT_CONTRACT_ADDRESS")?.Value<string>(),
+                Is.EqualTo("0x0000bff46984e3725691fa540a8c7589300d8282"));
+            Assert.That(result.SelectToken("result.current.systemContracts.BUILDER_EXIT_CONTRACT_ADDRESS")?.Value<string>(),
+                Is.EqualTo("0x000064d678505ad48f8ccb093bc65613800e8282"));
+        }
+    }
+
+    [Test]
     public async Task Eth_get_transaction_by_block_number_and_index()
     {
         using Context ctx = await Context.Create();


### PR DESCRIPTION
## Changes

- Add `BUILDER_DEPOSIT_CONTRACT_ADDRESS` and `BUILDER_EXIT_CONTRACT_ADDRESS` to `eth_config` when Amsterdam/EIP-8282 is active.
- Reuse the existing EIP-8282 predeploy addresses and preserve the alphabetical `systemContracts` ordering required by [EIP-7910](https://eips.ethereum.org/EIPS/eip-7910).
- Add regression coverage for both returned values.
- The values match [EIP-8282](https://eips.ethereum.org/EIPS/eip-8282) and the other execution clients observed on [Glamsterdam devnet-8 Dora](https://dora.glamsterdam-devnet-8.ethpandaops.io/clients/execution).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Focused RPC coverage, the full Nethermind solution build with warnings treated as errors, and formatting verification pass. A broader JSON-RPC run retains nine unrelated failures: one existing error-code assertion and socket tests whose endpoint refused connections.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
