### PR TITLE
Arm keccak

### DIFF
--- a/.github/workflows/collect-pgo-profile.yml
+++ b/.github/workflows/collect-pgo-profile.yml
@@ -261,8 +261,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Pin to v10.0.5 — matches the SDK/runtime in our Docker base images
-          git clone --depth 1 --branch v10.0.5 \
+          # Pin to the runtime in our Docker base images
+          git clone --depth 1 --branch v11.0.0-preview.7.26381.103 \
             https://github.com/dotnet/runtime.git "${RUNNER_TEMP}/dotnet-runtime"
           cd "${RUNNER_TEMP}/dotnet-runtime"
           # Build only dotnet-pgo (--projects bypasses subset traversal, avoids ILCompiler)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS instructions
 
-This guide helps to get started with the Nethermind Ethereum execution client repository, which targets `net10.0` and uses C# language version `14.0`. It covers the project structure, how to build and test the code, and follow the PR workflow.
+This guide helps to get started with the Nethermind Ethereum execution client repository, which targets `net11.0` and uses C# language version `14.0`. It covers the project structure, how to build and test the code, and follow the PR workflow.
 
 ## Repo structure
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <LangVersion>14.0</LangVersion>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- NU1900: vulnerability metadata fetch failure — don't break builds when a feed is down -->
     <NoWarn>$(NoWarn);NU1900</NoWarn>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,10 +28,10 @@
     <PackageVersion Include="JetBrains.Profiler.Api" Version="1.4.11" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="MathNet.Numerics.FSharp" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Git" Version="10.0.400" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Git" Version="11.0.100-preview.7.26381.103" />
     <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.1" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.5.1" />
     <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.1" />
@@ -42,17 +42,17 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="11.0.0-preview.7.26381.103" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.22.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="11.0.100-preview.7.26381.103" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="Nethermind.Crypto.Bls" Version="1.1.0" />
@@ -92,9 +92,9 @@
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.11" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.11" />
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.11" />
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.11" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="System.IO.Hashing" Version="11.0.0-preview.7.26381.103" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="11.0.0-preview.7.26381.103" />
     <PackageVersion Include="Testably.Abstractions" Version="10.3.0" />
     <PackageVersion Include="Testably.Abstractions.Testing" Version="7.0.1" />
     <PackageVersion Include="Websocket.Client" Version="5.5.0" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.400-resolute@sha256:8caacec8e070ea6ab07b1d9c2b6bf397fca92ab4de0e52bbf25d381409782158 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7-resolute@sha256:fd96d62893be03527912ce16b32e4331a64e6cf93393129f783a59b11e651790 AS build
 
 ARG BUILD_CONFIG=release
 ARG CI=true
@@ -26,7 +26,7 @@ RUN arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") && \
 # A temporary symlink to support the old executable name
 RUN ln -sr /publish/nethermind /publish/Nethermind.Runner
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.11-resolute@sha256:23837465b21b7883dc9a7e4d74bbb1be2d018142e9054beb6ef74dbb0dd0f247
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.7-resolute@sha256:1d636bd12f01151eaf001803fbd24a4afb35e22e086d00cdb25df97c85b36a1e
 
 WORKDIR /nethermind
 

--- a/Dockerfile.chiseled
+++ b/Dockerfile.chiseled
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.400-resolute@sha256:8caacec8e070ea6ab07b1d9c2b6bf397fca92ab4de0e52bbf25d381409782158 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7-resolute@sha256:fd96d62893be03527912ce16b32e4331a64e6cf93393129f783a59b11e651790 AS build
 
 ARG BUILD_CONFIG=release
 ARG CI=true
@@ -29,7 +29,7 @@ RUN cd /publish && \
   mkdir logs && \
   mkdir nethermind_db
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.11-resolute-chiseled@sha256:95fe45615d8ca4de2aa15206a827ce9383b67e8e34cc0aba58cb3261fb52c40c
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.7-resolute-chiseled@sha256:8822cb54d291897cfeec4d17e4f7c05bc45ab63b9199dccf639c679dd1924114
 
 WORKDIR /nethermind
 

--- a/Dockerfile.diag
+++ b/Dockerfile.diag
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-resolute AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7-resolute AS build
 
 ARG BUILD_CONFIG=release
 ARG CI=true
@@ -28,7 +28,7 @@ RUN dotnet tool install -g dotnet-dump && \
   dotnet tool install -g dotnet-trace && \
   dotnet tool install -g JetBrains.dotTrace.GlobalTools
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-resolute
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.7-resolute
 
 WORKDIR /nethermind
 

--- a/Dockerfile.pgo
+++ b/Dockerfile.pgo
@@ -7,7 +7,7 @@
 # Also writes edge/block profiling data (.jit) via DOTNET_WritePGOData
 # which is trimmed by PgoTrim and consumed at runtime via DOTNET_ReadPGOData.
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.400-resolute@sha256:8caacec8e070ea6ab07b1d9c2b6bf397fca92ab4de0e52bbf25d381409782158 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7-resolute@sha256:fd96d62893be03527912ce16b32e4331a64e6cf93393129f783a59b11e651790 AS build
 
 ARG BUILD_CONFIG=release
 ARG CI=true
@@ -33,7 +33,7 @@ RUN arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") && \
 # A temporary symlink to support the old executable name
 RUN ln -sr /publish/nethermind /publish/Nethermind.Runner
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.11-resolute@sha256:23837465b21b7883dc9a7e4d74bbb1be2d018142e9054beb6ef74dbb0dd0f247
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.7-resolute@sha256:1d636bd12f01151eaf001803fbd24a4afb35e22e086d00cdb25df97c85b36a1e
 
 WORKDIR /nethermind
 

--- a/flake.nix
+++ b/flake.nix
@@ -31,9 +31,13 @@
       });
 
       devShells = forAllSystems (pkgs: {
-        default = pkgs.mkShell {
-          packages = [ pkgs.dotnetCorePackages.sdk_10_0-bin ];
-        };
+        default =
+          let
+            dotnet = pkgs.callPackage ./nix/dotnet-11-preview7.nix { };
+          in
+          pkgs.mkShell {
+            packages = [ dotnet.sdk ];
+          };
       });
 
       checks = forAllSystems (

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.300",
-    "allowPrerelease": false,
+    "version": "11.0.100-preview.7.26381.103",
+    "allowPrerelease": true,
     "rollForward": "latestFeature"
   },
   "test": {

--- a/nix/dotnet-11-preview7.nix
+++ b/nix/dotnet-11-preview7.nix
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+# SPDX-License-Identifier: LGPL-3.0-only
+
+{
+  dotnetCorePackages,
+  fetchurl,
+  stdenv,
+}:
+let
+  runtimeVersion = "11.0.0-preview.7.26381.103";
+  sdkVersion = "11.0.100-preview.7.26381.103";
+
+  runtimeSources = {
+    x86_64-linux = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/${runtimeVersion}/dotnet-runtime-${runtimeVersion}-linux-x64.tar.gz";
+      hash = "sha512-z7osIdYxScMYHZj0+pseGnlc2vtD7cwHvscgFJ+utVXNRflelWoeAzB8iTcULHNDRryxZboKBPNFQFGdosjL+Q==";
+    };
+    aarch64-linux = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/${runtimeVersion}/dotnet-runtime-${runtimeVersion}-linux-arm64.tar.gz";
+      hash = "sha512-F00JSaQnJzI55dgspdEVL+epyUIou+wyOJNCTpjDzrelafFZpT92QA6LyGp8tLe0XNX7b/58bknSWoryDkqKHQ==";
+    };
+    x86_64-darwin = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/${runtimeVersion}/dotnet-runtime-${runtimeVersion}-osx-x64.tar.gz";
+      hash = "sha512-MMahcmKYRUVBx+3xC9m8EsPetL+2sNmS//X8JZ+J/M3RB8pNeQM8/qeFdNflkgEeDyeb0IoftQOElMPgJqGitA==";
+    };
+    aarch64-darwin = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/Runtime/${runtimeVersion}/dotnet-runtime-${runtimeVersion}-osx-arm64.tar.gz";
+      hash = "sha512-NuhSqZgCvPoRnMrL8rj+0A+onyhyxQUw17yivDDY68/MQmLUyP1pw2A3EbRXWVqyWzGLDA5AVFxXONvKTDUgmQ==";
+    };
+  };
+
+  aspnetcoreSources = {
+    x86_64-linux = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/${runtimeVersion}/aspnetcore-runtime-${runtimeVersion}-linux-x64.tar.gz";
+      hash = "sha512-pdi3nz+fmtkVyko7UJmCPKA1EdHJAKgRfB7WuMzB/oQ+Qw1PWNXAW5cd2st+iPr27SWO1wTsn0FKgfbAUyLGWw==";
+    };
+    aarch64-linux = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/${runtimeVersion}/aspnetcore-runtime-${runtimeVersion}-linux-arm64.tar.gz";
+      hash = "sha512-yt7GPJIj1XicF//1fEsmNItAt3KwtGGXLPYrJ0OlF4Gbfdjx5Sul2ngKbTEJqjygcY6KmAvfqzxz4z6ImeVOBw==";
+    };
+    x86_64-darwin = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/${runtimeVersion}/aspnetcore-runtime-${runtimeVersion}-osx-x64.tar.gz";
+      hash = "sha512-UMrvYn8zmqQ8y/p0kXoXD68fyWBgzR9udnChPljNvckO5QrkiLLe26A9a0hIWW5du9r2z9cnZOOAaE6h5nWcGg==";
+    };
+    aarch64-darwin = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/${runtimeVersion}/aspnetcore-runtime-${runtimeVersion}-osx-arm64.tar.gz";
+      hash = "sha512-4QFAcxUsU++Pry4YyaHN/eOfp5OIhKc1R4LFp3quEXfF9ewF/nVbvwlx8Hklnd0gSRVaT+6hrZLD3u68XZYowQ==";
+    };
+  };
+
+  sdkSources = {
+    x86_64-linux = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/${sdkVersion}/dotnet-sdk-${sdkVersion}-linux-x64.tar.gz";
+      hash = "sha512-Un+dyBBKhiFON+gcfOosfX+6MfYViiPnFFi4WgovulP7LGBqKj5Tondf2uPj0nzWRGN7QwOeVzOVrR3uSzlosQ==";
+    };
+    aarch64-linux = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/${sdkVersion}/dotnet-sdk-${sdkVersion}-linux-arm64.tar.gz";
+      hash = "sha512-ITtaSEVUAtvrub10tXbZp+w38w1MbOEJneX1oVP2ATBpdX1MZZeEygfkWshlKblenC/vJs3OlXj3eAa4dXITog==";
+    };
+    x86_64-darwin = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/${sdkVersion}/dotnet-sdk-${sdkVersion}-osx-x64.tar.gz";
+      hash = "sha512-vDmClyrY/AQyvWbelitBGr7OKhEpCNRLy2AB+JG+q4HsY+CDw8RcO71IhT8nKMr8R2Krs0LI6NRafZFcuhWFHw==";
+    };
+    aarch64-darwin = {
+      url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/${sdkVersion}/dotnet-sdk-${sdkVersion}-osx-arm64.tar.gz";
+      hash = "sha512-NmiS30GCD1VzL7eGvRCmZb2tXDKlnuJ48h8OLnjKCO0UgxW0ziLEUQbv7MfT5HK7uNaXBlV8TCGEC01k6a1vQA==";
+    };
+  };
+
+  sourceFor = sources: sources.${stdenv.hostPlatform.system} or (throw "Unsupported .NET host platform");
+
+  overrideBinary = package: version: sources: extraPassthru:
+    let
+      unwrapped = package.unwrapped.overrideAttrs (previous: {
+        inherit version;
+        src = fetchurl (sourceFor sources);
+        passthru = previous.passthru // extraPassthru;
+      });
+    in
+    package.overrideAttrs (_: {
+      inherit version;
+      src = unwrapped;
+      passthru = unwrapped.passthru // { inherit unwrapped; };
+    });
+
+  runtime = overrideBinary dotnetCorePackages.runtime_11_0-bin runtimeVersion runtimeSources { };
+  aspnetcore = overrideBinary dotnetCorePackages.aspnetcore_11_0-bin runtimeVersion aspnetcoreSources { };
+  sdk = overrideBinary dotnetCorePackages.sdk_11_0-bin sdkVersion sdkSources { inherit runtime aspnetcore; };
+in
+{
+  inherit runtime aspnetcore sdk;
+}

--- a/nix/nuget-deps.json
+++ b/nix/nuget-deps.json
@@ -200,24 +200,49 @@
     "hash": "sha256-pPbh8JdmMjBgEu84c/qV4YJ+LLr4+c31C6t++u29qBs="
   },
   {
+    "pname": "Microsoft.AspNetCore.App.Runtime.linux-arm64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-nOAmZ7VxR5YVn5FvNvS4C8VDGowe3Qd5abypQGZ3G2E="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-X3pAGK05Z/IbJ40vkGjKK0nzWSPtZ1iHOxoo9vS/nw8="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.osx-arm64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-QZMVqOdkCH7JFeIz8f9xbrkEMEuaXPruQAoK6Izjycg="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.osx-x64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-GpInWZM3VGTTeibX7Dknrhap+Y8uXkv3vkAmeO4+vjM="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.win-x64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-zCd1jKfgRAKMze9XzCwK0qX6f9++8SzdTvLVg4SevnQ="
+  },
+  {
     "pname": "Microsoft.AspNetCore.Cryptography.Internal",
-    "version": "10.0.11",
-    "hash": "sha256-WlCfhVYRIbwiN7m/ufzLAk4iLaCieosx4beEuDyl1ho="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-/zqQLhPMfky2laH12LpJJP2blWCJhOZ+PICD/RrGcNE="
   },
   {
     "pname": "Microsoft.AspNetCore.DataProtection",
-    "version": "10.0.11",
-    "hash": "sha256-bRFdI7XEUBIENvpC7KiWAvZA1ap/CEoWeJCKIckX4yo="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-XYQWxvL/vldNZlK6uCLkxrimP8LmPXk5OIyYEjzpitM="
   },
   {
     "pname": "Microsoft.AspNetCore.DataProtection.Abstractions",
-    "version": "10.0.11",
-    "hash": "sha256-wJKFqBW+X6ce4P164tIkrfnGjsvwltzQkq8YE8fOT1s="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-QHdCOZ4wlIPE0dq72Lc4X4C4wf8dvf0Bz96BjuTukX8="
   },
   {
     "pname": "Microsoft.AspNetCore.DataProtection.Extensions",
-    "version": "10.0.11",
-    "hash": "sha256-cGsc10F6EkkbyzTmqyBHLLWc0rT974RLntOR/ow2OEI="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-po5VyPjGWqC4vpshcU/N2jqRhegJk0qeybCfm4uEMlU="
   },
   {
     "pname": "Microsoft.Bcl.Cryptography",
@@ -226,8 +251,8 @@
   },
   {
     "pname": "Microsoft.Build.Tasks.Git",
-    "version": "10.0.400",
-    "hash": "sha256-BTXWWyyP+6BdpOVMbaC5tgOpxncCdOHP1fCncahFHDk="
+    "version": "11.0.100-preview.7.26381.103",
+    "hash": "sha256-YVJwm+7lBQSl/Zk4ZSxyQ1azP15MPbSFmvE11yI9uxU="
   },
   {
     "pname": "Microsoft.ClearScript.Core",
@@ -340,19 +365,14 @@
     "hash": "sha256-st6V0S7j+FyK7r9X6uObpuhSoac/z5QOF1DUPnhffgE="
   },
   {
-    "pname": "Microsoft.Extensions.Caching.Abstractions",
-    "version": "10.0.11",
-    "hash": "sha256-hhLHPCS06OOGQMlQT3KXU7x5dSp6BN48njsGY/aOFqA="
-  },
-  {
     "pname": "Microsoft.Extensions.Caching.Memory",
-    "version": "10.0.11",
-    "hash": "sha256-1LXlZK3RnwIxdFqG+8BH0+lc7NhKjA99xN2fe/nIq2I="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-tk5AZskrjE89Ou+ei6UbCTq+HmyQdShS4BQrsiI2njE="
   },
   {
     "pname": "Microsoft.Extensions.Configuration",
-    "version": "10.0.11",
-    "hash": "sha256-hhXsutV4pzMdy8CCG12Pqh4jV/emiQsuWUl1WpClZOs="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-N2HL2+6vFjiSbPIT+6xG5I4DEyGb/J8kzQZSu2rtnEc="
   },
   {
     "pname": "Microsoft.Extensions.Configuration",
@@ -365,24 +385,9 @@
     "hash": "sha256-9BPsASlxrV8ilmMCjdb3TiUcm5vFZxkBnAI/fNBSEyA="
   },
   {
-    "pname": "Microsoft.Extensions.Configuration.Abstractions",
-    "version": "10.0.11",
-    "hash": "sha256-gx/afsc4v9zRAUPsiySt6BcZVSMc9QJE4vqJMQpiOPk="
-  },
-  {
-    "pname": "Microsoft.Extensions.Configuration.Abstractions",
-    "version": "3.1.0",
-    "hash": "sha256-GMxvf0iAiWUWo0awlDczzcxNo8+MITBLp0/SqqYo8Lg="
-  },
-  {
-    "pname": "Microsoft.Extensions.Configuration.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-4eBpDkf7MJozTZnOwQvwcfgRKQGcNXe0K/kF+h5Rl8o="
-  },
-  {
     "pname": "Microsoft.Extensions.Configuration.Binder",
-    "version": "10.0.11",
-    "hash": "sha256-qcSKa+uJdahahMucYIIUO1pg/zrlsHlK1kg/lWHP/qo="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-Sn/e+jjeu2/1tHzP3TyhfqsQVnLT2/TfRF3k/2jq5aw="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Binder",
@@ -396,43 +401,8 @@
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection",
-    "version": "10.0.11",
-    "hash": "sha256-xuwGge8n7OjS+uS85QiR0LdDORIJ1gm6w3hMXtvuWj8="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "10.0.11",
-    "hash": "sha256-5PZeQgWmVo8K+7GgKEVAd6xcn+3XVNVzT4cg/DBtjqY="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "10.0.9",
-    "hash": "sha256-YzQpGAsrjLU18s016LmM7DMJKml0MzKl1bPPYJ/erEk="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "3.1.0",
-    "hash": "sha256-cG0XS3ibJ9siu8eaQGJnyRwlEbQ9c/eGCtvPjs7Rdd8="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "5.0.0",
-    "hash": "sha256-0sfuxZ07HsMZJpKatDrW6I671uJBYWsUgAyoDZA2n50="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "8.0.2",
-    "hash": "sha256-UfLfEQAkXxDaVPC7foE/J3FVEXd31Pu6uQIhTic3JgY="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "9.0.0",
-    "hash": "sha256-CncVwkKZ5CsIG2O0+OM9qXuYXh3p6UGyueTHSLDVL+c="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-mbVRsE7E4V+WFC6mqwVKR7au6n9sq4XzWs2lwixnYgg="
   },
   {
     "pname": "Microsoft.Extensions.DependencyModel",
@@ -445,21 +415,6 @@
     "hash": "sha256-fBLlb9xAfTgZb1cpBxFs/9eA+BlBvF8Xg0DMkBqdHD4="
   },
   {
-    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
-    "version": "10.0.11",
-    "hash": "sha256-JSjnETAdUU/8ymeWP1OKoXu5sS5COEqwQR4OpiUnavI="
-  },
-  {
-    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-USD5uZOaahMqi6u7owNWx/LR4EDrOwqPrAAim7iRpJY="
-  },
-  {
-    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
-    "version": "8.0.1",
-    "hash": "sha256-d5DVXhA8qJFY9YbhZjsTqs5w5kDuxF5v+GD/WZR1QL0="
-  },
-  {
     "pname": "Microsoft.Extensions.Diagnostics.HealthChecks",
     "version": "8.0.11",
     "hash": "sha256-wS+5kN0lREre+gv7//VuVb9oVkEzWHxKGiZJukj4Z30="
@@ -470,29 +425,9 @@
     "hash": "sha256-JjWYaK5c+w8GUkNudYQKf2m3NwOQLYEeSFwL8kgTWC0="
   },
   {
-    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
-    "version": "10.0.11",
-    "hash": "sha256-4NmJ1/Fgbn45wcD8iy0wV0aU//mCsrcwmLmzHpwJGqU="
-  },
-  {
-    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-uQSXmt47X2HGoVniavjLICbPtD2ReQOYQMgy3l0xuMU="
-  },
-  {
     "pname": "Microsoft.Extensions.FileProviders.Embedded",
-    "version": "10.0.11",
-    "hash": "sha256-YrqfaAL682C3DkJtYcyshdt1Uz8I9Xb+hBLpNTMw1JU="
-  },
-  {
-    "pname": "Microsoft.Extensions.Hosting.Abstractions",
-    "version": "10.0.11",
-    "hash": "sha256-8rr3hfiZ649GUTB0t4+R8Yjo+H3ch5yyl5DICPPNv8I="
-  },
-  {
-    "pname": "Microsoft.Extensions.Hosting.Abstractions",
-    "version": "8.0.1",
-    "hash": "sha256-/bIVL9uvBQhV/KQmjA1ZjR74sMfaAlBb15sVXsGDEVA="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-wm1Pkh2pNe7S3g8nOpLvrlt9BgbxOyq3fONLU0WvDOg="
   },
   {
     "pname": "Microsoft.Extensions.Http",
@@ -506,8 +441,8 @@
   },
   {
     "pname": "Microsoft.Extensions.Logging",
-    "version": "10.0.11",
-    "hash": "sha256-K8MjBeYsxUdOyY5+QryOojGfc4AkE/FHqrx5MxSuZhU="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-maSW9j7us1vuje/8k8+aoEwI1NhDq7n/wj3F0PoacnQ="
   },
   {
     "pname": "Microsoft.Extensions.Logging",
@@ -535,84 +470,29 @@
     "hash": "sha256-kR16c+N8nQrWeYLajqnXPg7RiXjZMSFLnKLEs4VfjcM="
   },
   {
-    "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "10.0.11",
-    "hash": "sha256-HdUH2q55lbAwMswMdQjX01DrgaxegtbyMo4VYezhB1o="
-  },
-  {
     "pname": "Microsoft.Extensions.Logging.Configuration",
-    "version": "10.0.11",
-    "hash": "sha256-UtMmi9ZlS4hUXQurxTJ3MAZLWcp5z1UyMxkK4ab8HYA="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-UVIx4Hg+67fpMxsxSu+5XkmjrVEzZS8uph9L7EEyQFg="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Console",
-    "version": "10.0.11",
-    "hash": "sha256-yC7fdI8lbD8FOjkHehbuPZkkkyoc4YuAhd9fnls3NDc="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-23Wqjeb+LA98QrPiSTIvKTmmxDXnd2WlUFgmP+/CCFM="
   },
   {
     "pname": "Microsoft.Extensions.ObjectPool",
-    "version": "10.0.11",
-    "hash": "sha256-6UC6KK8BMaJRYBuV3Z+74+DJg4IVoPrghatfCzrYur8="
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "10.0.11",
-    "hash": "sha256-djBqHYNsYC427UNbkyBo9x9lAtX2Ls460ixdRrSdMa8="
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "3.1.0",
-    "hash": "sha256-0EOsmu/oLAz9WXp1CtMlclzdvs5jea0zJmokeyFnbCo="
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "5.0.0",
-    "hash": "sha256-Xq2JIa2Rg9vnLnZ75k4ydyT4j2A+G6UUx6iDc959teU="
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "8.0.0",
-    "hash": "sha256-n2m4JSegQKUTlOsKLZUUHHKMq926eJ0w9N9G+I3FoFw="
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "8.0.2",
-    "hash": "sha256-AjcldddddtN/9aH9pg7ClEZycWtFHLi9IPe1GGhNQys="
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "9.0.0",
-    "hash": "sha256-DT5euAQY/ItB5LPI8WIp6Dnd0lSvBRP35vFkOXC68ck="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-iOGfcMuPxXvsUEF8c+A4RxwJRhrWlt+zC+wD7JEhFts="
   },
   {
     "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
-    "version": "10.0.11",
-    "hash": "sha256-sx6aAZ3i7yZVIzqVcs+W8zT1V/nEua/ZwfnHRJX2Nxo="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-DIBbJBtQ2lJQTtsV/XaDKkWBWAq9k9M/o07DNkNw2ZM="
   },
   {
     "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
     "version": "8.0.0",
     "hash": "sha256-A5Bbzw1kiNkgirk5x8kyxwg9lLTcSngojeD+ocpG1RI="
-  },
-  {
-    "pname": "Microsoft.Extensions.Primitives",
-    "version": "10.0.11",
-    "hash": "sha256-4z+bHf8r4cFzX2VwW3HdZ44yBjZpfhYzlgzkdpbS7o0="
-  },
-  {
-    "pname": "Microsoft.Extensions.Primitives",
-    "version": "5.0.0",
-    "hash": "sha256-pj1BdHlmYm5HZifp/yB3lwDkdw0/jcIF0vYg6O1kmGs="
-  },
-  {
-    "pname": "Microsoft.Extensions.Primitives",
-    "version": "8.0.0",
-    "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
-  },
-  {
-    "pname": "Microsoft.Extensions.Primitives",
-    "version": "9.0.0",
-    "hash": "sha256-ZNLusK1CRuq5BZYZMDqaz04PIKScE2Z7sS2tehU7EJs="
   },
   {
     "pname": "Microsoft.IdentityModel.Abstractions",
@@ -640,24 +520,74 @@
     "hash": "sha256-unFg/5EcU/XKJbob4GtQC43Ydgi5VjeBGs7hfhj4EYo="
   },
   {
+    "pname": "Microsoft.NETCore.App.Host.linux-arm64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-6Idh10UnrOv7/0LIesQLfqWu1Keqc3D9pW1h5hTwNks="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Host.linux-x64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-fDgj3DnWwQL7lswJ8yv9Nxt132pWGwqrrdlFyVEBqgM="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Host.osx-arm64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-eLaerz0ToqoO0oFeINiiyk3jKvx8aQGdkM/Ia9BINBY="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Host.osx-x64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-34oVE91IvCLbTFuDKzRYnEhr+Suvtch5yefdzduhgzs="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.linux-arm64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-EuxzsjcwzTpbgxw2szSS9AmGp9MQOF8yYOPUylz9pJI="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-wB3WzA7tJkeyCcYqc1wcWTPdTmn8Ua9hDK/Mfqaf9/w="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.osx-arm64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-pULaX/4EUnrM89FMWp+gZA8pI1SeaLhtzzXkorZzIjk="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.osx-x64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-v+2BQMlYpHBg0HaBgvJYwiv8mn6bIhmGsxziIPIaE24="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.win-x64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-HQXMMZlQ2Ey1FNy7QMSR2T2FY1fwSLyxJTvZwHCj3l8="
+  },
+  {
     "pname": "Microsoft.NETCore.Platforms",
     "version": "1.1.0",
     "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
   },
   {
     "pname": "Microsoft.SourceLink.Common",
-    "version": "10.0.400",
-    "hash": "sha256-QmeO7ZUX5i3PIcWkbDpm6rqZnDjNm65CQKCeKFEAeKM="
+    "version": "11.0.100-preview.7.26381.103",
+    "hash": "sha256-DhW6S5+CR40rpGb2e1ICdh5MSmcnDUFjJnP8efi0q4M="
   },
   {
     "pname": "Microsoft.SourceLink.GitHub",
-    "version": "10.0.400",
-    "hash": "sha256-ASTFjGeWHJ0i2d7gBgVi+xqWDFQz8wZr1TPdiq2byyc="
+    "version": "11.0.100-preview.7.26381.103",
+    "hash": "sha256-HIRkFlm9/UsB+QMXZWpKt+B8YOs3UgHFyIrXlyj9FK0="
   },
   {
     "pname": "Microsoft.VisualStudio.Azure.Containers.Tools.Targets",
     "version": "1.23.0",
     "hash": "sha256-9XfEk8iYkrOpuxBVLECcirUt/xVlVtuE6sou7G1UuQE="
+  },
+  {
+    "pname": "Microsoft.WindowsDesktop.App.Runtime.win-x64",
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-4/Etgnyo68q5HdQxtEuc+5hyL+DQs3p2rWa+fWwNFyE="
   },
   {
     "pname": "Mono.TextTemplating",
@@ -818,16 +748,6 @@
     "pname": "Nethermind.TurboPForBindings",
     "version": "1.0.0",
     "hash": "sha256-KJ1nNy+YMl/prCqhjVmJ+oepDzm7iT6z455sev2JCMQ="
-  },
-  {
-    "pname": "NETStandard.Library",
-    "version": "1.6.1",
-    "hash": "sha256-iNan1ix7RtncGWC9AjAZ2sk70DoxOsmEOgQ10fXm4Pw="
-  },
-  {
-    "pname": "NETStandard.Library",
-    "version": "2.0.0",
-    "hash": "sha256-Pp7fRylai8JrE1O+9TGfIEJrAOmnWTJRLWE+qJBahK0="
   },
   {
     "pname": "NETStandard.Library",
@@ -1001,18 +921,18 @@
   },
   {
     "pname": "System.Configuration.ConfigurationManager",
-    "version": "10.0.11",
-    "hash": "sha256-Oh+0KCTwU9ujLXUUXaXdqZXfe4aum3rCSrg2cPu4NkA="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-+LqtQqWRVxzdKspAhYasue562g6fV7M4esR7lF5pUNY="
   },
   {
     "pname": "System.Diagnostics.EventLog",
-    "version": "10.0.11",
-    "hash": "sha256-w/JzFTvPJr6x9srFpmeB7xPh9fkH1X9vf8izdvmxgt0="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-9lbJtbSdy83HPY/5gf2pA04J8L7xx+Yud3gd6sbU8WA="
   },
   {
     "pname": "System.IO.Hashing",
-    "version": "10.0.11",
-    "hash": "sha256-/jfgyL1M+xs27yRJeg/RJimNSHuzuiqhV241pvfooac="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-t6eUG3KM08b7eFgP95rCZRc76mikVDK90LOsWCqVjUk="
   },
   {
     "pname": "System.Memory",
@@ -1051,18 +971,18 @@
   },
   {
     "pname": "System.Security.Cryptography.Pkcs",
-    "version": "10.0.11",
-    "hash": "sha256-+L6ZL7/9VeyMlOJDcNjV/Rb7FMxXctLekfWROU0tMIM="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-x3XZdcIm/tdilDBMYqVXAl1aUA8lcBamlrZ5G/TX/XY="
   },
   {
     "pname": "System.Security.Cryptography.ProtectedData",
-    "version": "10.0.11",
-    "hash": "sha256-YZi5wcj1Rfnt4SygMIWtdPNitbMwJeNEbtfpa0gPTtE="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-AQVKLIoZ9vW7EDAa+f0gWH9IxYGgfJjbwh4Va/D++Hw="
   },
   {
     "pname": "System.Security.Cryptography.Xml",
-    "version": "10.0.11",
-    "hash": "sha256-oHuLaMtw4Pt0bwZ8hDmM0TpLpxcPoKD+gO4nFI3AmH0="
+    "version": "11.0.0-preview.7.26381.103",
+    "hash": "sha256-b4r/3W6dbzUtBW2Pkt+j/6RB5yLfVDBSAdx5wdjLQRo="
   },
   {
     "pname": "System.Text.Encoding.CodePages",

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,10 +4,11 @@
 {
   lib,
   buildDotnetModule,
-  dotnetCorePackages,
+  callPackage,
   sourceRevision ? null,
 }:
 let
+  dotnet = callPackage ./dotnet-11-preview7.nix { };
   buildProps = builtins.readFile ../src/Nethermind/Directory.Build.props;
   getXmlValue =
     name:
@@ -41,8 +42,8 @@ buildDotnetModule {
 
   nugetDeps = ./nuget-deps.json;
 
-  dotnet-sdk = dotnetCorePackages.sdk_10_0-bin;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_10_0-bin;
+  dotnet-sdk = dotnet.sdk;
+  dotnet-runtime = dotnet.aspnetcore;
 
   dotnetFlags = lib.optionals (sourceRevision != null) [ "-p:SourceRevisionId=${sourceRevision}" ];
 

--- a/scripts/build/Dockerfile
+++ b/scripts/build/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0.400-resolute@sha256:8caacec8e070ea6ab07b1d9c2b6bf397fca92ab4de0e52bbf25d381409782158
+FROM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7-resolute@sha256:fd96d62893be03527912ce16b32e4331a64e6cf93393129f783a59b11e651790
 
 ARG COMMIT_HASH
 ARG SOURCE_DATE_EPOCH

--- a/scripts/rpc-bench/run-ethcallchaos.sh
+++ b/scripts/rpc-bench/run-ethcallchaos.sh
@@ -31,7 +31,7 @@ ECC_LEADERBOARD_TOP="${ECC_LEADERBOARD_TOP:-50}"
 # qualifies nothing, so CI ranks slowest cases regardless (mean>1ms, cv gate off).
 ECC_MIN_MEAN_MS="${ECC_MIN_MEAN_MS:-1}"
 ECC_MAX_CV="${ECC_MAX_CV:-10}"
-SDK_IMAGE="${SDK_IMAGE:-mcr.microsoft.com/dotnet/sdk:10.0}"
+SDK_IMAGE="${SDK_IMAGE:-mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7}"
 CONTAINER_NAME="${ECC_CONTAINER_NAME:-ethcallchaos-bench}"
 
 mkdir -p "$OUT_DIR"

--- a/src/Nethermind/Nethermind.Benchmark/Core/KeccakPermutationBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/KeccakPermutationBenchmarks.cs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.Intrinsics.Arm;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Benchmarks.Core;
+
+[Config(typeof(ArmSha3Config))]
+public class KeccakPermutationBenchmarks
+{
+    private sealed class ArmSha3Config : ManualConfig
+    {
+        public ArmSha3Config() => AddFilter(new SimpleFilter(
+            benchmarkCase => benchmarkCase.Descriptor.WorkloadMethod.Name != nameof(ArmSha3) || Sha3.IsSupported));
+    }
+
+    private readonly ulong[] _scalarState = CreateState();
+    private readonly ulong[] _armSha3State = CreateState();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (!Sha3.IsSupported)
+        {
+            return;
+        }
+
+        ulong[] scalarState = CreateState();
+        ulong[] armSha3State = CreateState();
+        KeccakHash.KeccakF1600Scalar(scalarState);
+        KeccakHash.KeccakF1600ArmSha3(armSha3State);
+
+        if (!scalarState.AsSpan().SequenceEqual(armSha3State))
+        {
+            throw new InvalidOperationException("Arm SHA-3 permutation does not match the scalar implementation.");
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public ulong Scalar()
+    {
+        KeccakHash.KeccakF1600Scalar(_scalarState);
+        return _scalarState[0];
+    }
+
+    [Benchmark]
+    public ulong ArmSha3()
+    {
+        KeccakHash.KeccakF1600ArmSha3(_armSha3State);
+        return _armSha3State[0];
+    }
+
+    private static ulong[] CreateState()
+    {
+        ulong[] state = new ulong[25];
+        for (int lane = 0; lane < state.Length; lane++)
+        {
+            state[lane] = unchecked((ulong)(lane + 1) * 0x9e3779b97f4a7c15UL);
+        }
+
+        return state;
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.Intrinsics.Arm;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Serialization.Rlp;
@@ -165,6 +166,39 @@ namespace Nethermind.Core.Test
             {
                 Assert.That(Keccak.Compute(byteArray.AsSpan()), Is.EqualTo(expected));
                 Assert.That(Keccak.Compute(byteArray), Is.EqualTo(expected));
+            }
+        }
+
+        [Test]
+        public void Arm_sha3_permutation_matches_scalar()
+        {
+            if (!Sha3.IsSupported)
+            {
+                Assert.Ignore("Arm SHA-3 intrinsics are not supported on this machine.");
+            }
+
+            const int stateLength = 25;
+            ulong[] input = new ulong[stateLength];
+
+            for (int testCase = 0; testCase < 64; testCase++)
+            {
+                for (int lane = 0; lane < stateLength; lane++)
+                {
+                    input[lane] = testCase switch
+                    {
+                        0 => 0,
+                        1 => ulong.MaxValue,
+                        _ => unchecked((ulong)(testCase * stateLength + lane + 1) * 0x9e3779b97f4a7c15UL)
+                    };
+                }
+
+                ulong[] expected = (ulong[])input.Clone();
+                ulong[] actual = (ulong[])input.Clone();
+
+                KeccakHash.KeccakF1600Scalar(expected);
+                KeccakHash.KeccakF1600ArmSha3(actual);
+
+                Assert.That(actual, Is.EqualTo(expected), $"Permutation mismatch for test case {testCase}.");
             }
         }
 

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.arm64.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.arm64.cs
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+
+namespace Nethermind.Core.Crypto;
+
+public sealed partial class KeccakHash
+{
+    [SkipLocalsInit]
+    internal static unsafe void KeccakF1600ArmSha3(Span<ulong> st)
+    {
+        Debug.Assert(st.Length == STATE_SIZE / sizeof(ulong));
+
+        Vector128<ulong> aba, abe, abi, abo, abu;
+        Vector128<ulong> aga, age, agi, ago, agu;
+        Vector128<ulong> aka, ake, aki, ako, aku;
+        Vector128<ulong> ama, ame, ami, amo, amu;
+        Vector128<ulong> asa, ase, asi, aso, asu;
+        Vector128<ulong> bCa, bCe, bCi, bCo, bCu;
+        Vector128<ulong> da, de, di, @do, du;
+        Vector128<ulong> eba, ebe, ebi, ebo, ebu;
+        Vector128<ulong> ega, ege, egi, ego, egu;
+        Vector128<ulong> eka, eke, eki, eko, eku;
+        Vector128<ulong> ema, eme, emi, emo, emu;
+        Vector128<ulong> esa, ese, esi, eso, esu;
+
+        ref ulong state = ref MemoryMarshal.GetReference(st);
+        ref ulong roundConstants = ref MemoryMarshal.GetArrayDataReference(RoundConstants);
+
+        asu = Vector64.LoadUnsafe(ref state, 24).ToVector128Unsafe();
+        aso = Vector64.LoadUnsafe(ref state, 23).ToVector128Unsafe();
+        asi = Vector64.LoadUnsafe(ref state, 22).ToVector128Unsafe();
+        ase = Vector64.LoadUnsafe(ref state, 21).ToVector128Unsafe();
+        asa = Vector64.LoadUnsafe(ref state, 20).ToVector128Unsafe();
+        amu = Vector64.LoadUnsafe(ref state, 19).ToVector128Unsafe();
+        amo = Vector64.LoadUnsafe(ref state, 18).ToVector128Unsafe();
+        ami = Vector64.LoadUnsafe(ref state, 17).ToVector128Unsafe();
+        ame = Vector64.LoadUnsafe(ref state, 16).ToVector128Unsafe();
+        ama = Vector64.LoadUnsafe(ref state, 15).ToVector128Unsafe();
+        aku = Vector64.LoadUnsafe(ref state, 14).ToVector128Unsafe();
+        ako = Vector64.LoadUnsafe(ref state, 13).ToVector128Unsafe();
+        aki = Vector64.LoadUnsafe(ref state, 12).ToVector128Unsafe();
+        ake = Vector64.LoadUnsafe(ref state, 11).ToVector128Unsafe();
+        aka = Vector64.LoadUnsafe(ref state, 10).ToVector128Unsafe();
+        agu = Vector64.LoadUnsafe(ref state, 9).ToVector128Unsafe();
+        ago = Vector64.LoadUnsafe(ref state, 8).ToVector128Unsafe();
+        agi = Vector64.LoadUnsafe(ref state, 7).ToVector128Unsafe();
+        age = Vector64.LoadUnsafe(ref state, 6).ToVector128Unsafe();
+        aga = Vector64.LoadUnsafe(ref state, 5).ToVector128Unsafe();
+        abu = Vector64.LoadUnsafe(ref state, 4).ToVector128Unsafe();
+        abo = Vector64.LoadUnsafe(ref state, 3).ToVector128Unsafe();
+        abi = Vector64.LoadUnsafe(ref state, 2).ToVector128Unsafe();
+        abe = Vector64.LoadUnsafe(ref state, 1).ToVector128Unsafe();
+        aba = Vector64.LoadUnsafe(ref state).ToVector128Unsafe();
+
+        for (int round = 0; round < ROUNDS; round += 2)
+        {
+            bCa = Sha3.Xor(Sha3.Xor(aba, aga, aka), ama, asa);
+            bCe = Sha3.Xor(Sha3.Xor(abe, age, ake), ame, ase);
+            bCi = Sha3.Xor(Sha3.Xor(abi, agi, aki), ami, asi);
+            bCo = Sha3.Xor(Sha3.Xor(abo, ago, ako), amo, aso);
+            bCu = Sha3.Xor(Sha3.Xor(abu, agu, aku), amu, asu);
+
+            da = Sha3.BitwiseRotateLeftBy1AndXor(bCu, bCe);
+            de = Sha3.BitwiseRotateLeftBy1AndXor(bCa, bCi);
+            di = Sha3.BitwiseRotateLeftBy1AndXor(bCe, bCo);
+            @do = Sha3.BitwiseRotateLeftBy1AndXor(bCi, bCu);
+            du = Sha3.BitwiseRotateLeftBy1AndXor(bCo, bCa);
+
+            bCa = Vector128.Xor(aba, da);
+            bCe = Sha3.XorRotateRight(age, de, 20);
+            bCi = Sha3.XorRotateRight(aki, di, 21);
+            eba = Vector128.Xor(Sha3.BitwiseClearXor(bCa, bCi, bCe), Vector64.LoadUnsafe(ref roundConstants, (nuint)round).ToVector128Unsafe());
+            bCo = Sha3.XorRotateRight(amo, @do, 43);
+            ebe = Sha3.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sha3.XorRotateRight(asu, du, 50);
+            ebi = Sha3.BitwiseClearXor(bCi, bCu, bCo);
+            ebo = Sha3.BitwiseClearXor(bCo, bCa, bCu);
+            ebu = Sha3.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sha3.XorRotateRight(abo, @do, 36);
+            bCe = Sha3.XorRotateRight(agu, du, 44);
+            bCi = Sha3.XorRotateRight(aka, da, 61);
+            ega = Sha3.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sha3.XorRotateRight(ame, de, 19);
+            ege = Sha3.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sha3.XorRotateRight(asi, di, 3);
+            egi = Sha3.BitwiseClearXor(bCi, bCu, bCo);
+            ego = Sha3.BitwiseClearXor(bCo, bCa, bCu);
+            egu = Sha3.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sha3.XorRotateRight(abe, de, 63);
+            bCe = Sha3.XorRotateRight(agi, di, 58);
+            bCi = Sha3.XorRotateRight(ako, @do, 39);
+            eka = Sha3.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sha3.XorRotateRight(amu, du, 56);
+            eke = Sha3.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sha3.XorRotateRight(asa, da, 46);
+            eki = Sha3.BitwiseClearXor(bCi, bCu, bCo);
+            eko = Sha3.BitwiseClearXor(bCo, bCa, bCu);
+            eku = Sha3.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sha3.XorRotateRight(abu, du, 37);
+            bCe = Sha3.XorRotateRight(aga, da, 28);
+            bCi = Sha3.XorRotateRight(ake, de, 54);
+            ema = Sha3.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sha3.XorRotateRight(ami, di, 49);
+            eme = Sha3.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sha3.XorRotateRight(aso, @do, 8);
+            emi = Sha3.BitwiseClearXor(bCi, bCu, bCo);
+            emo = Sha3.BitwiseClearXor(bCo, bCa, bCu);
+            emu = Sha3.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sha3.XorRotateRight(abi, di, 2);
+            bCe = Sha3.XorRotateRight(ago, @do, 9);
+            bCi = Sha3.XorRotateRight(aku, du, 25);
+            esa = Sha3.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sha3.XorRotateRight(ama, da, 23);
+            ese = Sha3.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sha3.XorRotateRight(ase, de, 62);
+            esi = Sha3.BitwiseClearXor(bCi, bCu, bCo);
+            eso = Sha3.BitwiseClearXor(bCo, bCa, bCu);
+            esu = Sha3.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCe = Sha3.Xor(Sha3.Xor(ebe, ege, eke), eme, ese);
+            bCu = Sha3.Xor(Sha3.Xor(ebu, egu, eku), emu, esu);
+
+            da = Sha3.BitwiseRotateLeftBy1AndXor(bCu, bCe);
+            bCa = Sha3.Xor(Sha3.Xor(eba, ega, eka), ema, esa);
+            bCi = Sha3.Xor(Sha3.Xor(ebi, egi, eki), emi, esi);
+            de = Sha3.BitwiseRotateLeftBy1AndXor(bCa, bCi);
+            bCo = Sha3.Xor(Sha3.Xor(ebo, ego, eko), emo, eso);
+            di = Sha3.BitwiseRotateLeftBy1AndXor(bCe, bCo);
+            @do = Sha3.BitwiseRotateLeftBy1AndXor(bCi, bCu);
+            du = Sha3.BitwiseRotateLeftBy1AndXor(bCo, bCa);
+
+            bCi = Sha3.XorRotateRight(eki, di, 21);
+            bCe = Sha3.XorRotateRight(ege, de, 20);
+            bCa = Vector128.Xor(eba, da);
+            aba = Vector128.Xor(Sha3.BitwiseClearXor(bCa, bCi, bCe), Vector64.LoadUnsafe(ref roundConstants, (nuint)(round + 1)).ToVector128Unsafe());
+            bCo = Sha3.XorRotateRight(emo, @do, 43);
+            abe = Sha3.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sha3.XorRotateRight(esu, du, 50);
+            abi = Sha3.BitwiseClearXor(bCi, bCu, bCo);
+            abo = Sha3.BitwiseClearXor(bCo, bCa, bCu);
+            abu = Sha3.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sha3.XorRotateRight(ebo, @do, 36);
+            bCe = Sha3.XorRotateRight(egu, du, 44);
+            bCi = Sha3.XorRotateRight(eka, da, 61);
+            aga = Sha3.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sha3.XorRotateRight(eme, de, 19);
+            age = Sha3.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sha3.XorRotateRight(esi, di, 3);
+            agi = Sha3.BitwiseClearXor(bCi, bCu, bCo);
+            ago = Sha3.BitwiseClearXor(bCo, bCa, bCu);
+            agu = Sha3.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sha3.XorRotateRight(ebe, de, 63);
+            bCe = Sha3.XorRotateRight(egi, di, 58);
+            bCi = Sha3.XorRotateRight(eko, @do, 39);
+            aka = Sha3.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sha3.XorRotateRight(emu, du, 56);
+            ake = Sha3.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sha3.XorRotateRight(esa, da, 46);
+            aki = Sha3.BitwiseClearXor(bCi, bCu, bCo);
+            ako = Sha3.BitwiseClearXor(bCo, bCa, bCu);
+            aku = Sha3.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sha3.XorRotateRight(ebu, du, 37);
+            bCe = Sha3.XorRotateRight(ega, da, 28);
+            bCi = Sha3.XorRotateRight(eke, de, 54);
+            ama = Sha3.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sha3.XorRotateRight(emi, di, 49);
+            ame = Sha3.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sha3.XorRotateRight(eso, @do, 8);
+            ami = Sha3.BitwiseClearXor(bCi, bCu, bCo);
+            amo = Sha3.BitwiseClearXor(bCo, bCa, bCu);
+            amu = Sha3.BitwiseClearXor(bCu, bCe, bCa);
+
+            bCa = Sha3.XorRotateRight(ebi, di, 2);
+            bCe = Sha3.XorRotateRight(ego, @do, 9);
+            bCi = Sha3.XorRotateRight(eku, du, 25);
+            asa = Sha3.BitwiseClearXor(bCa, bCi, bCe);
+            bCo = Sha3.XorRotateRight(ema, da, 23);
+            ase = Sha3.BitwiseClearXor(bCe, bCo, bCi);
+            bCu = Sha3.XorRotateRight(ese, de, 62);
+            asi = Sha3.BitwiseClearXor(bCi, bCu, bCo);
+            aso = Sha3.BitwiseClearXor(bCo, bCa, bCu);
+            asu = Sha3.BitwiseClearXor(bCu, bCe, bCa);
+        }
+
+        fixed (ulong* destination = &state)
+        {
+            AdvSimd.Arm64.StorePair(destination, aba.GetLower(), abe.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 2, abi.GetLower(), abo.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 4, abu.GetLower(), aga.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 6, age.GetLower(), agi.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 8, ago.GetLower(), agu.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 10, aka.GetLower(), ake.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 12, aki.GetLower(), ako.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 14, aku.GetLower(), ama.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 16, ame.GetLower(), ami.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 18, amo.GetLower(), amu.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 20, asa.GetLower(), ase.GetLower());
+            AdvSimd.Arm64.StorePair(destination + 22, asi.GetLower(), aso.GetLower());
+            asu.GetLower().Store(destination + 24);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.std.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.std.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 
 using static System.Numerics.BitOperations;
@@ -29,16 +30,27 @@ public sealed partial class KeccakHash
         0x8000000000008080UL, 0x0000000080000001UL, 0x8000000080008008UL
     ];
 
+    // Shared lane-index vectors (Theta's [1,2,3,4,0] == Chi's permute1)
+    private static readonly Vector512<ulong> LaneShift1 = Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL);
+    private static readonly Vector512<ulong> LaneShift2 = Vector512.Create(2UL, 3UL, 4UL, 0UL, 1UL, 5UL, 6UL, 7UL);
+    private static readonly Vector512<ulong> ThetaRot4 = Vector512.Create(4UL, 0UL, 1UL, 2UL, 3UL, 5UL, 6UL, 7UL);
+
+    // Pre-broadcast round constants (kills the per-round vmovq)
+    private static readonly Vector512<ulong>[] RoundConstantVec =
+        Array.ConvertAll(RoundConstants, rc => Vector512.CreateScalar(rc));
+
     // update the state with given number of rounds
     private static partial void KeccakF(Span<ulong> st)
     {
-        if (Avx512F.IsSupported)
+        if (Sha3.IsSupported)
+            KeccakF1600ArmSha3(st);
+        else if (Avx512F.IsSupported)
             KeccakF1600Avx512F(st);
         else
-            KeccakF1600(st);
+            KeccakF1600Scalar(st);
     }
 
-    private static void KeccakF1600(Span<ulong> st)
+    internal static void KeccakF1600Scalar(Span<ulong> st)
     {
         Debug.Assert(st.Length == 25);
 
@@ -253,195 +265,87 @@ public sealed partial class KeccakHash
     [SkipLocalsInit]
     public static void KeccakF1600Avx512F(Span<ulong> state)
     {
-        {
-            // Redundant statement that removes all the in loop bounds checks
-            _ = state[24];
-        }
-
-        // Can straight load and over-read for start elements
+        ref ulong s = ref MemoryMarshal.GetReference(state);
         Vector512<ulong> mask = Vector512.Create(ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, 0UL, 0UL, 0UL);
-        Vector512<ulong> c0 = Unsafe.As<ulong, Vector512<ulong>>(ref MemoryMarshal.GetReference(state));
-        // Clear the over-read values from first vectors
-        c0 = Vector512.BitwiseAnd(mask, c0);
-        Vector512<ulong> c1 = Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 5));
-        c1 = Vector512.BitwiseAnd(mask, c1);
-        Vector512<ulong> c2 = Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 10));
-        c2 = Vector512.BitwiseAnd(mask, c2);
-        Vector512<ulong> c3 = Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 15));
-        c3 = Vector512.BitwiseAnd(mask, c3);
 
-        // Can't over-read for the last elements (8 items in vector 5 to be remaining)
-        // so read a Vector256 and ulong then combine
-        Vector256<ulong> c4a = Unsafe.As<ulong, Vector256<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 20));
-        Vector256<ulong> c4b = Vector256.Create(state[24], 0UL, 0UL, 0UL);
-        Vector512<ulong> c4 = Vector512.Create(c4a, c4b);
+        Vector512<ulong> c0 = Vector512.BitwiseAnd(mask, Unsafe.As<ulong, Vector512<ulong>>(ref s));
+        Vector512<ulong> c1 = Vector512.BitwiseAnd(mask, Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref s, 5)));
+        Vector512<ulong> c2 = Vector512.BitwiseAnd(mask, Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref s, 10)));
+        Vector512<ulong> c3 = Vector512.BitwiseAnd(mask, Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref s, 15)));
+        Vector512<ulong> c4 = Vector512.Create(
+            Unsafe.As<ulong, Vector256<ulong>>(ref Unsafe.Add(ref s, 20)),
+            Vector256.CreateScalar(state[24]));
 
-        Vector512<ulong> permute1 = Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL);
-        Vector512<ulong> permute2 = Vector512.Create(2UL, 3UL, 4UL, 0UL, 1UL, 5UL, 6UL, 7UL);
-        ulong[] roundConstants = RoundConstants;
-
-        // Use constant for loop so Jit expects to loop; unroll once
         for (int round = 0; round < ROUNDS; round += 2)
         {
-            // Iteration 1
-            {
-                ulong roundConstant = Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(roundConstants), round);
-                // Theta step
-                Vector512<ulong> parity = Avx512F.TernaryLogic(Avx512F.TernaryLogic(c0, c1, c2, 0x96), c3, c4, 0x96);
-
-                // Compute Theta
-                Vector512<ulong> bVecRot1Rotated = Avx512F.RotateLeft(Avx512F.PermuteVar8x64(parity, Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL)), 1);
-                Vector512<ulong> bVecRot4 = Avx512F.PermuteVar8x64(parity, Vector512.Create(4UL, 0UL, 1UL, 2UL, 3UL, 5UL, 6UL, 7UL));
-                Vector512<ulong> theta = Avx512F.Xor(bVecRot4, bVecRot1Rotated);
-
-                c0 = Avx512F.Xor(c0, theta);
-                c1 = Avx512F.Xor(c1, theta);
-                c2 = Avx512F.Xor(c2, theta);
-                c3 = Avx512F.Xor(c3, theta);
-                c4 = Avx512F.Xor(c4, theta);
-
-                // Rho step
-                Vector512<ulong> rhoVec0 = Vector512.Create(0UL, 1UL, 62UL, 28UL, 27UL, 0UL, 0UL, 0UL);
-                c0 = Avx512F.RotateLeftVariable(c0, rhoVec0);
-
-                Vector512<ulong> rhoVec1 = Vector512.Create(36UL, 44UL, 6UL, 55UL, 20UL, 0UL, 0UL, 0UL);
-                c1 = Avx512F.RotateLeftVariable(c1, rhoVec1);
-
-                Vector512<ulong> rhoVec2 = Vector512.Create(3UL, 10UL, 43UL, 25UL, 39UL, 0UL, 0UL, 0UL);
-                c2 = Avx512F.RotateLeftVariable(c2, rhoVec2);
-
-                Vector512<ulong> rhoVec3 = Vector512.Create(41UL, 45UL, 15UL, 21UL, 8UL, 0UL, 0UL, 0UL);
-                c3 = Avx512F.RotateLeftVariable(c3, rhoVec3);
-
-                Vector512<ulong> rhoVec4 = Vector512.Create(18UL, 2UL, 61UL, 56UL, 14UL, 0UL, 0UL, 0UL);
-                c4 = Avx512F.RotateLeftVariable(c4, rhoVec4);
-
-                // Pi step
-                Vector512<ulong> c0Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(0UL, 8 + 1, 2, 3, 4, 5, 6, 7), c1);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 8 + 2, 3, 4, 5, 6, 7), c2);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 8 + 3, 4, 5, 6, 7), c3);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 4, 5, 6, 7), c4);
-
-                Vector512<ulong> c1Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(3UL, 8 + 4, 2, 3, 4, 5, 6, 7), c1);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 8 + 0, 3, 4, 5, 6, 7), c2);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 8 + 1, 4, 5, 6, 7), c3);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 2, 5, 6, 7), c4);
-
-                Vector512<ulong> c2Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(1UL, 8 + 2, 2, 3, 4, 5, 6, 7), c1);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 8 + 3, 3, 4, 5, 6, 7), c2);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 8 + 4, 4, 5, 6, 7), c3);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 0, 5, 6, 7), c4);
-
-                Vector512<ulong> c3Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(4UL, 8 + 0, 2, 3, 4, 5, 6, 7), c1);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 8 + 1, 3, 4, 5, 6, 7), c2);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 2, 8 + 2, 4, 5, 6, 7), c3);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 3, 5, 6, 7), c4);
-
-                Vector512<ulong> c4Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(2UL, 8 + 3, 2, 3, 4, 5, 6, 7), c1);
-                c0 = c0Pi;
-                c1 = c1Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 8 + 4, 3, 4, 5, 6, 7), c2);
-                c2 = c2Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 8 + 0, 4, 5, 6, 7), c3);
-                c3 = c3Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 1, 5, 6, 7), c4);
-                c4 = c4Pi;
-
-                // Chi step
-
-                c0 = Avx512F.TernaryLogic(c0, Avx512F.PermuteVar8x64(c0, permute1), Avx512F.PermuteVar8x64(c0, permute2), 0xD2);
-                c1 = Avx512F.TernaryLogic(c1, Avx512F.PermuteVar8x64(c1, permute1), Avx512F.PermuteVar8x64(c1, permute2), 0xD2);
-                c2 = Avx512F.TernaryLogic(c2, Avx512F.PermuteVar8x64(c2, permute1), Avx512F.PermuteVar8x64(c2, permute2), 0xD2);
-                c3 = Avx512F.TernaryLogic(c3, Avx512F.PermuteVar8x64(c3, permute1), Avx512F.PermuteVar8x64(c3, permute2), 0xD2);
-                c4 = Avx512F.TernaryLogic(c4, Avx512F.PermuteVar8x64(c4, permute1), Avx512F.PermuteVar8x64(c4, permute2), 0xD2);
-
-                // Iota step
-                c0 = Vector512.Xor(c0, Vector512.Create(roundConstant, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL));
-            }
-            // Iteration 2
-            {
-                ulong roundConstant = Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(roundConstants), round + 1);
-                // Theta step
-                Vector512<ulong> parity = Avx512F.TernaryLogic(Avx512F.TernaryLogic(c0, c1, c2, 0x96), c3, c4, 0x96);
-
-                // Compute Theta
-                Vector512<ulong> bVecRot1Rotated = Avx512F.RotateLeft(Avx512F.PermuteVar8x64(parity, Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL)), 1);
-                Vector512<ulong> bVecRot4 = Avx512F.PermuteVar8x64(parity, Vector512.Create(4UL, 0UL, 1UL, 2UL, 3UL, 5UL, 6UL, 7UL));
-                Vector512<ulong> theta = Avx512F.Xor(bVecRot4, bVecRot1Rotated);
-
-                c0 = Avx512F.Xor(c0, theta);
-                c1 = Avx512F.Xor(c1, theta);
-                c2 = Avx512F.Xor(c2, theta);
-                c3 = Avx512F.Xor(c3, theta);
-                c4 = Avx512F.Xor(c4, theta);
-
-                // Rho step
-                Vector512<ulong> rhoVec0 = Vector512.Create(0UL, 1UL, 62UL, 28UL, 27UL, 0UL, 0UL, 0UL);
-                c0 = Avx512F.RotateLeftVariable(c0, rhoVec0);
-
-                Vector512<ulong> rhoVec1 = Vector512.Create(36UL, 44UL, 6UL, 55UL, 20UL, 0UL, 0UL, 0UL);
-                c1 = Avx512F.RotateLeftVariable(c1, rhoVec1);
-
-                Vector512<ulong> rhoVec2 = Vector512.Create(3UL, 10UL, 43UL, 25UL, 39UL, 0UL, 0UL, 0UL);
-                c2 = Avx512F.RotateLeftVariable(c2, rhoVec2);
-
-                Vector512<ulong> rhoVec3 = Vector512.Create(41UL, 45UL, 15UL, 21UL, 8UL, 0UL, 0UL, 0UL);
-                c3 = Avx512F.RotateLeftVariable(c3, rhoVec3);
-
-                Vector512<ulong> rhoVec4 = Vector512.Create(18UL, 2UL, 61UL, 56UL, 14UL, 0UL, 0UL, 0UL);
-                c4 = Avx512F.RotateLeftVariable(c4, rhoVec4);
-
-                // Pi step
-                Vector512<ulong> c0Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(0UL, 8 + 1, 2, 3, 4, 5, 6, 7), c1);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 8 + 2, 3, 4, 5, 6, 7), c2);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 8 + 3, 4, 5, 6, 7), c3);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 4, 5, 6, 7), c4);
-
-                Vector512<ulong> c1Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(3UL, 8 + 4, 2, 3, 4, 5, 6, 7), c1);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 8 + 0, 3, 4, 5, 6, 7), c2);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 8 + 1, 4, 5, 6, 7), c3);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 2, 5, 6, 7), c4);
-
-                Vector512<ulong> c2Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(1UL, 8 + 2, 2, 3, 4, 5, 6, 7), c1);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 8 + 3, 3, 4, 5, 6, 7), c2);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 8 + 4, 4, 5, 6, 7), c3);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 0, 5, 6, 7), c4);
-
-                Vector512<ulong> c3Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(4UL, 8 + 0, 2, 3, 4, 5, 6, 7), c1);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 8 + 1, 3, 4, 5, 6, 7), c2);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 2, 8 + 2, 4, 5, 6, 7), c3);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 3, 5, 6, 7), c4);
-
-                Vector512<ulong> c4Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(2UL, 8 + 3, 2, 3, 4, 5, 6, 7), c1);
-                c0 = c0Pi;
-                c1 = c1Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 8 + 4, 3, 4, 5, 6, 7), c2);
-                c2 = c2Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 8 + 0, 4, 5, 6, 7), c3);
-                c3 = c3Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 1, 5, 6, 7), c4);
-                c4 = c4Pi;
-
-                // Chi step
-
-                c0 = Avx512F.TernaryLogic(c0, Avx512F.PermuteVar8x64(c0, permute1), Avx512F.PermuteVar8x64(c0, permute2), 0xD2);
-                c1 = Avx512F.TernaryLogic(c1, Avx512F.PermuteVar8x64(c1, permute1), Avx512F.PermuteVar8x64(c1, permute2), 0xD2);
-                c2 = Avx512F.TernaryLogic(c2, Avx512F.PermuteVar8x64(c2, permute1), Avx512F.PermuteVar8x64(c2, permute2), 0xD2);
-                c3 = Avx512F.TernaryLogic(c3, Avx512F.PermuteVar8x64(c3, permute1), Avx512F.PermuteVar8x64(c3, permute2), 0xD2);
-                c4 = Avx512F.TernaryLogic(c4, Avx512F.PermuteVar8x64(c4, permute1), Avx512F.PermuteVar8x64(c4, permute2), 0xD2);
-
-                // Iota step
-                c0 = Vector512.Xor(c0, Vector512.Create(roundConstant, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL));
-            }
+            Round(ref c0, ref c1, ref c2, ref c3, ref c4, round);
+            Round(ref c0, ref c1, ref c2, ref c3, ref c4, round + 1);
         }
 
-        // Can over-write for first elements
-        Unsafe.As<ulong, Vector512<ulong>>(ref MemoryMarshal.GetReference(state)) = c0;
-        Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 5)) = c1;
-        Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 10)) = c2;
-        Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 15)) = c3;
-        // Can't over-write for last elements so write the upper Vector256 and then ulong
-        Unsafe.As<ulong, Vector256<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 20)) = c4.GetLower();
+        Unsafe.As<ulong, Vector512<ulong>>(ref s) = c0;
+        Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref s, 5)) = c1;
+        Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref s, 10)) = c2;
+        Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref s, 15)) = c3;
+        Unsafe.As<ulong, Vector256<ulong>>(ref Unsafe.Add(ref s, 20)) = c4.GetLower();
         state[24] = c4.GetElement(4);
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Round(ref Vector512<ulong> c0, ref Vector512<ulong> c1,
+        ref Vector512<ulong> c2, ref Vector512<ulong> c3, ref Vector512<ulong> c4, int round)
+    {
+        // Theta
+        Vector512<ulong> parity = Avx512F.TernaryLogic(Avx512F.TernaryLogic(c0, c1, c2, 0x96), c3, c4, 0x96);
+        Vector512<ulong> theta = Avx512F.Xor(
+            Avx512F.PermuteVar8x64(parity, ThetaRot4),
+            Avx512F.RotateLeft(Avx512F.PermuteVar8x64(parity, LaneShift1), 1));
+        c0 = Avx512F.Xor(c0, theta); c1 = Avx512F.Xor(c1, theta);
+        c2 = Avx512F.Xor(c2, theta); c3 = Avx512F.Xor(c3, theta); c4 = Avx512F.Xor(c4, theta);
+
+        // Rho
+        c0 = Avx512F.RotateLeftVariable(c0, Vector512.Create(0UL, 1UL, 62UL, 28UL, 27UL, 0UL, 0UL, 0UL));
+        c1 = Avx512F.RotateLeftVariable(c1, Vector512.Create(36UL, 44UL, 6UL, 55UL, 20UL, 0UL, 0UL, 0UL));
+        c2 = Avx512F.RotateLeftVariable(c2, Vector512.Create(3UL, 10UL, 43UL, 25UL, 39UL, 0UL, 0UL, 0UL));
+        c3 = Avx512F.RotateLeftVariable(c3, Vector512.Create(41UL, 45UL, 15UL, 21UL, 8UL, 0UL, 0UL, 0UL));
+        c4 = Avx512F.RotateLeftVariable(c4, Vector512.Create(18UL, 2UL, 61UL, 56UL, 14UL, 0UL, 0UL, 0UL));
+
+        // Pi
+        Vector512<ulong> c0Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(0UL, 8 + 1, 2, 3, 4, 5, 6, 7), c1);
+        c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 8 + 2, 3, 4, 5, 6, 7), c2);
+        c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 8 + 3, 4, 5, 6, 7), c3);
+        c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 4, 5, 6, 7), c4);
+
+        Vector512<ulong> c1Pi = Avx512F.PermuteVar8x64x2(c1, Vector512.Create(0UL, 4UL, 8 + 0, 3, 4, 5, 6, 7), c2);
+        c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 8 + 1, 4, 5, 6, 7), c3);
+        c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 2, 5, 6, 7), c4);
+        c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(8UL + 3, 1, 2, 3, 4, 5, 6, 7), c0);
+
+        Vector512<ulong> c2Pi = Avx512F.PermuteVar8x64x2(c2, Vector512.Create(0UL, 1, 3UL, 8 + 4, 4, 5, 6, 7), c3);
+        c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 0, 5, 6, 7), c4);
+        c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(8UL + 1, 1, 2, 3, 4, 5, 6, 7), c0);
+        c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 8 + 2, 2, 3, 4, 5, 6, 7), c1);
+
+        Vector512<ulong> c3Pi = Avx512F.PermuteVar8x64x2(c3, Vector512.Create(0UL, 1, 2, 2UL, 8 + 3, 5, 6, 7), c4);
+        c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(8UL + 4, 1, 2, 3, 4, 5, 6, 7), c0);
+        c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 8 + 0, 2, 3, 4, 5, 6, 7), c1);
+        c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 8 + 1, 3, 4, 5, 6, 7), c2);
+
+        Vector512<ulong> c4Pi = Avx512F.PermuteVar8x64x2(c4, Vector512.Create(8 + 2, 1, 2, 3, 1UL, 5, 6, 7), c0);
+        c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 8 + 3, 2, 3, 4, 5, 6, 7), c1);
+        c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 8 + 4, 3, 4, 5, 6, 7), c2);
+        c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 8 + 0, 4, 5, 6, 7), c3);
+
+        c0 = c0Pi; c1 = c1Pi; c2 = c2Pi; c3 = c3Pi; c4 = c4Pi;
+
+        // Chi
+        c0 = Avx512F.TernaryLogic(c0, Avx512F.PermuteVar8x64(c0, LaneShift1), Avx512F.PermuteVar8x64(c0, LaneShift2), 0xD2);
+        c1 = Avx512F.TernaryLogic(c1, Avx512F.PermuteVar8x64(c1, LaneShift1), Avx512F.PermuteVar8x64(c1, LaneShift2), 0xD2);
+        c2 = Avx512F.TernaryLogic(c2, Avx512F.PermuteVar8x64(c2, LaneShift1), Avx512F.PermuteVar8x64(c2, LaneShift2), 0xD2);
+        c3 = Avx512F.TernaryLogic(c3, Avx512F.PermuteVar8x64(c3, LaneShift1), Avx512F.PermuteVar8x64(c3, LaneShift2), 0xD2);
+        c4 = Avx512F.TernaryLogic(c4, Avx512F.PermuteVar8x64(c4, LaneShift1), Avx512F.PermuteVar8x64(c4, LaneShift2), 0xD2);
+
+        // Iota - Pre-broadcast constant, no vmovq
+        c0 = Vector512.Xor(c0, RoundConstantVec[round]);
     }
 }

--- a/src/Nethermind/Nethermind.Kademlia/Nethermind.Kademlia.csproj
+++ b/src/Nethermind/Nethermind.Kademlia/Nethermind.Kademlia.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Collections.Pooled" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Nethermind/Nethermind.Logging.Microsoft/Nethermind.Logging.Microsoft.csproj
+++ b/src/Nethermind/Nethermind.Logging.Microsoft/Nethermind.Logging.Microsoft.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Nethermind.Logging\Nethermind.Logging.csproj" />
   </ItemGroup>
 

--- a/src/Nethermind/Nethermind.Runner/Dockerfile
+++ b/src/Nethermind/Nethermind.Runner/Dockerfile
@@ -1,7 +1,7 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.7 AS base
 
 #USER app
 

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net10.0": {
+    "net11.0": {
       "AspNetCore.HealthChecks.UI.Client": {
         "type": "Direct",
         "requested": "[9.0.0, )",
@@ -13,18 +13,18 @@
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Direct",
-        "requested": "[10.0.400, )",
-        "resolved": "10.0.400",
-        "contentHash": "uXJ/eBDqAo9HlyPjvvvynjHb59KXQWG9txpBzyI1drO6MV3Lhndt2yhxuMKvIga4kND2UKc3xCNXlXBhWU8Hlg==",
+        "requested": "[11.0.100-preview.7.26381.103, )",
+        "resolved": "11.0.100-preview.7.26381.103",
+        "contentHash": "2IDatHnaDfSFo6dIkkAmrKgOG77bedvyvls4WU9+WVgLBFA/r0EFRQ3hBMFzo8Y07Gi6XCFgHr1JTHt9FCaWug==",
         "dependencies": {
-          "System.IO.Hashing": "10.0.11"
+          "System.IO.Hashing": "11.0.0-preview.7.26381.103"
         }
       },
       "Microsoft.Extensions.FileProviders.Embedded": {
         "type": "Direct",
-        "requested": "[10.0.11, )",
-        "resolved": "10.0.11",
-        "contentHash": "x1wiStyE0RsviK1jdE7a6ua7jIhA0xPXOq5YMfWCWN7RJ9D4Q70oSD9ZVEzHBvovB+f1YQFdPU4036Act442Ow=="
+        "requested": "[11.0.0-preview.7.26381.103, )",
+        "resolved": "11.0.0-preview.7.26381.103",
+        "contentHash": "Nzmzo/dv/IHer7A4Swnn9wPOWBiZsJfe4WDP1E2IdGgfvN64EIfo+VR9Uzzxcfz+gZj4Y4LkTajgcusUAgM+lA=="
       },
       "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": {
         "type": "Direct",
@@ -70,10 +70,7 @@
       "BinaryEncoding": {
         "type": "Transitive",
         "resolved": "1.4.0",
-        "contentHash": "1cnkP90c+zNcRyabjKSA3VYJvpYfkGEpXeekfF8KdTFo3VyUUFOioAsANbG8nsMyedGcmUOqHWd1d3fOXke4VA==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "contentHash": "1cnkP90c+zNcRyabjKSA3VYJvpYfkGEpXeekfF8KdTFo3VyUUFOioAsANbG8nsMyedGcmUOqHWd1d3fOXke4VA=="
       },
       "Common.Logging": {
         "type": "Transitive",
@@ -129,10 +126,7 @@
       "IPNetwork2": {
         "type": "Transitive",
         "resolved": "2.1.2",
-        "contentHash": "DZF2SbtyqukkLSzyu0KqcXUBdhDXQ/K3QWM27vlvdPo3W+iI81pgUCNTwyynNyVc5Q9AIn0znFVVhHGbhiofUg==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "contentHash": "DZF2SbtyqukkLSzyu0KqcXUBdhDXQ/K3QWM27vlvdPo3W+iI81pgUCNTwyynNyVc5Q9AIn0znFVVhHGbhiofUg=="
       },
       "JetBrains.FormatRipper": {
         "type": "Transitive",
@@ -283,11 +277,6 @@
           "Microsoft.Bcl.Cryptography": "10.0.2",
           "Microsoft.IdentityModel.Logging": "8.22.0"
         }
-      },
-      "Microsoft.NETCore.Platforms": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
       },
       "Mono.TextTemplating": {
         "type": "Transitive",
@@ -465,14 +454,6 @@
           "murmurhash": "1.0.2"
         }
       },
-      "NETStandard.Library": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "7jnbRU+L08FXKMxqUflxEXtVymWvNOrS8yHgu9s6EM8Anr6T/wIX4nZ08j/u3Asz+tCufp3YVwFSEvFTPYmBPA==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0"
-        }
-      },
       "Newtonsoft.Json": {
         "type": "Transitive",
         "resolved": "13.0.3",
@@ -483,7 +464,6 @@
         "resolved": "1.0.0",
         "contentHash": "fYnHQ8yZcj9W0fPGbzMkZUnE14aGGTFS8WE0Ow2hXiGhJ61Tv71cTi1yuugHxPCLyb87JpWMkq4lix8Rf06vtA==",
         "dependencies": {
-          "NETStandard.Library": "1.6.1",
           "libsodium": "1.0.16"
         }
       },
@@ -659,7 +639,7 @@
           "Nethermind.Core": "[1.40.0-unstable, )",
           "Nethermind.Network.Enr": "[1.40.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
-          "System.Configuration.ConfigurationManager": "[10.0.11, )"
+          "System.Configuration.ConfigurationManager": "[11.0.0-preview.7.26381.103, )"
         }
       },
       "nethermind.consensus": {
@@ -722,7 +702,7 @@
           "Nethermind.Numerics.Int256": "[1.6.0, )",
           "Nethermind.Serialization.Ssz": "[1.40.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
-          "System.IO.Hashing": "[10.0.11, )",
+          "System.IO.Hashing": "[11.0.0-preview.7.26381.103, )",
           "Testably.Abstractions": "[10.3.0, )"
         }
       },
@@ -734,7 +714,7 @@
           "Nethermind.Core": "[1.40.0-unstable, )",
           "Nethermind.Crypto.Bls": "[1.1.0, )",
           "Nethermind.Serialization.Rlp": "[1.40.0-unstable, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.11, )"
+          "System.Security.Cryptography.ProtectedData": "[11.0.0-preview.7.26381.103, )"
         }
       },
       "nethermind.db": {
@@ -1099,7 +1079,7 @@
       "nethermind.portfolioviewer.plugin": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Embedded": "[10.0.11, )",
+          "Microsoft.Extensions.FileProviders.Embedded": "[11.0.0-preview.7.26381.103, )",
           "Nethermind.Api": "[1.40.0-unstable, )",
           "Nethermind.Blockchain": "[1.40.0-unstable, )",
           "Nethermind.Consensus": "[1.40.0-unstable, )",
@@ -1191,7 +1171,7 @@
           "Nethermind.State": "[1.40.0-unstable, )",
           "Nethermind.Synchronization": "[1.40.0-unstable, )",
           "Nethermind.Trie": "[1.40.0-unstable, )",
-          "System.IO.Hashing": "[10.0.11, )"
+          "System.IO.Hashing": "[11.0.0-preview.7.26381.103, )"
         }
       },
       "nethermind.state.flat.history": {
@@ -1375,10 +1355,7 @@
         "type": "CentralTransitive",
         "requested": "[1.2.0, )",
         "resolved": "1.2.0",
-        "contentHash": "wNW/huzolu8MNKUnwCVKxjfAlCFpeI8AZVfF46iAWJ1+P6bTU1AZct7VAkDDEjgeeTJCVTkGZaD6jSd/fOiUkA==",
-        "dependencies": {
-          "NETStandard.Library": "2.0.0"
-        }
+        "contentHash": "wNW/huzolu8MNKUnwCVKxjfAlCFpeI8AZVfF46iAWJ1+P6bTU1AZct7VAkDDEjgeeTJCVTkGZaD6jSd/fOiUkA=="
       },
       "DnsClient": {
         "type": "CentralTransitive",
@@ -1704,24 +1681,24 @@
       },
       "System.Configuration.ConfigurationManager": {
         "type": "CentralTransitive",
-        "requested": "[10.0.11, )",
-        "resolved": "10.0.11",
-        "contentHash": "vFA8K0xj520MnLp+zkpTmLc3LOGUhkIDxHvhfm8Cr4b+ZVVeAXnfe1+2oixuITbsZfr4ALcU2NrAqQKhooX9yw==",
+        "requested": "[11.0.0-preview.7.26381.103, )",
+        "resolved": "11.0.0-preview.7.26381.103",
+        "contentHash": "OWFS75UgMfv0GCV/KB5eKfnAyA1+OCmuboDM741c4U7FXMX19RZ7XJGl6N6wD7AMPvnX9ZQcWXoDW1lWyRDA0w==",
         "dependencies": {
-          "System.Security.Cryptography.ProtectedData": "10.0.11"
+          "System.Security.Cryptography.ProtectedData": "11.0.0-preview.7.26381.103"
         }
       },
       "System.IO.Hashing": {
         "type": "CentralTransitive",
-        "requested": "[10.0.11, )",
-        "resolved": "10.0.11",
-        "contentHash": "OzKDcIRkeNJeC8qAsbn8yJXnfTLP1dtkWILe+T56Gf/z+IkAASi7sMqLqJQat08j5z/mRN5xVtoAwbkMNMoBUQ=="
+        "requested": "[11.0.0-preview.7.26381.103, )",
+        "resolved": "11.0.0-preview.7.26381.103",
+        "contentHash": "1phifWHmHO89ZOuc8+dXqxwt/FrvORA7m2OQuN7GVSeMpqAdZinYTH6YAG0MWs4FnsMhQugwF1QBaT+p8VYZ6A=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "CentralTransitive",
-        "requested": "[10.0.11, )",
-        "resolved": "10.0.11",
-        "contentHash": "PNoxCTPb+Tlux+GJyq4c89ddYdpioVSqfGx8pqOF6shCSKwUNNctXhQtRkCICjbJmGrJJsW8NY52kVYO/b8mlQ=="
+        "requested": "[11.0.0-preview.7.26381.103, )",
+        "resolved": "11.0.0-preview.7.26381.103",
+        "contentHash": "PvEsOtun6edmjYGl2xcukclT1ibYLwiJJmq5r6aNDPo573wjJkVuJL4ZEpf33fEyv2YVxzdjjt8drJSYApBwYA=="
       },
       "Testably.Abstractions": {
         "type": "CentralTransitive",
@@ -1755,7 +1732,7 @@
         "contentHash": "UIDFkA5DC3en3tOJ3Mof11yBx9kUQLsaeo/oFdvN6Bbkr9E9+VCqfIadHci8cu+I51K2Sl7XYWVl2R/mA75NBQ=="
       }
     },
-    "net10.0/linux-arm64": {
+    "net11.0/linux-arm64": {
       "Grpc.Core": {
         "type": "Transitive",
         "resolved": "2.46.6",
@@ -1856,7 +1833,7 @@
         }
       }
     },
-    "net10.0/linux-x64": {
+    "net11.0/linux-x64": {
       "Grpc.Core": {
         "type": "Transitive",
         "resolved": "2.46.6",
@@ -1957,7 +1934,7 @@
         }
       }
     },
-    "net10.0/osx-arm64": {
+    "net11.0/osx-arm64": {
       "Grpc.Core": {
         "type": "Transitive",
         "resolved": "2.46.6",
@@ -2058,7 +2035,7 @@
         }
       }
     },
-    "net10.0/osx-x64": {
+    "net11.0/osx-x64": {
       "Grpc.Core": {
         "type": "Transitive",
         "resolved": "2.46.6",
@@ -2159,7 +2136,7 @@
         }
       }
     },
-    "net10.0/win-x64": {
+    "net11.0/win-x64": {
       "Grpc.Core": {
         "type": "Transitive",
         "resolved": "2.46.6",

--- a/src/Nethermind/Nethermind.Test.Runner/Dockerfile
+++ b/src/Nethermind/Nethermind.Test.Runner/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute AS build
+FROM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7-resolute AS build
 
 COPY src/Nethermind src/Nethermind
 COPY Directory.*.props .
@@ -10,7 +10,7 @@ COPY nuget.config .
 
 RUN dotnet publish src/Nethermind/Nethermind.Test.Runner -c release -o /publish --sc false
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-resolute
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.7-resolute
 
 WORKDIR /nethermind
 

--- a/tools/EngineApiProxy/Dockerfile
+++ b/tools/EngineApiProxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7 AS build
 
 ARG BUILD_CONFIG=release
 ARG CI=true
@@ -18,7 +18,7 @@ RUN arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") && \
     dotnet publish tools/EngineApiProxy -c $BUILD_CONFIG -a $arch -o /publish --sc false \
       -p:BuildTimestamp=$BUILD_TIMESTAMP -p:Commit=$COMMIT_HASH
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0
+FROM mcr.microsoft.com/dotnet/aspnet:11.0.0-preview.7
 
 WORKDIR /engineproxy
 

--- a/tools/JitAsm/Program.cs
+++ b/tools/JitAsm/Program.cs
@@ -545,7 +545,7 @@ internal static class Program
 
                     foreach (JsonProperty dll in runtime.EnumerateObject())
                     {
-                        string dllRelativePath = dll.Name; // e.g. "lib/net10.0/Nethermind.Int256.dll"
+                        string dllRelativePath = dll.Name; // e.g. "lib/net11.0/Nethermind.Int256.dll"
                         string asmName = Path.GetFileNameWithoutExtension(dllRelativePath);
 
                         // Skip if already in the local directory

--- a/tools/Kute/Dockerfile
+++ b/tools/Kute/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute AS build
+FROM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7-resolute AS build
 
 ARG BUILD_CONFIG=release
 ARG TARGETARCH
@@ -11,7 +11,7 @@ COPY . .
 RUN arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") && \
   dotnet publish tools/Kute/Nethermind.Tools.Kute -c $BUILD_CONFIG -a $arch -o out --sc
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-resolute
+FROM mcr.microsoft.com/dotnet/runtime-deps:11.0.0-preview.7-resolute
 
 WORKDIR /nethermind
 

--- a/tools/RpcTests/RpcTests.Monitor/Dockerfile
+++ b/tools/RpcTests/RpcTests.Monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime:10.0
+FROM mcr.microsoft.com/dotnet/runtime:11.0.0-preview.7
 WORKDIR /app
 COPY . .
 ENTRYPOINT ["dotnet", "RpcTests.Monitor.dll"]

--- a/tools/RpcTests/RpcTests.Monitor/RpcTests.Monitor.csproj
+++ b/tools/RpcTests/RpcTests.Monitor/RpcTests.Monitor.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFramework>net11.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Nethermind.RpcTests.Monitor</RootNamespace>

--- a/tools/SendBlobs/Dockerfile
+++ b/tools/SendBlobs/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-resolute AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.7-resolute AS build
 
 ARG BUILD_CONFIG=release
 ARG BUILD_TIMESTAMP
@@ -21,7 +21,7 @@ RUN arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") && \
   -p:DebugType=None \
   -p:DebugSymbols=false
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-resolute
+FROM mcr.microsoft.com/dotnet/runtime-deps:11.0.0-preview.7-resolute
 
 WORKDIR /nethermind
 

--- a/tools/SendBlobs/README.md
+++ b/tools/SendBlobs/README.md
@@ -22,7 +22,7 @@ The default fork for now is Osaka, which means blobs will be sent with V1 proofs
 ## Build
 
 ```sh
-apt install libsnappy-dev dotnet-sdk-10.0 -y
+apt install libsnappy-dev dotnet-sdk-11.0 -y
 cd ./nethermind/tools/SendBlobs
 dotnet publish --sc -o .
 ./SendBlobs


### PR DESCRIPTION
## Changes

- Add `KeccakF1600ArmSha3`, a Keccak-f[1600] permutation built on the ARMv8.2-SHA3 intrinsics (`EOR3`/`RAX1`/`XAR`/`BCAX` via `Sha3.*`), and prefer it in `KeccakF` dispatch when supported
- Restructure the AVX-512 permutation into a shared inlined `Round` helper: shared lane-index vectors for Theta/Chi and pre-broadcast round constants (removes the per-round scalar broadcast)
- Rename the portable implementation to `KeccakF1600Scalar` (internal) so tests and benchmarks can target it directly
- Add an Arm-vs-scalar equivalence test and a `KeccakPermutationBenchmarks` BenchmarkDotNet suite
- Update to .NET 11 preview 7 (SDK `11.0.100-preview.7` in `global.json`, `net11.0` TFM, `Microsoft.*` 11.0 preview packages, Dockerfiles/nix/CI) - required for the `System.Runtime.Intrinsics.Arm.Sha3` API

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `Arm_sha3_permutation_matches_scalar` checks the Arm path against the scalar reference over 64 states (all-zero, all-ones, pseudo-random lanes); it skips where SHA-3 intrinsics are unavailable, so it needs an ARMv8.2-SHA3 machine (e.g. Graviton3+, Apple M-series) to exercise the new code
- `KeccakPermutationBenchmarks` re-verifies Arm/scalar equivalence in `GlobalSetup` before measuring
- Existing `KeccakTests` hash vectors cover the AVX-512 restructuring: 1050 passed on x64 with AVX-512

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Building from source now requires the .NET 11 preview 7 SDK (see `global.json`).
