### PR TITLE
fix(eth72): restore announced cell mask and stop charging local backpressure to peers

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -2886,7 +2886,10 @@ public class Eth72ProtocolHandlerTests
     }
 
     // Restoring the request mask would overwrite a broader announcement and downgrade a full
-    // provider, starving samplers gated on the full-provider count.
+    // provider, starving samplers gated on the full-provider count. The two cases share a requeue
+    // reason and separate its entry points: an empty response claimed from the wire, and a request
+    // the maintenance sweep found expired. The registry-refusal branch moved out to
+    // should_keep_announcement_when_registry_refuses_delivered_cells, which no longer strips.
     [TestCase(false, TestName = "should_restore_announced_mask_after_empty_cells_response")]
     [TestCase(true, TestName = "should_restore_announced_mask_after_cell_request_times_out")]
     public void should_restore_announced_mask_rather_than_request_mask(bool timeOutRequest)
@@ -3008,6 +3011,52 @@ public class Eth72ProtocolHandlerTests
         {
             registry.Received(1).TryRequestCells(tx.Hash!, cellMask, Arg.Any<PublicKey>());
             registry.DidNotReceive().RecordAnnouncement(_handler, tx.Hash!, Arg.Any<BlobCellMask>());
+        }
+    }
+
+    // The restore is recorded outside _cellStateLock, so a park landing in that gap re-strips the
+    // announcement and owes a new restore. Clearing by mask could not see that, because the mask the
+    // park re-adds is the one just restored; only the epoch distinguishes them.
+    [Test]
+    public void should_not_clear_a_restore_re_added_while_the_previous_one_was_being_recorded()
+    {
+        ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
+        registry.RemoveAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>()).Returns(BlobCellMask.Full);
+        Transaction tx = Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+            .WithNonce(0UL)
+            .SignedAndResolved()
+            .TestObject;
+        BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
+        bool reParked = false;
+        registry.RecordAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>(), Arg.Any<BlobCellMask>())
+            .Returns(_ =>
+            {
+                if (!reParked)
+                {
+                    // Stand in for a concurrent CellsMessage72: strips the announcement again and
+                    // re-parks the very same mask before the maintenance tick retakes the lock.
+                    reParked = true;
+                    ParkEmptyCellsResponse(tx.Hash!, cellMask);
+                }
+
+                return true;
+            });
+        RecreateHandler(sparseBlobPoolPeerRegistry: registry);
+
+        HandleIncomingStatusMessage();
+        ParkEmptyCellsResponse(tx.Hash!, cellMask);
+        registry.ClearReceivedCalls();
+
+        // Past the 5s backoff but inside the 15s pending-request TTL, for both the original park
+        // and the one the callback interleaves.
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(6));
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(11));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(reParked, Is.True);
+            registry.Received(2).RecordAnnouncement(_handler, tx.Hash!, BlobCellMask.Full);
         }
     }
 
@@ -5279,6 +5328,14 @@ public class Eth72ProtocolHandlerTests
             Disconnecting?.Invoke();
             Disconnects.Add((reason, details));
         }
+    }
+
+    /// <summary>Requests cells and answers with an empty response, parking them with a restore owed.</summary>
+    private void ParkEmptyCellsResponse(Hash256 hash, BlobCellMask cellMask)
+    {
+        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(hash, cellMask), Is.True);
+        using CellsMessage72 empty = new(GetLastGetCellsRequestId(hash, cellMask), [], [], BlobCellMask.Empty.ToBytes());
+        HandleZeroMessage(empty, Eth72MessageCode.Cells);
     }
 
     /// <summary>Runs every background task inline except those tagged with the rejected source.</summary>

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -3012,6 +3012,39 @@ public class Eth72ProtocolHandlerTests
         }
     }
 
+    // Placing the parked cells with another provider removes the pending entry; if the announcement
+    // restore was rejected on that same tick, the provider would be lost for good.
+    [Test]
+    public void should_keep_retrying_rejected_restore_after_cells_are_requested_elsewhere()
+    {
+        ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
+        registry.RemoveAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>()).Returns(BlobCellMask.Full);
+        registry.TryRequestCells(Arg.Any<Hash256>(), Arg.Any<BlobCellMask>(), Arg.Any<PublicKey>()).Returns(true);
+        registry.RecordAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>(), Arg.Any<BlobCellMask>())
+            .Returns(false, true);
+        RecreateHandler(sparseBlobPoolPeerRegistry: registry);
+        Transaction tx = Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+            .WithNonce(0UL)
+            .SignedAndResolved()
+            .TestObject;
+        BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
+
+        HandleIncomingStatusMessage();
+        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
+        using CellsMessage72 empty = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [], [], BlobCellMask.Empty.ToBytes());
+        HandleZeroMessage(empty, Eth72MessageCode.Cells);
+        registry.ClearReceivedCalls();
+
+        // The restore is refused, but the cells are placed with another provider on the same tick.
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(6));
+        registry.Received(1).TryRequestCells(tx.Hash!, cellMask, Arg.Any<PublicKey>());
+
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(7));
+
+        registry.Received(2).RecordAnnouncement(_handler, tx.Hash!, BlobCellMask.Full);
+    }
+
     // The symptom behind the mask fix, against the real registry: restoring the narrow request mask
     // drops the peer out of the full-provider count that a non-supernode sampler is gated on.
     [Test]
@@ -3033,7 +3066,7 @@ public class Eth72ProtocolHandlerTests
         Assert.That(_sparseBlobPoolPeerRegistry.GetFullProviderAnnouncementCount(tx.Hash!), Is.EqualTo(1));
 
         Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, requestMask), Is.True);
-        // Past the 5s request TTL, so the unanswered request is requeued.
+        // Past the 10s request TTL, so the unanswered request is requeued.
         ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(11));
         Assert.That(_sparseBlobPoolPeerRegistry.GetFullProviderAnnouncementCount(tx.Hash!), Is.Zero);
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -2894,6 +2894,7 @@ public class Eth72ProtocolHandlerTests
         ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
         registry.TryRequestCells(Arg.Any<Hash256>(), Arg.Any<BlobCellMask>(), Arg.Any<PublicKey>()).Returns(true);
         registry.RemoveAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>()).Returns(BlobCellMask.Full);
+        registry.RecordAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>(), Arg.Any<BlobCellMask>()).Returns(true);
         RecreateHandler(sparseBlobPoolPeerRegistry: registry);
         Transaction tx = Build.A.Transaction
             .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
@@ -2930,13 +2931,14 @@ public class Eth72ProtocolHandlerTests
         }
     }
 
-    // Restoring is one-shot: a pending request that cannot be placed keeps retrying, but the
-    // announcement must not be re-recorded on every maintenance tick.
+    // Restoring is one-shot once accepted: a pending request that cannot be placed keeps retrying,
+    // but the announcement must not be re-recorded on every maintenance tick.
     [Test]
     public void should_restore_announcement_only_once_when_pending_request_cannot_be_placed()
     {
         ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
         registry.RemoveAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>()).Returns(BlobCellMask.Full);
+        registry.RecordAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>(), Arg.Any<BlobCellMask>()).Returns(true);
         RecreateHandler(sparseBlobPoolPeerRegistry: registry);
         Transaction tx = Build.A.Transaction
             .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
@@ -2961,12 +2963,13 @@ public class Eth72ProtocolHandlerTests
         }
     }
 
-    // Local scheduler saturation is our fault, so the peer keeps its announcement and is not
-    // suppressed by the per-peer cell-announcement backoff.
+    // Local scheduler saturation is our fault: the retry is still throttled, but the peer keeps the
+    // announcement that marks it as a provider node-wide.
     [Test]
-    public void should_not_penalize_peer_when_cells_response_cannot_be_scheduled()
+    public void should_throttle_without_dropping_announcement_when_cells_response_cannot_be_scheduled()
     {
         ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
+        registry.TryRequestCells(Arg.Any<Hash256>(), Arg.Any<BlobCellMask>(), Arg.Any<PublicKey>()).Returns(true);
         RecreateHandler(
             backgroundTaskScheduler: new SourceRejectingBackgroundTaskScheduler(nameof(CellsMessage72)),
             sparseBlobPoolPeerRegistry: registry);
@@ -2993,9 +2996,83 @@ public class Eth72ProtocolHandlerTests
 
         using (Assert.EnterMultipleScope())
         {
+            // The announcement is what marks the peer as a provider, so it must survive.
             registry.DidNotReceive().RemoveAnnouncement(_handler, tx.Hash!);
-            registry.Received(1).RecordAnnouncement(_handler, tx.Hash!, cellMask);
+            // ...but a re-announcement must not immediately re-issue the request we just dropped.
+            registry.DidNotReceive().TryRequestCells(tx.Hash!, Arg.Any<BlobCellMask>(), Arg.Any<PublicKey>());
         }
+
+        // Past the 5s backoff but inside the 15s pending-request TTL.
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(11));
+
+        using (Assert.EnterMultipleScope())
+        {
+            registry.Received(1).TryRequestCells(tx.Hash!, cellMask, Arg.Any<PublicKey>());
+            registry.DidNotReceive().RecordAnnouncement(_handler, tx.Hash!, Arg.Any<BlobCellMask>());
+        }
+    }
+
+    // The symptom behind the mask fix, against the real registry: restoring the narrow request mask
+    // drops the peer out of the full-provider count that a non-supernode sampler is gated on.
+    [Test]
+    public void should_keep_counting_as_full_provider_after_cell_request_times_out()
+    {
+        RecreateHandler();
+        _blobCustodyTracker.Update(BlobCellMask.FromIndices([2, 7]));
+        Assert.That(SparseBlobPoolPeerRegistry.HasSupernodeCustody(_blobCustodyTracker.CurrentMask), Is.False);
+        Transaction tx = BuildBlobTransaction(fullProvider: true);
+        BlobCellMask requestMask = BlobCellMask.FromIndices([4]);
+
+        using NewPooledTransactionHashesMessage72 announcement = new(
+            [(byte)TxType.Blob],
+            [1024],
+            [tx.Hash!],
+            BlobCellMask.Full.ToBytes());
+        HandleIncomingStatusMessage();
+        HandleZeroMessage(announcement, Eth72MessageCode.NewPooledTransactionHashes);
+        Assert.That(_sparseBlobPoolPeerRegistry.GetFullProviderAnnouncementCount(tx.Hash!), Is.EqualTo(1));
+
+        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, requestMask), Is.True);
+        // Past the 5s request TTL, so the unanswered request is requeued.
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(11));
+        Assert.That(_sparseBlobPoolPeerRegistry.GetFullProviderAnnouncementCount(tx.Hash!), Is.Zero);
+
+        // Past the 5s backoff but inside the 15s pending-request TTL.
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(11));
+
+        // Restoring requestMask instead of the announced Full mask would leave this at zero.
+        Assert.That(_sparseBlobPoolPeerRegistry.GetFullProviderAnnouncementCount(tx.Hash!), Is.EqualTo(1));
+    }
+
+    // RecordAnnouncement also refuses at the peer announcement cap or under quarantine; giving up
+    // after one attempt would lose the provider exactly as the request-mask restore did.
+    [Test]
+    public void should_keep_retrying_announcement_restore_until_the_registry_accepts_it()
+    {
+        ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
+        registry.RemoveAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>()).Returns(BlobCellMask.Full);
+        registry.RecordAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>(), Arg.Any<BlobCellMask>())
+            .Returns(false, true);
+        RecreateHandler(sparseBlobPoolPeerRegistry: registry);
+        Transaction tx = Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+            .WithNonce(0UL)
+            .SignedAndResolved()
+            .TestObject;
+        BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
+
+        HandleIncomingStatusMessage();
+        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
+        using CellsMessage72 empty = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [], [], BlobCellMask.Empty.ToBytes());
+        HandleZeroMessage(empty, Eth72MessageCode.Cells);
+        registry.ClearReceivedCalls();
+
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(6));
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(7));
+        // The third tick must not restore again now that the second one was accepted.
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(8));
+
+        registry.Received(2).RecordAnnouncement(_handler, tx.Hash!, BlobCellMask.Full);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -2885,12 +2885,91 @@ public class Eth72ProtocolHandlerTests
         _transactionPool.DidNotReceive().MergeBlobCells(tx.Hash!, cellMask, Arg.Any<byte[][]>());
     }
 
-    [Test]
-    public void should_retry_received_cells_after_registry_capacity_rejects_them()
+    // Restoring the request mask would overwrite a broader announcement and downgrade a full
+    // provider, starving samplers gated on the full-provider count.
+    [TestCase(false, TestName = "should_restore_announced_mask_after_registry_capacity_rejects_cells")]
+    [TestCase(true, TestName = "should_restore_announced_mask_after_cell_request_times_out")]
+    public void should_restore_announced_mask_rather_than_request_mask(bool timeOutRequest)
     {
         ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
         registry.TryRequestCells(Arg.Any<Hash256>(), Arg.Any<BlobCellMask>(), Arg.Any<PublicKey>()).Returns(true);
+        registry.RemoveAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>()).Returns(BlobCellMask.Full);
         RecreateHandler(sparseBlobPoolPeerRegistry: registry);
+        Transaction tx = Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+            .WithNonce(0UL)
+            .SignedAndResolved()
+            .TestObject;
+        BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
+        Assert.That(BlobCellsHelper.TryGetFlattenedCells((ShardBlobNetworkWrapper)tx.NetworkWrapper!, cellMask, out byte[][] cells), Is.True);
+
+        HandleIncomingStatusMessage();
+        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
+        if (timeOutRequest)
+        {
+            ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(11));
+        }
+        else
+        {
+            using CellsMessage72 response = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [tx.Hash!], [cells], cellMask.ToBytes());
+            HandleZeroMessage(response, Eth72MessageCode.Cells);
+            registry.Received(1).RecordCells(_handler, tx.Hash!, cellMask, Arg.Any<byte[][]>());
+        }
+
+        registry.Received(1).RemoveAnnouncement(_handler, tx.Hash!);
+
+        registry.ClearReceivedCalls();
+        // Past the 5s backoff but inside the 15s pending-request TTL.
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(11));
+
+        using (Assert.EnterMultipleScope())
+        {
+            registry.Received(1).RecordAnnouncement(_handler, tx.Hash!, BlobCellMask.Full);
+            registry.DidNotReceive().RecordAnnouncement(_handler, tx.Hash!, cellMask);
+            registry.Received(1).TryRequestCells(tx.Hash!, cellMask, Arg.Any<PublicKey>());
+        }
+    }
+
+    // Restoring is one-shot: a pending request that cannot be placed keeps retrying, but the
+    // announcement must not be re-recorded on every maintenance tick.
+    [Test]
+    public void should_restore_announcement_only_once_when_pending_request_cannot_be_placed()
+    {
+        ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
+        registry.RemoveAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>()).Returns(BlobCellMask.Full);
+        RecreateHandler(sparseBlobPoolPeerRegistry: registry);
+        Transaction tx = Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+            .WithNonce(0UL)
+            .SignedAndResolved()
+            .TestObject;
+        BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
+
+        HandleIncomingStatusMessage();
+        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
+        using CellsMessage72 empty = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [], [], BlobCellMask.Empty.ToBytes());
+        HandleZeroMessage(empty, Eth72MessageCode.Cells);
+
+        registry.ClearReceivedCalls();
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(6));
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(7));
+
+        using (Assert.EnterMultipleScope())
+        {
+            registry.Received(1).RecordAnnouncement(_handler, tx.Hash!, BlobCellMask.Full);
+            registry.Received(2).TryRequestCells(tx.Hash!, cellMask, Arg.Any<PublicKey>());
+        }
+    }
+
+    // Local scheduler saturation is our fault, so the peer keeps its announcement and is not
+    // suppressed by the per-peer cell-announcement backoff.
+    [Test]
+    public void should_not_penalize_peer_when_cells_response_cannot_be_scheduled()
+    {
+        ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
+        RecreateHandler(
+            backgroundTaskScheduler: new SourceRejectingBackgroundTaskScheduler(nameof(CellsMessage72)),
+            sparseBlobPoolPeerRegistry: registry);
         Transaction tx = Build.A.Transaction
             .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
             .WithNonce(0UL)
@@ -2903,14 +2982,20 @@ public class Eth72ProtocolHandlerTests
         Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
         using CellsMessage72 response = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [tx.Hash!], [cells], cellMask.ToBytes());
         HandleZeroMessage(response, Eth72MessageCode.Cells);
-        registry.Received(1).RecordCells(_handler, tx.Hash!, cellMask, Arg.Any<byte[][]>());
-        registry.Received(1).RemoveAnnouncement(_handler, tx.Hash!);
 
         registry.ClearReceivedCalls();
-        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10));
+        using NewPooledTransactionHashesMessage72 announcement = new(
+            [(byte)TxType.Blob],
+            [1024],
+            [tx.Hash!],
+            cellMask.ToBytes());
+        HandleZeroMessage(announcement, Eth72MessageCode.NewPooledTransactionHashes);
 
-        registry.Received(1).RecordAnnouncement(_handler, tx.Hash!, cellMask);
-        registry.Received(1).TryRequestCells(tx.Hash!, cellMask, Arg.Any<PublicKey>());
+        using (Assert.EnterMultipleScope())
+        {
+            registry.DidNotReceive().RemoveAnnouncement(_handler, tx.Hash!);
+            registry.Received(1).RecordAnnouncement(_handler, tx.Hash!, cellMask);
+        }
     }
 
     [Test]
@@ -5023,6 +5108,18 @@ public class Eth72ProtocolHandlerTests
             Disconnecting?.Invoke();
             Disconnects.Add((reason, details));
         }
+    }
+
+    /// <summary>Runs every background task inline except those tagged with the rejected source.</summary>
+    private sealed class SourceRejectingBackgroundTaskScheduler(string rejectedSource) : IBackgroundTaskScheduler
+    {
+        public bool TryScheduleTask<TReq>(
+            TReq request,
+            Func<TReq, CancellationToken, Task> fulfillFunc,
+            TimeSpan? timeout = null,
+            string? source = null)
+            => source != rejectedSource
+            && RunImmediatelyScheduler.Instance.TryScheduleTask(request, fulfillFunc, timeout, source);
     }
 
     private sealed class RejectingBackgroundTaskScheduler : IBackgroundTaskScheduler

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -2950,9 +2950,7 @@ public class Eth72ProtocolHandlerTests
         BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
 
         HandleIncomingStatusMessage();
-        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
-        using CellsMessage72 empty = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [], [], BlobCellMask.Empty.ToBytes());
-        HandleZeroMessage(empty, Eth72MessageCode.Cells);
+        ParkEmptyCellsResponse(tx.Hash!, cellMask);
 
         registry.ClearReceivedCalls();
         ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(6));
@@ -3111,9 +3109,7 @@ public class Eth72ProtocolHandlerTests
         BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
 
         HandleIncomingStatusMessage();
-        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
-        using CellsMessage72 empty = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [], [], BlobCellMask.Empty.ToBytes());
-        HandleZeroMessage(empty, Eth72MessageCode.Cells);
+        ParkEmptyCellsResponse(tx.Hash!, cellMask);
         registry.ClearReceivedCalls();
 
         // Past the 15s pending-request TTL, so the entry is dropped on this tick.
@@ -3141,9 +3137,7 @@ public class Eth72ProtocolHandlerTests
         BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
 
         HandleIncomingStatusMessage();
-        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
-        using CellsMessage72 empty = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [], [], BlobCellMask.Empty.ToBytes());
-        HandleZeroMessage(empty, Eth72MessageCode.Cells);
+        ParkEmptyCellsResponse(tx.Hash!, cellMask);
         registry.ClearReceivedCalls();
 
         // The restore is refused, but the cells are placed with another provider on the same tick.
@@ -3205,9 +3199,7 @@ public class Eth72ProtocolHandlerTests
         BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
 
         HandleIncomingStatusMessage();
-        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
-        using CellsMessage72 empty = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [], [], BlobCellMask.Empty.ToBytes());
-        HandleZeroMessage(empty, Eth72MessageCode.Cells);
+        ParkEmptyCellsResponse(tx.Hash!, cellMask);
         registry.ClearReceivedCalls();
 
         ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(6));

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -2887,7 +2887,7 @@ public class Eth72ProtocolHandlerTests
 
     // Restoring the request mask would overwrite a broader announcement and downgrade a full
     // provider, starving samplers gated on the full-provider count.
-    [TestCase(false, TestName = "should_restore_announced_mask_after_registry_capacity_rejects_cells")]
+    [TestCase(false, TestName = "should_restore_announced_mask_after_empty_cells_response")]
     [TestCase(true, TestName = "should_restore_announced_mask_after_cell_request_times_out")]
     public void should_restore_announced_mask_rather_than_request_mask(bool timeOutRequest)
     {
@@ -2902,19 +2902,18 @@ public class Eth72ProtocolHandlerTests
             .SignedAndResolved()
             .TestObject;
         BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
-        Assert.That(BlobCellsHelper.TryGetFlattenedCells((ShardBlobNetworkWrapper)tx.NetworkWrapper!, cellMask, out byte[][] cells), Is.True);
 
         HandleIncomingStatusMessage();
         Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
         if (timeOutRequest)
         {
+            // Past the 10s request TTL, so the unanswered request is requeued.
             ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(11));
         }
         else
         {
-            using CellsMessage72 response = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [tx.Hash!], [cells], cellMask.ToBytes());
-            HandleZeroMessage(response, Eth72MessageCode.Cells);
-            registry.Received(1).RecordCells(_handler, tx.Hash!, cellMask, Arg.Any<byte[][]>());
+            using CellsMessage72 empty = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [], [], BlobCellMask.Empty.ToBytes());
+            HandleZeroMessage(empty, Eth72MessageCode.Cells);
         }
 
         registry.Received(1).RemoveAnnouncement(_handler, tx.Hash!);
@@ -3010,6 +3009,68 @@ public class Eth72ProtocolHandlerTests
             registry.Received(1).TryRequestCells(tx.Hash!, cellMask, Arg.Any<PublicKey>());
             registry.DidNotReceive().RecordAnnouncement(_handler, tx.Hash!, Arg.Any<BlobCellMask>());
         }
+    }
+
+    // The cells were already validated before RecordCells is reached, so a refusal there is almost
+    // always local capacity and must not cost the peer its provider standing.
+    [Test]
+    public void should_keep_announcement_when_registry_refuses_delivered_cells()
+    {
+        ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
+        registry.RemoveAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>()).Returns(BlobCellMask.Full);
+        registry.TryRequestCells(Arg.Any<Hash256>(), Arg.Any<BlobCellMask>(), Arg.Any<PublicKey>()).Returns(true);
+        RecreateHandler(sparseBlobPoolPeerRegistry: registry);
+        Transaction tx = Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+            .WithNonce(0UL)
+            .SignedAndResolved()
+            .TestObject;
+        BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
+        Assert.That(BlobCellsHelper.TryGetFlattenedCells((ShardBlobNetworkWrapper)tx.NetworkWrapper!, cellMask, out byte[][] cells), Is.True);
+
+        HandleIncomingStatusMessage();
+        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
+        using CellsMessage72 response = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [tx.Hash!], [cells], cellMask.ToBytes());
+        HandleZeroMessage(response, Eth72MessageCode.Cells);
+
+        using (Assert.EnterMultipleScope())
+        {
+            registry.Received(1).RecordCells(_handler, tx.Hash!, cellMask, Arg.Any<byte[][]>());
+            registry.DidNotReceive().RemoveAnnouncement(_handler, tx.Hash!);
+        }
+
+        // The retry is still throttled, so it only goes out once the backoff falls due.
+        registry.ClearReceivedCalls();
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(6));
+        registry.Received(1).TryRequestCells(tx.Hash!, cellMask, Arg.Any<PublicKey>());
+    }
+
+    // A restore the registry keeps refusing must not be swallowed when the pending entry ages out.
+    [Test]
+    public void should_attempt_announcement_restore_once_more_when_pending_request_expires()
+    {
+        ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
+        registry.RemoveAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>()).Returns(BlobCellMask.Full);
+        registry.RecordAnnouncement(Arg.Any<ISparseBlobPoolPeer>(), Arg.Any<Hash256>(), Arg.Any<BlobCellMask>())
+            .Returns(false);
+        RecreateHandler(sparseBlobPoolPeerRegistry: registry);
+        Transaction tx = Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+            .WithNonce(0UL)
+            .SignedAndResolved()
+            .TestObject;
+        BlobCellMask cellMask = BlobCellMask.FromIndices([4]);
+
+        HandleIncomingStatusMessage();
+        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
+        using CellsMessage72 empty = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [], [], BlobCellMask.Empty.ToBytes());
+        HandleZeroMessage(empty, Eth72MessageCode.Cells);
+        registry.ClearReceivedCalls();
+
+        // Past the 15s pending-request TTL, so the entry is dropped on this tick.
+        ((ISparseBlobPoolPeer)_handler).MaintainSparseBlobState(DateTimeOffset.UtcNow + TimeSpan.FromSeconds(16));
+
+        registry.Received(1).RecordAnnouncement(_handler, tx.Hash!, BlobCellMask.Full);
     }
 
     // Placing the parked cells with another provider removes the pending entry; if the announcement

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -88,7 +88,6 @@ public class Eth72ProtocolHandler(
     private static readonly TimeSpan CellResponseCorrelationTtl = Timeouts.Cleanup;
     private static readonly TimeSpan PartialCellResponseBackoff = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan PendingCellStateTtl = TimeSpan.FromSeconds(15);
-    private const long NoRestoreEpoch = 0;
     private static readonly TimeSpan RequestToAnnouncementWarmup = TimeSpan.FromSeconds(60);
     private readonly int _providerProbabilityPercent = txPoolConfig.SparseBlobProviderProbabilityPercent;
     private readonly Dictionary<ValueHash256, CellRequestState> _pendingCellRequests = [];
@@ -108,6 +107,8 @@ public class Eth72ProtocolHandler(
     private readonly ISparseBlobPoolPeerRegistry _sparseBlobPoolPeerRegistry = EnsureNotNull(sparseBlobPoolPeerRegistry, nameof(sparseBlobPoolPeerRegistry));
     private DateTimeOffset _requestRatioWarmupEndsAt;
     private Func<ClaimedCellsResponse, CancellationToken, ValueTask>? _handleCells;
+    /// <summary>Sentinel <c>RestoreEpoch</c> for a pending entry that owes no announcement restore.</summary>
+    private const long NoRestoreEpoch = 0;
     private long _cellStateRevision;
     private long _blobAnnouncementsReceived;
     private long _cellRequestsReceived;
@@ -1435,7 +1436,7 @@ public class Eth72ProtocolHandler(
     /// see that, so the epoch captured before the restore is what decides: a mismatch means a newer
     /// restore is owed and this one must not clear it.
     /// </remarks>
-    private void ClearPendingCellRestoreMaskLocked(ValueHash256 hash, long expectedRestoreEpoch)
+    private void ClearPendingCellRestoreLocked(ValueHash256 hash, long expectedRestoreEpoch)
     {
         ref CellRequestState state = ref CollectionsMarshal.GetValueRefOrNullRef(_pendingCellRequests, hash);
         if (Unsafe.IsNullRef(ref state) || state.RestoreEpoch != expectedRestoreEpoch)
@@ -1551,7 +1552,7 @@ public class Eth72ProtocolHandler(
                 {
                     lock (_cellStateLock)
                     {
-                        ClearPendingCellRestoreMaskLocked(key, restoreEpoch);
+                        ClearPendingCellRestoreLocked(key, restoreEpoch);
                     }
                 }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -1091,6 +1091,10 @@ public class Eth72ProtocolHandler(
 
     void ISparseBlobPoolPeer.DisconnectSparseBlobPeer(DisconnectReason reason, string details) => Disconnect(reason, details);
 
+    /// <summary>Queues cells to request once a provider and, when delayed, the retry time are available.</summary>
+    /// <param name="hash">The transaction whose cells are needed.</param>
+    /// <param name="requestMask">The cells to request.</param>
+    /// <param name="retryAt">When the request may be re-attempted, or <see langword="null"/> to retry as soon as a provider appears.</param>
     /// <param name="restoreMask">
     /// The announcement to put back once <paramref name="retryAt"/> elapses, or
     /// <see cref="BlobCellMask.Empty"/> when the peer's announcement was left in place.
@@ -1222,15 +1226,15 @@ public class Eth72ProtocolHandler(
                 RequestCellsWhenReady(requestedHash, sentRequest.Mask);
                 break;
             case CellRequeueReason.LocalBackpressure:
-                // We dropped the response, so the peer keeps its announcement and is not backed off.
-                AddPendingCellRequest(
-                    sentRequest.Hash,
-                    sentRequest.Mask,
-                    _timestamper.UtcNowOffset + PartialCellResponseBackoff);
+                // Throttling the retry is still right, but the announcement stays: it is what marks
+                // the peer as a provider node-wide, and we, not the peer, dropped the response.
+                ParkCellRequest(sentRequest.Hash, sentRequest.Mask, restoreMask: BlobCellMask.Empty);
                 break;
-            default:
+            case CellRequeueReason.PeerUnanswered:
                 BackOffAndParkCellRequest(requestedHash, sentRequest.Mask);
                 break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(reason), reason, null);
         }
     }
 
@@ -1246,13 +1250,18 @@ public class Eth72ProtocolHandler(
     /// restoring the narrower request mask would downgrade a full provider to a partial one and can
     /// starve samplers gated on <see cref="MinSamplerFullProviderAnnouncements"/>.
     /// </remarks>
-    private void BackOffAndParkCellRequest(Hash256 hash, BlobCellMask parkMask)
+    private void BackOffAndParkCellRequest(Hash256 hash, BlobCellMask parkMask) =>
+        ParkCellRequest(hash.ValueHash256, parkMask, _sparseBlobPoolPeerRegistry.RemoveAnnouncement(this, hash));
+
+    /// <summary>Holds cells back from the announcement re-request path until the retry falls due.</summary>
+    /// <param name="key">The transaction whose cells are parked.</param>
+    /// <param name="parkMask">The cells to request again once the backoff elapses.</param>
+    /// <param name="restoreMask">The announcement to put back, or empty when none was removed.</param>
+    private void ParkCellRequest(ValueHash256 key, BlobCellMask parkMask, BlobCellMask restoreMask)
     {
-        ValueHash256 key = hash.ValueHash256;
         DateTimeOffset retryAt = _timestamper.UtcNowOffset + PartialCellResponseBackoff;
-        BlobCellMask announcedMask = _sparseBlobPoolPeerRegistry.RemoveAnnouncement(this, hash);
         _partialCellResponseBackoff.Set(key, retryAt);
-        AddPendingCellRequest(key, parkMask, retryAt, announcedMask);
+        AddPendingCellRequest(key, parkMask, retryAt, restoreMask);
     }
 
     private void AddSentCellRequest(ValueHash256 hash, BlobCellMask requestMask, long requestId)
@@ -1489,15 +1498,6 @@ public class Eth72ProtocolHandler(
                 }
             }
 
-            // Restoring is one-shot; retries keep firing until the request is placed or expires.
-            if (dueRetries is not null)
-            {
-                for (int i = 0; i < dueRetries.Count; i++)
-                {
-                    ClearPendingCellRestoreMaskLocked(dueRetries[i].Hash);
-                }
-            }
-
             TrimPendingCellRequests();
             TrimSentCellRequests();
         }
@@ -1508,9 +1508,15 @@ public class Eth72ProtocolHandler(
             {
                 (ValueHash256 key, BlobCellMask restoreMask) = dueRetries[i];
                 Hash256 hash = key.ToHash256();
-                if (!restoreMask.IsEmpty)
+                // Restoring is one-shot only once it lands: RecordAnnouncement also refuses when the
+                // peer is at its announcement cap or the transaction is quarantined, and dropping the
+                // mask there would lose the provider for good.
+                if (restoreMask.IsEmpty || _sparseBlobPoolPeerRegistry.RecordAnnouncement(this, hash, restoreMask))
                 {
-                    _sparseBlobPoolPeerRegistry.RecordAnnouncement(this, hash, restoreMask);
+                    lock (_cellStateLock)
+                    {
+                        ClearPendingCellRestoreMaskLocked(key);
+                    }
                 }
 
                 TryRequestPendingCells(hash);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -88,6 +88,7 @@ public class Eth72ProtocolHandler(
     private static readonly TimeSpan CellResponseCorrelationTtl = Timeouts.Cleanup;
     private static readonly TimeSpan PartialCellResponseBackoff = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan PendingCellStateTtl = TimeSpan.FromSeconds(15);
+    private const long NoRestoreEpoch = 0;
     private static readonly TimeSpan RequestToAnnouncementWarmup = TimeSpan.FromSeconds(60);
     private readonly int _providerProbabilityPercent = txPoolConfig.SparseBlobProviderProbabilityPercent;
     private readonly Dictionary<ValueHash256, CellRequestState> _pendingCellRequests = [];
@@ -753,7 +754,10 @@ public class Eth72ProtocolHandler(
         _sparseBlobPoolPeerRegistry.OnCellsRequestCompleted(hash, requestedMask, this);
         if (!_sparseBlobPoolPeerRegistry.RecordCells(this, hash, availableMask, pending.Cells))
         {
-            BackOffAndParkCellRequest(hash, availableMask);
+            // The cells were already validated above, so a refusal here is almost always ours: the
+            // early-cell byte budget, the accounting replace, or a transient submit. Throttle the
+            // retry without taking away what marks the peer as a provider.
+            ParkCellRequest(key, availableMask, restoreMask: BlobCellMask.Empty);
             return;
         }
 
@@ -1105,7 +1109,7 @@ public class Eth72ProtocolHandler(
         DateTimeOffset? retryAt = null,
         BlobCellMask restoreMask = default)
     {
-        if (requestMask.IsEmpty)
+        if (requestMask.IsEmpty && restoreMask.IsEmpty)
         {
             return;
         }
@@ -1130,7 +1134,8 @@ public class Eth72ProtocolHandler(
                     Mask = combinedMask,
                     ExpiresAt = _timestamper.UtcNowOffset + PendingCellStateTtl,
                     RetryAt = combinedRetryAt,
-                    RestoreMask = existing.RestoreMask | restoreMask
+                    RestoreMask = existing.RestoreMask | restoreMask,
+                    RestoreEpoch = restoreMask.IsEmpty ? existing.RestoreEpoch : NextCellStateRevision()
                 };
                 TrimPendingCellRequests();
                 return;
@@ -1143,7 +1148,8 @@ public class Eth72ProtocolHandler(
                 RequestId: 0,
                 ExpiresAt: _timestamper.UtcNowOffset + PendingCellStateTtl,
                 RetryAt: retryAt,
-                RestoreMask: restoreMask);
+                RestoreMask: restoreMask,
+                RestoreEpoch: restoreMask.IsEmpty ? NoRestoreEpoch : NextCellStateRevision());
             _pendingCellRequestCount++;
             _pendingCellRequestWork += requestMask.Count;
             _pendingCellRequestOrder.Enqueue(new CellStateKey(hash, revision));
@@ -1291,7 +1297,14 @@ public class Eth72ProtocolHandler(
             long revision = NextCellStateRevision();
             DateTimeOffset expiresAt = now + CellRequestTtl;
             int maxResponseBytes = GetExpectedCellsResponseBound(requestId, requestMask);
-            state = new CellRequestState(requestMask, revision, requestId, expiresAt, RetryAt: null, RestoreMask: BlobCellMask.Empty);
+            state = new CellRequestState(
+                requestMask,
+                revision,
+                requestId,
+                expiresAt,
+                RetryAt: null,
+                RestoreMask: BlobCellMask.Empty,
+                RestoreEpoch: NoRestoreEpoch);
             _sentCellRequestIds[requestId] = new SentCellRequest(
                 hash,
                 requestMask,
@@ -1415,28 +1428,28 @@ public class Eth72ProtocolHandler(
         return true;
     }
 
-    /// <summary>Retires the part of a pending entry's announcement restore that has been recorded.</summary>
+    /// <summary>Retires a pending entry's announcement restore once it has been recorded.</summary>
     /// <remarks>
-    /// Only <paramref name="restoredMask"/> is cleared: the restore is recorded outside
-    /// <c>_cellStateLock</c>, so a concurrent response may have parked newer cells for the same
-    /// transaction in the meantime and those must still be restored.
+    /// The restore is recorded outside <c>_cellStateLock</c>, so a concurrent response can strip the
+    /// announcement again and re-park the very same mask meanwhile. Differencing the masks would not
+    /// see that, so the epoch captured before the restore is what decides: a mismatch means a newer
+    /// restore is owed and this one must not clear it.
     /// </remarks>
-    private void ClearPendingCellRestoreMaskLocked(ValueHash256 hash, BlobCellMask restoredMask)
+    private void ClearPendingCellRestoreMaskLocked(ValueHash256 hash, long expectedRestoreEpoch)
     {
         ref CellRequestState state = ref CollectionsMarshal.GetValueRefOrNullRef(_pendingCellRequests, hash);
-        if (Unsafe.IsNullRef(ref state))
+        if (Unsafe.IsNullRef(ref state) || state.RestoreEpoch != expectedRestoreEpoch)
         {
             return;
         }
 
-        BlobCellMask remainingRestoreMask = state.RestoreMask.Except(restoredMask);
-        if (remainingRestoreMask.IsEmpty && state.Mask.IsEmpty)
+        if (state.Mask.IsEmpty)
         {
             RemovePendingCellRequestLocked(hash);
             return;
         }
 
-        state = state with { RestoreMask = remainingRestoreMask };
+        state = state with { RestoreMask = BlobCellMask.Empty, RestoreEpoch = NoRestoreEpoch };
     }
 
     private void RemovePendingCellRequestLocked(ValueHash256 hash)
@@ -1451,7 +1464,7 @@ public class Eth72ProtocolHandler(
     private void MaintainSparseBlobState(DateTimeOffset now)
     {
         List<SentCellRequest>? expiredSentRequests = null;
-        List<(ValueHash256 Hash, BlobCellMask RestoreMask)>? dueRetries = null;
+        List<(ValueHash256 Hash, BlobCellMask RestoreMask, long RestoreEpoch)>? dueRetries = null;
         List<ValueHash256>? expiredPendingKeys = null;
         List<ValueHash256>? expiredSentKeys = null;
         List<long>? expiredCorrelationKeys = null;
@@ -1462,10 +1475,16 @@ public class Eth72ProtocolHandler(
                 if (entry.Value.ExpiresAt <= now)
                 {
                     (expiredPendingKeys ??= []).Add(entry.Key);
+                    // Expiry must not swallow an announcement we took away: a restore the registry
+                    // kept refusing gets one final attempt on the way out.
+                    if (!entry.Value.RestoreMask.IsEmpty)
+                    {
+                        (dueRetries ??= []).Add((entry.Key, entry.Value.RestoreMask, entry.Value.RestoreEpoch));
+                    }
                 }
                 else if (entry.Value.RetryAt is { } retryAt && retryAt <= now)
                 {
-                    (dueRetries ??= []).Add((entry.Key, entry.Value.RestoreMask));
+                    (dueRetries ??= []).Add((entry.Key, entry.Value.RestoreMask, entry.Value.RestoreEpoch));
                 }
             }
 
@@ -1523,7 +1542,7 @@ public class Eth72ProtocolHandler(
         {
             for (int i = 0; i < dueRetries.Count; i++)
             {
-                (ValueHash256 key, BlobCellMask restoreMask) = dueRetries[i];
+                (ValueHash256 key, BlobCellMask restoreMask, long restoreEpoch) = dueRetries[i];
                 Hash256 hash = key.ToHash256();
                 // Restoring is one-shot only once it lands: RecordAnnouncement also refuses when the
                 // peer is at its announcement cap or the transaction is quarantined, and dropping the
@@ -1532,7 +1551,7 @@ public class Eth72ProtocolHandler(
                 {
                     lock (_cellStateLock)
                     {
-                        ClearPendingCellRestoreMaskLocked(key, restoreMask);
+                        ClearPendingCellRestoreMaskLocked(key, restoreEpoch);
                     }
                 }
 
@@ -1861,7 +1880,8 @@ public class Eth72ProtocolHandler(
         long RequestId,
         DateTimeOffset ExpiresAt,
         DateTimeOffset? RetryAt,
-        BlobCellMask RestoreMask);
+        BlobCellMask RestoreMask,
+        long RestoreEpoch);
 
     /// <summary>Why an in-flight cell request is being returned to the pending queue.</summary>
     private enum CellRequeueReason

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -226,7 +226,7 @@ public class Eth72ProtocolHandler(
                     {
                         if (claimResult == CellRequestClaimResult.Expired)
                         {
-                            RequeueClaimedCellRequest(sentRequest, removePeer: false);
+                            RequeueClaimedCellRequest(sentRequest, CellRequeueReason.PeerUnanswered);
                         }
 
                         ReportIn($"Stale {nameof(CellsMessage72)} response ID {requestId} ignored", size);
@@ -235,7 +235,7 @@ public class Eth72ProtocolHandler(
 
                     if (size > sentRequest.MaxResponseBytes)
                     {
-                        RequeueClaimedCellRequest(sentRequest, removePeer: true);
+                        RequeueClaimedCellRequest(sentRequest, CellRequeueReason.PeerFault);
                         throw new SubprotocolException(
                             $"{nameof(CellsMessage72)} response ID {requestId} exceeds its {sentRequest.MaxResponseBytes}-byte request bound: {size} bytes.");
                     }
@@ -247,12 +247,12 @@ public class Eth72ProtocolHandler(
                     }
                     catch (RlpException)
                     {
-                        RequeueClaimedCellRequest(sentRequest, removePeer: true);
+                        RequeueClaimedCellRequest(sentRequest, CellRequeueReason.PeerFault);
                         throw;
                     }
                     catch (IncompleteDeserializationException)
                     {
-                        RequeueClaimedCellRequest(sentRequest, removePeer: true);
+                        RequeueClaimedCellRequest(sentRequest, CellRequeueReason.PeerFault);
                         throw;
                     }
 
@@ -263,9 +263,9 @@ public class Eth72ProtocolHandler(
                     if (!BackgroundTaskScheduler.TryScheduleBackgroundTask(response, _handleCells!, nameof(CellsMessage72)))
                     {
                         // Scheduler saturated or shutting down: release the in-flight reservation and
-                        // park the request so a later announcement can retry it.
+                        // park the request for a later retry.
                         response.Dispose();
-                        RequeueClaimedCellRequest(sentRequest, removePeer: false);
+                        RequeueClaimedCellRequest(sentRequest, CellRequeueReason.LocalBackpressure);
                     }
                 }
                 else
@@ -668,7 +668,7 @@ public class Eth72ProtocolHandler(
         }
         else
         {
-            RequeueClaimedCellRequest(claimedResponse.Request, removePeer: false);
+            RequeueClaimedCellRequest(claimedResponse.Request, CellRequeueReason.LocalBackpressure);
         }
 
         return ValueTask.CompletedTask;
@@ -747,19 +747,13 @@ public class Eth72ProtocolHandler(
         BlobCellMask missingMask = requestedMask.Except(availableMask);
         if (!missingMask.IsEmpty)
         {
-            DateTimeOffset retryAt = _timestamper.UtcNowOffset + PartialCellResponseBackoff;
-            _sparseBlobPoolPeerRegistry.RemoveAnnouncement(this, hash);
-            _partialCellResponseBackoff.Set(key, retryAt);
-            AddPendingCellRequest(key, missingMask, retryAt, restoreAnnouncement: true);
+            BackOffAndParkCellRequest(hash, missingMask);
         }
 
         _sparseBlobPoolPeerRegistry.OnCellsRequestCompleted(hash, requestedMask, this);
         if (!_sparseBlobPoolPeerRegistry.RecordCells(this, hash, availableMask, pending.Cells))
         {
-            DateTimeOffset retryAt = _timestamper.UtcNowOffset + PartialCellResponseBackoff;
-            _sparseBlobPoolPeerRegistry.RemoveAnnouncement(this, hash);
-            _partialCellResponseBackoff.Set(key, retryAt);
-            AddPendingCellRequest(key, availableMask, retryAt, restoreAnnouncement: true);
+            BackOffAndParkCellRequest(hash, availableMask);
             return;
         }
 
@@ -779,7 +773,7 @@ public class Eth72ProtocolHandler(
 
     /// <summary>
     /// Handles a response that carries none of the requested cells by backing off the peer before
-    /// restoring its announcement, allowing another provider to answer without losing the sole source.
+    /// restoring the cells it may still hold, letting another provider answer without losing the sole source.
     /// </summary>
     private void RetryUnansweredCellRequest(SentCellRequest sentRequest, BlobCellMask responseMask)
     {
@@ -788,7 +782,7 @@ public class Eth72ProtocolHandler(
             ThrowMalformedCellsResponse(sentRequest, $"Unexpected cell mask in empty {nameof(CellsMessage72)} response.");
         }
 
-        RequeueClaimedCellRequest(sentRequest, removePeer: false);
+        RequeueClaimedCellRequest(sentRequest, CellRequeueReason.PeerUnanswered);
     }
 
     private void OnPendingCellsApplied(Hash256 hash, ValueHash256 key, BlobCellMask availableMask, BlobCellMask missingMask)
@@ -1097,11 +1091,15 @@ public class Eth72ProtocolHandler(
 
     void ISparseBlobPoolPeer.DisconnectSparseBlobPeer(DisconnectReason reason, string details) => Disconnect(reason, details);
 
+    /// <param name="restoreMask">
+    /// The announcement to put back once <paramref name="retryAt"/> elapses, or
+    /// <see cref="BlobCellMask.Empty"/> when the peer's announcement was left in place.
+    /// </param>
     private void AddPendingCellRequest(
         ValueHash256 hash,
         BlobCellMask requestMask,
         DateTimeOffset? retryAt = null,
-        bool restoreAnnouncement = false)
+        BlobCellMask restoreMask = default)
     {
         if (requestMask.IsEmpty)
         {
@@ -1117,10 +1115,10 @@ public class Eth72ProtocolHandler(
                 BlobCellMask combinedMask = existing.Mask | requestMask;
                 _pendingCellRequestWork += combinedMask.Count - existing.Mask.Count;
                 DateTimeOffset? combinedRetryAt = existing.RetryAt;
-                if (restoreAnnouncement
-                    && (combinedRetryAt is null || retryAt > combinedRetryAt))
+                if (retryAt is { } requestedRetryAt
+                    && (combinedRetryAt is null || requestedRetryAt > combinedRetryAt))
                 {
-                    combinedRetryAt = retryAt;
+                    combinedRetryAt = requestedRetryAt;
                 }
 
                 state = existing with
@@ -1128,7 +1126,7 @@ public class Eth72ProtocolHandler(
                     Mask = combinedMask,
                     ExpiresAt = _timestamper.UtcNowOffset + PendingCellStateTtl,
                     RetryAt = combinedRetryAt,
-                    RestoreAnnouncement = existing.RestoreAnnouncement || restoreAnnouncement
+                    RestoreMask = existing.RestoreMask | restoreMask
                 };
                 TrimPendingCellRequests();
                 return;
@@ -1141,7 +1139,7 @@ public class Eth72ProtocolHandler(
                 RequestId: 0,
                 ExpiresAt: _timestamper.UtcNowOffset + PendingCellStateTtl,
                 RetryAt: retryAt,
-                RestoreAnnouncement: restoreAnnouncement);
+                RestoreMask: restoreMask);
             _pendingCellRequestCount++;
             _pendingCellRequestWork += requestMask.Count;
             _pendingCellRequestOrder.Enqueue(new CellStateKey(hash, revision));
@@ -1209,25 +1207,52 @@ public class Eth72ProtocolHandler(
 
     private void ThrowMalformedCellsResponse(SentCellRequest sentRequest, string message)
     {
-        RequeueClaimedCellRequest(sentRequest, removePeer: true);
+        RequeueClaimedCellRequest(sentRequest, CellRequeueReason.PeerFault);
         throw new SubprotocolException(message);
     }
 
-    private void RequeueClaimedCellRequest(SentCellRequest sentRequest, bool removePeer)
+    private void RequeueClaimedCellRequest(SentCellRequest sentRequest, CellRequeueReason reason)
     {
         Hash256 requestedHash = sentRequest.Hash.ToHash256();
         _sparseBlobPoolPeerRegistry.OnCellsRequestCompleted(requestedHash, sentRequest.Mask, this);
-        if (removePeer)
+        switch (reason)
         {
-            _sparseBlobPoolPeerRegistry.RemovePeer(this);
-            RequestCellsWhenReady(requestedHash, sentRequest.Mask);
-            return;
+            case CellRequeueReason.PeerFault:
+                _sparseBlobPoolPeerRegistry.RemovePeer(this);
+                RequestCellsWhenReady(requestedHash, sentRequest.Mask);
+                break;
+            case CellRequeueReason.LocalBackpressure:
+                // We dropped the response, so the peer keeps its announcement and is not backed off.
+                AddPendingCellRequest(
+                    sentRequest.Hash,
+                    sentRequest.Mask,
+                    _timestamper.UtcNowOffset + PartialCellResponseBackoff);
+                break;
+            default:
+                BackOffAndParkCellRequest(requestedHash, sentRequest.Mask);
+                break;
         }
+    }
 
+    /// <summary>
+    /// Backs the peer off for a transaction and parks the cells for a later retry, scheduling the
+    /// announcement to be restored so a temporary miss does not permanently lose the provider.
+    /// </summary>
+    /// <param name="hash">The transaction whose cells are parked.</param>
+    /// <param name="parkMask">The cells to request again once the backoff elapses.</param>
+    /// <remarks>
+    /// The mask restored is the one the peer announced, not the one we requested:
+    /// <see cref="ISparseBlobPoolPeerRegistry.RecordAnnouncement"/> overwrites a peer's mask, so
+    /// restoring the narrower request mask would downgrade a full provider to a partial one and can
+    /// starve samplers gated on <see cref="MinSamplerFullProviderAnnouncements"/>.
+    /// </remarks>
+    private void BackOffAndParkCellRequest(Hash256 hash, BlobCellMask parkMask)
+    {
+        ValueHash256 key = hash.ValueHash256;
         DateTimeOffset retryAt = _timestamper.UtcNowOffset + PartialCellResponseBackoff;
-        _sparseBlobPoolPeerRegistry.RemoveAnnouncement(this, requestedHash);
-        _partialCellResponseBackoff.Set(sentRequest.Hash, retryAt);
-        AddPendingCellRequest(sentRequest.Hash, sentRequest.Mask, retryAt, restoreAnnouncement: true);
+        BlobCellMask announcedMask = _sparseBlobPoolPeerRegistry.RemoveAnnouncement(this, hash);
+        _partialCellResponseBackoff.Set(key, retryAt);
+        AddPendingCellRequest(key, parkMask, retryAt, announcedMask);
     }
 
     private void AddSentCellRequest(ValueHash256 hash, BlobCellMask requestMask, long requestId)
@@ -1257,7 +1282,7 @@ public class Eth72ProtocolHandler(
             long revision = NextCellStateRevision();
             DateTimeOffset expiresAt = now + CellRequestTtl;
             int maxResponseBytes = GetExpectedCellsResponseBound(requestId, requestMask);
-            state = new CellRequestState(requestMask, revision, requestId, expiresAt, RetryAt: null, RestoreAnnouncement: false);
+            state = new CellRequestState(requestMask, revision, requestId, expiresAt, RetryAt: null, RestoreMask: BlobCellMask.Empty);
             _sentCellRequestIds[requestId] = new SentCellRequest(
                 hash,
                 requestMask,
@@ -1379,6 +1404,15 @@ public class Eth72ProtocolHandler(
         return true;
     }
 
+    private void ClearPendingCellRestoreMaskLocked(ValueHash256 hash)
+    {
+        ref CellRequestState state = ref CollectionsMarshal.GetValueRefOrNullRef(_pendingCellRequests, hash);
+        if (!Unsafe.IsNullRef(ref state))
+        {
+            state = state with { RestoreMask = BlobCellMask.Empty };
+        }
+    }
+
     private void RemovePendingCellRequestLocked(ValueHash256 hash)
     {
         if (_pendingCellRequests.Remove(hash, out CellRequestState state))
@@ -1391,7 +1425,7 @@ public class Eth72ProtocolHandler(
     private void MaintainSparseBlobState(DateTimeOffset now)
     {
         List<SentCellRequest>? expiredSentRequests = null;
-        List<(ValueHash256 Hash, BlobCellMask Mask)>? dueAnnouncementRestores = null;
+        List<(ValueHash256 Hash, BlobCellMask RestoreMask)>? dueRetries = null;
         List<ValueHash256>? expiredPendingKeys = null;
         List<ValueHash256>? expiredSentKeys = null;
         List<long>? expiredCorrelationKeys = null;
@@ -1403,11 +1437,9 @@ public class Eth72ProtocolHandler(
                 {
                     (expiredPendingKeys ??= []).Add(entry.Key);
                 }
-                else if (entry.Value.RestoreAnnouncement
-                    && entry.Value.RetryAt is { } retryAt
-                    && retryAt <= now)
+                else if (entry.Value.RetryAt is { } retryAt && retryAt <= now)
                 {
-                    (dueAnnouncementRestores ??= []).Add((entry.Key, entry.Value.Mask));
+                    (dueRetries ??= []).Add((entry.Key, entry.Value.RestoreMask));
                 }
             }
 
@@ -1457,17 +1489,30 @@ public class Eth72ProtocolHandler(
                 }
             }
 
+            // Restoring is one-shot; retries keep firing until the request is placed or expires.
+            if (dueRetries is not null)
+            {
+                for (int i = 0; i < dueRetries.Count; i++)
+                {
+                    ClearPendingCellRestoreMaskLocked(dueRetries[i].Hash);
+                }
+            }
+
             TrimPendingCellRequests();
             TrimSentCellRequests();
         }
 
-        if (dueAnnouncementRestores is not null)
+        if (dueRetries is not null)
         {
-            for (int i = 0; i < dueAnnouncementRestores.Count; i++)
+            for (int i = 0; i < dueRetries.Count; i++)
             {
-                (ValueHash256 key, BlobCellMask mask) = dueAnnouncementRestores[i];
+                (ValueHash256 key, BlobCellMask restoreMask) = dueRetries[i];
                 Hash256 hash = key.ToHash256();
-                _sparseBlobPoolPeerRegistry.RecordAnnouncement(this, hash, mask);
+                if (!restoreMask.IsEmpty)
+                {
+                    _sparseBlobPoolPeerRegistry.RecordAnnouncement(this, hash, restoreMask);
+                }
+
                 TryRequestPendingCells(hash);
             }
         }
@@ -1476,7 +1521,7 @@ public class Eth72ProtocolHandler(
         {
             for (int i = 0; i < expiredSentRequests.Count; i++)
             {
-                RequeueClaimedCellRequest(expiredSentRequests[i], removePeer: false);
+                RequeueClaimedCellRequest(expiredSentRequests[i], CellRequeueReason.PeerUnanswered);
             }
         }
     }
@@ -1793,7 +1838,20 @@ public class Eth72ProtocolHandler(
         long RequestId,
         DateTimeOffset ExpiresAt,
         DateTimeOffset? RetryAt,
-        bool RestoreAnnouncement);
+        BlobCellMask RestoreMask);
+
+    /// <summary>Why an in-flight cell request is being returned to the pending queue.</summary>
+    private enum CellRequeueReason
+    {
+        /// <summary>The peer answered with none of the requested cells, or missed its deadline.</summary>
+        PeerUnanswered,
+
+        /// <summary>The response was dropped locally, e.g. the background scheduler was saturated.</summary>
+        LocalBackpressure,
+
+        /// <summary>The peer broke the protocol and is being disconnected.</summary>
+        PeerFault,
+    }
 
     private readonly record struct CellStateKey(ValueHash256 Hash, long Revision);
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -1372,7 +1372,9 @@ public class Eth72ProtocolHandler(
                 return;
             }
 
-            if (remainingMask.IsEmpty)
+            // An entry that still owes an announcement restore outlives the cells it was parked for,
+            // otherwise placing the request elsewhere would drop the provider permanently.
+            if (remainingMask.IsEmpty && state.RestoreMask.IsEmpty)
             {
                 RemovePendingCellRequestLocked(hash);
                 return;
@@ -1413,13 +1415,28 @@ public class Eth72ProtocolHandler(
         return true;
     }
 
-    private void ClearPendingCellRestoreMaskLocked(ValueHash256 hash)
+    /// <summary>Retires the part of a pending entry's announcement restore that has been recorded.</summary>
+    /// <remarks>
+    /// Only <paramref name="restoredMask"/> is cleared: the restore is recorded outside
+    /// <c>_cellStateLock</c>, so a concurrent response may have parked newer cells for the same
+    /// transaction in the meantime and those must still be restored.
+    /// </remarks>
+    private void ClearPendingCellRestoreMaskLocked(ValueHash256 hash, BlobCellMask restoredMask)
     {
         ref CellRequestState state = ref CollectionsMarshal.GetValueRefOrNullRef(_pendingCellRequests, hash);
-        if (!Unsafe.IsNullRef(ref state))
+        if (Unsafe.IsNullRef(ref state))
         {
-            state = state with { RestoreMask = BlobCellMask.Empty };
+            return;
         }
+
+        BlobCellMask remainingRestoreMask = state.RestoreMask.Except(restoredMask);
+        if (remainingRestoreMask.IsEmpty && state.Mask.IsEmpty)
+        {
+            RemovePendingCellRequestLocked(hash);
+            return;
+        }
+
+        state = state with { RestoreMask = remainingRestoreMask };
     }
 
     private void RemovePendingCellRequestLocked(ValueHash256 hash)
@@ -1511,11 +1528,11 @@ public class Eth72ProtocolHandler(
                 // Restoring is one-shot only once it lands: RecordAnnouncement also refuses when the
                 // peer is at its announcement cap or the transaction is quarantined, and dropping the
                 // mask there would lose the provider for good.
-                if (restoreMask.IsEmpty || _sparseBlobPoolPeerRegistry.RecordAnnouncement(this, hash, restoreMask))
+                if (!restoreMask.IsEmpty && _sparseBlobPoolPeerRegistry.RecordAnnouncement(this, hash, restoreMask))
                 {
                     lock (_cellStateLock)
                     {
-                        ClearPendingCellRestoreMaskLocked(key);
+                        ClearPendingCellRestoreMaskLocked(key, restoreMask);
                     }
                 }
 

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/ISparseBlobPoolPeerRegistry.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/ISparseBlobPoolPeerRegistry.cs
@@ -29,7 +29,11 @@ public interface ISparseBlobPoolPeerRegistry
     /// Forgets a single peer's announcement for a transaction, e.g. after the peer answered
     /// a cell request with an empty response, so retries converge on other providers.
     /// </summary>
-    void RemoveAnnouncement(ISparseBlobPoolPeer peer, Hash256 hash);
+    /// <returns>
+    /// The mask the peer had announced, so a caller that backs the peer off temporarily can restore
+    /// it later; <see cref="BlobCellMask.Empty"/> when the peer had no announcement.
+    /// </returns>
+    BlobCellMask RemoveAnnouncement(ISparseBlobPoolPeer peer, Hash256 hash);
 
     /// <summary>
     /// Requests cells from a randomly selected announcing peer. Cells already held in the local

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/SparseBlobPoolPeerRegistry.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/SparseBlobPoolPeerRegistry.cs
@@ -799,7 +799,7 @@ public sealed class SparseBlobPoolPeerRegistry : ISparseBlobPoolPeerRegistry, ID
     }
 
     /// <inheritdoc/>
-    public void RemoveAnnouncement(ISparseBlobPoolPeer peer, Hash256 hash)
+    public BlobCellMask RemoveAnnouncement(ISparseBlobPoolPeer peer, Hash256 hash)
     {
         if (IsActivePeer(peer)
             && _transactions.TryGetValue(hash.ValueHash256, out TrackedSparseBlobTx? state))
@@ -808,16 +808,19 @@ public sealed class SparseBlobPoolPeerRegistry : ISparseBlobPoolPeerRegistry, ID
             {
                 if (!IsActivePeer(peer))
                 {
-                    return;
+                    return BlobCellMask.Empty;
                 }
 
                 PublicKey peerId = peer.Id;
-                if (state.Announcements.Remove(peerId))
+                if (state.Announcements.Remove(peerId, out BlobCellMask announcedMask))
                 {
                     ReleaseAnnouncement(peerId, hash.ValueHash256, state.Submitted);
+                    return announcedMask;
                 }
             }
         }
+
+        return BlobCellMask.Empty;
     }
 
     private bool RequestCellsForCustodyChange(

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -172,91 +172,94 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
     protected override bool TryGetValueForCellMerge(ValueHash256 hash, [NotNullWhen(true)] out Transaction? blobTx)
         => TryGetFullBlobTransactionOutsideLock(hash, out blobTx);
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// A concurrent second caller reports the transaction as absent rather than waiting for the
+    /// in-progress storage read, which keeps the read de-duplicated without blocking a pool thread.
+    /// The miss is safe: callers treat it as "not in the pool yet" and retry on a later announcement.
+    /// </remarks>
     internal override bool TryGetValueWithoutBlobs(ValueHash256 hash, [NotNullWhen(true)] out Transaction? blobTx)
     {
-        while (true)
+        Transaction? lightTx;
+        BlobCellMask lightCellMask;
+        using (McsLock.Disposable lockRelease = Lock.Acquire())
         {
-            Transaction? lightTx;
-            BlobCellMask lightCellMask;
-            using (McsLock.Disposable lockRelease = Lock.Acquire())
-            {
-                if (!base.TryGetValueNonLocked(hash, out lightTx))
-                {
-                    blobTx = default;
-                    return false;
-                }
-
-                if (TryGetCurrentValueWithoutBlobsNonLocked(hash, out blobTx))
-                {
-                    return true;
-                }
-
-                lightCellMask = lightTx is LightTransaction lightBlobTx
-                    ? lightBlobTx.BlobCellMask
-                    : BlobCellMask.Empty;
-            }
-
-            if (lightTx.SenderAddress is null)
+            if (!base.TryGetValueNonLocked(hash, out lightTx))
             {
                 blobTx = default;
                 return false;
             }
 
-            if (_blobTxMetadataStorage?.TryGetWithoutBlobs(hash, lightTx.SenderAddress, out Transaction? loadedTx) == true
-                && loadedTx is not null)
+            if (TryGetCurrentValueWithoutBlobsNonLocked(hash, out blobTx))
             {
-                return TryCompleteValueWithoutBlobsRead(hash, lightTx, lightCellMask, loadedTx, out blobTx);
+                return true;
             }
 
-            using (McsLock.Disposable lockRelease = Lock.Acquire())
+            lightCellMask = lightTx is LightTransaction lightBlobTx
+                ? lightBlobTx.BlobCellMask
+                : BlobCellMask.Empty;
+        }
+
+        if (lightTx.SenderAddress is null)
+        {
+            blobTx = default;
+            return false;
+        }
+
+        if (_blobTxMetadataStorage?.TryGetWithoutBlobs(hash, lightTx.SenderAddress, out Transaction? loadedTx) == true
+            && loadedTx is not null)
+        {
+            return TryCompleteValueWithoutBlobsRead(hash, lightTx, lightCellMask, loadedTx, out blobTx);
+        }
+
+        using (McsLock.Disposable lockRelease = Lock.Acquire())
+        {
+            if (!base.TryGetValueNonLocked(hash, out Transaction? currentLightTx))
             {
-                if (!base.TryGetValueNonLocked(hash, out Transaction? currentLightTx))
-                {
-                    blobTx = default;
-                    return false;
-                }
-
-                if (TryGetCurrentValueWithoutBlobsNonLocked(hash, out blobTx))
-                {
-                    return true;
-                }
-
-                if (!MatchesLightTransactionSnapshot(currentLightTx, lightTx, lightCellMask))
-                {
-                    blobTx = default;
-                    return false;
-                }
-
-                if (!_metadataFallbackReads.Add(hash))
-                {
-                    blobTx = default;
-                    return false;
-                }
+                blobTx = default;
+                return false;
             }
 
-            bool readCompleted = false;
-            try
+            if (TryGetCurrentValueWithoutBlobsNonLocked(hash, out blobTx))
             {
-                if (!_blobTxStorage.TryGet(hash, lightTx.SenderAddress, lightTx.Timestamp, out loadedTx)
-                    || loadedTx is null)
-                {
-                    blobTx = default;
-                    return false;
-                }
-
-                readCompleted = TryCompleteValueWithoutBlobsRead(hash, lightTx, lightCellMask, loadedTx, out blobTx);
-                if (readCompleted)
-                {
-                    TryPersistMetadataRecord(loadedTx);
-                }
-
-                return readCompleted;
+                return true;
             }
-            finally
+
+            if (!MatchesLightTransactionSnapshot(currentLightTx, lightTx, lightCellMask))
             {
-                using McsLock.Disposable lockRelease = Lock.Acquire();
-                _metadataFallbackReads.Remove(hash);
+                blobTx = default;
+                return false;
             }
+
+            if (!_metadataFallbackReads.Add(hash))
+            {
+                blobTx = default;
+                return false;
+            }
+        }
+
+        bool readCompleted = false;
+        try
+        {
+            if (!_blobTxStorage.TryGet(hash, lightTx.SenderAddress, lightTx.Timestamp, out loadedTx)
+                || loadedTx is null)
+            {
+                blobTx = default;
+                return false;
+            }
+
+            readCompleted = TryCompleteValueWithoutBlobsRead(hash, lightTx, lightCellMask, loadedTx, out blobTx);
+            if (readCompleted)
+            {
+                TryPersistMetadataRecord(loadedTx);
+            }
+
+            return readCompleted;
+        }
+        finally
+        {
+            using McsLock.Disposable lockRelease = Lock.Acquire();
+            _metadataFallbackReads.Remove(hash);
         }
     }
 


### PR DESCRIPTION
Follow-up to #11094, from a post-merge review of the sparse blob pool.

## Changes

- **Restore the announced cell mask, not the request mask.** When a cell request was backed off, the handler parked the *request* mask and later replayed it through `RecordAnnouncement`, which overwrites a peer's announcement rather than merging it. A peer that announced `Full` and merely timed out on a one-column request was thereafter recorded as announcing one column, so `GetFullProviderAnnouncementCount` stopped counting it. For non-supernodes `CanRequestCellsNow` requires `MinSamplerFullProviderAnnouncements` (2) full announcers, so a single timeout against a two-provider set could block further sparse cell requests for that transaction until the pending TTL expired. `RemoveAnnouncement` now returns the mask it removed, and that is what gets restored.
- **Stop charging local backpressure to the peer.** When the background scheduler could not take a `CellsMessage72`, the handler took the same path as a peer that withheld cells: it dropped the peer's announcement, which is what marks the peer as a provider node-wide. Requeue reasons are now explicit (`PeerUnanswered` / `LocalBackpressure` / `PeerFault`) and backpressure keeps the retry throttle but leaves the announcement alone.
- **Make the announcement restore one-shot.** A pending request that cannot be placed keeps retrying, but the announcement is no longer re-recorded on every maintenance tick.
- **Remove a dead retry loop** in `PersistentBlobTxDistinctSortedPool.TryGetValueWithoutBlobs`. The `while (true)` lost its only `continue` when the `TaskCompletionSource` wait was replaced; every path returns, so it ran exactly once while implying retry semantics that no longer exist. Documented the de-duplication trade-off it left behind — a concurrent second caller reports a miss instead of waiting.

No wire-format or Engine API behaviour changes.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New regression tests in `Eth72ProtocolHandlerTests`:

- `should_restore_announced_mask_rather_than_request_mask` — parameterized over the timeout and the capacity-rejection paths; asserts the announced mask is restored and the request mask is not.
- `should_restore_announcement_only_once_when_pending_request_cannot_be_placed`
- `should_not_penalize_peer_when_cells_response_cannot_be_scheduled`

`should_retry_received_cells_after_registry_capacity_rejects_them` was folded into the first — it asserted the buggy restore.

Local runs: `Nethermind.Network.Test` 1543/1543 green (177 eth/72). `Nethermind.TxPool.Test` 714/716, with `should_apply_pending_removal_before_same_hash_reinsertion(True,True,False)` failing identically on unmodified `master` — a pre-existing flake, unrelated to this change.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

### Trade-offs worth knowing

Widening the restored mask from *requested* to *announced* makes the stale-restore window wider in the other direction. The peer's mask is captured at park time, and the tx-level backoff lapses at exactly `retryAt`, so a fresh narrower announcement from that peer and the maintenance restore become eligible in the same instant; if the announcement lands first the restore overwrites it with the stale wider mask. `master` has the same race with the opposite bias (restoring too narrow). Exposure is bounded by the one-shot restore and self-heals on the peer's next announcement. Fixing it properly means versioning announcements so a restore cannot clobber a newer one — more than this follow-up should carry.

Smaller: `AddPendingCellRequest` takes `max(existing.RetryAt, retryAt)`, so a `LocalBackpressure` requeue landing on an already-parked entry pushes the announcement restore out past the point where the backoff has lapsed. The restore still lands, just later, and `TryRequestPendingCells` keeps firing meanwhile.


`ISparseBlobPoolPeerRegistry.RemoveAnnouncement` changes from `void` to `BlobCellMask`. That is a signature change on an interface introduced in #11094; it adds no new members, but the alternative would be threading the announced mask through `SentCellRequest` instead — happy to switch if preferred.

One finding from the same review was dropped after checking it: `engine_getBlobsV4` returning a non-null entry with all-null cells for a blob that is in the pool but holds none of the requested cells matches geth, which reserves `null` for "blob not found". Left as is.
