### PR TITLE
fix(frames): bound unpaid producer-side validation-prefix work with a retry budget

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -534,12 +534,12 @@ namespace Nethermind.Blockchain.Test
         // approves burns its whole budget for free. Nothing else evicts it, so without this the producer
         // repeats that work on every block it builds. A fee cap under the base fee must survive: it clears
         // on its own once the base fee falls.
-        [TestCase(FramePrefix.NeverApproves, true, TestName = "A prefix that can never approve is evicted after one attempt")]
-        [TestCase(FramePrefix.Approves, false, TestName = "A prefix that approves is included, not evicted")]
-        [TestCase(FramePrefix.BelowBaseFee, false, TestName = "A fee cap under the base fee is not an eviction reason")]
-        public void Frame_transaction_that_can_never_pay_is_evicted_from_the_pool(FramePrefix prefix, bool expectedEvicted)
+        [TestCase(FramePrefix.NeverApproves, true, 3, TestName = "A prefix that can never approve is evicted after the retry budget")]
+        [TestCase(FramePrefix.Approves, false, 1, TestName = "A prefix that approves is included, not evicted")]
+        [TestCase(FramePrefix.BelowBaseFee, false, 5, TestName = "A fee cap under the base fee is not an eviction reason")]
+        public void Frame_transaction_that_can_never_pay_is_evicted_from_the_pool(FramePrefix prefix, bool expectedEvicted, int expectedAttempts)
         {
-            const int blocks = 3;
+            const int blocks = 5;
             ISpecProvider specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
             IReleaseSpec spec = specProvider.GenesisSpec;
 
@@ -613,9 +613,89 @@ namespace Nethermind.Blockchain.Test
                 Assert.That(adapter.Attempts, Is.GreaterThan(0), "the transaction never reached execution");
                 Assert.That(evicted, Is.EqualTo(expectedEvicted));
                 Assert.That(included, Is.EqualTo(prefix == FramePrefix.Approves ? 1 : 0));
-                // One attempt after an eviction, one after an inclusion (the nonce has moved on), and one
-                // per block for the transaction that stays pooled: that last one is the cost being fixed.
-                Assert.That(adapter.Attempts, Is.EqualTo(prefix == FramePrefix.BelowBaseFee ? blocks : 1));
+                Assert.That(adapter.Attempts, Is.EqualTo(expectedAttempts));
+            }
+        }
+
+        [Test]
+        public void Frame_transaction_whose_failing_prefix_recovers_within_the_budget_is_not_evicted()
+        {
+            ISpecProvider specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
+            IReleaseSpec spec = specProvider.GenesisSpec;
+
+            IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+            using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+            stateProvider.CreateAccount(TestItem.AddressA, 100.Ether);
+            byte[] neverApproves = Prepare.EvmCode.Op(Instruction.JUMPDEST).PushData(0).Op(Instruction.JUMP).Done;
+            byte[] approves = Prepare.EvmCode.PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
+            stateProvider.InsertCode(TestItem.AddressA, neverApproves, spec);
+            stateProvider.Commit(spec);
+            stateProvider.CommitTree(0);
+
+            const ulong verifyGas = 100_000;
+            Transaction frameTx = new()
+            {
+                Type = TxType.FrameTx,
+                ChainId = TestBlockchainIds.ChainId,
+                Nonce = 0,
+                SenderAddress = TestItem.AddressA,
+                Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, verifyGas, UInt256.Zero, default)],
+                FrameSignatures = [],
+                GasLimit = verifyGas,
+                GasPrice = 1,
+                DecodedMaxFeePerGas = 1,
+            };
+            frameTx.Hash = frameTx.CalculateHash();
+
+            EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(specProvider), specProvider, LimboLogs.Instance);
+            ITransactionProcessor transactionProcessor = new EthereumTransactionProcessor(
+                BlobBaseFeeCalculator.Instance, specProvider, stateProvider, virtualMachine,
+                new EthereumCodeInfoRepository(stateProvider), LimboLogs.Instance);
+            CountingTxProcessorAdapter adapter = new(new BuildUpTransactionProcessorAdapter(transactionProcessor));
+
+            bool evicted = false;
+            ITxPool txPool = Substitute.For<ITxPool>();
+            txPool.EvictTransaction(frameTx).Returns(_ => evicted = true);
+
+            BlockProcessor.BlockProductionTransactionsExecutor txExecutor = new(
+                adapter,
+                stateProvider,
+                new BlockProcessor.BlockProductionTransactionPicker(specProvider),
+                LimboLogs.Instance,
+                NullBlockAccessListManager.Instance,
+                txPool);
+
+            int included = 0;
+            for (int i = 0; i < 3 && !evicted; i++)
+            {
+                if (i == 2)
+                {
+                    stateProvider.InsertCode(TestItem.AddressA, approves, spec);
+                    stateProvider.Commit(spec);
+                    stateProvider.CommitTree(1 + i);
+                }
+
+                Block block = Build.A.Block
+                    .WithNumber(1 + i)
+                    .WithBaseFeePerGas(UInt256.Zero)
+                    .WithGasLimit(30_000_000)
+                    .WithTransactions(frameTx)
+                    .TestObject;
+
+                BlockReceiptsTracer receiptsTracer = new();
+                receiptsTracer.StartNewBlockTrace(block);
+                txExecutor.SetBlockExecutionContext(new BlockExecutionContext(block.Header, spec));
+                txExecutor.ProcessTransactions(block, ProcessingOptions.ProducingBlock, receiptsTracer, CancellationToken.None);
+                receiptsTracer.EndBlockTrace();
+
+                if (block.Header.TxRoot != Keccak.EmptyTreeHash) included++;
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(adapter.Attempts, Is.EqualTo(3), "the transaction must be tried each block until its prefix recovers");
+                Assert.That(evicted, Is.False, "a prefix that recovers within the budget must not be evicted");
+                Assert.That(included, Is.EqualTo(1), "once the prefix approves the transaction is included");
             }
         }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
@@ -133,7 +133,7 @@ namespace Nethermind.Consensus.Processing
 
             /// <summary>
             /// Evicts an EIP-8141 frame transaction whose frames did not approve payment, so the producer runs
-            /// its validation prefix at most once per time the transaction is pooled.
+            /// its validation prefix at most <see cref="FrameProductionRetryBudget"/> times per time the transaction is pooled.
             /// </summary>
             /// <remarks>
             /// A frame transaction only charges a fee once a frame approves payment. One whose prefix does not
@@ -147,12 +147,16 @@ namespace Nethermind.Consensus.Processing
             /// frame reading storage), so <see cref="ITxPool.EvictTransaction"/> clears the long-term cache and
             /// the transaction can re-enter once that state changes.
             /// </remarks>
+            private const int FrameProductionRetryBudget = 3;
+
             private void EvictUnpaidFrameTx(Transaction tx, in TransactionResult result)
             {
                 if (!tx.SupportsFrames || result.Error != TransactionResult.ErrorType.MalformedTransaction) return;
 
+                if (++tx.FrameProductionFailures < FrameProductionRetryBudget) return;
+
                 if (txPool.EvictTransaction(tx) && _logger.IsDebug)
-                    _logger.Debug($"Evicted frame transaction {tx.ToShortString()} from the pool: {result.ErrorDescription}.");
+                    _logger.Debug($"Evicted frame transaction {tx.ToShortString()} from the pool after {tx.FrameProductionFailures} unpaid production attempts: {result.ErrorDescription}.");
             }
         }
     }

--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -291,6 +291,11 @@ namespace Nethermind.Core
         /// <remarks>Used for sorting in edge cases.</remarks>
         public ulong PoolIndex { get; set; }
 
+        /// <summary>
+        /// In-memory only. Consecutive block-production attempts in which this frame transaction's validation prefix failed to approve payment.
+        /// </summary>
+        public int FrameProductionFailures { get; set; }
+
         protected int? _size = null;
 
         /// <summary>
@@ -394,6 +399,7 @@ namespace Nethermind.Core
                 obj.NetworkWrapper = default;
                 obj.IsServiceTransaction = default;
                 obj.PoolIndex = default;
+                obj.FrameProductionFailures = default;
                 obj._size = default;
                 obj.AuthorizationList = default;
                 obj.Frames = default;


### PR DESCRIPTION
## Changes

Follow-up to #12753. That change evicts an EIP-8141 frame transaction from the pool the first time its validation prefix fails to approve payment during block production. A frame transaction is charged nothing until a frame approves, so a prefix that never approves burns its whole verify budget for free on every block it is offered, and nothing else evicts it — hence the eviction.

Evicting on the **first** failure is too aggressive: the failure that reaches this path (`MalformedTransaction`) can be transient rather than permanent.

- an unfunded payer that a later transaction in the same block funds;
- a VERIFY frame reading state that a preceding transaction changes;
- a recent-root reference not yet committed at the moment of the attempt.

A self-paying withdrawal whose sponsor funds it one transaction later is exactly this shape, and first-failure eviction drops it.

This bounds the unpaid work without dropping a recoverable transaction: count consecutive production failures on the transaction and evict only once the count reaches a small retry budget (3). The counter is in-memory, resets with the pooled object, and `ITxPool.EvictTransaction` clears the long-term cache, so an evicted transaction can still re-enter once the state its prefix reads changes. The budget is a producer policy; its value is not consensus.

## Measurements

Reference implementation, release build, arm64.

- Baseline (#12753's first-failure evict removed, i.e. no bound): a never-approving prefix is re-executed on **20/20** offered blocks; **2,000,000** gas burned unpaid at a 100k budget, **4,725,680** at the measured 236,285 pool prefix; beneficiary delta 0.
- With the retry budget: the never-approving prefix is dropped after **3** attempts; a transient prefix that recovers within the budget is included and never evicted; a fee cap under the base fee is not an eviction reason.
- Ingress is unaffected (~15µs, executes nothing), flat under a 10x sweep of the gas cap.

## Tests

`Nethermind.Blockchain.Test` `TransactionsExecutorTests`:

- a prefix that can never approve is evicted after the retry budget;
- a prefix that approves is included, not evicted;
- a fee cap under the base fee is not an eviction reason;
- a failing prefix that recovers within the budget is not evicted.

Mutation-verified: removing the budget guard fails exactly the recover-within-budget and the attempt-count assertions.

## Notes for reviewers

- Touches `BlockProcessor.BlockProductionTransactionsExecutor` (production path). This method exists only on the devnet-7 line (#12753); it is not present on devnet-8 / the phase-2 mempool stack, which still need the #12753 + this bound forward-ported.
- New field `Transaction.FrameProductionFailures` follows `PoolIndex` (in-memory, reset in the pool-return path).
