### PR TITLE
ci: wait for the publish-docker run we dispatched, not any concurrent one

### DIFF
--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -473,6 +473,14 @@ jobs:
           NAME_FILTER: Publish Docker image
           REF: ${{ needs.resolve.outputs.branch }}
         run: |
+          # An empty runId would silently fall back to run discovery - the exact false green this
+          # guards against. benc-uk/workflow-dispatch returns without setting outputs (and without
+          # failing) when the target workflow is disabled, and @v1 is a moving tag that could drop the
+          # output, so make the bypass impossible rather than unlikely.
+          if [ -z "${RUN_ID}" ]; then
+            echo "::error::The dispatch step produced no runId; refusing to fall back to run discovery."
+            exit 1
+          fi
           chmod +x scripts/wait-for-workflow.sh
           ./scripts/wait-for-workflow.sh
 

--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -443,6 +443,7 @@ jobs:
 
       - name: Trigger publish-docker.yml
         if: needs.resolve.outputs.should_trigger_publish_docker == 'true'
+        id: trigger-publish-docker
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: publish-docker.yml
@@ -465,6 +466,10 @@ jobs:
           TIMEOUT: "120"
           ORG_NAME: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
+          # Wait on the run we actually dispatched. Without this the script falls back to discovering a
+          # run by workflow name + branch, which silently latches onto any other concurrent build of the
+          # same branch and reports success for an image that was never produced.
+          RUN_ID: ${{ steps.trigger-publish-docker.outputs.runId }}
           NAME_FILTER: Publish Docker image
           REF: ${{ needs.resolve.outputs.branch }}
         run: |

--- a/scripts/wait-for-workflow.sh
+++ b/scripts/wait-for-workflow.sh
@@ -7,9 +7,6 @@ interval="${INTERVAL}"
 name_filter="${NAME_FILTER}"
 counter=0
 
-# Get the current time in ISO 8601 format
-current_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
 # Check if REF has the prefix "refs/heads/" and append it if not
 if [[ ! "$REF" =~ ^refs/heads/ ]]; then
   REF="refs/heads/$REF"
@@ -43,9 +40,13 @@ else
       echo "❌ Invalid input provided (organization, repository, or workflow ID). Please check your inputs."
       exit 1
     fi
+    # Match queued runs too, not just in_progress: a run dispatched moments ago is usually still
+    # queued, and skipping it makes this pick up an OLDER concurrent run of the same workflow and
+    # branch instead — reporting success for a build that was never requested. Highest id = newest.
+    # Callers that know their run id should pass RUN_ID and skip this discovery entirely.
     run_id=$(echo "$response" | \
-      jq -r --arg ref "$(echo "$REF" | sed 's/refs\/heads\///')" --arg current_time "$current_time" --arg expected_name "$name_filter" \
-      '.workflow_runs[] | select(.head_branch == $ref and .status == "in_progress" and (if $expected_name == "" then true else .name | test($expected_name) end)) | .id' | sort -r | head -n 1)
+      jq -r --arg ref "$(echo "$REF" | sed 's/refs\/heads\///')" --arg expected_name "$name_filter" \
+      '.workflow_runs[] | select(.head_branch == $ref and (.status == "queued" or .status == "in_progress") and (if $expected_name == "" then true else .name | test($expected_name) end)) | .id' | sort -rn | head -n 1)
     if [ -n "$run_id" ]; then
       echo "🎉 Workflow triggered! Run ID: $run_id"
       break

--- a/scripts/wait-for-workflow.sh
+++ b/scripts/wait-for-workflow.sh
@@ -7,6 +7,13 @@ interval="${INTERVAL}"
 name_filter="${NAME_FILTER}"
 counter=0
 
+# Lower bound for run discovery: a run older than this cannot be the one the caller just dispatched.
+# One minute of slack covers clock skew against GitHub and the gap between the dispatch step and this
+# one; every caller waits immediately after dispatching. created_at is ISO 8601, so string comparison
+# orders correctly.
+discover_since=$(date -u -d '-1 minute' +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+  || date -u -v-1M +"%Y-%m-%dT%H:%M:%SZ")
+
 # Check if REF has the prefix "refs/heads/" and append it if not
 if [[ ! "$REF" =~ ^refs/heads/ ]]; then
   REF="refs/heads/$REF"
@@ -40,13 +47,20 @@ else
       echo "❌ Invalid input provided (organization, repository, or workflow ID). Please check your inputs."
       exit 1
     fi
-    # Match queued runs too, not just in_progress: a run dispatched moments ago is usually still
-    # queued, and skipping it makes this pick up an OLDER concurrent run of the same workflow and
-    # branch instead — reporting success for a build that was never requested. Highest id = newest.
+    # Two things kept this from finding the run the caller had just dispatched, and made it select an
+    # OLDER concurrent run of the same workflow and branch instead — reporting success for a build that
+    # was never requested:
+    #   1. only `in_progress` matched, but a fresh run is still requested/pending/queued (and `waiting`
+    #      when the target workflow hits an environment protection rule), so `!= "completed"` is used
+    #      rather than enumerating the non-terminal set;
+    #   2. a run is not listed the instant it is dispatched, so on the first poll the newest entry can
+    #      still be somebody else's older run.
+    # Matching every non-terminal status fixes (1). The created_at floor fixes (2): an older run cannot
+    # match at all, so the loop keeps polling until the intended one appears instead of latching on.
     # Callers that know their run id should pass RUN_ID and skip this discovery entirely.
     run_id=$(echo "$response" | \
-      jq -r --arg ref "$(echo "$REF" | sed 's/refs\/heads\///')" --arg expected_name "$name_filter" \
-      '.workflow_runs[] | select(.head_branch == $ref and (.status == "queued" or .status == "in_progress") and (if $expected_name == "" then true else .name | test($expected_name) end)) | .id' | sort -rn | head -n 1)
+      jq -r --arg ref "$(echo "$REF" | sed 's/refs\/heads\///')" --arg expected_name "$name_filter" --arg since "$discover_since" \
+      '.workflow_runs[] | select(.head_branch == $ref and .status != "completed" and .created_at >= $since and (if $expected_name == "" then true else .name | test($expected_name) end)) | .id' | sort -rn | head -n 1)
     if [ -n "$run_id" ]; then
       echo "🎉 Workflow triggered! Run ID: $run_id"
       break


### PR DESCRIPTION
## Changes

`run-expb-reproducible-benchmarks.yml` dispatches `publish-docker.yml` and then waits for it with `scripts/wait-for-workflow.sh`, but never tells the script *which* run to watch — so the script falls back to discovering one by workflow name + branch. That discovery matched only `status == "in_progress"`, and a run dispatched seconds earlier is normally still **`queued`**. So it skipped the run just requested and latched onto an older concurrent build of the same branch, then reported success.

Caught on run [32278785651](https://github.com/NethermindEth/nethermind/actions/runs/32278785651), where `prepare-docker` logged:

```
🌐 Run URL: https://github.com/NethermindEth/nethermind/actions/runs/32278810049   ← dispatched
🎉 Workflow triggered! Run ID: 32278480843                                        ← waited on
✅ The workflow completed successfully! Exiting.
```

`32278480843` was an unrelated manual build of the same branch that pushed a different tag (`poolcap2-a4d64ef`). The job went green while the image it asked for was never pushed, and both benchmark legs then died pulling a tag that does not exist:

```
level=error event="Failed to execute scenario"
error="404 Client Error ... manifest for nethermindeth/nethermind:perf-evm-pool-contention
       not found: manifest unknown"
```

Zero blocks ran in either leg. The failure surfaces as `Analyze benchmark output` / `Enforce run quality gates`, because `Run expb scenarios` is `continue-on-error` — so the real cause is three steps upstream of where the job goes red, which makes this expensive to diagnose.

- **The expb caller now passes `RUN_ID`** from the dispatch action's `runId` output, so it waits on exactly the run it triggered and cannot race at all.
- **The discovery fallback now accepts `queued` as well as `in_progress`**, and sorts numerically, so the other five callers that don't pass a run id stop preferring an older run over the one they just triggered.
- Drops `current_time`, which was computed and threaded into the `jq` call as an argument the filter never referenced.

Callers that keep using discovery and therefore benefit from the second fix: `.github/actions/setup-runner`, `hive-consensus-tests.yml`, `run-a-geth-node.yml`, `run-a-single-node-from-branch.yml`.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

CI shell script; there is no test harness for `scripts/`. Verified locally instead:

- `bash -n scripts/wait-for-workflow.sh` — clean.
- The jq selector, fed a queued run id 2 alongside an in-progress id 1, now returns **2**. The previous selector returned **1** — i.e. the regression this PR fixes, reproduced and then shown fixed:

```bash
echo '{"workflow_runs":[
  {"head_branch":"b","status":"queued","name":"Publish Docker image","id":2},
  {"head_branch":"b","status":"in_progress","name":"Publish Docker image","id":1}]}' \
| jq -r --arg ref b --arg expected_name "Publish Docker image" \
  '.workflow_runs[] | select(.head_branch == $ref
     and (.status == "queued" or .status == "in_progress")
     and (if $expected_name == "" then true else .name | test($expected_name) end)) | .id' \
| sort -rn | head -n 1
# => 2
```

The `RUN_ID` path is the pre-existing branch at the top of the script (`if [ -n "${RUN_ID}" ]`), already exercised by other callers, so passing it is the low-risk half of the change.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Full disclosure on how this surfaced: the build that would have produced `perf-evm-pool-contention` (run `32278810049`) was cancelled — by me, while clearing what I misread as a duplicate of my own manual build on the same branch. That cancellation is what made the missing tag visible. But the false green is independent of it: `prepare-docker` was already waiting on the wrong run before anything was cancelled, so any overlapping manual build on the same branch produces the same silent mis-attribution. `publish-docker.yml` has no `concurrency:` block, so overlap is easy to hit.

Found while benchmarking #12905.
