### PR TITLE
ci: pin Go to 1.26 in the sedge sync workflows

### DIFF
--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -190,7 +190,8 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
+          # Pinned to 1.26: Go 1.27 breaks sedge's abigen build (cockroachdb/swiss has no go1.27 case)
+          go-version: '1.26'
           check-latest: true
           cache: true
 

--- a/.github/workflows/sync-pr-gate.yml
+++ b/.github/workflows/sync-pr-gate.yml
@@ -96,7 +96,8 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
+          # Pinned to 1.26: Go 1.27 breaks sedge's abigen build (cockroachdb/swiss has no go1.27 case)
+          go-version: '1.26'
           check-latest: true
           cache: true
 

--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -172,7 +172,8 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
+          # Pinned to 1.26: Go 1.27 breaks sedge's abigen build (cockroachdb/swiss has no go1.27 case)
+          go-version: '1.26'
           check-latest: true
           cache: true
 


### PR DESCRIPTION
## Changes

- Pin `actions/setup-go` to `go-version: '1.26'` (was `'stable'`) in the three workflows that build sedge: `sync-master-validation.yml`, `sync-pr-gate.yml`, `sync-supported-chains.yml`.

Go 1.27.0 reached the `actions/setup-go` manifest on 2026-08-20 and every sedge-building workflow started failing at `make compile`:

```
# github.com/cockroachdb/swiss
map.go:286:7: undefined: hashFn
map.go:337:14: undefined: getRuntimeHasher
map.go:338:22: undefined: fastrand64
make: *** [Makefile:78: install-abigen] Error 1
```

sedge's `install-abigen` target runs `go install github.com/ethereum/go-ethereum/cmd/abigen@latest` unpinned, which resolves a go-ethereum that pulls `cockroachdb/pebble/v2` → `cockroachdb/swiss`. That module build-tag-gates its runtime linkname shims and has no `go1.27` case, so the symbols disappear.

`check-latest: true` is kept, so 1.26.x patch releases are still picked up. 1.26.6 built fine hours before the flip.

This is a workaround, not the fix — the underlying problem is the unpinned `abigen@latest` in sedge. Revert to `'stable'` once sedge pins abigen or bumps past the broken swiss revision.

`rpc-comparison.yml` also uses `go-version: 'stable'` but does not build sedge, so it is left alone.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Not unit-testable. `Sync PR Gate (Hoodi)` triggers on `pull_request` against `master` and builds sedge, so this PR exercises the fix directly — a green `Install Sedge` step on this PR is the verification.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Unblocks `Sync Master Validation`, which has been red since 2026-08-18. Note that the Go break only started masking a separate, unrelated FlatDB `InvalidStateRoot` regression that has been failing every `Flat` job (mainnet and gnosis) since `6a56efd36d` (#12877) — that is being handled separately and is not addressed here.
