### PR TITLE
Reject legacy scalar-nonce frame transaction after EIP-8250

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -1091,6 +1091,23 @@ public class TxValidatorTests
         Assert.That(FrameTxFieldsTxValidator.Instance.IsWellFormed(tx, Bogota.Instance).AsBool(), Is.False);
     }
 
+    private static IEnumerable<TestCaseData> NonceKeysEnvelopeCases()
+    {
+        yield return new TestCaseData(null, false, true).SetName("IsWellFormed_FrameTxLegacyNonce_BeforeEip8250_ReturnTrue");
+        yield return new TestCaseData(null, true, false).SetName("IsWellFormed_FrameTxLegacyNonce_AfterEip8250_ReturnFalse");
+        yield return new TestCaseData(new UInt256[] { 0 }, false, false).SetName("IsWellFormed_FrameTxKeyedNonce_BeforeEip8250_ReturnFalse");
+        yield return new TestCaseData(new UInt256[] { 0 }, true, true).SetName("IsWellFormed_FrameTxKeyedNonce_AfterEip8250_ReturnTrue");
+    }
+
+    [TestCaseSource(nameof(NonceKeysEnvelopeCases))]
+    public void IsWellFormed_FrameTxNonceKeys_GatedOnEip8250(UInt256[]? nonceKeys, bool eip8250Enabled, bool expectedWellFormed)
+    {
+        Transaction tx = new() { Type = TxType.FrameTx, NonceKeys = nonceKeys };
+        IReleaseSpec releaseSpec = new ReleaseSpec { IsEip8250Enabled = eip8250Enabled };
+
+        Assert.That(FrameTxNonceKeysTxValidator.Instance.IsWellFormed(tx, releaseSpec).AsBool(), Is.EqualTo(expectedWellFormed));
+    }
+
     private static Transaction BuildBlobFrameTx(int blobCount, byte versionByte = KzgPolynomialCommitments.KzgBlobHashVersionV1)
     {
         byte[][] versionedHashes = new byte[blobCount][];

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -1097,6 +1097,7 @@ public class TxValidatorTests
         yield return new TestCaseData(null, true, false).SetName("IsWellFormed_FrameTxLegacyNonce_AfterEip8250_ReturnFalse");
         yield return new TestCaseData(new UInt256[] { 0 }, false, false).SetName("IsWellFormed_FrameTxKeyedNonce_BeforeEip8250_ReturnFalse");
         yield return new TestCaseData(new UInt256[] { 0 }, true, true).SetName("IsWellFormed_FrameTxKeyedNonce_AfterEip8250_ReturnTrue");
+        yield return new TestCaseData(new UInt256[] { 1, 1 }, true, false).SetName("IsWellFormed_FrameTxMalformedNonceKeys_AfterEip8250_ReturnFalse");
     }
 
     [TestCaseSource(nameof(NonceKeysEnvelopeCases))]
@@ -1107,6 +1108,29 @@ public class TxValidatorTests
 
         Assert.That(FrameTxNonceKeysTxValidator.Instance.IsWellFormed(tx, releaseSpec).AsBool(), Is.EqualTo(expectedWellFormed));
     }
+
+    [Test]
+    public void IsWellFormed_FrameTxKeyedNonceAtMaxSeq_AfterEip8250_ReturnFalse()
+    {
+        Transaction tx = new() { Type = TxType.FrameTx, NonceKeys = new UInt256[] { 0 }, Nonce = Eip8250Constants.MaxNonceSeq };
+        IReleaseSpec releaseSpec = new ReleaseSpec { IsEip8250Enabled = true };
+
+        Assert.That(FrameTxNonceKeysTxValidator.Instance.IsWellFormed(tx, releaseSpec).AsBool(), Is.False);
+    }
+
+    private static IEnumerable<TestCaseData> HeadRevalidationNonceEnvelopeCases()
+    {
+        yield return new TestCaseData(new Transaction { Type = TxType.FrameTx })
+        { TestName = "Pre-fork scalar-nonce frame tx is evicted after EIP-8250", ExpectedResult = false };
+        yield return new TestCaseData(new Transaction { Type = TxType.FrameTx, NonceKeys = new UInt256[] { 0 } })
+        { TestName = "Keyed-nonce frame tx is retained after EIP-8250", ExpectedResult = true };
+        yield return new TestCaseData(new Transaction { Type = TxType.EIP1559 })
+        { TestName = "Non-frame tx is untouched by the frame nonce gate after EIP-8250", ExpectedResult = true };
+    }
+
+    [TestCaseSource(nameof(HeadRevalidationNonceEnvelopeCases))]
+    public bool IsWellFormed_HeadRevalidationEvictsPreForkScalarNonceFrameTx(Transaction tx) =>
+        new HeadTxValidator().IsWellFormed(tx, new ReleaseSpec { IsEip8250Enabled = true }).AsBool();
 
     private static Transaction BuildBlobFrameTx(int blobCount, byte versionByte = KzgPolynomialCommitments.KzgBlobHashVersionV1)
     {

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeadTxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeadTxValidator.cs
@@ -7,5 +7,6 @@ public sealed class HeadTxValidator() :
     CompositeTxValidator(
         MaxBlobCountBlobTxValidator.Instance,
         GasLimitCapTxValidator.Instance,
-        MempoolBlobTxProofVersionValidator.Instance
+        MempoolBlobTxProofVersionValidator.Instance,
+        FrameTxNonceKeysTxValidator.Instance
     );

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -237,8 +237,10 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
 /// <summary>Admits the EIP-8250 keyed-nonce envelope only on forks that define it, and only well-formed.</summary>
 /// <remarks>
 /// Pre-fork the keys carry no replay protection at all — the account nonce is left untouched — so admitting
-/// one would make the transaction replayable. Well-formedness is re-checked because <c>eth_call</c>,
-/// <c>eth_estimateGas</c> and block building construct a transaction without going through the decoder.
+/// one would make the transaction replayable. Post-fork EIP-8250 replaces the scalar <c>nonce</c> with
+/// <c>nonce_keys, nonce_seq</c>, so the fork-blind decoder's legacy scalar-nonce shape is refused. Well-formedness
+/// is re-checked because <c>eth_call</c>, <c>eth_estimateGas</c> and block building construct a transaction
+/// without going through the decoder.
 /// </remarks>
 public sealed class FrameTxNonceKeysTxValidator : ITxValidator
 {
@@ -250,7 +252,9 @@ public sealed class FrameTxNonceKeysTxValidator : ITxValidator
         UInt256[]? nonceKeys = transaction.NonceKeys;
         if (nonceKeys is null)
         {
-            return ValidationResult.Success;
+            return releaseSpec.IsEip8250Enabled
+                ? FrameTxValidation.LegacyNonceNotAllowed
+                : ValidationResult.Success;
         }
 
         if (!releaseSpec.IsEip8250Enabled)

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -240,7 +240,9 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
 /// one would make the transaction replayable. Post-fork EIP-8250 replaces the scalar <c>nonce</c> with
 /// <c>nonce_keys, nonce_seq</c>, so the fork-blind decoder's legacy scalar-nonce shape is refused. Well-formedness
 /// is re-checked because <c>eth_call</c>, <c>eth_estimateGas</c> and block building construct a transaction
-/// without going through the decoder.
+/// without going through the decoder. A pre-fork scalar-nonce frame tx is valid on admission but invalid once
+/// EIP-8250 activates, so this also runs in <see cref="HeadTxValidator"/> to evict it at the transition; it
+/// guards on the frame type because that validator is not type-dispatched.
 /// </remarks>
 public sealed class FrameTxNonceKeysTxValidator : ITxValidator
 {
@@ -249,6 +251,11 @@ public sealed class FrameTxNonceKeysTxValidator : ITxValidator
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
     {
+        if (!transaction.SupportsFrames)
+        {
+            return ValidationResult.Success;
+        }
+
         UInt256[]? nonceKeys = transaction.NonceKeys;
         if (nonceKeys is null)
         {

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -41,6 +41,7 @@ public static class FrameTxValidation
     public const string ZeroDigestMsg = "explicit signature msg must not be the zero digest";
     public const string BlobFeeWithoutBlobs = "max fee per blob gas must be 0 when there are no blob hashes";
     public const string KeyedNoncesNotEnabled = "keyed nonces are not enabled";
+    public const string LegacyNonceNotAllowed = "legacy nonce is not allowed";
     public const string MalformedNonceKeySet = "malformed nonce key set";
     public const string TooManyRecentRootReferences = "at most 16 recent root references are allowed";
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2761,7 +2761,8 @@ namespace Nethermind.TxPool.Test
             SelfPayingFrameTx(nonce: 0, feePerGas: 1).IsOverflowInTxCostAndValue(out UInt256 unitCost);
             EnsureSenderBalance(TestItem.PrivateKeyA.Address, (UInt256)4 * unitCost); // fits one at fee 3, not two
 
-            AcceptTxResult first = _txPool.SubmitTx(SelfPayingFrameTx(nonce: 0, feePerGas: 3), TxHandlingOptions.None);
+            AcceptTxResult first = _txPool.SubmitTx(
+                SelfPayingFrameTx(nonce: 0, feePerGas: 3, nonceKeys: [(UInt256)0]), TxHandlingOptions.None);
             AcceptTxResult second = _txPool.SubmitTx(
                 SelfPayingFrameTx(nonce: 0, feePerGas: 3, nonceKeys: [(UInt256)0xbeef]), TxHandlingOptions.None);
 


### PR DESCRIPTION
## Changes

After EIP-8250 activates, the frame transaction envelope replaces the scalar `nonce` field with `nonce_keys` (an RLP list) followed by `nonce_seq`. The RLP decoder is fork-blind by design and still accepts the pre-8250 scalar-nonce shape, leaving `NonceKeys` null. `FrameTxNonceKeysTxValidator` returned success unconditionally for that null case, so a legacy scalar-nonce frame transaction was admitted and could be mined on a chain that has EIP-8250 enabled.

The spec is explicit that a decoder MUST reject such a payload once the fork applies:

- it does not match the schema after replacing `nonce` with `nonce_keys` and `nonce_seq`
- `nonce_keys` is not an RLP list

This adds the missing arm to the validator: when `NonceKeys` is null and EIP-8250 is enabled, the transaction is rejected. Pre-8250 behaviour is unchanged, and the `nonce_keys == [0]` legacy-alias path still passes.

The gate is the same one-directional fork check that already refused a keyed-nonce envelope before EIP-8250; only the opposite arm was missing.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`IsWellFormed_FrameTxNonceKeys_GatedOnEip8250` covers all four corners: legacy scalar nonce before the fork accepted, legacy scalar nonce after the fork rejected, keyed nonce before the fork rejected, keyed nonce after the fork accepted. Verified as a real regression test by disabling the new arm and confirming only the after-fork legacy case fails.

Full suites run locally on the integration branch: Blockchain.Test 1662, TxPool.Test 769, Evm.Test 5188, all passing.

## Documentation

Not required.
