### PR TITLE
Add timeout to create_a_runner in sync master validation

### DIFF
--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -120,6 +120,8 @@ jobs:
       matrix:
         config: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
+    # Normally ~3 min; caps apt mirror hangs that otherwise burn the 6h default (see run 32068506752)
+    timeout-minutes: 15
     steps:
       - name: Install sshpass
         run: sudo apt-get update && sudo apt-get install -y sshpass


### PR DESCRIPTION
## Changes

- Add `timeout-minutes: 15` to the `create_a_runner` job in `sync-master-validation.yml` (healthy runs finish in ~3 min)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

In [run 32068506752](https://github.com/NethermindEth/nethermind/actions/runs/32068506752/job/95506116927), `sudo apt-get update` in the `Install sshpass` step stalled after an `azure.archive.ubuntu.com` mirror outage (last output at 20:57:44, fallback fetch of `noble-security InRelease` hung with no further output). With no job timeout set, the job sat idle until GitHub's default 6-hour limit cancelled it. This caps such hangs at 15 minutes.