### PR TITLE
Fix simulation head reset during deferred block persistence

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -307,6 +307,23 @@ public class BlockTreeTests
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
+    public void TryUpdateMainChain_uses_preloaded_head_when_body_is_missing_from_store()
+    {
+        BlockTree blockTree = BuildBlockTree();
+        Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
+        AddToMain(blockTree, block0);
+
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
+        Assert.That(blockTree.SuggestHeader(block1.Header), Is.EqualTo(AddBlockResult.Added));
+        Assert.That(blockTree.FindBlock(block1.Hash!, BlockTreeLookupOptions.None), Is.Null, "precondition: body is not in the store");
+
+        bool updated = blockTree.TryUpdateMainChain(block1.Header, wereProcessed: true, preloadedBlocks: new[] { block1 });
+
+        Assert.That(updated, Is.True);
+        Assert.That(blockTree.Head!.Hash, Is.EqualTo(block1.Hash));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
     public void TryUpdateMainChain_returns_false_without_mutating_when_a_predecessor_is_missing()
     {
         BlockTree blockTree = BuildBlockTree();

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -347,8 +347,7 @@ public class BlockTreeTests
         Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
         AddToMain(baseTree, block0);
         Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
-        baseTree.SuggestBlock(block1);
-        baseTree.TryUpdateMainChain(block1.Header, wereProcessed: true, preloadedBlocks: new[] { block1 });
+        AddToMain(baseTree, block1);
 
         GeneratedBlockAccessList generatedBlockAccessList = new();
         byte[] encodedBlockAccessList = [1];

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -316,11 +316,57 @@ public class BlockTreeTests
         Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
         Assert.That(blockTree.SuggestHeader(block1.Header), Is.EqualTo(AddBlockResult.Added));
         Assert.That(blockTree.FindBlock(block1.Hash!, BlockTreeLookupOptions.None), Is.Null, "precondition: body is not in the store");
+        Assert.That(blockTree.TryUpdateMainChain(block1.Header, wereProcessed: true), Is.False, "no body and no preloaded block - still rejected");
 
         bool updated = blockTree.TryUpdateMainChain(block1.Header, wereProcessed: true, preloadedBlocks: new[] { block1 });
 
-        Assert.That(updated, Is.True);
-        Assert.That(blockTree.Head!.Hash, Is.EqualTo(block1.Hash));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(updated, Is.True);
+            Assert.That(blockTree.Head!.Hash, Is.EqualTo(block1.Hash));
+            Assert.That(blockTree.IsMainChain(block1.Header), Is.True);
+        }
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void BlockTreeOverlay_ResetMainChain_sets_overlay_head_without_mutating_base_head()
+    {
+        using TestMemDb baseBlocksDb = new();
+        using TestMemDb overlayBlocksDb = new();
+        using TestMemDb headersDb = new();
+        using TestMemDb blocksInfosDb = new();
+
+        BlockTree BuildTree(TestMemDb blocksDb) => Build.A.BlockTree()
+            .WithBlocksDb(blocksDb)
+            .WithHeadersDb(headersDb)
+            .WithBlockInfoDb(blocksInfosDb)
+            .WithoutSettingHead
+            .TestObject;
+
+        BlockTree baseTree = BuildTree(baseBlocksDb);
+        Block block0 = Build.A.Block.WithNumber(0).WithDifficulty(1).TestObject;
+        AddToMain(baseTree, block0);
+        Block block1 = Build.A.Block.WithNumber(1).WithDifficulty(2).WithParent(block0).TestObject;
+        baseTree.SuggestBlock(block1);
+        baseTree.TryUpdateMainChain(block1.Header, wereProcessed: true, preloadedBlocks: new[] { block1 });
+
+        GeneratedBlockAccessList generatedBlockAccessList = new();
+        byte[] encodedBlockAccessList = [1];
+        block1.GeneratedBlockAccessList = generatedBlockAccessList;
+        block1.EncodedBlockAccessList = encodedBlockAccessList;
+
+        BlockTree overlayTree = BuildTree(overlayBlocksDb);
+        Assert.That(overlayTree.FindBlock(block1.Hash!, BlockTreeLookupOptions.None), Is.Null, "precondition: body is not in the overlay store");
+        BlockTreeOverlay blockTreeOverlay = new(new ReadOnlyBlockTree(baseTree), overlayTree);
+
+        blockTreeOverlay.ResetMainChain();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(overlayTree.Head!.Hash, Is.EqualTo(block1.Hash));
+            Assert.That(block1.GeneratedBlockAccessList, Is.SameAs(generatedBlockAccessList));
+            Assert.That(block1.EncodedBlockAccessList, Is.SameAs(encodedBlockAccessList));
+        }
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -944,14 +944,14 @@ namespace Nethermind.Blockchain
 
         public bool TryUpdateMainChain(BlockHeader newHead, bool wereProcessed, bool forceUpdateHeadBlock = false, params ReadOnlySpan<Block> preloadedBlocks)
         {
+            PreloadedBlockLookup cache = PreloadedBlockLookup.Build(preloadedBlocks);
+
             // The head itself must have a body to be moved onto the main chain (the walk below checks every
             // ancestor the same way). Fail fast here rather than throwing later when GetBlock can't load it.
-            if (!_blockStore.HasBlock(newHead.Number, newHead.Hash!))
+            if (!cache.TryGet(newHead.Hash!, out _) && !_blockStore.HasBlock(newHead.Number, newHead.Hash!))
             {
                 return false;
             }
-
-            PreloadedBlockLookup cache = PreloadedBlockLookup.Build(preloadedBlocks);
 
             // Walk back from the new head, collecting the branch of headers down to the current main chain.
             // Only headers are loaded here, so this stays cheap regardless of reorg depth. A missing

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -946,8 +946,9 @@ namespace Nethermind.Blockchain
         {
             PreloadedBlockLookup cache = PreloadedBlockLookup.Build(preloadedBlocks);
 
-            // The head itself must have a body to be moved onto the main chain (the walk below checks every
-            // ancestor the same way). Fail fast here rather than throwing later when GetBlock can't load it.
+            // The head must have a body to be moved onto the main chain - preloaded by the caller or already in
+            // the store (the walk below checks every ancestor the same way). Fail fast here rather than throwing
+            // later when GetBlock can't load it.
             if (!cache.TryGet(newHead.Hash!, out _) && !_blockStore.HasBlock(newHead.Number, newHead.Hash!))
             {
                 return false;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
@@ -23,7 +23,7 @@ public class BlockTreeOverlay(IReadOnlyBlockTree baseTree, IBlockTree overlayTre
         Block head = _baseTree.Head!;
         // BAL persistence clears fields on the block instance, so do not pass the base tree's live head.
         Block detachedHead = new(head.Header, head.Body);
-        _overlayTree.TryUpdateMainChain(head.Header, wereProcessed: true, forceUpdateHeadBlock: true, preloadedBlocks: new[] { detachedHead });
+        _overlayTree.TryUpdateMainChain(head.Header, wereProcessed: true, forceUpdateHeadBlock: true, preloadedBlocks: [detachedHead]);
     }
 
     public ulong NetworkId => _baseTree.NetworkId;

--- a/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTreeOverlay.cs
@@ -18,8 +18,13 @@ public class BlockTreeOverlay(IReadOnlyBlockTree baseTree, IBlockTree overlayTre
     private readonly IBlockTree _overlayTree = overlayTree ?? throw new ArgumentNullException(nameof(overlayTree));
 
     // Cannot be called until blocktree is ready.
-    public void ResetMainChain() =>
-        _overlayTree.TryUpdateMainChain(_baseTree.Head!.Header, wereProcessed: true, forceUpdateHeadBlock: true, preloadedBlocks: new[] { _baseTree.Head! });
+    public void ResetMainChain()
+    {
+        Block head = _baseTree.Head!;
+        // BAL persistence clears fields on the block instance, so do not pass the base tree's live head.
+        Block detachedHead = new(head.Header, head.Body);
+        _overlayTree.TryUpdateMainChain(head.Header, wereProcessed: true, forceUpdateHeadBlock: true, preloadedBlocks: new[] { detachedHead });
+    }
 
     public ulong NetworkId => _baseTree.NetworkId;
     public ulong ChainId => _baseTree.ChainId;


### PR DESCRIPTION
## Changes

- Treat a caller-preloaded head block as available when updating the main chain, even if its body has not reached the backing block store yet.
- Prevent read-only simulation block trees from falling back to genesis during deferred block-body persistence.
- Pass a detached block wrapper into the simulation overlay so its BAL persistence cannot mutate the main tree's live head instance; the header and body are shared without copying or encoding.
- Add deterministic coverage for the stored-header/preloaded-body contract, the missing-body rejection path, canonicality, the real overlay reset path, and BAL ownership.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `TryUpdateMainChain_uses_preloaded_head_when_body_is_missing_from_store`
- `BlockTreeOverlay_ResetMainChain_sets_overlay_head_without_mutating_base_head`
- All 13 `BlockTreeTests.TryUpdateMainChain` tests
- All 8 cases of `TestSimulate_TimestampIsComputedCorrectly_WhenNoTimestampOverride`

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The preloaded lookup was already built by `TryUpdateMainChain`; this change only consults it before probing the block store. The common single-preloaded-block path remains allocation-free and avoids an unnecessary store lookup. `ResetMainChain` creates one detached `Block` wrapper to establish an ownership boundary, but shares the existing header and body and performs no body copy or encoding.