### PR TITLE
Downgrade discovery rate-limiting logs to Trace

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/NettyDiscoveryHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/NettyDiscoveryHandler.cs
@@ -151,13 +151,13 @@ public class NettyDiscoveryHandler(
 
         if (!_globalInboundMessageLimiter.TryAcquire())
         {
-            if (_logger.IsDebug) _logger.Debug($"Rate limiting discovery message globally, type: {type}, sender: {address}");
+            if (_logger.IsTrace) _logger.Trace($"Rate limiting discovery message globally, type: {type}, sender: {address}");
             return false;
         }
 
         if (address is IPEndPoint remoteEndpoint && !TryAcceptInbound(remoteEndpoint))
         {
-            if (_logger.IsDebug) _logger.Debug($"Rate limiting discovery message {type} from {remoteEndpoint}");
+            if (_logger.IsTrace) _logger.Trace($"Rate limiting discovery message {type} from {remoteEndpoint}");
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/Kademlia/KademliaAdapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/Kademlia/KademliaAdapter.cs
@@ -495,7 +495,7 @@ public sealed class KademliaAdapter(
 
         if (!TryAcceptChallenge(endpoint))
         {
-            if (Logger.IsDebug) Logger.Debug($"Rate limiting discv5 WHOAREYOU challenge to {endpoint}.");
+            if (Logger.IsTrace) Logger.Trace($"Rate limiting discv5 WHOAREYOU challenge to {endpoint}.");
             return;
         }
 


### PR DESCRIPTION
## Changes

- Downgrade the discv4 global inbound message limiter log from `Debug` to `Trace` (`NettyDiscoveryHandler`)
- Downgrade the discv4 per-endpoint inbound message limiter log from `Debug` to `Trace` (`NettyDiscoveryHandler`)
- Downgrade the discv5 WHOAREYOU challenge limiter log from `Debug` to `Trace` (`KademliaAdapter`)

Dropping packets at these limiters is routine on a public node — each one logged a line at `Debug`, which floods debug-level logs without giving the operator anything actionable. `Trace` keeps them available for diagnosing a suspected limiter misconfiguration.

These are the only rate-limiting sites in the codebase that log; the other limiters (discv4 outbound `RateLimiter`, `PeerManager`/`PeerPool`, `TxBroadcaster`) are silent when they throttle.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Log level adjustment

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Log-level only; no behavior change. No test asserts on these messages.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
