### PR TITLE
fix(docgen): derive JSON-RPC docs from the serializer contract

### DIFF
--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -38,21 +38,21 @@ internal static class JsonRpcGenerator
     {
         [typeof(Address)] = "_string_ (address)",
         [typeof(AddressAsKey)] = "_string_ (address)",
-        [typeof(BigInteger)] = "_string_ (hex integer)",
+        [typeof(BigInteger)] = "_string_ (decimal integer)",
         [typeof(BlockParameter)] = "_string_ (block number or hash or either of `earliest`, `finalized`, `latest`, `pending`, or `safe`)",
         [typeof(Bloom)] = "_string_ (hex data)",
         [typeof(bool)] = "_boolean_",
-        [typeof(byte)] = "_string_ (hex data)",
+        [typeof(byte)] = "_integer_",
         [typeof(byte[])] = "_string_ (hex data)",
         [typeof(byte[][])] = "array of _string_ (hex data)",
         [typeof(DateTime)] = "_string_ (date-time)",
+        [typeof(DateTimeOffset)] = "_string_ (date-time)",
         [typeof(double)] = "_number_",
         [typeof(double[])] = "array of _number_",
-        [typeof(DateTimeOffset)] = "_string_ (date-time)",
         [typeof(Hash256)] = "_string_ (hash)",
         [typeof(Hash256[])] = "array of _string_ (hash)",
         [typeof(HexBytes)] = "_string_ (hex data)",
-        [typeof(int)] = "_string_ (hex integer)",
+        [typeof(int)] = "_integer_",
         [typeof(IPAddress)] = "_string_",
         [typeof(long)] = "_string_ (hex integer)",
         [typeof(PublicKey)] = "_string_ (hex data)",
@@ -60,7 +60,7 @@ internal static class JsonRpcGenerator
         [typeof(string)] = "_string_",
         [typeof(TimeSpan)] = "_string_ (duration)",
         [typeof(TxType)] = "_string_ (transaction type)",
-        [typeof(uint)] = "_string_ (hex integer)",
+        [typeof(uint)] = "_integer_",
         [typeof(ulong)] = "_string_ (hex integer)",
         [typeof(UInt256)] = "_string_ (hex integer)",
         [typeof(ValueHash256)] = "_string_ (hash)",
@@ -362,8 +362,12 @@ internal static class JsonRpcGenerator
         if (underlyingType is not null)
             return GetJsonTypeName(underlyingType);
 
+        if (_knownTypeNames.TryGetValue(type, out string? knownName))
+            return knownName;
+
+        // An enum serializes as its numeric value unless a converter writes the member name instead
         if (type.IsEnum)
-            return "_integer_";
+            return type.GetCustomAttribute<JsonConverterAttribute>() is null ? "_integer_" : "_string_";
 
         if (type.IsGenericType)
         {
@@ -382,7 +386,7 @@ internal static class JsonRpcGenerator
         if (TryGetEnumerableItemType(type, out Type? itemType, out bool isDictionary))
             return $"{(isDictionary ? "map" : "array")} of {GetJsonTypeName(itemType!)}";
 
-        return _knownTypeNames.GetValueOrDefault(type, _objectTypeName);
+        return _objectTypeName;
     }
 
     private static Type GetReturnType(Type type)
@@ -405,9 +409,10 @@ internal static class JsonRpcGenerator
         {
             return EthereumJsonSerializer.JsonOptions.TryGetTypeInfo(type, out JsonTypeInfo? typeInfo) ? typeInfo : null;
         }
-        catch (ArgumentException)
+        catch (Exception e) when (e is ArgumentException or InvalidOperationException or NotSupportedException)
         {
-            // Never-serializable types (by-ref, pointer, open generic) throw instead of reporting false
+            // Types the serializer refuses to model (by-ref, pointer, open generic, colliding member
+            // names) throw instead of reporting false; each falls back to its CLR shape
             return null;
         }
     }
@@ -416,24 +421,28 @@ internal static class JsonRpcGenerator
     {
         JsonTypeInfo? contract = GetContract(type);
 
-        if (contract is not null && contract.Properties.Count != 0)
+        if (contract?.Kind is JsonTypeInfoKind.Object)
             return contract.Properties
                 .Where(p => p.Get is not null)
                 .Select(p => (Name: p.Name, Type: p.PropertyType))
                 .OrderBy(m => m.Name, StringComparer.Ordinal);
 
         // A hand-rolled converter exposes no contract members, leaving the CLR shape as the only guess
-        _guessedTypeNames.Add(type.Name);
+        _guessedTypeNames.Add($"{type.Namespace}.{type.Name}");
 
-        return type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(p => p.GetCustomAttribute<JsonIgnoreAttribute>()?.Condition is not JsonIgnoreCondition.Always)
-            .Select(p => (Name: GetFallbackName(p), Type: p.PropertyType))
+        const BindingFlags memberFlags = BindingFlags.Public | BindingFlags.Instance;
+
+        // The serializer sets IncludeFields, so public fields reach the wire alongside properties
+        return type.GetProperties(memberFlags).Select(p => (Member: (MemberInfo)p, Type: p.PropertyType))
+            .Concat(type.GetFields(memberFlags).Select(f => (Member: (MemberInfo)f, Type: f.FieldType)))
+            .Where(m => m.Member.GetCustomAttribute<JsonIgnoreAttribute>()?.Condition is not JsonIgnoreCondition.Always)
+            .Select(m => (Name: GetFallbackName(m.Member), Type: m.Type))
             .OrderBy(m => m.Name, StringComparer.Ordinal);
     }
 
-    private static string GetFallbackName(PropertyInfo prop) =>
-        prop.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
-            ?? JsonNamingPolicy.CamelCase.ConvertName(prop.Name);
+    private static string GetFallbackName(MemberInfo member) =>
+        member.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
+            ?? JsonNamingPolicy.CamelCase.ConvertName(member.Name);
 
     private static string Indent(int depth) => string.Empty.PadLeft(depth, ' ');
 

--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -1,14 +1,25 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Blockchain.Find;
+using Nethermind.Core;
+using Nethermind.Core.Buffers;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Int256;
 using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Evm;
 using Nethermind.JsonRpc.Modules.Rpc;
 using Nethermind.JsonRpc.Modules.Subscribe;
+using Nethermind.Serialization.Json;
 using Spectre.Console;
+using System.Net;
+using System.Numerics;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Nethermind.DocGen;
 
@@ -22,6 +33,38 @@ internal static class JsonRpcGenerator
         "Nethermind.JsonRpc"
     ];
     private const string _objectTypeName = "_object_";
+    private static readonly SortedSet<string> _guessedTypeNames = new(StringComparer.Ordinal);
+    private static readonly Dictionary<Type, string> _knownTypeNames = new()
+    {
+        [typeof(Address)] = "_string_ (address)",
+        [typeof(AddressAsKey)] = "_string_ (address)",
+        [typeof(BigInteger)] = "_string_ (hex integer)",
+        [typeof(BlockParameter)] = "_string_ (block number or hash or either of `earliest`, `finalized`, `latest`, `pending`, or `safe`)",
+        [typeof(Bloom)] = "_string_ (hex data)",
+        [typeof(bool)] = "_boolean_",
+        [typeof(byte)] = "_string_ (hex data)",
+        [typeof(byte[])] = "_string_ (hex data)",
+        [typeof(byte[][])] = "array of _string_ (hex data)",
+        [typeof(DateTime)] = "_string_ (date-time)",
+        [typeof(double)] = "_number_",
+        [typeof(double[])] = "array of _number_",
+        [typeof(DateTimeOffset)] = "_string_ (date-time)",
+        [typeof(Hash256)] = "_string_ (hash)",
+        [typeof(Hash256[])] = "array of _string_ (hash)",
+        [typeof(HexBytes)] = "_string_ (hex data)",
+        [typeof(int)] = "_string_ (hex integer)",
+        [typeof(IPAddress)] = "_string_",
+        [typeof(long)] = "_string_ (hex integer)",
+        [typeof(PublicKey)] = "_string_ (hex data)",
+        [typeof(Signature)] = "_string_ (hex data)",
+        [typeof(string)] = "_string_",
+        [typeof(TimeSpan)] = "_string_ (duration)",
+        [typeof(TxType)] = "_string_ (transaction type)",
+        [typeof(uint)] = "_string_ (hex integer)",
+        [typeof(ulong)] = "_string_ (hex integer)",
+        [typeof(UInt256)] = "_string_ (hex integer)",
+        [typeof(ValueHash256)] = "_string_ (hash)",
+    };
 
     internal static void Generate(string path)
     {
@@ -83,6 +126,10 @@ internal static class JsonRpcGenerator
 
             WriteMarkdown(path, ns, methodMap[ns], i++);
         }
+
+        if (_guessedTypeNames.Count != 0)
+            AnsiConsole.MarkupLine(
+                $"[yellow]Documented from CLR shape, no serializer contract:[/] {string.Join(", ", _guessedTypeNames)}");
     }
 
     private static void WriteMarkdown(string path, string ns, IEnumerable<MethodInfo> methods, int sidebarIndex)
@@ -242,6 +289,8 @@ internal static class JsonRpcGenerator
 
     private static void WriteExpandedType(StreamWriter file, Type type, int indentation = 0, bool omitTypeName = false, IEnumerable<string?>? parentTypes = null)
     {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+
         parentTypes ??= new List<string>();
 
         if (parentTypes.Any(a => type.FullName?.Equals(a, StringComparison.Ordinal) ?? false))
@@ -270,18 +319,19 @@ internal static class JsonRpcGenerator
         if (!omitTypeName)
             file.WriteLine(_objectTypeName);
 
-        IEnumerable<PropertyInfo> properties = GetSerializableProperties(type);
+        if (IsOpaqueJson(type))
+            return;
 
-        foreach (PropertyInfo prop in properties)
+        foreach ((string name, Type memberType) in GetSerializedMembers(type))
         {
-            string propJsonType = GetJsonTypeName(prop.PropertyType);
+            string memberJsonType = GetJsonTypeName(memberType);
 
-            file.WriteLine($"{Indent(indentation + 2)}- `{GetSerializedName(prop)}`: {propJsonType}");
+            file.WriteLine($"{Indent(indentation + 2)}- `{name}`: {memberJsonType}");
 
-            if (propJsonType.Equals(_objectTypeName, StringComparison.Ordinal))
-                WriteExpandedType(file, prop.PropertyType, indentation + 2, true, parentTypes.Append(type.FullName));
-            else if (propJsonType.Contains($" of {_objectTypeName}", StringComparison.Ordinal) &&
-                TryGetEnumerableItemType(prop.PropertyType, out Type? itemType, out bool _))
+            if (memberJsonType.Equals(_objectTypeName, StringComparison.Ordinal))
+                WriteExpandedType(file, memberType, indentation + 2, true, parentTypes.Append(type.FullName));
+            else if (memberJsonType.Contains($" of {_objectTypeName}", StringComparison.Ordinal) &&
+                TryGetEnumerableItemType(memberType, out Type? itemType, out bool _))
                 WriteExpandedType(file, itemType!, indentation + 2, true, parentTypes.Append(type.FullName));
         }
     }
@@ -304,6 +354,9 @@ internal static class JsonRpcGenerator
 
     private static string GetJsonTypeName(Type type)
     {
+        if (type.IsByRef && type.GetElementType() is { } elementType)
+            type = elementType;
+
         Type? underlyingType = Nullable.GetUnderlyingType(type);
 
         if (underlyingType is not null)
@@ -312,28 +365,24 @@ internal static class JsonRpcGenerator
         if (type.IsEnum)
             return "_integer_";
 
+        if (type.IsGenericType)
+        {
+            Type definition = type.GetGenericTypeDefinition();
+
+            // Buffer wrappers are written by a converter: as hex when they hold bytes, else as their items
+            if (definition == typeof(ArrayPoolList<>) || definition == typeof(CappedArray<>)
+                || definition == typeof(Memory<>) || definition == typeof(ReadOnlyMemory<>))
+            {
+                Type bufferItemType = type.GetGenericArguments()[0];
+
+                return bufferItemType == typeof(byte) ? "_string_ (hex data)" : $"array of {GetJsonTypeName(bufferItemType)}";
+            }
+        }
+
         if (TryGetEnumerableItemType(type, out Type? itemType, out bool isDictionary))
             return $"{(isDictionary ? "map" : "array")} of {GetJsonTypeName(itemType!)}";
 
-        return type.Name switch
-        {
-            "Address" => "_string_ (address)",
-            "BigInteger"
-                or "Int32"
-                or "Int64"
-                or "Int64&"
-                or "UInt64"
-                or "UInt256" => "_string_ (hex integer)",
-            "BlockParameter" => "_string_ (block number or hash or either of `earliest`, `finalized`, `latest`, `pending`, or `safe`)",
-            "Bloom"
-                or "Byte"
-                or "Byte[]" => "_string_ (hex data)",
-            "Boolean" => "_boolean_",
-            "Hash256" => "_string_ (hash)",
-            "String" => "_string_",
-            "TxType" => "_string_ (transaction type)",
-            _ => _objectTypeName
-        };
+        return _knownTypeNames.GetValueOrDefault(type, _objectTypeName);
     }
 
     private static Type GetReturnType(Type type)
@@ -347,12 +396,42 @@ internal static class JsonRpcGenerator
         return Nullable.GetUnderlyingType(returnType) ?? returnType;
     }
 
-    private static IEnumerable<PropertyInfo> GetSerializableProperties(Type type) =>
-        type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-            .Where(p => p.GetCustomAttribute<JsonIgnoreAttribute>()?.Condition is not JsonIgnoreCondition.Always)
-            .OrderBy(p => p.Name);
+    private static bool IsOpaqueJson(Type type) =>
+        typeof(JsonNode).IsAssignableFrom(type) || type == typeof(JsonElement) || type == typeof(JsonDocument);
 
-    private static string GetSerializedName(PropertyInfo prop) =>
+    private static JsonTypeInfo? GetContract(Type type)
+    {
+        try
+        {
+            return EthereumJsonSerializer.JsonOptions.TryGetTypeInfo(type, out JsonTypeInfo? typeInfo) ? typeInfo : null;
+        }
+        catch (ArgumentException)
+        {
+            // Never-serializable types (by-ref, pointer, open generic) throw instead of reporting false
+            return null;
+        }
+    }
+
+    private static IEnumerable<(string Name, Type Type)> GetSerializedMembers(Type type)
+    {
+        JsonTypeInfo? contract = GetContract(type);
+
+        if (contract is not null && contract.Properties.Count != 0)
+            return contract.Properties
+                .Where(p => p.Get is not null)
+                .Select(p => (Name: p.Name, Type: p.PropertyType))
+                .OrderBy(m => m.Name, StringComparer.Ordinal);
+
+        // A hand-rolled converter exposes no contract members, leaving the CLR shape as the only guess
+        _guessedTypeNames.Add(type.Name);
+
+        return type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetCustomAttribute<JsonIgnoreAttribute>()?.Condition is not JsonIgnoreCondition.Always)
+            .Select(p => (Name: GetFallbackName(p), Type: p.PropertyType))
+            .OrderBy(m => m.Name, StringComparer.Ordinal);
+    }
+
+    private static string GetFallbackName(PropertyInfo prop) =>
         prop.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
             ?? JsonNamingPolicy.CamelCase.ConvertName(prop.Name);
 
@@ -360,57 +439,13 @@ internal static class JsonRpcGenerator
 
     private static bool TryGetEnumerableItemType(Type type, out Type? itemType, out bool isDictionary)
     {
-        if (type.IsArray && type.HasElementType)
-        {
-            Type? elementType = type.GetElementType();
+        JsonTypeInfo? contract = GetContract(type);
 
-            // Ignore a byte array as it is treated as a hex string
-            if (elementType == typeof(byte))
-            {
-                itemType = null;
-                isDictionary = false;
+        isDictionary = contract?.Kind is JsonTypeInfoKind.Dictionary;
+        itemType = contract?.Kind is JsonTypeInfoKind.Enumerable or JsonTypeInfoKind.Dictionary
+            ? contract.ElementType
+            : null;
 
-                return false;
-            }
-
-            itemType = type.GetElementType();
-            isDictionary = false;
-
-            return true;
-        }
-
-        if (type.IsInterface && type.IsGenericType)
-        {
-            if (type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
-            {
-                itemType = type.GetGenericArguments().Last();
-                isDictionary = false;
-
-                return true;
-            }
-
-            if (type.GetGenericTypeDefinition() == typeof(IDictionary<,>))
-            {
-                itemType = type.GetGenericArguments().Last();
-                isDictionary = true;
-
-                return true;
-            }
-        }
-
-        if (type.IsGenericType && type.GetInterfaces()
-            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
-        {
-            itemType = type.GetGenericArguments().Last();
-            isDictionary = type.GetInterfaces()
-                .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
-
-            return true;
-        }
-
-        itemType = null;
-        isDictionary = false;
-
-        return false;
+        return itemType is not null;
     }
 }


### PR DESCRIPTION
Partial #12828, #12836, #12838, #12839 and #12841. Closes #12826.

## Changes

DocGen re-derived the serializer's rules by inspecting CLR types, and disagreed with them. It now reads the same contract the RPC layer serializes with, via the public `EthereumJsonSerializer.JsonOptions`.

- **Names and visibility come from the contract.** `JsonPropertyInfo.Name` is the final wire name and `Get is null` marks a hidden member, so naming policy, `[JsonPropertyName]`, `[JsonIgnore]` conditions, public fields and inherited members are no longer re-implemented. This surfaces the block fields `eth_simulateV1` and `trace_simulateV1` omitted.
- **Converter-backed types are documented as what they emit.** `eth_call` was an object with a `bytes` member instead of a hex string; `traceAddress` was an object with `isUncapped` instead of an array. A `typeof`-keyed table replaces the `type.Name switch` and covers these. By-ref and `Nullable<T>` unwrap first, removing the `hasValue`/`value` wrappers.
- **The table is consulted before shape inference, and its numeric rows match the registered converters.** Previously the enum and collection branches ran first, so the `TxType` row was unreachable and every transaction `type` was documented as `_integer_` while the wire is `"0x2"`. `int`, `uint` and `byte` have no hex converter and serialize as JSON numbers; `BigInteger` writes decimal digits, not hex. Enums serialize numerically unless a converter writes the name instead, so `admin_prune` is a string.
- **Collections use `Kind`/`ElementType`/`KeyType`**, deleting ~55 lines of hand-rolled detection.
- **Types with no contract fall back to CLR shape, and are reported once per run.** Hand-rolled converters expose no members. `JsonTypeInfoKind` selects the fallback rather than an empty property count, which would conflate "no contract" with "every member ignored"; public fields are included to match the serializer's `IncludeFields`; and a type the serializer refuses to model degrades to its CLR shape instead of aborting the run. Listing the fallbacks makes a guessed page visible.



## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing
Each changed shape was checked against geth's implementation and golden `testdata/*.json`, plus Nethermind's existing CI-asserted JSON.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x]  No

## Remarks
Fixed beyond the filed issues

| Method(s) | Was | Now |
|---|---|---|
| `eth_call` | `_object_` with a `bytes` member | `_string_ (hex data)` |
| `debug_getRawBlock`/`RawHeader`/`RawTransaction`, `eth_getRawTransactionBy*` | `array of _string_ (hex data)` | `_string_ (hex data)` |
| `eth_feeHistory` → `rewardPercentiles` | `array of _object_` | `array of _number_` |
| `eth_simulateV1` / `trace_simulateV1` | block fields absent | inherited block fields documented |
| `type` on every transaction and receipt (31 places) | `_integer_` | `_string_ (transaction type)` |
| `admin_prune` | `_integer_` | `_string_` |
| `debug_trace*` struct logs → `depth` | `_string_ (hex integer)` | `_integer_` |
| `admin_nodeInfo` → `ports.*`; `parity_netPeers` → `active`/`connected`/`max`; `clique_getSnapshot` → `votes`; `eth_simulateV1` → `code` | `_string_ (hex integer)` | `_integer_` |
| `admin_peers` → `version` | `_string_ (hex data)` | `_integer_` |
