### PR TITLE
Generate JSON-RPC docs for the EraE module

### DIFF
--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -16,6 +16,7 @@ internal static class JsonRpcGenerator
     private static readonly string[] _assemblies = [
         "Nethermind.Consensus.Clique",
         "Nethermind.Era1",
+        "Nethermind.EraE",
         "Nethermind.Flashbots",
         "Nethermind.HealthChecks",
         "Nethermind.JsonRpc"


### PR DESCRIPTION
`JsonRpcGenerator` discovers RPC modules from a hardcoded assembly list that includes `Nethermind.Era1` but not `Nethermind.EraE`. As a result `admin_importEraHistory` and `admin_exportEraHistory` have never been generated into the JSON-RPC reference, even though `EraEModule` registers them unconditionally and they ship (the module is loaded from `NethermindModule` and the `EraE.*` config options are already documented).

Verified by running `DocGen --jsonrpc` against a copy of the docs repo: with this line the two methods appear in `docs/interacting/json-rpc-ns/admin.md`; without it they do not.

The missing entries are being added to the docs site separately, so this only keeps future regenerations from dropping them again.
