### PR TITLE
fix(optimism): decode CL payloads with the generated SSZ decoder

### DIFF
--- a/src/Nethermind/Nethermind.Optimism.Test/CL/PayloadDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/CL/PayloadDecoderTests.cs
@@ -33,15 +33,19 @@ public class PayloadDecoderTests
         byte[] bytes = Convert.FromBase64String(testCase.Data);
 
         // The transactions region ends at the payload end and starts with one 4-byte offset per transaction
-        int transactionsOffset = bytes.Length - 4 * testCase.Payload.Transactions.Length;
+        Assert.That(testCase.Payload.Transactions, Is.Not.Empty);
+        int offsetTableSize = 4 * testCase.Payload.Transactions.Length;
+        int transactionsOffset = bytes.Length - offsetTableSize;
         foreach (byte[] transaction in testCase.Payload.Transactions)
         {
             transactionsOffset -= transaction.Length;
         }
+        Assert.That(BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(transactionsOffset, 4)), Is.EqualTo(offsetTableSize));
+
         BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(transactionsOffset, 4), firstTxOffset);
 
         Func<ExecutionPayloadV3> tryDecode = () => PayloadDecoder.Instance.DecodePayload(bytes);
-        Assert.That(tryDecode, Throws.TypeOf<InvalidDataException>().With.Message.Contains("Transaction"));
+        Assert.That(tryDecode, Throws.TypeOf<InvalidDataException>());
     }
 
     [TestCaseSource(nameof(RealPayloadsTestCases))]
@@ -91,6 +95,7 @@ public class PayloadDecoderTests
             try
             {
                 PayloadDecoder.Instance.DecodePayload(bytes.AsSpan(0, length));
+                Assert.Fail($"Truncating to {length} bytes decoded successfully");
             }
             catch (InvalidDataException)
             {
@@ -98,6 +103,37 @@ public class PayloadDecoderTests
             catch (Exception e)
             {
                 Assert.Fail($"Truncating to {length} bytes threw {e.GetType().Name}: {e.Message}");
+            }
+        }
+    }
+
+    /// <remarks>
+    /// Truncation is rejected by the container offset table before the transactions, extra data and
+    /// withdrawals regions are read, so corrupting each byte in turn is what reaches those.
+    /// </remarks>
+    [TestCaseSource(nameof(RealPayloadsTestCases))]
+    public void DecodePayload_CorruptedByte((string Data, ExecutionPayloadV3 Payload) testCase)
+    {
+        byte[] bytes = Convert.FromBase64String(testCase.Data);
+
+        for (int index = 0; index < bytes.Length; index++)
+        {
+            byte original = bytes[index];
+            bytes[index] = (byte)~original;
+            try
+            {
+                PayloadDecoder.Instance.DecodePayload(bytes);
+            }
+            catch (InvalidDataException)
+            {
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"Corrupting byte {index} threw {e.GetType().Name}: {e.Message}");
+            }
+            finally
+            {
+                bytes[index] = original;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Optimism.Test/CL/PayloadDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/CL/PayloadDecoderTests.cs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.IO;
 using Nethermind.Core;
 using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Optimism.CL.P2P;
 using NUnit.Framework;
@@ -19,6 +22,84 @@ public class PayloadDecoderTests
         byte[] bytes = Convert.FromBase64String(testCase.Data);
         ExecutionPayloadV3 decoded = PayloadDecoder.Instance.DecodePayload(bytes);
         ComparePayloads(testCase.Payload, decoded);
+    }
+
+    [Test]
+    public void DecodePayload_InvalidFirstTransactionOffset(
+        [ValueSource(nameof(RealPayloadsTestCases))] (string Data, ExecutionPayloadV3 Payload) testCase,
+        // Below the offset size, misaligned, past the transaction limit, and the whole 32-bit range
+        [Values(0u, 5u, 0x40000000u, 0xFFFFFFFCu)] UInt32 firstTxOffset)
+    {
+        byte[] bytes = Convert.FromBase64String(testCase.Data);
+
+        // The transactions region ends at the payload end and starts with one 4-byte offset per transaction
+        int transactionsOffset = bytes.Length - 4 * testCase.Payload.Transactions.Length;
+        foreach (byte[] transaction in testCase.Payload.Transactions)
+        {
+            transactionsOffset -= transaction.Length;
+        }
+        BinaryPrimitives.WriteUInt32LittleEndian(bytes.AsSpan(transactionsOffset, 4), firstTxOffset);
+
+        Func<ExecutionPayloadV3> tryDecode = () => PayloadDecoder.Instance.DecodePayload(bytes);
+        Assert.That(tryDecode, Throws.TypeOf<InvalidDataException>().With.Message.Contains("Transaction"));
+    }
+
+    [TestCaseSource(nameof(RealPayloadsTestCases))]
+    public void EncodePayload_ReproducesTheEncodersBytes((string Data, ExecutionPayloadV3 Payload) testCase)
+    {
+        byte[] bytes = Convert.FromBase64String(testCase.Data);
+        ExecutionPayloadV3 decoded = PayloadDecoder.Instance.DecodePayload(bytes);
+
+        Assert.That(PayloadDecoder.Instance.EncodePayload(decoded), Is.EqualTo(bytes));
+    }
+
+    /// <remarks>
+    /// Real payloads carry an empty withdrawals list, so a round trip is the only way to cover one.
+    /// </remarks>
+    [TestCaseSource(nameof(RealPayloadsTestCases))]
+    public void DecodePayload_Withdrawals((string Data, ExecutionPayloadV3 Payload) testCase)
+    {
+        ExecutionPayloadV3 payload = PayloadDecoder.Instance.DecodePayload(Convert.FromBase64String(testCase.Data));
+        payload.Withdrawals = [new Withdrawal { Index = 1, ValidatorIndex = 2, Address = TestItem.AddressA, AmountInGwei = 3 }];
+
+        ExecutionPayloadV3 decoded = PayloadDecoder.Instance.DecodePayload(PayloadDecoder.Instance.EncodePayload(payload));
+
+        Assert.That(decoded.Withdrawals, Is.EqualTo(payload.Withdrawals).UsingWithdrawalComparer());
+    }
+
+    [TestCaseSource(nameof(RealPayloadsTestCases))]
+    public void DecodePayload_TrailingBytes((string Data, ExecutionPayloadV3 Payload) testCase)
+    {
+        byte[] bytes = Convert.FromBase64String(testCase.Data);
+        Array.Resize(ref bytes, bytes.Length + 1);
+
+        Func<ExecutionPayloadV3> tryDecode = () => PayloadDecoder.Instance.DecodePayload(bytes);
+        Assert.That(tryDecode, Throws.TypeOf<InvalidDataException>());
+    }
+
+    /// <remarks>
+    /// <see cref="OptimismCLP2P"/> catches exactly <see cref="InvalidDataException"/> around the
+    /// decode; anything else escapes to the topic handler and is logged as an unhandled error.
+    /// </remarks>
+    [TestCaseSource(nameof(RealPayloadsTestCases))]
+    public void DecodePayload_TruncatedPayload((string Data, ExecutionPayloadV3 Payload) testCase)
+    {
+        byte[] bytes = Convert.FromBase64String(testCase.Data);
+
+        for (int length = 0; length < bytes.Length; length++)
+        {
+            try
+            {
+                PayloadDecoder.Instance.DecodePayload(bytes.AsSpan(0, length));
+            }
+            catch (InvalidDataException)
+            {
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"Truncating to {length} bytes threw {e.GetType().Name}: {e.Message}");
+            }
+        }
     }
 
     private void ComparePayloads(ExecutionPayloadV3 expected, ExecutionPayloadV3 actual)

--- a/src/Nethermind/Nethermind.Optimism/CL/P2P/IPayloadDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/P2P/IPayloadDecoder.cs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.IO;
 using Nethermind.Merge.Plugin.Data;
 
 namespace Nethermind.Optimism.CL.P2P;
 
 public interface IPayloadDecoder
 {
+    /// <summary>
+    /// Decodes an execution payload received over the CL P2P network.
+    /// </summary>
+    /// <exception cref="InvalidDataException">The data is not a well-formed payload.</exception>
     ExecutionPayloadV3 DecodePayload(ReadOnlySpan<byte> data);
     byte[] EncodePayload(ExecutionPayloadV3 payload);
 }

--- a/src/Nethermind/Nethermind.Optimism/CL/P2P/OptimismCLP2P.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/P2P/OptimismCLP2P.cs
@@ -7,6 +7,7 @@ using Nethermind.Libp2p.Protocols;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -281,7 +282,7 @@ public class OptimismCLP2P : IDisposable
         {
             payload = PayloadDecoder.Instance.DecodePayload(payloadData);
         }
-        catch (ArgumentException e)
+        catch (InvalidDataException e)
         {
             if (_logger.IsTrace) _logger.Trace($"Unable to decode payload from p2p. {e.Message}");
 

--- a/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadDecoder.cs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Buffers.Binary;
-using Nethermind.Core.Extensions;
+using System.IO;
+using Nethermind.Core.Crypto;
 using Nethermind.Merge.Plugin.Data;
+using Nethermind.Merge.Plugin.SszRest;
 
 namespace Nethermind.Optimism.CL.P2P;
 
@@ -12,79 +13,32 @@ public class PayloadDecoder : IPayloadDecoder
 {
     public static readonly PayloadDecoder Instance = new();
 
-    private const int PrefixDataSize = 560;
-
     private PayloadDecoder()
     {
     }
 
     public ExecutionPayloadV3 DecodePayload(ReadOnlySpan<byte> data)
     {
-        ExecutionPayloadV3 payload = new();
-
-        if (PrefixDataSize >= data.Length)
+        if (data.Length < Hash256.Size)
         {
-            throw new ArgumentException("Invalid payload data size");
+            throw new InvalidDataException($"Payload is shorter than the {Hash256.Size}-byte parent beacon block root");
         }
 
-        ReadOnlySpan<byte> movingData = data;
-        payload.ParentBeaconBlockRoot = new(movingData.TakeAndMove(32));
-        payload.ParentHash = new(movingData.TakeAndMove(32));
-        payload.FeeRecipient = new(movingData.TakeAndMove(20));
-        payload.StateRoot = new(movingData.TakeAndMove(32));
-        payload.ReceiptsRoot = new(movingData.TakeAndMove(32));
-        payload.LogsBloom = new(movingData.TakeAndMove(256));
-        payload.PrevRandao = new(movingData.TakeAndMove(32));
-        payload.BlockNumber = BinaryPrimitives.ReadUInt64LittleEndian(movingData.TakeAndMove(8));
-        payload.GasLimit = BinaryPrimitives.ReadUInt64LittleEndian(movingData.TakeAndMove(8));
-        payload.GasUsed = BinaryPrimitives.ReadUInt64LittleEndian(movingData.TakeAndMove(8));
-        payload.Timestamp = BinaryPrimitives.ReadUInt64LittleEndian(movingData.TakeAndMove(8));
-        UInt32 extraDataOffset = 32 + BinaryPrimitives.ReadUInt32LittleEndian(movingData.TakeAndMove(4));
-        payload.BaseFeePerGas = new(movingData.TakeAndMove(32));
-        payload.BlockHash = new(movingData.TakeAndMove(32));
-        UInt32 transactionsOffset = 32 + BinaryPrimitives.ReadUInt32LittleEndian(movingData.TakeAndMove(4));
-        UInt32 withdrawalsOffset = 32 + BinaryPrimitives.ReadUInt32LittleEndian(movingData.TakeAndMove(4));
-        payload.BlobGasUsed = BinaryPrimitives.ReadUInt64LittleEndian(movingData.TakeAndMove(8));
-        payload.ExcessBlobGas = BinaryPrimitives.ReadUInt64LittleEndian(movingData.TakeAndMove(8));
-
-        if (withdrawalsOffset > data.Length || transactionsOffset >= withdrawalsOffset || extraDataOffset > transactionsOffset || withdrawalsOffset != data.Length)
-        {
-            throw new ArgumentException($"Invalid offsets. Data length: {data.Length}, extraData: {extraDataOffset}, transactions: {transactionsOffset}, withdrawals: {withdrawalsOffset}");
-        }
-
-        payload.ExtraData = data[(int)extraDataOffset..(int)transactionsOffset].ToArray();
-        payload.Transactions = DecodeTransactions(data[(int)transactionsOffset..(int)withdrawalsOffset]);
-        payload.Withdrawals = [];
-
+        // The SSZ ExecutionPayload starts immediately after the parent_beacon_block_root prefix
+        SszExecutionPayloadV3.Decode(data[Hash256.Size..], out SszExecutionPayloadV3 ssz);
+        ExecutionPayloadV3 payload = ssz.AsExecutionPayload();
+        payload.ParentBeaconBlockRoot = new Hash256(data[..Hash256.Size]);
         return payload;
     }
 
-    byte[][] DecodeTransactions(ReadOnlySpan<byte> data)
+    public byte[] EncodePayload(ExecutionPayloadV3 payload)
     {
-        if (4 > data.Length) throw new ArgumentException("Invalid transaction data");
-        UInt32 firstTxOffset = BinaryPrimitives.ReadUInt32LittleEndian(data[..4]);
-        UInt32 txCount = firstTxOffset / 4;
-        byte[][] txs = new byte[txCount][];
-        int previous = (int)firstTxOffset;
-        for (int i = 0; i < txCount; i++)
-        {
-            int next;
-            if (i + 1 < txCount)
-            {
-                if (i * 4 + 8 > data.Length) throw new ArgumentException("Invalid transaction data");
-                next = (int)BinaryPrimitives.ReadUInt32LittleEndian(data[(i * 4 + 4)..(i * 4 + 8)]);
-            }
-            else
-            {
-                next = data.Length;
-            }
-            if (previous >= next || next > data.Length) throw new ArgumentException("Invalid transaction offset");
-            txs[i] = data[previous..next].ToArray();
-            previous = next;
-        }
+        ArgumentNullException.ThrowIfNull(payload.ParentBeaconBlockRoot);
 
-        return txs;
+        SszExecutionPayloadV3 ssz = new(payload);
+        byte[] encoded = new byte[Hash256.Size + SszExecutionPayloadV3.GetLength(ssz)];
+        payload.ParentBeaconBlockRoot.Bytes.CopyTo(encoded);
+        SszExecutionPayloadV3.Encode(encoded.AsSpan(Hash256.Size), ssz);
+        return encoded;
     }
-
-    public byte[] EncodePayload(ExecutionPayloadV3 payload) => throw new NotImplementedException();
 }

--- a/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/P2P/PayloadDecoder.cs
@@ -17,6 +17,7 @@ public class PayloadDecoder : IPayloadDecoder
     {
     }
 
+    /// <inheritdoc/>
     public ExecutionPayloadV3 DecodePayload(ReadOnlySpan<byte> data)
     {
         if (data.Length < Hash256.Size)


### PR DESCRIPTION
## Changes

- Replace the hand-written `PayloadDecoder` with `SszExecutionPayloadV3`, the container the SSZ  source generator already produces for `Merge.Plugin` and that the Engine API already decodes with. The OP wire format is `parent_beacon_block_root` concatenated with an SSZ `ExecutionPayload`, so the 32-byte prefix is all that stays hand-parsed.
- Fixes an unbounded allocation: `txCount` was `firstTxOffset / 4` taken straight off the wire with only `4 > data.Length` as a guard, so a small response could declare ~1.07 billion transactions and drive an ~8.6 GB `byte[txCount][]`. The generated decoder validates the offset table before allocating, and additionally enforces `MAX_TRANSACTIONS_PER_PAYLOAD`.
- Narrow the decode `catch` in `OptimismCLP2P` from `ArgumentException` to `InvalidDataException`, which is now the only exception a malformed payload produces.
- Implement `EncodePayload`, previously `throw new NotImplementedException()`.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [] No

#### Notes on testing

_Optional. Remove if not applicable._

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No