### PR TITLE
refactor(xdc): remove unused XDPoS config parameters

### DIFF
--- a/src/Nethermind/Chains/xdc-testnet.json
+++ b/src/Nethermind/Chains/xdc-testnet.json
@@ -3,10 +3,8 @@
   "engine": {
     "XDPoS": {
       "params": {
-        "period": 2,
         "epoch": 900,
         "reward": 5000,
-        "rewardCheckpoint": 900,
         "gap": 450,
         "foundationWalletAddr": "0x746249c61f5832c5eed53172776b460491bdcd5c",
         "switchEpoch": 63143,

--- a/src/Nethermind/Chains/xdc.json
+++ b/src/Nethermind/Chains/xdc.json
@@ -3,10 +3,8 @@
   "engine": {
     "XDPoS": {
       "params": {
-        "period": 2,
         "epoch": 900,
         "reward": 5000,
-        "rewardCheckpoint": 900,
         "gap": 450,
         "foundationWalletAddr": "0x92a289fe95a85c53b8d0d113cbaef0c1ec98ac65",
         "switchEpoch": 89300,

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcChainSpecRewardTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcChainSpecRewardTests.cs
@@ -25,7 +25,7 @@ public class XdcChainSpecRewardTests
 
     private const string RewardPlaceholder = "$REWARD$";
     private const string CoreParamsPlaceholder = "$CORE_PARAMS$";
-    private const string EnginePeriodPlaceholder = "$PERIOD$";
+    private const string EngineEpochPlaceholder = "$EPOCH$";
 
     private const string ChainSpecTemplate = $$"""
         {
@@ -33,8 +33,7 @@ public class XdcChainSpecRewardTests
           "engine": {
             "XDPoS": {
               "params": {
-                "period": {{EnginePeriodPlaceholder}},
-                "epoch": 900,
+                "epoch": {{EngineEpochPlaceholder}},
                 "masternodeReward": {{RewardPlaceholder}},
                 "v2Configs": [
                   {
@@ -91,7 +90,7 @@ public class XdcChainSpecRewardTests
     /// </summary>
     [Test]
     public void Fractional_value_in_an_unannotated_engine_field_is_rejected() =>
-        Assert.That(() => LoadEngineParameters("1", period: "2.0"), Throws.TypeOf<InvalidDataException>());
+        Assert.That(() => LoadEngineParameters("1", epoch: "2.0"), Throws.TypeOf<InvalidDataException>());
 
     /// <summary>
     /// The converter is attached to properties owned by <c>Nethermind.Xdc</c>, so nothing outside the
@@ -159,12 +158,12 @@ public class XdcChainSpecRewardTests
         throw new AssertionException($"No v2 config at switch round {ApothemRewardSwitchRound}");
     }
 
-    private static XdcChainSpecEngineParameters LoadEngineParameters(string reward, string coreParams = "", string period = "2")
+    private static XdcChainSpecEngineParameters LoadEngineParameters(string reward, string coreParams = "", string epoch = "900")
     {
         string json = ChainSpecTemplate
             .Replace(RewardPlaceholder, reward)
             .Replace(CoreParamsPlaceholder, coreParams)
-            .Replace(EnginePeriodPlaceholder, period);
+            .Replace(EngineEpochPlaceholder, epoch);
 
         using MemoryStream stream = new(Encoding.UTF8.GetBytes(json));
         ChainSpec chainSpec = new ChainSpecLoader(new EthereumJsonSerializer(), LimboLogs.Instance).Load(stream);

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
@@ -19,8 +19,6 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
     public virtual string SealEngineType => XdcConstants.XDPoS;
     public ulong Epoch { get; set; }
     public ulong Gap { get; set; }
-    public ulong Period { get; set; }
-    public bool SkipV1Validation { get; set; }
     public Address FoundationWalletAddr { get; set; }
     public ulong Reward { get; set; }
     public ulong SwitchEpoch { get; set; }
@@ -39,8 +37,6 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
 
     public ulong LimitPenaltyEpoch { get; set; }           // Epochs in a row that a penalty node needs to be penalized
     public ulong LimitPenaltyEpochV2 { get; set; }           // Epochs in a row that a penalty node needs to be penalized
-    public Address RelayerRegistrationSMC { get; set; }
-    public Address TRC21IssuerSMC { get; set; }
 
     private List<V2ConfigParams> _v2Configs = [];
     public List<V2ConfigParams> V2Configs

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcReleaseSpec.cs
@@ -44,7 +44,6 @@ public class XdcReleaseSpec : ReleaseSpec, IXdcReleaseSpec
     public Address XDCXLendingAddressBinary { get; set; }
     public Address XDCXAddressBinary { get; set; }
     public Address TradingStateAddressBinary { get; set; }
-    public ulong TIP2019Block { get; set; }
     public Address FoundationWallet { get; set; }
     public Address MasternodeVotingContract { get; set; }
     public bool IsTipUpgradeRewardEnabled { get; set; }
@@ -151,6 +150,5 @@ public interface IXdcReleaseSpec : IReleaseSpec
     public bool IsTIPXDCXReceiver { get; set; }
     public bool IsTipUpgradePenaltyEnabled { get; set; }
     public bool IsDynamicGasLimitBlock { get; set; }
-    public ulong TIP2019Block { get; set; }
     public void ApplyV2Config(ulong round);
 }


### PR DESCRIPTION
## Changes

Removes XDC config parameters that nothing reads, across the chainspec engine params, the release spec, and the two shipped chainspecs.

- `XdcChainSpecEngineParameters.Period` — never consumed. The `Period` in the `XDPoS_networkInformation` response comes from the v2 config's `MinePeriod`, not from this.
- `XdcChainSpecEngineParameters.SkipV1Validation`, `RelayerRegistrationSMC`, `TRC21IssuerSMC` — zero references in the repo, and absent from both shipped chainspecs.
- `IXdcReleaseSpec.TIP2019Block` (and its `XdcReleaseSpec` implementation) — never assigned by the spec provider *and* never read; a leftover duplicate of the engine parameter. The engine parameter stays: it drives `IsTIP2019` and the fork ID.
- `"period"` and `"rewardCheckpoint"` in `Chains/xdc.json` and `Chains/xdc-testnet.json`. The former is unbound now that the property is gone; the latter never had a matching property, so it was already silently ignored — rewards are paid at epoch switches via `IEpochSwitchManager`, not from a checkpoint constant.

Unknown chainspec keys are ignored by the deserializer, so an external chainspec that still carries any of these loads unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

One existing test needed a follow-up. `XdcChainSpecRewardTests.Fractional_value_in_an_unannotated_engine_field_is_rejected` used `period` as its example of an XDPoS field *without* the XDC→wei converter, so with the property gone the key was ignored and nothing threw. It now uses `epoch`, another unannotated `ulong` in the same section — same assertion, same intent.

- `Nethermind.Xdc.Test`: 656/656 pass
- `ConfigFilesTests.Xdc_archive_syncs_from_the_XDPoS_v2_switch_block`: passes
- `dotnet format whitespace src/Nethermind/ --folder --verify-no-changes`: clean

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Three related items were found and deliberately left in place — they are config-derived fork flags rather than parameters, and removing them would delete intentional coverage:

- `IXdcReleaseSpec.IsTIPXDCXMiner` — computed but unconsumed; its activation window is pinned by `XdcChainSpecTests` alongside `IsTIPXDCXReceiver`, which *is* used in `XdcExtensions.Transactions`.
- `IsTIP2019` — computed from `TIP2019Block`, no production consumer yet.
- `IXdcReleaseSpec.SwitchRound` — set by `ApplyV2Config`, read only by tests.

Happy to strip those too if reviewers prefer; each is a one-line re-add when a consumer lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
