### PR TITLE
Fix `admin_addPeer`/`admin_addTrustedPeer` dropping `persistent=true` for already-known peers

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -184,12 +184,13 @@ public class AdminModuleTests
         Assert.That(serialized, Does.Contain(stateAvailable ? "true" : "false"), "admin_isStateRootAvailable mirrors the state reader's HasStateForBlock answer");
     }
 
-    [TestCase(false, false, TestName = "AdminAddTrustedPeer_WhenPersistentFalse_KeepsAsInMemoryTrustedPeer")]
-    [TestCase(true, true, TestName = "AdminAddTrustedPeer_WhenPersistentTrue_AlsoWritesToTrustedNodesFile")]
-    public async Task AdminAddTrustedPeer_WithValidEnode_AddsAsTrustedPeerAndReturnsTrue(bool persistent, bool expectedUpdateFile)
+    [TestCase(false, false, false, TestName = "AdminAddTrustedPeer_WhenPersistentFalse_KeepsAsInMemoryTrustedPeer")]
+    [TestCase(true, true, false, TestName = "AdminAddTrustedPeer_WhenPersistentTrue_AlsoWritesToTrustedNodesFile")]
+    [TestCase(true, true, true, TestName = "AdminAddTrustedPeer_WhenAlreadyTrustedAndPersistent_StillRequestsFileUpdate")]
+    public async Task AdminAddTrustedPeer_WithValidEnode_AddsAsTrustedPeerAndReturnsTrue(bool persistent, bool expectedUpdateFile, bool alreadyTrusted)
     {
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(!alreadyTrusted));
         IPeerPool peerPool = Substitute.For<IPeerPool>();
         IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(peerPool: peerPool, trustedNodesManager: trustedNodesManager);
 
@@ -197,25 +198,9 @@ public class AdminModuleTests
 
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
         bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
-        Assert.That(result, Is.True, "a valid enode is added to the trusted peer set and the call must report success as a boolean");
+        Assert.That(result, Is.True, "addTrustedPeer is idempotent: adding a new or already-trusted peer must report success as a boolean, matching geth's Server.AddTrustedPeer semantics");
         await trustedNodesManager.Received(1).AddAsync(Arg.Any<Enode>(), expectedUpdateFile, Arg.Any<CancellationToken>());
         peerPool.Received(1).GetOrAdd(Arg.Any<NetworkNode>());
-    }
-
-    [Test]
-    public async Task AdminAddTrustedPeer_WhenAlreadyTrustedAndPersistent_StillRequestsFileUpdate()
-    {
-        ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
-        trustedNodesManager.IsTrusted(Arg.Any<Enode>()).Returns(true);
-        trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
-        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager);
-
-        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_addTrustedPeer", _enodeString, true);
-
-        JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
-        bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
-        Assert.That(result, Is.True, "addTrustedPeer is idempotent: trusting an already-trusted peer is success, matching geth's Server.AddTrustedPeer semantics");
-        await trustedNodesManager.Received(1).AddAsync(Arg.Any<Enode>(), true, Arg.Any<CancellationToken>());
     }
 
     [TestCase("admin_addPeer", "not-an-enode", TestName = "AdminAddPeer_WhenEnodeSchemeInvalid_ReturnsInvalidParamsError")]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -203,20 +203,19 @@ public class AdminModuleTests
     }
 
     [Test]
-    public async Task AdminAddTrustedPeer_WhenAlreadyTrusted_SkipsAddAsyncAndPoolInsert()
+    public async Task AdminAddTrustedPeer_WhenAlreadyTrustedAndPersistent_StillRequestsFileUpdate()
     {
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
         trustedNodesManager.IsTrusted(Arg.Any<Enode>()).Returns(true);
-        IPeerPool peerPool = Substitute.For<IPeerPool>();
-        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager, peerPool: peerPool);
+        trustedNodesManager.AddAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
+        IAdminRpcModule adminRpcModule = BuildAdminRpcModuleWith(trustedNodesManager: trustedNodesManager);
 
-        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_addTrustedPeer", _enodeString);
+        string serialized = await RpcTest.TestSerializedRequest(adminRpcModule, "admin_addTrustedPeer", _enodeString, true);
 
         JsonRpcSuccessResponse response = _serializer.Deserialize<JsonRpcSuccessResponse>(serialized);
         bool result = ((JsonElement)response.Result!).Deserialize<bool>(EthereumJsonSerializer.JsonOptions);
         Assert.That(result, Is.True, "addTrustedPeer is idempotent: trusting an already-trusted peer is success, matching geth's Server.AddTrustedPeer semantics");
-        await trustedNodesManager.DidNotReceive().AddAsync(Arg.Any<Enode>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        peerPool.DidNotReceive().GetOrAdd(Arg.Any<NetworkNode>());
+        await trustedNodesManager.Received(1).AddAsync(Arg.Any<Enode>(), true, Arg.Any<CancellationToken>());
     }
 
     [TestCase("admin_addPeer", "not-an-enode", TestName = "AdminAddPeer_WhenEnodeSchemeInvalid_ReturnsInvalidParamsError")]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -117,11 +117,6 @@ public class AdminRpcModule : IAdminRpcModule
     {
         if (TryParseAsEnode(enode, out Enode? enodeObj) is { } error) return error;
 
-        if (_trustedNodesManager.IsTrusted(enodeObj!))
-        {
-            return ResultWrapper<bool>.Success(true);
-        }
-
         using CancellationTokenSource timeout = BuildTimeoutCancellationTokenSource();
 
         try

--- a/src/Nethermind/Nethermind.Network.Test/NodesManagerPersistenceTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodesManagerPersistenceTests.cs
@@ -7,7 +7,6 @@ using Nethermind.Config;
 using Nethermind.Core.Test.IO;
 using Nethermind.Logging;
 using Nethermind.Network.StaticNodes;
-using Nethermind.Stats.Model;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Test;

--- a/src/Nethermind/Nethermind.Network.Test/NodesManagerPersistenceTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NodesManagerPersistenceTests.cs
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.IO;
+using System.Threading.Tasks;
+using Nethermind.Config;
+using Nethermind.Core.Test.IO;
+using Nethermind.Logging;
+using Nethermind.Network.StaticNodes;
+using Nethermind.Stats.Model;
+using NUnit.Framework;
+
+namespace Nethermind.Network.Test;
+
+/// <summary>Persistence contract shared by <see cref="StaticNodesManager"/> and <see cref="TrustedNodesManager"/>: the nodes file mirrors only the peers explicitly persisted.</summary>
+[Parallelizable(ParallelScope.Self)]
+public abstract class NodesManagerPersistenceTests<TManager>
+{
+    private const string EnodeA =
+        "enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@192.81.208.223:30303";
+
+    private const string EnodeB =
+        "enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f0a@192.81.208.223:30304";
+
+    protected abstract TManager CreateManager(string path);
+    protected abstract Task InitAsync(TManager manager);
+    protected abstract Task<bool> AddAsync(TManager manager, string enode, bool updateFile);
+    protected abstract Task<bool> RemoveAsync(TManager manager, string enode, bool updateFile);
+
+    [Test]
+    public async Task PersistentAdd_OfNodePreviouslyAddedInMemoryOnly_WritesItToFile()
+    {
+        using TempPath tempPath = TempPath.GetTempFile();
+        TManager manager = await CreateManagerWithLoadedFile(tempPath);
+
+        await AddAsync(manager, EnodeA, updateFile: false);
+        await AddAsync(manager, EnodeA, updateFile: true);
+
+        Assert.That(await File.ReadAllTextAsync(tempPath.Path), Does.Contain(PublicKeyOf(EnodeA)), "upgrading an in-memory node to persistent must write the file");
+    }
+
+    [Test]
+    public async Task PersistentRemove_OfNodePreviouslyRemovedInMemoryOnly_ScrubsItFromFile()
+    {
+        using TempPath tempPath = TempPath.GetTempFile();
+        TManager manager = await CreateManagerWithLoadedFile(tempPath);
+        await AddAsync(manager, EnodeA, updateFile: true);
+
+        await RemoveAsync(manager, EnodeA, updateFile: false);
+        await RemoveAsync(manager, EnodeA, updateFile: true);
+
+        Assert.That(await File.ReadAllTextAsync(tempPath.Path), Does.Not.Contain(PublicKeyOf(EnodeA)), "a persistent remove of an already-forgotten node must still scrub the file");
+    }
+
+    [Test]
+    public async Task PersistentAdd_DoesNotPersistUnrelatedInMemoryOnlyNodes()
+    {
+        using TempPath tempPath = TempPath.GetTempFile();
+        TManager manager = await CreateManagerWithLoadedFile(tempPath);
+
+        await AddAsync(manager, EnodeB, updateFile: false);
+        await AddAsync(manager, EnodeA, updateFile: true);
+
+        string file = await File.ReadAllTextAsync(tempPath.Path);
+        Assert.That(file, Does.Contain(PublicKeyOf(EnodeA)), "the promoted node must be persisted");
+        Assert.That(file, Does.Not.Contain(PublicKeyOf(EnodeB)), "a persistent add must not commit unrelated peers added with persistent=false");
+    }
+
+    [Test]
+    public async Task PersistentRemove_DoesNotDropUnrelatedNodesRemovedInMemoryOnly()
+    {
+        using TempPath tempPath = TempPath.GetTempFile();
+        TManager manager = await CreateManagerWithLoadedFile(tempPath);
+        await AddAsync(manager, EnodeA, updateFile: true);
+        await AddAsync(manager, EnodeB, updateFile: true);
+
+        await RemoveAsync(manager, EnodeB, updateFile: false);
+        await RemoveAsync(manager, EnodeA, updateFile: true);
+
+        string file = await File.ReadAllTextAsync(tempPath.Path);
+        Assert.That(file, Does.Not.Contain(PublicKeyOf(EnodeA)), "the persistently removed node must be scrubbed");
+        Assert.That(file, Does.Contain(PublicKeyOf(EnodeB)), "a persistent remove must not drop unrelated peers removed with persistent=false");
+    }
+
+    [Test]
+    public async Task NoOpRemove_WhenNodesWereNeverLoaded_DoesNotRewriteFile()
+    {
+        using TempPath tempPath = TempPath.GetTempFile();
+        string original = $"[\"{EnodeA}\"]";
+        await File.WriteAllTextAsync(tempPath.Path, original);
+        TManager manager = CreateManager(tempPath.Path);
+
+        await RemoveAsync(manager, EnodeB, updateFile: true);
+
+        Assert.That(await File.ReadAllTextAsync(tempPath.Path), Is.EqualTo(original), "a no-op remove must not clobber a file that was never loaded (e.g. after a failed init)");
+    }
+
+    private async Task<TManager> CreateManagerWithLoadedFile(TempPath tempPath)
+    {
+        await File.WriteAllTextAsync(tempPath.Path, "[]");
+        TManager manager = CreateManager(tempPath.Path);
+        await InitAsync(manager);
+        return manager;
+    }
+
+    private static string PublicKeyOf(string enode) => enode.Substring("enode://".Length, 128);
+}
+
+[TestFixture]
+public class StaticNodesManagerPersistenceTests : NodesManagerPersistenceTests<StaticNodesManager>
+{
+    protected override StaticNodesManager CreateManager(string path) => new(path, LimboLogs.Instance);
+    protected override Task InitAsync(StaticNodesManager manager) => manager.InitAsync();
+    protected override Task<bool> AddAsync(StaticNodesManager manager, string enode, bool updateFile) => manager.AddAsync(new NetworkNode(enode), updateFile);
+    protected override Task<bool> RemoveAsync(StaticNodesManager manager, string enode, bool updateFile) => manager.RemoveAsync(new NetworkNode(enode), updateFile);
+}
+
+[TestFixture]
+public class TrustedNodesManagerPersistenceTests : NodesManagerPersistenceTests<TrustedNodesManager>
+{
+    protected override TrustedNodesManager CreateManager(string path) => new(path, LimboLogs.Instance);
+    protected override Task InitAsync(TrustedNodesManager manager) => manager.InitAsync();
+    protected override Task<bool> AddAsync(TrustedNodesManager manager, string enode, bool updateFile) => manager.AddAsync(new Enode(enode), updateFile);
+    protected override Task<bool> RemoveAsync(TrustedNodesManager manager, string enode, bool updateFile) => manager.RemoveAsync(new Enode(enode), updateFile);
+}

--- a/src/Nethermind/Nethermind.Network.Test/StaticNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/StaticNodesManagerTests.cs
@@ -124,52 +124,6 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
-        public async Task add_with_update_file_should_persist_node_previously_added_in_memory_only()
-        {
-            using TempPath tempPath = TempPath.GetTempFile();
-            StaticNodesManager manager = await CreateManagerWithLoadedFile(tempPath);
-
-            await manager.AddAsync(Enode, updateFile: false);
-            await manager.AddAsync(Enode, updateFile: true);
-
-            Assert.That(await File.ReadAllTextAsync(tempPath.Path), Does.Contain(EnodeString), "upgrading an in-memory node to persistent must write the file");
-        }
-
-        [Test]
-        public async Task remove_with_update_file_should_unpersist_node_previously_removed_in_memory_only()
-        {
-            using TempPath tempPath = TempPath.GetTempFile();
-            StaticNodesManager manager = await CreateManagerWithLoadedFile(tempPath);
-            await manager.AddAsync(Enode, updateFile: true);
-
-            await manager.RemoveAsync(Enode, updateFile: false);
-            await manager.RemoveAsync(Enode, updateFile: true);
-
-            Assert.That(await File.ReadAllTextAsync(tempPath.Path), Does.Not.Contain(EnodeString), "a persistent remove of an already-forgotten node must still scrub the file");
-        }
-
-        [Test]
-        public async Task no_op_remove_should_not_rewrite_file_when_nodes_were_never_loaded()
-        {
-            using TempPath tempPath = TempPath.GetTempFile();
-            string original = $"[\"{EnodeString}\"]";
-            await File.WriteAllTextAsync(tempPath.Path, original);
-            StaticNodesManager manager = new(tempPath.Path, LimboLogs.Instance);
-
-            await manager.RemoveAsync(Enode, updateFile: true);
-
-            Assert.That(await File.ReadAllTextAsync(tempPath.Path), Is.EqualTo(original), "a no-op remove must not clobber a file that was never loaded (e.g. after a failed init)");
-        }
-
-        private static async Task<StaticNodesManager> CreateManagerWithLoadedFile(TempPath tempPath)
-        {
-            await File.WriteAllTextAsync(tempPath.Path, "[]");
-            StaticNodesManager manager = new(tempPath.Path, LimboLogs.Instance);
-            await manager.InitAsync();
-            return manager;
-        }
-
-        [Test]
         public async Task init_should_load_static_nodes_from_empty_file()
         {
             using TempPath tempFile = TempPath.GetTempFile();

--- a/src/Nethermind/Nethermind.Network.Test/StaticNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/StaticNodesManagerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -121,6 +122,31 @@ namespace Nethermind.Network.Test
             await _staticNodesManager.RemoveAsync(Enode, false);
             Assert.That(_staticNodesManager.Nodes.Count(), Is.EqualTo(0));
             Assert.That(eventRaised, Is.True);
+        }
+
+        [Test]
+        public async Task add_with_update_file_should_persist_node_previously_added_in_memory_only()
+        {
+            string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-static-nodes-{Guid.NewGuid():N}.json");
+            StaticNodesManager manager = new(path, LimboLogs.Instance);
+
+            await manager.AddAsync(Enode, updateFile: false);
+            await manager.AddAsync(Enode, updateFile: true);
+
+            Assert.That(await File.ReadAllTextAsync(path), Does.Contain(EnodeString), "upgrading an in-memory node to persistent must write the file");
+        }
+
+        [Test]
+        public async Task remove_with_update_file_should_unpersist_node_previously_removed_in_memory_only()
+        {
+            string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-static-nodes-{Guid.NewGuid():N}.json");
+            StaticNodesManager manager = new(path, LimboLogs.Instance);
+            await manager.AddAsync(Enode, updateFile: true);
+
+            await manager.RemoveAsync(Enode, updateFile: false);
+            await manager.RemoveAsync(Enode, updateFile: true);
+
+            Assert.That(await File.ReadAllTextAsync(path), Does.Not.Contain(EnodeString), "a persistent remove of an already-forgotten node must still scrub the file");
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/StaticNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/StaticNodesManagerTests.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -127,26 +126,47 @@ namespace Nethermind.Network.Test
         [Test]
         public async Task add_with_update_file_should_persist_node_previously_added_in_memory_only()
         {
-            string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-static-nodes-{Guid.NewGuid():N}.json");
-            StaticNodesManager manager = new(path, LimboLogs.Instance);
+            using TempPath tempPath = TempPath.GetTempFile();
+            StaticNodesManager manager = await CreateManagerWithLoadedFile(tempPath);
 
             await manager.AddAsync(Enode, updateFile: false);
             await manager.AddAsync(Enode, updateFile: true);
 
-            Assert.That(await File.ReadAllTextAsync(path), Does.Contain(EnodeString), "upgrading an in-memory node to persistent must write the file");
+            Assert.That(await File.ReadAllTextAsync(tempPath.Path), Does.Contain(EnodeString), "upgrading an in-memory node to persistent must write the file");
         }
 
         [Test]
         public async Task remove_with_update_file_should_unpersist_node_previously_removed_in_memory_only()
         {
-            string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-static-nodes-{Guid.NewGuid():N}.json");
-            StaticNodesManager manager = new(path, LimboLogs.Instance);
+            using TempPath tempPath = TempPath.GetTempFile();
+            StaticNodesManager manager = await CreateManagerWithLoadedFile(tempPath);
             await manager.AddAsync(Enode, updateFile: true);
 
             await manager.RemoveAsync(Enode, updateFile: false);
             await manager.RemoveAsync(Enode, updateFile: true);
 
-            Assert.That(await File.ReadAllTextAsync(path), Does.Not.Contain(EnodeString), "a persistent remove of an already-forgotten node must still scrub the file");
+            Assert.That(await File.ReadAllTextAsync(tempPath.Path), Does.Not.Contain(EnodeString), "a persistent remove of an already-forgotten node must still scrub the file");
+        }
+
+        [Test]
+        public async Task no_op_remove_should_not_rewrite_file_when_nodes_were_never_loaded()
+        {
+            using TempPath tempPath = TempPath.GetTempFile();
+            string original = $"[\"{EnodeString}\"]";
+            await File.WriteAllTextAsync(tempPath.Path, original);
+            StaticNodesManager manager = new(tempPath.Path, LimboLogs.Instance);
+
+            await manager.RemoveAsync(Enode, updateFile: true);
+
+            Assert.That(await File.ReadAllTextAsync(tempPath.Path), Is.EqualTo(original), "a no-op remove must not clobber a file that was never loaded (e.g. after a failed init)");
+        }
+
+        private static async Task<StaticNodesManager> CreateManagerWithLoadedFile(TempPath tempPath)
+        {
+            await File.WriteAllTextAsync(tempPath.Path, "[]");
+            StaticNodesManager manager = new(tempPath.Path, LimboLogs.Instance);
+            await manager.InitAsync();
+            return manager;
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
+using Nethermind.Core.Test.IO;
 using Nethermind.Logging;
 using NUnit.Framework;
 
@@ -44,30 +45,49 @@ public class TrustedNodesManagerTests
     [Test]
     public async Task AddAsync_WithUpdateFile_PersistsNodePreviouslyAddedInMemoryOnly()
     {
-        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-trusted-nodes-{System.Guid.NewGuid():N}.json");
-        await File.WriteAllTextAsync(path, "[]");
-        TrustedNodesManager manager = new(path, LimboLogs.Instance);
+        using TempPath tempPath = TempPath.GetTempFile();
+        TrustedNodesManager manager = await CreateManagerWithLoadedFile(tempPath);
         Enode enode = new(EnodeString);
 
         await manager.AddAsync(enode, updateFile: false);
         await manager.AddAsync(enode, updateFile: true);
 
-        Assert.That(await File.ReadAllTextAsync(path), Does.Contain(enode.PublicKey.ToString(false)), "upgrading an in-memory node to persistent must write the file");
+        Assert.That(await File.ReadAllTextAsync(tempPath.Path), Does.Contain(enode.PublicKey.ToString(false)), "upgrading an in-memory node to persistent must write the file");
     }
 
     [Test]
     public async Task RemoveAsync_WithUpdateFile_UnpersistsNodePreviouslyRemovedInMemoryOnly()
     {
-        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-trusted-nodes-{System.Guid.NewGuid():N}.json");
-        await File.WriteAllTextAsync(path, "[]");
-        TrustedNodesManager manager = new(path, LimboLogs.Instance);
+        using TempPath tempPath = TempPath.GetTempFile();
+        TrustedNodesManager manager = await CreateManagerWithLoadedFile(tempPath);
         Enode enode = new(EnodeString);
         await manager.AddAsync(enode, updateFile: true);
 
         await manager.RemoveAsync(enode, updateFile: false);
         await manager.RemoveAsync(enode, updateFile: true);
 
-        Assert.That(await File.ReadAllTextAsync(path), Does.Not.Contain(enode.PublicKey.ToString(false)), "a persistent remove of an already-forgotten node must still scrub the file");
+        Assert.That(await File.ReadAllTextAsync(tempPath.Path), Does.Not.Contain(enode.PublicKey.ToString(false)), "a persistent remove of an already-forgotten node must still scrub the file");
+    }
+
+    [Test]
+    public async Task NoOpRemove_WhenNodesWereNeverLoaded_DoesNotRewriteFile()
+    {
+        using TempPath tempPath = TempPath.GetTempFile();
+        string original = $"[\"{EnodeString}\"]";
+        await File.WriteAllTextAsync(tempPath.Path, original);
+        TrustedNodesManager manager = new(tempPath.Path, LimboLogs.Instance);
+
+        await manager.RemoveAsync(new Enode(EnodeString), updateFile: true);
+
+        Assert.That(await File.ReadAllTextAsync(tempPath.Path), Is.EqualTo(original), "a no-op remove must not clobber a file that was never loaded (e.g. after a failed init)");
+    }
+
+    private static async Task<TrustedNodesManager> CreateManagerWithLoadedFile(TempPath tempPath)
+    {
+        await File.WriteAllTextAsync(tempPath.Path, "[]");
+        TrustedNodesManager manager = new(tempPath.Path, LimboLogs.Instance);
+        await manager.InitAsync();
+        return manager;
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
-using Nethermind.Core.Test.IO;
 using Nethermind.Logging;
 using NUnit.Framework;
 
@@ -28,7 +27,8 @@ public class TrustedNodesManagerTests
         await File.WriteAllTextAsync(path, "[]");
         TrustedNodesManager manager = new(path, LimboLogs.Instance);
         Enode enode = new(EnodeString);
-        await manager.AddAsync(enode, updateFile: false);
+        // Persist the node so the persistent remove below actually reaches the (cancelled) file write.
+        await manager.AddAsync(enode, updateFile: true);
 
         bool nodeRemovedFired = false;
         manager.NodeRemoved += (_, _) => nodeRemovedFired = true;
@@ -40,54 +40,6 @@ public class TrustedNodesManagerTests
 
         Assert.That(nodeRemovedFired, Is.True, "NodeRemoved must fire before the file write, so a cancelled SaveFileAsync cannot leave the peer untrusted-in-memory yet still connected via the missed disconnect event chain");
         Assert.That(manager.Nodes, Has.None.Matches<NetworkNode>(n => n.NodeId == enode.PublicKey), "the in-memory dict must already be cleared before the cancellation point, so an aborted file write cannot leave the peer trusted in memory");
-    }
-
-    [Test]
-    public async Task AddAsync_WithUpdateFile_PersistsNodePreviouslyAddedInMemoryOnly()
-    {
-        using TempPath tempPath = TempPath.GetTempFile();
-        TrustedNodesManager manager = await CreateManagerWithLoadedFile(tempPath);
-        Enode enode = new(EnodeString);
-
-        await manager.AddAsync(enode, updateFile: false);
-        await manager.AddAsync(enode, updateFile: true);
-
-        Assert.That(await File.ReadAllTextAsync(tempPath.Path), Does.Contain(enode.PublicKey.ToString(false)), "upgrading an in-memory node to persistent must write the file");
-    }
-
-    [Test]
-    public async Task RemoveAsync_WithUpdateFile_UnpersistsNodePreviouslyRemovedInMemoryOnly()
-    {
-        using TempPath tempPath = TempPath.GetTempFile();
-        TrustedNodesManager manager = await CreateManagerWithLoadedFile(tempPath);
-        Enode enode = new(EnodeString);
-        await manager.AddAsync(enode, updateFile: true);
-
-        await manager.RemoveAsync(enode, updateFile: false);
-        await manager.RemoveAsync(enode, updateFile: true);
-
-        Assert.That(await File.ReadAllTextAsync(tempPath.Path), Does.Not.Contain(enode.PublicKey.ToString(false)), "a persistent remove of an already-forgotten node must still scrub the file");
-    }
-
-    [Test]
-    public async Task NoOpRemove_WhenNodesWereNeverLoaded_DoesNotRewriteFile()
-    {
-        using TempPath tempPath = TempPath.GetTempFile();
-        string original = $"[\"{EnodeString}\"]";
-        await File.WriteAllTextAsync(tempPath.Path, original);
-        TrustedNodesManager manager = new(tempPath.Path, LimboLogs.Instance);
-
-        await manager.RemoveAsync(new Enode(EnodeString), updateFile: true);
-
-        Assert.That(await File.ReadAllTextAsync(tempPath.Path), Is.EqualTo(original), "a no-op remove must not clobber a file that was never loaded (e.g. after a failed init)");
-    }
-
-    private static async Task<TrustedNodesManager> CreateManagerWithLoadedFile(TempPath tempPath)
-    {
-        await File.WriteAllTextAsync(tempPath.Path, "[]");
-        TrustedNodesManager manager = new(tempPath.Path, LimboLogs.Instance);
-        await manager.InitAsync();
-        return manager;
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/TrustedNodesManagerTests.cs
@@ -42,6 +42,35 @@ public class TrustedNodesManagerTests
     }
 
     [Test]
+    public async Task AddAsync_WithUpdateFile_PersistsNodePreviouslyAddedInMemoryOnly()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-trusted-nodes-{System.Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(path, "[]");
+        TrustedNodesManager manager = new(path, LimboLogs.Instance);
+        Enode enode = new(EnodeString);
+
+        await manager.AddAsync(enode, updateFile: false);
+        await manager.AddAsync(enode, updateFile: true);
+
+        Assert.That(await File.ReadAllTextAsync(path), Does.Contain(enode.PublicKey.ToString(false)), "upgrading an in-memory node to persistent must write the file");
+    }
+
+    [Test]
+    public async Task RemoveAsync_WithUpdateFile_UnpersistsNodePreviouslyRemovedInMemoryOnly()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-trusted-nodes-{System.Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(path, "[]");
+        TrustedNodesManager manager = new(path, LimboLogs.Instance);
+        Enode enode = new(EnodeString);
+        await manager.AddAsync(enode, updateFile: true);
+
+        await manager.RemoveAsync(enode, updateFile: false);
+        await manager.RemoveAsync(enode, updateFile: true);
+
+        Assert.That(await File.ReadAllTextAsync(path), Does.Not.Contain(enode.PublicKey.ToString(false)), "a persistent remove of an already-forgotten node must still scrub the file");
+    }
+
+    [Test]
     public async Task IsTrusted_AfterAdd_ReturnsTrueRegardlessOfHostOrPort()
     {
         string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"test-trusted-nodes-{System.Guid.NewGuid():N}.json");

--- a/src/Nethermind/Nethermind.Network/IStaticNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/IStaticNodesManager.cs
@@ -13,7 +13,12 @@ public interface IStaticNodesManager : INodeSource
 {
     IEnumerable<NetworkNode> Nodes { get; }
     Task InitAsync();
+    /// <summary>Adds a node to the in-memory set and, when <paramref name="updateFile"/> is <see langword="true"/>, rewrites the nodes file so the node is persisted even if it was already known.</summary>
+    /// <returns><see langword="true"/> when the node was newly added; <see langword="false"/> when it was already present.</returns>
     Task<bool> AddAsync(NetworkNode node, bool updateFile = true, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a node from the in-memory set and, when <paramref name="updateFile"/> is <see langword="true"/>, rewrites the nodes file so any stale entry is scrubbed even if the node was already forgotten.</summary>
+    /// <returns><see langword="true"/> when the node was removed; <see langword="false"/> when it was not present.</returns>
     Task<bool> RemoveAsync(NetworkNode node, bool updateFile = true, CancellationToken cancellationToken = default);
     bool IsStatic(NetworkNode node);
 

--- a/src/Nethermind/Nethermind.Network/ITrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/ITrustedNodesManager.cs
@@ -13,7 +13,12 @@ public interface ITrustedNodesManager : INodeSource
 {
     IEnumerable<NetworkNode> Nodes { get; }
     Task InitAsync();
+    /// <summary>Adds a node to the in-memory set and, when <paramref name="updateFile"/> is <see langword="true"/>, rewrites the nodes file so the node is persisted even if it was already known.</summary>
+    /// <returns><see langword="true"/> when the node was newly added; <see langword="false"/> when it was already present.</returns>
     Task<bool> AddAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a node from the in-memory set and, when <paramref name="updateFile"/> is <see langword="true"/>, rewrites the nodes file so any stale entry is scrubbed even if the node was already forgotten.</summary>
+    /// <returns><see langword="true"/> when the node was removed; <see langword="false"/> when it was not present.</returns>
     Task<bool> RemoveAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default);
     bool IsTrusted(Enode enode);
 

--- a/src/Nethermind/Nethermind.Network/NodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/NodesManager.cs
@@ -217,6 +217,15 @@ public abstract class NodesManager(string path, ILogger logger)
         return true;
     }
 
+    /// <summary>Logs the outcome of an add/remove and rewrites the nodes file when <paramref name="updateFile"/> is set.</summary>
+    /// <remarks>A no-op change still triggers the rewrite to reconcile an earlier <c>updateFile: false</c> call, but only once the file has been successfully loaded, so a failed init cannot truncate it.</remarks>
+    protected async Task<bool> LogAndSaveAsync(bool changed, string changedMessage, string noOpMessage, bool updateFile, CancellationToken cancellationToken)
+    {
+        if (_logger.IsInfo) _logger.Info(changed ? changedMessage : noOpMessage);
+        if (updateFile && (changed || Loaded)) await SaveFileAsync(cancellationToken);
+        return changed;
+    }
+
     protected virtual Task SaveFileAsync(CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);

--- a/src/Nethermind/Nethermind.Network/NodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/NodesManager.cs
@@ -36,6 +36,9 @@ public abstract class NodesManager(string path, ILogger logger)
     /// <summary>Returns <see langword="true"/> when any managed node is reachable at <paramref name="ip"/>.</summary>
     public bool ContainsIp(IPAddress ip) => _ipCounts.ContainsKey(ip);
 
+    /// <summary>Set once the nodes file has been successfully loaded, so no-op calls never rewrite the file from a never-loaded state.</summary>
+    protected bool Loaded { get; private set; }
+
     /// <summary>Adds a node and updates the IP index. Returns <see langword="false"/> if already present.</summary>
     protected bool TryAddNode(NetworkNode node)
     {
@@ -58,6 +61,8 @@ public abstract class NodesManager(string path, ILogger logger)
             {
                 _ipCounts.AddOrUpdate(kvp.Value.HostIp, 1, static (_, count) => count + 1);
             }
+
+            Loaded = true;
         }
     }
 

--- a/src/Nethermind/Nethermind.Network/NodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/NodesManager.cs
@@ -217,11 +217,10 @@ public abstract class NodesManager(string path, ILogger logger)
         return true;
     }
 
-    /// <summary>Logs the outcome of an add/remove and rewrites the nodes file when <paramref name="updateFile"/> is set.</summary>
+    /// <summary>Rewrites the nodes file when <paramref name="updateFile"/> is set and returns <paramref name="changed"/>.</summary>
     /// <remarks>A no-op change still triggers the rewrite to reconcile an earlier <c>updateFile: false</c> call, but only once the file has been successfully loaded, so a failed init cannot truncate it.</remarks>
-    protected async Task<bool> LogAndSaveAsync(bool changed, string changedMessage, string noOpMessage, bool updateFile, CancellationToken cancellationToken)
+    protected async Task<bool> SaveAsync(bool changed, bool updateFile, CancellationToken cancellationToken)
     {
-        if (_logger.IsInfo) _logger.Info(changed ? changedMessage : noOpMessage);
         if (updateFile && (changed || Loaded)) await SaveFileAsync(cancellationToken);
         return changed;
     }

--- a/src/Nethermind/Nethermind.Network/NodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/NodesManager.cs
@@ -36,8 +36,9 @@ public abstract class NodesManager(string path, ILogger logger)
     /// <summary>Returns <see langword="true"/> when any managed node is reachable at <paramref name="ip"/>.</summary>
     public bool ContainsIp(IPAddress ip) => _ipCounts.ContainsKey(ip);
 
-    /// <summary>Set once the nodes file has been successfully loaded, so no-op calls never rewrite the file from a never-loaded state.</summary>
-    protected bool Loaded { get; private set; }
+    // Nodes explicitly persisted (loaded from the file or added with updateFile=true). The file mirrors this set,
+    // so transient (updateFile=false) changes to _nodes never leak into it and a failed load cannot be amplified.
+    private ConcurrentDictionary<PublicKey, NetworkNode> _persistedNodes = [];
 
     /// <summary>Adds a node and updates the IP index. Returns <see langword="false"/> if already present.</summary>
     protected bool TryAddNode(NetworkNode node)
@@ -62,7 +63,7 @@ public abstract class NodesManager(string path, ILogger logger)
                 _ipCounts.AddOrUpdate(kvp.Value.HostIp, 1, static (_, count) => count + 1);
             }
 
-            Loaded = true;
+            _persistedNodes = new ConcurrentDictionary<PublicKey, NetworkNode>(nodes);
         }
     }
 
@@ -217,11 +218,17 @@ public abstract class NodesManager(string path, ILogger logger)
         return true;
     }
 
-    /// <summary>Rewrites the nodes file when <paramref name="updateFile"/> is set and returns <paramref name="changed"/>.</summary>
-    /// <remarks>A no-op change still triggers the rewrite to reconcile an earlier <c>updateFile: false</c> call, but only once the file has been successfully loaded, so a failed init cannot truncate it.</remarks>
-    protected async Task<bool> SaveAsync(bool changed, bool updateFile, CancellationToken cancellationToken)
+    /// <summary>Marks <paramref name="node"/> persistent when <paramref name="updateFile"/> is set, rewriting the nodes file if it was not persisted yet, and returns <paramref name="changed"/>.</summary>
+    protected async Task<bool> PersistAsync(bool changed, NetworkNode node, bool updateFile, CancellationToken cancellationToken)
     {
-        if (updateFile && (changed || Loaded)) await SaveFileAsync(cancellationToken);
+        if (updateFile && _persistedNodes.TryAdd(node.NodeId, node)) await SaveFileAsync(cancellationToken);
+        return changed;
+    }
+
+    /// <summary>Unmarks <paramref name="node"/> as persistent when <paramref name="updateFile"/> is set, rewriting the nodes file if it was persisted, and returns <paramref name="changed"/>.</summary>
+    protected async Task<bool> UnpersistAsync(bool changed, NetworkNode node, bool updateFile, CancellationToken cancellationToken)
+    {
+        if (updateFile && _persistedNodes.TryRemove(node.NodeId, out _)) await SaveFileAsync(cancellationToken);
         return changed;
     }
 
@@ -230,7 +237,7 @@ public abstract class NodesManager(string path, ILogger logger)
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
         string contents = JsonSerializer.Serialize(
-            _nodes.Select(static n => n.Value.ToString()),
+            _persistedNodes.Select(static n => n.Value.ToString()),
             EthereumJsonSerializer.JsonOptionsIndented
             );
 

--- a/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
@@ -34,6 +34,8 @@ public class StaticNodesManager(string staticNodesPath, ILogManager logManager) 
         if (!TryAddNode(networkNode))
         {
             if (_logger.IsInfo) _logger.Info($"Static node was already added: {networkNode}");
+            // The node may have been added earlier with updateFile=false; honor the upgrade to a persistent entry.
+            if (updateFile) await SaveFileAsync(cancellationToken);
             return false;
         }
 
@@ -55,6 +57,8 @@ public class StaticNodesManager(string staticNodesPath, ILogManager logManager) 
         if (!TryRemoveNode(networkNode.NodeId))
         {
             if (_logger.IsInfo) _logger.Info($"Static node was not found: {networkNode}");
+            // The node may have been removed earlier with updateFile=false; still scrub any stale file entry.
+            if (updateFile) await SaveFileAsync(cancellationToken);
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
@@ -32,16 +32,23 @@ public class StaticNodesManager(string staticNodesPath, ILogManager logManager) 
     public async Task<bool> AddAsync(NetworkNode networkNode, bool updateFile = true, CancellationToken cancellationToken = default)
     {
         bool added = TryAddNode(networkNode);
+        if (_logger.IsInfo) _logger.Info(added ? $"Static node added: {networkNode}" : $"Static node was already added: {networkNode}");
+
         if (added)
         {
             NodeAdded?.Invoke(this, new NodeEventArgs(new Node(networkNode, isStatic: true)));
         }
 
-        return await LogAndSaveAsync(added, $"Static node added: {networkNode}", $"Static node was already added: {networkNode}", updateFile, cancellationToken);
+        return await SaveAsync(added, updateFile, cancellationToken);
     }
 
-    public Task<bool> RemoveAsync(NetworkNode networkNode, bool updateFile = true, CancellationToken cancellationToken = default) =>
-        LogAndSaveAsync(TryRemoveNode(networkNode.NodeId), $"Static node was removed: {networkNode}", $"Static node was not found: {networkNode}", updateFile, cancellationToken);
+    public async Task<bool> RemoveAsync(NetworkNode networkNode, bool updateFile = true, CancellationToken cancellationToken = default)
+    {
+        bool removed = TryRemoveNode(networkNode.NodeId);
+        if (_logger.IsInfo) _logger.Info(removed ? $"Static node was removed: {networkNode}" : $"Static node was not found: {networkNode}");
+
+        return await SaveAsync(removed, updateFile, cancellationToken);
+    }
 
     public bool IsStatic(NetworkNode node) =>
         _nodes.TryGetValue(node.NodeId, out NetworkNode staticNode) &&

--- a/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
@@ -31,41 +31,17 @@ public class StaticNodesManager(string staticNodesPath, ILogManager logManager) 
 
     public async Task<bool> AddAsync(NetworkNode networkNode, bool updateFile = true, CancellationToken cancellationToken = default)
     {
-        if (!TryAddNode(networkNode))
+        bool added = TryAddNode(networkNode);
+        if (added)
         {
-            if (_logger.IsInfo) _logger.Info($"Static node was already added: {networkNode}");
-            // The node may have been added earlier with updateFile=false; honor the upgrade to a persistent entry.
-            if (updateFile && Loaded) await SaveFileAsync(cancellationToken);
-            return false;
+            NodeAdded?.Invoke(this, new NodeEventArgs(new Node(networkNode, isStatic: true)));
         }
 
-        if (_logger.IsInfo) _logger.Info($"Static node added: {networkNode}");
-
-        Node node = new(networkNode, isStatic: true);
-        NodeAdded?.Invoke(this, new NodeEventArgs(node));
-
-        if (updateFile)
-        {
-            await SaveFileAsync(cancellationToken);
-        }
-
-        return true;
+        return await LogAndSaveAsync(added, $"Static node added: {networkNode}", $"Static node was already added: {networkNode}", updateFile, cancellationToken);
     }
 
-    public async Task<bool> RemoveAsync(NetworkNode networkNode, bool updateFile = true, CancellationToken cancellationToken = default)
-    {
-        if (!TryRemoveNode(networkNode.NodeId))
-        {
-            if (_logger.IsInfo) _logger.Info($"Static node was not found: {networkNode}");
-            // The node may have been removed earlier with updateFile=false; still scrub any stale file entry.
-            if (updateFile && Loaded) await SaveFileAsync(cancellationToken);
-            return false;
-        }
-
-        if (_logger.IsInfo) _logger.Info($"Static node was removed: {networkNode}");
-        if (updateFile) await SaveFileAsync(cancellationToken);
-        return true;
-    }
+    public Task<bool> RemoveAsync(NetworkNode networkNode, bool updateFile = true, CancellationToken cancellationToken = default) =>
+        LogAndSaveAsync(TryRemoveNode(networkNode.NodeId), $"Static node was removed: {networkNode}", $"Static node was not found: {networkNode}", updateFile, cancellationToken);
 
     public bool IsStatic(NetworkNode node) =>
         _nodes.TryGetValue(node.NodeId, out NetworkNode staticNode) &&

--- a/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
@@ -35,7 +35,7 @@ public class StaticNodesManager(string staticNodesPath, ILogManager logManager) 
         {
             if (_logger.IsInfo) _logger.Info($"Static node was already added: {networkNode}");
             // The node may have been added earlier with updateFile=false; honor the upgrade to a persistent entry.
-            if (updateFile) await SaveFileAsync(cancellationToken);
+            if (updateFile && Loaded) await SaveFileAsync(cancellationToken);
             return false;
         }
 
@@ -58,7 +58,7 @@ public class StaticNodesManager(string staticNodesPath, ILogManager logManager) 
         {
             if (_logger.IsInfo) _logger.Info($"Static node was not found: {networkNode}");
             // The node may have been removed earlier with updateFile=false; still scrub any stale file entry.
-            if (updateFile) await SaveFileAsync(cancellationToken);
+            if (updateFile && Loaded) await SaveFileAsync(cancellationToken);
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/StaticNodes/StaticNodesManager.cs
@@ -39,7 +39,7 @@ public class StaticNodesManager(string staticNodesPath, ILogManager logManager) 
             NodeAdded?.Invoke(this, new NodeEventArgs(new Node(networkNode, isStatic: true)));
         }
 
-        return await SaveAsync(added, updateFile, cancellationToken);
+        return await PersistAsync(added, networkNode, updateFile, cancellationToken);
     }
 
     public async Task<bool> RemoveAsync(NetworkNode networkNode, bool updateFile = true, CancellationToken cancellationToken = default)
@@ -47,7 +47,7 @@ public class StaticNodesManager(string staticNodesPath, ILogManager logManager) 
         bool removed = TryRemoveNode(networkNode.NodeId);
         if (_logger.IsInfo) _logger.Info(removed ? $"Static node was removed: {networkNode}" : $"Static node was not found: {networkNode}");
 
-        return await SaveAsync(removed, updateFile, cancellationToken);
+        return await UnpersistAsync(removed, networkNode, updateFile, cancellationToken);
     }
 
     public bool IsStatic(NetworkNode node) =>

--- a/src/Nethermind/Nethermind.Network/TrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/TrustedNodesManager.cs
@@ -62,7 +62,7 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
                 _logger.Info($"Trusted node was already added: {enode}");
             }
             // The node may have been added earlier with updateFile=false; honor the upgrade to a persistent entry.
-            if (updateFile) await SaveFileAsync(cancellationToken);
+            if (updateFile && Loaded) await SaveFileAsync(cancellationToken);
             return false;
         }
 
@@ -91,7 +91,7 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
         {
             if (_logger.IsInfo) _logger.Info($"Trusted node was not found: {enode}");
             // The node may have been removed earlier with updateFile=false; still scrub any stale file entry.
-            if (updateFile) await SaveFileAsync(cancellationToken);
+            if (updateFile && Loaded) await SaveFileAsync(cancellationToken);
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Network/TrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/TrustedNodesManager.cs
@@ -64,17 +64,18 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
             await _nodeChannel.Writer.WriteAsync(new Node(networkNode) { IsTrusted = true }, cancellationToken);
         }
 
-        return await SaveAsync(added, updateFile, cancellationToken);
+        return await PersistAsync(added, networkNode, updateFile, cancellationToken);
     }
 
     public async Task<bool> RemoveAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default)
     {
+        NetworkNode networkNode = new(enode);
         // TryRemoveNode fires NodeRemoved BEFORE the file write: a cancelled SaveFileAsync must not leave
         // the peer disconnected in-memory but still persisted as trusted.
-        bool removed = TryRemoveNode(new NetworkNode(enode).NodeId);
+        bool removed = TryRemoveNode(networkNode.NodeId);
         if (_logger.IsInfo) _logger.Info(removed ? $"Trusted node was removed: {enode}" : $"Trusted node was not found: {enode}");
 
-        return await SaveAsync(removed, updateFile, cancellationToken);
+        return await UnpersistAsync(removed, networkNode, updateFile, cancellationToken);
     }
 
     public bool IsTrusted(Enode enode) => _nodes.ContainsKey(enode.PublicKey);

--- a/src/Nethermind/Nethermind.Network/TrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/TrustedNodesManager.cs
@@ -55,50 +55,20 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
     public async Task<bool> AddAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default)
     {
         NetworkNode networkNode = new(enode);
-        if (!TryAddNode(networkNode))
+        bool added = TryAddNode(networkNode);
+        if (added)
         {
-            if (_logger.IsInfo)
-            {
-                _logger.Info($"Trusted node was already added: {enode}");
-            }
-            // The node may have been added earlier with updateFile=false; honor the upgrade to a persistent entry.
-            if (updateFile && Loaded) await SaveFileAsync(cancellationToken);
-            return false;
+            // Publish the newly added node to the channel so DiscoverNodes will yield it.
+            await _nodeChannel.Writer.WriteAsync(new Node(networkNode) { IsTrusted = true }, cancellationToken);
         }
 
-        if (_logger.IsInfo)
-        {
-            _logger.Info($"Trusted node added: {enode}");
-        }
-
-        // Publish the newly added node to the channel so DiscoverNodes will yield it.
-        Node newNode = new(networkNode) { IsTrusted = true };
-        await _nodeChannel.Writer.WriteAsync(newNode, cancellationToken);
-
-        if (updateFile)
-        {
-            await SaveFileAsync(cancellationToken);
-        }
-        return true;
+        return await LogAndSaveAsync(added, $"Trusted node added: {enode}", $"Trusted node was already added: {enode}", updateFile, cancellationToken);
     }
 
-    public async Task<bool> RemoveAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default)
-    {
-        NetworkNode networkNode = new(enode);
-        // Fire NodeRemoved BEFORE the file write: a cancelled SaveFileAsync must not leave
-        // the peer disconnected in-memory but still persisted as trusted.
-        if (!TryRemoveNode(networkNode.NodeId))
-        {
-            if (_logger.IsInfo) _logger.Info($"Trusted node was not found: {enode}");
-            // The node may have been removed earlier with updateFile=false; still scrub any stale file entry.
-            if (updateFile && Loaded) await SaveFileAsync(cancellationToken);
-            return false;
-        }
-
-        if (_logger.IsInfo) _logger.Info($"Trusted node was removed: {enode}");
-        if (updateFile) await SaveFileAsync(cancellationToken);
-        return true;
-    }
+    // TryRemoveNode fires NodeRemoved BEFORE the file write: a cancelled SaveFileAsync must not leave
+    // the peer disconnected in-memory but still persisted as trusted.
+    public Task<bool> RemoveAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default) =>
+        LogAndSaveAsync(TryRemoveNode(new NetworkNode(enode).NodeId), $"Trusted node was removed: {enode}", $"Trusted node was not found: {enode}", updateFile, cancellationToken);
 
     public bool IsTrusted(Enode enode) => _nodes.ContainsKey(enode.PublicKey);
 }

--- a/src/Nethermind/Nethermind.Network/TrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/TrustedNodesManager.cs
@@ -61,6 +61,8 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
             {
                 _logger.Info($"Trusted node was already added: {enode}");
             }
+            // The node may have been added earlier with updateFile=false; honor the upgrade to a persistent entry.
+            if (updateFile) await SaveFileAsync(cancellationToken);
             return false;
         }
 
@@ -88,6 +90,8 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
         if (!TryRemoveNode(networkNode.NodeId))
         {
             if (_logger.IsInfo) _logger.Info($"Trusted node was not found: {enode}");
+            // The node may have been removed earlier with updateFile=false; still scrub any stale file entry.
+            if (updateFile) await SaveFileAsync(cancellationToken);
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Network/TrustedNodesManager.cs
+++ b/src/Nethermind/Nethermind.Network/TrustedNodesManager.cs
@@ -56,19 +56,26 @@ public class TrustedNodesManager(string trustedNodesPath, ILogManager logManager
     {
         NetworkNode networkNode = new(enode);
         bool added = TryAddNode(networkNode);
+        if (_logger.IsInfo) _logger.Info(added ? $"Trusted node added: {enode}" : $"Trusted node was already added: {enode}");
+
         if (added)
         {
             // Publish the newly added node to the channel so DiscoverNodes will yield it.
             await _nodeChannel.Writer.WriteAsync(new Node(networkNode) { IsTrusted = true }, cancellationToken);
         }
 
-        return await LogAndSaveAsync(added, $"Trusted node added: {enode}", $"Trusted node was already added: {enode}", updateFile, cancellationToken);
+        return await SaveAsync(added, updateFile, cancellationToken);
     }
 
-    // TryRemoveNode fires NodeRemoved BEFORE the file write: a cancelled SaveFileAsync must not leave
-    // the peer disconnected in-memory but still persisted as trusted.
-    public Task<bool> RemoveAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default) =>
-        LogAndSaveAsync(TryRemoveNode(new NetworkNode(enode).NodeId), $"Trusted node was removed: {enode}", $"Trusted node was not found: {enode}", updateFile, cancellationToken);
+    public async Task<bool> RemoveAsync(Enode enode, bool updateFile = true, CancellationToken cancellationToken = default)
+    {
+        // TryRemoveNode fires NodeRemoved BEFORE the file write: a cancelled SaveFileAsync must not leave
+        // the peer disconnected in-memory but still persisted as trusted.
+        bool removed = TryRemoveNode(new NetworkNode(enode).NodeId);
+        if (_logger.IsInfo) _logger.Info(removed ? $"Trusted node was removed: {enode}" : $"Trusted node was not found: {enode}");
+
+        return await SaveAsync(removed, updateFile, cancellationToken);
+    }
 
     public bool IsTrusted(Enode enode) => _nodes.ContainsKey(enode.PublicKey);
 }


### PR DESCRIPTION
Fixes #12796

## Changes

- `admin_addPeer` / `admin_addTrustedPeer` with `persistent=true` now persist a peer that is already in the in-memory set (e.g. added earlier with `persistent=false`), instead of silently returning early with a success response.
- Removed the `IsTrusted` short-circuit in `admin_addTrustedPeer` that skipped persistence entirely for already-trusted peers (leftover from a pre-#11489 `IsTrusted || AddAsync` expression; `AddAsync` already handles the already-trusted case and `PeerPool.GetOrAdd` is idempotent).
- Fixed the mirrored path: `RemoveAsync` with `updateFile: true` now scrubs a stale file entry even when the node was already removed from memory.
- Persistence is now target-scoped: `NodesManager` tracks an explicit persisted set (file content at load + persistent adds − persistent removes) and the nodes file mirrors that set, written exactly when it changes. A persistent change to one peer no longer commits or drops unrelated peers whose changes were requested with `persistent=false`, and a no-op call can never truncate a file that failed to load.
- Documented the `AddAsync`/`RemoveAsync` contract on `IStaticNodesManager`/`ITrustedNodesManager`.
- Regression tests in a shared `NodesManagerPersistenceTests<TManager>` fixture covering both managers: add-then-promote, remove-then-scrub, unrelated-peer isolation in both directions, and the never-loaded no-op guard; plus RPC delegation for an already-trusted peer.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New regression tests in `NodesManagerPersistenceTests` and `AdminModuleTests` fail without the fix; full `Nethermind.Network.Test` suite passes.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
