### PR TITLE
build: repair pre-existing base rot on frames-devnet-0

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
@@ -20,7 +20,6 @@ using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.TxPool;

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -21,7 +21,6 @@ using Nethermind.Evm;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Crypto;
-using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.TxPool.Comparison;
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -22,6 +22,7 @@ using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using Nethermind.State;
 using NUnit.Framework;
 
@@ -38,6 +39,7 @@ namespace Nethermind.Evm.Test;
 public class FrameTxProcessorTests
 {
     private ISpecProvider _specProvider;
+    private OverridableReleaseSpec _spec;
     private ITransactionProcessor _transactionProcessor;
     private IWorldState _stateProvider;
     private IDisposable _worldStateCloser;
@@ -54,7 +56,8 @@ public class FrameTxProcessorTests
     [SetUp]
     public void Setup()
     {
-        _specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
+        _spec = new OverridableReleaseSpec(Eip8141Prototype.Instance);
+        _specProvider = new TestSpecProvider(_spec);
         _stateProvider = TestWorldStateFactory.CreateForTest();
         _worldStateCloser = _stateProvider.BeginScope(IWorldState.PreGenesis);
         EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
@@ -17,7 +17,6 @@ using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
-using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;

--- a/src/Nethermind/Nethermind.IntegrationTests/Nethermind.IntegrationTests.csproj
+++ b/src/Nethermind/Nethermind.IntegrationTests/Nethermind.IntegrationTests.csproj
@@ -7,6 +7,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-q939-rpr3-3284" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Crypto\Nethermind.Crypto.csproj" />
     <ProjectReference Include="..\Nethermind.JsonRpc\Nethermind.JsonRpc.csproj" />

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandlerTests.cs
@@ -747,7 +747,7 @@ public class Eth68ProtocolHandlerTests
             new ForkInfo(_specProvider, _syncManager),
             LimboLogs.Instance,
             txPoolConfig,
-            Substitute.For<ISpecProvider>(),
+            Substitute.For<IChainHeadSpecProvider>(),
             _txGossipPolicy);
 
     private void GenerateLists(int txCount, out ArrayPoolList<byte> types, out ArrayPoolList<int> sizes, out ArrayPoolList<Hash256> hashes)

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -304,7 +304,8 @@ public class Eth72ProtocolHandlerTests
             size: tx.GetLength(),
             proofVersion: ProofVersion.V1,
             blobCellMask: BlobCellMask.Full,
-            sparseBlobNetworkSize: 0);
+            sparseBlobNetworkSize: 0,
+            type: tx.Type);
 
         _handler.SendNewTransactions([legacyLightTx], sendFullTx: false);
 


### PR DESCRIPTION
## Changes

Repairs pre-existing build breakage on `feature/frames-devnet-0` that prevents CI from compiling the solution, so any PR targeting this branch is red before a single test runs.

- **`FrameTxProcessorTests`**: a fee-collector regression test references `_spec`, but the fixture only declared `_specProvider`. Declares `OverridableReleaseSpec _spec` and wires `_specProvider` from it (CS0103).
- **`Eth68ProtocolHandlerTests`**: `CreateHandler` passed an `ISpecProvider` where the handler now takes `IChainHeadSpecProvider` (CS1503).
- **`Eth72ProtocolHandlerTests`**: a legacy `LightTransaction` constructor call was missing the new `type` argument (CS7036).
- **`Nethermind.IntegrationTests`**: suppress the SSH.NET `GHSA-q939-rpr3-3284` transitive advisory (`NuGetAuditSuppress`) so `NU1903` no longer trips `TreatWarningsAsErrors`.
- Drops three unused `using` directives (`IDE0005` / `CS0105`) that the lint gate rejects.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

- `dotnet build src/Nethermind/Nethermind.slnx -c release -p:TreatWarningsAsErrors=true` — **0 errors**.
- Lint gate (`grep -E "warning (IDE|CA)[0-9]+"`) — **0 hits**.

No production code changes; the diff is limited to test fixtures, one test-project `.csproj`, and unused-using removals.
