### PR TITLE
fix(docgen): probe member converters to document their real JSON kind

### DIFF
--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -13,6 +13,7 @@ using Nethermind.JsonRpc.Modules.Rpc;
 using Nethermind.JsonRpc.Modules.Subscribe;
 using Nethermind.Serialization.Json;
 using Spectre.Console;
+using System.Buffers;
 using System.Net;
 using System.Numerics;
 using System.Reflection;
@@ -329,9 +330,9 @@ internal static class JsonRpcGenerator
         if (IsOpaqueJson(type))
             return;
 
-        foreach ((string name, Type memberType) in GetSerializedMembers(type))
+        foreach ((string name, Type memberType, Type? memberConverter) in GetSerializedMembers(type))
         {
-            string memberJsonType = GetJsonTypeName(memberType);
+            string memberJsonType = GetJsonTypeName(memberType, memberConverter);
 
             file.WriteLine($"{Indent(indentation + 2)}- `{name}`: {memberJsonType}");
 
@@ -359,15 +360,28 @@ internal static class JsonRpcGenerator
         }
     }
 
-    private static string GetJsonTypeName(Type type)
+    private static string GetJsonTypeName(Type type, Type? converterType = null)
     {
         if (type.IsByRef && type.GetElementType() is { } elementType)
             type = elementType;
 
-        Type? underlyingType = Nullable.GetUnderlyingType(type);
+        type = Nullable.GetUnderlyingType(type) ?? type;
 
-        if (underlyingType is not null)
-            return GetJsonTypeName(underlyingType);
+        // A member can pin its own converter, and the CLR type alone cannot tell a hex-quantity string
+        // from a raw JSON number (e.g. two `ulong` fields, one with a raw-number converter). Probing that
+        // converter's actual output is the only reliable signal, and it works for any converter, not a
+        // hard-coded list. This is scoped to explicit member converters: probing a type's default
+        // serialization is unsound for value-dependent unions (e.g. `eth_syncing` returns `false` or an
+        // object), so those keep the editorial mapping below.
+        if (converterType is not null && TryProbeScalarKind(type, converterType, out JsonTokenType token))
+        {
+            if (token is JsonTokenType.Number)
+                return IsFloatingPoint(type) ? "_number_" : "_integer_";
+            if (token is JsonTokenType.True or JsonTokenType.False)
+                return "_boolean_";
+
+            // A string result keeps its flavour (hex data, hash, ...) from the editorial mapping below
+        }
 
         if (_knownTypeNames.TryGetValue(type, out string? knownName))
             return knownName;
@@ -394,6 +408,51 @@ internal static class JsonRpcGenerator
             return $"{(isDictionary ? "map" : "array")} of {GetJsonTypeName(itemType!)}";
 
         return _objectTypeName;
+    }
+
+    private static bool IsFloatingPoint(Type type) =>
+        type == typeof(double) || type == typeof(float) || type == typeof(decimal);
+
+    // Serializes a sample value through the member's converter and reports the JSON token it produces,
+    // so number-vs-string-vs-boolean is read from the serializer rather than guessed from the CLR type.
+    private static bool TryProbeScalarKind(Type type, Type converterType, out JsonTokenType token)
+    {
+        token = JsonTokenType.None;
+
+        try
+        {
+            object? sample = Activator.CreateInstance(type);
+
+            if (sample is null)
+                return false;
+
+            ArrayBufferWriter<byte> buffer = new();
+
+            using (Utf8JsonWriter writer = new(buffer))
+                InvokeConverterWrite(converterType, type, sample, writer);
+
+            Utf8JsonReader reader = new(buffer.WrittenSpan);
+            reader.Read();
+            token = reader.TokenType;
+
+            return token is JsonTokenType.Number or JsonTokenType.String or JsonTokenType.True or JsonTokenType.False;
+        }
+        // A converter that cannot serialize the sample (no default value, rejects zero, complex output)
+        // yields no usable token; the caller falls back to the editorial mapping.
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private static void InvokeConverterWrite(Type converterType, Type valueType, object sample, Utf8JsonWriter writer)
+    {
+        JsonConverter converter = (JsonConverter)Activator.CreateInstance(converterType)!;
+        MethodInfo write = converterType.GetMethod(
+            nameof(JsonConverter<object>.Write),
+            [typeof(Utf8JsonWriter), valueType, typeof(JsonSerializerOptions)])!;
+
+        write.Invoke(converter, [writer, sample, EthereumJsonSerializer.JsonOptions]);
     }
 
     private static Type GetReturnType(Type type)
@@ -424,14 +483,14 @@ internal static class JsonRpcGenerator
         }
     }
 
-    private static IEnumerable<(string Name, Type Type)> GetSerializedMembers(Type type)
+    private static IEnumerable<(string Name, Type Type, Type? Converter)> GetSerializedMembers(Type type)
     {
         JsonTypeInfo? contract = GetContract(type);
 
         if (contract?.Kind is JsonTypeInfoKind.Object)
             return contract.Properties
                 .Where(p => p.Get is not null)
-                .Select(p => (Name: p.Name, Type: p.PropertyType))
+                .Select(p => (Name: p.Name, Type: p.PropertyType, Converter: MemberConverter(p.AttributeProvider)))
                 .OrderBy(m => m.Name, StringComparer.Ordinal);
 
         // A hand-rolled converter exposes no contract members, leaving the CLR shape as the only guess
@@ -443,9 +502,17 @@ internal static class JsonRpcGenerator
         return type.GetProperties(memberFlags).Select(p => (Member: (MemberInfo)p, Type: p.PropertyType))
             .Concat(type.GetFields(memberFlags).Select(f => (Member: (MemberInfo)f, Type: f.FieldType)))
             .Where(m => m.Member.GetCustomAttribute<JsonIgnoreAttribute>()?.Condition is not JsonIgnoreCondition.Always)
-            .Select(m => (Name: GetFallbackName(m.Member), Type: m.Type))
+            .Select(m => (Name: GetFallbackName(m.Member), Type: m.Type, Converter: MemberConverter(m.Member)))
             .OrderBy(m => m.Name, StringComparer.Ordinal);
     }
+
+    // A member may pin its own converter via [JsonConverter], overriding the serialization its CLR type
+    // would otherwise get (e.g. a raw-number converter on a block number). Probing through that converter
+    // is what lets two fields of the same type document different wire forms.
+    private static Type? MemberConverter(ICustomAttributeProvider? member) =>
+        member?.GetCustomAttributes(typeof(JsonConverterAttribute), inherit: false) is [JsonConverterAttribute { ConverterType: { } converterType }]
+            ? converterType
+            : null;
 
     private static string GetFallbackName(MemberInfo member) =>
         member.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name

--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -367,20 +367,15 @@ internal static class JsonRpcGenerator
 
         type = Nullable.GetUnderlyingType(type) ?? type;
 
-        // A member can pin its own converter, and the CLR type alone cannot tell a hex-quantity string
-        // from a raw JSON number (e.g. two `ulong` fields, one with a raw-number converter). Probing that
-        // converter's actual output is the only reliable signal, and it works for any converter, not a
-        // hard-coded list. This is scoped to explicit member converters: probing a type's default
-        // serialization is unsound for value-dependent unions (e.g. `eth_syncing` returns `false` or an
-        // object), so those keep the editorial mapping below.
-        if (converterType is not null && TryProbeScalarKind(type, converterType, out JsonTokenType token))
+        // Only explicit member converters: probing a type's default serialization is unsound for
+        // value-dependent unions (e.g. `eth_syncing` returns `false` or an object).
+        if (converterType is not null && TryProbeScalarKind(converterType, out JsonTokenType token))
         {
             if (token is JsonTokenType.Number)
                 return IsFloatingPoint(type) ? "_number_" : "_integer_";
             if (token is JsonTokenType.True or JsonTokenType.False)
                 return "_boolean_";
-
-            // A string result keeps its flavour (hex data, hash, ...) from the editorial mapping below
+            // a string falls through to keep its flavour from the editorial mapping below
         }
 
         if (_knownTypeNames.TryGetValue(type, out string? knownName))
@@ -413,15 +408,23 @@ internal static class JsonRpcGenerator
     private static bool IsFloatingPoint(Type type) =>
         type == typeof(double) || type == typeof(float) || type == typeof(decimal);
 
-    // Serializes a sample value through the member's converter and reports the JSON token it produces,
-    // so number-vs-string-vs-boolean is read from the serializer rather than guessed from the CLR type.
-    private static bool TryProbeScalarKind(Type type, Type converterType, out JsonTokenType token)
+    // Reads the JSON token the converter actually emits, so number/string/boolean comes from the
+    // serializer rather than the CLR type.
+    private static bool TryProbeScalarKind(Type converterType, out JsonTokenType token)
     {
         token = JsonTokenType.None;
 
+        // Value type from the converter's own JsonConverter<T> base: nullable converters declare Write
+        // against `T?`, and a JsonConverterFactory declares none (null here).
+        Type? valueType = ConverterValueType(converterType);
+
+        if (valueType is null)
+            return false;
+
         try
         {
-            object? sample = Activator.CreateInstance(type);
+            // Non-null underlying value, else a nullable converter writes null
+            object? sample = Activator.CreateInstance(Nullable.GetUnderlyingType(valueType) ?? valueType);
 
             if (sample is null)
                 return false;
@@ -429,7 +432,7 @@ internal static class JsonRpcGenerator
             ArrayBufferWriter<byte> buffer = new();
 
             using (Utf8JsonWriter writer = new(buffer))
-                InvokeConverterWrite(converterType, type, sample, writer);
+                InvokeConverterWrite(converterType, valueType, sample, writer);
 
             Utf8JsonReader reader = new(buffer.WrittenSpan);
             reader.Read();
@@ -437,12 +440,20 @@ internal static class JsonRpcGenerator
 
             return token is JsonTokenType.Number or JsonTokenType.String or JsonTokenType.True or JsonTokenType.False;
         }
-        // A converter that cannot serialize the sample (no default value, rejects zero, complex output)
-        // yields no usable token; the caller falls back to the editorial mapping.
+        // Not a documentable scalar (uninstantiable, converter rejects the sample); fall back to the mapping
         catch (Exception)
         {
             return false;
         }
+    }
+
+    private static Type? ConverterValueType(Type converterType)
+    {
+        for (Type? t = converterType; t is not null; t = t.BaseType)
+            if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(JsonConverter<>))
+                return t.GetGenericArguments()[0];
+
+        return null;
     }
 
     private static void InvokeConverterWrite(Type converterType, Type valueType, object sample, Utf8JsonWriter writer)
@@ -506,9 +517,7 @@ internal static class JsonRpcGenerator
             .OrderBy(m => m.Name, StringComparer.Ordinal);
     }
 
-    // A member may pin its own converter via [JsonConverter], overriding the serialization its CLR type
-    // would otherwise get (e.g. a raw-number converter on a block number). Probing through that converter
-    // is what lets two fields of the same type document different wire forms.
+    // The member's [JsonConverter], if any: lets two fields of the same type document different wire forms
     private static Type? MemberConverter(ICustomAttributeProvider? member) =>
         member?.GetCustomAttributes(typeof(JsonConverterAttribute), inherit: false) is [JsonConverterAttribute { ConverterType: { } converterType }]
             ? converterType


### PR DESCRIPTION
Resolves #12838

Follow-up to #12868 (now merged), addressing the per-member converter case raised in review (https://github.com/NethermindEth/nethermind/pull/12868#discussion_r3802398660).

## Changes

#12868 derives JSON-RPC docs from the serializer contract and already fixes the plain-`int` case (`int`/`uint` → `_integer_`). The remaining #12838 gap is that a member's **CLR type alone doesn't determine its wire form**: a field with an explicit `[JsonConverter]` can emit something other than the hex-quantity string its type implies — the classic case being two `ulong` fields where one carries a raw-number converter (struct-log `gas` vs transaction `gas`).

Rather than hard-code the raw-number converter types, this **probes** the member's converter: it serializes a sample value through that converter and reads back the JSON token.
- `Number`/`True`/`False` → override the type-based label (`_integer_`/`_number_`/`_boolean_`).
- `String` → fall through and keep the editorial flavour (`hex data`, `hash`, …).

It works for **any** converter, not a fixed list — the same "ask the serializer, don't guess" principle as #12868. Probing is deliberately scoped to explicit **member** converters: probing a type's *default* serialization is unsound for value-dependent unions (e.g. `eth_syncing` returns `false` **or** an object; a default-value probe would collapse it to `_boolean_`).

## Result / verification

Diffed the generated docs against `master`. The **only** changes are the intended fields flipping hex-string → `_integer_`:
- `trace_*` result `blockNumber`
- `debug_*` Geth struct-log entries: `gas`, `gasCost`, `pc`, `refund`, `step`

`eth_syncing`, byte-buffer fields, hashes, addresses and all other shapes are unchanged. Together with #12868, every field reported in #12838 is now correct and matches the wire format (Geth/OpenEthereum/Erigon).

No RPC-module code changes: the implementation already matched the reference clients; only the generated docs were wrong.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Documentation update

## Testing

#### Requires testing

- [x] No

#### Notes on testing

The DocGen tool has no test project (consistent with #12858/#12868). Verified by regenerating the docs on this branch and diffing against `master`, confirming only the raw-number-converter fields change.

## Documentation

#### Requires documentation update

- [x] Yes

Regenerating the docs from this branch updates the `NethermindEth/docs` JSON-RPC pages.

#### Requires explanation in Release Notes

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)