### PR TITLE
Deflake RetryCacheTests.ExpiryQueue_ReleasesStorageAfterCumulativeChurn

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/RetryCacheTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/RetryCacheTests.cs
@@ -1153,8 +1153,11 @@ public class RetryCacheTests
                 }
 
                 Assert.That(cache.ResourcesInRetryQueue, Is.EqualTo(resourcesPerBatch));
-                timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
-                Assert.That(() => cache.ResourcesInRetryQueue, Is.Zero.After(AssertTimeoutMs, 10));
+                // Drive expiry synchronously: 64 drains each hinging on a timer tick's
+                // thread-pool dispatch flake under parallel-suite load on slow CI.
+                timeProvider.Elapse(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+                cache.ProcessRetryTick();
+                Assert.That(cache.ResourcesInRetryQueue, Is.Zero);
             }
 
             Assert.That(cache.ExpiringQueueReservationsSinceReset, Is.Zero);

--- a/src/Nethermind/Nethermind.TxPool.Test/RetryCacheTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/RetryCacheTests.cs
@@ -1153,8 +1153,6 @@ public class RetryCacheTests
                 }
 
                 Assert.That(cache.ResourcesInRetryQueue, Is.EqualTo(resourcesPerBatch));
-                // Drive expiry synchronously: 64 drains each hinging on a timer tick's
-                // thread-pool dispatch flake under parallel-suite load on slow CI.
                 timeProvider.Elapse(TimeSpan.FromMilliseconds(CacheTimeoutMs));
                 cache.ProcessRetryTick();
                 Assert.That(cache.ResourcesInRetryQueue, Is.Zero);

--- a/src/Nethermind/Nethermind.TxPool/RetryCache.cs
+++ b/src/Nethermind/Nethermind.TxPool/RetryCache.cs
@@ -194,7 +194,7 @@ public sealed class RetryCache<TMessage, TResourceId> : IAsyncDisposable
         if (_logger.IsDebug) _logger.Debug($"{typeof(TResourceId)} retry cache stopped");
     }
 
-    private void ProcessRetryTick()
+    internal void ProcessRetryTick()
     {
         Dictionary<IBatchMessageHandler<TMessage, TResourceId>, ArrayPoolList<TResourceId>>? batchedRetryRequests = null;
         try


### PR DESCRIPTION
## Changes

- Drive expiry processing synchronously in the churn test (`Elapse` + direct `ProcessRetryTick` call) instead of relying on 64 consecutive timer-tick thread-pool dispatches, each of which could exceed the assertion timeout under parallel-suite load on slow CI variants ([failed run](https://github.com/NethermindEth/nethermind/actions/runs/31803354221/job/94778510680)).
- Made `RetryCache.ProcessRetryTick` internal as a test hook, matching the existing internal members (`ResourcesInRetryQueue`, `ExpiringQueueStorage`, internal `TimeProvider` constructor).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

The change is itself a test fix: verified with the full `RetryCacheTests` suite (52/52) and repeated runs of the affected test. The drain assertion is now exact (`Is.Zero`) instead of a 10s poll, so the test is also faster.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

In production a delayed tick self-heals on the next 100 ms period, so the fragility was test-only. The other `RetryCacheTests` keep the timer-driven pattern, preserving timer-plumbing coverage; this test's purpose is storage-release accounting, which is now deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)