### PR TITLE
ci: fix sedge build on the sync runners (Go proxy 403 on redirected module zips)

### DIFF
--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -204,7 +204,7 @@ jobs:
         run: |
           git clone https://github.com/NethermindEth/sedge.git sedge --branch core --single-branch
           cd sedge
-          make compile
+          make compile-sedge
 
       - name: Run Sedge
         working-directory: sedge

--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -201,6 +201,10 @@ jobs:
           python-version: "3.X"
 
       - name: Install Sedge environment
+        env:
+          # proxy.golang.org serves large module zips as a redirect to storage.googleapis.com,
+          # unreachable from the sync runners; `|` falls back to direct on any error, not just 404/410
+          GOPROXY: https://proxy.golang.org|direct
         run: |
           git clone https://github.com/NethermindEth/sedge.git sedge --branch core --single-branch
           cd sedge

--- a/.github/workflows/sync-pr-gate.yml
+++ b/.github/workflows/sync-pr-gate.yml
@@ -115,6 +115,10 @@ jobs:
 
       - name: Install Sedge
         if: steps.cache-sedge.outputs.cache-hit != 'true'
+        env:
+          # proxy.golang.org serves large module zips as a redirect to storage.googleapis.com,
+          # unreachable from the sync runners; `|` falls back to direct on any error, not just 404/410
+          GOPROXY: https://proxy.golang.org|direct
         run: |
           git clone https://github.com/NethermindEth/sedge.git sedge --branch core --single-branch
           cd sedge

--- a/.github/workflows/sync-pr-gate.yml
+++ b/.github/workflows/sync-pr-gate.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           git clone https://github.com/NethermindEth/sedge.git sedge --branch core --single-branch
           cd sedge
-          make compile
+          make compile-sedge
 
       - name: Download PR image
         uses: actions/download-artifact@v4

--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -189,7 +189,7 @@ jobs:
           echo "Sources downloaded."
           cd sedge
           echo "Building sedge..."
-          make compile
+          make compile-sedge
 
       - name: Run Sedge
         working-directory: sedge

--- a/.github/workflows/sync-supported-chains.yml
+++ b/.github/workflows/sync-supported-chains.yml
@@ -183,6 +183,10 @@ jobs:
           python-version: "3.X"
 
       - name: Install Sedge environment
+        env:
+          # proxy.golang.org serves large module zips as a redirect to storage.googleapis.com,
+          # unreachable from the sync runners; `|` falls back to direct on any error, not just 404/410
+          GOPROXY: https://proxy.golang.org|direct
         run: |
           echo "Downloading sedge sources..."
           git clone https://github.com/NethermindEth/sedge.git sedge --branch core --single-branch


### PR DESCRIPTION
## Changes

Two commits, both scoped to the three workflows that build sedge (`sync-master-validation.yml`, `sync-pr-gate.yml`, `sync-supported-chains.yml`):

1. `make compile` → `make compile-sedge` — drops the `abigen`/`mockgen`/`go generate` prerequisites and the unused `lido-exporter` build.
2. `GOPROXY=https://proxy.golang.org|direct` on the sedge install step — pipe, not comma, so Go falls back to direct git fetches on **any** proxy error.

### The failure

Every `Sync …` job in **Sync Master Validation** has failed at **Install Sedge environment** since 2026-08-22 ([32607638037](https://github.com/NethermindEth/nethermind/actions/runs/32607638037), [32745825843](https://github.com/NethermindEth/nethermind/actions/runs/32745825843)):

```
go install github.com/ethereum/go-ethereum/cmd/abigen@latest
go: ... reading https://proxy.golang.org/github.com/ethereum/go-ethereum/@v/v1.17.5.zip: 403 Forbidden
make: *** [Makefile:78: install-abigen] Error 1
```

The later red steps (`Get Nethermind Debug Logs`, `Upload … artifact` "Input required and not supplied: path", `Get Consensus Logs` `docker: command not found`) are fallout of the node never starting.

### Root cause

The self-hosted sync runners **cannot reach `storage.googleapis.com`**. proxy.golang.org serves small module zips inline but hands out a 302 to GCS for large ones, and every one of those 403s on these runners. Measured against the modules in this build:

| module | proxy response | size | on runner |
|---|---|---|---|
| klauspost/compress@v1.17.2 | 302 → storage.googleapis.com | 39 MB | **403** |
| ferranbt/fastssz@v0.1.3 | 302 → storage.googleapis.com | 36 MB | **403** |
| go-ethereum@v1.14.5 | 302 → storage.googleapis.com | 15 MB | **403** |
| docker/docker@v27.2.0+incompatible | 200 inline | 6.3 MB | ok |
| zrnt, cobra, logrus, … | 200 inline | ≤1 MB | ok |

abigen was merely the first large module in the build order — [run 32747636630](https://github.com/NethermindEth/nethermind/actions/runs/32747636630/job/97497805948), with only commit 1 applied, got past abigen and then 403'd on sedge's own dependencies. Commit 1 alone is necessary but not sufficient.

The reason the default proxy chain cannot recover: in `GOPROXY`, a **comma** falls through only on 404/410; a **pipe** falls through on any error. Verified locally against an always-403 stand-in server:

```
GOPROXY="http://127.0.0.1:8973,direct" go mod download github.com/spf13/cobra@v1.7.0  → exit 1 (403 Forbidden)
GOPROXY="http://127.0.0.1:8973|direct" go mod download github.com/spf13/cobra@v1.7.0  → exit 0
```

Small modules keep the fast inline path; only the redirected ones take the direct git route (~25 s each, measured for all three above, so ~75 s added on a cold module cache). Checksum verification against sum.golang.org is unaffected — the direct fetches were verified with `GOSUMDB` at its default.

### Why only master validation was red

| workflow | `runs-on` | workspace | proxy fetch |
|---|---|---|---|
| sync-pr-gate | `ubuntu-arm64-8-core` (GitHub-hosted) | `/home/runner/work/…` | works |
| sync-master-validation | `matrix.config.runner_label` (self-hosted) | `/root/actions-runner/_work/…` | **403** |
| sync-supported-chains | same self-hosted labels | same | same exposure |

[PR-gate run 32742284000](https://github.com/NethermindEth/nethermind/actions/runs/32742284000/job/97480322084) missed its sedge cache (`Cache not found for input keys: sedge-core-ARM64`), ran the same `make compile`, and pulled go-ethereum v1.17.5 successfully 39 minutes before a master-validation job got 403 on the identical fetch. The pr-gate change is therefore hardening, not a fix — the pipe fallback only engages on an error the comma form would have died on.

### Why `compile-sedge` is safe

- `compile` = `install-mockgen install-abigen generate` + builds of **both** `sedge` and `lido-exporter`; these workflows only invoke `./build/sedge`. The `go build` line for `cmd/sedge/main.go` is identical in both targets.
- Every abigen output is committed on `core` (`CSModule.go`, `CSAccounting.go`, `CSFeeDistributor.go`, `MEVBoostRelayAllowedList.go`, `VEBO.go`, `StakingRouter.go`), and each is dated at or after its `.abi` in git history — nothing regenerated-but-uncommitted.
- `go list -deps ./cmd/sedge` resolves 38 sedge packages plus all externals from the committed tree with zero errors; the abigen-generated lido packages appear in that graph, and no mockgen package does (mocks are test-only).

### Infra follow-up

This PR routes around the block; it does not remove it. Egress from the self-hosted sync runners to `storage.googleapis.com` broke around 2026-08-22 and is worth fixing at the source — until then, any Go dependency large enough to be redirected pays the direct-fetch cost.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

CI is the test: `Install Sedge environment` must get past `make compile-sedge` and `Run Sedge` must start the node. Dispatched on this branch after the second commit; the run with commit 1 alone confirmed the diagnosis by failing one module later.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The `go-version: '1.26'` pin is annotated "Go 1.27 breaks sedge's abigen build". With abigen no longer built that rationale is stale, but I left the pin alone rather than change toolchain behaviour in a fix PR.
