### PR TITLE
Make merged master code frame-transaction aware (#13001 follow-ups)

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -497,6 +497,32 @@ public class Eth72ProtocolHandlerTests
         _session.DidNotReceive().DeliverMessage(Arg.Any<GetCellsMessage72>());
     }
 
+    // The frame-transaction gate reads the head spec, and an announcement carries up to MaxCount entries.
+    [Test]
+    public void should_resolve_the_frame_tx_gate_once_per_announcement()
+    {
+        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        spec.IsEip8141Enabled.Returns(true);
+        _specProvider.GetCurrentHeadSpec().Returns(spec);
+        _transactionPool.NotifyAboutTx(Arg.Any<Hash256>(), Arg.Any<IMessageHandler<PooledTransactionRequestMessage>>())
+            .Returns(AnnounceResult.RequestRequired);
+
+        Hash256[] hashes = [HashFromInt(1), HashFromInt(2), HashFromInt(3)];
+        using NewPooledTransactionHashesMessage72 message = new(
+            [.. Enumerable.Repeat((byte)TxType.FrameTx, hashes.Length)],
+            [.. Enumerable.Repeat(1024, hashes.Length)],
+            [.. hashes],
+            BlobCellMask.Empty.ToBytes());
+
+        HandleIncomingStatusMessage();
+        _specProvider.ClearReceivedCalls();
+        HandleZeroMessage(message, Eth72MessageCode.NewPooledTransactionHashes);
+
+        _specProvider.Received(1).GetCurrentHeadSpec();
+        _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m =>
+            m.EthMessage.Hashes.Count == hashes.Length));
+    }
+
     [Test]
     public void should_reject_announcement_above_peer_admission_limit()
     {

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -27,6 +27,7 @@ using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.Subprotocols;
 using Nethermind.Network.Contract.Messages;
+using Nethermind.Network.P2P.Subprotocols.Eth.V62;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66;
 using Nethermind.Network.P2P.Subprotocols.Eth.V66.Messages;
 using Nethermind.Network.P2P.ProtocolHandlers;
@@ -521,6 +522,25 @@ public class Eth72ProtocolHandlerTests
         _specProvider.Received(1).GetCurrentHeadSpec();
         _session.Received(1).DeliverMessage(Arg.Is<GetPooledTransactionsMessage>(m =>
             m.EthMessage.Hashes.Count == hashes.Length));
+    }
+
+    // Delivery validates every transaction in the packet, so the same gate has to be resolved once there too.
+    [Test]
+    public void should_resolve_the_frame_tx_gate_once_per_delivered_packet()
+    {
+        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        spec.IsEip8141Enabled.Returns(true);
+        _specProvider.GetCurrentHeadSpec().Returns(spec);
+
+        Transaction[] transactions = [FrameTx(TestItem.PrivateKeyA), FrameTx(TestItem.PrivateKeyB), FrameTx(TestItem.PrivateKeyC)];
+        using TransactionsMessage message = new(transactions.ToPooledList());
+
+        HandleIncomingStatusMessage();
+        _specProvider.ClearReceivedCalls();
+        HandleZeroMessage(message, Eth62MessageCode.Transactions);
+
+        _specProvider.Received(1).GetCurrentHeadSpec();
+        _transactionPool.Received(transactions.Length).SubmitTx(Arg.Is<Transaction>(tx => tx.Type == TxType.FrameTx), Arg.Any<TxHandlingOptions>());
     }
 
     [Test]
@@ -4741,6 +4761,15 @@ public class Eth72ProtocolHandlerTests
         BinaryPrimitives.WriteInt32BigEndian(bytes.AsSpan(28), value);
         return new Hash256(bytes);
     }
+
+    private static Transaction FrameTx(PrivateKey signer) => Build.A.Transaction
+        .WithType(TxType.FrameTx)
+        .WithNonce(0)
+        .WithMaxFeePerGas(1.GWei)
+        .WithMaxPriorityFeePerGas(1.GWei)
+        .WithGasLimit(100_000)
+        .WithTo(TestItem.AddressB)
+        .SignedAndResolved(signer).TestObject;
 
     private static void AssertCustodyRequest(
         (Hash256 Hash, BlobCellMask CellMask) request,

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -265,7 +265,7 @@ public class Eth68ProtocolHandler(ISession session,
         }
     }
 
-    private bool CanRequestPooledTransaction(TxType txType, ref bool? frameTxsEnabled) =>
+    private protected bool CanRequestPooledTransaction(TxType txType, ref bool? frameTxsEnabled) =>
         CanDecodeTransactionType(txType)
         && (txType is not TxType.Blob || _blobSupportEnabled)
         && (txType is not TxType.FrameTx || (frameTxsEnabled ??= FrameTxsEnabled()));

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V68/Eth68ProtocolHandler.cs
@@ -270,12 +270,6 @@ public class Eth68ProtocolHandler(ISession session,
         && (txType is not TxType.Blob || _blobSupportEnabled)
         && (txType is not TxType.FrameTx || (frameTxsEnabled ??= FrameTxsEnabled()));
 
-    private protected bool CanRequestPooledTransaction(TxType txType)
-    {
-        bool? frameTxsEnabled = null;
-        return CanRequestPooledTransaction(txType, ref frameTxsEnabled);
-    }
-
     private static bool CanDecodeTransactionType(TxType txType) => txType switch
     {
         TxType.Legacy or TxType.AccessList or TxType.EIP1559 or TxType.Blob or TxType.SetCode or TxType.FrameTx => true,

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -824,6 +824,10 @@ public class Eth72ProtocolHandler(
         try
         {
             bool isTrace = Logger.IsTrace;
+
+            // Resolved on the first type-6 transaction, so a batch without one does no head lookup.
+            bool? frameTxsEnabled = null;
+
             while (currentIdx < transactionsSpan.Length)
             {
                 if (cancellationToken.IsCancellationRequested)
@@ -845,7 +849,7 @@ public class Eth72ProtocolHandler(
                 }
 
                 Transaction tx = transactionsSpan[currentIdx];
-                if (!ValidateAnnouncedPooledTransaction(tx))
+                if (!ValidateAnnouncedPooledTransaction(tx, ref frameTxsEnabled))
                 {
                     throw new SubprotocolException("invalid pooled tx type or size");
                 }
@@ -1571,9 +1575,9 @@ public class Eth72ProtocolHandler(
         }
     }
 
-    private bool ValidateAnnouncedPooledTransaction(Transaction tx)
+    private bool ValidateAnnouncedPooledTransaction(Transaction tx, ref bool? frameTxsEnabled)
     {
-        if (!CanRequestPooledTransaction(tx.Type))
+        if (!CanRequestPooledTransaction(tx.Type, ref frameTxsEnabled))
         {
             return false;
         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -416,12 +416,15 @@ public class Eth72ProtocolHandler(
         int toRequestCount = 0;
         ArrayPoolList<Hash256>? hashesToRequest = null;
 
+        // Resolved on the first type-6 byte, so a batch without one does no head lookup.
+        bool? frameTxsEnabled = null;
+
         for (int i = 0; i < msg.Hashes.Length; i++)
         {
             Hash256 hash = msg.Hashes[i];
             TxType txType = (TxType)msg.Types[i];
             int txSize = msg.Sizes[i];
-            if (!CanRequestPooledTransaction(txType) || txSize <= 0)
+            if (!CanRequestPooledTransaction(txType, ref frameTxsEnabled) || txSize <= 0)
             {
                 continue;
             }

--- a/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
@@ -150,14 +150,15 @@ public class LightTxDecoderTests
         InterfaceLogger logger = Substitute.For<InterfaceLogger>();
         logger.IsWarn.Returns(true);
 
+        // The exception type is what tells a layout change apart from one corrupt record, so the summary names it.
+        string expectedType = Assert.Catch(() => LightTxDecoder.Decode(EncodeWithBlobFieldsLast(BlobCarryingTx(TxType.FrameTx))))!.GetType().Name;
+
         List<LightTransaction> loaded = [.. new BlobTxStorage(database, new OneLoggerLogManager(new ILogger(logger))).GetAll()];
 
         Assert.That(loaded, Is.Empty);
-        logger.Received(1).Warn(Arg.Is<string>(text => text.Contains(unreadableCount.ToString())));
+        logger.Received(1).Warn(Arg.Is<string>(text => text.Contains(unreadableCount.ToString()) && text.Contains(expectedType)));
     }
 
-    // GetAllValues does not promise an order, and none is needed: an unskipped decode failure would escape the
-    // enumeration from either position.
     private static readonly byte[] UnreadableRecordKey = [0];
     private static readonly byte[] ReadableRecordKey = [1];
 

--- a/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
@@ -11,9 +11,11 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Int256;
+using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs.Forks;
 using Nethermind.TxPool.Collections;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.TxPool.Test;
@@ -132,7 +134,30 @@ public class LightTxDecoderTests
         Assert.That(loaded[0].Hash, Is.EqualTo(readable.Hash));
     }
 
-    // GetAllValues walks the column in key order, so the unreadable record is reached first.
+    // A record layout change leaves every record unreadable at once, so the skips have to collapse into one line
+    // rather than one per blob transaction in the pool.
+    [Test]
+    public void Unreadable_records_are_reported_as_one_warning()
+    {
+        const int unreadableCount = 5;
+        MemColumnsDb<BlobTxsColumns> database = new();
+        IDb lightBlobTxs = database.GetColumnDb(BlobTxsColumns.LightBlobTxs);
+        for (int i = 0; i < unreadableCount; i++)
+        {
+            lightBlobTxs.Set([(byte)i], EncodeWithBlobFieldsLast(BlobCarryingTx(TxType.FrameTx)));
+        }
+
+        InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+        logger.IsWarn.Returns(true);
+
+        List<LightTransaction> loaded = [.. new BlobTxStorage(database, new OneLoggerLogManager(new ILogger(logger))).GetAll()];
+
+        Assert.That(loaded, Is.Empty);
+        logger.Received(1).Warn(Arg.Is<string>(text => text.Contains(unreadableCount.ToString())));
+    }
+
+    // GetAllValues does not promise an order, and none is needed: an unskipped decode failure would escape the
+    // enumeration from either position.
     private static readonly byte[] UnreadableRecordKey = [0];
     private static readonly byte[] ReadableRecordKey = [1];
 

--- a/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
@@ -9,6 +9,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
+using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs.Forks;
@@ -110,6 +111,70 @@ public class LightTxDecoderTests
         }
 
         return keys;
+    }
+
+    // The blob fields were later put ahead of the frame-transaction ones, so a record written by an earlier build of
+    // this branch no longer decodes. The pool is a cache, so it has to lose that record rather than refuse to start.
+    [TestCase(TxType.Blob, null)]
+    [TestCase(TxType.FrameTx, null)]
+    [TestCase(TxType.FrameTx, 1_000ul)]
+    public void Unreadable_record_is_skipped_and_leaves_the_rest_of_the_pool_loadable(TxType type, ulong? deadline)
+    {
+        Transaction readable = BlobCarryingTx(TxType.Blob);
+        MemColumnsDb<BlobTxsColumns> database = new();
+        IDb lightBlobTxs = database.GetColumnDb(BlobTxsColumns.LightBlobTxs);
+        lightBlobTxs.Set(UnreadableRecordKey, EncodeWithBlobFieldsLast(BlobCarryingTx(type, deadline)));
+        lightBlobTxs.Set(ReadableRecordKey, LightTxDecoder.Encode(readable));
+
+        List<LightTransaction> loaded = null;
+        Assert.That(() => loaded = [.. new BlobTxStorage(database).GetAll()], Throws.Nothing);
+        Assert.That(loaded, Has.Count.EqualTo(1));
+        Assert.That(loaded[0].Hash, Is.EqualTo(readable.Hash));
+    }
+
+    // GetAllValues walks the column in key order, so the unreadable record is reached first.
+    private static readonly byte[] UnreadableRecordKey = [0];
+    private static readonly byte[] ReadableRecordKey = [1];
+
+    /// <summary>Writes the record layout that preceded the blob fields moving in front of the frame-transaction ones.</summary>
+    private static byte[] EncodeWithBlobFieldsLast(Transaction tx)
+    {
+        bool hasDeadline = FrameTxValidation.TryGetExpiryDeadline(tx, out ulong expiryDeadline);
+        int length = Rlp.LengthOf(tx.Timestamp)
+            + Rlp.LengthOf(tx.SenderAddress)
+            + Rlp.LengthOf(tx.Nonce)
+            + Rlp.LengthOf(tx.Hash)
+            + Rlp.LengthOf(tx.Value)
+            + Rlp.LengthOf(tx.GasLimit)
+            + Rlp.LengthOf(tx.GasPrice)
+            + Rlp.LengthOf(tx.DecodedMaxFeePerGas)
+            + Rlp.LengthOf(tx.MaxFeePerBlobGas!.Value)
+            + Rlp.LengthOf(tx.BlobVersionedHashes!)
+            + Rlp.LengthOf(tx.PoolIndex)
+            + Rlp.LengthOf(tx.GetLength())
+            + Rlp.LengthOf(sizeof(byte))
+            + Rlp.LengthOf((byte)tx.Type)
+            + (hasDeadline ? Rlp.LengthOf(expiryDeadline) : 0);
+
+        byte[] bytes = new byte[length];
+        RlpWriter writer = new(bytes);
+        writer.Encode(tx.Timestamp);
+        writer.Encode(tx.SenderAddress);
+        writer.Encode(tx.Nonce);
+        writer.Encode(tx.Hash);
+        writer.Encode(in tx.ValueRef);
+        writer.Encode(tx.GasLimit);
+        writer.Encode(tx.GasPrice);
+        writer.Encode(tx.DecodedMaxFeePerGas);
+        writer.Encode(tx.MaxFeePerBlobGas!.Value);
+        writer.Encode(tx.BlobVersionedHashes!);
+        writer.Encode(tx.PoolIndex);
+        writer.Encode(tx.GetLength());
+        writer.Encode((byte)((tx.NetworkWrapper as ShardBlobNetworkWrapper)?.Version ?? default));
+        writer.Encode((byte)tx.Type);
+        if (hasDeadline) writer.Encode(expiryDeadline);
+
+        return bytes;
     }
 
     private static Transaction BlobCarryingTx(TxType type, ulong? deadline = null, UInt256[] nonceKeys = null)

--- a/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
@@ -159,6 +159,49 @@ public class LightTxDecoderTests
         logger.Received(1).Warn(Arg.Is<string>(text => text.Contains(unreadableCount.ToString()) && text.Contains(expectedType)));
     }
 
+    // The catch must span every shape a foreign or damaged record decodes into, not just the mask check:
+    // a truncated record surfaces from the reader's unchecked slice rather than as an RlpException.
+    [Test]
+    public void Records_failing_in_different_ways_are_all_skipped()
+    {
+        // A long-form list prefix mid-record makes the reader take a bogus length and index past the buffer,
+        // which is the third root and reaches neither the mask check nor the RLP grammar errors.
+        byte[] longFormPrefix = LightTxDecoder.Encode(BlobCarryingTx(TxType.Blob));
+        longFormPrefix[64] = 0xf8;
+
+        byte[][] corrupt =
+        [
+            EncodeWithBlobFieldsLast(BlobCarryingTx(TxType.FrameTx)),
+            LightTxDecoder.Encode(BlobCarryingTx(TxType.Blob))[..^5],
+            longFormPrefix,
+            [0xff, 0xff, 0xff, 0xff],
+        ];
+
+        HashSet<string> shapes = [];
+        foreach (byte[] record in corrupt)
+        {
+            shapes.Add(Assert.Catch(() => LightTxDecoder.Decode(record))!.GetType().Name);
+        }
+
+        Assert.That(shapes, Has.Count.GreaterThanOrEqualTo(3),
+            $"these records must span the roots the catch filter lists, but they only produced: {string.Join(", ", shapes)}");
+
+        Transaction readable = BlobCarryingTx(TxType.Blob);
+        MemColumnsDb<BlobTxsColumns> database = new();
+        IDb lightBlobTxs = database.GetColumnDb(BlobTxsColumns.LightBlobTxs);
+        for (int i = 0; i < corrupt.Length; i++)
+        {
+            lightBlobTxs.Set([(byte)i], corrupt[i]);
+        }
+
+        lightBlobTxs.Set([(byte)corrupt.Length], LightTxDecoder.Encode(readable));
+
+        List<LightTransaction> loaded = null;
+        Assert.That(() => loaded = [.. new BlobTxStorage(database).GetAll()], Throws.Nothing);
+        Assert.That(loaded, Has.Count.EqualTo(1));
+        Assert.That(loaded[0].Hash, Is.EqualTo(readable.Hash));
+    }
+
     private static readonly byte[] UnreadableRecordKey = [0];
     private static readonly byte[] ReadableRecordKey = [1];
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -4108,6 +4108,28 @@ namespace Nethermind.TxPool.Test
                 "a new head must not evict a reloaded keyed transaction whose sequence is current");
         }
 
+        // Block production takes the ready-filtered blob snapshot, and an EIP-8250 keyed sequence is unrelated to the
+        // account nonce, so comparing the two would keep the transaction out of every block it is otherwise ready for.
+        [Test]
+        public void Keyed_blob_carrying_frame_tx_is_ready_for_block_production()
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.InMemory };
+            _txPool = CreatePool(txPoolConfig, KeyedNonceSpecProvider());
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            // The account nonce advances independently of key 0xbeef, whose sequence stays at 0 and stays includable.
+            _stateProvider.IncrementNonce(TestItem.AddressA);
+
+            Transaction tx = BuildBlobFrameTx(nonce: 0, blobCount: 1, withSidecar: true, nonceKeys: [0xbeef]);
+            Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            IDictionary<AddressAsKey, Transaction[]> ready = _txPool.GetPendingLightBlobTransactionsBySender(filterToReadyTx: true);
+
+            Assert.That(ready.TryGetValue(TestItem.AddressA, out Transaction[] readyForSender), Is.True,
+                "a bucket whose lowest entry is keyed must not be filtered out wholesale");
+            Assert.That(readyForSender, Has.Length.EqualTo(1));
+        }
+
         private Transaction BuildBlobFrameTx(ulong nonce, int blobCount, ulong? deadline = null, UInt256? maxFeePerBlobGas = null, bool withSidecar = false, UInt256[] nonceKeys = null)
         {
             ShardBlobNetworkWrapper wrapper = null;

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -123,7 +123,9 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database, ILogManager? log
                 {
                     if (!TryDecodeLightTx(txBytes, out transaction)) continue;
                 }
-                catch (Exception e)
+                // A truncated record surfaces from the reader's unchecked Span.Slice, not as an RlpException, so
+                // the filter spans every root a corrupt or foreign-layout record is known to decode into.
+                catch (Exception e) when (e is RlpException or ArgumentException or IndexOutOfRangeException)
                 {
                     skipped++;
                     firstFailure ??= $"{e.GetType().Name}: {e.Message}";

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -107,7 +107,8 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database, ILogManager? log
     /// The blob pool is a cache, so a record this build cannot read — one left by another build's record layout —
     /// is skipped rather than allowed to abort the load and with it node startup. A record layout change makes
     /// every record unreadable at once, so the skipped records are reported as a single summary rather than one
-    /// line each; the first failure is quoted so a lone corrupt record is still diagnosable.
+    /// line each; the first failure's type and message are quoted, since the type is what tells a layout change
+    /// apart from a lone corrupt record.
     /// </remarks>
     public IEnumerable<LightTransaction> GetAll()
     {
@@ -125,7 +126,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database, ILogManager? log
                 catch (Exception e)
                 {
                     skipped++;
-                    firstFailure ??= e.Message;
+                    firstFailure ??= $"{e.GetType().Name}: {e.Message}";
                     continue;
                 }
 

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -105,24 +105,37 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database, ILogManager? log
     /// <summary>Enumerates every persisted light blob transaction record this build can read.</summary>
     /// <remarks>
     /// The blob pool is a cache, so a record this build cannot read — one left by another build's record layout —
-    /// is skipped rather than allowed to abort the load and with it node startup.
+    /// is skipped rather than allowed to abort the load and with it node startup. A record layout change makes
+    /// every record unreadable at once, so the skipped records are reported as a single summary rather than one
+    /// line each; the first failure is quoted so a lone corrupt record is still diagnosable.
     /// </remarks>
     public IEnumerable<LightTransaction> GetAll()
     {
-        foreach (byte[] txBytes in _lightBlobTxsDb.GetAllValues())
+        int skipped = 0;
+        string? firstFailure = null;
+        try
         {
-            LightTransaction? transaction;
-            try
+            foreach (byte[] txBytes in _lightBlobTxsDb.GetAllValues())
             {
-                if (!TryDecodeLightTx(txBytes, out transaction)) continue;
-            }
-            catch (Exception e)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Ignoring an unreadable persisted blob transaction: {e.Message}");
-                continue;
-            }
+                LightTransaction? transaction;
+                try
+                {
+                    if (!TryDecodeLightTx(txBytes, out transaction)) continue;
+                }
+                catch (Exception e)
+                {
+                    skipped++;
+                    firstFailure ??= e.Message;
+                    continue;
+                }
 
-            yield return transaction!;
+                yield return transaction!;
+            }
+        }
+        finally
+        {
+            if (skipped > 0 && _logger.IsWarn)
+                _logger.Warn($"Ignoring {skipped} unreadable persisted blob transaction(s). First failure: {firstFailure}");
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -13,11 +13,12 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Int256;
+using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.TxPool;
 
-public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage, IBlobTxMetadataStorage
+public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database, ILogManager? logManager = null) : IBlobTxStorage, IBlobTxMetadataStorage
 {
     private const int MaxPooledKeys = 128;
     private const int TransactionLockCount = 64;
@@ -34,6 +35,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     private readonly IDb _fullBlobTxsDb = database.GetColumnDb(BlobTxsColumns.FullBlobTxs);
     private readonly IDb _lightBlobTxsDb = database.GetColumnDb(BlobTxsColumns.LightBlobTxs);
     private readonly IDb _processedBlobTxsDb = database.GetColumnDb(BlobTxsColumns.ProcessedTxs);
+    private readonly ILogger _logger = (logManager ?? LimboLogs.Instance).GetClassLogger<BlobTxStorage>();
 
     public BlobTxStorage() : this(new MemColumnsDb<BlobTxsColumns>()) { }
 
@@ -100,14 +102,27 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         }
     }
 
+    /// <summary>Enumerates every persisted light blob transaction record this build can read.</summary>
+    /// <remarks>
+    /// The blob pool is a cache, so a record this build cannot read — one left by another build's record layout —
+    /// is skipped rather than allowed to abort the load and with it node startup.
+    /// </remarks>
     public IEnumerable<LightTransaction> GetAll()
     {
         foreach (byte[] txBytes in _lightBlobTxsDb.GetAllValues())
         {
-            if (TryDecodeLightTx(txBytes, out LightTransaction? transaction))
+            LightTransaction? transaction;
+            try
             {
-                yield return transaction!;
+                if (!TryDecodeLightTx(txBytes, out transaction)) continue;
             }
+            catch (Exception e)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Ignoring an unreadable persisted blob transaction: {e.Message}");
+                continue;
+            }
+
+            yield return transaction!;
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -271,7 +271,7 @@ namespace Nethermind.TxPool
 
         public IDictionary<AddressAsKey, Transaction[]> GetPendingLightBlobTransactionsBySender(bool filterToReadyTx, UInt256 baseFee = default) =>
             _blobTransactions.GetBucketSnapshot(filterToReadyTx
-                ? data => data.first.CanPayBaseFee(baseFee) && data.first.Nonce == _accounts.GetNonce(data.key)
+                ? data => data.first.CanPayBaseFee(baseFee) && IsNonceReady(data.first, data.key)
                 : null);
 
         public Transaction[] GetPendingTransactionsBySender(Address address) =>


### PR DESCRIPTION
## Changes

Carries forward three unaddressed review findings from the master merge in #13001. All three are the same class of defect: code that came across from master verbatim and is not aware of frame transactions.

- **`TxPool.GetPendingLightBlobTransactionsBySender(filterToReadyTx, baseFee)`** compared an [EIP-8250](https://eips.ethereum.org/EIPS/eip-8250) keyed sequence to the account nonce. A keyed nonce shares the `Nonce` field but counts in a separate per-key sequence, so a keyed blob-carrying frame transaction never looked ready — `BlockProducerBase` passes `filterSource: true`, so it was dropped from block production entirely. Now reuses the keyed-aware `IsNonceReady` the non-blob overload already uses. ([thread](https://github.com/NethermindEth/nethermind/pull/13001#discussion_r3867913541))
- **`BlobTxStorage.GetAll()`** let a decode failure escape. `GetAll()` is consumed from the `PersistentBlobTxDistinctSortedPool` constructor, which runs in the `TxPool` constructor, so an unreadable persisted record aborted node startup. #13001 deliberately accepted "wipe the blob-pool DB on upgrade" rather than reorder the record's fields, but a cache should degrade to empty, not refuse to start — the record is now skipped and logged. ([thread](https://github.com/NethermindEth/nethermind/pull/13001#discussion_r3867712773))
- **`Eth72ProtocolHandler.Handle(NewPooledTransactionHashesMessage72)`** used the single-argument `CanRequestPooledTransaction(TxType)`, which resolves `frameTxsEnabled` afresh per call, repeating the head-spec lookup for every type-6 entry in an announcement of up to `MaxCount`. Applies the hoist eth/68 already does. ([thread](https://github.com/NethermindEth/nethermind/pull/13001#discussion_r3867914791))

The fourth finding on #13001 — blob-carrying type-6 frame transactions skipping KZG verification in `BlobProofsTxFilter` — was fixed before that PR merged and needs nothing here.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

One regression test per finding, each revert-checked (reverting the fix fails that test and only that test):

- `TxPoolTests.Keyed_blob_carrying_frame_tx_is_ready_for_block_production` — pre-fix the sender's whole bucket is absent from the ready snapshot.
- `LightTxDecoderTests.Unreadable_record_is_skipped_and_leaves_the_rest_of_the_pool_loadable` — three cases, writing the previous record layout into the light-blob column. Pre-fix each throws `ArgumentOutOfRangeException` ("Blob cell mask must be exactly 16 bytes") out of `GetAll()`; note this is not an `RlpException`, so the catch is deliberately broad.
- `Eth72ProtocolHandlerTests.should_resolve_the_frame_tx_gate_once_per_announcement` — asserts one head-spec lookup for a three-entry type-6 announcement.

Suites run green: `Nethermind.TxPool.Test` (911, release and debug), `Nethermind.Network.Test` (1548), `Nethermind.Core.Test` (6195), `Nethermind.Blockchain.Test` (1762), `Nethermind.Runner.Test` (729, covers the DI graph after the `BlobTxStorage` constructor gained an optional `ILogManager`). The FOCIL lane (`tests-focil-devnet@v0.2.0`, `for_bogota`, `--engineTest`, CI's exclusion filter) is unchanged at 26,547 passing / 0 failures.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
