### PR TITLE
fix(state): omit no-op nonce change from block access list

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -110,6 +110,29 @@ public class TracedAccessWorldStateTests(bool parallel)
         }
     }
 
+    [TestCase(1ul, 1ul, false, TestName = "SetNonce_UnchangedValue_RecordsNoNonceChange")]
+    [TestCase(1ul, 2ul, true, TestName = "SetNonce_ChangedValue_RecordsNonceChange")]
+    public void SetNonce_RecordsNonceChange_OnlyWhenValueChanges(
+        ulong initialNonce, ulong newNonce, bool expectRecorded)
+    {
+        (TracedAccessWorldState tws, IDisposable scope) = CreateTracingState(ws =>
+            ws.CreateAccount(TestItem.AddressA, 0, initialNonce));
+        using (scope)
+        {
+            tws.SetNonce(TestItem.AddressA, newNonce);
+
+            AccountChangesAtIndex? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(ac?.NonceChange is not null, Is.EqualTo(expectRecorded));
+                if (expectRecorded)
+                {
+                    Assert.That(ac!.NonceChange!.Value.Value, Is.EqualTo(newNonce));
+                }
+            }
+        }
+    }
+
     [Test]
     public void InsertCode_RecordsCodeChange()
     {

--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -122,13 +122,15 @@ public class TracedAccessWorldStateTests(bool parallel)
             tws.SetNonce(TestItem.AddressA, newNonce);
 
             AccountChangesAtIndex? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
-            using (Assert.EnterMultipleScope())
+            if (expectRecorded)
             {
-                Assert.That(ac?.NonceChange is not null, Is.EqualTo(expectRecorded));
-                if (expectRecorded)
-                {
-                    Assert.That(ac!.NonceChange!.Value.Value, Is.EqualTo(newNonce));
-                }
+                Assert.That(ac, Is.Not.Null);
+                Assert.That(ac!.NonceChange, Is.Not.Null);
+                Assert.That(ac.NonceChange!.Value.Value, Is.EqualTo(newNonce));
+            }
+            else
+            {
+                Assert.That(ac, Is.Null);
             }
         }
     }

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -101,8 +101,12 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
 
     public override void SetNonce(Address address, in ulong nonce)
     {
+        ulong oldNonce = GetNonceInternal(address);
         base.SetNonce(address, nonce);
-        _generatingBlockAccessList.AddNonceChange(address, nonce);
+        if (nonce != oldNonce)
+        {
+            _generatingBlockAccessList.AddNonceChange(address, nonce);
+        }
     }
 
     public override bool InsertCode(Address address, in ValueHash256 codeHash, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false)


### PR DESCRIPTION
## Changes

`TracedAccessWorldState.SetNonce` recorded a nonce change into the block access list unconditionally, including when the written nonce equals the account's current nonce. EIP-7928 builds the access list from actual state transitions (`if nonce_changed(addr): append`), so a no-op write must not appear as a `nonce_change`.

This surfaces on any system path that re-asserts a nonce that is already set — e.g. a predeploy install that keeps an existing nonce (`Math.Max(nonce, 1)` when the nonce is already `1`). The redundant `SetNonce` produced a spurious `post == pre` nonce-change entry, making the block's access list disagree with the spec-derived list.

The fix reads the current nonce and records the change only when the value actually differs, matching the existing no-op guard already used for code changes in the same tracer.

## Types of changes

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

Parameterized regression in `TracedAccessWorldStateTests`: an unchanged `SetNonce` records no nonce change, a changed one still does. Verified as a real regression by a positive control (removing the guard fails the unchanged case).

Serial suites, all green: State 1184/0, Core (block access list) 63/0, Consensus (block access list) 14/0, Evm 5188/0, Blockchain (block access list) 27/0.

## Documentation

No documentation changes required.
