### PR TITLE
Align eth_unsubscribe not-found handling with geth

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -354,7 +354,7 @@ public class AdminModuleTests
     }
 
     [Test]
-    public async Task AdminUnsubscribe_AfterClientCloses_ReturnsFailure()
+    public async Task AdminUnsubscribe_AfterClientCloses_ReturnsFalse()
     {
         string serializedPeerEvents = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_subscribe", "peerEvents");
         string peerEventsId = serializedPeerEvents.Substring(serializedPeerEvents.Length - 44, 34);
@@ -364,10 +364,8 @@ public class AdminModuleTests
         _jsonRpcDuplexClient.Closed += Raise.Event();
 
         string serializedPeerEventsUnsub = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_unsubscribe", peerEventsId);
-        string expectedPeerEventsUnsub = string.Concat(
-            "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":\"Failed to unsubscribe: ",
-            peerEventsId, ".\"},\"id\":67}");
-        Assert.That(expectedPeerEventsUnsub, Is.EqualTo(serializedPeerEventsUnsub), "after the client closes, the subscription is removed and unsubscribe fails");
+        string expectedPeerEventsUnsub = "{\"jsonrpc\":\"2.0\",\"result\":false,\"id\":67}";
+        Assert.That(expectedPeerEventsUnsub, Is.EqualTo(serializedPeerEventsUnsub), "after the client closes, the subscription is removed and unsubscribe returns false");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -354,7 +354,7 @@ public class AdminModuleTests
     }
 
     [Test]
-    public async Task AdminUnsubscribe_AfterClientCloses_ReturnsFalse()
+    public async Task AdminUnsubscribe_AfterClientCloses_ReturnsNotFoundError()
     {
         string serializedPeerEvents = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_subscribe", "peerEvents");
         string peerEventsId = serializedPeerEvents.Substring(serializedPeerEvents.Length - 44, 34);
@@ -364,8 +364,8 @@ public class AdminModuleTests
         _jsonRpcDuplexClient.Closed += Raise.Event();
 
         string serializedPeerEventsUnsub = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_unsubscribe", peerEventsId);
-        string expectedPeerEventsUnsub = "{\"jsonrpc\":\"2.0\",\"result\":false,\"id\":67}";
-        Assert.That(expectedPeerEventsUnsub, Is.EqualTo(serializedPeerEventsUnsub), "after the client closes, the subscription is removed and unsubscribe returns false");
+        string expectedPeerEventsUnsub = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"subscription not found\"},\"id\":67}";
+        Assert.That(expectedPeerEventsUnsub, Is.EqualTo(serializedPeerEventsUnsub), "after the client closes, the subscription is removed and unsubscribe reports subscription not found");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/AdminModuleTests.cs
@@ -365,7 +365,7 @@ public class AdminModuleTests
 
         string serializedPeerEventsUnsub = await RpcTest.TestSerializedRequest(_adminRpcModule, "admin_unsubscribe", peerEventsId);
         string expectedPeerEventsUnsub = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"subscription not found\"},\"id\":67}";
-        Assert.That(expectedPeerEventsUnsub, Is.EqualTo(serializedPeerEventsUnsub), "after the client closes, the subscription is removed and unsubscribe reports subscription not found");
+        Assert.That(serializedPeerEventsUnsub, Is.EqualTo(expectedPeerEventsUnsub), "after the client closes, the subscription is removed and unsubscribe reports subscription not found");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -1169,16 +1169,16 @@ namespace Nethermind.JsonRpc.Test.Modules
         }
 
         [Test]
-        public async Task Eth_unsubscribe_unknown_subscription_returns_false()
+        public async Task Eth_unsubscribe_unknown_subscription_returns_not_found_error()
         {
             string serializedUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", "0xdeadbeef");
-            string expectedUnsub = "{\"jsonrpc\":\"2.0\",\"result\":false,\"id\":67}";
+            string expectedUnsub = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"subscription not found\"},\"id\":67}";
 
             Assert.That(expectedUnsub, Is.EqualTo(serializedUnsub));
         }
 
         [Test]
-        public async Task Eth_unsubscribe_already_removed_subscription_returns_false()
+        public async Task Eth_unsubscribe_already_removed_subscription_returns_not_found_error()
         {
             string serializedSub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "newHeads");
             string subscriptionId = serializedSub.Substring(serializedSub.Length - 44, 34);
@@ -1187,7 +1187,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             Assert.That(serializedFirstUnsub, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":true,\"id\":67}"));
 
             string serializedSecondUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", subscriptionId);
-            Assert.That(serializedSecondUnsub, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":false,\"id\":67}"));
+            Assert.That(serializedSecondUnsub, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"subscription not found\"},\"id\":67}"));
         }
 
         [Test]
@@ -1208,11 +1208,11 @@ namespace Nethermind.JsonRpc.Test.Modules
             _jsonRpcDuplexClient.Closed += Raise.Event();
 
             string serializedLogsUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", logsId);
-            string expectedLogsUnsub = "{\"jsonrpc\":\"2.0\",\"result\":false,\"id\":67}";
+            string expectedLogsUnsub = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"subscription not found\"},\"id\":67}";
             Assert.That(expectedLogsUnsub, Is.EqualTo(serializedLogsUnsub));
 
             string serializedNewPendingTxUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", newPendingTxId);
-            string expectedNewPendingTxUnsub = "{\"jsonrpc\":\"2.0\",\"result\":false,\"id\":67}";
+            string expectedNewPendingTxUnsub = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"subscription not found\"},\"id\":67}";
             Assert.That(expectedNewPendingTxUnsub, Is.EqualTo(serializedNewPendingTxUnsub));
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -1169,6 +1169,28 @@ namespace Nethermind.JsonRpc.Test.Modules
         }
 
         [Test]
+        public async Task Eth_unsubscribe_unknown_subscription_returns_false()
+        {
+            string serializedUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", "0xdeadbeef");
+            string expectedUnsub = "{\"jsonrpc\":\"2.0\",\"result\":false,\"id\":67}";
+
+            Assert.That(expectedUnsub, Is.EqualTo(serializedUnsub));
+        }
+
+        [Test]
+        public async Task Eth_unsubscribe_already_removed_subscription_returns_false()
+        {
+            string serializedSub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "newHeads");
+            string subscriptionId = serializedSub.Substring(serializedSub.Length - 44, 34);
+
+            string serializedFirstUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", subscriptionId);
+            Assert.That(serializedFirstUnsub, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":true,\"id\":67}"));
+
+            string serializedSecondUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", subscriptionId);
+            Assert.That(serializedSecondUnsub, Is.EqualTo("{\"jsonrpc\":\"2.0\",\"result\":false,\"id\":67}"));
+        }
+
+        [Test]
         public async Task Subscriptions_remove_after_closing_websockets_client()
         {
             string serializedLogs = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_subscribe", "logs");
@@ -1186,15 +1208,11 @@ namespace Nethermind.JsonRpc.Test.Modules
             _jsonRpcDuplexClient.Closed += Raise.Event();
 
             string serializedLogsUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", logsId);
-            string expectedLogsUnsub =
-                string.Concat("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":\"Failed to unsubscribe: ",
-                    logsId, ".\"},\"id\":67}");
+            string expectedLogsUnsub = "{\"jsonrpc\":\"2.0\",\"result\":false,\"id\":67}";
             Assert.That(expectedLogsUnsub, Is.EqualTo(serializedLogsUnsub));
 
             string serializedNewPendingTxUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", newPendingTxId);
-            string expectedNewPendingTxUnsub =
-                string.Concat("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":\"Failed to unsubscribe: ",
-                    newPendingTxId, ".\"},\"id\":67}");
+            string expectedNewPendingTxUnsub = "{\"jsonrpc\":\"2.0\",\"result\":false,\"id\":67}";
             Assert.That(expectedNewPendingTxUnsub, Is.EqualTo(serializedNewPendingTxUnsub));
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/SubscribeModuleTests.cs
@@ -1174,7 +1174,7 @@ namespace Nethermind.JsonRpc.Test.Modules
             string serializedUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", "0xdeadbeef");
             string expectedUnsub = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"subscription not found\"},\"id\":67}";
 
-            Assert.That(expectedUnsub, Is.EqualTo(serializedUnsub));
+            Assert.That(serializedUnsub, Is.EqualTo(expectedUnsub));
         }
 
         [Test]
@@ -1209,11 +1209,11 @@ namespace Nethermind.JsonRpc.Test.Modules
 
             string serializedLogsUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", logsId);
             string expectedLogsUnsub = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"subscription not found\"},\"id\":67}";
-            Assert.That(expectedLogsUnsub, Is.EqualTo(serializedLogsUnsub));
+            Assert.That(serializedLogsUnsub, Is.EqualTo(expectedLogsUnsub));
 
             string serializedNewPendingTxUnsub = await RpcTest.TestSerializedRequest(_subscribeRpcModule, "eth_unsubscribe", newPendingTxId);
             string expectedNewPendingTxUnsub = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"subscription not found\"},\"id\":67}";
-            Assert.That(expectedNewPendingTxUnsub, Is.EqualTo(serializedNewPendingTxUnsub));
+            Assert.That(serializedNewPendingTxUnsub, Is.EqualTo(expectedNewPendingTxUnsub));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/ErrorMessages.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ErrorMessages.cs
@@ -10,5 +10,10 @@ public static class ErrorMessages
     /// </summary>
     public const string PrunedHistoryUnavailable = "Pruned history unavailable";
 
+    /// <summary>
+    /// Geth-compatible message for unsubscribing an unknown subscription id, paired with <see cref="ErrorCodes.ResourceNotFound"/>
+    /// </summary>
+    public const string SubscriptionNotFound = "subscription not found";
+
     public static string MethodNotFound(string methodName) => $"the method {methodName} does not exist/is not available";
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -198,7 +198,10 @@ public class AdminRpcModule : IAdminRpcModule
     public ResultWrapper<bool> admin_unsubscribe(string subscriptionId)
     {
         bool unsubscribed = _subscriptionManager.RemoveSubscription(Context.DuplexClient, subscriptionId);
-        return ResultWrapper<bool>.Success(unsubscribed);
+        return unsubscribed
+            ? ResultWrapper<bool>.Success(true)
+            // Geth-compatible: unknown ids get a -32000 "subscription not found" error
+            : ResultWrapper<bool>.Fail("subscription not found", ErrorCodes.ResourceNotFound);
     }
 
     public JsonRpcContext Context { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -198,9 +198,7 @@ public class AdminRpcModule : IAdminRpcModule
     public ResultWrapper<bool> admin_unsubscribe(string subscriptionId)
     {
         bool unsubscribed = _subscriptionManager.RemoveSubscription(Context.DuplexClient, subscriptionId);
-        return unsubscribed
-            ? ResultWrapper<bool>.Success(true)
-            : ResultWrapper<bool>.Fail($"Failed to unsubscribe: {subscriptionId}.");
+        return ResultWrapper<bool>.Success(unsubscribed);
     }
 
     public JsonRpcContext Context { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/AdminRpcModule.cs
@@ -200,8 +200,7 @@ public class AdminRpcModule : IAdminRpcModule
         bool unsubscribed = _subscriptionManager.RemoveSubscription(Context.DuplexClient, subscriptionId);
         return unsubscribed
             ? ResultWrapper<bool>.Success(true)
-            // Geth-compatible: unknown ids get a -32000 "subscription not found" error
-            : ResultWrapper<bool>.Fail("subscription not found", ErrorCodes.ResourceNotFound);
+            : ResultWrapper<bool>.Fail(ErrorMessages.SubscriptionNotFound, ErrorCodes.ResourceNotFound, isTemporary: true);
     }
 
     public JsonRpcContext Context { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
@@ -111,6 +111,6 @@ public interface IAdminRpcModule : IContextAwareRpcModule
 
     [JsonRpcMethod(Description = "Subscribes to a particular event over WebSocket. For every event that matches the subscription, a notification with event details and subscription id is sent to a client.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
     ResultWrapper<string> admin_subscribe(string subscriptionName, string? args = null);
-    [JsonRpcMethod(Description = "Unsubscribes from a subscription. Returns true if the subscription was cancelled; false if it did not exist.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
+    [JsonRpcMethod(Description = "Unsubscribes from a subscription. Returns true on success; if the subscription does not exist, a 'subscription not found' error is returned.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
     ResultWrapper<bool> admin_unsubscribe(string subscriptionId);
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Admin/IAdminRpcModule.cs
@@ -111,6 +111,6 @@ public interface IAdminRpcModule : IContextAwareRpcModule
 
     [JsonRpcMethod(Description = "Subscribes to a particular event over WebSocket. For every event that matches the subscription, a notification with event details and subscription id is sent to a client.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
     ResultWrapper<string> admin_subscribe(string subscriptionName, string? args = null);
-    [JsonRpcMethod(Description = "Unsubscribes from a subscription.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
+    [JsonRpcMethod(Description = "Unsubscribes from a subscription. Returns true if the subscription was cancelled; false if it did not exist.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
     ResultWrapper<bool> admin_unsubscribe(string subscriptionId);
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/ISubscribeRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/ISubscribeRpcModule.cs
@@ -9,7 +9,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         [JsonRpcMethod(Description = "Starts a subscription (on WebSockets/Sockets) to a particular event. For every event that matches the subscription a JSON-RPC notification with event details and subscription ID will be sent to a client.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
         ResultWrapper<string> eth_subscribe(string subscriptionName, string? args = null);
 
-        [JsonRpcMethod(Description = "Unsubscribes from a subscription. Returns true if the subscription was cancelled; false if it did not exist.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
+        [JsonRpcMethod(Description = "Unsubscribes from a subscription. Returns true on success; if the subscription does not exist, a 'subscription not found' error is returned.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
         ResultWrapper<bool> eth_unsubscribe(string subscriptionId);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/ISubscribeRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/ISubscribeRpcModule.cs
@@ -9,7 +9,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         [JsonRpcMethod(Description = "Starts a subscription (on WebSockets/Sockets) to a particular event. For every event that matches the subscription a JSON-RPC notification with event details and subscription ID will be sent to a client.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
         ResultWrapper<string> eth_subscribe(string subscriptionName, string? args = null);
 
-        [JsonRpcMethod(Description = "Unsubscribes from a subscription.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
+        [JsonRpcMethod(Description = "Unsubscribes from a subscription. Returns true if the subscription was cancelled; false if it did not exist.", IsImplemented = true, IsSharable = false, Availability = RpcEndpoint.All & ~RpcEndpoint.Http)]
         ResultWrapper<bool> eth_unsubscribe(string subscriptionId);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscribeRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscribeRpcModule.cs
@@ -35,9 +35,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         public ResultWrapper<bool> eth_unsubscribe(string subscriptionId)
         {
             bool unsubscribed = subscriptionManager.RemoveSubscription(Context.DuplexClient, subscriptionId);
-            return unsubscribed
-                ? ResultWrapper<bool>.Success(true)
-                : ResultWrapper<bool>.Fail($"Failed to unsubscribe: {subscriptionId}.");
+            return ResultWrapper<bool>.Success(unsubscribed);
         }
 
         public JsonRpcContext Context { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscribeRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscribeRpcModule.cs
@@ -35,7 +35,10 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
         public ResultWrapper<bool> eth_unsubscribe(string subscriptionId)
         {
             bool unsubscribed = subscriptionManager.RemoveSubscription(Context.DuplexClient, subscriptionId);
-            return ResultWrapper<bool>.Success(unsubscribed);
+            return unsubscribed
+                ? ResultWrapper<bool>.Success(true)
+                // Geth-compatible: unknown ids get a -32000 "subscription not found" error
+                : ResultWrapper<bool>.Fail("subscription not found", ErrorCodes.ResourceNotFound);
         }
 
         public JsonRpcContext Context { get; set; }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscribeRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/SubscribeRpcModule.cs
@@ -37,8 +37,7 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
             bool unsubscribed = subscriptionManager.RemoveSubscription(Context.DuplexClient, subscriptionId);
             return unsubscribed
                 ? ResultWrapper<bool>.Success(true)
-                // Geth-compatible: unknown ids get a -32000 "subscription not found" error
-                : ResultWrapper<bool>.Fail("subscription not found", ErrorCodes.ResourceNotFound);
+                : ResultWrapper<bool>.Fail(ErrorMessages.SubscriptionNotFound, ErrorCodes.ResourceNotFound, isTemporary: true);
         }
 
         public JsonRpcContext Context { get; set; }


### PR DESCRIPTION
Fixes #12797

## Changes

- `eth_unsubscribe` and `admin_unsubscribe` now return a geth-compatible `-32000` `"subscription not found"` error for an unknown or already-removed subscription id, instead of `-32603` (internal error) with a custom message.
- Updated RPC method descriptions to document the error contract.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Regression tests added for unknown-id and double-unsubscribe; existing tests asserting the old error shape updated.

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

The docs currently promise `result: false` on failure; they need a follow-up edit in the docs repo to describe the error response instead.

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

geth, erigon and besu all return `-32000` `"subscription not found"` here (the message matches geth byte-for-byte); reth returns `result: false`. The previous `-32603` mislabeled a caller-input condition as an internal error and matched no other client. The execution-apis spec defines the result as a plain boolean and does not specify not-found behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)