### PR TITLE
fix(t8n): serialize receipt root/status as mutually exclusive

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/ReceiptsForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/ReceiptsForRpcTests.cs
@@ -82,12 +82,11 @@ namespace Nethermind.JsonRpc.Test.Data
 
         [TestCase(LeadingZeroRootHex, LeadingZeroRootHex)]
         [TestCase(LeadingZeroByteRootHex, LeadingZeroByteRootHex)]
-        [TestCase(null, "0x0000000000000000000000000000000000000000000000000000000000000000")]
-        public void Serializes_root_as_full_width_data(string? rootHex, string expectedRoot)
+        public void Serializes_root_as_full_width_data(string rootHex, string expectedRoot)
         {
-            // A receipt root is DATA per EIP-1474. The writer must keep all 64 digits. A null root becomes the full-width zero hash.
+            // A receipt root is DATA per EIP-1474. The writer must keep all 64 digits.
             TxReceipt receipt = CreateDiagnosticReceipt();
-            receipt.PostTransactionState = rootHex is null ? null : new Hash256(rootHex);
+            receipt.PostTransactionState = new Hash256(rootHex);
 
             string serialized = SerializeReceipt(receipt);
 
@@ -148,6 +147,56 @@ namespace Nethermind.JsonRpc.Test.Data
 
             Assert.That(receiptForRpc, Is.Not.Null);
             Assert.That(receiptForRpc!.ToReceipt().Error, Is.Null);
+        }
+
+        [Test]
+        public void Post_byzantium_receipt_serializes_status_without_root()
+        {
+            TxReceipt receipt = new()
+            {
+                Bloom = Bloom.Empty,
+                Index = 0,
+                Recipient = TestItem.AddressA,
+                Sender = TestItem.AddressB,
+                BlockHash = TestItem.KeccakA,
+                BlockNumber = 1,
+                GasUsed = 1000,
+                TxHash = Keccak.OfAnEmptyString,
+                StatusCode = 1,
+                GasUsedTotal = 1000,
+                Logs = []
+            };
+
+            using JsonDocument document = JsonDocument.Parse(SerializeReceipt(receipt));
+            JsonElement root = document.RootElement;
+
+            Assert.That(root.TryGetProperty("root", out _), Is.False);
+            Assert.That(root.GetProperty("status").GetString(), Is.EqualTo("0x1"));
+        }
+
+        [Test]
+        public void Pre_byzantium_receipt_serializes_root_without_status()
+        {
+            TxReceipt receipt = new()
+            {
+                Bloom = Bloom.Empty,
+                Index = 0,
+                Recipient = TestItem.AddressA,
+                Sender = TestItem.AddressB,
+                BlockHash = TestItem.KeccakA,
+                BlockNumber = 1,
+                GasUsed = 1000,
+                TxHash = Keccak.OfAnEmptyString,
+                PostTransactionState = TestItem.KeccakB,
+                GasUsedTotal = 1000,
+                Logs = []
+            };
+
+            using JsonDocument document = JsonDocument.Parse(SerializeReceipt(receipt));
+            JsonElement root = document.RootElement;
+
+            Assert.That(root.TryGetProperty("status", out _), Is.False);
+            Assert.That(root.GetProperty("root").GetString(), Is.EqualTo(TestItem.KeccakB.ToString()));
         }
 
         private static TxReceipt CreateDiagnosticReceipt()

--- a/src/Nethermind/Nethermind.JsonRpc/Converters/TxReceiptConverter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Converters/TxReceiptConverter.cs
@@ -30,10 +30,17 @@ public class TxReceiptConverter : JsonConverter<TxReceipt>
                 writer.WritePropertyName("type");
                 JsonSerializer.Serialize(writer, receipt.Type, options);
             }
-            writer.WritePropertyName("root");
-            JsonSerializer.Serialize(writer, receipt.Root ?? Keccak.Zero, options);
-            writer.WritePropertyName("status");
-            JsonSerializer.Serialize(writer, receipt.Status, options);
+            // EIP-658: a receipt carries either a post-state root (pre-Byzantium) or a status code, never both.
+            if (receipt.Root is not null)
+            {
+                writer.WritePropertyName("root");
+                JsonSerializer.Serialize(writer, receipt.Root, options);
+            }
+            else
+            {
+                writer.WritePropertyName("status");
+                JsonSerializer.Serialize(writer, receipt.Status, options);
+            }
 
             writer.WritePropertyName("cumulativeGasUsed");
             JsonSerializer.Serialize(writer, receipt.CumulativeGasUsed, options);


### PR DESCRIPTION
Refs #12835 (item 8 only — the rest need no code change; see below)

## Changes

`TxReceiptConverter.Write` now emits **either** the post-state `root` (pre-Byzantium, when `receipt.Root` is set) **or** the `status` code (post-Byzantium), instead of always writing both with `root` substituted by the zero hash. This matches EIP-658, the receipt schema in `ethereum/execution-apis`, and go-ethereum's `marshalReceipt` (`if len(PostState) > 0 { root } else { status }`).

- The pre-Byzantium `root` is still written through the fixed-width `Hash256` path, so #12706's full-width DATA fix is preserved (leading-zero roots stay 64 digits).
- This is exactly the "separate shape change" #12706 called out as deliberately out of scope: *"the converter still emits `root` on every receipt… Omitting the field instead would be a separate shape change."*

## Scope / who this affects

- **JSON-RPC receipt methods are unaffected.** `eth_getTransactionReceipt`, `eth_getBlockReceipts`, `parity_getBlockReceipts`, `proof_getTransactionReceipt` serialize the `ReceiptForRpc` DTO, which already emits `root`/`status` mutually exclusively via `JsonIgnoreCondition.WhenWritingNull`. No RPC output changes.
- **The only affected surface is the t8n tool** (`tools/Evm/T8n`), which serializes raw `TxReceipt[]`. t8n forces `PostTransactionState = null` for successful txs, so post-Byzantium t8n receipts previously carried a spurious `"root":"0x00…00"` alongside `"status"`. They now emit `"status"` only, matching Geth's `evm t8n`.

## Context on #12835

The issue lists 12 "serializes null but docs say non-null" items. Compared against `ethereum/execution-apis` and go-ethereum, **11 of 12 are not defects** — the nulls are intentional and spec-/Geth-conformant (pending blocks/txs, `to: null` for contract creation, conditional trace fields). Their docs-accuracy aspect is handled by #12868 (DocGen now derives from the serializer contract). This PR addresses only item 8, and only for the t8n path.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added `Post_byzantium_receipt_serializes_status_without_root` and `Pre_byzantium_receipt_serializes_root_without_status`. Kept #12706's `Serializes_root_as_full_width_data` (leading-zero cases) to guard the width fix; removed only its null-root case, which asserted the now-removed always-present zero root. `ReceiptsForRpcTests` (10) and `TransactionReceiptsSubscription` (13) green.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] Yes

t8n `result.receipts` for post-Byzantium transactions no longer include a zero-hash `root`; they now carry `status` only, matching go-ethereum's `evm t8n`. Pre-Byzantium receipts continue to emit a full-width `root`.

## Remarks

Builds on #12706 (full-width receipt root); makes the shape change that PR deferred. cc the #12706 author for the deliberate t8n shape decision.