### PR TITLE
Reject deposit logs with noncanonical ABI offsets

### DIFF
--- a/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
+++ b/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
@@ -688,6 +688,17 @@ public class AbiTests
         Assert.Throws<AbiException>(() => _abiEncoder.Decode(encodingStyle, signature, []));
     }
 
+    [Test]
+    public void Should_wrap_out_of_bounds_dynamic_bytes_length_one_decode()
+    {
+        AbiSignature abi = new("Test", AbiType.DynamicBytes);
+        byte[] data = new byte[64];
+        data[31] = 32;
+        data[63] = 1;
+
+        Assert.Throws<AbiException>(() => _abiEncoder.Decode(AbiEncodingStyle.None, abi, data));
+    }
+
     private static byte[] DynamicValueWithMissingPayload(UInt256 declaredLength, int trailingDataLength = 0)
     {
         byte[] data = new byte[64 + trailingDataLength];

--- a/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
+++ b/src/Nethermind/Nethermind.Abi.Test/AbiTests.cs
@@ -689,14 +689,13 @@ public class AbiTests
     }
 
     [Test]
-    public void Should_wrap_out_of_bounds_dynamic_bytes_length_one_decode()
+    public void Should_reject_dynamic_bytes_length_one_exceeding_data()
     {
-        AbiSignature abi = new("Test", AbiType.DynamicBytes);
-        byte[] data = new byte[64];
-        data[31] = 32;
-        data[63] = 1;
+        // Length 1 is the case that would reach `ByteArrayExtensions.Slice`'s one-byte fast path and
+        // surface as `IndexOutOfRangeException` if the bounds check were ever dropped.
+        AbiSignature signature = new("f", AbiType.DynamicBytes);
 
-        Assert.Throws<AbiException>(() => _abiEncoder.Decode(AbiEncodingStyle.None, abi, data));
+        Assert.Throws<AbiException>(() => _abiEncoder.Decode(AbiEncodingStyle.None, signature, DynamicValueWithMissingPayload(1)));
     }
 
     private static byte[] DynamicValueWithMissingPayload(UInt256 declaredLength, int trailingDataLength = 0)

--- a/src/Nethermind/Nethermind.Consensus.Test/ExecutionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/ExecutionProcessorTests.cs
@@ -9,6 +9,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.ExecutionRequest;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
@@ -42,12 +43,9 @@ public class ExecutionProcessorTests
     private static readonly AbiSignature _depositEventABI = new("DepositEvent", AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes);
     private static readonly AbiEncoder _abiEncoder = AbiEncoder.Instance;
     private const int AbiWordSize = 32;
-    private const int DepositEventDataLength = 576;
-    private const int DepositEventPubkeyOffset = 160;
-    private const int DepositEventWithdrawalCredentialsOffset = 256;
-    private const int DepositEventAmountOffset = 320;
-    private const int DepositEventSignatureOffset = 384;
-    private const int DepositEventIndexOffset = 512;
+    private const int DepositEventFieldCount = 5;
+    private const int PubkeyHeadWord = 0;
+    private const int AmountHeadWord = 2;
 
     private static readonly TestExecutionRequest[] _executionDepositRequests = [TestItem.ExecutionRequestA, TestItem.ExecutionRequestB, TestItem.ExecutionRequestC];
     private static readonly TestExecutionRequest[] _executionWithdrawalRequests = [TestItem.ExecutionRequestD, TestItem.ExecutionRequestE, TestItem.ExecutionRequestF];
@@ -181,43 +179,7 @@ public class ExecutionProcessorTests
     }
 
     private static LogEntry CreateLogEntry(byte[][] requestDataParts) =>
-        Build.A.LogEntry
-            .WithData(_abiEncoder.Encode(AbiEncodingStyle.None, _depositEventABI, requestDataParts!))
-            .WithTopics(ExecutionRequestsProcessor.DepositEventAbi.Hash)
-            .WithAddress(DepositContractAddress).TestObject;
-
-    [Test]
-    public void ShouldRejectDepositLogWithNonCanonicalAbiOffsets()
-    {
-        TxReceipt[] txReceipts = [
-            Build.A.Receipt.WithLogs(
-                CreateLogEntryWithSwappedAmountAndSignatureSlots(TestItem.ExecutionRequestA.RequestDataParts)
-            ).TestObject
-        ];
-
-        // EIP-6110 mandates the exact canonical ABI layout, so any deviation in the offset words
-        // invalidates the block even when every field still decodes to a correctly-sized byte array.
-        Assert.Throws<InvalidBlockException>(() => ProcessBlockAndGetRequestsHash(1, txReceipts));
-    }
-
-    [TestCase(DepositEventLayoutMutation.ExtraTrailingWord)]
-    [TestCase(DepositEventLayoutMutation.WrongAmountSize)]
-    [TestCase(DepositEventLayoutMutation.NonZeroHighByteInOffset)]
-    public void ShouldRejectDepositLogWithInvalidCanonicalAbiLayout(DepositEventLayoutMutation mutation)
-    {
-        byte[] data = BuildCanonicalDepositEventData(TestItem.ExecutionRequestA.RequestDataParts);
-        ApplyDepositEventLayoutMutation(data, mutation, out byte[] mutatedData);
-        TxReceipt[] txReceipts = [
-            Build.A.Receipt.WithLogs(
-                CreateDepositLogEntry(mutatedData)
-            ).TestObject
-        ];
-
-        Assert.Throws<InvalidBlockException>(() => ProcessBlockAndGetRequestsHash(1, txReceipts));
-    }
-
-    private static LogEntry CreateLogEntryWithSwappedAmountAndSignatureSlots(byte[][] requestDataParts) =>
-        CreateDepositLogEntry(BuildDepositEventDataWithSwappedAmountAndSignatureSlots(requestDataParts!));
+        CreateDepositLogEntry(EncodeDepositEventData(requestDataParts));
 
     private static LogEntry CreateDepositLogEntry(byte[] data) =>
         Build.A.LogEntry
@@ -225,82 +187,182 @@ public class ExecutionProcessorTests
             .WithTopics(ExecutionRequestsProcessor.DepositEventAbi.Hash)
             .WithAddress(DepositContractAddress).TestObject;
 
-    private static byte[] BuildCanonicalDepositEventData(byte[][] requestDataParts)
+    private static byte[] EncodeDepositEventData(byte[][] requestDataParts) =>
+        _abiEncoder.Encode(AbiEncodingStyle.None, _depositEventABI, requestDataParts);
+
+    [TestCase(DepositEventLayoutMutation.SwappedPubkeyAndCredentialsBlocks)]
+    [TestCase(DepositEventLayoutMutation.SwappedAmountAndSignatureBlocks)]
+    [TestCase(DepositEventLayoutMutation.BlocksShiftedByOneWord)]
+    [TestCase(DepositEventLayoutMutation.OffsetBeyondData)]
+    [TestCase(DepositEventLayoutMutation.OffsetHighBitsSet)]
+    [TestCase(DepositEventLayoutMutation.ExtraTrailingWord)]
+    [TestCase(DepositEventLayoutMutation.TruncatedData)]
+    public void ShouldRejectDepositLogWithNonCanonicalAbiLayout(DepositEventLayoutMutation mutation) =>
+        AssertDepositLogRejected(ApplyDepositEventLayoutMutation(CanonicalDepositEventData(), mutation));
+
+    /// <summary>
+    /// Every word the canonical layout pins — the five head offsets followed by the five field length words
+    /// they point at — has to match exactly, so incrementing any one of them must invalidate the block.
+    /// </summary>
+    [Test]
+    public void ShouldRejectDepositLogWithAlteredLayoutWord([Range(0, 2 * DepositEventFieldCount - 1)] int wordIndex)
     {
-        byte[] data = new byte[DepositEventDataLength];
+        byte[] data = CanonicalDepositEventData();
+        int wordOffset = wordIndex < DepositEventFieldCount
+            ? wordIndex * AbiWordSize
+            : ReadDepositEventOffset(data, wordIndex - DepositEventFieldCount);
+        WriteDepositEventWord(data, wordOffset, ReadDepositEventWord(data, wordOffset) + 1);
 
-        WriteDepositEventOffset(data, 0, DepositEventPubkeyOffset);
-        WriteDepositEventOffset(data, 1, DepositEventWithdrawalCredentialsOffset);
-        WriteDepositEventOffset(data, 2, DepositEventAmountOffset);
-        WriteDepositEventOffset(data, 3, DepositEventSignatureOffset);
-        WriteDepositEventOffset(data, 4, DepositEventIndexOffset);
-
-        WriteDepositEventField(data, DepositEventPubkeyOffset, requestDataParts[0]);
-        WriteDepositEventField(data, DepositEventWithdrawalCredentialsOffset, requestDataParts[1]);
-        WriteDepositEventField(data, DepositEventAmountOffset, requestDataParts[2]);
-        WriteDepositEventField(data, DepositEventSignatureOffset, requestDataParts[3]);
-        WriteDepositEventField(data, DepositEventIndexOffset, requestDataParts[4]);
-
-        return data;
+        AssertDepositLogRejected(data);
     }
 
-    private static byte[] BuildDepositEventDataWithSwappedAmountAndSignatureSlots(byte[][] requestDataParts)
+    /// <summary>
+    /// The bytes padding each field out to a whole word carry no meaning, and neither EIP-6110 nor EELS
+    /// requires them to be zero, so the deposit must still decode to exactly the same request.
+    /// </summary>
+    [Test]
+    public void ShouldAcceptDepositLogWithNonZeroFieldPadding()
     {
-        byte[] data = new byte[DepositEventDataLength];
+        byte[] data = CanonicalDepositEventData();
+        FillDepositEventFieldPadding(data);
+        TxReceipt[] txReceipts = [
+            Build.A.Receipt.WithLogs(
+                CreateDepositLogEntry(data)
+            ).TestObject
+        ];
 
-        WriteDepositEventOffset(data, 0, DepositEventPubkeyOffset);
-        WriteDepositEventOffset(data, 1, DepositEventWithdrawalCredentialsOffset);
-        WriteDepositEventOffset(data, 2, 448); // amount offset: canonical is 320
-        WriteDepositEventOffset(data, 3, 320); // signature offset: canonical is 384
-        WriteDepositEventOffset(data, 4, DepositEventIndexOffset);
-
-        WriteDepositEventField(data, DepositEventPubkeyOffset, requestDataParts[0]);
-        WriteDepositEventField(data, DepositEventWithdrawalCredentialsOffset, requestDataParts[1]);
-        WriteDepositEventField(data, DepositEventAmountOffset, requestDataParts[3]);
-        WriteDepositEventField(data, 448, requestDataParts[2]);
-        WriteDepositEventField(data, DepositEventIndexOffset, requestDataParts[4]);
-
-        return data;
+        Assert.That(ProcessBlockAndGetRequestsHash(1, txReceipts), Is.EqualTo(
+            CalculateHash([TestItem.ExecutionRequestA], _executionWithdrawalRequests, _executionConsolidationRequests)
+        ));
     }
 
-    private static void WriteDepositEventOffset(byte[] data, int wordIndex, int offset) =>
-        WriteDepositEventWord(data, wordIndex * AbiWordSize, offset);
+    /// <summary>
+    /// The payload every layout case starts from: the encoder output that <see cref="ShouldProcessExecutionRequests"/>
+    /// proves is accepted, so each case differs from a valid deposit log only by its own mutation.
+    /// </summary>
+    private static byte[] CanonicalDepositEventData() =>
+        EncodeDepositEventData(TestItem.ExecutionRequestA.RequestDataParts);
 
-    private static void WriteDepositEventField(byte[] data, int offset, byte[] field)
+    private void AssertDepositLogRejected(byte[] data)
     {
-        WriteDepositEventWord(data, offset, field.Length);
-        field.CopyTo(data.AsSpan(offset + AbiWordSize));
+        TxReceipt[] txReceipts = [
+            Build.A.Receipt.WithLogs(
+                CreateDepositLogEntry(data)
+            ).TestObject
+        ];
+
+        InvalidBlockException exception = Assert.Throws<InvalidBlockException>(() => ProcessBlockAndGetRequestsHash(1, txReceipts))!;
+        Assert.That(exception.Message, Does.StartWith(BlockErrorMessages.InvalidDepositEventLayout(string.Empty)));
     }
 
-    private static void WriteDepositEventWord(byte[] data, int offset, int value) =>
-        BinaryPrimitives.WriteInt32BigEndian(data.AsSpan(offset + AbiWordSize - sizeof(int), sizeof(int)), value);
-
-    private static void ApplyDepositEventLayoutMutation(byte[] data, DepositEventLayoutMutation mutation, out byte[] mutatedData)
+    /// <summary>
+    /// Rewrites canonically encoded deposit event data into a layout EIP-6110 does not allow, returning the
+    /// payload to use. The argument may be mutated in place, so pass a freshly encoded array.
+    /// </summary>
+    private static byte[] ApplyDepositEventLayoutMutation(byte[] data, DepositEventLayoutMutation mutation)
     {
-        mutatedData = data;
         switch (mutation)
         {
+            case DepositEventLayoutMutation.SwappedPubkeyAndCredentialsBlocks:
+                return SwapDepositEventBlockWithNext(data, PubkeyHeadWord);
+            case DepositEventLayoutMutation.SwappedAmountAndSignatureBlocks:
+                return SwapDepositEventBlockWithNext(data, AmountHeadWord);
+            case DepositEventLayoutMutation.BlocksShiftedByOneWord:
+                return ShiftDepositEventBlocksByOneWord(data);
+            case DepositEventLayoutMutation.OffsetBeyondData:
+                WriteDepositEventOffset(data, PubkeyHeadWord, int.MaxValue);
+                return data;
+            case DepositEventLayoutMutation.OffsetHighBitsSet:
+                data[0] = 1;
+                return data;
             case DepositEventLayoutMutation.ExtraTrailingWord:
-                Array.Resize(ref mutatedData, DepositEventDataLength + AbiWordSize);
-                break;
-            case DepositEventLayoutMutation.WrongAmountSize:
-                WriteDepositEventWord(mutatedData, DepositEventAmountOffset, ExecutionRequestExtensions.AmountSize + 1);
-                break;
-            case DepositEventLayoutMutation.NonZeroHighByteInOffset:
-                mutatedData[0] = 1;
-                break;
+                Array.Resize(ref data, data.Length + AbiWordSize);
+                return data;
+            case DepositEventLayoutMutation.TruncatedData:
+                return data[..^AbiWordSize];
             default:
-                throw new ArgumentOutOfRangeException(nameof(mutation), mutation, null);
+                throw new ArgumentOutOfRangeException(nameof(mutation));
         }
+    }
+
+    /// <summary>
+    /// Repacks the block at <paramref name="headWord"/> and the one after it in the opposite order. Every
+    /// field still decodes to the right size and the data length is unchanged, so only the two head offsets
+    /// stop being canonical — the shape a generic ABI decoder accepts and the spec rejects.
+    /// </summary>
+    private static byte[] SwapDepositEventBlockWithNext(byte[] data, int headWord)
+    {
+        int firstOffset = ReadDepositEventOffset(data, headWord);
+        int secondOffset = ReadDepositEventOffset(data, headWord + 1);
+        byte[] firstBlock = data[firstOffset..secondOffset];
+        byte[] secondBlock = data[secondOffset..DepositEventBlockEnd(data, headWord + 1)];
+
+        secondBlock.CopyTo(data.AsSpan(firstOffset));
+        firstBlock.CopyTo(data.AsSpan(firstOffset + secondBlock.Length));
+        WriteDepositEventOffset(data, headWord, firstOffset + secondBlock.Length);
+        WriteDepositEventOffset(data, headWord + 1, firstOffset);
+
+        return data;
+    }
+
+    /// <summary>
+    /// Inserts a word of padding between the head and the field blocks, the shape an encoder that does not
+    /// pack tightly would emit. Every field still decodes to the right size, but the data grows by a word.
+    /// </summary>
+    private static byte[] ShiftDepositEventBlocksByOneWord(byte[] data)
+    {
+        const int headLength = DepositEventFieldCount * AbiWordSize;
+        byte[] shifted = new byte[data.Length + AbiWordSize];
+        data.AsSpan(0, headLength).CopyTo(shifted);
+        data.AsSpan(headLength).CopyTo(shifted.AsSpan(headLength + AbiWordSize));
+
+        for (int headWord = 0; headWord < DepositEventFieldCount; headWord++)
+        {
+            WriteDepositEventOffset(shifted, headWord, ReadDepositEventOffset(shifted, headWord) + AbiWordSize);
+        }
+
+        return shifted;
+    }
+
+    private static void FillDepositEventFieldPadding(byte[] data)
+    {
+        for (int headWord = 0; headWord < DepositEventFieldCount; headWord++)
+        {
+            int offset = ReadDepositEventOffset(data, headWord);
+            int paddingStart = offset + AbiWordSize + ReadDepositEventWord(data, offset);
+            data.AsSpan(paddingStart, DepositEventBlockEnd(data, headWord) - paddingStart).Fill(0xFF);
+        }
+    }
+
+    private static int DepositEventBlockEnd(byte[] data, int headWord) =>
+        headWord + 1 < DepositEventFieldCount ? ReadDepositEventOffset(data, headWord + 1) : data.Length;
+
+    private static int ReadDepositEventOffset(byte[] data, int headWord) =>
+        ReadDepositEventWord(data, headWord * AbiWordSize);
+
+    private static void WriteDepositEventOffset(byte[] data, int headWord, int offset) =>
+        WriteDepositEventWord(data, headWord * AbiWordSize, offset);
+
+    private static int ReadDepositEventWord(byte[] data, int wordOffset) =>
+        BinaryPrimitives.ReadInt32BigEndian(WordTail(data, wordOffset));
+
+    private static void WriteDepositEventWord(byte[] data, int wordOffset, int value) =>
+        BinaryPrimitives.WriteInt32BigEndian(WordTail(data, wordOffset), value);
+
+    private static Span<byte> WordTail(byte[] data, int wordOffset) =>
+        data.AsSpan(wordOffset + AbiWordSize - sizeof(int), sizeof(int));
+
+    public enum DepositEventLayoutMutation
+    {
+        SwappedPubkeyAndCredentialsBlocks,
+        SwappedAmountAndSignatureBlocks,
+        BlocksShiftedByOneWord,
+        OffsetBeyondData,
+        OffsetHighBitsSet,
+        ExtraTrailingWord,
+        TruncatedData
     }
 
     [Test]
     public void ShouldUseCorrectDepositTopic() => Assert.That(ExecutionRequestsProcessor.DepositEventAbi.Hash, Is.EqualTo(new Hash256("0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5")));
-
-    public enum DepositEventLayoutMutation
-    {
-        ExtraTrailingWord,
-        WrongAmountSize,
-        NonZeroHighByteInOffset
-    }
 }

--- a/src/Nethermind/Nethermind.Consensus.Test/ExecutionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/ExecutionProcessorTests.cs
@@ -6,6 +6,7 @@ using Nethermind.Consensus.ExecutionRequests;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Exceptions;
 using Nethermind.Core.ExecutionRequest;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -20,6 +21,7 @@ using Nethermind.Evm.State;
 using NSubstitute;
 using NUnit.Framework;
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Blockchain.Tracing;
@@ -39,6 +41,13 @@ public class ExecutionProcessorTests
     private static readonly Address eip7251Account = Eip7251Constants.ConsolidationRequestPredeployAddress;
     private static readonly AbiSignature _depositEventABI = new("DepositEvent", AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes);
     private static readonly AbiEncoder _abiEncoder = AbiEncoder.Instance;
+    private const int AbiWordSize = 32;
+    private const int DepositEventDataLength = 576;
+    private const int DepositEventPubkeyOffset = 160;
+    private const int DepositEventWithdrawalCredentialsOffset = 256;
+    private const int DepositEventAmountOffset = 320;
+    private const int DepositEventSignatureOffset = 384;
+    private const int DepositEventIndexOffset = 512;
 
     private static readonly TestExecutionRequest[] _executionDepositRequests = [TestItem.ExecutionRequestA, TestItem.ExecutionRequestB, TestItem.ExecutionRequestC];
     private static readonly TestExecutionRequest[] _executionWithdrawalRequests = [TestItem.ExecutionRequestD, TestItem.ExecutionRequestE, TestItem.ExecutionRequestF];
@@ -178,5 +187,120 @@ public class ExecutionProcessorTests
             .WithAddress(DepositContractAddress).TestObject;
 
     [Test]
+    public void ShouldRejectDepositLogWithNonCanonicalAbiOffsets()
+    {
+        TxReceipt[] txReceipts = [
+            Build.A.Receipt.WithLogs(
+                CreateLogEntryWithSwappedAmountAndSignatureSlots(TestItem.ExecutionRequestA.RequestDataParts)
+            ).TestObject
+        ];
+
+        // EIP-6110 mandates the exact canonical ABI layout, so any deviation in the offset words
+        // invalidates the block even when every field still decodes to a correctly-sized byte array.
+        Assert.Throws<InvalidBlockException>(() => ProcessBlockAndGetRequestsHash(1, txReceipts));
+    }
+
+    [TestCase(DepositEventLayoutMutation.ExtraTrailingWord)]
+    [TestCase(DepositEventLayoutMutation.WrongAmountSize)]
+    [TestCase(DepositEventLayoutMutation.NonZeroHighByteInOffset)]
+    public void ShouldRejectDepositLogWithInvalidCanonicalAbiLayout(DepositEventLayoutMutation mutation)
+    {
+        byte[] data = BuildCanonicalDepositEventData(TestItem.ExecutionRequestA.RequestDataParts);
+        ApplyDepositEventLayoutMutation(data, mutation, out byte[] mutatedData);
+        TxReceipt[] txReceipts = [
+            Build.A.Receipt.WithLogs(
+                CreateDepositLogEntry(mutatedData)
+            ).TestObject
+        ];
+
+        Assert.Throws<InvalidBlockException>(() => ProcessBlockAndGetRequestsHash(1, txReceipts));
+    }
+
+    private static LogEntry CreateLogEntryWithSwappedAmountAndSignatureSlots(byte[][] requestDataParts) =>
+        CreateDepositLogEntry(BuildDepositEventDataWithSwappedAmountAndSignatureSlots(requestDataParts!));
+
+    private static LogEntry CreateDepositLogEntry(byte[] data) =>
+        Build.A.LogEntry
+            .WithData(data)
+            .WithTopics(ExecutionRequestsProcessor.DepositEventAbi.Hash)
+            .WithAddress(DepositContractAddress).TestObject;
+
+    private static byte[] BuildCanonicalDepositEventData(byte[][] requestDataParts)
+    {
+        byte[] data = new byte[DepositEventDataLength];
+
+        WriteDepositEventOffset(data, 0, DepositEventPubkeyOffset);
+        WriteDepositEventOffset(data, 1, DepositEventWithdrawalCredentialsOffset);
+        WriteDepositEventOffset(data, 2, DepositEventAmountOffset);
+        WriteDepositEventOffset(data, 3, DepositEventSignatureOffset);
+        WriteDepositEventOffset(data, 4, DepositEventIndexOffset);
+
+        WriteDepositEventField(data, DepositEventPubkeyOffset, requestDataParts[0]);
+        WriteDepositEventField(data, DepositEventWithdrawalCredentialsOffset, requestDataParts[1]);
+        WriteDepositEventField(data, DepositEventAmountOffset, requestDataParts[2]);
+        WriteDepositEventField(data, DepositEventSignatureOffset, requestDataParts[3]);
+        WriteDepositEventField(data, DepositEventIndexOffset, requestDataParts[4]);
+
+        return data;
+    }
+
+    private static byte[] BuildDepositEventDataWithSwappedAmountAndSignatureSlots(byte[][] requestDataParts)
+    {
+        byte[] data = new byte[DepositEventDataLength];
+
+        WriteDepositEventOffset(data, 0, DepositEventPubkeyOffset);
+        WriteDepositEventOffset(data, 1, DepositEventWithdrawalCredentialsOffset);
+        WriteDepositEventOffset(data, 2, 448); // amount offset: canonical is 320
+        WriteDepositEventOffset(data, 3, 320); // signature offset: canonical is 384
+        WriteDepositEventOffset(data, 4, DepositEventIndexOffset);
+
+        WriteDepositEventField(data, DepositEventPubkeyOffset, requestDataParts[0]);
+        WriteDepositEventField(data, DepositEventWithdrawalCredentialsOffset, requestDataParts[1]);
+        WriteDepositEventField(data, DepositEventAmountOffset, requestDataParts[3]);
+        WriteDepositEventField(data, 448, requestDataParts[2]);
+        WriteDepositEventField(data, DepositEventIndexOffset, requestDataParts[4]);
+
+        return data;
+    }
+
+    private static void WriteDepositEventOffset(byte[] data, int wordIndex, int offset) =>
+        WriteDepositEventWord(data, wordIndex * AbiWordSize, offset);
+
+    private static void WriteDepositEventField(byte[] data, int offset, byte[] field)
+    {
+        WriteDepositEventWord(data, offset, field.Length);
+        field.CopyTo(data.AsSpan(offset + AbiWordSize));
+    }
+
+    private static void WriteDepositEventWord(byte[] data, int offset, int value) =>
+        BinaryPrimitives.WriteInt32BigEndian(data.AsSpan(offset + AbiWordSize - sizeof(int), sizeof(int)), value);
+
+    private static void ApplyDepositEventLayoutMutation(byte[] data, DepositEventLayoutMutation mutation, out byte[] mutatedData)
+    {
+        mutatedData = data;
+        switch (mutation)
+        {
+            case DepositEventLayoutMutation.ExtraTrailingWord:
+                Array.Resize(ref mutatedData, DepositEventDataLength + AbiWordSize);
+                break;
+            case DepositEventLayoutMutation.WrongAmountSize:
+                WriteDepositEventWord(mutatedData, DepositEventAmountOffset, ExecutionRequestExtensions.AmountSize + 1);
+                break;
+            case DepositEventLayoutMutation.NonZeroHighByteInOffset:
+                mutatedData[0] = 1;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(mutation), mutation, null);
+        }
+    }
+
+    [Test]
     public void ShouldUseCorrectDepositTopic() => Assert.That(ExecutionRequestsProcessor.DepositEventAbi.Hash, Is.EqualTo(new Hash256("0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5")));
+
+    public enum DepositEventLayoutMutation
+    {
+        ExtraTrailingWord,
+        WrongAmountSize,
+        NonZeroHighByteInOffset
+    }
 }

--- a/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestsProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestsProcessor.cs
@@ -14,6 +14,7 @@ using Nethermind.Crypto;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
 using System;
 using System.Buffers.Binary;
 using Nethermind.Core.Messages;
@@ -25,6 +26,11 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
     public static readonly AbiSignature DepositEventAbi = new("DepositEvent", AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes);
 
     private const ulong GasLimit = Eip8037Constants.SystemCallGasLimit;
+
+    // Canonical ABI layout of the EIP-6110 `DepositEvent(bytes,bytes,bytes,bytes,bytes)` log data: five head
+    // words holding the offsets below, each pointing at a length word followed by the right-padded field.
+    // These are the values EIP-6110 `is_valid_deposit_event_data` and EELS `extract_deposit_data` require;
+    // the bytes between fields are deliberately not checked, as neither reference implementation checks them.
     private const int AbiWordSize = 32;
     private const int DepositEventDataLength = 576;
     private const int DepositEventPubkeyOffset = 160;
@@ -209,14 +215,10 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
     private static void ValidateDepositEventWord(Block block, byte[] data, int dataOffset, int expectedValue, string name)
     {
         ReadOnlySpan<byte> word = data.AsSpan(dataOffset, AbiWordSize);
-        if (!word.Slice(0, AbiWordSize - sizeof(uint)).IsZero())
+        if (!word.Slice(0, AbiWordSize - sizeof(uint)).IsZero()
+            || BinaryPrimitives.ReadUInt32BigEndian(word.Slice(AbiWordSize - sizeof(uint), sizeof(uint))) != (uint)expectedValue)
         {
-            throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Deposit event {name} does not match, expected {expectedValue}."));
-        }
-
-        if (BinaryPrimitives.ReadUInt32BigEndian(word.Slice(AbiWordSize - sizeof(uint), sizeof(uint))) != (uint)expectedValue)
-        {
-            throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Deposit event {name} does not match, expected {expectedValue}."));
+            throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Deposit event {name} does not match, expected {expectedValue}, got {new UInt256(word, isBigEndian: true)}."));
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestsProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/ExecutionRequests/ExecutionRequestsProcessor.cs
@@ -8,12 +8,14 @@ using Nethermind.Core;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Collections;
 using Nethermind.Core.ExecutionRequest;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 using System;
+using System.Buffers.Binary;
 using Nethermind.Core.Messages;
 
 namespace Nethermind.Consensus.ExecutionRequests;
@@ -21,9 +23,15 @@ namespace Nethermind.Consensus.ExecutionRequests;
 public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
 {
     public static readonly AbiSignature DepositEventAbi = new("DepositEvent", AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes, AbiType.DynamicBytes);
-    private readonly AbiEncoder _abiEncoder = AbiEncoder.Instance;
 
     private const ulong GasLimit = Eip8037Constants.SystemCallGasLimit;
+    private const int AbiWordSize = 32;
+    private const int DepositEventDataLength = 576;
+    private const int DepositEventPubkeyOffset = 160;
+    private const int DepositEventWithdrawalCredentialsOffset = 256;
+    private const int DepositEventAmountOffset = 320;
+    private const int DepositEventSignatureOffset = 384;
+    private const int DepositEventIndexOffset = 512;
 
     private readonly ITransactionProcessor _transactionProcessor;
 
@@ -166,51 +174,56 @@ public class ExecutionRequestsProcessor : IExecutionRequestsProcessor
             requests.Add(depositRequests.ToArray());
     }
 
-    private void DecodeDepositRequest(Block block, LogEntry log, Span<byte> buffer)
+    private static void DecodeDepositRequest(Block block, LogEntry log, Span<byte> buffer)
     {
-        object[] result;
-        try
-        {
-            result = _abiEncoder.Decode(AbiEncodingStyle.None, DepositEventAbi, log.Data);
-            ValidateLayout(result, block);
-        }
-        catch (AbiException e)
-        {
-            throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout(e.Message), e);
-        }
-
+        ValidateDepositEventLayout(block, log.Data);
         int offset = 0;
 
-        foreach (object item in result)
+        CopyDepositEventField(log.Data, DepositEventPubkeyOffset, ExecutionRequestExtensions.PublicKeySize, buffer, ref offset);
+        CopyDepositEventField(log.Data, DepositEventWithdrawalCredentialsOffset, ExecutionRequestExtensions.WithdrawalCredentialsSize, buffer, ref offset);
+        CopyDepositEventField(log.Data, DepositEventAmountOffset, ExecutionRequestExtensions.AmountSize, buffer, ref offset);
+        CopyDepositEventField(log.Data, DepositEventSignatureOffset, ExecutionRequestExtensions.SignatureSize, buffer, ref offset);
+        CopyDepositEventField(log.Data, DepositEventIndexOffset, ExecutionRequestExtensions.IndexSize, buffer, ref offset);
+    }
+
+    private static void ValidateDepositEventLayout(Block block, byte[] data)
+    {
+        if (data.Length != DepositEventDataLength)
         {
-            if (item is byte[] byteArray)
-            {
-                byteArray.CopyTo(buffer.Slice(offset, byteArray.Length));
-                offset += byteArray.Length;
-            }
+            throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Deposit event data length does not match, expected {DepositEventDataLength}, got {data.Length}."));
+        }
+
+        ValidateDepositEventWord(block, data, 0 * AbiWordSize, DepositEventPubkeyOffset, "pubkey offset");
+        ValidateDepositEventWord(block, data, 1 * AbiWordSize, DepositEventWithdrawalCredentialsOffset, "withdrawal credentials offset");
+        ValidateDepositEventWord(block, data, 2 * AbiWordSize, DepositEventAmountOffset, "amount offset");
+        ValidateDepositEventWord(block, data, 3 * AbiWordSize, DepositEventSignatureOffset, "signature offset");
+        ValidateDepositEventWord(block, data, 4 * AbiWordSize, DepositEventIndexOffset, "index offset");
+
+        ValidateDepositEventWord(block, data, DepositEventPubkeyOffset, ExecutionRequestExtensions.PublicKeySize, "pubkey size");
+        ValidateDepositEventWord(block, data, DepositEventWithdrawalCredentialsOffset, ExecutionRequestExtensions.WithdrawalCredentialsSize, "withdrawal credentials size");
+        ValidateDepositEventWord(block, data, DepositEventAmountOffset, ExecutionRequestExtensions.AmountSize, "amount size");
+        ValidateDepositEventWord(block, data, DepositEventSignatureOffset, ExecutionRequestExtensions.SignatureSize, "signature size");
+        ValidateDepositEventWord(block, data, DepositEventIndexOffset, ExecutionRequestExtensions.IndexSize, "index size");
+    }
+
+    private static void ValidateDepositEventWord(Block block, byte[] data, int dataOffset, int expectedValue, string name)
+    {
+        ReadOnlySpan<byte> word = data.AsSpan(dataOffset, AbiWordSize);
+        if (!word.Slice(0, AbiWordSize - sizeof(uint)).IsZero())
+        {
+            throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Deposit event {name} does not match, expected {expectedValue}."));
+        }
+
+        if (BinaryPrimitives.ReadUInt32BigEndian(word.Slice(AbiWordSize - sizeof(uint), sizeof(uint))) != (uint)expectedValue)
+        {
+            throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Deposit event {name} does not match, expected {expectedValue}."));
         }
     }
 
-    private static void ValidateLayout(object[] result, Block block)
+    private static void CopyDepositEventField(byte[] data, int dataOffset, int length, Span<byte> buffer, ref int bufferOffset)
     {
-        Validate(block, result[0], "pubkey", ExecutionRequestExtensions.PublicKeySize);
-        Validate(block, result[1], "withdrawalCredentials", ExecutionRequestExtensions.WithdrawalCredentialsSize);
-        Validate(block, result[2], "amount", ExecutionRequestExtensions.AmountSize);
-        Validate(block, result[3], "signature", ExecutionRequestExtensions.SignatureSize);
-        Validate(block, result[4], "index", ExecutionRequestExtensions.IndexSize);
-
-        static void Validate(Block block, object obj, string name, int expectedSize)
-        {
-            if (obj is not byte[] byteArray)
-            {
-                throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Decoded ABI result contains {name} as non-byte array element."));
-            }
-
-            if (byteArray.Length != expectedSize)
-            {
-                throw new InvalidBlockException(block, BlockErrorMessages.InvalidDepositEventLayout($"Decoded ABI result contains invalid {name} element, size does not match, expected {expectedSize}, got {byteArray.Length}."));
-            }
-        }
+        data.AsSpan(dataOffset + AbiWordSize, length).CopyTo(buffer.Slice(bufferOffset, length));
+        bufferOffset += length;
     }
 
     private void ReadRequests(Block block, IWorldState state, Address contractAddress, ref ArrayPoolListRef<byte[]> requests,


### PR DESCRIPTION
## Changes

- Validate the EIP-6110 deposit event ABI layout directly instead of running the log through the generic ABI decoder: the data length, the five head offset words and the five field length words must all equal the canonical values, otherwise the block is rejected.

  The decoder followed each head word wherever it pointed, so a deposit log that packed the fields in a non-canonical order still decoded into correctly sized fields and was accepted — and Nethermind then derived *different* request bytes than the reference clients from the same log, surfacing only as a `requests_hash` mismatch. The new checks are exactly those of EIP-6110 `is_valid_deposit_event_data` and EELS `extract_deposit_data`, including not requiring the padding between fields to be zero. (go-ethereum's `DepositLogToRequest` checks only the total length and reads the canonical positions unconditionally, so it is laxer than the spec here; there is no input the new code rejects that both references accept.)

  This also drops the per-log allocations — five `byte[]`, an `object[]` and a decode-budget scope — from block processing.

- No re-sync impact: the deposit contract deployed on mainnet, Hoodi, Sepolia and Gnosis is solc-emitted, so no already-imported block can carry a non-canonical layout.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Every case in `ExecutionProcessorTests` starts from the ABI encoder's own output — the payload `ShouldProcessExecutionRequests` proves is accepted — so each one differs from a valid deposit log only by its mutation:

- `ShouldRejectDepositLogWithNonCanonicalAbiLayout` covers both block orderings, a one-word shift of all blocks, an offset past the end of the data, an offset with bits set above the low word, a trailing word and truncated data. The first three are ABI-valid but non-canonical, and are the cases the previous implementation accepted.
- `ShouldRejectDepositLogWithAlteredLayoutWord` walks all ten pinned words — five head offsets and five field lengths — so dropping any single check fails a test.
- `ShouldAcceptDepositLogWithNonZeroFieldPadding` pins the other direction: garbage in the padding bytes must still yield the same requests hash, since neither reference implementation checks them.

`AbiTests` keeps a guard on the dynamic bytes bounds check that stops a length of 1 from reaching `ByteArrayExtensions.Slice`'s one-byte fast path.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
