### PR TITLE
test: load the frame transaction fixtures by mapping their fork name

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using Nethermind.Config;
 using Nethermind.Core;
@@ -364,6 +365,7 @@ namespace Ethereum.Test.Base
 
         private static readonly EthereumJsonSerializer _serializer = new();
         private static readonly ConcurrentDictionary<SpecOverrideCacheKey, IReleaseSpec> _overriddenSpecs = new();
+        private const string NeitherShapeMessage = "Fixture matches neither the standard nor the trimmed blockchain test shape.";
 
         public static IEnumerable<GeneralStateTest> ConvertStateTest(string json) =>
             ConvertStateTests(_serializer.Deserialize<Dictionary<string, GeneralStateTestJson>>(json));
@@ -417,29 +419,8 @@ namespace Ethereum.Test.Base
             return tests;
         }
 
-        private const string NeitherShapeMessage = "Fixture matches neither the standard nor the trimmed blockchain test shape.";
-
-        /// <remarks>Only deserialization falls back between shapes, so a conversion failure surfaces as itself.</remarks>
-        public static IEnumerable<BlockchainTest> ConvertToBlockchainTests(string json)
-        {
-            Dictionary<string, BlockchainTestJson> tests;
-            try
-            {
-                tests = _serializer.Deserialize<Dictionary<string, BlockchainTestJson>>(json);
-            }
-            catch (Exception standardShapeException)
-            {
-                try
-                {
-                    tests = CoerceFromHalf(_serializer.Deserialize<Dictionary<string, HalfBlockchainTestJson>>(json));
-                }
-                catch (Exception trimmedShapeException)
-                {
-                    throw new AggregateException(NeitherShapeMessage, standardShapeException, trimmedShapeException);
-                }
-            }
-            return ConvertToBlockchainTests(tests);
-        }
+        public static IEnumerable<BlockchainTest> ConvertToBlockchainTests(string json) =>
+            ConvertToBlockchainTests(Encoding.UTF8.GetBytes(json));
 
         /// <remarks>Only deserialization falls back between shapes, so a conversion failure surfaces as itself.</remarks>
         public static IEnumerable<BlockchainTest> ConvertToBlockchainTests(ReadOnlySpan<byte> json)

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -417,21 +417,49 @@ namespace Ethereum.Test.Base
             return tests;
         }
 
-        // The shape fallback deliberately wraps deserialization only: letting it span conversion
-        // made an unmapped fork name resurface as an unrelated error against the trimmed shape.
+        private const string NeitherShapeMessage = "Fixture matches neither the standard nor the trimmed blockchain test shape.";
+
+        /// <remarks>Only deserialization falls back between shapes, so a conversion failure surfaces as itself.</remarks>
         public static IEnumerable<BlockchainTest> ConvertToBlockchainTests(string json)
         {
             Dictionary<string, BlockchainTestJson> tests;
-            try { tests = _serializer.Deserialize<Dictionary<string, BlockchainTestJson>>(json); }
-            catch (Exception) { tests = CoerceFromHalf(_serializer.Deserialize<Dictionary<string, HalfBlockchainTestJson>>(json)); }
+            try
+            {
+                tests = _serializer.Deserialize<Dictionary<string, BlockchainTestJson>>(json);
+            }
+            catch (Exception standardShapeException)
+            {
+                try
+                {
+                    tests = CoerceFromHalf(_serializer.Deserialize<Dictionary<string, HalfBlockchainTestJson>>(json));
+                }
+                catch (Exception trimmedShapeException)
+                {
+                    throw new AggregateException(NeitherShapeMessage, standardShapeException, trimmedShapeException);
+                }
+            }
             return ConvertToBlockchainTests(tests);
         }
 
+        /// <remarks>Only deserialization falls back between shapes, so a conversion failure surfaces as itself.</remarks>
         public static IEnumerable<BlockchainTest> ConvertToBlockchainTests(ReadOnlySpan<byte> json)
         {
             Dictionary<string, BlockchainTestJson> tests;
-            try { tests = _serializer.Deserialize<Dictionary<string, BlockchainTestJson>>(json); }
-            catch (Exception) { tests = CoerceFromHalf(_serializer.Deserialize<Dictionary<string, HalfBlockchainTestJson>>(json)); }
+            try
+            {
+                tests = _serializer.Deserialize<Dictionary<string, BlockchainTestJson>>(json);
+            }
+            catch (Exception standardShapeException)
+            {
+                try
+                {
+                    tests = CoerceFromHalf(_serializer.Deserialize<Dictionary<string, HalfBlockchainTestJson>>(json));
+                }
+                catch (Exception trimmedShapeException)
+                {
+                    throw new AggregateException(NeitherShapeMessage, standardShapeException, trimmedShapeException);
+                }
+            }
             return ConvertToBlockchainTests(tests);
         }
 

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -417,16 +417,22 @@ namespace Ethereum.Test.Base
             return tests;
         }
 
+        // The shape fallback deliberately wraps deserialization only: letting it span conversion
+        // made an unmapped fork name resurface as an unrelated error against the trimmed shape.
         public static IEnumerable<BlockchainTest> ConvertToBlockchainTests(string json)
         {
-            try { return ConvertToBlockchainTests(_serializer.Deserialize<Dictionary<string, BlockchainTestJson>>(json)); }
-            catch (Exception) { return ConvertToBlockchainTests(CoerceFromHalf(_serializer.Deserialize<Dictionary<string, HalfBlockchainTestJson>>(json))); }
+            Dictionary<string, BlockchainTestJson> tests;
+            try { tests = _serializer.Deserialize<Dictionary<string, BlockchainTestJson>>(json); }
+            catch (Exception) { tests = CoerceFromHalf(_serializer.Deserialize<Dictionary<string, HalfBlockchainTestJson>>(json)); }
+            return ConvertToBlockchainTests(tests);
         }
 
         public static IEnumerable<BlockchainTest> ConvertToBlockchainTests(ReadOnlySpan<byte> json)
         {
-            try { return ConvertToBlockchainTests(_serializer.Deserialize<Dictionary<string, BlockchainTestJson>>(json)); }
-            catch (Exception) { return ConvertToBlockchainTests(CoerceFromHalf(_serializer.Deserialize<Dictionary<string, HalfBlockchainTestJson>>(json))); }
+            Dictionary<string, BlockchainTestJson> tests;
+            try { tests = _serializer.Deserialize<Dictionary<string, BlockchainTestJson>>(json); }
+            catch (Exception) { tests = CoerceFromHalf(_serializer.Deserialize<Dictionary<string, HalfBlockchainTestJson>>(json)); }
+            return ConvertToBlockchainTests(tests);
         }
 
         // Some BAL fixtures use the trimmed HalfBlockchainTestJson shape; coerce on demand.

--- a/src/Nethermind/Nethermind.Specs.Test/SpecNameParserTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/SpecNameParserTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Nethermind.Core.Specs;
+using Nethermind.Specs.Forks;
 using NUnit.Framework;
 
 namespace Nethermind.Specs.Test;
@@ -14,14 +15,16 @@ public class SpecNameParserTests
     {
         IReleaseSpec spec = SpecNameParser.Parse("Bogota");
 
-        Assert.That(spec.IsEip8141Enabled, Is.True);
+        Assert.That(spec, Is.SameAs(Bogota.Instance));
     }
 
-    [Test]
-    public void Parse_names_the_offending_fork_when_unmapped()
+    [TestCase("NotAFork", "NotAFork")]
+    [TestCase("Merge+9999", "Paris+9999")]
+    public void Parse_names_the_offending_fork_when_unmapped(string specName, string resolvedSpecName)
     {
-        NotSupportedException e = Assert.Throws<NotSupportedException>(() => SpecNameParser.Parse("NotAFork"));
+        NotSupportedException e = Assert.Throws<NotSupportedException>(() => SpecNameParser.Parse(specName))!;
 
-        Assert.That(e.Message, Does.Contain("NotAFork"));
+        Assert.That(e.Message, Does.Contain(specName));
+        Assert.That(e.Message, Does.Contain(resolvedSpecName));
     }
 }

--- a/src/Nethermind/Nethermind.Specs.Test/SpecNameParserTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/SpecNameParserTests.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Specs;
+using NUnit.Framework;
+
+namespace Nethermind.Specs.Test;
+
+public class SpecNameParserTests
+{
+    [Test]
+    public void Parse_maps_Bogota_to_the_frame_transactions_fork()
+    {
+        IReleaseSpec spec = SpecNameParser.Parse("Bogota");
+
+        Assert.That(spec.IsEip8141Enabled, Is.True);
+    }
+
+    [Test]
+    public void Parse_names_the_offending_fork_when_unmapped()
+    {
+        NotSupportedException e = Assert.Throws<NotSupportedException>(() => SpecNameParser.Parse("NotAFork"));
+
+        Assert.That(e.Message, Does.Contain("NotAFork"));
+    }
+}

--- a/src/Nethermind/Nethermind.Specs/SpecNameParser.cs
+++ b/src/Nethermind/Nethermind.Specs/SpecNameParser.cs
@@ -62,7 +62,8 @@ namespace Nethermind.Specs
                 "BPO4" => BPO4.Instance,
                 "BPO5" => BPO5.Instance,
                 "Amsterdam" => Amsterdam.Instance,
-                _ => throw new NotSupportedException()
+                "Bogota" => Bogota.Instance,
+                _ => throw new NotSupportedException($"Unknown fork name '{specName}'")
             };
         }
     }

--- a/src/Nethermind/Nethermind.Specs/SpecNameParser.cs
+++ b/src/Nethermind/Nethermind.Specs/SpecNameParser.cs
@@ -63,7 +63,9 @@ namespace Nethermind.Specs
                 "BPO5" => BPO5.Instance,
                 "Amsterdam" => Amsterdam.Instance,
                 "Bogota" => Bogota.Instance,
-                _ => throw new NotSupportedException($"Unknown fork name '{specName}'")
+                _ => throw new NotSupportedException(specName == unambiguousSpecName
+                    ? $"Unknown fork name '{specName}'"
+                    : $"Unknown fork name '{specName}' (resolved to '{unambiguousSpecName}')")
             };
         }
     }


### PR DESCRIPTION
## Changes

- Map `Bogota` in `SpecNameParser`, so the EIP-8141 fixture suites — which declare that network — load instead of failing every file.
- Narrow the `HalfBlockchainTestJson` shape fallback in `ConvertToBlockchainTests` to deserialization only. It previously wrapped conversion too, so an unmapped fork name was reported as an unrelated `Hash256` conversion error against the trimmed shape rather than as itself. A fixture matching neither shape now surfaces both causes instead of discarding the standard-shape one.
- Name the offending fork in the `NotSupportedException` instead of throwing it bare.

Before this change the whole suite failed to load; after it, all 159 blockchain cases load and execute.

Fixtures come from the `tests-frames-devnet@v0.0.0` release (`fixtures_frames-devnet.tar.gz`). Note that EIP-8141 merged to the `eips/amsterdam/eip-8141` branch rather than master, and the pyspec `DEFAULT_ARCHIVE_VERSION` pin contains none of these tests, so wiring this into CI needs a second archive pin.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`SpecNameParserTests` covers both the mapping and the exception message. Both assertions were revert-checked: removing the mapping and restoring the bare throw fails them.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

### The state-test path does not gate anything — do not wire it into CI

`TransactionJson` has no `frames`/`signatures` fields, so a frame transaction cannot be represented in a state-test fixture. The 40 EIP-8141 state-test files therefore load to **zero cases**, and the runner **exits 0**. Anything that runs that path today reports a pass while asserting nothing. Only the blockchain-test path, which decodes block RLP and so exercises the real frame decoder, is meaningful. Supporting state tests means adding the frame fields to the loader; until then that path should be treated as unwired, not as green.

### Loading is only half the story

This branch composes `Bogota` on Osaka, whereas the fixtures compose it on Amsterdam, so 96 of the 159 cases are still rejected at `BlockLevelAccessListHashNotEnabled` before they execute. That fork-composition question is deliberately left open here.

### Frame targets under EIP-7702 delegation

With `Bogota` composed on Amsterdam for measurement, the delegated-target cases fail on every branch tried, including one carrying devnet-8 gas and the frame entry charge. `ExecuteFrame` resolves the target's code with

```csharp
CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, spec, out _);
```

which follows the delegation for code but discards the delegation address, so the delegation target's access cost is never charged. Affects `test_delegated_target_entry_charge` (cold and warm), `test_delegated_to_precompile_target` and `test_verify_frame_delegated_to_precompile_target`.
