### PR TITLE
Fix peer update timer shutdown race

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -13,6 +13,7 @@ using Nethermind.Config;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Threading;
 using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Logging;
@@ -38,6 +39,44 @@ namespace Nethermind.Network.Test
             await using Context ctx = new();
             ctx.PeerManager.Start();
             await ctx.PeerManager.StopAsync();
+        }
+
+        [Test]
+        public async Task Periodic_peer_update_timer_signals_each_tick_and_stops_on_cancellation()
+        {
+            ManualTimeProvider timeProvider = new();
+            using CancellationTokenSource cancellationTokenSource = new();
+            using SemaphoreSlim signal = new(0);
+            TimeSpan interval = TimeSpan.FromMilliseconds(250);
+            Task timerTask = PeerManager.RunPeriodicPeerUpdatesAsync(
+                interval,
+                timeProvider,
+                () => signal.Release(),
+                cancellationTokenSource.Token);
+
+            timeProvider.AdvanceAndFireTimer(interval);
+            bool firstTickSignaled = await signal.WaitAsync(TimeSpan.FromSeconds(5));
+
+            timeProvider.AdvanceAndFireTimer(interval);
+            bool secondTickSignaled = await signal.WaitAsync(TimeSpan.FromSeconds(5));
+
+            cancellationTokenSource.Cancel();
+            OperationCanceledException? cancellationException = null;
+            try
+            {
+                await timerTask;
+            }
+            catch (OperationCanceledException e)
+            {
+                cancellationException = e;
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(firstTickSignaled, Is.True);
+                Assert.That(secondTickSignaled, Is.True);
+                Assert.That(cancellationException, Is.Not.Null);
+            }
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -13,7 +13,6 @@ using Nethermind.Config;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Threading;
 using Nethermind.Core.Timers;
 using Nethermind.Crypto;
 using Nethermind.Logging;
@@ -41,41 +40,59 @@ namespace Nethermind.Network.Test
             await ctx.PeerManager.StopAsync();
         }
 
-        [Test]
-        public async Task Periodic_peer_update_timer_signals_each_tick_and_stops_on_cancellation()
+        [TestCase(0)]
+        [TestCase(-1)]
+        public async Task Start_rejects_non_positive_peer_update_interval(int interval)
         {
-            ManualTimeProvider timeProvider = new();
-            using CancellationTokenSource cancellationTokenSource = new();
-            using SemaphoreSlim signal = new(0);
-            TimeSpan interval = TimeSpan.FromMilliseconds(250);
-            Task timerTask = PeerManager.RunPeriodicPeerUpdatesAsync(
-                interval,
-                timeProvider,
-                () => signal.Release(),
-                cancellationTokenSource.Token);
+            await using Context ctx = new();
+            ctx.NetworkConfig.PeersUpdateInterval = interval;
 
-            timeProvider.AdvanceAndFireTimer(interval);
-            bool firstTickSignaled = await signal.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(() => ctx.PeerManager.Start(), Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
 
-            timeProvider.AdvanceAndFireTimer(interval);
-            bool secondTickSignaled = await signal.WaitAsync(TimeSpan.FromSeconds(5));
+        [Test]
+        public async Task Periodic_peer_update_continues_after_no_candidate_iterations()
+        {
+            const int expectedSelectionCount = 3;
+            int selectionCount = 0;
+            TaskCompletionSource thirdSelection = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            ConcurrentDictionary<PublicKeyAsKey, Peer> peers = new();
+            IPeerPool peerPool = Substitute.For<IPeerPool>();
+            peerPool.Peers.Returns(_ =>
+            {
+                if (Interlocked.Increment(ref selectionCount) == expectedSelectionCount)
+                {
+                    thirdSelection.TrySetResult();
+                }
 
-            cancellationTokenSource.Cancel();
-            OperationCanceledException? cancellationException = null;
+                return peers;
+            });
+            peerPool.ActivePeers.Returns(new ConcurrentDictionary<PublicKeyAsKey, Peer>());
+            peerPool.StaticPeers.Returns(Array.Empty<Peer>());
+
+            INetworkConfig networkConfig = Substitute.For<INetworkConfig>();
+            networkConfig.MaxActivePeers.Returns(1);
+            networkConfig.NumConcurrentOutgoingConnects.Returns(1);
+            networkConfig.MaxOutgoingConnectPerSec.Returns(20);
+            networkConfig.PeersUpdateInterval.Returns(10);
+
+            PeerManager peerManager = new(
+                Substitute.For<IRlpxHost>(),
+                peerPool,
+                Substitute.For<INodeStatsManager>(),
+                networkConfig,
+                Substitute.For<IEnode>(),
+                LimboLogs.Instance);
+
+            peerManager.Start();
             try
             {
-                await timerTask;
+                await thirdSelection.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.That(Volatile.Read(ref selectionCount), Is.GreaterThanOrEqualTo(expectedSelectionCount));
             }
-            catch (OperationCanceledException e)
+            finally
             {
-                cancellationException = e;
-            }
-
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(firstTickSignaled, Is.True);
-                Assert.That(secondTickSignaled, Is.True);
-                Assert.That(cancellationException, Is.Not.Null);
+                await peerManager.StopAsync();
             }
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -12,6 +12,7 @@ using DotNetty.Transport.Channels;
 using Nethermind.Config;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Exceptions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
 using Nethermind.Crypto;
@@ -47,7 +48,10 @@ namespace Nethermind.Network.Test
             await using Context ctx = new();
             ctx.NetworkConfig.PeersUpdateInterval = interval;
 
-            Assert.That(() => ctx.PeerManager.Start(), Throws.TypeOf<ArgumentOutOfRangeException>());
+            InvalidConfigurationException exception = Assert.Throws<InvalidConfigurationException>(
+                () => ctx.PeerManager.Start())!;
+
+            Assert.That(exception.ExitCode, Is.EqualTo(ExitCodes.ForbiddenOptionValue));
         }
 
         [Test]
@@ -87,7 +91,7 @@ namespace Nethermind.Network.Test
             peerManager.Start();
             try
             {
-                await thirdSelection.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                await thirdSelection.Task.WaitAsync(TimeSpan.FromSeconds(10));
                 Assert.That(Volatile.Read(ref selectionCount), Is.GreaterThanOrEqualTo(expectedSelectionCount));
             }
             finally

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -173,9 +173,10 @@ namespace Nethermind.Network
 
         public void Start()
         {
-            if (_networkConfig.PeersUpdateInterval is <= 0)
+            int peersUpdateInterval = _networkConfig.PeersUpdateInterval;
+            if (peersUpdateInterval is <= 0)
             {
-                ThrowInvalidPeersUpdateInterval();
+                ThrowInvalidPeersUpdateInterval(peersUpdateInterval);
             }
 
             lock (_sessionLock)
@@ -1343,9 +1344,9 @@ namespace Nethermind.Network
             => throw new InvalidAsynchronousStateException($"Invalid session state in {nameof(OnDisconnected)} - {session.State}");
 
         [DoesNotReturn, StackTraceHidden]
-        private static void ThrowInvalidPeersUpdateInterval()
+        private static void ThrowInvalidPeersUpdateInterval(int peersUpdateInterval)
             => throw new InvalidConfigurationException(
-                $"{nameof(INetworkConfig.PeersUpdateInterval)} must be greater than zero.",
+                $"{nameof(INetworkConfig.PeersUpdateInterval)} must be greater than zero, but was {peersUpdateInterval}.",
                 ExitCodes.ForbiddenOptionValue);
     }
 }

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -172,6 +172,10 @@ namespace Nethermind.Network
 
         public void Start()
         {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+                _networkConfig.PeersUpdateInterval,
+                nameof(_networkConfig.PeersUpdateInterval));
+
             lock (_sessionLock)
             {
                 _isStopping = false;
@@ -625,11 +629,11 @@ namespace Nethermind.Network
 
             try
             {
-                await RunPeriodicPeerUpdatesAsync(
-                    TimeSpan.FromMilliseconds(_networkConfig.PeersUpdateInterval),
-                    TimeProvider.System,
-                    SignalPeerUpdateNeeded,
-                    _cancellationTokenSource.Token);
+                using PeriodicTimer timer = new(TimeSpan.FromMilliseconds(_networkConfig.PeersUpdateInterval));
+                while (await timer.WaitForNextTickAsync(_cancellationTokenSource.Token))
+                {
+                    SignalPeerUpdateNeeded();
+                }
             }
             catch (Exception e) when (e is not OperationCanceledException)
             {
@@ -638,19 +642,6 @@ namespace Nethermind.Network
             catch (OperationCanceledException)
             {
                 if (_logger.IsDebug) _logger.Debug("Peer update timer stopped.");
-            }
-        }
-
-        internal static async Task RunPeriodicPeerUpdatesAsync(
-            TimeSpan interval,
-            TimeProvider timeProvider,
-            Action signalPeerUpdateNeeded,
-            CancellationToken cancellationToken)
-        {
-            using PeriodicTimer timer = new(interval, timeProvider);
-            while (await timer.WaitForNextTickAsync(cancellationToken))
-            {
-                signalPeerUpdateNeeded();
             }
         }
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -18,6 +18,7 @@ using Nethermind.Core;
 using Nethermind.Core.Attributes;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.ServiceStopper;
 using Nethermind.Logging;
@@ -172,9 +173,10 @@ namespace Nethermind.Network
 
         public void Start()
         {
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
-                _networkConfig.PeersUpdateInterval,
-                nameof(_networkConfig.PeersUpdateInterval));
+            if (_networkConfig.PeersUpdateInterval is <= 0)
+            {
+                ThrowInvalidPeersUpdateInterval();
+            }
 
             lock (_sessionLock)
             {
@@ -1339,5 +1341,11 @@ namespace Nethermind.Network
         [DoesNotReturn, StackTraceHidden]
         private static void ThrowInvalidOnDisconnectedState(ISession session)
             => throw new InvalidAsynchronousStateException($"Invalid session state in {nameof(OnDisconnected)} - {session.State}");
+
+        [DoesNotReturn, StackTraceHidden]
+        private static void ThrowInvalidPeersUpdateInterval()
+            => throw new InvalidConfigurationException(
+                $"{nameof(INetworkConfig.PeersUpdateInterval)} must be greater than zero.",
+                ExitCodes.ForbiddenOptionValue);
     }
 }

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -188,7 +188,7 @@ namespace Nethermind.Network
                 _rlpxHost.SessionDisconnected += _onSessionDisconnected;
             }
 
-            _peerUpdateTimerTask = RunPeerUpdateTimerAsync();
+            _peerUpdateTimerTask = RunPeerUpdateTimerAsync(peersUpdateInterval);
             _peerUpdateLoopTask = RunPeerUpdateLoopAsync();
 
             _isStarted = true;
@@ -626,13 +626,13 @@ namespace Nethermind.Network
             }
         }
 
-        private async Task RunPeerUpdateTimerAsync()
+        private async Task RunPeerUpdateTimerAsync(int peersUpdateInterval)
         {
             if (_logger.IsDebug) _logger.Debug("Starting peer update timer");
 
             try
             {
-                using PeriodicTimer timer = new(TimeSpan.FromMilliseconds(_networkConfig.PeersUpdateInterval));
+                using PeriodicTimer timer = new(TimeSpan.FromMilliseconds(peersUpdateInterval));
                 while (await timer.WaitForNextTickAsync(_cancellationTokenSource.Token))
                 {
                     SignalPeerUpdateNeeded();

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -27,7 +27,6 @@ using Nethermind.Network.P2P.EventArg;
 using Nethermind.Network.Rlpx;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
-using Timer = System.Timers.Timer;
 
 namespace Nethermind.Network
 {
@@ -42,6 +41,7 @@ namespace Nethermind.Network
         private readonly INodeStatsManager _stats;
         private readonly SemaphoreSlim _peerUpdateRequested = new(0, 1);
         private Task? _peerUpdateLoopTask;
+        private Task? _peerUpdateTimerTask;
         private readonly IPeerPool _peerPool;
         private readonly Lock _sessionLock = new();
         private readonly List<PeerStats> _candidates;
@@ -52,8 +52,6 @@ namespace Nethermind.Network
         private int _newActiveNodes;
         private int _failedInitialConnect;
         private int _connectionRounds;
-
-        private Timer? _peerUpdateTimer;
 
         private int _maxPeerPoolLength;
 
@@ -183,8 +181,7 @@ namespace Nethermind.Network
                 _rlpxHost.SessionDisconnected += _onSessionDisconnected;
             }
 
-            StartPeerUpdateLoop();
-
+            _peerUpdateTimerTask = RunPeerUpdateTimerAsync();
             _peerUpdateLoopTask = RunPeerUpdateLoopAsync();
 
             _isStarted = true;
@@ -241,7 +238,10 @@ namespace Nethermind.Network
                 }
             }
 
-            StopTimers();
+            if (_peerUpdateTimerTask is not null)
+            {
+                await _peerUpdateTimerTask;
+            }
 
             if (_logger.IsInfo) _logger.Info("Peer Manager shutdown complete. Please wait for all components to close");
         }
@@ -360,8 +360,6 @@ namespace Nethermind.Network
                         await Task.Delay(1000, _cancellationTokenSource.Token);
                     }
                 }
-
-                _peerUpdateTimer?.Start();
             }
 
             taskChannel.Writer.Complete();
@@ -621,35 +619,38 @@ namespace Nethermind.Network
             }
         }
 
-        private void StartPeerUpdateLoop()
+        private async Task RunPeerUpdateTimerAsync()
         {
             if (_logger.IsDebug) _logger.Debug("Starting peer update timer");
 
-            _peerUpdateTimer = new Timer(_networkConfig.PeersUpdateInterval);
-            _peerUpdateTimer.Elapsed += PeerUpdateTimerOnElapsed;
-
-            _peerUpdateTimer.Start();
-        }
-
-        private void StopTimers()
-        {
             try
             {
-                if (_logger.IsDebug) _logger.Debug("Stopping peer timers");
-                Timer? peerUpdateTimer = _peerUpdateTimer;
-                if (peerUpdateTimer is null)
-                {
-                    return;
-                }
-
-                peerUpdateTimer.Elapsed -= PeerUpdateTimerOnElapsed;
-                peerUpdateTimer.Stop();
-                peerUpdateTimer.Dispose();
-                _peerUpdateTimer = null;
+                await RunPeriodicPeerUpdatesAsync(
+                    TimeSpan.FromMilliseconds(_networkConfig.PeersUpdateInterval),
+                    TimeProvider.System,
+                    SignalPeerUpdateNeeded,
+                    _cancellationTokenSource.Token);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not OperationCanceledException)
             {
-                _logger.Error("Error during peer timers stop", e);
+                if (_logger.IsError) _logger.Error("Peer update timer encountered an exception.", e);
+            }
+            catch (OperationCanceledException)
+            {
+                if (_logger.IsDebug) _logger.Debug("Peer update timer stopped.");
+            }
+        }
+
+        internal static async Task RunPeriodicPeerUpdatesAsync(
+            TimeSpan interval,
+            TimeProvider timeProvider,
+            Action signalPeerUpdateNeeded,
+            CancellationToken cancellationToken)
+        {
+            using PeriodicTimer timer = new(interval, timeProvider);
+            while (await timer.WaitForNextTickAsync(cancellationToken))
+            {
+                signalPeerUpdateNeeded();
             }
         }
 
@@ -678,12 +679,6 @@ namespace Nethermind.Network
             {
                 ProcessOutgoingConnection(session);
             }
-        }
-
-        private void PeerUpdateTimerOnElapsed(object? sender, System.Timers.ElapsedEventArgs e)
-        {
-            _peerUpdateTimer?.Stop();
-            SignalPeerUpdateNeeded();
         }
 
         private void CleanupCandidatePeers()


### PR DESCRIPTION
## Changes

- Replace the callback-based `System.Timers.Timer` peer update scheduler with a cancellation-aware `PeriodicTimer` pump.
- Feed periodic ticks through the existing coalescing peer-update semaphore and await the timer task during shutdown.
- Reject a non-positive peer update interval before event subscriptions are installed and include the rejected value in the logged configuration exception.
- Add regression coverage proving the real peer update loop remains scheduled across consecutive no-candidate iterations.

The previous timer could race with shutdown/disposal inside `System.Timers.Timer.UpdateTimer()`, producing a `NullReferenceException` from the peer update loop. `PeriodicTimer.WaitForNextTickAsync(CancellationToken)` keeps timer lifetime and cancellation within the async task instead of mutating a callback timer with `Start()`/`Stop()`.

`InitializeNetwork` continues to catch and log peer-manager startup failures, so this PR does not change process-exit behavior for invalid configuration. Validation before event subscription prevents a partially started manager and the rejected value makes the error actionable.

The periodic fallback now remains active after early loop exits. The previous one-shot timer could stay disarmed after paths such as having no available peer slot or no candidates. At maximum peers, the existing bounded availability check continues its lightweight 100 ms semaphore polling; keeping the fallback alive is intentional so the update loop cannot permanently lose its timer wake-up.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `PeerManagerTests`: 44 passed, 1 pre-existing skip.
- `Nethermind.Network.Test`: 1,536 passed, 8 pre-existing skips.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No