### PR TITLE
fix(focil): keep blob-carrying frame txs out of the inclusion list

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/InclusionListTxSourceTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/InclusionListTxSourceTests.cs
@@ -116,5 +116,35 @@ public class InclusionListTxSourceTests
             Is.EqualTo([1ul]));
     }
 
+    // EIP-8141: an IL entry is decoded from the canonical form, which carries no sidecar, so a blob-carrying
+    // frame tx forwarded into production would empty the whole payload's blobs bundle. Drop it like a type-3.
+    [Test]
+    public void Blob_carrying_frame_transactions_are_filtered_out()
+    {
+        InclusionListTxSource source = CreateSource();
+        Transaction normal = Build.A.Transaction.WithNonce(1).SignedAndResolved(TestItem.PrivateKeyA).TestObject;
+        Transaction blobFrame = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = MainnetSpecProvider.Instance.ChainId,
+            Nonce = 2,
+            SenderAddress = TestItem.AddressB,
+            Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, 50_000, UInt256.Zero, default)],
+            FrameSignatures = [],
+            GasLimit = 100_000,
+            GasPrice = 1.GWei,
+            DecodedMaxFeePerGas = 10.GWei,
+            MaxFeePerBlobGas = 10.GWei,
+            BlobVersionedHashes = [new byte[32]],
+        };
+        byte[][] il = [Encode(normal), Encode(blobFrame)];
+        PayloadAttributes attrs = Attributes(il);
+
+        source.Set(il, Bogota.Instance);
+        Assert.That(
+            source.GetTransactions(Build.A.BlockHeader.TestObject, 30_000_000UL, attrs).Select(t => t.Nonce),
+            Is.EqualTo([1ul]));
+    }
+
     private static byte[] Encode(Transaction tx) => TxDecoder.Instance.Encode(tx, RlpBehaviors.SkipTypedWrapping).Bytes;
 }

--- a/src/Nethermind/Nethermind.Consensus/Transactions/InclusionListTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/InclusionListTxSource.cs
@@ -76,19 +76,22 @@ public class InclusionListTxSource(
         return ordered;
     }
 
-    // FOCIL: blob (type-3) IL entries are ignored — drop them so block production never emits a blob
-    // tx that has no ShardBlobNetworkWrapper (which would make getPayloadV6 unusable for the CL).
+    // FOCIL: blob IL entries are ignored — drop them so block production never emits a blob tx that has no
+    // ShardBlobNetworkWrapper (which would make getPayloadV6 unusable for the CL). An IL is decoded from the
+    // canonical form, so this covers EIP-8141 blob-carrying frame txs too, not just type-3.
+    private static bool IsBlobCarrying(Transaction tx) => tx.SupportsBlobs || tx.CarriesBlobs;
+
     private static Transaction[] FilterBlobs(Transaction[] txs)
     {
         int kept = 0;
         for (int i = 0; i < txs.Length; i++)
-            if (!txs[i].SupportsBlobs) kept++;
+            if (!IsBlobCarrying(txs[i])) kept++;
         if (kept == txs.Length) return txs;
 
         Transaction[] result = new Transaction[kept];
         int j = 0;
         for (int i = 0; i < txs.Length; i++)
-            if (!txs[i].SupportsBlobs) result[j++] = txs[i];
+            if (!IsBlobCarrying(txs[i])) result[j++] = txs[i];
         return result;
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Validators/InclusionListValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/InclusionListValidator.cs
@@ -63,8 +63,8 @@ public static class InclusionListValidator
     private static bool CouldIncludeTx(Transaction tx, Block block, IReadOnlyStateProvider state, IReleaseSpec spec, ITxValidator txValidator, ref Dictionary<AddressAsKey, AccountStruct>? senderCache)
     {
         if (tx.SenderAddress is null) return false;
-        // Blob txs MUST NOT appear in an IL.
-        if (tx.SupportsBlobs) return false;
+        // Blob txs MUST NOT appear in an IL — including EIP-8141 blob-carrying frame txs.
+        if (tx.SupportsBlobs || tx.CarriesBlobs) return false;
         // Subtract on the block side (GasUsed <= GasLimit is invariant): block.GasLimit - tx.GasLimit
         // would underflow for an oversized tx.
         if (tx.GasLimit > block.GasLimit - block.GasUsed) return false;


### PR DESCRIPTION
## Changes

`InclusionListTxSource.FilterBlobs` gated on `tx.SupportsBlobs`, which is true only for type-3. An EIP-8141 frame transaction carrying blobs is not matched, so it passes straight into block production — which is precisely what that filter exists to prevent, as its own comment says:

> drop them so block production never emits a blob tx that has no `ShardBlobNetworkWrapper` (which would make `getPayloadV6` unusable for the CL)

An inclusion list is decoded from the canonical transaction form, which carries no sidecar, so such an entry always has `NetworkWrapper == null`. `BlobsBundleV2` throws `ArgumentException` on the first `CarriesBlobs` transaction without a wrapper, and its `catch (ArgumentException)` resets `Commitments`/`Blobs`/`Proofs` to empty — so **a single inclusion-list entry empties the blobs bundle for the entire payload**, taking every legitimate blob transaction in that block with it. Any inclusion-list committee member can place such an entry.

The fix gates on blob presence rather than the transaction type, matching the `SupportsBlobs || CarriesBlobs` pattern `TxValidator` already uses for the same distinction.

`InclusionListValidator.CouldIncludeTx` had the same `SupportsBlobs` gate. That one is already unreachable for a blob-carrying frame transaction — `Eip8369.Classify` returns `Outside` for it and the omission loop skips anything that is not Profile One — so this half is a behaviour-neutral consistency change with no test to distinguish it.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring (a non-breaking change that does not add functionality nor fixes an issue)
- [ ] Configuration change
- [ ] Test coverage improvement
- [ ] Performance improvement
- [ ] Other (please describe)

## Testing

Requires testing

- [x] Yes
- [ ] No

If yes, did you write tests?

- [x] Yes
- [ ] No

`Blob_carrying_frame_transactions_are_filtered_out` in `InclusionListTxSourceTests` puts a blob-carrying frame transaction in an inclusion list alongside a normal one and asserts only the normal one is produced. Revert-check: reverting only `InclusionListTxSource.cs` fails exactly that test (1 of 9 in the fixture, 0 others). Full `Nethermind.Consensus.Test` is green with the fix (163 passed, 1 skipped).

## Documentation

Requires documentation update

- [ ] Yes
- [x] No

Requires explanation in Release Notes

- [ ] Yes
- [x] No
