### PR TITLE
feat(frames): two-dimensional gas limits per EIP-8141 (devnet7)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionPickerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionPickerTests.cs
@@ -97,8 +97,45 @@ public class FrameTxBlockProductionPickerTests
             tx,
             new HashSet<Transaction>(),
             state,
+            cumulativeBlockExecutionGas: 0,
             cumulativeStateGas);
 
         Assert.That(args.Action, Is.EqualTo(expectedAction));
+    }
+
+    [Test]
+    public void Execution_headroom_is_measured_from_cumulative_execution_not_the_block_maximum()
+    {
+        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(Bogota.Instance);
+        BlockProcessor.BlockProductionTransactionPicker picker = new(specProvider, BlocksConfig.DefaultMaxTxKilobytes);
+        IReadOnlyStateProvider state = Substitute.For<IReadOnlyStateProvider>();
+        state.GetNonce(TestItem.AddressA).Returns(AccountNonce);
+
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = 1,
+            Nonce = AccountNonce,
+            SenderAddress = TestItem.AddressA,
+            Frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null,
+                    executionGasLimit: 500_000, stateGasLimit: 0, UInt256.Zero, default),
+            ],
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+        Block block = Build.A.Block.WithGasLimit(1_000_000).TestObject;
+
+        BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(
+            block,
+            tx,
+            new HashSet<Transaction>(),
+            state,
+            cumulativeBlockExecutionGas: 100_000,
+            cumulativeBlockStateGas: 600_000);
+
+        Assert.That(args.Action, Is.EqualTo(BlockProcessor.TxAction.Add));
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionPickerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionPickerTests.cs
@@ -63,4 +63,42 @@ public class FrameTxBlockProductionPickerTests
             Assert.That(args.Reason, expectedReason is null ? Is.Empty.Or.Null : Is.EqualTo(expectedReason));
         }
     }
+
+    [TestCase(0UL, BlockProcessor.TxAction.Add)]
+    [TestCase(600_000UL, BlockProcessor.TxAction.Skip)]
+    public void Frame_transaction_is_checked_against_each_remaining_block_dimension(
+        ulong cumulativeStateGas,
+        BlockProcessor.TxAction expectedAction)
+    {
+        ISpecProvider specProvider = new TestSingleReleaseSpecProvider(Bogota.Instance);
+        BlockProcessor.BlockProductionTransactionPicker picker = new(specProvider, BlocksConfig.DefaultMaxTxKilobytes);
+        IReadOnlyStateProvider state = Substitute.For<IReadOnlyStateProvider>();
+        state.GetNonce(TestItem.AddressA).Returns(AccountNonce);
+
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = 1,
+            Nonce = AccountNonce,
+            SenderAddress = TestItem.AddressA,
+            Frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null,
+                    executionGasLimit: 500_000, stateGasLimit: 500_000, UInt256.Zero, default),
+            ],
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+        Block block = Build.A.Block.WithGasLimit(1_000_000).TestObject;
+
+        BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(
+            block,
+            tx,
+            new HashSet<Transaction>(),
+            state,
+            cumulativeStateGas);
+
+        Assert.That(args.Action, Is.EqualTo(expectedAction));
+    }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -449,12 +449,8 @@ namespace Nethermind.Blockchain.Test
             if (expectedSkipReason is not null) Assert.That(args.Reason, Is.EqualTo(expectedSkipReason));
         }
 
-        // EIP-8141: a frame transaction's GasLimit is only the sum of its frame gas limits, so the picker must gate on
-        // max_gas or the produced block exceeds its own gas limit. The mandatory cost of the single frame below is
-        // FRAME_TX_INTRINSIC_COST + FRAME_TX_PER_FRAME_COST = 15,475, and each non-zero calldata byte adds 16 to the
-        // standard cost against 40 to the EIP-7623 floor, so the last case fits the block on its standard cost alone.
         [TestCase(100_000UL, 0, false)]
-        [TestCase(115_000UL, 0, true)]
+        [TestCase(118_000UL, 0, true)]
         [TestCase(10_000UL, 4000, true)]
         public void Frame_transaction_is_gated_on_its_max_gas(ulong frameGasLimit, int frameDataLength, bool expectedSkipped)
         {

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -485,7 +485,7 @@ namespace Nethermind.Blockchain.Test
             if (expectedSkipped)
             {
                 Assert.That(args.Action, Is.EqualTo(BlockProcessor.TxAction.Skip));
-                Assert.That(args.Reason, Does.StartWith("Not enough gas in block"));
+                Assert.That(args.Reason, Does.StartWith("Not enough").And.Contains("gas in block"));
             }
             else
             {

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -1063,6 +1063,34 @@ public class TxValidatorTests
         Assert.That(FrameTxEnvelopeTxValidator.Instance.IsWellFormed(tx, releaseSpec).AsBool(), Is.EqualTo(expectedWellFormed));
     }
 
+    [Test]
+    public void IsWellFormed_FrameTxExecutionReservationIsBoundedByEip7825()
+    {
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            SenderAddress = TestItem.AddressA,
+            Frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null,
+                    Eip7825Constants.DefaultTxGasLimitCap - 100_000, Eip7825Constants.DefaultTxGasLimitCap, UInt256.Zero, default),
+            ],
+            FrameSignatures = [],
+            DecodedMaxFeePerGas = 1,
+        };
+
+        Assert.That(FrameTxFieldsTxValidator.Instance.IsWellFormed(tx, Bogota.Instance).AsBool(), Is.True);
+
+        tx.Frames =
+        [
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null,
+                Eip7825Constants.DefaultTxGasLimitCap, stateGasLimit: 0, UInt256.Zero, default),
+        ];
+
+        Assert.That(FrameTxFieldsTxValidator.Instance.IsWellFormed(tx, Bogota.Instance).AsBool(), Is.False);
+    }
+
     private static Transaction BuildBlobFrameTx(int blobCount, byte versionByte = KzgPolynomialCommitments.KzgBlobHashVersionV1)
     {
         byte[][] versionedHashes = new byte[blobCount][];

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.Validation.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.Validation.cs
@@ -100,11 +100,24 @@ public partial class BlockAccessListManager
     {
         if (!spec.IsEip8037Enabled) return;
 
-        Eip8037BlockGasInclusionCheck.Outcome outcome = Eip8037BlockGasInclusionCheck.Validate(
-            block.Header.GasLimit,
-            cumulativeExecution,
-            cumulativeState,
-            tx.GasLimit);
+        Eip8037BlockGasInclusionCheck.Outcome outcome;
+        if (tx.SupportsFrames && FrameTxValidation.TryCalculateBlockGasReservations(tx, spec, out ulong executionReservation, out ulong stateReservation))
+        {
+            outcome = Eip8037BlockGasInclusionCheck.Validate(
+                block.Header.GasLimit,
+                cumulativeExecution,
+                cumulativeState,
+                executionReservation,
+                stateReservation);
+        }
+        else
+        {
+            outcome = Eip8037BlockGasInclusionCheck.Validate(
+                block.Header.GasLimit,
+                cumulativeExecution,
+                cumulativeState,
+                tx.GasLimit);
+        }
 
         if (outcome != Eip8037BlockGasInclusionCheck.Outcome.Ok)
         {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -36,12 +36,20 @@ namespace Nethermind.Consensus.Processing
                 Block block,
                 Transaction currentTx,
                 IReadOnlySet<Transaction> transactionsInBlock,
+                IReadOnlyStateProvider stateProvider) =>
+                CanAddTransaction(block, currentTx, transactionsInBlock, stateProvider, block.GasUsed, 0);
+
+            public virtual AddingTxEventArgs CanAddTransaction(
+                Block block,
+                Transaction currentTx,
+                IReadOnlySet<Transaction> transactionsInBlock,
                 IReadOnlyStateProvider stateProvider,
-                ulong cumulativeStateGas = 0)
+                ulong cumulativeBlockExecutionGas,
+                ulong cumulativeBlockStateGas)
             {
                 AddingTxEventArgs args = new(transactionsInBlock.Count, currentTx, block, transactionsInBlock);
 
-                ulong gasRemaining = block.Header.GasLimit - block.GasUsed;
+                ulong gasRemaining = block.Header.GasLimit.SaturatingSub(cumulativeBlockExecutionGas);
 
                 // No more gas available in block for any transactions,
                 // the only case we have to really stop
@@ -70,7 +78,7 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, "Transaction already in block");
                 }
 
-                ulong stateGasRemaining = block.Header.GasLimit.SaturatingSub(cumulativeStateGas);
+                ulong stateGasRemaining = block.Header.GasLimit.SaturatingSub(cumulativeBlockStateGas);
                 ulong executionReservation;
                 ulong stateReservation;
                 if (currentTx.SupportsFrames)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -32,7 +32,12 @@ namespace Nethermind.Consensus.Processing
 
             protected void OnAddingTransaction(AddingTxEventArgs e) => AddingTransaction?.Invoke(this, e);
 
-            public virtual AddingTxEventArgs CanAddTransaction(Block block, Transaction currentTx, IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider)
+            public virtual AddingTxEventArgs CanAddTransaction(
+                Block block,
+                Transaction currentTx,
+                IReadOnlySet<Transaction> transactionsInBlock,
+                IReadOnlyStateProvider stateProvider,
+                ulong cumulativeStateGas = 0)
             {
                 AddingTxEventArgs args = new(transactionsInBlock.Count, currentTx, block, transactionsInBlock);
 
@@ -65,17 +70,32 @@ namespace Nethermind.Consensus.Processing
                     return args.Set(TxAction.Skip, "Transaction already in block");
                 }
 
-                // A frame transaction's GasLimit is only the sum of its frame gas limits, so gating on it alone would
-                // let the produced block exceed its own gas limit. A transaction that cannot be priced never fits.
-                ulong txGasBudget = !currentTx.SupportsFrames
-                    ? currentTx.GasLimit
-                    : FrameTxValidation.TryCalculateGasBudget(currentTx, spec, out _, out _, out ulong frameTxMaxGas)
-                        ? frameTxMaxGas
-                        : ulong.MaxValue;
-
-                if (txGasBudget > gasRemaining)
+                ulong stateGasRemaining = block.Header.GasLimit.SaturatingSub(cumulativeStateGas);
+                ulong executionReservation;
+                ulong stateReservation;
+                if (currentTx.SupportsFrames)
                 {
-                    return args.Set(TxAction.Skip, $"Not enough gas in block, gas limit {txGasBudget} > {gasRemaining}");
+                    if (!FrameTxValidation.TryCalculateBlockGasReservations(currentTx, spec, out executionReservation, out stateReservation))
+                    {
+                        return args.Set(TxAction.Skip, "Cannot calculate frame transaction gas reservations");
+                    }
+                }
+                else
+                {
+                    executionReservation = spec.IsEip8037Enabled
+                        ? Math.Min(Eip7825Constants.DefaultTxGasLimitCap, currentTx.GasLimit)
+                        : currentTx.GasLimit;
+                    stateReservation = spec.IsEip8037Enabled ? currentTx.GasLimit : 0;
+                }
+
+                if (executionReservation > gasRemaining)
+                {
+                    return args.Set(TxAction.Skip, $"Not enough execution gas in block, gas limit {executionReservation} > {gasRemaining}");
+                }
+
+                if (stateReservation > stateGasRemaining)
+                {
+                    return args.Set(TxAction.Skip, $"Not enough state gas in block, gas limit {stateReservation} > {stateGasRemaining}");
                 }
 
                 if (currentTx.IsAboveInitCode(spec))

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -79,21 +79,9 @@ namespace Nethermind.Consensus.Processing
                 }
 
                 ulong stateGasRemaining = block.Header.GasLimit.SaturatingSub(cumulativeBlockStateGas);
-                ulong executionReservation;
-                ulong stateReservation;
-                if (currentTx.SupportsFrames)
+                if (!TryGetBlockGasReservations(currentTx, spec, out ulong executionReservation, out ulong stateReservation))
                 {
-                    if (!FrameTxValidation.TryCalculateBlockGasReservations(currentTx, spec, out executionReservation, out stateReservation))
-                    {
-                        return args.Set(TxAction.Skip, "Cannot calculate frame transaction gas reservations");
-                    }
-                }
-                else
-                {
-                    executionReservation = spec.IsEip8037Enabled
-                        ? Math.Min(Eip7825Constants.DefaultTxGasLimitCap, currentTx.GasLimit)
-                        : currentTx.GasLimit;
-                    stateReservation = spec.IsEip8037Enabled ? currentTx.GasLimit : 0;
+                    return args.Set(TxAction.Skip, "Cannot calculate frame transaction gas reservations");
                 }
 
                 if (executionReservation > gasRemaining)
@@ -137,6 +125,20 @@ namespace Nethermind.Consensus.Processing
 
                 OnAddingTransaction(args);
                 return args;
+            }
+
+            private static bool TryGetBlockGasReservations(Transaction currentTx, IReleaseSpec spec, out ulong executionReservation, out ulong stateReservation)
+            {
+                if (currentTx.SupportsFrames)
+                {
+                    return FrameTxValidation.TryCalculateBlockGasReservations(currentTx, spec, out executionReservation, out stateReservation);
+                }
+
+                executionReservation = spec.IsEip8037Enabled
+                    ? Math.Min(Eip7825Constants.DefaultTxGasLimitCap, currentTx.GasLimit)
+                    : currentTx.GasLimit;
+                stateReservation = spec.IsEip8037Enabled ? currentTx.GasLimit : 0;
+                return true;
             }
 
             private static bool HasEnoughFunds(Transaction transaction, in UInt256 senderBalance, AddingTxEventArgs e, Block block, IReleaseSpec releaseSpec)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
@@ -104,6 +104,7 @@ namespace Nethermind.Consensus.Processing
                     currentTx,
                     transactionsInBlock,
                     stateProvider,
+                    receiptsTracer.CumulativeExecutionGasUsed,
                     receiptsTracer.BlockStateGasUsed);
 
                 if (args.Action != TxAction.Add)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
@@ -99,7 +99,12 @@ namespace Nethermind.Consensus.Processing
                 ProcessingOptions processingOptions,
                 HashSet<Transaction> transactionsInBlock)
             {
-                AddingTxEventArgs args = txPicker.CanAddTransaction(block, currentTx, transactionsInBlock, stateProvider);
+                AddingTxEventArgs args = txPicker.CanAddTransaction(
+                    block,
+                    currentTx,
+                    transactionsInBlock,
+                    stateProvider,
+                    receiptsTracer.BlockStateGasUsed);
 
                 if (args.Action != TxAction.Add)
                 {

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.IBlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.IBlockProductionTransactionPicker.cs
@@ -17,7 +17,6 @@ public partial class BlockProcessor
         AddingTxEventArgs CanAddTransaction(Block block, Transaction currentTx,
             IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider);
 
-        // EIP-8037: per-dimension block gas; the default bridges to the legacy member so existing implementors keep binding.
         AddingTxEventArgs CanAddTransaction(Block block, Transaction currentTx,
             IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider,
             ulong cumulativeBlockExecutionGas, ulong cumulativeBlockStateGas)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.IBlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.IBlockProductionTransactionPicker.cs
@@ -15,6 +15,12 @@ public partial class BlockProcessor
         event EventHandler<AddingTxEventArgs>? AddingTransaction;
 
         AddingTxEventArgs CanAddTransaction(Block block, Transaction currentTx,
-            IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider, ulong cumulativeStateGas = 0);
+            IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider);
+
+        // EIP-8037: per-dimension block gas; the default bridges to the legacy member so existing implementors keep binding.
+        AddingTxEventArgs CanAddTransaction(Block block, Transaction currentTx,
+            IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider,
+            ulong cumulativeBlockExecutionGas, ulong cumulativeBlockStateGas)
+            => CanAddTransaction(block, currentTx, transactionsInBlock, stateProvider);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.IBlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.IBlockProductionTransactionPicker.cs
@@ -15,6 +15,6 @@ public partial class BlockProcessor
         event EventHandler<AddingTxEventArgs>? AddingTransaction;
 
         AddingTxEventArgs CanAddTransaction(Block block, Transaction currentTx,
-            IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider);
+            IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider, ulong cumulativeStateGas = 0);
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -206,6 +206,12 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
             return error!;
         }
 
+        if (!FrameTxValidation.TryCalculateBlockGasReservations(transaction, releaseSpec, out ulong executionReservation, out _)
+            || executionReservation > Eip7825Constants.DefaultTxGasLimitCap)
+        {
+            return FrameTxValidation.FrameExecutionGasExceedsCap;
+        }
+
         // EIP-7594: a blob-carrying frame tx is bound by the same per-tx blob-count limit and
         // versioned-hash version byte as a type-3 blob tx.
         byte[]?[]? blobVersionedHashes = transaction.BlobVersionedHashes;

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -206,10 +206,14 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
             return error!;
         }
 
-        if (!FrameTxValidation.TryCalculateBlockGasReservations(transaction, releaseSpec, out ulong executionReservation, out _)
-            || executionReservation > Eip7825Constants.DefaultTxGasLimitCap)
+        if (!FrameTxValidation.TryCalculateBlockGasReservations(transaction, releaseSpec, out ulong executionReservation, out _))
         {
-            return FrameTxValidation.FrameExecutionGasExceedsCap;
+            return FrameTxValidation.FrameGasOverflow;
+        }
+
+        if (releaseSpec.IsEip8037Enabled && executionReservation > Eip7825Constants.DefaultTxGasLimitCap)
+        {
+            return FrameTxValidation.FrameExecutionGasExceedsCap(executionReservation, Eip7825Constants.DefaultTxGasLimitCap);
         }
 
         // EIP-7594: a blob-carrying frame tx is bound by the same per-tx blob-count limit and

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -17,8 +17,9 @@ namespace Nethermind.Core.Test.Encoding;
 
 /// <summary>
 /// Round-trips of the EIP-8141 frame transaction payload
-/// <c>[chain_id, nonce, sender, frames, signatures, max_priority_fee_per_gas, max_fee_per_gas,
-/// max_fee_per_blob_gas, blob_versioned_hashes]</c> and the <c>compute_sig_hash</c> elision rule.
+/// <c>[chain_id, nonce, sender, frames, signatures, fees, blob_versioned_hashes]</c>, where
+/// <c>fees = [max_priority_fee_per_gas, max_fee_per_gas, max_fee_per_blob_gas]</c>, and the
+/// <c>compute_sig_hash</c> elision rule.
 /// The generic transaction comparer predates frames, so fields are asserted explicitly.
 /// </summary>
 [TestFixture]
@@ -123,9 +124,7 @@ public class FrameTxDecoderTests
             Rlp.Encode(TestItem.AddressA.Bytes),     // sender
             Rlp.Encode(Array.Empty<Rlp>()),          // frames
             Rlp.Encode(Array.Empty<Rlp>()),          // signatures
-            Rlp.Encode(0L),                          // max_priority_fee_per_gas
-            Rlp.Encode(0L),                          // max_fee_per_gas
-            Rlp.Encode(0L),                          // max_fee_per_blob_gas
+            Rlp.Encode(Rlp.Encode(0L), Rlp.Encode(0L), Rlp.Encode(0L)), // fees
             Rlp.Encode(Array.Empty<Rlp>()));         // blob_versioned_hashes
         Rlp wrapper = Rlp.Encode(new[] { body });
 
@@ -145,9 +144,9 @@ public class FrameTxDecoderTests
     [Test]
     public void Decode_PayloadWithTrailingSignature_Throws()
     {
-        // The payload is exactly 9 fields with no envelope signature. A padding attack that appends a
+        // The payload is exactly 7 fields with no envelope signature. A padding attack that appends a
         // [v, r, s] triple must be rejected — otherwise it decodes with a spurious signature while
-        // strict clients read exactly 9 elements and drop it, a decode divergence that also changes
+        // strict clients read exactly 7 elements and drop it, a decode divergence that also changes
         // the transaction hash.
         Rlp sequence = Rlp.Encode(
             Rlp.Encode(TestBlockchainIds.ChainId),   // chain_id
@@ -155,9 +154,7 @@ public class FrameTxDecoderTests
             Rlp.Encode(TestItem.AddressA.Bytes),     // sender
             Rlp.Encode(Array.Empty<Rlp>()),          // frames
             Rlp.Encode(Array.Empty<Rlp>()),          // signatures
-            Rlp.Encode(0L),                          // max_priority_fee_per_gas
-            Rlp.Encode(0L),                          // max_fee_per_gas
-            Rlp.Encode(0L),                          // max_fee_per_blob_gas
+            Rlp.Encode(Rlp.Encode(0L), Rlp.Encode(0L), Rlp.Encode(0L)), // fees
             Rlp.Encode(Array.Empty<Rlp>()),          // blob_versioned_hashes
             Rlp.Encode(27L),                         // trailing v
             Rlp.Encode(new byte[32]),                // trailing r
@@ -283,9 +280,7 @@ public class FrameTxDecoderTests
             Rlp.Encode(TestItem.AddressA.Bytes),
             Rlp.Encode(Array.Empty<Rlp>()),
             Rlp.Encode(Array.Empty<Rlp>()),
-            Rlp.Encode(0L),
-            Rlp.Encode(0L),
-            Rlp.Encode(0L),
+            Rlp.Encode(Rlp.Encode(0L), Rlp.Encode(0L), Rlp.Encode(0L)),
             Rlp.Encode(Array.Empty<Rlp>()),
             references);
 

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -374,6 +374,13 @@ public class FrameTxDecoderTests
             Frame(),
         ])).SetName("Roundtrip_AllModesFlagsTargetsAndData");
 
+        yield return new TestCaseData(CreateFrameTx(frames:
+        [
+            Frame(gasLimit: 500_000, stateGasLimit: 183_600),
+            Frame(mode: TxFrame.ModeVerify, gasLimit: 90_000, stateGasLimit: 0),
+            Frame(mode: TxFrame.ModeSender, gasLimit: ulong.MaxValue - 1, stateGasLimit: 1),
+        ])).SetName("Roundtrip_TwoDimensionalGasLimits");
+
         yield return new TestCaseData(CreateFrameTx(signatures:
         [
             new TxFrameSignature(TxFrameSignature.SchemeArbitrary, null, default, FilledBytes(11, 0x77)),
@@ -479,7 +486,8 @@ public class FrameTxDecoderTests
             Assert.That(actual[i].Mode, Is.EqualTo(expected[i].Mode), $"frame {i} mode");
             Assert.That(actual[i].Flags, Is.EqualTo(expected[i].Flags), $"frame {i} flags");
             Assert.That(actual[i].Target, Is.EqualTo(expected[i].Target), $"frame {i} target");
-            Assert.That(actual[i].GasLimit, Is.EqualTo(expected[i].GasLimit), $"frame {i} gas limit");
+            Assert.That(actual[i].ExecutionGasLimit, Is.EqualTo(expected[i].ExecutionGasLimit), $"frame {i} execution gas limit");
+            Assert.That(actual[i].StateGasLimit, Is.EqualTo(expected[i].StateGasLimit), $"frame {i} state gas limit");
             Assert.That(actual[i].Value, Is.EqualTo(expected[i].Value), $"frame {i} value");
             Assert.That(actual[i].Data.ToArray(), Is.EqualTo(expected[i].Data.ToArray()), $"frame {i} data");
         }
@@ -510,8 +518,8 @@ public class FrameTxDecoderTests
             DecodedMaxFeePerGas = 30.GWei,
         };
 
-    private static TxFrame Frame(byte mode = TxFrame.ModeDefault, byte flags = 0, Address? target = null, ulong gasLimit = 100_000, UInt256 value = default, byte[]? data = null) =>
-        new(mode, flags, target, gasLimit, value, data ?? Array.Empty<byte>());
+    private static TxFrame Frame(byte mode = TxFrame.ModeDefault, byte flags = 0, Address? target = null, ulong gasLimit = 100_000, ulong stateGasLimit = 0, UInt256 value = default, byte[]? data = null) =>
+        new(mode, flags, target, gasLimit, stateGasLimit, value, data ?? Array.Empty<byte>());
 
     private static byte[] FilledBytes(int length, byte fill)
     {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -45,9 +45,9 @@ public class FrameTxReceiptDecoderTests
         LogEntry frameOnlyLog = Log(0x02);
         TxReceipt frameReceipt = CreateStorageFrameReceipt(
             [unionLog],
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [unionLog]),
-            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, [frameOnlyLog]),
-            new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, []));
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 5_000, [unionLog]),
+            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, 0, [frameOnlyLog]),
+            new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, 0, []));
         TxReceipt legacyReceipt = Build.A.Receipt.WithAllFieldsFilled.WithCalculatedBloom().TestObject;
 
         ReceiptArrayStorageDecoder encoder = new(compactEncoding);
@@ -79,8 +79,8 @@ public class FrameTxReceiptDecoderTests
         LogEntry frameLog = Log(0x01);
         TxReceipt frameReceipt = CreateStorageFrameReceipt(
             [frameLog],
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [frameLog]),
-            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, [Log(0x02)]));
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 5_000, [frameLog]),
+            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, 0, [Log(0x02)]));
 
         // Distinct sender/gas on the neighbours so realigning onto `after` is provably not `before`.
         TxReceipt before = Build.A.Receipt.WithAllFieldsFilled
@@ -149,26 +149,26 @@ public class FrameTxReceiptDecoderTests
     private static IEnumerable<TestCaseData> RoundtripCases()
     {
         yield return new TestCaseData(CreateReceipt(
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, [Log(0x01)])),
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 5_000, [Log(0x01)])),
             TxFrameReceipt.StatusSuccess)
             .SetName("Roundtrip_SingleSuccessfulFrameWithLog");
 
         yield return new TestCaseData(CreateReceipt(
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 50_000, [Log(0x01), Log(0x02)]),
-            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, []),
-            new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, [])),
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 50_000, 9_000, [Log(0x01), Log(0x02)]),
+            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, 0, []),
+            new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, 0, [])),
             TxFrameReceipt.StatusFailure)
             .SetName("Roundtrip_SuccessFailureAndSkippedStatuses");
 
         // A frame skipped by a failed atomic batch is not a success either.
         yield return new TestCaseData(CreateReceipt(
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, []),
-            new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, [])),
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 5_000, []),
+            new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, 0, [])),
             TxFrameReceipt.StatusFailure)
             .SetName("Roundtrip_SkippedFrameIsNotASuccess");
 
         yield return new TestCaseData(CreateReceipt(
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 0, [])),
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 0, 0, [])),
             TxFrameReceipt.StatusSuccess)
             .SetName("Roundtrip_EmptyLogsAndZeroGas");
     }
@@ -179,7 +179,8 @@ public class FrameTxReceiptDecoderTests
         for (int i = 0; i < expected.Length; i++)
         {
             Assert.That(actual[i].Status, Is.EqualTo(expected[i].Status), $"frame receipt {i} status");
-            Assert.That(actual[i].GasUsed, Is.EqualTo(expected[i].GasUsed), $"frame receipt {i} gas used");
+            Assert.That(actual[i].ExecutionGasUsed, Is.EqualTo(expected[i].ExecutionGasUsed), $"frame receipt {i} execution gas used");
+            Assert.That(actual[i].StateGasUsed, Is.EqualTo(expected[i].StateGasUsed), $"frame receipt {i} state gas used");
             AssertLogsEqual(actual[i].Logs, expected[i].Logs);
         }
     }

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -174,6 +174,9 @@ public class FrameTxValidationTests
         yield return Case("ExpiryFrameWithShortData_InvalidExpiryFrame",
             static tx => tx.Frames = [Frame(mode: TxFrame.ModeVerify, target: Eip8141Constants.ExpiryVerifierAddress, data: new byte[Eip8141Constants.ExpiryDataLength - 1])],
             FrameTxValidation.InvalidExpiryFrame);
+        yield return Case("ExpiryFrameWithStateGas_InvalidExpiryFrame",
+            static tx => tx.Frames = [new TxFrame(TxFrame.ModeVerify, flags: 0, Eip8141Constants.ExpiryVerifierAddress, 30_000, 1, UInt256.Zero, new byte[Eip8141Constants.ExpiryDataLength])],
+            FrameTxValidation.InvalidExpiryFrame);
         yield return Case("TwoExpiryFrames_MultipleExpiryFrames",
             static tx => tx.Frames = [SelfVerifyFrame(), ExpiryFrame(), ExpiryFrame()],
             FrameTxValidation.MultipleExpiryFrames);

--- a/src/Nethermind/Nethermind.Core/Eip8141Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8141Constants.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Core;
 public static class Eip8141Constants
 {
     public const int MaxFrames = 64;
-    public const long IntrinsicGasCost = 15_000;
+    public const long IntrinsicGasCost = 12_000;
     public const long PerFrameGasCost = 475;
     public const ulong ArbitraryVerificationGasCost = 100;
     public const ulong Secp256k1VerificationGasCost = 2_800;

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -494,7 +494,7 @@ public static class FrameTxValidation
             totalFrameGas = accumulated;
             totalStateGas += frame.StateGasLimit;
 
-            if (!frame.Value.IsZero && frame.Target is not null && frame.Target != transaction.SenderAddress)
+            if (spec.IsEip2780Enabled && !frame.Value.IsZero && frame.Target is not null && frame.Target != transaction.SenderAddress)
             {
                 valueTransferCost += GasCostOf.TxValueCostEip2780;
             }

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -31,6 +31,7 @@ public static class FrameTxValidation
     public const string AtomicBatchFollowedByPostTxFrame = "an atomic batch frame must not be followed by a POST_TX frame";
     public const string ApprovalScopeInAtomicBatch = "frames belonging to an atomic batch must not carry approval scope";
     public const string FrameGasOverflow = "total frame gas must not exceed 2^64 - 1";
+    public const string FrameExecutionGasExceedsCap = "frame intrinsic and execution gas exceeds the transaction gas cap";
     public const string InvalidExpiryFrame = "expiry verifier frame must have zero flags, zero value, and 8-byte data";
     public const string MultipleExpiryFrames = "at most one expiry verifier frame is allowed";
     public const string InvalidSignatureScheme = "unknown signature scheme";
@@ -154,7 +155,7 @@ public static class FrameTxValidation
 
             if (frame.Mode == TxFrame.ModeVerify && frame.Target == Eip8141Constants.ExpiryVerifierAddress)
             {
-                if (frame.Flags != 0 || !frame.Value.IsZero || frame.Data.Length != Eip8141Constants.ExpiryDataLength)
+                if (frame.Flags != 0 || !frame.Value.IsZero || frame.StateGasLimit != 0 || frame.Data.Length != Eip8141Constants.ExpiryDataLength)
                 {
                     error = InvalidExpiryFrame;
                     return false;
@@ -169,8 +170,9 @@ public static class FrameTxValidation
                 hasExpiryFrame = true;
             }
 
-            ulong accumulated = totalFrameGas + frame.GasLimit;
-            if (accumulated < totalFrameGas)
+            ulong frameGas = frame.ExecutionGasLimit + frame.StateGasLimit;
+            ulong accumulated = totalFrameGas + frameGas;
+            if (frameGas < frame.ExecutionGasLimit || accumulated < totalFrameGas)
             {
                 error = FrameGasOverflow;
                 return false;
@@ -249,8 +251,10 @@ public static class FrameTxValidation
     };
 
     /// <summary>
-    /// An upper bound on the public-mempool validation work of <paramref name="transaction"/>: the gas limits
-    /// of its validation prefix plus the cost of verifying its signatures, saturating at <see cref="ulong.MaxValue"/>.
+    /// An upper bound on the public-mempool validation work of <paramref name="transaction"/>: the execution-gas
+    /// limits (EIP-8141 <c>MAX_VERIFY_GAS</c>) of its validation prefix plus the cost of verifying its signatures,
+    /// saturating at <see cref="ulong.MaxValue"/>. The prefix's <c>limits.state</c> is bounded separately by
+    /// <c>MAX_VERIFY_STATE_GAS</c> and does not enter this budget.
     /// </summary>
     /// <remarks>
     /// Derived from the frame layout alone, so no state is read. Each layout of EIP-8141 "Public
@@ -268,12 +272,33 @@ public static class FrameTxValidation
         ulong total = 0;
         for (int i = 0; i < counted; i++)
         {
-            total = Saturating(total, frames[i].GasLimit);
+            total = Saturating(total, frames[i].ExecutionGasLimit);
         }
 
         foreach (TxFrameSignature signature in transaction.FrameSignatures ?? [])
         {
             total = Saturating(total, SignatureVerificationGas(signature.Scheme));
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// An upper bound on the state growth EIP-8141 admits through the public mempool for
+    /// <paramref name="transaction"/>: the sum of its validation prefix's <c>limits.state</c>, saturating at
+    /// <see cref="ulong.MaxValue"/>. Bounded separately by <c>MAX_VERIFY_STATE_GAS</c>; signature verification
+    /// uses no state gas, so it does not enter this budget.
+    /// </summary>
+    /// <param name="transaction">The frame transaction to price.</param>
+    public static ulong ValidationWorkStateGas(Transaction transaction)
+    {
+        TxFrame[] frames = transaction.Frames ?? [];
+        int counted = RecognizedPrefixLength(frames, transaction.SenderAddress) ?? frames.Length;
+
+        ulong total = 0;
+        for (int i = 0; i < counted; i++)
+        {
+            total = Saturating(total, frames[i].StateGasLimit);
         }
 
         return total;
@@ -452,18 +477,27 @@ public static class FrameTxValidation
         ulong tokens = 0;
         ulong dataLength = 0;
         ulong totalFrameGas = 0;
+        ulong totalStateGas = 0;
+        ulong valueTransferCost = 0;
         foreach (TxFrame frame in frames)
         {
             tokens += CountCalldataTokens(frame.Data.Span, spec);
             dataLength += (ulong)frame.Data.Length;
 
-            ulong accumulated = totalFrameGas + frame.GasLimit;
-            if (accumulated < totalFrameGas)
+            ulong frameGas = frame.ExecutionGasLimit + frame.StateGasLimit;
+            ulong accumulated = totalFrameGas + frameGas;
+            if (frameGas < frame.ExecutionGasLimit || accumulated < totalFrameGas)
             {
                 return false;
             }
 
             totalFrameGas = accumulated;
+            totalStateGas += frame.StateGasLimit;
+
+            if (!frame.Value.IsZero && frame.Target is not null && frame.Target != transaction.SenderAddress)
+            {
+                valueTransferCost += GasCostOf.TxValueCostEip2780;
+            }
         }
 
         ulong signatureVerificationCost = 0;
@@ -505,6 +539,7 @@ public static class FrameTxValidation
         ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost
                              + (ulong)frames.Length * (ulong)Eip8141Constants.PerFrameGasCost
                              + signatureVerificationCost
+                             + valueTransferCost
                              + RecentRootReference.IntrinsicGas(transaction.RecentRootReferences, spec);
         ulong floorTokens = spec.IsEip7976Enabled ? dataLength * spec.GasCosts.TxDataNonZeroMultiplier : tokens;
         floorGas = spec.IsEip7623Enabled ? mandatoryGas + floorTokens * spec.GasCosts.TotalCostFloorPerToken : 0;
@@ -516,7 +551,51 @@ public static class FrameTxValidation
             return false;
         }
 
-        maxGas = Math.Max(standardGas, floorGas);
+        ulong floorReservation = floorGas + totalStateGas;
+        if (floorReservation < floorGas)
+        {
+            return false;
+        }
+
+        maxGas = Math.Max(standardGas, floorReservation);
+        return true;
+    }
+
+    /// <summary>Calculates the maximum execution and state gas a frame transaction can add to a block.</summary>
+    public static bool TryCalculateBlockGasReservations(
+        Transaction transaction,
+        IReleaseSpec spec,
+        out ulong executionReservation,
+        out ulong stateReservation)
+    {
+        executionReservation = 0;
+        stateReservation = 0;
+        if (!TryCalculateGasBudget(transaction, spec, out ulong intrinsicGas, out ulong floorGas, out _))
+        {
+            return false;
+        }
+
+        ulong frameExecution = 0;
+        foreach (TxFrame frame in transaction.Frames ?? [])
+        {
+            ulong nextExecution = frameExecution + frame.ExecutionGasLimit;
+            ulong nextState = stateReservation + frame.StateGasLimit;
+            if (nextExecution < frameExecution || nextState < stateReservation)
+            {
+                return false;
+            }
+
+            frameExecution = nextExecution;
+            stateReservation = nextState;
+        }
+
+        ulong standardExecution = intrinsicGas + frameExecution;
+        if (standardExecution < intrinsicGas)
+        {
+            return false;
+        }
+
+        executionReservation = Math.Max(standardExecution, floorGas);
         return true;
     }
 

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -31,7 +31,8 @@ public static class FrameTxValidation
     public const string AtomicBatchFollowedByPostTxFrame = "an atomic batch frame must not be followed by a POST_TX frame";
     public const string ApprovalScopeInAtomicBatch = "frames belonging to an atomic batch must not carry approval scope";
     public const string FrameGasOverflow = "total frame gas must not exceed 2^64 - 1";
-    public const string FrameExecutionGasExceedsCap = "frame intrinsic and execution gas exceeds the transaction gas cap";
+    public static string FrameExecutionGasExceedsCap(ulong executionReservation, ulong gasLimitCap) =>
+        $"frame intrinsic and execution gas ({executionReservation}) exceeds the transaction gas cap of {gasLimitCap}";
     public const string InvalidExpiryFrame = "expiry verifier frame must have zero flags, zero value, and 8-byte data";
     public const string MultipleExpiryFrames = "at most one expiry verifier frame is allowed";
     public const string InvalidSignatureScheme = "unknown signature scheme";
@@ -251,19 +252,10 @@ public static class FrameTxValidation
     };
 
     /// <summary>
-    /// An upper bound on the public-mempool validation work of <paramref name="transaction"/>: the execution-gas
-    /// limits (EIP-8141 <c>MAX_VERIFY_GAS</c>) of its validation prefix plus the cost of verifying its signatures,
-    /// saturating at <see cref="ulong.MaxValue"/>. The prefix's <c>limits.state</c> is bounded separately by
-    /// <c>MAX_VERIFY_STATE_GAS</c> and does not enter this budget.
+    /// Upper bound on the public-mempool validation work of a frame transaction: its validation prefix's
+    /// execution limits (EIP-8141 <c>MAX_VERIFY_GAS</c>) plus signature verification, saturating at
+    /// <see cref="ulong.MaxValue"/>. The prefix's <c>limits.state</c> is bounded separately by <c>MAX_VERIFY_STATE_GAS</c>.
     /// </summary>
-    /// <remarks>
-    /// Derived from the frame layout alone, so no state is read. Each layout of EIP-8141 "Public
-    /// Mempool-recognized Validation Prefixes" ends in a <c>VERIFY</c> frame targeting the sender, whose
-    /// approval is protocol-defined, so the prefix provably ends there. Under any other layout approval
-    /// depends on code at an attacker-chosen target, so the whole frame list is charged. Signature
-    /// validation counts against the same budget per EIP-8141 "Validation Prefix".
-    /// </remarks>
-    /// <param name="transaction">The frame transaction to price.</param>
     public static ulong ValidationWorkGas(Transaction transaction)
     {
         TxFrame[] frames = transaction.Frames ?? [];
@@ -284,12 +276,10 @@ public static class FrameTxValidation
     }
 
     /// <summary>
-    /// An upper bound on the state growth EIP-8141 admits through the public mempool for
-    /// <paramref name="transaction"/>: the sum of its validation prefix's <c>limits.state</c>, saturating at
-    /// <see cref="ulong.MaxValue"/>. Bounded separately by <c>MAX_VERIFY_STATE_GAS</c>; signature verification
-    /// uses no state gas, so it does not enter this budget.
+    /// Upper bound on the state growth EIP-8141 admits through the public mempool: the sum of a frame
+    /// transaction's validation prefix <c>limits.state</c>, saturating at <see cref="ulong.MaxValue"/> and
+    /// bounded separately by <c>MAX_VERIFY_STATE_GAS</c>.
     /// </summary>
-    /// <param name="transaction">The frame transaction to price.</param>
     public static ulong ValidationWorkStateGas(Transaction transaction)
     {
         TxFrame[] frames = transaction.Frames ?? [];

--- a/src/Nethermind/Nethermind.Core/TxFrame.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrame.cs
@@ -46,8 +46,6 @@ public class TxFrame(byte mode, byte flags, Address? target, ulong executionGasL
     public ulong StateGasLimit { get; } = stateGasLimit;
 
     /// <summary>The combined gas the frame reserves against the payer, <c>limits.execution + limits.state</c>.</summary>
-    /// <remarks>Static validation rejects a transaction whose frame reservations overflow, so this sum never
-    /// wraps for a frame reaching execution.</remarks>
     public ulong GasLimit => ExecutionGasLimit + StateGasLimit;
 
     public UInt256 Value { get; } = value;

--- a/src/Nethermind/Nethermind.Core/TxFrame.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrame.cs
@@ -7,10 +7,11 @@ using Nethermind.Int256;
 namespace Nethermind.Core;
 
 /// <summary>
-/// A single frame of an EIP-8141 frame transaction: <c>[mode, flags, target, gas_limit, value, data]</c>.
+/// A single frame of an EIP-8141 frame transaction: <c>[mode, flags, target, limits, value, data]</c>,
+/// where <c>limits = [execution, state]</c>.
 /// https://eips.ethereum.org/EIPS/eip-8141
 /// </summary>
-public class TxFrame(byte mode, byte flags, Address? target, ulong gasLimit, UInt256 value, ReadOnlyMemory<byte> data)
+public class TxFrame(byte mode, byte flags, Address? target, ulong executionGasLimit, ulong stateGasLimit, UInt256 value, ReadOnlyMemory<byte> data)
 {
     public const byte ModeDefault = 0;
     public const byte ModeVerify = 1;
@@ -26,13 +27,29 @@ public class TxFrame(byte mode, byte flags, Address? target, ulong gasLimit, UIn
     public const byte ApproveScopeMask = ApproveExecutionAndPayment;
     public const byte AtomicBatchFlag = 0x4;
 
+    /// <summary>Constructs a frame whose entire budget is execution gas, with <c>limits.state == 0</c>.</summary>
+    public TxFrame(byte mode, byte flags, Address? target, ulong gasLimit, UInt256 value, ReadOnlyMemory<byte> data)
+        : this(mode, flags, target, gasLimit, 0, value, data)
+    {
+    }
+
     public byte Mode { get; } = mode;
     public byte Flags { get; } = flags;
 
     /// <summary>Null resolves to the transaction sender during execution.</summary>
     public Address? Target { get; } = target;
 
-    public ulong GasLimit { get; } = gasLimit;
+    /// <summary>EIP-8141 <c>limits.execution</c>: the frame's execution-gas budget.</summary>
+    public ulong ExecutionGasLimit { get; } = executionGasLimit;
+
+    /// <summary>EIP-8141 <c>limits.state</c>: the frame's state-gas budget (EIP-8037).</summary>
+    public ulong StateGasLimit { get; } = stateGasLimit;
+
+    /// <summary>The combined gas the frame reserves against the payer, <c>limits.execution + limits.state</c>.</summary>
+    /// <remarks>Static validation rejects a transaction whose frame reservations overflow, so this sum never
+    /// wraps for a frame reaching execution.</remarks>
+    public ulong GasLimit => ExecutionGasLimit + StateGasLimit;
+
     public UInt256 Value { get; } = value;
     public ReadOnlyMemory<byte> Data { get; } = data;
 

--- a/src/Nethermind/Nethermind.Core/TxFrameReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrameReceipt.cs
@@ -6,10 +6,11 @@ using System;
 namespace Nethermind.Core;
 
 /// <summary>
-/// A per-frame receipt entry of an EIP-8141 frame transaction: <c>[status, gas_used, logs]</c>.
+/// A per-frame receipt entry of an EIP-8141 frame transaction: <c>[status, gas_used, logs]</c>,
+/// where <c>gas_used = [execution, state]</c>.
 /// https://eips.ethereum.org/EIPS/eip-8141
 /// </summary>
-public class TxFrameReceipt(byte status, ulong gasUsed, LogEntry[] logs)
+public class TxFrameReceipt(byte status, ulong executionGasUsed, ulong stateGasUsed, LogEntry[] logs)
 {
     public const byte StatusFailure = 0;
     public const byte StatusSuccess = 1;
@@ -18,7 +19,16 @@ public class TxFrameReceipt(byte status, ulong gasUsed, LogEntry[] logs)
     public const byte StatusSkipped = 2;
 
     public byte Status { get; } = status;
-    public ulong GasUsed { get; } = gasUsed;
+
+    /// <summary>Execution gas used by the frame (<c>gas_used.execution</c>), not accounting for refunds.</summary>
+    public ulong ExecutionGasUsed { get; } = executionGasUsed;
+
+    /// <summary>State gas attributed to the frame (<c>gas_used.state</c>) after all refills and rollbacks.</summary>
+    public ulong StateGasUsed { get; } = stateGasUsed;
+
+    /// <summary>The frame's combined gas: execution plus state.</summary>
+    public ulong GasUsed => ExecutionGasUsed + StateGasUsed;
+
     public LogEntry[] Logs { get; } = logs;
 
     /// <summary>The transaction-level status reported for a frame transaction with these frame receipts.</summary>

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -175,7 +175,7 @@ public class Eip8141ScenarioTests
         ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
         ulong tokens = CalldataTokens(frameData) + CalldataTokens(witnessBytes);
         ulong floorTokens = (ulong)(frameData.Length + witnessBytes.Length) * 4;
-        ulong expected = 15_000
+        ulong expected = (ulong)Eip8141Constants.IntrinsicGasCost
                          + 2 * 475UL
                          + 100 // ARBITRARY signature verification cost
                          + Math.Max(tokens * 4 + frameGasUsed, floorTokens * 16); // EIP-7976 floor rate
@@ -218,7 +218,7 @@ public class Eip8141ScenarioTests
         TxReceipt receipt = ProcessBlock(tx)[0];
 
         ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
-        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost + 2 * 475UL;
         using (Assert.EnterMultipleScope())
         {
             // EIP-7976 prices every byte as a non-zero token: 64 gas per data byte.
@@ -243,7 +243,7 @@ public class Eip8141ScenarioTests
         TxReceipt receipt = ProcessBlock(tx)[0];
 
         ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
-        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost + 2 * 475UL;
         ulong standardTokenCost = 64 * 4UL;
         using (Assert.EnterMultipleScope())
         {
@@ -268,7 +268,7 @@ public class Eip8141ScenarioTests
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
-        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost + 2 * 475UL;
         ulong standardGasLimit = mandatoryGas + (ulong)frameData.Length * 16UL + 40_000UL;
         ulong floorGas = mandatoryGas + (ulong)frameData.Length * 64UL;
         using (Assert.EnterMultipleScope())
@@ -301,7 +301,7 @@ public class Eip8141ScenarioTests
         TxReceipt receipt = ProcessBlock(tx)[0];
 
         ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
-        ulong mandatoryGas = 15_000 + 2 * 475UL;
+        ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost + 2 * 475UL;
         ulong floorGas = mandatoryGas + (ulong)frameData.Length * 64UL;
         ulong grossGas = mandatoryGas + (ulong)frameData.Length * 4UL + frameGasUsed;
         using (Assert.EnterMultipleScope())
@@ -333,7 +333,7 @@ public class Eip8141ScenarioTests
         TxReceipt receipt = ProcessBlock(tx)[0];
 
         ulong grossFrameGas = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
-        ulong gross = 15_000 + 2 * 475UL + grossFrameGas; // no calldata or signatures
+        ulong gross = (ulong)Eip8141Constants.IntrinsicGasCost + 2 * 475UL + grossFrameGas;
         ulong applied = gross - (ulong)receipt.GasUsed;
         using (Assert.EnterMultipleScope())
         {

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -70,7 +70,7 @@ public class Eip8141ScenarioTests
 
         Transaction tx = FrameTx(Sender, nonce: 0,
             SelfVerifyFrame(),
-            SenderFrame(Recipient, value: transferred));
+            SenderFrame(Recipient, value: transferred, stateGasLimit: (ulong)GasCostOf.NewAccountState));
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
@@ -96,7 +96,7 @@ public class Eip8141ScenarioTests
 
         Transaction tx = FrameTx(Sender, nonce: 0,
             SelfVerifyFrame(),
-            SenderFrame(Recipient, value: transferred));
+            SenderFrame(Recipient, value: transferred, stateGasLimit: (ulong)GasCostOf.NewAccountState));
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
@@ -132,9 +132,11 @@ public class Eip8141ScenarioTests
         _stateProvider.CommitTree(0);
 
         Transaction tx = FrameTx(smartSender, nonce: 0,
-            new TxFrame(TxFrame.ModeDefault, 0, factory, gasLimit: 500_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeDefault, 0, factory, executionGasLimit: 500_000,
+                stateGasLimit: (ulong)(GasCostOf.NewAccountState + GasCostOf.CodeDepositState * runtimeCode.Length),
+                UInt256.Zero, default),
             SelfVerifyFrame(),
-            SenderFrame(Recipient, value: 1_000));
+            SenderFrame(Recipient, value: 1_000, stateGasLimit: (ulong)GasCostOf.NewAccountState));
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
@@ -180,6 +182,26 @@ public class Eip8141ScenarioTests
         Assert.That((ulong)receipt.GasUsed, Is.EqualTo(expected));
         Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)receipt.GasUsed),
             "the refund must return exactly max cost minus charged gas at the effective price");
+    }
+
+    [Test]
+    public void ChargedGas_IncludesValueTransferCost_ForAnExternalValueFrame()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        DeployContract(Recipient, [], 1);
+
+        Transaction zeroValue = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient, gasLimit: 200_000, UInt256.Zero, default));
+        ulong zeroValueGas = (ulong)ProcessBlock(zeroValue)[0].GasUsed;
+
+        Transaction valued = FrameTx(Sender, nonce: 1,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient, gasLimit: 200_000, (UInt256)1, default));
+        ulong valuedGas = (ulong)ProcessBlock(valued)[0].GasUsed;
+
+        Assert.That(valuedGas - zeroValueGas, Is.EqualTo(GasCostOf.TxValueCostEip2780),
+            "a value-bearing SENDER frame to an external target is charged TX_VALUE_COST on top");
     }
 
     // Only the data tokens go through the max; the mandatory costs stay outside it.
@@ -366,8 +388,8 @@ public class Eip8141ScenarioTests
 
         Transaction tx = FrameTx(Sender, nonce: 0,
             SelfVerifyFrame(),
-            SenderFrame(token, flags: TxFrame.AtomicBatchFlag),
-            SenderFrame(dex));
+            SenderFrame(token, flags: TxFrame.AtomicBatchFlag, stateGasLimit: (ulong)GasCostOf.SSetState),
+            SenderFrame(dex, stateGasLimit: (ulong)GasCostOf.SSetState));
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
@@ -429,7 +451,7 @@ public class Eip8141ScenarioTests
         Transaction tx = FrameTx(Sender, nonce: 0,
             SelfVerifyFrame(),
             SenderFrame(logger),
-            SenderFrame(token, flags: TxFrame.AtomicBatchFlag),
+            SenderFrame(token, flags: TxFrame.AtomicBatchFlag, stateGasLimit: (ulong)GasCostOf.SSetState),
             SenderFrame(dex),
             SenderFrame(postLogger));
 
@@ -488,11 +510,11 @@ public class Eip8141ScenarioTests
         Transaction tx = FrameTx(Sender, nonce: 0,
             SelfVerifyFrame(),                                    // 0
             SenderFrame(logger),                                 // 1: pre-batch log survives
-            SenderFrame(tokenA, flags: TxFrame.AtomicBatchFlag), // 2: batch A, log discarded
+            SenderFrame(tokenA, flags: TxFrame.AtomicBatchFlag, stateGasLimit: (ulong)GasCostOf.SSetState), // 2: batch A, log discarded
             SenderFrame(dexRevert),                              // 3: batch A unrolls
             SenderFrame(logger),                                 // 4: between batches, log survives
-            SenderFrame(tokenB, flags: TxFrame.AtomicBatchFlag), // 5: batch B
-            SenderFrame(dexB),                                   // 6: batch B commits or unrolls
+            SenderFrame(tokenB, flags: TxFrame.AtomicBatchFlag, stateGasLimit: (ulong)GasCostOf.SSetState), // 5: batch B
+            SenderFrame(dexB, stateGasLimit: (ulong)GasCostOf.SSetState),                                   // 6: batch B commits or unrolls
             SenderFrame(logger));                                // 7: post-batch log survives
 
         TxReceipt receipt = ProcessBlock(tx)[0];
@@ -557,7 +579,7 @@ public class Eip8141ScenarioTests
         Transaction tx = FrameTx(Sender, nonce: 0,
             new TxFrame(TxFrame.ModeVerify, 0, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 100_000, UInt256.Zero, expiryData),
             SelfVerifyFrame(),
-            SenderFrame(Recipient, value: 1_000));
+            SenderFrame(Recipient, value: 1_000, stateGasLimit: (ulong)GasCostOf.NewAccountState));
 
         if (expired)
         {
@@ -669,7 +691,7 @@ public class Eip8141ScenarioTests
     {
         DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
 
-        Transaction first = FrameTx(Sender, nonce: 0, SelfVerifyFrame(), SenderFrame(Recipient, value: 100));
+        Transaction first = FrameTx(Sender, nonce: 0, SelfVerifyFrame(), SenderFrame(Recipient, value: 100, stateGasLimit: (ulong)GasCostOf.NewAccountState));
         Transaction second = FrameTx(Sender, nonce: 1, SelfVerifyFrame(), SenderFrame(Recipient, value: 200));
 
         TxReceipt[] receipts = ProcessBlock(first, second);
@@ -699,6 +721,110 @@ public class Eip8141ScenarioTests
         receiptsTracer.EndBlockTrace();
         return receiptsTracer.TxReceipts.ToArray();
     }
+
+    [Test]
+    public void CrossFrameReversal_ReducesTheCreatingFramesStateGas_NotTheReversingFrames()
+    {
+        Address slotOwner = TestItem.AddressD;
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        DeployContract(slotOwner, ToggleSlotZeroCode());
+
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, slotOwner, 200_000, 200_000, UInt256.Zero, default),
+            SenderFrame(slotOwner));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        Assert.That(FrameStatuses(receipt), Has.All.EqualTo(TxFrameReceipt.StatusSuccess));
+        Assert.That(receipt.FrameReceipts![1].StateGasUsed, Is.Zero,
+            "the creating frame's state gas is refunded to it once the later frame reverses the slot");
+        Assert.That(receipt.FrameReceipts![2].StateGasUsed, Is.Zero,
+            "the reversing frame is not credited state gas it never charged");
+        AssertStorage(slotOwner, 0, 0, "the reversing frame clears the slot");
+    }
+
+    [Test]
+    public void CrossFrameReversal_InAFrameThatReverts_LeavesTheCreatingFramesStateGasIntact()
+    {
+        Address slotOwner = TestItem.AddressD;
+        Address reverter = TestItem.AddressE;
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        DeployContract(slotOwner, ToggleSlotZeroCode());
+        DeployContract(reverter, Prepare.EvmCode
+            .Call(slotOwner, 200_000)
+            .PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, slotOwner, 200_000, 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, reverter, 400_000, 0, UInt256.Zero, default));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        Assert.That(FrameStatuses(receipt), Is.EqualTo(new[]
+        {
+            TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusFailure,
+        }));
+        Assert.That(receipt.FrameReceipts![1].StateGasUsed, Is.EqualTo((ulong)GasCostOf.SSetState),
+            "a reverted frame's refill to the creating frame is undone");
+        AssertStorage(slotOwner, 0, 1, "the reverted frame's clear is rolled back");
+    }
+
+    [Test]
+    public void CrossFrameReversal_InAnInnerCallThatReverts_LeavesTheCreatingFramesStateGasIntact()
+    {
+        Address slotOwner = TestItem.AddressD;
+        Address innerReverter = TestItem.AddressE;
+        Address outerCaller = TestItem.AddressF;
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        DeployContract(slotOwner, ToggleSlotZeroCode());
+        DeployContract(innerReverter, Prepare.EvmCode
+            .Call(slotOwner, 200_000)
+            .PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+        DeployContract(outerCaller, Prepare.EvmCode
+            .Call(innerReverter, 300_000).Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, slotOwner, 200_000, 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, outerCaller, 500_000, 0, UInt256.Zero, default));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        Assert.That(FrameStatuses(receipt), Has.All.EqualTo(TxFrameReceipt.StatusSuccess));
+        Assert.That(receipt.FrameReceipts![1].StateGasUsed, Is.EqualTo((ulong)GasCostOf.SSetState),
+            "an inner-call reversal that is itself reverted must not reduce the creating frame's state gas");
+        AssertStorage(slotOwner, 0, 1, "the inner-call reversal is rolled back");
+    }
+
+    [Test]
+    public void EntryStateCostAboveStateLimit_FailsTheFrame_WithoutSpillingIntoExecution()
+    {
+        Address freshTarget = TestItem.AddressD;
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+
+        Transaction tx = FrameTx(Sender, nonce: 0,
+            SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, freshTarget,
+                (ulong)GasCostOf.NewAccountState * 4, (ulong)GasCostOf.NewAccountState - 1, (UInt256)1_000, default));
+
+        TxReceipt receipt = ProcessBlock(tx)[0];
+
+        Assert.That(FrameStatuses(receipt), Is.EqualTo(new[]
+        {
+            TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusFailure,
+        }));
+        Assert.That(_stateProvider.GetBalance(freshTarget), Is.EqualTo(UInt256.Zero),
+            "the underfunded entry charge must fail the frame before the value transfer creates the account");
+        Assert.That(receipt.FrameReceipts![1].StateGasUsed, Is.Zero,
+            "a frame that halts on its entry charge owes no state gas");
+    }
+
+    private static byte[] ToggleSlotZeroCode() =>
+        Prepare.EvmCode
+            .PushData(0).Op(Instruction.SLOAD).Op(Instruction.ISZERO)
+            .PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done;
 
     private static Block BuildBlock(params Transaction[] transactions) =>
         Build.A.Block.WithNumber(1)
@@ -749,8 +875,8 @@ public class Eip8141ScenarioTests
     private static TxFrame SelfVerifyFrame() =>
         new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default);
 
-    private static TxFrame SenderFrame(Address target, byte flags = 0, UInt256 value = default) =>
-        new(TxFrame.ModeSender, flags, target, gasLimit: 200_000, value, default);
+    private static TxFrame SenderFrame(Address target, byte flags = 0, UInt256 value = default, ulong stateGasLimit = 0) =>
+        new(TxFrame.ModeSender, flags, target, 200_000, stateGasLimit, value, default);
 
     private static Transaction FrameTx(Address sender, ulong nonce, params TxFrame[] frames) =>
         new()

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
@@ -90,6 +90,153 @@ public class FrameTxBlockGasTests
             "a reverted frame commits no state, so it grows none");
     }
 
+    /// <summary>
+    /// A frame's state gas is drawn from its own <c>limits.state</c> reservoir, independent of
+    /// <c>limits.execution</c>: a fresh-slot write whose execution budget cannot absorb the state charge
+    /// still succeeds when the state budget covers it, and the same charge lands in the state dimension.
+    /// </summary>
+    [Test]
+    public void Execute_PayloadFrameStateBudgetCoversTheWrite_SucceedsFromTheStateReservoir()
+    {
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        const ulong executionBudget = 30_000;
+        TestAllTracerWithOutput tracer = new();
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, Writer, executionBudget, 150_000, UInt256.Zero, default));
+
+        Assert.That(Process(tx, tracer).TransactionExecuted, Is.True);
+
+        const ulong stateCharge = (ulong)GasCostOf.SSetState;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_state.Get(new StorageCell(Writer, (UInt256)0)).ToArray(), Is.Not.All.EqualTo((byte)0),
+                "the write committed, so its state gas came from the reservoir rather than out-of-gassing");
+            Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(stateCharge),
+                "the reservoir-funded write still bills the state dimension");
+            Assert.That(tracer.GasConsumedResult.EffectiveBlockGas,
+                Is.EqualTo(tracer.GasConsumedResult.SpentGas - stateCharge));
+        }
+    }
+
+    /// <summary>
+    /// With no state budget the same write's state charge exceeds the empty state pool, so the frame halts
+    /// and commits nothing: execution gas is never spent on the state charge.
+    /// </summary>
+    [Test]
+    public void Execute_PayloadFrameStateChargeExceedsEmptyStatePool_HaltsAndOwesNoStateGas()
+    {
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        const ulong executionBudget = 30_000;
+        TestAllTracerWithOutput tracer = new();
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, Writer, executionBudget, 0, UInt256.Zero, default));
+
+        Assert.That(Process(tx, tracer).TransactionExecuted, Is.True);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_state.Get(new StorageCell(Writer, (UInt256)0)).ToArray(), Is.All.EqualTo((byte)0),
+                "the write halted out of gas, so no slot was committed");
+            Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero);
+        }
+    }
+
+    /// <summary>
+    /// A fresh-slot write whose state charge exceeds a non-empty state pool halts even when the execution
+    /// budget could have absorbed the deficit: the pools are independent, so execution never funds state.
+    /// </summary>
+    [Test]
+    public void Execute_PayloadFrameStateChargeExceedsStatePool_HaltsInsteadOfSpillingIntoExecution()
+    {
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        const ulong executionBudget = 200_000;
+        const ulong stateBudget = 50_000;
+        TestAllTracerWithOutput tracer = new();
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, Writer, executionBudget, stateBudget, UInt256.Zero, default));
+
+        Assert.That(Process(tx, tracer).TransactionExecuted, Is.True);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_state.Get(new StorageCell(Writer, (UInt256)0)).ToArray(), Is.All.EqualTo((byte)0),
+                "the state pool could not cover the write and execution must not fund it, so no slot was committed");
+            Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero);
+        }
+    }
+
+    /// <summary>
+    /// A frame whose state reservoir covers a fresh-slot write but then exceptionally halts commits nothing,
+    /// so it owes zero state gas and is charged only its execution budget rather than the depleted reservoir.
+    /// </summary>
+    [Test]
+    public void Execute_PayloadFrameConsumesStateThenHalts_OwesNoStateGas()
+    {
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode
+            .PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.INVALID).Done);
+
+        const ulong executionBudget = 30_000;
+        TestAllTracerWithOutput tracer = new();
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, Writer, executionBudget, 150_000, UInt256.Zero, default));
+
+        Assert.That(Process(tx, tracer).TransactionExecuted, Is.True);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_state.Get(new StorageCell(Writer, (UInt256)0)).ToArray(), Is.All.EqualTo((byte)0),
+                "the frame halted, so its write rolled back and committed no slot");
+            Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.Zero,
+                "a halted frame grows no state, so it owes none even though it drew from the reservoir");
+            Assert.That(tracer.GasConsumedResult.EffectiveBlockGas,
+                Is.EqualTo(tracer.GasConsumedResult.SpentGas),
+                "no state charge is carved out of the regular dimension when the state gas is zero");
+        }
+    }
+
+    /// <summary>
+    /// When the calldata floor exceeds the execution component, the floor binds on the execution dimension
+    /// alone and the frame's state gas is charged on top, so gas_used is the floor plus the state gas rather
+    /// than the floor absorbing it.
+    /// </summary>
+    [Test]
+    public void Execute_CalldataFloorBindsWithStateGas_ChargesTheStateGasOnTopOfTheFloor()
+    {
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        byte[] calldata = new byte[8192];
+        TestAllTracerWithOutput tracer = new();
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, Writer, executionGasLimit: 200_000, stateGasLimit: 150_000, UInt256.Zero, calldata));
+
+        Assert.That(Process(tx, tracer).TransactionExecuted, Is.True);
+
+        const ulong stateCharge = (ulong)GasCostOf.SSetState;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_state.Get(new StorageCell(Writer, (UInt256)0)).ToArray(), Is.Not.All.EqualTo((byte)0),
+                "the write committed from the state reservoir");
+            Assert.That(tracer.GasConsumedResult.BlockStateGas, Is.EqualTo(stateCharge),
+                "the fresh slot's state charge lands in the state dimension");
+            Assert.That(tracer.GasConsumedResult.SpentGas,
+                Is.EqualTo(tracer.GasConsumedResult.EffectiveBlockGas + stateCharge),
+                "gas_used is the execution floor plus the state gas; the floor never absorbs the state charge");
+        }
+    }
+
     /// <summary>An atomic batch whose later frame fails gives back the state gas its earlier frame owed.</summary>
     /// <remarks>
     /// The unroll restores the pre-batch state, so the fresh slot the first frame wrote never reaches the
@@ -105,7 +252,7 @@ public class FrameTxBlockGasTests
         TestAllTracerWithOutput tracer = new();
         Transaction tx = FrameTx(nonce: 0,
             new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
-            new TxFrame(TxFrame.ModeSender, TxFrame.AtomicBatchFlag, Writer, gasLimit: 400_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, TxFrame.AtomicBatchFlag, Writer, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default),
             new TxFrame(TxFrame.ModeSender, 0, Inert, gasLimit: 400_000, UInt256.Zero, default));
 
         Assert.That(Process(tx, tracer).TransactionExecuted, Is.True);
@@ -128,7 +275,7 @@ public class FrameTxBlockGasTests
     private static Transaction FrameTx(ulong nonce, Address target) =>
         FrameTx(nonce,
             new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
-            new TxFrame(TxFrame.ModeSender, 0, target, gasLimit: 400_000, UInt256.Zero, default));
+            new TxFrame(TxFrame.ModeSender, 0, target, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default));
 
     private static Transaction FrameTx(ulong nonce, params TxFrame[] frames) =>
         new()

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -667,7 +667,7 @@ public class FrameTxProcessorTests
 
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Observer, Prepare.EvmCode
-            .PushData(0).PushData(8).PushData(4).PushData(0) // signatureIndex, length, dataOffset, memOffset (deepest to top)
+            .PushData(0).PushData(8).PushData(4).PushData(0)
             .Op(Instruction.SIGDATACOPY)
             .PushData(0).Op(Instruction.MLOAD).PushData(0).Op(Instruction.SSTORE)
             .Op(Instruction.STOP).Done);

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -53,7 +53,8 @@ public class FrameTxProcessorTests
     private static readonly Address Beneficiary = TestItem.AddressE;
 
     // The gas leg of max_cost (TXPARAM 0x06) for a SelfVerify + one DEFAULT frame at max fee 1, blob-free.
-    private const ulong BlobFreeMaxCost = 415_950;
+    private const ulong DefaultFrameStateGasLimit = 200_000;
+    private const ulong BlobFreeMaxCost = 615_950;
 
     [SetUp]
     public void Setup()
@@ -448,12 +449,12 @@ public class FrameTxProcessorTests
     [TestCase((byte)0x03, 1UL, TestName = "Execute_TxParam_MaxPriorityFee")]
     [TestCase((byte)0x04, 1UL, TestName = "Execute_TxParam_MaxFee")]
     [TestCase((byte)0x05, 0UL, TestName = "Execute_TxParam_MaxBlobFee")]
-    // Max cost = sum(frame gas) 400000 + intrinsic 15000 + per-frame 475×2 (no calldata/sig).
     [TestCase((byte)0x06, BlobFreeMaxCost, TestName = "Execute_TxParam_MaxCost")]
     [TestCase((byte)0x07, 0UL, TestName = "Execute_TxParam_BlobHashCount")]
     [TestCase((byte)0x09, 2UL, TestName = "Execute_TxParam_FrameCount")]
     [TestCase((byte)0x0A, 1UL, TestName = "Execute_TxParam_CurrentFrameIndex")]
     [TestCase((byte)0x0B, 0UL, TestName = "Execute_TxParam_SignatureCount")]
+    [TestCase((byte)0x11, DefaultFrameStateGasLimit, TestName = "Execute_TxParam_StateGasLeft")]
     public void Execute_TxParamIntrospection_ExposesTransactionField(byte param, ulong expected)
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
@@ -506,6 +507,7 @@ public class FrameTxProcessorTests
     [TestCase((byte)0x06, 3UL, TestName = "Execute_FrameParam_AllowedScope")]
     [TestCase((byte)0x07, 0UL, TestName = "Execute_FrameParam_AtomicBatch")]
     [TestCase((byte)0x08, 0UL, TestName = "Execute_FrameParam_Value")]
+    [TestCase((byte)0x09, 0UL, TestName = "Execute_FrameParam_StateGasLimit")]
     public void Execute_FrameParamIntrospection_ReadsCompletedFrame(byte param, ulong expected)
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
@@ -519,6 +521,52 @@ public class FrameTxProcessorTests
 
         Assert.That(result.TransactionExecuted, Is.True);
         AssertStorage(Observer, 0, (UInt256)expected);
+    }
+
+    [Test]
+    public void Execute_FrameParam_StateGasLimit_ReadsDeclaredStateBudget()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData(0x09).PushData(1).Op(Instruction.FRAMEPARAM).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeDefault, 0, Observer, 200_000, 150_000, UInt256.Zero, default));
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        AssertStorage(Observer, 0, (UInt256)150_000);
+    }
+
+    [TestCase((byte)0x0A, TestName = "Execute_FrameParam_ExecutionGasUsed")]
+    [TestCase((byte)0x0B, TestName = "Execute_FrameParam_StateGasUsed")]
+    public void Execute_FrameParamGasUsed_SplitsTheCompletedFramesDimensions(byte param)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode
+            .PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData(param).PushData(1).Op(Instruction.FRAMEPARAM).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(),
+            Frame(TxFrame.ModeDefault, target: Recipient),
+            Frame(TxFrame.ModeDefault, target: Observer));
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        UInt256 observed = new(_stateProvider.Get(new StorageCell(Observer, UInt256.Zero)), isBigEndian: true);
+        UInt256 stateGasUsed = (UInt256)(ulong)GasCostOf.SSetState;
+        if (param == 0x0B)
+        {
+            Assert.That(observed, Is.EqualTo(stateGasUsed), "the fresh-slot write lands in the state dimension");
+        }
+        else
+        {
+            Assert.That(observed, Is.GreaterThan(UInt256.Zero), "the writing frame spent execution gas too");
+            Assert.That(observed, Is.Not.EqualTo(stateGasUsed), "the execution dimension excludes the state charge");
+        }
     }
 
     [Test]
@@ -1181,12 +1229,14 @@ public class FrameTxProcessorTests
             Frame(TxFrame.ModePostTx, target: Recipient));
 
         UInt256 balanceBefore = _stateProvider.GetBalance(Sender);
-        CallOutputTracer tracer = new();
+        FrameReceiptTracer tracer = new();
         TransactionResult result = Process(tx, tracer: tracer);
 
         Assert.That(result.TransactionExecuted, Is.True, "a POST_TX revert must not invalidate the transaction");
         AssertStorage(Observer, 0, assertionFails ? UInt256.Zero : UInt256.One,
             "the execution body is kept exactly when the assertion holds");
+        Assert.That(tracer.FrameReceipts![1].StateGasUsed,
+            Is.EqualTo(assertionFails ? 0UL : (ulong)GasCostOf.SSetState));
         Assert.That(_stateProvider.GetBalance(Sender), Is.LessThan(balanceBefore), "the payer pays for what ran");
         return tracer.StatusCode;
     }
@@ -1390,6 +1440,47 @@ public class FrameTxProcessorTests
         }
     }
 
+    [TestCase((ulong)GasCostOf.SSetState, TxFrameReceipt.StatusFailure, 0UL, 0UL)]
+    [TestCase((ulong)(GasCostOf.SSetState + GasCostOf.NewAccountState), TxFrameReceipt.StatusSuccess, 1UL, (ulong)(GasCostOf.SSetState + GasCostOf.NewAccountState))]
+    public void Execute_PaymentApprovalChargesSenderCreationToTheApprovingFrame(
+        ulong stateGasLimit,
+        byte expectedStatus,
+        ulong expectedStorage,
+        ulong expectedStateGasUsed)
+    {
+        Address sponsorA = TestItem.AddressD;
+        Address sponsorB = TestItem.AddressF;
+        DeployContract(sponsorA,
+            Prepare.EvmCode
+                .PushData(1).PushData(0).Op(Instruction.SSTORE)
+                .PushData(TxFrame.ApprovePayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done,
+            1.Ether);
+        DeployContract(sponsorB, ApproveCode(TxFrame.ApprovePayment), 1.Ether);
+
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeDefault, TxFrame.ApprovePayment, sponsorA, executionGasLimit: 200_000, stateGasLimit, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeDefault, TxFrame.ApprovePayment, sponsorB, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, default)];
+        ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
+        Signature signature = new Ecdsa().Sign(TestItem.PrivateKeyA, in sigHash);
+        byte[] vrs = new byte[TxFrameSignature.Secp256k1SignatureLength];
+        vrs[0] = signature.RecoveryId;
+        signature.Bytes.CopyTo(vrs.AsSpan(1));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, vrs)];
+
+        FrameReceiptTracer tracer = new();
+        TransactionResult result = Process(tx, tracer: tracer);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(expectedStatus));
+            Assert.That(tracer.FrameReceipts[1].StateGasUsed, Is.EqualTo(expectedStateGasUsed));
+            AssertStorage(sponsorA, 0, (UInt256)expectedStorage);
+        }
+    }
+
     /// <summary>A codeless target of a non-<c>VERIFY</c> frame runs empty code in the VM, warming it.</summary>
     /// <remarks>Routing it to default code instead would skip the EVM and leave it cold.</remarks>
     [Test]
@@ -1580,8 +1671,10 @@ public class FrameTxProcessorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
-            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(frame.GasLimit),
-                "the halt consumes the frame's whole gas limit whatever its designation access cost");
+            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(frame.ExecutionGasLimit),
+                "the halt consumes the frame's whole execution limit whatever its designation access cost");
+            Assert.That(tracer.FrameReceipts[1].StateGasUsed, Is.Zero,
+                "a halted frame commits no state, so it owes no state gas");
         }
     }
 
@@ -2365,8 +2458,8 @@ public class FrameTxProcessorTests
     private static TxFrame SelfVerifyFrame() =>
         new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default);
 
-    private static TxFrame Frame(byte mode, byte flags = 0, Address? target = null, UInt256 value = default, byte[]? data = null) =>
-        new(mode, flags, target, gasLimit: 200_000, value, data ?? Array.Empty<byte>());
+    private static TxFrame Frame(byte mode, byte flags = 0, Address? target = null, UInt256 value = default, byte[]? data = null, ulong stateGasLimit = DefaultFrameStateGasLimit) =>
+        new(mode, flags, target, executionGasLimit: 200_000, stateGasLimit, value, data ?? Array.Empty<byte>());
 
     private static Transaction FrameTx(ulong nonce, params TxFrame[] frames) =>
         new()

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -54,7 +54,7 @@ public class FrameTxProcessorTests
 
     // The gas leg of max_cost (TXPARAM 0x06) for a SelfVerify + one DEFAULT frame at max fee 1, blob-free.
     private const ulong DefaultFrameStateGasLimit = 200_000;
-    private const ulong BlobFreeMaxCost = 615_950;
+    private const ulong BlobFreeMaxCost = 612_950;
 
     [SetUp]
     public void Setup()
@@ -454,7 +454,7 @@ public class FrameTxProcessorTests
     [TestCase((byte)0x09, 2UL, TestName = "Execute_TxParam_FrameCount")]
     [TestCase((byte)0x0A, 1UL, TestName = "Execute_TxParam_CurrentFrameIndex")]
     [TestCase((byte)0x0B, 0UL, TestName = "Execute_TxParam_SignatureCount")]
-    [TestCase((byte)0x11, DefaultFrameStateGasLimit, TestName = "Execute_TxParam_StateGasLeft")]
+    [TestCase((byte)0x0C, DefaultFrameStateGasLimit, TestName = "Execute_TxParam_StateGasLeft")]
     public void Execute_TxParamIntrospection_ExposesTransactionField(byte param, ulong expected)
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
@@ -657,19 +657,18 @@ public class FrameTxProcessorTests
     }
 
     [Test]
-    public void Execute_SigParamCopy_UsesMemOffsetDataOffsetLengthOrder()
+    public void Execute_SigDataCopy_UsesMemOffsetDataOffsetLengthOrder()
     {
         // signature bytes[i] == i; copy 8 bytes from dataOffset 4 into memOffset 0, then MLOAD(0).
-        // Operand order (top to bottom) is memOffset, dataOffset, length — matching CALLDATACOPY and
-        // FRAMEDATACOPY. Asymmetric operands catch a reversed pop order.
+        // Operand order (top to bottom) is memOffset, dataOffset, length, signatureIndex — matching
+        // CALLDATACOPY. Asymmetric operands catch a reversed pop order.
         byte[] signatureBytes = new byte[32];
         for (int i = 0; i < signatureBytes.Length; i++) signatureBytes[i] = (byte)i;
 
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Observer, Prepare.EvmCode
-            .PushData(8).PushData(4).PushData(0)   // length, dataOffset, memOffset (deepest to top)
-            .PushData(0x04).PushData(0)            // param (copy form), signatureIndex on top
-            .Op(Instruction.SIGPARAM)
+            .PushData(0).PushData(8).PushData(4).PushData(0) // signatureIndex, length, dataOffset, memOffset (deepest to top)
+            .Op(Instruction.SIGDATACOPY)
             .PushData(0).Op(Instruction.MLOAD).PushData(0).Op(Instruction.SSTORE)
             .Op(Instruction.STOP).Done);
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
@@ -2224,7 +2223,7 @@ public class FrameTxProcessorTests
         _stateProvider.IncrementNonce(Sender);
         _stateProvider.Commit(Spec);
         DeployContract(Observer, Prepare.EvmCode
-            .PushData(0x0C).Op(Instruction.TXPARAM).PushData(0).Op(Instruction.SSTORE)
+            .PushData(0x11).Op(Instruction.TXPARAM).PushData(0).Op(Instruction.SSTORE)
             .Op(Instruction.STOP).Done);
 
         Transaction tx = FrameTx(nonce: 1, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));

--- a/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
+++ b/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -138,11 +139,7 @@ public sealed class FrameTxContext(
         return net > 0 ? (ulong)net : 0;
     }
 
-    /// <summary>
-    /// Journal position covering the outstanding SSTORE-charge ownership map and the per-frame
-    /// <c>gas_used.state</c> corrections, captured when an EVM call frame begins so the same
-    /// rollback boundary that restores world state can restore these (EIP-8141 Gas Accounting).
-    /// </summary>
+    /// <summary>Journal position captured when an EVM call frame begins, so the rollback boundary that restores world state also restores the SSTORE-charge ownership map and per-frame <c>gas_used.state</c> corrections (EIP-8141 Gas Accounting).</summary>
     public int StateGasJournalCheckpoint => _stateGasJournal.Count;
 
     /// <summary>
@@ -152,9 +149,10 @@ public sealed class FrameTxContext(
     /// </summary>
     public void RecordStateChargeOwner(in StorageCell slot, int frame)
     {
-        int previousOwner = _stateChargeOwner.TryGetValue(slot, out int existing) ? existing : NoOwner;
+        ref int owner = ref CollectionsMarshal.GetValueRefOrAddDefault(_stateChargeOwner, slot, out bool existed);
+        int previousOwner = existed ? owner : NoOwner;
+        owner = frame;
         _stateGasJournal.Add(new StateGasJournalEntry(StateGasJournalKind.OwnerSet, slot, previousOwner, 0));
-        _stateChargeOwner[slot] = frame;
     }
 
     /// <summary>
@@ -164,13 +162,12 @@ public sealed class FrameTxContext(
     /// </summary>
     public bool TryResolveStateChargeOwner(in StorageCell slot, out int owner)
     {
-        if (!_stateChargeOwner.TryGetValue(slot, out owner))
+        if (!_stateChargeOwner.Remove(slot, out owner))
         {
             return false;
         }
 
         _stateGasJournal.Add(new StateGasJournalEntry(StateGasJournalKind.OwnerCleared, slot, owner, 0));
-        _stateChargeOwner.Remove(slot);
         return true;
     }
 
@@ -190,9 +187,13 @@ public sealed class FrameTxContext(
     /// </summary>
     public void RestoreStateGasJournal(int checkpoint)
     {
-        for (int k = _stateGasJournal.Count - 1; k >= checkpoint; k--)
+        int count = _stateGasJournal.Count;
+        if (count == checkpoint) return;
+
+        Span<StateGasJournalEntry> entries = CollectionsMarshal.AsSpan(_stateGasJournal);
+        for (int k = count - 1; k >= checkpoint; k--)
         {
-            StateGasJournalEntry entry = _stateGasJournal[k];
+            ref StateGasJournalEntry entry = ref entries[k];
             switch (entry.Kind)
             {
                 case StateGasJournalKind.OwnerSet:
@@ -214,25 +215,11 @@ public sealed class FrameTxContext(
             }
         }
 
-        _stateGasJournal.RemoveRange(checkpoint, _stateGasJournal.Count - checkpoint);
+        _stateGasJournal.RemoveRange(checkpoint, count - checkpoint);
     }
 
     /// <summary>The refill-driven reduction of <paramref name="frame"/>'s <c>gas_used.state</c>.</summary>
     public long StateGasCorrectionFor(int frame) => _frameStateGasCorrection[frame];
-
-    /// <summary>The total refill-driven reduction across all frames, subtracted from the tx dimensions at settlement.</summary>
-    public long TotalStateGasCorrection
-    {
-        get
-        {
-            long total = 0;
-            foreach (long correction in _frameStateGasCorrection)
-            {
-                total += correction;
-            }
-            return total;
-        }
-    }
 
     private enum StateGasJournalKind : byte
     {

--- a/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
+++ b/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -104,6 +105,143 @@ public sealed class FrameTxContext(
     public Address ResolvedTarget(int frameIndex) => Frames[frameIndex].Target ?? Sender;
 
     public Address ResolvedSigner(int signatureIndex) => Signatures[signatureIndex].Signer ?? Sender;
+
+    private const int NoOwner = -1;
+
+    private readonly Dictionary<StorageCell, int> _stateChargeOwner = [];
+    private readonly long[] _frameStateGasCorrection = new long[frames.Length];
+    private readonly ulong[] _frameExecutionGasUsed = new ulong[frames.Length];
+    private readonly ulong[] _frameStateGasUsed = new ulong[frames.Length];
+    private readonly List<StateGasJournalEntry> _stateGasJournal = [];
+
+    /// <summary>
+    /// Records a completed frame's attributed <c>gas_used</c> so a later frame can read it through
+    /// <c>FRAMEPARAM</c> (spec: <c>frame_receipts[frame_index].gas_used</c>). The state component is
+    /// the charge before any later refill; <see cref="StateGasUsedFor"/> nets off refill corrections.
+    /// </summary>
+    public void RecordFrameReceipt(int frame, ulong executionGasUsed, ulong stateGasUsed)
+    {
+        _frameExecutionGasUsed[frame] = executionGasUsed;
+        _frameStateGasUsed[frame] = stateGasUsed;
+    }
+
+    /// <summary>Drops a completed frame's attributed state gas when an atomic-batch unroll clears its receipt.</summary>
+    public void ClearFrameStateGasUsed(int frame) => _frameStateGasUsed[frame] = 0;
+
+    /// <summary>A completed frame's attributed <c>gas_used.execution</c> (execution gas is never refilled).</summary>
+    public ulong ExecutionGasUsedFor(int frame) => _frameExecutionGasUsed[frame];
+
+    /// <summary>A completed frame's attributed <c>gas_used.state</c>, net of refills a later frame applied to it.</summary>
+    public ulong StateGasUsedFor(int frame)
+    {
+        long net = (long)_frameStateGasUsed[frame] - _frameStateGasCorrection[frame];
+        return net > 0 ? (ulong)net : 0;
+    }
+
+    /// <summary>
+    /// Journal position covering the outstanding SSTORE-charge ownership map and the per-frame
+    /// <c>gas_used.state</c> corrections, captured when an EVM call frame begins so the same
+    /// rollback boundary that restores world state can restore these (EIP-8141 Gas Accounting).
+    /// </summary>
+    public int StateGasJournalCheckpoint => _stateGasJournal.Count;
+
+    /// <summary>
+    /// Records the frame that paid an <c>SSTORE</c> state charge as the outstanding-charge owner
+    /// of <paramref name="slot"/>, so a later refill reduces that frame's receipt (spec: journal
+    /// the charging frame's index as the outstanding charge owner).
+    /// </summary>
+    public void RecordStateChargeOwner(in StorageCell slot, int frame)
+    {
+        int previousOwner = _stateChargeOwner.TryGetValue(slot, out int existing) ? existing : NoOwner;
+        _stateGasJournal.Add(new StateGasJournalEntry(StateGasJournalKind.OwnerSet, slot, previousOwner, 0));
+        _stateChargeOwner[slot] = frame;
+    }
+
+    /// <summary>
+    /// Resolves and clears the outstanding-charge owner of <paramref name="slot"/> when a refill
+    /// fires, journaling the cleared owner so a revert restores it (spec: clear the slot's ownership
+    /// entry). Returns <c>false</c> when no frame owns an outstanding charge there.
+    /// </summary>
+    public bool TryResolveStateChargeOwner(in StorageCell slot, out int owner)
+    {
+        if (!_stateChargeOwner.TryGetValue(slot, out owner))
+        {
+            return false;
+        }
+
+        _stateGasJournal.Add(new StateGasJournalEntry(StateGasJournalKind.OwnerCleared, slot, owner, 0));
+        _stateChargeOwner.Remove(slot);
+        return true;
+    }
+
+    /// <summary>
+    /// Subtracts a refilled state-gas charge from the receipt of the frame that paid it
+    /// (spec: <c>frame_receipts[owner].gas_used.state -= amount</c>), journaled so a revert undoes it.
+    /// </summary>
+    public void ReduceFrameStateGas(int owner, long amount)
+    {
+        _frameStateGasCorrection[owner] += amount;
+        _stateGasJournal.Add(new StateGasJournalEntry(StateGasJournalKind.ReceiptReduced, default, owner, amount));
+    }
+
+    /// <summary>
+    /// Undoes ownership and receipt-correction journal entries recorded after
+    /// <paramref name="checkpoint"/>, at the same boundary that restores world state.
+    /// </summary>
+    public void RestoreStateGasJournal(int checkpoint)
+    {
+        for (int k = _stateGasJournal.Count - 1; k >= checkpoint; k--)
+        {
+            StateGasJournalEntry entry = _stateGasJournal[k];
+            switch (entry.Kind)
+            {
+                case StateGasJournalKind.OwnerSet:
+                    if (entry.Owner == NoOwner)
+                    {
+                        _stateChargeOwner.Remove(entry.Slot);
+                    }
+                    else
+                    {
+                        _stateChargeOwner[entry.Slot] = entry.Owner;
+                    }
+                    break;
+                case StateGasJournalKind.OwnerCleared:
+                    _stateChargeOwner[entry.Slot] = entry.Owner;
+                    break;
+                case StateGasJournalKind.ReceiptReduced:
+                    _frameStateGasCorrection[entry.Owner] -= entry.Amount;
+                    break;
+            }
+        }
+
+        _stateGasJournal.RemoveRange(checkpoint, _stateGasJournal.Count - checkpoint);
+    }
+
+    /// <summary>The refill-driven reduction of <paramref name="frame"/>'s <c>gas_used.state</c>.</summary>
+    public long StateGasCorrectionFor(int frame) => _frameStateGasCorrection[frame];
+
+    /// <summary>The total refill-driven reduction across all frames, subtracted from the tx dimensions at settlement.</summary>
+    public long TotalStateGasCorrection
+    {
+        get
+        {
+            long total = 0;
+            foreach (long correction in _frameStateGasCorrection)
+            {
+                total += correction;
+            }
+            return total;
+        }
+    }
+
+    private enum StateGasJournalKind : byte
+    {
+        OwnerSet,
+        OwnerCleared,
+        ReceiptReduced,
+    }
+
+    private readonly record struct StateGasJournalEntry(StateGasJournalKind Kind, StorageCell Slot, int Owner, long Amount);
 
     private static ValueHash256 ComputeNonceKeysHash(UInt256[] nonceKeys)
     {

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/Eip8037BlockGasInclusionCheck.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/Eip8037BlockGasInclusionCheck.cs
@@ -24,12 +24,7 @@ public static class Eip8037BlockGasInclusionCheck
         return Validate(blockGasLimit, cumulativeBlockExecution, cumulativeBlockState, worstCaseExecution, txGas);
     }
 
-    /// <summary>
-    /// EIP-8141 frame transactions declare exact per-dimension budgets, so their block reservations are
-    /// known rather than worst-cased: the execution reservation is the intrinsic execution cost plus the
-    /// frames' execution budgets (bounded below by the calldata floor), and the state reservation is the
-    /// frames' state budgets.
-    /// </summary>
+    /// <summary>Validates a frame transaction's exact per-dimension block reservations against the remaining execution and state capacity (EIP-8141).</summary>
     public static Outcome Validate(
         ulong blockGasLimit,
         ulong cumulativeBlockExecution,

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/Eip8037BlockGasInclusionCheck.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/Eip8037BlockGasInclusionCheck.cs
@@ -20,6 +20,23 @@ public static class Eip8037BlockGasInclusionCheck
         ulong cumulativeBlockState,
         ulong txGas)
     {
+        ulong worstCaseExecution = Math.Min(Eip7825Constants.DefaultTxGasLimitCap, txGas);
+        return Validate(blockGasLimit, cumulativeBlockExecution, cumulativeBlockState, worstCaseExecution, txGas);
+    }
+
+    /// <summary>
+    /// EIP-8141 frame transactions declare exact per-dimension budgets, so their block reservations are
+    /// known rather than worst-cased: the execution reservation is the intrinsic execution cost plus the
+    /// frames' execution budgets (bounded below by the calldata floor), and the state reservation is the
+    /// frames' state budgets.
+    /// </summary>
+    public static Outcome Validate(
+        ulong blockGasLimit,
+        ulong cumulativeBlockExecution,
+        ulong cumulativeBlockState,
+        ulong executionReservation,
+        ulong stateReservation)
+    {
         // A cumulative dimension that already exceeded the block limit must reject — silent saturation
         // would otherwise let the worst-case check pass and admit a tx that block-end validation rejects.
         if (cumulativeBlockExecution > blockGasLimit) return Outcome.ExecutionDimensionExceeded;
@@ -28,13 +45,10 @@ public static class Eip8037BlockGasInclusionCheck
         ulong executionAvailable = blockGasLimit - cumulativeBlockExecution;
         ulong stateAvailable = blockGasLimit - cumulativeBlockState;
 
-        // EIP-8037: reserve the full gas limit in each dimension (no intrinsic subtraction). Only the
-        // execution dimension is bounded by the EIP-7825 per-tx cap; state work can exceed it via the reservoir.
-        ulong worstCaseExecution = Math.Min(Eip7825Constants.DefaultTxGasLimitCap, txGas);
-        if (worstCaseExecution > executionAvailable)
+        if (executionReservation > executionAvailable)
             return Outcome.ExecutionDimensionExceeded;
 
-        if (txGas > stateAvailable)
+        if (stateReservation > stateAvailable)
             return Outcome.StateDimensionExceeded;
 
         return Outcome.Ok;

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -35,9 +35,24 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     public long StateGasSpillRefunded;
     /// <summary>Indicates that execution encountered an out of gas condition.</summary>
     public bool OutOfGas;
+    /// <summary>
+    /// When set, the state pool is independent of the execution pool: a state charge exceeding the
+    /// reservoir halts rather than spilling into <see cref="Value"/>.
+    /// </summary>
+    /// <remarks>EIP-8141: the EIP-8037 reservoir spill does not apply within a frame transaction.</remarks>
+    public bool IndependentStatePool;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static EthereumGasPolicy FromULong(ulong value) => new() { Value = value };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static EthereumGasPolicy FromFrameLimits(ulong executionGasLimit, ulong stateGasLimit) =>
+        new()
+        {
+            Value = executionGasLimit,
+            StateReservoir = stateGasLimit > long.MaxValue ? long.MaxValue : (long)stateGasLimit,
+            IndependentStatePool = true
+        };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static EthereumGasPolicy CreateSystemTransactionIntrinsicGas(ulong blockGasLimit) =>
@@ -132,6 +147,12 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
             gas.StateReservoir -= stateGasCost;
             gas.StateGasUsed += stateGasCost;
             return true;
+        }
+
+        if (gas.IndependentStatePool)
+        {
+            gas.OutOfGas = true;
+            return false;
         }
 
         ulong spillAmount = CalculateStateGasSpill(in gas, stateGasCost);
@@ -557,6 +578,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
             StateReservoir = childStateReservoir,
             StateGasUsed = 0,
             StateGasSpill = 0,
+            IndependentStatePool = parentGas.IndependentStatePool,
         };
     }
 

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -35,11 +35,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     public long StateGasSpillRefunded;
     /// <summary>Indicates that execution encountered an out of gas condition.</summary>
     public bool OutOfGas;
-    /// <summary>
-    /// When set, the state pool is independent of the execution pool: a state charge exceeding the
-    /// reservoir halts rather than spilling into <see cref="Value"/>.
-    /// </summary>
-    /// <remarks>EIP-8141: the EIP-8037 reservoir spill does not apply within a frame transaction.</remarks>
+    /// <summary>When set, a state charge exceeding the reservoir halts rather than spilling into <see cref="Value"/> (EIP-8141: no EIP-8037 reservoir spill within a frame transaction).</summary>
     public bool IndependentStatePool;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -15,6 +15,15 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 {
     static abstract TSelf FromULong(ulong value);
 
+    /// <summary>
+    /// Seeds an EIP-8141 frame budget from its two-dimensional <c>limits = [execution, state]</c>: the execution
+    /// dimension funds <c>gas_left</c> and the state dimension funds the state reservoir. Pre-EIP-8037 policies,
+    /// having no state dimension, fall back to a single combined budget.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static virtual TSelf FromFrameLimits(ulong executionGasLimit, ulong stateGasLimit) =>
+        TSelf.FromULong(executionGasLimit > ulong.MaxValue - stateGasLimit ? ulong.MaxValue : executionGasLimit + stateGasLimit);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual TSelf CreateSystemTransactionIntrinsicGas(ulong blockGasLimit) => TSelf.FromULong(0);
 

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -15,11 +15,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 {
     static abstract TSelf FromULong(ulong value);
 
-    /// <summary>
-    /// Seeds an EIP-8141 frame budget from its two-dimensional <c>limits = [execution, state]</c>: the execution
-    /// dimension funds <c>gas_left</c> and the state dimension funds the state reservoir. Pre-EIP-8037 policies,
-    /// having no state dimension, fall back to a single combined budget.
-    /// </summary>
+    /// <summary>Seeds a frame budget from EIP-8141 <c>limits = [execution, state]</c>; pre-EIP-8037 policies fall back to a single combined budget.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual TSelf FromFrameLimits(ulong executionGasLimit, ulong stateGasLimit) =>
         TSelf.FromULong(executionGasLimit > ulong.MaxValue - stateGasLimit ? ulong.MaxValue : executionGasLimit + stateGasLimit);

--- a/src/Nethermind/Nethermind.Evm/Instruction.cs
+++ b/src/Nethermind/Nethermind.Evm/Instruction.cs
@@ -166,9 +166,10 @@ public enum Instruction : byte
     FRAMEDATACOPY = 0xb2,
     FRAMEPARAM = 0xb3,
     SIGPARAM = 0xb4,
+    SIGDATACOPY = 0xb5,
 
     // EIP-8272 recent roots
-    RECENTROOTREFLOAD = 0xb5,
+    RECENTROOTREFLOAD = 0xb6,
 
     DUPN = 0xe6,
     SWAPN = 0xe7,

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -359,7 +359,8 @@ public static partial class EvmInstructions
                 env: callEnv,
                 stateForAccessLists: in vm.VmState.AccessTracker,
                 snapshot: in snapshot,
-                newAccountCharged: newAccountCharged);
+                newAccountCharged: newAccountCharged,
+                stateGasJournalCheckpoint: vm.TxExecutionContext.FrameTxContext?.StateGasJournalCheckpoint ?? 0);
 
             return EvmExceptionType.None;
         }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
@@ -239,7 +239,8 @@ public static partial class EvmInstructions
             env: callEnv,
             stateForAccessLists: in vm.VmState.AccessTracker,
             snapshot: in snapshot,
-            isCreateStateGasCharged: chargeCreateStateGas);
+            isCreateStateGasCharged: chargeCreateStateGas,
+            stateGasJournalCheckpoint: vm.TxExecutionContext.FrameTxContext?.StateGasJournalCheckpoint ?? 0);
 
         return EvmExceptionType.None;
         // Jump forward to be unpredicted by the branch predictor.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -91,7 +91,7 @@ public static unsafe partial class EvmInstructions
     }
 
     /// <summary>TXPARAM (0xb0): read a transaction-scoped field.</summary>
-    /// <typeparam name="TEip8250">Whether the fork defines the keyed-nonce indices 0x0C, 0x0D, 0x0E and 0x10.</typeparam>
+    /// <typeparam name="TEip8250">Whether the fork defines the keyed-nonce indices 0x0D, 0x0E, 0x10 and 0x11.</typeparam>
     /// <typeparam name="TEip8272">Whether the fork defines the recent-root reference count at index 0x0F.</typeparam>
     [SkipLocalsInit]
     public static EvmExceptionType InstructionTxParam<TGasPolicy, TTracingInst, TEip8250, TEip8272>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
@@ -124,17 +124,17 @@ public static unsafe partial class EvmInstructions
             0x0B => stack.PushUInt256<TTracingInst>((UInt256)ctx.Signatures.Length),
             // The two extensions claim disjoint indices, so each is gated on its own fork rather than
             // on one shared ceiling: 0x0F must stay undefined on a chain with EIP-8250 but not EIP-8272.
-            0x0C when TEip8250.IsActive => stack.PushUInt256<TTracingInst>(ctx.LegacyNonce),
+            0x0C => stack.PushUInt256<TTracingInst>((UInt256)(ulong)Math.Max(0, TGasPolicy.GetStateReservoir(in gas))),
             0x0D when TEip8250.IsActive => stack.PushUInt256<TTracingInst>((UInt256)(ctx.NonceKeys?.Length ?? 1)),
             0x0E when TEip8250.IsActive => stack.PushBytes<TTracingInst>(ctx.NonceKeysHash.BytesAsSpan),
             0x10 when TEip8250.IsActive => stack.PushUInt256<TTracingInst>(ctx.NonceKeys is { } keys ? keys[0] : UInt256.Zero),
+            0x11 when TEip8250.IsActive => stack.PushUInt256<TTracingInst>(ctx.LegacyNonce),
             0x0F when TEip8272.IsActive => stack.PushUInt256<TTracingInst>((UInt256)ctx.RecentRootReferences.Length),
-            0x11 => stack.PushUInt256<TTracingInst>((UInt256)(ulong)Math.Max(0, TGasPolicy.GetStateReservoir(in gas))),
             _ => EvmExceptionType.BadInstruction,
         };
     }
 
-    /// <summary>RECENTROOTREFLOAD (0xb5): read one field of a declared recent-root reference.</summary>
+    /// <summary>RECENTROOTREFLOAD (0xb6): read one field of a declared recent-root reference.</summary>
     /// <remarks>
     /// Reads the signed envelope, not the predeploy's storage: the references were checked against the
     /// pre-state before any frame ran, so the opcode is legal in every frame mode, <c>VERIFY</c> included.
@@ -264,7 +264,7 @@ public static unsafe partial class EvmInstructions
         return stack.PushUInt32<TTracingInst>(status);
     }
 
-    /// <summary>SIGPARAM (0xb4): read a signature-scoped field, or copy ARBITRARY signature bytes.</summary>
+    /// <summary>SIGPARAM (0xb4): read a signature-scoped field.</summary>
     [SkipLocalsInit]
     public static EvmExceptionType InstructionSigParam<TGasPolicy, TTracingInst>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
@@ -276,18 +276,10 @@ public static unsafe partial class EvmInstructions
         // Spec stack order: signatureIndex on top, param second.
         if (!stack.PopUInt256(out UInt256 signatureIndex, out UInt256 param)) return EvmExceptionType.StackUnderflow;
         if (signatureIndex >= (UInt256)ctx.Signatures.Length) return EvmExceptionType.BadInstruction;
-        if (param > 0x04) return EvmExceptionType.BadInstruction;
+        if (param > 0x03) return EvmExceptionType.BadInstruction;
 
         int index = (int)signatureIndex.u0;
         TxFrameSignature signature = ctx.Signatures[index];
-
-        if (param.u0 == 0x04)
-        {
-            if (signature.Scheme != TxFrameSignature.SchemeArbitrary) return EvmExceptionType.BadInstruction;
-            if (!stack.PopUInt256(out UInt256 memOffset, out UInt256 dataOffset, out UInt256 length))
-                return EvmExceptionType.StackUnderflow;
-            return DataCopyCore<TGasPolicy, TTracingInst>(vm, ref gas, in memOffset, in dataOffset, in length, signature.Signature.Span);
-        }
 
         TGasPolicy.Consume<BaseGasCost>(ref gas);
         return param.u0 switch
@@ -299,8 +291,30 @@ public static unsafe partial class EvmInstructions
             0x02 => signature.Msg.IsEmpty
                 ? stack.PushZero<TTracingInst>()
                 : stack.PushBytes<TTracingInst>(signature.Msg.Span),
-            0x03 => stack.PushUInt256<TTracingInst>((UInt256)signature.Signature.Length),
+            0x03 => signature.Scheme == TxFrameSignature.SchemeArbitrary
+                ? stack.PushUInt256<TTracingInst>((UInt256)signature.Signature.Length)
+                : EvmExceptionType.BadInstruction,
             _ => EvmExceptionType.BadInstruction,
         };
+    }
+
+    /// <summary>SIGDATACOPY (0xb5): copy an ARBITRARY signature's raw bytes into memory (CALLDATACOPY semantics).</summary>
+    [SkipLocalsInit]
+    public static EvmExceptionType InstructionSigDataCopy<TGasPolicy, TTracingInst>(VirtualMachine<TGasPolicy> vm, ref EvmStack stack, ref TGasPolicy gas, ref int programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+        where TTracingInst : struct, IFlag
+    {
+        FrameTxContext? ctx = vm.TxExecutionContext.FrameTxContext;
+        if (ctx is null) return EvmExceptionType.BadInstruction;
+
+        // Spec stack order: memOffset, dataOffset, length, signatureIndex (top to bottom, matching CALLDATACOPY).
+        if (!stack.PopUInt256(out UInt256 memOffset, out UInt256 dataOffset, out UInt256 length, out UInt256 signatureIndex))
+            return EvmExceptionType.StackUnderflow;
+        if (signatureIndex >= (UInt256)ctx.Signatures.Length) return EvmExceptionType.BadInstruction;
+
+        TxFrameSignature signature = ctx.Signatures[(int)signatureIndex.u0];
+        if (signature.Scheme != TxFrameSignature.SchemeArbitrary) return EvmExceptionType.BadInstruction;
+
+        return DataCopyCore<TGasPolicy, TTracingInst>(vm, ref gas, in memOffset, in dataOffset, in length, signature.Signature.Span);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -105,7 +105,7 @@ public static unsafe partial class EvmInstructions
 
         TGasPolicy.Consume<BaseGasCost>(ref gas);
         if (!stack.PopUInt256(out UInt256 param)) return EvmExceptionType.StackUnderflow;
-        if (param > 0x10U) return EvmExceptionType.BadInstruction;
+        if (param > 0x11U) return EvmExceptionType.BadInstruction;
 
         byte[][]? blobHashes = vm.TxExecutionContext.BlobVersionedHashes;
         return param.u0 switch
@@ -129,6 +129,7 @@ public static unsafe partial class EvmInstructions
             0x0E when TEip8250.IsActive => stack.PushBytes<TTracingInst>(ctx.NonceKeysHash.BytesAsSpan),
             0x10 when TEip8250.IsActive => stack.PushUInt256<TTracingInst>(ctx.NonceKeys is { } keys ? keys[0] : UInt256.Zero),
             0x0F when TEip8272.IsActive => stack.PushUInt256<TTracingInst>((UInt256)ctx.RecentRootReferences.Length),
+            0x11 => stack.PushUInt256<TTracingInst>((UInt256)(ulong)Math.Max(0, TGasPolicy.GetStateReservoir(in gas))),
             _ => EvmExceptionType.BadInstruction,
         };
     }
@@ -217,14 +218,14 @@ public static unsafe partial class EvmInstructions
         // Spec stack order: frameIndex on top, param second.
         if (!stack.PopUInt256(out UInt256 frameIndex, out UInt256 param)) return EvmExceptionType.StackUnderflow;
         if (frameIndex >= (UInt256)ctx.Frames.Length) return EvmExceptionType.BadInstruction;
-        if (param > 0x08) return EvmExceptionType.BadInstruction;
+        if (param > 0x0B) return EvmExceptionType.BadInstruction;
 
         int index = (int)frameIndex.u0;
         TxFrame frame = ctx.Frames[index];
         return param.u0 switch
         {
             0x00 => stack.PushAddress<TTracingInst>(ctx.ResolvedTarget(index)),
-            0x01 => stack.PushUInt256<TTracingInst>((UInt256)frame.GasLimit),
+            0x01 => stack.PushUInt256<TTracingInst>((UInt256)frame.ExecutionGasLimit),
             0x02 => stack.PushUInt32<TTracingInst>(frame.Mode),
             0x03 => stack.PushUInt32<TTracingInst>(frame.Flags),
             0x04 => stack.PushUInt256<TTracingInst>((UInt256)frame.Data.Length),
@@ -232,8 +233,25 @@ public static unsafe partial class EvmInstructions
             0x06 => stack.PushUInt32<TTracingInst>(frame.AllowedApproveScope),
             0x07 => stack.PushUInt32<TTracingInst>((uint)(frame.IsAtomicBatch ? 1 : 0)),
             0x08 => stack.PushUInt256<TTracingInst>(frame.Value),
+            0x09 => stack.PushUInt256<TTracingInst>((UInt256)frame.StateGasLimit),
+            0x0A => FrameExecutionGasUsed<TTracingInst>(ctx, index, ref stack),
+            0x0B => FrameStateGasUsed<TTracingInst>(ctx, index, ref stack),
             _ => EvmExceptionType.BadInstruction,
         };
+    }
+
+    private static EvmExceptionType FrameExecutionGasUsed<TTracingInst>(FrameTxContext ctx, int index, ref EvmStack stack)
+        where TTracingInst : struct, IFlag
+    {
+        if (!ctx.IsFrameCompleted(index)) return EvmExceptionType.BadInstruction;
+        return stack.PushUInt256<TTracingInst>((UInt256)ctx.ExecutionGasUsedFor(index));
+    }
+
+    private static EvmExceptionType FrameStateGasUsed<TTracingInst>(FrameTxContext ctx, int index, ref EvmStack stack)
+        where TTracingInst : struct, IFlag
+    {
+        if (!ctx.IsFrameCompleted(index)) return EvmExceptionType.BadInstruction;
+        return stack.PushUInt256<TTracingInst>((UInt256)ctx.StateGasUsedFor(index));
     }
 
     private static EvmExceptionType FrameStatus<TTracingInst>(FrameTxContext ctx, int index, ref EvmStack stack)

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -518,8 +518,7 @@ public static partial class EvmInstructions
                 {
                     bool ssetOutOfGas = !TGasPolicy.ConsumeStorageWrite<TEip8037, OnFlag>(ref gas, spec);
                     if (ssetOutOfGas) goto OutOfGas;
-                    FrameTxContext? chargeFrameCtx = vm.TxExecutionContext.FrameTxContext;
-                    if (chargeFrameCtx is not null)
+                    if (TEip8037.IsActive && vm.TxExecutionContext.FrameTxContext is { } chargeFrameCtx)
                     {
                         chargeFrameCtx.RecordStateChargeOwner(in storageCell, chargeFrameCtx.CurrentFrameIndex);
                     }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -518,6 +518,11 @@ public static partial class EvmInstructions
                 {
                     bool ssetOutOfGas = !TGasPolicy.ConsumeStorageWrite<TEip8037, OnFlag>(ref gas, spec);
                     if (ssetOutOfGas) goto OutOfGas;
+                    FrameTxContext? chargeFrameCtx = vm.TxExecutionContext.FrameTxContext;
+                    if (chargeFrameCtx is not null)
+                    {
+                        chargeFrameCtx.RecordStateChargeOwner(in storageCell, chargeFrameCtx.CurrentFrameIndex);
+                    }
                 }
                 else
                 {
@@ -567,7 +572,18 @@ public static partial class EvmInstructions
 
                     if (TEip8037.IsActive && originalIsZero)
                     {
-                        vm.CreditStateGasRefund(ref gas, TGasPolicy.GetStorageSetStateCost());
+                        long stateGasCost = TGasPolicy.GetStorageSetStateCost();
+                        FrameTxContext? reversalFrameCtx = vm.TxExecutionContext.FrameTxContext;
+                        if (reversalFrameCtx is not null
+                            && reversalFrameCtx.TryResolveStateChargeOwner(in storageCell, out int chargeOwner)
+                            && chargeOwner != reversalFrameCtx.CurrentFrameIndex)
+                        {
+                            reversalFrameCtx.ReduceFrameStateGas(chargeOwner, stateGasCost);
+                        }
+                        else
+                        {
+                            vm.CreditStateGasRefund(ref gas, stateGasCost);
+                        }
                         if (!spec.IsEip8038Enabled)
                             refundFromReversal = (long)(GasCostOf.SSetExecution - GasCostOf.WarmStateRead);
                     }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.cs
@@ -142,6 +142,7 @@ public static unsafe partial class EvmInstructions
             lookup[(int)Instruction.FRAMEDATACOPY] = &InstructionFrameDataCopy<TGasPolicy, TTracingInst>;
             lookup[(int)Instruction.FRAMEPARAM] = &InstructionFrameParam<TGasPolicy, TTracingInst>;
             lookup[(int)Instruction.SIGPARAM] = &InstructionSigParam<TGasPolicy, TTracingInst>;
+            lookup[(int)Instruction.SIGDATACOPY] = &InstructionSigDataCopy<TGasPolicy, TTracingInst>;
         }
         if (spec.BlobBaseFeeEnabled)
         {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -297,7 +297,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             bool frameSucceeded = !substate.ShouldRevert && !substate.IsError;
             if (frameSucceeded && frameContext.ApprovalScopeSignal != 0)
             {
-                long remainingStateGas = (long)frame.StateGasLimit - frameStateGas;
+                long remainingStateGas = (frame.StateGasLimit > long.MaxValue ? long.MaxValue : (long)frame.StateGasLimit) - frameStateGas;
                 if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
                 {
                     frameSucceeded = false;
@@ -673,7 +673,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
                 if (!substate.ShouldRevert && !substate.IsError && frameContext.ApprovalScopeSignal != 0)
                 {
-                    long remainingStateGas = (long)boundedFrame.StateGasLimit - frameStateGas;
+                    long remainingStateGas = (boundedFrame.StateGasLimit > long.MaxValue ? long.MaxValue : (long)boundedFrame.StateGasLimit) - frameStateGas;
                     if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
                     {
                         substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
@@ -937,9 +937,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             ? VirtualMachine.ExecuteTransaction<OnFlag>(state, WorldState, tracer)
             : VirtualMachine.ExecuteTransaction(state, WorldState, tracer);
 
+        long stateReservoirSeed = frame.StateGasLimit > long.MaxValue ? long.MaxValue : (long)frame.StateGasLimit;
         if (substate.IsError || substate.ShouldRevert)
         {
-            TGasPolicy.ResetForHalt(ref state.Gas, (long)frame.StateGasLimit, 0);
+            TGasPolicy.ResetForHalt(ref state.Gas, stateReservoirSeed, 0);
         }
 
         ulong combinedLimit = frame.ExecutionGasLimit + frame.StateGasLimit;
@@ -950,7 +951,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         if (!substate.ShouldRevert && !substate.IsError && frameContext.ApprovalScopeSignal != 0)
         {
-            long remainingStateGas = (long)frame.StateGasLimit - stateGasUsed;
+            long remainingStateGas = stateReservoirSeed - stateGasUsed;
             if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
             {
                 substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
@@ -1084,6 +1085,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             }
 
             frameContext.Payer = resolvedTarget;
+            // EIP-8141: payment approval warms the payer for later same-account access.
             if (spec.UseHotAndColdStorage) accessTracker.WarmUp(resolvedTarget);
         }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -1086,7 +1086,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             }
 
             frameContext.Payer = resolvedTarget;
-            // EIP-8141: payment approval warms the payer for later same-account access.
             if (spec.UseHotAndColdStorage) accessTracker.WarmUp(resolvedTarget);
         }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -242,10 +242,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         int batchStartIndex = 0;
         long batchStartRefund = 0;
         long batchStartStateGas = 0;
+        int batchStartJournal = 0;
 
         Snapshot prefixEndSnapshot = txSnapshot;
         int prefixEndIndex = -1;
         long prefixEndRefund = 0;
+        long prefixEndStateGas = 0;
+        int prefixEndJournal = 0;
         bool postTxReverted = false;
 
         for (int i = 0; i < frames.Length; i++)
@@ -263,6 +266,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 batchStartIndex = i;
                 batchStartRefund = refundCounter;
                 batchStartStateGas = totalFrameStateGasUsed;
+                batchStartJournal = frameContext.StateGasJournalCheckpoint;
             }
 
             // Transient storage (TSTORE/TLOAD) is discarded between frames (spec: Cross-frame
@@ -286,10 +290,33 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
             // The shared journal accumulates logs across frames; this frame's own logs start here.
             int frameLogStart = accessTracker.Logs.Count;
+            int frameStartJournal = frameContext.StateGasJournalCheckpoint;
+            bool payerWasSet = frameContext.Payer is not null;
             TransactionSubstate substate = ExecuteFrame(frame, resolvedTarget, caller, isStatic, frameContext, in accessTracker, spec, tracer, out ulong frameGasUsed, out long frameStateGas);
-            totalFrameGasUsed += frameGasUsed;
 
             bool frameSucceeded = !substate.ShouldRevert && !substate.IsError;
+            if (frameSucceeded && frameContext.ApprovalScopeSignal != 0)
+            {
+                long remainingStateGas = (long)frame.StateGasLimit - frameStateGas;
+                if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
+                {
+                    frameSucceeded = false;
+                    substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+                    frameGasUsed = frame.ExecutionGasLimit;
+                    frameStateGas = 0;
+                }
+                else
+                {
+                    frameGasUsed += (ulong)approvalStateGas;
+                    frameStateGas += approvalStateGas;
+                }
+            }
+            else if (!frameSucceeded)
+            {
+                frameContext.ApprovalScopeSignal = 0;
+            }
+
+            totalFrameGasUsed += frameGasUsed;
             if (frameSucceeded)
             {
                 totalFrameStateGasUsed += frameStateGas;
@@ -321,10 +348,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             {
                 frameLogs = [];
             }
+            ulong frameStateGasUsed = frameSucceeded ? (ulong)frameStateGas : 0;
             frameReceipts[i] = new TxFrameReceipt(
                 frameSucceeded ? TxFrameReceipt.StatusSuccess : TxFrameReceipt.StatusFailure,
-                frameGasUsed,
+                frameGasUsed - frameStateGasUsed,
+                frameStateGasUsed,
                 frameLogs);
+            frameContext.RecordFrameReceipt(i, frameGasUsed - frameStateGasUsed, frameStateGasUsed);
 
             if (frame.Mode == TxFrame.ModeVerify && !frameSucceeded)
             {
@@ -345,15 +375,20 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 for (int s = prefixEndIndex + 1; s < i; s++)
                 {
                     TxFrameReceipt reverted = frameReceipts[s];
-                    if (reverted.Logs.Length > 0)
+                    if (reverted.Logs.Length > 0 || reverted.StateGasUsed > 0)
                     {
-                        frameReceipts[s] = new TxFrameReceipt(reverted.Status, reverted.GasUsed, []);
+                        frameReceipts[s] = new TxFrameReceipt(reverted.Status, reverted.ExecutionGasUsed, 0, []);
+                        frameContext.ClearFrameStateGasUsed(s);
                     }
                 }
 
+                totalFrameGasUsed -= (ulong)(totalFrameStateGasUsed - prefixEndStateGas);
+                totalFrameStateGasUsed = prefixEndStateGas;
+                frameContext.RestoreStateGasJournal(prefixEndJournal);
+
                 for (int s = i + 1; s < frames.Length; s++)
                 {
-                    frameReceipts[s] = new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, []);
+                    frameReceipts[s] = new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, 0, []);
                     frameContext.MarkFrameSkipped(s);
                 }
 
@@ -363,8 +398,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
             if (frameSucceeded)
             {
-                bool payerWasSet = frameContext.Payer is not null;
-                ApplyApproval(frameContext, resolvedTarget, spec);
                 if (!payerWasSet && frameContext.Payer is not null)
                 {
                     // End of the validation prefix (the shortest prefix whose success sets the payer):
@@ -373,13 +406,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                     prefixEndSnapshot = WorldState.TakeSnapshot();
                     prefixEndIndex = i;
                     prefixEndRefund = refundCounter;
+                    prefixEndStateGas = totalFrameStateGasUsed;
+                    prefixEndJournal = frameContext.StateGasJournalCheckpoint;
                 }
             }
-            else
+            else if (!inBatch)
             {
-                // An APPROVE that terminated an inner call can leave a signal behind even though
-                // the enclosing frame reverted; its effects must not apply.
-                frameContext.ApprovalScopeSignal = 0;
+                frameContext.RestoreStateGasJournal(frameStartJournal);
             }
 
             if (inBatch)
@@ -398,15 +431,18 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                     for (int s = batchStartIndex; s < i; s++)
                     {
                         TxFrameReceipt earlier = frameReceipts[s];
-                        if (earlier.Logs.Length > 0)
+                        if (earlier.Logs.Length > 0 || earlier.StateGasUsed > 0)
                         {
-                            frameReceipts[s] = new TxFrameReceipt(earlier.Status, earlier.GasUsed, []);
+                            frameReceipts[s] = new TxFrameReceipt(earlier.Status, earlier.ExecutionGasUsed, 0, []);
+                            frameContext.ClearFrameStateGasUsed(s);
                         }
                     }
 
                     // The unrolled frames' writes are gone with the snapshot, so their state charges
                     // are not owed either; the counter only grows, so the batch-start value undoes them.
+                    totalFrameGasUsed -= (ulong)(totalFrameStateGasUsed - batchStartStateGas);
                     totalFrameStateGasUsed = batchStartStateGas;
+                    frameContext.RestoreStateGasJournal(batchStartJournal);
                     // Refunds from the reverted batch are discarded with its state, so roll the counter back.
                     // No payer/sender_approved rollback is needed: EIP-8141 forbids approval scope on batch frames.
                     refundCounter = batchStartRefund;
@@ -418,13 +454,15 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                         prefixEndSnapshot = batchStartSnapshot;
                         prefixEndIndex = batchStartIndex - 1;
                         prefixEndRefund = batchStartRefund;
+                        prefixEndStateGas = batchStartStateGas;
+                        prefixEndJournal = batchStartJournal;
                     }
 
                     int terminal = i;
                     while (terminal < frames.Length && frames[terminal].IsAtomicBatch) terminal++;
                     for (int s = i + 1; s <= terminal && s < frames.Length; s++)
                     {
-                        frameReceipts[s] = new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, []);
+                        frameReceipts[s] = new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, 0, []);
                         frameContext.MarkFrameSkipped(s);
                     }
 
@@ -449,13 +487,25 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // the accumulated counter is capped at a fifth of the gross gas and subtracted here. Per-frame
         // receipts stay gross; only this transaction total is netted. The EIP-7623 floor then bounds
         // the net charge from below.
-        ulong grossGas = intrinsicGas + totalFrameGasUsed;
-        ulong spentGas = Math.Max(grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)refundCounter, spec), floorGas);
-        ulong blockStateGas = (ulong)totalFrameStateGasUsed;
-        // blockStateGas <= grossGas by the reservoir-0 invariant: each frame rents an empty state-gas
-        // reservoir, so every state charge is already counted inside totalFrameGasUsed (hence grossGas),
-        // which is what makes the SaturatingSub in CalculateBlockExecutionGas sound.
-        ulong blockRegularGas = Eip8037BlockGasInclusionCheck.CalculateBlockExecutionGas(grossGas, blockStateGas, floorGas);
+        long stateGasCorrection = frameContext.TotalStateGasCorrection;
+        for (int f = 0; f < frameReceipts.Length; f++)
+        {
+            long correction = frameContext.StateGasCorrectionFor(f);
+            if (correction > 0)
+            {
+                TxFrameReceipt corrected = frameReceipts[f];
+                ulong reducedState = corrected.StateGasUsed > (ulong)correction ? corrected.StateGasUsed - (ulong)correction : 0;
+                frameReceipts[f] = new TxFrameReceipt(corrected.Status, corrected.ExecutionGasUsed, reducedState, corrected.Logs);
+            }
+        }
+
+        ulong grossGasBeforeCorrection = intrinsicGas + totalFrameGasUsed;
+        ulong stateGasCorrectionApplied = (ulong)Math.Max(0, stateGasCorrection);
+        ulong grossGas = grossGasBeforeCorrection > stateGasCorrectionApplied ? grossGasBeforeCorrection - stateGasCorrectionApplied : 0;
+        ulong gasAfterRefund = grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)refundCounter, spec);
+        ulong blockStateGas = (ulong)Math.Max(0, totalFrameStateGasUsed - stateGasCorrection);
+        ulong blockRegularGas = Eip8037BlockGasInclusionCheck.CalculateBlockExecutionGas(gasAfterRefund, blockStateGas, floorGas);
+        ulong spentGas = blockRegularGas + blockStateGas;
         // Block-level gas accounting reads Transaction.BlockGasUsed, whose getter otherwise falls back
         // to tx.GasLimit (the frame-gas sum, not the gas actually spent). Set it explicitly like the
         // regular path so parallel block validation (BlockAccessListManager) accumulates the frame
@@ -619,9 +669,25 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 VirtualMachine.SetTxExecutionContext(new TxExecutionContext(
                     caller, _codeInfoRepository, tx.BlobVersionedHashes, in effectiveGasPrice, frameContext));
 
-                TransactionSubstate substate = ExecuteFrame(boundedFrame, resolvedTarget, caller, isStatic: true, frameContext, in accessTracker, spec, tracer, out ulong frameGasUsed, out _);
+                TransactionSubstate substate = ExecuteFrame(boundedFrame, resolvedTarget, caller, isStatic: true, frameContext, in accessTracker, spec, tracer, out ulong frameGasUsed, out long frameStateGas);
 
-                verifyGasUsed += frameGasUsed;
+                if (!substate.ShouldRevert && !substate.IsError && frameContext.ApprovalScopeSignal != 0)
+                {
+                    long remainingStateGas = (long)boundedFrame.StateGasLimit - frameStateGas;
+                    if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
+                    {
+                        substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+                        frameGasUsed = boundedFrame.ExecutionGasLimit;
+                        frameStateGas = 0;
+                    }
+                    else
+                    {
+                        frameGasUsed += (ulong)approvalStateGas;
+                        frameStateGas += approvalStateGas;
+                    }
+                }
+
+                verifyGasUsed += frameGasUsed - (ulong)frameStateGas;
 
                 if (substate.ShouldRevert || substate.IsError)
                 {
@@ -633,7 +699,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 }
 
                 frameContext.MarkFrameSucceeded(i);
-                ApplyApproval(frameContext, resolvedTarget, spec);
 
                 // Simulation stops at the first payer, once its frame has completed successfully.
                 if (frameContext.Payer is not null)
@@ -738,14 +803,14 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             : TransactionResult.Ok;
     }
 
-    /// <summary>Bounds a prefix frame's gas by what is left of <c>MAX_VERIFY_GAS</c>.</summary>
+    /// <summary>Bounds a prefix frame's execution gas by what is left of <c>MAX_VERIFY_GAS</c>.</summary>
     /// <remarks>An opaque prefix's declared gas_limits are not structurally bounded, so this cap is what
     /// keeps cumulative validation work under the budget.</remarks>
     private static TxFrame CapFrameGas(TxFrame frame, ulong remainingVerifyGas, out bool capped)
     {
-        capped = frame.GasLimit > remainingVerifyGas;
+        capped = frame.ExecutionGasLimit > remainingVerifyGas;
         return capped
-            ? new TxFrame(frame.Mode, frame.Flags, frame.Target, remainingVerifyGas, frame.Value, frame.Data)
+            ? new TxFrame(frame.Mode, frame.Flags, frame.Target, remainingVerifyGas, frame.StateGasLimit, frame.Value, frame.Data)
             : frame;
     }
 
@@ -786,9 +851,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             : 0;
         // Checked before the deadness query below, which is itself a recorded read: a frame that cannot
         // afford its target's access must leave the target untouched, as the CALL path does.
-        if (entryExecution > frame.GasLimit)
+        if (entryExecution > frame.ExecutionGasLimit)
         {
-            gasUsed = frame.GasLimit;
+            gasUsed = frame.ExecutionGasLimit;
             return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
         }
 
@@ -796,10 +861,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         long entryState = spec.IsEip8037Enabled && !value.IsZero && WorldState.IsDeadAccount(resolvedTarget)
             ? TGasPolicy.GetNewAccountStateCost()
             : 0;
-        ulong entryCharge = entryExecution + (ulong)entryState;
-        if (entryCharge > frame.GasLimit)
+        TGasPolicy frameGas = TGasPolicy.FromFrameLimits(frame.ExecutionGasLimit, frame.StateGasLimit);
+        if (!TGasPolicy.TryConsumeStateAndExecutionGas(ref frameGas, entryState, entryExecution))
         {
-            gasUsed = frame.GasLimit;
+            gasUsed = frame.ExecutionGasLimit;
             return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
         }
 
@@ -809,12 +874,12 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             // resolve_delegated_code_address: the target counts as accessed by now, so a self-designation is warm.
             if (spec.UseHotAndColdStorage)
             {
-                entryCharge += delegation != resolvedTarget && accessTracker.IsCold(delegation) && !spec.IsPrecompile(delegation)
+                ulong delegationAccess = delegation != resolvedTarget && accessTracker.IsCold(delegation) && !spec.IsPrecompile(delegation)
                     ? TGasPolicy.GetColdAccountAccessCost(spec)
                     : Eip8038Constants.WarmAccess;
-                if (entryCharge > frame.GasLimit)
+                if (!TGasPolicy.TryConsume(ref frameGas, delegationAccess))
                 {
-                    gasUsed = frame.GasLimit;
+                    gasUsed = frame.ExecutionGasLimit;
                     return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
                 }
             }
@@ -858,9 +923,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             if (delegation is not null) frameTracker.WarmUp(delegation);
         }
 
-        // The reservoir starts empty, so the VM cannot draw the entry state gas back out of it.
         using VmState<TGasPolicy> state = VmState<TGasPolicy>.RentTopLevel(
-            TGasPolicy.FromULong(frame.GasLimit - entryCharge),
+            frameGas,
             isStatic ? ExecutionType.STATICCALL : ExecutionType.TRANSACTION,
             env,
             in frameTracker,
@@ -873,12 +937,32 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             ? VirtualMachine.ExecuteTransaction<OnFlag>(state, WorldState, tracer)
             : VirtualMachine.ExecuteTransaction(state, WorldState, tracer);
 
-        ulong remainingGas = substate.IsError ? 0 : TGasPolicy.GetRemainingGas(in state.Gas);
-        gasUsed = frame.GasLimit - remainingGas;
-        // Clamp rather than assert: unlike the standard path, this also runs for reverted or errored
-        // frames, where the state-gas value carries no non-negativity guarantee. The caller discards it
-        // unless the frame succeeded, so the entry state gas is added unconditionally.
-        stateGasUsed = Math.Max(0, TGasPolicy.GetStateGasUsed(in state.Gas)) + entryState;
+        if (substate.IsError || substate.ShouldRevert)
+        {
+            TGasPolicy.ResetForHalt(ref state.Gas, (long)frame.StateGasLimit, 0);
+        }
+
+        ulong combinedLimit = frame.ExecutionGasLimit + frame.StateGasLimit;
+        gasUsed = substate.IsError
+            ? combinedLimit - (ulong)Math.Max(0, TGasPolicy.GetStateReservoir(in state.Gas))
+            : TGasPolicy.GetPreRefundGas(in state.Gas, combinedLimit);
+        stateGasUsed = Math.Max(0, TGasPolicy.GetStateGasUsed(in state.Gas));
+
+        if (!substate.ShouldRevert && !substate.IsError && frameContext.ApprovalScopeSignal != 0)
+        {
+            long remainingStateGas = (long)frame.StateGasLimit - stateGasUsed;
+            if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
+            {
+                substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+                gasUsed = frame.ExecutionGasLimit;
+                stateGasUsed = 0;
+            }
+            else
+            {
+                gasUsed += (ulong)approvalStateGas;
+                stateGasUsed += approvalStateGas;
+            }
+        }
 
         if (substate.ShouldRevert || substate.IsError)
         {
@@ -924,10 +1008,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             && frameContext.NonceKeys is { } nonceKeys)
         {
             ulong surcharge = KeyedNonceManager.FirstUseSurcharge(WorldState, frameContext.Sender, nonceKeys);
-            if (surcharge > frame.GasLimit)
+            if (surcharge > frame.ExecutionGasLimit)
             {
-                // Match the EVM path, which charges an error frame its whole limit.
-                gasUsed = frame.GasLimit;
+                gasUsed = frame.ExecutionGasLimit;
                 return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
             }
 
@@ -941,46 +1024,55 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     private static TransactionSubstate DefaultCodeSuccess() =>
         new(ReadOnlyMemory<byte>.Empty, refund: 0, destroyList: null, logs: null, shouldRevert: false);
 
-    private void ApplyApproval(FrameTxContext frameContext, Address resolvedTarget, IReleaseSpec spec)
+    private bool TryApplyApproval(FrameTxContext frameContext, Address resolvedTarget, IReleaseSpec spec, in StackAccessTracker accessTracker, long availableStateGas, out long stateGasCharged)
     {
-        // Approval validity (scope allowance, re-approval, target, prior execution approval, payer
-        // balance) is enforced by the APPROVE handler, which reverts the frame on violation; the
-        // outer loop only forwards signals of successfully completed frames.
+        stateGasCharged = 0;
         byte scope = frameContext.ApprovalScopeSignal;
-        if (scope == 0) return;
+        if (scope == 0) return true;
         frameContext.ApprovalScopeSignal = 0;
 
-        if ((scope & TxFrame.ApproveExecution) != 0)
+        bool approvesExecution = (scope & TxFrame.ApproveExecution) != 0;
+        bool approvesPayment = (scope & TxFrame.ApprovePayment) != 0;
+        bool applyPayment = false;
+        bool usesAccountNonce = false;
+        long newAccountCost = 0;
+
+        if (approvesPayment)
+        {
+            UInt256[]? keys = frameContext.NonceKeys;
+            usesAccountNonce = keys is null || !KeyedNonceManager.UsesKeyedDomain(keys);
+            if (usesAccountNonce && WorldState.GetNonce(frameContext.Sender) >= Eip8250Constants.MaxNonceSeq)
+            {
+                return false;
+            }
+
+            bool executionApproved = frameContext.SenderApproved || approvesExecution;
+            if (frameContext.Payer is null
+                && executionApproved
+                && WorldState.GetBalance(resolvedTarget) >= frameContext.MaxCost)
+            {
+                applyPayment = true;
+                if (usesAccountNonce && !WorldState.AccountExists(frameContext.Sender))
+                {
+                    newAccountCost = TGasPolicy.GetNewAccountStateCost();
+                    if (availableStateGas < newAccountCost) return false;
+                }
+            }
+        }
+
+        if (approvesExecution)
         {
             frameContext.SenderApproved = true;
         }
 
-        if ((scope & TxFrame.ApprovePayment) != 0)
+        if (applyPayment)
         {
-            // The APPROVE opcode rejects a second payer and payment before execution approval
-            // (EvmInstructions.FrameTx.cs), but the default-code sponsor path signals approval
-            // directly, bypassing those guards — so they must be re-enforced here for both paths to
-            // agree. Without this, two payment approvals against the same target charge MaxCost and
-            // increment the nonce twice while only the last payer is refunded.
-            if (frameContext.Payer is not null || !frameContext.SenderApproved) return;
-
-            // Re-checked at charge time: the frame may have moved the payer's balance after an
-            // APPROVE issued from an inner call, and the debit must never throw mid-block. A void
-            // payment leaves Payer unset, so the transaction fails the payer gate unless a later
-            // frame approves payment.
-            if (WorldState.GetBalance(resolvedTarget) < frameContext.MaxCost) return;
-
-            // EIP-8250: the account nonce cannot advance past MAX_NONCE_SEQ, and an approval that
-            // cannot consume its nonce performs no approval effects at all.
-            UInt256[]? keys = frameContext.NonceKeys;
-            if ((keys is null || (keys.Length == 1 && keys[0].IsZero))
-                && WorldState.GetNonce(frameContext.Sender) >= Eip8250Constants.MaxNonceSeq)
+            if (newAccountCost > 0)
             {
-                return;
+                stateGasCharged = newAccountCost;
+                WorldState.CreateAccountIfNotExists(frameContext.Sender, UInt256.Zero);
             }
 
-            // Charge the max cost up front from the payer and consume the sender nonce; unused
-            // gas is refunded to the payer at the end of the transaction.
             WorldState.SubtractFromBalance(resolvedTarget, frameContext.MaxCost, spec);
             if (frameContext.NonceKeys is { } nonceKeys)
             {
@@ -992,6 +1084,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             }
 
             frameContext.Payer = resolvedTarget;
+            if (spec.UseHotAndColdStorage) accessTracker.WarmUp(resolvedTarget);
         }
+
+        return true;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -487,12 +487,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // the accumulated counter is capped at a fifth of the gross gas and subtracted here. Per-frame
         // receipts stay gross; only this transaction total is netted. The EIP-7623 floor then bounds
         // the net charge from below.
-        long stateGasCorrection = frameContext.TotalStateGasCorrection;
+        long stateGasCorrection = 0;
         for (int f = 0; f < frameReceipts.Length; f++)
         {
             long correction = frameContext.StateGasCorrectionFor(f);
             if (correction > 0)
             {
+                stateGasCorrection += correction;
                 TxFrameReceipt corrected = frameReceipts[f];
                 ulong reducedState = corrected.StateGasUsed > (ulong)correction ? corrected.StateGasUsed - (ulong)correction : 0;
                 frameReceipts[f] = new TxFrameReceipt(corrected.Status, corrected.ExecutionGasUsed, reducedState, corrected.Logs);

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -478,6 +478,7 @@ public partial class VirtualMachine<TGasPolicy>(
             }
             RemoveAdvancedStateGasRefund(previousState, ref _currentState.Gas);
             _worldState.Restore(previousState.Snapshot);
+            _txExecutionContext.FrameTxContext?.RestoreStateGasJournal(previousState.StateGasJournalCheckpoint);
             if (!previousState.IsCreateOnPreExistingAccount)
             {
                 _worldState.DeleteAccount(callCodeOwner);
@@ -517,6 +518,7 @@ public partial class VirtualMachine<TGasPolicy>(
     {
         // Restore the world state to the snapshot taken before the execution of the call.
         _worldState.Restore(previousState.Snapshot);
+        _txExecutionContext.FrameTxContext?.RestoreStateGasJournal(previousState.StateGasJournalCheckpoint);
 
         // Cache the output bytes from the call result to avoid multiple property accesses.
         ReadOnlyMemory<byte> outputBytes = callResult.Output;
@@ -635,6 +637,7 @@ public partial class VirtualMachine<TGasPolicy>(
     private void PopAndRestoreParentState()
     {
         VmState<TGasPolicy> childState = _currentState;
+        _txExecutionContext.FrameTxContext?.RestoreStateGasJournal(childState.StateGasJournalCheckpoint);
         _currentState = _stateStack.Pop();
         RemoveAdvancedStateGasRefund(childState, ref childState.Gas);
         TGasPolicy.RestoreChildStateGasOnHalt(ref _currentState.Gas, in childState.Gas);

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -36,6 +36,11 @@ public class VmState<TGasPolicy> : IDisposable
     // State-gas refund already made spendable in this frame while its accounting correction
     // still has to reach the ancestor frame that originally paid the state gas.
     public long StateGasRefundAdvanced;
+    /// <summary>
+    /// EIP-8141 outstanding-charge/receipt journal position at this call frame's entry; the same
+    /// boundary that restores world state on revert/halt restores the journal to here.
+    /// </summary>
+    public int StateGasJournalCheckpoint;
     internal long OutputDestination { get; private set; } // TODO: move to CallEnv
     internal long OutputLength { get; private set; } // TODO: move to CallEnv
     public long Refund { get; set; }
@@ -105,7 +110,8 @@ public class VmState<TGasPolicy> : IDisposable
         in Snapshot snapshot,
         bool isTopLevel = false,
         bool newAccountCharged = false,
-        bool isCreateStateGasCharged = false)
+        bool isCreateStateGasCharged = false,
+        int stateGasJournalCheckpoint = 0)
     {
         VmState<TGasPolicy> state = Rent();
         state.Initialize(
@@ -120,7 +126,8 @@ public class VmState<TGasPolicy> : IDisposable
             newAccountCharged: newAccountCharged,
             env: env,
             stateForAccessLists: stateForAccessLists,
-            snapshot: snapshot);
+            snapshot: snapshot,
+            stateGasJournalCheckpoint: stateGasJournalCheckpoint);
         return state;
     }
 
@@ -143,7 +150,8 @@ public class VmState<TGasPolicy> : IDisposable
         bool newAccountCharged,
         ExecutionEnvironment env,
         in StackAccessTracker stateForAccessLists,
-        in Snapshot snapshot)
+        in Snapshot snapshot,
+        int stateGasJournalCheckpoint = 0)
     {
         _env = env;
         _snapshot = snapshot;
@@ -163,6 +171,7 @@ public class VmState<TGasPolicy> : IDisposable
         Gas = gas;
         InitialStateGasUsed = TGasPolicy.GetStateGasUsed(in gas);
         StateGasRefundAdvanced = 0;
+        StateGasJournalCheckpoint = stateGasJournalCheckpoint;
         OutputDestination = outputDestination;
         OutputLength = outputLength;
         Refund = 0;

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameForRpc.cs
@@ -8,13 +8,15 @@ using Nethermind.Int256;
 
 namespace Nethermind.Facade.Eth.RpcTransaction;
 
-/// <summary>JSON-RPC view of an EIP-8141 frame: <c>[mode, flags, target, gas_limit, value, data]</c>.</summary>
+/// <summary>JSON-RPC view of an EIP-8141 frame: <c>[mode, flags, target, limits, value, data]</c>,
+/// where <c>limits = [execution, state]</c>.</summary>
 public class FrameForRpc
 {
     public byte Mode { get; set; }
     public byte Flags { get; set; }
     public Address? Target { get; set; }
-    public ulong GasLimit { get; set; }
+    public ulong ExecutionGasLimit { get; set; }
+    public ulong StateGasLimit { get; set; }
     public UInt256 Value { get; set; }
     public byte[] Data { get; set; } = [];
 
@@ -26,12 +28,13 @@ public class FrameForRpc
         Mode = frame.Mode;
         Flags = frame.Flags;
         Target = frame.Target;
-        GasLimit = frame.GasLimit;
+        ExecutionGasLimit = frame.ExecutionGasLimit;
+        StateGasLimit = frame.StateGasLimit;
         Value = frame.Value;
         Data = frame.Data.ToArray();
     }
 
-    public TxFrame ToFrame() => new(Mode, Flags, Target, GasLimit, Value, Data);
+    public TxFrame ToFrame() => new(Mode, Flags, Target, ExecutionGasLimit, StateGasLimit, Value, Data);
 
     public static FrameForRpc[]? FromFrames(TxFrame[]? frames) =>
         frames?.Select(static f => new FrameForRpc(f)).ToArray();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
@@ -88,7 +88,8 @@ public class FrameTransactionForRpcTests
             Assert.That(frames[0].GetProperty("mode").GetInt32(), Is.EqualTo(TxFrame.ModeVerify));
             Assert.That(frames[0].GetProperty("flags").GetInt32(), Is.EqualTo(TxFrame.ApproveExecutionAndPayment));
             Assert.That(frames[0].GetProperty("target").GetString(), Is.EqualTo(TestItem.AddressB.ToString()));
-            Assert.That(frames[0].GetProperty("gasLimit").GetString(), Does.Match("^0x[0-9a-f]+$"));
+            Assert.That(frames[0].GetProperty("executionGasLimit").GetString(), Does.Match("^0x[0-9a-f]+$"));
+            Assert.That(frames[0].GetProperty("stateGasLimit").GetString(), Does.Match("^0x[0-9a-f]+$"));
         }
     }
 
@@ -326,7 +327,7 @@ public class FrameTransactionForRpcTests
             BlockHash = Keccak.Zero,
             FrameReceipts =
             [
-                new TxFrameReceipt(TxFrameReceipt.StatusSuccess, gasUsed: 21_000, logs: []),
+                new TxFrameReceipt(TxFrameReceipt.StatusSuccess, executionGasUsed: 21_000, stateGasUsed: 97_920, logs: []),
             ],
         };
 
@@ -336,6 +337,8 @@ public class FrameTransactionForRpcTests
         {
             Assert.That(receiptForRpc.FrameReceipts, Has.Length.EqualTo(1));
             Assert.That(receiptForRpc.FrameReceipts![0].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess));
+            Assert.That(receiptForRpc.FrameReceipts[0].ExecutionGasUsed, Is.EqualTo(21_000));
+            Assert.That(receiptForRpc.FrameReceipts[0].StateGasUsed, Is.EqualTo(97_920));
         }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Data/FrameReceiptForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/FrameReceiptForRpc.cs
@@ -15,11 +15,13 @@ public class FrameReceiptForRpc
     public FrameReceiptForRpc(TxFrameReceipt frameReceipt)
     {
         Status = frameReceipt.Status;
-        GasUsed = frameReceipt.GasUsed;
+        ExecutionGasUsed = frameReceipt.ExecutionGasUsed;
+        StateGasUsed = frameReceipt.StateGasUsed;
         Logs = frameReceipt.Logs;
     }
 
     public byte Status { get; set; }
-    public ulong GasUsed { get; set; }
+    public ulong ExecutionGasUsed { get; set; }
+    public ulong StateGasUsed { get; set; }
     public LogEntry[] Logs { get; set; } = [];
 }

--- a/src/Nethermind/Nethermind.Optimism/OptimismBlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismBlockProductionTransactionPicker.cs
@@ -12,10 +12,11 @@ namespace Nethermind.Optimism;
 public class OptimismBlockProductionTransactionPicker(ISpecProvider specProvider, long maxTxLengthKilobytes) : BlockProcessor.BlockProductionTransactionPicker(specProvider, maxTxLengthKilobytes)
 {
     public override BlockProcessor.AddingTxEventArgs CanAddTransaction(Block block, Transaction currentTx,
-        IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider, ulong cumulativeStateGas = 0)
+        IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider,
+        ulong cumulativeBlockExecutionGas, ulong cumulativeBlockStateGas)
     {
         if (!currentTx.IsDeposit())
-            return base.CanAddTransaction(block, currentTx, transactionsInBlock, stateProvider, cumulativeStateGas);
+            return base.CanAddTransaction(block, currentTx, transactionsInBlock, stateProvider, cumulativeBlockExecutionGas, cumulativeBlockStateGas);
 
         // Trusting CL with deposit tx validation
         BlockProcessor.AddingTxEventArgs args = new(transactionsInBlock.Count, currentTx, block, transactionsInBlock);

--- a/src/Nethermind/Nethermind.Optimism/OptimismBlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismBlockProductionTransactionPicker.cs
@@ -12,10 +12,10 @@ namespace Nethermind.Optimism;
 public class OptimismBlockProductionTransactionPicker(ISpecProvider specProvider, long maxTxLengthKilobytes) : BlockProcessor.BlockProductionTransactionPicker(specProvider, maxTxLengthKilobytes)
 {
     public override BlockProcessor.AddingTxEventArgs CanAddTransaction(Block block, Transaction currentTx,
-        IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider)
+        IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider, ulong cumulativeStateGas = 0)
     {
         if (!currentTx.IsDeposit())
-            return base.CanAddTransaction(block, currentTx, transactionsInBlock, stateProvider);
+            return base.CanAddTransaction(block, currentTx, transactionsInBlock, stateProvider, cumulativeStateGas);
 
         // Trusting CL with deposit tx validation
         BlockProcessor.AddingTxEventArgs args = new(transactionsInBlock.Count, currentTx, block, transactionsInBlock);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -185,7 +185,10 @@ namespace Nethermind.Serialization.Rlp
             {
                 int frameEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
                 byte status = decoderContext.DecodeByte();
-                ulong gasUsed = decoderContext.DecodeULong();
+                int gasUsedEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
+                ulong executionGasUsed = decoderContext.DecodeULong();
+                ulong stateGasUsed = decoderContext.DecodeULong();
+                decoderContext.Check(gasUsedEnd);
 
                 int logsEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
                 using ArrayPoolListRef<LogEntry> frameLogs = new(4);
@@ -194,7 +197,7 @@ namespace Nethermind.Serialization.Rlp
                     frameLogs.Add(CompactLogEntryDecoder.Instance.Decode(ref decoderContext, RlpBehaviors.AllowExtraBytes));
                 }
 
-                frameReceipts.Add(new TxFrameReceipt(status, gasUsed, frameLogs.ToArray()));
+                frameReceipts.Add(new TxFrameReceipt(status, executionGasUsed, stateGasUsed, frameLogs.ToArray()));
                 decoderContext.Check(frameEnd);
             }
 
@@ -215,9 +218,12 @@ namespace Nethermind.Serialization.Rlp
             {
                 TxFrameReceipt frameReceipt = frameReceipts[i];
                 int logsLength = GetFrameLogsLength(frameReceipt);
-                writer.StartSequence(Rlp.LengthOf((ulong)frameReceipt.Status) + Rlp.LengthOf(frameReceipt.GasUsed) + Rlp.LengthOfSequence(logsLength));
+                int gasUsedLength = Rlp.LengthOf(frameReceipt.ExecutionGasUsed) + Rlp.LengthOf(frameReceipt.StateGasUsed);
+                writer.StartSequence(Rlp.LengthOf((ulong)frameReceipt.Status) + Rlp.LengthOfSequence(gasUsedLength) + Rlp.LengthOfSequence(logsLength));
                 writer.Encode((ulong)frameReceipt.Status);
-                writer.Encode(frameReceipt.GasUsed);
+                writer.StartSequence(gasUsedLength);
+                writer.Encode(frameReceipt.ExecutionGasUsed);
+                writer.Encode(frameReceipt.StateGasUsed);
                 writer.StartSequence(logsLength);
                 for (int j = 0; j < frameReceipt.Logs.Length; j++)
                 {
@@ -228,7 +234,7 @@ namespace Nethermind.Serialization.Rlp
 
         private static int GetFrameReceiptContentLength(TxFrameReceipt frameReceipt) =>
             Rlp.LengthOf((ulong)frameReceipt.Status)
-            + Rlp.LengthOf(frameReceipt.GasUsed)
+            + Rlp.LengthOfSequence(Rlp.LengthOf(frameReceipt.ExecutionGasUsed) + Rlp.LengthOf(frameReceipt.StateGasUsed))
             + Rlp.LengthOfSequence(GetFrameLogsLength(frameReceipt));
 
         private static int GetFrameLogsLength(TxFrameReceipt frameReceipt)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -124,7 +124,10 @@ namespace Nethermind.Serialization.Rlp
             {
                 int frameEnd = ctx.ReadSequenceLength() + ctx.Position;
                 byte status = ctx.DecodeByte();
-                ulong gasUsed = ctx.DecodeULong();
+                int gasUsedEnd = ctx.ReadSequenceLength() + ctx.Position;
+                ulong executionGasUsed = ctx.DecodeULong();
+                ulong stateGasUsed = ctx.DecodeULong();
+                ctx.Check(gasUsedEnd);
 
                 int logsEnd = ctx.ReadSequenceLength() + ctx.Position;
                 int logCount = ctx.PeekNumberOfItemsRemaining(logsEnd, LogsRlpLimit.Limit + 1);
@@ -135,7 +138,7 @@ namespace Nethermind.Serialization.Rlp
                     logs[j] = Rlp.Decode<LogEntry>(ref ctx, RlpBehaviors.AllowExtraBytes);
                 }
 
-                frameReceipts[i] = new TxFrameReceipt(status, gasUsed, logs);
+                frameReceipts[i] = new TxFrameReceipt(status, executionGasUsed, stateGasUsed, logs);
                 totalLogs += logCount;
                 ctx.Check(frameEnd);
             }
@@ -192,7 +195,7 @@ namespace Nethermind.Serialization.Rlp
             }
 
             return Rlp.LengthOf((ulong)frameReceipt.Status)
-                   + Rlp.LengthOf(frameReceipt.GasUsed)
+                   + Rlp.LengthOfSequence(Rlp.LengthOf(frameReceipt.ExecutionGasUsed) + Rlp.LengthOf(frameReceipt.StateGasUsed))
                    + Rlp.LengthOfSequence(logsLength);
         }
 
@@ -222,9 +225,12 @@ namespace Nethermind.Serialization.Rlp
                     logsLength += Rlp.LengthOf(frameReceipt.Logs[j]);
                 }
 
-                writer.StartSequence(Rlp.LengthOf((ulong)frameReceipt.Status) + Rlp.LengthOf(frameReceipt.GasUsed) + Rlp.LengthOfSequence(logsLength));
+                int gasUsedLength = Rlp.LengthOf(frameReceipt.ExecutionGasUsed) + Rlp.LengthOf(frameReceipt.StateGasUsed);
+                writer.StartSequence(Rlp.LengthOf((ulong)frameReceipt.Status) + Rlp.LengthOfSequence(gasUsedLength) + Rlp.LengthOfSequence(logsLength));
                 writer.Encode((ulong)frameReceipt.Status);
-                writer.Encode(frameReceipt.GasUsed);
+                writer.StartSequence(gasUsedLength);
+                writer.Encode(frameReceipt.ExecutionGasUsed);
+                writer.Encode(frameReceipt.StateGasUsed);
                 writer.StartSequence(logsLength);
                 for (int j = 0; j < frameReceipt.Logs.Length; j++)
                 {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -200,7 +200,10 @@ namespace Nethermind.Serialization.Rlp
             {
                 int frameEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
                 byte status = decoderContext.DecodeByte();
-                ulong gasUsed = decoderContext.DecodeULong();
+                int gasUsedEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
+                ulong executionGasUsed = decoderContext.DecodeULong();
+                ulong stateGasUsed = decoderContext.DecodeULong();
+                decoderContext.Check(gasUsedEnd);
 
                 int logsEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
                 List<LogEntry> frameLogs = [];
@@ -209,7 +212,7 @@ namespace Nethermind.Serialization.Rlp
                     frameLogs.Add(Rlp.Decode<LogEntry>(ref decoderContext, RlpBehaviors.AllowExtraBytes));
                 }
 
-                frameReceipts.Add(new TxFrameReceipt(status, gasUsed, frameLogs.ToArray()));
+                frameReceipts.Add(new TxFrameReceipt(status, executionGasUsed, stateGasUsed, frameLogs.ToArray()));
                 decoderContext.Check(frameEnd);
             }
 
@@ -230,9 +233,12 @@ namespace Nethermind.Serialization.Rlp
             {
                 TxFrameReceipt frameReceipt = frameReceipts[i];
                 int logsLength = GetFrameLogsLength(frameReceipt);
-                writer.StartSequence(Rlp.LengthOf((ulong)frameReceipt.Status) + Rlp.LengthOf(frameReceipt.GasUsed) + Rlp.LengthOfSequence(logsLength));
+                int gasUsedLength = Rlp.LengthOf(frameReceipt.ExecutionGasUsed) + Rlp.LengthOf(frameReceipt.StateGasUsed);
+                writer.StartSequence(Rlp.LengthOf((ulong)frameReceipt.Status) + Rlp.LengthOfSequence(gasUsedLength) + Rlp.LengthOfSequence(logsLength));
                 writer.Encode((ulong)frameReceipt.Status);
-                writer.Encode(frameReceipt.GasUsed);
+                writer.StartSequence(gasUsedLength);
+                writer.Encode(frameReceipt.ExecutionGasUsed);
+                writer.Encode(frameReceipt.StateGasUsed);
                 writer.StartSequence(logsLength);
                 for (int j = 0; j < frameReceipt.Logs.Length; j++)
                 {
@@ -243,7 +249,7 @@ namespace Nethermind.Serialization.Rlp
 
         private static int GetFrameReceiptContentLength(TxFrameReceipt frameReceipt) =>
             Rlp.LengthOf((ulong)frameReceipt.Status)
-            + Rlp.LengthOf(frameReceipt.GasUsed)
+            + Rlp.LengthOfSequence(Rlp.LengthOf(frameReceipt.ExecutionGasUsed) + Rlp.LengthOf(frameReceipt.StateGasUsed))
             + Rlp.LengthOfSequence(GetFrameLogsLength(frameReceipt));
 
         private static int GetFrameLogsLength(TxFrameReceipt frameReceipt)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -144,7 +144,10 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         ulong gasLimit = 0;
         foreach (TxFrame frame in transaction.Frames)
         {
-            gasLimit = frame.GasLimit > ulong.MaxValue - gasLimit ? ulong.MaxValue : gasLimit + frame.GasLimit;
+            ulong frameLimit = frame.ExecutionGasLimit > ulong.MaxValue - frame.StateGasLimit
+                ? ulong.MaxValue
+                : frame.ExecutionGasLimit + frame.StateGasLimit;
+            gasLimit = frameLimit > ulong.MaxValue - gasLimit ? ulong.MaxValue : gasLimit + frameLimit;
         }
         transaction.GasLimit = gasLimit;
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -132,9 +132,12 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         transaction.SenderAddress = decoderContext.DecodeAddress() ?? ThrowMissingSender();
         transaction.Frames = decoderContext.DecodeArray(TxFrameDecoder.Instance, limit: FramesCountLimit);
         transaction.FrameSignatures = decoderContext.DecodeArray(TxFrameSignatureDecoder.Instance, limit: SignaturesCountLimit);
+        int feesLength = decoderContext.ReadSequenceLength();
+        int feesCheck = feesLength + decoderContext.Position;
         transaction.GasPrice = decoderContext.DecodeUInt256(); // max_priority_fee_per_gas
         transaction.DecodedMaxFeePerGas = decoderContext.DecodeUInt256();
         transaction.MaxFeePerBlobGas = decoderContext.DecodeUInt256();
+        decoderContext.Check(feesCheck);
         transaction.BlobVersionedHashes = decoderContext.DecodeByteArrays(BlobVersionedHashesCountLimit, innerSize: Hash256.Size);
         transaction.RecentRootReferences = null;
 
@@ -223,6 +226,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         writer.Encode(transaction.SenderAddress);
         TxFrameDecoder.Instance.EncodeArray(ref writer, transaction.Frames);
         TxFrameSignatureDecoder.Instance.EncodeArray(ref writer, transaction.FrameSignatures, elideCanonicalSignatureBytes);
+        writer.StartSequence(GetFeesContentLength(transaction));
         writer.Encode(transaction.GasPrice);
         writer.Encode(transaction.DecodedMaxFeePerGas);
         writer.Encode(transaction.MaxFeePerBlobGas.GetValueOrDefault());
@@ -233,6 +237,11 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         }
     }
 
+    private static int GetFeesContentLength(Transaction transaction) =>
+        Rlp.LengthOf(transaction.GasPrice)
+        + Rlp.LengthOf(transaction.DecodedMaxFeePerGas)
+        + Rlp.LengthOf(transaction.MaxFeePerBlobGas.GetValueOrDefault());
+
     protected override int GetContentLength(Transaction transaction, RlpBehaviors rlpBehaviors, bool forSigning,
         bool isEip155Enabled = false, ulong chainId = 0) =>
         Rlp.LengthOf(transaction.ChainId ?? 0)
@@ -240,9 +249,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         + Rlp.LengthOf(transaction.SenderAddress)
         + TxFrameDecoder.Instance.GetArrayLength(transaction.Frames)
         + TxFrameSignatureDecoder.Instance.GetArrayLength(transaction.FrameSignatures, elideCanonicalSignatureBytes: forSigning)
-        + Rlp.LengthOf(transaction.GasPrice)
-        + Rlp.LengthOf(transaction.DecodedMaxFeePerGas)
-        + Rlp.LengthOf(transaction.MaxFeePerBlobGas.GetValueOrDefault())
+        + Rlp.LengthOfSequence(GetFeesContentLength(transaction))
         + Rlp.LengthOf(transaction.BlobVersionedHashes ?? EmptyVersionedHashes)
         + (transaction.RecentRootReferences is { } references ? RecentRootReferenceDecoder.Instance.GetArrayLength(references) : 0);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxFrameDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxFrameDecoder.cs
@@ -9,7 +9,8 @@ using Nethermind.Int256;
 namespace Nethermind.Serialization.Rlp;
 
 /// <summary>
-/// Decodes the EIP-8141 frame tuple <c>[mode, flags, target, gas_limit, value, data]</c>.
+/// Decodes the EIP-8141 frame tuple <c>[mode, flags, target, limits, value, data]</c>, where
+/// <c>limits = [execution, state]</c>.
 /// An empty target byte string decodes to null (resolves to the transaction sender).
 /// </summary>
 public sealed class TxFrameDecoder : RlpDecoder<TxFrame>
@@ -27,7 +28,13 @@ public sealed class TxFrameDecoder : RlpDecoder<TxFrame>
         byte mode = decoderContext.DecodeByte();
         byte flags = decoderContext.DecodeByte();
         Address? target = decoderContext.DecodeAddressOrNull();
-        ulong gasLimit = decoderContext.DecodeULong();
+
+        int limitsLength = decoderContext.ReadSequenceLength();
+        int limitsCheck = limitsLength + decoderContext.Position;
+        ulong executionGasLimit = decoderContext.DecodeULong();
+        ulong stateGasLimit = decoderContext.DecodeULong();
+        decoderContext.Check(limitsCheck);
+
         UInt256 value = decoderContext.DecodeUInt256();
         ReadOnlyMemory<byte> data = decoderContext.DecodeByteArrayMemory(_dataRlpLimit);
 
@@ -36,7 +43,7 @@ public sealed class TxFrameDecoder : RlpDecoder<TxFrame>
             decoderContext.Check(check);
         }
 
-        return new TxFrame(mode, flags, target, gasLimit, value, data);
+        return new TxFrame(mode, flags, target, executionGasLimit, stateGasLimit, value, data);
     }
 
     public override void Encode<TWriter>(ref TWriter writer, TxFrame item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
@@ -45,7 +52,9 @@ public sealed class TxFrameDecoder : RlpDecoder<TxFrame>
         writer.Encode((ulong)item.Mode);
         writer.Encode((ulong)item.Flags);
         writer.Encode(item.Target);
-        writer.Encode(item.GasLimit);
+        writer.StartSequence(GetLimitsContentLength(item));
+        writer.Encode(item.ExecutionGasLimit);
+        writer.Encode(item.StateGasLimit);
         writer.Encode(item.Value);
         writer.Encode(item.Data);
     }
@@ -85,7 +94,10 @@ public sealed class TxFrameDecoder : RlpDecoder<TxFrame>
         Rlp.LengthOf((ulong)item.Mode)
         + Rlp.LengthOf((ulong)item.Flags)
         + Rlp.LengthOf(item.Target)
-        + Rlp.LengthOf(item.GasLimit)
+        + Rlp.LengthOfSequence(GetLimitsContentLength(item))
         + Rlp.LengthOf(item.Value)
         + Rlp.LengthOf(item.Data);
+
+    private static int GetLimitsContentLength(TxFrame item) =>
+        Rlp.LengthOf(item.ExecutionGasLimit) + Rlp.LengthOf(item.StateGasLimit);
 }

--- a/src/Nethermind/Nethermind.Specs.Test/SpecNameParserTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/SpecNameParserTests.cs
@@ -15,7 +15,12 @@ public class SpecNameParserTests
     {
         IReleaseSpec spec = SpecNameParser.Parse("Bogota");
 
-        Assert.That(spec, Is.SameAs(Bogota.Instance));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(spec, Is.SameAs(Bogota.Instance));
+            Assert.That(spec.IsEip8037Enabled, Is.True);
+            Assert.That(spec.IsEip8141Enabled, Is.True);
+        }
     }
 
     [TestCase("NotAFork", "NotAFork")]

--- a/src/Nethermind/Nethermind.Specs/Forks/Bogota.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/Bogota.cs
@@ -3,11 +3,7 @@
 
 namespace Nethermind.Specs.Forks;
 
-/// <summary>
-/// Devnet fork enabling EIP-8141 frame transactions on top of Amsterdam. Matches the frame
-/// transactions devnet layout, where the genesis generator schedules the frame-tx opcodes via
-/// <c>bogotaTime</c> over an Amsterdam-from-genesis network. Not scheduled on any public network.
-/// </summary>
+/// <summary>Fork enabling EIP-8141 frame transactions on top of Amsterdam.</summary>
 public class Bogota() : NamedReleaseSpec<Bogota>(Amsterdam.Instance)
 {
     public override void Apply(NamedReleaseSpec spec)

--- a/src/Nethermind/Nethermind.Specs/Forks/Bogota.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/Bogota.cs
@@ -4,11 +4,11 @@
 namespace Nethermind.Specs.Forks;
 
 /// <summary>
-/// Devnet fork enabling EIP-8141 frame transactions on top of Osaka. Matches the frame
+/// Devnet fork enabling EIP-8141 frame transactions on top of Amsterdam. Matches the frame
 /// transactions devnet layout, where the genesis generator schedules the frame-tx opcodes via
-/// <c>bogotaTime</c> over an Osaka-from-genesis network. Not scheduled on any public network.
+/// <c>bogotaTime</c> over an Amsterdam-from-genesis network. Not scheduled on any public network.
 /// </summary>
-public class Bogota() : NamedReleaseSpec<Bogota>(Osaka.Instance)
+public class Bogota() : NamedReleaseSpec<Bogota>(Amsterdam.Instance)
 {
     public override void Apply(NamedReleaseSpec spec)
     {

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.TxPool.Filters;
 using NSubstitute;
@@ -32,6 +34,32 @@ internal class FrameTxVerifyGasFilterTest
     {
         Transaction tx = FrameTx(frames);
         FrameTxVerifyGasFilter filter = new(new TxPoolConfig { FrameTxMaxVerifyGas = 100_000 }, LimboLogs.Instance.GetClassLogger<FrameTxVerifyGasFilterTest>());
+        TxFilteringState state = new(tx, Substitute.For<IAccountStateProvider>());
+
+        Assert.That(filter.Accept(tx, ref state, TxHandlingOptions.None), Is.EqualTo(expected));
+    }
+
+    private static TxFrame SelfVerifyWithState(ulong executionGasLimit, ulong stateGasLimit) =>
+        new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, executionGasLimit, stateGasLimit, UInt256.Zero, default);
+
+    private static TxFrame ExecutionWithState(ulong executionGasLimit, ulong stateGasLimit) =>
+        new(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, executionGasLimit, stateGasLimit, UInt256.Zero, default);
+
+    private static IEnumerable<TestCaseData> StatePrefixCases()
+    {
+        yield return new TestCaseData(new[] { SelfVerifyWithState(1_000, 500_000) }, AcceptTxResult.Accepted)
+            .SetName("prefix state exactly at MAX_VERIFY_STATE_GAS is accepted");
+        yield return new TestCaseData(new[] { SelfVerifyWithState(1_000, 500_001) }, AcceptTxResult.FrameTxVerifyGasTooHigh)
+            .SetName("prefix state one gas over MAX_VERIFY_STATE_GAS is rejected");
+        yield return new TestCaseData(new[] { SelfVerify(1_000), ExecutionWithState(1_000, 3_000_000) }, AcceptTxResult.Accepted)
+            .SetName("state behind a recognized prefix is outside the ceiling");
+    }
+
+    [TestCaseSource(nameof(StatePrefixCases))]
+    public void Accept_BoundsThePrefixStateGas(TxFrame[] frames, AcceptTxResult expected)
+    {
+        Transaction tx = FrameTx(frames);
+        FrameTxVerifyGasFilter filter = new(new TxPoolConfig { FrameTxMaxVerifyGas = 0, FrameTxMaxVerifyStateGas = 500_000 }, LimboLogs.Instance.GetClassLogger<FrameTxVerifyGasFilterTest>());
         TxFilteringState state = new(tx, Substitute.For<IAccountStateProvider>());
 
         Assert.That(filter.Accept(tx, ref state, TxHandlingOptions.None), Is.EqualTo(expected));

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
@@ -49,7 +49,7 @@ internal class FrameTxVerifyGasFilterTest
     {
         yield return new TestCaseData(new[] { SelfVerifyWithState(1_000, 500_000) }, AcceptTxResult.Accepted)
             .SetName("prefix state exactly at MAX_VERIFY_STATE_GAS is accepted");
-        yield return new TestCaseData(new[] { SelfVerifyWithState(1_000, 500_001) }, AcceptTxResult.FrameTxVerifyGasTooHigh)
+        yield return new TestCaseData(new[] { SelfVerifyWithState(1_000, 500_001) }, AcceptTxResult.FrameTxVerifyStateGasTooHigh)
             .SetName("prefix state one gas over MAX_VERIFY_STATE_GAS is rejected");
         yield return new TestCaseData(new[] { SelfVerify(1_000), ExecutionWithState(1_000, 3_000_000) }, AcceptTxResult.Accepted)
             .SetName("state behind a recognized prefix is outside the ceiling");

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2180,14 +2180,15 @@ namespace Nethermind.TxPool.Test
             return frameTx;
         }
 
-        // EIP-8141: a frame transaction's GasLimit is only the sum of its frame gas limits, so the pool must gate on
-        // max_gas or it admits transactions that can never fit in a block. The mandatory cost of the single frame below
-        // is FRAME_TX_INTRINSIC_COST + FRAME_TX_PER_FRAME_COST = 15,475, and each non-zero calldata byte adds 16 to the
-        // standard cost against 40 to the EIP-7623 floor, so the last case is admissible on its standard cost alone.
-        [TestCase(100_000UL, 0, true)]
-        [TestCase(115_000UL, 0, false)]
-        [TestCase(10_000UL, 4000, false)]
-        public void SubmitTx_FrameTransaction_IsGatedOnMaxGas(ulong frameGasLimit, int frameDataLength, bool expectedAccepted)
+        [TestCase(100_000UL, 0UL, 0, true)]
+        [TestCase(115_000UL, 0UL, 0, false)]
+        [TestCase(10_000UL, 0UL, 4000, false)]
+        [TestCase(70_000UL, 70_000UL, 0, true)]
+        public void SubmitTx_FrameTransaction_IsGatedOnBlockDimensions(
+            ulong executionGasLimit,
+            ulong stateGasLimit,
+            int frameDataLength,
+            bool expectedAccepted)
         {
             _txPool = CreatePool(null, new TestSpecProvider(Bogota.Instance));
             _headInfo.BlockGasLimit = 130_000;
@@ -2199,9 +2200,9 @@ namespace Nethermind.TxPool.Test
                 ChainId = _specProvider.ChainId,
                 Nonce = 0,
                 SenderAddress = TestItem.PrivateKeyA.Address,
-                Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, frameGasLimit, UInt256.Zero, frameData)],
+                Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, executionGasLimit, stateGasLimit, UInt256.Zero, frameData)],
                 FrameSignatures = [],
-                GasLimit = frameGasLimit,
+                GasLimit = executionGasLimit + stateGasLimit,
                 GasPrice = 1.GWei,
                 DecodedMaxFeePerGas = 1.GWei,
             };
@@ -2551,7 +2552,7 @@ namespace Nethermind.TxPool.Test
             _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Bogota.Instance));
             EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
 
-            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null, verifyGasLimit: 30_000_000);
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null, verifyGasLimit: 15_000_000);
 
             Assert.That(_txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
         }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2181,7 +2181,7 @@ namespace Nethermind.TxPool.Test
         }
 
         [TestCase(100_000UL, 0UL, 0, true)]
-        [TestCase(115_000UL, 0UL, 0, false)]
+        [TestCase(118_000UL, 0UL, 0, false)]
         [TestCase(10_000UL, 0UL, 4000, false)]
         [TestCase(70_000UL, 70_000UL, 0, true)]
         public void SubmitTx_FrameTransaction_IsGatedOnBlockDimensions(

--- a/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
+++ b/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
@@ -132,6 +132,12 @@ namespace Nethermind.TxPool
         public static readonly AcceptTxResult FrameTxVerifyGasTooHigh = new(21, TxPoolErrorMessages.FrameTxVerifyGasTooHigh);
 
         /// <summary>
+        /// An EIP-8141 frame transaction whose validation prefix budgets more state gas than <c>MAX_VERIFY_STATE_GAS</c>.
+        /// A separate mempool bound from <see cref="FrameTxVerifyGasTooHigh"/>; it too refuses only propagation, not validity.
+        /// </summary>
+        public static readonly AcceptTxResult FrameTxVerifyStateGasTooHigh = new(29, TxPoolErrorMessages.FrameTxVerifyStateGasTooHigh);
+
+        /// <summary>
         /// An EIP-8250 transaction whose selected nonce keys are not all at its <c>nonce_seq</c> in the head state.
         /// Unlike an account nonce this is an exact match in both directions, so the transaction is neither old nor future.
         /// </summary>

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -8,26 +8,43 @@ namespace Nethermind.TxPool.Filters;
 
 /// <summary>
 /// Rejects an EIP-8141 frame transaction whose validation prefix and signature verification would cost more than
-/// <c>MAX_VERIFY_GAS</c> to check.
+/// <c>MAX_VERIFY_GAS</c> to check, or whose validation prefix budgets more than <c>MAX_VERIFY_STATE_GAS</c> of state gas.
 /// </summary>
 /// <remarks>
 /// A public-mempool DoS bound, not a validity rule: a block carrying such a transaction stays valid. Must run after
 /// <see cref="MalformedTxFilter"/>, which guarantees the frame list is well-formed. A configured limit of 0 lifts the
-/// bound, matching the other per-sender pool limits.
+/// respective bound, matching the other per-sender pool limits.
 /// </remarks>
 internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger logger) : IIncomingTxFilter
 {
     private readonly ulong _maxVerifyGas = txPoolConfig.FrameTxMaxVerifyGas;
+    private readonly ulong _maxVerifyStateGas = txPoolConfig.FrameTxMaxVerifyStateGas;
 
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        if (tx.SupportsFrames && _maxVerifyGas != 0)
+        if (!tx.SupportsFrames)
+        {
+            return AcceptTxResult.Accepted;
+        }
+
+        if (_maxVerifyGas != 0)
         {
             ulong verifyGas = FrameTxValidation.ValidationWorkGas(tx);
             if (verifyGas > _maxVerifyGas)
             {
                 Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;
                 if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, validation prefix costs {verifyGas} gas (max {_maxVerifyGas}).");
+                return AcceptTxResult.FrameTxVerifyGasTooHigh;
+            }
+        }
+
+        if (_maxVerifyStateGas != 0)
+        {
+            ulong verifyStateGas = FrameTxValidation.ValidationWorkStateGas(tx);
+            if (verifyStateGas > _maxVerifyStateGas)
+            {
+                Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;
+                if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, validation prefix budgets {verifyStateGas} state gas (max {_maxVerifyStateGas}).");
                 return AcceptTxResult.FrameTxVerifyGasTooHigh;
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -43,9 +43,9 @@ internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger
             ulong verifyStateGas = FrameTxValidation.ValidationWorkStateGas(tx);
             if (verifyStateGas > _maxVerifyStateGas)
             {
-                Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;
+                Metrics.PendingTransactionsFrameTxVerifyStateGasTooHigh++;
                 if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, validation prefix budgets {verifyStateGas} state gas (max {_maxVerifyStateGas}).");
-                return AcceptTxResult.FrameTxVerifyGasTooHigh;
+                return AcceptTxResult.FrameTxVerifyStateGasTooHigh;
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Nethermind.Core;
+using Nethermind.Core.Specs;
 using Nethermind.Logging;
 
 namespace Nethermind.TxPool.Filters
@@ -20,15 +21,22 @@ namespace Nethermind.TxPool.Filters
         {
             ulong gasLimit = Math.Min(chainHeadInfoProvider.BlockGasLimit ?? ulong.MaxValue, _configuredGasLimit);
 
-            // A frame transaction's GasLimit is only the sum of its frame gas limits, so gating on it alone would
-            // admit transactions whose reservation can never fit in a block. One that cannot be priced never fits.
-            ulong txGasBudget = !tx.SupportsFrames
-                ? tx.GasLimit
-                : FrameTxValidation.TryCalculateGasBudget(tx, chainHeadInfoProvider.SpecProvider.GetCurrentHeadSpec(), out _, out _, out ulong frameTxMaxGas)
-                    ? frameTxMaxGas
-                    : ulong.MaxValue;
+            IReleaseSpec spec = chainHeadInfoProvider.SpecProvider.GetCurrentHeadSpec();
+            bool exceedsLimit;
+            ulong rejectedBudget;
+            if (tx.SupportsFrames)
+            {
+                bool calculated = FrameTxValidation.TryCalculateBlockGasReservations(tx, spec, out ulong executionReservation, out ulong stateReservation);
+                rejectedBudget = calculated ? Math.Max(executionReservation, stateReservation) : ulong.MaxValue;
+                exceedsLimit = !calculated || executionReservation > gasLimit || stateReservation > gasLimit;
+            }
+            else
+            {
+                rejectedBudget = tx.GasLimit;
+                exceedsLimit = rejectedBudget > gasLimit;
+            }
 
-            if (txGasBudget > gasLimit)
+            if (exceedsLimit)
             {
                 Metrics.PendingTransactionsGasLimitTooHigh++;
 
@@ -40,7 +48,7 @@ namespace Nethermind.TxPool.Filters
                 bool isNotLocal = (handlingOptions & TxHandlingOptions.PersistentBroadcast) == 0;
                 return isNotLocal ?
                     AcceptTxResult.GasLimitExceeded :
-                    AcceptTxResult.GasLimitExceeded.WithMessage($"Gas limit: {gasLimit}, gas limit of rejected tx: {txGasBudget}");
+                    AcceptTxResult.GasLimitExceeded.WithMessage($"Gas limit: {gasLimit}, gas limit of rejected tx: {rejectedBudget}");
             }
 
             return AcceptTxResult.Accepted;

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -35,6 +35,9 @@ public interface ITxPoolConfig : IConfig
     [ConfigItem(DefaultValue = "300000", Description = "EIP-8141 `MAX_VERIFY_GAS`: the max gas a frame transaction's validation prefix and signature verification may cost for the transaction to be accepted into the public mempool. `0` to lift the limit. It bounds the declared-gas check only: an opaque prefix that has to be simulated is additionally capped, frame by frame, at the fixed `Eip8141Constants.MaxVerifyGas`, which raising this value does not move. Raise it only on a test network.")]
     ulong FrameTxMaxVerifyGas { get; set; }
 
+    [ConfigItem(DefaultValue = "500000", Description = "EIP-8141 `MAX_VERIFY_STATE_GAS`: the max state gas a frame transaction's validation prefix may budget across its `limits.state` for the transaction to be accepted into the public mempool. `0` to lift the limit. Raise it only on a test network.")]
+    ulong FrameTxMaxVerifyStateGas { get; set; }
+
     [ConfigItem(DefaultValue = "16", Description = "The max number of pending blob transactions per single sender. `0` to lift the limit.")]
     int MaxPendingBlobTxsPerSender { get; set; }
 

--- a/src/Nethermind/Nethermind.TxPool/Metrics.cs
+++ b/src/Nethermind/Nethermind.TxPool/Metrics.cs
@@ -45,6 +45,10 @@ namespace Nethermind.TxPool
         public static long PendingTransactionsFrameTxVerifyGasTooHigh { get; set; }
 
         [CounterMetric]
+        [Description("Number of pending EIP-8141 frame transactions received that were ignored because their validation prefix exceeds MAX_VERIFY_STATE_GAS.")]
+        public static long PendingTransactionsFrameTxVerifyStateGasTooHigh { get; set; }
+
+        [CounterMetric]
         [Description("Number of pending EIP-8141 frame transactions received that were ignored because one of their protocol-validated signatures does not verify.")]
         public static long PendingTransactionsFrameTxSignatureInvalid { get; set; }
 

--- a/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
@@ -19,6 +19,7 @@ public class TxPoolConfig : ITxPoolConfig
     public int InMemoryBlobPoolSize { get; set; } = 512; // it is used when persistent pool is disabled
     public int MaxPendingTxsPerSender { get; set; } = 0;
     public ulong FrameTxMaxVerifyGas { get; set; } = 300_000;
+    public ulong FrameTxMaxVerifyStateGas { get; set; } = 500_000;
     public int MaxPendingBlobTxsPerSender { get; set; } = 16;
     public int HashCacheSize { get; set; } = 512 * 1024;
     public ulong? GasLimit { get; set; } = null;

--- a/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolErrorMessages.cs
@@ -30,6 +30,7 @@ public static class TxPoolErrorMessages
     public const string NodeIsSyncing = "node is syncing";
     public const string FrameTxExpired = "frame transaction expired";
     public const string FrameTxVerifyGasTooHigh = "frame transaction validation prefix exceeds MAX_VERIFY_GAS";
+    public const string FrameTxVerifyStateGasTooHigh = "frame transaction validation prefix exceeds MAX_VERIFY_STATE_GAS";
     public const string KeyedNonceUnmet = "keyed nonce sequence not current";
     public const string FrameTxPayerExposureExceeded = "frame transaction payer exposure exceeds balance";
     public const string FrameTxNoPayer = "frame transaction never approves a payer";


### PR DESCRIPTION
## Changes

Ports the EIP-8141 two-dimensional per-frame gas model onto
`eip8141-frame-txs-devnet7`. Each frame declares `limits = [execution, state]`
and each frame receipt reports `gas_used = [execution, state]`, per
[EIP-8141](https://eips.ethereum.org/EIPS/eip-8141) adopting the
[EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) split.

- `TxFrame` / `TxFrameReceipt`: split gas fields, back-compatible single-arg
  ctor for existing callers.
- Independent per-frame execution and state pools; a state charge above
  `limits.state` halts the frame and never spends execution gas.
- State-gas attribution, outstanding-charge ownership and cross-frame refills,
  journaled and restored at call / frame / atomic-batch rollback boundaries.
- RLP wire format for frame limits and receipt gas_used; JSON-RPC receipt view
  split into `ExecutionGasUsed` / `StateGasUsed`.
- Settlement: calldata floor binds the execution dimension only; state gas is
  charged on top. Block inclusion, mempool admission and block production check
  each dimension separately.
- Static validity: per-dimension overflow, expiry frame `limits.state == 0`,
  `value_transfer_cost` (EIP-2780 `TX_VALUE_COST`) folded into the intrinsic,
  EIP-7825 cap on `intrinsic + sum(limits.execution)`.
- Payment approval that creates an absent sender charges `NEW_ACCOUNT` from the
  approving frame's state budget, atomically before the nonce increment.
- `Bogota` derives from `Amsterdam` so EIP-8037 is active under frame txs.
- `FRAMEPARAM` exposes `limits.state` and per-dimension `gas_used`; `TXPARAM`
  `state_gas_left` uses `0x11` to avoid the EIP-8250 `0x0C` legacy-nonce
  collision (spec update to follow).

Deferred to separate coordinated PRs (they change bytes / opcode slots and must
be switched cross-client in lock-step, out of scope here): the outer `fees`
nested-list RLP migration and `SIGDATACOPY (0xb5)`.

## Types of changes

- [x] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)

## Testing

- [x] Yes

#### Notes on testing

Frame suites green: Evm.Test `~FrameTx` 205, `~Eip8141` 25; Core.Test
`~FrameTx` 109; TxPool.Test `~FrameTx` 80; Blockchain.Test `~Frame` 34;
JsonRpc.Test `~Frame` 18. RED/GREEN control confirmed for the value-transfer
charge and the payment-approval NEW_ACCOUNT charge. execution-specs (#3396
frame-tx fixtures) and a cross-client Kurtosis devnet with ethrex are being run
against this branch.

## Documentation

- [ ] Requires documentation update
