### PR TITLE
Fix flaky witness-capture bytecode test (tx pool head sync)

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
@@ -707,6 +707,8 @@ public partial class EngineModuleTests
     {
         if (txs.Length > 0) chain.AddTransactions(txs);
         (ExecutionPayloadV4 payload, byte[][]? requests) = await BuildAmsterdamPayload(chain);
+        Assert.That(payload.Transactions, Has.Length.EqualTo(txs.Length),
+            "the built payload must contain exactly the submitted transactions");
         ResultWrapper<NewPayloadWithWitnessV1Result> result =
             await chain.EngineRpcModule.engine_newPayloadWithWitnessV5(payload, [], TestItem.KeccakE, requests ?? []);
 
@@ -721,14 +723,18 @@ public partial class EngineModuleTests
     {
         if (txs.Length > 0) chain.AddTransactions(txs);
         (ExecutionPayloadV4 payload, byte[][]? requests) = await BuildAmsterdamPayload(chain);
+        Assert.That(payload.Transactions, Has.Length.EqualTo(txs.Length),
+            "the built payload must contain exactly the submitted transactions");
         await chain.EngineRpcModule.engine_newPayloadV5(payload, [], TestItem.KeccakE, requests ?? []);
 
         Task txPoolHeadWait = Wait.ForEventCondition<Block>(chain.CancellationToken,
             h => chain.TxPool.TxPoolHeadChanged += h,
             h => chain.TxPool.TxPoolHeadChanged -= h,
             b => b.Hash == payload.BlockHash);
-        await chain.EngineRpcModule.engine_forkchoiceUpdatedV4(
+        ResultWrapper<ForkchoiceUpdatedV1Result> fcuResult = await chain.EngineRpcModule.engine_forkchoiceUpdatedV4(
             new ForkchoiceStateV1(payload.BlockHash!, payload.BlockHash!, payload.BlockHash!), null);
+        Assert.That(fcuResult.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid),
+            "the canonicalizing forkchoiceUpdated must succeed, otherwise the tx pool head wait would time out");
         await txPoolHeadWait;
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
@@ -723,9 +723,6 @@ public partial class EngineModuleTests
         (ExecutionPayloadV4 payload, byte[][]? requests) = await BuildAmsterdamPayload(chain);
         await chain.EngineRpcModule.engine_newPayloadV5(payload, [], TestItem.KeccakE, requests ?? []);
 
-        // The tx pool applies head changes asynchronously; wait for it to process this block so its txs
-        // are removed and follow-up txs (e.g. the sender's next nonce) are selectable for the next payload —
-        // otherwise a leftover tx can slip into the next produced block.
         Task txPoolHeadWait = Wait.ForEventCondition<Block>(chain.CancellationToken,
             h => chain.TxPool.TxPoolHeadChanged += h,
             h => chain.TxPool.TxPoolHeadChanged -= h,

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
@@ -14,6 +14,7 @@ using Nethermind.Consensus.Stateless;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Events;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm;
@@ -721,8 +722,17 @@ public partial class EngineModuleTests
         if (txs.Length > 0) chain.AddTransactions(txs);
         (ExecutionPayloadV4 payload, byte[][]? requests) = await BuildAmsterdamPayload(chain);
         await chain.EngineRpcModule.engine_newPayloadV5(payload, [], TestItem.KeccakE, requests ?? []);
+
+        // The tx pool applies head changes asynchronously; wait for it to process this block so its txs
+        // are removed and follow-up txs (e.g. the sender's next nonce) are selectable for the next payload —
+        // otherwise a leftover tx can slip into the next produced block.
+        Task txPoolHeadWait = Wait.ForEventCondition<Block>(chain.CancellationToken,
+            h => chain.TxPool.TxPoolHeadChanged += h,
+            h => chain.TxPool.TxPoolHeadChanged -= h,
+            b => b.Hash == payload.BlockHash);
         await chain.EngineRpcModule.engine_forkchoiceUpdatedV4(
             new ForkchoiceStateV1(payload.BlockHash!, payload.BlockHash!, payload.BlockHash!), null);
+        await txPoolHeadWait;
     }
 
     /// <summary>


### PR DESCRIPTION
## Changes

- Fixes flaky `EngineModuleTests.Witness_includes_bytecode_and_storage_proof_for_a_called_contract` (seen on [this run](https://github.com/NethermindEth/nethermind/actions/runs/31916916369/job/95091192467), PR #12834). The tx pool applies head changes asynchronously, so after `ProduceCanonicalBlock` returned, the pool could still hold a stale view of the sender while the next (witnessed) payload was being built, and a payload could be built without the expected transactions. The contract CREATE could then end up executing in the witnessed block instead of the canonical one — and `WitnessGeneratingWorldState` deliberately excludes in-block-deployed code from the witness (the verifier replays the CREATE), so the bytecode assertion failed even though the block was VALID.
- `ProduceCanonicalBlock` now waits for `TxPoolHeadChanged` for the canonicalized block before returning — the same synchronization `TestBlockchainUtil.AddBlock` uses ("Wait for tx new head event so that processed tx was removed from txpool").
- The helpers are now self-verifying: both assert the built payload contains exactly the submitted transactions, and `ProduceCanonicalBlock` asserts the canonicalizing `forkchoiceUpdated` returns `VALID` — so any recurrence fails fast at the cause instead of on the distant witness-content assertion or a 30 s head-wait timeout.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: flaky test fix

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Witness-capture suite run in both `Nethermind.Merge.Plugin.Test` and `Nethermind.Merge.AuRa.Test`, plus repeated runs of the affected test — all green.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No