### PR TITLE
docs(xdc): add a subnet setup guide to the module README

### DIFF
--- a/src/Nethermind/Nethermind.Xdc/README.md
+++ b/src/Nethermind/Nethermind.Xdc/README.md
@@ -594,6 +594,119 @@ Example — mainnet's current entry:
 | Rewards | [`XdcSubnetRewardCalculator`](XdcSubnetRewardCalculator.cs) | Subnet reward model |
 | Chainspec loading | [`XdcSubnetChainSpecLoader`](XdcSubnetChainSpecLoader.cs) | Builds a subnet genesis header |
 
+### Setting up a subnet
+
+A subnet is a standalone chain, so bringing one up is a chainspec plus one node config per node. A chainspec
+for a three-masternode local subnet looks like this:
+
+```json
+{
+  "name": "xdc-subnet-local",
+  "engine": {
+    "XDPoSSubnet": {
+      "params": {
+        "period": 1,
+        "epoch": 90,
+        "gap": 45,
+        "reward": 2,
+        "switchBlock": 0,
+        "switchEpoch": 0,
+        "tip2019Block": 1,
+        "MergeSignRange": 15,
+        "RangeReturnSigner": 150,
+        "foundationWalletAddr": "0x5cb041be27deb4a506ad63d082c6043b4a5c6898",
+        "masternodeVotingContract": "0x0000000000000000000000000000000000000088",
+        "blockSignerContract": "0x0000000000000000000000000000000000000089",
+        "randomizeSMCBinary": "0x0000000000000000000000000000000000000090",
+        "XDCXAddressBinary": "0x0000000000000000000000000000000000000091",
+        "tradingStateAddressBinary": "0x0000000000000000000000000000000000000092",
+        "XDCXLendingAddressBinary": "0x0000000000000000000000000000000000000093",
+        "XDCXLendingFinalizedTradeAddressBinary": "0x0000000000000000000000000000000000000094",
+        "v2Configs": [
+          {
+            "SwitchRound": 0,
+            "MaxMasternodes": 108,
+            "CertificateThreshold": 0.5,
+            "TimeoutSyncThreshold": 3,
+            "TimeoutPeriod": 10,
+            "MinePeriod": 1
+          }
+        ]
+      }
+    }
+  },
+  "params": { "chainId": 26381 },
+  "genesis": {
+    "difficulty": "0x1",
+    "gasLimit": "0x47b760",
+    "timestamp": "0x6a0ed3e2",
+    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "extraData": "0x…"
+  },
+  "accounts": {
+    "0000000000000000000000000000000000000088": {
+      "balance": "0x18d0bf423c03d8de000000",
+      "code": "0x6080604052…",
+      "storage": { "0x…": "0x…" }
+    }
+  },
+  "nodes": []
+}
+```
+
+What that file has to get right:
+
+- **Engine key** — `engine.XDPoSSubnet` is what activates [`XdcSubnetPlugin`](XdcSubnetPlugin.cs); the seal
+  engine type is derived from it, and it has to be the only engine in the file.
+- **No V1 era** — keep `switchBlock` and `switchEpoch` at `0`. The genesis committee then comes from the
+  genesis `extraData`, laid out as 32 bytes of vanity, one 20-byte masternode address each, and 65 bytes of
+  (zero) seal — 157 bytes for three masternodes. `genesisMasternodes` is only read when `switchBlock > 0`.
+- **Voting contract** — `extraData` seeds the genesis committee only; every later epoch takes its candidates
+  from `masternodeVotingContract`, so that contract must be pre-deployed under `accounts` with its storage
+  seeded (candidate list, stakes, owners). Without it the committee is empty from the first gap block on.
+- **`params`** — the block above is trimmed to `chainId`. Copy the rest of the `params` block from
+  [`Chains/xdc.json`](../Chains/xdc.json) and change the chain id: Nethermind chainspecs use parity-style
+  `eip…Transition` keys, and geth genesis-config names (`homesteadBlock`, `eip150Block`, `byzantiumBlock`, …)
+  are silently ignored, which leaves the chain on Frontier rules.
+- **Epoch geometry** — `gap` must be smaller than `epoch`; the snapshot for an epoch is taken at
+  `epochStart - gap`. `CertificateThreshold` is a fraction of the epoch's committee size, so `0.5` with three
+  masternodes means two votes per certificate.
+
+Each node then needs a config pointing at the chainspec:
+
+```json
+{
+  "Init": {
+    "ChainSpecPath": "chainspec/xdc-subnet.json",
+    "BaseDbPath": "nethermind_db/xdc-subnet",
+    "LogFileName": "xdc-subnet.log"
+  },
+  "Network": { "FilterDiscoveryNodesByRecentIp": false, "EnableEnrDiscovery": false },
+  "Discovery": { "DiscoveryVersion": "V4" },
+  "TxPool": { "BlobsSupport": "Disabled" },
+  "Merge": { "Enabled": false },
+  "JsonRpc": { "Enabled": true, "EnabledModules": ["Eth", "Net", "Web3", "Xdc"] },
+  "Mining": { "Enabled": true },
+  "KeyStore": { "TestNodeKey": "<masternode private key>" }
+}
+```
+
+```bash
+dotnet run --project src/Nethermind/Nethermind.Runner -c release -- --config ./xdc-subnet-node.json --data-dir ./subnet-node-1
+```
+
+- A relative `ChainSpecPath` resolves against the executable's directory, so either drop the chainspec into
+  the build output's `chainspec/` folder or give an absolute path. `--config` needs a path (`./file.json`);
+  a bare name is looked up among the built-in configs.
+- `Mining.Enabled` gates both block production and the signer — without it the node follows the chain but
+  never proposes or votes. The signing key is `KeyStore.BlockAuthorAccount` from the keystore, falling back to
+  the node key, which `KeyStore.TestNodeKey` overrides with a plaintext key (dev only; it doubles as the
+  node's enode key). Its address has to be in the committee for the node's blocks and votes to count.
+- Give every node its own `--data-dir`, and point them at each other with the chainspec `nodes` array or
+  `Network.StaticPeers`.
+- Sanity checks once it runs: `XDPoS_getMasternodesByNumber` should list the committee, and
+  `XDPoS_getV2BlockByNumber` should show rounds advancing and blocks being committed.
+
 ---
 
 ## Testing

--- a/src/Nethermind/Nethermind.Xdc/README.md
+++ b/src/Nethermind/Nethermind.Xdc/README.md
@@ -596,14 +596,13 @@ Example — mainnet's current entry:
 
 ### Setting up a subnet
 
-A subnet is a standalone chain shared by Go (`xinfinorg/xdcsubnets`) and Nethermind nodes, and both clients
-have to be configured from the *same* description of it. In a generated deployment that is a pair of files —
-`genesis.json` for the Go nodes, `chainspec.json` for the Nethermind ones — emitted together by
-`xinfinorg/subnet-generator` with `CHAINSPEC_ENGINE=XDPoSSubnet`. Translate rather than hand-write: the
-generator image carries a `check-chainspec` converter that regenerates the chainspec from `genesis.json` and
-reports drift, and a stale chainspec is the usual reason Nethermind nodes never sync with the Go ones.
+A subnet is a standalone chain shared by Go (`xinfinorg/xdcsubnets`) and Nethermind nodes, described to each
+by its own file — `genesis.json` for the Go nodes, `chainspec.json` here. The two are hand-maintained and have
+to agree: the formats differ field by field, no conversion between them is trustworthy, and a chainspec that
+drifts from the genesis is the usual reason Nethermind nodes never sync with the Go ones. Check every value
+below against the genesis rather than assuming it was carried over.
 
-A generated subnet chainspec looks like this (four masternodes, chain id 63473):
+A working subnet chainspec looks like this (four masternodes, chain id 63473):
 
 ```json
 {
@@ -700,20 +699,22 @@ What that file has to get right:
 
 - **Engine key** — `engine.XDPoSSubnet` is what activates [`XdcSubnetPlugin`](XdcSubnetPlugin.cs); the seal
   engine type is derived from it, and it has to be the only engine in the file. Keys bind case-insensitively,
-  so the generator's `switchRound`/`minePeriod` spelling works as well as `SwitchRound`/`MinePeriod`.
+  so `switchRound`/`minePeriod` works as well as `SwitchRound`/`MinePeriod`.
 - **No V1 era** — keep `switchBlock` and `switchEpoch` at `0`. The genesis committee then comes from the
   genesis `extraData`, laid out as 32 bytes of vanity, one 20-byte masternode address each, and 65 bytes of
   (zero) seal — 177 bytes for four masternodes. `genesisMasternodes` is only read when `switchBlock > 0`.
-- **Fork schedule** — the part that most needs to be exact, and where "set everything to `0`" is wrong: the
-  subnet runs the *Go* client's EVM, which is neither current Ethereum nor mainnet XDC's schedule. A generated
-  subnet stages the pre-Byzantium forks at blocks 1–4, mirroring the Go `config` block (`homesteadBlock` →
-  `eip7Transition`, `eip150Block`, `eip155Block`/`eip158Block`, `byzantiumBlock`); enables a specific
-  Constantinople/Istanbul/Shanghai subset from `0` — note `eip3198` and `eip3855` are in it and `eip2028` is
-  not; and pushes Berlin and later out of reach with `999999999999`, so there are no typed transactions, no
-  EIP-1559, no 2929/3529 repricing and no transient storage. Copying mainnet's `params` from
-  [`Chains/xdc.json`](../Chains/xdc.json) does not work either — its activation heights are tens of millions
-  of blocks up, so a chain starting at block 0 lands somewhere else again. Take the block from the generated
-  chainspec, and if the two clients disagree here they will diverge on execution rather than fail loudly.
+- **Fork schedule** — the part that most needs to be exact, and the one no mechanical translation of the
+  genesis gets right: the Go `config` block names four forks (`homesteadBlock`, `eip150Block`,
+  `eip155Block`/`eip158Block`, `byzantiumBlock`), while XDPoSChain's EVM implements a good deal more than that
+  unconditionally. Every EIP has to be placed by hand to match what that EVM actually does — which is neither
+  current Ethereum nor mainnet XDC. Both "set everything to `0`" and copying mainnet's `params` from
+  [`Chains/xdc.json`](../Chains/xdc.json) (activation heights tens of millions of blocks up, none of which a
+  chain starting at 0 reaches) produce a subnet on the wrong rules. The schedule above is the one a working
+  subnet runs: the four genesis forks staged at blocks 1–4, a specific Constantinople/Istanbul/Shanghai subset
+  from `0` — `eip3198` and `eip3855` are in it, `eip2028` is not — and Berlin and later pushed out of reach
+  with `999999999999`, so there are no typed transactions, no EIP-1559, no 2929/3529 repricing and no
+  transient storage. Where the two clients disagree here they diverge on execution rather than fail loudly, so
+  verify against the Go client's behaviour, not against its config.
 - **Genesis fields** — only the members of
   [`ChainSpecGenesisJson`](../Nethermind.Specs/ChainSpecStyle/Json/ChainSpecGenesisJson.cs) are bound, and
   unmapped JSON members are dropped without a warning: the beneficiary key is `author`, not `coinbase`, and a
@@ -727,8 +728,8 @@ What that file has to get right:
   block is the only block that ever gets a snapshot, silently. The snapshot for an epoch is taken at
   `epochStart - gap`. `CertificateThreshold` is a fraction of the epoch's committee size, so `0.667` with four
   masternodes means three votes per certificate.
-- **Keys that look active but are not** — a generated chainspec also carries `period`, `rewardCheckpoint`,
-  `eip1234Transition` and `XDCXAddrBinary`, none of which Nethermind binds; unmapped members are dropped
+- **Keys that look active but are not** — `period`, `rewardCheckpoint`, `eip1234Transition` and
+  `XDCXAddrBinary` all appear in chainspecs in the wild and none of them bind; unmapped members are dropped
   silently here too. Harmless for a subnet, but block spacing comes from `v2Configs[].minePeriod` rather than
   `period`, and the DEX contract only takes effect under the bound spelling, `XDCXAddressBinary` — which is
   what the skeleton above uses.
@@ -765,11 +766,11 @@ dotnet run --project src/Nethermind/Nethermind.Runner -c release -- --config ./x
   never proposes or votes. The signing key is `KeyStore.BlockAuthorAccount` from the keystore, falling back to
   the node key, which `KeyStore.TestNodeKey` overrides with a plaintext key (dev only; it doubles as the
   node's enode key). Its address has to be in the committee for the node's blocks and votes to count.
-- Per node: `Network.Bootnodes` (a generated deployment runs a dedicated bootnode, and leaves the chainspec's
-  `nodes` array empty — `Network.StaticPeers` works instead when there is none), `Network.P2PPort` and
-  `Network.DiscoveryPort` (keep the two equal), `Network.ExternalIp` set to the address peers should dial,
-  `KeyStore.TestNodeKey`, `--data-dir`, and the `JsonRpc` settings — with `Xdc` among
-  `JsonRpc.EnabledModules`, since the `XDPoS_*` methods are not in the default set.
+- Per node: `Network.Bootnodes` (running a dedicated bootnode and leaving the chainspec's `nodes` array empty
+  keeps the chain description free of deployment detail — `Network.StaticPeers` works instead when there is no
+  bootnode), `Network.P2PPort` and `Network.DiscoveryPort` (keep the two equal), `Network.ExternalIp` set to
+  the address peers should dial, `KeyStore.TestNodeKey`, `--data-dir`, and the `JsonRpc` settings — with `Xdc`
+  among `JsonRpc.EnabledModules`, since the `XDPoS_*` methods are not in the default set.
 - Sanity checks once it runs: `net_peerCount` should see the other nodes, `XDPoS_getMasternodesByNumber`
   should list the committee, and `XDPoS_getV2BlockByNumber` should show rounds advancing and blocks being
   committed.

--- a/src/Nethermind/Nethermind.Xdc/README.md
+++ b/src/Nethermind/Nethermind.Xdc/README.md
@@ -661,16 +661,27 @@ What that file has to get right:
 - **No V1 era** — keep `switchBlock` and `switchEpoch` at `0`. The genesis committee then comes from the
   genesis `extraData`, laid out as 32 bytes of vanity, one 20-byte masternode address each, and 65 bytes of
   (zero) seal — 157 bytes for three masternodes. `genesisMasternodes` is only read when `switchBlock > 0`.
+- **Genesis fields** — only the members of
+  [`ChainSpecGenesisJson`](../Nethermind.Specs/ChainSpecStyle/Json/ChainSpecGenesisJson.cs) are bound, and
+  unmapped JSON members are dropped without a warning: the beneficiary key is `author`, not `coinbase`, and a
+  Go-client genesis' `validators`, `nextValidators`, `penalties`, `number`, `nonce`, `mixHash` and `gasUsed`
+  have no effect — the subnet genesis header ends up with empty validator and penalty fields. Compare the
+  resulting genesis hash against the Go client before peering the two implementations.
 - **Voting contract** — `extraData` seeds the genesis committee only; every later epoch takes its candidates
   from `masternodeVotingContract`, so that contract must be pre-deployed under `accounts` with its storage
   seeded (candidate list, stakes, owners). Without it the committee is empty from the first gap block on.
 - **`params`** — the block above is trimmed to `chainId`. Copy the rest of the `params` block from
-  [`Chains/xdc.json`](../Chains/xdc.json) and change the chain id: Nethermind chainspecs use parity-style
-  `eip…Transition` keys, and geth genesis-config names (`homesteadBlock`, `eip150Block`, `byzantiumBlock`, …)
-  are silently ignored, which leaves the chain on Frontier rules.
-- **Epoch geometry** — `gap` must be smaller than `epoch`; the snapshot for an epoch is taken at
-  `epochStart - gap`. `CertificateThreshold` is a fraction of the epoch's committee size, so `0.5` with three
-  masternodes means two votes per certificate.
+  [`Chains/xdc.json`](../Chains/xdc.json), change the chain id, and then rewrite the `eip…Transition` values:
+  the ones in that file are mainnet activation heights (`eip1559Transition` is block 98,800,200,
+  `eip1153Transition` 98,802,000), which a chain starting at block 0 never reaches, so set every fork the
+  subnet should run with to `0` and drop the rest. Nethermind chainspecs use parity-style `eip…Transition`
+  keys, and geth genesis-config names (`homesteadBlock`, `eip150Block`, `byzantiumBlock`, …) are silently
+  ignored, which leaves the chain on Frontier rules.
+- **Epoch geometry** — `gap` must be non-zero and smaller than `epoch`; both degenerate cases silently stop
+  snapshots from ever being taken. The snapshot for an epoch is taken at `epochStart - gap`.
+  `CertificateThreshold` is a fraction of the epoch's committee size, so `0.5` with three masternodes means
+  two votes per certificate. Block spacing is `v2Configs[].MinePeriod` — the top-level `period` is carried
+  for parity with the Go client and is not read.
 
 Each node then needs a config pointing at the chainspec:
 
@@ -696,8 +707,10 @@ dotnet run --project src/Nethermind/Nethermind.Runner -c release -- --config ./x
 ```
 
 - A relative `ChainSpecPath` resolves against the executable's directory, so either drop the chainspec into
-  the build output's `chainspec/` folder or give an absolute path. `--config` needs a path (`./file.json`);
-  a bare name is looked up among the built-in configs.
+  the build output's `chainspec/` folder or give an absolute path. Embedded chainspecs are probed before the
+  filesystem — even for an absolute path — so give the file a name that doesn't collide with a shipped one
+  (`xdc.json`, `xdc-testnet.json`, …), or the embedded copy is loaded instead. `--config` needs a path
+  (`./file.json`); a bare name is looked up among the built-in configs.
 - `Mining.Enabled` gates both block production and the signer — without it the node follows the chain but
   never proposes or votes. The signing key is `KeyStore.BlockAuthorAccount` from the keystore, falling back to
   the node key, which `KeyStore.TestNodeKey` overrides with a plaintext key (dev only; it doubles as the

--- a/src/Nethermind/Nethermind.Xdc/README.md
+++ b/src/Nethermind/Nethermind.Xdc/README.md
@@ -596,25 +596,34 @@ Example — mainnet's current entry:
 
 ### Setting up a subnet
 
-A subnet is a standalone chain, so bringing one up is a chainspec plus one node config per node. A chainspec
-for a three-masternode local subnet looks like this:
+A subnet is a standalone chain shared by Go (`xinfinorg/xdcsubnets`) and Nethermind nodes, and both clients
+have to be configured from the *same* description of it. In a generated deployment that is a pair of files —
+`genesis.json` for the Go nodes, `chainspec.json` for the Nethermind ones — emitted together by
+`xinfinorg/subnet-generator` with `CHAINSPEC_ENGINE=XDPoSSubnet`. Translate rather than hand-write: the
+generator image carries a `check-chainspec` converter that regenerates the chainspec from `genesis.json` and
+reports drift, and a stale chainspec is the usual reason Nethermind nodes never sync with the Go ones.
+
+A generated subnet chainspec looks like this (four masternodes, chain id 63473):
 
 ```json
 {
-  "name": "xdc-subnet-local",
+  "name": "xdpos-chain",
   "engine": {
     "XDPoSSubnet": {
       "params": {
-        "period": 1,
         "epoch": 90,
         "gap": 45,
         "reward": 2,
         "switchBlock": 0,
         "switchEpoch": 0,
         "tip2019Block": 1,
+        "TipTrc21Fee": 1,
         "MergeSignRange": 15,
         "RangeReturnSigner": 150,
-        "foundationWalletAddr": "0x5cb041be27deb4a506ad63d082c6043b4a5c6898",
+        "DynamicGasLimitBlock": 99999999999999,
+        "BlackListHFNumber": 99999999999999,
+        "blackListedAddresses": [],
+        "foundationWalletAddr": "0xe03629a8664f947f1bea4bced2ce5475e801ac94",
         "masternodeVotingContract": "0x0000000000000000000000000000000000000088",
         "blockSignerContract": "0x0000000000000000000000000000000000000089",
         "randomizeSMCBinary": "0x0000000000000000000000000000000000000090",
@@ -624,23 +633,56 @@ for a three-masternode local subnet looks like this:
         "XDCXLendingFinalizedTradeAddressBinary": "0x0000000000000000000000000000000000000094",
         "v2Configs": [
           {
-            "SwitchRound": 0,
-            "MaxMasternodes": 108,
-            "CertificateThreshold": 0.5,
-            "TimeoutSyncThreshold": 3,
-            "TimeoutPeriod": 10,
-            "MinePeriod": 1
+            "switchRound": 0,
+            "maxMasternodes": 108,
+            "certificateThreshold": 0.667,
+            "timeoutSyncThreshold": 3,
+            "timeoutPeriod": 10,
+            "minePeriod": 1
           }
         ]
       }
     }
   },
-  "params": { "chainId": 26381 },
+  "params": {
+    "chainId": 63473,
+    "eip7Transition": 1,
+    "eip150Transition": 2,
+    "eip155Transition": 3,
+    "eip160Transition": 3,
+    "eip161abcTransition": 3,
+    "eip161dTransition": 3,
+    "MaxCodeSizeTransition": 3,
+    "MaxCodeSize": 24576,
+    "eip140Transition": 4,
+    "eip211Transition": 4,
+    "eip214Transition": 4,
+    "eip658Transition": 4,
+    "eip145Transition": 0,
+    "eip1014Transition": 0,
+    "eip1052Transition": 0,
+    "eip1283Transition": 0,
+    "eip152Transition": 0,
+    "eip1108Transition": 0,
+    "eip1344Transition": 0,
+    "eip1884Transition": 0,
+    "eip2200Transition": 0,
+    "eip3198Transition": 0,
+    "eip3855Transition": 0,
+    "eip2718Transition": 999999999999,
+    "eip2930Transition": 999999999999,
+    "eip1559Transition": 999999999999,
+    "eip2929Transition": 999999999999,
+    "eip1153Transition": 999999999999,
+    "eip4844Transition": 999999999999,
+    "eip1559ElasticityMultiplier": "0x1"
+  },
   "genesis": {
     "difficulty": "0x1",
     "gasLimit": "0x47b760",
-    "timestamp": "0x6a0ed3e2",
+    "timestamp": "0x6a9368ff",
     "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "baseFeePerGas": "0x2e90edd00",
     "extraData": "0x…"
   },
   "accounts": {
@@ -657,10 +699,21 @@ for a three-masternode local subnet looks like this:
 What that file has to get right:
 
 - **Engine key** — `engine.XDPoSSubnet` is what activates [`XdcSubnetPlugin`](XdcSubnetPlugin.cs); the seal
-  engine type is derived from it, and it has to be the only engine in the file.
+  engine type is derived from it, and it has to be the only engine in the file. Keys bind case-insensitively,
+  so the generator's `switchRound`/`minePeriod` spelling works as well as `SwitchRound`/`MinePeriod`.
 - **No V1 era** — keep `switchBlock` and `switchEpoch` at `0`. The genesis committee then comes from the
   genesis `extraData`, laid out as 32 bytes of vanity, one 20-byte masternode address each, and 65 bytes of
-  (zero) seal — 157 bytes for three masternodes. `genesisMasternodes` is only read when `switchBlock > 0`.
+  (zero) seal — 177 bytes for four masternodes. `genesisMasternodes` is only read when `switchBlock > 0`.
+- **Fork schedule** — the part that most needs to be exact, and where "set everything to `0`" is wrong: the
+  subnet runs the *Go* client's EVM, which is neither current Ethereum nor mainnet XDC's schedule. A generated
+  subnet stages the pre-Byzantium forks at blocks 1–4, mirroring the Go `config` block (`homesteadBlock` →
+  `eip7Transition`, `eip150Block`, `eip155Block`/`eip158Block`, `byzantiumBlock`); enables a specific
+  Constantinople/Istanbul/Shanghai subset from `0` — note `eip3198` and `eip3855` are in it and `eip2028` is
+  not; and pushes Berlin and later out of reach with `999999999999`, so there are no typed transactions, no
+  EIP-1559, no 2929/3529 repricing and no transient storage. Copying mainnet's `params` from
+  [`Chains/xdc.json`](../Chains/xdc.json) does not work either — its activation heights are tens of millions
+  of blocks up, so a chain starting at block 0 lands somewhere else again. Take the block from the generated
+  chainspec, and if the two clients disagree here they will diverge on execution rather than fail loudly.
 - **Genesis fields** — only the members of
   [`ChainSpecGenesisJson`](../Nethermind.Specs/ChainSpecStyle/Json/ChainSpecGenesisJson.cs) are bound, and
   unmapped JSON members are dropped without a warning: the beneficiary key is `author`, not `coinbase`, and a
@@ -670,34 +723,32 @@ What that file has to get right:
 - **Voting contract** — `extraData` seeds the genesis committee only; every later epoch takes its candidates
   from `masternodeVotingContract`, so that contract must be pre-deployed under `accounts` with its storage
   seeded (candidate list, stakes, owners). Without it the committee is empty from the first gap block on.
-- **`params`** — the block above is trimmed to `chainId`. Copy the rest of the `params` block from
-  [`Chains/xdc.json`](../Chains/xdc.json), change the chain id, and then rewrite the `eip…Transition` values:
-  the ones in that file are mainnet activation heights (`eip1559Transition` is block 98,800,200,
-  `eip1153Transition` 98,802,000), which a chain starting at block 0 never reaches, so set every fork the
-  subnet should run with to `0` and drop the rest. Nethermind chainspecs use parity-style `eip…Transition`
-  keys, and geth genesis-config names (`homesteadBlock`, `eip150Block`, `byzantiumBlock`, …) are silently
-  ignored, which leaves the chain on Frontier rules.
 - **Epoch geometry** — `gap` must be non-zero and smaller than `epoch`; in both degenerate cases the switch
   block is the only block that ever gets a snapshot, silently. The snapshot for an epoch is taken at
-  `epochStart - gap`. `CertificateThreshold` is a fraction of the epoch's committee size, so `0.5` with three
-  masternodes means two votes per certificate. Block spacing is `v2Configs[].MinePeriod` — the top-level
-  `period` is carried for parity with the Go client and is not read.
+  `epochStart - gap`. `CertificateThreshold` is a fraction of the epoch's committee size, so `0.667` with four
+  masternodes means three votes per certificate.
+- **Keys that look active but are not** — a generated chainspec also carries `period`, `rewardCheckpoint`,
+  `eip1234Transition` and `XDCXAddrBinary`, none of which Nethermind binds; unmapped members are dropped
+  silently here too. Harmless for a subnet, but block spacing comes from `v2Configs[].minePeriod` rather than
+  `period`, and the DEX contract only takes effect under the bound spelling, `XDCXAddressBinary` — which is
+  what the skeleton above uses.
 
 Each node then needs a config pointing at the chainspec:
 
 ```json
 {
   "Init": {
-    "ChainSpecPath": "chainspec/xdc-subnet.json",
+    "ChainSpecPath": "/work/chainspec.json",
     "BaseDbPath": "nethermind_db/xdc-subnet",
     "LogFileName": "xdc-subnet.log"
   },
-  "Network": { "FilterDiscoveryNodesByRecentIp": false, "EnableEnrDiscovery": false },
-  "Discovery": { "DiscoveryVersion": "V4" },
   "TxPool": { "BlobsSupport": "Disabled" },
+  "Blocks": { "TargetBlockGasLimit": 420000000 },
+  "Sync": { "FastSync": true, "NeedToWaitForHeader": true, "VerifyTrieOnStateSyncFinished": true },
   "Merge": { "Enabled": false },
-  "JsonRpc": { "Enabled": true, "EnabledModules": ["Eth", "Net", "Web3", "Xdc"] },
+  "TraceStore": { "Enabled": false },
   "Mining": { "Enabled": true },
+  "JsonRpc": { "Enabled": true, "EnabledModules": ["Eth", "Xdc"] },
   "KeyStore": { "TestNodeKey": "<masternode private key>" }
 }
 ```
@@ -715,10 +766,15 @@ dotnet run --project src/Nethermind/Nethermind.Runner -c release -- --config ./x
   never proposes or votes. The signing key is `KeyStore.BlockAuthorAccount` from the keystore, falling back to
   the node key, which `KeyStore.TestNodeKey` overrides with a plaintext key (dev only; it doubles as the
   node's enode key). Its address has to be in the committee for the node's blocks and votes to count.
-- Give every node its own `--data-dir`, and point them at each other with the chainspec `nodes` array or
-  `Network.StaticPeers`.
-- Sanity checks once it runs: `XDPoS_getMasternodesByNumber` should list the committee, and
-  `XDPoS_getV2BlockByNumber` should show rounds advancing and blocks being committed.
+- `JsonRpc.EnabledModules` has to include `Xdc` for the `XDPoS_*` methods — it is not in the default set.
+- Everything per-node stays out of the shared config file, as CLI options or `NETHERMIND_*` environment
+  variables. A generated deployment runs a dedicated bootnode and gives each node `Network.Bootnodes`, its own
+  `Network.P2PPort` and `Network.DiscoveryPort` (keep the two equal), `Network.ExternalIp` set to the address
+  peers should dial, its own `KeyStore.TestNodeKey`, and its own `--data-dir`; the chainspec's `nodes` array
+  stays empty. `Network.StaticPeers` works instead when there is no bootnode.
+- Sanity checks once it runs: `net_peerCount` should see the other nodes, `XDPoS_getMasternodesByNumber`
+  should list the committee, and `XDPoS_getV2BlockByNumber` should show rounds advancing and blocks being
+  committed.
 
 ---
 

--- a/src/Nethermind/Nethermind.Xdc/README.md
+++ b/src/Nethermind/Nethermind.Xdc/README.md
@@ -677,11 +677,11 @@ What that file has to get right:
   subnet should run with to `0` and drop the rest. Nethermind chainspecs use parity-style `eip…Transition`
   keys, and geth genesis-config names (`homesteadBlock`, `eip150Block`, `byzantiumBlock`, …) are silently
   ignored, which leaves the chain on Frontier rules.
-- **Epoch geometry** — `gap` must be non-zero and smaller than `epoch`; both degenerate cases silently stop
-  snapshots from ever being taken. The snapshot for an epoch is taken at `epochStart - gap`.
-  `CertificateThreshold` is a fraction of the epoch's committee size, so `0.5` with three masternodes means
-  two votes per certificate. Block spacing is `v2Configs[].MinePeriod` — the top-level `period` is carried
-  for parity with the Go client and is not read.
+- **Epoch geometry** — `gap` must be non-zero and smaller than `epoch`; in both degenerate cases the switch
+  block is the only block that ever gets a snapshot, silently. The snapshot for an epoch is taken at
+  `epochStart - gap`. `CertificateThreshold` is a fraction of the epoch's committee size, so `0.5` with three
+  masternodes means two votes per certificate. Block spacing is `v2Configs[].MinePeriod` — the top-level
+  `period` is carried for parity with the Go client and is not read.
 
 Each node then needs a config pointing at the chainspec:
 

--- a/src/Nethermind/Nethermind.Xdc/README.md
+++ b/src/Nethermind/Nethermind.Xdc/README.md
@@ -733,7 +733,9 @@ What that file has to get right:
   `period`, and the DEX contract only takes effect under the bound spelling, `XDCXAddressBinary` — which is
   what the skeleton above uses.
 
-Each node then needs a config pointing at the chainspec:
+The node config only has to point at the chainspec and turn on block production; everything else about a node
+— JSON-RPC, ports, peers, keys, data directory — is per-node and belongs in its own CLI options or
+`NETHERMIND_*` environment variables, not in the chain description:
 
 ```json
 {
@@ -746,10 +748,7 @@ Each node then needs a config pointing at the chainspec:
   "Blocks": { "TargetBlockGasLimit": 420000000 },
   "Sync": { "FastSync": true, "NeedToWaitForHeader": true, "VerifyTrieOnStateSyncFinished": true },
   "Merge": { "Enabled": false },
-  "TraceStore": { "Enabled": false },
-  "Mining": { "Enabled": true },
-  "JsonRpc": { "Enabled": true, "EnabledModules": ["Eth", "Xdc"] },
-  "KeyStore": { "TestNodeKey": "<masternode private key>" }
+  "Mining": { "Enabled": true }
 }
 ```
 
@@ -766,12 +765,11 @@ dotnet run --project src/Nethermind/Nethermind.Runner -c release -- --config ./x
   never proposes or votes. The signing key is `KeyStore.BlockAuthorAccount` from the keystore, falling back to
   the node key, which `KeyStore.TestNodeKey` overrides with a plaintext key (dev only; it doubles as the
   node's enode key). Its address has to be in the committee for the node's blocks and votes to count.
-- `JsonRpc.EnabledModules` has to include `Xdc` for the `XDPoS_*` methods — it is not in the default set.
-- Everything per-node stays out of the shared config file, as CLI options or `NETHERMIND_*` environment
-  variables. A generated deployment runs a dedicated bootnode and gives each node `Network.Bootnodes`, its own
-  `Network.P2PPort` and `Network.DiscoveryPort` (keep the two equal), `Network.ExternalIp` set to the address
-  peers should dial, its own `KeyStore.TestNodeKey`, and its own `--data-dir`; the chainspec's `nodes` array
-  stays empty. `Network.StaticPeers` works instead when there is no bootnode.
+- Per node: `Network.Bootnodes` (a generated deployment runs a dedicated bootnode, and leaves the chainspec's
+  `nodes` array empty — `Network.StaticPeers` works instead when there is none), `Network.P2PPort` and
+  `Network.DiscoveryPort` (keep the two equal), `Network.ExternalIp` set to the address peers should dial,
+  `KeyStore.TestNodeKey`, `--data-dir`, and the `JsonRpc` settings — with `Xdc` among
+  `JsonRpc.EnabledModules`, since the `XDPoS_*` methods are not in the default set.
 - Sanity checks once it runs: `net_peerCount` should see the other nodes, `XDPoS_getMasternodesByNumber`
   should list the committee, and `XDPoS_getV2BlockByNumber` should show rounds advancing and blocks being
   committed.

--- a/src/Nethermind/Nethermind.Xdc/README.md
+++ b/src/Nethermind/Nethermind.Xdc/README.md
@@ -769,8 +769,10 @@ dotnet run --project src/Nethermind/Nethermind.Runner -c release -- --config ./x
 - Per node: `Network.Bootnodes` (running a dedicated bootnode and leaving the chainspec's `nodes` array empty
   keeps the chain description free of deployment detail — `Network.StaticPeers` works instead when there is no
   bootnode), `Network.P2PPort` and `Network.DiscoveryPort` (keep the two equal), `Network.ExternalIp` set to
-  the address peers should dial, `KeyStore.TestNodeKey`, `--data-dir`, and the `JsonRpc` settings — with `Xdc`
-  among `JsonRpc.EnabledModules`, since the `XDPoS_*` methods are not in the default set.
+  the address peers should dial, `KeyStore.TestNodeKey`, `--data-dir`, and the `JsonRpc` settings.
+  `JsonRpc.EnabledModules` replaces the default list rather than adding to it, so name `Xdc` for the
+  `XDPoS_*` methods *and* everything else the node should still serve — `Net` for `net_peerCount`, for
+  instance.
 - Sanity checks once it runs: `net_peerCount` should see the other nodes, `XDPoS_getMasternodesByNumber`
   should list the committee, and `XDPoS_getV2BlockByNumber` should show rounds advancing and blocks being
   committed.

--- a/src/Nethermind/Nethermind.Xdc/README.md
+++ b/src/Nethermind/Nethermind.Xdc/README.md
@@ -514,7 +514,6 @@ on the block number *and* the consensus round.
 | --- | --- | --- |
 | `epoch` | blocks | Epoch length; also the modulus for leader rotation. `900` on mainnet and Apothem |
 | `gap` | blocks | Distance before an epoch start at which the candidate snapshot is taken. `450` |
-| `period` | seconds | Nominal block period |
 | `switchBlock` | block | First V2 block; below it, V1 (clique-style) rules apply |
 | `switchEpoch` | epoch | Epoch number corresponding to `switchBlock`, used to number V2 epochs |
 | `reward` | XDC | Per-epoch reward pool used before `TIPUpgradeReward` |


### PR DESCRIPTION
## Changes

Adds a **Setting up a subnet** subsection to `src/Nethermind/Nethermind.Xdc/README.md`, inside the existing `## Subnets` section. The `## Subnets` section documented which components `XdcSubnetModule` overrides but nothing about bringing a subnet up, so every attempt started by reverse-engineering the mainnet chainspec.

The guide covers:

- A reference chainspec for a four-masternode subnet — engine block, `params`, genesis and the pre-deployed voting contract.
- The parts that have to be exact, with why each one bites:
  - `engine.XDPoSSubnet` is what activates `XdcSubnetPlugin`, and has to be the only engine in the file.
  - `switchBlock`/`switchEpoch` stay at `0`, which is what makes the genesis committee come from `extraData` (32-byte vanity + N × 20-byte address + 65-byte seal); `genesisMasternodes` is only read when `switchBlock > 0`.
  - **The fork schedule**, which is the part nothing derives for you: the Go `config` block names four forks while XDPoSChain's EVM implements considerably more unconditionally, so every EIP has to be placed against what that EVM *does*. Neither "everything at `0`" nor mainnet's `params` produces the right rules, and a mismatch diverges execution silently rather than failing.
  - Only `ChainSpecGenesisJson`'s members bind, and unmapped ones are dropped without a warning — so a genesis carried over from the Go client loses `validators`, `nextValidators`, `penalties`, `coinbase`, `nonce`, `mixHash`, `number` and `gasUsed`.
  - The masternode voting contract has to be pre-deployed with seeded storage, because only the genesis committee comes from `extraData`.
  - `gap` must be non-zero and below `epoch`; either degenerate case silently leaves every epoch after the switch block without a snapshot.
  - The keys that appear in subnet chainspecs but do not bind: `period`, `rewardCheckpoint`, `eip1234Transition`, `XDCXAddrBinary`.
- A node config and run command, plus `ChainSpecPath` resolution (embedded chainspecs are probed before the filesystem), the `Mining.Enabled` → signer chain, the per-node peering settings, and `XDPoS_*` sanity checks.

Documentation only — no source changes.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Written against a working four-masternode subnet (two Go nodes, two Nethermind nodes) rather than from the code alone, then every claim checked back against the code: engine-key → plugin selection (`XdcSubnetPlugin`, `ChainSpecParametersProvider`), the `SwitchBlock == 0` genesis-masternode path (`XdcChainSpecBasedSpecProvider`, `BaseEpochSwitchManager`), candidate lookup via the voting contract (`SubnetSnapshotManager`), snapshot timing (`ISnapshotManager.IsTimeForSnapshot`), certificate arithmetic (`QuorumCertificateManager`), the bound member sets (`ChainSpecGenesisJson`, `ChainSpecParamsJson`, `XdcChainSpecEngineParameters`), chainspec resolution (`ChainSpecFileLoader`), and the signer wiring (`KeyStoreModule`, `NodeKeyManager`, `BlockProductionPolicy`). Both JSON blocks in the section parse.

Re-verified against master at `68ce888a8f`: the new `LoadTransitions` refusal (a block-number transition ordered after a timestamp transition) cannot fire for a chainspec of this shape — `CreateTransitions` emits all block transitions first — so the sentinel `999999999999` values in the example are fine.

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

This PR is the documentation update; no docs-site change needed.

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Two client-side rough edges turned up while writing this, both left as-is here since they are not documentation problems:

- Unbound chainspec members are dropped silently at every level — engine params, `params`, and `genesis`. `XDCXAddrBinary` (against the bound `XDCXAddressBinary`) and a Go-style `coinbase` both read as configured and do nothing. A warning naming unmapped keys would have saved most of the work behind this guide.
- A subnet's `params` block has to restate XDPoSChain's whole fork schedule by hand, including pushing about twenty EIPs out of range with a sentinel block number. Nothing validates that the result matches the Go client, and a mismatch shows up as divergent execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
