### PR TITLE
perf(state): unswitch tracing branches in commit loops

### DIFF
--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -142,7 +142,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         HashSet<AddressAsKey> toUpdateRoots = (_tempToUpdateRoots ??= []);
 
-        ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes)[..(currentPosition + 1)];
+        ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes);
         Dictionary<StorageCell, StorageChangeTrace>? trace;
         if (tracer.IsTracingStorage)
         {

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -142,14 +142,74 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         HashSet<AddressAsKey> toUpdateRoots = (_tempToUpdateRoots ??= []);
 
-        bool isTracing = tracer.IsTracingStorage;
-        Dictionary<StorageCell, StorageChangeTrace>? trace = null;
-        if (isTracing)
+        ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes);
+        Dictionary<StorageCell, StorageChangeTrace>? trace;
+        if (tracer.IsTracingStorage)
         {
             trace = [];
+            CommitChanges<OnFlag>(changes, currentPosition, toUpdateRoots, trace);
+        }
+        else
+        {
+            trace = null;
+            CommitChanges<OffFlag>(changes, currentPosition, toUpdateRoots, trace);
         }
 
-        ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes);
+        foreach (AddressAsKey address in toUpdateRoots)
+        {
+            // since the accounts could be empty accounts that are removing (EIP-158)
+            if (_stateProvider.AccountExists(address))
+            {
+                _toUpdateRoots[address] = true;
+                // Add storage tree, will accessed later, which may be in parallel
+                // As we can't add a new storage tries in parallel to the _storages Dict do it here
+                GetOrCreateStorage(address).EnsureStorageTree();
+            }
+            else
+            {
+                _toUpdateRoots.Remove(address);
+                if (_storages.TryGetValue(address, out PerContractState? storage))
+                {
+                    // BlockChange need to be kept to keep selfdestruct marker (via DefaultableDictionary) working.
+                    storage.RemoveStorageTree();
+                }
+            }
+        }
+        toUpdateRoots.Clear();
+
+        if (trace is not null)
+        {
+            foreach ((StorageCell cell, byte[] originalValue) in _originalValues)
+            {
+                if (trace.TryGetValue(cell, out StorageChangeTrace changeTrace))
+                {
+                    trace[cell] = new StorageChangeTrace(originalValue, changeTrace.After);
+                }
+                else
+                {
+                    tracer.ReportStorageRead(cell);
+                }
+            }
+        }
+
+        base.CommitCore(tracer);
+        EndOriginalsRound();
+        _committedThisRound.ClearAndTrim();
+        _destroyedThisRound.ClearAndTrim();
+
+        if (trace is not null)
+        {
+            ReportChanges(tracer, trace);
+        }
+    }
+
+    private void CommitChanges<TStorageTracing>(
+        ReadOnlySpan<Change> changes,
+        int currentPosition,
+        HashSet<AddressAsKey> toUpdateRoots,
+        Dictionary<StorageCell, StorageChangeTrace>? trace)
+        where TStorageTracing : struct, IFlag
+    {
         for (int i = 0; i <= currentPosition; i++)
         {
             ref readonly Change change = ref changes[currentPosition - i];
@@ -168,7 +228,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 // tracers still see the cell zeroed, as the journaled path reported it.
                 if (_destroyedThisRound.Count != 0 && _destroyedThisRound.Contains(change.StorageCell.Address))
                 {
-                    if (isTracing)
+                    if (TStorageTracing.IsActive)
                     {
                         trace![change.StorageCell] = new StorageChangeTrace(StorageTree.ZeroBytes);
                     }
@@ -194,58 +254,11 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                         .SaveChange(change.StorageCell, change.Value);
                 }
 
-                if (isTracing)
+                if (TStorageTracing.IsActive)
                 {
                     trace![change.StorageCell] = new StorageChangeTrace(change.Value);
                 }
             }
-        }
-
-        foreach (AddressAsKey address in toUpdateRoots)
-        {
-            // since the accounts could be empty accounts that are removing (EIP-158)
-            if (_stateProvider.AccountExists(address))
-            {
-                _toUpdateRoots[address] = true;
-                // Add storage tree, will accessed later, which may be in parallel
-                // As we can't add a new storage tries in parallel to the _storages Dict do it here
-                GetOrCreateStorage(address).EnsureStorageTree();
-            }
-            else
-            {
-                _toUpdateRoots.Remove(address);
-                if (_storages.TryGetValue(address, out PerContractState? storage))
-                {
-                    // BlockChange need to be kept to keep selfdestruct marker (via DefaultableDictionary) working.
-                    storage.RemoveStorageTree();
-                }
-            }
-        }
-        toUpdateRoots.Clear();
-
-        if (isTracing)
-        {
-            foreach ((StorageCell cell, byte[] originalValue) in _originalValues)
-            {
-                if (trace!.TryGetValue(cell, out StorageChangeTrace changeTrace))
-                {
-                    trace[cell] = new StorageChangeTrace(originalValue, changeTrace.After);
-                }
-                else
-                {
-                    tracer.ReportStorageRead(cell);
-                }
-            }
-        }
-
-        base.CommitCore(tracer);
-        EndOriginalsRound();
-        _committedThisRound.ClearAndTrim();
-        _destroyedThisRound.ClearAndTrim();
-
-        if (isTracing)
-        {
-            ReportChanges(tracer!, trace!);
         }
     }
 

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -142,17 +142,17 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         HashSet<AddressAsKey> toUpdateRoots = (_tempToUpdateRoots ??= []);
 
-        ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes);
+        ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes)[..(currentPosition + 1)];
         Dictionary<StorageCell, StorageChangeTrace>? trace;
         if (tracer.IsTracingStorage)
         {
             trace = [];
-            CommitChanges<OnFlag>(changes, currentPosition, toUpdateRoots, trace);
+            CommitChanges<OnFlag>(changes, toUpdateRoots, trace);
         }
         else
         {
             trace = null;
-            CommitChanges<OffFlag>(changes, currentPosition, toUpdateRoots, null);
+            CommitChanges<OffFlag>(changes, toUpdateRoots, null);
         }
 
         foreach (AddressAsKey address in toUpdateRoots)
@@ -205,24 +205,23 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
     private void CommitChanges<TStorageTracing>(
         ReadOnlySpan<Change> changes,
-        int currentPosition,
         HashSet<AddressAsKey> toUpdateRoots,
         Dictionary<StorageCell, StorageChangeTrace>? trace)
         where TStorageTracing : struct, IFlag
     {
         Debug.Assert(TStorageTracing.IsActive == (trace is not null));
 
-        for (int i = 0; i <= currentPosition; i++)
+        for (int i = changes.Length - 1; i >= 0; i--)
         {
-            ref readonly Change change = ref changes[currentPosition - i];
+            ref readonly Change change = ref changes[i];
             if (!_committedThisRound.Add(change!.StorageCell))
             {
                 continue;
             }
 
             // Debug-only: A broken index surfaces anyway as a storage-root mismatch on the block.
-            Debug.Assert(_intraBlockCache[change.StorageCell].CurrentIdx == currentPosition - i,
-                $"Expected the cached index to equal {currentPosition} - {i}");
+            Debug.Assert(_intraBlockCache[change.StorageCell].CurrentIdx == i,
+                $"Expected the cached index to equal {i}");
 
             if (change.ChangeType == ChangeType.Update)
             {
@@ -240,7 +239,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
                 if (_logger.IsTrace)
                 {
-                    _logger.Trace($"  Update {change.StorageCell.Address}_{change.StorageCell.Index} V = {change.Value.ToHexString(true)}");
+                    TraceUpdate(change);
                 }
 
                 if (_originalValues.TryGetValue(change.StorageCell, out byte[] initialValue) &&
@@ -263,6 +262,10 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             }
         }
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceUpdate(in Change change)
+        => _logger.Trace($"  Update {change.StorageCell.Address}_{change.StorageCell.Index} V = {change.Value.ToHexString(true)}");
 
     internal void FlushToTree(IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch)
     {

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -152,7 +152,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         else
         {
             trace = null;
-            CommitChanges<OffFlag>(changes, currentPosition, toUpdateRoots, trace);
+            CommitChanges<OffFlag>(changes, currentPosition, toUpdateRoots, null);
         }
 
         foreach (AddressAsKey address in toUpdateRoots)
@@ -210,6 +210,8 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         Dictionary<StorageCell, StorageChangeTrace>? trace)
         where TStorageTracing : struct, IFlag
     {
+        Debug.Assert(TStorageTracing.IsActive == (trace is not null));
+
         for (int i = 0; i <= currentPosition; i++)
         {
             ref readonly Change change = ref changes[currentPosition - i];

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -522,7 +522,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         }
 
         bool removeEmptyAccounts = releaseSpec.IsEip158Enabled && !isGenesis;
-        ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes)[..(stepsBack + 1)];
+        ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes);
         if (stateTracer.IsTracingState)
         {
             Dictionary<AddressAsKey, ChangeTrace> trace = [];
@@ -613,7 +613,10 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
                 continue;
             }
 
-            if (_committedThisRound.Contains(change!.Address))
+            bool alreadyCommitted = TStateTracing.IsActive
+                ? _committedThisRound.Contains(change!.Address)
+                : !_committedThisRound.Add(change!.Address);
+            if (alreadyCommitted)
             {
                 if (TStateTracing.IsActive && change.ChangeType == ChangeType.JustCache)
                 {
@@ -637,7 +640,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
                 ThrowUnexpectedCommitPosition(i, forAssertion);
             }
 
-            _committedThisRound.Add(change.Address);
+            if (TStateTracing.IsActive) _committedThisRound.Add(change.Address);
 
             switch (change.ChangeType)
             {

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -602,6 +602,8 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         Dictionary<AddressAsKey, ChangeTrace>? trace)
         where TStateTracing : struct, IFlag
     {
+        Debug.Assert(TStateTracing.IsActive == (trace is not null));
+
         for (int i = 0; i <= stepsBack; i++)
         {
             ref readonly Change change = ref changes[stepsBack - i];
@@ -633,7 +635,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             int forAssertion = _intraTxCache[change.Address];
             if (forAssertion != stepsBack - i)
             {
-                ThrowUnexpectedPosition(stepsBack, i, forAssertion);
+                ThrowUnexpectedCommitPosition(stepsBack, i, forAssertion);
             }
 
             _committedThisRound.Add(change.Address);
@@ -726,7 +728,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     private static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException("changeType", "Unknown change type.");
 
     [DoesNotReturn, StackTraceHidden]
-    private static void ThrowUnexpectedPosition(int currentPosition, int i, int forAssertion)
+    private static void ThrowUnexpectedCommitPosition(int currentPosition, int i, int forAssertion)
         => throw new InvalidOperationException($"Expected checked value {forAssertion} to be equal to {currentPosition} - {i}");
 
     internal void FlushToTree(IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch)

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -521,114 +521,17 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             ThrowStartOfCommitIsNull(stepsBack);
         }
 
-        Dictionary<AddressAsKey, ChangeTrace>? trace = !stateTracer.IsTracingState ? null : [];
-
         ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes);
-        for (int i = 0; i <= stepsBack; i++)
+        if (stateTracer.IsTracingState)
         {
-            ref readonly Change change = ref changes[stepsBack - i];
-            if (trace is null && change!.ChangeType == ChangeType.JustCache)
-            {
-                // Safe to skip without touching the head: JustCache is always the bottom of its chain.
-                Debug.Assert(change.PrevIdx == -1);
-                continue;
-            }
-
-            if (_committedThisRound.Contains(change!.Address))
-            {
-                if (change.ChangeType == ChangeType.JustCache)
-                {
-                    trace?.UpdateTrace(change.Address, change.Account);
-                }
-
-                continue;
-            }
-
-            // because it was not committed yet it means that the just cache is the only state (so it was read only)
-            if (trace is not null && change.ChangeType == ChangeType.JustCache)
-            {
-                Debug.Assert(change.PrevIdx == -1);
-                _nullAccountReads.Add(change.Address);
-                continue;
-            }
-
-            int forAssertion = _intraTxCache[change.Address];
-            if (forAssertion != stepsBack - i)
-            {
-                ThrowUnexpectedPosition(stepsBack, i, forAssertion);
-            }
-
-            _committedThisRound.Add(change.Address);
-
-            switch (change.ChangeType)
-            {
-                case ChangeType.JustCache:
-                    break;
-                case ChangeType.Touch:
-                case ChangeType.Update:
-                    {
-                        if (releaseSpec.IsEip158Enabled && change.Account.IsEmpty && !isGenesis)
-                        {
-                            if (isTracing) TraceRemoveEmpty(change);
-                            SetState(change.Address, null);
-                            trace?.AddToTrace(change.Address, null);
-                        }
-                        else
-                        {
-                            if (isTracing) TraceUpdate(change);
-                            SetState(change.Address, change.Account);
-                            trace?.AddToTrace(change.Address, change.Account);
-                        }
-
-                        break;
-                    }
-                case ChangeType.New:
-                    {
-                        if (!releaseSpec.IsEip158Enabled || !change.Account.IsEmpty || isGenesis)
-                        {
-                            if (isTracing) TraceCreate(change);
-                            SetState(change.Address, change.Account);
-                            trace?.AddToTrace(change.Address, change.Account);
-                        }
-
-                        break;
-                    }
-                case ChangeType.RecreateEmpty:
-                    {
-                        if (isTracing) TraceCreate(change);
-                        SetState(change.Address, change.Account);
-                        trace?.AddToTrace(change.Address, change.Account);
-
-                        break;
-                    }
-                case ChangeType.Delete:
-                    {
-                        if (isTracing) TraceRemove(change);
-                        bool wasItCreatedNow = false;
-                        for (int previousOne = change.PrevIdx; previousOne != -1; previousOne = changes[previousOne].PrevIdx)
-                        {
-                            if (changes[previousOne].ChangeType == ChangeType.New)
-                            {
-                                wasItCreatedNow = true;
-                                break;
-                            }
-                        }
-
-                        if (!wasItCreatedNow)
-                        {
-                            SetState(change.Address, null);
-                            trace?.AddToTrace(change.Address, null);
-                        }
-
-                        break;
-                    }
-                default:
-                    ThrowUnknownChangeType();
-                    break;
-            }
+            Dictionary<AddressAsKey, ChangeTrace> trace = [];
+            CommitChanges<OnFlag>(changes, stepsBack, releaseSpec, isGenesis, isTracing, trace);
+            trace.ReportStateTrace(stateTracer, _nullAccountReads, this);
         }
-
-        trace?.ReportStateTrace(stateTracer, _nullAccountReads, this);
+        else
+        {
+            CommitChanges<OffFlag>(changes, stepsBack, releaseSpec, isGenesis, isTracing, null);
+        }
 
         InvalidateFrontCache();
         _changes.Clear();
@@ -685,32 +588,146 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         [MethodImpl(MethodImplOptions.NoInlining)]
         void TraceNoChanges() => _logger.Trace("No state changes to commit");
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        void TraceRemove(in Change change) => _logger.Trace($"Commit remove {change.Address}");
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        void TraceCreate(in Change change)
-            => _logger.Trace($"Commit create {change.Address} B = {change.Account.Balance.ToHexString(skipLeadingZeros: true)} N = {change.Account.Nonce.ToHexString(skipLeadingZeros: true)}");
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        void TraceUpdate(in Change change)
-            => _logger.Trace($"Commit update {change.Address} B = {change.Account.Balance.ToHexString(skipLeadingZeros: true)} N = {change.Account.Nonce.ToHexString(skipLeadingZeros: true)} C = {change.Account.CodeHash}");
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        void TraceRemoveEmpty(in Change change)
-            => _logger.Trace($"Commit remove empty {change.Address} B = {change.Account.Balance.ToHexString(skipLeadingZeros: true)} N = {change.Account.Nonce.ToHexString(skipLeadingZeros: true)}");
-
         [DoesNotReturn, StackTraceHidden]
         static void ThrowStartOfCommitIsNull(int currentPosition)
             => throw new InvalidOperationException($"Change at current position {currentPosition} was null when committing {nameof(StateProvider)}");
-
-        [DoesNotReturn, StackTraceHidden]
-        static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException("changeType", "Unknown change type.");
-
-        [DoesNotReturn, StackTraceHidden]
-        static void ThrowUnexpectedPosition(int currentPosition, int i, int forAssertion)
-            => throw new InvalidOperationException($"Expected checked value {forAssertion} to be equal to {currentPosition} - {i}");
     }
+
+    private void CommitChanges<TStateTracing>(
+        ReadOnlySpan<Change> changes,
+        int stepsBack,
+        IReleaseSpec releaseSpec,
+        bool isGenesis,
+        bool isTracing,
+        Dictionary<AddressAsKey, ChangeTrace>? trace)
+        where TStateTracing : struct, IFlag
+    {
+        for (int i = 0; i <= stepsBack; i++)
+        {
+            ref readonly Change change = ref changes[stepsBack - i];
+            if (!TStateTracing.IsActive && change!.ChangeType == ChangeType.JustCache)
+            {
+                // Safe to skip without touching the head: JustCache is always the bottom of its chain.
+                Debug.Assert(change.PrevIdx == -1);
+                continue;
+            }
+
+            if (_committedThisRound.Contains(change!.Address))
+            {
+                if (TStateTracing.IsActive && change.ChangeType == ChangeType.JustCache)
+                {
+                    trace!.UpdateTrace(change.Address, change.Account);
+                }
+
+                continue;
+            }
+
+            // because it was not committed yet it means that the just cache is the only state (so it was read only)
+            if (TStateTracing.IsActive && change.ChangeType == ChangeType.JustCache)
+            {
+                Debug.Assert(change.PrevIdx == -1);
+                _nullAccountReads.Add(change.Address);
+                continue;
+            }
+
+            int forAssertion = _intraTxCache[change.Address];
+            if (forAssertion != stepsBack - i)
+            {
+                ThrowUnexpectedPosition(stepsBack, i, forAssertion);
+            }
+
+            _committedThisRound.Add(change.Address);
+
+            switch (change.ChangeType)
+            {
+                case ChangeType.JustCache:
+                    break;
+                case ChangeType.Touch:
+                case ChangeType.Update:
+                    {
+                        if (releaseSpec.IsEip158Enabled && change.Account.IsEmpty && !isGenesis)
+                        {
+                            if (isTracing) TraceRemoveEmpty(change);
+                            SetState(change.Address, null);
+                            if (TStateTracing.IsActive) trace!.AddToTrace(change.Address, null);
+                        }
+                        else
+                        {
+                            if (isTracing) TraceUpdate(change);
+                            SetState(change.Address, change.Account);
+                            if (TStateTracing.IsActive) trace!.AddToTrace(change.Address, change.Account);
+                        }
+
+                        break;
+                    }
+                case ChangeType.New:
+                    {
+                        if (!releaseSpec.IsEip158Enabled || !change.Account.IsEmpty || isGenesis)
+                        {
+                            if (isTracing) TraceCreate(change);
+                            SetState(change.Address, change.Account);
+                            if (TStateTracing.IsActive) trace!.AddToTrace(change.Address, change.Account);
+                        }
+
+                        break;
+                    }
+                case ChangeType.RecreateEmpty:
+                    {
+                        if (isTracing) TraceCreate(change);
+                        SetState(change.Address, change.Account);
+                        if (TStateTracing.IsActive) trace!.AddToTrace(change.Address, change.Account);
+
+                        break;
+                    }
+                case ChangeType.Delete:
+                    {
+                        if (isTracing) TraceRemove(change);
+                        bool wasItCreatedNow = false;
+                        for (int previousOne = change.PrevIdx; previousOne != -1; previousOne = changes[previousOne].PrevIdx)
+                        {
+                            if (changes[previousOne].ChangeType == ChangeType.New)
+                            {
+                                wasItCreatedNow = true;
+                                break;
+                            }
+                        }
+
+                        if (!wasItCreatedNow)
+                        {
+                            SetState(change.Address, null);
+                            if (TStateTracing.IsActive) trace!.AddToTrace(change.Address, null);
+                        }
+
+                        break;
+                    }
+                default:
+                    ThrowUnknownChangeType();
+                    break;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceRemove(in Change change) => _logger.Trace($"Commit remove {change.Address}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceCreate(in Change change)
+        => _logger.Trace($"Commit create {change.Address} B = {change.Account.Balance.ToHexString(skipLeadingZeros: true)} N = {change.Account.Nonce.ToHexString(skipLeadingZeros: true)}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceUpdate(in Change change)
+        => _logger.Trace($"Commit update {change.Address} B = {change.Account.Balance.ToHexString(skipLeadingZeros: true)} N = {change.Account.Nonce.ToHexString(skipLeadingZeros: true)} C = {change.Account.CodeHash}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceRemoveEmpty(in Change change)
+        => _logger.Trace($"Commit remove empty {change.Address} B = {change.Account.Balance.ToHexString(skipLeadingZeros: true)} N = {change.Account.Nonce.ToHexString(skipLeadingZeros: true)}");
+
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException("changeType", "Unknown change type.");
+
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowUnexpectedPosition(int currentPosition, int i, int forAssertion)
+        => throw new InvalidOperationException($"Expected checked value {forAssertion} to be equal to {currentPosition} - {i}");
 
     internal void FlushToTree(IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch)
     {

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -521,16 +521,17 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             ThrowStartOfCommitIsNull(stepsBack);
         }
 
-        ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes);
+        bool removeEmptyAccounts = releaseSpec.IsEip158Enabled && !isGenesis;
+        ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes)[..(stepsBack + 1)];
         if (stateTracer.IsTracingState)
         {
             Dictionary<AddressAsKey, ChangeTrace> trace = [];
-            CommitChanges<OnFlag>(changes, stepsBack, releaseSpec, isGenesis, isTracing, trace);
+            CommitChanges<OnFlag>(changes, removeEmptyAccounts, isTracing, trace);
             trace.ReportStateTrace(stateTracer, _nullAccountReads, this);
         }
         else
         {
-            CommitChanges<OffFlag>(changes, stepsBack, releaseSpec, isGenesis, isTracing, null);
+            CommitChanges<OffFlag>(changes, removeEmptyAccounts, isTracing, null);
         }
 
         InvalidateFrontCache();
@@ -595,18 +596,16 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
     private void CommitChanges<TStateTracing>(
         ReadOnlySpan<Change> changes,
-        int stepsBack,
-        IReleaseSpec releaseSpec,
-        bool isGenesis,
+        bool removeEmptyAccounts,
         bool isTracing,
         Dictionary<AddressAsKey, ChangeTrace>? trace)
         where TStateTracing : struct, IFlag
     {
         Debug.Assert(TStateTracing.IsActive == (trace is not null));
 
-        for (int i = 0; i <= stepsBack; i++)
+        for (int i = changes.Length - 1; i >= 0; i--)
         {
-            ref readonly Change change = ref changes[stepsBack - i];
+            ref readonly Change change = ref changes[i];
             if (!TStateTracing.IsActive && change!.ChangeType == ChangeType.JustCache)
             {
                 // Safe to skip without touching the head: JustCache is always the bottom of its chain.
@@ -633,9 +632,9 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             }
 
             int forAssertion = _intraTxCache[change.Address];
-            if (forAssertion != stepsBack - i)
+            if (forAssertion != i)
             {
-                ThrowUnexpectedCommitPosition(stepsBack, i, forAssertion);
+                ThrowUnexpectedCommitPosition(i, forAssertion);
             }
 
             _committedThisRound.Add(change.Address);
@@ -647,7 +646,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
                 case ChangeType.Touch:
                 case ChangeType.Update:
                     {
-                        if (releaseSpec.IsEip158Enabled && change.Account.IsEmpty && !isGenesis)
+                        if (removeEmptyAccounts && change.Account.IsEmpty)
                         {
                             if (isTracing) TraceRemoveEmpty(change);
                             SetState(change.Address, null);
@@ -664,7 +663,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
                     }
                 case ChangeType.New:
                     {
-                        if (!releaseSpec.IsEip158Enabled || !change.Account.IsEmpty || isGenesis)
+                        if (!removeEmptyAccounts || !change.Account.IsEmpty)
                         {
                             if (isTracing) TraceCreate(change);
                             SetState(change.Address, change.Account);
@@ -728,8 +727,8 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     private static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException("changeType", "Unknown change type.");
 
     [DoesNotReturn, StackTraceHidden]
-    private static void ThrowUnexpectedCommitPosition(int currentPosition, int i, int forAssertion)
-        => throw new InvalidOperationException($"Expected checked value {forAssertion} to be equal to {currentPosition} - {i}");
+    private static void ThrowUnexpectedCommitPosition(int expected, int actual)
+        => throw new InvalidOperationException($"Expected checked value {actual} to be equal to {expected}");
 
     internal void FlushToTree(IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch)
     {


### PR DESCRIPTION
## Changes

- Extract the `StateProvider.Commit` change-application loop into `CommitChanges<TStateTracing>`, specialized on the existing `OnFlag`/`OffFlag` structs from `Nethermind.Core.TypeFlags`, so the JIT constant-folds state-tracing branches out of the non-tracing instantiation used on every block.
- Apply the same specialization to `PersistentStorageProvider.CommitCore` via `CommitChanges<TStorageTracing>`.
- Tighten the specialized loops further using FullOpts JitAsm inspection:
  - Extract the storage loop's interpolated trace log into a `[MethodImpl(NoInlining)]` `TraceUpdate` helper. This keeps the `DefaultInterpolatedStringHandler`, `ArrayPool`, hexadecimal conversion, and string-construction machinery out of the hot loop.
  - Hoist `releaseSpec.IsEip158Enabled && !isGenesis` into a `removeEmptyAccounts` local, replacing two non-devirtualized interface call sites inside the state loop with a register-held boolean.
  - Iterate the existing change spans downward (`for (int i = changes.Length - 1; i >= 0; i--)`), preserving indices `last..0` while removing duplicated `last - i` arithmetic. Identity slices at the callers were removed after review.
  - On the untraced state path, use `_committedThisRound.Add` as the membership test so each new entry is hashed once rather than by separate `Contains` and `Add` calls. The traced path retains deferred insertion required by `JustCache` trace handling.
- Trailer code (storage-root updates, original-value trace fixup, cache clears, and code flush) stays in the callers. `Debug.Assert`s encode the generic flag/trace-dictionary nullability invariant. Behavior and report/clear ordering are unchanged on both tracing paths.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

This is a behavior-preserving transform covered by the existing state, storage, and tracer suites.

- `dotnet build src/Nethermind/Nethermind.State/Nethermind.State.csproj -c release`: succeeded with 0 warnings.
- Focused `StateProviderTests` and `StorageProviderTests`: 148 passed, 0 failed, rerun after the final review changes.
- `git diff --check`: clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

FullOpts x64 JitAsm measurements for the per-block untraced path, comparing master (`2eba23124f`) with this PR (`ec62db5f45`):

| Executed per block | master | this PR |
|---|---:|---:|
| `StateProvider`: `Commit` + `CommitChanges<OffFlag>` | 1602 B monolith | 845 + 585 = 1430 B |
| `PersistentStorageProvider`: `CommitCore` + `CommitChanges<OffFlag>` | 3535 B monolith | 1804 + 465 = 2269 B |

The substantive changes in that path are:

- State loop: both per-change `IReleaseSpec.IsEip158Enabled` interface call sites are gone; trace-dictionary operations fold out; and new committed entries use one hash lookup instead of `Contains` followed by `Add`.
- Storage loop: calls in the loop method dropped from 22 to 9; interpolated trace formatting is outside the loop body; `CommitCore`'s stack frame shrank from 904 to 512 bytes; and the specialized OffFlag loop's frame shrank from 264 to 168 bytes.
- Loop skeleton: direct indexing with a `dec`/`jns` backedge. One `cmp`/`jae` bounds check per iteration remains because the JIT declines loop cloning on these call-heavy bodies; the Delete-case `PrevIdx` walk inherently retains its check because indices come from state.

Specialized loop bodies, initial unswitch versus current PR:

| Instantiation | Initial unswitch | Current |
|---|---:|---:|
| `StateProvider.CommitChanges<OffFlag>` | 832 B | 585 B |
| `StateProvider.CommitChanges<OnFlag>` | 959 B | 730 B |
| `PersistentStorageProvider.CommitChanges<OffFlag>` | 1334 B | 465 B |
| `PersistentStorageProvider.CommitChanges<OnFlag>` | 1828 B | 952 B |

The `OnFlag` instantiations only JIT when a state-tracing call such as `trace_*` or `debug_*` commits.