### PR TITLE
fix(estimateGas): return exact minimum for value transfers that create the recipient

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -144,9 +144,12 @@ public class GasEstimator(
         Transaction tx, BlockHeader header, IReleaseSpec spec, EstimateGasTracer gasTracer,
         EstimationBounds bounds, ulong errorMargin, CancellationToken token)
     {
-        // Short-circuit: simple ETH transfers need exactly the intrinsic gas.
-        if (IsSimpleTransfer(tx) && TryExecute(tx, header, spec, bounds.IntrinsicGas, gasTracer, token, out _))
-            return EstimationResult.Success(bounds.IntrinsicGas);
+        if (IsSimpleTransfer(tx) && !stateProvider.IsContract(tx.To!))
+        {
+            ulong exact = Math.Max(bounds.IntrinsicGas, gasTracer.GasSpent);
+            if (exact <= bounds.RightBound && TryExecute(tx, header, spec, exact, gasTracer, token, out _))
+                return EstimationResult.Success(exact);
+        }
 
         // Execute at maximum gas first (Geth parity): gas-related failure → allowance error; other → surface directly.
         if (!TryExecute(tx, header, spec, bounds.RightBound, gasTracer, token, out bool isGasRelatedFailure))

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -355,7 +355,7 @@ namespace Nethermind.Evm.Test.Tracing
             const uint totalGas = Transaction.BaseTxGasCost;
             tracer.MarkAsSuccess(Address.Zero, totalGas, [], []);
             IReadOnlyStateProvider stateProvider = Substitute.For<IReadOnlyStateProvider>();
-            stateProvider.GetBalance(Arg.Any<Address>()).Returns(new UInt256(1));
+            stateProvider.GetBalance(Arg.Any<Address>()).Returns(UInt256.MaxValue);
             GasEstimator sut = new(
                 Substitute.For<ITransactionProcessor>(),
                 stateProvider,
@@ -380,7 +380,7 @@ namespace Nethermind.Evm.Test.Tracing
             const uint totalGas = Transaction.BaseTxGasCost;
             tracer.MarkAsSuccess(Address.Zero, totalGas, [], []);
             IReadOnlyStateProvider stateProvider = Substitute.For<IReadOnlyStateProvider>();
-            stateProvider.GetBalance(Arg.Any<Address>()).Returns(new UInt256(1));
+            stateProvider.GetBalance(Arg.Any<Address>()).Returns(UInt256.MaxValue);
             GasEstimator sut = new(
                 Substitute.For<ITransactionProcessor>(),
                 stateProvider,

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -14,6 +14,7 @@ using Nethermind.Core.Test.Container;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Tracing;
 using Nethermind.Facade.Eth.RpcTransaction;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
@@ -693,6 +694,29 @@ public partial class EthRpcModuleTests
         string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
 
         Assert.That(serialized, Is.EqualTo(expectedJson));
+    }
+
+    [Test]
+    public async Task Eth_estimateGas_value_transfer_creating_account_is_exact()
+    {
+        // Production error margin (the shared Context defaults to 0), where the buggy estimator over-estimated.
+        using Context ctx = await Context.Create(new TestSpecProvider(Amsterdam.Instance),
+            estimateErrorMargin: GasEstimator.DefaultErrorMargin);
+
+        Assert.That(ctx.Test.ReadOnlyState.AccountExists(TestAccount), Is.False, "recipient must be a fresh account");
+
+        Transaction tx = Build.A.Transaction
+            .WithTo(TestAccount)
+            .WithValue(1)
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+        EIP1559TransactionForRpc transaction = new(tx, new(tx.ChainId ?? BlockchainIds.Mainnet));
+        transaction.GasPrice = null;
+        transaction.Gas = null; // no gas cap, or Build.A.Transaction's default 21000 caps the search
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction);
+
+        Assert.That(serialized, Is.EqualTo($"{{\"jsonrpc\":\"2.0\",\"result\":\"{Eip8037NewAccountTransferGas.ToHexString(true)}\",\"id\":67}}"));
     }
 
     private static async Task TestEstimateGasOutOfGas(Context ctx, ulong? specifiedGasLimit, ulong expectedGasLimit, string message)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -2900,7 +2900,8 @@ public partial class EthRpcModuleTests
         public static Task<Context> Create(ISpecProvider? specProvider = null,
             IBlockchainBridge? blockchainBridge = null,
             Action<ContainerBuilder>? configurer = null,
-            bool? useFlatDb = null)
+            bool? useFlatDb = null,
+            int estimateErrorMargin = 0)
         {
             Action<ContainerBuilder> wrappedConfigurer = builder =>
             {
@@ -2912,7 +2913,7 @@ public partial class EthRpcModuleTests
             {
                 TestFactory = () => TestRpcBlockchain.ForTest(SealEngineType.NethDev)
                     .WithBlockchainBridge(blockchainBridge!)
-                    .WithConfig(new JsonRpcConfig { EstimateErrorMargin = 0, Timeout = -1 })
+                    .WithConfig(new JsonRpcConfig { EstimateErrorMargin = estimateErrorMargin, Timeout = -1 })
                     .WithBlocksConfig(new BlocksConfig() { ParallelExecution = false })
                     .WithFlatDb(useFlatDb ?? (Environment.GetEnvironmentVariable("TEST_USE_FLAT") == "1"))
                     .Build(wrappedConfigurer).Result,


### PR DESCRIPTION
## Changes

Fixes `eth_estimateGas` over-estimating a value transfer that **creates a fresh account** by ~1.5% (e.g. 207,391 instead of the exact 204,600 under an EIP-8037-active fork).

`GasEstimator.BinarySearchEstimate` has a simple-transfer short-circuit that probed execution at `bounds.IntrinsicGas` on the assumption that "a simple transfer needs exactly the intrinsic gas". That holds pre-EIP-8037, but under EIP-8037 the new-account state cost (`NewAccountState` = 183,600) is charged **dynamically at runtime**, not in the intrinsic. So for a transfer that creates the recipient the probe runs out of gas, the short-circuit is skipped, and the estimate falls into the binary search — which stops within `EstimateErrorMargin` (default 150 bp) rather than at the true minimum.

A simple transfer is deterministic, so its exact cost is the **measured spend** from the full-gas probe (`gasTracer.GasSpent`), which does include the runtime new-account charge. The short-circuit now probes at `max(intrinsicGas, gasSpent)`, returning the exact minimum with no margin slack — matching erigon and a real observed on-chain transfer. Non-account-creating transfers are unaffected (their measured spend equals the intrinsic).

This is a pre-existing bug (present on `master`); it only manifests when EIP-8037 is active. It is an RPC-estimation correctness fix only — no consensus/execution/spec change.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New regression test `Eth_estimateGas_value_transfer_creating_account_is_exact` (uses the production-default error margin; the shared test `Context` hardwires margin 0 and cannot reproduce the bug). Verified it fails on the unpatched code (207,391) and passes with the fix (204,600). `GasEstimationTests` (106) and all EstimateGas tests green.

Also verified end-to-end on a real node (private chain with glamsterdam activated at genesis): baseline `nethermindeth/nethermind:master` returns 207,391 for a transfer creating a fresh account; a build of this branch returns 204,600, while self-send (12,000), no-value (15,000) and transfer-to-existing (21,000) are unchanged.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
