### PR TITLE
Fix flaky NewPayloadV5 BAL golden-hash test

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -164,6 +164,8 @@ public abstract partial class BaseEngineModuleTests
         /// Waits for an improved block built on <paramref name="parentHash"/> that carries at least
         /// <paramref name="minTransactions"/> transactions.
         /// </summary>
+        /// <param name="parentHash">The required parent hash, or <see langword="null"/> to match any parent.</param>
+        /// <param name="minTransactions">The minimum transaction count, or zero to impose no transaction requirement.</param>
         public Task WaitForImprovedBlock(Hash256? parentHash = null, int minTransactions = 0) =>
             StoringBlockImprovementContextFactory.WaitForImprovedBlockWithCondition(CreateCancellationSource().Token,
                 b => (parentHash is null || b.Header.ParentHash == parentHash)

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.cs
@@ -160,9 +160,14 @@ public abstract partial class BaseEngineModuleTests
         public IPayloadPreparationService PayloadPreparationService => Container.Resolve<IPayloadPreparationService>();
         public StoringBlockImprovementContextFactory StoringBlockImprovementContextFactory => (StoringBlockImprovementContextFactory)BlockImprovementContextFactory;
 
-        public Task WaitForImprovedBlock(Hash256? parentHash = null) =>
+        /// <summary>
+        /// Waits for an improved block built on <paramref name="parentHash"/> that carries at least
+        /// <paramref name="minTransactions"/> transactions.
+        /// </summary>
+        public Task WaitForImprovedBlock(Hash256? parentHash = null, int minTransactions = 0) =>
             StoringBlockImprovementContextFactory.WaitForImprovedBlockWithCondition(CreateCancellationSource().Token,
-                b => parentHash is null || b.Header.ParentHash == parentHash);
+                b => (parentHash is null || b.Header.ParentHash == parentHash)
+                     && b.Transactions.Length >= minTransactions);
 
 
         public IBeaconPivot BeaconPivot => Container.Resolve<IBeaconPivot>();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -1443,7 +1443,8 @@ public partial class EngineModuleTests
         };
 
         ForkchoiceStateV1 fcuState = new(parentHash, parentHash, parentHash);
-        Task blockImprovementWait = chain.WaitForImprovedBlock(parentHash);
+        // All three transactions have sequential nonces and must land for the expected hashes below to be meaningful.
+        Task blockImprovementWait = chain.WaitForImprovedBlock(parentHash, minTransactions: 3);
         ResultWrapper<ForkchoiceUpdatedV1Result> fcuResponse = await rpc.engine_forkchoiceUpdatedV4(fcuState, payloadAttributes);
         Assert.That(fcuResponse.Result.ResultType, Is.EqualTo(ResultType.Success));
         await blockImprovementWait;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -1426,9 +1426,9 @@ public partial class EngineModuleTests
 
         (Transaction tx, Transaction tx2, Transaction tx3, Withdrawal withdrawal) = BuildTestTransactionsAndWithdrawal(gasPrice, gasLimit);
 
-        chain.TxPool.SubmitTx(tx, TxHandlingOptions.None);
-        chain.TxPool.SubmitTx(tx2, TxHandlingOptions.None);
-        chain.TxPool.SubmitTx(tx3, TxHandlingOptions.None);
+        Assert.That(chain.TxPool.SubmitTx(tx, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+        Assert.That(chain.TxPool.SubmitTx(tx2, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+        Assert.That(chain.TxPool.SubmitTx(tx3, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
         Hash256 parentHash = chain.BlockTree.HeadHash;
         PayloadAttributes payloadAttributes = new()


### PR DESCRIPTION
## Changes

- Restore the optional `minTransactions` condition on `MergeTestBlockchain.WaitForImprovedBlock` while preserving the existing zero-transaction default for every other caller.
- Make the V5 BAL golden-hash fixture wait until all three submitted sequential-nonce transactions are present before calling `engine_getPayloadV6`.
- Prevent the fixture from accepting an empty or partial payload improvement merely because it has the expected parent hash.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Built `Nethermind.Merge.Plugin.Test` successfully with existing project references.
- Ran all 8 `NewPayloadV5_accepts_valid_BAL` cases successfully.
- Repeated the 8-case set 10 additional times: 80/80 passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This is a regression of the race previously fixed in [`3cffc67d4f`](https://github.com/NethermindEth/nethermind/commit/3cffc67d4f28e29da493cb349a54ae7fdd9d6039). That change made transaction-bearing fixtures wait for an improvement containing their submitted transactions because tx-pool head processing is asynchronous. A later V6 engine-build helper refactor/merge reintroduced the parent-only wait, allowing `engine_getPayloadV6` to observe an empty or partial payload and produce a different golden hash. This PR restores the original synchronization contract without changing production code.
