### PR TITLE
fix(core): do not price recent-root references before their fork

### DIFF
--- a/src/Nethermind/Nethermind.Core/RecentRootReference.cs
+++ b/src/Nethermind/Nethermind.Core/RecentRootReference.cs
@@ -22,12 +22,13 @@ public class RecentRootReference(in ValueHash256 sourceId, ulong slot, in ValueH
     /// storage key, plus the two Keccak computations deriving the key and the committed entry hash.
     /// </summary>
     /// <remarks>
-    /// A mandatory cost charged outside the EIP-7623 floored term. The access-list rates are resolved from
-    /// the spec, so a reference cannot be priced against a fork the transaction does not execute under.
+    /// A mandatory cost charged outside the EIP-7623 floored term. Both the rates and the fork itself are
+    /// resolved from the spec, so a reference cannot be priced against a fork the transaction does not
+    /// execute under: before EIP-8272 it warms no predeploy and derives no key, so it costs nothing.
     /// </remarks>
     public static ulong IntrinsicGas(RecentRootReference[]? references, IReleaseSpec spec)
     {
-        if (references is null || references.Length == 0)
+        if (references is null || references.Length == 0 || !spec.IsEip8272Enabled)
         {
             return 0;
         }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1974,6 +1974,26 @@ public class FrameTxProcessorTests
         }
     }
 
+    /// <remarks>
+    /// EIP-8141 and EIP-8272 have independent transitions. Before the reference fork the charge buys nothing —
+    /// no predeploy is installed and no key is derived — so a declared reference must leave the budget alone,
+    /// as its calldata already does.
+    /// </remarks>
+    [Test]
+    public void GasBudget_RecentRootReferencesBeforeTheReferenceFork_AreNotPriced()
+    {
+        _spec.IsEip8272Enabled = false;
+
+        Transaction plain = FrameTx(nonce: 0, SelfVerifyFrame());
+        Transaction referenced = FrameTx(nonce: 0, SelfVerifyFrame());
+        referenced.RecentRootReferences = [new RecentRootReference(default, ReferencedSlot, default)];
+
+        Assert.That(FrameTxValidation.TryCalculateGasBudget(plain, _spec, out ulong plainIntrinsic, out _, out _), Is.True);
+        Assert.That(FrameTxValidation.TryCalculateGasBudget(referenced, _spec, out ulong referencedIntrinsic, out _, out _), Is.True);
+
+        Assert.That(referencedIntrinsic, Is.EqualTo(plainIntrinsic).And.Not.Zero);
+    }
+
     [Test]
     public void Execute_RecentRootReference_RecordsThePredeploySlotInBal()
     {


### PR DESCRIPTION
## Changes

- Return zero from `RecentRootReference.IntrinsicGas` when the recent-root fork is not scheduled, matching the reference calldata term beside it in `FrameTxValidation.TryCalculateGasBudget`.
- Add a regression test for the 8141-on / 8272-off window.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`GasBudget_RecentRootReferencesBeforeTheReferenceFork_AreNotPriced` in `FrameTxProcessorTests`. Verified failing before the fix (21577 vs 15475 — 6102 gas of charge for a fork that is not scheduled) and passing after. `Nethermind.Evm.Test` (5217), `Nethermind.Core.Test` (6138) and `Nethermind.TxPool.Test` (785) all pass. No behaviour change once the fork is scheduled, which the existing `RecentRootReference_intrinsic_gas_prices_the_address_and_both_keyed_preimages` pins.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`TryCalculateGasBudget` gates the reference calldata bytes on the fork but adds the per-reference mandatory gas unconditionally, so before the fork the budget was internally inconsistent — priced for the extension, without the extension's calldata.

Scope of the impact today: every consumer that reaches this pricing before the transaction is rejected. `GasLimitTxFilter` is a pre-hash pool filter and so runs ahead of `MalformedTxFilter`; `GasEstimator.EstimateFrameTx` runs on the `eth_estimateGas` path, which never runs the transaction validator and where the caller controls `recentRootReferences` through the JSON-RPC field. In both cases the transaction is ultimately rejected anyway — by `FrameTxEnvelopeTxValidator` or by the processor's own fork check — so I could not construct a case where the mispricing changes an outcome rather than a rejection reason. The value here is removing a latent dependency on a delta feature that the surrounding code otherwise consistently gates.

Based on `eip8141-frame-txs-devnet7`, where both `RecentRootReference` and `IsEip8272Enabled` live.
