### PR TITLE
Use a conservative block-body transaction count limit

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockBodyDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockBodyDecoderTests.cs
@@ -25,6 +25,7 @@ public class BlockBodyDecoderTests
     }
 
     // check for RlpLimitException specifically, which should fire before decoding, so 0xC0 placeholders are fine here.
+    // Tx bound at the default 1 GGas MaxBlockGas: 1,000,000,000 / 4,500 + 1 == 222,223 entries.
     [TestCase(222_224, 0, null, TestName = "transactions")]
     [TestCase(0, 3, null, TestName = "uncles")]
     [TestCase(0, 0, 64_001, TestName = "withdrawals")]

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockBodyDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockBodyDecoderTests.cs
@@ -25,13 +25,14 @@ public class BlockBodyDecoderTests
     }
 
     // check for RlpLimitException specifically, which should fire before decoding, so 0xC0 placeholders are fine here.
-    [TestCase(60_000, 0, null, TestName = "transactions")]
+    [TestCase(222_224, 0, null, TestName = "transactions")]
     [TestCase(0, 3, null, TestName = "uncles")]
     [TestCase(0, 0, 64_001, TestName = "withdrawals")]
     public void Decode_count_over_limit_throws(int txCount, int uncleCount, int? withdrawalCount) =>
         Assert.Throws<RlpLimitException>(() => DecodeBody(BuildBodyStream(txCount, uncleCount, withdrawalCount)));
 
     // array of 0xC0's (interpreted as null) within the count limit
+    [TestCase(222_223, 0, null, TestName = "transaction at count limit")]
     [TestCase(10, 0, null, TestName = "transaction")]
     [TestCase(0, 1, null, TestName = "uncle")]
     [TestCase(0, 0, 6, TestName = "withdrawal")]

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockBodyDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockBodyDecoderTests.cs
@@ -25,15 +25,16 @@ public class BlockBodyDecoderTests
     }
 
     // check for RlpLimitException specifically, which should fire before decoding, so 0xC0 placeholders are fine here.
-    // Tx bound at the default 1 GGas MaxBlockGas: 1,000,000,000 / 4,500 + 1 == 222,223 entries.
-    [TestCase(222_224, 0, null, TestName = "transactions")]
+    // Tx bound at the default 1 GGas MaxBlockGas:
+    // 1,000,000,000 / GasCostOf.TransactionEip2780 (12,000) + 1 == 83,334 entries.
+    [TestCase(83_335, 0, null, TestName = "transactions")]
     [TestCase(0, 3, null, TestName = "uncles")]
     [TestCase(0, 0, 64_001, TestName = "withdrawals")]
     public void Decode_count_over_limit_throws(int txCount, int uncleCount, int? withdrawalCount) =>
         Assert.Throws<RlpLimitException>(() => DecodeBody(BuildBodyStream(txCount, uncleCount, withdrawalCount)));
 
     // array of 0xC0's (interpreted as null) within the count limit
-    [TestCase(222_223, 0, null, TestName = "transaction at count limit")]
+    [TestCase(83_334, 0, null, TestName = "transaction at count limit")]
     [TestCase(10, 0, null, TestName = "transaction")]
     [TestCase(0, 1, null, TestName = "uncle")]
     [TestCase(0, 0, 6, TestName = "withdrawal")]

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
@@ -9,8 +9,14 @@ namespace Nethermind.Serialization.Rlp;
 [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(BlockBodyDecoder))]
 public sealed class BlockBodyDecoder(IHeaderDecoder? headerDecoder = null) : RlpDecoder<BlockBody>
 {
+    // This is a defensive allocation bound, not consensus validation. It matches Geth's
+    // Amsterdam receipt-count safety floor. It must stay at or below the lowest minimum gas
+    // among supported transaction types; 4,500 leaves headroom below EIP-2780's 12,000 gas floor.
+    // https://github.com/ethereum/go-ethereum/blob/e9e35a42f8213235da1fde4f9ac8f3e9ff666b87/eth/protocols/eth/peer.go#L583-L592
+    private const ulong TransactionGasSafetyFloor = 4_500;
+
     private static RlpLimit TransactionsCountLimit => RlpLimit.For<BlockBody>(
-        checked((int)(RlpLimit.MaxBlockGas / GasCostOf.Transaction + 1)),
+        checked((int)(RlpLimit.MaxBlockGas / TransactionGasSafetyFloor + 1)),
         nameof(BlockBody.Transactions)
     );
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
@@ -9,19 +9,8 @@ namespace Nethermind.Serialization.Rlp;
 [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(BlockBodyDecoder))]
 public sealed class BlockBodyDecoder(IHeaderDecoder? headerDecoder = null) : RlpDecoder<BlockBody>
 {
-    /// <summary>
-    /// Per-transaction gas floor used to bound the transaction count in a block body before allocation.
-    /// </summary>
-    /// <remarks>
-    /// This is a defensive allocation heuristic, not consensus validation. It sits well below
-    /// EIP-2780's 12,000-gas base cost (<see cref="GasCostOf.TransactionEip2780"/>) and matches
-    /// Geth's Amsterdam receipt-count safety floor:
-    /// https://github.com/ethereum/go-ethereum/blob/e9e35a42f8213235da1fde4f9ac8f3e9ff666b87/eth/protocols/eth/peer.go#L583-L592
-    /// </remarks>
-    private const ulong TransactionGasSafetyFloor = 4_500;
-
     private static RlpLimit TransactionsCountLimit => RlpLimit.For<BlockBody>(
-        checked((int)(RlpLimit.MaxBlockGas / TransactionGasSafetyFloor + 1)),
+        checked((int)(RlpLimit.MaxBlockGas / GasCostOf.TransactionEip2780 + 1)),
         nameof(BlockBody.Transactions)
     );
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockBodyDecoder.cs
@@ -9,10 +9,15 @@ namespace Nethermind.Serialization.Rlp;
 [method: DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(BlockBodyDecoder))]
 public sealed class BlockBodyDecoder(IHeaderDecoder? headerDecoder = null) : RlpDecoder<BlockBody>
 {
-    // This is a defensive allocation bound, not consensus validation. It matches Geth's
-    // Amsterdam receipt-count safety floor. It must stay at or below the lowest minimum gas
-    // among supported transaction types; 4,500 leaves headroom below EIP-2780's 12,000 gas floor.
-    // https://github.com/ethereum/go-ethereum/blob/e9e35a42f8213235da1fde4f9ac8f3e9ff666b87/eth/protocols/eth/peer.go#L583-L592
+    /// <summary>
+    /// Per-transaction gas floor used to bound the transaction count in a block body before allocation.
+    /// </summary>
+    /// <remarks>
+    /// This is a defensive allocation heuristic, not consensus validation. It sits well below
+    /// EIP-2780's 12,000-gas base cost (<see cref="GasCostOf.TransactionEip2780"/>) and matches
+    /// Geth's Amsterdam receipt-count safety floor:
+    /// https://github.com/ethereum/go-ethereum/blob/e9e35a42f8213235da1fde4f9ac8f3e9ff666b87/eth/protocols/eth/peer.go#L583-L592
+    /// </remarks>
     private const ulong TransactionGasSafetyFloor = 4_500;
 
     private static RlpLimit TransactionsCountLimit => RlpLimit.For<BlockBody>(


### PR DESCRIPTION
## Changes

- Replace the legacy 21,000-gas assumption in the block-body RLP allocation guard with EIP-2780's 12,000-gas transaction base cost.
- Use the named `GasCostOf.TransactionEip2780` constant so the bound tracks Nethermind's supported protocol costs without a separate heuristic.
- Pin the exact default boundary with regression coverage: 83,334 transaction entries are admitted to decoding and 83,335 are rejected before allocation.

References: [EIP-2780](https://eips.ethereum.org/EIPS/eip-2780) and [EIP-7934](https://eips.ethereum.org/EIPS/eip-7934).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- The focused block-body decoder suite passes all 11 cases, including both exact transaction-count boundaries.
- The main and benchmark solutions build with warnings treated as errors and report no warnings or errors.
- The EthereumTests solution cannot complete because this checkout does not contain its external JSON fixtures under `src/tests`; its reported errors are limited to those missing inputs.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This remains a defensive allocation bound rather than consensus validation. With the default 1 GGas safety ceiling, the new limit caps the initial transaction-reference array at roughly 651 KiB while admitting the maximum transaction count permitted by EIP-2780 today.
