### PR TITLE
ci(arm): stop RPC benchmarks from filling the runner's root disk

### DIFF
--- a/.github/workflows/arm-runner-maintenance.yml
+++ b/.github/workflows/arm-runner-maintenance.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches: [feature/jsonbench-extra-eth-calls]
     paths: [.github/workflows/arm-runner-maintenance.yml]
+  # No `schedule:` here on purpose — cron only fires for workflows on the default branch, so it would be
+  # dead config until this file reaches master. Until then the benchmark job reclaims per run, and the
+  # tagged-image backlog is cleared by dispatching this with prune_unused_images=true.
   workflow_dispatch:
     inputs:
       prune_unused_images:

--- a/.github/workflows/run-rpc-benchmarks.yml
+++ b/.github/workflows/run-rpc-benchmarks.yml
@@ -435,6 +435,18 @@ jobs:
             image_ref="nethermind-rpcbench:${clean_branch}"
           fi
 
+          # Building Nethermind on this box fills its ~19G root disk, which kills the runner daemon and
+          # takes the runner offline until someone restarts it over SSH (2026-08-18, 2026-08-19 twice).
+          # Fail in seconds instead: images belong on Docker Hub, built by publish-docker.
+          if [[ "${image_mode}" == "build" ]]; then
+            echo "The reproducible-benchmarks-arm runner does not support building images (branch '${branch}' has no prebuilt image)."
+            echo "Build one first, then pass it explicitly:"
+            echo "  gh workflow run publish-docker.yml --ref ${branch} -f image-name=nethermind -f tag=<tag> -f dockerfile=Dockerfile -f build-config=release"
+            echo "  gh workflow run run-rpc-benchmarks.yml --ref ${branch} -f docker_image=nethermindeth/nethermind:<tag> ..."
+            echo "Note: tool_config 'clients' @image entries do NOT cover this — the top-level docker_image is prepared regardless."
+            exit 1
+          fi
+
           ref_image_ref=""
           if [[ "${comparison}" == "true" ]]; then
             ref_image_ref="$(nc '.reference_image')"
@@ -534,6 +546,34 @@ jobs:
 
       - name: Make scripts executable
         run: chmod +x scripts/rpc-bench/*.sh
+
+      - name: Reclaim root disk before pulling
+        shell: bash
+        # The box has a ~19G root disk. A pull that runs it out of space kills the docker daemon and the
+        # runner with it, so reclaim what is safely reclaimable first and refuse to start if still tight.
+        # Tagged benchmark images are never touched — pinned A/B images must survive between runs.
+        run: |
+          set -uo pipefail
+          MIN_FREE_GB=6
+          df -h / || true
+          avail_gb() { df -BG --output=avail / | tail -1 | tr -dc '0-9'; }
+          echo "Free before reclaim: $(avail_gb)G"
+          docker container prune -f || true
+          docker network prune -f || true
+          docker builder prune -af || true
+          docker image prune -f || true
+          docker volume ls -q | grep -E '^expb-' | xargs -r docker volume rm -f || true
+          find /root/actions-runner/_diag -type f -name '*.log' -mtime +1 -delete 2>/dev/null || true
+          rm -rf /root/actions-runner/_work/_temp/* 2>/dev/null || true
+          free="$(avail_gb)"
+          echo "Free after reclaim: ${free}G (need ${MIN_FREE_GB}G)"
+          docker system df || true
+          if (( free < MIN_FREE_GB )); then
+            echo "::error::Only ${free}G free on / — refusing to start rather than risk killing the runner daemon."
+            echo "Dispatch 'ARM Runner Maintenance' with prune_unused_images=true to drop stale tagged images."
+            docker images --format '{{.Size}}\t{{.Repository}}:{{.Tag}}' | sort -rh | head -20 || true
+            exit 1
+          fi
 
       - name: Prepare Docker image
         env:
@@ -977,6 +1017,22 @@ jobs:
         # Belt-and-suspenders: reaps stale containers, unmounts and wipes scratch subtrees — same canonical-path guards as
         # start-node.sh, so it can never reach the snapshot. Never fails the job.
         run: ./scripts/rpc-bench/cleanup.sh || true
+
+      - name: Reclaim root disk after the run
+        if: always()
+        shell: bash
+        # Leave / no fuller than we found it, so disk pressure cannot accumulate run over run into the
+        # daemon death this workflow used to cause. Tagged images survive; only garbage is dropped.
+        run: |
+          set -uo pipefail
+          docker container prune -f || true
+          docker network prune -f || true
+          docker builder prune -af || true
+          docker image prune -f || true
+          docker volume ls -q | grep -E '^expb-' | xargs -r docker volume rm -f || true
+          rm -rf /root/actions-runner/_work/_temp/* 2>/dev/null || true
+          df -h / || true
+          docker system df || true
 
       - name: Enforce quality gates
         if: always() && needs.resolve.outputs.benchmark_tool != 'jsonbench-sweep'


### PR DESCRIPTION
## Changes

The ARM benchmark box has a **~19 GB root disk**, and filling it kills the docker daemon and the runner process with it — the runner goes `offline` until someone restarts it over SSH. That has happened three times: **2026-08-18**, and **twice on 2026-08-19** (06:21 and 16:29).

Every occurrence had the same cause: a dispatch that left `docker_image` empty, so `resolve` falls through to `image_mode=build` and a full Nethermind image gets built on a 4-core box with no room for it. Evidence from the most recent outage, run [32276171876](https://github.com/NethermindEth/nethermind/actions/runs/32276171876):

```
Resolved: tool=jsonbench-sweep client=nethermind reference=none
          branch=feature/jsonbench-extra-eth-calls layout=flat
          image_mode=build image=nethermind-rpcbench:feature-jsonbench-extra-eth-calls
```

The `benchmark` job fails with **`Prepare Docker image` conclusion `null`**, every later step `null`, and **zero log lines** for that step. That reads like an infrastructure blip rather than the input mistake it is, which is why it keeps recurring. Same fingerprint on `32222868238`, `32222880060`, `32276187285`.

- **`resolve` now refuses `image_mode=build`** and prints how to build via `publish-docker` and pass `docker_image`. `resolve` runs on `ubuntu-latest`, so this fails in seconds **without ever touching the ARM box**. It also spells out that `tool_config` `clients` `@image` entries do *not* cover this — the top-level image is prepared regardless, which is the specific trap behind all three outages.
- **Pre-pull reclaim + floor.** Before pulling, reclaim what is safely reclaimable and refuse to start below 6 GB free, printing the 20 largest images. Better than discovering the shortfall by killing the daemon mid-pull.
- **Post-run reclaim**, so pressure cannot accumulate run over run.

Both reclaim steps deliberately **leave tagged images alone** — pinned A/B images must survive between runs, per the existing note in `arm-runner-maintenance.yml`. That backlog is the one consumer that grows monotonically across campaigns, so clearing it stays a deliberate act via **ARM Runner Maintenance** with `prune_unused_images=true`.

I also documented in `arm-runner-maintenance.yml` why it carries no `schedule:` — cron only fires for workflows on the **default branch**, so a cron there would be dead config until that file reaches master.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Workflow-only. The `image_mode=build` guard is exercised by any dispatch that omits `docker_image` — it should now fail in the `resolve` job on `ubuntu-latest` in seconds instead of reaching the runner. I did **not** dispatch a live test, because the ARM runner is currently offline from this exact failure and a test run would queue behind the six still-queued build-mode runs.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Targets `feature/jsonbench-extra-eth-calls` because that is where the ARM-retargeted workflow and the maintenance workflow live; neither is on master. Raised as a PR rather than pushed to that branch directly since it is an active campaign branch.

**Two things this PR does not fix, both needing a human:**

1. **The runner is offline now** and this cannot repair it — the maintenance workflow is `runs-on: [self-hosted, reproducible-benchmarks-arm]`, i.e. it runs on the very runner that is down, so it queues forever. Recovery is still a manual SSH restart.
2. **Six build-mode runs are still queued** (`32276201397`, `32276215683`, `32276657553`, `32276692277`, `32276730322`, `32276768618`). A workflow-file change does not retroactively apply to already-queued runs, so **these should be cancelled before the runner is restarted** or they will re-fill the disk and take it down again immediately. I have not cancelled them — they are someone else's runs.

Suggested order: cancel those six → SSH restart → dispatch ARM Runner Maintenance with `prune_unused_images=true` → merge this → resume benchmarks with explicit `docker_image`.

Context: this blocks the `LocalStacksPooled` capacity A/B for #12905, whose images are already built and waiting.
