### PR TITLE
fix(sync): resolve permanent snapshot-recalculation loop on patricia/archive backend

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -1947,6 +1947,23 @@ public class BlockTreeTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
+    public void FindHeader_ignores_a_resolved_header_whose_decoded_number_does_not_match_requested_number()
+    {
+        // Simulates a corrupted/stale record: the caller asks for a header at a given block number and hash,
+        // but the header actually decoded from the store (e.g. via the legacy hash-only fallback key) reports
+        // a different Number - a leftover/garbage record surviving an unclean shutdown. Trusting header.Number
+        // here would silently poison callers that index by number (e.g. LoadBestKnown -> BestSuggestedHeader).
+        BlockTree blockTree = Build.A.BlockTree().OfChainLength(3).TestObject;
+
+        ulong requestedNumber = 1;
+        Hash256 requestedHash = blockTree.FindHeader(requestedNumber, BlockTreeLookupOptions.None)!.Hash!;
+        BlockHeader header = blockTree.FindHeader(requestedHash, BlockTreeLookupOptions.None)!;
+        header.Number = requestedNumber + 100; // corrupt the decoded number without touching the hash
+
+        Assert.That(blockTree.FindHeader(requestedHash, BlockTreeLookupOptions.None, blockNumber: requestedNumber), Is.Null);
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
     public void Can_delete_one_block()
     {
         BlockTree blockTree = Build.A.BlockTree().OfChainLength(3).TestObject;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -546,6 +546,16 @@ namespace Nethermind.Blockchain
                 return header;
             }
 
+            if (blockNumber is not null && header.Number != blockNumber.Value)
+            {
+                // The number-prefixed lookup missed and the legacy hash-only fallback resolved to a
+                // header for a different block number than requested (e.g. a stale/corrupted record).
+                // Trusting header.Number here would silently poison callers that index by number
+                // (e.g. BlockTree.FindHeader(ulong, ...) / LoadBestKnown), so treat it as not found.
+                if (Logger.IsWarn) Logger.Warn($"Header lookup for block {blockNumber.Value} with hash {blockHash} resolved to a header for block {header.Number} instead; ignoring mismatched record.");
+                return null;
+            }
+
             header.Hash ??= blockHash;
             bool totalDifficultyNeeded = (options & BlockTreeLookupOptions.TotalDifficultyNotNeeded) == BlockTreeLookupOptions.None;
             bool createLevelIfMissing = (options & BlockTreeLookupOptions.DoNotCreateLevelIfMissing) == BlockTreeLookupOptions.None;

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorSnapshotRecoveryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/MultiSyncModeSelectorSnapshotRecoveryTests.cs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.Peers;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.ParallelSync;
+
+[Parallelizable(ParallelScope.All)]
+public class MultiSyncModeSelectorSnapshotRecoveryTests
+{
+    /// <summary>
+    /// If <see cref="ISyncProgressResolver"/> reports a snapshot that stays invalid even after
+    /// <see cref="ISyncProgressResolver.RecalculateProgressPointers"/> (e.g. a corrupted/stale block-tree
+    /// record - see the header-number-mismatch case in BlockTree.FindHeader), <see cref="MultiSyncModeSelector.Update"/>
+    /// must not let that failure skip <c>UpdateSyncModes</c>. Doing so would leave <c>Current</c> frozen at
+    /// whatever it was, so the exact same failure repeats every tick forever with no chance for the pointers to
+    /// recover - this reproduces the "Cannot recalculate snapshot progress" infinite loop.
+    /// </summary>
+    [Test]
+    public void Update_does_not_wedge_sync_mode_when_snapshot_stays_invalid_after_recalculation()
+    {
+        ISyncProgressResolver syncProgressResolver = Substitute.For<ISyncProgressResolver>();
+        // Processed > Block is one of the IsSnapshotInvalid conditions, and it never clears - simulating a
+        // corrupted record that recalculation cannot fix.
+        syncProgressResolver.FindBestProcessedBlock().Returns(100UL);
+        syncProgressResolver.FindBestFullBlock().Returns(0UL);
+        syncProgressResolver.FindBestHeader().Returns(0UL);
+        syncProgressResolver.FindBestFullState().Returns(0UL);
+        syncProgressResolver.ChainDifficulty.Returns(UInt256.Zero);
+        syncProgressResolver.SyncPivot.Returns((0UL, Keccak.Zero));
+
+        ISyncPeerPool syncPeerPool = Substitute.For<ISyncPeerPool>();
+        ISyncPeer syncPeer = Substitute.For<ISyncPeer>();
+        syncPeer.HeadNumber.Returns(200UL);
+        syncPeer.TotalDifficulty.Returns((UInt256?)null);
+        syncPeer.HeadHash.Returns(TestItem.KeccakA);
+        syncPeerPool.InitializedPeers.Returns(new List<PeerInfo> { new(syncPeer) });
+
+        ISyncConfig syncConfig = new SyncConfig { FastSync = false, SynchronizationEnabled = true };
+        IBetterPeerStrategy betterPeerStrategy = new TotalDifficultyBetterPeerStrategy(LimboLogs.Instance);
+
+        MultiSyncModeSelector selector = new(
+            syncProgressResolver,
+            syncPeerPool,
+            syncConfig,
+            No.BeaconSync,
+            betterPeerStrategy,
+            LimboLogs.Instance);
+
+        Assert.DoesNotThrow(() => selector.Update());
+
+        // Current must have actually been updated (not left at its pre-Update() default) - proving
+        // UpdateSyncModes ran instead of being skipped by a propagated exception.
+        Assert.That(selector.Current, Is.EqualTo(SyncMode.Disconnected));
+
+        // A second tick reproduces the exact same persistently-invalid snapshot; Update must keep
+        // completing (and keep calling UpdateSyncModes) rather than wedging after the first failure.
+        Assert.DoesNotThrow(() => selector.Update());
+        Assert.That(selector.Current, Is.EqualTo(SyncMode.Disconnected));
+
+        syncProgressResolver.Received(2).RecalculateProgressPointers();
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/MultiSyncModeSelector.cs
@@ -127,9 +127,16 @@ namespace Nethermind.Synchronization.ParallelSync
                     reason = "No Useful Peers";
                 }
                 // to avoid expensive checks we make this simple check at the beginning
+                else if (!TryEnsureSnapshot(peerDifficulty, peerBlock.Value, inBeaconControl, out Snapshot best, out newModes, out reason))
+                {
+                    // Progress pointers could not be reconciled even after a recalculation attempt.
+                    // Falling through to UpdateSyncModes below (rather than letting the exception
+                    // propagate out of Update, as before) means Current still gets set instead of
+                    // staying frozen - otherwise this exact failure would repeat every tick forever
+                    // with no chance for the pointers to recover.
+                }
                 else
                 {
-                    Snapshot best = EnsureSnapshot(peerDifficulty, peerBlock.Value, inBeaconControl);
                     best.IsInBeaconHeaders = ShouldBeInBeaconHeaders();
 
                     if (!FastSyncEnabled)
@@ -587,6 +594,28 @@ namespace Nethermind.Synchronization.ParallelSync
         }
 
         public void Dispose() => CancellationTokenExtensions.CancelDisposeAndClear(ref _cancellation);
+
+        /// <summary>
+        /// Same reconciliation as <see cref="EnsureSnapshot"/> but reports an unrecoverable snapshot
+        /// via the return value instead of throwing, so a caller can still set a sync mode (rather than
+        /// leave <see cref="Current"/> frozen) and give the next tick a chance for the pointers to recover.
+        /// </summary>
+        private bool TryEnsureSnapshot(in UInt256? peerDifficulty, ulong peerBlock, bool inBeaconControl, out Snapshot best, out SyncMode newModes, out string reason)
+        {
+            newModes = SyncMode.Disconnected;
+            reason = string.Empty;
+            try
+            {
+                best = EnsureSnapshot(peerDifficulty, peerBlock, inBeaconControl);
+                return true;
+            }
+            catch (InvalidAsynchronousStateException)
+            {
+                best = default;
+                reason = "Snapshot Misalignment";
+                return false;
+            }
+        }
 
         private Snapshot EnsureSnapshot(in UInt256? peerDifficulty, ulong peerBlock, bool inBeaconControl)
         {


### PR DESCRIPTION
## Summary

Fixes #12803 - `MultiSyncModeSelector` gets permanently stuck in a "Cannot recalculate snapshot progress" loop after DB catch-up on a patricia/archive-backend node.

Two related fixes:

1. **Root cause** (`BlockTree.FindHeader`): `HeaderStore.Get` falls back to a legacy hash-only key when the number-prefixed lookup misses. If that fallback resolves a stale/corrupted record, `FindHeader(Hash256?, options, blockNumber)` returned it without checking `header.Number` actually matched the requested `blockNumber` - letting a wrong header silently propagate into `BestSuggestedHeader` (via `LoadBestKnown`). This matches the reported symptom: `RecalculateProgressPointers` logs resolving a real, non-zero header, but the very next snapshot reads `header: 0`.

2. **Defensive hardening** (`MultiSyncModeSelector.Update`): even with (1) fixed, any future case where a snapshot stays invalid after recalculation would still wedge the sync loop forever - `EnsureSnapshot`'s exception was only caught by the outer handler in `StartAsync`, which skips `UpdateSyncModes` for that tick and leaves `Current` frozen. Every subsequent tick then repeats the identical failure with no path to recovery. `Update()` now falls through to `Disconnected` on this failure (mirroring the existing `FastSync`-branch handling of the same exception) so later ticks get a chance to recover.

Both commits include regression tests that fail on the pre-fix code and pass on the fix (verified by temporarily reverting each fix locally).

## Context

Found while investigating a Hoodi archive node (`hoodi_archive.json`, patricia/trie backend, `Pruning.Enabled = false`) stuck looping on:
```
Invalid snapshot calculation: processed: 3409897 | state: 3409897 | block: 0 | header: 0 | chain difficulty: 0 | target block: ... 
Cannot recalculate snapshot progress. ...
Sync mode update failed System.ComponentModel.InvalidAsynchronousStateException: ...
```
reproduced across both a service restart and a full OS reboot, on `1.39.3+28cbe2a0`. This is a different code path than the flat-DB gap issue fixed in #12260/#12356 (this node runs `State backend: patricia (flat DB disabled)`), and the underlying data corruption is plausibly tied to a failing NVMe on the host with a history of unsafe shutdowns - full details in #12803.

Marking as draft since I'd like maintainer input on whether the `FindHeader` mismatch guard is the right layer to fix this at, versus e.g. hardening `HeaderStore.Get`'s hash-only fallback itself.

## Test plan
- [x] `Nethermind.Blockchain.Test` - 1616 passed, 0 failed
- [x] `Nethermind.Synchronization.Test` - 2096 passed, 0 failed
- [x] New regression tests confirmed to fail against the pre-fix code, pass against the fix