### PR TITLE
ci(bench): per-client snapshots and per-arm node flags in an RPC sweep

### DIFF
--- a/.github/workflows/run-rpc-benchmarks.yml
+++ b/.github/workflows/run-rpc-benchmarks.yml
@@ -96,6 +96,8 @@ on:
           Tool config as JSON — empty is fine for defaults. Common recipes:
           (1) cross-client sweep: {"clients":"nethermind reth","rps_list":"50 100","duration":"60s"} —
           clients take an optional @image (nethermind@nethermindeth/nethermind:master reth@ghcr.io/paradigmxyz/reth:v2.2.0), run one at a time;
+          an entry may append +flag,flag to pass node flags to that arm alone, which is how one dispatch A/Bs a flag
+          against the same image; {ARM_SCRATCH} in a flag expands to an empty per-arm directory (wiped, not inherited);
           (2) PRIVATE corpus sweep (latency + response parity on every eth-call-corpus*.jsonl.gz found on the runner; call contents never reach logs/artifacts — see README "Private eth_call corpus"):
           {"eth_call_corpus":true,"clients":"nethermind reth","rps_list":"10 100","duration":"120s"} — first client is the parity baseline;
           (3) single-node jsonbench: {"benchmark_config":"ethcall-contracts-head","rps":"50","duration":"60s"} (add "eth_call_corpus":true to use the default private corpus instead of the config's calls);

--- a/.github/workflows/run-rpc-benchmarks.yml
+++ b/.github/workflows/run-rpc-benchmarks.yml
@@ -96,8 +96,11 @@ on:
           Tool config as JSON — empty is fine for defaults. Common recipes:
           (1) cross-client sweep: {"clients":"nethermind reth","rps_list":"50 100","duration":"60s"} —
           clients take an optional @image (nethermind@nethermindeth/nethermind:master reth@ghcr.io/paradigmxyz/reth:v2.2.0), run one at a time;
-          an entry may append +flag,flag to pass node flags to that arm alone, which is how one dispatch A/Bs a flag
-          against the same image; {ARM_SCRATCH} in a flag expands to an empty per-arm directory (wiped, not inherited);
+          an entry may append +flag;flag to pass node flags to that arm alone (semicolon separates flags; commas stay
+          inside values), which is how one dispatch A/Bs a flag against the same image; {ARM_SCRATCH} expands to an
+          empty per-arm host directory bind-mounted at the identical container path (wiped, not inherited); reth uses
+          sequential direct isolation, so its snapshot accumulates startup writes in arm order and is not a clean A/B;
+          direct reth does not refresh the fingerprint anchor; any old anchor is diagnostic only;
           (2) PRIVATE corpus sweep (latency + response parity on every eth-call-corpus*.jsonl.gz found on the runner; call contents never reach logs/artifacts — see README "Private eth_call corpus"):
           {"eth_call_corpus":true,"clients":"nethermind reth","rps_list":"10 100","duration":"120s"} — first client is the parity baseline;
           (3) single-node jsonbench: {"benchmark_config":"ethcall-contracts-head","rps":"50","duration":"60s"} (add "eth_call_corpus":true to use the default private corpus instead of the config's calls);

--- a/.github/workflows/run-rpc-benchmarks.yml
+++ b/.github/workflows/run-rpc-benchmarks.yml
@@ -886,8 +886,8 @@ jobs:
           corpus_dir="$(get '.corpus_dir')";               [[ -z "${corpus_dir}" ]] && corpus_dir="${RESOLVED_CORPUS_DIR}"
           [[ -n "${corpus_dir}" ]] && export CORPUS_DIR="${corpus_dir}"
           corpus_glob="$(get '.corpus_glob')";             [[ -n "${corpus_glob}" ]] && export CORPUS_GLOB="${corpus_glob}"
-          # Sweep mode resolves one Nethermind flat snapshot, so the geth/reth default it used to carry
-          # made a bare dispatch fail its own guard. Cross-client work belongs in single-node mode.
+          # A bare dispatch benchmarks Nethermind: the geth/reth default this used to carry made every
+          # one of them start two extra nodes nobody asked for. Name them explicitly to sweep them.
           export CLIENTS="$(get '.clients')";              [[ -z "${CLIENTS}" ]] && export CLIENTS="nethermind"
           # An ABSENT rps_list means "use the default"; an explicitly EMPTY one means "no k6 cells"
           # (corpus runs that only want parity/timings). `// empty` cannot tell those apart.

--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -37,6 +37,30 @@ therefore differs, so **never read a cross-type disk-read delta as a code
 difference** — within one type it is uniform, which is what a version comparison
 needs.
 
+Sweep arms run sequentially. This is safe for overlay-backed clients, but reth's
+direct isolation intentionally opens its snapshot read-write: each arm and each
+later dispatch inherits the startup writes left by the previous one. Consequently
+reth multi-arm results are order-dependent and are **not a clean A/B comparison**;
+the direct reth path does not refresh the cross-run fingerprint anchor. If an old anchor exists,
+it is diagnostic only: it cannot monitor the accumulated writes, restore isolation, or make those timings
+comparable. Use separate fresh reth
+snapshots/runs when a clean A/B is required.
+
+### Per-arm flags
+
+`tool_config.clients` entries use `client[@image][+flag;flag;...]`. The semicolon
+is the flag separator, so comma-valued flags remain intact; for example:
+
+```json
+{"clients":"nethermind@nethermindeth/nethermind:master+--JsonRpc.EnabledModules=Eth,Debug;--Pruning.Mode=None nethermind@nethermindeth/nethermind:master+--JsonRpc.EnabledModules=Eth"}
+```
+
+Entries and flags must be non-empty, and each flag must start with `--` and have
+no whitespace or semicolon. `{ARM_SCRATCH}` is replaced with a freshly recreated
+host directory for that arm and bind-mounted at the same absolute path inside
+the node container, so a flag can direct client-owned scratch state there without
+sharing a predecessor's files.
+
 ## Goals
 
 1. **A CI to check current node RPC performance** with any of three tools.
@@ -143,11 +167,11 @@ no longer byte-identical — acceptable for read-only benchmarks (no transaction
 no `newPayload`), where the only writes are engine startup housekeeping.
 
 **`direct` caveats:** (1) the tamper tripwire records the diff and warns instead
-of failing (below); (2) never point two nodes at the same `direct` snapshot
-concurrently (DB lock conflict) — comparison runs are fine, each client uses its
-own snapshot; (3) if a snapshot is shared with another consumer (e.g. expb reuses
-the nethermind sets), don't put that client on `direct` — hence nethermind/geth
-stay on `overlay`.
+of failing (below); it is a diagnostic, not an isolation mechanism; (2) never
+point two nodes at the same `direct` snapshot concurrently (DB lock conflict) —
+comparison runs are fine only when each client uses its own fresh snapshot; (3) if
+a snapshot is shared with another consumer (e.g. expb reuses the nethermind sets),
+don't put that client on `direct` — hence nethermind/geth stay on `overlay`.
 
 ### Tamper tripwire (active verification of goal #2)
 
@@ -157,12 +181,13 @@ size, mtime, mode, owner, symlink target) plus a sha256 of the small RocksDB
 control files rewritten the instant a DB is opened read-write (`CURRENT`,
 `IDENTITY`, `MANIFEST-*`, `OPTIONS-*`). Any difference **fails the job** — except
 under `direct`, where changes are expected: it warns, logs the changed-line
-count, and does not update the cross-run anchor. Hashing only the control files
+count, and does not update the cross-run anchor. The direct reth path therefore
+does not refresh an old anchor; any anchor it finds is diagnostic only. Hashing only the control files
 keeps the check fast on a multi-TB DB; listing errors are fatal rather than
-producing a partial fingerprint. After a clean verify the fingerprint persists
-(`<scratch_root>/fingerprints/`) as a **cross-run anchor** — the next run warns
-if the snapshot changed in between (e.g. a hard-interrupted run whose verify
-never ran).
+producing a partial fingerprint. After a clean non-direct verify the fingerprint
+persists (`<scratch_root>/fingerprints/`) as a **cross-run anchor** — the next
+non-direct run warns if the snapshot changed in between (e.g. a hard-interrupted
+run whose verify never ran).
 
 Path safety is layered: `resolve` validates `db_source`/`scratch_root` shape, and
 every script canonicalizes them (`realpath`, symlink-proof), rejects shallow

--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -203,7 +203,7 @@ the workflow's defensive-cleanup step).
 | `client` | `nethermind`, `geth` or `reth` — whichever has a snapshot set on the selected runner (arm64 serves Nethermind only). |
 | `reference_client` | Second client to compare against, or `none`. Needs that client's same-block set on the selected runner. For a perf A/B prefer two single-node runs or a `jsonbench-sweep`; a comparison run shares the box between both nodes, so it measures correctness rather than clean latency. |
 | `arch` | Benchmark runner: `amd64` (default, `/mnt/sda`) or `arm64` (`/data`). Drives every path. |
-| `snapshot_block` | Snapshot set tag (`<snapshot root>/nethermind-flat-<tag>`); empty = `25490000`. |
+| `snapshot_block` | Snapshot set tag (`<snapshot root>/<client>-<tag>`, or `<snapshot root>/nethermind-flat-<tag>` for Nethermind's flat set); empty = `25490000`. |
 | `docker_image` | Optional explicit image for the benchmarked client (skips build/reuse resolution). |
 | `dottrace` | `false` (default), `sampling`, `tracing`, or `timeline` — profiling mode for the node. Works with **any** Nethermind image. `sampling`/`tracing` are post-processed to XML; `timeline` is a UI-only snapshot. `true` is a legacy alias for `sampling`. |
 | `state_layout` | `flat` — the only layout with a snapshot set on this runner. |

--- a/scripts/rpc-bench/README.md
+++ b/scripts/rpc-bench/README.md
@@ -19,12 +19,23 @@ snapshot set — Nethermind in the **flat** layout — so there `client`,
 and an image it would have to build is refused as well (that box's ~19G root disk
 dies under a build). `resolve` checks those limits against the selected runner.
 
-Independently of the runner, **sweep mode** (`jsonbench-sweep`) resolves one
-Nethermind flat snapshot and varies only the image, so `run-rpc-sweep.sh` refuses
-a non-Nethermind entry in `tool_config.clients`
-instead of those inputs. `start-node.sh` stays client-generic, so re-enabling
-geth/reth or a second layout is a matter of provisioning the snapshot set and
-widening those two guards.
+**Sweep mode** (`jsonbench-sweep`) resolves a snapshot set per client type, the
+same `<snapshot root>/<client>-<block>` layout the single-node path uses, so
+`tool_config.clients` may name `geth` and `reth` entries alongside Nethermind
+ones. `run-rpc-sweep.sh` checks every requested type's set exists before it
+starts a node, so a type the selected box cannot serve is one clear error rather
+than a per-client warning and a partly-empty matrix reported as success. As of
+2026-08 the amd64 box carries `nethermind-flat-25490000`,
+`nethermind-25490000`, `nethermind-flat-snapshot`, `geth-25490000` and
+`reth-25490000`; the arm64 box carries the Nethermind flat set only.
+
+Isolation is per client type too. reth's DB is a single large `mdbx.dat` whose
+first write forces overlayfs to copy the whole file up before the node opens, so
+reth runs `direct` (a read-write bind mount of its own set, which is not shared
+with expb); everything else stays on `overlay`. Across types the isolation
+therefore differs, so **never read a cross-type disk-read delta as a code
+difference** — within one type it is uniform, which is what a version comparison
+needs.
 
 ## Goals
 
@@ -164,8 +175,8 @@ the workflow's defensive-cleanup step).
 | Input | Meaning |
 |---|---|
 | `benchmark_tool` | `flood`, `ethcallchaos`, `jsonbench`, or `jsonbench-sweep`. |
-| `client` | `nethermind` — the only client with a snapshot set on this runner. |
-| `reference_client` | `none` — cross-client comparison needs a second client's snapshot, which this runner does not carry. Compare two Nethermind builds with a `jsonbench-sweep` instead. |
+| `client` | `nethermind`, `geth` or `reth` — whichever has a snapshot set on the selected runner (arm64 serves Nethermind only). |
+| `reference_client` | Second client to compare against, or `none`. Needs that client's same-block set on the selected runner. For a perf A/B prefer two single-node runs or a `jsonbench-sweep`; a comparison run shares the box between both nodes, so it measures correctness rather than clean latency. |
 | `arch` | Benchmark runner: `amd64` (default, `/mnt/sda`) or `arm64` (`/data`). Drives every path. |
 | `snapshot_block` | Snapshot set tag (`<snapshot root>/nethermind-flat-<tag>`); empty = `25490000`. |
 | `docker_image` | Optional explicit image for the benchmarked client (skips build/reuse resolution). |

--- a/scripts/rpc-bench/cleanup.sh
+++ b/scripts/rpc-bench/cleanup.sh
@@ -35,7 +35,7 @@ while IFS= read -r m; do
   as_root umount "$m" 2>/dev/null || as_root umount -l "$m" 2>/dev/null || true
 done < <(awk -v d="$SCRATCH_ROOT" '$2 == d || index($2, d "/") == 1 { print $2 }' /proc/self/mounts 2>/dev/null | sort -r)
 
-for sub in run run-reference diag ethcallchaos jsonbench parity warmup-cell; do
+for sub in run run-reference diag ethcallchaos jsonbench parity warmup-cell arm; do
   target="$SCRATCH_ROOT/$sub"
   [[ -e "$target" ]] || continue
   if ! (assert_no_mounts_under "$target") 2>/dev/null; then

--- a/scripts/rpc-bench/run-rpc-sweep.sh
+++ b/scripts/rpc-bench/run-rpc-sweep.sh
@@ -412,8 +412,11 @@ for arm_index in "${!SWEEP_ENTRIES[@]}"; do
     if ! as_root mkdir -p -- "$arm_scratch_dir"; then
       echo "::error::failed to recreate per-arm scratch directory '$arm_scratch_dir'"; exit 1
     fi
-    if [[ ! -d "$arm_scratch_dir" || -L "$arm_scratch_dir" ]]; then
-      echo "::error::per-arm scratch path '$arm_scratch_dir' is not a directory after recreation"; exit 1
+    if ! as_root chmod 0777 -- "$arm_scratch_dir"; then
+      echo "::error::failed to make per-arm scratch directory '$arm_scratch_dir' writable"; exit 1
+    fi
+    if [[ ! -d "$arm_scratch_dir" || -L "$arm_scratch_dir" || ! -w "$arm_scratch_dir" ]]; then
+      echo "::error::per-arm scratch path '$arm_scratch_dir' is not a writable, non-symlink directory after recreation"; exit 1
     fi
     arm_flags="${arm_flags//\{ARM_SCRATCH\}/$arm_scratch_dir}"
   fi

--- a/scripts/rpc-bench/run-rpc-sweep.sh
+++ b/scripts/rpc-bench/run-rpc-sweep.sh
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 #
 # Cross-client sweep, one node per client pinned to the same SNAPSHOT_BLOCK: ISOLATED
-# (each scenario alone) and MIXED (all together). A node that fails to start is skipped.
+# (each scenario alone) and MIXED (all together). A node that fails to start has its cells skipped,
+# but the incomplete matrix still fails the sweep.
 set -uo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/rpc-bench/lib.sh
@@ -107,13 +108,56 @@ snap_path() {
   esac
 }
 
+# Each entry is whitespace-delimited. A `+` segment contains semicolon-delimited flags; commas
+# remain part of a flag value (for example, `--JsonRpc.EnabledModules=Eth,Debug`). Validate every
+# entry before any node starts so a malformed arm cannot leave a one-arm matrix looking successful.
+if [[ "$CLIENTS" == *$'\n'* || "$CLIENTS" == *$'\r'* ]]; then
+  echo "::error::clients must be a single line of whitespace-delimited entries"; exit 1
+fi
+read -r -a SWEEP_ENTRIES <<< "$CLIENTS"
+if [[ "${#SWEEP_ENTRIES[@]}" -eq 0 ]]; then
+  echo "::error::clients must contain at least one entry"; exit 1
+fi
+declare -a SWEEP_SPECS=()
+declare -a SWEEP_FLAG_SPECS=()
+declare -A SWEEP_CTYPES=()
+for entry in "${SWEEP_ENTRIES[@]}"; do
+  spec="${entry%%+*}"
+  arm_flag_spec=""
+  [[ "$entry" == *+* ]] && arm_flag_spec="${entry#*+}"
+  ctype="${spec%%@*}"
+  if [[ -z "$spec" || -z "$ctype" ]]; then
+    echo "::error::malformed sweep client entry '${entry}'"; exit 1
+  fi
+  if [[ "$spec" == *@* && -z "${spec#*@}" ]]; then
+    echo "::error::sweep client entry '${entry}' has an empty image"; exit 1
+  fi
+  if [[ "$arm_flag_spec" == *';'* ]]; then
+    if [[ "$arm_flag_spec" == ';'* || "$arm_flag_spec" == *';' || "$arm_flag_spec" == *';;'* ]]; then
+      echo "::error::malformed flag list in '${entry}' — use one non-empty flag per ';'"; exit 1
+    fi
+  fi
+  if [[ -n "$arm_flag_spec" ]]; then
+    IFS=';' read -r -a parsed_arm_flags <<< "$arm_flag_spec"
+    for arm_flag in "${parsed_arm_flags[@]}"; do
+      if [[ ! "$arm_flag" =~ ^--[^[:space:]\;]+$ ]]; then
+        echo "::error::malformed arm flag '${arm_flag}' in '${entry}' — flags must start with '--' and contain no whitespace or ';'"; exit 1
+      fi
+    done
+  elif [[ "$entry" == *+* ]]; then
+    echo "::error::empty arm flag list in '${entry}'"; exit 1
+  fi
+  SWEEP_SPECS+=("$spec")
+  SWEEP_FLAG_SPECS+=("$arm_flag_spec")
+  SWEEP_CTYPES["$ctype"]=1
+done
 # A client whose snapshot set is absent reaches start-node.sh with a DB_SOURCE that does not exist,
 # and that is only a per-client `::warning::` — the sweep would report a two-thirds-empty matrix as
 # success, and in corpus mode a baseline with no candidate, i.e. no parity verdict at all. Check
 # every requested type up front instead, and only the state_layout axis the request actually uses
 # (a reth-only sweep resolves no Nethermind path, so the flat pin does not apply to it).
-declare -A SWEEP_CTYPES=()
-for entry in $CLIENTS; do spec="${entry%%+*}"; SWEEP_CTYPES["${spec%%@*}"]=1; done
+SCRATCH_ROOT="$(realpath -m -- "$SCRATCH_ROOT")" || { echo "::error::cannot canonicalize SCRATCH_ROOT"; exit 1; }
+assert_sane_dir "$SCRATCH_ROOT" "SCRATCH_ROOT"
 for ctype in "${!SWEEP_CTYPES[@]}"; do
   case "$ctype" in
     nethermind|geth|reth) ;;
@@ -125,7 +169,22 @@ for ctype in "${!SWEEP_CTYPES[@]}"; do
     ls -1d "${SNAPSHOT_ROOT}"/*-"${SNAPSHOT_BLOCK}" 2>/dev/null | sed 's|^|::error::  |' || true
     exit 1
   fi
+  snap_real="$(realpath -e -- "$(snap_path "$ctype")")" || {
+    echo "::error::cannot canonicalize ${ctype} snapshot at $(snap_path "$ctype")"; exit 1
+  }
+  [[ "$snap_real" != "$SCRATCH_ROOT" ]] || { echo "::error::SCRATCH_ROOT must not equal the ${ctype} snapshot"; exit 1; }
+  case "$snap_real/" in
+    "$SCRATCH_ROOT"/*) echo "::error::SCRATCH_ROOT must not contain the ${ctype} snapshot"; exit 1 ;;
+  esac
+  case "$SCRATCH_ROOT/" in
+    "$snap_real"/*) echo "::error::SCRATCH_ROOT must not be inside the ${ctype} snapshot"; exit 1 ;;
+  esac
 done
+if [[ ! -d "$SCRATCH_ROOT" ]] && ! as_root mkdir -p -- "$SCRATCH_ROOT"; then
+  echo "::error::failed to create SCRATCH_ROOT '$SCRATCH_ROOT'"; exit 1
+fi
+[[ -d "$SCRATCH_ROOT" ]] || { echo "::error::SCRATCH_ROOT '$SCRATCH_ROOT' is not a directory"; exit 1; }
+SCRATCH_ROOT="$(realpath -e -- "$SCRATCH_ROOT")" || { echo "::error::cannot canonicalize SCRATCH_ROOT"; exit 1; }
 if [[ -n "${SWEEP_CTYPES[nethermind]:-}" && "$STATE_LAYOUT" != "flat" ]]; then
   echo "::error::sweep mode resolves a flat Nethermind snapshot, so state_layout '${STATE_LAYOUT}' cannot run here"; exit 1
 fi
@@ -244,6 +303,7 @@ declare -a LABELS=()
 declare -a CORPORA=()
 declare -a PARITY_ROWS=()
 node_issue=0
+start_fail=0  # requested arm failed to start; an incomplete matrix must fail the sweep
 cell_fail=0   # load-test cells that ran but failed (distinct from a client skipped for never starting)
 stop_fail=0   # stop-node.sh reported a DB-integrity/teardown failure (overlay clients; direct only warns)
 parity_fail=0 # corpus parity defects or a failed parity replay
@@ -285,7 +345,7 @@ if [[ "$JB_ETH_CALL_CORPUS" == "true" ]]; then
   rm -rf "$PARITY_STATE"; mkdir -p "$PARITY_STATE"
 fi
 
-# Each entry is `ctype[@image][+flag,flag,...]` (e.g. nethermind@nethermindeth/nethermind:master) for
+# Each entry is `ctype[@image][+flag;flag;...]` (e.g. nethermind@nethermindeth/nethermind:master) for
 # same-client version comparisons. Sequential (one node up at a time), so same-snapshot variants are safe.
 # Listing the same image twice is how a sweep measures its own run-to-run drift, so repeats get a
 # distinct label: sharing one would make each repeat overwrite the previous one's cells and state,
@@ -296,29 +356,66 @@ fi
 # two arms neither collide nor need reading from the config to tell apart. `{ARM_SCRATCH}` in a flag
 # expands to an empty per-arm directory (wiped here, not inherited from an earlier arm or dispatch) —
 # a flag pointing a node's storage there measures every arm against the same starting state instead
-# of the state its predecessor left behind. Image tags cannot contain `+`, so the split is unambiguous.
+# of the state its predecessor left behind. Semicolons separate flags; commas are preserved in values.
+# Image tags cannot contain `+`, so the split is unambiguous.
 log_system_provenance
 
 declare -A LABEL_SEEN=()
-for entry in $CLIENTS; do
-  spec="${entry%%+*}"
+for arm_index in "${!SWEEP_ENTRIES[@]}"; do
+  entry="${SWEEP_ENTRIES[$arm_index]}"
+  spec="${SWEEP_SPECS[$arm_index]}"
+  arm_flag_spec="${SWEEP_FLAG_SPECS[$arm_index]}"
   arm_flags=""
-  [[ "$entry" == *+* ]] && arm_flags="${entry#*+}"
-  arm_flags="${arm_flags//,/ }"
+  if [[ -n "$arm_flag_spec" ]]; then
+    IFS=';' read -r -a parsed_arm_flags <<< "$arm_flag_spec"
+    arm_flags="${parsed_arm_flags[*]}"
+  fi
   ctype="${spec%%@*}"
   if [[ "$spec" == *@* ]]; then
     img="${spec#*@}"; label="${ctype}_$(printf '%s' "${img##*:}" | tr -c 'a-zA-Z0-9' '_')"
   else
     img="$NM_IMAGE"; label="$ctype"
   fi
-  [[ -n "$arm_flags" ]] && label="${label}_$(printf '%s' "$arm_flags" | tr -c 'a-zA-Z0-9' '_' | cut -c1-24)"
+  arm_scratch_dir=""
+  if [[ -n "$arm_flag_spec" ]]; then
+    # Keep a readable prefix, but derive uniqueness from the complete unexpanded specification.
+    # A prefix alone made flags sharing their first 24 characters collide and become _rN repeats.
+    arm_flag_hash="$(printf '%s' "$arm_flag_spec" | sha256sum | cut -c1-12)"
+    arm_flag_prefix="$(printf '%s' "$arm_flag_spec" | tr -c 'a-zA-Z0-9' '_' | cut -c1-24)"
+    label="${label}_${arm_flag_prefix}_${arm_flag_hash}"
+  fi
   LABEL_SEEN["$label"]=$(( ${LABEL_SEEN["$label"]:-0} + 1 ))
   (( ${LABEL_SEEN["$label"]} > 1 )) && label="${label}_r${LABEL_SEEN["$label"]}"
-  if [[ "$arm_flags" == *"{ARM_SCRATCH}"* ]]; then
-    arm_scratch="$SCRATCH_ROOT/arm/$label"
-    assert_no_mounts_under "$arm_scratch"
-    rm -rf "$arm_scratch"; mkdir -p "$arm_scratch"
-    arm_flags="${arm_flags//\{ARM_SCRATCH\}/$arm_scratch}"
+  if [[ "$arm_flag_spec" == *"{ARM_SCRATCH}"* ]]; then
+    arm_root="$SCRATCH_ROOT/arm"
+    if [[ -L "$arm_root" ]]; then
+      echo "::error::per-arm scratch root '$arm_root' must not be a symlink"; exit 1
+    fi
+    if [[ ! -d "$arm_root" ]] && ! as_root mkdir -p -- "$arm_root"; then
+      echo "::error::failed to create per-arm scratch root '$arm_root'"; exit 1
+    fi
+    [[ -d "$arm_root" && ! -L "$arm_root" ]] || {
+      echo "::error::per-arm scratch root '$arm_root' is not a directory"; exit 1
+    }
+    arm_root="$(realpath -e -- "$arm_root")" || {
+      echo "::error::cannot canonicalize per-arm scratch root"; exit 1
+    }
+    [[ "$arm_root/" == "$SCRATCH_ROOT/"* ]] || {
+      echo "::error::per-arm scratch root must be inside SCRATCH_ROOT"; exit 1
+    }
+    arm_scratch_dir="$arm_root/$label"
+    assert_sane_dir "$arm_scratch_dir" "ARM_SCRATCH_DIR"
+    assert_no_mounts_under "$arm_scratch_dir"
+    if ! as_root rm -rf -- "$arm_scratch_dir"; then
+      echo "::error::failed to wipe per-arm scratch directory '$arm_scratch_dir'"; exit 1
+    fi
+    if ! as_root mkdir -p -- "$arm_scratch_dir"; then
+      echo "::error::failed to recreate per-arm scratch directory '$arm_scratch_dir'"; exit 1
+    fi
+    if [[ ! -d "$arm_scratch_dir" || -L "$arm_scratch_dir" ]]; then
+      echo "::error::per-arm scratch path '$arm_scratch_dir' is not a directory after recreation"; exit 1
+    fi
+    arm_flags="${arm_flags//\{ARM_SCRATCH\}/$arm_scratch_dir}"
   fi
   [[ -n "$arm_flags" ]] && echo "arm flags: $arm_flags"
   docker pull "$img" >/dev/null 2>&1 || echo "pull failed — assuming $img is local"
@@ -330,11 +427,12 @@ for entry in $CLIENTS; do
        DB_SOURCE="$snap" DB_ISOLATION="$iso" \
        SCRATCH_ROOT="$SCRATCH_ROOT" STATE_DIR="$cst" NETWORK="$NETWORK" \
        JSONRPC_MODULES="$JSONRPC_MODULES" LAYOUT_FLAGS="$NM_LAYOUT_FLAGS" \
-       ADDITIONAL_FLAGS="$arm_flags" HEALTH_TIMEOUT="$HEALTH_TIMEOUT" DOTTRACE="false" \
+       ADDITIONAL_FLAGS="$arm_flags" ARM_SCRATCH_DIR="$arm_scratch_dir" \
+       HEALTH_TIMEOUT="$HEALTH_TIMEOUT" DOTTRACE="false" \
        RPC_GAS_CAP="$([[ "$JB_ETH_CALL_CORPUS" == "true" ]] && echo "$CORPUS_RPC_GAS_CAP")" \
        DIAG_DIR="$DIAG_DIR" CONTAINER_NAME="$cname" RPC_PORT="8545" \
        "$here/start-node.sh"; then
-    echo "::warning::${label} failed to start — skipping its cells"; echo "::endgroup::"; continue
+    echo "::warning::${label} failed to start — skipping its cells"; start_fail=$((start_fail + 1)); echo "::endgroup::"; continue
   fi
   LABELS+=("$label")
 
@@ -589,6 +687,12 @@ if [[ "${#LABELS[@]}" -ge 2 ]]; then
   done
 fi
 fail=0
+if [[ "${#LABELS[@]}" -eq 0 ]]; then
+  echo "::error::no sweep arms started successfully — refusing to report an empty matrix as success"; fail=1
+fi
+if [[ "$start_fail" -gt 0 ]]; then
+  echo "::error::${start_fail} sweep arm(s) failed to start — the matrix is incomplete, failing"; fail=1
+fi
 if [[ "$node_issue" -eq 1 ]]; then
   echo "::error::node health issue (Exception / invalid block / missing shutdown marker) in a sweep node log — failing"; fail=1
 fi

--- a/scripts/rpc-bench/run-rpc-sweep.sh
+++ b/scripts/rpc-bench/run-rpc-sweep.sh
@@ -93,32 +93,47 @@ if [[ ! "$CORPUS_WARMUP_DURATION" =~ ^[0-9]+s?$ ]]; then
 fi
 WARMUP_SECONDS="${CORPUS_WARMUP_DURATION%s}"
 
-# Sweep mode resolves ONE snapshot set — Nethermind, flat layout, at SNAPSHOT_BLOCK — and varies only
-# the image, so a geth/reth entry would reach start-node.sh with a DB_SOURCE that does not exist. That
-# is only a per-client `::warning::`, so the sweep would report a two-thirds-empty matrix as success —
-# and in corpus mode a baseline with no candidate, i.e. no parity verdict at all. Refuse it up front.
-# (Cross-client comparison lives in single-node mode, which resolves a path per client.) The single-node
-# workflow rejects the same two axes, but it reads the top-level inputs that sweep mode supersedes, so
-# the sweep has to check its own. Widening this means teaching it a per-client snapshot path.
-for entry in $CLIENTS; do
-  if [[ "${entry%%@*}" != "nethermind" ]]; then
-    echo "::error::sweep mode resolves one Nethermind snapshot set, so client '${entry%%@*}' cannot run here"
-    echo "::error::use benchmark_tool=jsonbench (single-node) with client/reference_client for cross-client work"
+# Snapshot root differs per benchmark box (/mnt/sda on amd64, /data/nethermind on arm64); the workflow
+# passes the resolved one. Each client type has its own block-tagged set there, mirroring the
+# single-node path's `<root>/<client>-<block>`; `ctype@image` variants share their type's set, so
+# within one client type the image is the only variable.
+SNAPSHOT_ROOT="${SNAPSHOT_ROOT:-/data/nethermind}"
+NM_LAYOUT_FLAGS="--FlatDb.Enabled=true"
+
+snap_path() {
+  case "$1" in
+    nethermind) printf '%s' "${SNAPSHOT_ROOT}/nethermind-flat-${SNAPSHOT_BLOCK}" ;;
+    *)          printf '%s' "${SNAPSHOT_ROOT}/$1-${SNAPSHOT_BLOCK}" ;;
+  esac
+}
+
+# A client whose snapshot set is absent reaches start-node.sh with a DB_SOURCE that does not exist,
+# and that is only a per-client `::warning::` — the sweep would report a two-thirds-empty matrix as
+# success, and in corpus mode a baseline with no candidate, i.e. no parity verdict at all. Check
+# every requested type up front instead, and only the state_layout axis the request actually uses
+# (a reth-only sweep resolves no Nethermind path, so the flat pin does not apply to it).
+declare -A SWEEP_CTYPES=()
+for entry in $CLIENTS; do SWEEP_CTYPES["${entry%%@*}"]=1; done
+for ctype in "${!SWEEP_CTYPES[@]}"; do
+  case "$ctype" in
+    nethermind|geth|reth) ;;
+    *) echo "::error::unknown sweep client type '${ctype}' (expected nethermind | geth | reth)"; exit 1 ;;
+  esac
+  if [[ ! -d "$(snap_path "$ctype")" ]]; then
+    echo "::error::no ${ctype} snapshot set at $(snap_path "$ctype") — this box cannot serve that client"
+    echo "::error::snapshot sets present under ${SNAPSHOT_ROOT}:"
+    ls -1d "${SNAPSHOT_ROOT}"/*-"${SNAPSHOT_BLOCK}" 2>/dev/null | sed 's|^|::error::  |' || true
     exit 1
   fi
 done
-if [[ "$STATE_LAYOUT" != "flat" ]]; then
-  echo "::error::sweep mode resolves a flat snapshot, so state_layout '${STATE_LAYOUT}' cannot run here"; exit 1
+if [[ -n "${SWEEP_CTYPES[nethermind]:-}" && "$STATE_LAYOUT" != "flat" ]]; then
+  echo "::error::sweep mode resolves a flat Nethermind snapshot, so state_layout '${STATE_LAYOUT}' cannot run here"; exit 1
 fi
-
-# Snapshot root differs per benchmark box (/mnt/sda on amd64, /data/nethermind on arm64); the workflow
-# passes the resolved one. `ctype@image` variants share that set, so the image is the only variable.
-SNAPSHOT_ROOT="${SNAPSHOT_ROOT:-/data/nethermind}"
-SNAPSHOT_PATH="${SNAPSHOT_ROOT}/nethermind-flat-${SNAPSHOT_BLOCK}"
-NM_LAYOUT_FLAGS="--FlatDb.Enabled=true"
-# One isolation mode for every node, so storage counters stay comparable: overlayfs adds a layer and
-# changes readahead and page-cache behaviour, so disk-read-per-request would otherwise measure a
-# harness difference as much as a code one. DB_ISOLATION_ALL forces a specific mode; `copy` is the
+# One isolation mode per client type, so storage counters stay comparable between the images of one
+# type: overlayfs adds a layer and changes readahead and page-cache behaviour, so
+# disk-read-per-request would otherwise measure a harness difference as much as a code one. Across
+# types they can differ (reth cannot use overlay at all, below) — never read a cross-type disk-read
+# delta as a code difference. DB_ISOLATION_ALL forces one mode on every node; `copy` is the
 # overlay-free choice that still leaves the snapshot intact.
 #
 # `direct` is refused without explicit consent. It bind-mounts the snapshot READ-WRITE, and a node's
@@ -133,7 +148,17 @@ if [[ "$DB_ISOLATION_ALL" == "direct" && "$DB_ISOLATION_ALLOW_SNAPSHOT_MUTATION"
   echo "::error::comparison, or set DB_ISOLATION_ALLOW_SNAPSHOT_MUTATION=true on a private snapshot."
   exit 1
 fi
-DB_ISOLATION="${DB_ISOLATION_ALL:-overlay}"
+# reth's DB is a single large mdbx.dat, and its startup write forces overlayfs to copy the whole file
+# up before the node opens (~200 s on the mainnet set, and the copy has to fit on the box), so reth
+# runs `direct` — a read-write bind mount of its own set. That set is reth-only; the refusal above
+# exists because the *Nethermind* sets are shared with expb.
+db_isolation_for() {
+  if [[ -n "$DB_ISOLATION_ALL" ]]; then printf '%s' "$DB_ISOLATION_ALL"; return; fi
+  case "$1" in
+    reth) printf 'direct' ;;
+    *)    printf 'overlay' ;;
+  esac
+}
 
 # One json-bench cell: $1=config (repo-relative) $2=rps $3=duration $4=out dir $5=client
 # $6=label $7=corpus file (empty = normal cell; set = private corpus cell, aggregate-only output)
@@ -280,9 +305,10 @@ for entry in $CLIENTS; do
   docker pull "$img" >/dev/null 2>&1 || echo "pull failed — assuming $img is local"
   cst="$STATE_ROOT/$label"; mkdir -p "$cst"
   cname="rpcbench-sweep-${label}-${GITHUB_RUN_ID:-local}"
-  echo "::group::sweep ${label} (type=${ctype}, image=${img}, db=${SNAPSHOT_PATH}, head=${SNAPSHOT_BLOCK})"
+  snap="$(snap_path "$ctype")"; iso="$(db_isolation_for "$ctype")"
+  echo "::group::sweep ${label} (type=${ctype}, image=${img}, db=${snap}, isolation=${iso}, head=${SNAPSHOT_BLOCK})"
   if ! CLIENT="$ctype" INSTANCE="primary" NODE_IMAGE="$img" \
-       DB_SOURCE="$SNAPSHOT_PATH" DB_ISOLATION="$DB_ISOLATION" \
+       DB_SOURCE="$snap" DB_ISOLATION="$iso" \
        SCRATCH_ROOT="$SCRATCH_ROOT" STATE_DIR="$cst" NETWORK="$NETWORK" \
        JSONRPC_MODULES="$JSONRPC_MODULES" LAYOUT_FLAGS="$NM_LAYOUT_FLAGS" \
        ADDITIONAL_FLAGS="" HEALTH_TIMEOUT="$HEALTH_TIMEOUT" DOTTRACE="false" \

--- a/scripts/rpc-bench/run-rpc-sweep.sh
+++ b/scripts/rpc-bench/run-rpc-sweep.sh
@@ -180,7 +180,7 @@ for ctype in "${!SWEEP_CTYPES[@]}"; do
     "$snap_real"/*) echo "::error::SCRATCH_ROOT must not be inside the ${ctype} snapshot"; exit 1 ;;
   esac
 done
-if [[ ! -d "$SCRATCH_ROOT" ]] && ! as_root mkdir -p -- "$SCRATCH_ROOT"; then
+if [[ ! -d "$SCRATCH_ROOT" ]] && ! mkdir -p -- "$SCRATCH_ROOT" 2>/dev/null && ! as_root mkdir -p -- "$SCRATCH_ROOT"; then
   echo "::error::failed to create SCRATCH_ROOT '$SCRATCH_ROOT'"; exit 1
 fi
 [[ -d "$SCRATCH_ROOT" ]] || { echo "::error::SCRATCH_ROOT '$SCRATCH_ROOT' is not a directory"; exit 1; }

--- a/scripts/rpc-bench/run-rpc-sweep.sh
+++ b/scripts/rpc-bench/run-rpc-sweep.sh
@@ -113,7 +113,7 @@ snap_path() {
 # every requested type up front instead, and only the state_layout axis the request actually uses
 # (a reth-only sweep resolves no Nethermind path, so the flat pin does not apply to it).
 declare -A SWEEP_CTYPES=()
-for entry in $CLIENTS; do SWEEP_CTYPES["${entry%%@*}"]=1; done
+for entry in $CLIENTS; do spec="${entry%%+*}"; SWEEP_CTYPES["${spec%%@*}"]=1; done
 for ctype in "${!SWEEP_CTYPES[@]}"; do
   case "$ctype" in
     nethermind|geth|reth) ;;
@@ -285,23 +285,42 @@ if [[ "$JB_ETH_CALL_CORPUS" == "true" ]]; then
   rm -rf "$PARITY_STATE"; mkdir -p "$PARITY_STATE"
 fi
 
-# Each entry is a client type or 'ctype@image' (e.g. nethermind@nethermindeth/nethermind:master) for
+# Each entry is `ctype[@image][+flag,flag,...]` (e.g. nethermind@nethermindeth/nethermind:master) for
 # same-client version comparisons. Sequential (one node up at a time), so same-snapshot variants are safe.
 # Listing the same image twice is how a sweep measures its own run-to-run drift, so repeats get a
 # distinct label: sharing one would make each repeat overwrite the previous one's cells and state,
 # and the sweep would silently report fewer results than it ran.
+#
+# The `+` segment appends node flags for that arm alone, which is what makes a flag itself A/B-able:
+# the same image can appear twice with different flags, and the flags are part of the label so the
+# two arms neither collide nor need reading from the config to tell apart. `{ARM_SCRATCH}` in a flag
+# expands to an empty per-arm directory (wiped here, not inherited from an earlier arm or dispatch) —
+# a flag pointing a node's storage there measures every arm against the same starting state instead
+# of the state its predecessor left behind. Image tags cannot contain `+`, so the split is unambiguous.
 log_system_provenance
 
 declare -A LABEL_SEEN=()
 for entry in $CLIENTS; do
-  ctype="${entry%%@*}"
-  if [[ "$entry" == *@* ]]; then
-    img="${entry#*@}"; label="${ctype}_$(printf '%s' "${img##*:}" | tr -c 'a-zA-Z0-9' '_')"
+  spec="${entry%%+*}"
+  arm_flags=""
+  [[ "$entry" == *+* ]] && arm_flags="${entry#*+}"
+  arm_flags="${arm_flags//,/ }"
+  ctype="${spec%%@*}"
+  if [[ "$spec" == *@* ]]; then
+    img="${spec#*@}"; label="${ctype}_$(printf '%s' "${img##*:}" | tr -c 'a-zA-Z0-9' '_')"
   else
     img="$NM_IMAGE"; label="$ctype"
   fi
+  [[ -n "$arm_flags" ]] && label="${label}_$(printf '%s' "$arm_flags" | tr -c 'a-zA-Z0-9' '_' | cut -c1-24)"
   LABEL_SEEN["$label"]=$(( ${LABEL_SEEN["$label"]:-0} + 1 ))
   (( ${LABEL_SEEN["$label"]} > 1 )) && label="${label}_r${LABEL_SEEN["$label"]}"
+  if [[ "$arm_flags" == *"{ARM_SCRATCH}"* ]]; then
+    arm_scratch="$SCRATCH_ROOT/arm/$label"
+    assert_no_mounts_under "$arm_scratch"
+    rm -rf "$arm_scratch"; mkdir -p "$arm_scratch"
+    arm_flags="${arm_flags//\{ARM_SCRATCH\}/$arm_scratch}"
+  fi
+  [[ -n "$arm_flags" ]] && echo "arm flags: $arm_flags"
   docker pull "$img" >/dev/null 2>&1 || echo "pull failed — assuming $img is local"
   cst="$STATE_ROOT/$label"; mkdir -p "$cst"
   cname="rpcbench-sweep-${label}-${GITHUB_RUN_ID:-local}"
@@ -311,7 +330,7 @@ for entry in $CLIENTS; do
        DB_SOURCE="$snap" DB_ISOLATION="$iso" \
        SCRATCH_ROOT="$SCRATCH_ROOT" STATE_DIR="$cst" NETWORK="$NETWORK" \
        JSONRPC_MODULES="$JSONRPC_MODULES" LAYOUT_FLAGS="$NM_LAYOUT_FLAGS" \
-       ADDITIONAL_FLAGS="" HEALTH_TIMEOUT="$HEALTH_TIMEOUT" DOTTRACE="false" \
+       ADDITIONAL_FLAGS="$arm_flags" HEALTH_TIMEOUT="$HEALTH_TIMEOUT" DOTTRACE="false" \
        RPC_GAS_CAP="$([[ "$JB_ETH_CALL_CORPUS" == "true" ]] && echo "$CORPUS_RPC_GAS_CAP")" \
        DIAG_DIR="$DIAG_DIR" CONTAINER_NAME="$cname" RPC_PORT="8545" \
        "$here/start-node.sh"; then

--- a/scripts/rpc-bench/start-node.sh
+++ b/scripts/rpc-bench/start-node.sh
@@ -51,6 +51,7 @@ RETH_HTTP_API="${RETH_HTTP_API:-eth,net,web3,debug,trace,txpool}"
 RPC_GAS_CAP="${RPC_GAS_CAP:-1000000000}"
 LAYOUT_FLAGS="${LAYOUT_FLAGS:-}"                   # e.g. --FlatDb.Enabled=true for the flat snapshot (nethermind only)
 ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS:-}"
+ARM_SCRATCH_DIR="${ARM_SCRATCH_DIR:-}"               # optional host directory mounted at this same absolute path
 NODE_ENV_VARS="${NODE_ENV_VARS:-}"                 # extra docker -e assignments, e.g. "DOTNET_TieredCompilation=0"
 NODE_CPUSET="${NODE_CPUSET:-}"                     # e.g. 2-7,10-15 (expb pins the client to these cores)
 NODE_MEMORY="${NODE_MEMORY:-}"                     # e.g. 64g
@@ -75,6 +76,13 @@ mkdir -p "$STATE_DIR"
 # Canonicalize (symlink-proof) and enforce DB_SOURCE / SCRATCH_ROOT sanity and
 # disjointness — scratch is wiped on teardown and must never reach the snapshot.
 guard_paths
+if [[ -n "$ARM_SCRATCH_DIR" ]]; then
+  ARM_SCRATCH_DIR="$(realpath -e -- "$ARM_SCRATCH_DIR")" || die "cannot canonicalize ARM_SCRATCH_DIR '$ARM_SCRATCH_DIR'"
+  assert_sane_dir "$ARM_SCRATCH_DIR" "ARM_SCRATCH_DIR"
+  [[ -d "$ARM_SCRATCH_DIR" ]] || die "ARM_SCRATCH_DIR '$ARM_SCRATCH_DIR' is not a directory"
+  [[ "$ARM_SCRATCH_DIR" != "$SCRATCH_ROOT" && "$ARM_SCRATCH_DIR/" == "$SCRATCH_ROOT/"* ]] \
+    || die "ARM_SCRATCH_DIR must be a child of SCRATCH_ROOT"
+fi
 
 log "=== RPC benchmark node startup ==="
 log "Client:     $CLIENT  (instance: $INSTANCE)"
@@ -103,10 +111,14 @@ db_fingerprint "$DB_SOURCE" "$BASELINE_FILE"
 log "  baseline: $(wc -l < "$BASELINE_FILE") lines, sha256=$(sha256sum "$BASELINE_FILE" | cut -d' ' -f1)"
 
 # Compare against the last cleanly-verified run's fingerprint so a mutation during a
-# hard-interrupted run isn't silently adopted as baseline; drift warns (snapshots get refreshed).
+# hard-interrupted run isn't silently adopted as baseline; direct mode never refreshes this anchor,
+# so any warning there is diagnostic only.
 ANCHOR_DIR="$SCRATCH_ROOT/fingerprints"
 ANCHOR_FILE="$ANCHOR_DIR/$(basename "$DB_SOURCE").txt"
 mkdir -p "$ANCHOR_DIR"
+if [[ "$DB_ISOLATION" == "direct" && -f "$ANCHOR_FILE" ]]; then
+  log "::warning::direct mode does not refresh the fingerprint anchor; any existing anchor is diagnostic only."
+fi
 if [[ -f "$ANCHOR_FILE" ]]; then
   if [[ "$(head -n 1 "$ANCHOR_FILE")" == "$(head -n 1 "$BASELINE_FILE")" ]] \
       && ! diff -q "$ANCHOR_FILE" "$BASELINE_FILE" >/dev/null 2>&1; then
@@ -191,6 +203,7 @@ log "  datadir view: $DATA_DIR_SOURCE  (mounted $MOUNT_OPT into container at $DA
   echo "DB_ISOLATION=$DB_ISOLATION"
   echo "RUN_SCRATCH=$RUN_SCRATCH"
   echo "SCRATCH_ROOT=$SCRATCH_ROOT"
+  echo "ARM_SCRATCH_DIR=$ARM_SCRATCH_DIR"
   echo "DB_SOURCE=$DB_SOURCE"
   echo "DIAG_DIR=$DIAG_DIR"
   echo "DOTTRACE=$DOTTRACE"
@@ -250,8 +263,12 @@ case "$CLIENT" in
     )
     ;;
 esac
-# shellcheck disable=SC2206
-node_args+=($ADDITIONAL_FLAGS)
+if [[ -n "$ADDITIONAL_FLAGS" ]]; then
+  # Flags are whitespace-delimited by the caller; read into an array so values cannot undergo
+  # pathname expansion before Docker receives them.
+  read -r -a additional_args <<< "$ADDITIONAL_FLAGS"
+  node_args+=("${additional_args[@]}")
+fi
 
 docker_args=(
   -d --name "$CONTAINER_NAME"
@@ -262,6 +279,11 @@ docker_args=(
   -p "127.0.0.1:${RPC_PORT}:8545"
   -v "$DATA_DIR_SOURCE:$DATA_MOUNT_TARGET:$MOUNT_OPT"
 )
+if [[ -n "$ARM_SCRATCH_DIR" ]]; then
+  # Keep the host and container paths identical: per-arm flags can point at this path without
+  # accidentally writing into the container's datadir or another arm's scratch.
+  docker_args+=(--mount "type=bind,source=$ARM_SCRATCH_DIR,target=$ARM_SCRATCH_DIR")
+fi
 # Production-default code generation (no DOTNET_* pins); one-off experiments use NODE_ENV_VARS.
 # shellcheck disable=SC2086
 for kv in $NODE_ENV_VARS; do docker_args+=(-e "$kv"); done

--- a/scripts/rpc-bench/start-node.sh
+++ b/scripts/rpc-bench/start-node.sh
@@ -117,7 +117,7 @@ ANCHOR_DIR="$SCRATCH_ROOT/fingerprints"
 ANCHOR_FILE="$ANCHOR_DIR/$(basename "$DB_SOURCE").txt"
 mkdir -p "$ANCHOR_DIR"
 if [[ "$DB_ISOLATION" == "direct" && -f "$ANCHOR_FILE" ]]; then
-  log "::warning::direct mode does not refresh the fingerprint anchor; any existing anchor is diagnostic only."
+  echo "::warning::direct mode does not refresh the fingerprint anchor; any existing anchor is diagnostic only."
 fi
 if [[ -f "$ANCHOR_FILE" ]]; then
   if [[ "$(head -n 1 "$ANCHOR_FILE")" == "$(head -n 1 "$BASELINE_FILE")" ]] \
@@ -266,7 +266,12 @@ esac
 if [[ -n "$ADDITIONAL_FLAGS" ]]; then
   # Flags are whitespace-delimited by the caller; read into an array so values cannot undergo
   # pathname expansion before Docker receives them.
-  read -r -a additional_args <<< "$ADDITIONAL_FLAGS"
+  additional_args=()
+  while IFS= read -r additional_flags_line || [[ -n "$additional_flags_line" ]]; do
+    line_args=()
+    read -r -a line_args <<< "$additional_flags_line"
+    additional_args+=("${line_args[@]}")
+  done <<< "$ADDITIONAL_FLAGS"
   node_args+=("${additional_args[@]}")
 fi
 

--- a/scripts/rpc-bench/test_rpc_sweep.py
+++ b/scripts/rpc-bench/test_rpc_sweep.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+# SPDX-License-Identifier: LGPL-3.0-only
+
+import hashlib
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("run-rpc-sweep.sh")
+START_NODE = Path(__file__).with_name("start-node.sh")
+LIB = Path(__file__).with_name("lib.sh")
+
+
+class RpcSweepTests(unittest.TestCase):
+    @unittest.skipIf(os.name == "nt", "sweep harness tests require POSIX bash")
+    def test_rejects_malformed_flags_before_any_node_starts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            environment = {
+                "OUT_DIR": str(root / "out"),
+                "STATE_ROOT": str(root / "state"),
+                "SCRATCH_ROOT": str(root / "scratch"),
+                "NM_IMAGE": "nethermind:test",
+                "SNAPSHOT_BLOCK": "1",
+                "SNAPSHOT_ROOT": str(root / "snapshots"),
+                "JB_REF": "test",
+                "JB_BENCHMARK_CONFIG": "config.yaml",
+                "CLIENTS": "nethermind+--JsonRpc.EnabledModules=Eth;;Debug",
+                "RPS_LIST": "",
+            }
+            result = subprocess.run(
+                ["bash", str(SCRIPT)], env={**os.environ, **environment},
+                text=True, capture_output=True, check=False,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("malformed flag list", result.stdout)
+        self.assertNotIn("Starting", result.stdout)
+
+    @unittest.skipIf(os.name == "nt", "sweep harness tests require POSIX bash")
+    def test_preserves_comma_values_and_hashes_the_complete_flag_specification(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            runner = root / "runner"
+            runner.mkdir()
+            (runner / "lib.sh").write_bytes(LIB.read_bytes())
+            (runner / "run-rpc-sweep.sh").write_bytes(SCRIPT.read_bytes())
+            (runner / "stop-node.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            (runner / "start-node.sh").write_text(
+                "#!/usr/bin/env bash\n"
+                "printf '%s|%s|%s\\n' \"$(basename \"$STATE_DIR\")\" \"$ADDITIONAL_FLAGS\" \"$ARM_SCRATCH_DIR\" >> \"$CAPTURE\"\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            (fake_bin / "docker").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            for path in (
+                runner / "run-rpc-sweep.sh", runner / "start-node.sh",
+                runner / "stop-node.sh", fake_bin / "docker",
+            ):
+                path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+            scratch = root / "scratch"
+            scratch.mkdir()
+            snapshots = root / "snapshots"
+            (snapshots / "nethermind-flat-1").mkdir(parents=True)
+            capture = root / "capture.txt"
+            first_flags = "--JsonRpc.EnabledModules=Eth,Debug;--LongFlagPrefixThatIsSharedByBothArms=one;--Cache.Path={ARM_SCRATCH}"
+            second_flags = "--JsonRpc.EnabledModules=Eth,Debug;--LongFlagPrefixThatIsSharedByBothArms=two;--Cache.Path={ARM_SCRATCH}"
+            environment = {
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+                "OUT_DIR": str(root / "out"),
+                "STATE_ROOT": str(root / "state"),
+                "SCRATCH_ROOT": str(scratch),
+                "NM_IMAGE": "nethermind:test",
+                "SNAPSHOT_BLOCK": "1",
+                "SNAPSHOT_ROOT": str(snapshots),
+                "JB_REF": "test",
+                "JB_BENCHMARK_CONFIG": "config.yaml",
+                "CLIENTS": f"nethermind@repo:image+{first_flags} nethermind@repo:image+{second_flags}",
+                "RPS_LIST": "",
+                "CAPTURE": str(capture),
+                "JB_ETH_CALL_CORPUS": "false",
+            }
+            result = subprocess.run(
+                ["bash", str(runner / "run-rpc-sweep.sh")],
+                env={**os.environ, **environment}, text=True, capture_output=True, check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            rows = capture.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(rows), 2)
+            labels = [row.split("|", 1)[0] for row in rows]
+            self.assertNotEqual(labels[0], labels[1])
+            self.assertNotIn("_r2", " ".join(labels))
+            self.assertIn(hashlib.sha256(first_flags.encode()).hexdigest()[:12], labels[0])
+            self.assertIn(hashlib.sha256(second_flags.encode()).hexdigest()[:12], labels[1])
+            self.assertIn("--JsonRpc.EnabledModules=Eth,Debug", rows[0])
+            for row, label in zip(rows, labels):
+                _, captured_flags, captured_scratch = row.split("|", 2)
+                self.assertNotIn("{ARM_SCRATCH}", captured_flags)
+                self.assertIn(f"--Cache.Path={captured_scratch}", captured_flags)
+                self.assertEqual(captured_scratch, str(scratch / "arm" / label))
+                self.assertTrue((scratch / "arm" / label).is_dir())
+
+    def test_per_arm_scratch_is_wired_as_an_identical_path_bind_mount(self):
+        sweep = SCRIPT.read_text(encoding="utf-8")
+        start = START_NODE.read_text(encoding="utf-8")
+        self.assertIn('ARM_SCRATCH_DIR="$arm_scratch_dir"', sweep)
+        self.assertIn(
+            'docker_args+=(--mount "type=bind,source=$ARM_SCRATCH_DIR,target=$ARM_SCRATCH_DIR")',
+            start,
+        )
+        self.assertIn("direct mode does not refresh the fingerprint anchor", start)
+        self.assertIn("as_root rm -rf -- \"$arm_scratch_dir\"", sweep)
+        self.assertIn("as_root mkdir -p -- \"$arm_scratch_dir\"", sweep)
+
+    def test_docs_describe_separator_and_direct_sweep_limitations(self):
+        readme = Path(__file__).with_name("README.md").read_text(encoding="utf-8")
+        workflow = Path(__file__).parents[2] / ".github" / "workflows" / "run-rpc-benchmarks.yml"
+        workflow_text = workflow.read_text(encoding="utf-8")
+        self.assertIn("semicolon\nis the flag separator", readme)
+        self.assertIn("order-dependent", readme)
+        self.assertIn("not a clean A/B", readme)
+        self.assertIn("direct reth", readme)
+        self.assertIn("does not refresh the cross-run fingerprint anchor", readme)
+        self.assertIn("old anchor exists", readme)
+        self.assertIn("+flag;flag", workflow_text)
+        self.assertIn("commas stay", workflow_text)
+        self.assertIn("does not refresh the fingerprint anchor", workflow_text)
+        self.assertIn("any old anchor is diagnostic only", workflow_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/rpc-bench/test_rpc_sweep.py
+++ b/scripts/rpc-bench/test_rpc_sweep.py
@@ -60,9 +60,10 @@ class RpcSweepTests(unittest.TestCase):
             fake_bin = root / "bin"
             fake_bin.mkdir()
             (fake_bin / "docker").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            (fake_bin / "sudo").write_text("#!/usr/bin/env bash\nexec \"$@\"\n", encoding="utf-8")
             for path in (
                 runner / "run-rpc-sweep.sh", runner / "start-node.sh",
-                runner / "stop-node.sh", fake_bin / "docker",
+                runner / "stop-node.sh", fake_bin / "docker", fake_bin / "sudo",
             ):
                 path.chmod(path.stat().st_mode | stat.S_IXUSR)
 

--- a/scripts/rpc-bench/test_rpc_sweep.py
+++ b/scripts/rpc-bench/test_rpc_sweep.py
@@ -109,24 +109,33 @@ class RpcSweepTests(unittest.TestCase):
                 self.assertIn(f"--Cache.Path={captured_scratch}", captured_flags)
                 self.assertEqual(captured_scratch, str(scratch / "arm" / label))
                 self.assertTrue((scratch / "arm" / label).is_dir())
+                self.assertEqual(stat.S_IMODE((scratch / "arm" / label).stat().st_mode), 0o777)
 
     def test_per_arm_scratch_is_wired_as_an_identical_path_bind_mount(self):
         sweep = SCRIPT.read_text(encoding="utf-8")
         start = START_NODE.read_text(encoding="utf-8")
-        self.assertIn('ARM_SCRATCH_DIR="$arm_scratch_dir"', sweep)
-        self.assertIn(
-            'docker_args+=(--mount "type=bind,source=$ARM_SCRATCH_DIR,target=$ARM_SCRATCH_DIR")',
+        cleanup = Path(__file__).with_name("cleanup.sh").read_text(encoding="utf-8")
+        self.assertRegex(sweep, r'ARM_SCRATCH_DIR="\$arm_scratch_dir"')
+        self.assertRegex(
             start,
+            r'docker_args\+=\(--mount "type=bind,source=\$ARM_SCRATCH_DIR,target=\$ARM_SCRATCH_DIR"\)',
         )
-        self.assertIn("direct mode does not refresh the fingerprint anchor", start)
-        self.assertIn("as_root rm -rf -- \"$arm_scratch_dir\"", sweep)
-        self.assertIn("as_root mkdir -p -- \"$arm_scratch_dir\"", sweep)
+        self.assertRegex(start, r'(?m)^\s*echo "::warning::direct mode does not refresh the fingerprint anchor;')
+        self.assertRegex(sweep, r'as_root rm -rf -- "\$arm_scratch_dir"')
+        self.assertRegex(sweep, r'as_root mkdir -p -- "\$arm_scratch_dir"')
+        self.assertRegex(sweep, r'as_root chmod 0777 -- "\$arm_scratch_dir"')
+        self.assertRegex(sweep, r'! -w "\$arm_scratch_dir"')
+        self.assertRegex(cleanup, r'(?m)^for sub in .*\barm\b')
+
+        self.assertNotIn('read -r -a additional_args <<< "$ADDITIONAL_FLAGS"', start)
+        self.assertRegex(start, r'while IFS= read -r additional_flags_line .*?\n\s+line_args=\(\)')
+        self.assertIn('additional_args+=("${line_args[@]}")', start)
 
     def test_docs_describe_separator_and_direct_sweep_limitations(self):
         readme = Path(__file__).with_name("README.md").read_text(encoding="utf-8")
         workflow = Path(__file__).parents[2] / ".github" / "workflows" / "run-rpc-benchmarks.yml"
         workflow_text = workflow.read_text(encoding="utf-8")
-        self.assertIn("semicolon\nis the flag separator", readme)
+        self.assertRegex(readme, r"semicolon\s+is the flag separator")
         self.assertIn("order-dependent", readme)
         self.assertIn("not a clean A/B", readme)
         self.assertIn("direct reth", readme)

--- a/scripts/rpc-bench/test_rpc_sweep.py
+++ b/scripts/rpc-bench/test_rpc_sweep.py
@@ -60,7 +60,15 @@ class RpcSweepTests(unittest.TestCase):
             fake_bin = root / "bin"
             fake_bin.mkdir()
             (fake_bin / "docker").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
-            (fake_bin / "sudo").write_text("#!/usr/bin/env bash\nexec \"$@\"\n", encoding="utf-8")
+            (fake_bin / "sudo").write_text(
+                "#!/usr/bin/env bash\n"
+                "if [[ \"$1\" == mkdir && \"${!#}\" == \"$SUDO_ROOT\" ]]; then\n"
+                "  echo \"unexpected privileged SCRATCH_ROOT creation\" >&2\n"
+                "  exit 1\n"
+                "fi\n"
+                "exec \"$@\"\n",
+                encoding="utf-8",
+            )
             for path in (
                 runner / "run-rpc-sweep.sh", runner / "start-node.sh",
                 runner / "stop-node.sh", fake_bin / "docker", fake_bin / "sudo",
@@ -68,7 +76,6 @@ class RpcSweepTests(unittest.TestCase):
                 path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
             scratch = root / "scratch"
-            scratch.mkdir()
             snapshots = root / "snapshots"
             (snapshots / "nethermind-flat-1").mkdir(parents=True)
             capture = root / "capture.txt"
@@ -87,6 +94,7 @@ class RpcSweepTests(unittest.TestCase):
                 "CLIENTS": f"nethermind@repo:image+{first_flags} nethermind@repo:image+{second_flags}",
                 "RPS_LIST": "",
                 "CAPTURE": str(capture),
+                "SUDO_ROOT": str(scratch),
                 "JB_ETH_CALL_CORPUS": "false",
             }
             result = subprocess.run(


### PR DESCRIPTION
## Changes

Restores cross-client sweeps and adds per-arm node flags, both of which came out of using `jsonbench-sweep` to bisect a competing client's `eth_call` performance across ~1100 upstream commits.

**1. A sweep resolves a snapshot set per client type again**

`jsonbench-sweep` was pinned to a single Nethermind flat path, so a `geth`/`reth` entry in `tool_config.clients` was refused outright. That refusal existed because such an entry would otherwise reach `start-node.sh` with a non-existent `DB_SOURCE`, which is only a per-client `::warning::` — the sweep would report a partly-empty matrix as success, and in corpus mode a parity baseline with no candidate.

This restores the pre-corpus-mode `<snapshot root>/<client>-<block>` resolution and fixes the underlying problem properly: every requested client type's set is checked **before any node starts**, so a type the box cannot serve is one clear error listing what is present. The `state_layout` pin is now applied only when a Nethermind arm is actually requested.

Isolation becomes per client type for the same reason it is in the single-node path: reth's DB is one large `mdbx.dat` whose first write forces overlayfs to copy the entire file up before the node opens, so reth runs `direct` against its own (non-expb-shared) set. **The `DB_ISOLATION_ALL=direct` consent guard is untouched** — that guard exists for the Nethermind sets expb shares, and this does not weaken it.

**2. Per-arm node flags: `ctype[@image][+flag,flag,...]`**

The sweep passed `ADDITIONAL_FLAGS=""`, so no node flag could reach a sweep arm at all. An entry may now append `+flag,flag`, applying to that arm alone — which is what makes a node flag itself A/B-able: the same image can appear twice with different flags, and since the flags are part of the label the two arms neither collide nor need reading from the config to tell apart. Image tags cannot contain `+`, so the split is unambiguous.

`{ARM_SCRATCH}` in a flag expands to an empty per-arm directory, wiped here rather than inherited from an earlier arm or dispatch. That is what makes a multi-version ladder against one snapshot possible: older builds of a client often cannot open storage a newer build has already written, so each arm has to start from the same state rather than its predecessor's.

**3. Docs** — the README claimed the sweep refuses non-Nethermind clients and that this runner carries no second client's snapshot. Both are stale: the amd64 box carries `geth-25490000` and `reth-25490000` alongside the Nethermind sets. Also documents the new entry syntax and notes that isolation differs across client types, so a cross-type disk-read delta is a harness difference, not a code one.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

CI-only change, so no unit tests. Exercised on the amd64 runner across ~20 dispatches while bisecting an upstream client, which is what surfaced both gaps:

- **Per-client snapshots**: reth arms started against `/mnt/sda/reth-25490000` and served the 497-record `eth_call` corpus with parity 497/497 and a 0.00% fail rate. A deliberately absent set produced the intended single up-front error listing the available sets, rather than N warnings.
- **Per-arm flags**: verified as an in-run A/B — the same image with and without `--datadir.rocksdb={ARM_SCRATCH}/rocksdb` came out response-identical (parity 497/497 byte-for-byte against the untreated arm) and within the run's A/A floor on latency, while an older build that could not otherwise open the snapshot at all booted and matched all 497 records.
- Entry parsing, `{ARM_SCRATCH}` substitution, label separation and repeat suffixing dry-run locally over the real code path, including the `ctype`-only, `@image`, `+flags` and duplicate-entry cases.
- `bash -n` on `run-rpc-sweep.sh`, YAML parse of the workflow, `git diff --check`.

**Not covered:** no geth arm has been run through a sweep. The geth snapshot set exists and `start-node.sh`'s geth profile is unchanged, but the path is untested here.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

In-repo docs (`scripts/rpc-bench/README.md`, workflow input help) are updated here.

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Both commits are independent: the first restores a capability, the second adds one. Either can be dropped without affecting the other.
