### PR TITLE
ci: add the EIP-8141 frame-fixture nethtest lane

### DIFF
--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -37,6 +37,11 @@ on:
         required: false
         default: tests-focil-devnet@v0.2.0
         type: string
+      frames_version:
+        description: Frame-transaction fixtures release tag (frameTest only) - pin to an exact tag
+        required: false
+        default: tests-frames-devnet@v0.1.0
+        type: string
       filter:
         description: Regex filter for test names
         required: false
@@ -88,6 +93,11 @@ on:
         required: false
         default: tests-focil-devnet@v0.2.0
         type: string
+      frames_version:
+        description: Frame-transaction fixtures release tag (frameTest only) - pin to an exact tag
+        required: false
+        default: tests-frames-devnet@v0.1.0
+        type: string
       filter:
         description: Regex filter for test names (optional)
         required: false
@@ -122,6 +132,17 @@ env:
   # FOCIL fixtures ship in their own release line, resolved instead of EEST_VERSION. Keep it an exact
   # tag: latest-<keyword> resolution scans only the 20 newest releases and never reaches that line.
   FOCIL_VERSION: ${{ inputs.focil_version || 'tests-focil-devnet@v0.2.0' }}
+  # EIP-8141 frame-transaction fixtures, likewise their own release line and likewise an exact tag.
+  # This archive labels its fork "Bogota" meaning Amsterdam plus EIP-8141, where the FOCIL archive
+  # means Amsterdam plus EIP-7805; nothing inside a fixture separates the two, so the lane names the
+  # fork it means through the runner's --forkAlias.
+  # Not in any caller's test_types yet: 201 of the 214 cases fail on one defect - the frame-entry
+  # EIP-2929 access charge is skipped on the default-code path, so a frame costs 100 gas too little.
+  # Run it with workflow_dispatch, and add frameTest to the callers once that charge lands.
+  FRAMES_VERSION: ${{ inputs.frames_version || 'tests-frames-devnet@v0.1.0' }}
+  # Cases the pinned release ships under that scope. Asserted so a scope resolving to nothing fails
+  # rather than reporting a clean run of no tests.
+  FRAME_MIN_CASES: '214'
   # ubuntu-latest runners have 16 GB of RAM. The runner ships with server GC
   # (throughput-oriented, collects lazily), which previously ballooned past the
   # runner limit on the full fixture set. Workstation GC keeps the heap tight,
@@ -147,6 +168,7 @@ jobs:
       eest_version: ${{ steps.resolve.outputs.eest_version }}
       zkevm_version: ${{ steps.resolve.outputs.zkevm_version }}
       focil_version: ${{ steps.resolve.outputs.focil_version }}
+      frames_version: ${{ steps.resolve.outputs.frames_version }}
     steps:
       # Build the runner ONCE here and share it as an artifact, instead of rebuilding the
       # identical binary in every matrix job (~80s/job of pure redundancy). Test jobs
@@ -311,6 +333,13 @@ jobs:
                   emit "$type" sequential bogota '' false false 4 2
                 fi
                 ;;
+              frameTest)
+                # One EIP's worth of engine fixtures, so the BAL toggles and the flat layout add
+                # nothing over the Amsterdam corpus the other lanes already run.
+                if run_sequential; then
+                  emit "$type" sequential frames '' false false 4 1
+                fi
+                ;;
               *)
                 echo "::error::Unknown test type: '$type'"
                 exit 1
@@ -372,6 +401,12 @@ jobs:
             echo "Resolved FOCIL release: $RESOLVED_FOCIL"
           fi
 
+          if [[ "$TEST_TYPES" == *frameTest* ]]; then
+            RESOLVED_FRAMES="$(resolve "$FRAMES_VERSION")"
+            echo "frames_version=$RESOLVED_FRAMES" >> "$GITHUB_OUTPUT"
+            echo "Resolved frame-transaction release: $RESOLVED_FRAMES"
+          fi
+
   nethtest:
     name: nethtest ${{ matrix.test_type }} ${{ matrix.test_setup }} ${{ matrix.chunk }}
     needs: prepare-matrix
@@ -410,6 +445,7 @@ jobs:
           RESOLVED_EEST: ${{ needs.prepare-matrix.outputs.eest_version }}
           RESOLVED_ZKEVM: ${{ needs.prepare-matrix.outputs.zkevm_version }}
           RESOLVED_FOCIL: ${{ needs.prepare-matrix.outputs.focil_version }}
+          RESOLVED_FRAMES: ${{ needs.prepare-matrix.outputs.frames_version }}
         run: |
           # Releases are resolved once in prepare-matrix; this step only picks the
           # release line and archive for this job's test type.
@@ -421,6 +457,10 @@ jobs:
             RESOLVED_EEST_VERSION="$RESOLVED_FOCIL"
             VERSION_INPUT="$FOCIL_VERSION"
             EEST_ARCHIVE="fixtures_focil-devnet.tar.gz"
+          elif [ "$TEST_TYPE" = "frameTest" ]; then
+            RESOLVED_EEST_VERSION="$RESOLVED_FRAMES"
+            VERSION_INPUT="$FRAMES_VERSION"
+            EEST_ARCHIVE="fixtures_frames-devnet.tar.gz"
           else
             RESOLVED_EEST_VERSION="$RESOLVED_EEST"
             VERSION_INPUT="$EEST_VERSION"
@@ -483,6 +523,8 @@ jobs:
             zkevmTest)  FIXTURE_NAME=blockchain_tests;        RUNNER_FLAG=--zkevmTest ;;
             # The FOCIL archive ships engine-format fixtures; only for_bogota is populated.
             focilTest)  FIXTURE_NAME=blockchain_tests_engine; RUNNER_FLAG=--engineTest ;;
+            # The frame-transaction archive likewise ships engine-format fixtures.
+            frameTest)  FIXTURE_NAME=blockchain_tests_engine; RUNNER_FLAG=--engineTest ;;
             *) echo "::error::Unknown test type: '$TEST_TYPE'"; exit 1 ;;
           esac
 
@@ -510,6 +552,19 @@ jobs:
               exit 1
             fi
             FIXTURE_DIR="$SCOPED_DIR"
+          elif [ "$SCOPE" = "frames" ]; then
+            # Only the frame-transaction tests: the rest of this archive's for_bogota tree duplicates
+            # the Amsterdam corpus the other lanes already run against their own pinned release.
+            SCOPED_DIR="$(find "$FIXTURE_DIR" -maxdepth 3 -type d -name 'eip8141_frame_transactions' | head -1)"
+            if [ -z "$SCOPED_DIR" ]; then
+              echo "::error::Could not find the frame-transaction fixture subdirectory in $FIXTURE_DIR"
+              find "$FIXTURE_DIR" -maxdepth 3 -type d | head -30
+              exit 1
+            fi
+            FIXTURE_DIR="$SCOPED_DIR"
+            # This archive's fixtures declare fork "Bogota" meaning Amsterdam plus EIP-8141, which is
+            # Eip8141Prototype here; the FOCIL archive gives the same name a different meaning.
+            echo "fork_alias=Bogota=Eip8141Prototype" >> "$GITHUB_OUTPUT"
           fi
 
           # Fixtures whose expectations are knowingly not met, excluded by exact test id so the lane
@@ -553,12 +608,19 @@ jobs:
           EEST_ARCHIVE: ${{ steps.eest_release.outputs.archive }}
           RUNNER_FLAG: ${{ steps.fixtures.outputs.runner_flag }}
           EXTRA_FILTER: ${{ steps.fixtures.outputs.extra_filter }}
+          FORK_ALIAS: ${{ steps.fixtures.outputs.fork_alias }}
         run: |
           # Empty for every test type that declares no known-failure exclusions.
           [ -z "$FILTER" ] && FILTER="$EXTRA_FILTER"
           FILTER_ARG=""
           if [ -n "$FILTER" ]; then
             FILTER_ARG="--filter $FILTER"
+          fi
+
+          # Empty for every archive whose fork names need no reinterpretation.
+          ALIAS_ARG=""
+          if [ -n "$FORK_ALIAS" ]; then
+            ALIAS_ARG="--forkAlias $FORK_ALIAS"
           fi
 
           SETUP_ARGS="--chunk $CHUNK"
@@ -687,7 +749,7 @@ jobs:
               echo "# 2. Build and run"
               echo "cd src/Nethermind"
               echo "dotnet build Nethermind.Test.Runner/Nethermind.Test.Runner.csproj -c Release -p:PublishReadyToRun=false"
-              echo "dotnet run --no-build --no-launch-profile -c Release --project Nethermind.Test.Runner/Nethermind.Test.Runner.csproj -- $RUNNER_FLAG --input /tmp/eest/fixtures --jsonout --workers '$WORKERS' --neverTrace ${SETUP_ARGS}${FILTER_CMD}"
+              echo "dotnet run --no-build --no-launch-profile -c Release --project Nethermind.Test.Runner/Nethermind.Test.Runner.csproj -- $RUNNER_FLAG --input /tmp/eest/fixtures --jsonout --workers '$WORKERS' --neverTrace ${SETUP_ARGS}${FILTER_CMD}${ALIAS_ARG:+ $ALIAS_ARG}"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
 
@@ -804,6 +866,7 @@ jobs:
             --neverTrace \
             $SETUP_ARGS \
             $FILTER_ARG \
+            $ALIAS_ARG \
             > "$RESULTS_FILE" \
             2> >(tee "$STDERR_FILE" >&2) &
           NETHTEST_PID=$!
@@ -839,6 +902,16 @@ jobs:
             if [ "$FAILED_AFTER_RUN" -gt 0 ]; then
               echo "::error::$FAILED_AFTER_RUN nethtest cases failed"
               rc=1
+            fi
+
+            # A scope that resolved to nothing reports no failures, so the narrowed lanes assert they
+            # actually ran their fixtures. Only the unfiltered run has a known count.
+            if [ "$TEST_TYPE" = "frameTest" ] && [ -z "$FILTER" ] && [ $rc -eq 0 ]; then
+              RAN=$(jq 'length' "$RESULTS_FILE" 2>/dev/null || echo 0)
+              if [ "$RAN" -lt "$FRAME_MIN_CASES" ]; then
+                echo "::error::frameTest ran $RAN cases, fewer than the $FRAME_MIN_CASES expected; the fixture scope or the release pin has moved"
+                rc=1
+              fi
             fi
           fi
 

--- a/src/Nethermind/Ethereum.Test.Base/ForkAliases.cs
+++ b/src/Nethermind/Ethereum.Test.Base/ForkAliases.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+namespace Ethereum.Test.Base;
+
+/// <summary>Remaps the fork name a fixture declares onto the fork the loaded archive actually means.</summary>
+/// <remarks>
+/// Separate EEST release lines can define one fork name incompatibly, and the fixture carries no EIP list
+/// to tell them apart — only the archive does. The FOCIL line's <c>Bogota</c> is Amsterdam plus EIP-7805;
+/// the frame-transaction line's is Amsterdam plus EIP-8141, which is <c>Eip8141Prototype</c> here. Whoever
+/// selects the archive therefore names the fork it means, rather than the parser guessing from a name that
+/// is genuinely ambiguous. Aliases must be set before any fixture is loaded; they are read from every
+/// parse worker afterwards.
+/// </remarks>
+public static class ForkAliases
+{
+    private static volatile FrozenDictionary<string, string> _aliases = FrozenDictionary<string, string>.Empty;
+
+    /// <summary>Replaces the alias table with <paramref name="aliases"/>, each given as <c>From=To</c>.</summary>
+    /// <exception cref="ArgumentException">An entry is not a single <c>From=To</c> pair.</exception>
+    public static void Set(IReadOnlyList<string> aliases)
+    {
+        Dictionary<string, string> parsed = new(StringComparer.Ordinal);
+        foreach (string alias in aliases)
+        {
+            string[] parts = alias.Split('=');
+            if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0)
+            {
+                throw new ArgumentException($"Fork alias '{alias}' is not of the form From=To", nameof(aliases));
+            }
+
+            parsed[parts[0]] = parts[1];
+        }
+
+        _aliases = parsed.ToFrozenDictionary(StringComparer.Ordinal);
+    }
+
+    /// <summary>Returns the fork name <paramref name="forkName"/> is aliased to, or itself when unaliased.</summary>
+    public static string Resolve(string forkName) =>
+        _aliases.TryGetValue(forkName, out string? target) ? target : forkName;
+}

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -481,7 +481,8 @@ namespace Ethereum.Test.Base
 
         private static IReleaseSpec LoadSpec(string name, Dictionary<string, BlobScheduleEntryJson>? blobSchedule)
         {
-            IReleaseSpec spec = SpecNameParser.Parse(name);
+            IReleaseSpec spec = SpecNameParser.Parse(ForkAliases.Resolve(name));
+            // The blob schedule stays keyed by the name the fixture declares, not by the alias target.
             if (blobSchedule is null || !blobSchedule.TryGetValue(name, out BlobScheduleEntryJson? blobCount))
             {
                 return spec;
@@ -490,7 +491,7 @@ namespace Ethereum.Test.Base
             SpecOverrideCacheKey key = new(name, blobCount.Max, blobCount.Target, blobCount.BaseFeeUpdateFraction);
             return _overriddenSpecs.GetOrAdd(key, static key =>
             {
-                IReleaseSpec spec = SpecNameParser.Parse(key.Name);
+                IReleaseSpec spec = SpecNameParser.Parse(ForkAliases.Resolve(key.Name));
                 return new OverridableReleaseSpec(spec)
                 {
                     MaxBlobCount = System.Convert.ToUInt64(key.MaxBlobCount, 16),

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -29,7 +29,7 @@ public abstract class TransactionTestBase
         IReleaseSpec spec;
         try
         {
-            spec = SpecNameParser.Parse(test.Fork);
+            spec = SpecNameParser.Parse(ForkAliases.Resolve(test.Fork));
         }
         catch (Exception ex)
         {

--- a/src/Nethermind/Nethermind.Specs.Test/SpecNameParserTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/SpecNameParserTests.cs
@@ -26,6 +26,22 @@ public class SpecNameParserTests
         }
     }
 
+    // The frame-transaction fixtures label their fork "Bogota" too, meaning Amsterdam plus EIP-8141 rather
+    // than plus EIP-7805. Only the archive tells the two apart, so the runner aliases that name onto this
+    // one, which therefore has to resolve.
+    [Test]
+    public void Parse_maps_Eip8141Prototype_to_the_frame_transaction_fork()
+    {
+        IReleaseSpec spec = SpecNameParser.Parse("Eip8141Prototype");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(spec, Is.SameAs(Eip8141Prototype.Instance));
+            Assert.That(spec.IsEip8141Enabled, Is.True);
+            Assert.That(spec.IsEip7805Enabled, Is.False);
+        }
+    }
+
     [TestCase("NotAFork", "NotAFork")]
     [TestCase("Merge+9999", "Paris+9999")]
     public void Parse_names_the_offending_fork_when_unmapped(string specName, string resolvedSpecName)

--- a/src/Nethermind/Nethermind.Specs/SpecNameParser.cs
+++ b/src/Nethermind/Nethermind.Specs/SpecNameParser.cs
@@ -63,6 +63,7 @@ namespace Nethermind.Specs
                 "BPO5" => BPO5.Instance,
                 "Amsterdam" => Amsterdam.Instance,
                 "Bogota" => Bogota.Instance,
+                "Eip8141Prototype" => Eip8141Prototype.Instance,
                 _ => throw new NotSupportedException(specName == unambiguousSpecName
                     ? $"Unknown fork name '{specName}'"
                     : $"Unknown fork name '{specName}' (resolved to '{unambiguousSpecName}')")

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -85,6 +85,9 @@ internal class Program
 
         public static Option<bool?> BatchRead { get; } =
             new("--batchRead") { Description = "Force BAL batch-read prewarming on or off; when omitted, the client config default is used. [Only for Blockchain/Engine Test]" };
+
+        public static Option<string[]> ForkAlias { get; } =
+            new("--forkAlias") { Description = "Resolve a fixture's declared fork name as another fork, e.g. 'Bogota=Eip8141Prototype'. Repeatable; needed where separate fixture releases give one fork name incompatible meanings.", AllowMultipleArgumentsPerToken = true };
     }
 
     private static readonly IJsonSerializer _serializer = new EthereumJsonSerializer();
@@ -114,6 +117,7 @@ internal class Program
             Options.FlatDb,
             Options.ParallelExecution,
             Options.BatchRead,
+            Options.ForkAlias,
         ];
         rootCommand.SetAction(Run);
 
@@ -157,6 +161,9 @@ internal class Program
         bool enableWarmup = parseResult.GetValue(Options.EnableWarmup);
         bool? parallelExecution = parseResult.GetValue(Options.ParallelExecution);
         bool? batchRead = parseResult.GetValue(Options.BatchRead);
+
+        // Set before any fixture is loaded: the parse workers only ever read the table.
+        ForkAliases.Set(parseResult.GetValue(Options.ForkAlias) ?? []);
 
         if (parseResult.GetValue(Options.FlatDb))
         {


### PR DESCRIPTION
## Changes

Wires the EIP-8141 frame-transaction fixtures into `run-nethtest.yml` as a `frameTest` lane, mirroring `focilTest`: a `frames_version` input, a pinned `FRAMES_VERSION`, a job output plus resolve branch, a matrix case, the `fixtures_frames-devnet.tar.gz` archive branch, the fixture-path case and a `frames` fork-scope branch.

Release: `tests-frames-devnet@v0.1.0`, asset `fixtures_frames-devnet.tar.gz` (confirmed from the release, not guessed; the URL resolves 200).

### The fork-name collision

The frame fixtures declare fork **`Bogota`** — the same name the FOCIL archive uses, with an incompatible meaning:

| | FOCIL `tests-focil-devnet@v0.2.0` | Frames `tests-frames-devnet@v0.1.0` |
|---|---|---|
| `for_bogota` source dirs | includes `bogota/eip7805_focil` | **no `bogota/` dir at all** |
| Engine versions | newPayloadV6 / fcuV5 | **newPayloadV5 / fcuV4** |
| Meaning | Amsterdam + EIP-7805 | Amsterdam + EIP-8141 |

The engine versions are decisive: this branch's `Bogota` mandates V6/V5, so the frames archive's fork is not EIP-7805. Amsterdam + EIP-8141 is exactly `Eip8141Prototype` here.

Nothing inside a fixture separates the two — `config` carries only the fork name and a blob schedule, no EIP list. Only the archive distinguishes them, and no fork schedule satisfies both: EIP-8141 installs the expiry-verifier predeploy, which is a code change in every block's EIP-7928 access list and shifts every hash the FOCIL vectors pin.

So the resolution is to map by archive as well as name. The runner gains `--forkAlias From=To`, and the lane passes `Bogota=Eip8141Prototype`. Whoever selects an archive names the fork it means, rather than the parser guessing from a genuinely ambiguous name.

Two controls confirm the alias target is right:

- The archive's `for_amsterdam` Amsterdam baseline is **1842/1842** green — the archive's Amsterdam matches this branch, so nothing is skewed underneath.
- The archive's `for_bogota` **non**-8141 tests are **1647/1647** green *with* the alias applied — including 1028 EIP-7928 BAL cases. Those pass only if the expiry-verifier predeploy is present, which independently confirms this archive's Bogota activates EIP-8141.

### Why the lane is dispatch-only

Run exactly as CI issues it, the lane collects **214** cases: **13 pass, 201 fail**. That is not gateable, and the failures are not fixture lag — they are one client defect:

- 35 of 36 `HeaderGasUsedMismatch` failures are **exactly 100 gas** short, across totals from 23,109 to 517,750.
- `ExecuteFrame` early-returns into `ExecuteDefaultVerifyCode` before computing the resolved target's EIP-2929 access charge, and that method opens with `gasUsed = 0`. The spec charges the access before the balance check and before dispatch, explicitly including the default-code path.
- The remaining ~97 `InvalidReceiptsRoot` failures are the same delta surfacing in per-frame receipts, and `default_code_entry_gas_shortfall.json` is the purpose-built fixture: expected per-frame `0x64` (100, warm sender) and `0xbb8` (3000, cold target), with a 2999 variant expecting `TYPE_6_INVALID_FRAME_EXECUTION`.

Excluding 201 of 214 cases would gate nothing and would need wholesale deletion the moment the charge lands, so the lane follows the precedent already in this file: fully wired, pinned, runnable by `workflow_dispatch`, with the blocking defect named in the `FRAMES_VERSION` comment. Adding it to `nethermind-tests.yml` is a one-line follow-up once the charge is implemented.

The lane also asserts `FRAME_MIN_CASES`, so a scope that silently resolved to nothing fails instead of reporting a clean run of no tests.

### Verification

- FOCIL lane re-run end to end with its exclusions: **26,547 collected / 26,547 passed / 0 failed** — unchanged.
- Matrix generation is byte-identical for `engineTest`, `blockTest`, `stateTest`, `syncTest`, `txTest`, `zkevmTest` and `focilTest` across all three setup groups.
- The fork-scope block gained a branch rather than being generalised; the 20+ jobs sharing it resolve unchanged.
- `actionlint` before/after: 7 to 8 findings. The one addition is `SC2086` on `$ALIAS_ARG`, the same deliberate word-splitting as the adjacent `$SETUP_ARGS` and `$FILTER_ARG`.
- Lint gate clean with both enforce flags and `-t:Rebuild`, positive-controlled with an unused `using`. `dotnet format whitespace --verify-no-changes` clean.

### Relationship to #12888

Not a port. #12888 predates the split of the fork classes and targets the older `tests-frames-devnet@v0.0.0`; its base is 143 commits stale, the predeploy fix it cherry-picked has since landed, and the `extra_filter` mechanism it worked around now exists. Its `FRAME_SKIP` env approach is superseded by the current per-lane exclusion pattern, and it did not address the fork-name collision, which is the substance here. **#12888 should be closed as superseded.**

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`SpecNameParserTests` gains a case pinning `Eip8141Prototype` resolution, alongside the existing one pinning `Bogota` to the inclusion-list fork. The CI wiring itself is verified by running the job's own invocation locally, as above.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
