### PR TITLE
ci: add a manual workflow for the frame-transaction measurement harnesses

### DIFF
--- a/.github/workflows/run-frame-tx-measurements.yml
+++ b/.github/workflows/run-frame-tx-measurements.yml
@@ -26,13 +26,15 @@ jobs:
     runs-on: [self-hosted, reproducible-benchmarks]
     timeout-minutes: 120
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
       # One source of truth for the output path: the `runner` context is not
-      # available in a job-level `env`, so it is exported here instead.
+      # available in a job-level `env`, so it is exported here instead. This runs
+      # before the checkout so that the `if: always()` steps below never observe
+      # it unset, which would upload the runner's whole filesystem.
       - name: Resolve the output directory
         run: echo "OUTPUT_DIR=${RUNNER_TEMP}/frame-tx-measurements" >> "${GITHUB_ENV}"
+
+      - name: Check out repository
+        uses: actions/checkout@v6
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
@@ -54,7 +56,7 @@ jobs:
             echo "::group::${fixture}"
             dotnet test --project "${project}/${project}.csproj" -c release -- \
               --no-ansi --filter "FullyQualifiedName~${fixture}" \
-              | tee "${OUTPUT_DIR}/${fixture}.txt" || rc=$?
+              2>&1 | tee "${OUTPUT_DIR}/${fixture}.txt" || rc=$?
             echo "::endgroup::"
             return "${rc}"
           }
@@ -82,7 +84,7 @@ jobs:
               echo '```'
               # Only the reported figures, so the summary stays well inside its 1 MiB
               # cap and no stray backtick from test output breaks the fence.
-              grep '^RESULT' "${report}" || echo 'no RESULT lines; see the uploaded artifact'
+              grep 'RESULT' "${report}" || echo 'no RESULT lines; see the uploaded artifact'
               echo '```'
             } >> "${GITHUB_STEP_SUMMARY}"
           done

--- a/.github/workflows/run-frame-tx-measurements.yml
+++ b/.github/workflows/run-frame-tx-measurements.yml
@@ -1,0 +1,86 @@
+name: Run Frame Transaction Measurements
+
+on:
+  workflow_dispatch:
+    inputs:
+      harness:
+        description: Which measurement harness to run
+        required: true
+        type: choice
+        options:
+          - both
+          - verify
+          - mempool
+        default: both
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  measure:
+    name: Measure the frame-transaction validation prefix
+    runs-on: [self-hosted, reproducible-benchmarks]
+    timeout-minutes: 120
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+
+      - name: Run measurement harnesses
+        id: measure
+        working-directory: src/Nethermind
+        env:
+          HARNESS: ${{ inputs.harness }}
+        run: |
+          set -euo pipefail
+          output_dir="${RUNNER_TEMP}/frame-tx-measurements"
+          mkdir -p "${output_dir}"
+
+          run_harness() {
+            local project=$1 fixture=$2
+            if [[ ! -f "${project}/${fixture}.cs" ]]; then
+              echo "::error::${fixture} is not present on ${GITHUB_REF_NAME}. Dispatch this workflow against a ref that carries the harness."
+              exit 1
+            fi
+            echo "::group::${fixture}"
+            dotnet test --project "${project}/${project}.csproj" -c release -- \
+              --filter "FullyQualifiedName~${fixture}" \
+              | tee "${output_dir}/${fixture}.txt"
+            echo "::endgroup::"
+          }
+
+          if [[ "${HARNESS}" == "both" || "${HARNESS}" == "verify" ]]; then
+            run_harness Nethermind.Evm.Test FrameTxVerifyDosMeasurement
+          fi
+          if [[ "${HARNESS}" == "both" || "${HARNESS}" == "mempool" ]]; then
+            run_harness Nethermind.TxPool.Test FrameTxMempoolDosMeasurement
+          fi
+
+          echo "output_dir=${output_dir}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish the reported figures to the run summary
+        if: always()
+        run: |
+          set -euo pipefail
+          output_dir="${RUNNER_TEMP}/frame-tx-measurements"
+          for report in "${output_dir}"/*.txt; do
+            [[ -f "${report}" ]] || continue
+            {
+              echo "## $(basename "${report}" .txt)"
+              echo '```'
+              cat "${report}"
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+          done
+
+      - name: Upload the measurement output
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: frame-tx-measurements
+          path: ${{ runner.temp }}/frame-tx-measurements/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/run-frame-tx-measurements.yml
+++ b/.github/workflows/run-frame-tx-measurements.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   measure:
     name: Measure the frame-transaction validation prefix
@@ -26,52 +29,60 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      # One source of truth for the output path: the `runner` context is not
+      # available in a job-level `env`, so it is exported here instead.
+      - name: Resolve the output directory
+        run: echo "OUTPUT_DIR=${RUNNER_TEMP}/frame-tx-measurements" >> "${GITHUB_ENV}"
+
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
 
       - name: Run measurement harnesses
-        id: measure
         working-directory: src/Nethermind
         env:
           HARNESS: ${{ inputs.harness }}
         run: |
-          set -euo pipefail
-          output_dir="${RUNNER_TEMP}/frame-tx-measurements"
-          mkdir -p "${output_dir}"
+          set -uo pipefail
+          mkdir -p "${OUTPUT_DIR}"
 
           run_harness() {
-            local project=$1 fixture=$2
-            if [[ ! -f "${project}/${fixture}.cs" ]]; then
+            local project=$1 fixture=$2 rc=0
+            if [[ -z "$(find "${project}" -name "${fixture}.cs" -print -quit)" ]]; then
               echo "::error::${fixture} is not present on ${GITHUB_REF_NAME}. Dispatch this workflow against a ref that carries the harness."
-              exit 1
+              return 1
             fi
             echo "::group::${fixture}"
             dotnet test --project "${project}/${project}.csproj" -c release -- \
-              --filter "FullyQualifiedName~${fixture}" \
-              | tee "${output_dir}/${fixture}.txt"
+              --no-ansi --filter "FullyQualifiedName~${fixture}" \
+              | tee "${OUTPUT_DIR}/${fixture}.txt" || rc=$?
             echo "::endgroup::"
+            return "${rc}"
           }
 
+          # Each harness is attempted even when an earlier one fails, so a run never
+          # reports a partial set of figures as if it were the whole set.
+          status=0
           if [[ "${HARNESS}" == "both" || "${HARNESS}" == "verify" ]]; then
-            run_harness Nethermind.Evm.Test FrameTxVerifyDosMeasurement
+            run_harness Nethermind.Evm.Test FrameTxVerifyDosMeasurement || status=1
           fi
           if [[ "${HARNESS}" == "both" || "${HARNESS}" == "mempool" ]]; then
-            run_harness Nethermind.TxPool.Test FrameTxMempoolDosMeasurement
+            run_harness Nethermind.TxPool.Test FrameTxMempoolDosMeasurement || status=1
           fi
 
-          echo "output_dir=${output_dir}" >> "${GITHUB_OUTPUT}"
+          exit "${status}"
 
       - name: Publish the reported figures to the run summary
         if: always()
         run: |
-          set -euo pipefail
-          output_dir="${RUNNER_TEMP}/frame-tx-measurements"
-          for report in "${output_dir}"/*.txt; do
+          set -uo pipefail
+          for report in "${OUTPUT_DIR}"/*.txt; do
             [[ -f "${report}" ]] || continue
             {
               echo "## $(basename "${report}" .txt)"
               echo '```'
-              cat "${report}"
+              # Only the reported figures, so the summary stays well inside its 1 MiB
+              # cap and no stray backtick from test output breaks the fence.
+              grep '^RESULT' "${report}" || echo 'no RESULT lines; see the uploaded artifact'
               echo '```'
             } >> "${GITHUB_STEP_SUMMARY}"
           done
@@ -81,6 +92,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: frame-tx-measurements
-          path: ${{ runner.temp }}/frame-tx-measurements/
+          path: ${{ env.OUTPUT_DIR }}/
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/run-frame-tx-measurements.yml
+++ b/.github/workflows/run-frame-tx-measurements.yml
@@ -13,6 +13,10 @@ on:
           - mempool
         default: both
 
+# Deliberately deviates from the repo default: the group carries no `github.ref`
+# and in-progress runs are not cancelled, so dispatches queue instead of
+# contending for the single shared measurement runner. Do not "fix" this back to
+# the PR-workflow default -- two concurrent runs would distort each other's numbers.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false

--- a/.github/workflows/run-frame-tx-measurements.yml
+++ b/.github/workflows/run-frame-tx-measurements.yml
@@ -27,9 +27,9 @@ jobs:
     timeout-minutes: 120
     steps:
       # One source of truth for the output path: the `runner` context is not
-      # available in a job-level `env`, so it is exported here instead. This runs
-      # before the checkout so that the `if: always()` steps below never observe
-      # it unset, which would upload the runner's whole filesystem.
+      # available in a job-level `env`, so it is exported here instead. It runs
+      # before the checkout, and the `if: always()` steps below still guard on it
+      # being set, because an unset value would make them address the runner's root.
       - name: Resolve the output directory
         run: echo "OUTPUT_DIR=${RUNNER_TEMP}/frame-tx-measurements" >> "${GITHUB_ENV}"
 
@@ -74,7 +74,7 @@ jobs:
           exit "${status}"
 
       - name: Publish the reported figures to the run summary
-        if: always()
+        if: always() && env.OUTPUT_DIR != ''
         run: |
           set -uo pipefail
           for report in "${OUTPUT_DIR}"/*.txt; do
@@ -90,7 +90,7 @@ jobs:
           done
 
       - name: Upload the measurement output
-        if: always()
+        if: always() && env.OUTPUT_DIR != ''
         uses: actions/upload-artifact@v7
         with:
           name: frame-tx-measurements


### PR DESCRIPTION
Re-bases #12738 onto `eip8141-frame-txs-devnet7` where the frame-tx measurement harnesses live. Same workflow file, no content change; the five commits collapse to the single 103-line workflow. Closes #12738 (was based on `master`).