### PR TITLE
EIP-8141: charge a frame's entry gas and its target's delegation access

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1491,6 +1491,79 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_FrameGasBelowItsTargetAccess_LeavesTheTargetOutOfTheBal()
+    {
+        // EIP-7928: the deadness query behind a value transfer is itself a recorded read, so it has to
+        // sit behind the access charge or an unaffordable frame writes its target into the list anyway.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+
+        (EthereumTransactionProcessor tracedProcessor, TracedAccessWorldState tracedState) = TracedProcessor();
+
+        TxFrame frame = new(TxFrame.ModeSender, flags: 0, Recipient,
+            gasLimit: Eip8038Constants.ColdAccountAccess - 1, value: 1, default);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), frame);
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+
+        Assert.That(tracedProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance).TransactionExecuted, Is.True);
+
+        BlockAccessListAtIndex bal = tracedState.GetGeneratingBlockAccessList()!;
+        Assert.That(bal.GetAccountChanges(Recipient), Is.Null,
+            "a frame that cannot pay its target's access must not read the target");
+    }
+
+    [Test]
+    public void Execute_FrameTargetDesignatesItself_HaltsOnTheDesignatorBytes()
+    {
+        // Designations are resolved once, so the frame ends up executing the designator itself.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. Observer.Bytes]);
+
+        TxFrame frame = Frame(TxFrame.ModeDefault, target: Observer);
+        FrameReceiptTracer tracer = new();
+
+        Assert.That(Process(FrameTx(nonce: 0, SelfVerifyFrame(), frame), tracer: tracer).TransactionExecuted, Is.True);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
+            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(frame.GasLimit),
+                "the halt consumes the frame's whole gas limit whatever its designation access cost");
+        }
+    }
+
+    [Test]
+    public void Execute_TwoFramesShareATarget_ChargesColdAccessAgainOnlyWhenTheFirstReverted()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        DeployContract(Observer, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        FrameReceiptTracer succeeding = new();
+        Assert.That(Process(FrameTx(nonce: 0, SelfVerifyFrame(),
+            Frame(TxFrame.ModeDefault, target: Recipient), Frame(TxFrame.ModeDefault, target: Recipient)),
+            tracer: succeeding).TransactionExecuted, Is.True);
+
+        FrameReceiptTracer reverting = new();
+        Assert.That(Process(FrameTx(nonce: 1, SelfVerifyFrame(),
+            Frame(TxFrame.ModeDefault, target: Observer), Frame(TxFrame.ModeDefault, target: Observer)),
+            tracer: reverting).TransactionExecuted, Is.True);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(succeeding.FrameReceipts![1].GasUsed, Is.EqualTo(Eip8038Constants.ColdAccountAccess),
+                "the first frame finds its target cold");
+            Assert.That(succeeding.FrameReceipts[2].GasUsed, Is.EqualTo(Eip8038Constants.WarmAccess),
+                "the shared journal carries the warm touch into the next frame");
+            Assert.That(reverting.FrameReceipts![2].GasUsed, Is.EqualTo(reverting.FrameReceipts[1].GasUsed),
+                "a reverting frame rolls its warm touch back, so the next frame pays cold again");
+        }
+    }
+
+    [Test]
     public void Execute_FrameGasBelowItsEntryCharge_FailsConsumingTheWholeFrameLimit()
     {
         // create_evm_from_frame raises instead of building the EVM, so the frame halts exceptionally.
@@ -1509,6 +1582,97 @@ public class FrameTxProcessorTests
             Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(Eip8038Constants.ColdAccountAccess - 1),
                 "a frame failing at entry consumes its whole gas limit");
         }
+    }
+
+    [TestCase(false, TestName = "Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess(contract designation)")]
+    [TestCase(true, TestName = "Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess(precompile designation)")]
+    public void Execute_FrameTargetingDelegatedAccount_PaysTheDelegateAccess(bool designatePrecompile)
+    {
+        // resolve_delegated_code_address charges the designated address's access on top of the target's own.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        Address designated = designatePrecompile ? IdentityPrecompile.Address : Recipient;
+        DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. designated.Bytes]);
+
+        ulong expected = designatePrecompile ? Eip8038Constants.WarmAccess : Eip8038Constants.ColdAccountAccess;
+
+        Assert.That(EntryGasDelta(Observer, Recipient), Is.EqualTo((long)expected),
+            "resolving the designation must charge the access of the designated address");
+    }
+
+    [Test]
+    public void Execute_FrameGasCoveringOnlyTheTargetAccess_FailsOnTheDelegateAccess()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. Recipient.Bytes]);
+
+        TxFrame frame = new(TxFrame.ModeDefault, flags: 0, Observer,
+            gasLimit: Eip8038Constants.ColdAccountAccess, UInt256.Zero, default);
+        FrameReceiptTracer tracer = new();
+
+        Assert.That(Process(FrameTx(nonce: 0, SelfVerifyFrame(), frame), tracer: tracer).TransactionExecuted, Is.True);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure),
+                "gas covering only the target access must not reach the designated code");
+            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(Eip8038Constants.ColdAccountAccess),
+                "a frame failing at entry consumes its whole gas limit");
+        }
+    }
+
+    [Test]
+    public void Execute_FrameGasCoveringOnlyTheTargetAccess_LeavesTheDesignatedAccountOutOfTheBal()
+    {
+        // EIP-7928: the designated code is read only once its access is paid for.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. Recipient.Bytes]);
+
+        (EthereumTransactionProcessor tracedProcessor, TracedAccessWorldState tracedState) = TracedProcessor();
+
+        TxFrame frame = new(TxFrame.ModeDefault, flags: 0, Observer,
+            gasLimit: Eip8038Constants.ColdAccountAccess, UInt256.Zero, default);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), frame);
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+
+        Assert.That(tracedProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance).TransactionExecuted, Is.True);
+
+        BlockAccessListAtIndex bal = tracedState.GetGeneratingBlockAccessList()!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(bal.GetAccountChanges(Observer), Is.Not.Null, "the target is read to find the designation");
+            Assert.That(bal.GetAccountChanges(Recipient), Is.Null,
+                "a frame that cannot pay the designation access must not read the designated account");
+        }
+    }
+
+    [Test]
+    public void Execute_FrameTargetDesignatesAPrecompile_RecordsThePrecompileInTheBal()
+    {
+        // EIP-7928: the precompile branch asks the repository for nothing, so only the explicit read records it.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, [.. Eip7702Constants.DelegationHeader, .. IdentityPrecompile.Address.Bytes]);
+
+        (EthereumTransactionProcessor tracedProcessor, TracedAccessWorldState tracedState) = TracedProcessor();
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+
+        Assert.That(tracedProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance).TransactionExecuted, Is.True);
+
+        BlockAccessListAtIndex bal = tracedState.GetGeneratingBlockAccessList()!;
+        Assert.That(bal.GetAccountChanges(IdentityPrecompile.Address), Is.Not.Null,
+            "resolving a designation accesses the designated precompile");
     }
 
     private sealed class FrameReceiptTracer : CallOutputTracer, IFrameTxReceiptTracer
@@ -1530,6 +1694,17 @@ public class FrameTxProcessorTests
             tracer: baselineTracer).TransactionExecuted, Is.True);
 
         return (long)targetTracer.GasSpent - (long)baselineTracer.GasSpent;
+    }
+
+    /// <summary>A processor over a <see cref="TracedAccessWorldState"/> that generates a block access list.</summary>
+    private (EthereumTransactionProcessor Processor, TracedAccessWorldState State) TracedProcessor()
+    {
+        TracedAccessWorldState tracedState = new(_stateProvider, parallel: false);
+        tracedState.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
+        EthereumCodeInfoRepository codeInfoRepository = new(tracedState);
+        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        return (new EthereumTransactionProcessor(BlobBaseFeeCalculator.Instance, _specProvider, tracedState,
+            virtualMachine, codeInfoRepository, LimboLogs.Instance), tracedState);
     }
 
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null, ulong? slotNumber = null)

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1376,12 +1376,12 @@ public class FrameTxProcessorTests
     }
 
     /// <summary>A frame whose resolved target is a precompile executes the precompile.</summary>
-    /// <remarks>A frame pays no entry cost on this branch, so the identity gas is the whole figure.</remarks>
+    /// <remarks>The frame pays warm entry access on top, precompiles being pre-warmed by EIP-2929.</remarks>
     [TestCase(TxFrame.ModeDefault, 1, 18UL, TestName = "Execute_FrameTargetsPrecompile_RunsIt(DEFAULT, one byte)")]
     [TestCase(TxFrame.ModeDefault, 64, 21UL, TestName = "Execute_FrameTargetsPrecompile_RunsIt(DEFAULT, two words)")]
     [TestCase(TxFrame.ModeSender, 1, 18UL, TestName = "Execute_FrameTargetsPrecompile_RunsIt(SENDER)")]
     [TestCase(TxFrame.ModePostTx, 1, 18UL, TestName = "Execute_FrameTargetsPrecompile_RunsIt(POST_TX)")]
-    public void Execute_FrameTargetsPrecompile_RunsIt(byte mode, int dataLength, ulong expectedGas)
+    public void Execute_FrameTargetsPrecompile_RunsIt(byte mode, int dataLength, ulong identityGas)
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         byte[] data = new byte[dataLength];
@@ -1395,7 +1395,8 @@ public class FrameTxProcessorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess));
-            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(expectedGas), "the frame must be charged for the precompile it ran");
+            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(identityGas + Eip8038Constants.WarmAccess),
+                "the frame must be charged for the precompile it ran, plus its warm entry access");
         }
     }
 
@@ -1415,7 +1416,10 @@ public class FrameTxProcessorTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(tracer.FrameReceipts![1].GasUsed, Is.EqualTo(18UL), "the frame must be charged for the precompile it ran");
+            // The precompile account is not alive, so the transfer also pays the NEW_ACCOUNT state cost.
+            Assert.That(tracer.FrameReceipts![1].GasUsed,
+                Is.EqualTo(18UL + Eip8038Constants.WarmAccess + (ulong)GasCostOf.NewAccountState),
+                "the frame must be charged for the precompile it ran, plus its entry charge");
             Assert.That(_stateProvider.GetBalance(IdentityPrecompile.Address), Is.EqualTo(value), "the value must reach the target");
             Assert.That(tracer.FrameReceipts[1].Logs, Has.Length.EqualTo(1), "the EIP-7708 transfer log must land in the frame receipt");
         }
@@ -1471,11 +1475,61 @@ public class FrameTxProcessorTests
         }
     }
 
+    [Test]
+    public void Execute_FrameTargetIsAPrecompile_PaysWarmEntryAccessWhereAColdAccountPaysCold()
+    {
+        // create_evm_from_frame charges the target's access; EIP-2929 pre-warms every precompile.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        // The baseline still runs the precompile over its empty input, which the STOP target does not.
+        long identityBaseGas = (long)IdentityPrecompile.Instance.BaseGasCost(Spec);
+
+        Assert.That(EntryGasDelta(Recipient, IdentityPrecompile.Address) + identityBaseGas,
+            Is.EqualTo((long)(Eip8038Constants.ColdAccountAccess - Eip8038Constants.WarmAccess)),
+            "a cold account target must pay cold entry access where a precompile pays warm");
+    }
+
+    [Test]
+    public void Execute_FrameGasBelowItsEntryCharge_FailsConsumingTheWholeFrameLimit()
+    {
+        // create_evm_from_frame raises instead of building the EVM, so the frame halts exceptionally.
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        TxFrame frame = new(TxFrame.ModeDefault, flags: 0, Recipient,
+            gasLimit: Eip8038Constants.ColdAccountAccess - 1, UInt256.Zero, default);
+        FrameReceiptTracer tracer = new();
+
+        Assert.That(Process(FrameTx(nonce: 0, SelfVerifyFrame(), frame), tracer: tracer).TransactionExecuted, Is.True);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
+            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(Eip8038Constants.ColdAccountAccess - 1),
+                "a frame failing at entry consumes its whole gas limit");
+        }
+    }
+
     private sealed class FrameReceiptTracer : CallOutputTracer, IFrameTxReceiptTracer
     {
         public TxFrameReceipt[]? FrameReceipts { get; private set; }
 
         public void ReportFrameTxReceipt(Address payer, TxFrameReceipt[] frameReceipts) => FrameReceipts = frameReceipts;
+    }
+
+    /// <summary>Difference in frame gas between two <c>DEFAULT</c> frames, isolating their entry charges.</summary>
+    private long EntryGasDelta(Address target, Address baseline)
+    {
+        CallOutputTracer targetTracer = new();
+        Assert.That(Process(FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: target)),
+            tracer: targetTracer).TransactionExecuted, Is.True);
+
+        CallOutputTracer baselineTracer = new();
+        Assert.That(Process(FrameTx(nonce: 1, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: baseline)),
+            tracer: baselineTracer).TransactionExecuted, Is.True);
+
+        return (long)targetTracer.GasSpent - (long)baselineTracer.GasSpent;
     }
 
     private TransactionResult Process(Transaction tx, UInt256 baseFeePerGas = default, ITxTracer? tracer = null, ulong? slotNumber = null)
@@ -1926,10 +1980,9 @@ public class FrameTxProcessorTests
     /// An empty reference list is a different envelope from an absent one and still occupies the single
     /// byte <c>0xc0</c> on the wire, so it is priced: EIP-8272 short-circuits the per-reference term at
     /// zero references, not the calldata term over <c>rlp(recent_root_references)</c>, which enters the
-    /// EIP-7623/7976 floor at the same per-byte rate as frame and signature data. The absent baseline is
-    /// standard-bound, so it spends its frame execution above its floor; the empty envelope is floor-bound,
-    /// so that headroom is subsumed. The extra gas is therefore the floor charge for the added byte less
-    /// the baseline's headroom over its own floor.
+    /// EIP-7623/7976 floor at the same per-byte rate as frame and signature data. Both envelopes clear
+    /// their floors once the frame entry charge is counted, so the extra gas is the standard calldata
+    /// charge for the added byte rather than its floor charge.
     /// </remarks>
     [Test]
     public void Execute_EmptyRecentRootReferenceList_IsPricedAsTheBytesItAdds()
@@ -1946,11 +1999,8 @@ public class FrameTxProcessorTests
         Assert.That(Process(absent, tracer: absentTracer).TransactionExecuted, Is.True);
 
         (int zeroBytes, int nonZeroBytes) = empty.ReferenceCalldataStats;
-        ulong referenceFloorCharge = ((ulong)zeroBytes + (ulong)nonZeroBytes * Spec.GasCosts.TxDataNonZeroMultiplier)
-            * Spec.GasCosts.TotalCostFloorPerToken;
-        FrameTxValidation.TryCalculateGasBudget(absent, Spec, out _, out ulong absentFloor, out _);
-        ulong baselineHeadroom = absentTracer.GasSpent - absentFloor;
-        Assert.That(emptyTracer.GasSpent - absentTracer.GasSpent, Is.EqualTo(referenceFloorCharge - baselineHeadroom));
+        ulong referenceTokens = (ulong)zeroBytes + (ulong)nonZeroBytes * Spec.GasCosts.TxDataNonZeroMultiplier;
+        Assert.That(emptyTracer.GasSpent - absentTracer.GasSpent, Is.EqualTo(referenceTokens * GasCostOf.TxDataZero));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -245,14 +245,15 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         // WarmUp first so the warm path skips IsPrecompile; precompiles are pre-warmed at tx start.
         return (accessTracker.WarmUp(address) && !spec.IsPrecompile(address)) switch
         {
-            true => UpdateGas(ref gas, ColdAccountAccessCost(spec)),
+            true => UpdateGas(ref gas, GetColdAccountAccessCost(spec)),
             false when kind == AccountAccessKind.SelfDestructBeneficiary => true,
             false => UpdateGas(ref gas, GasCostOf.WarmStateRead)
         };
     }
 
+    /// <inheritdoc cref="IGasPolicy{TSelf}.GetColdAccountAccessCost"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static ulong ColdAccountAccessCost(IReleaseSpec spec) =>
+    public static ulong GetColdAccountAccessCost(IReleaseSpec spec) =>
         spec.IsEip8038Enabled ? Eip8038Constants.ColdAccountAccess : GasCostOf.ColdAccountAccess;
 
     public static bool ConsumeStorageAccessGas(ref EthereumGasPolicy gas,
@@ -682,7 +683,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         // Self-transfers coalesce into the sender leaf write already priced into TX_BASE_COST.
         if (tx.SenderAddress == tx.To) return 0;
 
-        ulong cost = ColdAccountAccessCost(spec);
+        ulong cost = GetColdAccountAccessCost(spec);
         if (hasValue)
             cost += GasCostOf.TransferLogEip2780 + GasCostOf.TxValueCostEip2780;
 

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -24,6 +24,9 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     static abstract ulong GetRemainingGas(in TSelf gas);
 
+    /// <summary>Cold account-access cost (EIP-2929), repriced by EIP-8038.</summary>
+    static abstract ulong GetColdAccountAccessCost(IReleaseSpec spec);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong CombineBlockGas(ulong blockExecutionGas, ulong blockStateGas) => Math.Max(blockExecutionGas, blockStateGas);
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -561,26 +561,57 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return ExecuteDefaultVerifyCode(frame, resolvedTarget, frameContext, tracer, out gasUsed);
         }
 
-        // create_evm_from_frame: the frame pays cold/warm target access plus the EIP-8037 NEW_ACCOUNT
-        // state cost of a value transfer reviving a dead target, from its own gas limit.
-        // EIP-2929 seeds the accessed set with every precompile, which the shared tracker does not hold.
+        // create_evm_from_frame: the frame pays its target's access, plus the state cost of a value
+        // transfer reviving a dead target, out of its own gas limit. Precompiles are checked explicitly
+        // because EIP-2929 pre-warms them without the shared tracker holding them.
         ulong entryExecution = spec.UseHotAndColdStorage
             ? (accessTracker.IsCold(resolvedTarget) && !spec.IsPrecompile(resolvedTarget)
                 ? TGasPolicy.GetColdAccountAccessCost(spec)
                 : Eip8038Constants.WarmAccess)
             : 0;
+        // Checked before the deadness query below, which is itself a recorded read: a frame that cannot
+        // afford its target's access must leave the target untouched, as the CALL path does.
+        if (entryExecution > frame.GasLimit)
+        {
+            gasUsed = frame.GasLimit;
+            return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+        }
+
+        // The revival charge has no pre-EIP-8037 form here: EIP-8141 is only composed onto specs carrying it.
         long entryState = spec.IsEip8037Enabled && !value.IsZero && WorldState.IsDeadAccount(resolvedTarget)
             ? TGasPolicy.GetNewAccountStateCost()
             : 0;
         ulong entryCharge = entryExecution + (ulong)entryState;
-        // An entry charge the frame cannot afford halts it exceptionally, consuming its whole gas limit.
         if (entryCharge > frame.GasLimit)
         {
             gasUsed = frame.GasLimit;
             return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
         }
 
-        CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, spec, out _);
+        CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, followDelegation: false, spec, out Address? delegation);
+        if (delegation is not null)
+        {
+            // resolve_delegated_code_address: the target counts as accessed by now, so a self-designation is warm.
+            if (spec.UseHotAndColdStorage)
+            {
+                entryCharge += delegation != resolvedTarget && accessTracker.IsCold(delegation) && !spec.IsPrecompile(delegation)
+                    ? TGasPolicy.GetColdAccountAccessCost(spec)
+                    : Eip8038Constants.WarmAccess;
+                if (entryCharge > frame.GasLimit)
+                {
+                    gasUsed = frame.GasLimit;
+                    return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+                }
+            }
+
+            // create_evm_from_frame reads the designated code only after its access is paid for.
+            // EIP-7702: a precompile must not execute via delegation.
+            WorldState.AddAccountRead(delegation);
+            codeInfo = spec.IsPrecompile(delegation)
+                ? CodeInfo.Empty
+                : _codeInfoRepository.GetCachedCodeInfoNoDelegation(delegation, spec);
+        }
+
         ReadOnlyMemory<byte> inputData = frame.Data;
 
         // VmState.Dispose releases its environment only below the top level, so this one is caller-owned;
@@ -609,6 +640,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         if (spec.UseHotAndColdStorage)
         {
             frameTracker.WarmUp(resolvedTarget);
+            if (delegation is not null) frameTracker.WarmUp(delegation);
         }
 
         // The reservoir starts empty, so the VM cannot draw the entry state gas back out of it.
@@ -629,10 +661,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         ulong remainingGas = substate.IsError ? 0 : TGasPolicy.GetRemainingGas(in state.Gas);
         gasUsed = frame.GasLimit - remainingGas;
         // Clamp rather than assert: unlike the standard path, this also runs for reverted or errored
-        // frames, where the state-gas value carries no non-negativity guarantee.
-        // A reverted or halted frame rolls the revival back, so its entry state gas commits nothing.
-        stateGasUsed = Math.Max(0, TGasPolicy.GetStateGasUsed(in state.Gas))
-            + (substate.ShouldRevert || substate.IsError ? 0 : entryState);
+        // frames, where the state-gas value carries no non-negativity guarantee. The caller discards it
+        // unless the frame succeeded, so the entry state gas is added unconditionally.
+        stateGasUsed = Math.Max(0, TGasPolicy.GetStateGasUsed(in state.Gas)) + entryState;
 
         if (substate.ShouldRevert || substate.IsError)
         {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -561,8 +561,25 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return ExecuteDefaultVerifyCode(frame, resolvedTarget, frameContext, tracer, out gasUsed);
         }
 
-        // EIP8141: create_evm_from_frame charges the target's access and any value transfer reviving it
-        // from the frame's own gas. That entry charge is pending branch-wide, so every frame here is short by it.
+        // create_evm_from_frame: the frame pays cold/warm target access plus the EIP-8037 NEW_ACCOUNT
+        // state cost of a value transfer reviving a dead target, from its own gas limit.
+        // EIP-2929 seeds the accessed set with every precompile, which the shared tracker does not hold.
+        ulong entryExecution = spec.UseHotAndColdStorage
+            ? (accessTracker.IsCold(resolvedTarget) && !spec.IsPrecompile(resolvedTarget)
+                ? TGasPolicy.GetColdAccountAccessCost(spec)
+                : Eip8038Constants.WarmAccess)
+            : 0;
+        long entryState = spec.IsEip8037Enabled && !value.IsZero && WorldState.IsDeadAccount(resolvedTarget)
+            ? TGasPolicy.GetNewAccountStateCost()
+            : 0;
+        ulong entryCharge = entryExecution + (ulong)entryState;
+        // An entry charge the frame cannot afford halts it exceptionally, consuming its whole gas limit.
+        if (entryCharge > frame.GasLimit)
+        {
+            gasUsed = frame.GasLimit;
+            return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+        }
+
         CodeInfo codeInfo = _codeInfoRepository.GetCachedCodeInfo(resolvedTarget, spec, out _);
         ReadOnlyMemory<byte> inputData = frame.Data;
 
@@ -594,8 +611,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             frameTracker.WarmUp(resolvedTarget);
         }
 
+        // The reservoir starts empty, so the VM cannot draw the entry state gas back out of it.
         using VmState<TGasPolicy> state = VmState<TGasPolicy>.RentTopLevel(
-            TGasPolicy.FromULong(frame.GasLimit),
+            TGasPolicy.FromULong(frame.GasLimit - entryCharge),
             isStatic ? ExecutionType.STATICCALL : ExecutionType.TRANSACTION,
             env,
             in frameTracker,
@@ -612,7 +630,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         gasUsed = frame.GasLimit - remainingGas;
         // Clamp rather than assert: unlike the standard path, this also runs for reverted or errored
         // frames, where the state-gas value carries no non-negativity guarantee.
-        stateGasUsed = Math.Max(0, TGasPolicy.GetStateGasUsed(in state.Gas));
+        // A reverted or halted frame rolls the revival back, so its entry state gas commits nothing.
+        stateGasUsed = Math.Max(0, TGasPolicy.GetStateGasUsed(in state.Gas))
+            + (substate.ShouldRevert || substate.IsError ? 0 : entryState);
 
         if (substate.ShouldRevert || substate.IsError)
         {


### PR DESCRIPTION
## Changes

Two consecutive gaps on the EIP-8141 frame execution path, both in `create_evm_from_frame`:

- **Frame entry gas** (was pending branch-wide, and the code said so). Every frame now pays, from its own gas limit, cold or warm access for its resolved target, plus the EIP-8037 `NEW_ACCOUNT` state cost when a value transfer revives a dead target. EIP-2929 seeds the accessed set with every precompile, which the shared frame tracker does not hold, so a precompile target pays warm. A charge the frame cannot afford halts it exceptionally, consuming its whole gas limit; a caller that cannot fund the value transfer still reverts before the charge, consuming nothing.
- **Delegation access.** A frame whose target is an EIP-7702 delegated EOA followed the designation for code but discarded the resolved address, so the delegation target's access was never charged or warmed. It is now charged on top of the target's own entry charge, warmed for later frames, and the designated code is read only once its access is paid for — keeping an unaffordable designation out of the block access list. EIP-7702 bars a precompile reached through a delegation from executing as one.

The cold account-access price is exposed on the gas policy so the frame path prices it exactly as the VM's account-access metering does.

The affordability check is split so the target's access charge is tested before the deadness query behind the value transfer. That query is itself a recorded read on the BAL-generating world state, and BAL reads survive the frame's failure, so testing the sum first would write an unaffordable frame's target into the block access list — a header-visible divergence. The CALL path is sequenced the same way.

Both follow the reference `create_evm_from_frame` / `resolve_delegated_code_address`, including the ordering: the target's access is charged and the target marked accessed *before* the designation is resolved, so a self-designation resolves warm.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`FrameTxProcessorTests` covers both charges: cold-vs-warm target entry access, a frame whose gas is below its entry charge, the designated address's access for a contract and a precompile designation, a frame that can pay the target access but not the designation, and the resulting block access list in both cases. Two frames sharing one target pin the cross-frame warmth and its rollback when the first frame reverts, a self-designating target pins that it halts on its own designator bytes, and a frame priced below its target's access pins that the target stays out of the block access list.

Each change was revert-checked separately and serialized. Reverting the delegation production code fails exactly the four discriminating delegation tests; reverting the entry charge fails exactly ten, matching the prediction in both cases. Frame suites are green across Core (110), Evm (178), TxPool (77) and Blockchain (29).

Existing expectations that pinned the *absence* of an entry charge were updated rather than removed: the precompile-target gas cases now read `identityGas + WarmAccess`, and the EIP-8272 empty-reference case is now standard-bound rather than floor-bound, since the entry charge lifts both envelopes over their calldata floors.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The merged EIP-8141 fixtures cannot validate this on `eip8141-frame-txs-devnet7` yet. `Bogota` here composes as Osaka + EIP-8141, while the fixtures are Amsterdam-composed, so the blocks are rejected at header validation (`BlockLevelAccessListHashNotEnabled`) before any gas is metered — the whole `target_resolution` suite scores the same with and without these changes. The unit tests are the working oracle on this branch because `Eip8141Prototype` derives from Amsterdam and therefore carries the block access list, EIP-8037 and EIP-8038.

Verified end to end against the fixtures on the devnet-8 composition, where the same two charges take all four delegation cases from failing to passing: `test_delegated_target_entry_charge` (cold and warm), `test_delegated_to_precompile_target` and `test_verify_frame_delegated_to_precompile_target`.


