### PR TITLE
perf(db): use LZ4 instead of Snappy for the default database codec

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -41,7 +41,11 @@ public class DbConfig : IDbConfig
         // Increase it to reduce stalls under heavy compaction.
         "max_compaction_bytes=4000000000;" +
 
-        "compression=kSnappyCompression;" +
+        // LZ4 over Snappy: same ratio class, but markedly cheaper both ways. Profiling
+        // showed Snappy at ~47% of compaction-thread CPU on fusaka block processing and
+        // ~60% on the eth_call corpus - all of it from the databases that inherit this
+        // default, since the state and flat databases already select LZ4 below.
+        "compression=kLZ4Compression;" +
         "optimize_filters_for_hits=true;" +
         "advise_random_on_open=true;" +
 


### PR DESCRIPTION
Draft — benchmark A/B in progress, numbers to follow. **fusaka arm** of a pair; the eth_call arm carries the same one-line change and is cross-linked below.

## Where this comes from

dotTrace reports everything below a P/Invoke as one `[Native or optimized code]` node — recently the third-largest entry in a snapshot, with no breakdown. Profiling the client with `perf` (tooling in #12952) opens that node, and in **both** benchmarked workloads the largest resolved native cost is the database compression codec:

| workload | Snappy share of compaction CPU | compaction share of process CPU | Snappy of total |
|---|---|---|---|
| expb fusaka, 2000 payloads | 47.5% | 16.2% | **~7.7%** |
| eth_call 497 corpus, 100rps | 60.2% | 14.0% | **~8.4%** |

fusaka compaction threads, self time:

```
snappy::internal::CompressFragment            23.21%
[unknown] (librocksdb.so)                     18.90%
snappy::LittleEndian::Load32                  10.62%
snappy::DecompressBranchless                  10.47%
LZ4_compress_fast_extState                     2.99%
```

LZ4 registers at ~3% against Snappy's ~47% on the same threads because the state and flat databases already select it. Every Snappy sample comes from a database inheriting the default in `DbConfig.RocksDbOptions`, which no per-database override touches — `ReceiptsDbRocksDbOptions` sets write buffer, block cache and filters but not compression, and the same is true of blocks, headers and code.

On the eth_call corpus the cost is symmetric — `CompressFragment` 24.3% and `DecompressBranchless` 13.1% — so read-serving pays it as well as writing.

## The change

One line: the default codec becomes LZ4. Same compression-ratio class, markedly cheaper in both directions, already linked into the shipped library.

No migration: existing SST files keep the codec they were written with, and compaction rewrites them with the new one.

## Scope

Strictly the codec on the path the profile implicates. Deliberately untouched:

- `GetHashDbOptions()` pins Snappy for hash-db layouts. Neither benchmark exercises that layout, and the surrounding comment records the pin as guarding against a regression — changing it would be an unmeasured change.
- `blob_compression_type` is a separate storage path (blob files). Worth a follow-up, but bundling it would confound the attribution of this A/B.

## Verification

A/B pending on expb fusaka. Draft until the numbers are in; if the win does not materialise on the benchmark this PR gets closed rather than argued for on profile share alone.