### PR TITLE
refactor(evm): drop the unused EIP-8272 native recent-root write path

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -2179,8 +2179,8 @@ public class FrameTxProcessorTests
         ValueHash256 salt = TestItem.KeccakA.ValueHash256;
         ValueHash256 sourceId = RecentRootStore.SourceId(Observer, salt);
         ValueHash256 root = TestItem.KeccakB.ValueHash256;
-        // Written through the production path so the test cannot keep passing against a stale encoding.
-        RecentRootStore.Write(_stateProvider, Observer, salt, root, committedSlot, Spec);
+        _stateProvider.Set(RecentRootStore.ReferenceCell(sourceId, committedSlot),
+            RecentRootStore.EntryHash(sourceId, committedSlot, root).Bytes.WithoutLeadingZeros().ToArray());
         _stateProvider.Commit(Spec);
 
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());

--- a/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/RecentRootStoreTests.cs
@@ -4,12 +4,11 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
-using Nethermind.Specs.Forks;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;
@@ -21,7 +20,6 @@ public class RecentRootStoreTests
     private static readonly ValueHash256 Salt = TestItem.KeccakA.ValueHash256;
     private static readonly ValueHash256 Root = TestItem.KeccakB.ValueHash256;
     private static readonly ValueHash256 OtherRoot = TestItem.KeccakC.ValueHash256;
-    private static readonly IReleaseSpec Spec = Amsterdam.Instance;
 
     [Test]
     public void SourceId_is_deterministic_and_distinct_per_input()
@@ -88,7 +86,7 @@ public class RecentRootStoreTests
         using (scope)
         {
             const ulong writeSlot = 100_000;
-            RecentRootStore.Write(state, Source, Salt, Root, writeSlot, Spec);
+            Write(state, Source, Salt, Root, writeSlot);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             Assert.That(RecentRootStore.IsReferenceValid(state, sourceId, writeSlot, Root, writeSlot + 1), Is.True);
@@ -110,7 +108,7 @@ public class RecentRootStoreTests
         {
             const ulong writeSlot = 1000;
             const ulong currentSlot = 1001;
-            RecentRootStore.Write(state, Source, Salt, Root, writeSlot, Spec);
+            Write(state, Source, Salt, Root, writeSlot);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             Assert.That(RecentRootStore.IsReferenceValid(state, sourceId, writeSlot, Root, currentSlot), Is.True);
@@ -125,7 +123,7 @@ public class RecentRootStoreTests
         {
             const ulong writeSlot = 1000;
             const ulong currentSlot = 1001;
-            RecentRootStore.Write(state, Source, Salt, Root, writeSlot, Spec);
+            Write(state, Source, Salt, Root, writeSlot);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
             ValueHash256 wrongSource = RecentRootStore.SourceId(TestItem.AddressB, Salt);
 
@@ -143,7 +141,7 @@ public class RecentRootStoreTests
         {
             const ulong writtenSlot = 5;
             ulong aliasedSlot = writtenSlot + Eip8272Constants.RecentRootLength;
-            RecentRootStore.Write(state, Source, Salt, Root, writtenSlot, Spec);
+            Write(state, Source, Salt, Root, writtenSlot);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             Assert.That(
@@ -178,8 +176,8 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
-            RecentRootStore.Write(state, Source, Salt, OtherRoot, 150, Spec);
+            Write(state, Source, Salt, Root, 100);
+            Write(state, Source, Salt, OtherRoot, 150);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             Assert.That(Validate(state, [new(sourceId, 100, Root), new(sourceId, 150, OtherRoot)]), Is.True);
@@ -192,7 +190,7 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            Write(state, Source, Salt, Root, 100);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             Assert.That(Validate(state, [new(sourceId, 100, Root), new(sourceId, 100, OtherRoot)]), Is.False);
@@ -205,7 +203,7 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            Write(state, Source, Salt, Root, 100);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
 
             Assert.That(Validate(state, [new(sourceId, 100, Root), new(sourceId, 100, Root)]), Is.True);
@@ -219,7 +217,7 @@ public class RecentRootStoreTests
         IWorldState state = CreateState(out IDisposable scope);
         using (scope)
         {
-            RecentRootStore.Write(state, Source, Salt, Root, 100, Spec);
+            Write(state, Source, Salt, Root, 100);
             ValueHash256 sourceId = RecentRootStore.SourceId(Source, Salt);
             using StackAccessTracker accessTracker = new(false);
 
@@ -240,7 +238,7 @@ public class RecentRootStoreTests
             for (int i = 0; i < references.Length; i++)
             {
                 ulong slot = (ulong)(100 + i);
-                RecentRootStore.Write(state, Source, Salt, Root, slot, Spec);
+                Write(state, Source, Salt, Root, slot);
                 references[i] = new RecentRootReference(sourceId, slot, Root);
             }
 
@@ -252,6 +250,13 @@ public class RecentRootStoreTests
     {
         using StackAccessTracker accessTracker = new(false);
         return RecentRootReferences.Validate(state, references, currentSlot, in accessTracker);
+    }
+
+    private static void Write(IWorldState state, Address source, in ValueHash256 salt, in ValueHash256 root, ulong slot)
+    {
+        ValueHash256 sourceId = RecentRootStore.SourceId(source, salt);
+        StorageCell cell = RecentRootStore.ReferenceCell(sourceId, slot);
+        state.Set(cell, RecentRootStore.EntryHash(sourceId, slot, root).Bytes.WithoutLeadingZeros().ToArray());
     }
 
     private static IWorldState CreateState(out IDisposable scope)

--- a/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
+++ b/src/Nethermind/Nethermind.Evm/RecentRootStore.cs
@@ -5,13 +5,12 @@ using System;
 using System.Buffers.Binary;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Extensions;
-using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
 
 namespace Nethermind.Evm;
 
 /// <summary>Key/commitment derivations and the pre-state reference check for <see href="https://eips.ethereum.org/EIPS/eip-8272">EIP-8272</see> recent roots.</summary>
+/// <remarks>Recent-root storage is written by the <c>RECENT_ROOT_ADDRESS</c> predeploy bytecode during ordinary execution, not by the client, so this type only derives keys and validates references against already-written state.</remarks>
 public static class RecentRootStore
 {
     private const int HashLength = 32;
@@ -73,14 +72,6 @@ public static class RecentRootStore
         Span<byte> padded = stackalloc byte[HashLength];
         stored.CopyTo(padded.Slice(HashLength - stored.Length));
         return new ValueHash256(padded) == EntryHash(sourceId, slot, root);
-    }
-
-    public static void Write(IWorldState state, Address sourceAddress, in ValueHash256 salt, in ValueHash256 root, ulong currentSlot, IReleaseSpec spec)
-    {
-        ValueHash256 sourceId = SourceId(sourceAddress, salt);
-        StorageCell cell = RingBufferCell(sourceId, currentSlot % Eip8272Constants.RecentRootLength);
-        ValueHash256 entryHash = EntryHash(sourceId, currentSlot, root);
-        state.Set(cell, entryHash.Bytes.WithoutLeadingZeros().ToArray());
     }
 
     /// <summary>The predeploy storage cell a reference to <paramref name="slot"/> reads.</summary>


### PR DESCRIPTION
## Changes

devnet7 counterpart of #12762 (which does the same on `master`).

`RecentRootStore.Write` is dead on this branch: recent-root storage is written by the `RECENT_ROOT_ADDRESS` predeploy bytecode during ordinary execution, never by the client. The only callers were tests. This drops the method and the two usings it alone pulled in (`Nethermind.Core.Extensions`, `Nethermind.Core.Specs`), and documents on the type that writes come from the predeploy.

Test call sites are migrated to write the same cell/commitment directly through the retained production derivations (`SourceId`/`StorageKey`/`EntryHash`/`ReferenceCell`), so a stale encoding still cannot slip past:

- `RecentRootStoreTests` gets a private `Write` helper (same body the removed method had) and keeps its existing `Source`/`Salt` fixtures.
- `FrameTxProcessorTests.Execute_RecentRootReference_...` writes via `ReferenceCell` + `EntryHash`, matching the pattern the same fixture already uses elsewhere.

## Tests

`Nethermind.Evm.Test`, release, arm64: `RecentRootStoreTests` + `Execute_RecentRootReference_IsCheckedAgainstTheCommittedEntry` — 23/23 pass. `Write_then_validate_round_trips` is the positive control that the migrated write is byte-identical to the removed one: the production read path validates it.
