### PR TITLE
fix: reconcile keyed-nonce signatures with master so the merge tree builds

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Core/Keccak256Benchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Core/Keccak256Benchmarks.cs
@@ -4,7 +4,6 @@
 using System;
 using BenchmarkDotNet.Attributes;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Test.Builders;
 //using Nethermind.HashLib;
 
 namespace Nethermind.Benchmarks.Core
@@ -15,19 +14,11 @@ namespace Nethermind.Benchmarks.Core
 
         private byte[] _a;
 
-        private byte[][] _scenarios =
-        {
-            Array.Empty<byte>(),
-            new byte[]{1},
-            new byte[100000],
-            TestItem.AddressA.Bytes.ToArray()
-        };
-
-        [Params(1)]
-        public int ScenarioIndex { get; set; }
+        [Params(20, 32, 64)]
+        public int Length { get; set; }
 
         [GlobalSetup]
-        public void Setup() => _a = _scenarios[ScenarioIndex];
+        public void Setup() => _a = new byte[Length];
 
         [Benchmark]
         public void MeadowHashSpan() => MeadowHashBenchmarks.ComputeHash(_a);

--- a/src/Nethermind/Nethermind.Benchmark/Evm/KeyedNonceStorageSlotBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Evm/KeyedNonceStorageSlotBenchmarks.cs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+
+namespace Nethermind.Benchmarks.Evm;
+
+public class KeyedNonceStorageSlotBenchmarks
+{
+    private readonly UInt256[] _keys = new UInt256[Eip8250Constants.MaxNonceKeys];
+    private readonly UInt256[] _indices = new UInt256[Eip8250Constants.MaxNonceKeys];
+
+    [Params(8, Eip8250Constants.MaxNonceKeys)]
+    public int Count { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        for (int i = 0; i < _keys.Length; i++)
+        {
+            _keys[i] = (UInt256)(i + 1);
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public UInt256 Individual()
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            _indices[i] = KeyedNonceManager.StorageSlot(Address.SystemUser, _keys[i]).Index;
+        }
+
+        return _indices[Count - 1];
+    }
+
+    [Benchmark]
+    public UInt256 Batched()
+    {
+        KeyedNonceManager.StorageIndices(Address.SystemUser, _keys.AsSpan(0, Count), _indices);
+        return _indices[Count - 1];
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.Intrinsics.X86;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Serialization.Rlp;
@@ -166,6 +167,115 @@ namespace Nethermind.Core.Test
                 Assert.That(Keccak.Compute(byteArray.AsSpan()), Is.EqualTo(expected));
                 Assert.That(Keccak.Compute(byteArray), Is.EqualTo(expected));
             }
+        }
+
+        [Test]
+        public void Avx512VL_permutation_matches_scalar()
+        {
+            if (!Avx512F.VL.IsSupported)
+            {
+                Assert.Ignore("AVX-512VL intrinsics are not supported on this machine.");
+            }
+
+            const int stateLength = 25;
+            ulong[] expected = new ulong[stateLength];
+            ulong[] actual = new ulong[stateLength];
+
+            for (int testCase = 0; testCase < 64; testCase++)
+            {
+                for (int lane = 0; lane < stateLength; lane++)
+                {
+                    actual[lane] = testCase switch
+                    {
+                        0 => 0,
+                        1 => ulong.MaxValue,
+                        _ => unchecked((ulong)(testCase * stateLength + lane + 1) * 0x9e3779b97f4a7c15UL)
+                    };
+                }
+
+                actual.CopyTo(expected, 0);
+
+                KeccakHash.KeccakF1600Scalar(ref expected[0]);
+                KeccakHash.KeccakF1600Avx512VL(ref actual[0]);
+
+                Assert.That(actual, Is.EqualTo(expected), $"Permutation mismatch for test case {testCase}.");
+            }
+        }
+
+        [Test]
+        public void Avx512_eight_way_64_byte_hash_matches_individual_hashes()
+        {
+            if (!Avx512F.IsSupported)
+            {
+                Assert.Ignore("AVX-512F intrinsics are not supported on this machine.");
+            }
+
+            const int inputLength = 64;
+            const int hashLength = 32;
+            const int batchSize = 8;
+            byte[] input = new byte[inputLength * batchSize];
+            byte[] output = new byte[hashLength * batchSize];
+
+            Random random = new(42);
+            for (int iteration = 0; iteration < 16; iteration++)
+            {
+                random.NextBytes(input);
+                KeccakHash.ComputeHash64Bytes8Avx512(ref input[0], ref output[0]);
+
+                for (int i = 0; i < batchSize; i++)
+                {
+                    ValueHash256 expected = ValueKeccak.Compute(input.AsSpan(i * inputLength, inputLength));
+                    Assert.That(output.AsSpan(i * hashLength, hashLength).SequenceEqual(expected.Bytes), Is.True,
+                        $"Hash mismatch at iteration {iteration}, batch index {i}.");
+                }
+            }
+        }
+
+        [Test]
+        public void Avx512vl_two_way_532_byte_hash_matches_individual_hashes()
+        {
+            if (!Avx512F.VL.IsSupported)
+            {
+                Assert.Ignore("AVX-512VL intrinsics are not supported on this machine.");
+            }
+
+            byte[] input0 = new byte[532];
+            byte[] input1 = new byte[532];
+            byte[][] inputs = [input0, input1];
+            byte[] output = new byte[2 * Hash256.Size];
+            Random random = new(42);
+
+            for (int iteration = 0; iteration < 16; iteration++)
+            {
+                random.NextBytes(input0);
+                random.NextBytes(input1);
+                KeccakHash.ComputeHash532Bytes2Avx512VL(ref input0[0], ref input1[0], ref output[0]);
+
+                for (int i = 0; i < inputs.Length; i++)
+                {
+                    ValueHash256 expected = ValueKeccak.Compute(inputs[i]);
+                    Assert.That(output.AsSpan(i * Hash256.Size, Hash256.Size).SequenceEqual(expected.Bytes), Is.True,
+                        $"Hash mismatch at iteration {iteration}, batch index {i}.");
+                }
+            }
+        }
+
+        // Expected hashes were generated with PyCryptodome's independent Keccak-256 implementation.
+        [TestCase(20, "50c02dbeee2be79b9595060fe30efbd78f06acedf7a1fe8cb05df7ddd76f2b1b")]
+        [TestCase(32, "d064c972ea7cbd9f1237bbd922fd5f08ca57895c13bc9ea2b91913f7099809a1")]
+        [TestCase(64, "52c1f4616862f9d5011ed6a2a77d89a2102e51ee7db2db045bb5fb267fba98d1")]
+        public void Common_input_lengths_match_known_hash(int inputLength, string expected)
+        {
+            byte[] input = new byte[inputLength];
+            byte[] output = new byte[32];
+            for (int i = 0; i < input.Length; i++)
+            {
+                input[i] = (byte)(i * 37 + 11);
+            }
+
+            KeccakHash.ComputeHash(input, output);
+
+            Assert.That(output.ToHexString(), Is.EqualTo(expected));
         }
 
         [TestCase("0x", "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")]

--- a/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/Keccak.cs
@@ -49,6 +49,7 @@ namespace Nethermind.Core.Crypto
         }
 
         [DebuggerStepThrough]
+        [SkipLocalsInit]
         public static ValueHash256 Compute(ReadOnlySpan<byte> input)
         {
             if (input.Length == 0)
@@ -61,6 +62,7 @@ namespace Nethermind.Core.Crypto
             return keccak;
         }
 
+        [SkipLocalsInit]
         internal static ValueHash256 InternalCompute(byte[] input)
         {
             Unsafe.SkipInit(out ValueHash256 keccak);

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.avx512vl.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.avx512vl.cs
@@ -1,0 +1,453 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace Nethermind.Core.Crypto;
+
+public sealed partial class KeccakHash
+{
+    // A struct local preserves tiering and dynamic PGO. Stackalloc would pin the hashing method at
+    // Tier0 FullOpts and add per-call GS-cookie and stack-probe checks.
+    [InlineArray(STATE_LANES)]
+    private struct KeccakStateX2
+    {
+        private Vector128<ulong> _lane0;
+    }
+
+    // vpternlog immediates: bit n of the immediate is the output for input bits (a, b, c) = binary n.
+    private const byte Xor3 = 0x96; // a ^ b ^ c
+    private const byte Chi = 0xD2; // a ^ (~b & c)
+
+    /// <summary>AVX-512VL Keccak-f[1600] permutation.</summary>
+    /// <param name="state">Lane 0 of a 25-lane state; all 25 lanes are read and written.</param>
+    [SkipLocalsInit]
+    internal static void KeccakF1600Avx512VL(ref ulong state)
+    {
+        Debug.Assert(Avx512F.VL.IsSupported);
+
+        Vector128<ulong> a0 = Vector128.CreateScalarUnsafe(state);
+        Vector128<ulong> a1 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 1));
+        Vector128<ulong> a2 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 2));
+        Vector128<ulong> a3 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 3));
+        Vector128<ulong> a4 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 4));
+        Vector128<ulong> a5 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 5));
+        Vector128<ulong> a6 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 6));
+        Vector128<ulong> a7 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 7));
+        Vector128<ulong> a8 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 8));
+        Vector128<ulong> a9 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 9));
+        Vector128<ulong> a10 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 10));
+        Vector128<ulong> a11 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 11));
+        Vector128<ulong> a12 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 12));
+        Vector128<ulong> a13 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 13));
+        Vector128<ulong> a14 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 14));
+        Vector128<ulong> a15 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 15));
+        Vector128<ulong> a16 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 16));
+        Vector128<ulong> a17 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 17));
+        Vector128<ulong> a18 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 18));
+        Vector128<ulong> a19 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 19));
+        Vector128<ulong> a20 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 20));
+        Vector128<ulong> a21 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 21));
+        Vector128<ulong> a22 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 22));
+        Vector128<ulong> a23 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 23));
+        Vector128<ulong> a24 = Vector128.CreateScalarUnsafe(Unsafe.Add(ref state, 24));
+
+        ref ulong roundConstants = ref MemoryMarshal.GetArrayDataReference(RoundConstants);
+        for (int round = 0; round < ROUNDS; round++)
+        {
+            RoundX1(
+                ref a0, ref a1, ref a2, ref a3, ref a4,
+                ref a5, ref a6, ref a7, ref a8, ref a9,
+                ref a10, ref a11, ref a12, ref a13, ref a14,
+                ref a15, ref a16, ref a17, ref a18, ref a19,
+                ref a20, ref a21, ref a22, ref a23, ref a24,
+                Vector128.CreateScalarUnsafe(Unsafe.Add(ref roundConstants, round)));
+        }
+
+        state = a0.GetElement(0);
+        Unsafe.Add(ref state, 1) = a1.GetElement(0);
+        Unsafe.Add(ref state, 2) = a2.GetElement(0);
+        Unsafe.Add(ref state, 3) = a3.GetElement(0);
+        Unsafe.Add(ref state, 4) = a4.GetElement(0);
+        Unsafe.Add(ref state, 5) = a5.GetElement(0);
+        Unsafe.Add(ref state, 6) = a6.GetElement(0);
+        Unsafe.Add(ref state, 7) = a7.GetElement(0);
+        Unsafe.Add(ref state, 8) = a8.GetElement(0);
+        Unsafe.Add(ref state, 9) = a9.GetElement(0);
+        Unsafe.Add(ref state, 10) = a10.GetElement(0);
+        Unsafe.Add(ref state, 11) = a11.GetElement(0);
+        Unsafe.Add(ref state, 12) = a12.GetElement(0);
+        Unsafe.Add(ref state, 13) = a13.GetElement(0);
+        Unsafe.Add(ref state, 14) = a14.GetElement(0);
+        Unsafe.Add(ref state, 15) = a15.GetElement(0);
+        Unsafe.Add(ref state, 16) = a16.GetElement(0);
+        Unsafe.Add(ref state, 17) = a17.GetElement(0);
+        Unsafe.Add(ref state, 18) = a18.GetElement(0);
+        Unsafe.Add(ref state, 19) = a19.GetElement(0);
+        Unsafe.Add(ref state, 20) = a20.GetElement(0);
+        Unsafe.Add(ref state, 21) = a21.GetElement(0);
+        Unsafe.Add(ref state, 22) = a22.GetElement(0);
+        Unsafe.Add(ref state, 23) = a23.GetElement(0);
+        Unsafe.Add(ref state, 24) = a24.GetElement(0);
+    }
+
+    /// <summary>Computes Keccak-256 for a supported one-block input with one Keccak lane per AVX-512VL vector.</summary>
+    [SkipLocalsInit]
+    private static void ComputeHash256Avx512VL(ref byte input, int inputLength, ref byte output)
+    {
+        Debug.Assert(Avx512F.VL.IsSupported);
+        Debug.Assert(inputLength is Address.Size or 32 or 64);
+
+        Vector128<ulong> a0 = LoadScalar128(ref input, 0);
+        Vector128<ulong> a1 = LoadScalar128(ref input, 8);
+        Vector128<ulong> a2 = Vector128<ulong>.Zero;
+        Vector128<ulong> a3 = Vector128<ulong>.Zero;
+        Vector128<ulong> a4 = Vector128<ulong>.Zero;
+        Vector128<ulong> a5 = Vector128<ulong>.Zero;
+        Vector128<ulong> a6 = Vector128<ulong>.Zero;
+        Vector128<ulong> a7 = Vector128<ulong>.Zero;
+        Vector128<ulong> a8 = Vector128<ulong>.Zero;
+        Vector128<ulong> a9 = Vector128<ulong>.Zero;
+        Vector128<ulong> a10 = Vector128<ulong>.Zero;
+        Vector128<ulong> a11 = Vector128<ulong>.Zero;
+        Vector128<ulong> a12 = Vector128<ulong>.Zero;
+        Vector128<ulong> a13 = Vector128<ulong>.Zero;
+        Vector128<ulong> a14 = Vector128<ulong>.Zero;
+        Vector128<ulong> a15 = Vector128<ulong>.Zero;
+        // Multi-rate padding (FIPS 202 sec. 5.1): 0x80 at byte 135, the last byte of the
+        // 136-byte rate, is the top bit of lane 16; 0x01 goes right after the message below.
+        Vector128<ulong> a16 = Vector128.CreateScalarUnsafe(0x8000000000000000UL);
+        Vector128<ulong> a17 = Vector128<ulong>.Zero;
+        Vector128<ulong> a18 = Vector128<ulong>.Zero;
+        Vector128<ulong> a19 = Vector128<ulong>.Zero;
+        Vector128<ulong> a20 = Vector128<ulong>.Zero;
+        Vector128<ulong> a21 = Vector128<ulong>.Zero;
+        Vector128<ulong> a22 = Vector128<ulong>.Zero;
+        Vector128<ulong> a23 = Vector128<ulong>.Zero;
+        Vector128<ulong> a24 = Vector128<ulong>.Zero;
+
+        switch (inputLength)
+        {
+            case Address.Size:
+                // Lane 2 holds the final 4 address bytes with the 0x01 pad in the byte above them (input offset 20).
+                a2 = Vector128.CreateScalarUnsafe(
+                    Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref input, 16)) | (1UL << 32));
+                break;
+            case 32:
+                a2 = LoadScalar128(ref input, 16);
+                a3 = LoadScalar128(ref input, 24);
+                a4 = Vector128.CreateScalarUnsafe(1UL); // 0x01 pad at input offset 32
+                break;
+            case 64:
+                a2 = LoadScalar128(ref input, 16);
+                a3 = LoadScalar128(ref input, 24);
+                a4 = LoadScalar128(ref input, 32);
+                a5 = LoadScalar128(ref input, 40);
+                a6 = LoadScalar128(ref input, 48);
+                a7 = LoadScalar128(ref input, 56);
+                a8 = Vector128.CreateScalarUnsafe(1UL); // 0x01 pad at input offset 64
+                break;
+        }
+
+        ref ulong roundConstants = ref MemoryMarshal.GetArrayDataReference(RoundConstants);
+        for (int round = 0; round < ROUNDS; round++)
+        {
+            RoundX1(
+                ref a0, ref a1, ref a2, ref a3, ref a4,
+                ref a5, ref a6, ref a7, ref a8, ref a9,
+                ref a10, ref a11, ref a12, ref a13, ref a14,
+                ref a15, ref a16, ref a17, ref a18, ref a19,
+                ref a20, ref a21, ref a22, ref a23, ref a24,
+                Vector128.CreateScalarUnsafe(Unsafe.Add(ref roundConstants, round)));
+        }
+
+        Unsafe.WriteUnaligned(ref output, a0.GetElement(0));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref output, 8), a1.GetElement(0));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref output, 16), a2.GetElement(0));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref output, 24), a3.GetElement(0));
+    }
+
+    /// <summary>Hashes two 532-byte inputs into two consecutive 32-byte outputs.</summary>
+    /// <remarks>The caller must ensure that AVX-512VL is supported and both inputs have the required fixed size.</remarks>
+    [SkipLocalsInit]
+    internal static void ComputeHash532Bytes2Avx512VL(ref byte input0, ref byte input1, ref byte output)
+    {
+        Debug.Assert(Avx512F.VL.IsSupported);
+
+        KeccakStateX2 stateBuffer = default;
+        ref Vector128<ulong> state = ref stateBuffer[0];
+        for (int blockOffset = 0; blockOffset < 3 * HASH_DATA_AREA; blockOffset += HASH_DATA_AREA)
+        {
+            for (int lane = 0; lane < HASH_DATA_AREA / sizeof(ulong); lane++)
+            {
+                int offset = blockOffset + lane * sizeof(ulong);
+                Unsafe.Add(ref state, lane) ^= LoadPair(ref input0, ref input1, offset);
+            }
+
+            KeccakF1600x2Avx512VL(ref state);
+        }
+
+        const int finalBlockOffset = 3 * HASH_DATA_AREA;
+        for (int lane = 0; lane < 15; lane++)
+        {
+            int offset = finalBlockOffset + lane * sizeof(ulong);
+            Unsafe.Add(ref state, lane) ^= LoadPair(ref input0, ref input1, offset);
+        }
+
+        Unsafe.Add(ref state, 15) ^= Vector128.Create(
+            Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref input0, finalBlockOffset + 120)) | (1UL << 32),
+            Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref input1, finalBlockOffset + 120)) | (1UL << 32));
+        Unsafe.Add(ref state, 16) ^= Vector128.Create(0x8000000000000000UL);
+        KeccakF1600x2Avx512VL(ref state);
+
+        StoreHashPair(ref output, 0, state, Unsafe.Add(ref state, 1), Unsafe.Add(ref state, 2), Unsafe.Add(ref state, 3));
+        StoreHashPair(ref output, 1, state, Unsafe.Add(ref state, 1), Unsafe.Add(ref state, 2), Unsafe.Add(ref state, 3));
+    }
+
+    [SkipLocalsInit]
+    private static void KeccakF1600x2Avx512VL(ref Vector128<ulong> state)
+    {
+        Vector128<ulong> a0 = state;
+        Vector128<ulong> a1 = Unsafe.Add(ref state, 1);
+        Vector128<ulong> a2 = Unsafe.Add(ref state, 2);
+        Vector128<ulong> a3 = Unsafe.Add(ref state, 3);
+        Vector128<ulong> a4 = Unsafe.Add(ref state, 4);
+        Vector128<ulong> a5 = Unsafe.Add(ref state, 5);
+        Vector128<ulong> a6 = Unsafe.Add(ref state, 6);
+        Vector128<ulong> a7 = Unsafe.Add(ref state, 7);
+        Vector128<ulong> a8 = Unsafe.Add(ref state, 8);
+        Vector128<ulong> a9 = Unsafe.Add(ref state, 9);
+        Vector128<ulong> a10 = Unsafe.Add(ref state, 10);
+        Vector128<ulong> a11 = Unsafe.Add(ref state, 11);
+        Vector128<ulong> a12 = Unsafe.Add(ref state, 12);
+        Vector128<ulong> a13 = Unsafe.Add(ref state, 13);
+        Vector128<ulong> a14 = Unsafe.Add(ref state, 14);
+        Vector128<ulong> a15 = Unsafe.Add(ref state, 15);
+        Vector128<ulong> a16 = Unsafe.Add(ref state, 16);
+        Vector128<ulong> a17 = Unsafe.Add(ref state, 17);
+        Vector128<ulong> a18 = Unsafe.Add(ref state, 18);
+        Vector128<ulong> a19 = Unsafe.Add(ref state, 19);
+        Vector128<ulong> a20 = Unsafe.Add(ref state, 20);
+        Vector128<ulong> a21 = Unsafe.Add(ref state, 21);
+        Vector128<ulong> a22 = Unsafe.Add(ref state, 22);
+        Vector128<ulong> a23 = Unsafe.Add(ref state, 23);
+        Vector128<ulong> a24 = Unsafe.Add(ref state, 24);
+
+        ref ulong roundConstants = ref MemoryMarshal.GetArrayDataReference(RoundConstants);
+        for (int round = 0; round < ROUNDS; round++)
+        {
+            RoundX1(
+                ref a0, ref a1, ref a2, ref a3, ref a4,
+                ref a5, ref a6, ref a7, ref a8, ref a9,
+                ref a10, ref a11, ref a12, ref a13, ref a14,
+                ref a15, ref a16, ref a17, ref a18, ref a19,
+                ref a20, ref a21, ref a22, ref a23, ref a24,
+                Vector128.Create(Unsafe.Add(ref roundConstants, round)));
+        }
+
+        state = a0;
+        Unsafe.Add(ref state, 1) = a1;
+        Unsafe.Add(ref state, 2) = a2;
+        Unsafe.Add(ref state, 3) = a3;
+        Unsafe.Add(ref state, 4) = a4;
+        Unsafe.Add(ref state, 5) = a5;
+        Unsafe.Add(ref state, 6) = a6;
+        Unsafe.Add(ref state, 7) = a7;
+        Unsafe.Add(ref state, 8) = a8;
+        Unsafe.Add(ref state, 9) = a9;
+        Unsafe.Add(ref state, 10) = a10;
+        Unsafe.Add(ref state, 11) = a11;
+        Unsafe.Add(ref state, 12) = a12;
+        Unsafe.Add(ref state, 13) = a13;
+        Unsafe.Add(ref state, 14) = a14;
+        Unsafe.Add(ref state, 15) = a15;
+        Unsafe.Add(ref state, 16) = a16;
+        Unsafe.Add(ref state, 17) = a17;
+        Unsafe.Add(ref state, 18) = a18;
+        Unsafe.Add(ref state, 19) = a19;
+        Unsafe.Add(ref state, 20) = a20;
+        Unsafe.Add(ref state, 21) = a21;
+        Unsafe.Add(ref state, 22) = a22;
+        Unsafe.Add(ref state, 23) = a23;
+        Unsafe.Add(ref state, 24) = a24;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<ulong> LoadPair(ref byte input0, ref byte input1, int offset) =>
+        Vector128.Create(
+            Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref input0, offset)),
+            Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref input1, offset)));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void StoreHashPair(ref byte output, int hashIndex,
+        Vector128<ulong> a0, Vector128<ulong> a1, Vector128<ulong> a2, Vector128<ulong> a3)
+    {
+        ref byte destination = ref Unsafe.Add(ref output, hashIndex * HASH_SIZE);
+        Unsafe.WriteUnaligned(ref destination, a0.GetElement(hashIndex));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref destination, 8), a1.GetElement(hashIndex));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref destination, 16), a2.GetElement(hashIndex));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref destination, 24), a3.GetElement(hashIndex));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<ulong> LoadScalar128(ref byte input, int offset) =>
+        Vector128.CreateScalarUnsafe(Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref input, offset)));
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void RoundX1(
+        ref Vector128<ulong> a0, ref Vector128<ulong> a1, ref Vector128<ulong> a2, ref Vector128<ulong> a3, ref Vector128<ulong> a4,
+        ref Vector128<ulong> a5, ref Vector128<ulong> a6, ref Vector128<ulong> a7, ref Vector128<ulong> a8, ref Vector128<ulong> a9,
+        ref Vector128<ulong> a10, ref Vector128<ulong> a11, ref Vector128<ulong> a12, ref Vector128<ulong> a13, ref Vector128<ulong> a14,
+        ref Vector128<ulong> a15, ref Vector128<ulong> a16, ref Vector128<ulong> a17, ref Vector128<ulong> a18, ref Vector128<ulong> a19,
+        ref Vector128<ulong> a20, ref Vector128<ulong> a21, ref Vector128<ulong> a22, ref Vector128<ulong> a23, ref Vector128<ulong> a24,
+        Vector128<ulong> roundConstant)
+    {
+        // Theta: column parities C[x] = A[x,0] ^ A[x,1] ^ A[x,2] ^ A[x,3] ^ A[x,4].
+        Vector128<ulong> c0 = Avx512F.VL.TernaryLogic(Avx512F.VL.TernaryLogic(a0, a5, a10, Xor3), a15, a20, Xor3);
+        Vector128<ulong> c1 = Avx512F.VL.TernaryLogic(Avx512F.VL.TernaryLogic(a1, a6, a11, Xor3), a16, a21, Xor3);
+        Vector128<ulong> c2 = Avx512F.VL.TernaryLogic(Avx512F.VL.TernaryLogic(a2, a7, a12, Xor3), a17, a22, Xor3);
+        Vector128<ulong> c3 = Avx512F.VL.TernaryLogic(Avx512F.VL.TernaryLogic(a3, a8, a13, Xor3), a18, a23, Xor3);
+        Vector128<ulong> c4 = Avx512F.VL.TernaryLogic(Avx512F.VL.TernaryLogic(a4, a9, a14, Xor3), a19, a24, Xor3);
+
+        // Theta: A[x,y] ^= C[x-1] ^ ROL(C[x+1], 1); both XORs fuse into one ternary op per lane.
+        Vector128<ulong> rolC1 = Avx512F.VL.RotateLeft(c1, 1);
+        a0 = Avx512F.VL.TernaryLogic(a0, c4, rolC1, Xor3);
+        a5 = Avx512F.VL.TernaryLogic(a5, c4, rolC1, Xor3);
+        a10 = Avx512F.VL.TernaryLogic(a10, c4, rolC1, Xor3);
+        a15 = Avx512F.VL.TernaryLogic(a15, c4, rolC1, Xor3);
+        a20 = Avx512F.VL.TernaryLogic(a20, c4, rolC1, Xor3);
+
+        Vector128<ulong> rolC2 = Avx512F.VL.RotateLeft(c2, 1);
+        a1 = Avx512F.VL.TernaryLogic(a1, c0, rolC2, Xor3);
+        a6 = Avx512F.VL.TernaryLogic(a6, c0, rolC2, Xor3);
+        a11 = Avx512F.VL.TernaryLogic(a11, c0, rolC2, Xor3);
+        a16 = Avx512F.VL.TernaryLogic(a16, c0, rolC2, Xor3);
+        a21 = Avx512F.VL.TernaryLogic(a21, c0, rolC2, Xor3);
+
+        Vector128<ulong> rolC3 = Avx512F.VL.RotateLeft(c3, 1);
+        a2 = Avx512F.VL.TernaryLogic(a2, c1, rolC3, Xor3);
+        a7 = Avx512F.VL.TernaryLogic(a7, c1, rolC3, Xor3);
+        a12 = Avx512F.VL.TernaryLogic(a12, c1, rolC3, Xor3);
+        a17 = Avx512F.VL.TernaryLogic(a17, c1, rolC3, Xor3);
+        a22 = Avx512F.VL.TernaryLogic(a22, c1, rolC3, Xor3);
+
+        Vector128<ulong> rolC4 = Avx512F.VL.RotateLeft(c4, 1);
+        a3 = Avx512F.VL.TernaryLogic(a3, c2, rolC4, Xor3);
+        a8 = Avx512F.VL.TernaryLogic(a8, c2, rolC4, Xor3);
+        a13 = Avx512F.VL.TernaryLogic(a13, c2, rolC4, Xor3);
+        a18 = Avx512F.VL.TernaryLogic(a18, c2, rolC4, Xor3);
+        a23 = Avx512F.VL.TernaryLogic(a23, c2, rolC4, Xor3);
+
+        Vector128<ulong> rolC0 = Avx512F.VL.RotateLeft(c0, 1);
+        a4 = Avx512F.VL.TernaryLogic(a4, c3, rolC0, Xor3);
+        a9 = Avx512F.VL.TernaryLogic(a9, c3, rolC0, Xor3);
+        a14 = Avx512F.VL.TernaryLogic(a14, c3, rolC0, Xor3);
+        a19 = Avx512F.VL.TernaryLogic(a19, c3, rolC0, Xor3);
+        a24 = Avx512F.VL.TernaryLogic(a24, c3, rolC0, Xor3);
+
+        // Rho + Pi: walk the single 24-lane Pi cycle, rotating each lane into its permuted
+        // position; lane 0 is the cycle's fixed point. The two temporaries update the lanes
+        // in place, which keeps all 25 lanes enregistered; a fresh local per lane instead
+        // makes the JIT spill (measured ~2.6x slower).
+        Vector128<ulong> source = a1;
+        Vector128<ulong> displaced;
+        displaced = a10;
+        a10 = Avx512F.VL.RotateLeft(source, 1);
+        source = displaced;
+        displaced = a7;
+        a7 = Avx512F.VL.RotateLeft(source, 3);
+        source = displaced;
+        displaced = a11;
+        a11 = Avx512F.VL.RotateLeft(source, 6);
+        source = displaced;
+        displaced = a17;
+        a17 = Avx512F.VL.RotateLeft(source, 10);
+        source = displaced;
+        displaced = a18;
+        a18 = Avx512F.VL.RotateLeft(source, 15);
+        source = displaced;
+        displaced = a3;
+        a3 = Avx512F.VL.RotateLeft(source, 21);
+        source = displaced;
+        displaced = a5;
+        a5 = Avx512F.VL.RotateLeft(source, 28);
+        source = displaced;
+        displaced = a16;
+        a16 = Avx512F.VL.RotateLeft(source, 36);
+        source = displaced;
+        displaced = a8;
+        a8 = Avx512F.VL.RotateLeft(source, 45);
+        source = displaced;
+        displaced = a21;
+        a21 = Avx512F.VL.RotateLeft(source, 55);
+        source = displaced;
+        displaced = a24;
+        a24 = Avx512F.VL.RotateLeft(source, 2);
+        source = displaced;
+        displaced = a4;
+        a4 = Avx512F.VL.RotateLeft(source, 14);
+        source = displaced;
+        displaced = a15;
+        a15 = Avx512F.VL.RotateLeft(source, 27);
+        source = displaced;
+        displaced = a23;
+        a23 = Avx512F.VL.RotateLeft(source, 41);
+        source = displaced;
+        displaced = a19;
+        a19 = Avx512F.VL.RotateLeft(source, 56);
+        source = displaced;
+        displaced = a13;
+        a13 = Avx512F.VL.RotateLeft(source, 8);
+        source = displaced;
+        displaced = a12;
+        a12 = Avx512F.VL.RotateLeft(source, 25);
+        source = displaced;
+        displaced = a2;
+        a2 = Avx512F.VL.RotateLeft(source, 43);
+        source = displaced;
+        displaced = a20;
+        a20 = Avx512F.VL.RotateLeft(source, 62);
+        source = displaced;
+        displaced = a14;
+        a14 = Avx512F.VL.RotateLeft(source, 18);
+        source = displaced;
+        displaced = a22;
+        a22 = Avx512F.VL.RotateLeft(source, 39);
+        source = displaced;
+        displaced = a9;
+        a9 = Avx512F.VL.RotateLeft(source, 61);
+        source = displaced;
+        displaced = a6;
+        a6 = Avx512F.VL.RotateLeft(source, 20);
+        source = displaced;
+        a1 = Avx512F.VL.RotateLeft(source, 44);
+
+        // Chi: A[x,y] = B[x,y] ^ (~B[x+1,y] & B[x+2,y]), applied in place one row at a time.
+        ChiRowX1(ref a0, ref a1, ref a2, ref a3, ref a4);
+        ChiRowX1(ref a5, ref a6, ref a7, ref a8, ref a9);
+        ChiRowX1(ref a10, ref a11, ref a12, ref a13, ref a14);
+        ChiRowX1(ref a15, ref a16, ref a17, ref a18, ref a19);
+        ChiRowX1(ref a20, ref a21, ref a22, ref a23, ref a24);
+        // Iota: fold the round constant into lane 0.
+        a0 = Vector128.Xor(a0, roundConstant);
+    }
+
+    /// <summary>Applies the Keccak chi mapping to one row of five lanes in place.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ChiRowX1(ref Vector128<ulong> a0, ref Vector128<ulong> a1, ref Vector128<ulong> a2,
+        ref Vector128<ulong> a3, ref Vector128<ulong> a4)
+    {
+        Vector128<ulong> b0 = a0;
+        Vector128<ulong> b1 = a1;
+        a0 = Avx512F.VL.TernaryLogic(a0, a1, a2, Chi);
+        a1 = Avx512F.VL.TernaryLogic(a1, a2, a3, Chi);
+        a2 = Avx512F.VL.TernaryLogic(a2, a3, a4, Chi);
+        a3 = Avx512F.VL.TernaryLogic(a3, a4, b0, Chi);
+        a4 = Avx512F.VL.TernaryLogic(a4, b0, b1, Chi);
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.avx512x8.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.avx512x8.cs
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace Nethermind.Core.Crypto;
+
+public sealed partial class KeccakHash
+{
+    /// <summary>Hashes eight consecutive 64-byte inputs into eight consecutive 32-byte outputs.</summary>
+    /// <remarks>The caller must ensure that AVX-512F is supported and provide 512 input bytes and 256 output bytes.</remarks>
+    [SkipLocalsInit]
+    internal static unsafe void ComputeHash64Bytes8Avx512(ref byte input, ref byte output)
+    {
+        Debug.Assert(Avx512F.IsSupported);
+        Debug.Assert(Avx2.IsSupported);
+
+        Vector512<ulong> a0;
+        Vector512<ulong> a1;
+        Vector512<ulong> a2;
+        Vector512<ulong> a3;
+        Vector512<ulong> a4;
+        Vector512<ulong> a5;
+        Vector512<ulong> a6;
+        Vector512<ulong> a7;
+        // Each gather reads one lane from all eight 64-byte inputs; lane 7 reaches the final input byte.
+        fixed (byte* inputPtr = &input)
+        {
+            a0 = GatherLane(inputPtr, 0);
+            a1 = GatherLane(inputPtr, 1);
+            a2 = GatherLane(inputPtr, 2);
+            a3 = GatherLane(inputPtr, 3);
+            a4 = GatherLane(inputPtr, 4);
+            a5 = GatherLane(inputPtr, 5);
+            a6 = GatherLane(inputPtr, 6);
+            a7 = GatherLane(inputPtr, 7);
+        }
+        // Multi-rate padding (FIPS 202 sec. 5.1): 0x01 right after each 64-byte input, and 0x80
+        // at byte 135, the last byte of the 136-byte rate, which is the top bit of lane 16.
+        Vector512<ulong> a8 = Vector512.Create(1UL);
+        Vector512<ulong> a9 = Vector512<ulong>.Zero;
+        Vector512<ulong> a10 = Vector512<ulong>.Zero;
+        Vector512<ulong> a11 = Vector512<ulong>.Zero;
+        Vector512<ulong> a12 = Vector512<ulong>.Zero;
+        Vector512<ulong> a13 = Vector512<ulong>.Zero;
+        Vector512<ulong> a14 = Vector512<ulong>.Zero;
+        Vector512<ulong> a15 = Vector512<ulong>.Zero;
+        Vector512<ulong> a16 = Vector512.Create(0x8000000000000000UL);
+        Vector512<ulong> a17 = Vector512<ulong>.Zero;
+        Vector512<ulong> a18 = Vector512<ulong>.Zero;
+        Vector512<ulong> a19 = Vector512<ulong>.Zero;
+        Vector512<ulong> a20 = Vector512<ulong>.Zero;
+        Vector512<ulong> a21 = Vector512<ulong>.Zero;
+        Vector512<ulong> a22 = Vector512<ulong>.Zero;
+        Vector512<ulong> a23 = Vector512<ulong>.Zero;
+        Vector512<ulong> a24 = Vector512<ulong>.Zero;
+
+        ref ulong roundConstants = ref MemoryMarshal.GetArrayDataReference(RoundConstants);
+        for (int round = 0; round < ROUNDS; round++)
+        {
+            RoundX8(
+                ref a0, ref a1, ref a2, ref a3, ref a4,
+                ref a5, ref a6, ref a7, ref a8, ref a9,
+                ref a10, ref a11, ref a12, ref a13, ref a14,
+                ref a15, ref a16, ref a17, ref a18, ref a19,
+                ref a20, ref a21, ref a22, ref a23, ref a24,
+                Vector512.Create(Unsafe.Add(ref roundConstants, round)));
+        }
+
+        StoreHash(ref output, 0, a0, a1, a2, a3);
+        StoreHash(ref output, 1, a0, a1, a2, a3);
+        StoreHash(ref output, 2, a0, a1, a2, a3);
+        StoreHash(ref output, 3, a0, a1, a2, a3);
+        StoreHash(ref output, 4, a0, a1, a2, a3);
+        StoreHash(ref output, 5, a0, a1, a2, a3);
+        StoreHash(ref output, 6, a0, a1, a2, a3);
+        StoreHash(ref output, 7, a0, a1, a2, a3);
+    }
+
+    /// <summary>Gathers Keccak lane <paramref name="lane"/> from each of the eight consecutive 64-byte inputs.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe Vector512<ulong> GatherLane(byte* input, int lane)
+    {
+        ulong* lanePtr = (ulong*)(input + lane * sizeof(ulong));
+        Vector256<ulong> lower = Avx2.GatherVector256(lanePtr, Vector256.Create(0L, 8L, 16L, 24L), 8);
+        Vector256<ulong> upper = Avx2.GatherVector256(lanePtr, Vector256.Create(32L, 40L, 48L, 56L), 8);
+        return Vector512.Create(lower, upper);
+    }
+
+    /// <summary>Writes the 32-byte hash of batch element <paramref name="hashIndex"/> from the first four state lanes.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void StoreHash(ref byte output, int hashIndex,
+        Vector512<ulong> a0, Vector512<ulong> a1, Vector512<ulong> a2, Vector512<ulong> a3)
+    {
+        ref byte destination = ref Unsafe.Add(ref output, hashIndex * HASH_SIZE);
+        Unsafe.WriteUnaligned(ref destination, a0.GetElement(hashIndex));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref destination, 8), a1.GetElement(hashIndex));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref destination, 16), a2.GetElement(hashIndex));
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref destination, 24), a3.GetElement(hashIndex));
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void RoundX8(
+        ref Vector512<ulong> a0, ref Vector512<ulong> a1, ref Vector512<ulong> a2, ref Vector512<ulong> a3, ref Vector512<ulong> a4,
+        ref Vector512<ulong> a5, ref Vector512<ulong> a6, ref Vector512<ulong> a7, ref Vector512<ulong> a8, ref Vector512<ulong> a9,
+        ref Vector512<ulong> a10, ref Vector512<ulong> a11, ref Vector512<ulong> a12, ref Vector512<ulong> a13, ref Vector512<ulong> a14,
+        ref Vector512<ulong> a15, ref Vector512<ulong> a16, ref Vector512<ulong> a17, ref Vector512<ulong> a18, ref Vector512<ulong> a19,
+        ref Vector512<ulong> a20, ref Vector512<ulong> a21, ref Vector512<ulong> a22, ref Vector512<ulong> a23, ref Vector512<ulong> a24,
+        Vector512<ulong> roundConstant)
+    {
+        // Theta: column parities C[x] = A[x,0] ^ A[x,1] ^ A[x,2] ^ A[x,3] ^ A[x,4].
+        Vector512<ulong> c0 = Avx512F.TernaryLogic(Avx512F.TernaryLogic(a0, a5, a10, Xor3), a15, a20, Xor3);
+        Vector512<ulong> c1 = Avx512F.TernaryLogic(Avx512F.TernaryLogic(a1, a6, a11, Xor3), a16, a21, Xor3);
+        Vector512<ulong> c2 = Avx512F.TernaryLogic(Avx512F.TernaryLogic(a2, a7, a12, Xor3), a17, a22, Xor3);
+        Vector512<ulong> c3 = Avx512F.TernaryLogic(Avx512F.TernaryLogic(a3, a8, a13, Xor3), a18, a23, Xor3);
+        Vector512<ulong> c4 = Avx512F.TernaryLogic(Avx512F.TernaryLogic(a4, a9, a14, Xor3), a19, a24, Xor3);
+
+        // Theta: A[x,y] ^= C[x-1] ^ ROL(C[x+1], 1); both XORs fuse into one ternary op per lane.
+        Vector512<ulong> rolC1 = Avx512F.RotateLeft(c1, 1);
+        a0 = Avx512F.TernaryLogic(a0, c4, rolC1, Xor3);
+        a5 = Avx512F.TernaryLogic(a5, c4, rolC1, Xor3);
+        a10 = Avx512F.TernaryLogic(a10, c4, rolC1, Xor3);
+        a15 = Avx512F.TernaryLogic(a15, c4, rolC1, Xor3);
+        a20 = Avx512F.TernaryLogic(a20, c4, rolC1, Xor3);
+
+        Vector512<ulong> rolC2 = Avx512F.RotateLeft(c2, 1);
+        a1 = Avx512F.TernaryLogic(a1, c0, rolC2, Xor3);
+        a6 = Avx512F.TernaryLogic(a6, c0, rolC2, Xor3);
+        a11 = Avx512F.TernaryLogic(a11, c0, rolC2, Xor3);
+        a16 = Avx512F.TernaryLogic(a16, c0, rolC2, Xor3);
+        a21 = Avx512F.TernaryLogic(a21, c0, rolC2, Xor3);
+
+        Vector512<ulong> rolC3 = Avx512F.RotateLeft(c3, 1);
+        a2 = Avx512F.TernaryLogic(a2, c1, rolC3, Xor3);
+        a7 = Avx512F.TernaryLogic(a7, c1, rolC3, Xor3);
+        a12 = Avx512F.TernaryLogic(a12, c1, rolC3, Xor3);
+        a17 = Avx512F.TernaryLogic(a17, c1, rolC3, Xor3);
+        a22 = Avx512F.TernaryLogic(a22, c1, rolC3, Xor3);
+
+        Vector512<ulong> rolC4 = Avx512F.RotateLeft(c4, 1);
+        a3 = Avx512F.TernaryLogic(a3, c2, rolC4, Xor3);
+        a8 = Avx512F.TernaryLogic(a8, c2, rolC4, Xor3);
+        a13 = Avx512F.TernaryLogic(a13, c2, rolC4, Xor3);
+        a18 = Avx512F.TernaryLogic(a18, c2, rolC4, Xor3);
+        a23 = Avx512F.TernaryLogic(a23, c2, rolC4, Xor3);
+
+        Vector512<ulong> rolC0 = Avx512F.RotateLeft(c0, 1);
+        a4 = Avx512F.TernaryLogic(a4, c3, rolC0, Xor3);
+        a9 = Avx512F.TernaryLogic(a9, c3, rolC0, Xor3);
+        a14 = Avx512F.TernaryLogic(a14, c3, rolC0, Xor3);
+        a19 = Avx512F.TernaryLogic(a19, c3, rolC0, Xor3);
+        a24 = Avx512F.TernaryLogic(a24, c3, rolC0, Xor3);
+
+        // Rho + Pi: walk the single 24-lane Pi cycle, rotating each lane into its permuted
+        // position; lane 0 is the cycle's fixed point. The two temporaries update the lanes
+        // in place, which keeps all 25 lanes enregistered; a fresh local per lane instead
+        // makes the JIT spill (measured ~2.6x slower).
+        Vector512<ulong> source = a1;
+        Vector512<ulong> displaced;
+        displaced = a10;
+        a10 = Avx512F.RotateLeft(source, 1);
+        source = displaced;
+        displaced = a7;
+        a7 = Avx512F.RotateLeft(source, 3);
+        source = displaced;
+        displaced = a11;
+        a11 = Avx512F.RotateLeft(source, 6);
+        source = displaced;
+        displaced = a17;
+        a17 = Avx512F.RotateLeft(source, 10);
+        source = displaced;
+        displaced = a18;
+        a18 = Avx512F.RotateLeft(source, 15);
+        source = displaced;
+        displaced = a3;
+        a3 = Avx512F.RotateLeft(source, 21);
+        source = displaced;
+        displaced = a5;
+        a5 = Avx512F.RotateLeft(source, 28);
+        source = displaced;
+        displaced = a16;
+        a16 = Avx512F.RotateLeft(source, 36);
+        source = displaced;
+        displaced = a8;
+        a8 = Avx512F.RotateLeft(source, 45);
+        source = displaced;
+        displaced = a21;
+        a21 = Avx512F.RotateLeft(source, 55);
+        source = displaced;
+        displaced = a24;
+        a24 = Avx512F.RotateLeft(source, 2);
+        source = displaced;
+        displaced = a4;
+        a4 = Avx512F.RotateLeft(source, 14);
+        source = displaced;
+        displaced = a15;
+        a15 = Avx512F.RotateLeft(source, 27);
+        source = displaced;
+        displaced = a23;
+        a23 = Avx512F.RotateLeft(source, 41);
+        source = displaced;
+        displaced = a19;
+        a19 = Avx512F.RotateLeft(source, 56);
+        source = displaced;
+        displaced = a13;
+        a13 = Avx512F.RotateLeft(source, 8);
+        source = displaced;
+        displaced = a12;
+        a12 = Avx512F.RotateLeft(source, 25);
+        source = displaced;
+        displaced = a2;
+        a2 = Avx512F.RotateLeft(source, 43);
+        source = displaced;
+        displaced = a20;
+        a20 = Avx512F.RotateLeft(source, 62);
+        source = displaced;
+        displaced = a14;
+        a14 = Avx512F.RotateLeft(source, 18);
+        source = displaced;
+        displaced = a22;
+        a22 = Avx512F.RotateLeft(source, 39);
+        source = displaced;
+        displaced = a9;
+        a9 = Avx512F.RotateLeft(source, 61);
+        source = displaced;
+        displaced = a6;
+        a6 = Avx512F.RotateLeft(source, 20);
+        source = displaced;
+        a1 = Avx512F.RotateLeft(source, 44);
+
+        // Chi: A[x,y] = B[x,y] ^ (~B[x+1,y] & B[x+2,y]), applied in place one row at a time.
+        ChiRow(ref a0, ref a1, ref a2, ref a3, ref a4);
+        ChiRow(ref a5, ref a6, ref a7, ref a8, ref a9);
+        ChiRow(ref a10, ref a11, ref a12, ref a13, ref a14);
+        ChiRow(ref a15, ref a16, ref a17, ref a18, ref a19);
+        ChiRow(ref a20, ref a21, ref a22, ref a23, ref a24);
+        // Iota: fold the round constant into lane 0.
+        a0 = Avx512F.Xor(a0, roundConstant);
+    }
+
+    /// <summary>Applies the Keccak chi mapping to one row of five lanes in place.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ChiRow(ref Vector512<ulong> a0, ref Vector512<ulong> a1, ref Vector512<ulong> a2,
+        ref Vector512<ulong> a3, ref Vector512<ulong> a4)
+    {
+        Vector512<ulong> b0 = a0;
+        Vector512<ulong> b1 = a1;
+        a0 = Avx512F.TernaryLogic(a0, a1, a2, Chi);
+        a1 = Avx512F.TernaryLogic(a1, a2, a3, Chi);
+        a2 = Avx512F.TernaryLogic(a2, a3, a4, Chi);
+        a3 = Avx512F.TernaryLogic(a3, a4, b0, Chi);
+        a4 = Avx512F.TernaryLogic(a4, b0, b1, Chi);
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 using System.Security.Cryptography;
 
 namespace Nethermind.Core.Crypto;
@@ -15,7 +16,21 @@ public sealed partial class KeccakHash
 {
     private const int HASH_SIZE = 32;
     private const int STATE_SIZE = 200;
+    private const int STATE_LANES = STATE_SIZE / sizeof(ulong);
     private const int HASH_DATA_AREA = 136;
+    private const int ROUNDS = 24;
+
+    private static readonly ulong[] RoundConstants =
+    [
+        0x0000000000000001UL, 0x0000000000008082UL, 0x800000000000808aUL,
+        0x8000000080008000UL, 0x000000000000808bUL, 0x0000000080000001UL,
+        0x8000000080008081UL, 0x8000000000008009UL, 0x000000000000008aUL,
+        0x0000000000000088UL, 0x0000000080008009UL, 0x000000008000000aUL,
+        0x000000008000808bUL, 0x800000000000008bUL, 0x8000000000008089UL,
+        0x8000000000008003UL, 0x8000000000008002UL, 0x8000000000000080UL,
+        0x000000000000800aUL, 0x800000008000000aUL, 0x8000000080008081UL,
+        0x8000000000008080UL, 0x0000000080000001UL, 0x8000000080008008UL
+    ];
 
     private byte[] _remainderBuffer = [];
     private ulong[] _state = [];
@@ -69,6 +84,7 @@ public sealed partial class KeccakHash
 
     public KeccakHash Copy() => new(this);
 
+    [SkipLocalsInit]
     public static void ComputeHash(ReadOnlySpan<byte> input, Span<byte> output)
     {
         if ((uint)(output.Length - 1) >= STATE_SIZE)
@@ -81,9 +97,22 @@ public sealed partial class KeccakHash
             return;
         }
 #endif
+        int inputLength = input.Length;
+        // One-block fast path for the dominant EVM input sizes: address (20), word or hash (32), two words (64).
+        if (Avx512F.VL.IsSupported && output.Length == HASH_SIZE &&
+            inputLength is Address.Size or 32 or 64)
+        {
+            ComputeHash256Avx512VL(
+                ref MemoryMarshal.GetReference(input), inputLength, ref MemoryMarshal.GetReference(output));
+            return;
+        }
+
         int roundSize = GetRoundSize(output.Length);
 
-        Span<ulong> state = stackalloc ulong[STATE_SIZE / sizeof(ulong)];
+        // A struct local rather than stackalloc: localloc would pin this method at Tier0-FullOpts
+        // (no tiering or dynamic PGO) and add GS-cookie and stack-probe overhead per call.
+        KeccakState stateBuffer = default; // the sponge state must start all-zero
+        Span<ulong> state = stateBuffer;
         Span<byte> stateBytes = MemoryMarshal.AsBytes(state);
 
         if (input.Length == Address.Size)
@@ -173,6 +202,7 @@ public sealed partial class KeccakHash
         return output;
     }
 
+    [SkipLocalsInit]
     public ValueHash256 GenerateValueHash()
     {
         Unsafe.SkipInit(out ValueHash256 output);
@@ -180,6 +210,7 @@ public sealed partial class KeccakHash
         return output;
     }
 
+    [SkipLocalsInit]
     public void Update(ReadOnlySpan<byte> input)
     {
         if (_hash is not null)
@@ -259,6 +290,7 @@ public sealed partial class KeccakHash
         }
     }
 
+    [SkipLocalsInit]
     public void UpdateFinalTo(Span<byte> output)
     {
         if (_hash is not null)
@@ -364,7 +396,8 @@ public sealed partial class KeccakHash
 
     private static partial void KeccakF(Span<ulong> st);
 
-    private static int GetRoundSize(int hashSize) => checked(STATE_SIZE - 2 * hashSize);
+    // Callers bound hashSize to [1, STATE_SIZE], so the arithmetic cannot overflow.
+    private static int GetRoundSize(int hashSize) => STATE_SIZE - 2 * hashSize;
 
     private byte[] GenerateHash()
     {
@@ -468,6 +501,12 @@ public sealed partial class KeccakHash
     [DoesNotReturn]
     private static void ThrowInvalidOutputSize(int length) => throw new ArgumentOutOfRangeException(
         nameof(length), length, $"Must be between 1 and {STATE_SIZE}.");
+
+    [InlineArray(STATE_LANES)]
+    private struct KeccakState
+    {
+        private ulong _lane0;
+    }
 
     private static class Pool
     {

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.std.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.std.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
 using static System.Numerics.BitOperations;
@@ -14,33 +12,26 @@ namespace Nethermind.Core.Crypto;
 
 public sealed partial class KeccakHash
 {
-    private const int ROUNDS = 24;
     private const int LANE_BITS = 8 * 8;
     private const int TEMP_BUFF_SIZE = 144;
-    private static readonly ulong[] RoundConstants =
-    [
-        0x0000000000000001UL, 0x0000000000008082UL, 0x800000000000808aUL,
-        0x8000000080008000UL, 0x000000000000808bUL, 0x0000000080000001UL,
-        0x8000000080008081UL, 0x8000000000008009UL, 0x000000000000008aUL,
-        0x0000000000000088UL, 0x0000000080008009UL, 0x000000008000000aUL,
-        0x000000008000808bUL, 0x800000000000008bUL, 0x8000000000008089UL,
-        0x8000000000008003UL, 0x8000000000008002UL, 0x8000000000000080UL,
-        0x000000000000800aUL, 0x800000008000000aUL, 0x8000000080008081UL,
-        0x8000000000008080UL, 0x0000000080000001UL, 0x8000000080008008UL
-    ];
 
     // update the state with given number of rounds
     private static partial void KeccakF(Span<ulong> st)
     {
-        if (Avx512F.IsSupported)
-            KeccakF1600Avx512F(st);
+        Debug.Assert(st.Length == STATE_LANES);
+
+        ref ulong state = ref MemoryMarshal.GetReference(st);
+        if (Avx512F.VL.IsSupported)
+            KeccakF1600Avx512VL(ref state);
         else
-            KeccakF1600(st);
+            KeccakF1600Scalar(ref state);
     }
 
-    private static void KeccakF1600(Span<ulong> st)
+    /// <summary>Portable Keccak-f[1600] permutation.</summary>
+    /// <param name="state">Lane 0 of a 25-lane state; all 25 lanes are read and written.</param>
+    internal static void KeccakF1600Scalar(ref ulong state)
     {
-        Debug.Assert(st.Length == 25);
+        Span<ulong> st = MemoryMarshal.CreateSpan(ref state, STATE_LANES);
 
         ulong aba, abe, abi, abo, abu;
         ulong aga, age, agi, ago, agu;
@@ -248,200 +239,5 @@ public sealed partial class KeccakHash
         st[2] = abi;
         st[1] = abe;
         st[0] = aba;
-    }
-
-    [SkipLocalsInit]
-    public static void KeccakF1600Avx512F(Span<ulong> state)
-    {
-        {
-            // Redundant statement that removes all the in loop bounds checks
-            _ = state[24];
-        }
-
-        // Can straight load and over-read for start elements
-        Vector512<ulong> mask = Vector512.Create(ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, 0UL, 0UL, 0UL);
-        Vector512<ulong> c0 = Unsafe.As<ulong, Vector512<ulong>>(ref MemoryMarshal.GetReference(state));
-        // Clear the over-read values from first vectors
-        c0 = Vector512.BitwiseAnd(mask, c0);
-        Vector512<ulong> c1 = Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 5));
-        c1 = Vector512.BitwiseAnd(mask, c1);
-        Vector512<ulong> c2 = Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 10));
-        c2 = Vector512.BitwiseAnd(mask, c2);
-        Vector512<ulong> c3 = Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 15));
-        c3 = Vector512.BitwiseAnd(mask, c3);
-
-        // Can't over-read for the last elements (8 items in vector 5 to be remaining)
-        // so read a Vector256 and ulong then combine
-        Vector256<ulong> c4a = Unsafe.As<ulong, Vector256<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 20));
-        Vector256<ulong> c4b = Vector256.Create(state[24], 0UL, 0UL, 0UL);
-        Vector512<ulong> c4 = Vector512.Create(c4a, c4b);
-
-        Vector512<ulong> permute1 = Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL);
-        Vector512<ulong> permute2 = Vector512.Create(2UL, 3UL, 4UL, 0UL, 1UL, 5UL, 6UL, 7UL);
-        ulong[] roundConstants = RoundConstants;
-
-        // Use constant for loop so Jit expects to loop; unroll once
-        for (int round = 0; round < ROUNDS; round += 2)
-        {
-            // Iteration 1
-            {
-                ulong roundConstant = Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(roundConstants), round);
-                // Theta step
-                Vector512<ulong> parity = Avx512F.TernaryLogic(Avx512F.TernaryLogic(c0, c1, c2, 0x96), c3, c4, 0x96);
-
-                // Compute Theta
-                Vector512<ulong> bVecRot1Rotated = Avx512F.RotateLeft(Avx512F.PermuteVar8x64(parity, Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL)), 1);
-                Vector512<ulong> bVecRot4 = Avx512F.PermuteVar8x64(parity, Vector512.Create(4UL, 0UL, 1UL, 2UL, 3UL, 5UL, 6UL, 7UL));
-                Vector512<ulong> theta = Avx512F.Xor(bVecRot4, bVecRot1Rotated);
-
-                c0 = Avx512F.Xor(c0, theta);
-                c1 = Avx512F.Xor(c1, theta);
-                c2 = Avx512F.Xor(c2, theta);
-                c3 = Avx512F.Xor(c3, theta);
-                c4 = Avx512F.Xor(c4, theta);
-
-                // Rho step
-                Vector512<ulong> rhoVec0 = Vector512.Create(0UL, 1UL, 62UL, 28UL, 27UL, 0UL, 0UL, 0UL);
-                c0 = Avx512F.RotateLeftVariable(c0, rhoVec0);
-
-                Vector512<ulong> rhoVec1 = Vector512.Create(36UL, 44UL, 6UL, 55UL, 20UL, 0UL, 0UL, 0UL);
-                c1 = Avx512F.RotateLeftVariable(c1, rhoVec1);
-
-                Vector512<ulong> rhoVec2 = Vector512.Create(3UL, 10UL, 43UL, 25UL, 39UL, 0UL, 0UL, 0UL);
-                c2 = Avx512F.RotateLeftVariable(c2, rhoVec2);
-
-                Vector512<ulong> rhoVec3 = Vector512.Create(41UL, 45UL, 15UL, 21UL, 8UL, 0UL, 0UL, 0UL);
-                c3 = Avx512F.RotateLeftVariable(c3, rhoVec3);
-
-                Vector512<ulong> rhoVec4 = Vector512.Create(18UL, 2UL, 61UL, 56UL, 14UL, 0UL, 0UL, 0UL);
-                c4 = Avx512F.RotateLeftVariable(c4, rhoVec4);
-
-                // Pi step
-                Vector512<ulong> c0Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(0UL, 8 + 1, 2, 3, 4, 5, 6, 7), c1);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 8 + 2, 3, 4, 5, 6, 7), c2);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 8 + 3, 4, 5, 6, 7), c3);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 4, 5, 6, 7), c4);
-
-                Vector512<ulong> c1Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(3UL, 8 + 4, 2, 3, 4, 5, 6, 7), c1);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 8 + 0, 3, 4, 5, 6, 7), c2);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 8 + 1, 4, 5, 6, 7), c3);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 2, 5, 6, 7), c4);
-
-                Vector512<ulong> c2Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(1UL, 8 + 2, 2, 3, 4, 5, 6, 7), c1);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 8 + 3, 3, 4, 5, 6, 7), c2);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 8 + 4, 4, 5, 6, 7), c3);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 0, 5, 6, 7), c4);
-
-                Vector512<ulong> c3Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(4UL, 8 + 0, 2, 3, 4, 5, 6, 7), c1);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 8 + 1, 3, 4, 5, 6, 7), c2);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 2, 8 + 2, 4, 5, 6, 7), c3);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 3, 5, 6, 7), c4);
-
-                Vector512<ulong> c4Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(2UL, 8 + 3, 2, 3, 4, 5, 6, 7), c1);
-                c0 = c0Pi;
-                c1 = c1Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 8 + 4, 3, 4, 5, 6, 7), c2);
-                c2 = c2Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 8 + 0, 4, 5, 6, 7), c3);
-                c3 = c3Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 1, 5, 6, 7), c4);
-                c4 = c4Pi;
-
-                // Chi step
-
-                c0 = Avx512F.TernaryLogic(c0, Avx512F.PermuteVar8x64(c0, permute1), Avx512F.PermuteVar8x64(c0, permute2), 0xD2);
-                c1 = Avx512F.TernaryLogic(c1, Avx512F.PermuteVar8x64(c1, permute1), Avx512F.PermuteVar8x64(c1, permute2), 0xD2);
-                c2 = Avx512F.TernaryLogic(c2, Avx512F.PermuteVar8x64(c2, permute1), Avx512F.PermuteVar8x64(c2, permute2), 0xD2);
-                c3 = Avx512F.TernaryLogic(c3, Avx512F.PermuteVar8x64(c3, permute1), Avx512F.PermuteVar8x64(c3, permute2), 0xD2);
-                c4 = Avx512F.TernaryLogic(c4, Avx512F.PermuteVar8x64(c4, permute1), Avx512F.PermuteVar8x64(c4, permute2), 0xD2);
-
-                // Iota step
-                c0 = Vector512.Xor(c0, Vector512.Create(roundConstant, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL));
-            }
-            // Iteration 2
-            {
-                ulong roundConstant = Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(roundConstants), round + 1);
-                // Theta step
-                Vector512<ulong> parity = Avx512F.TernaryLogic(Avx512F.TernaryLogic(c0, c1, c2, 0x96), c3, c4, 0x96);
-
-                // Compute Theta
-                Vector512<ulong> bVecRot1Rotated = Avx512F.RotateLeft(Avx512F.PermuteVar8x64(parity, Vector512.Create(1UL, 2UL, 3UL, 4UL, 0UL, 5UL, 6UL, 7UL)), 1);
-                Vector512<ulong> bVecRot4 = Avx512F.PermuteVar8x64(parity, Vector512.Create(4UL, 0UL, 1UL, 2UL, 3UL, 5UL, 6UL, 7UL));
-                Vector512<ulong> theta = Avx512F.Xor(bVecRot4, bVecRot1Rotated);
-
-                c0 = Avx512F.Xor(c0, theta);
-                c1 = Avx512F.Xor(c1, theta);
-                c2 = Avx512F.Xor(c2, theta);
-                c3 = Avx512F.Xor(c3, theta);
-                c4 = Avx512F.Xor(c4, theta);
-
-                // Rho step
-                Vector512<ulong> rhoVec0 = Vector512.Create(0UL, 1UL, 62UL, 28UL, 27UL, 0UL, 0UL, 0UL);
-                c0 = Avx512F.RotateLeftVariable(c0, rhoVec0);
-
-                Vector512<ulong> rhoVec1 = Vector512.Create(36UL, 44UL, 6UL, 55UL, 20UL, 0UL, 0UL, 0UL);
-                c1 = Avx512F.RotateLeftVariable(c1, rhoVec1);
-
-                Vector512<ulong> rhoVec2 = Vector512.Create(3UL, 10UL, 43UL, 25UL, 39UL, 0UL, 0UL, 0UL);
-                c2 = Avx512F.RotateLeftVariable(c2, rhoVec2);
-
-                Vector512<ulong> rhoVec3 = Vector512.Create(41UL, 45UL, 15UL, 21UL, 8UL, 0UL, 0UL, 0UL);
-                c3 = Avx512F.RotateLeftVariable(c3, rhoVec3);
-
-                Vector512<ulong> rhoVec4 = Vector512.Create(18UL, 2UL, 61UL, 56UL, 14UL, 0UL, 0UL, 0UL);
-                c4 = Avx512F.RotateLeftVariable(c4, rhoVec4);
-
-                // Pi step
-                Vector512<ulong> c0Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(0UL, 8 + 1, 2, 3, 4, 5, 6, 7), c1);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 8 + 2, 3, 4, 5, 6, 7), c2);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 8 + 3, 4, 5, 6, 7), c3);
-                c0Pi = Avx512F.PermuteVar8x64x2(c0Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 4, 5, 6, 7), c4);
-
-                Vector512<ulong> c1Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(3UL, 8 + 4, 2, 3, 4, 5, 6, 7), c1);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 8 + 0, 3, 4, 5, 6, 7), c2);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 8 + 1, 4, 5, 6, 7), c3);
-                c1Pi = Avx512F.PermuteVar8x64x2(c1Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 2, 5, 6, 7), c4);
-
-                Vector512<ulong> c2Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(1UL, 8 + 2, 2, 3, 4, 5, 6, 7), c1);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 8 + 3, 3, 4, 5, 6, 7), c2);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 8 + 4, 4, 5, 6, 7), c3);
-                c2Pi = Avx512F.PermuteVar8x64x2(c2Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 0, 5, 6, 7), c4);
-
-                Vector512<ulong> c3Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(4UL, 8 + 0, 2, 3, 4, 5, 6, 7), c1);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 8 + 1, 3, 4, 5, 6, 7), c2);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 2, 8 + 2, 4, 5, 6, 7), c3);
-                c3Pi = Avx512F.PermuteVar8x64x2(c3Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 3, 5, 6, 7), c4);
-
-                Vector512<ulong> c4Pi = Avx512F.PermuteVar8x64x2(c0, Vector512.Create(2UL, 8 + 3, 2, 3, 4, 5, 6, 7), c1);
-                c0 = c0Pi;
-                c1 = c1Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 8 + 4, 3, 4, 5, 6, 7), c2);
-                c2 = c2Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 8 + 0, 4, 5, 6, 7), c3);
-                c3 = c3Pi;
-                c4Pi = Avx512F.PermuteVar8x64x2(c4Pi, Vector512.Create(0UL, 1, 2, 3, 8 + 1, 5, 6, 7), c4);
-                c4 = c4Pi;
-
-                // Chi step
-
-                c0 = Avx512F.TernaryLogic(c0, Avx512F.PermuteVar8x64(c0, permute1), Avx512F.PermuteVar8x64(c0, permute2), 0xD2);
-                c1 = Avx512F.TernaryLogic(c1, Avx512F.PermuteVar8x64(c1, permute1), Avx512F.PermuteVar8x64(c1, permute2), 0xD2);
-                c2 = Avx512F.TernaryLogic(c2, Avx512F.PermuteVar8x64(c2, permute1), Avx512F.PermuteVar8x64(c2, permute2), 0xD2);
-                c3 = Avx512F.TernaryLogic(c3, Avx512F.PermuteVar8x64(c3, permute1), Avx512F.PermuteVar8x64(c3, permute2), 0xD2);
-                c4 = Avx512F.TernaryLogic(c4, Avx512F.PermuteVar8x64(c4, permute1), Avx512F.PermuteVar8x64(c4, permute2), 0xD2);
-
-                // Iota step
-                c0 = Vector512.Xor(c0, Vector512.Create(roundConstant, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL));
-            }
-        }
-
-        // Can over-write for first elements
-        Unsafe.As<ulong, Vector512<ulong>>(ref MemoryMarshal.GetReference(state)) = c0;
-        Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 5)) = c1;
-        Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 10)) = c2;
-        Unsafe.As<ulong, Vector512<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 15)) = c3;
-        // Can't over-write for last elements so write the upper Vector256 and then ulong
-        Unsafe.As<ulong, Vector256<ulong>>(ref Unsafe.Add(ref MemoryMarshal.GetReference(state), 20)) = c4.GetLower();
-        state[24] = c4.GetElement(4);
     }
 }

--- a/src/Nethermind/Nethermind.Core/InternalsVisibility.cs
+++ b/src/Nethermind/Nethermind.Core/InternalsVisibility.cs
@@ -6,3 +6,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Nethermind.Core.Test")]
 [assembly: InternalsVisibleTo("Nethermind.Blockchain.Test")]
 [assembly: InternalsVisibleTo("Nethermind.Clique.Test")]
+[assembly: InternalsVisibleTo("Nethermind.Evm")]
+[assembly: InternalsVisibleTo("Nethermind.Trie")]

--- a/src/Nethermind/Nethermind.Evm.Test/Eip1014Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip1014Tests.cs
@@ -77,6 +77,28 @@ namespace Nethermind.Evm.Test
             AssertEip1014(expectedAddress, []);
         }
 
+        /// <summary>
+        /// EIP-7610: storage written earlier in the same block is not in the storage root yet - block
+        /// processing merkleizes once at the end of the block - so the collision check must consult the
+        /// block-level changes, not only the committed root.
+        /// </summary>
+        [Test]
+        public void Test_existing_account_with_unmerkleized_storage_is_not_empty()
+        {
+            (Address expectedAddress, byte[] callCode) = PrepareCreate2(_defaultSalt, _defaultInitCode, callGas: 32100);
+
+            TestState.CreateAccount(expectedAddress, 1.Ether);
+            TestState.Set(new StorageCell(expectedAddress, 1), [1, 2, 3, 4, 5]);
+            TestState.Commit(Spec, commitRoots: false);
+
+            Assert.That(TestState.IsStorageEmpty(expectedAddress), Is.False);
+
+            Execute(callCode);
+
+            Assert.That(TestState.IsStorageEmpty(expectedAddress), Is.False);
+            AssertEip1014(expectedAddress, []);
+        }
+
         [Test]
         public void Test_out_of_gas_non_existing_account()
         {

--- a/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
@@ -49,6 +49,35 @@ public class KeyedNonceManagerTests
         Assert.That(slotB1.Index, Is.Not.EqualTo(slotA1.Index), "distinct senders must yield distinct slots");
     }
 
+    [TestCase(8)]
+    [TestCase(Eip8250Constants.MaxNonceKeys)]
+    public void Batched_storage_indices_match_individual_slots(int count)
+    {
+        UInt256[] keys = StrictlyIncreasing(count);
+        UInt256[] indices = new UInt256[count];
+
+        KeyedNonceManager.StorageIndices(TestItem.AddressA, keys, indices);
+
+        for (int i = 0; i < count; i++)
+        {
+            Assert.That(indices[i], Is.EqualTo(KeyedNonceManager.StorageSlot(TestItem.AddressA, keys[i]).Index));
+        }
+    }
+
+    [Test]
+    public void Batched_nonce_set_is_consumed_and_validated()
+    {
+        UInt256[] keys = StrictlyIncreasing(Eip8250Constants.MaxNonceKeys);
+
+        KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, keys, nonceSeq: 41);
+
+        foreach (UInt256 key in keys)
+        {
+            Assert.That(KeyedNonceManager.CurrentNonceSeq(_state, TestItem.AddressA, key), Is.EqualTo(42UL));
+        }
+        Assert.That(KeyedNonceManager.IsNonceSetValid(_state, TestItem.AddressA, keys, nonceSeq: 42), Is.True);
+    }
+
     [Test]
     public void CurrentNonceSeq_for_key_zero_returns_account_nonce()
     {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/KeyedNonceManager.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -15,6 +17,8 @@ namespace Nethermind.Evm.TransactionProcessing;
 public static class KeyedNonceManager
 {
     private const int SlotPreimageLength = 2 * 32;
+    /// <summary>Batch width of <see cref="KeccakHash.ComputeHash64Bytes8Avx512"/>.</summary>
+    private const int HashBatchSize = 8;
 
     public static StorageCell StorageSlot(Address sender, in UInt256 nonceKey)
     {
@@ -33,7 +37,12 @@ public static class KeyedNonceManager
             return state.GetNonce(sender);
         }
 
-        UInt256 stored = new(state.Get(StorageSlot(sender, nonceKey)), isBigEndian: true);
+        return CurrentNonceSeq(state, StorageSlot(sender, nonceKey));
+    }
+
+    private static ulong CurrentNonceSeq(IWorldState state, in StorageCell slot)
+    {
+        UInt256 stored = new(state.Get(slot), isBigEndian: true);
         // Clamp so a crafted high-bit slot cannot false-match a valid nonce_seq < MAX_NONCE_SEQ.
         return stored > Eip8250Constants.MaxNonceSeq ? ulong.MaxValue : (ulong)stored;
     }
@@ -52,6 +61,19 @@ public static class KeyedNonceManager
         Span<byte> buffer = stackalloc byte[32];
         ((UInt256)nonceSeq + UInt256.One).ToBigEndian(buffer);
         byte[] nextSeq = buffer.WithoutLeadingZeros().ToArray();
+
+        if (Avx512F.IsSupported && nonceKeys.Length is >= HashBatchSize and <= Eip8250Constants.MaxNonceKeys)
+        {
+            Span<UInt256> indices = stackalloc UInt256[Eip8250Constants.MaxNonceKeys];
+            StorageIndices(sender, nonceKeys, indices);
+            for (int i = 0; i < nonceKeys.Length; i++)
+            {
+                Debug.Assert(!nonceKeys[i].IsZero, "key 0 must not appear in a non-[0] nonce_keys set");
+                state.Set(new StorageCell(Eip8250Constants.NonceManagerAddress, indices[i]), nextSeq);
+            }
+            return;
+        }
+
         foreach (UInt256 nonceKey in nonceKeys)
         {
             // EIP-8250 rejects key 0 in a non-[0] set; the decode-time validity check owns that, this guards the primitive.
@@ -108,6 +130,23 @@ public static class KeyedNonceManager
             return false;
         }
 
+        // A well-formed multi-key set is bounded and cannot contain key 0, so every key uses a storage slot.
+        if (Avx512F.IsSupported && nonceKeys.Length >= HashBatchSize)
+        {
+            Debug.Assert(!nonceKeys[0].IsZero, "key 0 cannot appear in a well-formed multi-key set");
+            Span<UInt256> indices = stackalloc UInt256[Eip8250Constants.MaxNonceKeys];
+            StorageIndices(sender, nonceKeys, indices);
+            for (int i = 0; i < nonceKeys.Length; i++)
+            {
+                StorageCell slot = new(Eip8250Constants.NonceManagerAddress, indices[i]);
+                if (CurrentNonceSeq(state, slot) != nonceSeq)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         foreach (ref readonly UInt256 nonceKey in nonceKeys)
         {
             if (CurrentNonceSeq(state, sender, nonceKey) != nonceSeq)
@@ -117,5 +156,47 @@ public static class KeyedNonceManager
         }
 
         return true;
+    }
+
+    /// <summary>Computes the NONCE_MANAGER storage index for each key in <paramref name="nonceKeys"/>, batching the Keccak hashes with AVX-512 where possible.</summary>
+    [SkipLocalsInit]
+    internal static void StorageIndices(Address sender, ReadOnlySpan<UInt256> nonceKeys, Span<UInt256> indices)
+    {
+        Debug.Assert(indices.Length >= nonceKeys.Length);
+
+        int keyIndex = 0;
+        if (Avx512F.IsSupported && nonceKeys.Length >= HashBatchSize)
+        {
+            Span<byte> preimages = stackalloc byte[SlotPreimageLength * HashBatchSize];
+            Span<byte> hashes = stackalloc byte[Keccak.Size * HashBatchSize];
+
+            for (int i = 0; i < HashBatchSize; i++)
+            {
+                Span<byte> senderBlock = preimages.Slice(i * SlotPreimageLength, 32);
+                senderBlock[..(32 - Address.Size)].Clear();
+                sender.Bytes.CopyTo(senderBlock[(32 - Address.Size)..]);
+            }
+
+            do
+            {
+                for (int i = 0; i < HashBatchSize; i++)
+                {
+                    nonceKeys[keyIndex + i].ToBigEndian(preimages.Slice(i * SlotPreimageLength + 32, 32));
+                }
+
+                KeccakHash.ComputeHash64Bytes8Avx512(ref preimages[0], ref hashes[0]);
+                for (int i = 0; i < HashBatchSize; i++)
+                {
+                    indices[keyIndex + i] = new UInt256(hashes.Slice(i * Keccak.Size, Keccak.Size), isBigEndian: true);
+                }
+
+                keyIndex += HashBatchSize;
+            } while (keyIndex <= nonceKeys.Length - HashBatchSize);
+        }
+
+        for (; keyIndex < nonceKeys.Length; keyIndex++)
+        {
+            indices[keyIndex] = StorageSlot(sender, nonceKeys[keyIndex]).Index;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
+++ b/src/Nethermind/Nethermind.Facade/BlockchainBridge.cs
@@ -161,7 +161,7 @@ namespace Nethermind.Facade
         private CallOutput CallShareable(BlockHeader header, Transaction tx, CancellationToken cancellationToken)
         {
             using IReadOnlyTxProcessingScope scope = shareableTxProcessorSource.Build(header);
-            return RunCall(stateReader, scope.TransactionProcessor, header, tx, blobBaseFeeOverride: null, cancellationToken);
+            return RunCall(scope.WorldState, scope.TransactionProcessor, header, tx, blobBaseFeeOverride: null, cancellationToken);
         }
 
         private CallOutput CallExclusive(BlockHeader header, Transaction tx, Dictionary<Address, AccountOverride>? stateOverride, UInt256? blobBaseFeeOverride, BlockOverride? blockOverride, CancellationToken cancellationToken)
@@ -171,13 +171,13 @@ namespace Nethermind.Facade
             using Scope<BlockProcessingComponents> scope = processingEnv.BuildAndOverride(header, stateOverride, blockOverride);
             // Dual-write: RequestState feeds the VM-time decorator; RunCall applies it during pre-VM header prep.
             scope.Component.RequestState.BlobBaseFeeOverride = blobBaseFeeOverride;
-            return RunCall(scope.Component.StateReader, scope.Component.TransactionProcessor, header, tx, blobBaseFeeOverride, cancellationToken);
+            return RunCall(scope.Component.WorldState, scope.Component.TransactionProcessor, header, tx, blobBaseFeeOverride, cancellationToken);
         }
 
-        private CallOutput RunCall(IStateReader nonceReader, ITransactionProcessor txProcessor, BlockHeader header, Transaction tx, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
+        private CallOutput RunCall(IWorldState nonceSource, ITransactionProcessor txProcessor, BlockHeader header, Transaction tx, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
         {
             CallOutputTracer tracer = new();
-            TransactionResult result = TryCallAndRestore(nonceReader, txProcessor, header, tx, treatBlockHeaderAsParentBlock: false,
+            TransactionResult result = TryCallAndRestore(nonceSource, txProcessor, header, tx, treatBlockHeaderAsParentBlock: false,
                 blobBaseFeeOverride, tracer.WithCancellation(cancellationToken));
 
             return new CallOutput
@@ -211,7 +211,7 @@ namespace Nethermind.Facade
         private CallOutput EstimateGasShareable(BlockHeader header, Transaction tx, int errorMargin, CancellationToken cancellationToken)
         {
             using IReadOnlyTxProcessingScope scope = shareableTxProcessorSource.Build(header);
-            return RunEstimateGas(stateReader, scope.TransactionProcessor, scope.WorldState, header, tx, errorMargin, blobBaseFeeOverride: null, cancellationToken);
+            return RunEstimateGas(scope.TransactionProcessor, scope.WorldState, header, tx, errorMargin, blobBaseFeeOverride: null, cancellationToken);
         }
 
         private CallOutput EstimateGasExclusive(BlockHeader header, Transaction tx, int errorMargin, Dictionary<Address, AccountOverride>? stateOverride, UInt256? blobBaseFeeOverride, BlockOverride? blockOverride, CancellationToken cancellationToken)
@@ -219,10 +219,10 @@ namespace Nethermind.Facade
             using Scope<BlockProcessingComponents> scope = processingEnv.BuildAndOverride(header, stateOverride, blockOverride);
             BlockProcessingComponents components = scope.Component;
             components.RequestState.BlobBaseFeeOverride = blobBaseFeeOverride;
-            return RunEstimateGas(components.StateReader, components.TransactionProcessor, components.WorldState, header, tx, errorMargin, blobBaseFeeOverride, cancellationToken);
+            return RunEstimateGas(components.TransactionProcessor, components.WorldState, header, tx, errorMargin, blobBaseFeeOverride, cancellationToken);
         }
 
-        private CallOutput RunEstimateGas(IStateReader nonceReader, ITransactionProcessor txProcessor, IWorldState worldState, BlockHeader header, Transaction tx, int errorMargin, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
+        private CallOutput RunEstimateGas(ITransactionProcessor txProcessor, IWorldState worldState, BlockHeader header, Transaction tx, int errorMargin, UInt256? blobBaseFeeOverride, CancellationToken cancellationToken)
         {
             // Cap tx.GasLimit to the sender's affordable allowance before the initial probe,
             // mirroring Geth's hi = min(hi, (balance - value - blobFee) / gasFeeCap), where blobFee = 0 outside EIP-4844. This ensures
@@ -241,7 +241,7 @@ namespace Nethermind.Facade
             }
 
             EstimateGasTracer estimateGasTracer = new();
-            TransactionResult tryCallResult = TryCallAndRestore(nonceReader, txProcessor, header, tx, true,
+            TransactionResult tryCallResult = TryCallAndRestore(worldState, txProcessor, header, tx, true,
                 blobBaseFeeOverride, estimateGasTracer.WithCancellation(cancellationToken));
 
             GasEstimator gasEstimator = new(txProcessor, worldState, specProvider, blocksConfig);
@@ -291,7 +291,7 @@ namespace Nethermind.Facade
             AccessList? originalAccessList = tx.AccessList;
             try
             {
-                return ConvergeAccessList(stateReader, scope.TransactionProcessor, blobBaseFeeOverride: null, header, tx, optimize, cancellationToken);
+                return ConvergeAccessList(scope.WorldState, scope.TransactionProcessor, blobBaseFeeOverride: null, header, tx, optimize, cancellationToken);
             }
             finally
             {
@@ -308,7 +308,7 @@ namespace Nethermind.Facade
             AccessList? originalAccessList = tx.AccessList;
             try
             {
-                return ConvergeAccessList(components.StateReader, components.TransactionProcessor, blobBaseFeeOverride, header, tx, optimize, cancellationToken);
+                return ConvergeAccessList(components.WorldState, components.TransactionProcessor, blobBaseFeeOverride, header, tx, optimize, cancellationToken);
             }
             finally
             {
@@ -320,14 +320,14 @@ namespace Nethermind.Facade
         // slots, repeat until the AL stabilizes. Gas and error come from the final (warm) run, so
         // cold-read overcounting is eliminated and OOG due to AL intrinsic cost is surfaced.
         // Starts from the caller-supplied AL so user-provided entries are preserved and counted.
-        private CallOutput ConvergeAccessList(IStateReader nonceReader, ITransactionProcessor txProcessor, UInt256? blobBaseFeeOverride, BlockHeader header, Transaction tx, bool optimize, CancellationToken cancellationToken)
+        private CallOutput ConvergeAccessList(IWorldState nonceSource, ITransactionProcessor txProcessor, UInt256? blobBaseFeeOverride, BlockHeader header, Transaction tx, bool optimize, CancellationToken cancellationToken)
         {
             // Loop-invariant: the addresses to filter from the discovered AL depend only on header
             // and tx, neither of which change between iterations. Compute once and reuse.
             FrozenSet<AddressAsKey> precompiles = specProvider.GetSpec(header).Precompiles;
             int bufferSize = (optimize ? 3 : 1) + precompiles.Count;
             Address[] addressBuffer = new Address[bufferSize];
-            FillAddressesToOptimize(addressBuffer, header, tx, optimize, precompiles);
+            FillAddressesToOptimize(addressBuffer, nonceSource, header, tx, optimize, precompiles);
 
             AccessList? previousAccessList = tx.AccessList;
             AccessTxTracer accessTracer = new(addressBuffer);
@@ -341,7 +341,7 @@ namespace Nethermind.Facade
                 accessTracer.Reset();
                 outputTracer.Reset();
                 tx.AccessList = previousAccessList;
-                result = TryCallAndRestore(nonceReader, txProcessor, header, tx, false, blobBaseFeeOverride, tracer);
+                result = TryCallAndRestore(nonceSource, txProcessor, header, tx, false, blobBaseFeeOverride, tracer);
                 stop = !result.TransactionExecuted || HasConverged(previousAccessList, accessTracer.AccessList);
                 previousAccessList = accessTracer.AccessList;
             } while (!stop);
@@ -365,7 +365,7 @@ namespace Nethermind.Facade
             };
         }
 
-        private void FillAddressesToOptimize(Span<Address> buffer, BlockHeader header, Transaction tx, bool optimize, FrozenSet<AddressAsKey> precompiles)
+        private void FillAddressesToOptimize(Span<Address> buffer, IWorldState nonceSource, BlockHeader header, Transaction tx, bool optimize, FrozenSet<AddressAsKey> precompiles)
         {
             int idx;
             if (!optimize)
@@ -377,7 +377,10 @@ namespace Nethermind.Facade
             {
                 // EIP-2930: sender, recipient and gas beneficiary are implicitly accessed,
                 // so excluding them keeps the returned access list minimal.
-                UInt256 senderNonce = tx.IsContractCreation ? stateReader.GetNonce(header, tx.SenderAddress) : UInt256.Zero;
+                // The nonce comes from the executing world state: the header's state root does not
+                // reflect an unmerkleized override, so a nonce override would resolve to the wrong
+                // CREATE address here.
+                UInt256 senderNonce = tx.IsContractCreation ? nonceSource.GetNonce(tx.SenderAddress) : UInt256.Zero;
                 buffer[0] = tx.SenderAddress;
                 buffer[1] = tx.GetRecipient(senderNonce);
                 buffer[2] = header.GasBeneficiary;
@@ -399,7 +402,7 @@ namespace Nethermind.Facade
         }
 
         private TransactionResult TryCallAndRestore(
-            IStateReader nonceReader,
+            IWorldState nonceSource,
             ITransactionProcessor txProcessor,
             BlockHeader blockHeader,
             Transaction transaction,
@@ -409,7 +412,7 @@ namespace Nethermind.Facade
         {
             try
             {
-                return CallAndRestore(nonceReader, txProcessor, blockHeader, transaction, treatBlockHeaderAsParentBlock, blobBaseFeeOverride, tracer);
+                return CallAndRestore(nonceSource, txProcessor, blockHeader, transaction, treatBlockHeaderAsParentBlock, blobBaseFeeOverride, tracer);
             }
             catch (InsufficientBalanceException)
             {
@@ -418,7 +421,7 @@ namespace Nethermind.Facade
         }
 
         private TransactionResult CallAndRestore(
-            IStateReader nonceReader,
+            IWorldState nonceSource,
             ITransactionProcessor txProcessor,
             BlockHeader blockHeader,
             Transaction transaction,
@@ -428,8 +431,10 @@ namespace Nethermind.Facade
         {
             transaction.SenderAddress ??= Address.Zero;
 
-            //Ignore nonce on all CallAndRestore calls
-            transaction.Nonce = nonceReader.GetNonce(blockHeader, transaction.SenderAddress);
+            // Ignore nonce on all CallAndRestore calls. Read it from the executing world state rather
+            // than through a root-resolved reader: that reflects any state override and avoids building
+            // a second state snapshot per call.
+            transaction.Nonce = nonceSource.GetNonce(transaction.SenderAddress);
 
             BlockHeader callHeader = blockHeader.Clone();
             if (treatBlockHeaderAsParentBlock)
@@ -599,7 +604,6 @@ namespace Nethermind.Facade
         }
 
         public record BlockProcessingComponents(
-            IStateReader StateReader,
             ITransactionProcessor TransactionProcessor,
             IWorldState WorldState,
             SingleCallRequestState RequestState
@@ -652,19 +656,59 @@ namespace Nethermind.Facade
             // and turn burst override traffic into long-lived memory.
             IOverridableEnv<BlockchainBridge.BlockProcessingComponents> inner =
                 overridableScopeLifetime.Resolve<IOverridableEnv<BlockchainBridge.BlockProcessingComponents>>();
-            return new DisposableOverridableEnv(inner, overridableScopeLifetime);
+            return new DisposableOverridableEnv(
+                inner,
+                overridableScopeLifetime,
+                overridableScopeLifetime.Resolve<IOverridableCodeInfoRepository>(),
+                overridableScopeLifetime.Resolve<ISpecProvider>());
         }
 
         private sealed class DisposableOverridableEnv(
             IOverridableEnv<BlockchainBridge.BlockProcessingComponents> inner,
-            IDisposable scope) : IOverridableEnv<BlockchainBridge.BlockProcessingComponents>, IDisposable
+            IDisposable scope,
+            IOverridableCodeInfoRepository codeInfoRepository,
+            ISpecProvider specProvider) : IOverridableEnv<BlockchainBridge.BlockProcessingComponents>, IDisposable
         {
+            /// <inheritdoc/>
+            /// <remarks>
+            /// Deviates from <see cref="IOverridableEnv.BuildAndOverride"/>: the state override is applied to
+            /// the scope's world state but left unmerkleized, because everything the bridge runs in this scope
+            /// executes against that world state and never resolves state through a root, so the trie path load
+            /// and rehash per overridden account is pure cost. The header therefore does not receive a
+            /// post-state-override root (a <paramref name="blockOverride"/> is still applied and committed by the
+            /// inner env), and nonces on these paths must be read from the world state rather than through an
+            /// <see cref="IStateReader"/>.
+            /// </remarks>
             public Scope<BlockchainBridge.BlockProcessingComponents> BuildAndOverride(
                 BlockHeader? header,
                 Dictionary<Address, AccountOverride>? stateOverride = null,
                 IReleaseSpec? specOverride = null,
-                BlockOverride? blockOverride = null) =>
-                inner.BuildAndOverride(header, stateOverride, specOverride, blockOverride);
+                BlockOverride? blockOverride = null)
+            {
+                // A block override still goes through the env so it keeps committing the unchanged state at
+                // the overridden block number, which the overridden header relies on to resolve.
+                Scope<BlockchainBridge.BlockProcessingComponents> scope =
+                    inner.BuildAndOverride(header, stateOverride: null, specOverride, blockOverride);
+
+                if (stateOverride is null || header is null) return scope;
+
+                try
+                {
+                    // EIP-158 must not delete accounts whose code and nonce were overridden to zero while
+                    // storage remains, or the EIP-7610 collision check would stop seeing that storage.
+                    IReleaseSpec spec = specProvider.GetSpec(header).WithoutEip158();
+                    IWorldState worldState = scope.Component.WorldState;
+                    worldState.ApplyStateOverridesNoCommit(codeInfoRepository, stateOverride, spec);
+                    worldState.Commit(spec, commitRoots: false);
+                }
+                catch
+                {
+                    scope.Dispose();
+                    throw;
+                }
+
+                return scope;
+            }
 
             public void Dispose() => scope.Dispose();
         }

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -62,6 +62,48 @@ public class StorageProviderTests(bool useFlat)
 
     private WorldState BuildStorageProvider(Context ctx) => ctx.StateProvider;
 
+    /// <summary>
+    /// <see cref="IWorldState.IsStorageEmpty"/> backs the EIP-7610 CREATE collision check. State overrides
+    /// are applied with <c>commitRoots: false</c>, so the write never reaches the storage trie and the
+    /// committed root cannot see it — the block-level change set has to be consulted.
+    /// </summary>
+    /// <remarks>
+    /// The <paramref name="clearFirst"/> arms pin the check order: a full <c>state</c> override clears the
+    /// storage before writing and the clear marker survives until the trie flush, so testing the marker
+    /// before the change set would report the account empty and bypass EIP-7610.
+    /// </remarks>
+    [TestCase(false, false, false, TestName = "Uncommitted_write_is_visible")]
+    [TestCase(true, false, false, TestName = "Uncommitted_write_after_clear_is_visible")]
+    [TestCase(false, true, true, TestName = "Uncommitted_write_reverted_to_zero_stays_empty")]
+    [TestCase(true, true, true, TestName = "Clear_then_write_reverted_to_zero_stays_empty")]
+    public void IsStorageEmpty_sees_uncommitted_storage_change(bool clearFirst, bool zeroAfterwards, bool expectedEmpty)
+    {
+        using Context ctx = new(useFlat, setInitialState: false);
+        IWorldState provider = BuildStorageProvider(ctx);
+
+        BlockHeader baseBlock = null;
+        using (provider.BeginScope(baseBlock))
+        {
+            provider.CreateAccountIfNotExists(TestItem.AddressA, 100);
+            if (clearFirst)
+            {
+                provider.ClearStorage(TestItem.AddressA);
+            }
+
+            StorageCell cell = new(TestItem.AddressA, 1);
+            provider.Set(cell, [0x2a]);
+            if (zeroAfterwards)
+            {
+                provider.Set(cell, StorageTree.ZeroBytes);
+            }
+
+            // The state-override path: commit the journal without flushing anything to the trie.
+            provider.Commit(Frontier.Instance, commitRoots: false);
+
+            Assert.That(provider.IsStorageEmpty(TestItem.AddressA), Is.EqualTo(expectedEmpty));
+        }
+    }
+
     [Test]
     [NonParallelizable]
     public void Oversized_per_contract_state_dictionary_is_trimmed_when_returned()

--- a/src/Nethermind/Nethermind.State/OverridableEnv/IShareableOverridableEnvSource.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/IShareableOverridableEnvSource.cs
@@ -18,6 +18,10 @@ public interface IShareableOverridableEnvSource<T> : IDisposable
     /// <remarks>
     /// When <paramref name="blockOverride"/> is supplied it is applied to <paramref name="header"/> <b>in place</b>;
     /// see <see cref="IOverridableEnv.BuildAndOverride"/>. Callers must pass a header they own (e.g. a clone).
+    /// Unlike <see cref="IOverridableEnv.BuildAndOverride"/>, an implementation may leave
+    /// <paramref name="stateOverride"/> unmerkleized when its consumers only read through the scope's world
+    /// state, in which case <paramref name="header"/> receives no post-state-override root and state must not
+    /// be resolved through one.
     /// </remarks>
     Scope<T> BuildAndOverride(BlockHeader? header, Dictionary<Address, AccountOverride>? stateOverride = null, BlockOverride? blockOverride = null);
 }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -424,6 +424,23 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         public int EstimatedSize => _dictionary.Count + (_missingAreDefault ? 1 : 0);
         public bool HasClear => _missingAreDefault;
 
+        /// <summary>Whether any uncommitted block-level change leaves a slot at a non-zero value.</summary>
+        public bool HasNonZeroValue
+        {
+            get
+            {
+                foreach (StorageChangeTrace trace in _dictionary.Values)
+                {
+                    if (!trace.After.IsZero())
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
         public void Reset(int capacity)
         {
             _missingAreDefault = false;
@@ -507,6 +524,16 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         {
             get
             {
+                // Block-level writes that have not been merkleized yet are invisible to the storage root
+                // (state overrides, and every tx before the block's single root computation), so consult
+                // them first: a "state" override clears the storage before writing, leaving the clear
+                // marker set alongside non-zero entries, and testing the marker first would report empty.
+                // Gated on _wasWritten because only writes can hide from the root - a non-zero read implies
+                // a non-empty root, which the check below already reports.
+                // Writes made by the currently executing transaction still live in the journal and are not
+                // seen here; this reports block-level state, which is what EIP-7610 needs.
+                if (_wasWritten && BlockChange.HasNonZeroValue) return false;
+
                 // _backend.RootHash is not reflected until after commit, but this need to be reflected before commit
                 // for SelfDestruct, since the deletion is not part of changelog, it need to be handled here.
                 if (BlockChange.HasClear) return true;

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -214,6 +214,71 @@ public class TrieNodeTests
         Assert.That(decodedTiniest.Keccak, Is.EqualTo(decoded.GetChildHash(11)), "value");
     }
 
+    [TestCase(0x0001)]
+    [TestCase(0x0003)]
+    [TestCase(0x0007)]
+    [TestCase(0x5555)]
+    [TestCase(0xffff)]
+    public void Resolves_full_branch_children_to_their_individual_hashes(int branchMask)
+    {
+        if (!System.Runtime.Intrinsics.X86.Avx512F.VL.IsSupported)
+        {
+            Assert.Ignore("AVX-512VL intrinsics are not supported on this machine.");
+        }
+
+        TrieNode root = new(NodeType.Branch);
+        TrieNode?[] branches = new TrieNode?[TrieNode.BranchesCount];
+
+        for (int i = 0; i < TrieNode.BranchesCount; i++)
+        {
+            if ((branchMask & (1 << i)) == 0)
+            {
+                continue;
+            }
+
+            TrieNode branch = branches[i] = new TrieNode(NodeType.Branch);
+            root.SetChild(i, branch);
+            for (int childIndex = 0; childIndex < TrieNode.BranchesCount; childIndex++)
+            {
+                Hash256 childHash = Keccak.Compute([(byte)i, (byte)childIndex]);
+                branch.SetChild(childIndex, new TrieNode(NodeType.Unknown, childHash));
+            }
+        }
+
+        TrieNode? nonCandidate = null;
+        if (branchMask != 0xffff)
+        {
+            const int nonCandidateIndex = TrieNode.BranchesCount - 1;
+            nonCandidate = new TrieNode(NodeType.Branch);
+            nonCandidate.SetChild(0, new TrieNode(NodeType.Unknown, Keccak.Compute([0xff])));
+            root.SetChild(nonCandidateIndex, nonCandidate);
+        }
+
+        TreePath path = TreePath.Empty;
+        root.ResolveKey(NullTrieNodeResolver.Instance, ref path, canBeParallel: false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            for (int i = 0; i < branches.Length; i++)
+            {
+                TrieNode? branch = branches[i];
+                if (branch is not null)
+                {
+                    Assert.That(branch.FullRlp.Length, Is.EqualTo(532), $"RLP length at branch {i}");
+                    Assert.That(branch.Keccak, Is.EqualTo(Keccak.Compute(branch.FullRlp.AsSpan())), $"hash at branch {i}");
+                }
+            }
+
+            if (nonCandidate is not null)
+            {
+                Assert.That(nonCandidate.FullRlp.Length, Is.Not.EqualTo(532), "non-candidate RLP length");
+                Assert.That(nonCandidate.Keccak, Is.EqualTo(Keccak.Compute(nonCandidate.FullRlp.AsSpan())),
+                    "non-candidate hash");
+            }
+            Assert.That(root.Keccak, Is.EqualTo(Keccak.Compute(root.FullRlp.AsSpan())), "root hash");
+        }
+    }
+
     [Test]
     public void Can_encode_decode_tiny_extension()
     {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -5,7 +5,9 @@ using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 using System.Threading;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Cpu;
@@ -27,6 +29,9 @@ namespace Nethermind.Trie
 
         private class TrieNodeDecoder
         {
+            private const int FullBranchRlpLength = 532;
+            private const int HashPairSize = 2;
+
             [SkipLocalsInit]
             public static CappedArray<byte> EncodeExtension(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
@@ -175,6 +180,65 @@ namespace Nethermind.Trie
                 }
             }
 
+            private static void HashPreparedBranches(TrieNode item, ushort candidateMask)
+            {
+                int firstIndex = BitOperations.TrailingZeroCount(candidateMask);
+                candidateMask ^= (ushort)(1 << firstIndex);
+                if (candidateMask == 0)
+                {
+                    Unsafe.As<TrieNode>(item._nodeData[firstIndex]).ResolvePreparedKey();
+                    return;
+                }
+
+                HashPreparedBranchPairs(item, firstIndex, candidateMask);
+            }
+
+            [SkipLocalsInit]
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private static void HashPreparedBranchPairs(TrieNode item, int firstIndex, ushort candidateMask)
+            {
+                Span<byte> hashes = stackalloc byte[HashPairSize * Hash256.Size];
+
+                while (true)
+                {
+                    int secondIndex = BitOperations.TrailingZeroCount(candidateMask);
+                    candidateMask ^= (ushort)(1 << secondIndex);
+                    TrieNode first = Unsafe.As<TrieNode>(item._nodeData[firstIndex]);
+                    TrieNode second = Unsafe.As<TrieNode>(item._nodeData[secondIndex]);
+                    CappedArray<byte> firstRlp = first.FullRlp;
+                    CappedArray<byte> secondRlp = second.FullRlp;
+                    if (firstRlp.Length != FullBranchRlpLength || secondRlp.Length != FullBranchRlpLength)
+                    {
+                        ThrowUnexpectedPreparedBranchLength();
+                    }
+
+                    Span<byte> rlp0 = firstRlp.AsSpan();
+                    Span<byte> rlp1 = secondRlp.AsSpan();
+                    KeccakHash.ComputeHash532Bytes2Avx512VL(ref rlp0[0], ref rlp1[0], ref hashes[0]);
+                    ValueHash256 firstHash = new(hashes[..Hash256.Size]);
+                    ValueHash256 secondHash = new(hashes[Hash256.Size..]);
+                    first.SetPreparedKey(in firstHash);
+                    second.SetPreparedKey(in secondHash);
+
+                    if (candidateMask == 0)
+                    {
+                        return;
+                    }
+
+                    firstIndex = BitOperations.TrailingZeroCount(candidateMask);
+                    candidateMask ^= (ushort)(1 << firstIndex);
+                    if (candidateMask == 0)
+                    {
+                        Unsafe.As<TrieNode>(item._nodeData[firstIndex]).ResolvePreparedKey();
+                        return;
+                    }
+                }
+
+                [DoesNotReturn, StackTraceHidden]
+                static void ThrowUnexpectedPreparedBranchLength() =>
+                    throw new TrieException("A prepared full branch changed before batched hashing.");
+            }
+
             private static int GetChildrenRlpLengthForBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool? bufferPool, bool canBeParallel) =>
                 // Tail call optimized.
                 item.HasRlp
@@ -225,6 +289,7 @@ namespace Nethermind.Trie
             private static int GetChildrenRlpLengthForBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool bufferPool, bool canBeParallel)
             {
                 int totalLength = 0;
+                ushort candidateMask = 0;
                 for (int i = 0; i < BranchesCount; i++)
                 {
                     object? data = item._nodeData[i];
@@ -240,11 +305,34 @@ namespace Nethermind.Trie
                     {
                         path.AppendMut(i);
                         TrieNode childNode = Unsafe.As<TrieNode>(data);
-                        childNode.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
+                        if (Avx512F.VL.IsSupported && childNode is { IsBranch: true, Keccak: null })
+                        {
+                            CappedArray<byte> rlp = childNode.PrepareRlp(tree, ref path, bufferPool, canBeParallel);
+                            if (rlp.Length == FullBranchRlpLength)
+                            {
+                                candidateMask |= (ushort)(1 << i);
+                                totalLength += Rlp.LengthOfKeccakRlp;
+                            }
+                            else
+                            {
+                                childNode.ResolvePreparedKey(in rlp);
+                                totalLength += childNode.Keccak is null ? rlp.Length : Rlp.LengthOfKeccakRlp;
+                            }
+                        }
+                        else
+                        {
+                            childNode.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
+                            totalLength += childNode.Keccak is null ? childNode.FullRlp.Length : Rlp.LengthOfKeccakRlp;
+                        }
                         path.TruncateOne();
-                        totalLength += childNode.Keccak is null ? childNode.FullRlp.Length : Rlp.LengthOfKeccakRlp;
                     }
                 }
+
+                if (candidateMask != 0)
+                {
+                    HashPreparedBranches(item, candidateMask);
+                }
+
                 return totalLength;
             }
 
@@ -293,6 +381,7 @@ namespace Nethermind.Trie
             private static int GetChildrenRlpLengthForBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int totalLength = 0;
+                ushort candidateMask = 0;
                 RlpReader rlpReader = item.RlpReader;
                 item.SeekChild(ref rlpReader, 0);
                 for (int i = 0; i < BranchesCount; i++)
@@ -319,13 +408,35 @@ namespace Nethermind.Trie
                             path.AppendMut(i);
                             Debug.Assert(data is TrieNode, "Data is not TrieNode");
                             TrieNode childNode = Unsafe.As<TrieNode>(data);
-                            childNode.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
+                            if (Avx512F.VL.IsSupported && childNode is { IsBranch: true, Keccak: null })
+                            {
+                                CappedArray<byte> rlp = childNode.PrepareRlp(tree, ref path, bufferPool, canBeParallel);
+                                if (rlp.Length == FullBranchRlpLength)
+                                {
+                                    candidateMask |= (ushort)(1 << i);
+                                    totalLength += Rlp.LengthOfKeccakRlp;
+                                }
+                                else
+                                {
+                                    childNode.ResolvePreparedKey(in rlp);
+                                    totalLength += childNode.Keccak is null ? rlp.Length : Rlp.LengthOfKeccakRlp;
+                                }
+                            }
+                            else
+                            {
+                                childNode.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
+                                totalLength += childNode.Keccak is null ? childNode.FullRlp.Length : Rlp.LengthOfKeccakRlp;
+                            }
                             path.TruncateOne();
-                            totalLength += childNode.Keccak is null ? childNode.FullRlp.Length : Rlp.LengthOfKeccakRlp;
                         }
 
                         rlpReader.SkipItem();
                     }
+                }
+
+                if (candidateMask != 0)
+                {
+                    HashPreparedBranches(item, candidateMask);
                 }
 
                 return totalLength;

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -536,6 +536,22 @@ namespace Nethermind.Trie
             ICappedArrayPool? bufferPool = null, bool canBeParallel = true)
         {
             bool isRoot = path.Length == 0;
+            CappedArray<byte> rlp = PrepareRlp(tree, ref path, bufferPool, canBeParallel);
+
+            // Descendant nodes with RLP shorter than a hash are embedded in their parent.
+            if (rlp.Length >= 32 || isRoot)
+            {
+                Metrics.IncrementTreeNodeHashCalculations();
+                return Nethermind.Core.Crypto.Keccak.Compute(rlp.AsSpan());
+            }
+
+            return null;
+        }
+
+        internal CappedArray<byte> PrepareRlp(ITrieNodeResolver tree, ref TreePath path,
+            ICappedArrayPool? bufferPool, bool canBeParallel)
+        {
+            bool isRoot = path.Length == 0;
             CappedArray<byte> rlp = ReadRlp();
             if (rlp.IsNull || IsDirty)
             {
@@ -553,16 +569,28 @@ namespace Nethermind.Trie
                 WriteRlp(rlp = fullRlp);
             }
 
-            /* nodes that are descendants of other nodes are stored inline
-             * if their serialized length is less than Keccak length
-             * */
-            if (rlp.Length >= 32 || isRoot)
+            return rlp;
+        }
+
+        internal void ResolvePreparedKey()
+        {
+            CappedArray<byte> rlp = ReadRlp();
+            ResolvePreparedKey(in rlp);
+        }
+
+        private void ResolvePreparedKey(in CappedArray<byte> rlp)
+        {
+            if (rlp.Length >= 32)
             {
                 Metrics.IncrementTreeNodeHashCalculations();
-                return Nethermind.Core.Crypto.Keccak.Compute(rlp.AsSpan());
+                Keccak = Nethermind.Core.Crypto.Keccak.Compute(rlp.AsSpan());
             }
+        }
 
-            return null;
+        internal void SetPreparedKey(in ValueHash256 hash)
+        {
+            Metrics.IncrementTreeNodeHashCalculations();
+            Keccak = new Hash256(in hash);
         }
 
         internal CappedArray<byte> RlpEncode(ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? bufferPool = null, bool canBeParallel = false)


### PR DESCRIPTION
Merges current `master` into `eip8141-frame-txs-devnet7` and resolves the two overlaps that leave #12526's merge tree broken.

`#12526` is currently `CONFLICTING`, and the last merge tree GitHub did build (`refs/pull/12526/merge`, base `e9f724c02`) failed to compile with two `CS1503`s that reproduce on neither branch alone:

```
KeyedNonceManager.cs(46,32): error CS1503: Argument 1: cannot convert from
  'Nethermind.Evm.State.IReadOnlyStateProvider' to 'Nethermind.Evm.State.IWorldState'
KeyedNonceManager.cs(177,37): error CS1503: ... (same)
```

`master` added a batched storage-index path to `KeyedNonceManager` whose private nonce read takes `IWorldState`; this branch had independently narrowed the public read APIs to `IReadOnlyStateProvider`. Git auto-merges both without a conflict into a file that does not compile.

## Changes

- Merge `master` (`615eb31d5`) into `eip8141-frame-txs-devnet7`.
- `KeyedNonceManager`: keep `master`'s batched storage-index path in full, and narrow its private nonce read to `IReadOnlyStateProvider`. The narrowing is forced rather than preferred — `TxPool` and `KeyedNonceFilter` only ever hold `IChainHeadInfoProvider.ReadOnlyStateProvider`, and `KeyedNonceFilterTests` drives the filter with a `TestReadOnlyStateProvider` that is not an `IWorldState`. Every caller on the `master` side passes an `IWorldState`, which the narrower parameter still accepts, so nothing there changes. The write path (`ConsumeNonceSet`) keeps `IWorldState`.
- `KeyedNonceManager`: the type's `<remarks>` still claimed every access goes through `IWorldState`, which the narrowing had already made untrue; reworded to say the supplied state.
- `BlockchainBridge`: keep the frame-aware `IsCappedBySenderAllowance` helper on top of `master`'s new `RunEstimateGas` signature. The conflict was positional only — the helper was inserted directly above the signature line `master` changed.

No behaviour changes: `Eip8250Constants` carries identical values on both sides (`MaxNonceKeys` 16, `MaxNonceSeq` `ulong.MaxValue`, `KeyedNonceFirstUseGas` 20 000, `NONCE_MANAGER` address and its `revert(0, 0)` bytecode), and the slot derivation, clamping and first-use accounting are untouched.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

The break is a compile error, not a behaviour change, so there is nothing new to assert. Both narrowed signatures are already compile-guarded by production call sites (`TxPool.IsKeyedNonceBehind`, `KeyedNonceFilter`) and by `KeyedNonceFilterTests`, which cannot compile against an `IWorldState` parameter; widening either back would fail the build.

Verified locally:

- Merging this branch into `master` (`615eb31d5`) — the equivalent of the recomputed `refs/pull/12526/merge` — merges cleanly and builds `Nethermind.slnx` with 0 errors, 0 warnings. The same merge before this change is the failure quoted above.
- `Nethermind.slnx` plus `Nethermind.Stateless.Executor`, `Ethereum.Ssz.Test` and `Ethereum.Blockchain.Pyspec.Test` all build clean.
- Code-lint invocation reports no `IDE`/`CA` warnings (gate positive-controlled), and `dotnet format whitespace --verify-no-changes` is clean.
- Evm, Core, TxPool and Blockchain suites run.

The batched storage-index path is `Avx512F`-gated, so it stays dormant on non-x86 hardware and was not exercised by the local run.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
