### PR TITLE
fix(simulate): flaky eth_simulateV1 parent when a block body write is pending

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateDictionaryBlockStore.cs
@@ -9,7 +9,10 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Facade.Simulate;
 
-public class SimulateDictionaryBlockStore(IBlockStore readonlyBaseBlockStore) : IBlockStore
+/// <remarks>
+/// The base store is the node's live writable one, so every mutator must stay overridden here.
+/// </remarks>
+public class SimulateDictionaryBlockStore(IBlockStore baseBlockStore) : IBlockStore
 {
     private readonly Dictionary<Hash256AsKey, Block> _blockDict = [];
     private readonly Dictionary<ulong, Block> _blockNumDict = [];
@@ -53,7 +56,7 @@ public class SimulateDictionaryBlockStore(IBlockStore readonlyBaseBlockStore) : 
             return block;
         }
 
-        block = readonlyBaseBlockStore.Get(blockNumber, blockHash, rlpBehaviors, false);
+        block = baseBlockStore.Get(blockNumber, blockHash, rlpBehaviors, false);
         if (block is not null && shouldCache)
         {
             Cache(block);
@@ -67,17 +70,17 @@ public class SimulateDictionaryBlockStore(IBlockStore readonlyBaseBlockStore) : 
         {
             return _blockDecoder.EncodeAsBytes(block);
         }
-        return readonlyBaseBlockStore.GetRlp(blockNumber, blockHash);
+        return baseBlockStore.GetRlp(blockNumber, blockHash);
     }
 
     public ReceiptRecoveryBlock? GetReceiptRecoveryBlock(ulong blockNumber, Hash256 blockHash) =>
         _blockNumDict.TryGetValue(blockNumber, out Block block)
             ? new ReceiptRecoveryBlock(block)
-            : readonlyBaseBlockStore.GetReceiptRecoveryBlock(blockNumber, blockHash);
+            : baseBlockStore.GetReceiptRecoveryBlock(blockNumber, blockHash);
 
     public void Cache(Block block)
         => Insert(block);
 
     public bool HasBlock(ulong blockNumber, Hash256 blockHash)
-        => _blockNumDict.ContainsKey(blockNumber) || readonlyBaseBlockStore.HasBlock(blockNumber, blockHash);
+        => _blockNumDict.ContainsKey(blockNumber) || baseBlockStore.HasBlock(blockNumber, blockHash);
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateReadOnlyBlocksProcessingEnvFactory.cs
@@ -30,6 +30,7 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
     IOverridableEnvFactory overridableEnvFactory,
     ILifetimeScope rootLifetimeScope,
     IReadOnlyBlockTree baseBlockTree,
+    IBlockStore baseBlockStore,
     IDbProvider dbProvider,
     ISpecProvider specProvider,
     IReadOnlyList<IBlockValidationModule> validationModules,
@@ -45,7 +46,7 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
 
         IBlockAccessListStore mainBalStore = new BlockAccessListStore(editableDbProvider.BlockAccessListDb);
 
-        BlockTree tempBlockTree = CreateTempBlockTree(editableDbProvider, specProvider, logManager, editableDbProvider, tmpHeaderStore, mainBalStore);
+        BlockTree tempBlockTree = CreateTempBlockTree(editableDbProvider, specProvider, logManager, editableDbProvider, tmpHeaderStore, mainBalStore, baseBlockStore);
         BlockTreeOverlay overrideBlockTree = new(baseBlockTree, tempBlockTree);
 
         ILifetimeScope envLifetimeScope = rootLifetimeScope.BeginLifetimeScope((builder) => builder
@@ -92,13 +93,13 @@ public class SimulateReadOnlyBlocksProcessingEnvFactory(
         ILogManager logManager,
         IReadOnlyDbProvider editableDbProvider,
         SimulateDictionaryHeaderStore tmpHeaderStore,
-        IBlockAccessListStore tmpBalStore)
+        IBlockAccessListStore tmpBalStore,
+        IBlockStore baseBlockStore)
     {
         IHeaderDecoder headerDecoder = (IHeaderDecoder)Rlp.GetDecoderOrThrow<BlockHeader>();
-        IBlockStore mainBlockStore = new BlockStore(editableDbProvider.BlocksDb, headerDecoder);
         const int badBlocksStored = 1;
 
-        SimulateDictionaryBlockStore tmpBlockStore = new(mainBlockStore);
+        SimulateDictionaryBlockStore tmpBlockStore = new(baseBlockStore);
         IBadBlockStore badBlockStore = new BadBlockStore(editableDbProvider.BadBlocksDb, badBlocksStored, headerDecoder);
 
         return new(tmpBlockStore,

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -275,6 +276,59 @@ public class EthSimulateTestsBlocksAndTransactions
     private sealed class GenesisOnlyRpcBlockchain : TestRpcBlockchain
     {
         protected override Task AddBlocksOnStart() => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Genesis persisted, the block below still queued: a body is readable only through the store that queued
+    /// its deferred write, so eth_simulateV1 must read through that store or silently build on an older parent.
+    /// </summary>
+    [Test]
+    public async Task Test_eth_simulateV1_builds_on_requested_parent_while_its_body_write_is_pending()
+    {
+        PausedDeferredBlockDataWriter deferredWriter = new();
+        TestRpcBlockchain chain = await TestRpcBlockchain
+            .ForTest(new GenesisOnlyRpcBlockchain())
+            .Build((builder) => builder
+                .AddSingleton<ISpecProvider>(new TestSpecProvider(London.Instance))
+                .AddSingleton<IDeferredBlockDataWriter>(deferredWriter));
+
+        deferredWriter.Drain();
+        Block parent = await chain.AddBlock();
+
+        SimulatePayload<TransactionForRpc> payload = new() { BlockStateCalls = [new()] };
+
+        SimulateBlockResult<SimulateCallResult> simulated =
+            chain.EthRpcModule.eth_simulateV1(payload, new BlockParameter(parent.Number)).Data[0];
+
+        Assert.That(simulated.ParentHash, Is.EqualTo(parent.Hash));
+        Assert.That(simulated.Number, Is.EqualTo(parent.Number + 1));
+    }
+
+    private sealed class PausedDeferredBlockDataWriter : IDeferredBlockDataWriter
+    {
+        private readonly List<Action> _queued = [];
+
+        public bool Enabled => true;
+
+        public void Enqueue(Action work)
+        {
+            lock (_queued) _queued.Add(work);
+        }
+
+        public void Drain()
+        {
+            lock (_queued)
+            {
+                foreach (Action work in _queued) work();
+                _queued.Clear();
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Drain();
+            return ValueTask.CompletedTask;
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -317,11 +317,14 @@ public class EthSimulateTestsBlocksAndTransactions
 
         public void Drain()
         {
+            Action[] pending;
             lock (_queued)
             {
-                foreach (Action work in _queued) work();
+                pending = [.. _queued];
                 _queued.Clear();
             }
+
+            foreach (Action work in pending) work();
         }
 
         public ValueTask DisposeAsync()


### PR DESCRIPTION
## Changes

- Fixed the flaky `TestSimulate_TimestampIsComputedCorrectly_WhenNoTimestampOverride`.
- Why it was flaky: a block body is only readable through the store that queued its deferred write. The simulate env used its own `BlockStore` over the same DB, so it saw the chain ending at the last flushed block. Its head fell back to genesis and `GetParent` silently built on that instead of the requested parent. Whether the background write had landed is timing, so the test failed at random. A live node can answer `eth_simulateV1` on the wrong parent the same way.
- Fix: read blocks through the node's `IBlockStore`. Writes still go to `SimulateDictionaryBlockStore`, so simulate stays isolated.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No