### PR TITLE
Release native list buffer when construction fails

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Collections/NativeMemoryListTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Collections/NativeMemoryListTests.cs
@@ -234,28 +234,30 @@ public class NativeMemoryListTests
     public void Ref_struct_constructor_releases_pinned_buffer_when_enumeration_throws()
     {
         const int capacity = 16;
-        HandleLeakMarker[] expected = ArrayPool<HandleLeakMarker>.Shared.Rent(capacity);
-        ArrayPool<HandleLeakMarker>.Shared.Return(expected);
+        PoolMarker[] expected = ArrayPool<PoolMarker>.Shared.Rent(capacity);
+        ArrayPool<PoolMarker>.Shared.Return(expected);
 
         Assert.Throws<InvalidOperationException>(ConstructFromThrowingEnumerable);
 
-        HandleLeakMarker[] actual = ArrayPool<HandleLeakMarker>.Shared.Rent(capacity);
+        // The private element type isolates this .NET 10 SharedArrayPool TLS bucket, whose next Rent
+        // returns its most recently returned array; identity therefore proves constructor cleanup.
+        PoolMarker[] actual = ArrayPool<PoolMarker>.Shared.Rent(capacity);
         try
         {
             Assert.That(actual, Is.SameAs(expected));
         }
         finally
         {
-            ArrayPool<HandleLeakMarker>.Shared.Return(actual);
+            ArrayPool<PoolMarker>.Shared.Return(actual);
         }
 
         static void ConstructFromThrowingEnumerable()
         {
-            NativeMemoryListRef<HandleLeakMarker> list = new(capacity, ThrowAfterOneItem());
+            NativeMemoryListRef<PoolMarker> list = new(capacity, ThrowAfterOneItem());
             list.Dispose();
         }
 
-        static IEnumerable<HandleLeakMarker> ThrowAfterOneItem()
+        static IEnumerable<PoolMarker> ThrowAfterOneItem()
         {
             yield return default;
             throw new InvalidOperationException();
@@ -354,5 +356,5 @@ public class NativeMemoryListTests
         static void CtorRef(int bad) { NativeMemoryListRef<int> _ = new(4, bad); }
     }
 
-    private readonly struct HandleLeakMarker;
+    private readonly struct PoolMarker;
 }

--- a/src/Nethermind/Nethermind.Core.Test/Collections/NativeMemoryListTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Collections/NativeMemoryListTests.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
@@ -229,6 +231,38 @@ public class NativeMemoryListTests
     }
 
     [Test]
+    public void Ref_struct_constructor_releases_pinned_buffer_when_enumeration_throws()
+    {
+        const int capacity = 16;
+        HandleLeakMarker[] expected = ArrayPool<HandleLeakMarker>.Shared.Rent(capacity);
+        ArrayPool<HandleLeakMarker>.Shared.Return(expected);
+
+        Assert.Throws<InvalidOperationException>(ConstructFromThrowingEnumerable);
+
+        HandleLeakMarker[] actual = ArrayPool<HandleLeakMarker>.Shared.Rent(capacity);
+        try
+        {
+            Assert.That(actual, Is.SameAs(expected));
+        }
+        finally
+        {
+            ArrayPool<HandleLeakMarker>.Shared.Return(actual);
+        }
+
+        static void ConstructFromThrowingEnumerable()
+        {
+            NativeMemoryListRef<HandleLeakMarker> list = new(capacity, ThrowAfterOneItem());
+            list.Dispose();
+        }
+
+        static IEnumerable<HandleLeakMarker> ThrowAfterOneItem()
+        {
+            yield return default;
+            throw new InvalidOperationException();
+        }
+    }
+
+    [Test]
     public void Empty_constructor_returns_disposable_zero_capacity()
     {
         using NativeMemoryList<int> empty = NativeMemoryList<int>.Empty();
@@ -319,4 +353,6 @@ public class NativeMemoryListTests
 
         static void CtorRef(int bad) { NativeMemoryListRef<int> _ = new(4, bad); }
     }
+
+    private readonly struct HandleLeakMarker;
 }

--- a/src/Nethermind/Nethermind.Core/Collections/NativeMemoryListRef.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/NativeMemoryListRef.cs
@@ -22,7 +22,18 @@ public unsafe ref struct NativeMemoryListRef<T> where T : unmanaged
     private int _capacity;
     private int _count;
 
-    public NativeMemoryListRef(int capacity, IEnumerable<T> items) : this(capacity) => AddRange(items);
+    public NativeMemoryListRef(int capacity, IEnumerable<T> items) : this(capacity)
+    {
+        try
+        {
+            AddRange(items);
+        }
+        catch
+        {
+            Dispose();
+            throw;
+        }
+    }
     public NativeMemoryListRef(int capacity, params ReadOnlySpan<T> items) : this(capacity) => AddRange(items);
     public NativeMemoryListRef(ReadOnlySpan<T> span) : this(span.Length) => AddRange(span);
 


### PR DESCRIPTION
## Changes

- Release the `NativeMemoryListRef<T>` backing buffer before rethrowing when enumerable construction fails.
- Add a regression test that verifies the pinned array is returned to its pool after an enumeration exception.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`dotnet test --project D:\GitHub\nethermind\src\Nethermind\Nethermind.Core.Test\Nethermind.Core.Test.csproj -c release -- --filter FullyQualifiedName~NativeMemoryListTests` (26 passed)

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No