### PR TITLE
bench: archive index eth_call pipeline

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Benchmark.Runner/Program.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using BenchmarkDotNet.Columns;
 using Nethermind.Merge.Plugin.Benchmark;
 using Nethermind.Precompiles.Benchmark;
+using Nethermind.State.Flat.History.Test.Archive;
 
 namespace Nethermind.Benchmark.Runner
 {
@@ -46,8 +47,17 @@ namespace Nethermind.Benchmark.Runner
 
     public static class Program
     {
+        /// <summary>Builds the archive-index benchmark database and exits, instead of running any benchmark.</summary>
+        private const string GenerateArchiveDbArgument = "--generate-archive-db";
+
         public static void Main(string[] args)
         {
+            if (args.Contains(GenerateArchiveDbArgument))
+            {
+                GenerateArchiveDb();
+                return;
+            }
+
             bool quickMode = args.Contains("--quick");
             string[] benchmarkArgs = args.Where(static arg => arg != "--quick").ToArray();
             Job benchmarkJob = (quickMode ? Job.ShortRun : Job.MediumRun).WithRuntime(CoreRuntime.Core10_0);
@@ -80,6 +90,26 @@ namespace Nethermind.Benchmark.Runner
                     .FromAssemblies(releaseAssemblies)
                     .Run(benchmarkArgs, new PrecompileBenchmarkConfig(benchmarkJob));
             }
+        }
+
+        /// <summary>
+        /// Generates the chain <see cref="JsonRpc.Benchmark.ArchiveEthCallBenchmarks"/> measures, overwriting whatever
+        /// is at the target path. Running this first keeps the multi-minute build out of the benchmark's own timing,
+        /// and lets the same database be reused by a run on the other branch.
+        /// </summary>
+        private static void GenerateArchiveDb()
+        {
+            ArchiveChainShape shape = ArchiveChainShape.FromEnvironment();
+            using ArchiveChainFixture fixture = new(shape);
+
+            Console.WriteLine($"Generating {shape} into '{fixture.DbPath}' (overwriting anything already there)...");
+
+            Stopwatch elapsed = Stopwatch.StartNew();
+            fixture.RegenerateAsync().GetAwaiter().GetResult();
+
+            Console.WriteLine(
+                $"Done in {elapsed.Elapsed}. Head block {fixture.HeadBlock}, query block {fixture.QueryBlock}, " +
+                $"{shape.HistoryRows} history rows written.");
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/ArchiveEthCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/ArchiveEthCallBenchmarks.cs
@@ -16,23 +16,13 @@ namespace Nethermind.JsonRpc.Benchmark
     /// state scope and the EVM.
     /// </summary>
     /// <remarks>
-    /// This benchmark cannot compare the two implementations by itself: <c>ISortedKeyValueStore.TryGetCeiling</c> is
-    /// a default interface method that <c>ColumnDb</c> only overrides on the branch under test. Run it on one branch,
-    /// keep the artifact, switch branch and run it again against the <em>same</em> generated directory. Quote the
-    /// ratio, never the absolute microseconds: the generated database is a small-buffer proxy for a production LSM,
-    /// so its level count transfers and its timings do not.
-    /// <para>
     /// The first run generates the chain, which takes minutes. Later runs — including the separate process
     /// BenchmarkDotNet starts per parameter combination — reuse the directory. Delete it to rebuild.
-    /// </para>
     /// </remarks>
     [MemoryDiagnoser]
     public class ArchiveEthCallBenchmarks
     {
-        /// <summary>
-        /// Moves the read window far between invocations. Without it the pooled seek iterator would still be sitting
-        /// on the answer from the previous call and the win would be inflated several times over.
-        /// </summary>
+        // moves the read window far between invocations
         private const int WindowStride = 7919;
 
         private ArchiveChainFixture _fixture = null!;

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/ArchiveEthCallBenchmarks.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/ArchiveEthCallBenchmarks.cs
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.State.Flat.History.Test.Archive;
+
+namespace Nethermind.JsonRpc.Benchmark
+{
+    /// <summary>
+    /// Measures <c>eth_call</c> at a historical block against a real on-disk chain, so the archive-index read path
+    /// is timed with everything above it in place — the RPC module, the blockchain bridge, the historical world
+    /// state scope and the EVM.
+    /// </summary>
+    /// <remarks>
+    /// This benchmark cannot compare the two implementations by itself: <c>ISortedKeyValueStore.TryGetCeiling</c> is
+    /// a default interface method that <c>ColumnDb</c> only overrides on the branch under test. Run it on one branch,
+    /// keep the artifact, switch branch and run it again against the <em>same</em> generated directory. Quote the
+    /// ratio, never the absolute microseconds: the generated database is a small-buffer proxy for a production LSM,
+    /// so its level count transfers and its timings do not.
+    /// <para>
+    /// The first run generates the chain, which takes minutes. Later runs — including the separate process
+    /// BenchmarkDotNet starts per parameter combination — reuse the directory. Delete it to rebuild.
+    /// </para>
+    /// </remarks>
+    [MemoryDiagnoser]
+    public class ArchiveEthCallBenchmarks
+    {
+        /// <summary>
+        /// Moves the read window far between invocations. Without it the pooled seek iterator would still be sitting
+        /// on the answer from the previous call and the win would be inflated several times over.
+        /// </summary>
+        private const int WindowStride = 7919;
+
+        private ArchiveChainFixture _fixture = null!;
+        private CallWorkers _workers = null!;
+        private int _invocation;
+        private ulong _targetBlock;
+        private int _windowRange;
+
+        [Params(1, 4)]
+        public int Threads { get; set; }
+
+        [Params(8, 200)]
+        public int SlotsPerCall { get; set; }
+
+        [GlobalSetup]
+        public async Task GlobalSetup()
+        {
+            _fixture = new ArchiveChainFixture(ArchiveChainShape.FromEnvironment());
+            await _fixture.BuildAsync();
+
+            _windowRange = _fixture.Shape.TotalSlots - SlotsPerCall;
+            if (_windowRange <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(SlotsPerCall)}={SlotsPerCall} does not fit in {_fixture.Shape.TotalSlots} slots.");
+            }
+
+            _workers = new CallWorkers(Threads, RunOneCall);
+
+            // Fail here rather than reporting the timing of an error response.
+            _targetBlock = _fixture.QueryBlock;
+            RunOneCall(0);
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            _workers?.Dispose();
+            _fixture?.Dispose();
+        }
+
+        /// <summary>The measured case: the state comes from the history index.</summary>
+        [Benchmark]
+        public void CallAtHistoricalBlock()
+        {
+            _targetBlock = _fixture.QueryBlock;
+            _workers.RunOnce();
+        }
+
+        /// <summary>
+        /// The same call against the head state, which never touches the history index. It carries the fixed cost
+        /// of the RPC and EVM layers, so the gap between the two is what the archive-index read actually costs.
+        /// </summary>
+        [Benchmark(Baseline = true)]
+        public void CallAtHead()
+        {
+            _targetBlock = _fixture.HeadBlock;
+            _workers.RunOnce();
+        }
+
+        private void RunOneCall(int workerIndex)
+        {
+            long invocation = (uint)Interlocked.Increment(ref _invocation);
+            ulong firstSlot = (ulong)(invocation * WindowStride % _windowRange);
+            ResultWrapper<HexBytes> result = _fixture.Call(firstSlot, SlotsPerCall, _targetBlock);
+
+            if (result.Result.ResultType != ResultType.Success)
+            {
+                throw new InvalidOperationException($"eth_call at block {_targetBlock} failed: {result.Result.Error}");
+            }
+        }
+
+        /// <summary>
+        /// Runs one call per worker on dedicated threads, released together and joined before the operation ends.
+        /// </summary>
+        /// <remarks>
+        /// Dedicated threads rather than the thread pool: the RocksDB seek iterators under test are pooled per
+        /// thread and refreshed on a timer, so pool threads would keep handing the benchmark a cold pool and hide
+        /// exactly the contention this parameter exists to expose. The release/join handshake costs the same at
+        /// every thread count, so it does not distort the comparison between them.
+        /// </remarks>
+        private sealed class CallWorkers : IDisposable
+        {
+            private readonly SemaphoreSlim[] _release;
+            private readonly CountdownEvent _completed;
+            private readonly Thread[] _threads;
+            private readonly Action<int> _work;
+            private volatile bool _stopping;
+
+            public CallWorkers(int count, Action<int> work)
+            {
+                _work = work;
+                _release = new SemaphoreSlim[count];
+                _completed = new CountdownEvent(count);
+                _threads = new Thread[count];
+
+                for (int i = 0; i < count; i++)
+                {
+                    _release[i] = new SemaphoreSlim(0, 1);
+                    int index = i;
+                    _threads[i] = new Thread(() => Loop(index)) { IsBackground = true, Name = $"archive-call-{index}" };
+                    _threads[i].Start();
+                }
+            }
+
+            public void RunOnce()
+            {
+                _completed.Reset(_threads.Length);
+                foreach (SemaphoreSlim release in _release) release.Release();
+                _completed.Wait();
+            }
+
+            public void Dispose()
+            {
+                _stopping = true;
+                RunOnce();
+
+                foreach (Thread thread in _threads) thread.Join();
+                foreach (SemaphoreSlim release in _release) release.Dispose();
+                _completed.Dispose();
+            }
+
+            private void Loop(int index)
+            {
+                while (true)
+                {
+                    _release[index].Wait();
+
+                    try
+                    {
+                        if (_stopping) return;
+                        _work(index);
+                    }
+                    finally
+                    {
+                        _completed.Signal();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc.Benchmark/Nethermind.JsonRpc.Benchmark.csproj
+++ b/src/Nethermind/Nethermind.JsonRpc.Benchmark/Nethermind.JsonRpc.Benchmark.csproj
@@ -11,6 +11,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
     <ProjectReference Include="..\Nethermind.JsonRpc\Nethermind.JsonRpc.csproj" />
+    <!-- ArchiveChainFixture lives there: the generated chain is a state/history fixture and the benchmark is only
+         its eth_call entry point. -->
+    <ProjectReference Include="..\Nethermind.State.Flat.History.Test\Nethermind.State.Flat.History.Test.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveChainFixture.cs
+++ b/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveChainFixture.cs
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
+using Nethermind.Evm;
+using Nethermind.Facade.Eth.RpcTransaction;
+using Nethermind.JsonRpc;
+using Nethermind.JsonRpc.Modules.Eth;
+
+namespace Nethermind.State.Flat.History.Test.Archive;
+
+/// <summary>
+/// A real on-disk chain whose history index was produced by real block processing, and the <c>eth_call</c> entry
+/// point that reads it back at a historical block.
+/// </summary>
+public sealed class ArchiveChainFixture(ArchiveChainShape shape, string? dbPath = null, TimeSpan? settleFor = null) : IDisposable
+{
+    private const string MarkerFileName = "archive-bench.marker";
+
+    /// <summary>Long enough for background compaction to form the level structure the seek cost depends on.</summary>
+    private static readonly TimeSpan DefaultSettleFor = TimeSpan.FromSeconds(15);
+
+    private readonly string _dbPath = dbPath
+        ?? Environment.GetEnvironmentVariable("NETHERMIND_ARCHIVE_CALL_BENCH_DB")
+        ?? Path.Combine(Path.GetTempPath(), "nm-archive-call-bench");
+
+    private readonly TimeSpan _settleFor = settleFor ?? DefaultSettleFor;
+    private ArchiveRpcBlockchain? _chain;
+
+    public IEthRpcModule EthRpcModule => Built.EthRpcModule;
+    public ArchiveChainShape Shape => shape;
+    public string DbPath => _dbPath;
+
+    /// <summary>The chain head, which is also the persisted flat state and the history watermark.</summary>
+    public ulong HeadBlock { get; private set; }
+
+    /// <summary>The block the benchmark calls at: well below the barrier, and past the first full sweep cycle.</summary>
+    public ulong QueryBlock { get; private set; }
+
+    private ArchiveRpcBlockchain Built =>
+        _chain ?? throw new InvalidOperationException($"{nameof(BuildAsync)} has to run before the chain is used.");
+
+    /// <summary>True when this run had to build the chain rather than reuse a populated directory.</summary>
+    public bool WasGenerated { get; private set; }
+
+    public async Task BuildAsync(CancellationToken cancellationToken = default)
+    {
+        shape.Validate();
+
+        bool reuse = TryReadMarker(out ArchiveChainShape existingShape, out ulong head, out ulong queryBlock);
+        switch (reuse)
+        {
+            case true when existingShape != shape:
+                throw new InvalidOperationException($"'{_dbPath}' holds a chain of shape {existingShape} but {shape} was requested. Clear the DB folder.");
+            case true:
+                HeadBlock = head;
+                QueryBlock = queryBlock;
+                break;
+            default:
+                await GenerateAsync(cancellationToken);
+                WasGenerated = true;
+                break;
+        }
+
+        // Always a fresh open, generated or not: cold block cache, everything read from SST as a restarted node
+        // would read it.
+        _chain = await ArchiveRpcBlockchain.Create(_dbPath, shape, resume: true);
+        VerifyResumedHead();
+    }
+
+    /// <summary>Runs the read half of the sweep contract at <paramref name="blockNumber"/>.</summary>
+    public ResultWrapper<HexBytes> Call(ulong firstSlot, int slotCount, ulong blockNumber) =>
+        EthRpcModule.eth_call(
+            new LegacyTransactionForRpc
+            {
+                From = TestItem.AddressA,
+                To = StorageSweepContract.Address,
+                Input = StorageSweepContract.ReadCallData(firstSlot, slotCount),
+                Gas = (ulong)StorageSweepContract.ReadGas(slotCount),
+                GasPrice = 0,
+            },
+            new BlockParameter(blockNumber));
+
+    /// <summary>The highest block history serves. Equals the head once generation finished.</summary>
+    public ulong CapturedWatermark => Built.Container.Resolve<HistoryWriter>().LastCapturedBlock;
+
+    public void Dispose() => _chain?.Dispose();
+
+    /// <summary>
+    /// Produces one sweep transaction per block in a throwaway chain, then settles and closes it. The marker is
+    /// written last, so its presence means the directory holds a complete, cleanly closed chain.
+    /// </summary>
+    private async Task GenerateAsync(CancellationToken cancellationToken)
+    {
+        RejectPartialDirectory();
+
+        using (ArchiveRpcBlockchain chain = await ArchiveRpcBlockchain.Create(_dbPath, shape, resume: false))
+        {
+            await ProduceSweepBlocks(chain, cancellationToken);
+
+            HeadBlock = chain.BlockTree.Head!.Number;
+            QueryBlock = shape.QueryBlock;
+
+            SettleLsm(chain);
+        }
+
+        WriteMarker();
+    }
+
+    /// <summary>
+    /// Builds the directory and stops. Any existing one is deleted first, and no chain is left open for reading, so
+    /// this is only useful for producing the database ahead of a benchmark run rather than as part of one.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately separate from <see cref="BuildAsync"/>, which never destroys anything: reusing a populated
+    /// directory is the normal case, and overwriting one is a thing the caller has to ask for by name.
+    /// </remarks>
+    public async Task RegenerateAsync(CancellationToken cancellationToken = default)
+    {
+        shape.Validate();
+
+        if (Directory.Exists(_dbPath)) Directory.Delete(_dbPath, recursive: true);
+
+        await GenerateAsync(cancellationToken);
+        WasGenerated = true;
+    }
+
+    /// <summary>
+    /// Generation suggests genesis, so it needs an empty directory. Only reached once <see cref="TryReadMarker"/>
+    /// has failed, so any content here is a run that crashed before it could write the marker. Generating on top of
+    /// it would restart the sweep windows at slot 0, so they would no longer line up with block numbers — and the
+    /// marker written at the end would stamp that as valid.
+    /// </summary>
+    private void RejectPartialDirectory()
+    {
+        // Not a marker check: the caller already knows there is no usable marker. This only asks whether data is
+        // present regardless.
+        if (!Directory.Exists(_dbPath) || Directory.GetFileSystemEntries(_dbPath).Length == 0) return;
+
+        throw new InvalidOperationException(
+            $"'{_dbPath}' holds data but no complete marker, so an earlier generation did not finish. Delete the " +
+            "directory, or point NETHERMIND_ARCHIVE_CALL_BENCH_DB somewhere else.");
+    }
+
+    private async Task ProduceSweepBlocks(ArchiveRpcBlockchain chain, CancellationToken cancellationToken)
+    {
+        ulong nonce = chain.StateReader.GetNonce(chain.BlockTree.Head!.Header, TestItem.AddressA);
+        ulong txGasLimit = shape.BlockGasLimit - 100_000;
+        IReceiptFinder receipts = chain.ReceiptFinder;
+
+        for (int i = 0; i < shape.Blocks; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Transaction sweep = Build.A.Transaction
+                .WithTo(StorageSweepContract.Address)
+                .WithData(StorageSweepContract.WriteCallData(shape.FirstSlotAt(i), shape.SlotsPerBlock))
+                .WithGasLimit(txGasLimit)
+                .WithGasPrice(1)
+                .WithNonce(nonce++)
+                .SignedAndResolved(TestItem.PrivateKeyA).TestObject;
+
+            Block block = await chain.AddBlock(sweep);
+            VerifySweepSucceeded(receipts, block, i);
+
+            // Capture only runs when the flat state persists. Left alone, persistence waits for the ~256-block
+            // backstop (there is no consensus layer here to advance finality), so the barrier would trail the head
+            // by that much and where it sat would depend on timing.
+            if ((i + 1) % shape.FlushEveryBlocks == 0) chain.WorldStateManager.FlushCache(CancellationToken.None);
+        }
+
+        // Brings the barrier all the way to the head, so every block below it is served from history.
+        chain.WorldStateManager.FlushCache(CancellationToken.None);
+    }
+
+    /// <summary>
+    /// An out-of-gas sweep is still included in its block, writes no storage, and would leave the history index
+    /// nearly empty while the benchmark still ran and reported numbers. Fail loudly instead.
+    /// </summary>
+    private static void VerifySweepSucceeded(IReceiptFinder receipts, Block block, int blockIndex)
+    {
+        TxReceipt[] found = receipts.Get(block, recover: false, recoverSender: false);
+        if (found is { Length: 1 } && found[0].StatusCode == StatusCode.Success) return;
+
+        string status = found is { Length: > 0 } ? found[0].StatusCode.ToString(CultureInfo.InvariantCulture) : "no receipt";
+        throw new InvalidOperationException(
+            $"The sweep transaction of generated block {blockIndex} (block {block.Number}) did not succeed " +
+            $"(status: {status}, gas used {block.GasUsed} of {block.GasLimit}). It writes no storage when it fails, " +
+            $"so the history index would come out empty. Lower {nameof(ArchiveChainShape.SlotsPerBlock)}, or raise " +
+            $"the per-slot gas allowance in {nameof(StorageSweepContract)}.");
+    }
+
+    /// <summary>
+    /// Flushes and lets background compaction settle. Deliberately does <em>not</em> call <c>Compact()</c>: a full
+    /// manual compaction collapses everything into one level, the one shape that would hide the per-seek cost this
+    /// fixture exists to measure.
+    /// </summary>
+    private void SettleLsm(ArchiveRpcBlockchain chain)
+    {
+        IColumnsDb<FlatHistoryColumns> history = chain.Container.Resolve<IColumnsDb<FlatHistoryColumns>>();
+        history.Flush();
+
+        if (_settleFor <= TimeSpan.Zero) return;
+
+        // Best-effort: RocksDB compaction is asynchronous and exposes no drain signal. The wait only has to be long
+        // enough for the level structure to form; a short one biases toward more L0 files, not fewer.
+        Thread.Sleep(_settleFor);
+        history.Flush();
+    }
+
+    private void VerifyResumedHead()
+    {
+        ulong? actualHead = Built.BlockTree.Head?.Number;
+        if (actualHead == HeadBlock) return;
+
+        throw new InvalidOperationException(
+            $"'{_dbPath}' reopened at block {actualHead?.ToString(CultureInfo.InvariantCulture) ?? "none"} but a head " +
+            $"of {HeadBlock} was expected. The directory is not a complete generated chain; delete it and rebuild.");
+    }
+
+    private string MarkerPath => Path.Combine(_dbPath, MarkerFileName);
+
+    private void WriteMarker() => File.WriteAllLines(MarkerPath,
+    [
+        shape.Blocks.ToString(CultureInfo.InvariantCulture),
+        shape.SlotsPerBlock.ToString(CultureInfo.InvariantCulture),
+        shape.TotalSlots.ToString(CultureInfo.InvariantCulture),
+        shape.FlushEveryBlocks.ToString(CultureInfo.InvariantCulture),
+        HeadBlock.ToString(CultureInfo.InvariantCulture),
+        QueryBlock.ToString(CultureInfo.InvariantCulture),
+    ]);
+
+    private bool TryReadMarker(out ArchiveChainShape existingShape, out ulong head, out ulong queryBlock)
+    {
+        existingShape = default;
+        head = 0;
+        queryBlock = 0;
+
+        // Written last, so its absence also covers a generation that crashed half way.
+        if (!File.Exists(MarkerPath)) return false;
+
+        string[] lines = File.ReadAllLines(MarkerPath);
+        if (lines.Length < 6) return false;
+
+        existingShape = new ArchiveChainShape(
+            int.Parse(lines[0], CultureInfo.InvariantCulture),
+            int.Parse(lines[1], CultureInfo.InvariantCulture),
+            int.Parse(lines[2], CultureInfo.InvariantCulture),
+            int.Parse(lines[3], CultureInfo.InvariantCulture));
+        head = ulong.Parse(lines[4], CultureInfo.InvariantCulture);
+        queryBlock = ulong.Parse(lines[5], CultureInfo.InvariantCulture);
+        return true;
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveChainShape.cs
+++ b/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveChainShape.cs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+
+namespace Nethermind.State.Flat.History.Test.Archive;
+
+/// <summary>How much chain the archive-index benchmark generates, and how the storage writes are spread over it.</summary>
+/// <param name="Blocks">Blocks produced after genesis, each carrying one sweep transaction.</param>
+/// <param name="SlotsPerBlock">Slots one block writes. Widening this is much cheaper than adding blocks.</param>
+/// <param name="TotalSlots">Distinct slots the sweep cycles through, so a slot gets a new version every cycle.</param>
+/// <param name="FlushEveryBlocks">
+/// Blocks between forced persist+capture passes. Capture only runs when the flat state persists, so this is what
+/// turns produced blocks into history rows.
+/// </param>
+public readonly record struct ArchiveChainShape(int Blocks, int SlotsPerBlock, int TotalSlots, int FlushEveryBlocks)
+{
+    private const string BlocksVariable = "NETHERMIND_ARCHIVE_BENCH_BLOCKS";
+    private const string SlotsPerBlockVariable = "NETHERMIND_ARCHIVE_BENCH_SLOTS_PER_BLOCK";
+    private const string TotalSlotsVariable = "NETHERMIND_ARCHIVE_BENCH_TOTAL_SLOTS";
+
+    /// <summary>~1M history rows over 2 000 blocks. Minutes to build; the shape the published numbers use.</summary>
+    public static ArchiveChainShape Benchmark => new(Blocks: 2_000, SlotsPerBlock: 500, TotalSlots: 20_000, FlushEveryBlocks: 64);
+
+    /// <summary>Seconds to build. For correctness tests only — far too shallow to time anything.</summary>
+    public static ArchiveChainShape Tiny => new(Blocks: 40, SlotsPerBlock: 20, TotalSlots: 200, FlushEveryBlocks: 8);
+
+    /// <summary><see cref="Benchmark"/> with the three sizes overridable per run.</summary>
+    public static ArchiveChainShape FromEnvironment()
+    {
+        ArchiveChainShape shape = Benchmark;
+        return shape with
+        {
+            Blocks = ReadInt(BlocksVariable, shape.Blocks),
+            SlotsPerBlock = ReadInt(SlotsPerBlockVariable, shape.SlotsPerBlock),
+            TotalSlots = ReadInt(TotalSlotsVariable, shape.TotalSlots),
+        };
+    }
+
+    /// <summary>Storage history rows the generation writes, before de-duplication by RocksDB.</summary>
+    public long HistoryRows => (long)Blocks * SlotsPerBlock;
+
+    /// <summary>Blocks the first cycle takes; below it some slots have no version yet.</summary>
+    public int PrimingBlocks => TotalSlots / SlotsPerBlock;
+
+    /// <summary>
+    /// The block the benchmark calls at. Half way between the first full cycle and the head, so it is past priming
+    /// and well below the barrier. <see cref="Validate"/> rejects shapes where it would land on the head, because
+    /// there the "historical" call would read live flat state and quietly report the wrong thing.
+    /// </summary>
+    public ulong QueryBlock => (ulong)(PrimingBlocks + (Blocks - PrimingBlocks) / 2 + 1);
+
+    /// <summary>
+    /// Set at genesis and never adjusted afterwards, so the whole chain has room for one sweep per block.
+    /// The bound divisor only lets the produced limit drift ~0.1% per block, which is far too slow to ramp up.
+    /// </summary>
+    public ulong BlockGasLimit => (ulong)StorageSweepContract.WriteGas(SlotsPerBlock) + 1_000_000;
+
+    /// <summary>First slot the sweep in the given generated block writes.</summary>
+    public ulong FirstSlotAt(int blockIndex) => (ulong)((long)blockIndex * SlotsPerBlock % TotalSlots);
+
+    public void Validate()
+    {
+        if (Blocks <= 0 || SlotsPerBlock <= 0 || TotalSlots <= 0 || FlushEveryBlocks <= 0)
+            throw new ArgumentOutOfRangeException(nameof(Blocks), this, "Every dimension must be positive.");
+
+        // Otherwise a cycle straddles the wrap and the windows stop tiling, leaving slots with uneven version counts.
+        if (TotalSlots % SlotsPerBlock != 0)
+            throw new ArgumentOutOfRangeException(nameof(TotalSlots), this, $"{nameof(TotalSlots)} must be a multiple of {nameof(SlotsPerBlock)}.");
+
+        // Without a full cycle some slots are never written and the read call would sum absent values.
+        if (Blocks < PrimingBlocks * 2)
+            throw new ArgumentOutOfRangeException(nameof(Blocks), this, $"{nameof(Blocks)} must cover at least two full cycles of {PrimingBlocks} blocks.");
+
+        // Two cycles of one or two blocks each put the query block on the head, where nothing historical is read.
+        if (QueryBlock <= (ulong)PrimingBlocks || QueryBlock >= (ulong)Blocks)
+            throw new ArgumentOutOfRangeException(nameof(Blocks), this,
+                $"{nameof(QueryBlock)} of {QueryBlock} must sit above the first cycle of {PrimingBlocks} blocks and " +
+                $"below the head at block {Blocks}. Add blocks, or lower {nameof(SlotsPerBlock)} to shorten the cycle.");
+    }
+
+    private static int ReadInt(string variable, int fallback) =>
+        int.TryParse(Environment.GetEnvironmentVariable(variable), out int value) ? value : fallback;
+}

--- a/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveEthCallTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveEthCallTests.cs
@@ -16,6 +16,7 @@ namespace Nethermind.State.Flat.History.Test.Archive;
 /// <c>eth_call</c> reaches the history index rather than the head state.
 /// </summary>
 [TestFixture]
+[Explicit("Benchmark harness: generates a real chain on disk. Run when touching the archive-index benchmark.")]
 public class ArchiveEthCallTests
 {
     private static readonly ArchiveChainShape Shape = ArchiveChainShape.Tiny;

--- a/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveEthCallTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveEthCallTests.cs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Int256;
+using Nethermind.JsonRpc;
+using NUnit.Framework;
+
+namespace Nethermind.State.Flat.History.Test.Archive;
+
+/// <summary>
+/// Proves the generated chain the archive-index benchmark measures is actually readable, and that a historical
+/// <c>eth_call</c> reaches the history index rather than the head state.
+/// </summary>
+[TestFixture]
+public class ArchiveEthCallTests
+{
+    private static readonly ArchiveChainShape Shape = ArchiveChainShape.Tiny;
+
+    private string _dbPath = null!;
+
+    [SetUp]
+    public void SetUp() => _dbPath = Path.Combine(Path.GetTempPath(), "nm-archive-call-test", Guid.NewGuid().ToString("N"));
+
+    [TearDown]
+    public void TearDown()
+    {
+        try
+        {
+            if (Directory.Exists(_dbPath)) Directory.Delete(_dbPath, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a run over.
+        }
+    }
+
+    [Test]
+    public async Task Historical_call_reads_the_value_of_its_own_block_not_the_head()
+    {
+        using ArchiveChainFixture fixture = NewFixture();
+        await fixture.BuildAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(fixture.WasGenerated, Is.True);
+            // Capture is driven by persistence; a watermark short of the head means the flush pass never ran.
+            Assert.That(fixture.CapturedWatermark, Is.EqualTo(fixture.HeadBlock), "history watermark");
+            Assert.That(fixture.QueryBlock, Is.LessThan(fixture.HeadBlock), "query block must sit below the barrier");
+        }
+
+        UInt256 atQueryBlock = ReadWindowSum(fixture, fixture.QueryBlock);
+        UInt256 atHead = ReadWindowSum(fixture, fixture.HeadBlock);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(atQueryBlock, Is.EqualTo(ExpectedWindowSum(fixture.QueryBlock)), "historical value");
+            Assert.That(atHead, Is.EqualTo(ExpectedWindowSum(fixture.HeadBlock)), "head value");
+            // The whole point of the archive index: the two answers must differ.
+            Assert.That(atQueryBlock, Is.Not.EqualTo(atHead));
+        }
+    }
+
+    [Test]
+    public async Task Reopened_chain_serves_the_same_historical_call()
+    {
+        ulong queryBlock;
+        UInt256 expected;
+
+        using (ArchiveChainFixture generated = NewFixture())
+        {
+            await generated.BuildAsync();
+            queryBlock = generated.QueryBlock;
+            expected = ReadWindowSum(generated, queryBlock);
+        }
+
+        using ArchiveChainFixture reopened = NewFixture();
+        await reopened.BuildAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reopened.WasGenerated, Is.False, "the populated directory must be reused, not rebuilt");
+            Assert.That(reopened.QueryBlock, Is.EqualTo(queryBlock));
+            Assert.That(ReadWindowSum(reopened, queryBlock), Is.EqualTo(expected));
+        }
+    }
+
+    [Test]
+    public async Task Rejects_a_directory_generated_with_a_different_shape()
+    {
+        using (ArchiveChainFixture generated = NewFixture())
+        {
+            await generated.BuildAsync();
+        }
+
+        using ArchiveChainFixture mismatched = new(Shape with { SlotsPerBlock = Shape.SlotsPerBlock * 2 }, _dbPath, TimeSpan.Zero);
+
+        await Assert.ThatAsync(() => mismatched.BuildAsync(), Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public async Task Rejects_a_populated_directory_that_has_no_marker()
+    {
+        Directory.CreateDirectory(_dbPath);
+        await File.WriteAllTextAsync(Path.Combine(_dbPath, "LOG"), "left over from a generation that crashed");
+
+        using ArchiveChainFixture fixture = NewFixture();
+
+        await Assert.ThatAsync(() => fixture.BuildAsync(), Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    /// <summary>
+    /// Two cycles of two blocks each put the query block on the head. That shape would still generate and still
+    /// benchmark, but the "historical" call would read live flat state, so it has to fail before any of that.
+    /// </summary>
+    [Test]
+    public void Rejects_a_shape_whose_query_block_lands_on_the_head()
+    {
+        ArchiveChainShape degenerate = new(Blocks: 4, SlotsPerBlock: 20, TotalSlots: 40, FlushEveryBlocks: 8);
+
+        Assert.That(degenerate.QueryBlock, Is.EqualTo((ulong)degenerate.Blocks), "the case under test");
+        Assert.That(degenerate.Validate, Throws.InstanceOf<ArgumentOutOfRangeException>());
+    }
+
+    /// <summary>
+    /// Reads the first sweep window. Every slot in one window is written by the same block, so the expected sum is
+    /// exactly <c>SlotsPerBlock * blockNumber</c> — no per-slot bookkeeping needed.
+    /// </summary>
+    private static UInt256 ReadWindowSum(ArchiveChainFixture fixture, ulong blockNumber)
+    {
+        ResultWrapper<HexBytes> result = fixture.Call(firstSlot: 0, Shape.SlotsPerBlock, blockNumber);
+        Assert.That(result.Result.ResultType, Is.EqualTo(ResultType.Success), $"{result.Result.Error}");
+        return new UInt256(result.Data.Bytes.Span, isBigEndian: true);
+    }
+
+    /// <summary>The block that last wrote window 0 at or below <paramref name="blockNumber"/>, times the window size.</summary>
+    private static UInt256 ExpectedWindowSum(ulong blockNumber)
+    {
+        // Generated block i carries block number i + 1 and writes window (i % PrimingBlocks).
+        ulong cycle = (ulong)Shape.PrimingBlocks;
+        ulong lastWritingIndex = (blockNumber - 1) / cycle * cycle;
+        return (UInt256)(lastWritingIndex + 1) * (UInt256)(ulong)Shape.SlotsPerBlock;
+    }
+
+    private ArchiveChainFixture NewFixture() => new(Shape, _dbPath, TimeSpan.Zero);
+}

--- a/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveRpcBlockchain.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -23,7 +23,7 @@ namespace Nethermind.State.Flat.History.Test.Archive;
 /// <summary>
 /// A <see cref="TestRpcBlockchain"/> whose databases are RocksDB on a fixed path, with the flat backend and history capture on.
 /// </summary>
-public sealed class ArchiveRpcBlockchain: TestRpcBlockchain
+public sealed class ArchiveRpcBlockchain : TestRpcBlockchain
 {
     // Shrinks the history write buffers and level targets so the generated rows reach the same level count
     // production reaches with hundreds of GB. Level count is what drives the number of child iterators each seek

--- a/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveRpcBlockchain.cs
@@ -25,14 +25,22 @@ namespace Nethermind.State.Flat.History.Test.Archive;
 /// </summary>
 public sealed class ArchiveRpcBlockchain: TestRpcBlockchain
 {
-    // Shrinks the history write buffers and level targets so a few hundred MB of generated rows reaches the
-    // same level count production reaches with hundreds of GB. Level count is what drives the number
-    // of child iterators each seek builds, so the A/B ratio transfers even though the absolute numbers do not.
+    // Shrinks the history write buffers and level targets so the generated rows reach the same level count
+    // production reaches with hundreds of GB. Level count is what drives the number of child iterators each seek
+    // builds, so the A/B ratio transfers even though the absolute numbers do not.
+    //
+    // The targets are this small because the rows compress far harder than their raw size suggests: the keys are
+    // sorted and nearly identical, so a million of them land in ~8 MB. With a level base of any ordinary size the
+    // whole index fits in L1 and no deeper level ever forms. Sizing is static here
+    // (level_compaction_dynamic_level_bytes is false), so the targets are exactly base * multiplier^(n-1):
+    // L1 0.3 MB, L2 0.6, L3 1.2, L4 2.4, L5 4.8 — 9.3 MB of capacity through L5, which puts ~8 MB of index across
+    // five levels. A multiplier of 3 reaches L4 and stops, which is not enough seek depth to measure.
     private const string SmallBufferShapeOptions =
-        "write_buffer_size=4000000;" +
+        "write_buffer_size=1000000;" +
         "max_write_buffer_number=2;" +
-        "target_file_size_base=4000000;" +
-        "max_bytes_for_level_base=16000000;" +
+        "target_file_size_base=300000;" +
+        "max_bytes_for_level_base=300000;" +
+        "max_bytes_for_level_multiplier=2;" +
         "level0_file_num_compaction_trigger=4;";
 
     private string _dbPath = null!;

--- a/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/ArchiveRpcBlockchain.cs
@@ -1,0 +1,86 @@
+﻿// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Autofac;
+using Nethermind.Api;
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Test.Blockchain;
+using Nethermind.Core.Test.Container;
+using Nethermind.Db;
+using Nethermind.Db.Rocks;
+using Nethermind.Db.Rocks.Config;
+using Nethermind.Evm.State;
+using Nethermind.Init.Modules;
+using Nethermind.JsonRpc.Test.Modules;
+
+namespace Nethermind.State.Flat.History.Test.Archive;
+
+/// <summary>
+/// A <see cref="TestRpcBlockchain"/> whose databases are RocksDB on a fixed path, with the flat backend and history capture on.
+/// </summary>
+public sealed class ArchiveRpcBlockchain: TestRpcBlockchain
+{
+    // Shrinks the history write buffers and level targets so a few hundred MB of generated rows reaches the
+    // same level count production reaches with hundreds of GB. Level count is what drives the number
+    // of child iterators each seek builds, so the A/B ratio transfers even though the absolute numbers do not.
+    private const string SmallBufferShapeOptions =
+        "write_buffer_size=4000000;" +
+        "max_write_buffer_number=2;" +
+        "target_file_size_base=4000000;" +
+        "max_bytes_for_level_base=16000000;" +
+        "level0_file_num_compaction_trigger=4;";
+
+    private string _dbPath = null!;
+    private ArchiveChainShape _shape;
+
+    private ArchiveRpcBlockchain()
+    {
+        SealEngineType = Nethermind.Core.SealEngineType.NethDev;
+        UseFlatDb = true;
+        // Generation produces blocks of tens of millions of gas; the 30s default trips on the slower ones.
+        TestTimeout = (long)TimeSpan.FromMinutes(10).TotalMilliseconds;
+    }
+
+    public static Task<ArchiveRpcBlockchain> Create(string dbPath, ArchiveChainShape shape, bool resume)
+    {
+        Directory.CreateDirectory(dbPath);
+
+        ArchiveRpcBlockchain chain = new()
+        {
+            _dbPath = dbPath,
+            _shape = shape
+        };
+
+        return ForTest(chain).Build(chain.Configure(resume));
+    }
+
+    protected override IEnumerable<IConfig> CreateConfigs() =>
+    [
+        .. base.CreateConfigs(),
+        new InitConfig {BaseDbPath = _dbPath},
+        new FlatDbConfig {Enabled = true, HistoryEnabled = true},
+        new DbConfig {FlatHistoryDbAdditionalRocksDbOptions = SmallBufferShapeOptions},
+    ];
+
+    private Action<ContainerBuilder> Configure(bool resume) => builder => builder
+        .AddSingleton<IDbFactory, RocksDbFactory>() // replaces MemDbFactory
+        .AddColumnDatabase<FlatDbColumns>(DbNames.Flat) // PseudoNethermindModule uses in-memory DB for flat columns, use factory instead
+        .ConfigureTestConfiguration(conf =>
+        {
+            conf.AddBlockOnStart = false;
+            conf.SuggestGenesisOnStart = !resume; // On reuse the chain, including genesis, comes back from disk.
+        })
+        .WithGenesisPostProcessor((block, worldState, specProvider) =>
+        {
+            // The produced limit only drifts by ~1/1024 per block, so the room for a whole sweep has to exist from genesis.
+            block.Header.GasLimit = _shape.BlockGasLimit;
+
+            worldState.CreateAccount(StorageSweepContract.Address, 0);
+            worldState.InsertCode(StorageSweepContract.Address, StorageSweepContract.RuntimeCode, specProvider.GenesisSpec);
+        });
+}

--- a/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/StorageSweepContract.cs
+++ b/src/Nethermind/Nethermind.State.Flat.History.Test/Archive/StorageSweepContract.cs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Evm;
+
+namespace Nethermind.State.Flat.History.Test.Archive;
+
+/// <summary>
+/// The single contract for <see cref="ArchiveChainFixture"/>.
+/// Sweeps a window of storage slots, writing the current block number into each, and reads a window back summing the values.
+/// </summary>
+/// <remarks>
+/// Both halves live in one contract because the read must reach the storage the write produced, and
+/// <c>SLOAD</c> only sees the executing contract's own slots. The written value is <c>NUMBER</c> so every block
+/// changes every slot it touches: an unchanged slot produces no changeset entry and therefore no history row,
+/// which would leave the generated index silently empty.
+/// </remarks>
+public static class StorageSweepContract
+{
+    /// <summary>Fixed address: the code is placed at genesis, so no deploy transaction and no nonce arithmetic.</summary>
+    public static readonly Address Address = new("0x00000000000000000000000000000000000a5501");
+
+    /// <summary>Gas an <c>SSTORE</c> of a fresh (zero-valued) slot costs, plus the surrounding loop.</summary>
+    private const long WriteGasPerSlot = 25_000;
+
+    /// <summary>Gas a cold <c>SLOAD</c> costs, plus the surrounding loop.</summary>
+    private const long ReadGasPerSlot = 2_400;
+
+    private const long IntrinsicGas = 30_000;
+
+    public static byte[] RuntimeCode { get; } = BuildRuntimeCode();
+
+    public static long WriteGas(int slotCount) => IntrinsicGas + slotCount * WriteGasPerSlot;
+
+    public static long ReadGas(int slotCount) => IntrinsicGas + slotCount * ReadGasPerSlot;
+
+    /// <summary>Writes <paramref name="slotCount"/> slots from <paramref name="firstSlot"/>, each set to the block number.</summary>
+    public static byte[] WriteCallData(ulong firstSlot, int slotCount) => CallData(op: 0, firstSlot, slotCount);
+
+    /// <summary>Reads <paramref name="slotCount"/> slots from <paramref name="firstSlot"/> and returns their sum.</summary>
+    public static byte[] ReadCallData(ulong firstSlot, int slotCount) => CallData(op: 1, firstSlot, slotCount);
+
+    private static byte[] CallData(ulong op, ulong firstSlot, int slotCount)
+    {
+        byte[] data = new byte[96];
+        BinaryPrimitives.WriteUInt64BigEndian(data.AsSpan(24, 8), op);
+        BinaryPrimitives.WriteUInt64BigEndian(data.AsSpan(56, 8), firstSlot);
+        BinaryPrimitives.WriteUInt64BigEndian(data.AsSpan(88, 8), (ulong)slotCount);
+        return data;
+    }
+
+    /// <summary>
+    /// Calldata layout: word 0 selects write (zero) or read (non-zero), word 1 is the first slot, word 2 the count.
+    /// </summary>
+    private static byte[] BuildRuntimeCode()
+    {
+        const string read = "read";
+        const string writeLoop = "writeLoop";
+        const string writeEnd = "writeEnd";
+        const string readLoop = "readLoop";
+        const string readEnd = "readEnd";
+
+        Assembler asm = new();
+
+        // [] -> op, branch on it
+        asm.Push1(0).Op(Instruction.CALLDATALOAD).PushLabel(read).Op(Instruction.JUMPI);
+
+        // Write: stack is [slot, remaining] throughout the loop.
+        LoadWindowArguments(asm);
+        asm.Mark(writeLoop)
+            .Op(Instruction.DUP1).Op(Instruction.ISZERO).PushLabel(writeEnd).Op(Instruction.JUMPI)
+            // SSTORE pops the key first, so the key has to end up above the value.
+            .Op(Instruction.DUP2).Op(Instruction.NUMBER).Op(Instruction.SWAP1).Op(Instruction.SSTORE);
+        AdvanceWindow(asm);
+        asm.PushLabel(writeLoop).Op(Instruction.JUMP)
+            .Mark(writeEnd).Op(Instruction.STOP);
+
+        // Read: stack is [slot, remaining, accumulator].
+        asm.Mark(read);
+        LoadWindowArguments(asm);
+        asm.Push1(0)
+            .Mark(readLoop)
+            .Op(Instruction.DUP2).Op(Instruction.ISZERO).PushLabel(readEnd).Op(Instruction.JUMPI)
+            .Op(Instruction.DUP3).Op(Instruction.SLOAD).Op(Instruction.ADD)
+            // Bring the slot to the top, bump it, put it back under the accumulator.
+            .Op(Instruction.SWAP2).Push1(1).Op(Instruction.ADD).Op(Instruction.SWAP2)
+            // Same for the counter.
+            .Op(Instruction.SWAP1).Push1(1).Op(Instruction.SWAP1).Op(Instruction.SUB).Op(Instruction.SWAP1)
+            .PushLabel(readLoop).Op(Instruction.JUMP)
+            .Mark(readEnd)
+            .Push1(0).Op(Instruction.MSTORE)
+            .Push1(32).Push1(0).Op(Instruction.RETURN);
+
+        return asm.Done();
+    }
+
+    /// <summary>Pushes calldata words 1 and 2, leaving [slot, remaining].</summary>
+    private static void LoadWindowArguments(Assembler asm) =>
+        asm.Push1(32).Op(Instruction.CALLDATALOAD).Push1(64).Op(Instruction.CALLDATALOAD);
+
+    /// <summary>Turns [slot, remaining] into [slot + 1, remaining - 1].</summary>
+    private static void AdvanceWindow(Assembler asm) =>
+        asm.Push1(1).Op(Instruction.SWAP1).Op(Instruction.SUB)
+            .Op(Instruction.SWAP1).Push1(1).Op(Instruction.ADD).Op(Instruction.SWAP1);
+
+    /// <summary>Emits bytecode with forward jump targets resolved on <see cref="Done"/>.</summary>
+    private sealed class Assembler
+    {
+        private readonly List<byte> _code = [];
+        private readonly Dictionary<string, int> _labels = [];
+        private readonly List<(int Position, string Label)> _patches = [];
+
+        public Assembler Op(Instruction instruction)
+        {
+            _code.Add((byte)instruction);
+            return this;
+        }
+
+        public Assembler Push1(byte value)
+        {
+            _code.Add((byte)Instruction.PUSH1);
+            _code.Add(value);
+            return this;
+        }
+
+        public Assembler PushLabel(string label)
+        {
+            _code.Add((byte)Instruction.PUSH2);
+            _patches.Add((_code.Count, label));
+            _code.Add(0);
+            _code.Add(0);
+            return this;
+        }
+
+        public Assembler Mark(string label)
+        {
+            _labels[label] = _code.Count;
+            return Op(Instruction.JUMPDEST);
+        }
+
+        public byte[] Done()
+        {
+            foreach ((int position, string label) in _patches)
+            {
+                int target = _labels[label];
+                _code[position] = (byte)(target >> 8);
+                _code[position + 1] = (byte)target;
+            }
+
+            return [.. _code];
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat.History.Test/Nethermind.State.Flat.History.Test.csproj
+++ b/src/Nethermind/Nethermind.State.Flat.History.Test/Nethermind.State.Flat.History.Test.csproj
@@ -12,6 +12,11 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
+    <!-- The archive-index fixture measures a real LSM: the read path's cost is RocksDB iterator setup, which an
+         in-memory column DB does not have. -->
+    <ProjectReference Include="..\Nethermind.Db.Rocks\Nethermind.Db.Rocks.csproj" />
+    <!-- ...and it drives that read through eth_call, for which TestRpcBlockchain is the ready-made host. -->
+    <ProjectReference Include="..\Nethermind.JsonRpc.Test\Nethermind.JsonRpc.Test.csproj" />
     <ProjectReference Include="..\Nethermind.State.Flat\Nethermind.State.Flat.csproj" />
     <ProjectReference Include="..\Nethermind.State.Flat.History\Nethermind.State.Flat.History.csproj" />
     <ProjectReference Include="..\Nethermind.State.Flat.Test\Nethermind.State.Flat.Test.csproj" />


### PR DESCRIPTION
Adds a production-shaped benchmark for the archive index (flat history) read path, so changes to it can be measured end to end through `eth_call` rather than through a synthetic store.

The chain is generated locally rather than taken from a network or an existing chain database: the fixture signs one synthetic sweep transaction per block and has the block producer build on top of the previous block. What is real is everything around it - real block production and processing, real EVM execution, real state commit and history capture, and a real RocksDB on disk. The benchmark then calls at a historical block with the RPC module, the blockchain bridge, the historical world state scope and the EVM all in place. RocksDB level targets are shrunk so the generated index reaches the same LSM level count production reaches with hundreds of GB, because level count is what drives the number of child iterators each seek builds.

## Changes

- Adds `ArchiveChainShape`, the record that describes how much chain to generate and how the storage writes spread over it.
  - Derives the query block, the priming length and the block gas limit from the three sizes, and validates that the shapes it accepts are measurable.
- Adds `StorageSweepContract`, hand-assembled runtime code placed at genesis that writes a window of storage slots and reads a window back.
  - Writes `NUMBER` into each slot, so every block changes every slot it touches; an unchanged slot produces no changeset entry and therefore no history row.
  - Keeps both halves in one contract because `SLOAD` only reaches the executing contract's own storage.
- Adds `ArchiveRpcBlockchain`, a `TestRpcBlockchain` configured for a persistent RocksDB flat DB with history enabled, able to either build a chain or resume one from disk.
- Adds `ArchiveChainFixture`, which produces the chain, settles the LSM, and reuses an existing directory on later runs.
  - Forces a persist and capture pass every N blocks, because capture only runs when the flat state persists and the finality trigger never fires without a consensus layer.
  - Writes a marker file last, holding the shape, the head and the query block, so a directory is only reused when it is complete and matches.
  - Rejects a populated directory that has no marker, and rejects a shape mismatch.
  - Deliberately avoids a manual `Compact()`, which would collapse the level structure the benchmark exists to measure.
- Adds `ArchiveEthCallTests`, covering the fixture the benchmark depends on.
- Adds `ArchiveEthCallBenchmarks`, which times `eth_call` at a historical block against the head-state call as a baseline.
  - Moves the read window between invocations, so a pooled seek iterator cannot still be sitting on the previous answer.
  - Runs the calls on dedicated threads rather than the thread pool, because the RocksDB seek iterators are pooled per thread and refreshed on a timer.
- Adds a `--generate-archive-db` mode to `Nethermind.Benchmark.Runner`, which builds the database and exits, keeping the multi-minute generation out of the benchmark's own timing and letting the same directory serve a run on another branch.
- Adds the project references the above needs, each with a note on why.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: benchmark

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No