### PR TITLE
perf(db): use LZ4 instead of Snappy for the default database codec (eth_call arm)

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Config/DbConfig.cs
@@ -41,7 +41,11 @@ public class DbConfig : IDbConfig
         // Increase it to reduce stalls under heavy compaction.
         "max_compaction_bytes=4000000000;" +
 
-        "compression=kSnappyCompression;" +
+        // LZ4 over Snappy: same ratio class, but markedly cheaper both ways. Profiling
+        // showed Snappy at ~47% of compaction-thread CPU on fusaka block processing and
+        // ~60% on the eth_call corpus - all of it from the databases that inherit this
+        // default, since the state and flat databases already select LZ4 below.
+        "compression=kLZ4Compression;" +
         "optimize_filters_for_hits=true;" +
         "advise_random_on_open=true;" +
 


### PR DESCRIPTION
Draft — benchmark A/B in progress, numbers to follow. **eth_call arm** of a pair with #12955, which carries the identical one-line change validated on fusaka.

Same lever, because the profiles say so: perf shows the database compression codec as the largest resolved native cost in *both* workloads, inside the region dotTrace collapses into one `[Native or optimized code]` node.

## eth_call 497 corpus, 100 rps, 138,615 samples

The workload is 75.9% managed, so its native block is small — but what is in it is concentrated in one place. Compaction threads are 14.0% of process CPU, and **60.2% of that is Snappy** (≈8.4% of total):

```
snappy::internal::CompressFragment            24.28%
[unknown] (librocksdb.so)                     22.10%
snappy::DecompressBranchless                  13.14%
snappy::LittleEndian::Load32                  11.61%
snappy::UNALIGNED_LOAD64                       2.61%
```

Note the cost is symmetric here: compression *and* decompression, so a read-serving workload pays it in both directions while competing for the same cores as request handling.

For contrast, the rest of eth_call's native block is diffuse and offers nothing comparable — `libcoreclr` 4.04% spread across hundreds of call sites, VSD interface-dispatch stubs 1.20%, vdso clock reads 1.01%, and `memset@plt` just 0.10% (so the EVM-memory-zeroing hypothesis does not apply to this corpus).

## Relationship to #12955

Identical diff. Kept as two PRs because the two benchmarks were requested separately and each is validated independently; they can be collapsed into one merge — I would suggest doing exactly that, with both benchmark results recorded on the survivor.

## Verification

A/B pending on the eth_call 497 corpus sweep, same shape as the `performance is good` configuration (497 records, 100 rps, 120s). Draft until the numbers are in; parity divergence or no measurable win means this gets closed.