### PR TITLE
ci: disable .NET package caching again

### DIFF
--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -37,9 +37,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Install dependencies
         run: dotnet restore src/Nethermind/${{ matrix.solution }}.slnx --locked-mode

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -34,9 +34,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Redirect build output to the large scratch disk (Linux)
         # Build on the ~70 GB /mnt; the multi-RID output overflows the ~21 GB root disk.

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -30,9 +30,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Register problem matcher
         run: echo "::add-matcher::.github/problem-matchers/dotnet-format.json"

--- a/.github/workflows/evm-opcode-benchmark-diff.yml
+++ b/.github/workflows/evm-opcode-benchmark-diff.yml
@@ -105,9 +105,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Create base worktree
         shell: bash

--- a/.github/workflows/nethermind-tests-checked.yml
+++ b/.github/workflows/nethermind-tests-checked.yml
@@ -124,9 +124,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Download test binaries
         uses: ./.github/actions/download-test-artifacts
@@ -180,9 +177,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Download test binaries
         uses: ./.github/actions/download-test-artifacts

--- a/.github/workflows/nethermind-tests-flat.yml
+++ b/.github/workflows/nethermind-tests-flat.yml
@@ -88,9 +88,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Download test binaries
         uses: ./.github/actions/download-test-artifacts

--- a/.github/workflows/run-block-processing-benchmark.yml
+++ b/.github/workflows/run-block-processing-benchmark.yml
@@ -86,9 +86,6 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
-        with:
-          cache: true
-          cache-dependency-path: src/Nethermind/Nethermind.Runner/packages.lock.json
 
       - name: Build base branch
         run: |


### PR DESCRIPTION
## Changes

Remove `cache: true` / `cache-dependency-path` from the 8 `actions/setup-dotnet` call sites, so CI restores packages from nuget.org rather than from the Actions cache.

#11653 ("Disabled .NET package caching as it's flaky and does more harm than help") removed `cache: true` from the three test workflows, and #12371 put it back on exactly those while adding the new `build-test-artifacts` producer.

This goes wider than #11653 did: it also drops the `build-solutions`, `code-lint`, `evm-opcode-benchmark-diff` and `run-block-processing-benchmark` sites that #11653 left in place. Those are the ones that matter for the budget — the 1.07 GB PR-scoped save measured below came from `Check code lint`, and the 593 MB master entry plus its two per-ref duplicates come from `build-solutions` — so removing only the test-workflow sites would leave the duplication untouched. #11444 ("Replaced the manual buggy NuGet package caching") and #11440 ("racing and failing") are the two earlier steps away from manual caching.

### It costs the whole cache budget

The repository sits at the 10 GiB Actions cache ceiling (`active_caches_size_in_bytes: 10011466894` across 27 entries), and 7.3 GB of that is duplicated NuGet folders:

| key | ref | size |
|---|---|---:|
| `dotnet-cache-Linux-95ccabf` | `refs/heads/master` | 593 MB |
| `dotnet-cache-Linux-95ccabf` | `refs/pull/12844/merge` | 1070 MB |
| `dotnet-cache-Linux-95ccabf` | `refs/pull/12870/merge` | 1070 MB |
| `dotnet-cache-Linux-2c4c539` | `refs/pull/12881/merge` | 1070 MB |
| `dotnet-cache-Linux-2c4c539` | `refs/pull/12881/merge` | 1167 MB |
| `dotnet-cache-Linux-2c4c539` | `refs/pull/12897/merge` | 1167 MB |
| `dotnet-cache-Linux-a945cb3` | `refs/pull/12893/merge` | 1070 MB |
| `dotnet-cache-Linux-a945cb3` | `refs/pull/12893/merge` | 551 MB |

Three distinct dependency sets, eight copies: a save is scoped to the ref that wrote it, so one PR's copy is unusable by the next, which writes its own.

Everything else in the repository is then LRU-evicted inside about an hour — when this was measured, the oldest surviving cache of any kind had last been accessed 77 minutes earlier. That is what keeps breaking the EXPB benchmark comparison comments: the baseline saved by a `master` push run at 12:11 ("Cache saved with key: expb-master-metrics-v3-superblocks-32249874374") was already gone when a PR run looked for it at 14:04, so the comment renders with no master column.

### And it does not buy time

Measured across identical `build-solutions` matrix cells, `Set up .NET` + `dotnet restore`:

| | mean | max |
|---|---:|---:|
| cache hit (3 runs, n=18) | 28.7 s | 38 s |
| no cache entry (2 runs, n=12) | 28.7 s | 58 s |

A hit adds ~7-9 s of cache download to `Set up .NET` and removes ~5-7 s from `dotnet restore`, so the mean is a wash. `code-lint` shows the same: 223 s warm (n=6) vs 227 s cold. The cache does trim the tail (nuget.org download time varies — one cold cell took 50 s), but a miss also pays an 11-12 s save (`Post Set up .NET`), and under the eviction rate above, misses are common.

Self-hosted `benchmark` runners keep `~/.nuget/packages` warm between runs regardless, so the two benchmark workflows lose nothing.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

The cold-restore numbers above come from an earlier revision of this PR, whose new cache key namespace prefix-matched nothing: every job on it ran with no NuGet cache at all and all builds, lints and test suites passed. That is exactly the state this revision makes permanent.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Earlier revisions of this PR split restore from save (restore everywhere, seed once from `master`) to keep a warm copy while ending the per-ref duplication. @rubo pointed out that shape had already been rejected twice, and the history backs that up — #11440 removed a near-identical `actions/cache` + `~/.nuget/packages` + `hashFiles('Directory.Packages.props', ...)` block for random failures, explicitly noting the warmup job was not worth the overhead. A single shared entry also makes a bad entry worse, since it would poison every job until the key changed. Dropped that approach in favour of this deletion.

The EXPB baseline is only unblocked by this, not fixed: it remains an Actions cache entry that GitHub can drop at any time. The durable fix is for `run-expb-reproducible-benchmarks.yml` to read the baseline from the `expb-single-metrics-*` artifact of the latest successful `master` push run (30-day retention, not evictable), and to stop keying restores on `github.event.pull_request.base.sha` while saves use `github.run_id` — a primary key that can never hit, so every comparison silently falls back to whichever baseline is still alive. Happy to send that separately.

