### PR TITLE
perf: streamline hot-path loops and collection updates

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsRecovery.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsRecovery.cs
@@ -25,13 +25,10 @@ namespace Nethermind.Blockchain.Receipts
                 if (needRecover)
                 {
                     using IReceiptsRecovery.IRecoveryContext ctx = CreateRecoveryContext(block, forceRecoverSender);
-                    for (int receiptIndex = 0; receiptIndex < block.TransactionCount; receiptIndex++)
+                    for (int receiptIndex = 0; receiptIndex < receipts.Length; receiptIndex++)
                     {
-                        if (receipts.Length > receiptIndex)
-                        {
-                            TxReceipt receipt = receipts[receiptIndex];
-                            ctx.RecoverReceiptData(receipt);
-                        }
+                        TxReceipt receipt = receipts[receiptIndex];
+                        ctx.RecoverReceiptData(receipt);
                     }
 
                     if (_reinsertReceiptOnRecover)

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ReportingContractBasedValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Validators/ReportingContractBasedValidator.cs
@@ -188,13 +188,12 @@ namespace Nethermind.Consensus.AuRa.Validators
                     {
                         if (skippedValidator != ValidatorContract.NodeAddress)
                         {
-                            if (reported.Contains(skippedValidator))
+                            if (!reported.Add(skippedValidator))
                             {
                                 break;
                             }
 
                             ReportBenign(skippedValidator, header.Number, IReportingValidator.BenignCause.SkippedStep);
-                            reported.Add(skippedValidator);
                             if (_logger.IsDebug) _logger.Debug($"Found skipped step {step} by author {skippedValidator}, actual author {header.Beneficiary} at block {header.Number}.");
                         }
                         else

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Collections.Pooled;
@@ -747,12 +748,8 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                 continue;
             }
 
-            if (!groups.TryGetValue(sender, out ArrayPoolList<(int, Transaction)> list))
-            {
-                list = new(4);
-                groups[sender] = list;
-            }
-            list.Add((i, tx));
+            ref ArrayPoolList<(int, Transaction)>? list = ref CollectionsMarshal.GetValueRefOrAddDefault(groups, sender, out _);
+            (list ??= new(4)).Add((i, tx));
         }
 
         ArrayPoolList<WarmupJob> result = new(groups.Count);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -418,7 +418,7 @@ public partial class BlockProcessor(
                 // we need this tracer to be able to track any potential miner account creation
                 using ITxTracer txTracer = tracer.StartNewTxTrace(null);
 
-                ApplyMinerReward(block, reward, spec);
+                ApplyMinerReward(reward, spec);
 
                 tracer.EndTxTrace();
                 tracer.ReportReward(reward.Address, reward.RewardType.ToLowerString(), reward.Value);
@@ -432,17 +432,21 @@ public partial class BlockProcessor(
         {
             for (int i = 0; i < rewards.Length; i++)
             {
-                ApplyMinerReward(block, rewards[i], spec);
+                ApplyMinerReward(rewards[i], spec);
             }
         }
     }
 
-    private void ApplyMinerReward(Block block, BlockReward reward, IReleaseSpec spec)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ApplyMinerReward(BlockReward reward, IReleaseSpec spec)
     {
-        if (_logger.IsTrace) _logger.Trace($"  {(BigInteger)reward.Value / (BigInteger)Unit.Ether:N3}{Unit.EthSymbol} for account at {reward.Address}");
+        if (_logger.IsTrace) TraceMinerReward(reward);
 
         _stateProvider.AddToBalanceAndCreateIfNotExists(reward.Address, reward.Value, spec);
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceMinerReward(BlockReward reward) => _logger.Trace($"  {(BigInteger)reward.Value / (BigInteger)Unit.Ether:N3}{Unit.EthSymbol} for account at {reward.Address}");
 
     private void ApplyDaoTransition(Block block)
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/MempoolStatePrewarmer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Nethermind.Blockchain;
 using Nethermind.Config;
@@ -147,21 +148,18 @@ public sealed class MempoolStatePrewarmer : IDisposable
         foreach (Transaction tx in orderedTxs)
         {
             if (tx.SenderAddress is not Address sender) continue;
-            if (!bySender.TryGetValue(sender, out List<Transaction>? group))
-            {
-                group = new(4);
-                bySender[sender] = group;
-            }
-            group.Add(tx);
+            ref List<Transaction>? group = ref CollectionsMarshal.GetValueRefOrAddDefault(bySender, sender, out _);
+            (group ??= new(4)).Add(tx);
             total++;
         }
 
         using ArrayPoolListRef<Transaction> delta = new(total);
         foreach (KeyValuePair<AddressAsKey, List<Transaction>> senderGroup in bySender)
         {
-            if (senderGroup.Value.Count <= warmedPerSender.GetValueOrDefault(senderGroup.Key)) continue;
+            ref int warmed = ref CollectionsMarshal.GetValueRefOrAddDefault(warmedPerSender, senderGroup.Key, out _);
+            if (senderGroup.Value.Count <= warmed) continue;
             delta.AddRange(senderGroup.Value);
-            warmedPerSender[senderGroup.Key] = senderGroup.Value.Count;
+            warmed = senderGroup.Value.Count;
         }
 
         return delta.ToArray();

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -311,6 +311,7 @@ public class BlockValidator(
     protected virtual bool ValidateTransactions(Block block, IReleaseSpec spec, ref string? errorMessage)
     {
         Transaction[] transactions = block.Transactions;
+        bool isEip2780Enabled = spec.IsEip2780Enabled;
 
         for (int txIndex = 0; txIndex < transactions.Length; txIndex++)
         {
@@ -318,7 +319,7 @@ public class BlockValidator(
 
             // Recover the sender if a preprocessor hasn't yet: the EIP-2780 self-transfer discount
             // makes the intrinsic-gas validation below sender-dependent.
-            if (spec.IsEip2780Enabled && transaction.SenderAddress is null && transaction.Signature is not null)
+            if (isEip2780Enabled && transaction.SenderAddress is null && transaction.Signature is not null)
                 transaction.SenderAddress = _ecdsa.RecoverAddress(transaction, !spec.ValidateChainId);
 
             ValidationResult isWellFormed = _txValidator.IsWellFormed(transaction, spec, block.Header.GasLimit);

--- a/src/Nethermind/Nethermind.Consensus/Withdrawals/WithdrawalProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Withdrawals/WithdrawalProcessor.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
@@ -27,7 +28,7 @@ public class WithdrawalProcessor : IWithdrawalProcessor
         if (!spec.WithdrawalsEnabled)
             return;
 
-        if (_logger.IsTrace) _logger.Trace($"Applying withdrawals for block {block}");
+        if (_logger.IsTrace) TraceApplyingWithdrawals(block);
 
         if (block.Withdrawals is not null)
         {
@@ -35,13 +36,22 @@ public class WithdrawalProcessor : IWithdrawalProcessor
             for (int i = 0; i < blockWithdrawals.Length; i++)
             {
                 Withdrawal withdrawal = blockWithdrawals[i];
-                if (_logger.IsTrace) _logger.Trace($"  {withdrawal.AmountInGwei} GWei to account {withdrawal.Address}");
+                if (_logger.IsTrace) TraceWithdrawal(withdrawal);
 
                 // Consensus clients are using Gwei for withdrawals amount. We need to convert it to Wei before applying state changes https://github.com/ethereum/execution-apis/pull/354
                 _stateProvider.AddToBalanceAndCreateIfNotExists(withdrawal.Address, withdrawal.AmountInWei, spec);
             }
         }
 
-        if (_logger.IsTrace) _logger.Trace($"Withdrawals applied for block {block}");
+        if (_logger.IsTrace) TraceWithdrawalsApplied(block);
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceApplyingWithdrawals(Block block) => _logger.Trace($"Applying withdrawals for block {block}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceWithdrawal(Withdrawal withdrawal) => _logger.Trace($"  {withdrawal.AmountInGwei} GWei to account {withdrawal.Address}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceWithdrawalsApplied(Block block) => _logger.Trace($"Withdrawals applied for block {block}");
 }

--- a/src/Nethermind/Nethermind.Core/Collections/LinkedHashSet.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/LinkedHashSet.cs
@@ -165,10 +165,9 @@ namespace Nethermind.Core.Collections
             for (int index = 0; index < ts.Length; index++)
             {
                 T t = ts[index];
-                if (set.Contains(t))
+                if (set.Remove(t))
                 {
                     Remove(t);
-                    set.Remove(t);
                 }
             }
 

--- a/src/Nethermind/Nethermind.Kademlia/NodeHealthTracker.cs
+++ b/src/Nethermind/Nethermind.Kademlia/NodeHealthTracker.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -278,16 +279,19 @@ public class NodeHealthTracker<TKey, TNode, TKadKey>(
         {
             lock (_lock)
             {
-                if (_values.TryGetValue(hash, out (int FailureCount, LinkedListNode<TKadKey> OrderNode) entry))
+                ref (int FailureCount, LinkedListNode<TKadKey> OrderNode) entry =
+                    ref CollectionsMarshal.GetValueRefOrAddDefault(_values, hash, out bool exists);
+                if (exists)
                 {
-                    _order.Remove(entry.OrderNode);
-                    _order.AddLast(entry.OrderNode);
-                    _values[hash] = (failureCount, entry.OrderNode);
+                    LinkedListNode<TKadKey> existingOrderNode = entry.OrderNode;
+                    _order.Remove(existingOrderNode);
+                    _order.AddLast(existingOrderNode);
+                    entry = (failureCount, existingOrderNode);
                     return;
                 }
 
                 LinkedListNode<TKadKey> orderNode = _order.AddLast(hash);
-                _values[hash] = (failureCount, orderNode);
+                entry = (failureCount, orderNode);
                 Trim();
             }
         }

--- a/src/Nethermind/Nethermind.Merge.AuRa/Withdrawals/AuraWithdrawalProcessor.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa/Withdrawals/AuraWithdrawalProcessor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using Nethermind.Consensus.Withdrawals;
 using Nethermind.Core;
 using Nethermind.Core.Exceptions;
@@ -34,20 +35,21 @@ public class AuraWithdrawalProcessor : IWithdrawalProcessor
         if (!spec.WithdrawalsEnabled || block.IsGenesis || block.Withdrawals is null)
             return;
 
-        if (_logger.IsTrace) _logger.Trace($"Applying withdrawals for block {block}");
+        if (_logger.IsTrace) TraceApplyingWithdrawals(block);
 
-        int count = block.Withdrawals.Length;
+        Withdrawal[] withdrawals = block.Withdrawals;
+        int count = withdrawals.Length;
         using ArrayPoolList<ulong> amounts = new(count);
         using ArrayPoolList<Address> addresses = new(count);
 
         for (int i = 0; i < count; i++)
         {
-            Withdrawal withdrawal = block.Withdrawals[i];
+            Withdrawal withdrawal = withdrawals[i];
 
             addresses.Add(withdrawal.Address);
             amounts.Add(withdrawal.AmountInGwei);
 
-            if (_logger.IsTrace) _logger.Trace($"  {(BigInteger)withdrawal.AmountInWei / (BigInteger)Unit.Ether:N3}GNO to account {withdrawal.Address}");
+            if (_logger.IsTrace) TraceWithdrawal(withdrawal);
         }
 
         try
@@ -59,6 +61,15 @@ public class AuraWithdrawalProcessor : IWithdrawalProcessor
             throw new InvalidBlockException(block, "failed to execute withdrawals contract", ex);
         }
 
-        if (_logger.IsTrace) _logger.Trace($"Withdrawals applied for block {block}");
+        if (_logger.IsTrace) TraceWithdrawalsApplied(block);
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceApplyingWithdrawals(Block block) => _logger.Trace($"Applying withdrawals for block {block}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceWithdrawal(Withdrawal withdrawal) => _logger.Trace($"  {(BigInteger)withdrawal.AmountInWei / (BigInteger)Unit.Ether:N3}GNO to account {withdrawal.Address}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceWithdrawalsApplied(Block block) => _logger.Trace($"Withdrawals applied for block {block}");
 }

--- a/src/Nethermind/Nethermind.Network/NetworkStorage.cs
+++ b/src/Nethermind/Nethermind.Network/NetworkStorage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Nethermind.Config;
@@ -104,19 +105,15 @@ namespace Nethermind.Network
         {
             EnsureLoadedFromDbNoLock();
 
-            (_currentBatch ?? (IWriteOnlyKeyValueStore)_fullDb).PutSpan(node.NodeId.Bytes, rlp);
+            PublicKey nodeId = node.NodeId;
+            (_currentBatch ?? (IWriteOnlyKeyValueStore)_fullDb).PutSpan(nodeId.Bytes, rlp);
             _updateCounter++;
 
-            if (!_nodesDict.ContainsKey(node.NodeId))
-            {
-                _nodesDict[node.NodeId] = node;
-                // New node, clear the cache
-                _nodes = null;
-            }
-            else
-            {
-                _nodesDict[node.NodeId] = node;
-            }
+            ref NetworkNode? storedNode = ref CollectionsMarshal.GetValueRefOrAddDefault(_nodesDict, nodeId, out bool exists);
+            storedNode = node;
+
+            // New node, clear the cache
+            if (!exists) _nodes = null;
         }
 
         public void UpdateNodes(IEnumerable<NetworkNode> nodes)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
@@ -461,8 +461,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                     if (_returned[i])
                     {
                         ulong fingerprint = _fingerprints[i];
-                        creditedFingerprints.TryGetValue(fingerprint, out int count);
-                        creditedFingerprints[fingerprint] = count + 1;
+                        creditedFingerprints.Increment(fingerprint);
                     }
                 }
             }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetty.Buffers;
@@ -1108,8 +1110,10 @@ public class Eth72ProtocolHandler(
 
         lock (_cellStateLock)
         {
-            if (_pendingCellRequests.TryGetValue(hash, out CellRequestState existing))
+            ref CellRequestState state = ref CollectionsMarshal.GetValueRefOrAddDefault(_pendingCellRequests, hash, out bool exists);
+            if (exists)
             {
+                CellRequestState existing = state;
                 BlobCellMask combinedMask = existing.Mask | requestMask;
                 _pendingCellRequestWork += combinedMask.Count - existing.Mask.Count;
                 DateTimeOffset? combinedRetryAt = existing.RetryAt;
@@ -1119,7 +1123,7 @@ public class Eth72ProtocolHandler(
                     combinedRetryAt = retryAt;
                 }
 
-                _pendingCellRequests[hash] = existing with
+                state = existing with
                 {
                     Mask = combinedMask,
                     ExpiresAt = _timestamper.UtcNowOffset + PendingCellStateTtl,
@@ -1131,7 +1135,7 @@ public class Eth72ProtocolHandler(
             }
 
             long revision = NextCellStateRevision();
-            _pendingCellRequests[hash] = new CellRequestState(
+            state = new CellRequestState(
                 requestMask,
                 revision,
                 RequestId: 0,
@@ -1231,13 +1235,15 @@ public class Eth72ProtocolHandler(
         lock (_cellStateLock)
         {
             DateTimeOffset now = _timestamper.UtcNowOffset;
-            if (_sentCellRequests.TryGetValue(hash, out CellRequestState existing))
+            ref CellRequestState state = ref CollectionsMarshal.GetValueRefOrAddDefault(_sentCellRequests, hash, out bool exists);
+            if (exists)
             {
+                CellRequestState existing = state;
                 BlobCellMask combinedMask = existing.Mask | requestMask;
                 _sentCellRequestWork += combinedMask.Count - existing.Mask.Count;
                 DateTimeOffset updatedExpiresAt = now + CellRequestTtl;
                 int updatedMaxResponseBytes = GetExpectedCellsResponseBound(requestId, combinedMask);
-                _sentCellRequests[hash] = existing with { Mask = combinedMask, RequestId = requestId, ExpiresAt = updatedExpiresAt };
+                state = existing with { Mask = combinedMask, RequestId = requestId, ExpiresAt = updatedExpiresAt };
                 _sentCellRequestIds[requestId] = new SentCellRequest(
                     hash,
                     combinedMask,
@@ -1251,7 +1257,7 @@ public class Eth72ProtocolHandler(
             long revision = NextCellStateRevision();
             DateTimeOffset expiresAt = now + CellRequestTtl;
             int maxResponseBytes = GetExpectedCellsResponseBound(requestId, requestMask);
-            _sentCellRequests[hash] = new CellRequestState(requestMask, revision, requestId, expiresAt, RetryAt: null, RestoreAnnouncement: false);
+            state = new CellRequestState(requestMask, revision, requestId, expiresAt, RetryAt: null, RestoreAnnouncement: false);
             _sentCellRequestIds[requestId] = new SentCellRequest(
                 hash,
                 requestMask,
@@ -1320,8 +1326,8 @@ public class Eth72ProtocolHandler(
     {
         lock (_cellStateLock)
         {
-            if (!_pendingCellRequests.TryGetValue(hash, out CellRequestState state)
-                || (expectedRevision != 0 && state.Revision != expectedRevision))
+            ref CellRequestState state = ref CollectionsMarshal.GetValueRefOrNullRef(_pendingCellRequests, hash);
+            if (Unsafe.IsNullRef(ref state) || (expectedRevision != 0 && state.Revision != expectedRevision))
             {
                 return;
             }
@@ -1339,7 +1345,7 @@ public class Eth72ProtocolHandler(
             }
 
             _pendingCellRequestWork -= state.Mask.Count - remainingMask.Count;
-            _pendingCellRequests[hash] = state with { Mask = remainingMask };
+            state = state with { Mask = remainingMask };
         }
     }
 

--- a/src/Nethermind/Nethermind.Optimism/CL/P2P/P2PBlockValidator.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/P2P/P2PBlockValidator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
@@ -40,8 +41,8 @@ public class P2PBlockValidator(
     public ValidityStatus IsBlockNumberPerHeightLimitReached(ExecutionPayloadV3 payload)
     {
         // [REJECT] if more than 5 different blocks have been seen with the same block height
-        _numberOfBlocksSeen.TryGetValue(payload.BlockNumber, out long currentCount);
-        _numberOfBlocksSeen[payload.BlockNumber] = currentCount + 1;
+        ref long count = ref CollectionsMarshal.GetValueRefOrAddDefault(_numberOfBlocksSeen, payload.BlockNumber, out _);
+        long currentCount = count++;
         return currentCount > 5 ? ValidityStatus.Reject : ValidityStatus.Valid;
     }
 

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -147,12 +147,26 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         if (tracer.IsTracingStorage)
         {
             trace = [];
-            CommitChanges<OnFlag>(changes, toUpdateRoots, trace);
+            if (_destroyedThisRound.Count == 0)
+            {
+                CommitChanges<OnFlag, OffFlag>(changes, toUpdateRoots, trace);
+            }
+            else
+            {
+                CommitChanges<OnFlag, OnFlag>(changes, toUpdateRoots, trace);
+            }
         }
         else
         {
             trace = null;
-            CommitChanges<OffFlag>(changes, toUpdateRoots, null);
+            if (_destroyedThisRound.Count == 0)
+            {
+                CommitChanges<OffFlag, OffFlag>(changes, toUpdateRoots, null);
+            }
+            else
+            {
+                CommitChanges<OffFlag, OnFlag>(changes, toUpdateRoots, null);
+            }
         }
 
         foreach (AddressAsKey address in toUpdateRoots)
@@ -203,13 +217,15 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
     }
 
-    private void CommitChanges<TStorageTracing>(
+    private void CommitChanges<TStorageTracing, HasDestroyedAccounts>(
         ReadOnlySpan<Change> changes,
         HashSet<AddressAsKey> toUpdateRoots,
         Dictionary<StorageCell, StorageChangeTrace>? trace)
         where TStorageTracing : struct, IFlag
+        where HasDestroyedAccounts : struct, IFlag
     {
         Debug.Assert(TStorageTracing.IsActive == (trace is not null));
+        Debug.Assert(HasDestroyedAccounts.IsActive == (_destroyedThisRound.Count != 0));
 
         for (int i = changes.Length - 1; i >= 0; i--)
         {
@@ -227,7 +243,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             {
                 // A SaveChange would resurrect the dead value over the Clear() marker;
                 // tracers still see the cell zeroed, as the journaled path reported it.
-                if (_destroyedThisRound.Count != 0 && _destroyedThisRound.Contains(change.StorageCell.Address))
+                if (HasDestroyedAccounts.IsActive && _destroyedThisRound.Contains(change.StorageCell.Address))
                 {
                     if (TStorageTracing.IsActive)
                     {

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -389,14 +389,13 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
         ReadOnlySpan<Change> changes = CollectionsMarshal.AsSpan(_changes);
         // Roll back each change from newest down to target
-        for (int i = 0; i < stepsBack; i++)
+        for (int nextPosition = changes.Length - 1; nextPosition > snapshot; nextPosition--)
         {
-            int nextPosition = lastIndex - i;
             ref readonly Change change = ref changes[nextPosition];
             ref int head = ref CollectionsMarshal.GetValueRefOrNullRef(_intraTxCache, change!.Address);
 
-            if (Unsafe.IsNullRef(ref head)) ThrowUnexpectedPosition(lastIndex, i, -1);
-            if (head != nextPosition) ThrowUnexpectedPosition(lastIndex, i, head);
+            if (Unsafe.IsNullRef(ref head)) ThrowUnexpectedPosition(nextPosition, -1);
+            if (head != nextPosition) ThrowUnexpectedPosition(nextPosition, head);
 
             if (change.PrevIdx != -1)
             {
@@ -436,8 +435,8 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             => throw new InvalidOperationException($"{nameof(StateProvider)} tried to restore snapshot {snap} beyond current position {current}");
 
         [DoesNotReturn, StackTraceHidden]
-        static void ThrowUnexpectedPosition(int current, int step, int actual)
-            => throw new InvalidOperationException($"Expected actual position {actual} to be equal to {current} - {step}");
+        static void ThrowUnexpectedPosition(int expected, int actual)
+            => throw new InvalidOperationException($"Expected actual position {actual} to be equal to {expected}");
     }
 
     public void CreateAccount(Address address, in UInt256 balance, in ulong nonce = default)

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcRpcModule.cs
@@ -13,6 +13,7 @@ using Nethermind.Xdc.Spec;
 using Nethermind.Xdc.Types;
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Nethermind.Xdc.RLP;
 
 namespace Nethermind.Xdc.RPC;
@@ -341,8 +342,8 @@ internal class XdcRpcModule(IBlockTree tree, ISnapshotManager snapshotManager, I
 
             foreach ((string holder, UInt256 amount) in epochReward.DelegatedReward ?? [])
             {
-                totalDelegatedReward.TryGetValue(holder, out UInt256 existing);
-                totalDelegatedReward[holder] = existing + amount;
+                ref UInt256 total = ref CollectionsMarshal.GetValueRefOrAddDefault(totalDelegatedReward, holder, out _);
+                total += amount;
             }
         }
 

--- a/src/Nethermind/Nethermind.Xdc/XdcRewardCalculator.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcRewardCalculator.cs
@@ -14,6 +14,7 @@ using Nethermind.Xdc.Spec;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Nethermind.Xdc;
 
@@ -194,9 +195,8 @@ public class XdcRewardCalculator(IEpochSwitchManager epochSwitchManager,
             {
                 Hash256 blockHash = ExtractBlockHashFromSigningTxData(tx.Data);
                 tx.SenderAddress ??= _ethereumEcdsa.RecoverAddress(tx);
-                if (!hashToSigningAddress.ContainsKey(blockHash))
-                    hashToSigningAddress[blockHash] = [];
-                hashToSigningAddress[blockHash].Add(tx.SenderAddress);
+                ref HashSet<Address>? signingAddresses = ref CollectionsMarshal.GetValueRefOrAddDefault(hashToSigningAddress, blockHash, out _);
+                (signingAddresses ??= []).Add(tx.SenderAddress);
             }
 
             if (blockIdx == 0) break;

--- a/src/Nethermind/Nethermind.Xdc/XdcRewardCalculator.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcRewardCalculator.cs
@@ -262,10 +262,11 @@ public class XdcRewardCalculator(IEpochSwitchManager epochSwitchManager,
 
     private static void IncrementSignerCount(Dictionary<Address, XdcRewardLog> signers, Address addr)
     {
-        if (signers.TryGetValue(addr, out XdcRewardLog? rewardLog))
+        ref XdcRewardLog? rewardLog = ref CollectionsMarshal.GetValueRefOrAddDefault(signers, addr, out _);
+        if (rewardLog is not null)
             rewardLog.Sign++;
         else
-            signers[addr] = new XdcRewardLog { Sign = 1 };
+            rewardLog = new XdcRewardLog { Sign = 1 };
     }
 
     private Hash256 ExtractBlockHashFromSigningTxData(ReadOnlyMemory<byte> data)


### PR DESCRIPTION
## Changes

FullOpts JitAsm was checked before and after each change:

- `ReceiptsRecovery.TryRecover`: **564 -> 475 bytes**. Using the receipt length as the sole loop bound removes the cloned fallback body, its second `RecoverReceiptData` call site, and the `CORINFO_HELP_RNGCHKFAIL` path.
- `StateProvider.Restore`: **680 -> 650 bytes**. Counting down on the change index removes the per-iteration `lastIndex - i` subtraction and one throw-helper argument.
- `PersistentStorageProvider.CommitChanges<OffFlag, OffFlag>`: **465 -> 439 bytes**. Specializing on whether destroyed accounts exist removes the `_destroyedThisRound` probe and `HashSet.FindItemIndex` from the common path. The destroyed-account specialization is 463 bytes and drops the per-change `Count` test; the once-per-commit four-way dispatch grows `CommitCore` from 1,804 to 1,913 bytes.
- `WithdrawalProcessor.ProcessWithdrawals`: **2,368 -> 1,080 bytes**. No-inline helpers keep disabled block and per-withdrawal trace formatting out of the processing method while preserving bounds-check elimination.
- `AuraWithdrawalProcessor.ProcessWithdrawals`: **4,177 -> 1,911 bytes**. No-inline helpers remove trace formatting, `BigInteger` conversion, and division from the method; the withdrawal loop becomes a pointer walk without its previous array range check.
- `BlockProcessor.ApplyMinerRewards`: **436 -> 422 bytes**, and `ApplyMinerReward`: **1,050 -> 114 bytes**; combined **1,486 -> 536 bytes**. Reward formatting moves to a cold no-inline trace helper without duplicating `ApplyMinerReward` into both loops.
- `BlockValidator.ValidateTransactions`: **817 -> 831 bytes**. The small size tradeoff removes a non-devirtualized `IReleaseSpec.IsEip2780Enabled` interface call from every transaction iteration and replaces it with one pre-loop read.
- `NetworkStorage.UpdateNodeImpl`: **265 -> 201 bytes**. One `GetValueRefOrAddDefault` replaces `FindValue` plus `TryInsert`, and `NodeId` is computed once instead of twice.
- `XdcRewardCalculator.GetSigningTxCount`: **3,448 -> 3,425 bytes**. The signer loop replaces `FindValue`/`TryInsert`/`FindValue` with one `GetValueRefOrAddDefault` call.
- `Eth72ProtocolHandler.AddPendingCellRequest`: **1,513 -> 1,393 bytes**; `AddSentCellRequest`: **2,000 -> 1,874 bytes**; `RemovePendingCellRequestMask`: **531 -> 455 bytes**. Each cell-state path now performs one dictionary helper call instead of lookup-plus-indexer updates.
- `SampledPooledTransactionRequest.AddCreditsTo`: **123 -> 103 bytes**. `DictionaryExtensions.Increment` replaces `FindValue` plus `TryInsert` with one ref-based lookup.
- `BlockCachePreWarmer.GroupTransactionsBySender`: **3,380 -> 3,380 bytes**. Although total size is unchanged, sender grouping replaces `FindValue` plus `TryInsert` with one `GetValueRefOrAddDefault`; the remaining range-check helper belongs to later result processing.
- `MempoolStatePrewarmer.SelectDelta`: **1,234 -> 1,173 bytes**. Ref slots remove lookup-plus-insert pairs from both per-sender grouping and warmed-count updates.
- `P2PBlockValidator.IsBlockNumberPerHeightLimitReached`: **91 -> 58 bytes**. An in-place ref increment replaces `FindValue` plus `TryInsert`.
- `XdcRewardCalculator.IncrementSignerCount`: **105 -> 110 bytes**. The slight size tradeoff replaces `FindValue` plus conditional `TryInsert` with one `GetValueRefOrAddDefault`; an explicit exists-flag variant was larger at 112 bytes.
- `XdcRpcModule.XDPoS_getRewardByAccount`: **2,894 -> 2,816 bytes**. Delegated rewards accumulate through a value ref, replacing `FindValue` plus `TryInsert` with one lookup.
- `PeerFailureCache.Set`: **287 -> 262 bytes**. One `GetValueRefOrAddDefault` replaces `FindValue` and branch-specific `TryInsert` calls while the existing lock protects the ref update.
- `ReportingContractBasedValidator.TryReportSkipped`: **4,069 -> 4,057 bytes**. Using `HashSet.Add`'s result removes `FindItemIndex` and retains one `AddIfNotPresent` call in the loop.
- `LinkedHashSet<int>.SymmetricExceptWith`: **335 -> 324 bytes**. Using `HashSet.Remove`'s result removes `FindItemIndex` while retaining only the required set and linked-set removals.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Each change was inspected with FullOpts JitAsm before and after editing. Exact code-generation details are also retained in the individual commit messages.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

No behavior changes are intended. Candidates that regressed generated code without removing a more expensive operation were not included.
