### PR TITLE
docs(eip8141): correct the pre-activation gap list

### DIFF
--- a/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
@@ -26,11 +26,10 @@ internal sealed class NotSupportedTxFilter(ITxPoolConfig txPoolConfig, IChainHea
         }
 
         // EIP8141-GAP (devnet only): frame txs are admitted while the fork is unscheduled on public networks.
-        // Still missing before any public activation: validation-prefix simulation, paymaster reservation, the
-        // failed-APPROVE replay bound, dependency-set revalidation/eviction ordering, and payer-exposure
-        // accounting beyond natively-resolved payers (under-reserved until the shared max_cost helper) and for
-        // blob-pool records restored from disk, whose payer is not persisted so they hold no reservation.
-        // MalformedTxFilter still enforces static well-formedness downstream.
+        // Still missing: the paymaster rules (no canonical runtime is pinned, so no instance can be recognized
+        // and every code-carrying pay target stays uncapped), a bound on simulation work, head-change
+        // revalidation and the eviction order, max_cost pricing of the payer exposure bound, and the payer on
+        // blob-pool records restored from disk.
         if (tx.SupportsFrames && !_specProvider.GetCurrentHeadSpec().IsEip8141Enabled)
         {
             Metrics.PendingTransactionsNotSupportedTxType++;


### PR DESCRIPTION
## Changes

An audit of the `EIP8141-GAP` list in `NotSupportedTxFilter`, item by item, against the merged EIP-8141 and against what is actually on this branch. The list was wrong in both directions, so it is rewritten rather than trimmed.

**Listed but no longer missing.** Validation-prefix simulation has landed — `FrameTxSimulationFilter` runs before the exposure filter, so a simulated third-party payer is reserved for, and `FrameTxPrefixSimulator` rejects a prefix that reaches no `APPROVE` (`"validation prefix set no payer"`). The failed-`APPROVE` *rule* is therefore enforced; what is missing is the *bound* on the work a repeatedly-failing prefix costs, which is the item the list should have been carrying.

**Missing but not listed.** Neither paymaster rule is on this branch. There is no `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` cap, so one sponsor may back an unbounded pending set, and no canonical instance can be recognised — see below.

**Listed and confirmed.** The payer exposure bound prices `GasLimit x max_fee_per_gas`, which for a frame transaction is the frame-gas sum alone, omitting the intrinsic, floor and blob terms of `TXPARAM(0x06)`. Nothing revalidates a pending prefix once admitted. `LightTxDecoder` persists the expiry deadline and `nonce_keys` but not the payer, so a restored blob-pool record is unattributed.

**Dropped as not a gap.** Reorg re-admission beyond one transaction per sponsor. `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` bounds the *pending* set, and the spec is explicit that "Evicted and replaced transactions must not be re-propagated. Re-admission requires receiving the transaction again." Letting one transaction per sponsor back in after a reorg is the specified behaviour, not a shortfall.

### On the canonical paymaster

Worth recording, because it blocks the item rather than merely deferring it. The spec identifies a canonical instance by exact runtime-code match:

> a paymaster instance is considered canonical if and only if the runtime code at the `pay` frame target exactly matches the canonical paymaster implementation.

`EIPS/eip-8141.md` pins no runtime bytecode and no code hash for it. The implementation lives at `assets/eip-8141/CanonicalPaymaster.sol` as Solidity under a floating `pragma ^0.8.24`, with no compiler version or settings fixed and no link from the spec body — unlike the expiry verifier, whose runtime code the spec gives inline. Recognition therefore has no interoperable artifact to match against today: any client that implements it is matching its own build.

The consequence is a liveness gap, not a safety one. With no recognition, every code-carrying `pay` target falls under the non-canonical rules, which are strictly more conservative than the canonical reservation. The reservation itself is largely already covered, too: for a `pay` prefix the paymaster *is* the payer, so `reserved_pending_cost` is what `PayerExposureCache` already tracks. The only canonical-specific term is subtracting `pending_withdrawal_amount`, and reading that storage slot is only safe once the instance is known to be canonical.

## Types of changes

#### What types of changes does your code introduce?

- [x] Documentation update

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Comment only, no behavioural change. `Nethermind.TxPool` builds with 0 warnings / 0 errors under the `code-lint.yml` flags (`EnforceCodeStyleInBuild` + `GenerateDocumentationFile`), positive-controlled with an unused `using` (2 IDE0005 hits, restored). `dotnet format whitespace --verify-no-changes` clean.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

---

### Overlap

#12921 also rewrites this comment on the same base. Its version keeps only the failed-`APPROVE` bound and the unpersisted payer, dropping the paymaster and revalidation items — both of which are genuinely absent here. Whichever lands second, this side is the audited one.
