### PR TITLE
Make stale blob replacement test deterministic

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -2587,7 +2587,8 @@ namespace Nethermind.TxPool.Test
                 new FailingBlobTxUpdateStorage(),
                 txPoolConfig,
                 comparer,
-                LimboLogs.Instance);
+                LimboLogs.Instance,
+                new ManualTimeProvider());
             Transaction template = Build.A.Transaction
                 .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
                 .WithMaxFeePerGas(1.GWei)
@@ -3458,8 +3459,9 @@ namespace Nethermind.TxPool.Test
             ITxStorage blobTxStorage,
             ITxPoolConfig txPoolConfig,
             IComparer<Transaction> comparer,
-            ILogManager logManager)
-            : PersistentBlobTxDistinctSortedPool(blobTxStorage, txPoolConfig, comparer, logManager)
+            ILogManager logManager,
+            TimeProvider timeProvider)
+            : PersistentBlobTxDistinctSortedPool(blobTxStorage, txPoolConfig, comparer, logManager, timeProvider)
         {
             private Action _nextUpdate;
             private ValueHash256 _nextUpdateHash;

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -2573,7 +2573,7 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
-        public async Task should_not_evict_same_hash_replacement_for_stale_unpersistable_update()
+        public void should_not_evict_same_hash_replacement_for_stale_unpersistable_update()
         {
             TxPoolConfig txPoolConfig = new()
             {
@@ -2583,7 +2583,7 @@ namespace Nethermind.TxPool.Test
                 Size = 4,
             };
             IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
-            using BlockingPersistentBlobTxDistinctSortedPool blobPool = new(
+            using InterceptingPersistentBlobTxDistinctSortedPool blobPool = new(
                 new FailingBlobTxUpdateStorage(),
                 txPoolConfig,
                 comparer,
@@ -2605,21 +2605,15 @@ namespace Nethermind.TxPool.Test
                 blobPool.MergeCells(retainedTx.Hash!.ValueHash256, updateMask, updateCells),
                 Is.EqualTo(BlobCellMergeResult.Accepted));
 
-            blobPool.BlockNextUpdate();
-            Task<BlobCellMergeResult> staleUpdate = RunOnDedicatedThread(() =>
-                blobPool.MergeCells(replacementTx.Hash!.ValueHash256, updateMask, updateCells));
-            Assert.That(blobPool.WaitForBlockedUpdate(TimeSpan.FromSeconds(5)), Is.True);
-            try
+            blobPool.InterceptNextUpdate(() =>
             {
                 Assert.That(blobPool.TryRemove(replacementTx.Hash!.ValueHash256), Is.True);
                 Assert.That(blobPool.TryInsert(replacementTx.Hash, replacementTx, out _), Is.True);
-            }
-            finally
-            {
-                blobPool.ReleaseBlockedUpdate();
-            }
+            });
 
-            Assert.That(await staleUpdate, Is.EqualTo(BlobCellMergeResult.Accepted));
+            Assert.That(
+                blobPool.MergeCells(replacementTx.Hash!.ValueHash256, updateMask, updateCells),
+                Is.EqualTo(BlobCellMergeResult.Accepted));
             Assert.That(blobPool.TryGetValue(replacementTx.Hash!.ValueHash256, out _), Is.True);
         }
 
@@ -3460,49 +3454,20 @@ namespace Nethermind.TxPool.Test
             public void DeleteBlobTransactionsFromBlock(ulong blockNumber) => _inner.DeleteBlobTransactionsFromBlock(blockNumber);
         }
 
-        private sealed class BlockingPersistentBlobTxDistinctSortedPool(
+        private sealed class InterceptingPersistentBlobTxDistinctSortedPool(
             ITxStorage blobTxStorage,
             ITxPoolConfig txPoolConfig,
             IComparer<Transaction> comparer,
             ILogManager logManager)
             : PersistentBlobTxDistinctSortedPool(blobTxStorage, txPoolConfig, comparer, logManager)
         {
-            private readonly TaskCompletionSource _updateEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            private readonly TaskCompletionSource _releaseUpdate = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            private int _blockNextUpdate;
+            private Action _nextUpdate;
 
-            public void BlockNextUpdate() => Volatile.Write(ref _blockNextUpdate, 1);
-
-            public bool WaitForBlockedUpdate(TimeSpan timeout)
-            {
-                try
-                {
-                    _updateEntered.Task.WaitAsync(timeout).GetAwaiter().GetResult();
-                    return true;
-                }
-                catch (TimeoutException)
-                {
-                    return false;
-                }
-            }
-
-            public void ReleaseBlockedUpdate() => _releaseUpdate.TrySetResult();
+            public void InterceptNextUpdate(Action action) => _nextUpdate = action;
 
             protected override void OnBlobTransactionUpdated(ValueHash256 hash, in UInt256 timestamp)
             {
-                if (Interlocked.Exchange(ref _blockNextUpdate, 0) != 0)
-                {
-                    _updateEntered.TrySetResult();
-                    try
-                    {
-                        _releaseUpdate.Task.WaitAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
-                    }
-                    catch (TimeoutException)
-                    {
-                        throw new TimeoutException("Timed out waiting to release the sparse blob update callback.");
-                    }
-                }
-
+                Interlocked.Exchange(ref _nextUpdate, null)?.Invoke();
                 base.OnBlobTransactionUpdated(hash, timestamp);
             }
         }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -2605,7 +2605,7 @@ namespace Nethermind.TxPool.Test
                 blobPool.MergeCells(retainedTx.Hash!.ValueHash256, updateMask, updateCells),
                 Is.EqualTo(BlobCellMergeResult.Accepted));
 
-            blobPool.InterceptNextUpdate(() =>
+            blobPool.InterceptNextUpdate(replacementTx.Hash!.ValueHash256, () =>
             {
                 Assert.That(blobPool.TryRemove(replacementTx.Hash!.ValueHash256), Is.True);
                 Assert.That(blobPool.TryInsert(replacementTx.Hash, replacementTx, out _), Is.True);
@@ -3462,12 +3462,21 @@ namespace Nethermind.TxPool.Test
             : PersistentBlobTxDistinctSortedPool(blobTxStorage, txPoolConfig, comparer, logManager)
         {
             private Action _nextUpdate;
+            private ValueHash256 _nextUpdateHash;
 
-            public void InterceptNextUpdate(Action action) => _nextUpdate = action;
+            public void InterceptNextUpdate(in ValueHash256 hash, Action action)
+            {
+                _nextUpdateHash = hash;
+                Volatile.Write(ref _nextUpdate, action);
+            }
 
             protected override void OnBlobTransactionUpdated(ValueHash256 hash, in UInt256 timestamp)
             {
-                Interlocked.Exchange(ref _nextUpdate, null)?.Invoke();
+                if (hash == _nextUpdateHash)
+                {
+                    Interlocked.Exchange(ref _nextUpdate, null)?.Invoke();
+                }
+
                 base.OnBlobTransactionUpdated(hash, timestamp);
             }
         }


### PR DESCRIPTION
## Changes

- Replace scheduler-dependent coordination in `should_not_evict_same_hash_replacement_for_stale_unpersistable_update` with a synchronous one-shot interception at the `OnBlobTransactionUpdated` boundary.
- Preserve the tested interleaving: record the stale failed generation, install a same-hash replacement, then let persistent-pool reconciliation verify reference identity before eviction.
- Remove the dedicated thread, task completion sources, and independent 5-second/10-second waits that both timed out under CI load.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Exact checked test repeated 10 times successfully.
- Full `Nethermind.TxPool.Test` checked run: 715 passed, 1 skipped.
- Full `Nethermind.TxPool.Test` release run: 715 passed, 1 skipped.
- Whitespace formatting and `git diff --check` passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No