### PR TITLE
fix(consensus): install the expiry verifier predeploy without a nonce

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -305,18 +305,19 @@ public class BlockProcessorTests
 
     private static IEnumerable<TestCaseData> PredeployInstallCases()
     {
-        yield return new TestCaseData(Eip8141Prototype.Instance, Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode)
+        // EIP-8141 mandates the runtime code alone, so its account keeps the nonce it already had.
+        yield return new TestCaseData(Eip8141Prototype.Instance, Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, 0ul)
             .SetName("Installs_eip8141_expiry_verifier_predeploy_once_and_captures_it_in_bal");
-        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode.ToArray())
+        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode.ToArray(), 1ul)
             .SetName("Installs_eip8250_nonce_manager_predeploy_once_and_captures_it_in_bal");
         // A storage namespace with empty canonical code: its activation update is the nonce alone, so a
         // code-only idempotency probe would never fire it.
-        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8272Enabled = true }, Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode.ToArray())
+        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8272Enabled = true }, Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode.ToArray(), 1ul)
             .SetName("Installs_eip8272_recent_root_predeploy_once_and_captures_it_in_bal");
     }
 
     [TestCaseSource(nameof(PredeployInstallCases)), MaxTime(Timeout.MaxTestTime)]
-    public void Installs_predeploy_once_and_captures_it_in_bal(IReleaseSpec releaseSpec, Address predeploy, byte[] code)
+    public void Installs_predeploy_once_and_captures_it_in_bal(IReleaseSpec releaseSpec, Address predeploy, byte[] code, ulong expectedNonce)
     {
         ISpecProvider specProvider = new TestSingleReleaseSpecProvider(releaseSpec);
         (BlockProcessor processor, _, IWorldState stateProvider) = CreateProcessorAndBranch(specProvider: specProvider);
@@ -327,12 +328,12 @@ public class BlockProcessorTests
         stateProvider.Commit(spec);
         stateProvider.CommitTree(0);
 
-        // First post-activation block installs the predeploy: code + nonce == 1.
+        // First post-activation block installs the predeploy: its code, and its nonce where the EIP mandates one.
         Block block1 = Build.A.Block.WithNumber(1).WithAuthor(TestItem.AddressD).TestObject;
         (Block processed1, _) = processor.ProcessOne(block1, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
 
         Assert.That(stateProvider.GetCode(predeploy), Is.EqualTo(code));
-        Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(1ul));
+        Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(expectedNonce));
         if (!spec.IsEip8250Enabled)
         {
             // In the EIP-8141 case, the independent NONCE_MANAGER must stay absent, proving unrelated predeploys are not installed.
@@ -350,8 +351,13 @@ public class BlockProcessorTests
                 Assert.That(installChanges.CodeChanges[0].Code, Is.EqualTo(code));
             }
 
-            Assert.That(installChanges.NonceChanges, Has.Count.EqualTo(1));
-            Assert.That(installChanges.NonceChanges[0].Value, Is.EqualTo(1ul));
+            // No nonce entry at all where the EIP mandates none: an unmandated one moves the BAL hash and the
+            // block is rejected before execution.
+            Assert.That(installChanges.NonceChanges, Has.Count.EqualTo(expectedNonce == 0 ? 0 : 1));
+            if (expectedNonce != 0)
+            {
+                Assert.That(installChanges.NonceChanges[0].Value, Is.EqualTo(expectedNonce));
+            }
         }
 
         // Second block is a no-op: state unchanged and no BAL entry for the predeploy.
@@ -359,7 +365,7 @@ public class BlockProcessorTests
         (Block processed2, _) = processor.ProcessOne(block2, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
 
         Assert.That(stateProvider.GetCode(predeploy), Is.EqualTo(code));
-        Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(1ul));
+        Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(expectedNonce));
         Assert.That(processed2.GeneratedBlockAccessList!.GetAccountChanges(predeploy), Is.Null,
             "a re-install must not churn state or the BAL once the code is already present");
     }

--- a/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -28,5 +29,41 @@ public class PredeployInstallerTests
 
         readState.DidNotReceive().GetCode(Eip8272Constants.RecentRootAddress);
         writeState.DidNotReceive().SetNonce(Eip8272Constants.RecentRootAddress, Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void Expiry_verifier_predeploy_installs_its_code_without_touching_the_nonce()
+    {
+        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        spec.IsEip8141Enabled.Returns(true);
+
+        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
+        readState.GetNonce(Eip8141Constants.ExpiryVerifierAddress).Returns(0ul);
+        readState.GetCode(Eip8141Constants.ExpiryVerifierAddress).Returns([]);
+
+        IWorldState writeState = Substitute.For<IWorldState>();
+
+        PredeployInstaller.Install(readState, writeState, spec);
+
+        writeState.Received().InsertCode(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, spec);
+        writeState.DidNotReceive().SetNonce(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void Expiry_verifier_predeploy_carrying_its_code_at_a_zero_nonce_writes_nothing()
+    {
+        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        spec.IsEip8141Enabled.Returns(true);
+
+        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
+        readState.GetNonce(Eip8141Constants.ExpiryVerifierAddress).Returns(0ul);
+        readState.GetCode(Eip8141Constants.ExpiryVerifierAddress).Returns(Eip8141Constants.ExpiryVerifierCode);
+
+        IWorldState writeState = Substitute.For<IWorldState>();
+
+        PredeployInstaller.Install(readState, writeState, spec);
+
+        writeState.DidNotReceive().InsertCode(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ReadOnlyMemory<byte>>(), spec);
+        writeState.DidNotReceive().SetNonce(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ulong>());
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
@@ -16,16 +16,8 @@ public class PredeployInstallerTests
     [Test]
     public void Empty_canonical_predeploy_at_its_nonce_reads_no_code_and_writes_nothing()
     {
-        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
-        spec.IsEip8272Enabled.Returns(true);
-
-        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
-        readState.GetNonce(Eip8272Constants.RecentRootAddress).Returns(1ul);
-        readState.GetCode(Eip8272Constants.RecentRootAddress).Returns([0x60, 0x00]);
-
-        IWorldState writeState = Substitute.For<IWorldState>();
-
-        PredeployInstaller.Install(readState, writeState, spec);
+        (_, IReadOnlyStateProvider readState, IWorldState writeState) =
+            Install(static spec => spec.IsEip8272Enabled.Returns(true), Eip8272Constants.RecentRootAddress, nonce: 1, code: [0x60, 0x00]);
 
         readState.DidNotReceive().GetCode(Eip8272Constants.RecentRootAddress);
         writeState.DidNotReceive().SetNonce(Eip8272Constants.RecentRootAddress, Arg.Any<ulong>());
@@ -34,16 +26,8 @@ public class PredeployInstallerTests
     [Test]
     public void Expiry_verifier_predeploy_installs_its_code_without_touching_the_nonce()
     {
-        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
-        spec.IsEip8141Enabled.Returns(true);
-
-        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
-        readState.GetNonce(Eip8141Constants.ExpiryVerifierAddress).Returns(0ul);
-        readState.GetCode(Eip8141Constants.ExpiryVerifierAddress).Returns([]);
-
-        IWorldState writeState = Substitute.For<IWorldState>();
-
-        PredeployInstaller.Install(readState, writeState, spec);
+        (IReleaseSpec spec, _, IWorldState writeState) =
+            Install(static spec => spec.IsEip8141Enabled.Returns(true), Eip8141Constants.ExpiryVerifierAddress, nonce: 0, code: []);
 
         writeState.Received().InsertCode(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, spec);
         writeState.DidNotReceive().SetNonce(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ulong>());
@@ -52,18 +36,29 @@ public class PredeployInstallerTests
     [Test]
     public void Expiry_verifier_predeploy_carrying_its_code_at_a_zero_nonce_writes_nothing()
     {
-        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
-        spec.IsEip8141Enabled.Returns(true);
-
-        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
-        readState.GetNonce(Eip8141Constants.ExpiryVerifierAddress).Returns(0ul);
-        readState.GetCode(Eip8141Constants.ExpiryVerifierAddress).Returns(Eip8141Constants.ExpiryVerifierCode);
-
-        IWorldState writeState = Substitute.For<IWorldState>();
-
-        PredeployInstaller.Install(readState, writeState, spec);
+        (IReleaseSpec spec, _, IWorldState writeState) =
+            Install(static spec => spec.IsEip8141Enabled.Returns(true), Eip8141Constants.ExpiryVerifierAddress, nonce: 0, code: Eip8141Constants.ExpiryVerifierCode);
 
         writeState.DidNotReceive().InsertCode(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ReadOnlyMemory<byte>>(), spec);
         writeState.DidNotReceive().SetNonce(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ulong>());
+        // Re-creating the account each block would land back in the BAL, which is the failure this predeploy's
+        // null nonce exists to avoid.
+        writeState.DidNotReceiveWithAnyArgs().CreateAccountIfNotExists(default!, default, default);
+    }
+
+    private static (IReleaseSpec Spec, IReadOnlyStateProvider ReadState, IWorldState WriteState) Install(
+        Action<IReleaseSpec> activate, Address predeploy, ulong nonce, byte[] code)
+    {
+        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        activate(spec);
+
+        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
+        readState.GetNonce(predeploy).Returns(nonce);
+        readState.GetCode(predeploy).Returns(code);
+
+        IWorldState writeState = Substitute.For<IWorldState>();
+        PredeployInstaller.Install(readState, writeState, spec);
+
+        return (spec, readState, writeState);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
@@ -39,7 +39,7 @@ public class PredeployInstallerTests
         (IReleaseSpec spec, _, IWorldState writeState) =
             Install(static spec => spec.IsEip8141Enabled.Returns(true), Eip8141Constants.ExpiryVerifierAddress, nonce: 0, code: Eip8141Constants.ExpiryVerifierCode);
 
-        writeState.DidNotReceive().InsertCode(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ReadOnlyMemory<byte>>(), spec);
+        writeState.DidNotReceiveWithAnyArgs().InsertCode(default!, default, default!);
         writeState.DidNotReceive().SetNonce(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ulong>());
         // Re-creating the account each block would land back in the BAL, which is the failure this predeploy's
         // null nonce exists to avoid.

--- a/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
@@ -18,17 +18,19 @@ namespace Nethermind.Consensus.Processing;
 /// entry rather than another installer. The install is idempotent: a non-empty predeploy re-installs only
 /// when the account's code differs from the canonical bytecode or its nonce is below the predeploy nonce;
 /// an empty-canonical predeploy (a protocol-managed storage namespace such as EIP-8272's) is gated on the
-/// nonce alone, since it writes no code to compare against. The predeploy nonce is 1, matching the
-/// EIP-2935/4788/7002/7251 convention. <c>max(existing_nonce, 1)</c> is applied only where a predeploy
-/// sets <see cref="Predeploy.PreservesHigherNonce"/> (EIP-8272).
+/// nonce alone, since it writes no code to compare against. A predeploy nonce of 1 matches the
+/// EIP-2935/4788/7002/7251 convention; a null nonce installs the code alone and leaves the account's
+/// nonce as it stands. <c>max(existing_nonce, 1)</c> is applied only where a predeploy sets
+/// <see cref="Predeploy.PreservesHigherNonce"/> (EIP-8272).
 /// </remarks>
 public static class PredeployInstaller
 {
-    private readonly record struct Predeploy(Address Address, ReadOnlyMemory<byte> Code, ulong Nonce, Func<IReleaseSpec, bool> IsActive, bool PreservesHigherNonce = false);
+    private readonly record struct Predeploy(Address Address, ReadOnlyMemory<byte> Code, ulong? Nonce, Func<IReleaseSpec, bool> IsActive, bool PreservesHigherNonce = false);
 
     private static readonly Predeploy[] Predeploys =
     [
-        new(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, 1, static spec => spec.IsEip8141Enabled),
+        // EIP-8141 mandates the runtime code only; the account's other fields survive activation untouched.
+        new(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, null, static spec => spec.IsEip8141Enabled),
         new(Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode, 1, static spec => spec.IsEip8250Enabled),
         new(Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode, 1, static spec => spec.IsEip8272Enabled, PreservesHigherNonce: true),
     ];
@@ -74,7 +76,7 @@ public static class PredeployInstaller
             ReadOnlyMemory<byte> code = predeploy.Code;
             ulong nonce = readState.GetNonce(predeploy.Address);
             bool codeSatisfied = code.IsEmpty || readState.GetCode(predeploy.Address).AsSpan().SequenceEqual(code.Span);
-            if (codeSatisfied && nonce >= predeploy.Nonce)
+            if (codeSatisfied && nonce >= (predeploy.Nonce ?? 0))
             {
                 continue;
             }
@@ -85,7 +87,10 @@ public static class PredeployInstaller
                 writeState.InsertCode(predeploy.Address, code, spec);
             }
 
-            writeState.SetNonce(predeploy.Address, predeploy.PreservesHigherNonce ? Math.Max(nonce, predeploy.Nonce) : predeploy.Nonce);
+            if (predeploy.Nonce is ulong predeployNonce)
+            {
+                writeState.SetNonce(predeploy.Address, predeploy.PreservesHigherNonce ? Math.Max(nonce, predeployNonce) : predeployNonce);
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
@@ -18,9 +18,10 @@ namespace Nethermind.Consensus.Processing;
 /// entry rather than another installer. The install is idempotent: a non-empty predeploy re-installs only
 /// when the account's code differs from the canonical bytecode or its nonce is below the predeploy nonce;
 /// an empty-canonical predeploy (a protocol-managed storage namespace such as EIP-8272's) is gated on the
-/// nonce alone, since it writes no code to compare against. A predeploy nonce of 1 matches the
-/// EIP-2935/4788/7002/7251 convention; a null nonce installs the code alone and leaves the account's
-/// nonce as it stands. <c>max(existing_nonce, 1)</c> is applied only where a predeploy sets
+/// nonce alone, since it writes no code to compare against — so such an entry must declare a nonce, or it
+/// has nothing to be gated on and never installs. A predeploy nonce of 1 matches the EIP-2935/4788/7002/7251
+/// convention; a null nonce installs the code alone and leaves the account's nonce as it stands.
+/// <c>max(existing_nonce, 1)</c> is applied only where a predeploy sets
 /// <see cref="Predeploy.PreservesHigherNonce"/> (EIP-8272).
 /// </remarks>
 public static class PredeployInstaller
@@ -76,7 +77,7 @@ public static class PredeployInstaller
             ReadOnlyMemory<byte> code = predeploy.Code;
             ulong nonce = readState.GetNonce(predeploy.Address);
             bool codeSatisfied = code.IsEmpty || readState.GetCode(predeploy.Address).AsSpan().SequenceEqual(code.Span);
-            if (codeSatisfied && nonce >= (predeploy.Nonce ?? 0))
+            if (codeSatisfied && (predeploy.Nonce is not ulong required || nonce >= required))
             {
                 continue;
             }


### PR DESCRIPTION
## Changes

- Install the EIP-8141 expiry verifier predeploy's runtime code without writing a nonce. The EIP mandates the runtime code alone at activation; the account's nonce and balance survive it, unlike the EIP-2935/4788/7002/7251 predeploys whose specs set the nonce to 1.
- `Predeploy.Nonce` becomes nullable so an entry can say "code only" as data, rather than needing another branch in the installer.

The spurious `SetNonce` wrote a nonce change into the block-level access list at block-access index 0, which moved the block's BAL hash. Every block carrying a frame transaction was then rejected on `InvalidBlockLevelAccessListHash` before any of it executed — including the block-start history and beacon-root writes.

Measured against the `tests-frames-devnet@v0.0.0` `eip8141_frame_transactions` fixtures on the devnet-8 integration branch, this takes the suite from **63/159 to 147/159** (84 cases). Every one of the 84 failed with the same BAL-hash rejection.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Two cases in `PredeployInstallerTests`: a fresh expiry verifier account gets the code but never a `SetNonce`, and an account already carrying the canonical code at nonce 0 is left completely alone. Revert-checked — both fail on the previous installer, and the existing EIP-8272 case keeps passing.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
