### PR TITLE
ci(bench): restore the amd64 benchmark runner and select it by input

### DIFF
--- a/.github/workflows/arm-runner-maintenance.yml
+++ b/.github/workflows/arm-runner-maintenance.yml
@@ -68,7 +68,7 @@ jobs:
             cutoff=$(( $(date +%s) - 96*3600 ))
             while IFS=$'	' read -r created img; do
               [[ -z "${img:-}" || "${img}" == *'<none>'* ]] && continue
-              ts=$(date -d "${created}" +%s 2>/dev/null) || continue
+              ts=$(date -d "${created% *}" +%s 2>/dev/null) || continue
               (( ts > cutoff )) && continue
               [[ -n "$(docker ps -aq --filter "ancestor=${img}" 2>/dev/null)" ]] && continue
               docker rmi "${img}" >/dev/null 2>&1 && echo "removed ${img} (created ${created})"

--- a/.github/workflows/arm-runner-maintenance.yml
+++ b/.github/workflows/arm-runner-maintenance.yml
@@ -2,7 +2,9 @@ name: ARM Runner Maintenance
 
 # Frees disk on the reproducible-benchmarks-arm runner after benchmark runs fill it
 # (docker layer churn, leftover containers/networks, runner diag/work debris).
-# Never removes tagged images - the pinned armbench-*/master-* A/B images must survive.
+# By default never removes tagged images - the pinned armbench-*/master-* A/B images must survive.
+# prune_unused_images=true additionally drops unreferenced tags older than 96h, which is the only
+# thing that reclaims this box's containerd-backed image store (see that step for why).
 
 on:
   # push registers the workflow for dispatch on this branch (dispatch-only workflows on
@@ -59,7 +61,18 @@ jobs:
           docker builder prune -af || true
           docker image prune -f || true
           if [[ "${PRUNE_UNUSED_IMAGES}" == "true" ]]; then
-            docker image prune -af --filter "until=96h" || true
+            # Docker here uses the CONTAINERD image store, so image content lives in /var/lib/containerd
+            # rather than /var/lib/docker, and `image prune -a --filter until=` reports 0B against it
+            # (`docker system df` even reports a negative reclaimable). Only an explicit rmi frees it,
+            # so age-filter the tags ourselves and remove those no container references.
+            cutoff=$(( $(date +%s) - 96*3600 ))
+            while IFS=$'	' read -r created img; do
+              [[ -z "${img:-}" || "${img}" == *'<none>'* ]] && continue
+              ts=$(date -d "${created}" +%s 2>/dev/null) || continue
+              (( ts > cutoff )) && continue
+              [[ -n "$(docker ps -aq --filter "ancestor=${img}" 2>/dev/null)" ]] && continue
+              docker rmi "${img}" >/dev/null 2>&1 && echo "removed ${img} (created ${created})"
+            done < <(docker images --format '{{.CreatedAt}}	{{.Repository}}:{{.Tag}}')
           fi
 
       - name: Trim runner diag and work debris

--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -3,6 +3,18 @@ name: Run EXPB Reproducible Benchmarks
 on:
   workflow_dispatch:
     inputs:
+      arch:
+        description: >-
+          Which self-hosted benchmark runner to use, and with it every path that differs between the
+          boxes. amd64 = `reproducible-benchmarks` (EPYC 4344P, snapshots under /mnt/sda); arm64 =
+          `reproducible-benchmarks-arm` (Axion, snapshots under /data, flat layout only). Timings from
+          the two boxes are NOT comparable — never mix them in one A/B.
+        required: false
+        type: choice
+        options:
+          - amd64
+          - arm64
+        default: amd64
       expb_repo:
         description: execution-payloads-benchmarks repository in owner/repo format
         required: false
@@ -19,18 +31,6 @@ on:
           - halfpath
           - flat
         default: flat
-      arch:
-        description: >-
-          Which self-hosted benchmark runner to use, and with it every path that differs between the
-          boxes. amd64 = `reproducible-benchmarks` (EPYC 4344P, snapshots under /mnt/sda); arm64 =
-          `reproducible-benchmarks-arm` (Axion, snapshots under /data, flat layout only). Timings from
-          the two boxes are NOT comparable — never mix them in one A/B.
-        required: false
-        type: choice
-        options:
-          - amd64
-          - arm64
-        default: amd64
       payload_set:
         description: Payload set mode
         required: true
@@ -61,6 +61,9 @@ on:
           --FlatDb.PersistenceWriteBufferFloor. Keeps small-CompactSize persistence batches from
           shrinking RocksDB memtables (decouples write amplification from CompactSize). Set empty to
           disable. Ignored for non-flat layouts and when additional_extra_flags already sets it.
+          SET THIS EMPTY when benchmarking an image built before 2026-06-16 (#11936 added the flag):
+          older clients reject an unknown argument by printing CLI usage and exiting, which looks
+          like a workflow failure rather than a flag mismatch.
         required: false
         default: "67108864"
       expb_env:
@@ -663,6 +666,7 @@ jobs:
       - name: Print resolved inputs
         run: |
           echo "Event: ${{ github.event_name }}"
+          echo "Runner: ${{ needs.resolve.outputs.runner_label }}"
           echo "Payload set: ${{ matrix.payload_set }}"
           echo "Nethermind branch: ${{ needs.resolve.outputs.branch }}"
           echo "Docker image: ${NETHERMIND_IMAGE}"
@@ -1834,6 +1838,7 @@ jobs:
       - name: Print resolved inputs
         run: |
           echo "Multi-image benchmark run"
+          echo "Runner: ${{ needs.resolve.outputs.runner_label }}"
           echo "Docker image: ${NETHERMIND_IMAGE}"
           echo "Image tag: ${{ matrix.tag }}"
           echo "Run: ${{ matrix.run }} of ${{ needs.resolve.outputs.run_count }}"

--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -355,6 +355,13 @@ jobs:
               ;;
           esac
 
+          # The ARM box stocks only a flat snapshot, and the config render rewrites only the flat
+          # paths, so a halfpath run there would fail deep inside expb instead of here in seconds.
+          if [[ "${arch}" == "arm64" && "${state_layout}" != "flat" ]]; then
+            echo "::error::The reproducible-benchmarks-arm runner only serves a flat snapshot - dispatch with arch=amd64 for halfpath."
+            exit 1
+          fi
+
           # Default the FlatDb write-buffer (memtable) floor for flat layout by routing it through the
           # extra-flags pipeline, so it actually reaches Nethermind (same path as additional_extra_flags).
           # Skipped for non-flat layouts, when disabled (empty), or when the caller already set it.

--- a/.github/workflows/run-expb-reproducible-benchmarks.yml
+++ b/.github/workflows/run-expb-reproducible-benchmarks.yml
@@ -16,8 +16,21 @@ on:
         required: true
         type: choice
         options:
+          - halfpath
           - flat
         default: flat
+      arch:
+        description: >-
+          Which self-hosted benchmark runner to use, and with it every path that differs between the
+          boxes. amd64 = `reproducible-benchmarks` (EPYC 4344P, snapshots under /mnt/sda); arm64 =
+          `reproducible-benchmarks-arm` (Axion, snapshots under /data, flat layout only). Timings from
+          the two boxes are NOT comparable — never mix them in one A/B.
+        required: false
+        type: choice
+        options:
+          - amd64
+          - arm64
+        default: amd64
       payload_set:
         description: Payload set mode
         required: true
@@ -153,6 +166,9 @@ jobs:
       expb_repo: ${{ steps.resolve.outputs.expb_repo }}
       expb_branch: ${{ steps.resolve.outputs.expb_branch }}
       expb_data_dir: ${{ steps.resolve.outputs.expb_data_dir }}
+      runner_label: ${{ steps.resolve.outputs.runner_label }}
+      flat_snapshot_dir: ${{ steps.resolve.outputs.flat_snapshot_dir }}
+      flat_snapshot_block_dir: ${{ steps.resolve.outputs.flat_snapshot_block_dir }}
       delay_seconds: ${{ steps.resolve.outputs.delay_seconds }}
       amount: ${{ steps.resolve.outputs.amount }}
       additional_extra_flags: ${{ steps.resolve.outputs.additional_extra_flags }}
@@ -182,6 +198,7 @@ jobs:
           CURRENT_REPO: ${{ github.repository }}
           PUSH_BRANCH: ${{ github.ref_name }}
           DISPATCH_STATE_LAYOUT: ${{ inputs.state_layout }}
+          DISPATCH_ARCH: ${{ inputs.arch }}
           DISPATCH_PAYLOAD_SET: ${{ inputs.payload_set }}
           DISPATCH_EXPB_REPO: ${{ inputs.expb_repo }}
           DISPATCH_EXPB_BRANCH: ${{ inputs.expb_branch }}
@@ -213,7 +230,7 @@ jobs:
             payload_set="${DISPATCH_PAYLOAD_SET}"
             expb_repo="${DISPATCH_EXPB_REPO}"
             expb_branch="${DISPATCH_EXPB_BRANCH}"
-            expb_data_dir="/data/expb-data"
+            arch="${DISPATCH_ARCH:-amd64}"
             delay_seconds="${DISPATCH_DELAY_SECONDS:-0}"
             if [[ -n "${DISPATCH_AMOUNT}" ]]; then
               amount="${DISPATCH_AMOUNT}"
@@ -281,7 +298,7 @@ jobs:
             payload_sets='["superblocks","realblocks","fusaka"]'
             expb_repo="NethermindEth/execution-payloads-benchmarks"
             expb_branch="main"
-            expb_data_dir="/data/expb-data"
+            arch="amd64"
             delay_seconds="0"
             amount=""
             additional_extra_flags=""
@@ -299,7 +316,7 @@ jobs:
             payload_sets='["superblocks","realblocks","fusaka"]'
             expb_repo="NethermindEth/execution-payloads-benchmarks"
             expb_branch="main"
-            expb_data_dir="/data/expb-data"
+            arch="amd64"
             delay_seconds="0"
             amount=""
             additional_extra_flags=""
@@ -311,6 +328,29 @@ jobs:
             trace_blocks=""
             client_env=""
           fi
+
+          # One switch drives the runner and every path that differs between the two boxes, so a
+          # dispatch cannot end up on one runner holding the other's snapshot paths.
+          case "${arch}" in
+            arm64)
+              runner_label="reproducible-benchmarks-arm"
+              expb_data_dir="/data/expb-data"
+              # This box carries a single flat snapshot and serves both config spellings from it.
+              flat_snapshot_dir="/data/nethermind/nethermind-flat-25490000"
+              flat_snapshot_block_dir="/data/nethermind/nethermind-flat-25490000"
+              ;;
+            amd64)
+              runner_label="reproducible-benchmarks"
+              expb_data_dir="/mnt/sda/expb-data"
+              # Identity rewrites: the configs on this box already carry these paths.
+              flat_snapshot_dir="/mnt/sda/nethermind-flat-snapshot"
+              flat_snapshot_block_dir="/mnt/sda/nethermind-flat-25490000"
+              ;;
+            *)
+              echo "::error::Unsupported arch '${arch}' (expected amd64 or arm64)."
+              exit 1
+              ;;
+          esac
 
           # Default the FlatDb write-buffer (memtable) floor for flat layout by routing it through the
           # extra-flags pipeline, so it actually reaches Nethermind (same path as additional_extra_flags).
@@ -402,6 +442,9 @@ jobs:
             echo "expb_repo=${expb_repo}"
             echo "expb_branch=${expb_branch}"
             echo "expb_data_dir=${expb_data_dir}"
+            echo "runner_label=${runner_label}"
+            echo "flat_snapshot_dir=${flat_snapshot_dir}"
+            echo "flat_snapshot_block_dir=${flat_snapshot_block_dir}"
             echo "delay_seconds=${delay_seconds}"
             echo "amount=${amount}"
             echo "cleanup_grace_seconds=${cleanup_grace_seconds}"
@@ -574,10 +617,12 @@ jobs:
         payload_set: ${{ fromJson(needs.resolve.outputs.payload_sets) }}
       max-parallel: 1
       fail-fast: false
-    runs-on: [self-hosted, reproducible-benchmarks-arm]
+    runs-on: [self-hosted, "${{ needs.resolve.outputs.runner_label }}"]
     timeout-minutes: 720
     env:
       EXPB_DATA_DIR: ${{ needs.resolve.outputs.expb_data_dir }}
+      FLAT_SNAPSHOT_DIR: ${{ needs.resolve.outputs.flat_snapshot_dir }}
+      FLAT_SNAPSHOT_BLOCK_DIR: ${{ needs.resolve.outputs.flat_snapshot_block_dir }}
       NETHERMIND_IMAGE: ${{ needs.resolve.outputs.image_label }}
       CLEANUP_GRACE_SECONDS: ${{ needs.resolve.outputs.cleanup_grace_seconds }}
     steps:
@@ -745,8 +790,8 @@ jobs:
             -e "s#<<DELAY>>#${DELAY_SECONDS}#g" \
             ${AMOUNT:+-e "s#<<AMOUNT>>#${AMOUNT}#g"} \
             -e "s#/mnt/sda/expb-data#${EXPB_DATA_DIR}#g" \
-            -e "s#/mnt/sda/nethermind-flat-snapshot#/data/nethermind/nethermind-flat-25490000#g" \
-            -e "s#/mnt/sda/nethermind-flat-25490000#/data/nethermind/nethermind-flat-25490000#g" \
+            -e "s#/mnt/sda/nethermind-flat-snapshot#${FLAT_SNAPSHOT_DIR}#g" \
+            -e "s#/mnt/sda/nethermind-flat-25490000#${FLAT_SNAPSHOT_BLOCK_DIR}#g" \
             -e "s#^\([[:space:]]*\)nethermind:#\1${SCENARIO_NAME}:#g" \
             "${SOURCE_CONFIG_FILE}" > "${RENDERED_CONFIG_FILE}"
 
@@ -1776,10 +1821,12 @@ jobs:
       matrix: ${{ fromJson(needs.resolve-images.outputs.matrix) }}
       max-parallel: 1
       fail-fast: false
-    runs-on: [self-hosted, reproducible-benchmarks-arm]
+    runs-on: [self-hosted, "${{ needs.resolve.outputs.runner_label }}"]
     timeout-minutes: 720
     env:
       EXPB_DATA_DIR: ${{ needs.resolve.outputs.expb_data_dir }}
+      FLAT_SNAPSHOT_DIR: ${{ needs.resolve.outputs.flat_snapshot_dir }}
+      FLAT_SNAPSHOT_BLOCK_DIR: ${{ needs.resolve.outputs.flat_snapshot_block_dir }}
       CONFIG_FILE: ${{ needs.resolve.outputs.config_file }}
       NETHERMIND_IMAGE: ${{ matrix.image }}
       CLEANUP_GRACE_SECONDS: ${{ needs.resolve.outputs.cleanup_grace_seconds }}
@@ -1889,8 +1936,8 @@ jobs:
             -e "s#<<DELAY>>#${DELAY_SECONDS}#g" \
             ${AMOUNT:+-e "s#<<AMOUNT>>#${AMOUNT}#g"} \
             -e "s#/mnt/sda/expb-data#${EXPB_DATA_DIR}#g" \
-            -e "s#/mnt/sda/nethermind-flat-snapshot#/data/nethermind/nethermind-flat-25490000#g" \
-            -e "s#/mnt/sda/nethermind-flat-25490000#/data/nethermind/nethermind-flat-25490000#g" \
+            -e "s#/mnt/sda/nethermind-flat-snapshot#${FLAT_SNAPSHOT_DIR}#g" \
+            -e "s#/mnt/sda/nethermind-flat-25490000#${FLAT_SNAPSHOT_BLOCK_DIR}#g" \
             -e "s#^\([[:space:]]*\)nethermind:#\1${SCENARIO_NAME}:#g" \
             "${SOURCE_CONFIG_FILE}" > "${RENDERED_CONFIG_FILE}"
 

--- a/.github/workflows/run-rpc-benchmarks.yml
+++ b/.github/workflows/run-rpc-benchmarks.yml
@@ -8,6 +8,18 @@ name: Run RPC Benchmarks
 on:
   workflow_dispatch:
     inputs:
+      arch:
+        description: >-
+          Which self-hosted benchmark runner to use, and with it every path that differs between the
+          boxes. amd64 = `reproducible-benchmarks` (EPYC 4344P, snapshots under /mnt/sda, all clients
+          and both layouts); arm64 = `reproducible-benchmarks-arm` (Axion, snapshots under /data,
+          Nethermind + flat only, prebuilt images only). Timings from the two boxes are NOT comparable.
+        required: false
+        type: choice
+        options:
+          - amd64
+          - arm64
+        default: amd64
       benchmark_tool:
         description: Load-testing tool to use (with reference_client, flood runs --equality and jsonbench runs compare)
         required: true
@@ -75,18 +87,6 @@ on:
           - halfpath
           - flat
         default: flat
-      arch:
-        description: >-
-          Which self-hosted benchmark runner to use, and with it every path that differs between the
-          boxes. amd64 = `reproducible-benchmarks` (EPYC 4344P, snapshots under /mnt/sda, all clients
-          and both layouts); arm64 = `reproducible-benchmarks-arm` (Axion, snapshots under /data,
-          Nethermind + flat only, prebuilt images only). Timings from the two boxes are NOT comparable.
-        required: false
-        type: choice
-        options:
-          - amd64
-          - arm64
-        default: amd64
       additional_nethermind_flags:
         description: "Extra Nethermind flags appended to the node command (e.g. --Pruning.CacheMb=4000)"
         required: false
@@ -149,6 +149,7 @@ jobs:
       scratch_root: ${{ steps.resolve.outputs.scratch_root }}
       runner_label: ${{ steps.resolve.outputs.runner_label }}
       corpus_dir: ${{ steps.resolve.outputs.corpus_dir }}
+      snapshot_root: ${{ steps.resolve.outputs.snapshot_root }}
       network: ${{ steps.resolve.outputs.network }}
       jsonrpc_modules: ${{ steps.resolve.outputs.jsonrpc_modules }}
       layout_flags: ${{ steps.resolve.outputs.layout_flags }}
@@ -518,6 +519,7 @@ jobs:
             echo "scratch_root=${scratch_root}"
             echo "runner_label=${runner_label}"
             echo "corpus_dir=${bench_data_dir}/rpc-bench"
+            echo "snapshot_root=${snapshot_root}"
             echo "network=${network}"
             echo "jsonrpc_modules=${jsonrpc_modules}"
             echo "layout_flags=${layout_flags}"
@@ -574,6 +576,7 @@ jobs:
 
       - name: Print resolved configuration
         run: |
+          echo "Runner:      ${{ needs.resolve.outputs.runner_label }}"
           echo "Tool:        ${{ needs.resolve.outputs.benchmark_tool }}"
           echo "Client:      ${{ needs.resolve.outputs.client }}"
           echo "Reference:   ${{ needs.resolve.outputs.reference_client }} (comparison: ${{ needs.resolve.outputs.comparison }})"
@@ -586,6 +589,7 @@ jobs:
           echo "Ref DB:      ${{ needs.resolve.outputs.ref_db_source }}"
           echo "Isolation:   ${{ needs.resolve.outputs.db_isolation }}"
           echo "Scratch:     ${{ needs.resolve.outputs.scratch_root }}"
+          echo "Corpus dir:  ${{ needs.resolve.outputs.corpus_dir }}"
           echo "Layout flags: ${{ needs.resolve.outputs.layout_flags }}"
 
       - name: Prepare scratch and output dirs
@@ -599,28 +603,59 @@ jobs:
         if: needs.resolve.outputs.runner_label == 'reproducible-benchmarks-arm'
         shell: bash
         # The box has a ~19G root disk. A pull that runs it out of space kills the docker daemon and the
-        # runner with it, so reclaim what is safely reclaimable first and refuse to start if still tight.
-        # Tagged benchmark images are never touched — pinned A/B images must survive between runs.
+        # runner with it, so reclaim first and only refuse to start if the disk is still tight afterwards.
+        env:
+          KEEP_IMAGES: |
+            ${{ needs.resolve.outputs.image_ref }}
+            ${{ needs.resolve.outputs.ref_image_ref }}
         run: |
           set -uo pipefail
           MIN_FREE_GB=6
-          df -h / || true
           avail_gb() { df -BG --output=avail / | tail -1 | tr -dc '0-9'; }
+          report() { df -h /; du -xsh /var/lib/containerd /var/lib/docker 2>/dev/null || true; }
+
+          echo "== before =="; report
           echo "Free before reclaim: $(avail_gb)G"
+
+          # Cheap, always-safe garbage first.
           docker container prune -f || true
           docker network prune -f || true
           docker builder prune -af || true
           docker image prune -f || true
+          # 'volume prune' only removes anonymous volumes; named expb volumes outlive their output dirs
+          # and later fail mounts with a 500.
           docker volume ls -q | grep -E '^expb-' | xargs -r docker volume rm -f || true
           find /root/actions-runner/_diag -type f -name '*.log' -mtime +1 -delete 2>/dev/null || true
           rm -rf /root/actions-runner/_work/_temp/* 2>/dev/null || true
+          apt-get clean 2>/dev/null || true
+          journalctl --vacuum-size=200M 2>/dev/null || true
+
+          # Stale benchmark images are the monotonic consumer: every campaign pushes multi-GB tags and
+          # nothing retires them. Docker here uses the CONTAINERD image store, so that content lands in
+          # /var/lib/containerd and `docker image prune -a --filter until=<age>` reports 0B against it
+          # (`docker system df` even reports a negative reclaimable) — an explicit `docker rmi` is the
+          # only thing that frees it. Drop unused tags oldest-first, and only as many as needed, so
+          # pinned A/B images survive whenever there is already room.
+          if (( $(avail_gb) < MIN_FREE_GB )); then
+            keep_re="$(printf '%s\n' "${KEEP_IMAGES}" | tr -d ' ' | grep -v '^$' | paste -sd'|' -)"
+            echo "Reclaiming stale images (keeping: ${keep_re:-none})"
+            while IFS= read -r img; do
+              (( $(avail_gb) >= MIN_FREE_GB )) && break
+              [[ -z "${img}" || "${img}" == *'<none>'* ]] && continue
+              [[ -n "${keep_re}" ]] && [[ "${img}" =~ ^(${keep_re})$ ]] && continue
+              # Never touch an image a container still references (another queued job may be mid-run).
+              [[ -n "$(docker ps -aq --filter "ancestor=${img}" 2>/dev/null)" ]] && continue
+              if docker rmi "${img}" >/dev/null 2>&1; then echo "  dropped ${img}"; fi
+            done < <(docker images --format '{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}' | sort | cut -f2-)
+          fi
+
           free="$(avail_gb)"
+          echo "== after =="; report
           echo "Free after reclaim: ${free}G (need ${MIN_FREE_GB}G)"
-          docker system df || true
           if (( free < MIN_FREE_GB )); then
-            echo "::error::Only ${free}G free on / — refusing to start rather than risk killing the runner daemon."
-            echo "Dispatch 'ARM Runner Maintenance' with prune_unused_images=true to drop stale tagged images."
-            docker images --format '{{.Size}}\t{{.Repository}}:{{.Tag}}' | sort -rh | head -20 || true
+            echo "::error::Only ${free}G free on / after reclaim — refusing to start rather than risk killing the runner daemon."
+            echo "Everything reclaimable is already gone; the remaining usage needs a look over SSH."
+            du -xh --max-depth=2 /var /usr /root 2>/dev/null | sort -rh | head -15 || true
             exit 1
           fi
 
@@ -829,6 +864,7 @@ jobs:
           TOOL_CONFIG: ${{ needs.resolve.outputs.tool_config }}
           RESOLVED_ETH_CALL_CORPUS: ${{ needs.resolve.outputs.eth_call_corpus }}
           RESOLVED_CORPUS_DIR: ${{ needs.resolve.outputs.corpus_dir }}
+          SNAPSHOT_ROOT: ${{ needs.resolve.outputs.snapshot_root }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1237,5 +1273,3 @@ jobs:
               echo ""
             } >> "${GITHUB_STEP_SUMMARY}"
           done
-
-  # Temporary side-branch entry point for building pinned comparison images on the ARM runner.

--- a/.github/workflows/run-rpc-benchmarks.yml
+++ b/.github/workflows/run-rpc-benchmarks.yml
@@ -608,6 +608,7 @@ jobs:
           KEEP_IMAGES: |
             ${{ needs.resolve.outputs.image_ref }}
             ${{ needs.resolve.outputs.ref_image_ref }}
+          KEEP_TOOL_CONFIG: ${{ needs.resolve.outputs.tool_config }}
         run: |
           set -uo pipefail
           MIN_FREE_GB=6
@@ -637,7 +638,12 @@ jobs:
           # only thing that frees it. Drop unused tags oldest-first, and only as many as needed, so
           # pinned A/B images survive whenever there is already room.
           if (( $(avail_gb) < MIN_FREE_GB )); then
-            keep_re="$(printf '%s\n' "${KEEP_IMAGES}" | tr -d ' ' | grep -v '^$' | paste -sd'|' -)"
+            # Sweep arms come from tool_config.clients as `ctype@image`, and run-rpc-sweep.sh treats a
+            # failed pull as "probably local" — so dropping one of those yields a silently partial matrix
+            # rather than an error. Keep them too.
+            sweep_keep="$(printf '%s' "${KEEP_TOOL_CONFIG:-}" | jq -r '.clients // empty' 2>/dev/null \
+              | tr ' ' '\n' | sed 's/.*@//' | grep -v '^$' || true)"
+            keep_re="$(printf '%s\n%s\n' "${KEEP_IMAGES}" "${sweep_keep}" | tr -d ' ' | grep -v '^$' | sort -u | paste -sd'|' -)"
             echo "Reclaiming stale images (keeping: ${keep_re:-none})"
             while IFS= read -r img; do
               (( $(avail_gb) >= MIN_FREE_GB )) && break
@@ -776,6 +782,7 @@ jobs:
           SCRATCH_ROOT: ${{ needs.resolve.outputs.scratch_root }}
           TOOL_CONFIG: ${{ needs.resolve.outputs.tool_config }}
           RESOLVED_ETH_CALL_CORPUS: ${{ needs.resolve.outputs.eth_call_corpus }}
+          RESOLVED_CORPUS_DIR: ${{ needs.resolve.outputs.corpus_dir }}
           CLIENT_TYPE: ${{ needs.resolve.outputs.client }}
           COMPARISON: ${{ needs.resolve.outputs.comparison }}
           REFERENCE_CLIENT: ${{ needs.resolve.outputs.reference_client }}
@@ -803,7 +810,10 @@ jobs:
           # Which corpus to replay. The sweep picks one with corpus_glob; this path had no
           # equivalent and always replayed the default file, so a profile taken here could not be
           # compared against a sweep measured on a different corpus.
-          jb_corpus="$(get '.corpus_file')";             [[ -n "${jb_corpus}" ]] && export JB_ETH_CALL_CORPUS_FILE="${jb_corpus}"
+          # Default to the selected runner's corpus dir; only an explicit corpus_file overrides it.
+          jb_corpus="$(get '.corpus_file')"
+          [[ -z "${jb_corpus}" && -n "${RESOLVED_CORPUS_DIR:-}" ]] && jb_corpus="${RESOLVED_CORPUS_DIR}/eth-call-corpus.jsonl.gz"
+          [[ -n "${jb_corpus}" ]] && export JB_ETH_CALL_CORPUS_FILE="${jb_corpus}"
           jb_html="$(getb '.html_report')";              [[ -n "${jb_html}" ]] && export JB_HTML_REPORT="${jb_html}"
           export JB_FAIL_ON_DIFF="$(getb '.fail_on_diff')"
           # getb: '// empty' would swallow an explicit 0 (jq treats it as truthy-false).
@@ -876,7 +886,9 @@ jobs:
           corpus_dir="$(get '.corpus_dir')";               [[ -z "${corpus_dir}" ]] && corpus_dir="${RESOLVED_CORPUS_DIR}"
           [[ -n "${corpus_dir}" ]] && export CORPUS_DIR="${corpus_dir}"
           corpus_glob="$(get '.corpus_glob')";             [[ -n "${corpus_glob}" ]] && export CORPUS_GLOB="${corpus_glob}"
-          export CLIENTS="$(get '.clients')";              [[ -z "${CLIENTS}" ]] && export CLIENTS="nethermind geth reth"
+          # Sweep mode resolves one Nethermind flat snapshot, so the geth/reth default it used to carry
+          # made a bare dispatch fail its own guard. Cross-client work belongs in single-node mode.
+          export CLIENTS="$(get '.clients')";              [[ -z "${CLIENTS}" ]] && export CLIENTS="nethermind"
           # An ABSENT rps_list means "use the default"; an explicitly EMPTY one means "no k6 cells"
           # (corpus runs that only want parity/timings). `// empty` cannot tell those apart.
           if [[ "$(echo "${cfg}" | jq -r 'has("rps_list")')" == "true" ]]; then

--- a/.github/workflows/run-rpc-benchmarks.yml
+++ b/.github/workflows/run-rpc-benchmarks.yml
@@ -1,6 +1,7 @@
 name: Run RPC Benchmarks
 
-# Benchmark a client's JSON-RPC on the self-hosted `reproducible-benchmarks-arm` runner, reusing its DB snapshots.
+# Benchmark a client's JSON-RPC on a self-hosted benchmark runner, reusing its DB snapshots.
+# The `arch` input picks the box: amd64 -> `reproducible-benchmarks`, arm64 -> `reproducible-benchmarks-arm`.
 # Only read-only RPCs are benchmarked (eth_call/getBalance/trace/debug — none change state); each snapshot is fingerprinted before/after. Under overlay/copy the snapshot is never mounted writable, so any change FAILS the job.
 # reth's 'direct' mode mounts the snapshot read-write, where the node's DB-engine startup writes are expected — there the tripwire warns instead of failing. See scripts/rpc-bench/README.md.
 
@@ -23,6 +24,8 @@ on:
         type: choice
         options:
           - nethermind
+          - geth
+          - reth
         default: nethermind
       reference_client:
         description: Start a second client from its same-block snapshot and compare responses (flood/jsonbench only)
@@ -30,10 +33,13 @@ on:
         type: choice
         options:
           - none
+          - geth
+          - nethermind
+          - reth
         default: none
       snapshot_block:
         description: >-
-          Snapshot set tag: picks /data/nethermind/<client>-<tag> (nethermind resolves to
+          Snapshot set tag: picks <snapshot root>/<client>-<tag> on the selected runner (nethermind resolves to
           nethermind-flat-<tag>). Empty = the expb snapshot for
           nethermind, and 25490000 for geth/reth or whenever reference_client is set
           (a comparison needs both nodes at the same head).
@@ -66,8 +72,21 @@ on:
         required: true
         type: choice
         options:
+          - halfpath
           - flat
         default: flat
+      arch:
+        description: >-
+          Which self-hosted benchmark runner to use, and with it every path that differs between the
+          boxes. amd64 = `reproducible-benchmarks` (EPYC 4344P, snapshots under /mnt/sda, all clients
+          and both layouts); arm64 = `reproducible-benchmarks-arm` (Axion, snapshots under /data,
+          Nethermind + flat only, prebuilt images only). Timings from the two boxes are NOT comparable.
+        required: false
+        type: choice
+        options:
+          - amd64
+          - arm64
+        default: amd64
       additional_nethermind_flags:
         description: "Extra Nethermind flags appended to the node command (e.g. --Pruning.CacheMb=4000)"
         required: false
@@ -90,7 +109,7 @@ on:
       node_config:
         description: >-
           Advanced node/runner overrides as JSON:
-          {"db_source":"","db_isolation":"overlay|copy|readonly-bind|direct","scratch_root":"/data/expb-data/rpc-bench-scratch",
+          {"db_source":"","db_isolation":"overlay|copy|readonly-bind|direct","scratch_root":"<defaults to the runner's expb data dir>",
           "network":"mainnet","jsonrpc_modules":"Eth,...","health_timeout_minutes":30,"cpuset":"2-7,10-15","memory":"64g",
           "reference_db_source":"","reference_image":"","reference_flags":"","reference_db_isolation":""}.
           Leave empty for defaults (db_source resolved from client/state_layout/snapshot_block; db_isolation defaults to 'direct' for reth — RW mount, no overlay copy-up — else 'overlay').
@@ -108,7 +127,7 @@ permissions:
 jobs:
   # Normalize inputs and decide how the Docker image is obtained.
   resolve:
-    if: ${{ !startsWith(inputs.docker_image, 'build-arm-pr-') && (github.event_name != 'pull_request' || (github.event.action == 'labeled' && contains(fromJSON('["rpc-benchmark","performance is good"]'), github.event.label.name) && github.event.pull_request.head.repo.full_name == github.repository)) }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action == 'labeled' && contains(fromJSON('["rpc-benchmark","performance is good"]'), github.event.label.name) && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.resolve.outputs.should_run }}
@@ -128,6 +147,8 @@ jobs:
       db_isolation: ${{ steps.resolve.outputs.db_isolation }}
       ref_db_isolation: ${{ steps.resolve.outputs.ref_db_isolation }}
       scratch_root: ${{ steps.resolve.outputs.scratch_root }}
+      runner_label: ${{ steps.resolve.outputs.runner_label }}
+      corpus_dir: ${{ steps.resolve.outputs.corpus_dir }}
       network: ${{ steps.resolve.outputs.network }}
       jsonrpc_modules: ${{ steps.resolve.outputs.jsonrpc_modules }}
       layout_flags: ${{ steps.resolve.outputs.layout_flags }}
@@ -155,6 +176,7 @@ jobs:
           IN_DOCKER_IMAGE: ${{ inputs.docker_image }}
           IN_DOTTRACE: ${{ inputs.dottrace }}
           IN_STATE_LAYOUT: ${{ inputs.state_layout }}
+          IN_ARCH: ${{ inputs.arch }}
           IN_FLAGS: ${{ inputs.additional_nethermind_flags }}
           IN_TOOL_CONFIG: ${{ inputs.tool_config }}
           IN_NODE_CONFIG: ${{ inputs.node_config }}
@@ -211,8 +233,31 @@ jobs:
             none|nethermind|geth|reth) ;;
             *) echo "Unknown reference_client '${reference_client}'."; exit 1;;
           esac
-          if [[ "${client}" != "nethermind" || "${reference_client}" != "none" ]]; then
-            echo "The reproducible-benchmarks-arm runner only supports a single Nethermind client."
+
+          # One switch drives the runner label and every path that differs between the two boxes, so a
+          # dispatch can never land on one runner carrying the other's snapshot paths.
+          arch="${IN_ARCH:-amd64}"
+          case "${arch}" in
+            arm64)
+              runner_label="reproducible-benchmarks-arm"
+              snapshot_root="/data/nethermind"
+              bench_data_dir="/data/expb-data"
+              ;;
+            amd64)
+              runner_label="reproducible-benchmarks"
+              snapshot_root="/mnt/sda"
+              bench_data_dir="/mnt/sda/expb-data"
+              ;;
+            *)
+              echo "::error::Unsupported arch '${arch}' (expected amd64 or arm64)."
+              exit 1
+              ;;
+          esac
+
+          # The ARM box stocks Nethermind flat snapshots only, so its narrower capabilities are checked
+          # against the selected runner instead of being removed from the inputs for everyone.
+          if [[ "${arch}" == "arm64" ]] && [[ "${client}" != "nethermind" || "${reference_client}" != "none" ]]; then
+            echo "::error::The reproducible-benchmarks-arm runner only supports a single Nethermind client - dispatch with arch=amd64 for geth/reth or a reference client."
             exit 1
           fi
           comparison="false"
@@ -281,12 +326,12 @@ jobs:
 
           nc() { echo "${node_config}" | jq -r "$1 // empty"; }
 
-          if [[ "${state_layout}" != "flat" ]]; then
-            echo "The reproducible-benchmarks-arm runner only supports the flat state layout."
+          if [[ "${arch}" == "arm64" && "${state_layout}" != "flat" ]]; then
+            echo "::error::The reproducible-benchmarks-arm runner only supports the flat state layout - dispatch with arch=amd64 for halfpath."
             exit 1
           fi
 
-          # Named snapshot sets follow /data/nethermind/<client>-<block>; without a tag nethermind falls back to the expb snapshots.
+          # Named snapshot sets follow <snapshot_root>/<client>-<block>; without a tag nethermind falls back to the expb snapshots.
           # geth/reth and comparison runs need same-head sets, so they default to the standing 25490000 tag.
           DEFAULT_SNAPSHOT_BLOCK="25490000"
           if [[ -z "${snapshot_block}" ]] && { [[ "${comparison}" == "true" ]] || [[ "${client}" != "nethermind" ]]; }; then
@@ -299,19 +344,19 @@ jobs:
             if [[ -n "${snapshot_block}" ]]; then
               if [[ "${c}" == "nethermind" ]]; then
                 if [[ "${state_layout}" == "flat" ]]; then
-                  echo "/data/nethermind/nethermind-flat-${snapshot_block}"
+                  echo "${snapshot_root}/nethermind-flat-${snapshot_block}"
                 else
-                  echo "/data/nethermind/nethermind-${snapshot_block}"
+                  echo "${snapshot_root}/nethermind-${snapshot_block}"
                 fi
               else
-                echo "/data/nethermind/${c}-${snapshot_block}"
+                echo "${snapshot_root}/${c}-${snapshot_block}"
               fi
             else
               # Legacy expb snapshots exist for nethermind only (guarded above).
               if [[ "${state_layout}" == "flat" ]]; then
-                echo "/data/nethermind/nethermind-flat-snapshot"
+                echo "${snapshot_root}/nethermind-flat-snapshot"
               else
-                echo "/data/nethermind/nethermind-snapshot"
+                echo "${snapshot_root}/nethermind-snapshot"
               fi
             fi
           }
@@ -340,7 +385,7 @@ jobs:
           if [[ -z "${db_isolation}" ]]; then
             if [[ "${client}" == "reth" ]]; then db_isolation="direct"; else db_isolation="overlay"; fi
           fi
-          scratch_root="$(nc '.scratch_root')";     [[ -z "${scratch_root}" ]] && scratch_root="/data/expb-data/rpc-bench-scratch"
+          scratch_root="$(nc '.scratch_root')";     [[ -z "${scratch_root}" ]] && scratch_root="${bench_data_dir}/rpc-bench-scratch"
           network="$(nc '.network')";               [[ -z "${network}" ]] && network="mainnet"
           jsonrpc_modules="$(nc '.jsonrpc_modules')"
           [[ -z "${jsonrpc_modules}" ]] && jsonrpc_modules="Eth,Subscribe,Trace,TxPool,Web3,Proof,Net,Parity,Health,Rpc,Debug"
@@ -438,8 +483,8 @@ jobs:
           # Building Nethermind on this box fills its ~19G root disk, which kills the runner daemon and
           # takes the runner offline until someone restarts it over SSH (2026-08-18, 2026-08-19 twice).
           # Fail in seconds instead: images belong on Docker Hub, built by publish-docker.
-          if [[ "${image_mode}" == "build" ]]; then
-            echo "The reproducible-benchmarks-arm runner does not support building images (branch '${branch}' has no prebuilt image)."
+          if [[ "${arch}" == "arm64" && "${image_mode}" == "build" ]]; then
+            echo "::error::The reproducible-benchmarks-arm runner does not support building images (branch '${branch}' has no prebuilt image)."
             echo "Build one first, then pass it explicitly:"
             echo "  gh workflow run publish-docker.yml --ref ${branch} -f image-name=nethermind -f tag=<tag> -f dockerfile=Dockerfile -f build-config=release"
             echo "  gh workflow run run-rpc-benchmarks.yml --ref ${branch} -f docker_image=nethermindeth/nethermind:<tag> ..."
@@ -471,6 +516,8 @@ jobs:
             echo "db_isolation=${db_isolation}"
             echo "ref_db_isolation=${ref_db_isolation}"
             echo "scratch_root=${scratch_root}"
+            echo "runner_label=${runner_label}"
+            echo "corpus_dir=${bench_data_dir}/rpc-bench"
             echo "network=${network}"
             echo "jsonrpc_modules=${jsonrpc_modules}"
             echo "layout_flags=${layout_flags}"
@@ -492,7 +539,7 @@ jobs:
   benchmark:
     needs: [resolve]
     if: needs.resolve.outputs.should_run == 'true'
-    runs-on: [self-hosted, reproducible-benchmarks-arm]
+    runs-on: [self-hosted, "${{ needs.resolve.outputs.runner_label }}"]
     timeout-minutes: 800
     env:
       # NB: the `runner` context is not available in job-level env, so OUT_DIR /
@@ -548,6 +595,8 @@ jobs:
         run: chmod +x scripts/rpc-bench/*.sh
 
       - name: Reclaim root disk before pulling
+        # Only the ARM box has the ~19G root disk this protects; see its rationale below.
+        if: needs.resolve.outputs.runner_label == 'reproducible-benchmarks-arm'
         shell: bash
         # The box has a ~19G root disk. A pull that runs it out of space kills the docker daemon and the
         # runner with it, so reclaim what is safely reclaimable first and refuse to start if still tight.
@@ -779,6 +828,7 @@ jobs:
           NETWORK: ${{ needs.resolve.outputs.network }}
           TOOL_CONFIG: ${{ needs.resolve.outputs.tool_config }}
           RESOLVED_ETH_CALL_CORPUS: ${{ needs.resolve.outputs.eth_call_corpus }}
+          RESOLVED_CORPUS_DIR: ${{ needs.resolve.outputs.corpus_dir }}
         shell: bash
         run: |
           set -euo pipefail
@@ -787,7 +837,8 @@ jobs:
           # For booleans '// empty' would swallow an explicit false — test null instead.
           getb() { echo "${cfg}" | jq -r "$1 | if . == null then \"\" else tostring end"; }
           export JB_ETH_CALL_CORPUS="${RESOLVED_ETH_CALL_CORPUS}"   # resolved once in `resolve`
-          corpus_dir="$(get '.corpus_dir')";               [[ -n "${corpus_dir}" ]] && export CORPUS_DIR="${corpus_dir}"
+          corpus_dir="$(get '.corpus_dir')";               [[ -z "${corpus_dir}" ]] && corpus_dir="${RESOLVED_CORPUS_DIR}"
+          [[ -n "${corpus_dir}" ]] && export CORPUS_DIR="${corpus_dir}"
           corpus_glob="$(get '.corpus_glob')";             [[ -n "${corpus_glob}" ]] && export CORPUS_GLOB="${corpus_glob}"
           export CLIENTS="$(get '.clients')";              [[ -z "${CLIENTS}" ]] && export CLIENTS="nethermind geth reth"
           # An ABSENT rps_list means "use the default"; an explicitly EMPTY one means "no k6 cells"
@@ -1019,7 +1070,7 @@ jobs:
         run: ./scripts/rpc-bench/cleanup.sh || true
 
       - name: Reclaim root disk after the run
-        if: always()
+        if: always() && needs.resolve.outputs.runner_label == 'reproducible-benchmarks-arm'
         shell: bash
         # Leave / no fuller than we found it, so disk pressure cannot accumulate run over run into the
         # daemon death this workflow used to cause. Tagged images survive; only garbage is dropped.
@@ -1188,106 +1239,3 @@ jobs:
           done
 
   # Temporary side-branch entry point for building pinned comparison images on the ARM runner.
-  build-arm-pr-comparison:
-    if: ${{ github.event_name == 'workflow_dispatch' && startsWith(inputs.docker_image, 'build-arm-pr-') }}
-    runs-on: [self-hosted, reproducible-benchmarks-arm]
-    timeout-minutes: 180
-    strategy:
-      max-parallel: 1
-      fail-fast: false
-      matrix:
-        include:
-          - label: master
-            ref: d1342e127f238db332c133dad2b28f02b21934cb
-          - label: pr12798
-            ref: 2d0a843c35d5e6ed11a1bc1a386bfdf64d4d7f7b
-          - label: pr12801
-            ref: e39ececb4b7a5221e68a65e7f5458a841b26d245
-          - label: pr12843
-            ref: 6a78ef9c2c03f7608c080b70ac83e5ab18720974
-    steps:
-      - name: Check out pinned source
-        if: ${{ inputs.docker_image == 'build-arm-pr-comparison' || inputs.docker_image == format('build-arm-pr-image-{0}', matrix.label) }}
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ matrix.ref }}
-          persist-credentials: false
-
-      - name: Ensure Docker is installed
-        if: ${{ inputs.docker_image == 'build-arm-pr-comparison' || inputs.docker_image == format('build-arm-pr-image-{0}', matrix.label) }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! command -v docker >/dev/null 2>&1; then
-            run_as_root() { if [[ "${EUID}" -eq 0 ]]; then "$@"; else sudo "$@"; fi; }
-            run_as_root apt-get update
-            run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io
-            run_as_root systemctl start docker || run_as_root service docker start
-          fi
-          docker version
-
-      - name: Set up Docker Buildx
-        if: ${{ inputs.docker_image == 'build-arm-pr-comparison' || inputs.docker_image == format('build-arm-pr-image-{0}', matrix.label) }}
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker
-
-      - name: Record ARM host details
-        if: ${{ inputs.docker_image == 'build-arm-pr-comparison' || inputs.docker_image == format('build-arm-pr-image-{0}', matrix.label) }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          {
-            echo "## ARM benchmark image build"
-            echo
-            echo '```text'
-            uname -a
-            lscpu
-            echo '```'
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Build pinned image
-        if: ${{ inputs.docker_image == 'build-arm-pr-comparison' || inputs.docker_image == format('build-arm-pr-image-{0}', matrix.label) }}
-        shell: bash
-        env:
-          LABEL: ${{ matrix.label }}
-          EXPECTED_REF: ${{ matrix.ref }}
-        run: |
-          set -euo pipefail
-
-          echo '| Variant | Commit | Local image | Architecture |' >> "${GITHUB_STEP_SUMMARY}"
-          echo '|---|---|---|---|' >> "${GITHUB_STEP_SUMMARY}"
-
-          actual_ref="$(git rev-parse HEAD)"
-          if [[ "${actual_ref}" != "${EXPECTED_REF}" ]]; then
-            echo "Expected ${EXPECTED_REF} for ${LABEL}, got ${actual_ref}."
-            exit 1
-          fi
-
-          short_ref="${actual_ref:0:12}"
-          image="nethermindeth/nethermind:armbench-${LABEL}-${short_ref}"
-          source_date_epoch="$(git log -1 --format=%ct)"
-          pull_arg=()
-          if [[ "${LABEL}" == "master" ]]; then
-            pull_arg=(--pull)
-          fi
-
-          docker buildx build "${pull_arg[@]}" \
-            --load \
-            --progress plain \
-            --platform linux/arm64 \
-            --file Dockerfile \
-            --tag "${image}" \
-            --build-arg BUILD_CONFIG=release \
-            --build-arg CI=true \
-            --build-arg COMMIT_HASH="${actual_ref}" \
-            --build-arg SOURCE_DATE_EPOCH="${source_date_epoch}" \
-            .
-
-          architecture="$(docker image inspect "${image}" --format '{{.Architecture}}')"
-          if [[ "${architecture}" != "arm64" ]]; then
-            echo "Image ${image} has unexpected architecture ${architecture}."
-            exit 1
-          fi
-          echo "| ${LABEL} | \`${actual_ref}\` | \`${image}\` | ${architecture} |" >> "${GITHUB_STEP_SUMMARY}"
-          docker image inspect "${image}" --format '{{.RepoTags}} {{.Id}} {{.Architecture}} {{.Size}}'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,14 +138,16 @@ See [global.json](./global.json) for the required .NET SDK version.
 This repository contains a dedicated workflow for reproducible payload benchmarks:
 
 - Workflow file: [`.github/workflows/run-expb-reproducible-benchmarks.yml`](./.github/workflows/run-expb-reproducible-benchmarks.yml)
-- Main execution runner label: `reproducible-benchmarks-arm`. That runner carries a single snapshot
-  set — Nethermind in the **flat** layout under `/data/nethermind/nethermind-flat-<block>` — so the
-  benchmark workflows accept only that configuration and refuse any other client or layout up front.
+- Execution runner: chosen by the `arch` input — `amd64` (default) runs on `reproducible-benchmarks`
+  with snapshots under `/mnt/sda`; `arm64` runs on `reproducible-benchmarks-arm` with snapshots under
+  `/data`. The ARM box carries a single snapshot set — Nethermind in the **flat** layout — so it
+  refuses any other client, layout, or an image it would have to build; the amd64 box takes all of
+  them. **Never compare timings across the two boxes.**
 
 ### What the workflow does
 
 - Resolves runtime inputs (branch, state layout, payload set, delay, optional extra flags).
-- Selects one benchmark config file from `/data/expb-data`.
+- Selects one benchmark config file from the runner's expb data dir (`/mnt/sda/expb-data` on amd64, `/data/expb-data` on arm64).
 - Builds or reuses Nethermind Docker image tag depending on branch rules.
 - Renders a temporary config (does not modify source files) by:
   - replacing `<<DOCKER_TAG>>`
@@ -217,3 +219,23 @@ This repository contains a dedicated workflow for reproducible payload benchmark
 - Keep benchmark-related changes isolated to the workflow and benchmark guidance unless explicitly asked otherwise.
 - Optional low-variance mode: pass `-f expb_env="EXPB_EVM_WARMUP=1"` to enable expb's per-block EVM warmup (`eth_simulateV1` before each measured block). It serves the measured block's reads from warm caches, which lowers both run-to-run CV (~1.8%→~0.55% on flat-realblocks) and AVG. Pair it with a raised RPC gas cap — `-f additional_extra_flags="--JsonRpc.GasCap=1000000000000"` — otherwise the per-request gas budget (default 100M) is exhausted on dense blocks and the warmup `eth_simulateV1` calls fail with `-38013` (intrinsic gas), silently leaving those blocks un-warmed. Caveat: warmup minimizes cold RocksDB/storage interaction, so it is a low-variance *compute* signal, not a substitute for the default cold benchmark — don't use it when measuring storage-layer changes.
 - dotTrace XML reports are 50-70MB. **Never load full XML into context.** Use [`scripts/dottrace-report.sh`](./scripts/dottrace-report.sh): `top <report.xml> [N]` for hot spots, `compare <a.xml> <b.xml> [N]` for regressions/improvements. Runs in <2 seconds via grep+awk.
+
+## RPC Benchmark Workflow Guidance
+
+- Workflow file: [`.github/workflows/run-rpc-benchmarks.yml`](./.github/workflows/run-rpc-benchmarks.yml)
+- Scripts and full reference: [`scripts/rpc-bench/README.md`](./scripts/rpc-bench/README.md)
+
+`run-rpc-benchmarks` measures state-reading JSON-RPC (`eth_call`, `eth_getBalance`, `trace_*`,
+`debug_*`) against a parked DB snapshot on the same two benchmark runners as expb — pick the box with
+`arch`, and always pass `docker_image` explicitly so the runner pulls a prebuilt tag rather than
+building one. For an A/B use `benchmark_tool=jsonbench-sweep` with `tool_config.clients` listing one
+`nethermind@<image>` per arm (the first is the response-parity baseline, compared byte-for-byte), then
+dispatch the same config a second time with the arms swapped, because position artifacts on this rig
+reach ~10% and have pointed in opposite directions on different workloads.
+
+```bash
+gh workflow run run-rpc-benchmarks.yml --ref <branch> \
+  -f arch=amd64 -f benchmark_tool=jsonbench-sweep \
+  -f docker_image=nethermindeth/nethermind:master-<sha> \
+  -f tool_config='{"clients":"nethermind@nethermindeth/nethermind:master-<sha> nethermind@nethermindeth/nethermind:<pr-tag>","rps_list":"100","duration":"120s"}'
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,35 @@ building one. For an A/B use `benchmark_tool=jsonbench-sweep` with `tool_config.
 dispatch the same config a second time with the arms swapped, because position artifacts on this rig
 reach ~10% and have pointed in opposite directions on different workloads.
 
+### What the runners actually hold
+
+Both boxes carry **one** private `eth_call` corpus, `eth-call-corpus-20260805T104605Z-497-safe.jsonl.gz`
+= **497 records** (heavy simulation traffic: every record carries state overrides, median ~331 KiB). The
+sweep discovers it by glob and prints `Corpus scenarios: …` / `corpus OK: 497 records` — read those lines
+rather than assuming a corpus set. Pin one with `corpus_glob` when more are added.
+
+The canonical cell, and what the `performance is good` label runs, is **100 rps for 120 s after a
+discarded 120 s warm-up**. Rates are the thing to get right:
+
+| rate | usable? |
+|---|---|
+| 10 | **no** — 300 requests gives mean CV ~70%, p99 CV ~206%; one cold outlier dominates |
+| 50–100 | yes; CV ~1–3% on mean/p50, p99 needs n>=3 |
+| 300 | amd64 only — on arm64 it drove a **1.22% HTTP fail rate**, tripping the 1% gate, after which percentiles above p98 describe failures, not latency |
+
+Size a cell by request count instead of duration with `corpus_requests` (absolute) or `corpus_passes`
+(a multiple of the corpus's record count) — `corpus_passes: 5` on 497 records at 100 rps is ~2,485
+requests. Note these are draws *with replacement*, so coverage is `N x (1 - (1 - 1/N)^requests)`, not a
+full pass. `corpus_parity.py` refuses corpora above **10,000 records** unless `max_corpus_records` is
+raised, and the k6 fixture is the real ceiling long before parity is (~142 MB for 497 records), so a
+50k-record capture wants sampling down rather than a bigger cap.
+
+For reference, expb's sweeps on the same boxes are sized by `amount`: `superblocks` defaults to 100,
+`realblocks` and `fusaka` to 1000, and both of the latter have 10k payloads available (fusaka covers
+blocks 25,490,001-25,499,999). Separately, `benchmark_tool=ethcallchaos` uses the EthCallChaos SQLite
+corpus (`corpus-v2`, ~1.1 GB) rather than these JSONL corpora, and with a seeded corpus it re-reports
+its own stale timings — use the json-bench per-category config for an A/B instead.
+
 ```bash
 gh workflow run run-rpc-benchmarks.yml --ref <branch> \
   -f arch=amd64 -f benchmark_tool=jsonbench-sweep \

--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -177,7 +177,7 @@ from `Dockerfile` on the runner.
 {
   "db_source": "",                 // snapshot path; empty = resolved from snapshot_block
   "db_isolation": "",              // overlay | copy | readonly-bind | direct; empty = overlay
-  "scratch_root": "/data/expb-data/rpc-bench-scratch",
+  "scratch_root": "",   // empty = <expb data dir>/rpc-bench-scratch on the selected runner
   "network": "mainnet",
   "jsonrpc_modules": "Eth,Subscribe,Trace,TxPool,Web3,Proof,Net,Parity,Health,Rpc,Debug",
   "health_timeout_minutes": 30,
@@ -329,7 +329,8 @@ parity/timings only with an empty `rps_list`.
 
 **Corpus files** (JSON Lines, one `{"method":"eth_call","params":[...]}` per
 line, extra fields ignored, optionally gzipped) go to the runner at
-`/data/expb-data/rpc-bench/eth-call-corpus[-<label>].jsonl.gz`. A
+`<expb data dir>/rpc-bench/eth-call-corpus[-<label>].jsonl.gz` — `/mnt/sda/expb-data` on the
+amd64 runner, `/data/expb-data` on arm64, selected by the `arch` input. A
 `jsonbench-sweep` with `eth_call_corpus:true` discovers **every**
 `eth-call-corpus*.jsonl.gz` there and runs each as its own scenario;
 single-node `jsonbench` uses the default `eth-call-corpus.jsonl.gz` only.
@@ -488,7 +489,7 @@ The `reproducible-benchmarks-arm` self-hosted runner must provide:
   (`/data/nethermind/nethermind-flat-<block>`, e.g. `nethermind-flat-25490000`).
   A client or layout with no set there is refused up front rather than run.
 - **A writable scratch location** on the same large disk (default
-  `/data/expb-data/rpc-bench-scratch`).
+  `<expb data dir>/rpc-bench-scratch`).
 - **`mount`/`umount` privileges** and overlayfs (expb already uses both).
 - **`jq`, `curl`, `git`**, **`python3` + `pip`** (flood; json-bench also renders
   its benchmark config via `python3` + PyYAML), and the **.NET SDK** (only if

--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -2,18 +2,26 @@
 
 Scripts behind the [`run-rpc-benchmarks.yml`](../../.github/workflows/run-rpc-benchmarks.yml)
 workflow, which benchmarks Nethermind's **state-reading JSON-RPC**
-(`eth_call`, `eth_getBalance`, `trace_*`, `debug_*`, …) on the
-`reproducible-benchmarks-arm` runner, reusing the EXPB workflow's DB snapshots.
+(`eth_call`, `eth_getBalance`, `trace_*`, `debug_*`, …) on a self-hosted
+benchmark runner, reusing the EXPB workflow's DB snapshots.
 Drives three load tools and can optionally capture a JetBrains dotTrace snapshot
 and post-process it to XML.
 
-**Supported configuration.** That runner carries exactly one kind of snapshot
-set — Nethermind in the **flat** layout under
-`/data/nethermind/nethermind-flat-<block>` — so `client`, `reference_client`
-(i.e. cross-client comparison mode) and `state_layout` are pinned to
-`nethermind` / `none` / `flat`. Anything else is refused before a node starts —
-by the workflow's `resolve` job for a single-node run, and by
-`run-rpc-sweep.sh` for the `tool_config.clients` list that sweep mode uses
+**Which runner, and what it can serve.** The `arch` input picks the box:
+`amd64` (default) is `reproducible-benchmarks` with snapshots under `/mnt/sda`,
+`arm64` is `reproducible-benchmarks-arm` with snapshots under `/data`. Every
+path below follows that choice. **Never compare timings across the two boxes.**
+
+The amd64 box holds the full snapshot set, so it serves every `client`,
+`reference_client` and `state_layout`. The arm64 box carries exactly one kind of
+snapshot set — Nethermind in the **flat** layout — so there `client`,
+`reference_client` and `state_layout` are held to `nethermind` / `none` / `flat`,
+and an image it would have to build is refused as well (that box's ~19G root disk
+dies under a build). `resolve` checks those limits against the selected runner.
+
+Independently of the runner, **sweep mode** (`jsonbench-sweep`) resolves one
+Nethermind flat snapshot and varies only the image, so `run-rpc-sweep.sh` refuses
+a non-Nethermind entry in `tool_config.clients`
 instead of those inputs. `start-node.sh` stays client-generic, so re-enabling
 geth/reth or a second layout is a matter of provisioning the snapshot set and
 widening those two guards.
@@ -36,7 +44,7 @@ which uses the same snapshots on this runner:
   bound to `/execution-data`; the node runs
   `--datadir=/execution-data --Init.BaseDbPath=<network>` — same as expb's
   `NethermindConfig`.
-- `state_layout=flat` → `/data/nethermind/nethermind-flat-<block>` +
+- `state_layout=flat` → `<snapshot root>/nethermind-flat-<block>` +
   `--FlatDb.Enabled=true` (the `snapshot_source` of
   `github-action-mainnet-flat.yaml`). Override via `node_config.db_source`.
 - The default `overlay` isolation matches expb's `snapshot_backend: overlay`,
@@ -51,7 +59,7 @@ which uses the same snapshots on this runner:
 ## Snapshot sets
 
 The runner keeps **block-tagged snapshot sets** under
-`/data/nethermind/nethermind-flat-<block>` — e.g. `nethermind-flat-25490000` —
+`<snapshot root>/nethermind-flat-<block>` — e.g. `nethermind-flat-25490000` —
 each carrying provenance sidecars (`_snapshot_metadata.json`,
 `_snapshot_web3_clientVersion.json`, `_snapshot_eth_getBlockByNumber.json`) that
 `start-node.sh` logs at startup.
@@ -158,7 +166,8 @@ the workflow's defensive-cleanup step).
 | `benchmark_tool` | `flood`, `ethcallchaos`, `jsonbench`, or `jsonbench-sweep`. |
 | `client` | `nethermind` — the only client with a snapshot set on this runner. |
 | `reference_client` | `none` — cross-client comparison needs a second client's snapshot, which this runner does not carry. Compare two Nethermind builds with a `jsonbench-sweep` instead. |
-| `snapshot_block` | Snapshot set tag (`/data/nethermind/nethermind-flat-<tag>`); empty = `25490000`. |
+| `arch` | Benchmark runner: `amd64` (default, `/mnt/sda`) or `arm64` (`/data`). Drives every path. |
+| `snapshot_block` | Snapshot set tag (`<snapshot root>/nethermind-flat-<tag>`); empty = `25490000`. |
 | `docker_image` | Optional explicit image for the benchmarked client (skips build/reuse resolution). |
 | `dottrace` | `false` (default), `sampling`, `tracing`, or `timeline` — profiling mode for the node. Works with **any** Nethermind image. `sampling`/`tracing` are post-processed to XML; `timeline` is a UI-only snapshot. `true` is a legacy alias for `sampling`. |
 | `state_layout` | `flat` — the only layout with a snapshot set on this runner. |
@@ -486,7 +495,7 @@ The `reproducible-benchmarks-arm` self-hosted runner must provide:
 - **Docker** (nodes run as containers; EthCallChaos runs in a .NET SDK container;
   json-bench builds and runs its own runner image).
 - **The block-tagged Nethermind flat snapshot sets** shared with expb
-  (`/data/nethermind/nethermind-flat-<block>`, e.g. `nethermind-flat-25490000`).
+  (`<snapshot root>/nethermind-flat-<block>`, e.g. `nethermind-flat-25490000`).
   A client or layout with no set there is refused up front rather than run.
 - **A writable scratch location** on the same large disk (default
   `<expb data dir>/rpc-bench-scratch`).

--- a/scripts/rpc-bench/run-jsonbench.sh
+++ b/scripts/rpc-bench/run-jsonbench.sh
@@ -46,7 +46,8 @@ JB_DEEP_CHECK="${JB_DEEP_CHECK:-false}"
 # machine: raw tool output goes to VM scratch instead of the job log, per-call outputs are not
 # copied to OUT_DIR, and only a sanitized aggregate summary.json is published.
 JB_ETH_CALL_CORPUS="${JB_ETH_CALL_CORPUS:-false}"
-JB_ETH_CALL_CORPUS_FILE="${JB_ETH_CALL_CORPUS_FILE:-/data/expb-data/rpc-bench/eth-call-corpus.jsonl.gz}"
+# Follows the selected runner: the workflow exports this, and CORPUS_DIR covers direct invocation.
+JB_ETH_CALL_CORPUS_FILE="${JB_ETH_CALL_CORPUS_FILE:-${CORPUS_DIR:-/data/expb-data/rpc-bench}/eth-call-corpus.jsonl.gz}"
 # Response differences are reported (and warned about) by default; opt in to
 # failing the step on any diff once the method set is curated for the clients.
 JB_FAIL_ON_DIFF="${JB_FAIL_ON_DIFF:-false}"

--- a/scripts/rpc-bench/run-rpc-sweep.sh
+++ b/scripts/rpc-bench/run-rpc-sweep.sh
@@ -35,7 +35,7 @@ DIAG_DIR="${DIAG_DIR:-$SCRATCH_ROOT/diag}"
 # summaries; parity reports carry counts, never request/response bytes; node logs are scanned as
 # counts only and deleted.
 JB_ETH_CALL_CORPUS="${JB_ETH_CALL_CORPUS:-false}"
-CORPUS_DIR="${CORPUS_DIR:-/data/expb-data/rpc-bench}"
+CORPUS_DIR="${CORPUS_DIR:-/data/expb-data/rpc-bench}"   # the workflow passes the selected runner's dir
 # Filename filter within CORPUS_DIR — set to an exact filename to run a single corpus.
 CORPUS_GLOB="${CORPUS_GLOB:-eth-call-corpus*.jsonl.gz}"
 # Size a corpus cell by request count instead of wall time. CORPUS_REQUESTS is absolute;
@@ -93,24 +93,28 @@ if [[ ! "$CORPUS_WARMUP_DURATION" =~ ^[0-9]+s?$ ]]; then
 fi
 WARMUP_SECONDS="${CORPUS_WARMUP_DURATION%s}"
 
-# The benchmark runner carries ONE snapshot set — Nethermind, flat layout, at SNAPSHOT_BLOCK — so
-# nothing else can produce a result there. Refuse the rest up front: a geth/reth entry otherwise
-# reaches start-node.sh with a DB_SOURCE that does not exist, which is only a per-client
-# `::warning::`, so the sweep would report a two-thirds-empty matrix as success — and in corpus mode
-# a baseline with no candidate, i.e. no parity verdict at all. The single-node workflow rejects the
-# same two axes, but it reads the top-level inputs that sweep mode supersedes, so the sweep has to
-# check its own. Re-enabling a client or layout means provisioning its snapshot and widening this.
+# Sweep mode resolves ONE snapshot set — Nethermind, flat layout, at SNAPSHOT_BLOCK — and varies only
+# the image, so a geth/reth entry would reach start-node.sh with a DB_SOURCE that does not exist. That
+# is only a per-client `::warning::`, so the sweep would report a two-thirds-empty matrix as success —
+# and in corpus mode a baseline with no candidate, i.e. no parity verdict at all. Refuse it up front.
+# (Cross-client comparison lives in single-node mode, which resolves a path per client.) The single-node
+# workflow rejects the same two axes, but it reads the top-level inputs that sweep mode supersedes, so
+# the sweep has to check its own. Widening this means teaching it a per-client snapshot path.
 for entry in $CLIENTS; do
   if [[ "${entry%%@*}" != "nethermind" ]]; then
-    echo "::error::client '${entry%%@*}' has no snapshot on this runner — only nethermind is supported"; exit 1
+    echo "::error::sweep mode resolves one Nethermind snapshot set, so client '${entry%%@*}' cannot run here"
+    echo "::error::use benchmark_tool=jsonbench (single-node) with client/reference_client for cross-client work"
+    exit 1
   fi
 done
 if [[ "$STATE_LAYOUT" != "flat" ]]; then
-  echo "::error::state_layout '${STATE_LAYOUT}' has no snapshot on this runner — only flat is supported"; exit 1
+  echo "::error::sweep mode resolves a flat snapshot, so state_layout '${STATE_LAYOUT}' cannot run here"; exit 1
 fi
 
-# `ctype@image` variants share the one snapshot set, so the image is the only thing that varies.
-SNAPSHOT_PATH="/data/nethermind/nethermind-flat-${SNAPSHOT_BLOCK}"
+# Snapshot root differs per benchmark box (/mnt/sda on amd64, /data/nethermind on arm64); the workflow
+# passes the resolved one. `ctype@image` variants share that set, so the image is the only variable.
+SNAPSHOT_ROOT="${SNAPSHOT_ROOT:-/data/nethermind}"
+SNAPSHOT_PATH="${SNAPSHOT_ROOT}/nethermind-flat-${SNAPSHOT_BLOCK}"
 NM_LAYOUT_FLAGS="--FlatDb.Enabled=true"
 # One isolation mode for every node, so storage counters stay comparable: overlayfs adds a layer and
 # changes readahead and page-cache behaviour, so disk-read-per-request would otherwise measure a
@@ -119,7 +123,7 @@ NM_LAYOUT_FLAGS="--FlatDb.Enabled=true"
 #
 # `direct` is refused without explicit consent. It bind-mounts the snapshot READ-WRITE, and a node's
 # startup alone rewrites RocksDB MANIFEST/CURRENT/WAL and triggers flushes across every column
-# family. The Nethermind snapshots under /data/nethermind are shared with expb, so one direct run
+# family. The Nethermind snapshots on these boxes are shared with expb, so one direct run
 # silently replaces the fixture every later benchmark compares against — which happened on
 # 2026-08-13 and cost a day of measurements (eth_call p99 tripled while an untouched client moved 2%).
 DB_ISOLATION_ALL="${DB_ISOLATION_ALL:-}"


### PR DESCRIPTION
## Changes

#12704 carried the ARM-side variant of both benchmark workflows. Merging it repointed master's expb and RPC benchmarks at `reproducible-benchmarks-arm` **exclusively** — after the merge no workflow on master targeted the EPYC box except `collect-pgo-profile.yml`:

| workflow (master today) | amd64 refs | arm64 refs |
|---|---|---|
| `run-expb-reproducible-benchmarks.yml` | **0** | 2 |
| `run-rpc-benchmarks.yml` | **0** | 6 |

So every PR auto-run (`push`, `performance is good`, `rpc-benchmark`) now queues on the ARM box, silently changing the machine behind every historical baseline, while the EPYC box sits idle. It also narrowed master's inputs to what that one box can serve.

- **Add an `arch` input** (`amd64` default, `arm64`) to both workflows. The runner label and every path that differs between the boxes are derived from it in one `case`, so a dispatch cannot land on one runner holding the other's snapshot paths:

  | arch | runner label | snapshots / expb data |
  |---|---|---|
  | `amd64` | `reproducible-benchmarks` | `/mnt/sda` |
  | `arm64` | `reproducible-benchmarks-arm` | `/data` |

  Auto-triggers resolve to `amd64`, restoring the pre-merge machine. An unrecognized value fails the resolve job rather than defaulting.

- **Restore the removed capabilities**: `halfpath` in both workflows, and `geth`/`reth` plus the reference clients in RPC. The ARM box genuinely cannot serve those, so its three limits — single Nethermind client, flat only, no image builds — now test the **selected runner** instead of being deleted from the inputs for everyone.

- **Gate the root-disk reclaim steps to `arm64`.** Their rationale is that box's ~19G root disk; the 6G refusal would be a brand-new failure mode on amd64, which never had those steps.

- **Drop `build-arm-pr-comparison`** (−104 lines). It pinned four commit SHAs from the finished ARM Keccak comparison (#12798 / #12801 / #12843) as a hardcoded matrix, so on master it was dead scaffolding that could only ever rebuild that one campaign. `publish-docker.yml` already builds multi-arch images from any ref.

- Snapshot roots, scratch root and the corpus directory follow the selected runner, so `corpus_dir` no longer has to be passed by hand to reach the amd64 box.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Workflow-only change, so validation is static plus a dispatch on each arch:

- Both files parse as YAML; `runs-on` resolves to `['self-hosted', '${{ needs.resolve.outputs.runner_label }}']` for `benchmark` and `benchmark-multi`.
- Both `resolve` scripts pass `bash -n`.
- The derivation was exercised directly: `amd64` yields `reproducible-benchmarks` + `/mnt/sda/expb-data` + `/mnt/sda/nethermind-flat-snapshot`; `arm64` yields `reproducible-benchmarks-arm` + `/data/expb-data` + `/data/nethermind/nethermind-flat-25490000`; an unknown arch exits non-zero.
- No hardcoded ARM label or `/data` path remains outside the `arm64` branch, the ARM-only guard messages, and the docs.
- Still to run before merge: one expb dispatch per arch and one RPC corpus dispatch per arch, confirming each lands on the intended box.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

`scripts/rpc-bench/README.md` paths generalized in this PR (they named the ARM box's `/data` as if it were the only one).

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Found while running a dual-ISA A/B: an expb dispatch on `master` asking for the EPYC box resolved its matrix onto the ARM runner instead.

One related issue is **not** fixed here, because it is a separate concern: `arm-runner-maintenance.yml` cannot reclaim that box's disk. Docker there uses the containerd image store, so image content lives in `/var/lib/containerd` (measured 5.8 GB) while the workflow only prunes `/var/lib/docker` (2.4 GB) — `docker image prune -a --filter until=96h` reports `Total reclaimed space: 0B` while `docker system df` claims 6.18 GB of images and a *negative* reclaimable figure. Dropping the stale tags explicitly took `/` from 5.2 G to 11 G free. That guard took the ARM box out twice today, and with master's benchmarks pointed solely at it, it was blocking all perf gating.