### PR TITLE
perf(rpc): apply eth_call state overrides without merkleizing them

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip1014Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip1014Tests.cs
@@ -77,6 +77,28 @@ namespace Nethermind.Evm.Test
             AssertEip1014(expectedAddress, []);
         }
 
+        /// <summary>
+        /// EIP-7610: storage written earlier in the same block is not in the storage root yet - block
+        /// processing merkleizes once at the end of the block - so the collision check must consult the
+        /// block-level changes, not only the committed root.
+        /// </summary>
+        [Test]
+        public void Test_existing_account_with_unmerkleized_storage_is_not_empty()
+        {
+            (Address expectedAddress, byte[] callCode) = PrepareCreate2(_defaultSalt, _defaultInitCode, callGas: 32100);
+
+            TestState.CreateAccount(expectedAddress, 1.Ether);
+            TestState.Set(new StorageCell(expectedAddress, 1), [1, 2, 3, 4, 5]);
+            TestState.Commit(Spec, commitRoots: false);
+
+            Assert.That(TestState.IsStorageEmpty(expectedAddress), Is.False);
+
+            Execute(callCode);
+
+            Assert.That(TestState.IsStorageEmpty(expectedAddress), Is.False);
+            AssertEip1014(expectedAddress, []);
+        }
+
         [Test]
         public void Test_out_of_gas_non_existing_account()
         {

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -604,7 +604,6 @@ namespace Nethermind.Facade
         }
 
         public record BlockProcessingComponents(
-            IStateReader StateReader,
             ITransactionProcessor TransactionProcessor,
             IWorldState WorldState,
             SingleCallRequestState RequestState
@@ -672,11 +671,13 @@ namespace Nethermind.Facade
         {
             /// <inheritdoc/>
             /// <remarks>
-            /// The state override is applied to the scope's world state but left unmerkleized: everything the
-            /// bridge runs in this scope executes against that world state and never resolves state through a
-            /// root, so the trie path load and rehash per overridden account is pure cost. Consequently the
-            /// header keeps its original state root, and nonces on these paths are read from the world state
-            /// rather than through an <see cref="IStateReader"/>.
+            /// Deviates from <see cref="IOverridableEnv.BuildAndOverride"/>: the state override is applied to
+            /// the scope's world state but left unmerkleized, because everything the bridge runs in this scope
+            /// executes against that world state and never resolves state through a root, so the trie path load
+            /// and rehash per overridden account is pure cost. The header therefore does not receive a
+            /// post-state-override root (a <paramref name="blockOverride"/> is still applied and committed by the
+            /// inner env), and nonces on these paths must be read from the world state rather than through an
+            /// <see cref="IStateReader"/>.
             /// </remarks>
             public Scope<BlockchainBridge.BlockProcessingComponents> BuildAndOverride(
                 BlockHeader? header,

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -161,7 +161,7 @@ namespace Nethermind.Facade
         private CallOutput CallShareable(BlockHeader header, Transaction tx, CancellationToken cancellationToken)
         {
             using IReadOnlyTxProcessingScope scope = shareableTxProcessorSource.Build(header);
-            return RunCall(stateReader, scope.TransactionProcessor, header, tx, blobBaseFeeOverride: null, cancellationToken);
+            return RunCall(scope.WorldState, scope.TransactionProcessor, header, tx, blobBaseFeeOverride: null, cancellationToken);
         }
 
         private CallOutput CallExclusive(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, UInt256? blobBaseFeeOverride, BlockOverride? blockOverride, CancellationToken cancellationToken)
@@ -171,13 +171,13 @@ namespace Nethermind.Facade
             using Scope<BlockProcessingComponents> scope = processingEnv.BuildAndOverride(header, stateOverride, blockOverride);
             // Dual-write: RequestState feeds the VM-time decorator; RunCall applies it during pre-VM header prep.
             scope.Component.RequestState.BlobBaseFeeOverride = blobBaseFeeOverride;
-            return RunCall(scope.Component.StateReader, scope.Component.TransactionProcessor, header, tx, blobBaseFeeOverride, cancellationToken);
+            return RunCall(scope.Component.WorldState, scope.Component.TransactionProcessor, header, tx, blobBaseFeeOverride, cancellationToken);
         }
 
-        private CallOutput RunCall(IStateReader nonceReader, ITransactionProcessor txProcessor, BlockHeader header, Transaction tx, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
+        private CallOutput RunCall(IWorldState nonceSource, ITransactionProcessor txProcessor, BlockHeader header, Transaction tx, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
         {
             CallOutputTracer tracer = new();
-            TransactionResult result = TryCallAndRestore(nonceReader, txProcessor, header, tx, treatBlockHeaderAsParentBlock: false,
+            TransactionResult result = TryCallAndRestore(nonceSource, txProcessor, header, tx, treatBlockHeaderAsParentBlock: false,
                 blobBaseFeeOverride, tracer.WithCancellation(cancellationToken));
 
             return new CallOutput
@@ -211,7 +211,7 @@ namespace Nethermind.Facade
         private CallOutput EstimateGasShareable(BlockHeader header, Transaction tx, int errorMargin, CancellationToken cancellationToken)
         {
             using IReadOnlyTxProcessingScope scope = shareableTxProcessorSource.Build(header);
-            return RunEstimateGas(stateReader, scope.TransactionProcessor, scope.WorldState, header, tx, errorMargin, blobBaseFeeOverride: null, cancellationToken);
+            return RunEstimateGas(scope.TransactionProcessor, scope.WorldState, header, tx, errorMargin, blobBaseFeeOverride: null, cancellationToken);
         }
 
         private CallOutput EstimateGasExclusive(BlockHeader header, Transaction tx, int errorMargin, Dictionary<Address, AccountOverride>? stateOverride, UInt256? blobBaseFeeOverride, BlockOverride? blockOverride, CancellationToken cancellationToken)
@@ -219,10 +219,10 @@ namespace Nethermind.Facade
             using Scope<BlockProcessingComponents> scope = processingEnv.BuildAndOverride(header, stateOverride, blockOverride);
             BlockProcessingComponents components = scope.Component;
             components.RequestState.BlobBaseFeeOverride = blobBaseFeeOverride;
-            return RunEstimateGas(components.StateReader, components.TransactionProcessor, components.WorldState, header, tx, errorMargin, blobBaseFeeOverride, cancellationToken);
+            return RunEstimateGas(components.TransactionProcessor, components.WorldState, header, tx, errorMargin, blobBaseFeeOverride, cancellationToken);
         }
 
-        private CallOutput RunEstimateGas(IStateReader nonceReader, ITransactionProcessor txProcessor, IWorldState worldState, BlockHeader header, Transaction tx, int errorMargin, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
+        private CallOutput RunEstimateGas(ITransactionProcessor txProcessor, IWorldState worldState, BlockHeader header, Transaction tx, int errorMargin, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
         {
             // Cap tx.GasLimit to the sender's affordable allowance before the initial probe,
             // mirroring Geth's hi = min(hi, (balance - value - blobFee) / gasFeeCap), where blobFee = 0 outside EIP-4844. This ensures
@@ -241,7 +241,7 @@ namespace Nethermind.Facade
             }
 
             EstimateGasTracer estimateGasTracer = new();
-            TransactionResult tryCallResult = TryCallAndRestore(nonceReader, txProcessor, header, tx, true,
+            TransactionResult tryCallResult = TryCallAndRestore(worldState, txProcessor, header, tx, true,
                 blobBaseFeeOverride, estimateGasTracer.WithCancellation(cancellationToken));
 
             GasEstimator gasEstimator = new(txProcessor, worldState, specProvider, blocksConfig);
@@ -291,7 +291,7 @@ namespace Nethermind.Facade
             AccessList? originalAccessList = tx.AccessList;
             try
             {
-                return ConvergeAccessList(stateReader, scope.TransactionProcessor, blobBaseFeeOverride: null, header, tx, optimize, cancellationToken);
+                return ConvergeAccessList(scope.WorldState, scope.TransactionProcessor, blobBaseFeeOverride: null, header, tx, optimize, cancellationToken);
             }
             finally
             {
@@ -308,7 +308,7 @@ namespace Nethermind.Facade
             AccessList? originalAccessList = tx.AccessList;
             try
             {
-                return ConvergeAccessList(components.StateReader, components.TransactionProcessor, blobBaseFeeOverride, header, tx, optimize, cancellationToken);
+                return ConvergeAccessList(components.WorldState, components.TransactionProcessor, blobBaseFeeOverride, header, tx, optimize, cancellationToken);
             }
             finally
             {
@@ -320,14 +320,14 @@ namespace Nethermind.Facade
         // slots, repeat until the AL stabilizes. Gas and error come from the final (warm) run, so
         // cold-read overcounting is eliminated and OOG due to AL intrinsic cost is surfaced.
         // Starts from the caller-supplied AL so user-provided entries are preserved and counted.
-        private CallOutput ConvergeAccessList(IStateReader nonceReader, ITransactionProcessor txProcessor, UInt256? blobBaseFeeOverride, BlockHeader header, Transaction tx, bool optimize, CancellationToken cancellationToken)
+        private CallOutput ConvergeAccessList(IWorldState nonceSource, ITransactionProcessor txProcessor, UInt256? blobBaseFeeOverride, BlockHeader header, Transaction tx, bool optimize, CancellationToken cancellationToken)
         {
             // Loop-invariant: the addresses to filter from the discovered AL depend only on header
             // and tx, neither of which change between iterations. Compute once and reuse.
             FrozenSet<AddressAsKey> precompiles = specProvider.GetSpec(header).Precompiles;
             int bufferSize = (optimize ? 3 : 1) + precompiles.Count;
             Address[] addressBuffer = new Address[bufferSize];
-            FillAddressesToOptimize(addressBuffer, header, tx, optimize, precompiles);
+            FillAddressesToOptimize(addressBuffer, nonceSource, header, tx, optimize, precompiles);
 
             AccessList? previousAccessList = tx.AccessList;
             AccessTxTracer accessTracer = new(addressBuffer);
@@ -341,7 +341,7 @@ namespace Nethermind.Facade
                 accessTracer.Reset();
                 outputTracer.Reset();
                 tx.AccessList = previousAccessList;
-                result = TryCallAndRestore(nonceReader, txProcessor, header, tx, false, blobBaseFeeOverride, tracer);
+                result = TryCallAndRestore(nonceSource, txProcessor, header, tx, false, blobBaseFeeOverride, tracer);
                 stop = !result.TransactionExecuted || HasConverged(previousAccessList, accessTracer.AccessList);
                 previousAccessList = accessTracer.AccessList;
             } while (!stop);
@@ -365,7 +365,7 @@ namespace Nethermind.Facade
             };
         }
 
-        private void FillAddressesToOptimize(Span<Address> buffer, BlockHeader header, Transaction tx, bool optimize, FrozenSet<AddressAsKey> precompiles)
+        private void FillAddressesToOptimize(Span<Address> buffer, IWorldState nonceSource, BlockHeader header, Transaction tx, bool optimize, FrozenSet<AddressAsKey> precompiles)
         {
             int idx;
             if (!optimize)
@@ -377,7 +377,10 @@ namespace Nethermind.Facade
             {
                 // EIP-2930: sender, recipient and gas beneficiary are implicitly accessed,
                 // so excluding them keeps the returned access list minimal.
-                UInt256 senderNonce = tx.IsContractCreation ? stateReader.GetNonce(header, tx.SenderAddress) : UInt256.Zero;
+                // The nonce comes from the executing world state: the header's state root does not
+                // reflect an unmerkleized override, so a nonce override would resolve to the wrong
+                // CREATE address here.
+                UInt256 senderNonce = tx.IsContractCreation ? nonceSource.GetNonce(tx.SenderAddress) : UInt256.Zero;
                 buffer[0] = tx.SenderAddress;
                 buffer[1] = tx.GetRecipient(senderNonce);
                 buffer[2] = header.GasBeneficiary;
@@ -399,7 +402,7 @@ namespace Nethermind.Facade
         }
 
         private TransactionResult TryCallAndRestore(
-            IStateReader nonceReader,
+            IWorldState nonceSource,
             ITransactionProcessor txProcessor,
             BlockHeader blockHeader,
             Transaction transaction,
@@ -409,7 +412,7 @@ namespace Nethermind.Facade
         {
             try
             {
-                return CallAndRestore(nonceReader, txProcessor, blockHeader, transaction, treatBlockHeaderAsParentBlock, blobBaseFeeOverride, tracer);
+                return CallAndRestore(nonceSource, txProcessor, blockHeader, transaction, treatBlockHeaderAsParentBlock, blobBaseFeeOverride, tracer);
             }
             catch (InsufficientBalanceException)
             {
@@ -418,7 +421,7 @@ namespace Nethermind.Facade
         }
 
         private TransactionResult CallAndRestore(
-            IStateReader nonceReader,
+            IWorldState nonceSource,
             ITransactionProcessor txProcessor,
             BlockHeader blockHeader,
             Transaction transaction,
@@ -428,8 +431,10 @@ namespace Nethermind.Facade
         {
             transaction.SenderAddress ??= Address.Zero;
 
-            //Ignore nonce on all CallAndRestore calls
-            transaction.Nonce = nonceReader.GetNonce(blockHeader, transaction.SenderAddress);
+            // Ignore nonce on all CallAndRestore calls. Read it from the executing world state rather
+            // than through a root-resolved reader: that reflects any state override and avoids building
+            // a second state snapshot per call.
+            transaction.Nonce = nonceSource.GetNonce(transaction.SenderAddress);
 
             BlockHeader callHeader = blockHeader.Clone();
             if (treatBlockHeaderAsParentBlock)
@@ -652,19 +657,57 @@ namespace Nethermind.Facade
             // and turn burst override traffic into long-lived memory.
             IOverridableEnv<BlockchainBridge.BlockProcessingComponents> inner =
                 overridableScopeLifetime.Resolve<IOverridableEnv<BlockchainBridge.BlockProcessingComponents>>();
-            return new DisposableOverridableEnv(inner, overridableScopeLifetime);
+            return new DisposableOverridableEnv(
+                inner,
+                overridableScopeLifetime,
+                overridableScopeLifetime.Resolve<IOverridableCodeInfoRepository>(),
+                overridableScopeLifetime.Resolve<ISpecProvider>());
         }
 
         private sealed class DisposableOverridableEnv(
             IOverridableEnv<BlockchainBridge.BlockProcessingComponents> inner,
-            IDisposable scope) : IOverridableEnv<BlockchainBridge.BlockProcessingComponents>, IDisposable
+            IDisposable scope,
+            IOverridableCodeInfoRepository codeInfoRepository,
+            ISpecProvider specProvider) : IOverridableEnv<BlockchainBridge.BlockProcessingComponents>, IDisposable
         {
+            /// <inheritdoc/>
+            /// <remarks>
+            /// The state override is applied to the scope's world state but left unmerkleized: everything the
+            /// bridge runs in this scope executes against that world state and never resolves state through a
+            /// root, so the trie path load and rehash per overridden account is pure cost. Consequently the
+            /// header keeps its original state root, and nonces on these paths are read from the world state
+            /// rather than through an <see cref="IStateReader"/>.
+            /// </remarks>
             public Scope<BlockchainBridge.BlockProcessingComponents> BuildAndOverride(
                 BlockHeader? header,
                 Dictionary<Address, AccountOverride>? stateOverride = null,
                 IReleaseSpec? specOverride = null,
-                BlockOverride? blockOverride = null) =>
-                inner.BuildAndOverride(header, stateOverride, specOverride, blockOverride);
+                BlockOverride? blockOverride = null)
+            {
+                // A block override still goes through the env so it keeps committing the unchanged state at
+                // the overridden block number, which the overridden header relies on to resolve.
+                Scope<BlockchainBridge.BlockProcessingComponents> scope =
+                    inner.BuildAndOverride(header, stateOverride: null, specOverride, blockOverride);
+
+                if (stateOverride is null || header is null) return scope;
+
+                try
+                {
+                    // EIP-158 must not delete accounts whose code and nonce were overridden to zero while
+                    // storage remains, or the EIP-7610 collision check would stop seeing that storage.
+                    IReleaseSpec spec = specProvider.GetSpec(header).WithoutEip158();
+                    IWorldState worldState = scope.Component.WorldState;
+                    worldState.ApplyStateOverridesNoCommit(codeInfoRepository, stateOverride, spec);
+                    worldState.Commit(spec, commitRoots: false);
+                }
+                catch
+                {
+                    scope.Dispose();
+                    throw;
+                }
+
+                return scope;
+            }
 
             public void Dispose() => scope.Dispose();
         }

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -62,6 +62,48 @@ public class StorageProviderTests(bool useFlat)
 
     private WorldState BuildStorageProvider(Context ctx) => ctx.StateProvider;
 
+    /// <summary>
+    /// <see cref="IWorldState.IsStorageEmpty"/> backs the EIP-7610 CREATE collision check. State overrides
+    /// are applied with <c>commitRoots: false</c>, so the write never reaches the storage trie and the
+    /// committed root cannot see it — the block-level change set has to be consulted.
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="clearFirst"/> arms pin the check order: a full <c>state</c> override clears the
+    /// storage before writing and the clear marker survives until the trie flush, so testing the marker
+    /// before the change set would report the account empty and bypass EIP-7610.
+    /// </remarks>
+    [TestCase(false, false, false, TestName = "Uncommitted_write_is_visible")]
+    [TestCase(true, false, false, TestName = "Uncommitted_write_after_clear_is_visible")]
+    [TestCase(false, true, true, TestName = "Uncommitted_write_reverted_to_zero_stays_empty")]
+    [TestCase(true, true, true, TestName = "Clear_then_write_reverted_to_zero_stays_empty")]
+    public void IsStorageEmpty_sees_uncommitted_storage_change(bool clearFirst, bool zeroAfterwards, bool expectedEmpty)
+    {
+        using Context ctx = new(useFlat, setInitialState: false);
+        IWorldState provider = BuildStorageProvider(ctx);
+
+        BlockHeader baseBlock = null;
+        using (provider.BeginScope(baseBlock))
+        {
+            provider.CreateAccountIfNotExists(TestItem.AddressA, 100);
+            if (clearFirst)
+            {
+                provider.ClearStorage(TestItem.AddressA);
+            }
+
+            StorageCell cell = new(TestItem.AddressA, 1);
+            provider.Set(cell, [0x2a]);
+            if (zeroAfterwards)
+            {
+                provider.Set(cell, StorageTree.ZeroBytes);
+            }
+
+            // The state-override path: commit the journal without flushing anything to the trie.
+            provider.Commit(Frontier.Instance, commitRoots: false);
+
+            Assert.That(provider.IsStorageEmpty(TestItem.AddressA), Is.EqualTo(expectedEmpty));
+        }
+    }
+
     [Test]
     [NonParallelizable]
     public void Oversized_per_contract_state_dictionary_is_trimmed_when_returned()

--- a/src/Nethermind/Nethermind.State/OverridableEnv/IShareableOverridableEnvSource.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/IShareableOverridableEnvSource.cs
@@ -18,6 +18,10 @@ public interface IShareableOverridableEnvSource<T> : IDisposable
     /// <remarks>
     /// When <paramref name="blockOverride"/> is supplied it is applied to <paramref name="header"/> <b>in place</b>;
     /// see <see cref="IOverridableEnv.BuildAndOverride"/>. Callers must pass a header they own (e.g. a clone).
+    /// Unlike <see cref="IOverridableEnv.BuildAndOverride"/>, an implementation may leave
+    /// <paramref name="stateOverride"/> unmerkleized when its consumers only read through the scope's world
+    /// state, in which case <paramref name="header"/> receives no post-state-override root and state must not
+    /// be resolved through one.
     /// </remarks>
     Scope<T> BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null, BlockOverride? blockOverride = null);
 }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -424,6 +424,23 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         public int EstimatedSize => _dictionary.Count + (_missingAreDefault ? 1 : 0);
         public bool HasClear => _missingAreDefault;
 
+        /// <summary>Whether any uncommitted block-level change leaves a slot at a non-zero value.</summary>
+        public bool HasNonZeroValue
+        {
+            get
+            {
+                foreach (StorageChangeTrace trace in _dictionary.Values)
+                {
+                    if (!trace.After.IsZero())
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
         public void Reset(int capacity)
         {
             _missingAreDefault = false;
@@ -507,6 +524,12 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         {
             get
             {
+                // Uncommitted writes must be tested before the clear marker: a "state" override clears
+                // the storage and then writes into it, leaving the marker set alongside non-zero entries.
+                // Only writes can hide from the committed root (see Commit(commitRoots: false)); a non-zero
+                // read implies a non-empty root, which the check below already reports.
+                if (_wasWritten && BlockChange.HasNonZeroValue) return false;
+
                 // _backend.RootHash is not reflected until after commit, but this need to be reflected before commit
                 // for SelfDestruct, since the deletion is not part of changelog, it need to be handled here.
                 if (BlockChange.HasClear) return true;

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -524,10 +524,14 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         {
             get
             {
-                // Uncommitted writes must be tested before the clear marker: a "state" override clears
-                // the storage and then writes into it, leaving the marker set alongside non-zero entries.
-                // Only writes can hide from the committed root (see Commit(commitRoots: false)); a non-zero
-                // read implies a non-empty root, which the check below already reports.
+                // Block-level writes that have not been merkleized yet are invisible to the storage root
+                // (state overrides, and every tx before the block's single root computation), so consult
+                // them first: a "state" override clears the storage before writing, leaving the clear
+                // marker set alongside non-zero entries, and testing the marker first would report empty.
+                // Gated on _wasWritten because only writes can hide from the root - a non-zero read implies
+                // a non-empty root, which the check below already reports.
+                // Writes made by the currently executing transaction still live in the journal and are not
+                // seen here; this reports block-level state, which is what EIP-7610 needs.
                 if (_wasWritten && BlockChange.HasNonZeroValue) return false;
 
                 // _backend.RootHash is not reflected until after commit, but this need to be reflected before commit


### PR DESCRIPTION
## Changes

Every `eth_call` carrying state overrides merkleized them before executing — `ApplyStateOverrides` +
`Commit(commitRoots: true)` + a state-root recompute, i.e. a trie path load and rehash for every
overridden account and slot — to produce a state root nothing on the call path reads. The call runs
against the scope's world state, not through the root.

The bridge's own overridable-env adapter now applies the override to that world state and commits
the journal with `commitRoots: false`, which makes it visible to block-level reads without touching
the trie. `IOverridableEnv.BuildAndOverride` is unchanged, so tracers (`debug_trace*`), receipt
regeneration and block re-processing keep the committed root exactly as before — **no public
interface changes**.

Because the header keeps its original state root, nonces on these paths are read from the executing
world state rather than through a root-resolved `IStateReader`. That includes
`FillAddressesToOptimize`, which resolved the sender nonce through `header.StateRoot` to compute the
CREATE address it filters out of a returned access list — with an unmerkleized override that would
have been the wrong address.

### EIP-7610

The one consumer of the committed root on this path is the EIP-7610 CREATE/CREATE2 collision check
(`IWorldState.IsNonZeroAccount` → `IsStorageEmpty`), which previously consulted only the committed
storage root. `PersistentStorageProvider` now also reports non-empty when an uncommitted
block-level write leaves a slot at a non-zero value.

Two details worth reviewing closely:

- **The uncommitted check must precede the clear marker.** A full `state` override clears the
  account's storage before writing, and the marker survives until the trie flush, so testing it
  first would report the account empty and silently bypass EIP-7610. The added test pins this.
- **It is gated on the per-contract write flag**, so the block-processing path costs one bool test
  rather than a walk of the change set. This is exactly equivalent: only writes can hide from the
  committed root, and a non-zero *read* implies a non-empty root, which the existing root check
  already reports.

Scope note: the decorators that override `IsStorageEmpty` (`BlockAccessListBasedWorldState`,
`TracedAccessWorldState`) are constructed only by `BlockAccessListManager.TxProcessorPool` on the
block-processing path and never wrap an `eth_call` override scope; `WitnessGeneratingWorldState`
delegates to its base. Block processing also cannot reach the check with a large change set:
`IsNonZeroAccount` only consults `IsStorageEmpty` for an account with no code and a zero nonce.

Because the adapter cannot tell which bridge method called it, `eth_estimateGas` and
`eth_createAccessList` also stop merkleizing their overrides. That is intended — both execute
purely against the scope's world state (`GasEstimator` takes the world state, and the estimator's
binary search restores with `resetBlockChanges: false`, which preserves the block-level layer the
override lives in) — but it is broader than the benchmark below, which measures `eth_call` only.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New `StorageProviderTests.IsStorageEmpty_sees_uncommitted_storage_change` covers the four
combinations of {clear first, write reverted to zero} against both storage backends. It
discriminates: **4 of its 8 cases fail without the `PersistentStorageProvider` change** and all 8
pass with it (verified by reverting that file and re-running).

Existing suites, all green on this branch: `Nethermind.JsonRpc.Test` 1972, `Nethermind.Evm.Test`
5029, `Nethermind.State.Test` 1193, `Nethermind.Facade.Test` 126 — including the 34 EIP-7610 and
state-override cases across `eth_call`, `trace_call` and `eth_simulate`.

Ethereum Foundation consensus suites on this commit: `Ethereum.Blockchain.Pyspec.Test` **3670/3670**
and `Ethereum.Blockchain.Block.Test` **1143/1143**, zero failures — these cover the EIP-7610 change
on the block-processing side, which is the path the `IsStorageEmpty` gate touches.

## Benchmarks

Private 497-record `eth_call` corpus (override-heavy: the great majority of records carry a
`stateDiff`), 100 rps, 120 s warm-up + 120 s measured, flat layout @25490000. Baseline image built
from this branch's parent commit. Every arm was measured in **four** order-balanced sweeps per
architecture, so sweep-position effects cancel and the spread is visible:

| | avg delta | std dev | negative in |
|---|---|---|---|
| x86-64 (EPYC 4344P) | **−2.28%** | 0.65 | 4/4 runs |
| arm64 (Axion, Neoverse-V2) | **−1.39%** | 1.51 | 3/4 runs |

Response parity against the baseline image: **497/497 matched on both architectures, in both sweep
orders.**

A block-processing A/B (EXPB, fusaka payloads, 3 runs per arm) against the same baseline image is
running to confirm the `IsStorageEmpty` gate costs nothing on the CREATE path; results will be
posted as a comment.
