### PR TITLE
ci(hive): drop testing_buildBlockV1 build-block tests from known failures

### DIFF
--- a/scripts/known-failing-hive-tests.txt
+++ b/scripts/known-failing-hive-tests.txt
@@ -1,8 +1,3 @@
-# rpc-compat
-
-testing_buildBlockV1/build-block-empty-transactions (nethermind)
-testing_buildBlockV1/build-block-with-transactions (nethermind)
-
 # graphql
 
 01_eth_blockNumber (nethermind)


### PR DESCRIPTION
## Changes

Removes two entries from `scripts/known-failing-hive-tests.txt`:

```
testing_buildBlockV1/build-block-empty-transactions (nethermind)
testing_buildBlockV1/build-block-with-transactions (nethermind)
```

They now **pass**, so the Hive job fails on every master push with `Unexpected passes: 2`.

### Root cause

Hive [#1585](https://github.com/ethereum/hive/pull/1585) ("Support Prague consensus fixtures and RPC gas target", merged 2026-08-25 ~14:13 UTC) updated the `ethereum/rpc-compat` fixtures such that Nethermind now passes both `build-block-*` tests. Because the Hive workflow checks out `ethereum/hive@master` fresh on every run, master's Hive job started reporting these as unexpected passes from the first push after #1585 landed.

This is unrelated to any Nethermind change — it's purely the Hive fixture update. The success→failure boundary on master (`#12970` run at 13:21 UTC = green, `#12866` run at 14:40 UTC = red) straddles #1585's merge time; the commit at the boundary is coincidental.

### Verification (local, controlled)

Same Nethermind client image, only the Hive version varied:

| Hive rpc-compat fixtures | build-block-empty | build-block-with-tx |
|---|---|---|
| pre-#1585 (Jul) | FAIL | FAIL |
| current master (post-#1585) | **PASS** | **PASS** |

The now-empty `# rpc-compat` section header is removed as well.

## Types of changes

- [x] Build-related changes

## Testing

#### Requires testing

- [x] No

#### Notes on testing

The Hive job on this PR / on master after merge should go green (no unexpected passes) once it runs against current `ethereum/hive@master`.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No