### PR TITLE
fix(eip8250): round-trip nonce keys through the frame tx RPC view

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1489,6 +1489,15 @@ public class FrameTxProcessorTests
         return _transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), tracer ?? NullTxTracer.Instance);
     }
 
+    private TransactionResult CallAndRestore(Transaction tx)
+    {
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+        return _transactionProcessor.CallAndRestore(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance);
+    }
+
     private TransactionResult ProcessWithBlobHeader(Transaction tx, ulong excessBlobGas, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)
     {
         Block block = Build.A.Block.WithNumber(1)
@@ -1612,6 +1621,24 @@ public class FrameTxProcessorTests
 
             Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0UL), "a keyed set leaves the account nonce alone");
         }
+    }
+
+    /// <remarks>
+    /// <c>eth_call</c> and <c>eth_estimateGas</c> replace the supplied nonce with the sender's account nonce,
+    /// which a keyed sequence has no relation to, so the nonce check has to follow <c>SkipValidation</c> as
+    /// the account-nonce path does or a keyed transaction is unreachable from those entry points.
+    /// </remarks>
+    [Test]
+    public void CallAndRestore_KeyedNonceOutOfSequence_IsStillSimulated()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction executed = FrameTx(nonce: 5, SelfVerifyFrame());
+        executed.NonceKeys = [7];
+        Transaction simulated = FrameTx(nonce: 5, SelfVerifyFrame());
+        simulated.NonceKeys = [7];
+
+        Assert.That(Process(executed).TransactionExecuted, Is.False, "key 7 sits at sequence 0, so the set is not consumable");
+        Assert.That(CallAndRestore(simulated).TransactionExecuted, Is.True);
     }
 
     // The property the set semantics exist for: one advanced key makes the whole set unusable.

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1641,6 +1641,30 @@ public class FrameTxProcessorTests
         Assert.That(CallAndRestore(simulated).TransactionExecuted, Is.True);
     }
 
+    /// <remarks>
+    /// Only the state half of the nonce check may follow <c>SkipValidation</c>. The RPC view caps nothing and
+    /// <c>eth_call</c> reaches the processor without a validator, so an oversized set would otherwise arrive at
+    /// the fixed-size buffers downstream, which take a well-formed set as their precondition.
+    /// </remarks>
+    [Test]
+    public void CallAndRestore_KeyedNonceSetOverTheLimit_IsMalformedNotThrown()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        // Full-width and strictly increasing, so the length is the only thing that is wrong with the set.
+        UInt256[] keys = new UInt256[Eip8250Constants.MaxNonceKeys + 1];
+        for (int i = 0; i < keys.Length; i++)
+        {
+            keys[i] = UInt256.MaxValue - (UInt256)(keys.Length - 1 - i);
+        }
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.NonceKeys = keys;
+
+        TransactionResult result = CallAndRestore(tx);
+
+        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+    }
+
     // The property the set semantics exist for: one advanced key makes the whole set unusable.
     [Test]
     public void Execute_KeyedNonce_PartiallyAdvancedSetIsNotReplayable()

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -76,9 +76,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("keyed nonces are not enabled");
         }
 
-        // Pre-flight: nonce and protocol-validated signatures.
-        TransactionResult nonceResult = ValidateFrameTxNonce(tx, sender);
-        if (!nonceResult) return nonceResult;
+        // Pre-flight: nonce and protocol-validated signatures. Skipped where validation is, as on the
+        // account-nonce path: eth_call overwrites the supplied nonce with the sender's account nonce.
+        if (ShouldValidate(opts))
+        {
+            TransactionResult nonceResult = ValidateFrameTxNonce(tx, sender);
+            if (!nonceResult) return nonceResult;
+        }
 
         ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
         // EIP-7928: resolved without recording an account access - a tx that never takes the P256

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -29,7 +29,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     /// <remarks>
     /// With <see cref="Transaction.NonceKeys"/> every selected key must currently sit at
     /// <see cref="Transaction.Nonce"/>, so the set is consumed as a unit and a partially advanced set is not
-    /// replayable. A malformed set is rejected as malformed, not as a nonce mismatch: it names no sequence.
+    /// replayable. Assumes the caller has already checked well-formedness, which is not state-dependent and
+    /// so is enforced whether or not the entry point validates.
     /// </remarks>
     private TransactionResult ValidateFrameTxNonce(Transaction tx, Address sender)
     {
@@ -49,17 +50,12 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return TransactionResult.Ok;
         }
 
-        // Cold path only: re-read to report the same too-low / too-high distinction as the account nonce.
-        if (!KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys))
-        {
-            return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction nonce key set is not well-formed");
-        }
-
         if (tx.Nonce >= Eip8250Constants.MaxNonceSeq)
         {
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction nonce sequence is exhausted");
         }
 
+        // Cold path only: re-read to report the same too-low / too-high distinction as the account nonce.
         ulong current = KeyedNonceManager.CurrentNonceSeq(WorldState, sender, nonceKeys[0]);
         return (tx.Nonce < current
             ? TransactionResult.ErrorType.TransactionNonceTooLow
@@ -76,8 +72,15 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail("keyed nonces are not enabled");
         }
 
-        // Pre-flight: nonce and protocol-validated signatures. Skipped where validation is, as on the
-        // account-nonce path: eth_call overwrites the supplied nonce with the sender's account nonce.
+        // Structural, so it holds even where validation is skipped: the fixed-size buffers reached below
+        // take a well-formed set as their precondition, and eth_call arrives here without a validator.
+        if (tx.NonceKeys is { } nonceKeys && !KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys))
+        {
+            return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction nonce key set is not well-formed");
+        }
+
+        // Pre-flight: nonce and protocol-validated signatures. The state comparison follows SkipValidation
+        // as the account-nonce path does: eth_call overwrites the supplied nonce with the account nonce.
         if (ShouldValidate(opts))
         {
             TransactionResult nonceResult = ValidateFrameTxNonce(tx, sender);

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
@@ -19,6 +19,13 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
 
     public override TxType? Type => TxType;
 
+    /// <summary><c>nonce_keys</c>, sharing the sequence number reported as <c>nonce</c>.</summary>
+    /// <remarks>
+    /// Absent for an envelope nonce, which is a different signing payload from the key set <c>[0]</c>.
+    /// See <see href="https://eips.ethereum.org/EIPS/eip-8250">EIP-8250</see>.
+    /// </remarks>
+    public UInt256[]? NonceKeys { get; set; }
+
     [JsonDiscriminator]
     public FrameForRpc[]? Frames { get; set; }
 
@@ -40,6 +47,7 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
     public FrameTransactionForRpc(Transaction transaction, in TransactionForRpcContext extraData)
         : base(transaction, extraData)
     {
+        NonceKeys = transaction.NonceKeys;
         Frames = FrameForRpc.FromFrames(transaction.Frames);
         Signatures = FrameSignatureForRpc.FromSignatures(transaction.FrameSignatures);
         RecentRootReferences = RecentRootReferenceForRpc.FromReferences(transaction.RecentRootReferences);
@@ -55,6 +63,7 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
         if (baseResult.IsError) return baseResult;
 
         Transaction tx = baseResult.Data;
+        tx.NonceKeys = NonceKeys;
         tx.Frames = FrameForRpc.ToFrames(Frames);
         tx.FrameSignatures = FrameSignatureForRpc.ToSignatures(Signatures);
         tx.MaxFeePerBlobGas = MaxFeePerBlobGas;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -200,6 +202,100 @@ public class FrameTransactionForRpcTests
         {
             Assert.That(roundTripped.MaxFeePerBlobGas, Is.EqualTo((UInt256)456));
             Assert.That(roundTripped.BlobVersionedHashes, Has.Length.EqualTo(1));
+        }
+    }
+
+    private static Transaction BuildKeyedFrameTx(UInt256[]? nonceKeys, ulong nonceSeq = 3)
+    {
+        Transaction tx = BuildMinimalFrameTx();
+        tx.NonceKeys = nonceKeys;
+        tx.Nonce = nonceSeq;
+        return tx;
+    }
+
+    private static IEnumerable<TestCaseData> NonceKeySets()
+    {
+        yield return new TestCaseData(new UInt256[] { 1, 7 }, new[] { "0x1", "0x7" }).SetArgDisplayNames("MultiKey");
+        // [0] is the account-nonce domain, a different payload from the absent list.
+        yield return new TestCaseData(new UInt256[] { 0 }, new[] { "0x0" }).SetArgDisplayNames("LegacyDomainSingleton");
+    }
+
+    [TestCaseSource(nameof(NonceKeySets))]
+    public void FrameTransactionForRpc_SerializesNonceKeys(UInt256[] nonceKeys, string[] expected)
+    {
+        Transaction tx = BuildKeyedFrameTx(nonceKeys);
+        TransactionForRpc rpc = TransactionForRpc.FromTransaction(tx);
+
+        string json = new EthereumJsonSerializer().Serialize(rpc);
+        using JsonDocument doc = JsonDocument.Parse(json);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(doc.RootElement.TryGetProperty("nonceKeys", out JsonElement keys), Is.True);
+            Assert.That(keys.EnumerateArray().Select(static k => k.GetString()), Is.EqualTo(expected));
+            Assert.That(doc.RootElement.GetProperty("nonce").GetString(), Is.EqualTo("0x3"));
+        }
+    }
+
+    [Test]
+    public void FrameTransactionForRpc_OmitsNonceKeys_ForEnvelopeNonce()
+    {
+        Transaction tx = BuildKeyedFrameTx(nonceKeys: null);
+        TransactionForRpc rpc = TransactionForRpc.FromTransaction(tx);
+
+        string json = new EthereumJsonSerializer().Serialize(rpc);
+        using JsonDocument doc = JsonDocument.Parse(json);
+
+        Assert.That(doc.RootElement.TryGetProperty("nonceKeys", out _), Is.False);
+    }
+
+    [TestCaseSource(nameof(NonceKeySets))]
+    public void FrameTransactionForRpc_ToTransaction_RoundTripsNonceKeys(UInt256[] nonceKeys, string[] _)
+    {
+        Transaction original = BuildKeyedFrameTx(nonceKeys);
+        TransactionForRpc rpc = TransactionForRpc.FromTransaction(original);
+
+        Transaction roundTripped = ((FrameTransactionForRpc)rpc).ToTransaction().Data!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(roundTripped.NonceKeys, Is.EqualTo(nonceKeys));
+            Assert.That(roundTripped.Nonce, Is.EqualTo(original.Nonce));
+        }
+    }
+
+    [Test]
+    public void FrameTransactionForRpc_ToTransaction_KeepsAbsentNonceKeys()
+    {
+        Transaction original = BuildKeyedFrameTx(nonceKeys: null);
+        TransactionForRpc rpc = TransactionForRpc.FromTransaction(original);
+
+        Transaction roundTripped = ((FrameTransactionForRpc)rpc).ToTransaction().Data!;
+
+        Assert.That(roundTripped.NonceKeys, Is.Null);
+    }
+
+    [Test]
+    public void FrameTransactionForRpc_DeserializesNonceKeys_FromCallParams()
+    {
+        const string json = """
+            {
+                "from": "0x0000000000000000000000000000000000000001",
+                "nonce": "0x3",
+                "nonceKeys": ["0x1", "0x7"],
+                "frames": [{"mode": 0, "flags": 3, "gasLimit": "0x186a0", "value": "0x0", "data": "0x"}]
+            }
+            """;
+
+        TransactionForRpc rpc = new EthereumJsonSerializer().Deserialize<TransactionForRpc>(json);
+
+        Assert.That(rpc, Is.InstanceOf<FrameTransactionForRpc>());
+        Transaction tx = rpc.ToTransaction().Data!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tx.NonceKeys, Is.EqualTo(new UInt256[] { 1, 7 }));
+            Assert.That(tx.Nonce, Is.EqualTo(3UL));
         }
     }
 


### PR DESCRIPTION
## Changes

`FrameTransactionForRpc` had no `nonceKeys` property, so EIP-8250 nonce keys were dropped in both directions:

- **Output** — `eth_getTransactionByHash` and `eth_getBlockByNumber(true)` reported only `nonce` (which is `nonce_seq`) for a keyed frame transaction. Since `nonce_keys` is covered by the signature hash, a consumer could neither rebuild the signed payload nor re-derive the reported `hash`. This is the same reason `maxFeePerBlobGas` and `blobVersionedHashes` are already reported unconditionally on this class.
- **Input** — `ToTransaction` never read the key set, so keyed nonces could not be exercised through `eth_call`, `eth_estimateGas` or `eth_simulate` at all.

`RecentRootReferences` is already round-tripped on the same class, so this was an asymmetry rather than a deliberate omission. `NonceKeys` is now mapped the same way: a nullable property, so an absent list stays absent on the wire instead of collapsing into the key set `[0]` — those are different signing payloads.

Not marked `[JsonDiscriminator]`: `frames` remains the sole marker that selects the concrete type.

Second commit: reaching the transaction was not enough on its own. `CallAndRestore` replaces the caller's nonce with the sender's account nonce, and `ExecuteFrameTx` validated the nonce unconditionally — unlike `IncrementNonce`, which has always gated the account-nonce comparison on `ShouldValidate(opts)`. A keyed set therefore only survived `eth_call` when its sequence happened to equal the account nonce. The frame path now follows the same gate.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added to `FrameTransactionForRpcTests`, alongside the existing blob-field round-trip cases:

- `FrameTransactionForRpc_SerializesNonceKeys` — `nonceKeys` emitted as hex quantities next to `nonce`, for a multi-key set and for the `[0]` singleton.
- `FrameTransactionForRpc_OmitsNonceKeys_ForEnvelopeNonce` / `..._ToTransaction_KeepsAbsentNonceKeys` — absent stays absent, not `[]` or `[0]`.
- `FrameTransactionForRpc_ToTransaction_RoundTripsNonceKeys` — key set and sequence number survive the round trip.
- `FrameTransactionForRpc_DeserializesNonceKeys_FromCallParams` — a JSON call object carrying `nonceKeys` dispatches to `FrameTransactionForRpc` and reaches the transaction, covering the `eth_call` / `eth_simulate` input path.

- `CallAndRestore_KeyedNonceOutOfSequence_IsStillSimulated` (`FrameTxProcessorTests`) — the same out-of-sequence keyed transaction is refused by `Execute` and simulated by `CallAndRestore`. Dropping the `ShouldValidate` guard fails exactly this test.

The five positive cases fail on the base branch and pass with the fix. Full `Nethermind.JsonRpc.Test` is green (1943 passed, 22 skipped), as are `Nethermind.Evm.Test` (5217) and `Nethermind.Facade.Test` (126).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

