### PR TITLE
fix(evm): dispatch a precompile a VERIFY frame targets

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1486,19 +1486,34 @@ public class FrameTxProcessorTests
     }
 
     /// <summary>A precompile that rejects its input fails the frame that targeted it.</summary>
-    /// <remarks>The rejection is an exceptional halt, so the frame forfeits its whole gas limit.</remarks>
-    [Test]
-    public void Execute_FrameTargetsPrecompileThatRejectsItsInput_FailsTheFrame()
+    /// <remarks>The rejection is an exceptional halt, so the frame forfeits its whole gas limit. In a
+    /// <c>VERIFY</c> frame that halt invalidates the transaction, which then reports no receipts at all.</remarks>
+    [TestCase(TxFrame.ModeDefault, TestName = "Execute_FrameTargetsPrecompileThatRejectsItsInput_FailsTheFrame(DEFAULT)")]
+    [TestCase(TxFrame.ModeVerify, TestName = "Execute_FrameTargetsPrecompileThatRejectsItsInput_FailsTheFrame(VERIFY)")]
+    public void Execute_FrameTargetsPrecompileThatRejectsItsInput_FailsTheFrame(byte mode)
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         byte[] notOnTheCurve = new byte[128];
         notOnTheCurve.AsSpan().Fill(0xff);
 
         FrameReceiptTracer tracer = new();
-        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: BN254AddPrecompile.Address, data: notOnTheCurve));
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(mode, target: BN254AddPrecompile.Address, data: notOnTheCurve));
 
-        Assert.That(Process(tx, tracer: tracer).TransactionExecuted, Is.True);
+        TransactionResult result = Process(tx, tracer: tracer);
 
+        if (mode == TxFrame.ModeVerify)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.TransactionExecuted, Is.False);
+                Assert.That(result.ErrorDescription, Does.Contain("VERIFY frame reverted"),
+                    "the halt invalidates the whole transaction, not just the frame that took it");
+            }
+
+            return;
+        }
+
+        Assert.That(result.TransactionExecuted, Is.True);
         using (Assert.EnterMultipleScope())
         {
             Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1431,6 +1431,7 @@ public class FrameTxProcessorTests
     [TestCase(TxFrame.ModeDefault, 64, 21UL, TestName = "Execute_FrameTargetsPrecompile_RunsIt(DEFAULT, two words)")]
     [TestCase(TxFrame.ModeSender, 1, 18UL, TestName = "Execute_FrameTargetsPrecompile_RunsIt(SENDER)")]
     [TestCase(TxFrame.ModePostTx, 1, 18UL, TestName = "Execute_FrameTargetsPrecompile_RunsIt(POST_TX)")]
+    [TestCase(TxFrame.ModeVerify, 1, 18UL, TestName = "Execute_FrameTargetsPrecompile_RunsIt(VERIFY)")]
     public void Execute_FrameTargetsPrecompile_RunsIt(byte mode, int dataLength, ulong identityGas)
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
@@ -1505,10 +1506,10 @@ public class FrameTxProcessorTests
         }
     }
 
-    /// <summary>A <c>VERIFY</c> frame targeting a precompile runs default code, not the precompile.</summary>
-    /// <remarks>No signature can resolve to a precompile address, so the default code reverts.</remarks>
+    /// <summary>A <c>VERIFY</c> frame targeting a precompile approves nothing.</summary>
+    /// <remarks>The precompile takes the place of the default code, and only the default code approves.</remarks>
     [Test]
-    public void Execute_VerifyFrameTargetsPrecompile_RunsDefaultCodeAndInvalidatesTheTransaction()
+    public void Execute_VerifyFrameTargetsPrecompile_ApprovesNothing()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         Transaction tx = FrameTx(nonce: 0,
@@ -1520,8 +1521,8 @@ public class FrameTxProcessorTests
         {
             Assert.That(result.TransactionExecuted, Is.False);
             Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
-            Assert.That(result.ErrorDescription, Does.Contain("VERIFY frame reverted"),
-                "the transaction must be rejected by the default code reverting, not by an earlier check");
+            Assert.That(result.ErrorDescription, Does.Contain("never set a payer"),
+                "the frame itself must succeed, leaving the transaction unpaid rather than reverted");
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -769,9 +769,11 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return new TransactionSubstate(EvmExceptionType.Revert, tracer.IsTracingInstructions);
         }
 
-        // Only a VERIFY frame's codeless target runs default code (execute_frame, execution-specs);
-        // every other frame runs a top-level call, which dispatches a precompile by address.
-        if (frame.Mode == TxFrame.ModeVerify && WorldState.GetCodeHash(resolvedTarget) == Keccak.OfAnEmptyString)
+        // A precompile dispatches in every mode, so default code is left to a VERIFY frame's codeless
+        // target. The repository is what dispatches the frame, so it decides what counts as a precompile.
+        if (frame.Mode == TxFrame.ModeVerify
+            && _codeInfoRepository.GetPrecompile(resolvedTarget, spec) is null
+            && WorldState.GetCodeHash(resolvedTarget) == Keccak.OfAnEmptyString)
         {
             return ExecuteDefaultVerifyCode(frame, resolvedTarget, frameContext, tracer, out gasUsed);
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -769,8 +769,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return new TransactionSubstate(EvmExceptionType.Revert, tracer.IsTracingInstructions);
         }
 
-        // A precompile dispatches in every mode, so default code is left to a VERIFY frame's codeless
-        // target. The repository is what dispatches the frame, so it decides what counts as a precompile.
+        // EIP-8141: a precompile dispatches in every mode, leaving default code to a VERIFY frame's codeless
+        // non-precompile target. The repository decides what is a precompile, being what dispatches the frame.
         if (frame.Mode == TxFrame.ModeVerify
             && _codeInfoRepository.GetPrecompile(resolvedTarget, spec) is null
             && WorldState.GetCodeHash(resolvedTarget) == Keccak.OfAnEmptyString)


### PR DESCRIPTION
## Changes

- Dispatch a precompile that an EIP-8141 `VERIFY` frame resolves to, instead of running the frame's default code.
- Extend the precompile-frame test parameterization with `VERIFY`, and re-point the `VERIFY` rejection case at the approval it now withholds.

[ethereum/EIPs#12157](https://github.com/ethereum/EIPs/pull/12157) settles this unconditionally:

> - If `resolved_target` is an active precompile at the current fork, the frame dispatches it as an ordinary call would.
> - Otherwise, if `resolved_target` code hash is empty, i.e. `0xc5d2...a470`, execute the logic described in default code.

There is no mode condition, so a `VERIFY` frame dispatches a precompile too. A `VERIFY` frame already runs as a static call and only a `SENDER` frame may carry non-zero value, so a precompile there is pure computation with no state effect — which is why this was preferred over banning a precompile target in `VERIFY`.

A precompile account carries the empty code hash the default-code guard keys on, so a `VERIFY` frame targeting one took the default-code route and never dispatched. The guard now asks the code repository — what actually dispatches the frame — whether the target is a precompile. The only carve-out left is a non-precompile codeless target in `VERIFY`; the `SENDER`/`DEFAULT` default-code route stays removed.

A target designated to a precompile is unaffected: it is not codeless, so it never reached this branch.

The reference change is [ethereum/execution-specs#3407](https://github.com/ethereum/execution-specs/pull/3407), against the EIP-8141 branch where the reference implementation lives.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Revert-checked: with the processor change reverted and the tests kept, exactly `Execute_FrameTargetsPrecompile_RunsIt(VERIFY)` and `Execute_VerifyFrameTargetsPrecompile_ApprovesNothing` fail, and nothing else moves. Full `Nethermind.Evm.Test`, `Nethermind.Core.Test` and `Nethermind.TxPool.Test` pass.

The frames fixture release (`tests-frames-devnet@v0.0.0`) predates the EIP change: its `verify_frame_precompile_target` case encodes the old rejection, and it passes either way because it asserts only that the block is rejected. Once the reference PR lands and the release is refilled, that case becomes three `verify_mode` cases under `test_precompile_target`, which the existing `FRAME_SKIP` alternation already covers.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
