### PR TITLE
build(zisk): bump zisk toolchain image and ZiskOS runtime

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.6.0" />
     <PackageVersion Include="Nethermind.TurboPForBindings" Version="1.0.0" />
     <PackageVersion Include="Nethermind.Zkvm.Abstractions" Version="1.0.0-preview.2" />
-    <PackageVersion Include="Nethermind.ZiskOS.Runtime" Version="1.0.0-preview.7" />
+    <PackageVersion Include="Nethermind.ZiskOS.Runtime" Version="1.0.0-preview.8" />
     <PackageVersion Include="Nito.Collections.Deque" Version="1.2.1" />
     <PackageVersion Include="NJsonSchema" Version="11.6.1" />
     <PackageVersion Include="NLog" Version="5.5.1" />

--- a/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
+++ b/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
@@ -7,7 +7,7 @@ GUEST_DIR := $(MAKEFILE_DIR)
 BIN_DIR := /nethermind/bin
 SRC_DIR := /nethermind/src
 BFLAT_IMAGE ?= nethermindeth/bflat-riscv64:acee0ec11a2bb2199e941380ae0336caa429cdea@sha256:ede3b4bc5f751e0acb21341bc6a75b2ac4a0bfa49a89f91f99d8a450364f04a1
-ZISK_IMAGE ?= nethermindeth/zisk:1.1.0-alpha@sha256:ded53e7e25f759e477d3bec34056da403716a957cfbd22a6d01c893da0f83368
+ZISK_IMAGE ?= nethermindeth/zisk:1.2.0-alpha@sha256:7b3ea05815cf902f0bceb17458d9fbc36b34043b81370b69e57a18cbd91c2d1c
 # ziskemu ROMs the whole .text, so even unreachable F/D/C/A instructions reject
 # the guest - fail at build time instead.
 ISA_GATES ?= --error-on-float --error-on-float-binary --error-on-compressed --error-on-atomic


### PR DESCRIPTION
Update the guest build image to zisk 1.2.0-alpha and the Nethermind.ZiskOS.Runtime package to 1.0.0-preview.8 so the guest builds against a matching runtime ABI.

## Changes

- Upgrade ZiskOS to 1.2.0-alpha

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
