### PR TITLE
Make snap request sizer test independent of the wall clock

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Threading/ManualTimeProvider.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Threading/ManualTimeProvider.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Core.Test.Threading;
+
+public sealed class ManualTimeProvider : TimeProvider
+{
+    private sealed class NoopTimer : ITimer
+    {
+        public bool Change(TimeSpan dueTime, TimeSpan period) => true;
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => default;
+    }
+
+    private static readonly NoopTimer SharedTimer = new();
+    private readonly TaskCompletionSource _timerCreated = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private TimerCallback? _timerCallback;
+    private object? _timerState;
+    private long _elapsedTicks;
+    private long _utcTicks;
+
+    public Task TimerCreated => _timerCreated.Task;
+
+    public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+    public override long GetTimestamp() => Volatile.Read(ref _elapsedTicks);
+
+    public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(Volatile.Read(ref _utcTicks));
+
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        _timerCallback = callback;
+        _timerState = state;
+        _timerCreated.TrySetResult();
+        return SharedTimer;
+    }
+
+    public void Advance(TimeSpan elapsed)
+    {
+        Interlocked.Add(ref _elapsedTicks, elapsed.Ticks);
+        Interlocked.Add(ref _utcTicks, elapsed.Ticks);
+    }
+
+    public void JumpUtc(TimeSpan delta) => Interlocked.Add(ref _utcTicks, delta.Ticks);
+
+    public void AdvanceAndFireTimer(TimeSpan elapsed)
+    {
+        Advance(elapsed);
+        _timerCallback?.Invoke(_timerState);
+    }
+}

--- a/src/Nethermind/Nethermind.Core/RequestSizer/LatencyAndMessageSizeBasedRequestSizer.cs
+++ b/src/Nethermind/Nethermind.Core/RequestSizer/LatencyAndMessageSizeBasedRequestSizer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Nethermind.Core.Collections;
 
@@ -20,12 +19,14 @@ public class LatencyAndMessageSizeBasedRequestSizer(
     TimeSpan upperLatencyWatermark,
     long maxResponseSize,
     int? initialRequestSize,
-    double adjustmentFactor = 1.5
+    double adjustmentFactor = 1.5,
+    TimeProvider? timeProvider = null
     )
 {
     private readonly TimeSpan _upperLatencyWatermark = upperLatencyWatermark;
     private readonly TimeSpan _lowerLatencyWatermark = lowerLatencyWatermark;
     private readonly long _maxResponseSize = maxResponseSize;
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
     private readonly AdaptiveRequestSizer _requestSizer = new(
             minRequestLimit,
             maxRequestLimit,
@@ -48,13 +49,13 @@ public class LatencyAndMessageSizeBasedRequestSizer(
     /// <returns></returns>
     public Task<TResponse> Run<TResponse, TRequest, TResponseItem>(IReadOnlyList<TRequest> request, Func<IReadOnlyList<TRequest>, Task<(TResponse, long)>> func) where TResponse : IReadOnlyList<TResponseItem> => _requestSizer.Run(async (adjustedRequestSize) =>
     {
-        long startTime = Stopwatch.GetTimestamp();
+        long startTime = _timeProvider.GetTimestamp();
         long affectiveRequestSize = Math.Min(adjustedRequestSize, request.Count);
         IReadOnlyList<TRequest> cappedRequest = affectiveRequestSize == request.Count
             ? request
             : request.Slice(0, (int)affectiveRequestSize);
         (TResponse result, long messageSize) = await func(cappedRequest);
-        TimeSpan duration = Stopwatch.GetElapsedTime(startTime);
+        TimeSpan duration = _timeProvider.GetElapsedTime(startTime);
         if (messageSize > _maxResponseSize)
         {
             return (result, AdaptiveRequestSizer.Direction.Decrease);

--- a/src/Nethermind/Nethermind.Core/RequestSizer/LatencyBasedRequestSizer.cs
+++ b/src/Nethermind/Nethermind.Core/RequestSizer/LatencyBasedRequestSizer.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Nethermind.Core.RequestSizer;
@@ -12,11 +11,13 @@ public class LatencyBasedRequestSizer(
     int maxRequestLimit,
     TimeSpan lowerWatermark,
     TimeSpan upperWatermark,
-    double adjustmentFactor = 1.5
+    double adjustmentFactor = 1.5,
+    TimeProvider? timeProvider = null
     )
 {
     private readonly TimeSpan _upperWatermark = upperWatermark;
     private readonly TimeSpan _lowerWatermark = lowerWatermark;
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
     private readonly AdaptiveRequestSizer _requestSizer = new(minRequestLimit, maxRequestLimit, adjustmentFactor: adjustmentFactor);
     public int RequestSize => _requestSizer.RequestSize;
 
@@ -28,9 +29,9 @@ public class LatencyBasedRequestSizer(
     /// <returns></returns>
     public Task<TResponse> MeasureLatency<TResponse>(Func<int, Task<TResponse>> func) => _requestSizer.Run(async (requestSize) =>
     {
-        long startTime = Stopwatch.GetTimestamp();
+        long startTime = _timeProvider.GetTimestamp();
         TResponse result = await func(requestSize);
-        TimeSpan duration = Stopwatch.GetElapsedTime(startTime);
+        TimeSpan duration = _timeProvider.GetElapsedTime(startTime);
         if (duration < _lowerWatermark)
         {
             return (result, AdaptiveRequestSizer.Direction.Increase);

--- a/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
+++ b/src/Nethermind/Nethermind.Network.Stats/NodeStatsLight.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Stats;
 /// <summary>
 /// Initial version of Reputation calculation mostly based on EthereumJ impl
 /// </summary>
-public class NodeStatsLight(Node node, float latestSpeedWeight = 0.25f) : INodeStats
+public class NodeStatsLight(Node node, float latestSpeedWeight = 0.25f, TimeProvider timeProvider = null) : INodeStats
 {
     private readonly StatsParameters _statsParameters = StatsParameters.Instance;
 
@@ -65,7 +65,8 @@ public class NodeStatsLight(Node node, float latestSpeedWeight = 0.25f) : INodeS
         // or receipts. This is not great as large message size are harder for DotNetty to pool byte buffer, causing
         // higher memory usage. Reducing this even further does seems to help with memory, but may reduce throughput.
         maxResponseSize: 3_000_000,
-        initialRequestSize: 4
+        initialRequestSize: 4,
+        timeProvider: timeProvider
     );
 
     private readonly LatencyAndMessageSizeBasedRequestSizer _receiptsRequestSizer = new(
@@ -82,14 +83,16 @@ public class NodeStatsLight(Node node, float latestSpeedWeight = 0.25f) : INodeS
         // or receipts. This is not great as large message size are harder for DotNetty to pool byte buffer, causing
         // higher memory usage. Reducing this even further does seems to help with memory, but may reduce throughput.
         maxResponseSize: 3_000_000,
-        initialRequestSize: 8
+        initialRequestSize: 8,
+        timeProvider: timeProvider
     );
 
     private readonly LatencyBasedRequestSizer _snapRequestSizer = new(
         minRequestLimit: 50000,
         maxRequestLimit: 3_000_000,
         lowerWatermark: TimeSpan.FromMilliseconds(2000),
-        upperWatermark: TimeSpan.FromMilliseconds(3500)
+        upperWatermark: TimeSpan.FromMilliseconds(3500),
+        timeProvider: timeProvider
     );
 
     public long CurrentNodeReputation(DateTime nowUTC) => CalculateCurrentReputation(nowUTC);

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Snap1ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Snap1ProtocolHandlerTests.cs
@@ -31,8 +31,21 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1;
 
 public class Snap1ProtocolHandlerTests
 {
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public void Advance(TimeSpan delta) => _timestamp += delta.Ticks;
+    }
+
     private class Context
     {
+        private readonly ManualTimeProvider _timeProvider = new();
+
         public ISession Session { get; set; } = Substitute.For<ISession>();
 
         private IMessageSerializationService? _messageSerializationService;
@@ -57,7 +70,7 @@ public class Snap1ProtocolHandlerTests
                 if (_nodeStatsManager is null)
                 {
                     _nodeStatsManager = Substitute.For<INodeStatsManager>();
-                    _nodeStatsManager.GetOrAdd(Arg.Any<Node>()).Returns((c) => new NodeStatsLight((Node)c[0]));
+                    _nodeStatsManager.GetOrAdd(Arg.Any<Node>()).Returns((c) => new NodeStatsLight((Node)c[0], timeProvider: _timeProvider));
                 }
                 return _nodeStatsManager;
             }
@@ -84,6 +97,8 @@ public class Snap1ProtocolHandlerTests
 
         public TimeSpan SimulatedLatency { get; set; } = TimeSpan.Zero;
 
+        public TimeSpan SimulatedStall { get; set; } = TimeSpan.Zero;
+
         private readonly List<long> _recordedResponseBytesLength = [];
 
         public Context WithResponseBytesRecorder
@@ -97,9 +112,11 @@ public class Snap1ProtocolHandlerTests
                         GetAccountRangeMessage accountRangeMessage = (GetAccountRangeMessage)callInfo[0];
                         _recordedResponseBytesLength.Add(accountRangeMessage.ResponseBytes);
 
-                        if (SimulatedLatency > TimeSpan.Zero)
+                        _timeProvider.Advance(SimulatedLatency);
+
+                        if (SimulatedStall > TimeSpan.Zero)
                         {
-                            Task.Delay(SimulatedLatency).Wait();
+                            Task.Delay(SimulatedStall).Wait();
                         }
 
                         IByteBuffer buffer = MessageSerializationService.ZeroSerialize(new AccountRangeMessage()
@@ -227,9 +244,9 @@ public class Snap1ProtocolHandlerTests
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         ctx.RecordedMessageSizesShouldIncrease();
 
-        ctx.SimulatedLatency = Timeouts.Eth + TimeSpan.FromSeconds(1);
+        ctx.SimulatedStall = Timeouts.Eth + TimeSpan.FromSeconds(1);
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
-        ctx.SimulatedLatency = TimeSpan.Zero; // The read value is the request down, but it is adjusted on above request
+        ctx.SimulatedStall = TimeSpan.Zero; // The read value is the request down, but it is adjusted on above request
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         ctx.RecordedMessageSizesShouldDecrease();
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Snap1ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Snap1ProtocolHandlerTests.cs
@@ -12,6 +12,7 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test;
+using Nethermind.Core.Test.Threading;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
@@ -31,17 +32,6 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1;
 
 public class Snap1ProtocolHandlerTests
 {
-    private sealed class ManualTimeProvider : TimeProvider
-    {
-        private long _timestamp;
-
-        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
-
-        public override long GetTimestamp() => _timestamp;
-
-        public void Advance(TimeSpan delta) => _timestamp += delta.Ticks;
-    }
-
     private class Context
     {
         private readonly ManualTimeProvider _timeProvider = new();
@@ -95,9 +85,9 @@ public class Snap1ProtocolHandlerTests
             }
         }
 
-        public TimeSpan SimulatedLatency { get; set; } = TimeSpan.Zero;
+        public TimeSpan VirtualLatency { get; set; } = TimeSpan.Zero;
 
-        public TimeSpan SimulatedStall { get; set; } = TimeSpan.Zero;
+        public TimeSpan RealTimeStall { get; set; } = TimeSpan.Zero;
 
         private readonly List<long> _recordedResponseBytesLength = [];
 
@@ -112,11 +102,11 @@ public class Snap1ProtocolHandlerTests
                         GetAccountRangeMessage accountRangeMessage = (GetAccountRangeMessage)callInfo[0];
                         _recordedResponseBytesLength.Add(accountRangeMessage.ResponseBytes);
 
-                        _timeProvider.Advance(SimulatedLatency);
+                        _timeProvider.Advance(VirtualLatency);
 
-                        if (SimulatedStall > TimeSpan.Zero)
+                        if (RealTimeStall > TimeSpan.Zero)
                         {
-                            Task.Delay(SimulatedStall).Wait();
+                            Task.Delay(RealTimeStall).Wait();
                         }
 
                         IByteBuffer buffer = MessageSerializationService.ZeroSerialize(new AccountRangeMessage()
@@ -151,17 +141,17 @@ public class Snap1ProtocolHandlerTests
 
         Snap1ProtocolHandler protocolHandler = ctx.Snap1ProtocolHandler;
 
-        ctx.SimulatedLatency = TimeSpan.Zero;
+        ctx.VirtualLatency = TimeSpan.Zero;
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         ctx.RecordedMessageSizesShouldIncrease();
 
-        ctx.SimulatedLatency = TimeSpan.FromMilliseconds(2001);
+        ctx.VirtualLatency = TimeSpan.FromMilliseconds(2001);
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         ctx.RecordedMessageSizesShouldNotChange();
 
-        ctx.SimulatedLatency = TimeSpan.FromMilliseconds(3501);
+        ctx.VirtualLatency = TimeSpan.FromMilliseconds(3501);
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         ctx.RecordedMessageSizesShouldDecrease();
@@ -244,9 +234,9 @@ public class Snap1ProtocolHandlerTests
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         ctx.RecordedMessageSizesShouldIncrease();
 
-        ctx.SimulatedStall = Timeouts.Eth + TimeSpan.FromSeconds(1);
+        ctx.RealTimeStall = Timeouts.Eth + TimeSpan.FromSeconds(1);
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
-        ctx.SimulatedStall = TimeSpan.Zero; // The read value is the request down, but it is adjusted on above request
+        ctx.RealTimeStall = TimeSpan.Zero; // The read value is the request down, but it is adjusted on above request
         (await protocolHandler.GetAccountRange(new AccountRange(Keccak.Zero, Keccak.Zero), CancellationToken.None)).Dispose();
         ctx.RecordedMessageSizesShouldDecrease();
     }

--- a/src/Nethermind/Nethermind.TxPool.Test/RetryCacheTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/RetryCacheTests.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Core;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Test.Threading;
 using Nethermind.Logging;
 using NUnit.Framework;
 using System;
@@ -98,53 +99,6 @@ public class RetryCacheTests
     private sealed class BlockingHandler : IMessageHandler<BlockingRequestMessage>
     {
         public void HandleMessage(BlockingRequestMessage message) { }
-    }
-
-    private sealed class ManualTimeProvider : TimeProvider
-    {
-        private sealed class Timer : System.Threading.ITimer
-        {
-            public bool Change(TimeSpan dueTime, TimeSpan period) => true;
-            public void Dispose() { }
-            public ValueTask DisposeAsync() => default;
-        }
-
-        private static readonly Timer _timer = new();
-        private readonly TaskCompletionSource _timerCreated = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private TimerCallback _timerCallback;
-        private object _timerState;
-        private long _elapsedTicks;
-        private long _utcTicks;
-
-        public Task TimerCreated => _timerCreated.Task;
-
-        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
-
-        public override long GetTimestamp() => Volatile.Read(ref _elapsedTicks);
-
-        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(Volatile.Read(ref _utcTicks));
-
-        public override System.Threading.ITimer CreateTimer(TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
-        {
-            _timerCallback = callback;
-            _timerState = state;
-            _timerCreated.TrySetResult();
-            return _timer;
-        }
-
-        public void Elapse(TimeSpan elapsed)
-        {
-            Interlocked.Add(ref _elapsedTicks, elapsed.Ticks);
-            Interlocked.Add(ref _utcTicks, elapsed.Ticks);
-        }
-
-        public void JumpUtc(TimeSpan delta) => Interlocked.Add(ref _utcTicks, delta.Ticks);
-
-        public void Advance(TimeSpan elapsed)
-        {
-            Elapse(elapsed);
-            _timerCallback(_timerState);
-        }
     }
 
     public interface ITestHandler : IMessageHandler<ResourceRequestMessage>;
@@ -254,11 +208,11 @@ public class RetryCacheTests
         _cache.Announced(1, request2);
         _cache.Announced(1, request3);
 
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(
             () => request2.HandleMessageCallCount + request3.HandleMessageCallCount,
             Is.EqualTo(1).After(AssertTimeoutMs, 10));
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
 
         using (Assert.EnterMultipleScope())
         {
@@ -282,7 +236,7 @@ public class RetryCacheTests
         _cache.Announced(2, request3);
         _cache.Announced(2, request4);
 
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => request2.WasCalled, Is.True.After(AssertTimeoutMs, 100));
         Assert.That(() => request4.WasCalled, Is.True.After(AssertTimeoutMs, 100));
         Assert.That(request1.WasCalled, Is.False);
@@ -302,7 +256,7 @@ public class RetryCacheTests
         _cache.Announced(2, request3);
         _cache.Announced(2, batchRequest);
 
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => batchRequest.HandleMessagesCallCount, Is.EqualTo(1).After(AssertTimeoutMs, 100));
 
         using (Assert.EnterMultipleScope())
@@ -337,7 +291,7 @@ public class RetryCacheTests
             cache.Announced(2, sharedHandler);
             cache.Announced(2, otherHandler);
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
 
             Assert.That(() => sharedHandler.HandleMessagesCallCount, Is.EqualTo(1).After(AssertTimeoutMs, 10));
             using (Assert.EnterMultipleScope())
@@ -397,7 +351,7 @@ public class RetryCacheTests
                 cache.Announced(resourceId, sharedHandler);
             }
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
 
             Assert.That(() => sharedHandler.HandleMessagesCallCount, Is.EqualTo(1).After(AssertTimeoutMs, 10));
             Assert.That(sharedHandler.BatchResourceValues, Has.Length.EqualTo(resourceCount));
@@ -431,7 +385,7 @@ public class RetryCacheTests
             cache.Announced(2, new TestHandler());
             cache.Announced(2, secondHandler);
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
 
             Assert.That(
                 () => firstHandler.HandleMessagesCallCount + secondHandler.HandleMessagesCallCount,
@@ -478,17 +432,17 @@ public class RetryCacheTests
             cache.Announced(1, new TestHandler());
             cache.Announced(1, controlHandler);
 
-            timeProvider.Elapse(TimeSpan.FromMilliseconds(CacheTimeoutMs / 2));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs / 2));
             cache.Announced(2, new TestHandler());
             cache.Announced(2, retryHandler);
 
             timeProvider.JumpUtc(TimeSpan.FromDays(1));
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs / 2));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs / 2));
             Assert.That(() => controlHandler.WasCalled, Is.True.After(AssertTimeoutMs, 10));
             Assert.That(retryHandler.WasCalled, Is.False);
 
             timeProvider.JumpUtc(TimeSpan.FromDays(-2));
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs / 2));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs / 2));
             Assert.That(() => retryHandler.WasCalled, Is.True.After(AssertTimeoutMs, 10));
         }
         finally
@@ -510,7 +464,7 @@ public class RetryCacheTests
         _cache.Announced(1, request3);
         _cache.Received(1);
 
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => _cache.ResourcesInRetryQueue, Is.Zero.After(AssertTimeoutMs, 10));
 
         using (Assert.EnterMultipleScope())
@@ -546,11 +500,11 @@ public class RetryCacheTests
 
             for (int retry = 1; retry <= 4; retry++)
             {
-                timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+                timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
                 Assert.That(() => GetTotalCalls(handlers), Is.EqualTo(retry * 100).After(AssertTimeoutMs, 10));
             }
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
 
             Assert.That(() => cache.ResourcesInRetryQueue, Is.Zero.After(AssertTimeoutMs, 10));
         }
@@ -583,10 +537,10 @@ public class RetryCacheTests
                 cache.Announced(resourceId, retryHandler);
             }
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
             Assert.That(() => retryHandler.HandleMessageCallCount, Is.EqualTo(256).After(AssertTimeoutMs, 10));
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(1));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(1));
             Assert.That(() => retryHandler.HandleMessageCallCount, Is.EqualTo(resourceCount).After(AssertTimeoutMs, 10));
         }
         finally
@@ -607,7 +561,7 @@ public class RetryCacheTests
         _cache.Announced(2, new TestHandler());
         _cache.Announced(2, normalRequest);
 
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => normalRequest.WasCalled, Is.True.After(AssertTimeoutMs, 100));
     }
 
@@ -621,13 +575,13 @@ public class RetryCacheTests
         _cache.Announced(1, request2);
         _cache.Announced(1, request3);
 
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(
             () => request2.HandleMessageCallCount + request3.HandleMessageCallCount,
             Is.EqualTo(1).After(AssertTimeoutMs, 100));
 
         _cache.Received(1);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => _cache.ResourcesInRetryQueue, Is.Zero.After(AssertTimeoutMs, 10));
 
         Assert.That(request2.HandleMessageCallCount + request3.HandleMessageCallCount, Is.EqualTo(1));
@@ -641,7 +595,7 @@ public class RetryCacheTests
         Assert.That(_cache.Announced(1, source), Is.EqualTo(AnnounceResult.RequestRequired));
         Assert.That(_cache.Announced(1, source), Is.EqualTo(AnnounceResult.Delayed));
 
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => _cache.ResourcesInRetryQueue, Is.Zero.After(AssertTimeoutMs, 10));
 
         Assert.That(source.HandleMessageCallCount, Is.Zero);
@@ -655,11 +609,11 @@ public class RetryCacheTests
 
         _cache.Announced(1, new TestHandler());
         _cache.Announced(1, firstAlternate);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => firstAlternate.WasCalled, Is.True.After(AssertTimeoutMs, 100));
 
         Assert.That(_cache.Announced(1, lateAlternate), Is.EqualTo(AnnounceResult.Delayed));
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => lateAlternate.WasCalled, Is.True.After(AssertTimeoutMs, 100));
     }
 
@@ -670,11 +624,11 @@ public class RetryCacheTests
 
         _cache.Announced(1, new TestHandler());
         _cache.Announced(1, batchHandler);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => batchHandler.HandleMessagesCallCount, Is.EqualTo(1).After(AssertTimeoutMs, 100));
 
         Assert.That(_cache.Announced(1, batchHandler), Is.EqualTo(AnnounceResult.Delayed));
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => _cache.ResourcesInRetryQueue, Is.Zero.After(AssertTimeoutMs, 10));
 
         Assert.That(batchHandler.HandleMessagesCallCount, Is.EqualTo(1));
@@ -696,19 +650,19 @@ public class RetryCacheTests
         {
             await timeProvider.TimerCreated.WaitAsync(TimeSpan.FromMilliseconds(AssertTimeoutMs), cancellationTokenSource.Token);
             cache.Announced(1, new TestHandler());
-            timeProvider.Elapse(TimeSpan.FromMilliseconds(timeoutMs / 2));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(timeoutMs / 2));
 
             cache.Received(1);
             TestHandler retryHandler = new();
             cache.Announced(1, new TestHandler());
             cache.Announced(1, retryHandler);
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(timeoutMs / 2));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(timeoutMs / 2));
 
             Assert.That(() => cache.ResourcesInRetryQueue, Is.EqualTo(1).After(AssertTimeoutMs, 10));
             Assert.That(retryHandler.WasCalled, Is.False);
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(timeoutMs / 2));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(timeoutMs / 2));
 
             Assert.That(() => retryHandler.WasCalled, Is.True.After(AssertTimeoutMs, 100));
         }
@@ -736,7 +690,7 @@ public class RetryCacheTests
     {
         _cache.Announced(1, new TestHandler());
 
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
         Assert.That(() => _cache.ResourcesInRetryQueue, Is.Zero.After(AssertTimeoutMs, 10));
 
         Assert.That(_cache.Announced(1, new TestHandler()), Is.EqualTo(AnnounceResult.RequestRequired));
@@ -769,11 +723,11 @@ public class RetryCacheTests
             AnnounceResult result2 = cache.Announced(1, request3);
             AnnounceResult result3 = cache.Announced(1, rejectedRequest);
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
             Assert.That(
                 () => request2.HandleMessageCallCount + request3.HandleMessageCallCount,
                 Is.EqualTo(1).After(AssertTimeoutMs, 100));
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
             Assert.That(
                 () => request2.HandleMessageCallCount + request3.HandleMessageCallCount,
                 Is.EqualTo(2).After(AssertTimeoutMs, 100));
@@ -1108,11 +1062,11 @@ public class RetryCacheTests
 
             Assert.That(cache.ResourcesInRetryQueue, Is.EqualTo(staleResources + 1));
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
             Assert.That(() => cache.ResourcesInRetryQueue, Is.EqualTo(2).After(AssertTimeoutMs, 10));
             Assert.That(retryHandler.WasCalled, Is.False);
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs / 5));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs / 5));
 
             Assert.That(() => retryHandler.WasCalled, Is.True.After(AssertTimeoutMs, 10));
         }
@@ -1153,7 +1107,7 @@ public class RetryCacheTests
                 }
 
                 Assert.That(cache.ResourcesInRetryQueue, Is.EqualTo(resourcesPerBatch));
-                timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+                timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
                 Assert.That(() => cache.ResourcesInRetryQueue, Is.Zero.After(AssertTimeoutMs, 10));
             }
 
@@ -1222,16 +1176,16 @@ public class RetryCacheTests
         {
             await timeProvider.TimerCreated.WaitAsync(TimeSpan.FromMilliseconds(AssertTimeoutMs), cancellationTokenSource.Token);
 
-            timeProvider.Elapse(TimeSpan.FromMilliseconds(CacheTimeoutMs - 1));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs - 1));
             AnnounceResult initial = cache.Announced(1, new TestHandler());
             AnnounceResult duplicate = cache.Announced(1, new TestHandler());
             cache.Announced(2, new TestHandler());
             AnnounceResult full = cache.Announced(3, new TestHandler());
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(1));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(1));
             AnnounceResult acrossBoundary = cache.Announced(1, new TestHandler());
             AnnounceResult capacityAcrossBoundary = cache.Announced(3, new TestHandler());
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
             AnnounceResult afterTimeout = cache.Announced(1, new TestHandler());
 
             using (Assert.EnterMultipleScope())
@@ -1273,7 +1227,7 @@ public class RetryCacheTests
             Assert.That(cache.Announced(2, new TestHandler()), Is.EqualTo(AnnounceResult.Delayed));
 
             timeProvider.JumpUtc(TimeSpan.FromDays(-2));
-            timeProvider.Elapse(TimeSpan.FromMilliseconds(CacheTimeoutMs * 2));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs * 2));
             Assert.That(cache.Announced(2, new TestHandler()), Is.EqualTo(AnnounceResult.RequestRequired));
         }
         finally
@@ -1300,10 +1254,10 @@ public class RetryCacheTests
         {
             Assert.That(cache.Announced(1, new TestHandler()), Is.EqualTo(AnnounceResult.RequestRequired));
 
-            timeProvider.Elapse(TimeSpan.FromMilliseconds(CacheTimeoutMs * 2 - 1));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs * 2 - 1));
             Assert.That(cache.Announced(1, new TestHandler()), Is.EqualTo(AnnounceResult.Delayed));
 
-            timeProvider.Elapse(TimeSpan.FromMilliseconds(1));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(1));
             Assert.That(cache.Announced(1, new TestHandler()), Is.EqualTo(AnnounceResult.RequestRequired));
         }
         finally
@@ -1342,7 +1296,7 @@ public class RetryCacheTests
 
             AnnounceResult limited = cache.Announced(new CollisionResourceId(overflowLimit), handler);
             int retainedCapacityAtLimit = cache.OverflowRetainedCapacity;
-            timeProvider.Elapse(TimeSpan.FromMilliseconds(CacheTimeoutMs * 2));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs * 2));
             AnnounceResult afterExpiry = cache.Announced(new CollisionResourceId(overflowLimit), handler);
 
             using (Assert.EnterMultipleScope())
@@ -1386,7 +1340,7 @@ public class RetryCacheTests
             int retainedCapacityAtPeak = cache.OverflowRetainedCapacity;
             Assert.That(retainedCapacityAtPeak, Is.GreaterThan(resourceCount));
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs * 2));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs * 2));
 
             Assert.That(() => cache.OverflowRequestsInUse, Is.Zero.After(AssertTimeoutMs, 10));
             Assert.That(() => cache.OverflowRetainedCapacity, Is.Zero.After(AssertTimeoutMs, 10));
@@ -1564,7 +1518,7 @@ public class RetryCacheTests
                 cache.Announced(resourceId, alternate);
             }
 
-            timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
             Assert.That(() => alternate.HandleMessageCallCount, Is.EqualTo(2).After(AssertTimeoutMs, 100));
         }
         finally
@@ -1663,7 +1617,7 @@ public class RetryCacheTests
 
         _cache.Announced(42, new TestHandler());
         _cache.Announced(42, retryHandler);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(CacheTimeoutMs));
+        _timeProvider.AdvanceAndFireTimer(TimeSpan.FromMilliseconds(CacheTimeoutMs));
 
         Assert.That(() => receivedResourceId, Is.EqualTo(42).After(AssertTimeoutMs, 100));
     }


### PR DESCRIPTION
`Test_response_bytes_adjust_with_latency` fails intermittently on the Windows runner, reporting a request size of 168750 where it expects 112500.

## Cause

The test drives the sizer through three latency phases and asserts on a one millisecond margin: the 2001 ms phase has to measure at or above the sizer's 2000 ms lower watermark for the request size to hold steady rather than grow.

It produced that latency with `Task.Delay(2001)`, but `LatencyBasedRequestSizer` measured the elapsed time with `Stopwatch`. Those are two different clocks. `Task.Delay` completes when `Environment.TickCount64 - start >= dueTime`, and both endpoints are quantised to the OS tick - about 15.6 ms on Windows, against sub-millisecond granularity on Linux and macOS. The delay can therefore return a full tick before 2000 ms of `Stopwatch` time have elapsed. The sizer then reads the request as faster than the lower watermark, returns `Increase`, and the next request goes out at 112500 * 1.5 = 168750, which is exactly the observed value.

`Nethermind.Network.Test` runs on `windows-latest`, which is why this only shows up there.

## Fix

Inject a `TimeProvider` into `LatencyBasedRequestSizer`, `LatencyAndMessageSizeBasedRequestSizer` and `NodeStatsLight`, defaulting to `TimeProvider.System`. That is the same clock source `Stopwatch` uses, so production behaviour is unchanged; the parameter only opens a seam for the test. This follows the pattern already used in `Kademlia` and `RetryCache`.

The test now advances a manual provider by the simulated latency instead of sleeping. The 2001 / 3501 ms values are kept, and are now exact rather than approximate, so the test pins the watermark boundaries instead of racing them. The `[Explicit]` timeout test keeps a real delay through a separate knob, since it needs the request to genuinely expire.

## Verification

- 12 consecutive runs of the fixture, 9 tests each, 0 failures.
- Full `Nethermind.Network.Test`: 1291 passed, 8 skipped, 0 failed.
- `Nethermind.Core.Test` request sizer tests: 18/18.
- Fixture wall time drops from ~18-26 s to ~7-10 s, since the ~11 s of real delays are gone.
