### PR TITLE
Release the payer exposure a blob frame transaction reserved

### DIFF
--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -247,6 +247,16 @@ namespace Nethermind.Core
         /// </summary>
         public Address? PayerAddress { get; set; }
 
+        /// <summary>
+        /// Exposure reserved against <see cref="PayerAddress"/> at mempool admission, released unchanged when the
+        /// transaction leaves the pool. In-memory only (not encoded).
+        /// </summary>
+        /// <remarks>
+        /// Held rather than re-derived on release: the pool keeps a blob-carrying frame transaction as a light
+        /// record with no frames, which cannot be priced, and the pricing spec moves with the head besides.
+        /// </remarks>
+        public UInt256? PayerExposure { get; set; }
+
         /// <summary>The EIP-8141 expiry deadline recovered from storage, for a transaction reloaded without
         /// its frames. Null for every in-memory transaction, which carries the deadline in its frames.</summary>
         public virtual ulong? PersistedExpiryDeadline => null;
@@ -403,6 +413,7 @@ namespace Nethermind.Core
                 obj.Frames = default;
                 obj.FrameSignatures = default;
                 obj.PayerAddress = default;
+                obj.PayerExposure = default;
                 obj.NonceKeys = default;
                 obj.RecentRootReferences = default;
                 obj.ReferenceCalldataStats = default;
@@ -442,6 +453,7 @@ namespace Nethermind.Core
             tx.Frames = Frames;
             tx.FrameSignatures = FrameSignatures;
             tx.PayerAddress = PayerAddress;
+            tx.PayerExposure = PayerExposure;
             tx.NonceKeys = NonceKeys;
             tx.RecentRootReferences = RecentRootReferences;
             tx.ReferenceCalldataStats = ReferenceCalldataStats;

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerExposureFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerExposureFilterTests.cs
@@ -87,6 +87,8 @@ public class FrameTxPayerExposureFilterTests
 
         Transaction incumbent = FrameTxCostingExactly(incumbentCost, payer: incumbentPaidByAnother ? TestItem.AddressC : null);
         incumbent.Hash = TestItem.KeccakA;
+        // Already pending, so it carries the reservation admission recorded on it; that is what a bump discounts.
+        incumbent.PayerExposure = incumbentCost;
         Transaction bump = FrameTxCostingExactly(bumpCost);
         bump.Nonce = bumpNonce;
         bump.Hash = TestItem.KeccakB;
@@ -107,14 +109,19 @@ public class FrameTxPayerExposureFilterTests
         TestReadOnlyStateProvider state = StateWithPayerBalance(TestCost + TestCost / 2);
         PayerExposureCache cache = new();
 
-        AcceptTxResult first = Accept(state, cache, FrameTxCostingExactly(TestCost));
-        AcceptTxResult second = Accept(state, cache, FrameTxCostingExactly(TestCost));
+        Transaction admitted = FrameTxCostingExactly(TestCost);
+        Transaction turnedAway = FrameTxCostingExactly(TestCost);
+
+        AcceptTxResult first = Accept(state, cache, admitted);
+        AcceptTxResult second = Accept(state, cache, turnedAway);
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(first, Is.EqualTo(AcceptTxResult.Accepted));
             Assert.That(second, Is.EqualTo(AcceptTxResult.FrameTxPayerExposureExceeded));
             Assert.That(cache.GetReserved(Payer), Is.EqualTo((UInt256)TestCost), "only the admitted tx is reserved");
+            Assert.That(admitted.PayerExposure, Is.EqualTo((UInt256)TestCost), "the admitted tx carries what it reserved, so its removal releases the same");
+            Assert.That(turnedAway.PayerExposure, Is.Null, "a rejected tx must not claim a reservation it never took");
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -1665,6 +1665,9 @@ namespace Nethermind.TxPool.Test
         // The persistent pool holds a light record, and it is that record's removal which releases the payer's
         // reservation — a record without the payer would leak it and lock the payer out of the pool for good.
         [Test]
+        // The gauge asserted below is a process-wide static and this fixture is ParallelScope.All, so any frame
+        // transaction admitted alongside would move it.
+        [NonParallelizable]
         public void Blob_carrying_frame_tx_releases_its_payer_exposure_when_it_leaves_the_persistent_pool()
         {
             // The prefix ceiling has to clear the verify frame plus its signature, or no payer resolves natively.
@@ -1684,7 +1687,8 @@ namespace Nethermind.TxPool.Test
                 + (UInt256)Eip4844Constants.GasPerBlob * first.MaxFeePerBlobGas!.Value);
 
             // The gauge, not a second submission: the payer here is the sender, whose balance already covers
-            // several such reservations, so nothing it submits later can observe the leak.
+            // several such reservations, so nothing it submits later can observe the leak. The baseline absorbs
+            // residue from earlier tests, whose pools are never disposed.
             long payersBefore = Metrics.FrameTxPayersWithReservedExposure;
 
             Assert.That(_txPool.SubmitTx(first, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -1680,16 +1680,19 @@ namespace Nethermind.TxPool.Test
             }
 
             Transaction first = SignedBlobFrameTx(deadline: null);
-            // Balance for exactly one such tx, so a reservation outliving the first rejects the second.
             EnsureSenderBalance(TestItem.AddressA, (UInt256)first.GasLimit * first.MaxFeePerGas
                 + (UInt256)Eip4844Constants.GasPerBlob * first.MaxFeePerBlobGas!.Value);
 
+            // The gauge, not a second submission: the payer here is the sender, whose balance already covers
+            // several such reservations, so nothing it submits later can observe the leak.
+            long payersBefore = Metrics.FrameTxPayersWithReservedExposure;
+
             Assert.That(_txPool.SubmitTx(first, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
             Assert.That(first.PayerAddress, Is.EqualTo(TestItem.AddressA), "no reservation is taken unless the payer resolves");
-            Assert.That(_txPool.RemoveTransaction(first.Hash), Is.True);
+            Assert.That(Metrics.FrameTxPayersWithReservedExposure, Is.EqualTo(payersBefore + 1), "admission must reserve against the payer");
 
-            // Same payer and same cost, told apart only by its expiry frame: only a leaked reservation rejects it.
-            Assert.That(_txPool.SubmitTx(SignedBlobFrameTx(deadline: 1_000_000), TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.RemoveTransaction(first.Hash), Is.True);
+            Assert.That(Metrics.FrameTxPayersWithReservedExposure, Is.EqualTo(payersBefore), "the light record's removal must release the whole reservation");
         }
 
         // EIP-8141: a blob-carrying frame tx counts against the per-sender blob limit (MaxPendingBlobTxsPerSender),

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPayerExposureFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPayerExposureFilter.cs
@@ -46,7 +46,7 @@ internal sealed class FrameTxPayerExposureFilter(
 
         // A snapshot: AddCore settles the replacement later, under the pool lock. TryReserve ignores the
         // discount when the payer holds no reservation, so skip the bucket walk and its pool lock there.
-        UInt256 replaced = exposure.GetReserved(payer).IsZero ? UInt256.Zero : ReplacedPendingReservation(tx, payer, spec);
+        UInt256 replaced = exposure.GetReserved(payer).IsZero ? UInt256.Zero : ReplacedPendingReservation(tx, payer);
         if (!exposure.TryReserve(payer, maxCost, balance, out UInt256 reserved, replaced))
         {
             // Atomic: this filter runs under the pool's head read lock, so payers reject concurrently.
@@ -65,10 +65,11 @@ internal sealed class FrameTxPayerExposureFilter(
     /// set instead.</summary>
     /// <remarks>Matched on the pool's own competing key, so an EIP-8250 same-nonce transaction in another
     /// domain is not discounted, and on the payer, since displacing another payer's tx frees that payer.
-    /// Priced with the helper the reservation used, or the discount under-refunds.</remarks>
-    private UInt256 ReplacedPendingReservation(Transaction tx, Address payer, IReleaseSpec spec)
+    /// Read from what the incumbent recorded at admission, so the discount cannot drift from what its removal
+    /// releases.</remarks>
+    private UInt256 ReplacedPendingReservation(Transaction tx, Address payer)
     {
-        ReplacementSearch search = new(tx, payer, spec);
+        ReplacementSearch search = new(tx, payer);
         TxDistinctSortedPool pool = tx.CarriesBlobs ? blobPool : standardPool;
         pool.VisitBucket(tx.SenderAddress!, ref search, static (Transaction pending, ref ReplacementSearch state) =>
         {
@@ -91,12 +92,11 @@ internal sealed class FrameTxPayerExposureFilter(
         return search.Reserved;
     }
 
-    private struct ReplacementSearch(Transaction tx, Address payer, IReleaseSpec spec)
+    private struct ReplacementSearch(Transaction tx, Address payer)
     {
         public readonly Transaction Tx = tx;
         public readonly ulong Nonce = tx.Nonce;
         public readonly Address Payer = payer;
-        public readonly IReleaseSpec Spec = spec;
         public UInt256 Reserved;
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPayerExposureFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPayerExposureFilter.cs
@@ -56,6 +56,8 @@ internal sealed class FrameTxPayerExposureFilter(
             return AcceptTxResult.FrameTxPayerExposureExceeded;
         }
 
+        // Held so the release subtracts exactly this, whatever the transaction still carries by then.
+        tx.PayerExposure = maxCost;
         return AcceptTxResult.Accepted;
     }
 
@@ -76,7 +78,7 @@ internal sealed class FrameTxPayerExposureFilter(
 
             if (CompetingTransactionEqualityComparer.Instance.Equals(state.Tx, pending)
                 && pending.PayerAddress == state.Payer
-                && FrameTxValidation.TryCalculateMaxCost(pending, state.Spec, out UInt256 cost))
+                && pending.PayerExposure is { } cost)
             {
                 state.Reserved = cost;
                 return false;

--- a/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
@@ -32,6 +32,7 @@ public class LightTransaction : Transaction
         ProofVersion = fullTx.GetProofVersion();
         // The pool holds this record, not the full tx, so its Removed event is what releases the payer's reservation.
         PayerAddress = fullTx.PayerAddress;
+        PayerExposure = fullTx.PayerExposure;
         PersistedExpiryDeadline = FrameTxValidation.TryGetExpiryDeadline(fullTx, out ulong deadline) ? deadline : null;
         _size = fullTx.GetLength();
     }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -866,16 +866,9 @@ namespace Nethermind.TxPool
         /// </remarks>
         private void ReleasePayerExposure(Transaction tx)
         {
-            if (!tx.SupportsFrames || tx.PayerAddress is null) return;
-
-            if (FrameTxValidation.TryCalculateMaxCost(tx, _specProvider.GetCurrentHeadSpec(), out UInt256 maxCost))
+            if (tx.PayerAddress is not null && tx.PayerExposure is { } maxCost)
             {
                 _payerExposure.Subtract(tx.PayerAddress, maxCost);
-            }
-            else if (_logger.IsWarn)
-            {
-                // Unreachable while pricing is deterministic; a phantom reservation would otherwise be silent.
-                _logger.Warn($"Could not price frame transaction {tx.Hash} to release payer {tx.PayerAddress} exposure.");
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -861,8 +861,9 @@ namespace Nethermind.TxPool
         /// </summary>
         /// <remarks>
         /// Covers eviction, replacement, inclusion and reorg removal (all funnel through the pool
-        /// <c>Removed</c> event) plus the paths in <see cref="AddCore"/> that never insert. Prices with
-        /// the same shared helper the reservation used so the two amounts cannot disagree.
+        /// <c>Removed</c> event) plus the paths in <see cref="AddCore"/> that never insert. Replays the amount
+        /// admission recorded on the transaction, since a pooled blob-carrying frame transaction is a light
+        /// record with no frames to re-price, and the pricing spec moves with the head besides.
         /// </remarks>
         private void ReleasePayerExposure(Transaction tx)
         {


### PR DESCRIPTION
## Changes

A blob-carrying frame transaction leaks its payer's entire mempool reservation when it leaves the pool, locking that payer out until restart.

The persistent blob pool stores a light record, which has no frames. `TryCalculateMaxCost` returns `false` for one, so `ReleasePayerExposure` took the "could not price" branch and never subtracted. Re-deriving the amount on release was fragile for a second reason as well: it prices against the spec at the current head, which is not the spec admission priced against once a fork activates, so the release would differ from the reservation across any repricing fork.

- `Transaction.PayerExposure` holds what admission reserved, and removal releases exactly that. The light record copies it as it already copies the payer.
- The replacement discount reads the same field instead of re-pricing the incumbent, so the discount cannot drift from the reservation it is meant to cancel either.

Found by the DEBUG mempool bookkeeping assertions in #12885: merging them into the branches stacked on this one made the ledger disagree with the pool.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Blob_carrying_frame_tx_releases_its_payer_exposure_when_it_leaves_the_persistent_pool` exists to guard exactly this, but had become vacuous: it funds the payer with the pre-repricing cost, several times the reservation actually taken, so no later submission could ever observe a leak. The payer here is the sender, whose balance is already gated more tightly by the ordinary balance filter, so no second submission can — it now asserts on the reserved-payers gauge instead.

Revert-check: with the fix reverted and the test kept, that one test fails (`Expected: 0, But was: 1`) and the other seven blob frame-transaction tests still pass.

`Accept_DiscountsOnlyTheReservationItDisplaces` builds its pending incumbent by hand, so it now sets the reservation admission would have recorded on it; `Accept_ReservesOnAdmission_SoASecondTxFromOnePayerSeesIt` pins that admission records it on the admitted transaction and not on the rejected one.

TxPool suite green in Debug and Release; Core and Blockchain suites green.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
