### PR TITLE
ci: gate on the EIP-8141 frame fixtures

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -361,7 +361,7 @@ jobs:
     name: EEST nethtest
     uses: ./.github/workflows/run-nethtest.yml
     with:
-      test_types: engineTest,blockTest,stateTest,syncTest,txTest,zkevmTest
+      test_types: engineTest,blockTest,stateTest,syncTest,txTest,zkevmTest,frameTest
       setup_group: sequential
 
   tests-summary:

--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -122,11 +122,19 @@ env:
   # EIP-8141 frame-transaction fixtures. execution-specs merged them to the eips/amsterdam
   # branch, not master, so they ship in their own release line rather than the devnet archive
   # this branch otherwise pins; frameTest jobs resolve this instead of EEST_VERSION.
-  # Not in any caller's test_types yet: v0.0.0 encodes the type-6 envelope without the EIP-8272
-  # recent-root and EIP-8250 keyed-nonce fields this stack now decodes, so only 63 of its 159
-  # cases can pass. Run it with workflow_dispatch, and add frameTest to the callers once a
-  # release matching the envelope ships (as for the FOCIL archive).
   FRAMES_VERSION: ${{ inputs.frames_version || 'tests-frames-devnet@v0.0.0' }}
+  # Frame cases this branch is known to fail. Each is a client defect with a fix in flight rather
+  # than a fixture mismatch, so an entry goes away as its fix lands and the suite must reach 159.
+  #   test_precompile_target (6 cases) and test_precompile_target_rejecting_its_input: a precompile
+  #     frame target carries no code, so the codeless short-circuit returns before the VM runs and
+  #     the precompile's own gas is never charged.
+  #   test_delegated_target_entry_charge (2 cases), test_delegated_to_precompile_target,
+  #     test_verify_frame_delegated_to_precompile_target and test_bal_unaffordable_designation_absent:
+  #     a frame does not pay for resolving its target's delegation (PR #12786).
+  FRAME_SKIP: ^(?!.*(test_precompile_target|test_delegated_target_entry_charge|test_delegated_to_precompile_target|test_verify_frame_delegated_to_precompile_target|test_bal_unaffordable_designation_absent))
+  # Cases the frame suite must still run once FRAME_SKIP is applied; a scope that silently resolved
+  # to nothing would otherwise pass by running nothing at all.
+  FRAME_MIN_CASES: '147'
   # ubuntu-latest runners have 16 GB of RAM. The runner ships with server GC
   # (throughput-oriented, collects lazily), which previously ballooned past the
   # runner limit on the full fixture set. Workstation GC keeps the heap tight,
@@ -538,6 +546,8 @@ jobs:
           FILTER_ARG=""
           if [ -n "$FILTER" ]; then
             FILTER_ARG="--filter $FILTER"
+          elif [ "$TEST_TYPE" = "frameTest" ]; then
+            FILTER_ARG="--filter $FRAME_SKIP"
           fi
 
           SETUP_ARGS="--chunk $CHUNK"
@@ -818,6 +828,14 @@ jobs:
             if [ "$FAILED_AFTER_RUN" -gt 0 ]; then
               echo "::error::$FAILED_AFTER_RUN nethtest cases failed"
               rc=1
+            fi
+
+            if [ "$TEST_TYPE" = "frameTest" ] && [ $rc -eq 0 ]; then
+              RAN=$(jq 'length' "$RESULTS_FILE" 2>/dev/null || echo 0)
+              if [ "$RAN" -lt "$FRAME_MIN_CASES" ]; then
+                echo "::error::frameTest ran $RAN cases, fewer than the $FRAME_MIN_CASES expected; the fixture scope or the release pin has moved"
+                rc=1
+              fi
             fi
           fi
 

--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -125,13 +125,14 @@ env:
   FRAMES_VERSION: ${{ inputs.frames_version || 'tests-frames-devnet@v0.0.0' }}
   # Frame cases this branch is known to fail. Each is a client defect with a fix in flight rather
   # than a fixture mismatch, so an entry goes away as its fix lands and the suite must reach 159.
-  #   test_precompile_target (6 cases) and test_precompile_target_rejecting_its_input: a precompile
-  #     frame target carries no code, so the codeless short-circuit returns before the VM runs and
-  #     the precompile's own gas is never charged.
+  # Alternatives match anywhere in the case name, and the runner anchors the whole filter itself.
+  #   test_precompile_target, covering both the 6 cases of that name and, by prefix,
+  #     test_precompile_target_rejecting_its_input: a precompile frame target carries no code, so the
+  #     codeless short-circuit returns before the VM runs and the precompile's own gas is never charged.
   #   test_delegated_target_entry_charge (2 cases), test_delegated_to_precompile_target,
   #     test_verify_frame_delegated_to_precompile_target and test_bal_unaffordable_designation_absent:
   #     a frame does not pay for resolving its target's delegation (PR #12786).
-  FRAME_SKIP: ^(?!.*(test_precompile_target|test_delegated_target_entry_charge|test_delegated_to_precompile_target|test_verify_frame_delegated_to_precompile_target|test_bal_unaffordable_designation_absent))
+  FRAME_SKIP: (?!.*(test_precompile_target|test_delegated_target_entry_charge|test_delegated_to_precompile_target|test_verify_frame_delegated_to_precompile_target|test_bal_unaffordable_designation_absent))
   # Cases the frame suite must still run once FRAME_SKIP is applied; a scope that silently resolved
   # to nothing would otherwise pass by running nothing at all.
   FRAME_MIN_CASES: '147'
@@ -830,7 +831,9 @@ jobs:
               rc=1
             fi
 
-            if [ "$TEST_TYPE" = "frameTest" ] && [ $rc -eq 0 ]; then
+            # Only the unfiltered, FRAME_SKIP-scoped run has a known case count; a narrowing dispatch
+            # filter legitimately runs fewer.
+            if [ "$TEST_TYPE" = "frameTest" ] && [ -z "$FILTER" ] && [ $rc -eq 0 ]; then
               RAN=$(jq 'length' "$RESULTS_FILE" 2>/dev/null || echo 0)
               if [ "$RAN" -lt "$FRAME_MIN_CASES" ]; then
                 echo "::error::frameTest ran $RAN cases, fewer than the $FRAME_MIN_CASES expected; the fixture scope or the release pin has moved"

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -305,18 +305,19 @@ public class BlockProcessorTests
 
     private static IEnumerable<TestCaseData> PredeployInstallCases()
     {
-        yield return new TestCaseData(Eip8141Prototype.Instance, Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode)
+        // EIP-8141 mandates the runtime code alone, so its account keeps the nonce it already had.
+        yield return new TestCaseData(Eip8141Prototype.Instance, Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, 0ul)
             .SetName("Installs_eip8141_expiry_verifier_predeploy_once_and_captures_it_in_bal");
-        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode.ToArray())
+        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8250Enabled = true }, Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode.ToArray(), 1ul)
             .SetName("Installs_eip8250_nonce_manager_predeploy_once_and_captures_it_in_bal");
         // A storage namespace with empty canonical code: its activation update is the nonce alone, so a
         // code-only idempotency probe would never fire it.
-        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8272Enabled = true }, Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode.ToArray())
+        yield return new TestCaseData(new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8272Enabled = true }, Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode.ToArray(), 1ul)
             .SetName("Installs_eip8272_recent_root_predeploy_once_and_captures_it_in_bal");
     }
 
     [TestCaseSource(nameof(PredeployInstallCases)), MaxTime(Timeout.MaxTestTime)]
-    public void Installs_predeploy_once_and_captures_it_in_bal(IReleaseSpec releaseSpec, Address predeploy, byte[] code)
+    public void Installs_predeploy_once_and_captures_it_in_bal(IReleaseSpec releaseSpec, Address predeploy, byte[] code, ulong expectedNonce)
     {
         ISpecProvider specProvider = new TestSingleReleaseSpecProvider(releaseSpec);
         (BlockProcessor processor, _, IWorldState stateProvider) = CreateProcessorAndBranch(specProvider: specProvider);
@@ -327,12 +328,12 @@ public class BlockProcessorTests
         stateProvider.Commit(spec);
         stateProvider.CommitTree(0);
 
-        // First post-activation block installs the predeploy: code + nonce == 1.
+        // First post-activation block installs the predeploy: its code, and its nonce where the EIP mandates one.
         Block block1 = Build.A.Block.WithNumber(1).WithAuthor(TestItem.AddressD).TestObject;
         (Block processed1, _) = processor.ProcessOne(block1, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
 
         Assert.That(stateProvider.GetCode(predeploy), Is.EqualTo(code));
-        Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(1ul));
+        Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(expectedNonce));
         if (!spec.IsEip8250Enabled)
         {
             // In the EIP-8141 case, the independent NONCE_MANAGER must stay absent, proving unrelated predeploys are not installed.
@@ -350,8 +351,13 @@ public class BlockProcessorTests
                 Assert.That(installChanges.CodeChanges[0].Code, Is.EqualTo(code));
             }
 
-            Assert.That(installChanges.NonceChanges, Has.Count.EqualTo(1));
-            Assert.That(installChanges.NonceChanges[0].Value, Is.EqualTo(1ul));
+            // No nonce entry at all where the EIP mandates none: an unmandated one moves the BAL hash and the
+            // block is rejected before execution.
+            Assert.That(installChanges.NonceChanges, Has.Count.EqualTo(expectedNonce == 0 ? 0 : 1));
+            if (expectedNonce != 0)
+            {
+                Assert.That(installChanges.NonceChanges[0].Value, Is.EqualTo(expectedNonce));
+            }
         }
 
         // Second block is a no-op: state unchanged and no BAL entry for the predeploy.
@@ -359,7 +365,7 @@ public class BlockProcessorTests
         (Block processed2, _) = processor.ProcessOne(block2, ProcessingOptions.NoValidation, NullBlockTracer.Instance, spec, CancellationToken.None);
 
         Assert.That(stateProvider.GetCode(predeploy), Is.EqualTo(code));
-        Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(1ul));
+        Assert.That(stateProvider.GetNonce(predeploy), Is.EqualTo(expectedNonce));
         Assert.That(processed2.GeneratedBlockAccessList!.GetAccountChanges(predeploy), Is.Null,
             "a re-install must not churn state or the BAL once the code is already present");
     }

--- a/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -28,5 +29,41 @@ public class PredeployInstallerTests
 
         readState.DidNotReceive().GetCode(Eip8272Constants.RecentRootAddress);
         writeState.DidNotReceive().SetNonce(Eip8272Constants.RecentRootAddress, Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void Expiry_verifier_predeploy_installs_its_code_without_touching_the_nonce()
+    {
+        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        spec.IsEip8141Enabled.Returns(true);
+
+        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
+        readState.GetNonce(Eip8141Constants.ExpiryVerifierAddress).Returns(0ul);
+        readState.GetCode(Eip8141Constants.ExpiryVerifierAddress).Returns([]);
+
+        IWorldState writeState = Substitute.For<IWorldState>();
+
+        PredeployInstaller.Install(readState, writeState, spec);
+
+        writeState.Received().InsertCode(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, spec);
+        writeState.DidNotReceive().SetNonce(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void Expiry_verifier_predeploy_carrying_its_code_at_a_zero_nonce_writes_nothing()
+    {
+        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        spec.IsEip8141Enabled.Returns(true);
+
+        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
+        readState.GetNonce(Eip8141Constants.ExpiryVerifierAddress).Returns(0ul);
+        readState.GetCode(Eip8141Constants.ExpiryVerifierAddress).Returns(Eip8141Constants.ExpiryVerifierCode);
+
+        IWorldState writeState = Substitute.For<IWorldState>();
+
+        PredeployInstaller.Install(readState, writeState, spec);
+
+        writeState.DidNotReceive().InsertCode(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ReadOnlyMemory<byte>>(), spec);
+        writeState.DidNotReceive().SetNonce(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ulong>());
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
@@ -16,16 +16,8 @@ public class PredeployInstallerTests
     [Test]
     public void Empty_canonical_predeploy_at_its_nonce_reads_no_code_and_writes_nothing()
     {
-        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
-        spec.IsEip8272Enabled.Returns(true);
-
-        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
-        readState.GetNonce(Eip8272Constants.RecentRootAddress).Returns(1ul);
-        readState.GetCode(Eip8272Constants.RecentRootAddress).Returns([0x60, 0x00]);
-
-        IWorldState writeState = Substitute.For<IWorldState>();
-
-        PredeployInstaller.Install(readState, writeState, spec);
+        (_, IReadOnlyStateProvider readState, IWorldState writeState) =
+            Install(static spec => spec.IsEip8272Enabled.Returns(true), Eip8272Constants.RecentRootAddress, nonce: 1, code: [0x60, 0x00]);
 
         readState.DidNotReceive().GetCode(Eip8272Constants.RecentRootAddress);
         writeState.DidNotReceive().SetNonce(Eip8272Constants.RecentRootAddress, Arg.Any<ulong>());
@@ -34,16 +26,8 @@ public class PredeployInstallerTests
     [Test]
     public void Expiry_verifier_predeploy_installs_its_code_without_touching_the_nonce()
     {
-        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
-        spec.IsEip8141Enabled.Returns(true);
-
-        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
-        readState.GetNonce(Eip8141Constants.ExpiryVerifierAddress).Returns(0ul);
-        readState.GetCode(Eip8141Constants.ExpiryVerifierAddress).Returns([]);
-
-        IWorldState writeState = Substitute.For<IWorldState>();
-
-        PredeployInstaller.Install(readState, writeState, spec);
+        (IReleaseSpec spec, _, IWorldState writeState) =
+            Install(static spec => spec.IsEip8141Enabled.Returns(true), Eip8141Constants.ExpiryVerifierAddress, nonce: 0, code: []);
 
         writeState.Received().InsertCode(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, spec);
         writeState.DidNotReceive().SetNonce(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ulong>());
@@ -52,18 +36,29 @@ public class PredeployInstallerTests
     [Test]
     public void Expiry_verifier_predeploy_carrying_its_code_at_a_zero_nonce_writes_nothing()
     {
-        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
-        spec.IsEip8141Enabled.Returns(true);
-
-        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
-        readState.GetNonce(Eip8141Constants.ExpiryVerifierAddress).Returns(0ul);
-        readState.GetCode(Eip8141Constants.ExpiryVerifierAddress).Returns(Eip8141Constants.ExpiryVerifierCode);
-
-        IWorldState writeState = Substitute.For<IWorldState>();
-
-        PredeployInstaller.Install(readState, writeState, spec);
+        (IReleaseSpec spec, _, IWorldState writeState) =
+            Install(static spec => spec.IsEip8141Enabled.Returns(true), Eip8141Constants.ExpiryVerifierAddress, nonce: 0, code: Eip8141Constants.ExpiryVerifierCode);
 
         writeState.DidNotReceive().InsertCode(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ReadOnlyMemory<byte>>(), spec);
         writeState.DidNotReceive().SetNonce(Eip8141Constants.ExpiryVerifierAddress, Arg.Any<ulong>());
+        // Re-creating the account each block would land back in the BAL, which is the failure this predeploy's
+        // null nonce exists to avoid.
+        writeState.DidNotReceiveWithAnyArgs().CreateAccountIfNotExists(default!, default, default);
+    }
+
+    private static (IReleaseSpec Spec, IReadOnlyStateProvider ReadState, IWorldState WriteState) Install(
+        Action<IReleaseSpec> activate, Address predeploy, ulong nonce, byte[] code)
+    {
+        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        activate(spec);
+
+        IReadOnlyStateProvider readState = Substitute.For<IReadOnlyStateProvider>();
+        readState.GetNonce(predeploy).Returns(nonce);
+        readState.GetCode(predeploy).Returns(code);
+
+        IWorldState writeState = Substitute.For<IWorldState>();
+        PredeployInstaller.Install(readState, writeState, spec);
+
+        return (spec, readState, writeState);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
@@ -18,17 +18,19 @@ namespace Nethermind.Consensus.Processing;
 /// entry rather than another installer. The install is idempotent: a non-empty predeploy re-installs only
 /// when the account's code differs from the canonical bytecode or its nonce is below the predeploy nonce;
 /// an empty-canonical predeploy (a protocol-managed storage namespace such as EIP-8272's) is gated on the
-/// nonce alone, since it writes no code to compare against. The predeploy nonce is 1, matching the
-/// EIP-2935/4788/7002/7251 convention. <c>max(existing_nonce, 1)</c> is applied only where a predeploy
-/// sets <see cref="Predeploy.PreservesHigherNonce"/> (EIP-8272).
+/// nonce alone, since it writes no code to compare against. A predeploy nonce of 1 matches the
+/// EIP-2935/4788/7002/7251 convention; a null nonce installs the code alone and leaves the account's
+/// nonce as it stands. <c>max(existing_nonce, 1)</c> is applied only where a predeploy sets
+/// <see cref="Predeploy.PreservesHigherNonce"/> (EIP-8272).
 /// </remarks>
 public static class PredeployInstaller
 {
-    private readonly record struct Predeploy(Address Address, ReadOnlyMemory<byte> Code, ulong Nonce, Func<IReleaseSpec, bool> IsActive, bool PreservesHigherNonce = false);
+    private readonly record struct Predeploy(Address Address, ReadOnlyMemory<byte> Code, ulong? Nonce, Func<IReleaseSpec, bool> IsActive, bool PreservesHigherNonce = false);
 
     private static readonly Predeploy[] Predeploys =
     [
-        new(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, 1, static spec => spec.IsEip8141Enabled),
+        // EIP-8141 mandates the runtime code only; the account's other fields survive activation untouched.
+        new(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode, null, static spec => spec.IsEip8141Enabled),
         new(Eip8250Constants.NonceManagerAddress, Eip8250Constants.NonceManagerCode, 1, static spec => spec.IsEip8250Enabled),
         new(Eip8272Constants.RecentRootAddress, Eip8272Constants.RecentRootCode, 1, static spec => spec.IsEip8272Enabled, PreservesHigherNonce: true),
     ];
@@ -74,7 +76,7 @@ public static class PredeployInstaller
             ReadOnlyMemory<byte> code = predeploy.Code;
             ulong nonce = readState.GetNonce(predeploy.Address);
             bool codeSatisfied = code.IsEmpty || readState.GetCode(predeploy.Address).AsSpan().SequenceEqual(code.Span);
-            if (codeSatisfied && nonce >= predeploy.Nonce)
+            if (codeSatisfied && nonce >= (predeploy.Nonce ?? 0))
             {
                 continue;
             }
@@ -85,7 +87,10 @@ public static class PredeployInstaller
                 writeState.InsertCode(predeploy.Address, code, spec);
             }
 
-            writeState.SetNonce(predeploy.Address, predeploy.PreservesHigherNonce ? Math.Max(nonce, predeploy.Nonce) : predeploy.Nonce);
+            if (predeploy.Nonce is ulong predeployNonce)
+            {
+                writeState.SetNonce(predeploy.Address, predeploy.PreservesHigherNonce ? Math.Max(nonce, predeployNonce) : predeployNonce);
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/PredeployInstaller.cs
@@ -18,9 +18,10 @@ namespace Nethermind.Consensus.Processing;
 /// entry rather than another installer. The install is idempotent: a non-empty predeploy re-installs only
 /// when the account's code differs from the canonical bytecode or its nonce is below the predeploy nonce;
 /// an empty-canonical predeploy (a protocol-managed storage namespace such as EIP-8272's) is gated on the
-/// nonce alone, since it writes no code to compare against. A predeploy nonce of 1 matches the
-/// EIP-2935/4788/7002/7251 convention; a null nonce installs the code alone and leaves the account's
-/// nonce as it stands. <c>max(existing_nonce, 1)</c> is applied only where a predeploy sets
+/// nonce alone, since it writes no code to compare against — so such an entry must declare a nonce, or it
+/// has nothing to be gated on and never installs. A predeploy nonce of 1 matches the EIP-2935/4788/7002/7251
+/// convention; a null nonce installs the code alone and leaves the account's nonce as it stands.
+/// <c>max(existing_nonce, 1)</c> is applied only where a predeploy sets
 /// <see cref="Predeploy.PreservesHigherNonce"/> (EIP-8272).
 /// </remarks>
 public static class PredeployInstaller
@@ -76,7 +77,7 @@ public static class PredeployInstaller
             ReadOnlyMemory<byte> code = predeploy.Code;
             ulong nonce = readState.GetNonce(predeploy.Address);
             bool codeSatisfied = code.IsEmpty || readState.GetCode(predeploy.Address).AsSpan().SequenceEqual(code.Span);
-            if (codeSatisfied && nonce >= (predeploy.Nonce ?? 0))
+            if (codeSatisfied && (predeploy.Nonce is not ulong required || nonce >= required))
             {
                 continue;
             }


### PR DESCRIPTION
## Changes

- `frameTest` joins `nethermind-tests.yml`'s `test_types`, so the EIP-8141 frame fixtures gate instead of only being reachable by `workflow_dispatch`.
- The twelve cases this branch still fails are excluded by name through `FRAME_SKIP`, each annotated with the defect behind it. Every one is a client defect with a fix in flight, not fixture lag, so the entries shrink as the fixes land and the suite must reach 159.
- The job asserts it actually ran `FRAME_MIN_CASES` cases. A frame run whose fixture scope resolved to nothing would otherwise report zero failures and pass.
- Carries the expiry-verifier predeploy fix (PR #12887, opened against `eip8141-frame-txs-devnet7`) as a cherry-pick, so the gate is green on arrival rather than red pending a merge-forward. The commits de-duplicate when the devnet-7 branch merges forward.

### Why the suite was red

All 96 failures were ours; none were fixture lag. The earlier reading — a stale release encoding the type-6 envelope without this stack's newer fields — does not hold: a probe showed the frame decoder was never the rejection point, and the reference implementation on `eips/amsterdam/eip-8141` agrees with the fixtures on every field involved.

| Cases | Cause | Where it is fixed |
|---|---|---|
| 84 | The expiry verifier predeploy was installed with nonce 1. The EIP mandates the runtime code alone; the nonce and balance survive activation. The spurious nonce write entered the block-level access list at index 0 and moved the block's BAL hash, so every block carrying a frame transaction was rejected before executing. | PR #12887, cherry-picked here |
| 5 | A frame does not pay for resolving its target's delegation. | PR #12786 |
| 7 | A precompile frame target carries no code, so the codeless short-circuit returns before the VM runs and the precompile's own gas is never charged. | Fix in progress |

### Verification

Running the exact command the job issues, against `tests-frames-devnet@v0.0.0` scoped to `eip8141_frame_transactions`: **147 cases run, 0 failed**. Without `FRAME_SKIP` the same build is 147/159. Before the predeploy fix it was 63/159.

The case-count guard was positive-controlled: an empty result set and a truncated 10-case set both trip it; the real 147-case run does not.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

The predeploy fix carries revert-checked unit cases in `PredeployInstallerTests`. The CI wiring is verified by running the job's own invocation locally, as above.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Wired into the default caller only. The `checked` and `no-intrinsics` variants would multiply CI time for the same fixture set, and the frame suite exercises transaction-level semantics rather than the overflow-check or SIMD-fallback paths those variants exist to cover. The flat caller is likewise skipped: the frame release re-ships the whole suite, and the state-layout and BAL toggles are already covered by the Amsterdam variants.
