### PR TITLE
fix(frames): report missing frames distinctly from a gas overflow in EstimateFrameTx

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -49,6 +49,8 @@ public class GasEstimator(
     public const string CannotEstimateGasExceeded = "Cannot estimate gas, gas spent exceeded transaction and block gas limit or transaction gas limit cap";
     private const string ExecutionReverted = "execution reverted";
     private const string FrameTxGasLimitOverflows = "frame transaction gas limit overflows";
+    /// <summary>Message emitted when a frame transaction carries no frames to derive a budget from.</summary>
+    public const string FrameTxHasNoFrames = "frame transaction has no frames";
 
     public ulong Estimate(
         Transaction tx,
@@ -108,6 +110,10 @@ public class GasEstimator(
     /// </remarks>
     private static EstimationResult EstimateFrameTx(Transaction tx, BlockHeader header, IReleaseSpec spec)
     {
+        // Reached on the transaction type alone, so the absent frames must be reported before the overflow path.
+        if (tx.Frames is null)
+            return EstimationResult.Failure(FrameTxHasNoFrames);
+
         if (!FrameTxValidation.TryCalculateGasBudget(tx, spec, out _, out _, out ulong maxGas))
             return EstimationResult.Failure(FrameTxGasLimitOverflows);
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -49,8 +49,6 @@ public class GasEstimator(
     public const string CannotEstimateGasExceeded = "Cannot estimate gas, gas spent exceeded transaction and block gas limit or transaction gas limit cap";
     private const string ExecutionReverted = "execution reverted";
     private const string FrameTxGasLimitOverflows = "frame transaction gas limit overflows";
-    /// <summary>Message emitted when a frame transaction carries no frames to derive a budget from.</summary>
-    public const string FrameTxHasNoFrames = "frame transaction has no frames";
 
     public ulong Estimate(
         Transaction tx,
@@ -110,9 +108,10 @@ public class GasEstimator(
     /// </remarks>
     private static EstimationResult EstimateFrameTx(Transaction tx, BlockHeader header, IReleaseSpec spec)
     {
-        // Reached on the transaction type alone, so the absent frames must be reported before the overflow path.
-        if (tx.Frames is null)
-            return EstimationResult.Failure(FrameTxHasNoFrames);
+        // The budget below is computable from an empty or oversized frame list, so a count no valid
+        // transaction can carry is reported rather than priced.
+        if (tx.Frames is not { Length: > 0 and <= Eip8141Constants.MaxFrames })
+            return EstimationResult.Failure(FrameTxValidation.MissingFrames);
 
         if (!FrameTxValidation.TryCalculateGasBudget(tx, spec, out _, out _, out ulong maxGas))
             return EstimationResult.Failure(FrameTxGasLimitOverflows);

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -874,6 +874,26 @@ public class FrameTxProcessorTests
         Assert.That(error, Is.EqualTo(GasEstimator.CannotEstimateGasExceeded));
     }
 
+    /// <remarks>
+    /// A type-6 transaction reaches the frame estimator on its type alone, so one submitted without any frames
+    /// must report the missing frames rather than a gas-limit overflow that never happened.
+    /// </remarks>
+    [Test]
+    public void EstimateGas_FrameTxWithNoFrames_ReportsTheMissingFrames()
+    {
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Recipient));
+        tx.Frames = null;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithGasLimit(30_000_000).TestObject;
+
+        EstimateGasTracer gasTracer = new();
+        GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
+        estimator.Estimate(tx, header, gasTracer, out string? error);
+
+        Assert.That(error, Is.EqualTo(GasEstimator.FrameTxHasNoFrames));
+    }
+
     /// <summary>A reverting POST_TX frame fails the probe's status but keeps the transaction valid and
     /// its frame budget well-defined, so the estimate is returned rather than reported as a failure.</summary>
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -875,14 +875,17 @@ public class FrameTxProcessorTests
     }
 
     /// <remarks>
-    /// A type-6 transaction reaches the frame estimator on its type alone, so one submitted without any frames
-    /// must report the missing frames rather than a gas-limit overflow that never happened.
+    /// A type-6 transaction reaches the frame estimator on its type alone, so a frame count EIP-8141 never
+    /// admits must be reported as such: an absent list is not the gas-limit overflow the estimator blamed,
+    /// and an empty or oversized one prices into a budget no block can ever spend.
     /// </remarks>
-    [Test]
-    public void EstimateGas_FrameTxWithNoFrames_ReportsTheMissingFrames()
+    [TestCase(null)]
+    [TestCase(0)]
+    [TestCase(Eip8141Constants.MaxFrames + 1)]
+    public void EstimateGas_FrameTxWithAFrameCountOutsideTheAdmittedRange_ReportsTheFrameCount(int? frameCount)
     {
-        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Recipient));
-        tx.Frames = null;
+        Transaction tx = FrameTx(nonce: 0);
+        tx.Frames = frameCount is { } count ? RepeatedFrames(count) : null;
         BlockHeader header = Build.A.BlockHeader.WithNumber(1)
             .WithBeneficiary(Beneficiary)
             .WithGasLimit(30_000_000).TestObject;
@@ -891,7 +894,27 @@ public class FrameTxProcessorTests
         GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
         estimator.Estimate(tx, header, gasTracer, out string? error);
 
-        Assert.That(error, Is.EqualTo(GasEstimator.FrameTxHasNoFrames));
+        Assert.That(error, Is.EqualTo(FrameTxValidation.MissingFrames));
+    }
+
+    /// <remarks>
+    /// The processor dereferences the frame list, and eth_call reaches it without a validator, so the same
+    /// counts must be refused there rather than faulting on the absent list.
+    /// </remarks>
+    [TestCase(null)]
+    [TestCase(0)]
+    public void Execute_FrameTxWithNoFrames_IsRejectedAsMalformed(int? frameCount)
+    {
+        Transaction tx = FrameTx(nonce: 0);
+        tx.Frames = frameCount is { } count ? RepeatedFrames(count) : null;
+
+        TransactionResult result = CallAndRestore(tx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+            Assert.That(result.ErrorDescription, Is.EqualTo(FrameTxValidation.MissingFrames));
+        }
     }
 
     /// <summary>A reverting POST_TX frame fails the probe's status but keeps the transaction valid and
@@ -2495,6 +2518,13 @@ public class FrameTxProcessorTests
 
     private static TxFrame Frame(byte mode, byte flags = 0, Address? target = null, UInt256 value = default, byte[]? data = null, ulong stateGasLimit = DefaultFrameStateGasLimit) =>
         new(mode, flags, target, executionGasLimit: 200_000, stateGasLimit, value, data ?? Array.Empty<byte>());
+
+    private static TxFrame[] RepeatedFrames(int count)
+    {
+        TxFrame[] frames = new TxFrame[count];
+        Array.Fill(frames, Frame(TxFrame.ModeSender, target: Recipient));
+        return frames;
+    }
 
     private static Transaction FrameTx(ulong nonce, params TxFrame[] frames) =>
         new()

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -898,12 +898,14 @@ public class FrameTxProcessorTests
     }
 
     /// <remarks>
-    /// The processor dereferences the frame list, and eth_call reaches it without a validator, so the same
-    /// counts must be refused there rather than faulting on the absent list.
+    /// The processor dereferences the frame list, and eth_call reaches it without a validator, so it must
+    /// refuse the same counts the estimator refuses rather than faulting on the absent list or running an
+    /// oversized one frame by frame.
     /// </remarks>
     [TestCase(null)]
     [TestCase(0)]
-    public void Execute_FrameTxWithNoFrames_IsRejectedAsMalformed(int? frameCount)
+    [TestCase(Eip8141Constants.MaxFrames + 1)]
+    public void Execute_FrameTxWithAFrameCountOutsideTheAdmittedRange_IsRejectedAsMalformed(int? frameCount)
     {
         Transaction tx = FrameTx(nonce: 0);
         tx.Frames = frameCount is { } count ? RepeatedFrames(count) : null;

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
@@ -183,7 +183,9 @@ public class FrameTxVerifyDosMeasurement
             $"us_per_Mgas={best * 1_000_000 / verifyGas:F1} " +
             $"tx_per_block={txPerBlock} unpaid_block_ms={best * txPerBlock / 1000.0:F1}";
         TestContext.Out.WriteLine(line);
-        System.IO.File.AppendAllText("/tmp/frame-dos-results.txt", line + System.Environment.NewLine);
+        string path = Environment.GetEnvironmentVariable("FRAME_RETRY_OUT")
+                      ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(), "frame-dos-results.txt");
+        System.IO.File.AppendAllText(path, line + Environment.NewLine);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -96,7 +96,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     {
         // Structural, so it holds even where validation is skipped: the frame list is dereferenced
         // throughout, and eth_call arrives here without a validator.
-        if (tx.Frames is not { Length: > 0 })
+        if (tx.Frames is not { Length: > 0 and <= Eip8141Constants.MaxFrames })
         {
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail(FrameTxValidation.MissingFrames);
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -94,6 +94,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
     private TransactionResult ExecuteFrameTx(Transaction tx, ITxTracer tracer, ExecutionOptions opts, BlockHeader header, IReleaseSpec spec)
     {
+        // Structural, so it holds even where validation is skipped: the frame list is dereferenced
+        // throughout, and eth_call arrives here without a validator.
+        if (tx.Frames is not { Length: > 0 })
+        {
+            return TransactionResult.ErrorType.MalformedTransaction.WithDetail(FrameTxValidation.MissingFrames);
+        }
+
         if (opts.HasFlag(ExecutionOptions.FrameValidationPrefixOnly))
         {
             return SimulateFrameValidationPrefix(tx, tracer, header, spec);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -853,4 +853,27 @@ public partial class EthRpcModuleTests
         Assert.That(parsed["error"]!["code"]!.Value<int>(), Is.EqualTo(-32602));
     }
 
+    /// <remarks>
+    /// A type-6 transaction reaches the frame estimator and the processor on its type alone, and
+    /// eth_estimateGas probes the transaction before estimating it, so an absent frame list must be
+    /// reported to the caller rather than faulting on the probe.
+    /// </remarks>
+    [TestCase("""{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","type":"0x6"}""")]
+    [TestCase("""{"from":"0x0001020304050607080910111213141516171819","to":"0x0000000000000000000000000000000000000000","type":"0x6","frames":[]}""")]
+    public async Task Eth_estimateGas_frame_transaction_without_frames_returns_error(string txJson)
+    {
+        TestSpecProvider specProvider = new(Eip8141Prototype.Instance);
+        using Context ctx = await Context.Create(specProvider);
+
+        object transaction = JsonSerializer.Deserialize<object>(txJson)!;
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest");
+
+        JToken parsed = JToken.Parse(serialized);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(parsed["error"]!["code"]!.Value<int>(), Is.EqualTo(ErrorCodes.InvalidInput));
+            Assert.That(parsed["error"]!["message"]!.Value<string>(), Does.Contain(FrameTxValidation.MissingFrames));
+        }
+    }
 }


### PR DESCRIPTION
## Changes

Two independent fixes salvaged from #12790, which was closed as superseded — both were still valid against `eip8141-frame-txs-devnet7` and are re-applied here, adapted to the base as it stands after the two-dimensional gas work (#12942) and the FOCIL integration (#12977). Credit for finding and fixing both goes to the original PR.

- A type-6 transaction reaches both the frame processor and the frame estimator on its type alone, so an entry point that skips validation (`eth_call`, `eth_estimateGas`) can hand either one a transaction whose frame list is absent or empty.
  - `ExecuteFrameTx` dereferenced that list unguarded, so `eth_estimateGas` for a type-6 transaction without frames faulted with a `NullReferenceException` and answered the caller with `-32603 Internal error` and a stack trace. It now refuses the transaction as `MalformedTransaction` under the canonical `FrameTxValidation.MissingFrames`, alongside the structural rules already re-enforced there for unvalidated entry points. That is the message the caller sees: `eth_estimateGas` probes before it estimates, and the probe's error wins the precedence switch.
  - `GasEstimator.EstimateFrameTx` reported `"frame transaction gas limit overflows"` for an absent frame list, an overflow that never happened — `TryCalculateGasBudget` returns `false` on its `frames is null` guard first. For an empty or oversized list it was worse: neither bails, so the estimator returned a *successful* budget for a transaction `IsWellFormed` rejects. The guard now matches the canonical frame-count check exactly and reuses its message.

- `FrameTxVerifyDosMeasurement` appended its results to the literal path `/tmp/frame-dos-results.txt`, which throws on Windows. It now resolves the destination from the `FRAME_RETRY_OUT` environment variable with a `Path.GetTempPath()` fallback, matching `UnpaidBurnPerAttempt` in the same file and the sibling retry harnesses.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Three tests cover the first fix:

- `EthRpcModuleTests.Eth_estimateGas_frame_transaction_without_frames_returns_error` drives a real `eth_estimateGas` for a type-6 transaction with `frames` omitted and with `frames: []`, and pins the JSON-RPC error the caller receives. Without the processor guard the first case comes back as `-32603 Internal error` with a `NullReferenceException` stack trace and the second as `frame transaction never set a payer`.
- `FrameTxProcessorTests.Execute_FrameTxWithNoFrames_IsRejectedAsMalformed` pins the processor-level rejection.
- `FrameTxProcessorTests.EstimateGas_FrameTxWithAFrameCountOutsideTheAdmittedRange_ReportsTheFrameCount` covers `null` / `0` / `MaxFrames + 1` at the estimator. Reverting the estimator guard fails all three (`frame transaction gas limit overflows`, then two returned estimates with no error) and nothing else.

Suites are green on this branch:

- `Nethermind.Evm.Test` — 5474 total, 0 failed, 19 skipped (the pre-existing macOS skips)
- `Nethermind.JsonRpc.Test` — 1993 total, 0 failed, 22 skipped
- `Nethermind.Blockchain.Test` — 1756 total, 0 failed, 9 skipped
- `Nethermind.TxPool.Test` — 834 total, 0 failed, 4 skipped

The DoS harness was re-run with `FRAME_RETRY_OUT` set and its 11 cases pass, writing to the configured destination rather than the hardcoded one.

`dotnet format whitespace --verify-no-changes` is clean, and the touched projects build under the code-lint gate (`EnforceCodeStyleInBuild=true -p:GenerateDocumentationFile=true`, rebuilt) with no IDE/CA diagnostics.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

