### PR TITLE
fix(evm): gate POST_TX frames on the assertion fork in the processor

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1135,6 +1135,35 @@ public class FrameTxProcessorTests
         Assert.That(result.ErrorDescription, Does.Contain("not enabled"));
     }
 
+    /// <remarks>
+    /// Driven through <c>CallAndRestore</c> — the <c>eth_call</c> / <c>eth_estimateGas</c> path, which runs with
+    /// <see cref="ExecutionOptions.SkipValidation"/> — because static validation already refuses these modes.
+    /// An unrecognised mode is neither SENDER nor read-only, so without the processor check it would run as a
+    /// DEFAULT frame: state-changing, called from the entry point, and reported as a successful execution.
+    /// </remarks>
+    [TestCase((byte)(TxFrame.ModePostTx + 1), TestName = "CallAndRestore_FrameModeJustAboveTheDefinedRange_IsRejected")]
+    [TestCase(byte.MaxValue, TestName = "CallAndRestore_FrameModeMaxByte_IsRejected")]
+    public void CallAndRestore_UndefinedFrameMode_IsRejected(byte mode)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(mode, target: Observer));
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithGasLimit(30_000_000).TestObject;
+
+        _transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, Spec));
+        TransactionResult result = _transactionProcessor.CallAndRestore(tx, NullTxTracer.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.False, "an undefined mode executed instead of being refused");
+            Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+            Assert.That(result.ErrorDescription, Is.EqualTo(FrameTxValidation.InvalidMode));
+        }
+    }
+
     // The difference from a VERIFY revert: the body unwinds but the transaction stays valid and pays.
     [TestCase(false, ExpectedResult = StatusCode.Success, TestName = "Execute_PostTxAsserts_TransactionSucceeds")]
     [TestCase(true, ExpectedResult = StatusCode.Failure, TestName = "Execute_PostTxReverts_TransactionFailsButIsIncluded")]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1114,6 +1114,27 @@ public class FrameTxProcessorTests
         return Process(FrameTx(nonce: 0, SelfVerifyFrame())).TransactionExecuted;
     }
 
+    /// <remarks>
+    /// EIP-8141 and EIP-7906 have independent transitions, so an 8141-on / 7906-off window is representable.
+    /// Static validation is not on the path from <c>eth_call</c>, <c>eth_estimateGas</c> or block building,
+    /// so the mode has to be refused here too rather than running with assertion semantics.
+    /// </remarks>
+    [Test]
+    public void Execute_PostTxFrameBeforeTheAssertionFork_IsRejected()
+    {
+        _spec.IsEip7906Enabled = false;
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModePostTx, target: Recipient));
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.False);
+        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+        Assert.That(result.ErrorDescription, Does.Contain("not enabled"));
+    }
+
     // The difference from a VERIFY revert: the body unwinds but the transaction stays valid and pays.
     [TestCase(false, ExpectedResult = StatusCode.Success, TestName = "Execute_PostTxAsserts_TransactionSucceeds")]
     [TestCase(true, ExpectedResult = StatusCode.Failure, TestName = "Execute_PostTxReverts_TransactionFailsButIsIncluded")]

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -109,6 +109,12 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 return TransactionResult.ErrorType.MalformedTransaction.WithDetail("approval scope on atomic batch frame");
             }
 
+            // The mode is undefined until EIP-7906 defines it, so it must not run with assertion semantics.
+            if (frame.Mode == TxFrame.ModePostTx && !spec.IsEip7906Enabled)
+            {
+                return TransactionResult.ErrorType.MalformedTransaction.WithDetail(FrameTxValidation.PostTxNotEnabled);
+            }
+
             prevIsAtomicBatch = frame.IsAtomicBatch;
         }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -109,6 +109,12 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 return TransactionResult.ErrorType.MalformedTransaction.WithDetail("approval scope on atomic batch frame");
             }
 
+            // An undefined mode would otherwise fall through to DEFAULT semantics and execute.
+            if (frame.Mode > TxFrame.ModePostTx)
+            {
+                return TransactionResult.ErrorType.MalformedTransaction.WithDetail(FrameTxValidation.InvalidMode);
+            }
+
             // The mode is undefined until EIP-7906 defines it, so it must not run with assertion semantics.
             if (frame.Mode == TxFrame.ModePostTx && !spec.IsEip7906Enabled)
             {


### PR DESCRIPTION
## Changes

- Reject a frame transaction carrying a `POST_TX` frame in `ExecuteFrameTx` when the assertion fork is not scheduled, alongside the existing keyed-nonce and recent-root fork checks.
- Add a processor-level regression test for the 8141-on / 7906-off window.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Execute_PostTxFrameBeforeTheAssertionFork_IsRejected` in `FrameTxProcessorTests`. Verified failing before the fix (`Expected: False, But was: True` — the frame executed with assertion semantics) and passing after. Full `Nethermind.Evm.Test` (5217) and `Nethermind.Blockchain.Test` (1669) suites pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The processor already re-checks `IsEip8250Enabled` and `IsEip8272Enabled` so that callers which skip static validation cannot run either extension before its fork; the comment above the frame loop states the invariant. `POST_TX` was the one extension missing that re-check — its only gate was `FrameTxValidation.IsWellFormed`, reached solely through `TxValidator`.

`eth_call`, `eth_estimateGas`, `eth_simulate` and `debug_traceCall` reach the processor without running `TxValidator`. On a chain scheduling frame transactions without the assertion fork they therefore executed a `POST_TX` frame as a static frame with body unwinding, while block validation and mempool admission rejected the same transaction. No consensus path was affected — block import and pool admission both run `TxValidator` — so this is a simulation/estimation divergence rather than a fork risk.

Based on `eip8141-frame-txs-devnet7`, where both the `POST_TX` frame mode and `IsEip7906Enabled` live.
