### PR TITLE
ci(sync): pin Go to 1.26 for the sedge build

### DIFF
--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -190,7 +190,8 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
+          # Pinned to 1.26: sedge's cockroachdb/swiss dependency fails to build on Go 1.27 (removed runtime linkname targets). Bump when swiss supports it.
+          go-version: '1.26.x'
           check-latest: true
           cache: true
 

--- a/.github/workflows/sync-pr-gate.yml
+++ b/.github/workflows/sync-pr-gate.yml
@@ -96,7 +96,8 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
+          # Pinned to 1.26: sedge's cockroachdb/swiss dependency fails to build on Go 1.27 (removed runtime linkname targets). Bump when swiss supports it.
+          go-version: '1.26.x'
           check-latest: true
           cache: true
 

--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -172,7 +172,8 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
+          # Pinned to 1.26: sedge's cockroachdb/swiss dependency fails to build on Go 1.27 (removed runtime linkname targets). Bump when swiss supports it.
+          go-version: '1.26.x'
           check-latest: true
           cache: true
 


### PR DESCRIPTION
## Changes

Pin the Go toolchain used to build sedge in the sync workflows to the `1.26` line instead of `stable` + `check-latest`.

## Why

`Sync Master Validation`, `Sync PR Gate` and `Sync Supported Chains` build sedge from source (`make compile`) before starting Nethermind. That build pulls the `cockroachdb/swiss` transitive dependency, which resolves a runtime hasher via `//go:linkname` into internal runtime symbols. Go 1.27 removed those symbols, so the build fails at `install-abigen`:

```
undefined: hashFn
undefined: fastrand64
undefined: getRuntimeHasher
make: *** [Makefile:78: install-abigen] Error 1
```

`setup-go` was configured with `go-version: 'stable'` and `check-latest: true`, so the just-released **Go 1.27.0** was picked up automatically. The runner also has `GOTOOLCHAIN=local`, so Go cannot fall back to a compatible toolchain from `go.mod`.

Timeline (master): last green `Sync Master Validation` at 2026-08-18 14:26Z (Go 1.26), continuous failures from ~15:59Z onward — matching the Go 1.27.0 release. Every job fails identically (`mainnet`/`gnosis` × `Flat`/`HalfPath`) at the sedge build step, before the client runs, which rules out a Nethermind code cause.

## Fix

`go-version: '1.26.x'` restores the last-known-good toolchain. Revert to `stable` once `cockroachdb/swiss` (via sedge) supports Go 1.27.

Failing runs: [32347885850](https://github.com/NethermindEth/nethermind/actions/runs/32347885850), [32286041804](https://github.com/NethermindEth/nethermind/actions/runs/32286041804).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Change is CI-only (workflow Go pin). Verified on the failing runs that all four sync jobs fail at the `Install Sedge environment` step with the `undefined: fastrand64 / getRuntimeHasher / hashFn` signature, before Nethermind starts.
- Sedge `core` `go.mod` declares `go 1.22.0`; the `1.26` line is well within its supported range and was the toolchain in use during the last green run.

## Documentation

- [ ] Requires documentation update
