### PR TITLE
Update Glamsterdam devnet EEST fixtures to v8.1.1

### DIFF
--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -25,7 +25,7 @@ on:
       eest_version:
         description: EEST release tag, or latest / latest-<keyword> to resolve dynamically
         required: false
-        default: tests-glamsterdam-devnet@v8.1.0
+        default: tests-glamsterdam-devnet@v8.1.1
         type: string
       zkevm_version:
         description: zkEVM fixtures release tag (zkevmTest only), or latest / latest-<keyword>
@@ -71,7 +71,7 @@ on:
       eest_version:
         description: EEST release tag, or latest / latest-<keyword> to resolve dynamically
         required: false
-        default: tests-glamsterdam-devnet@v8.1.0
+        default: tests-glamsterdam-devnet@v8.1.1
         type: string
       zkevm_version:
         description: zkEVM fixtures release tag (zkevmTest only), or latest / latest-<keyword>
@@ -101,9 +101,9 @@ env:
   IDLE_TIMEOUT_MINUTES: ${{ inputs.idle_timeout_minutes || '10' }}
   # Fixture source: the glamsterdam-devnet releases of ethereum/execution-specs. They ship
   # fixtures for all forks (Frontier..Amsterdam) with the devnet-8 Amsterdam semantics
-  # this branch implements. Pass an exact tag (e.g. tests-glamsterdam-devnet@v8.1.0) to pin.
+  # this branch implements. Pass an exact tag (e.g. tests-glamsterdam-devnet@v8.1.1) to pin.
   EEST_REPOSITORY: ethereum/execution-specs
-  EEST_VERSION: ${{ inputs.eest_version || 'tests-glamsterdam-devnet@v8.1.0' }}
+  EEST_VERSION: ${{ inputs.eest_version || 'tests-glamsterdam-devnet@v8.1.1' }}
   EEST_ARCHIVE: fixtures_glamsterdam-devnet.tar.gz
   # zkEVM stateless-preview fixtures ship in their own release line of the same repo;
   # zkevmTest jobs resolve this instead of EEST_VERSION. Pinned to the release whose stateless

--- a/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
+++ b/src/Nethermind/Ethereum.Blockchain.Pyspec.Test/Constants.cs
@@ -6,6 +6,6 @@ namespace Ethereum.Blockchain.Pyspec.Test;
 public class Constants
 {
     public const string ARCHIVE_URL_TEMPLATE = "https://github.com/ethereum/execution-specs/releases/download/{0}/{1}";
-    public const string DEFAULT_ARCHIVE_VERSION = "tests-glamsterdam-devnet@v8.1.0";
+    public const string DEFAULT_ARCHIVE_VERSION = "tests-glamsterdam-devnet@v8.1.1";
     public const string DEFAULT_ARCHIVE_NAME = "fixtures_glamsterdam-devnet.tar.gz";
 }

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -607,8 +607,6 @@ public abstract class BlockchainTestBase
         ("BlockException.GAS_USED_OVERFLOW", "ExceededGasLimit:"),
         ("BlockException.RLP_BLOCK_LIMIT_EXCEEDED", "ExceededBlockSizeLimit: Exceeded block size limit"),
         ("BlockException.INVALID_DEPOSIT_EVENT_LAYOUT", "DepositsInvalid: Invalid deposit event layout:"),
-        // A layout that still decodes yields well-formed but wrong requests, so it surfaces as a
-        // hash mismatch: the requests hash pre-Amsterdam, the BAL hash once EIP-7928 covers the log.
         ("BlockException.INVALID_BASEFEE_PER_GAS", "InvalidBaseFeePerGas: Does not match calculated"),
         ("BlockException.INVALID_BLOCK_TIMESTAMP_OLDER_THAN_PARENT", "InvalidTimestamp: Timestamp in header cannot be lower than ancestor"),
         ("BlockException.INVALID_BLOCK_NUMBER", "InvalidBlockNumber: Block number does not match the parent"),

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -609,8 +609,6 @@ public abstract class BlockchainTestBase
         ("BlockException.INVALID_DEPOSIT_EVENT_LAYOUT", "DepositsInvalid: Invalid deposit event layout:"),
         // A layout that still decodes yields well-formed but wrong requests, so it surfaces as a
         // hash mismatch: the requests hash pre-Amsterdam, the BAL hash once EIP-7928 covers the log.
-        ("BlockException.INVALID_DEPOSIT_EVENT_LAYOUT", "InvalidRequestsHash: Requests hash mismatch in block"),
-        ("BlockException.INVALID_DEPOSIT_EVENT_LAYOUT", "InvalidBlockLevelAccessListHash:"),
         ("BlockException.INVALID_BASEFEE_PER_GAS", "InvalidBaseFeePerGas: Does not match calculated"),
         ("BlockException.INVALID_BLOCK_TIMESTAMP_OLDER_THAN_PARENT", "InvalidTimestamp: Timestamp in header cannot be lower than ancestor"),
         ("BlockException.INVALID_BLOCK_NUMBER", "InvalidBlockNumber: Block number does not match the parent"),

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -125,7 +125,6 @@ public abstract class TransactionTestBase
 
     private static readonly System.Collections.Generic.Dictionary<string, string[]> s_exceptionToErrorFragments = new()
     {
-        ["TransactionException.NONCE_OVERFLOW"] = ["NonceTooHigh"],
         ["TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST"] = ["EIP-7702 transaction with empty auth list"],
         ["TransactionException.TYPE_4_INVALID_AUTHORIZATION_FORMAT"] = ["InvalidAuthorityList", .. s_rlpDecodeFragments],
         ["TransactionException.TYPE_4_INVALID_AUTHORITY_SIGNATURE"] = ["InvalidAuthoritySignature", .. s_rlpDecodeFragments],


### PR DESCRIPTION
## Changes

- Update the default EEST fixture release from `tests-glamsterdam-devnet@v8.1.0` to `tests-glamsterdam-devnet@v8.1.1`.
- Continue using `fixtures_glamsterdam-devnet.tar.gz` from the [execution-specs Glamsterdam devnet v8.1.1 release](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet%40v8.1.1).

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Test fixture update

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The v8.1.1 archive downloaded and extracted successfully. The EEST project built with warnings treated as errors. Targeted Amsterdam validation passed 56 transaction cases and 24 blockchain cases, with no failures or skips. The broad local Amsterdam matrix was stopped after making no progress, so the full matrix is not claimed green.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No