### PR TITLE
docs: drop devnet divergence note from ExecuteDefaultVerifyCode

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -628,9 +628,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     /// SECP256K1 signature signed by the target, then APPROVE. No gas beyond the EIP-8250 surcharge.
     /// The signature's cryptographic validity is already checked in pre-flight; default code checks
     /// only the structural conditions the spec pins.
-    /// EIP8141-ISSUE: the spec reads the signature from the hoisted <c>signatures</c> list at index
-    /// 0; the ethrex public devnet carries it in the VERIFY frame's data instead — an open
-    /// cross-client divergence to raise upstream. This follows the spec (hoisted list).
     /// </summary>
     private TransactionSubstate ExecuteDefaultVerifyCode(TxFrame frame, Address resolvedTarget, FrameTxContext frameContext, ITxTracer tracer, out ulong gasUsed)
     {


### PR DESCRIPTION
## Changes

- Remove the `EIP8141-ISSUE` note from the `ExecuteDefaultVerifyCode` XML doc comment in `TransactionProcessorBase.FrameTx.cs`. The note described a devnet payload divergence in where the VERIFY signature is carried, and named another execution client while doing so. The remaining summary already states the contract: the signature comes from the hoisted `signatures` list, per the spec.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Comment-only change; no behaviour is affected. `Nethermind.Evm` builds clean in release.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
