### PR TITLE
fix(flat): restore the trie warmer negative cache without poisoning live reads

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
@@ -30,8 +30,11 @@ public class SnapshotBundleWarmerTests
 
     private sealed class NullTrieNodeCache : ITrieNodeCache
     {
+        public int TryGetCount;
+
         public bool TryGet(Hash256? address, in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node)
         {
+            TryGetCount++;
             node = null;
             return false;
         }
@@ -126,7 +129,7 @@ public class SnapshotBundleWarmerTests
     [Test]
     public void Repeated_warmer_miss_is_served_from_the_negative_cache()
     {
-        CountingTrieNodeCache cache = new();
+        NullTrieNodeCache cache = new();
         using SnapshotBundle bundle = new(FlatTestHelpers.MakeBundle(_pool), cache, _pool, ResourcePool.Usage.MainBlockProcessing);
 
         TreePath path = TreePath.FromHexString("12");
@@ -136,21 +139,6 @@ public class SnapshotBundleWarmerTests
         bundle.FindStateNodeOrUnknownForTrieWarmer(path, hash);
 
         Assert.That(cache.TryGetCount, Is.EqualTo(1));
-    }
-
-    private sealed class CountingTrieNodeCache : ITrieNodeCache
-    {
-        public int TryGetCount;
-
-        public bool TryGet(Hash256? address, in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node)
-        {
-            TryGetCount++;
-            node = null;
-            return false;
-        }
-
-        public void Add(TransientResource transientResource) { }
-        public void Clear() { }
     }
 
     // Dispose releases the transient back to the pool while warmer jobs may still be in flight. A read that

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Int256;
+using Nethermind.Logging;
 using Nethermind.Trie;
 using NUnit.Framework;
 
@@ -92,6 +93,29 @@ public class SnapshotBundleWarmerTests
             Assert.That(normalStateRead, Is.SameAs(committedNode));
             Assert.That(normalStorageRead, Is.SameAs(committedStorageNode));
         }
+    }
+
+    [Test]
+    public void Promoted_warmer_miss_does_not_poison_a_later_live_read()
+    {
+        TrieNodeCache cache = new(new FlatDbConfig(), LimboLogs.Instance);
+        using SnapshotBundle bundle = new(FlatTestHelpers.MakeBundle(_pool), cache, _pool, ResourcePool.Usage.MainBlockProcessing);
+
+        TreePath path = TreePath.FromHexString("12");
+        Hash256 hash = TestItem.KeccakA;
+
+        TrieNode warmed = bundle.FindStateNodeOrUnknownForTrieWarmer(path, hash);
+        Assert.That(warmed.NodeType, Is.EqualTo(NodeType.Unknown));
+
+        (_, TransientResource? retired) = bundle.CollectAndApplySnapshot(StateId.PreGenesis, new StateId(1, TestItem.KeccakA));
+        cache.Add(retired!);
+
+        TrieNode realNode = Leaf(0x99);
+        bundle.SetStateNode(path, realNode);
+        bundle.CollectAndApplySnapshot(new StateId(1, TestItem.KeccakA), new StateId(2, TestItem.KeccakB), returnSnapshot: false);
+
+        TrieNode read = bundle.FindStateNodeOrUnknown(path, hash);
+        Assert.That(read, Is.SameAs(realNode));
     }
 
     // Dispose releases the transient back to the pool while warmer jobs may still be in flight. A read that

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
@@ -98,7 +99,7 @@ public class SnapshotBundleWarmerTests
     [Test]
     public void Promoted_warmer_miss_does_not_poison_a_later_live_read()
     {
-        TrieNodeCache cache = new(new FlatDbConfig(), LimboLogs.Instance);
+        TrieNodeCache cache = new(new FlatDbConfig { TrieCacheMemoryBudget = MemorySizes.MiB }, LimboLogs.Instance);
         using SnapshotBundle bundle = new(FlatTestHelpers.MakeBundle(_pool), cache, _pool, ResourcePool.Usage.MainBlockProcessing);
 
         TreePath path = TreePath.FromHexString("12");
@@ -109,6 +110,7 @@ public class SnapshotBundleWarmerTests
 
         (_, TransientResource? retired) = bundle.CollectAndApplySnapshot(StateId.PreGenesis, new StateId(1, TestItem.KeccakA));
         cache.Add(retired!);
+        retired!.ReleaseLease();
 
         TrieNode realNode = Leaf(0x99);
         bundle.SetStateNode(path, realNode);
@@ -116,6 +118,39 @@ public class SnapshotBundleWarmerTests
 
         TrieNode read = bundle.FindStateNodeOrUnknown(path, hash);
         Assert.That(read, Is.SameAs(realNode));
+    }
+
+    // The regression this PR fixes is a +3-5% AVG slowdown from #12793 dropping the warmer's negative cache.
+    // Pin that the cache exists: a second warmer visit to the same missing path must be served from the
+    // transient sentinel and must not re-probe the persistence-backed lookup a second time.
+    [Test]
+    public void Repeated_warmer_miss_is_served_from_the_negative_cache()
+    {
+        CountingTrieNodeCache cache = new();
+        using SnapshotBundle bundle = new(FlatTestHelpers.MakeBundle(_pool), cache, _pool, ResourcePool.Usage.MainBlockProcessing);
+
+        TreePath path = TreePath.FromHexString("12");
+        Hash256 hash = TestItem.KeccakA;
+
+        bundle.FindStateNodeOrUnknownForTrieWarmer(path, hash);
+        bundle.FindStateNodeOrUnknownForTrieWarmer(path, hash);
+
+        Assert.That(cache.TryGetCount, Is.EqualTo(1));
+    }
+
+    private sealed class CountingTrieNodeCache : ITrieNodeCache
+    {
+        public int TryGetCount;
+
+        public bool TryGet(Hash256? address, in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node)
+        {
+            TryGetCount++;
+            node = null;
+            return false;
+        }
+
+        public void Add(TransientResource transientResource) { }
+        public void Clear() { }
     }
 
     // Dispose releases the transient back to the pool while warmer jobs may still be in flight. A read that

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -166,7 +166,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
-        else if (_transientResource.TryGetStateNode(path, hash, out node) && !IsWarmerMiss(node))
+        else if (_transientResource.TryGetStateNode(path, hash, out node) && !TrieNodeCache.IsWarmerMiss(node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
@@ -288,7 +288,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
-        else if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out node) && !IsWarmerMiss(node))
+        else if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out node) && !TrieNodeCache.IsWarmerMiss(node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
@@ -338,8 +338,6 @@ public sealed class SnapshotBundle : IDisposable
         return transientResource.GetOrAddStorageNode((Hash256AsKey)address, path,
             TryFindStorageNodeInPersistence(address, path, hash, out node) ? node : new TrieNode(NodeType.Unknown, hash));
     }
-
-    private static bool IsWarmerMiss(TrieNode node) => node.NodeType == NodeType.Unknown && node.FullRlp.Length == 0;
 
     private bool TryFindStorageNodeInPersistence(Hash256 address, in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node)
     {

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -166,7 +166,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
-        else if (_transientResource.TryGetStateNode(path, hash, out node) && !TrieNodeCache.IsWarmerMiss(node))
+        else if (_transientResource.TryGetStateNode(path, hash, out node) && !TrieNodeCache.IsPlaceholder(node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
@@ -288,7 +288,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
-        else if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out node) && !TrieNodeCache.IsWarmerMiss(node))
+        else if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out node) && !TrieNodeCache.IsPlaceholder(node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -166,7 +166,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
-        else if (_transientResource.TryGetStateNode(path, hash, out node))
+        else if (_transientResource.TryGetStateNode(path, hash, out node) && !IsWarmerMiss(node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
@@ -210,9 +210,8 @@ public sealed class SnapshotBundle : IDisposable
             return node;
         }
 
-        return TryFindStateNodeInPersistence(path, hash, out node)
-            ? transientResource.GetOrAddStateNode(path, node)
-            : new TrieNode(NodeType.Unknown, hash);
+        return transientResource.GetOrAddStateNode(path,
+            TryFindStateNodeInPersistence(path, hash, out node) ? node : new TrieNode(NodeType.Unknown, hash));
     }
 
     // Returns a leased transient, or null once the bundle is being torn down. A stale read can acquire a
@@ -289,7 +288,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
-        else if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out node))
+        else if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out node) && !IsWarmerMiss(node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
@@ -336,10 +335,11 @@ public sealed class SnapshotBundle : IDisposable
             return node;
         }
 
-        return TryFindStorageNodeInPersistence(address, path, hash, out node)
-            ? transientResource.GetOrAddStorageNode((Hash256AsKey)address, path, node)
-            : new TrieNode(NodeType.Unknown, hash);
+        return transientResource.GetOrAddStorageNode((Hash256AsKey)address, path,
+            TryFindStorageNodeInPersistence(address, path, hash, out node) ? node : new TrieNode(NodeType.Unknown, hash));
     }
+
+    private static bool IsWarmerMiss(TrieNode node) => node.NodeType == NodeType.Unknown && node.FullRlp.Length == 0;
 
     private bool TryFindStorageNodeInPersistence(Hash256 address, in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node)
     {

--- a/src/Nethermind/Nethermind.State.Flat/TrieNodeCache.cs
+++ b/src/Nethermind/Nethermind.State.Flat/TrieNodeCache.cs
@@ -133,7 +133,7 @@ public sealed class TrieNodeCache : ITrieNodeCache
             (int hashCode, TrieNode? node)[] shard = transientResource.Nodes.Shards[i];
             for (int j = 0; j < shard.Length; j++)
             {
-                if (shard[j].node is { } newNode) AddToCacheWithHashCode(i, shard[j].hashCode, newNode);
+                if (shard[j].node is { } newNode && !IsWarmerMiss(newNode)) AddToCacheWithHashCode(i, shard[j].hashCode, newNode);
             }
         });
 
@@ -168,6 +168,13 @@ public sealed class TrieNodeCache : ITrieNodeCache
 
         Nethermind.Trie.Pruning.Metrics.MemoryUsedByCache = currentTotalMemory;
     }
+
+    /// <summary>
+    /// Identifies the trie warmer's negative-cache sentinel: an <see cref="NodeType.Unknown"/> node with empty RLP,
+    /// recording that a path is absent from persistence. It is not an authoritative node, so it must neither enter
+    /// this shared cache nor satisfy a live read.
+    /// </summary>
+    internal static bool IsWarmerMiss(TrieNode node) => node.NodeType == NodeType.Unknown && node.FullRlp.Length == 0;
 
     /// <summary>
     /// Clears all cached trie nodes.

--- a/src/Nethermind/Nethermind.State.Flat/TrieNodeCache.cs
+++ b/src/Nethermind/Nethermind.State.Flat/TrieNodeCache.cs
@@ -133,7 +133,7 @@ public sealed class TrieNodeCache : ITrieNodeCache
             (int hashCode, TrieNode? node)[] shard = transientResource.Nodes.Shards[i];
             for (int j = 0; j < shard.Length; j++)
             {
-                if (shard[j].node is { } newNode && !IsWarmerMiss(newNode)) AddToCacheWithHashCode(i, shard[j].hashCode, newNode);
+                if (shard[j].node is { } newNode && !IsPlaceholder(newNode)) AddToCacheWithHashCode(i, shard[j].hashCode, newNode);
             }
         });
 
@@ -170,11 +170,12 @@ public sealed class TrieNodeCache : ITrieNodeCache
     }
 
     /// <summary>
-    /// Identifies the trie warmer's negative-cache sentinel: an <see cref="NodeType.Unknown"/> node with empty RLP,
-    /// recording that a path is absent from persistence. It is not an authoritative node, so it must neither enter
-    /// this shared cache nor satisfy a live read.
+    /// Identifies a placeholder trie node: <see cref="NodeType.Unknown"/> with empty RLP, carrying only a hash. The
+    /// trie warmer's negative cache and the trie commit path both produce it; it is not an authoritative node, so it
+    /// must neither enter this shared cache nor satisfy a live read - callers fall through to the snapshots or
+    /// persistence lookup instead.
     /// </summary>
-    internal static bool IsWarmerMiss(TrieNode node) => node.NodeType == NodeType.Unknown && node.FullRlp.Length == 0;
+    internal static bool IsPlaceholder(TrieNode node) => node.NodeType == NodeType.Unknown && node.FullRlp.Length == 0;
 
     /// <summary>
     /// Clears all cached trie nodes.


### PR DESCRIPTION
## Summary

PR #12793 stopped the FlatDB trie warmer from caching its persistence miss as an `Unknown` sentinel. That fixed a correctness bug (a cached `Unknown` poisoned a real read and produced `InvalidStateRoot` right after sync), but it also removed the warmer's negative cache, which turned into a ~+3-5% AVG block-processing regression on FlatDB.

### Why the regression

The prewarmer traverses the trie from the root for every queued key, so high-fanout upper nodes are visited many times per block. Those nodes change every block, so they live in the recyclable `_snapshots`, not in persistence. With the negative cache gone, each visit re-ran the full `TryFind...InPersistence` lookup (concurrent-dict probe plus a persisted-snapshot read that can reach RocksDB) and found nothing, every time.

Confirmation run [32120208695](https://github.com/NethermindEth/nethermind/actions/runs/32120208695) (3x before `master-4b0d9a2` vs 3x after `master-8b7a4ac`): AVG 30.24 / 30.09 / 29.78 ms → 31.02 / 31.17 / 31.82 ms (+2.6…+5.2%, monotonic).

### Fix

Restore the negative cache without the poison:

- The warmer caches the miss as a bare `Unknown` sentinel again (`GetOrAdd`), so repeat visits short-circuit instead of re-hitting persistence.
- The live reads (`FindStateNodeOrUnknown` / `FindStorageNodeOrUnknown`) now treat that sentinel as absent (`!IsWarmerMiss(node)`) and fall through to the authoritative `_snapshots`/persistence lookup. A warmed miss can no longer be returned to a real read, so the `InvalidStateRoot` #12793 fixed does not come back.

The transient node cache is a pure accelerator — authoritative nodes live in `_changedStateNodes` (during commit) and `_snapshots`/persistence otherwise — so evicting a slot to a sentinel is safe: a live read that misses the transient re-resolves from those sources. `IsWarmerMiss` reuses the existing miss discriminator (`NodeType.Unknown && FullRlp.Length == 0`) already used in `PersistedSnapshotUtils`/`PersistedSnapshotBuilder`.

## Changes

- `SnapshotBundle.WarmUpStateNode` / `WarmUpStorageNode`: cache the persistence miss as the `Unknown` sentinel.
- `SnapshotBundle.FindStateNodeOrUnknown` / `FindStorageNodeOrUnknown`: skip the sentinel via `IsWarmerMiss`.

## Types of changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Optimization

## Testing

- `Nethermind.State.Flat.Test`: 963 passed / 10 skipped / 0 failed (arm64).
- `Nethermind.State.Flat.History.Test`: 100 / 0.
- Positive control (live-read poisoning): with the two `!IsPlaceholder` guards removed, `Trie_warmer_reads_persistence_only_and_ignores_recyclable_snapshots` fails on the `normalStateRead`/`normalStorageRead` assertions, and passes with the guards.
- Regression test (promotion path): `Promoted_warmer_miss_does_not_poison_a_later_live_read` warms a miss, commits, populates a real `TrieNodeCache`, and asserts a later live read still resolves the real node. RED without the `TrieNodeCache.Add` filter.
- Regression test (negative cache): `Repeated_warmer_miss_is_served_from_the_negative_cache` asserts a second warmer visit to the same missing path is served from the transient sentinel (no re-probe). RED without the sentinel.
- Reproducible payload benchmarks, A/B on the `reproducible-benchmarks` runner ([run 32143868026](https://github.com/NethermindEth/nethermind/actions/runs/32143868026), superblocks × flat × 3): regressed `master-8b7a4ac` AVG 922.96 / 917.14 / 933.30 ms vs this branch 881.09 / 912.34 / 903.96 ms — mean 924.5 → 899.1 ms (−2.7%), every fix run below the master mean. The +2.6…+5.2% regression is recovered.

## Documentation

- [ ] Requires documentation update

