### PR TITLE
perf(db): single-call RocksDB point reads via rocksdb_get_into_buffer

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -820,46 +820,100 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     private DisposableLazy<IteratorManager> CreateLazyIteratorManager(ColumnFamilyHandle? cf, ReadOptions readOptions) =>
         new(() => new IteratorManager(_db, cf, readOptions));
 
+    /// <summary>
+    /// Stack-buffer size for the single-call read fast path; values larger than this are re-read through the pinned API.
+    /// </summary>
+    internal const int GetStackBufferSize = 1024;
+
+    [SkipLocalsInit]
     internal unsafe byte[]? Get(ReadOnlySpan<byte> key, ColumnFamilyHandle? cf, ReadOptions readOptions)
     {
-        // TODO: update when merged upstream: https://github.com/curiosity-ai/rocksdb-sharp/pull/61
-        // return _db.Get(key, cf, (flags & ReadFlags.HintCacheMiss) != 0 ? _hintCacheMissOptions : _defaultReadOptions);
+        const int StackBufferSize = GetStackBufferSize;
 
         nint db = _db.Handle;
-        nint read_options = readOptions.Handle;
-        UIntPtr skLength = (UIntPtr)key.Length;
-        IntPtr handle;
-        IntPtr errPtr;
-        fixed (byte* ptr = &MemoryMarshal.GetReference(key))
+        nint readOptionsHandle = readOptions.Handle;
+        nint cfHandle = cf?.Handle ?? 0;
+
+        byte* buffer = stackalloc byte[StackBufferSize];
+
+        nuint valueLength;
+        byte found;
+
+        byte fits;
+
+        fixed (byte* keyPtr = &MemoryMarshal.GetReference(key))
         {
-            handle = cf is null
-                ? Native.Instance.rocksdb_get_pinned(db, read_options, ptr, skLength, out errPtr)
-                : Native.Instance.rocksdb_get_pinned_cf(db, read_options, cf.Handle, ptr, skLength, out errPtr);
+            fits = cfHandle != 0
+                ? Native.Instance.rocksdb_get_into_buffer_cf(
+                    db,
+                    readOptionsHandle,
+                    cfHandle,
+                    (nint)keyPtr,
+                    (nuint)key.Length,
+                    (nint)buffer,
+                    (nuint)StackBufferSize,
+                    out valueLength,
+                    out found)
+                : Native.Instance.rocksdb_get_into_buffer(
+                    db,
+                    readOptionsHandle,
+                    (nint)keyPtr,
+                    (nuint)key.Length,
+                    (nint)buffer,
+                    (nuint)StackBufferSize,
+                    out valueLength,
+                    out found);
         }
 
-        if (errPtr != IntPtr.Zero) ThrowRocksDbException(errPtr);
-        if (handle == IntPtr.Zero) return null;
+        if (found == 0)
+            return null;
 
-        try
+        int length = checked((int)valueLength);
+
+        if (fits == 0)
+            return GetLarge(db, readOptionsHandle, cfHandle, key);
+
+        byte[] result = GC.AllocateUninitializedArray<byte>(length);
+        new ReadOnlySpan<byte>(buffer, length).CopyTo(result);
+
+        return result;
+
+        // The value may have been rewritten since the probe call reported its size, so re-read through the
+        // pinned API and size the result from the pinned value rather than trusting the earlier length.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static byte[]? GetLarge(
+            nint db,
+            nint readOptionsHandle,
+            nint cfHandle,
+            ReadOnlySpan<byte> key)
         {
-            IntPtr valuePtr = Native.Instance.rocksdb_pinnableslice_value(handle, out UIntPtr valueLength);
-            if (valuePtr == IntPtr.Zero)
+            IntPtr handle;
+            fixed (byte* keyPtr = &MemoryMarshal.GetReference(key))
             {
-                return null;
+                handle = cfHandle != 0
+                    ? Native.Instance.rocksdb_get_pinned_cf_v2(db, readOptionsHandle, cfHandle, keyPtr, (nuint)key.Length)
+                    : Native.Instance.rocksdb_get_pinned_v2(db, readOptionsHandle, keyPtr, (nuint)key.Length);
             }
 
-            int length = (int)valueLength;
-            byte[] result = new byte[length];
-            new ReadOnlySpan<byte>((void*)valuePtr, length).CopyTo(new Span<byte>(result));
-            return result;
-        }
-        finally
-        {
-            Native.Instance.rocksdb_pinnableslice_destroy(handle);
-        }
+            if (handle == IntPtr.Zero)
+                return null;
 
-        [DoesNotReturn, StackTraceHidden]
-        static void ThrowRocksDbException(nint errPtr) => throw new RocksDbException(errPtr);
+            try
+            {
+                IntPtr valuePtr = Native.Instance.rocksdb_pinnable_handle_get_value(handle, out UIntPtr valueLength);
+                if (valuePtr == IntPtr.Zero)
+                    return null;
+
+                int length = checked((int)valueLength);
+                byte[] result = GC.AllocateUninitializedArray<byte>(length);
+                new ReadOnlySpan<byte>((void*)valuePtr, length).CopyTo(result);
+                return result;
+            }
+            finally
+            {
+                Native.Instance.rocksdb_pinnable_handle_destroy(handle);
+            }
+        }
     }
 
     /// <summary>
@@ -1015,41 +1069,45 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
         UpdateReadMetrics();
 
-        nint db = _db.Handle;
-        nint readOptionsHandle = readOptions.Handle;
-        UIntPtr skLength = (UIntPtr)key.Length;
-        IntPtr errPtr;
-        IntPtr slice;
-        fixed (byte* ptr = &MemoryMarshal.GetReference(key))
+        nuint valueLength;
+        byte found;
+        byte fits;
+
+        fixed (byte* keyPtr = &MemoryMarshal.GetReference(key))
+        fixed (byte* outputPtr = &MemoryMarshal.GetReference(output))
         {
-            slice = cf is null
-                ? Native.Instance.rocksdb_get_pinned(db, readOptionsHandle, ptr, skLength, out errPtr)
-                : Native.Instance.rocksdb_get_pinned_cf(db, readOptionsHandle, cf.Handle, ptr, skLength, out errPtr);
+            nint db = _db.Handle;
+            nint readOptionsHandle = readOptions.Handle;
+            nint cfHandle = cf?.Handle ?? 0;
+
+            fits = cfHandle != 0
+                ? Native.Instance.rocksdb_get_into_buffer_cf(
+                    db,
+                    readOptionsHandle,
+                    cfHandle,
+                    (nint)keyPtr,
+                    (nuint)key.Length,
+                    (nint)outputPtr,
+                    (nuint)output.Length,
+                    out valueLength,
+                    out found)
+                : Native.Instance.rocksdb_get_into_buffer(
+                    db,
+                    readOptionsHandle,
+                    (nint)keyPtr,
+                    (nuint)key.Length,
+                    (nint)outputPtr,
+                    (nuint)output.Length,
+                    out valueLength,
+                    out found);
         }
 
-        if (errPtr != IntPtr.Zero) ThrowRocksDbException(errPtr);
-        if (slice == IntPtr.Zero) return 0;
+        if (found == 0) return 0;
 
-        IntPtr valuePtr = Native.Instance.rocksdb_pinnableslice_value(slice, out UIntPtr valueLength);
-        if (valuePtr == IntPtr.Zero)
-        {
-            Native.Instance.rocksdb_pinnableslice_destroy(slice);
-            return 0;
-        }
+        int length = checked((int)valueLength);
+        if (fits == 0) ThrowNotEnoughMemory(length, output.Length);
 
-        int length = (int)valueLength;
-        if (output.Length < length)
-        {
-            Native.Instance.rocksdb_pinnableslice_destroy(slice);
-            ThrowNotEnoughMemory(length, output.Length);
-        }
-
-        new ReadOnlySpan<byte>((void*)valuePtr, length).CopyTo(output);
-        Native.Instance.rocksdb_pinnableslice_destroy(slice);
         return length;
-
-        [DoesNotReturn, StackTraceHidden]
-        static void ThrowRocksDbException(nint errPtr) => throw new RocksDbException(errPtr);
 
         [DoesNotReturn, StackTraceHidden]
         static void ThrowNotEnoughMemory(int length, int bufferLength) =>
@@ -1122,8 +1180,8 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         fixed (byte* ptr = &MemoryMarshal.GetReference(key))
         {
             slice = cf is null
-                ? Native.Instance.rocksdb_get_pinned(db, read_options, ptr, skLength, out errPtr)
-                : Native.Instance.rocksdb_get_pinned_cf(db, read_options, cf.Handle, ptr, skLength, out errPtr);
+                ? Native.Instance.rocksdb_get_pinned_v2(db, read_options, ptr, skLength, out errPtr)
+                : Native.Instance.rocksdb_get_pinned_cf_v2(db, read_options, cf.Handle, ptr, skLength, out errPtr);
         }
 
         if (errPtr != IntPtr.Zero) ThrowRocksDbException(errPtr);
@@ -1131,10 +1189,10 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
         try
         {
-            IntPtr valuePtr = Native.Instance.rocksdb_pinnableslice_value(slice, out UIntPtr valueLength);
+            IntPtr valuePtr = Native.Instance.rocksdb_pinnable_handle_get_value(slice, out UIntPtr valueLength);
             if (valuePtr == IntPtr.Zero)
             {
-                Native.Instance.rocksdb_pinnableslice_destroy(slice);
+                Native.Instance.rocksdb_pinnable_handle_destroy(slice);
                 return null;
             }
 
@@ -1144,7 +1202,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         }
         catch
         {
-            Native.Instance.rocksdb_pinnableslice_destroy(slice);
+            Native.Instance.rocksdb_pinnable_handle_destroy(slice);
             throw;
         }
 
@@ -1155,7 +1213,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     public void DangerousReleaseHandle(IntPtr handle)
     {
         if (handle != default)
-            Native.Instance.rocksdb_pinnableslice_destroy(handle);
+            Native.Instance.rocksdb_pinnable_handle_destroy(handle);
     }
 
     public void Remove(ReadOnlySpan<byte> key)

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -820,99 +820,41 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
     private DisposableLazy<IteratorManager> CreateLazyIteratorManager(ColumnFamilyHandle? cf, ReadOptions readOptions) =>
         new(() => new IteratorManager(_db, cf, readOptions));
 
-    /// <summary>
-    /// Stack-buffer size for the single-call read fast path; values larger than this are re-read through the pinned API.
-    /// </summary>
-    internal const int GetStackBufferSize = 1024;
-
-    [SkipLocalsInit]
     internal unsafe byte[]? Get(ReadOnlySpan<byte> key, ColumnFamilyHandle? cf, ReadOptions readOptions)
     {
-        const int StackBufferSize = GetStackBufferSize;
-
         nint db = _db.Handle;
         nint readOptionsHandle = readOptions.Handle;
         nint cfHandle = cf?.Handle ?? 0;
 
-        byte* buffer = stackalloc byte[StackBufferSize];
-
-        nuint valueLength;
-        byte found;
-
-        byte fits;
-
+        // The key remains pinned for the native call, and the returned value remains valid until the handle is destroyed.
+        IntPtr handle;
         fixed (byte* keyPtr = &MemoryMarshal.GetReference(key))
         {
-            fits = cfHandle != 0
-                ? Native.Instance.rocksdb_get_into_buffer_cf(
-                    db,
-                    readOptionsHandle,
-                    cfHandle,
-                    (nint)keyPtr,
-                    (nuint)key.Length,
-                    (nint)buffer,
-                    (nuint)StackBufferSize,
-                    out valueLength,
-                    out found)
-                : Native.Instance.rocksdb_get_into_buffer(
-                    db,
-                    readOptionsHandle,
-                    (nint)keyPtr,
-                    (nuint)key.Length,
-                    (nint)buffer,
-                    (nuint)StackBufferSize,
-                    out valueLength,
-                    out found);
+            handle = cfHandle != 0
+                ? Native.Instance.rocksdb_get_pinned_cf_v2(db, readOptionsHandle, cfHandle, keyPtr, (nuint)key.Length)
+                : Native.Instance.rocksdb_get_pinned_v2(db, readOptionsHandle, keyPtr, (nuint)key.Length);
         }
 
-        if (found == 0)
+        if (handle == IntPtr.Zero)
             return null;
 
-        int length = checked((int)valueLength);
-
-        if (fits == 0)
-            return GetLarge(db, readOptionsHandle, cfHandle, key);
-
-        byte[] result = GC.AllocateUninitializedArray<byte>(length);
-        new ReadOnlySpan<byte>(buffer, length).CopyTo(result);
-
-        return result;
-
-        // The value may have been rewritten since the probe call reported its size, so re-read through the
-        // pinned API and size the result from the pinned value rather than trusting the earlier length.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static byte[]? GetLarge(
-            nint db,
-            nint readOptionsHandle,
-            nint cfHandle,
-            ReadOnlySpan<byte> key)
+        try
         {
-            IntPtr handle;
-            fixed (byte* keyPtr = &MemoryMarshal.GetReference(key))
-            {
-                handle = cfHandle != 0
-                    ? Native.Instance.rocksdb_get_pinned_cf_v2(db, readOptionsHandle, cfHandle, keyPtr, (nuint)key.Length)
-                    : Native.Instance.rocksdb_get_pinned_v2(db, readOptionsHandle, keyPtr, (nuint)key.Length);
-            }
+            IntPtr valuePtr = Native.Instance.rocksdb_pinnable_handle_get_value(handle, out UIntPtr valueLength);
+            int length = checked((int)valueLength);
+            if (length == 0)
+                return [];
 
-            if (handle == IntPtr.Zero)
+            if (valuePtr == IntPtr.Zero)
                 return null;
 
-            try
-            {
-                IntPtr valuePtr = Native.Instance.rocksdb_pinnable_handle_get_value(handle, out UIntPtr valueLength);
-                if (valuePtr == IntPtr.Zero)
-                    return null;
-
-                int length = checked((int)valueLength);
-                byte[] result = GC.AllocateUninitializedArray<byte>(length);
-                new ReadOnlySpan<byte>((void*)valuePtr, length).CopyTo(result);
-                return result;
-            }
-            finally
-            {
-                Native.Instance.rocksdb_pinnable_handle_destroy(handle);
-            }
+            byte[] result = GC.AllocateUninitializedArray<byte>(length);
+            new ReadOnlySpan<byte>((void*)valuePtr, length).CopyTo(result);
+            return result;
+        }
+        finally
+        {
+            Native.Instance.rocksdb_pinnable_handle_destroy(handle);
         }
     }
 
@@ -1072,13 +1014,16 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         nuint valueLength;
         byte found;
         byte fits;
+        byte emptyOutput = 0;
 
+        // Both spans remain pinned for the native call, which copies only when the complete value fits in output.
         fixed (byte* keyPtr = &MemoryMarshal.GetReference(key))
         fixed (byte* outputPtr = &MemoryMarshal.GetReference(output))
         {
             nint db = _db.Handle;
             nint readOptionsHandle = readOptions.Handle;
             nint cfHandle = cf?.Handle ?? 0;
+            byte* destination = output.IsEmpty ? &emptyOutput : outputPtr;
 
             fits = cfHandle != 0
                 ? Native.Instance.rocksdb_get_into_buffer_cf(
@@ -1087,7 +1032,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                     cfHandle,
                     (nint)keyPtr,
                     (nuint)key.Length,
-                    (nint)outputPtr,
+                    (nint)destination,
                     (nuint)output.Length,
                     out valueLength,
                     out found)
@@ -1096,7 +1041,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
                     readOptionsHandle,
                     (nint)keyPtr,
                     (nuint)key.Length,
-                    (nint)outputPtr,
+                    (nint)destination,
                     (nuint)output.Length,
                     out valueLength,
                     out found);
@@ -1104,13 +1049,12 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
         if (found == 0) return 0;
 
-        int length = checked((int)valueLength);
-        if (fits == 0) ThrowNotEnoughMemory(length, output.Length);
+        if (fits == 0 || valueLength > (nuint)output.Length) ThrowNotEnoughMemory(valueLength, output.Length);
 
-        return length;
+        return checked((int)valueLength);
 
         [DoesNotReturn, StackTraceHidden]
-        static void ThrowNotEnoughMemory(int length, int bufferLength) =>
+        static void ThrowNotEnoughMemory(nuint length, int bufferLength) =>
             throw new ArgumentException($"Output buffer not large enough. Output size: {length}, Buffer size: {bufferLength}");
     }
 

--- a/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/DbOnTheRocks.cs
@@ -841,7 +841,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
         try
         {
             IntPtr valuePtr = Native.Instance.rocksdb_pinnable_handle_get_value(handle, out UIntPtr valueLength);
-            int length = checked((int)valueLength);
+            int length = (int)valueLength;
             if (length == 0)
                 return [];
 
@@ -1051,7 +1051,7 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
         if (fits == 0 || valueLength > (nuint)output.Length) ThrowNotEnoughMemory(valueLength, output.Length);
 
-        return checked((int)valueLength);
+        return (int)valueLength;
 
         [DoesNotReturn, StackTraceHidden]
         static void ThrowNotEnoughMemory(nuint length, int bufferLength) =>
@@ -1112,9 +1112,6 @@ public partial class DbOnTheRocks : IDb, ITunableDb, IReadOnlyNativeKeyValueStor
 
     public unsafe ReadOnlySpan<byte> GetNativeSlice(scoped ReadOnlySpan<byte> key, ColumnFamilyHandle? cf, out IntPtr handle, ReadFlags flags)
     {
-        // TODO: update when merged upstream: https://github.com/curiosity-ai/rocksdb-sharp/pull/61
-        // return _db.Get(key, cf, (flags & ReadFlags.HintCacheMiss) != 0 ? _hintCacheMissOptions : _defaultReadOptions);
-
         handle = default;
         nint db = _db.Handle;
         nint read_options = ((flags & ReadFlags.HintCacheMiss) != 0 ? _hintCacheMissOptions : _defaultReadOptions).Handle;

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -683,19 +683,62 @@ namespace Nethermind.Db.Test
             AssertCanGetViaAllMethod(_db, [2, 3, 4], [5, 6, 7]);
         }
 
-        // Straddles the stack buffer of the single-call Get fast path; the last case exercises the pinned large-value path.
         [TestCase(1)]
-        [TestCase(DbOnTheRocks.GetStackBufferSize - 1)]
-        [TestCase(DbOnTheRocks.GetStackBufferSize)]
-        [TestCase(DbOnTheRocks.GetStackBufferSize + 1)]
-        [TestCase(DbOnTheRocks.GetStackBufferSize * 8)]
-        public void Smoke_test_value_size_boundaries(int valueSize)
+        [TestCase(1024)]
+        [TestCase(8192)]
+        public void Smoke_test_value_sizes(int valueSize)
         {
             byte[] value = new byte[valueSize];
             new Random(valueSize).NextBytes(value);
 
             _db[[1, 2, 3]] = value;
             AssertCanGetViaAllMethod(_db, [1, 2, 3], value);
+        }
+
+        [Test]
+        public void Missing_value_uses_existing_get_semantics()
+        {
+            byte[] output = [0xA5, 0xA5, 0xA5];
+            byte[]? value = _db.Get([1, 2, 3]);
+            int length = _db.Get([1, 2, 3], output);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(value, Is.Null);
+                Assert.That(length, Is.Zero);
+                Assert.That(output, Is.EqualTo(new byte[] { 0xA5, 0xA5, 0xA5 }));
+            }
+        }
+
+        [TestCase(0)]
+        [TestCase(3)]
+        public void C_style_get_rejects_undersized_output_without_modifying_it(int outputSize)
+        {
+            byte[] key = [1, 2, 3];
+            _db[key] = [4, 5, 6, 7];
+            byte[] output = new byte[outputSize];
+            Array.Fill(output, (byte)0xA5);
+            byte[] expectedOutput = (byte[])output.Clone();
+
+            Assert.That(() => _db.Get(key, output), Throws.ArgumentException);
+            Assert.That(output, Is.EqualTo(expectedOutput));
+        }
+
+        [Test]
+        public void Empty_value_round_trips_without_modifying_output()
+        {
+            byte[] key = [1, 2, 3];
+            _db[key] = [];
+            byte[] output = [0xA5];
+            byte[]? value = _db.Get(key);
+            int length = _db.Get(key, output);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(value, Is.Empty);
+                Assert.That(length, Is.Zero);
+                Assert.That(output, Is.EqualTo(new byte[] { 0xA5 }));
+            }
         }
 
         [Test(Description = "Different kind of ceiling seeks using pooled iterators on a mutable db")]

--- a/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/DbOnTheRocksTests.cs
@@ -683,6 +683,21 @@ namespace Nethermind.Db.Test
             AssertCanGetViaAllMethod(_db, [2, 3, 4], [5, 6, 7]);
         }
 
+        // Straddles the stack buffer of the single-call Get fast path; the last case exercises the pinned large-value path.
+        [TestCase(1)]
+        [TestCase(DbOnTheRocks.GetStackBufferSize - 1)]
+        [TestCase(DbOnTheRocks.GetStackBufferSize)]
+        [TestCase(DbOnTheRocks.GetStackBufferSize + 1)]
+        [TestCase(DbOnTheRocks.GetStackBufferSize * 8)]
+        public void Smoke_test_value_size_boundaries(int valueSize)
+        {
+            byte[] value = new byte[valueSize];
+            new Random(valueSize).NextBytes(value);
+
+            _db[[1, 2, 3]] = value;
+            AssertCanGetViaAllMethod(_db, [1, 2, 3], value);
+        }
+
         [Test(Description = "Different kind of ceiling seeks using pooled iterators on a mutable db")]
         public void TryGetCeiling_sees_writes_made_after_the_pooled_iterator_was_created([Values] bool midFlush, [Values] bool postFlush)
         {


### PR DESCRIPTION
## Changes

- `DbOnTheRocks.Get` now uses `rocksdb_get_pinned(_cf)_v2` with the matching `rocksdb_pinnable_handle_*` accessor and destroy functions. Every array-returning read performs one `DB::Get`, sizes the managed array from that pinned result, copies once into managed memory, and releases the native handle in `finally`.
- `GetCStyleWithColumnFamily` (the caller-buffer account/storage point-read path) uses one `rocksdb_get_into_buffer(_cf)` call to write directly into the destination `Span<byte>`. It validates both the `fits` flag and returned length, passes a valid dummy address for an empty span, and preserves missing/undersized-buffer semantics.
- `GetNativeSlice` and `DangerousReleaseHandle` use the same `_v2` pinned-handle API family, avoiding allocator/accessor mismatches.
- Returned arrays use `GC.AllocateUninitializedArray`; zero-length stored values explicitly return an empty array.

### What happens inside RocksDB

RocksDB introduced these high-performance C APIs in [facebook/rocksdb#13911](https://github.com/facebook/rocksdb/pull/13911). The motivation was the native allocation and copy chain around an otherwise normal `DB::Get`.

Counts below cover one successful read where RocksDB can pin the value from a memtable or block-cache entry. They count work at the C/C++ boundary, before any managed allocation:

| C API path | `DB::Get` calls | Value-sized native heap allocations | Small native handle allocations | Value copies in C/C++ | Returned storage |
| --- | ---: | ---: | ---: | ---: | --- |
| Old `rocksdb_get` implementation | 1 | 2: `std::string` + `CopyString` `malloc` | 0 | 2 | Caller-owned `malloc` buffer |
| RocksDB 10.10 `rocksdb_get` | 1 | 1: `CopyString` `malloc` | 0 | 1 | Caller-owned `malloc` buffer |
| `rocksdb_get_pinned_v2` | 1 | 0 | 1 | 0 | Borrowed pointer, valid until handle destruction |
| `rocksdb_get_into_buffer` | 1 | 0 | 0 | 1 | Final caller-provided buffer |

`rocksdb_get_pinned_v2` therefore removes the mandatory value-sized return allocation and `CopyString` copy. It keeps a small heap-allocated handle containing the `PinnableSlice`, which owns or pins the value until `rocksdb_pinnable_handle_destroy`.

`rocksdb_get_into_buffer` goes further when the caller already knows the maximum value size: RocksDB creates the `PinnableSlice` on its native stack, performs one `DB::Get`, and `memcpy`s straight into the caller's pinned span only if the complete value fits. An undersized buffer receives the required length and no bytes are copied.

If RocksDB cannot pin the source value, `PinnableSlice` may materialize owned storage internally. The table isolates the C API overhead these new entry points remove.

### Nethermind before and after

| Nethermind path | Native API | `DB::Get` calls | Value-sized C API `malloc`s | Handle allocations / frees | P/Invoke calls | Copies into final managed storage | Managed allocation |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| Array `Get` before | Legacy `rocksdb_get_pinned` | 1 | 0 | 1 / 1 | 3 | 1 | One zero-initialized `byte[]` |
| Array `Get` after | `rocksdb_get_pinned_v2` | 1 | 0 | 1 / 1 | 3 | 1 | One uninitialized `byte[]` |
| Caller-buffer `Get` before | Legacy `rocksdb_get_pinned` | 1 | 0 | 1 / 1 | 3 | 1, managed copy | None |
| Caller-buffer `Get` after | `rocksdb_get_into_buffer` | 1 | 0 | 0 / 0 | 1 | 1, native copy directly to destination | None |

The array path cannot provide a correctly sized destination until RocksDB returns the value length. `_v2` keeps that path to one lookup without falling back to `rocksdb_get`'s value-sized `malloc`; Nethermind then allocates the final array and copies once. The previous Nethermind implementation was already pinned, so the native handle count is intentionally unchanged.

The caller-buffer path already has its final destination. `get_into_buffer` removes the heap handle, value-accessor call, destroy call, and managed copy while retaining a single unavoidable copy into that destination.

The RocksDbSharp convenience overloads still pass the native `errptr` internally and throw `RocksDbException` for non-`NotFound` statuses, so corruption and I/O failures remain distinguishable from missing keys.

Raw block RLP, cold contract code, and full blob transactions use the one-lookup array path. Known large-value decoding paths for blocks and receipts continue to use `GetNativeSlice`/`GetSpan`, which are single-lookup pinned reads.

### Profiling

Profiling (dotTrace, SLOAD-heavy replay): under `BaseFlatPersistence.Reader.TryGetStorage`, the caller-buffer read is now one `IL_STUB_PInvoke` with approximately 0.3% managed-side overhead; previously it used the pinned handle call, value accessor, native-to-managed copy, and destroy call.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Smoke_test_value_sizes` round-trips randomized 1-byte, 1 KiB, and 8 KiB values through every read method. Additional tests cover missing keys, empty stored values, and undersized output buffers (including an empty buffer), and verify failed caller-buffer reads do not modify the destination.

- `FullyQualifiedName~DbOnTheRocks`: 78 passed
- `FullyQualifiedName~BaseFlatPersistenceReader`: 5 passed

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No