### PR TITLE
Restore best-suggested pointers for non-canonical post-merge levels on block tree load

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -3123,6 +3123,51 @@ public class BlockTreeTests
         Assert.That(tree.LowestInsertedBeaconHeader?.Number, Is.EqualTo(6UL));
     }
 
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Loads_best_suggested_post_merge_when_suggested_blocks_sit_ahead_of_head()
+    {
+        // Repro of #12803: after an unclean shutdown a post-merge node restarts with
+        // suggested-but-unprocessed blocks above the processed head. Those levels have no
+        // main-chain block, so the canonical-only FindHeader(number) lookup cannot restore
+        // BestSuggestedHeader/BestSuggestedBody and sync mode selection sees header/block = 0.
+        CustomSpecProvider specProvider = new(((ForkActivation)0, London.Instance))
+        {
+            TerminalTotalDifficulty = UInt256.Zero
+        };
+
+        BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
+        BlockTree tree = builder.TestObject;
+
+        Block previous = Build.A.Block.WithNumber(0).WithDifficulty(0).TestObject;
+        tree.SuggestBlock(previous);
+        tree.TryUpdateMainChain(previous.Header, true, preloadedBlocks: new[] { previous });
+        for (ulong i = 1; i <= 4; i++)
+        {
+            Block block = Build.A.Block.WithNumber(i).WithDifficulty(0).WithParent(previous).TestObject;
+            tree.SuggestBlock(block);
+            tree.TryUpdateMainChain(block.Header, true, preloadedBlocks: new[] { block });
+            previous = block;
+        }
+
+        // Received but not yet processed when the node went down.
+        Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
+        Block block6 = Build.A.Block.WithNumber(6).WithDifficulty(0).WithParent(block5).TestObject;
+        tree.SuggestBlock(block5);
+        tree.SuggestBlock(block6);
+
+        BlockTree reloaded = Build.A.BlockTree(specProvider)
+            .WithDatabaseFrom(builder)
+            .WithoutSettingHead
+            .TestObject;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reloaded.Head?.Number, Is.EqualTo(4UL), "head");
+            Assert.That(reloaded.BestSuggestedHeader?.Number, Is.EqualTo(6UL), "suggested header");
+            Assert.That(reloaded.BestSuggestedBody?.Number, Is.EqualTo(6UL), "suggested body");
+        }
+    }
+
     private static void AssertSuggestNotifications(AddBlockResult result, bool hasNotified, bool hasNotifiedNewSuggested)
     {
         using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -3076,7 +3076,7 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void RecalculateTreeLevels_WhenBestSuggestedHeaderUnresolvableInPoS_StopsAtBeaconJunction()
     {
-        // Post-merge repro of the O(n) startup walk (#12273): reconciliation must stop at the
+        // Post-merge repro of the O(n) startup walk: reconciliation must stop at the
         // beacon/non-beacon junction rather than walking every already-synced header to genesis.
         CustomSpecProvider specProvider = PostMergeSpecProvider();
 
@@ -3108,7 +3108,6 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Loads_best_suggested_post_merge_when_suggested_blocks_sit_ahead_of_head()
     {
-        // Repro of #12803.
         CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
@@ -3137,7 +3136,6 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Loads_best_suggested_beacon_post_merge_when_beacon_blocks_sit_ahead_of_head()
     {
-        // Beacon variant of #12803.
         CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -3077,14 +3077,10 @@ public class BlockTreeTests
     public void RecalculateTreeLevels_WhenBestSuggestedHeaderUnresolvableInPoS_StopsAtBeaconJunction()
     {
         // Post-merge repro of the O(n) startup walk (#12273): on a node whose best-suggested
-        // header sits ahead of the processed main-chain head, FindHeader(number, None) returns
-        // null (GetBlockHashOnMainOrBestDifficultyHash bails post-merge), so BestSuggestedHeader
-        // is null and the old stop bound collapsed to 1. The reconciliation must still stop at the
-        // beacon/non-beacon junction rather than walking every already-synced header to genesis.
-        CustomSpecProvider specProvider = new(((ForkActivation)0, London.Instance))
-        {
-            TerminalTotalDifficulty = UInt256.Zero
-        };
+        // header sits ahead of the processed main-chain head, the reconciliation must stop at
+        // the beacon/non-beacon junction rather than walking every already-synced header to
+        // genesis (the old stop bound collapsed to 1 when BestSuggestedHeader restored as null).
+        CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         _blocksDb = new TestMemDb();
         _headersDb = new TestMemDb();
@@ -3097,19 +3093,10 @@ public class BlockTreeTests
             .TestObject;
 
         // Already-synced, processed main chain 0..4 (non-beacon, canonical).
-        Block previous = Build.A.Block.WithNumber(0).WithDifficulty(0).TestObject;
-        tree.SuggestBlock(previous);
-        tree.TryUpdateMainChain(previous.Header, true, preloadedBlocks: new[] { previous });
-        for (int i = 1; i <= 4; i++)
-        {
-            Block block = Build.A.Block.WithNumber((ulong)i).WithDifficulty(0).WithParent(previous).TestObject;
-            tree.SuggestBlock(block);
-            tree.TryUpdateMainChain(block.Header, true, preloadedBlocks: new[] { block });
-            previous = block;
-        }
+        Block previous = SuggestProcessedPostMergeChain(tree);
 
-        // A non-beacon header suggested ahead of the processed head: the best-suggested number
-        // resolves to a level with no main-chain block, so BestSuggestedHeader is null post-merge.
+        // A non-beacon header suggested ahead of the processed head, on a level with no
+        // main-chain block.
         Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
         tree.SuggestBlock(block5);
 
@@ -3130,24 +3117,12 @@ public class BlockTreeTests
         // suggested-but-unprocessed blocks above the processed head. Those levels have no
         // main-chain block, so the canonical-only FindHeader(number) lookup cannot restore
         // BestSuggestedHeader/BestSuggestedBody and sync mode selection sees header/block = 0.
-        CustomSpecProvider specProvider = new(((ForkActivation)0, London.Instance))
-        {
-            TerminalTotalDifficulty = UInt256.Zero
-        };
+        CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
         BlockTree tree = builder.TestObject;
 
-        Block previous = Build.A.Block.WithNumber(0).WithDifficulty(0).TestObject;
-        tree.SuggestBlock(previous);
-        tree.TryUpdateMainChain(previous.Header, true, preloadedBlocks: new[] { previous });
-        for (ulong i = 1; i <= 4; i++)
-        {
-            Block block = Build.A.Block.WithNumber(i).WithDifficulty(0).WithParent(previous).TestObject;
-            tree.SuggestBlock(block);
-            tree.TryUpdateMainChain(block.Header, true, preloadedBlocks: new[] { block });
-            previous = block;
-        }
+        Block previous = SuggestProcessedPostMergeChain(tree);
 
         // Received but not yet processed when the node went down.
         Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
@@ -3166,6 +3141,60 @@ public class BlockTreeTests
             Assert.That(reloaded.BestSuggestedHeader?.Number, Is.EqualTo(6UL), "suggested header");
             Assert.That(reloaded.BestSuggestedBody?.Number, Is.EqualTo(6UL), "suggested body");
         }
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Loads_best_suggested_beacon_post_merge_when_beacon_blocks_sit_ahead_of_head()
+    {
+        // Beacon variant of #12803: beacon inserts are NotOnMainChain, so the canonical-only
+        // lookup cannot restore the beacon pointers after a restart mid beacon sync.
+        CustomSpecProvider specProvider = PostMergeSpecProvider();
+
+        BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
+        BlockTree tree = builder.TestObject;
+
+        Block previous = SuggestProcessedPostMergeChain(tree);
+
+        // Beacon-downloaded but not yet processed when the node went down.
+        Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
+        Block block6 = Build.A.Block.WithNumber(6).WithDifficulty(0).WithParent(block5).TestObject;
+        tree.Insert(block5, BlockTreeInsertBlockOptions.SaveHeader, BlockTreeInsertHeaderOptions.BeaconBlockInsert);
+        tree.Insert(block6, BlockTreeInsertBlockOptions.SaveHeader, BlockTreeInsertHeaderOptions.BeaconBlockInsert);
+
+        BlockTree reloaded = Build.A.BlockTree(specProvider)
+            .WithDatabaseFrom(builder)
+            .WithoutSettingHead
+            .TestObject;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reloaded.BestSuggestedBeaconHeader?.Number, Is.EqualTo(6UL), "beacon header");
+            Assert.That(reloaded.BestSuggestedBeaconBody?.Number, Is.EqualTo(6UL), "beacon body");
+        }
+    }
+
+    private static CustomSpecProvider PostMergeSpecProvider() => new(((ForkActivation)0, London.Instance))
+    {
+        TerminalTotalDifficulty = UInt256.Zero
+    };
+
+    /// <summary>
+    /// Suggests and processes a canonical post-merge chain 0..4, returning the head block.
+    /// </summary>
+    private static Block SuggestProcessedPostMergeChain(BlockTree tree)
+    {
+        Block previous = Build.A.Block.WithNumber(0).WithDifficulty(0).TestObject;
+        tree.SuggestBlock(previous);
+        tree.TryUpdateMainChain(previous.Header, true, preloadedBlocks: new[] { previous });
+        for (ulong i = 1; i <= 4; i++)
+        {
+            Block block = Build.A.Block.WithNumber(i).WithDifficulty(0).WithParent(previous).TestObject;
+            tree.SuggestBlock(block);
+            tree.TryUpdateMainChain(block.Header, true, preloadedBlocks: new[] { block });
+            previous = block;
+        }
+
+        return previous;
     }
 
     private static void AssertSuggestNotifications(AddBlockResult result, bool hasNotified, bool hasNotifiedNewSuggested)

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -3076,10 +3076,8 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void RecalculateTreeLevels_WhenBestSuggestedHeaderUnresolvableInPoS_StopsAtBeaconJunction()
     {
-        // Post-merge repro of the O(n) startup walk (#12273): on a node whose best-suggested
-        // header sits ahead of the processed main-chain head, the reconciliation must stop at
-        // the beacon/non-beacon junction rather than walking every already-synced header to
-        // genesis (the old stop bound collapsed to 1 when BestSuggestedHeader restored as null).
+        // Post-merge repro of the O(n) startup walk (#12273): reconciliation must stop at the
+        // beacon/non-beacon junction rather than walking every already-synced header to genesis.
         CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         _blocksDb = new TestMemDb();
@@ -3092,7 +3090,6 @@ public class BlockTreeTests
             .WithoutSettingHead
             .TestObject;
 
-        // Already-synced, processed main chain 0..4 (non-beacon, canonical).
         Block previous = SuggestProcessedPostMergeChain(tree);
 
         // A non-beacon header suggested ahead of the processed head, on a level with no
@@ -3113,10 +3110,8 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Loads_best_suggested_post_merge_when_suggested_blocks_sit_ahead_of_head()
     {
-        // Repro of #12803: after an unclean shutdown a post-merge node restarts with
-        // suggested-but-unprocessed blocks above the processed head. Those levels have no
-        // main-chain block, so the canonical-only FindHeader(number) lookup cannot restore
-        // BestSuggestedHeader/BestSuggestedBody and sync mode selection sees header/block = 0.
+        // Repro of #12803: a post-merge restart with suggested-but-unprocessed blocks above the
+        // head must restore the best-suggested pointers from levels with no main-chain block.
         CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
@@ -3146,8 +3141,8 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Loads_best_suggested_beacon_post_merge_when_beacon_blocks_sit_ahead_of_head()
     {
-        // Beacon variant of #12803: beacon inserts are NotOnMainChain, so the canonical-only
-        // lookup cannot restore the beacon pointers after a restart mid beacon sync.
+        // Beacon variant of #12803: beacon inserts are NotOnMainChain, invisible to the
+        // canonical-only lookup on restart.
         CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
@@ -3178,9 +3173,7 @@ public class BlockTreeTests
         TerminalTotalDifficulty = UInt256.Zero
     };
 
-    /// <summary>
-    /// Suggests and processes a canonical post-merge chain 0..4, returning the head block.
-    /// </summary>
+    /// <summary>Suggests and processes a canonical post-merge chain 0..4, returning the head block.</summary>
     private static Block SuggestProcessedPostMergeChain(BlockTree tree)
     {
         Block previous = Build.A.Block.WithNumber(0).WithDifficulty(0).TestObject;

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -3092,8 +3092,6 @@ public class BlockTreeTests
 
         Block previous = SuggestProcessedPostMergeChain(tree);
 
-        // A non-beacon header suggested ahead of the processed head, on a level with no
-        // main-chain block.
         Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
         tree.SuggestBlock(block5);
 
@@ -3110,8 +3108,7 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Loads_best_suggested_post_merge_when_suggested_blocks_sit_ahead_of_head()
     {
-        // Repro of #12803: a post-merge restart with suggested-but-unprocessed blocks above the
-        // head must restore the best-suggested pointers from levels with no main-chain block.
+        // Repro of #12803.
         CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
@@ -3119,7 +3116,6 @@ public class BlockTreeTests
 
         Block previous = SuggestProcessedPostMergeChain(tree);
 
-        // Received but not yet processed when the node went down.
         Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
         Block block6 = Build.A.Block.WithNumber(6).WithDifficulty(0).WithParent(block5).TestObject;
         tree.SuggestBlock(block5);
@@ -3141,8 +3137,7 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Loads_best_suggested_beacon_post_merge_when_beacon_blocks_sit_ahead_of_head()
     {
-        // Beacon variant of #12803: beacon inserts are NotOnMainChain, invisible to the
-        // canonical-only lookup on restart.
+        // Beacon variant of #12803.
         CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
@@ -3150,7 +3145,6 @@ public class BlockTreeTests
 
         Block previous = SuggestProcessedPostMergeChain(tree);
 
-        // Beacon-downloaded but not yet processed when the node went down.
         Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
         Block block6 = Build.A.Block.WithNumber(6).WithDifficulty(0).WithParent(block5).TestObject;
         tree.Insert(block5, BlockTreeInsertBlockOptions.SaveHeader, BlockTreeInsertHeaderOptions.BeaconBlockInsert);
@@ -3173,7 +3167,6 @@ public class BlockTreeTests
         TerminalTotalDifficulty = UInt256.Zero
     };
 
-    /// <summary>Suggests and processes a canonical post-merge chain 0..4, returning the head block.</summary>
     private static Block SuggestProcessedPostMergeChain(BlockTree tree)
     {
         Block previous = Build.A.Block.WithNumber(0).WithDifficulty(0).TestObject;

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -3074,10 +3074,13 @@ public class BlockTreeTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
-    public void RecalculateTreeLevels_WhenBestSuggestedHeaderUnresolvableInPoS_StopsAtBeaconJunction()
+    public void RecalculateTreeLevels_WhenBeaconSegmentOverlapsBestSuggested_MovesPointerToBeaconJunction()
     {
-        // Post-merge repro of the O(n) startup walk: reconciliation must stop at the
+        // Post-merge repro of the O(n) startup walk: reconciliation must walk down to the
         // beacon/non-beacon junction rather than walking every already-synced header to genesis.
+        // The beacon fork overlaps the best-suggested level, so a stop bound anchored on the
+        // BestSuggestedHeader number would refuse the walk entirely — only the IsKnownBlock
+        // anchor moves the pointer while still stopping at the junction.
         CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         _blocksDb = new TestMemDb();
@@ -3090,19 +3093,29 @@ public class BlockTreeTests
             .WithoutSettingHead
             .TestObject;
 
-        Block previous = SuggestProcessedPostMergeChain(tree);
+        Block previous = SuggestProcessedPostMergeChain(tree)[^1];
 
         Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
         tree.SuggestBlock(block5);
 
-        // Beacon header backfilled on top; pointer parked one above the junction.
-        BlockHeader header6 = Build.A.BlockHeader.WithNumber(6).WithParent(block5.Header).TestObject;
-        tree.Insert(header6, BlockTreeInsertHeaderOptions.BeaconHeaderInsert | BlockTreeInsertHeaderOptions.TotalDifficultyNotNeeded);
+        // A beacon fork next to the suggested block; an interrupted backfill parked the pointer
+        // above the beacon header it had already inserted.
+        BlockHeader beacon5 = Build.A.BlockHeader.WithParent(previous.Header).WithExtraData(new byte[] { 2 }).TestObject;
+        BlockHeader beacon6 = Build.A.BlockHeader.WithParent(beacon5).TestObject;
+        BlockTreeInsertHeaderOptions beaconInsert = BlockTreeInsertHeaderOptions.BeaconHeaderInsert | BlockTreeInsertHeaderOptions.TotalDifficultyNotNeeded;
+        tree.Insert(beacon5, beaconInsert);
+        tree.Insert(beacon6, beaconInsert);
+        tree.LowestInsertedBeaconHeader = beacon6;
 
         tree.RecalculateTreeLevels();
 
-        // Must stay at the lowest beacon header, not descend into the synced chain (was 1 before the fix).
-        Assert.That(tree.LowestInsertedBeaconHeader?.Number, Is.EqualTo(6UL));
+        using (Assert.EnterMultipleScope())
+        {
+            // Must descend to the lowest inserted beacon header, not into the synced chain (was 1 before the fix).
+            Assert.That(tree.LowestInsertedBeaconHeader?.Number, Is.EqualTo(5UL), "lowest beacon");
+            // The mixed level restores the non-beacon suggestion, not the beacon fork header.
+            Assert.That(tree.BestSuggestedHeader?.Hash, Is.EqualTo(block5.Hash), "suggested header");
+        }
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
@@ -3113,7 +3126,7 @@ public class BlockTreeTests
         BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
         BlockTree tree = builder.TestObject;
 
-        Block previous = SuggestProcessedPostMergeChain(tree);
+        Block previous = SuggestProcessedPostMergeChain(tree)[^1];
 
         Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
         Block block6 = Build.A.Block.WithNumber(6).WithDifficulty(0).WithParent(block5).TestObject;
@@ -3128,8 +3141,63 @@ public class BlockTreeTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(reloaded.Head?.Number, Is.EqualTo(4UL), "head");
-            Assert.That(reloaded.BestSuggestedHeader?.Number, Is.EqualTo(6UL), "suggested header");
-            Assert.That(reloaded.BestSuggestedBody?.Number, Is.EqualTo(6UL), "suggested body");
+            Assert.That(reloaded.BestSuggestedHeader?.Hash, Is.EqualTo(block6.Hash), "suggested header");
+            Assert.That(reloaded.BestSuggestedBody?.Hash, Is.EqualTo(block6.Hash), "suggested body");
+        }
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Loads_latest_suggested_sibling_post_merge_when_level_has_competing_payloads()
+    {
+        CustomSpecProvider specProvider = PostMergeSpecProvider();
+
+        BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
+        BlockTree tree = builder.TestObject;
+
+        Block previous = SuggestProcessedPostMergeChain(tree)[^1];
+
+        Block olderSibling = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).WithExtraData(new byte[] { 1 }).TestObject;
+        Block latestSibling = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).WithExtraData(new byte[] { 2 }).TestObject;
+        tree.SuggestBlock(olderSibling);
+        tree.SuggestBlock(latestSibling);
+        Assert.That(tree.BestSuggestedHeader?.Hash, Is.EqualTo(latestSibling.Hash), "runtime pointer");
+
+        BlockTree reloaded = Build.A.BlockTree(specProvider)
+            .WithDatabaseFrom(builder)
+            .WithoutSettingHead
+            .TestObject;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reloaded.BestSuggestedHeader?.Hash, Is.EqualTo(latestSibling.Hash), "suggested header");
+            Assert.That(reloaded.BestSuggestedBody?.Hash, Is.EqualTo(latestSibling.Hash), "suggested body");
+        }
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Loads_best_suggested_post_merge_when_header_sits_ahead_of_body()
+    {
+        CustomSpecProvider specProvider = PostMergeSpecProvider();
+
+        BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
+        BlockTree tree = builder.TestObject;
+
+        Block previous = SuggestProcessedPostMergeChain(tree)[^1];
+
+        Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
+        Block block6 = Build.A.Block.WithNumber(6).WithDifficulty(0).WithParent(block5).TestObject;
+        tree.SuggestBlock(block5);
+        tree.SuggestHeader(block6.Header);
+
+        BlockTree reloaded = Build.A.BlockTree(specProvider)
+            .WithDatabaseFrom(builder)
+            .WithoutSettingHead
+            .TestObject;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reloaded.BestSuggestedHeader?.Hash, Is.EqualTo(block6.Hash), "suggested header");
+            Assert.That(reloaded.BestSuggestedBody?.Hash, Is.EqualTo(block5.Hash), "suggested body");
         }
     }
 
@@ -3141,7 +3209,7 @@ public class BlockTreeTests
         BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
         BlockTree tree = builder.TestObject;
 
-        Block previous = SuggestProcessedPostMergeChain(tree);
+        Block previous = SuggestProcessedPostMergeChain(tree)[^1];
 
         Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
         Block block6 = Build.A.Block.WithNumber(6).WithDifficulty(0).WithParent(block5).TestObject;
@@ -3155,9 +3223,32 @@ public class BlockTreeTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(reloaded.BestSuggestedBeaconHeader?.Number, Is.EqualTo(6UL), "beacon header");
-            Assert.That(reloaded.BestSuggestedBeaconBody?.Number, Is.EqualTo(6UL), "beacon body");
+            Assert.That(reloaded.BestSuggestedBeaconHeader?.Hash, Is.EqualTo(block6.Hash), "beacon header");
+            Assert.That(reloaded.BestSuggestedBeaconBody?.Hash, Is.EqualTo(block6.Hash), "beacon body");
         }
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Loads_best_suggested_beacon_from_beacon_entry_when_level_also_has_canonical_block()
+    {
+        CustomSpecProvider specProvider = PostMergeSpecProvider();
+
+        BlockTreeBuilder builder = Build.A.BlockTree(specProvider).WithoutSettingHead;
+        BlockTree tree = builder.TestObject;
+
+        Block[] chain = SuggestProcessedPostMergeChain(tree);
+
+        // A beacon fork header at the processed head's level: the canonical lookup resolves the
+        // main-chain sibling, so the restore must probe the beacon entries first.
+        BlockHeader beaconSibling = Build.A.BlockHeader.WithParent(chain[3].Header).WithExtraData(new byte[] { 2 }).TestObject;
+        tree.Insert(beaconSibling, BlockTreeInsertHeaderOptions.BeaconHeaderInsert | BlockTreeInsertHeaderOptions.TotalDifficultyNotNeeded);
+
+        BlockTree reloaded = Build.A.BlockTree(specProvider)
+            .WithDatabaseFrom(builder)
+            .WithoutSettingHead
+            .TestObject;
+
+        Assert.That(reloaded.BestSuggestedBeaconHeader?.Hash, Is.EqualTo(beaconSibling.Hash));
     }
 
     private static CustomSpecProvider PostMergeSpecProvider() => new(((ForkActivation)0, London.Instance))
@@ -3165,20 +3256,21 @@ public class BlockTreeTests
         TerminalTotalDifficulty = UInt256.Zero
     };
 
-    private static Block SuggestProcessedPostMergeChain(BlockTree tree)
+    private static Block[] SuggestProcessedPostMergeChain(BlockTree tree)
     {
-        Block previous = Build.A.Block.WithNumber(0).WithDifficulty(0).TestObject;
+        Block[] chain = new Block[5];
+        Block previous = chain[0] = Build.A.Block.WithNumber(0).WithDifficulty(0).TestObject;
         tree.SuggestBlock(previous);
         tree.TryUpdateMainChain(previous.Header, true, preloadedBlocks: new[] { previous });
-        for (ulong i = 1; i <= 4; i++)
+        for (int i = 1; i <= 4; i++)
         {
-            Block block = Build.A.Block.WithNumber(i).WithDifficulty(0).WithParent(previous).TestObject;
+            Block block = chain[i] = Build.A.Block.WithNumber((ulong)i).WithDifficulty(0).WithParent(previous).TestObject;
             tree.SuggestBlock(block);
             tree.TryUpdateMainChain(block.Header, true, preloadedBlocks: new[] { block });
             previous = block;
         }
 
-        return previous;
+        return chain;
     }
 
     private static void AssertSuggestNotifications(AddBlockResult result, bool hasNotified, bool hasNotifiedNewSuggested)

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -3076,11 +3076,9 @@ public class BlockTreeTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void RecalculateTreeLevels_WhenBeaconSegmentOverlapsBestSuggested_MovesPointerToBeaconJunction()
     {
-        // Post-merge repro of the O(n) startup walk: reconciliation must walk down to the
-        // beacon/non-beacon junction rather than walking every already-synced header to genesis.
-        // The beacon fork overlaps the best-suggested level, so a stop bound anchored on the
-        // BestSuggestedHeader number would refuse the walk entirely — only the IsKnownBlock
-        // anchor moves the pointer while still stopping at the junction.
+        // The beacon fork overlaps the best-suggested level: a stop bound anchored on the
+        // BestSuggestedHeader number would refuse the walk entirely, while an unanchored
+        // walk would descend past the junction into the synced chain.
         CustomSpecProvider specProvider = PostMergeSpecProvider();
 
         _blocksDb = new TestMemDb();
@@ -3098,8 +3096,6 @@ public class BlockTreeTests
         Block block5 = Build.A.Block.WithNumber(5).WithDifficulty(0).WithParent(previous).TestObject;
         tree.SuggestBlock(block5);
 
-        // A beacon fork next to the suggested block; an interrupted backfill parked the pointer
-        // above the beacon header it had already inserted.
         BlockHeader beacon5 = Build.A.BlockHeader.WithParent(previous.Header).WithExtraData(new byte[] { 2 }).TestObject;
         BlockHeader beacon6 = Build.A.BlockHeader.WithParent(beacon5).TestObject;
         BlockTreeInsertHeaderOptions beaconInsert = BlockTreeInsertHeaderOptions.BeaconHeaderInsert | BlockTreeInsertHeaderOptions.TotalDifficultyNotNeeded;
@@ -3111,9 +3107,7 @@ public class BlockTreeTests
 
         using (Assert.EnterMultipleScope())
         {
-            // Must descend to the lowest inserted beacon header, not into the synced chain (was 1 before the fix).
             Assert.That(tree.LowestInsertedBeaconHeader?.Number, Is.EqualTo(5UL), "lowest beacon");
-            // The mixed level restores the non-beacon suggestion, not the beacon fork header.
             Assert.That(tree.BestSuggestedHeader?.Hash, Is.EqualTo(block5.Hash), "suggested header");
         }
     }
@@ -3238,8 +3232,7 @@ public class BlockTreeTests
 
         Block[] chain = SuggestProcessedPostMergeChain(tree);
 
-        // A beacon fork header at the processed head's level: the canonical lookup resolves the
-        // main-chain sibling, so the restore must probe the beacon entries first.
+        // beacon fork at the head's level: the canonical lookup would resolve the main-chain sibling
         BlockHeader beaconSibling = Build.A.BlockHeader.WithParent(chain[3].Header).WithExtraData(new byte[] { 2 }).TestObject;
         tree.Insert(beaconSibling, BlockTreeInsertHeaderOptions.BeaconHeaderInsert | BlockTreeInsertHeaderOptions.TotalDifficultyNotNeeded);
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -36,10 +36,8 @@ public partial class BlockTree
         // An unclean shutdown between a beacon header write and its pointer update can leave
         // LowestInsertedBeaconHeader parked above headers the backfill had already inserted.
         // Walk down through the contiguous beacon segment and stop at the merge junction — the
-        // first already-synced non-beacon block. Anchoring on IsKnownBlock (rather than the
-        // BestSuggestedHeader number) keeps the walk bounded to the beacon segment even when
-        // the suggested pointers are missing or stale; a collapsed stop bound used to drag the
-        // walk down the whole canonical chain (#12273).
+        // first already-synced non-beacon block. Anchoring on IsKnownBlock keeps the walk bounded
+        // to the beacon segment even when the suggested pointers are missing or stale (#12273).
         BlockHeader current = lowest;
         while (current.ParentHash is not null)
         {
@@ -259,19 +257,15 @@ public partial class BlockTree
         }
 
         BestKnownNumber = bestKnownNumberFound;
-        // FindHeader(number) is canonical-only and post-merge returns null for levels with no
-        // main-chain block — where suggested-but-unprocessed blocks live after a restart. Fall
-        // back to any header/body at the resolved level, mirroring HeaderExists/BodyExists.
+        // The canonical FindHeader(number)/FindBlock(number) miss post-merge levels with no
+        // main-chain block — where suggested-but-unprocessed blocks live after a restart (#12803).
         BestSuggestedHeader = FindHeader(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None)
             ?? FindHeaderAtLevel(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None, findBeacon: false);
         BestSuggestedBody = FindBlock(bestSuggestedBodyNumber, BlockTreeLookupOptions.None)
             ?? FindBlockAtLevel(bestSuggestedBodyNumber, BlockTreeLookupOptions.None, findBeacon: false);
     }
 
-    /// <summary>
-    /// Finds a stored header at the given level matching the <see cref="HeaderExists"/> predicate,
-    /// regardless of whether the level has a main-chain block.
-    /// </summary>
+    /// <summary>Finds a stored header at the given level, canonical or not; mirrors <see cref="HeaderExists"/>.</summary>
     private BlockHeader? FindHeaderAtLevel(ulong blockNumber, BlockTreeLookupOptions options, bool findBeacon)
     {
         ChainLevelInfo? level = LoadLevel(blockNumber);
@@ -297,10 +291,7 @@ public partial class BlockTree
         return null;
     }
 
-    /// <summary>
-    /// Finds a stored block at the given level matching the <see cref="BodyExists"/> predicate,
-    /// regardless of whether the level has a main-chain block.
-    /// </summary>
+    /// <summary>Finds a stored block at the given level, canonical or not; mirrors <see cref="BodyExists"/>.</summary>
     private Block? FindBlockAtLevel(ulong blockNumber, BlockTreeLookupOptions options, bool findBeacon)
     {
         ChainLevelInfo? level = LoadLevel(blockNumber);

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -134,61 +134,12 @@ public partial class BlockTree
         return level is not null && level.HasNonBeaconBlocks;
     }
 
-    private bool HeaderExists(ulong blockNumber, bool findBeacon = false)
-    {
-        ChainLevelInfo level = LoadLevel(blockNumber);
-        if (level is null)
-        {
-            return false;
-        }
+    private bool HeaderExists(ulong blockNumber, bool findBeacon = false) =>
+        FindHeaderAtLevel(blockNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.DoNotCreateLevelIfMissing, findBeacon) is not null;
 
-        foreach (BlockInfo blockInfo in level.BlockInfos)
-        {
-            BlockHeader? header = FindHeader(blockInfo.BlockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.DoNotCreateLevelIfMissing);
-            if (header is not null)
-            {
-                if (findBeacon && blockInfo.IsBeaconHeader)
-                {
-                    return true;
-                }
+    private bool BodyExists(ulong blockNumber, bool findBeacon = false) =>
+        FindBlockAtLevel(blockNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.DoNotCreateLevelIfMissing, findBeacon) is not null;
 
-                if (!findBeacon && !blockInfo.IsBeaconHeader)
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private bool BodyExists(ulong blockNumber, bool findBeacon = false)
-    {
-        ChainLevelInfo level = LoadLevel(blockNumber);
-        if (level is null)
-        {
-            return false;
-        }
-
-        foreach (BlockInfo blockInfo in level.BlockInfos)
-        {
-            Block? block = FindBlock(blockInfo.BlockHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded | BlockTreeLookupOptions.DoNotCreateLevelIfMissing);
-            if (block is not null)
-            {
-                if (findBeacon && blockInfo.IsBeaconBody)
-                {
-                    return true;
-                }
-
-                if (!findBeacon && !blockInfo.IsBeaconBody)
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
     private void LoadForkChoiceInfo()
     {
         Logger.Info("Loading fork choice info");
@@ -260,9 +211,9 @@ public partial class BlockTree
         // The canonical FindHeader(number)/FindBlock(number) miss post-merge levels with no
         // main-chain block — where suggested-but-unprocessed blocks live after a restart.
         BestSuggestedHeader = FindHeader(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None)
-            ?? FindHeaderAtLevel(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None, findBeacon: false);
+            ?? FindHeaderAtLevel(bestSuggestedHeaderNumber, BlockTreeLookupOptions.DoNotCreateLevelIfMissing, findBeacon: false);
         BestSuggestedBody = FindBlock(bestSuggestedBodyNumber, BlockTreeLookupOptions.None)
-            ?? FindBlockAtLevel(bestSuggestedBodyNumber, BlockTreeLookupOptions.None, findBeacon: false);
+            ?? FindBlockAtLevel(bestSuggestedBodyNumber, BlockTreeLookupOptions.DoNotCreateLevelIfMissing, findBeacon: false);
     }
 
     private BlockHeader? FindHeaderAtLevel(ulong blockNumber, BlockTreeLookupOptions options, bool findBeacon)
@@ -273,6 +224,7 @@ public partial class BlockTree
             return null;
         }
 
+        BlockHeader? found = null;
         foreach (BlockInfo blockInfo in level.BlockInfos)
         {
             if (blockInfo.IsBeaconHeader != findBeacon)
@@ -281,13 +233,29 @@ public partial class BlockTree
             }
 
             BlockHeader? header = FindHeader(blockInfo.BlockHash, options, blockNumber: blockNumber);
-            if (header is not null)
+            if (header is null)
             {
-                return header;
+                continue;
+            }
+
+            if (findBeacon)
+            {
+                // Mirror ChainLevelInfo.BeaconMainChainBlock: the beacon-main-chain entry wins, else the first entry.
+                if (blockInfo.IsBeaconMainChain)
+                {
+                    return header;
+                }
+                found ??= header;
+            }
+            else
+            {
+                // InsertBlockInfo appends, and at equal height the latest suggestion wins
+                // (BestSuggestedImprovementRequirementsSatisfied uses <=), so the last entry matches the runtime pointer.
+                found = header;
             }
         }
 
-        return null;
+        return found;
     }
 
     private Block? FindBlockAtLevel(ulong blockNumber, BlockTreeLookupOptions options, bool findBeacon)
@@ -298,6 +266,7 @@ public partial class BlockTree
             return null;
         }
 
+        Block? found = null;
         foreach (BlockInfo blockInfo in level.BlockInfos)
         {
             if (blockInfo.IsBeaconBody != findBeacon)
@@ -306,13 +275,26 @@ public partial class BlockTree
             }
 
             Block? block = FindBlock(blockInfo.BlockHash, options, blockNumber: blockNumber);
-            if (block is not null)
+            if (block is null)
             {
-                return block;
+                continue;
+            }
+
+            if (findBeacon)
+            {
+                if (blockInfo.IsBeaconMainChain)
+                {
+                    return block;
+                }
+                found ??= block;
+            }
+            else
+            {
+                found = block;
             }
         }
 
-        return null;
+        return found;
     }
 
 
@@ -352,11 +334,12 @@ public partial class BlockTree
         }
 
         BestKnownBeaconNumber = bestKnownNumberFound;
-        // Beacon inserts are NotOnMainChain, so post-merge the canonical lookup misses them too.
-        BestSuggestedBeaconHeader = FindHeader(bestBeaconHeaderNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded)
-            ?? FindHeaderAtLevel(bestBeaconHeaderNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded, findBeacon: true);
-        BestSuggestedBeaconBody = FindBlock(bestBeaconBodyNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded)
-            ?? FindBlockAtLevel(bestBeaconBodyNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded, findBeacon: true);
+        // The numbers came from beacon-filtered searches, so probe the beacon entries first: beacon
+        // inserts are NotOnMainChain, and the canonical lookup can resolve a non-beacon sibling.
+        BestSuggestedBeaconHeader = FindHeaderAtLevel(bestBeaconHeaderNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded, findBeacon: true)
+            ?? FindHeader(bestBeaconHeaderNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+        BestSuggestedBeaconBody = FindBlockAtLevel(bestBeaconBodyNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded, findBeacon: true)
+            ?? FindBlock(bestBeaconBodyNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
     }
 
     private Hash256? DecodeMetadataKeccak(int key)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -37,9 +37,9 @@ public partial class BlockTree
         // LowestInsertedBeaconHeader parked above headers the backfill had already inserted.
         // Walk down through the contiguous beacon segment and stop at the merge junction — the
         // first already-synced non-beacon block. Anchoring on IsKnownBlock (rather than the
-        // BestSuggestedHeader number) keeps the walk bounded to the beacon segment: post-merge
-        // BestSuggestedHeader can be null when headers sit ahead of the processed head, which
-        // used to collapse the stop bound and drag the walk down the whole canonical chain.
+        // BestSuggestedHeader number) keeps the walk bounded to the beacon segment even when
+        // the suggested pointers are missing or stale; a collapsed stop bound used to drag the
+        // walk down the whole canonical chain (#12273).
         BlockHeader current = lowest;
         while (current.ParentHash is not null)
         {
@@ -263,19 +263,16 @@ public partial class BlockTree
         // main-chain block — where suggested-but-unprocessed blocks live after a restart. Fall
         // back to any header/body at the resolved level, mirroring HeaderExists/BodyExists.
         BestSuggestedHeader = FindHeader(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None)
-            ?? FindHeaderAtLevel(bestSuggestedHeaderNumber, findBeacon: false);
-        BlockHeader? bestSuggestedBodyHeader = FindHeader(bestSuggestedBodyNumber, BlockTreeLookupOptions.None);
-        BestSuggestedBody = (bestSuggestedBodyHeader is null
-            ? null
-            : FindBlock(bestSuggestedBodyHeader.Hash, BlockTreeLookupOptions.None))
-            ?? FindBlockAtLevel(bestSuggestedBodyNumber, findBeacon: false);
+            ?? FindHeaderAtLevel(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None, findBeacon: false);
+        BestSuggestedBody = FindBlock(bestSuggestedBodyNumber, BlockTreeLookupOptions.None)
+            ?? FindBlockAtLevel(bestSuggestedBodyNumber, BlockTreeLookupOptions.None, findBeacon: false);
     }
 
     /// <summary>
     /// Finds a stored header at the given level matching the <see cref="HeaderExists"/> predicate,
     /// regardless of whether the level has a main-chain block.
     /// </summary>
-    private BlockHeader? FindHeaderAtLevel(ulong blockNumber, bool findBeacon)
+    private BlockHeader? FindHeaderAtLevel(ulong blockNumber, BlockTreeLookupOptions options, bool findBeacon)
     {
         ChainLevelInfo? level = LoadLevel(blockNumber);
         if (level is null)
@@ -290,7 +287,7 @@ public partial class BlockTree
                 continue;
             }
 
-            BlockHeader? header = FindHeader(blockInfo.BlockHash, BlockTreeLookupOptions.None, blockNumber: blockNumber);
+            BlockHeader? header = FindHeader(blockInfo.BlockHash, options, blockNumber: blockNumber);
             if (header is not null)
             {
                 return header;
@@ -304,7 +301,7 @@ public partial class BlockTree
     /// Finds a stored block at the given level matching the <see cref="BodyExists"/> predicate,
     /// regardless of whether the level has a main-chain block.
     /// </summary>
-    private Block? FindBlockAtLevel(ulong blockNumber, bool findBeacon)
+    private Block? FindBlockAtLevel(ulong blockNumber, BlockTreeLookupOptions options, bool findBeacon)
     {
         ChainLevelInfo? level = LoadLevel(blockNumber);
         if (level is null)
@@ -319,7 +316,7 @@ public partial class BlockTree
                 continue;
             }
 
-            Block? block = FindBlock(blockInfo.BlockHash, BlockTreeLookupOptions.None, blockNumber: blockNumber);
+            Block? block = FindBlock(blockInfo.BlockHash, options, blockNumber: blockNumber);
             if (block is not null)
             {
                 return block;
@@ -366,11 +363,11 @@ public partial class BlockTree
         }
 
         BestKnownBeaconNumber = bestKnownNumberFound;
-        BestSuggestedBeaconHeader = FindHeader(bestBeaconHeaderNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-        BlockHeader? bestBeaconBodyHeader = FindHeader(bestBeaconBodyNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-        BestSuggestedBeaconBody = bestBeaconBodyHeader is null
-            ? null
-            : FindBlock(bestBeaconBodyHeader.Hash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+        // Beacon inserts are NotOnMainChain, so post-merge the canonical lookup misses them too.
+        BestSuggestedBeaconHeader = FindHeader(bestBeaconHeaderNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded)
+            ?? FindHeaderAtLevel(bestBeaconHeaderNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded, findBeacon: true);
+        BestSuggestedBeaconBody = FindBlock(bestBeaconBodyNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded)
+            ?? FindBlockAtLevel(bestBeaconBodyNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded, findBeacon: true);
     }
 
     private Hash256? DecodeMetadataKeccak(int key)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -37,7 +37,7 @@ public partial class BlockTree
         // LowestInsertedBeaconHeader parked above headers the backfill had already inserted.
         // Walk down through the contiguous beacon segment and stop at the merge junction — the
         // first already-synced non-beacon block. Anchoring on IsKnownBlock keeps the walk bounded
-        // to the beacon segment even when the suggested pointers are missing or stale (#12273).
+        // to the beacon segment even when the suggested pointers are missing or stale.
         BlockHeader current = lowest;
         while (current.ParentHash is not null)
         {
@@ -258,7 +258,7 @@ public partial class BlockTree
 
         BestKnownNumber = bestKnownNumberFound;
         // The canonical FindHeader(number)/FindBlock(number) miss post-merge levels with no
-        // main-chain block — where suggested-but-unprocessed blocks live after a restart (#12803).
+        // main-chain block — where suggested-but-unprocessed blocks live after a restart.
         BestSuggestedHeader = FindHeader(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None)
             ?? FindHeaderAtLevel(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None, findBeacon: false);
         BestSuggestedBody = FindBlock(bestSuggestedBodyNumber, BlockTreeLookupOptions.None)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -240,7 +240,7 @@ public partial class BlockTree
 
             if (findBeacon)
             {
-                // Mirror ChainLevelInfo.BeaconMainChainBlock: the beacon-main-chain entry wins, else the first entry.
+                // mirrors ChainLevelInfo.BeaconMainChainBlock
                 if (blockInfo.IsBeaconMainChain)
                 {
                     return header;
@@ -249,8 +249,7 @@ public partial class BlockTree
             }
             else
             {
-                // InsertBlockInfo appends, and at equal height the latest suggestion wins
-                // (BestSuggestedImprovementRequirementsSatisfied uses <=), so the last entry matches the runtime pointer.
+                // last entry: at equal height the latest suggestion wins
                 found = header;
             }
         }
@@ -334,8 +333,7 @@ public partial class BlockTree
         }
 
         BestKnownBeaconNumber = bestKnownNumberFound;
-        // The numbers came from beacon-filtered searches, so probe the beacon entries first: beacon
-        // inserts are NotOnMainChain, and the canonical lookup can resolve a non-beacon sibling.
+        // beacon entries first — the canonical lookup can resolve a non-beacon sibling
         BestSuggestedBeaconHeader = FindHeaderAtLevel(bestBeaconHeaderNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded, findBeacon: true)
             ?? FindHeader(bestBeaconHeaderNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
         BestSuggestedBeaconBody = FindBlockAtLevel(bestBeaconBodyNumber, BlockTreeLookupOptions.TotalDifficultyNotNeeded, findBeacon: true)

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -259,11 +259,74 @@ public partial class BlockTree
         }
 
         BestKnownNumber = bestKnownNumberFound;
-        BestSuggestedHeader = FindHeader(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None);
+        // FindHeader(number) is canonical-only and post-merge returns null for levels with no
+        // main-chain block — where suggested-but-unprocessed blocks live after a restart. Fall
+        // back to any header/body at the resolved level, mirroring HeaderExists/BodyExists.
+        BestSuggestedHeader = FindHeader(bestSuggestedHeaderNumber, BlockTreeLookupOptions.None)
+            ?? FindHeaderAtLevel(bestSuggestedHeaderNumber, findBeacon: false);
         BlockHeader? bestSuggestedBodyHeader = FindHeader(bestSuggestedBodyNumber, BlockTreeLookupOptions.None);
-        BestSuggestedBody = bestSuggestedBodyHeader is null
+        BestSuggestedBody = (bestSuggestedBodyHeader is null
             ? null
-            : FindBlock(bestSuggestedBodyHeader.Hash, BlockTreeLookupOptions.None);
+            : FindBlock(bestSuggestedBodyHeader.Hash, BlockTreeLookupOptions.None))
+            ?? FindBlockAtLevel(bestSuggestedBodyNumber, findBeacon: false);
+    }
+
+    /// <summary>
+    /// Finds a stored header at the given level matching the <see cref="HeaderExists"/> predicate,
+    /// regardless of whether the level has a main-chain block.
+    /// </summary>
+    private BlockHeader? FindHeaderAtLevel(ulong blockNumber, bool findBeacon)
+    {
+        ChainLevelInfo? level = LoadLevel(blockNumber);
+        if (level is null)
+        {
+            return null;
+        }
+
+        foreach (BlockInfo blockInfo in level.BlockInfos)
+        {
+            if (blockInfo.IsBeaconHeader != findBeacon)
+            {
+                continue;
+            }
+
+            BlockHeader? header = FindHeader(blockInfo.BlockHash, BlockTreeLookupOptions.None, blockNumber: blockNumber);
+            if (header is not null)
+            {
+                return header;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds a stored block at the given level matching the <see cref="BodyExists"/> predicate,
+    /// regardless of whether the level has a main-chain block.
+    /// </summary>
+    private Block? FindBlockAtLevel(ulong blockNumber, bool findBeacon)
+    {
+        ChainLevelInfo? level = LoadLevel(blockNumber);
+        if (level is null)
+        {
+            return null;
+        }
+
+        foreach (BlockInfo blockInfo in level.BlockInfos)
+        {
+            if (blockInfo.IsBeaconBody != findBeacon)
+            {
+                continue;
+            }
+
+            Block? block = FindBlock(blockInfo.BlockHash, BlockTreeLookupOptions.None, blockNumber: blockNumber);
+            if (block is not null)
+            {
+                return block;
+            }
+        }
+
+        return null;
     }
 
 

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.Initializer.cs
@@ -265,7 +265,6 @@ public partial class BlockTree
             ?? FindBlockAtLevel(bestSuggestedBodyNumber, BlockTreeLookupOptions.None, findBeacon: false);
     }
 
-    /// <summary>Finds a stored header at the given level, canonical or not; mirrors <see cref="HeaderExists"/>.</summary>
     private BlockHeader? FindHeaderAtLevel(ulong blockNumber, BlockTreeLookupOptions options, bool findBeacon)
     {
         ChainLevelInfo? level = LoadLevel(blockNumber);
@@ -291,7 +290,6 @@ public partial class BlockTree
         return null;
     }
 
-    /// <summary>Finds a stored block at the given level, canonical or not; mirrors <see cref="BodyExists"/>.</summary>
     private Block? FindBlockAtLevel(ulong blockNumber, BlockTreeLookupOptions options, bool findBeacon)
     {
         ChainLevelInfo? level = LoadLevel(blockNumber);


### PR DESCRIPTION
Fixes #12803

## Changes

- `LoadBestKnown` restored `BestSuggestedHeader`/`BestSuggestedBody` through the canonical-only `FindHeader(number)` lookup, which post-merge returns null for levels with no main-chain block (#10876). After a restart with suggested-but-unprocessed blocks above the head, both pointers came back null and `MultiSyncModeSelector` looped forever on `Invalid snapshot calculation` (`header: 0 | block: 0`), so sync never resumed.
- Fall back to any header/body stored at the resolved level, mirroring the `HeaderExists`/`BodyExists` predicates the number search used.
- Apply the same fallback to `LoadBeaconBestKnown` — beacon inserts are `NotOnMainChain`, so the canonical lookup always missed them post-merge and the beacon pointers restored as null after every restart mid beacon sync.
- Add regression tests reloading a post-merge tree with suggested (and beacon-inserted) blocks ahead of the processed head.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Regression tests reload a post-merge `BlockTree` from the same DBs (the constructor runs `RecalculateTreeLevels`) with suggested/beacon-inserted blocks above the processed head and assert the pointers restore. Both fail without the fix (pointers were null). Full Nethermind.Blockchain.Test, Nethermind.Synchronization.Test, and Nethermind.Merge.Plugin.Test suites pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Fixes a permanent "Invalid snapshot calculation" sync-selector loop after restarting a post-merge node that had received blocks it had not yet processed (e.g. after an unclean shutdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)