### PR TITLE
fix(docgen): honour System.Text.Json ignore conditions and property names

### DIFF
--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -7,6 +7,7 @@ using Nethermind.JsonRpc.Modules.Rpc;
 using Nethermind.JsonRpc.Modules.Subscribe;
 using Spectre.Console;
 using System.Reflection;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Nethermind.DocGen;
@@ -353,7 +354,7 @@ internal static class JsonRpcGenerator
 
     private static string GetSerializedName(PropertyInfo prop) =>
         prop.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
-            ?? $"{prop.Name[0].ToString().ToLowerInvariant()}{prop.Name[1..]}"; // Ugly incomplete camel case
+            ?? JsonNamingPolicy.CamelCase.ConvertName(prop.Name);
 
     private static string Indent(int depth) => string.Empty.PadLeft(depth, ' ');
 

--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -5,9 +5,9 @@ using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Evm;
 using Nethermind.JsonRpc.Modules.Rpc;
 using Nethermind.JsonRpc.Modules.Subscribe;
-using Newtonsoft.Json;
 using Spectre.Console;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 namespace Nethermind.DocGen;
 
@@ -348,11 +348,11 @@ internal static class JsonRpcGenerator
 
     private static IEnumerable<PropertyInfo> GetSerializableProperties(Type type) =>
         type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-            .Where(p => p.GetCustomAttribute<JsonIgnoreAttribute>() is null)
+            .Where(p => p.GetCustomAttribute<JsonIgnoreAttribute>()?.Condition is not JsonIgnoreCondition.Always)
             .OrderBy(p => p.Name);
 
     private static string GetSerializedName(PropertyInfo prop) =>
-        prop.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName
+        prop.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
             ?? $"{prop.Name[0].ToString().ToLowerInvariant()}{prop.Name[1..]}"; // Ugly incomplete camel case
 
     private static string Indent(int depth) => string.Empty.PadLeft(depth, ' ');


### PR DESCRIPTION
Partially Fixes #12836 #12828

## Changes

- `tools/DocGen` looked up Newtonsoft's `[JsonIgnore]`/`[JsonProperty]`, but the RPC layer has serialized with `System.Text.Json`. Both libraries declare a `JsonIgnoreAttribute`, so the lookups compiled, always returned  `null`, and silently reported that nothing was ever hidden or renamed.  Retargeted to `System.Text.Json.Serialization`.
- Only `JsonIgnoreCondition.Always` hides a member; `Never` and the conditional forms still reach the wire and stay documented.


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks
Partially addresses #12836 (fields renamed or omitted on the wire) and #12828 (internal CLR members leaking into the schema): `[JsonIgnore]`members are no longer published, and `[JsonPropertyName]` renames are now honoured. Both close once the generator also resolves `[JsonConverter]`-backed types, in a follow-up PR.