### PR TITLE
fix(txpool): carry nonce_keys on the light blob tx record

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -32,7 +32,6 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 
     private static readonly RlpLimit FramesCountLimit = RlpLimit.For<Transaction>(Eip8141Constants.MaxFrames, nameof(Transaction.Frames));
     private static readonly RlpLimit SignaturesCountLimit = RlpLimit.For<Transaction>(SignaturesDecodeCap, nameof(Transaction.FrameSignatures));
-    private static readonly RlpLimit NonceKeysCountLimit = RlpLimit.For<Transaction>(Eip8250Constants.MaxNonceKeys, nameof(Transaction.NonceKeys));
     // EIP8141-GAP: the spec does not bound blob_versioned_hashes; mirrors the blob tx decode cap.
     private static readonly RlpLimit BlobVersionedHashesCountLimit = RlpLimit.For<Transaction>(ShardBlobNetworkWrapperRlp.BlobCountLimit, nameof(Transaction.BlobVersionedHashes));
 
@@ -128,7 +127,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         // EIP8141-DEVIATION: the spec allows chain_id < 2^256; decoded as u64 like every other
         // Nethermind transaction type (codebase-wide ChainId width).
         transaction.ChainId = decoderContext.DecodeULong();
-        transaction.NonceKeys = decoderContext.IsSequenceNext() ? DecodeNonceKeys(ref decoderContext) : null;
+        transaction.NonceKeys = decoderContext.IsSequenceNext() ? FrameTxNonceCalldata.DecodeKeys(ref decoderContext) : null;
         transaction.Nonce = decoderContext.DecodeULong();
         transaction.SenderAddress = decoderContext.DecodeAddress() ?? ThrowMissingSender();
         transaction.Frames = decoderContext.DecodeArray(TxFrameDecoder.Instance, limit: FramesCountLimit);
@@ -254,30 +253,6 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     [DoesNotReturn, StackTraceHidden]
     private static void ThrowTrailingSignature() => throw new RlpException("frame transaction must not carry a trailing signature");
 
-    /// <summary>Reads <c>nonce_keys</c> as a list of integers.</summary>
-    /// <remarks>
-    /// Not <c>DecodeArray</c>: it substitutes the default for an empty-list element, turning the wire
-    /// bytes <c>c1 c0</c> into the key set <c>[0]</c> instead of rejecting them.
-    /// </remarks>
-    private static UInt256[] DecodeNonceKeys(ref RlpReader decoderContext)
-    {
-        int contentLength = decoderContext.ReadSequenceLength();
-        int end = decoderContext.Position + contentLength;
-        Span<UInt256> buffer = stackalloc UInt256[Eip8250Constants.MaxNonceKeys];
-        int count = 0;
-        while (decoderContext.Position < end)
-        {
-            if (count == buffer.Length)
-            {
-                throw new RlpLimitException($"Exceeded {NonceKeysCountLimit.CollectionExpression}");
-            }
-
-            buffer[count++] = decoderContext.DecodeUInt256();
-        }
-
-        return buffer[..count].ToArray();
-    }
-
     [DoesNotReturn, StackTraceHidden]
     private static Address ThrowMissingSender() => throw new RlpException("frame transaction sender must be a 20-byte address");
 }
@@ -292,27 +267,63 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 /// </remarks>
 public static class FrameTxNonceCalldata
 {
+    private static readonly RlpLimit KeysCountLimit = RlpLimit.For<Transaction>(Eip8250Constants.MaxNonceKeys, nameof(Transaction.NonceKeys));
+
     public static void Encode<TWriter>(Transaction transaction, ref TWriter writer)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
     {
         if (transaction.NonceKeys is { } nonceKeys)
         {
-            writer.StartSequence(KeysContentLength(nonceKeys));
-            foreach (UInt256 nonceKey in nonceKeys)
-            {
-                writer.Encode(nonceKey);
-            }
+            EncodeKeys(nonceKeys, ref writer);
         }
 
         writer.Encode(transaction.Nonce);
     }
 
+    /// <summary>Writes <c>nonce_keys</c> as a list of integers.</summary>
+    public static void EncodeKeys<TWriter>(UInt256[] nonceKeys, ref TWriter writer)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct
+    {
+        writer.StartSequence(KeysContentLength(nonceKeys));
+        foreach (UInt256 nonceKey in nonceKeys)
+        {
+            writer.Encode(nonceKey);
+        }
+    }
+
+    /// <summary>Reads <c>nonce_keys</c> as a list of integers.</summary>
+    /// <remarks>
+    /// Not <c>DecodeArray</c>: it substitutes the default for an empty-list element, turning the wire
+    /// bytes <c>c1 c0</c> into the key set <c>[0]</c> instead of rejecting them.
+    /// </remarks>
+    public static UInt256[] DecodeKeys(ref RlpReader decoderContext)
+    {
+        int contentLength = decoderContext.ReadSequenceLength();
+        int end = decoderContext.Position + contentLength;
+        Span<UInt256> buffer = stackalloc UInt256[Eip8250Constants.MaxNonceKeys];
+        int count = 0;
+        while (decoderContext.Position < end)
+        {
+            if (count == buffer.Length)
+            {
+                throw new RlpLimitException($"Exceeded {KeysCountLimit.CollectionExpression}");
+            }
+
+            buffer[count++] = decoderContext.DecodeUInt256();
+        }
+
+        return buffer[..count].ToArray();
+    }
+
     /// <summary>Length in bytes of what <see cref="Encode{TWriter}"/> writes for <paramref name="transaction"/>.</summary>
     public static int Length(Transaction transaction) =>
-        (transaction.NonceKeys is { } nonceKeys ? Rlp.LengthOfSequence(KeysContentLength(nonceKeys)) : 0)
+        (transaction.NonceKeys is { } nonceKeys ? KeysLength(nonceKeys) : 0)
         + Rlp.LengthOf(transaction.Nonce);
 
-    internal static int KeysContentLength(UInt256[] nonceKeys)
+    /// <summary>Length in bytes of what <see cref="EncodeKeys{TWriter}"/> writes for <paramref name="nonceKeys"/>.</summary>
+    public static int KeysLength(UInt256[] nonceKeys) => Rlp.LengthOfSequence(KeysContentLength(nonceKeys));
+
+    private static int KeysContentLength(UInt256[] nonceKeys)
     {
         int contentLength = 0;
         foreach (UInt256 nonceKey in nonceKeys)

--- a/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
@@ -44,8 +45,12 @@ public class LightTxDecoderTests
 
         LightTransaction decoded = LightTxDecoder.Decode(full[..^droppedTrailingFields]);
 
-        Assert.That(decoded.Type, Is.EqualTo(TxType.Blob));
-        Assert.That(decoded.ProofVersion, Is.EqualTo(expectedProofVersion));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.Type, Is.EqualTo(TxType.Blob));
+            Assert.That(decoded.ProofVersion, Is.EqualTo(expectedProofVersion));
+            Assert.That(decoded.NonceKeys, Is.Null);
+        }
     }
 
     // ProofVersion.V0 encodes as the RLP empty string, which a raw byte read returns as 128.
@@ -59,18 +64,49 @@ public class LightTxDecoderTests
         Assert.That(LightTxDecoder.Decode(LightTxDecoder.Encode(tx)).ProofVersion, Is.EqualTo(version));
     }
 
-    // Zero is a deadline, not an absent field: the trailing fields are positional, so the two must decode apart.
-    [TestCase(null)]
-    [TestCase(0ul)]
-    [TestCase(1_000ul)]
-    public void Round_trip_preserves_the_expiry_deadline(ulong? deadline)
+    // Both trailing fields are optional and positional, so every combination has to decode back to what was
+    // written - in particular a zero deadline is a deadline, not an absent field.
+    [TestCaseSource(nameof(TrailingFieldCases))]
+    public void Round_trip_preserves_the_optional_trailing_fields(UInt256[] nonceKeys, ulong? deadline)
     {
-        Transaction tx = BlobCarryingTx(TxType.FrameTx, deadline);
+        Transaction tx = BlobCarryingTx(TxType.FrameTx, deadline, nonceKeys);
 
-        Assert.That(LightTxDecoder.Decode(LightTxDecoder.Encode(tx)).PersistedExpiryDeadline, Is.EqualTo(deadline));
+        LightTransaction decoded = LightTxDecoder.Decode(LightTxDecoder.Encode(tx));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.NonceKeys, Is.EqualTo(nonceKeys));
+            Assert.That(decoded.PersistedExpiryDeadline, Is.EqualTo(deadline));
+        }
     }
 
-    private static Transaction BlobCarryingTx(TxType type, ulong? deadline = null)
+    private static IEnumerable<TestCaseData> TrailingFieldCases()
+    {
+        // [0] aliases the account nonce, so it must survive as itself rather than collapse to an absent field.
+        UInt256[][] nonceKeySets = [null, [UInt256.Zero], [0xbeef], [1, UInt256.MaxValue], FullWidthKeys()];
+        foreach (ulong? deadline in (ulong?[])[null, 0ul, 1_000ul])
+        {
+            foreach (UInt256[] nonceKeys in nonceKeySets)
+            {
+                yield return new TestCaseData(nonceKeys, deadline);
+            }
+        }
+    }
+
+    // A full set of 32-byte keys is the only case that reaches the long-form sequence header and fills the
+    // decoder's stack buffer exactly.
+    private static UInt256[] FullWidthKeys()
+    {
+        UInt256[] keys = new UInt256[Eip8250Constants.MaxNonceKeys];
+        for (int i = 0; i < keys.Length; i++)
+        {
+            keys[i] = UInt256.MaxValue - (UInt256)(keys.Length - 1 - i);
+        }
+
+        return keys;
+    }
+
+    private static Transaction BlobCarryingTx(TxType type, ulong? deadline = null, UInt256[] nonceKeys = null)
     {
         byte[][] versionedHashes = [new byte[32]];
         Transaction tx = new()
@@ -88,6 +124,7 @@ public class LightTxDecoderTests
             PoolIndex = 11,
             Timestamp = 42,
             NetworkWrapper = new ShardBlobNetworkWrapper([[1]], [[2]], [[3]], ProofVersion.V1),
+            NonceKeys = nonceKeys,
         };
 
         if (type == TxType.FrameTx)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -1773,7 +1773,35 @@ namespace Nethermind.TxPool.Test
 
         private static ISpecProvider GetBogotaSpecProvider() => new TestSpecProvider(Bogota.Instance);
 
-        private Transaction BuildBlobFrameTx(ulong nonce, int blobCount, ulong? deadline = null, UInt256? maxFeePerBlobGas = null, bool withSidecar = false)
+        // The pool holds a light record, not the full transaction, and UpdateBucket reads its nonce. Without the
+        // keys that read is an account-nonce comparison, which a keyed sequence has no relation to.
+        [Test]
+        public async Task Keyed_blob_carrying_frame_tx_is_not_evicted_as_stale_after_a_restart()
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.StorageWithReorgs, PersistentBlobStorageSize = 10, BlobCacheSize = 10 };
+            BlobTxStorage blobTxStorage = new();
+            _txPool = CreatePool(txPoolConfig, KeyedNonceSpecProvider(), txStorage: blobTxStorage);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            // The account nonce advances independently of key 0xbeef, whose sequence stays at 0 and stays includable.
+            _stateProvider.IncrementNonce(TestItem.AddressA);
+
+            Transaction tx = BuildBlobFrameTx(nonce: 0, blobCount: 1, withSidecar: true, nonceKeys: [0xbeef]);
+            Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            // A fresh pool over the same storage stands in for a node restart.
+            _txPool = CreatePool(txPoolConfig, KeyedNonceSpecProvider(), txStorage: blobTxStorage);
+            Transaction[] restored = _txPool.GetPendingLightBlobTransactionsBySender(TestItem.AddressA);
+            Assert.That(restored, Has.Length.EqualTo(1), "the restart must not evict a keyed transaction whose sequence is current");
+            Assert.That(restored[0].NonceKeys, Is.EqualTo(tx.NonceKeys), "the reloaded record must still select the keyed nonce domain");
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).TestObject);
+
+            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1),
+                "a new head must not evict a reloaded keyed transaction whose sequence is current");
+        }
+
+        private Transaction BuildBlobFrameTx(ulong nonce, int blobCount, ulong? deadline = null, UInt256? maxFeePerBlobGas = null, bool withSidecar = false, UInt256[] nonceKeys = null)
         {
             ShardBlobNetworkWrapper wrapper = null;
             byte[][] versionedHashes = null;
@@ -1834,6 +1862,7 @@ namespace Nethermind.TxPool.Test
                 FrameSignatures = [],
                 BlobVersionedHashes = versionedHashes,
                 NetworkWrapper = wrapper,
+                NonceKeys = nonceKeys,
             };
             tx.Hash = tx.CalculateHash();
             return tx;

--- a/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
@@ -32,6 +32,8 @@ public class LightTransaction : Transaction
         ProofVersion = fullTx.GetProofVersion();
         // The pool holds this record, not the full tx, so its Removed event is what releases the payer's reservation.
         PayerAddress = fullTx.PayerAddress;
+        // Without the keys the pool reads Nonce as an account nonce, and EIP-8250 nonce_seq is not one.
+        NonceKeys = fullTx.NonceKeys;
         PersistedExpiryDeadline = FrameTxValidation.TryGetExpiryDeadline(fullTx, out ulong deadline) ? deadline : null;
         _size = fullTx.GetLength();
     }
@@ -72,7 +74,8 @@ public class LightTransaction : Transaction
         int size,
         ProofVersion proofVersion,
         TxType type,
-        ulong? expiryDeadline = null)
+        ulong? expiryDeadline = null,
+        UInt256[]? nonceKeys = null)
     {
         Type = type;
         Hash = hash;
@@ -88,6 +91,7 @@ public class LightTransaction : Transaction
         PoolIndex = poolIndex;
         ProofVersion = proofVersion;
         PersistedExpiryDeadline = expiryDeadline;
+        NonceKeys = nonceKeys;
         _size = size;
     }
 

--- a/src/Nethermind/Nethermind.TxPool/LightTxDecoder.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTxDecoder.cs
@@ -24,7 +24,8 @@ public class LightTxDecoder : TxDecoder<Transaction>
                + Rlp.LengthOf(tx.GetLength())
                + Rlp.LengthOf(sizeof(byte))
                + Rlp.LengthOf((byte)tx.Type)
-               + (FrameTxValidation.TryGetExpiryDeadline(tx, out ulong expiryDeadline) ? Rlp.LengthOf(expiryDeadline) : 0);
+               + (FrameTxValidation.TryGetExpiryDeadline(tx, out ulong expiryDeadline) ? Rlp.LengthOf(expiryDeadline) : 0)
+               + (tx.NonceKeys is { } nonceKeys ? FrameTxNonceCalldata.KeysLength(nonceKeys) : 0);
 
     public static byte[] Encode(Transaction tx)
     {
@@ -48,6 +49,9 @@ public class LightTxDecoder : TxDecoder<Transaction>
         writer.Encode((byte)tx.Type);
         // Expiry needs the deadline after a reload, where the frames that carried it are gone.
         if (FrameTxValidation.TryGetExpiryDeadline(tx, out ulong expiryDeadline)) writer.Encode(expiryDeadline);
+        // A sequence, so the decoder tells it apart from the expiry deadline that only sometimes precedes it.
+        // Any further optional trailing field must also be a list: a second optional scalar would be ambiguous.
+        if (tx.NonceKeys is { } nonceKeys) FrameTxNonceCalldata.EncodeKeys(nonceKeys, ref writer);
 
         return bytes;
     }
@@ -71,6 +75,7 @@ public class LightTxDecoder : TxDecoder<Transaction>
             size: ctx.DecodePositiveInt(),
             proofVersion: ctx.PeekNumberOfItemsRemaining(maxSearch: 1) == 1 ? (ProofVersion)ctx.DecodeByte() : default,
             type: ctx.PeekNumberOfItemsRemaining(maxSearch: 1) == 1 ? (TxType)ctx.DecodeByte() : TxType.Blob,
-            expiryDeadline: ctx.PeekNumberOfItemsRemaining(maxSearch: 1) == 1 ? ctx.DecodeULong() : null);
+            expiryDeadline: ctx.PeekNumberOfItemsRemaining(maxSearch: 1) == 1 && !ctx.IsSequenceNext() ? ctx.DecodeULong() : null,
+            nonceKeys: ctx.PeekNumberOfItemsRemaining(maxSearch: 1) == 1 ? FrameTxNonceCalldata.DecodeKeys(ref ctx) : null);
     }
 }


### PR DESCRIPTION
## Changes

`PersistentBlobTxDistinctSortedPool.InsertCore` and `TxBroadcaster.StartBroadcast` replace a blob-carrying transaction with a `LightTransaction` once it is admitted, and that record did not carry `Transaction.NonceKeys`. For a blob-carrying frame transaction using EIP-8250 keyed nonces, every later pool operation therefore saw `NonceKeys == null` and read `Nonce` — which is `nonce_seq` — as an account nonce:

- `TxPool.UpdateBucket` and `UpdateGasBottleneckAndMarkForEviction` compared `nonce_seq` against the sender's account nonce, so a keyed transaction whose sequence was current got evicted (or a stale one retained).
- `CompetingTransactionEqualityComparer` treated it as occupying the account-nonce slot, letting it displace an unrelated plain transaction.
- `TxPoolInfoProvider.KeyOf` keyed it by nonce rather than hash, so several same-`nonce_seq` keyed transactions collided in `txpool_content`.

The fix threads `NonceKeys` through `LightTransaction` (both the copy constructor and the decode constructor) and appends it to the persisted record in `LightTxDecoder`. It is written as a trailing field, matching how the type byte and the expiry deadline were added, so records written before it still decode. It is encoded as an RLP sequence rather than a scalar, which is what lets the decoder tell it apart from the optional expiry deadline that precedes it — both are optional, so their presence combinations have to be distinguishable positionally. Any further optional trailing field must also be a list — a second optional scalar would be ambiguous with the deadline.

The `nonce_keys` wire shape itself is not written twice: `FrameTxNonceCalldata` now owns encode, length and decode (`EncodeKeys`, `KeysLength`, `DecodeKeys`, plus the `RlpLimit`), and `FrameTxDecoder` and `LightTxDecoder` both call it.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `LightTxDecoderTests.Round_trip_preserves_the_nonce_keys` covers the record round-trip across every combination of nonce-key set (absent, `[0]`, single keyed, multi-key) and expiry deadline (absent, `0`, non-zero), since both are optional trailing fields.
- `LightTxDecoderTests.Legacy_record_decodes_as_a_blob_tx` now also asserts a pre-existing record decodes with `NonceKeys` null.
- `TxPoolTests.Keyed_blob_carrying_frame_tx_is_not_evicted_as_stale_after_a_restart` is the pool-behaviour regression: a keyed blob-carrying frame transaction on a sender whose account nonce has moved on must survive a pool restart over the same storage, and must survive the following new head.

Both new tests were confirmed red before the fix — 10 of the 13 cases failed, the 3 green ones being the `nonceKeys: null` cases; the pool test showed the reloaded transaction evicted outright (`Length` 0 rather than 1). Full `Nethermind.TxPool.Test` suite passes after the fix (794 passed, 4 pre-existing skips).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

