### PR TITLE
fix(flat): isolate the trie warmer negative cache (InvalidStateRoot on Flat live-head sync)

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotBundle.cs
@@ -166,7 +166,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
-        else if (_transientResource.TryGetStateNode(path, hash, out node) && !TrieNodeCache.IsPlaceholder(node))
+        else if (_transientResource.TryGetStateNode(path, hash, out node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
@@ -210,8 +210,14 @@ public sealed class SnapshotBundle : IDisposable
             return node;
         }
 
-        return transientResource.GetOrAddStateNode(path,
-            TryFindStateNodeInPersistence(path, hash, out node) ? node : new TrieNode(NodeType.Unknown, hash));
+        if (transientResource.TryGetMissStateNode(path, hash, out node))
+        {
+            return node;
+        }
+
+        return TryFindStateNodeInPersistence(path, hash, out node)
+            ? transientResource.GetOrAddStateNode(path, node)
+            : transientResource.GetOrAddMissStateNode(path, new TrieNode(NodeType.Unknown, hash));
     }
 
     // Returns a leased transient, or null once the bundle is being torn down. A stale read can acquire a
@@ -288,7 +294,7 @@ public sealed class SnapshotBundle : IDisposable
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
-        else if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out node) && !TrieNodeCache.IsPlaceholder(node))
+        else if (_transientResource.TryGetStorageNode((Hash256AsKey)address, path, hash, out node))
         {
             Nethermind.Trie.Pruning.Metrics.IncrementLoadedFromCacheNodesCount();
         }
@@ -335,8 +341,14 @@ public sealed class SnapshotBundle : IDisposable
             return node;
         }
 
-        return transientResource.GetOrAddStorageNode((Hash256AsKey)address, path,
-            TryFindStorageNodeInPersistence(address, path, hash, out node) ? node : new TrieNode(NodeType.Unknown, hash));
+        if (transientResource.TryGetMissStorageNode((Hash256AsKey)address, path, hash, out node))
+        {
+            return node;
+        }
+
+        return TryFindStorageNodeInPersistence(address, path, hash, out node)
+            ? transientResource.GetOrAddStorageNode((Hash256AsKey)address, path, node)
+            : transientResource.GetOrAddMissStorageNode((Hash256AsKey)address, path, new TrieNode(NodeType.Unknown, hash));
     }
 
     private bool TryFindStorageNodeInPersistence(Hash256 address, in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node)

--- a/src/Nethermind/Nethermind.State.Flat/TransientResource.cs
+++ b/src/Nethermind/Nethermind.State.Flat/TransientResource.cs
@@ -34,6 +34,14 @@ public record TransientResource(TransientResource.Size size) : IDisposable, IRes
     public BloomFilter PrewarmedAddresses = new(size.PrewarmedAddressSize, 14); // 14 is exactly 8 probes, which the SIMD instruction does.
     public TrieNodeCache.ChildCache Nodes = new(size.NodesCacheSize);
 
+    /// <summary>
+    /// The trie warmer's negative cache: paths whose persistence lookup missed, keyed like <see cref="Nodes"/> but
+    /// holding only unresolved placeholders. It is read and written exclusively by the warmer and is never consulted
+    /// by a live read nor promoted into the shared <see cref="TrieNodeCache"/>, so a stale miss can never reach the
+    /// state-root computation.
+    /// </summary>
+    public TrieNodeCache.ChildCache MissNodes = new(size.NodesCacheSize);
+
     internal void OnRented(IResourcePool pool, ResourcePool.Usage usage)
     {
         _returnPool = pool;
@@ -73,6 +81,7 @@ public record TransientResource(TransientResource.Size size) : IDisposable, IRes
     public void Reset()
     {
         Nodes.Reset();
+        MissNodes.Reset();
 
         if (PrewarmedAddresses.Count > PrewarmedAddresses.Capacity)
         {
@@ -117,9 +126,17 @@ public record TransientResource(TransientResource.Size size) : IDisposable, IRes
 
     public void UpdateStateNode(in TreePath path, TrieNode node) => Nodes.Set(null, path, node);
 
+    public bool TryGetMissStateNode(in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node) => MissNodes.TryGet(null, path, hash, out node);
+
+    public TrieNode GetOrAddMissStateNode(in TreePath path, TrieNode trieNode) => MissNodes.GetOrAdd(null, path, trieNode);
+
     public bool TryGetStorageNode(Hash256AsKey address, in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node) => Nodes.TryGet(address, path, hash, out node);
 
     public TrieNode GetOrAddStorageNode(Hash256AsKey address, in TreePath path, TrieNode trieNode) => Nodes.GetOrAdd(address, path, trieNode);
 
     public void UpdateStorageNode(Hash256AsKey address, in TreePath path, TrieNode node) => Nodes.Set(address, path, node);
+
+    public bool TryGetMissStorageNode(Hash256AsKey address, in TreePath path, Hash256 hash, [NotNullWhen(true)] out TrieNode? node) => MissNodes.TryGet(address, path, hash, out node);
+
+    public TrieNode GetOrAddMissStorageNode(Hash256AsKey address, in TreePath path, TrieNode trieNode) => MissNodes.GetOrAdd(address, path, trieNode);
 }

--- a/src/Nethermind/Nethermind.State.Flat/TransientResource.cs
+++ b/src/Nethermind/Nethermind.State.Flat/TransientResource.cs
@@ -35,10 +35,9 @@ public record TransientResource(TransientResource.Size size) : IDisposable, IRes
     public TrieNodeCache.ChildCache Nodes = new(size.NodesCacheSize);
 
     /// <summary>
-    /// The trie warmer's negative cache: paths whose persistence lookup missed, keyed like <see cref="Nodes"/> but
-    /// holding only unresolved placeholders. It is read and written exclusively by the warmer and is never consulted
-    /// by a live read nor promoted into the shared <see cref="TrieNodeCache"/>, so a stale miss can never reach the
-    /// state-root computation.
+    /// The trie warmer's negative cache: paths whose in-memory lookup missed, keyed like <see cref="Nodes"/> but
+    /// holding only unresolved placeholders. No live read consults it (live reads use <see cref="Nodes"/> only) and
+    /// <see cref="TrieNodeCache.Add"/> never promotes it into the shared <see cref="TrieNodeCache"/>.
     /// </summary>
     public TrieNodeCache.ChildCache MissNodes = new(size.NodesCacheSize);
 

--- a/src/Nethermind/Nethermind.State.Flat/TrieNodeCache.cs
+++ b/src/Nethermind/Nethermind.State.Flat/TrieNodeCache.cs
@@ -133,7 +133,7 @@ public sealed class TrieNodeCache : ITrieNodeCache
             (int hashCode, TrieNode? node)[] shard = transientResource.Nodes.Shards[i];
             for (int j = 0; j < shard.Length; j++)
             {
-                if (shard[j].node is { } newNode && !IsPlaceholder(newNode)) AddToCacheWithHashCode(i, shard[j].hashCode, newNode);
+                if (shard[j].node is { } newNode) AddToCacheWithHashCode(i, shard[j].hashCode, newNode);
             }
         });
 
@@ -168,14 +168,6 @@ public sealed class TrieNodeCache : ITrieNodeCache
 
         Nethermind.Trie.Pruning.Metrics.MemoryUsedByCache = currentTotalMemory;
     }
-
-    /// <summary>
-    /// Identifies a placeholder trie node: <see cref="NodeType.Unknown"/> with empty RLP, carrying only a hash. The
-    /// trie warmer's negative cache and the trie commit path both produce it; it is not an authoritative node, so it
-    /// must neither enter this shared cache nor satisfy a live read - callers fall through to the snapshots or
-    /// persistence lookup instead.
-    /// </summary>
-    internal static bool IsPlaceholder(TrieNode node) => node.NodeType == NodeType.Unknown && node.FullRlp.Length == 0;
 
     /// <summary>
     /// Clears all cached trie nodes.


### PR DESCRIPTION
## Changes

Fix-forward for a correctness regression on the **flat** state layout introduced by #12877 (`6a56efd36d`): the trie warmer's negative-miss cache could feed an unresolved placeholder into the state-root computation, producing `InvalidStateRoot` on a live-head sync. #12877 itself was a performance fix for #12793 (`8b7a4acb34`); this change keeps the correctness intent without the unsafe mechanism it used.

### Root cause

#12877 stored warmer misses (unresolved `NodeType.Unknown` placeholders) in the same `TransientResource.Nodes` structure that live reads consult, guarded by an `IsPlaceholder` predicate re-checked at every read site. That guard is a lock-free predicate on a hot path shared with concurrent live reads: the sentinel lives in the same structure the live path reads, so the predicate leaves a window where a stale placeholder is observed as a real node, and `TrieNodeCache.Add` could promote it into the cross-block cache. On flat mainnet+gnosis this surfaced as `InvalidStateRoot` during `Wait for sync` (first red run `32157771920`, sha `6a56efd`).

### Fix — correct by construction

- **Dedicated `TransientResource.MissNodes`** holds the warmer's negative cache. Live reads use `Nodes` only and never consult `MissNodes`, so an unresolved placeholder can never reach a live read or the state root.
- **`SnapshotBundle` warmer paths** (`FindStateNodeOrUnknownForTrieWarmer` / `FindStorageNodeOrUnknownTrieWarmer`) look up three-stage: `Nodes` → `MissNodes` → persistence, writing misses only into `MissNodes`.
- **`TrieNodeCache.Add`** no longer filters on a placeholder predicate; `Nodes` now contains only real nodes, and the `IsPlaceholder` predicate plus its per-read guards are removed as dead code. Removing the predicate-based hot-path guard is the point — a predicate re-checked under concurrency is exactly the class of defect that produced the regression.

Rationale for `MissNodes` sized at parity with `Nodes`: both start at 1024 and grow with the block's working set via `ChildCache.Reset` (grow-only). On a cold live-head sync — the regression scenario — misses are a large fraction of the traversal; undersizing `MissNodes` would thrash it within a block (`Reset` runs only between blocks) and re-probe persistence, which is the cost #12877 set out to remove.

## Correctness validation

Unit tests are **not** sufficient here: the broken #12877 passed its own unit tests. The gate is a green flat sync on a live head.

- **Sync Master Validation** [run 32367702647](https://github.com/NethermindEth/nethermind/actions/runs/32367702647), `mode=Both`, image built from this branch: `Wait for sync` **green on all four** — Flat mainnet, Flat gnosis, HalfPath mainnet, HalfPath gnosis. No `InvalidStateRoot` / `Invalid Block` / `Exception` in node logs.
- `Nethermind.State.Flat.Test`: 1000 total / 0 failed / 10 skipped, build 0 warnings / 0 errors.

## Performance

A/B on the `reproducible-benchmarks` runner, `flat` / `realblocks`, metric `expb_client_processing` (SSE client processing — Nethermind's internal per-payload time), baseline `master-942eabf` (the branch's base commit) vs this branch, single difference = this diff.

- [run 32367705931](https://github.com/NethermindEth/nethermind/actions/runs/32367705931), n=3: **AVG +2.2%** (20.02 → 20.46 ms), **MEDIAN +2.3%** (17.37 → 17.77 ms), CV ~0.6%.

This ~2.2% against current master is real and is the **cost of correct isolation**: #12877's −2.7% came from keeping warmer-resolved nodes in the shared `Nodes` structure so `TrieNodeCache.Add` promoted them into the cross-block cache. That promotion is the same shared-instance retention that produced the regression, so it cannot be kept.

### Why the obvious optimization was rejected (measured)

I implemented and benchmarked the promotion path (promote only *resolved* `MissNodes` entries, gated on `NodeType != Unknown`, into the cross-block cache):

- Perf recovered to noise vs master — [run 32417565010](https://github.com/NethermindEth/nethermind/actions/runs/32417565010) (n=3) and [run 32429803521](https://github.com/NethermindEth/nethermind/actions/runs/32429803521) (n=5): AVG −0.42%, MEDIAN +0.11% at rig CV ~1–2%.
- But it **reintroduced the regression**: Sync Master Validation [run 32438552571](https://github.com/NethermindEth/nethermind/actions/runs/32438552571) → Flat mainnet + gnosis **failed** `Wait for sync` with `InvalidStateRoot` (mainnet: expected `0x2b5daf7a…c488`, got `0x9a72d2fd…283c`); HalfPath both green. The `NodeType` gate does not help — the promoted node is a shared instance with the live tree, and `TrieNodeCache.Add` runs `PrunePersistedRecursively(1)` on it concurrently.

That commit was dropped from the branch. Recovering the −2.7% safely requires a lease-drain barrier so promotion runs only against a quiesced warmer; that is a separate, correctness-critical change and out of scope here.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.State.Flat.Test` green (1000/0/10). Correctness proven by a full flat + halfpath sync on mainnet and gnosis ([run 32367702647](https://github.com/NethermindEth/nethermind/actions/runs/32367702647)); the rejected promotion variant is disproven by [run 32438552571](https://github.com/NethermindEth/nethermind/actions/runs/32438552571). Perf measured by A/B ([run 32367705931](https://github.com/NethermindEth/nethermind/actions/runs/32367705931)).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No
