### PR TITLE
fix(optimism): validate the transaction offset table when decoding payloads

### DIFF
--- a/src/Nethermind/Nethermind.Optimism.Test/CL/PayloadDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/CL/PayloadDecoderTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Test;
@@ -19,6 +20,26 @@ public class PayloadDecoderTests
         byte[] bytes = Convert.FromBase64String(testCase.Data);
         ExecutionPayloadV3 decoded = PayloadDecoder.Instance.DecodePayload(bytes);
         ComparePayloads(testCase.Payload, decoded);
+    }
+
+    [Test]
+    public void DecodePayload_InvalidFirstTransactionOffset(
+        [ValueSource(nameof(RealPayloadsTestCases))] (string Data, ExecutionPayloadV3 Payload) testCase,
+        // Zero, misaligned, and past the end of the transactions region
+        [Values(0u, 1u, 0xFFFFFFFCu, UInt32.MaxValue)] UInt32 firstTxOffset)
+    {
+        byte[] bytes = Convert.FromBase64String(testCase.Data);
+
+        // The transactions region ends at the payload end and starts with one 4-byte offset per transaction
+        int transactionsOffset = bytes.Length - 4 * testCase.Payload.Transactions.Length;
+        foreach (byte[] transaction in testCase.Payload.Transactions)
+        {
+            transactionsOffset -= transaction.Length;
+        }
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(transactionsOffset, 4), firstTxOffset);
+
+        Func<ExecutionPayloadV3> tryDecode = () => PayloadDecoder.Instance.DecodePayload(bytes);
+        Assert.That(tryDecode, Throws.TypeOf<ArgumentException>().With.Message.Contains("transaction offset"));
     }
 
     private void ComparePayloads(ExecutionPayloadV3 expected, ExecutionPayloadV3 actual)

--- a/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadDecoder.cs
@@ -64,7 +64,7 @@ public class PayloadDecoder : IPayloadDecoder
         if (4 > data.Length) throw new ArgumentException("Invalid transaction data");
         UInt32 firstTxOffset = BinaryPrimitives.ReadUInt32LittleEndian(data[..4]);
         // SSZ layout: the first transaction starts after a 4-byte offset per transaction.
-        if (firstTxOffset is 0 || firstTxOffset % 4 != 0 || firstTxOffset > data.Length) throw new ArgumentException("Invalid transaction offset");
+        if (firstTxOffset is 0 || firstTxOffset % 4 != 0 || firstTxOffset > data.Length) throw new ArgumentException("Invalid first transaction offset");
         UInt32 txCount = firstTxOffset / 4;
         byte[][] txs = new byte[txCount][];
         int previous = (int)firstTxOffset;

--- a/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadDecoder.cs
@@ -63,6 +63,8 @@ public class PayloadDecoder : IPayloadDecoder
     {
         if (4 > data.Length) throw new ArgumentException("Invalid transaction data");
         UInt32 firstTxOffset = BinaryPrimitives.ReadUInt32LittleEndian(data[..4]);
+        // SSZ layout: the first transaction starts after a 4-byte offset per transaction.
+        if (firstTxOffset is 0 || firstTxOffset % 4 != 0 || firstTxOffset > data.Length) throw new ArgumentException("Invalid transaction offset");
         UInt32 txCount = firstTxOffset / 4;
         byte[][] txs = new byte[txCount][];
         int previous = (int)firstTxOffset;
@@ -71,7 +73,6 @@ public class PayloadDecoder : IPayloadDecoder
             int next;
             if (i + 1 < txCount)
             {
-                if (i * 4 + 8 > data.Length) throw new ArgumentException("Invalid transaction data");
                 next = (int)BinaryPrimitives.ReadUInt32LittleEndian(data[(i * 4 + 4)..(i * 4 + 8)]);
             }
             else


### PR DESCRIPTION
## Changes
- Validate the transactions offset table before allocating in `PayloadDecoder.DecodeTransactions`. `txCount` was derived as `firstTxOffset / 4` straight from the wire, guarded only by `4 > data.Length`, so nothing related the count to the buffer: a small response could declare ~1.07 billion transactions and drive a multi-gigabyte `byte[txCount][]` allocation. Requiring `firstTxOffset % 4 == 0` and `firstTxOffset <= data.Length` makes the allocation proportional to the response, which `PayloadByNumberProtocol` already caps at 10 MB.
- Add a regression test over the real op-mainnet payload fixtures.


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No