### PR TITLE
Fix flaky AssociativeCache retrievability test (hash-seed set skew)

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Caching/AssociativeCacheTestsBase.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/AssociativeCacheTestsBase.cs
@@ -156,9 +156,10 @@ public abstract class AssociativeCacheTestsBase
     {
         // Catches hash signature extraction bugs: if the signature is computed from
         // wrong bits, Get won't find keys that were just inserted (tag mismatch).
-        // Insert only 50% of capacity to avoid set-conflict eviction.
+        // Hashing is process-seeded, so key-to-set placement is arbitrary; cap inserts
+        // at one set's worth (8 ways) so no set can overflow and evict a fresh key.
         CreateCache(capacity);
-        int insertCount = Math.Min(capacity / 2, _keys.Length - 1);
+        int insertCount = Math.Min(capacity / 2, 8);
 
         for (int i = 0; i < insertCount; i++)
             Assert.That(Set(in _keys[i], i), Is.True);


### PR DESCRIPTION
## Changes

- Fixes flaky `AssociativeCacheTests.All_inserted_keys_retrievable_at_various_capacities(32)` (seen on [this run](https://github.com/NethermindEth/nethermind/actions/runs/31916916369/job/95091190998), PR #12834). Key hashing is process-seeded, so key-to-set placement is arbitrary per test run: at capacity 32 (4 sets × 8 ways) inserting 16 keys has a ~3% chance that some set receives more than 8 keys, which evicts a just-inserted key and fails the retrievability assertions.
- Cap the insert count at one set's worth (8 = `Ways`), so no hash distribution can overflow a set. The test's purpose — catching hash signature extraction bugs across different set counts — is unaffected, since a single mis-tagged key already fails the lookup.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: flaky test fix

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`All_inserted_keys_retrievable_at_various_capacities` re-run across multiple fresh processes (fresh hash seeds) locally — all green. With ≤8 inserts, set overflow is impossible regardless of seed.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
