### PR TITLE
fix(sync): record snap progress per backend

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapTrieFactoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapTrieFactoryTests.cs
@@ -69,6 +69,16 @@ public class FlatSnapTrieFactoryTests
         persistence.DidNotReceive().Clear();
     }
 
+    [Test]
+    public void AccountRangePhase_NeverCarriesIntoTheNextRun()
+    {
+        (FlatSnapTrieFactory factory, _) = Build();
+
+        factory.MarkAccountRangePhaseCompleted();
+
+        Assert.That(factory.IsAccountRangePhaseCompleted(), Is.False);
+    }
+
     [TestCase(true)]
     [TestCase(false)]
     public void Factory_CreatesTreesWithoutThrowing_ForBothDoubleWriteFlagValues(bool doubleWriteCheck)

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapTrieFactoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapTrieFactoryTests.cs
@@ -70,13 +70,13 @@ public class FlatSnapTrieFactoryTests
     }
 
     [Test]
-    public void AccountRangePhase_NeverCarriesIntoTheNextRun()
+    public void RangePhase_NeverCarriesIntoTheNextRun()
     {
         (FlatSnapTrieFactory factory, _) = Build();
 
-        factory.MarkAccountRangePhaseCompleted();
+        factory.MarkRangePhaseFinished();
 
-        Assert.That(factory.IsAccountRangePhaseCompleted(), Is.False);
+        Assert.That(factory.IsRangePhaseFinished(), Is.False);
     }
 
     [TestCase(true)]

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapTrieFactoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/FlatSnapTrieFactoryTests.cs
@@ -72,7 +72,8 @@ public class FlatSnapTrieFactoryTests
     [Test]
     public void RangePhase_NeverCarriesIntoTheNextRun()
     {
-        (FlatSnapTrieFactory factory, _) = Build();
+        (FlatSnapTrieFactory flatFactory, _) = Build();
+        ISnapTrieFactory factory = flatFactory;
 
         factory.MarkRangePhaseFinished();
 

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
@@ -29,9 +29,6 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
 
     public void FinalizeSync() => persistence.Flush();
 
-    public bool IsRangePhaseFinished() => false;
-    public void MarkRangePhaseFinished() { }
-
     public ISnapTree<PathWithAccount> CreateStateTree()
     {
         IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
@@ -29,6 +29,9 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
 
     public void FinalizeSync() => persistence.Flush();
 
+    public bool IsAccountRangePhaseCompleted() => false;
+    public void MarkAccountRangePhaseCompleted() { }
+
     public ISnapTree<PathWithAccount> CreateStateTree()
     {
         IPersistence.IPersistenceReader reader = persistence.CreateReader(ReaderFlags.Sync);

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapTrieFactory.cs
@@ -29,8 +29,8 @@ public class FlatSnapTrieFactory(IPersistence persistence, ISyncConfig syncConfi
 
     public void FinalizeSync() => persistence.Flush();
 
-    public bool IsAccountRangePhaseCompleted() => false;
-    public void MarkAccountRangePhaseCompleted() { }
+    public bool IsRangePhaseFinished() => false;
+    public void MarkRangePhaseFinished() { }
 
     public ISnapTree<PathWithAccount> CreateStateTree()
     {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/PatriciaSnapTrieFactoryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/PatriciaSnapTrieFactoryTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Logging;
 using Nethermind.Synchronization.SnapSync;

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/PatriciaSnapTrieFactoryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/PatriciaSnapTrieFactoryTests.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
+using Nethermind.Logging;
+using Nethermind.Synchronization.SnapSync;
+using Nethermind.Trie;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.SnapSync;
+
+[TestFixture]
+public class PatriciaSnapTrieFactoryTests
+{
+    // Pinned: databases written by earlier versions are read back with this key and value.
+    private static readonly byte[] AccountProgressKey = "AccountProgressKey"u8.ToArray();
+
+    [Test]
+    public void Records_completed_account_range_phase_in_the_state_db()
+    {
+        TestMemDb stateDb = new();
+        PatriciaSnapTrieFactory factory = new(new NodeStorage(stateDb), stateDb, LimboLogs.Instance);
+        Assert.That(factory.IsAccountRangePhaseCompleted(), Is.False);
+
+        factory.MarkAccountRangePhaseCompleted();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(stateDb[AccountProgressKey], Is.EqualTo(Keccak.MaxValue.BytesToArray()));
+            Assert.That(stateDb.WasFlushed, Is.True);
+        }
+    }
+
+    // The flag shares the state DB with the trie nodes it describes, so neither outlives the other.
+    [Test]
+    public void Reads_back_a_phase_completed_by_an_earlier_run()
+    {
+        TestMemDb stateDb = new();
+        PatriciaSnapTrieFactory before = new(new NodeStorage(stateDb), stateDb, LimboLogs.Instance);
+        before.MarkAccountRangePhaseCompleted();
+
+        PatriciaSnapTrieFactory afterRestart = new(new NodeStorage(stateDb), stateDb, LimboLogs.Instance);
+
+        Assert.That(afterRestart.IsAccountRangePhaseCompleted(), Is.True);
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/PatriciaSnapTrieFactoryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/PatriciaSnapTrieFactoryTests.cs
@@ -18,13 +18,13 @@ public class PatriciaSnapTrieFactoryTests
     private static readonly byte[] AccountProgressKey = "AccountProgressKey"u8.ToArray();
 
     [Test]
-    public void Records_completed_account_range_phase_in_the_state_db()
+    public void Records_finished_range_phase_in_the_state_db()
     {
         TestMemDb stateDb = new();
         PatriciaSnapTrieFactory factory = new(new NodeStorage(stateDb), stateDb, LimboLogs.Instance);
-        Assert.That(factory.IsAccountRangePhaseCompleted(), Is.False);
+        Assert.That(factory.IsRangePhaseFinished(), Is.False);
 
-        factory.MarkAccountRangePhaseCompleted();
+        factory.MarkRangePhaseFinished();
 
         using (Assert.EnterMultipleScope())
         {
@@ -35,14 +35,14 @@ public class PatriciaSnapTrieFactoryTests
 
     // The flag shares the state DB with the trie nodes it describes, so neither outlives the other.
     [Test]
-    public void Reads_back_a_phase_completed_by_an_earlier_run()
+    public void Reads_back_a_range_phase_finished_by_an_earlier_run()
     {
         TestMemDb stateDb = new();
         PatriciaSnapTrieFactory before = new(new NodeStorage(stateDb), stateDb, LimboLogs.Instance);
-        before.MarkAccountRangePhaseCompleted();
+        before.MarkRangePhaseFinished();
 
         PatriciaSnapTrieFactory afterRestart = new(new NodeStorage(stateDb), stateDb, LimboLogs.Instance);
 
-        Assert.That(afterRestart.IsAccountRangePhaseCompleted(), Is.True);
+        Assert.That(afterRestart.IsRangePhaseFinished(), Is.True);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -137,7 +137,7 @@ public class ProgressTrackerTests
     }
 
     [Test]
-    public void Will_mark_account_range_phase_completed_when_finished()
+    public void Will_mark_range_phase_finished_when_ranges_drain()
     {
         ISnapTrieFactory snapTrieFactory = Substitute.For<ISnapTrieFactory>();
         using ProgressTracker progressTracker = CreateProgressTracker(snapTrieFactory: snapTrieFactory);
@@ -150,14 +150,14 @@ public class ProgressTrackerTests
         bool finished = progressTracker.IsFinished(out _);
         Assert.That(finished, Is.True);
 
-        snapTrieFactory.Received(1).MarkAccountRangePhaseCompleted();
+        snapTrieFactory.Received(1).MarkRangePhaseFinished();
     }
 
     [Test]
-    public void Will_skip_account_range_phase_when_already_completed()
+    public void Will_skip_account_ranges_when_range_phase_already_finished()
     {
         ISnapTrieFactory snapTrieFactory = Substitute.For<ISnapTrieFactory>();
-        snapTrieFactory.IsAccountRangePhaseCompleted().Returns(true);
+        snapTrieFactory.IsRangePhaseFinished().Returns(true);
         using ProgressTracker progressTracker = CreateProgressTracker(snapTrieFactory: snapTrieFactory);
 
         progressTracker.LoadProgress();
@@ -168,10 +168,10 @@ public class ProgressTrackerTests
 
     // Regression: account ranges must be requested again rather than skipped over a store that was just emptied.
     [Test]
-    public void Will_request_account_ranges_when_store_reports_no_completed_phase()
+    public void Will_request_account_ranges_when_range_phase_not_finished()
     {
         ISnapTrieFactory snapTrieFactory = Substitute.For<ISnapTrieFactory>();
-        snapTrieFactory.IsAccountRangePhaseCompleted().Returns(false);
+        snapTrieFactory.IsRangePhaseFinished().Returns(false);
         using ProgressTracker progressTracker = CreateProgressTracker(snapTrieFactory: snapTrieFactory);
 
         progressTracker.LoadProgress();

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -7,7 +7,6 @@ using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
 using Nethermind.State.Snap;

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -9,11 +9,11 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State.Snap;
 using Nethermind.Synchronization.FastSync;
 using Nethermind.Synchronization.SnapSync;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Synchronization.Test.SnapSync;
@@ -137,14 +137,10 @@ public class ProgressTrackerTests
     }
 
     [Test]
-    public void Will_mark_progress_and_flush_when_finished()
+    public void Will_mark_account_range_phase_completed_when_finished()
     {
-        BlockTree blockTree = Build.A.BlockTree()
-            .WithStateRoot(Keccak.EmptyTreeHash)
-            .OfChainLength(2).TestObject;
-        TestMemDb memDb = new();
-        SyncConfig syncConfig = new TestSyncConfig() { SnapSyncAccountRangePartitionCount = 1 };
-        using ProgressTracker progressTracker = new(memDb, syncConfig, new StateSyncPivot(blockTree, syncConfig, LimboLogs.Instance), LimboLogs.Instance);
+        ISnapTrieFactory snapTrieFactory = Substitute.For<ISnapTrieFactory>();
+        using ProgressTracker progressTracker = CreateProgressTracker(snapTrieFactory: snapTrieFactory);
 
         progressTracker.IsFinished(out SnapSyncBatch? request);
         Assert.That(request!.AccountRangeRequest, Is.Not.Null);
@@ -154,8 +150,35 @@ public class ProgressTrackerTests
         bool finished = progressTracker.IsFinished(out _);
         Assert.That(finished, Is.True);
 
-        Assert.That(memDb.WasFlushed, Is.True);
-        Assert.That(memDb[ProgressTracker.ACC_PROGRESS_KEY], Is.EqualTo(Keccak.MaxValue.BytesToArray()));
+        snapTrieFactory.Received(1).MarkAccountRangePhaseCompleted();
+    }
+
+    [Test]
+    public void Will_skip_account_range_phase_when_already_completed()
+    {
+        ISnapTrieFactory snapTrieFactory = Substitute.For<ISnapTrieFactory>();
+        snapTrieFactory.IsAccountRangePhaseCompleted().Returns(true);
+        using ProgressTracker progressTracker = CreateProgressTracker(snapTrieFactory: snapTrieFactory);
+
+        progressTracker.LoadProgress();
+
+        Assert.That(progressTracker.IsFinished(out SnapSyncBatch? request), Is.True);
+        Assert.That(request, Is.Null);
+    }
+
+    // Regression: account ranges must be requested again rather than skipped over a store that was just emptied.
+    [Test]
+    public void Will_request_account_ranges_when_store_reports_no_completed_phase()
+    {
+        ISnapTrieFactory snapTrieFactory = Substitute.For<ISnapTrieFactory>();
+        snapTrieFactory.IsAccountRangePhaseCompleted().Returns(false);
+        using ProgressTracker progressTracker = CreateProgressTracker(snapTrieFactory: snapTrieFactory);
+
+        progressTracker.LoadProgress();
+
+        Assert.That(progressTracker.IsFinished(out SnapSyncBatch? request), Is.False);
+        Assert.That(request!.AccountRangeRequest, Is.Not.Null);
+        request.Dispose();
     }
 
     [TestCase("0x0000000000000000000000000000000000000000000000000000000000000000", "0x2000000000000000000000000000000000000000000000000000000000000000", null, "0x8fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")]
@@ -225,10 +248,10 @@ public class ProgressTrackerTests
         Assert.That(batch1?.StorageRangeRequest?.LimitHash, Is.EqualTo(limitHash ?? Keccak.MaxValue));
     }
 
-    private ProgressTracker CreateProgressTracker(int accountRangePartition = 1, bool enableStorageSplits = false)
+    private ProgressTracker CreateProgressTracker(int accountRangePartition = 1, bool enableStorageSplits = false, ISnapTrieFactory? snapTrieFactory = null)
     {
         BlockTree blockTree = Build.A.BlockTree().WithStateRoot(Keccak.EmptyTreeHash).OfChainLength(2).TestObject;
         SyncConfig syncConfig = new TestSyncConfig() { SnapSyncAccountRangePartitionCount = accountRangePartition, EnableSnapSyncStorageRangeSplit = enableStorageSplits };
-        return new(new MemDb(), syncConfig, new StateSyncPivot(blockTree, syncConfig, LimboLogs.Instance), LimboLogs.Instance);
+        return new(snapTrieFactory ?? Substitute.For<ISnapTrieFactory>(), syncConfig, new StateSyncPivot(blockTree, syncConfig, LimboLogs.Instance), LimboLogs.Instance);
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapStateServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapStateServerTests.cs
@@ -62,9 +62,10 @@ public class SnapStateServerTests
             Server = new SnapStateServer(_store.AsReadOnly(), LimboLogs.Instance, lastNStateRootTracker);
 
             _clientStateDb = new MemDb();
-            using ProgressTracker progressTracker = new(_clientStateDb, new TestSyncConfig(), new StateSyncPivot(null!, new TestSyncConfig(), LimboLogs.Instance), LimboLogs.Instance);
             INodeStorage nodeStorage = new NodeStorage(_clientStateDb);
-            SnapProvider = new SnapProvider(progressTracker, new MemDb(), new PatriciaSnapTrieFactory(nodeStorage, LimboLogs.Instance), LimboLogs.Instance);
+            PatriciaSnapTrieFactory snapTrieFactory = new(nodeStorage, _clientStateDb, LimboLogs.Instance);
+            using ProgressTracker progressTracker = new(snapTrieFactory, new TestSyncConfig(), new StateSyncPivot(null!, new TestSyncConfig(), LimboLogs.Instance), LimboLogs.Instance);
+            SnapProvider = new SnapProvider(progressTracker, new MemDb(), snapTrieFactory, LimboLogs.Instance);
         }
 
         public IWriteBatch BeginWriteBatch() => new WriteBatch(this);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncRunnerTests.cs
@@ -5,6 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Logging;
+using Nethermind.Synchronization.FastSync;
 using Nethermind.Synchronization.SnapSync;
 using NSubstitute;
 using NUnit.Framework;
@@ -25,6 +28,15 @@ public class SnapSyncRunnerTests
         ISnapTrieFactory factory = Substitute.For<ISnapTrieFactory>();
         factory.When(f => f.EnsureInitialize()).Do(_ => calls.Add("EnsureInitialize"));
         factory.When(f => f.FinalizeSync()).Do(_ => calls.Add("FinalizeSync"));
+        factory.IsAccountRangePhaseCompleted().Returns(_ =>
+        {
+            calls.Add("LoadProgress");
+            return false;
+        });
+
+        ISyncConfig syncConfig = Substitute.For<ISyncConfig>();
+        syncConfig.SnapSyncAccountRangePartitionCount.Returns(1);
+        using ProgressTracker progressTracker = new(factory, syncConfig, Substitute.For<IStateSyncPivot>(), LimboLogs.Instance);
 
         using CancellationTokenSource cts = new();
         if (outcome == DispatcherOutcome.Cancels) cts.Cancel();
@@ -38,7 +50,7 @@ public class SnapSyncRunnerTests
                 DispatcherOutcome.Cancels => throw new OperationCanceledException(token),
                 _ => Task.CompletedTask,
             };
-        }, factory);
+        }, factory, progressTracker);
 
         Func<Task> act = () => runner.Run(cts.Token);
         if (expectedException is null)
@@ -46,6 +58,6 @@ public class SnapSyncRunnerTests
         else
             Assert.That(async () => await act(), Throws.InstanceOf(expectedException));
 
-        Assert.That(calls, Is.EqualTo(new[] { "EnsureInitialize", "dispatcher", "FinalizeSync" }));
+        Assert.That(calls, Is.EqualTo(new[] { "EnsureInitialize", "LoadProgress", "dispatcher", "FinalizeSync" }));
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncRunnerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncRunnerTests.cs
@@ -28,7 +28,7 @@ public class SnapSyncRunnerTests
         ISnapTrieFactory factory = Substitute.For<ISnapTrieFactory>();
         factory.When(f => f.EnsureInitialize()).Do(_ => calls.Add("EnsureInitialize"));
         factory.When(f => f.FinalizeSync()).Do(_ => calls.Add("FinalizeSync"));
-        factory.IsAccountRangePhaseCompleted().Returns(_ =>
+        factory.IsRangePhaseFinished().Returns(_ =>
         {
             calls.Add("LoadProgress");
             return false;

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/TestSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/TestSnapTrieFactory.cs
@@ -12,12 +12,12 @@ internal class TestSnapTrieFactory(
     Func<ISnapTree<PathWithAccount>> createStateTree,
     Func<ISnapTree<PathWithStorageSlot>>? createStorageTree = null) : ISnapTrieFactory
 {
-    private bool _accountRangePhaseCompleted;
+    private bool _rangePhaseFinished;
 
     public ISnapTree<PathWithAccount> CreateStateTree() => createStateTree();
     public ISnapTree<PathWithStorageSlot> CreateStorageTree(in ValueHash256 accountPath) =>
         createStorageTree is not null ? createStorageTree() : throw new NotSupportedException("No storage tree factory provided");
 
-    public bool IsAccountRangePhaseCompleted() => _accountRangePhaseCompleted;
-    public void MarkAccountRangePhaseCompleted() => _accountRangePhaseCompleted = true;
+    public bool IsRangePhaseFinished() => _rangePhaseFinished;
+    public void MarkRangePhaseFinished() => _rangePhaseFinished = true;
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/TestSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/TestSnapTrieFactory.cs
@@ -12,7 +12,12 @@ internal class TestSnapTrieFactory(
     Func<ISnapTree<PathWithAccount>> createStateTree,
     Func<ISnapTree<PathWithStorageSlot>>? createStorageTree = null) : ISnapTrieFactory
 {
+    private bool _accountRangePhaseCompleted;
+
     public ISnapTree<PathWithAccount> CreateStateTree() => createStateTree();
     public ISnapTree<PathWithStorageSlot> CreateStorageTree(in ValueHash256 accountPath) =>
         createStorageTree is not null ? createStorageTree() : throw new NotSupportedException("No storage tree factory provided");
+
+    public bool IsAccountRangePhaseCompleted() => _accountRangePhaseCompleted;
+    public void MarkAccountRangePhaseCompleted() => _accountRangePhaseCompleted = true;
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapTrieFactory.cs
@@ -15,8 +15,8 @@ public interface ISnapTrieFactory
     ISnapTree<PathWithAccount> CreateStateTree();
     ISnapTree<PathWithStorageSlot> CreateStorageTree(in ValueHash256 accountPath);
 
-    // Marked when the account-range phase drains, read after EnsureInitialize, so a later run over the same
-    // data skips the phase. Only a backend that keeps its store across runs can report true.
-    bool IsAccountRangePhaseCompleted();
-    void MarkAccountRangePhaseCompleted();
+    // Marked when the range phase drains, read after EnsureInitialize, so a later run over the same data
+    // skips the phase. Only a backend that keeps its store across runs can report true.
+    bool IsRangePhaseFinished();
+    void MarkRangePhaseFinished();
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapTrieFactory.cs
@@ -14,4 +14,9 @@ public interface ISnapTrieFactory
 
     ISnapTree<PathWithAccount> CreateStateTree();
     ISnapTree<PathWithStorageSlot> CreateStorageTree(in ValueHash256 accountPath);
+
+    // Marked when the account-range phase drains, read after EnsureInitialize, so a later run over the same
+    // data skips the phase. Only a backend that keeps its store across runs can report true.
+    bool IsAccountRangePhaseCompleted();
+    void MarkAccountRangePhaseCompleted();
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapTrieFactory.cs
@@ -16,7 +16,8 @@ public interface ISnapTrieFactory
     ISnapTree<PathWithStorageSlot> CreateStorageTree(in ValueHash256 accountPath);
 
     // Marked when the range phase drains, read after EnsureInitialize, so a later run over the same data
-    // skips the phase. Only a backend that keeps its store across runs can report true.
-    bool IsRangePhaseFinished();
-    void MarkRangePhaseFinished();
+    // skips the phase. Records nothing by default, so a backend that does not keep its store across runs
+    // re-requests the ranges instead of skipping them over data it discarded.
+    bool IsRangePhaseFinished() => false;
+    void MarkRangePhaseFinished() { }
 }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/PatriciaSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/PatriciaSnapTrieFactory.cs
@@ -17,19 +17,19 @@ public class PatriciaSnapTrieFactory(
     [KeyFilter(DbNames.State)] IDb stateDb,
     ILogManager logManager) : ISnapTrieFactory
 {
-    private static readonly byte[] AccountRangePhaseKey = "AccountProgressKey"u8.ToArray();
+    private static readonly byte[] RangePhaseKey = "AccountProgressKey"u8.ToArray();
 
     private readonly RawScopedTrieStore _stateTrieStore = new(nodeStorage, null);
 
-    public bool IsAccountRangePhaseCompleted()
+    public bool IsRangePhaseFinished()
     {
-        byte[]? recorded = stateDb.Get(AccountRangePhaseKey);
+        byte[]? recorded = stateDb.Get(RangePhaseKey);
         return recorded is { Length: 32 } && new ValueHash256(recorded) == ValueKeccak.MaxValue;
     }
 
-    public void MarkAccountRangePhaseCompleted()
+    public void MarkRangePhaseFinished()
     {
-        stateDb.PutSpan(AccountRangePhaseKey, ValueKeccak.MaxValue.Bytes, WriteFlags.DisableWAL);
+        stateDb.PutSpan(RangePhaseKey, ValueKeccak.MaxValue.Bytes, WriteFlags.DisableWAL);
         stateDb.Flush();
     }
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/PatriciaSnapTrieFactory.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/PatriciaSnapTrieFactory.cs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Autofac.Features.AttributeFilters;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.State.Snap;
@@ -9,9 +12,26 @@ using Nethermind.Trie.Pruning;
 
 namespace Nethermind.Synchronization.SnapSync;
 
-public class PatriciaSnapTrieFactory(INodeStorage nodeStorage, ILogManager logManager) : ISnapTrieFactory
+public class PatriciaSnapTrieFactory(
+    INodeStorage nodeStorage,
+    [KeyFilter(DbNames.State)] IDb stateDb,
+    ILogManager logManager) : ISnapTrieFactory
 {
+    private static readonly byte[] AccountRangePhaseKey = "AccountProgressKey"u8.ToArray();
+
     private readonly RawScopedTrieStore _stateTrieStore = new(nodeStorage, null);
+
+    public bool IsAccountRangePhaseCompleted()
+    {
+        byte[]? recorded = stateDb.Get(AccountRangePhaseKey);
+        return recorded is { Length: 32 } && new ValueHash256(recorded) == ValueKeccak.MaxValue;
+    }
+
+    public void MarkAccountRangePhaseCompleted()
+    {
+        stateDb.PutSpan(AccountRangePhaseKey, ValueKeccak.MaxValue.Bytes, WriteFlags.DisableWAL);
+        stateDb.Flush();
+    }
 
     public ISnapTree<PathWithAccount> CreateStateTree()
     {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -7,13 +7,11 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Autofac.Features.AttributeFilters;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.State.Snap;
@@ -29,7 +27,6 @@ namespace Nethermind.Synchronization.SnapSync
         private const int CODES_BATCH_SIZE = 1_000;
         public const int HIGH_CODES_QUEUE_SIZE = CODES_BATCH_SIZE * 5;
         private const uint StorageRangeSplitFactor = 2;
-        internal static readonly byte[] ACC_PROGRESS_KEY = "AccountProgressKey"u8.ToArray();
 
         // This does not need to be a lot as it spawn other requests. In fact 8 is probably too much. It is severely
         // bottlenecked by _syncCommit lock in SnapProviderHelper, which in turns is limited by the IO.
@@ -47,7 +44,7 @@ namespace Nethermind.Synchronization.SnapSync
         private int _activeAccRefreshRequests;
 
         private readonly ILogger _logger;
-        private readonly IDb _db;
+        private readonly ISnapTrieFactory _snapTrieFactory;
         string? _lastStateRangesReport;
         private DateTimeOffset _lastLogTime = DateTimeOffset.MinValue;
         private readonly TimeSpan _maxTimeBetweenLog = TimeSpan.FromSeconds(5);
@@ -67,10 +64,10 @@ namespace Nethermind.Synchronization.SnapSync
         private readonly FastSync.IStateSyncPivot _pivot;
         private readonly bool _enableStorageRangeSplit;
 
-        public ProgressTracker([KeyFilter(DbNames.State)] IDb db, ISyncConfig syncConfig, FastSync.IStateSyncPivot pivot, ILogManager? logManager)
+        public ProgressTracker(ISnapTrieFactory snapTrieFactory, ISyncConfig syncConfig, FastSync.IStateSyncPivot pivot, ILogManager? logManager)
         {
             _logger = logManager?.GetClassLogger<ProgressTracker>() ?? throw new ArgumentNullException(nameof(logManager));
-            _db = db ?? throw new ArgumentNullException(nameof(db));
+            _snapTrieFactory = snapTrieFactory ?? throw new ArgumentNullException(nameof(snapTrieFactory));
 
             _pivot = pivot;
 
@@ -82,9 +79,6 @@ namespace Nethermind.Synchronization.SnapSync
             _enableStorageRangeSplit = syncConfig.EnableSnapSyncStorageRangeSplit;
 
             SetupAccountRangePartition();
-
-            //TODO: maybe better to move to a init method instead of the constructor
-            GetSyncProgress();
         }
 
         private void SetupAccountRangePartition()
@@ -191,7 +185,7 @@ namespace Nethermind.Synchronization.SnapSync
                 if (rangePhaseFinished)
                 {
                     _logger.Info("Snap - State Ranges (Phase 1) finished.");
-                    FinishRangePhase();
+                    _snapTrieFactory.MarkAccountRangePhaseCompleted();
                 }
 
                 LogRequest(NO_REQUEST);
@@ -463,35 +457,16 @@ namespace Nethermind.Synchronization.SnapSync
                    && _activeCodeRequests == 0
                    && _activeAccRefreshRequests == 0;
 
-        private void GetSyncProgress()
+        public void LoadProgress()
         {
-            // Note, as before, the progress actually only store MaxValue or 0. So we can't actually resume
-            // snap sync on restart.
-            byte[] progress = _db.Get(ACC_PROGRESS_KEY);
-            if (progress is { Length: 32 })
+            if (!_snapTrieFactory.IsAccountRangePhaseCompleted()) return;
+
+            _logger.Info($"Snap - State Ranges (Phase 1) is finished.");
+            foreach (KeyValuePair<ValueHash256, AccountRangePartition> partition in AccountRangePartitions)
             {
-                ValueHash256 path = new(progress);
-
-                if (path == ValueKeccak.MaxValue)
-                {
-                    _logger.Info($"Snap - State Ranges (Phase 1) is finished.");
-                    foreach (KeyValuePair<ValueHash256, AccountRangePartition> partition in AccountRangePartitions)
-                    {
-                        partition.Value.MoreAccountsToRight = false;
-                    }
-                    AccountRangeReadyForRequest.Clear();
-                }
-                else
-                {
-                    _logger.Info($"Snap - State Ranges (Phase 1) progress loaded from DB:{path}");
-                }
+                partition.Value.MoreAccountsToRight = false;
             }
-        }
-
-        private void FinishRangePhase()
-        {
-            _db.PutSpan(ACC_PROGRESS_KEY, ValueKeccak.MaxValue.Bytes, WriteFlags.DisableWAL);
-            _db.Flush();
+            AccountRangeReadyForRequest.Clear();
         }
 
         public void TrackAccountToHeal(ValueHash256 path)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -185,7 +185,7 @@ namespace Nethermind.Synchronization.SnapSync
                 if (rangePhaseFinished)
                 {
                     _logger.Info("Snap - State Ranges (Phase 1) finished.");
-                    _snapTrieFactory.MarkAccountRangePhaseCompleted();
+                    _snapTrieFactory.MarkRangePhaseFinished();
                 }
 
                 LogRequest(NO_REQUEST);
@@ -459,7 +459,7 @@ namespace Nethermind.Synchronization.SnapSync
 
         public void LoadProgress()
         {
-            if (!_snapTrieFactory.IsAccountRangePhaseCompleted()) return;
+            if (!_snapTrieFactory.IsRangePhaseFinished()) return;
 
             _logger.Info($"Snap - State Ranges (Phase 1) is finished.");
             foreach (KeyValuePair<ValueHash256, AccountRangePartition> partition in AccountRangePartitions)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -322,7 +322,7 @@ namespace Nethermind.Synchronization.SnapSync
             {
                 // Empty-backed isolated factory: a proof node that cannot be resolved from the proof itself fails
                 // verification instead of being completed from (or racing) the live client state DB.
-                ISnapTrieFactory factory = new PatriciaSnapTrieFactory(new NodeStorage(new MemDb()), logManager);
+                ISnapTrieFactory factory = new PatriciaSnapTrieFactory(new NodeStorage(new MemDb()), new MemDb(), logManager);
                 result = SnapProviderHelper.VerifyAccountRange(factory, stateRoot, path, path.IncrementPath(), accounts, response.Proofs);
             }
             catch (Exception)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -322,7 +322,7 @@ namespace Nethermind.Synchronization.SnapSync
             {
                 // Empty-backed isolated factory: a proof node that cannot be resolved from the proof itself fails
                 // verification instead of being completed from (or racing) the live client state DB.
-                ISnapTrieFactory factory = new PatriciaSnapTrieFactory(new NodeStorage(new MemDb()), new MemDb(), logManager);
+                ISnapTrieFactory factory = new PatriciaSnapTrieFactory(new NodeStorage(new MemDb()), NullDb.Instance, logManager);
                 result = SnapProviderHelper.VerifyAccountRange(factory, stateRoot, path, path.IncrementPath(), accounts, response.Proofs);
             }
             catch (Exception)

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncRunner.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncRunner.cs
@@ -8,14 +8,18 @@ using Nethermind.Synchronization.ParallelSync;
 
 namespace Nethermind.Synchronization.SnapSync;
 
-public class SnapSyncRunner(Func<CancellationToken, Task> runDispatcher, ISnapTrieFactory snapTrieFactory) : ISnapSyncRunner
+public class SnapSyncRunner(
+    Func<CancellationToken, Task> runDispatcher,
+    ISnapTrieFactory snapTrieFactory,
+    ProgressTracker progressTracker) : ISnapSyncRunner
 {
-    public SnapSyncRunner(SimpleDispatcher<SnapSyncBatch> dispatcher, ISnapTrieFactory snapTrieFactory)
-        : this(dispatcher.Run, snapTrieFactory) { }
+    public SnapSyncRunner(SimpleDispatcher<SnapSyncBatch> dispatcher, ISnapTrieFactory snapTrieFactory, ProgressTracker progressTracker)
+        : this(dispatcher.Run, snapTrieFactory, progressTracker) { }
 
     public async Task Run(CancellationToken token)
     {
         snapTrieFactory.EnsureInitialize();
+        progressTracker.LoadProgress();
         try
         {
             await runDispatcher(token);


### PR DESCRIPTION
## Changes

If a flat node stops during healing after snap sync, after restart it comes back as a patricia node.

Snap sync stores its range progress in the state DB, whatever the backend is:

```csharp
// ProgressTracker, injected with [KeyFilter(DbNames.State)] IDb db
_db.PutSpan(ACC_PROGRESS_KEY, ValueKeccak.MaxValue.Bytes, WriteFlags.DisableWAL);
```

and the same DB is what decides whether flat is active:

```csharp
// FlatStateActivationPolicy.DecideBackend -> patricia
if (patriciaStateDb.Value.GetAllKeys().Any())
```

The fix stores the progress per backend: patricia keeps it in the state DB as before, flat stores nothing because it wipes its DB on every run.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_


