### PR TITLE
feat(frames): two-dimensional gas limits per EIP-8141

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -374,6 +374,13 @@ public class FrameTxDecoderTests
             Frame(),
         ])).SetName("Roundtrip_AllModesFlagsTargetsAndData");
 
+        yield return new TestCaseData(CreateFrameTx(frames:
+        [
+            Frame(gasLimit: 500_000, stateGasLimit: 183_600),
+            Frame(mode: TxFrame.ModeVerify, gasLimit: 90_000, stateGasLimit: 0),
+            Frame(mode: TxFrame.ModeSender, gasLimit: ulong.MaxValue - 1, stateGasLimit: 1),
+        ])).SetName("Roundtrip_TwoDimensionalGasLimits");
+
         yield return new TestCaseData(CreateFrameTx(signatures:
         [
             new TxFrameSignature(TxFrameSignature.SchemeArbitrary, null, default, FilledBytes(11, 0x77)),
@@ -479,7 +486,8 @@ public class FrameTxDecoderTests
             Assert.That(actual[i].Mode, Is.EqualTo(expected[i].Mode), $"frame {i} mode");
             Assert.That(actual[i].Flags, Is.EqualTo(expected[i].Flags), $"frame {i} flags");
             Assert.That(actual[i].Target, Is.EqualTo(expected[i].Target), $"frame {i} target");
-            Assert.That(actual[i].GasLimit, Is.EqualTo(expected[i].GasLimit), $"frame {i} gas limit");
+            Assert.That(actual[i].ExecutionGasLimit, Is.EqualTo(expected[i].ExecutionGasLimit), $"frame {i} execution gas limit");
+            Assert.That(actual[i].StateGasLimit, Is.EqualTo(expected[i].StateGasLimit), $"frame {i} state gas limit");
             Assert.That(actual[i].Value, Is.EqualTo(expected[i].Value), $"frame {i} value");
             Assert.That(actual[i].Data.ToArray(), Is.EqualTo(expected[i].Data.ToArray()), $"frame {i} data");
         }
@@ -510,8 +518,8 @@ public class FrameTxDecoderTests
             DecodedMaxFeePerGas = 30.GWei,
         };
 
-    private static TxFrame Frame(byte mode = TxFrame.ModeDefault, byte flags = 0, Address? target = null, ulong gasLimit = 100_000, UInt256 value = default, byte[]? data = null) =>
-        new(mode, flags, target, gasLimit, value, data ?? Array.Empty<byte>());
+    private static TxFrame Frame(byte mode = TxFrame.ModeDefault, byte flags = 0, Address? target = null, ulong gasLimit = 100_000, ulong stateGasLimit = 0, UInt256 value = default, byte[]? data = null) =>
+        new(mode, flags, target, gasLimit, stateGasLimit, value, data ?? Array.Empty<byte>());
 
     private static byte[] FilledBytes(int length, byte fill)
     {

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -174,6 +174,9 @@ public class FrameTxValidationTests
         yield return Case("ExpiryFrameWithShortData_InvalidExpiryFrame",
             static tx => tx.Frames = [Frame(mode: TxFrame.ModeVerify, target: Eip8141Constants.ExpiryVerifierAddress, data: new byte[Eip8141Constants.ExpiryDataLength - 1])],
             FrameTxValidation.InvalidExpiryFrame);
+        yield return Case("ExpiryFrameWithStateGas_InvalidExpiryFrame",
+            static tx => tx.Frames = [new TxFrame(TxFrame.ModeVerify, flags: 0, Eip8141Constants.ExpiryVerifierAddress, 30_000, 1, UInt256.Zero, new byte[Eip8141Constants.ExpiryDataLength])],
+            FrameTxValidation.InvalidExpiryFrame);
         yield return Case("TwoExpiryFrames_MultipleExpiryFrames",
             static tx => tx.Frames = [SelfVerifyFrame(), ExpiryFrame(), ExpiryFrame()],
             FrameTxValidation.MultipleExpiryFrames);

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -155,7 +155,7 @@ public static class FrameTxValidation
 
             if (frame.Mode == TxFrame.ModeVerify && frame.Target == Eip8141Constants.ExpiryVerifierAddress)
             {
-                if (frame.Flags != 0 || !frame.Value.IsZero || frame.Data.Length != Eip8141Constants.ExpiryDataLength)
+                if (frame.Flags != 0 || !frame.Value.IsZero || frame.StateGasLimit != 0 || frame.Data.Length != Eip8141Constants.ExpiryDataLength)
                 {
                     error = InvalidExpiryFrame;
                     return false;
@@ -170,8 +170,9 @@ public static class FrameTxValidation
                 hasExpiryFrame = true;
             }
 
-            ulong accumulated = totalFrameGas + frame.GasLimit;
-            if (accumulated < totalFrameGas)
+            ulong frameGas = frame.ExecutionGasLimit + frame.StateGasLimit;
+            ulong accumulated = totalFrameGas + frameGas;
+            if (frameGas < frame.ExecutionGasLimit || accumulated < totalFrameGas)
             {
                 error = FrameGasOverflow;
                 return false;
@@ -250,8 +251,10 @@ public static class FrameTxValidation
     };
 
     /// <summary>
-    /// An upper bound on the public-mempool validation work of <paramref name="transaction"/>: the gas limits
-    /// of its validation prefix plus the cost of verifying its signatures, saturating at <see cref="ulong.MaxValue"/>.
+    /// An upper bound on the public-mempool validation work of <paramref name="transaction"/>: the execution-gas
+    /// limits (EIP-8141 <c>MAX_VERIFY_GAS</c>) of its validation prefix plus the cost of verifying its signatures,
+    /// saturating at <see cref="ulong.MaxValue"/>. The prefix's <c>limits.state</c> is bounded separately by
+    /// <c>MAX_VERIFY_STATE_GAS</c> and does not enter this budget.
     /// </summary>
     /// <remarks>
     /// Derived from the frame layout alone, so no state is read. Each layout of EIP-8141 "Public
@@ -269,7 +272,7 @@ public static class FrameTxValidation
         ulong total = 0;
         for (int i = 0; i < counted; i++)
         {
-            total = Saturating(total, frames[i].GasLimit);
+            total = Saturating(total, frames[i].ExecutionGasLimit);
         }
 
         foreach (TxFrameSignature signature in transaction.FrameSignatures ?? [])
@@ -401,8 +404,9 @@ public static class FrameTxValidation
             tokens += CountCalldataTokens(frame.Data.Span, spec);
             dataLength += (ulong)frame.Data.Length;
 
-            ulong accumulated = totalFrameGas + frame.GasLimit;
-            if (accumulated < totalFrameGas)
+            ulong frameGas = frame.ExecutionGasLimit + frame.StateGasLimit;
+            ulong accumulated = totalFrameGas + frameGas;
+            if (frameGas < frame.ExecutionGasLimit || accumulated < totalFrameGas)
             {
                 return false;
             }

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -284,6 +284,27 @@ public static class FrameTxValidation
     }
 
     /// <summary>
+    /// An upper bound on the state growth EIP-8141 admits through the public mempool for
+    /// <paramref name="transaction"/>: the sum of its validation prefix's <c>limits.state</c>, saturating at
+    /// <see cref="ulong.MaxValue"/>. Bounded separately by <c>MAX_VERIFY_STATE_GAS</c>; signature verification
+    /// uses no state gas, so it does not enter this budget.
+    /// </summary>
+    /// <param name="transaction">The frame transaction to price.</param>
+    public static ulong ValidationWorkStateGas(Transaction transaction)
+    {
+        TxFrame[] frames = transaction.Frames ?? [];
+        int counted = RecognizedPrefixLength(frames, transaction.SenderAddress) ?? frames.Length;
+
+        ulong total = 0;
+        for (int i = 0; i < counted; i++)
+        {
+            total = Saturating(total, frames[i].StateGasLimit);
+        }
+
+        return total;
+    }
+
+    /// <summary>
     /// The number of leading frames forming a validation prefix EIP-8141 recognizes for the public
     /// mempool, or <c>null</c> when the layout matches none of them.
     /// </summary>

--- a/src/Nethermind/Nethermind.Core/TxFrame.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrame.cs
@@ -7,10 +7,11 @@ using Nethermind.Int256;
 namespace Nethermind.Core;
 
 /// <summary>
-/// A single frame of an EIP-8141 frame transaction: <c>[mode, flags, target, gas_limit, value, data]</c>.
+/// A single frame of an EIP-8141 frame transaction: <c>[mode, flags, target, limits, value, data]</c>,
+/// where <c>limits = [execution, state]</c>.
 /// https://eips.ethereum.org/EIPS/eip-8141
 /// </summary>
-public class TxFrame(byte mode, byte flags, Address? target, ulong gasLimit, UInt256 value, ReadOnlyMemory<byte> data)
+public class TxFrame(byte mode, byte flags, Address? target, ulong executionGasLimit, ulong stateGasLimit, UInt256 value, ReadOnlyMemory<byte> data)
 {
     public const byte ModeDefault = 0;
     public const byte ModeVerify = 1;
@@ -26,13 +27,29 @@ public class TxFrame(byte mode, byte flags, Address? target, ulong gasLimit, UIn
     public const byte ApproveScopeMask = ApproveExecutionAndPayment;
     public const byte AtomicBatchFlag = 0x4;
 
+    /// <summary>Constructs a frame whose entire budget is execution gas, with <c>limits.state == 0</c>.</summary>
+    public TxFrame(byte mode, byte flags, Address? target, ulong gasLimit, UInt256 value, ReadOnlyMemory<byte> data)
+        : this(mode, flags, target, gasLimit, 0, value, data)
+    {
+    }
+
     public byte Mode { get; } = mode;
     public byte Flags { get; } = flags;
 
     /// <summary>Null resolves to the transaction sender during execution.</summary>
     public Address? Target { get; } = target;
 
-    public ulong GasLimit { get; } = gasLimit;
+    /// <summary>EIP-8141 <c>limits.execution</c>: the frame's execution-gas budget.</summary>
+    public ulong ExecutionGasLimit { get; } = executionGasLimit;
+
+    /// <summary>EIP-8141 <c>limits.state</c>: the frame's state-gas budget (EIP-8037).</summary>
+    public ulong StateGasLimit { get; } = stateGasLimit;
+
+    /// <summary>The combined gas the frame reserves against the payer, <c>limits.execution + limits.state</c>.</summary>
+    /// <remarks>Static validation rejects a transaction whose frame reservations overflow, so this sum never
+    /// wraps for a frame reaching execution.</remarks>
+    public ulong GasLimit => ExecutionGasLimit + StateGasLimit;
+
     public UInt256 Value { get; } = value;
     public ReadOnlyMemory<byte> Data { get; } = data;
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
@@ -90,6 +90,63 @@ public class FrameTxBlockGasTests
             "a reverted frame commits no state, so it grows none");
     }
 
+    /// <summary>
+    /// A frame's state gas is drawn from its own <c>limits.state</c> reservoir, independent of
+    /// <c>limits.execution</c>: a fresh-slot write whose execution budget cannot absorb the state charge
+    /// still succeeds when the state budget covers it, and the same charge lands in the state dimension.
+    /// </summary>
+    [Test]
+    public void Execute_PayloadFrameStateBudgetCoversTheWrite_SucceedsFromTheStateReservoir()
+    {
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        const ulong executionBudget = 30_000;
+        TestAllTracerWithOutput tracer = new();
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, Writer, executionBudget, 150_000, UInt256.Zero, default));
+
+        Assert.That(Process(tx, tracer).TransactionExecuted, Is.True);
+
+        const ulong stateCharge = (ulong)GasCostOf.SSetState;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_state.Get(new StorageCell(Writer, (UInt256)0)).ToArray(), Is.Not.All.EqualTo((byte)0),
+                "the write committed, so its state gas came from the reservoir rather than out-of-gassing");
+            Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(stateCharge),
+                "the reservoir-funded write still bills the state dimension");
+            Assert.That(tracer.GasConsumedResult.EffectiveBlockGas,
+                Is.EqualTo(tracer.GasConsumedResult.SpentGas - stateCharge));
+        }
+    }
+
+    /// <summary>
+    /// With no state budget the same write's state charge spills into <c>limits.execution</c>, which cannot
+    /// cover it, so the frame halts and commits nothing — proving the two budgets are independent pools.
+    /// </summary>
+    [Test]
+    public void Execute_PayloadFrameStateSpillsIntoTooSmallExecutionBudget_HaltsAndOwesNoStateGas()
+    {
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        const ulong executionBudget = 30_000;
+        TestAllTracerWithOutput tracer = new();
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, Writer, executionBudget, 0, UInt256.Zero, default));
+
+        Assert.That(Process(tx, tracer).TransactionExecuted, Is.True);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_state.Get(new StorageCell(Writer, (UInt256)0)).ToArray(), Is.All.EqualTo((byte)0),
+                "the write halted out of gas, so no slot was committed");
+            Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero);
+        }
+    }
+
     /// <summary>An atomic batch whose later frame fails gives back the state gas its earlier frame owed.</summary>
     /// <remarks>
     /// The unroll restores the pre-batch state, so the fresh slot the first frame wrote never reaches the

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -496,6 +496,7 @@ public class FrameTxProcessorTests
     [TestCase((byte)0x06, 3UL, TestName = "Execute_FrameParam_AllowedScope")]
     [TestCase((byte)0x07, 0UL, TestName = "Execute_FrameParam_AtomicBatch")]
     [TestCase((byte)0x08, 0UL, TestName = "Execute_FrameParam_Value")]
+    [TestCase((byte)0x09, 0UL, TestName = "Execute_FrameParam_StateGasLimit")]
     public void Execute_FrameParamIntrospection_ReadsCompletedFrame(byte param, ulong expected)
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
@@ -509,6 +510,22 @@ public class FrameTxProcessorTests
 
         Assert.That(result.TransactionExecuted, Is.True);
         AssertStorage(Observer, 0, (UInt256)expected);
+    }
+
+    [Test]
+    public void Execute_FrameParam_StateGasLimit_ReadsDeclaredStateBudget()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData(0x09).PushData(1).Op(Instruction.FRAMEPARAM).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeDefault, 0, Observer, 200_000, 50_000, UInt256.Zero, default));
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        AssertStorage(Observer, 0, (UInt256)50_000);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -40,6 +40,10 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     public static EthereumGasPolicy FromULong(ulong value) => new() { Value = value };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static EthereumGasPolicy FromFrameLimits(ulong executionGasLimit, ulong stateGasLimit) =>
+        new() { Value = executionGasLimit, StateReservoir = (long)stateGasLimit };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static EthereumGasPolicy CreateSystemTransactionIntrinsicGas(ulong blockGasLimit) =>
         new()
         {

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -15,6 +15,15 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 {
     static abstract TSelf FromULong(ulong value);
 
+    /// <summary>
+    /// Seeds an EIP-8141 frame budget from its two-dimensional <c>limits = [execution, state]</c>: the execution
+    /// dimension funds <c>gas_left</c> and the state dimension funds the state reservoir. Pre-EIP-8037 policies,
+    /// having no state dimension, fall back to a single combined budget.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static virtual TSelf FromFrameLimits(ulong executionGasLimit, ulong stateGasLimit) =>
+        TSelf.FromULong(executionGasLimit > ulong.MaxValue - stateGasLimit ? ulong.MaxValue : executionGasLimit + stateGasLimit);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual TSelf CreateSystemTransactionIntrinsicGas(ulong blockGasLimit) => TSelf.FromULong(0);
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -217,14 +217,14 @@ public static unsafe partial class EvmInstructions
         // Spec stack order: frameIndex on top, param second.
         if (!stack.PopUInt256(out UInt256 frameIndex, out UInt256 param)) return EvmExceptionType.StackUnderflow;
         if (frameIndex >= (UInt256)ctx.Frames.Length) return EvmExceptionType.BadInstruction;
-        if (param > 0x08) return EvmExceptionType.BadInstruction;
+        if (param > 0x09) return EvmExceptionType.BadInstruction;
 
         int index = (int)frameIndex.u0;
         TxFrame frame = ctx.Frames[index];
         return param.u0 switch
         {
             0x00 => stack.PushAddress<TTracingInst>(ctx.ResolvedTarget(index)),
-            0x01 => stack.PushUInt256<TTracingInst>((UInt256)frame.GasLimit),
+            0x01 => stack.PushUInt256<TTracingInst>((UInt256)frame.ExecutionGasLimit),
             0x02 => stack.PushUInt32<TTracingInst>(frame.Mode),
             0x03 => stack.PushUInt32<TTracingInst>(frame.Flags),
             0x04 => stack.PushUInt256<TTracingInst>((UInt256)frame.Data.Length),
@@ -232,6 +232,7 @@ public static unsafe partial class EvmInstructions
             0x06 => stack.PushUInt32<TTracingInst>(frame.AllowedApproveScope),
             0x07 => stack.PushUInt32<TTracingInst>((uint)(frame.IsAtomicBatch ? 1 : 0)),
             0x08 => stack.PushUInt256<TTracingInst>(frame.Value),
+            0x09 => stack.PushUInt256<TTracingInst>((UInt256)frame.StateGasLimit),
             _ => EvmExceptionType.BadInstruction,
         };
     }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -428,9 +428,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         ulong grossGas = intrinsicGas + totalFrameGasUsed;
         ulong spentGas = Math.Max(grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)refundCounter, spec), floorGas);
         ulong blockStateGas = (ulong)totalFrameStateGasUsed;
-        // blockStateGas <= grossGas by the reservoir-0 invariant: each frame rents an empty state-gas
-        // reservoir, so every state charge is already counted inside totalFrameGasUsed (hence grossGas),
-        // which is what makes the SaturatingSub in CalculateBlockExecutionGas sound.
+        // blockStateGas <= grossGas: each frame's charge folded into totalFrameGasUsed already includes
+        // the state gas it used, whether drawn from its limits.state reservoir or spilled into
+        // limits.execution, so the state total is a subset of grossGas, which is what makes the
+        // SaturatingSub in CalculateBlockExecutionGas sound.
         ulong blockRegularGas = Eip8037BlockGasInclusionCheck.CalculateBlockExecutionGas(grossGas, blockStateGas, floorGas);
         // Block-level gas accounting reads Transaction.BlockGasUsed, whose getter otherwise falls back
         // to tx.GasLimit (the frame-gas sum, not the gas actually spent). Set it explicitly like the
@@ -591,7 +592,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         }
 
         using VmState<TGasPolicy> state = VmState<TGasPolicy>.RentTopLevel(
-            TGasPolicy.FromULong(frame.GasLimit),
+            TGasPolicy.FromFrameLimits(frame.ExecutionGasLimit, frame.StateGasLimit),
             isStatic ? ExecutionType.STATICCALL : ExecutionType.TRANSACTION,
             env,
             in frameTracker,
@@ -604,8 +605,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             ? VirtualMachine.ExecuteTransaction<OnFlag>(state, WorldState, tracer)
             : VirtualMachine.ExecuteTransaction(state, WorldState, tracer);
 
-        ulong remainingGas = substate.IsError ? 0 : TGasPolicy.GetRemainingGas(in state.Gas);
-        gasUsed = frame.GasLimit - remainingGas;
+        ulong combinedLimit = frame.ExecutionGasLimit + frame.StateGasLimit;
+        gasUsed = substate.IsError
+            ? combinedLimit - (ulong)Math.Max(0, TGasPolicy.GetStateReservoir(in state.Gas))
+            : TGasPolicy.GetPreRefundGas(in state.Gas, combinedLimit);
         // Clamp rather than assert: unlike the standard path, this also runs for reverted or errored
         // frames, where the state-gas value carries no non-negativity guarantee.
         stateGasUsed = Math.Max(0, TGasPolicy.GetStateGasUsed(in state.Gas));

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameForRpc.cs
@@ -8,13 +8,15 @@ using Nethermind.Int256;
 
 namespace Nethermind.Facade.Eth.RpcTransaction;
 
-/// <summary>JSON-RPC view of an EIP-8141 frame: <c>[mode, flags, target, gas_limit, value, data]</c>.</summary>
+/// <summary>JSON-RPC view of an EIP-8141 frame: <c>[mode, flags, target, limits, value, data]</c>,
+/// where <c>limits = [execution, state]</c>.</summary>
 public class FrameForRpc
 {
     public byte Mode { get; set; }
     public byte Flags { get; set; }
     public Address? Target { get; set; }
-    public ulong GasLimit { get; set; }
+    public ulong ExecutionGasLimit { get; set; }
+    public ulong StateGasLimit { get; set; }
     public UInt256 Value { get; set; }
     public byte[] Data { get; set; } = [];
 
@@ -26,12 +28,13 @@ public class FrameForRpc
         Mode = frame.Mode;
         Flags = frame.Flags;
         Target = frame.Target;
-        GasLimit = frame.GasLimit;
+        ExecutionGasLimit = frame.ExecutionGasLimit;
+        StateGasLimit = frame.StateGasLimit;
         Value = frame.Value;
         Data = frame.Data.ToArray();
     }
 
-    public TxFrame ToFrame() => new(Mode, Flags, Target, GasLimit, Value, Data);
+    public TxFrame ToFrame() => new(Mode, Flags, Target, ExecutionGasLimit, StateGasLimit, Value, Data);
 
     public static FrameForRpc[]? FromFrames(TxFrame[]? frames) =>
         frames?.Select(static f => new FrameForRpc(f)).ToArray();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
@@ -86,7 +86,8 @@ public class FrameTransactionForRpcTests
             Assert.That(frames[0].GetProperty("mode").GetInt32(), Is.EqualTo(TxFrame.ModeVerify));
             Assert.That(frames[0].GetProperty("flags").GetInt32(), Is.EqualTo(TxFrame.ApproveExecutionAndPayment));
             Assert.That(frames[0].GetProperty("target").GetString(), Is.EqualTo(TestItem.AddressB.ToString()));
-            Assert.That(frames[0].GetProperty("gasLimit").GetString(), Does.Match("^0x[0-9a-f]+$"));
+            Assert.That(frames[0].GetProperty("executionGasLimit").GetString(), Does.Match("^0x[0-9a-f]+$"));
+            Assert.That(frames[0].GetProperty("stateGasLimit").GetString(), Does.Match("^0x[0-9a-f]+$"));
         }
     }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxFrameDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxFrameDecoder.cs
@@ -9,7 +9,8 @@ using Nethermind.Int256;
 namespace Nethermind.Serialization.Rlp;
 
 /// <summary>
-/// Decodes the EIP-8141 frame tuple <c>[mode, flags, target, gas_limit, value, data]</c>.
+/// Decodes the EIP-8141 frame tuple <c>[mode, flags, target, limits, value, data]</c>, where
+/// <c>limits = [execution, state]</c>.
 /// An empty target byte string decodes to null (resolves to the transaction sender).
 /// </summary>
 public sealed class TxFrameDecoder : RlpDecoder<TxFrame>
@@ -27,7 +28,16 @@ public sealed class TxFrameDecoder : RlpDecoder<TxFrame>
         byte mode = decoderContext.DecodeByte();
         byte flags = decoderContext.DecodeByte();
         Address? target = decoderContext.DecodeAddressOrNull();
-        ulong gasLimit = decoderContext.DecodeULong();
+
+        int limitsLength = decoderContext.ReadSequenceLength();
+        int limitsCheck = limitsLength + decoderContext.Position;
+        ulong executionGasLimit = decoderContext.DecodeULong();
+        ulong stateGasLimit = decoderContext.DecodeULong();
+        if (!rlpBehaviors.HasFlag(RlpBehaviors.AllowExtraBytes))
+        {
+            decoderContext.Check(limitsCheck);
+        }
+
         UInt256 value = decoderContext.DecodeUInt256();
         ReadOnlyMemory<byte> data = decoderContext.DecodeByteArrayMemory(_dataRlpLimit);
 
@@ -36,7 +46,7 @@ public sealed class TxFrameDecoder : RlpDecoder<TxFrame>
             decoderContext.Check(check);
         }
 
-        return new TxFrame(mode, flags, target, gasLimit, value, data);
+        return new TxFrame(mode, flags, target, executionGasLimit, stateGasLimit, value, data);
     }
 
     public override void Encode<TWriter>(ref TWriter writer, TxFrame item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -45,7 +55,9 @@ public sealed class TxFrameDecoder : RlpDecoder<TxFrame>
         writer.Encode((ulong)item.Mode);
         writer.Encode((ulong)item.Flags);
         writer.Encode(item.Target);
-        writer.Encode(item.GasLimit);
+        writer.StartSequence(GetLimitsContentLength(item));
+        writer.Encode(item.ExecutionGasLimit);
+        writer.Encode(item.StateGasLimit);
         writer.Encode(item.Value);
         writer.Encode(item.Data);
     }
@@ -85,7 +97,10 @@ public sealed class TxFrameDecoder : RlpDecoder<TxFrame>
         Rlp.LengthOf((ulong)item.Mode)
         + Rlp.LengthOf((ulong)item.Flags)
         + Rlp.LengthOf(item.Target)
-        + Rlp.LengthOf(item.GasLimit)
+        + Rlp.LengthOfSequence(GetLimitsContentLength(item))
         + Rlp.LengthOf(item.Value)
         + Rlp.LengthOf(item.Data);
+
+    private static int GetLimitsContentLength(TxFrame item) =>
+        Rlp.LengthOf(item.ExecutionGasLimit) + Rlp.LengthOf(item.StateGasLimit);
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
@@ -57,6 +57,32 @@ internal class FrameTxVerifyGasFilterTest
         Assert.That(filter.Accept(tx, ref state, TxHandlingOptions.None), Is.EqualTo(expected));
     }
 
+    private static TxFrame SelfVerifyWithState(ulong executionGasLimit, ulong stateGasLimit) =>
+        new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, executionGasLimit, stateGasLimit, UInt256.Zero, default);
+
+    private static TxFrame ExecutionWithState(ulong executionGasLimit, ulong stateGasLimit) =>
+        new(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, executionGasLimit, stateGasLimit, UInt256.Zero, default);
+
+    private static IEnumerable<TestCaseData> StatePrefixCases()
+    {
+        yield return new TestCaseData(new[] { SelfVerifyWithState(1_000, 500_000) }, AcceptTxResult.Accepted)
+            .SetName("prefix state exactly at MAX_VERIFY_STATE_GAS is accepted");
+        yield return new TestCaseData(new[] { SelfVerifyWithState(1_000, 500_001) }, AcceptTxResult.FrameTxVerifyGasTooHigh)
+            .SetName("prefix state one gas over MAX_VERIFY_STATE_GAS is rejected");
+        yield return new TestCaseData(new[] { SelfVerify(1_000), ExecutionWithState(1_000, 3_000_000) }, AcceptTxResult.Accepted)
+            .SetName("state behind a recognized prefix is outside the ceiling");
+    }
+
+    [TestCaseSource(nameof(StatePrefixCases))]
+    public void Accept_BoundsThePrefixStateGas(TxFrame[] frames, AcceptTxResult expected)
+    {
+        Transaction tx = FrameTx(frames);
+        FrameTxVerifyGasFilter filter = new(new TxPoolConfig { FrameTxMaxVerifyGas = 0, FrameTxMaxVerifyStateGas = 500_000 }, LimboLogs.Instance.GetClassLogger<FrameTxVerifyGasFilterTest>());
+        TxFilteringState state = new(tx, Substitute.For<IAccountStateProvider>());
+
+        Assert.That(filter.Accept(tx, ref state, TxHandlingOptions.None), Is.EqualTo(expected));
+    }
+
     // The pool's account cache stores the empty account on a miss while the reader beneath it may
     // leave the out-value zeroed, so a filter reading the first probe and a filter reading the
     // second one must not see a different sender.

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -8,26 +8,43 @@ namespace Nethermind.TxPool.Filters;
 
 /// <summary>
 /// Rejects an EIP-8141 frame transaction whose validation prefix and signature verification would cost more than
-/// <c>MAX_VERIFY_GAS</c> to check.
+/// <c>MAX_VERIFY_GAS</c> to check, or whose validation prefix budgets more than <c>MAX_VERIFY_STATE_GAS</c> of state gas.
 /// </summary>
 /// <remarks>
 /// A public-mempool DoS bound, not a validity rule: a block carrying such a transaction stays valid. Must run after
 /// <see cref="MalformedTxFilter"/>, which guarantees the frame list is well-formed. A configured limit of 0 lifts the
-/// bound, matching the other per-sender pool limits.
+/// respective bound, matching the other per-sender pool limits.
 /// </remarks>
 internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger logger) : IIncomingTxFilter
 {
     private readonly ulong _maxVerifyGas = txPoolConfig.FrameTxMaxVerifyGas;
+    private readonly ulong _maxVerifyStateGas = txPoolConfig.FrameTxMaxVerifyStateGas;
 
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        if (tx.SupportsFrames && _maxVerifyGas != 0)
+        if (!tx.SupportsFrames)
+        {
+            return AcceptTxResult.Accepted;
+        }
+
+        if (_maxVerifyGas != 0)
         {
             ulong verifyGas = FrameTxValidation.ValidationWorkGas(tx);
             if (verifyGas > _maxVerifyGas)
             {
                 Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;
                 if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, validation prefix costs {verifyGas} gas (max {_maxVerifyGas}).");
+                return AcceptTxResult.FrameTxVerifyGasTooHigh;
+            }
+        }
+
+        if (_maxVerifyStateGas != 0)
+        {
+            ulong verifyStateGas = FrameTxValidation.ValidationWorkStateGas(tx);
+            if (verifyStateGas > _maxVerifyStateGas)
+            {
+                Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;
+                if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, validation prefix budgets {verifyStateGas} state gas (max {_maxVerifyStateGas}).");
                 return AcceptTxResult.FrameTxVerifyGasTooHigh;
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -35,6 +35,9 @@ public interface ITxPoolConfig : IConfig
     [ConfigItem(DefaultValue = "100000", Description = "EIP-8141 `MAX_VERIFY_GAS`: the max gas a frame transaction's validation prefix and signature verification may cost for the transaction to be accepted into the public mempool. `0` to lift the limit. Raise it only on a test network.")]
     ulong FrameTxMaxVerifyGas { get; set; }
 
+    [ConfigItem(DefaultValue = "500000", Description = "EIP-8141 `MAX_VERIFY_STATE_GAS`: the max state gas a frame transaction's validation prefix may budget across its `limits.state` for the transaction to be accepted into the public mempool. `0` to lift the limit. Raise it only on a test network.")]
+    ulong FrameTxMaxVerifyStateGas { get; set; }
+
     [ConfigItem(DefaultValue = "16", Description = "The max number of pending blob transactions per single sender. `0` to lift the limit.")]
     int MaxPendingBlobTxsPerSender { get; set; }
 

--- a/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
@@ -19,6 +19,7 @@ public class TxPoolConfig : ITxPoolConfig
     public int InMemoryBlobPoolSize { get; set; } = 512; // it is used when persistent pool is disabled
     public int MaxPendingTxsPerSender { get; set; } = 0;
     public ulong FrameTxMaxVerifyGas { get; set; } = 100_000;
+    public ulong FrameTxMaxVerifyStateGas { get; set; } = 500_000;
     public int MaxPendingBlobTxsPerSender { get; set; } = 16;
     public int HashCacheSize { get; set; } = 512 * 1024;
     public ulong? GasLimit { get; set; } = null;


### PR DESCRIPTION
## What

Implements EIP-8141 two-dimensional frame gas `limits = [execution, state]` (ethereum/EIPs#12062) end to end, in one change: the field split plus the runtime semantics that give it meaning.

### Field split
- `TxFrame` carries `ExecutionGasLimit` and `StateGasLimit`; `GasLimit` stays as their sum for the combined budget (max-cost reservation, overflow checks).
- RLP encodes `limits` as a nested `[execution, state]` list; the decoder reads both.
- Static validation sums `execution + state` per frame with overflow guards; an expiry-verifier frame must keep `limits.state == 0`.
- Intrinsic/`standard_gas_limit` accounts for both dimensions.
- `FRAMEPARAM`: `0x01` returns `limits.execution`, new `0x09` returns `limits.state`.
- JSON-RPC exposes `executionGasLimit` / `stateGasLimit`.

### Runtime two-pool semantics
- Each frame is now rented with `gas_left = limits.execution` and its state-gas reservoir seeded from `limits.state`, so state work is drawn from the state dimension independently of the execution budget. Before this, a frame rented an empty reservoir and every state charge spilled into execution.
- The per-frame charge folded into the transaction total is execution gas used plus the reservoir-funded state gas. This equals `GetPreRefundGas(gas, execution + state)` on the success/revert path and `execution + state − unspent_reservoir` on an exceptional halt, mirroring the standard EIP-8037 halt formula (`gas_left` is burned; only the unspent reservoir escapes the charge).
- Because the folded charge still includes the state gas each frame used — whether reservoir-funded or spilled — the payer charge and the block state/regular split (`blockStateGas`, `CalculateBlockExecutionGas`) are unchanged. The change is behavioral only where a frame's state budget now lets it do state work its execution budget could not have absorbed.

### Public-mempool bound
- Adds `MAX_VERIFY_STATE_GAS` (default 500,000, config `FrameTxMaxVerifyStateGas`, `0` lifts it): the sum of the validation prefix's `limits.state` must not exceed it, enforced at ingress alongside `MAX_VERIFY_GAS`. State gas does not measure node validation work, so it stays out of the `MAX_VERIFY_GAS` budget.

## Testing

- New regression: a fresh-slot write with an execution budget too small to absorb its `SSetState` charge succeeds when `limits.state` covers it and bills the same state dimension; the negative control with `state = 0` spills into execution and halts out of gas, committing nothing.
- New regression: the `MAX_VERIFY_STATE_GAS` ingress bound (at, over, and behind a recognized prefix).
- Full frame + EIP-8037 suites green: Core 104, Evm 334, TxPool 57, Blockchain 145.

Behavior on the settlement and halt paths is consensus-affecting, so this is queued for the reproducible stand and a cross-client Kurtosis run before it leaves the family branch.

## Open question

The reference spec lists `FRAMEPARAM` `0x0A` / `0x0B` (`gas_used.execution` / `gas_used.state`) and a two-field frame receipt. Those are gas-used introspection rather than the limits split, and are not implemented here — should they land in this change or a follow-up? Happy to fold them in if you'd prefer one card.
