### PR TITLE
Return INVALID for a malformed block access list envelope

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -645,7 +645,7 @@ public abstract class BlockchainTestBase
         ("BlockException.SYSTEM_CONTRACT_EMPTY", ValidationErrorRegex(@"(Withdrawals|Consolidations|BuilderDeposits|BuilderExits)Empty: Contract is not deployed\.")),
         ("BlockException.SYSTEM_CONTRACT_CALL_FAILED", ValidationErrorRegex(@"(Withdrawals|Consolidations|BuilderDeposits|BuilderExits)Failed: Contract execution failed\.")),
         ("BlockException.INVALID_BAL_HASH", ValidationErrorRegex(@"InvalidBlockLevelAccessListHash:")),
-        ("BlockException.INVALID_BLOCK_ACCESS_LIST", ValidationErrorRegex(@"InvalidBlockLevelAccessListHash:|InvalidBlockLevelAccessList:|Error decoding block access list:|Block access list must be a complete RLP list")),
+        ("BlockException.INVALID_BLOCK_ACCESS_LIST", ValidationErrorRegex(@"InvalidBlockLevelAccessListHash:|InvalidBlockLevelAccessList:|Error decoding block access list:")),
         ("BlockException.INCORRECT_BLOCK_FORMAT", ValidationErrorRegex(@"Error decoding block access list:")),
         ("TransactionException.GAS_ALLOWANCE_EXCEEDED", ValidationErrorRegex(@"TxGasLimitCapExceeded:")),
         ("BlockException.INVALID_BAL_EXTRA_ACCOUNT", ValidationErrorRegex(@"Error decoding block access list:.*Account changes were in incorrect order")),

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -645,7 +645,7 @@ public abstract class BlockchainTestBase
         ("BlockException.SYSTEM_CONTRACT_EMPTY", ValidationErrorRegex(@"(Withdrawals|Consolidations|BuilderDeposits|BuilderExits)Empty: Contract is not deployed\.")),
         ("BlockException.SYSTEM_CONTRACT_CALL_FAILED", ValidationErrorRegex(@"(Withdrawals|Consolidations|BuilderDeposits|BuilderExits)Failed: Contract execution failed\.")),
         ("BlockException.INVALID_BAL_HASH", ValidationErrorRegex(@"InvalidBlockLevelAccessListHash:")),
-        ("BlockException.INVALID_BLOCK_ACCESS_LIST", ValidationErrorRegex(@"InvalidBlockLevelAccessListHash:|InvalidBlockLevelAccessList:|Error decoding block access list:")),
+        ("BlockException.INVALID_BLOCK_ACCESS_LIST", ValidationErrorRegex(@"InvalidBlockLevelAccessListHash:|InvalidBlockLevelAccessList:|Error decoding block access list:|Block access list must be a complete RLP list")),
         ("BlockException.INCORRECT_BLOCK_FORMAT", ValidationErrorRegex(@"Error decoding block access list:")),
         ("TransactionException.GAS_ALLOWANCE_EXCEEDED", ValidationErrorRegex(@"TxGasLimitCapExceeded:")),
         ("BlockException.INVALID_BAL_EXTRA_ACCOUNT", ValidationErrorRegex(@"Error decoding block access list:.*Account changes were in incorrect order")),

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -351,16 +351,16 @@ public partial class EngineModuleTests
         }
     }
 
-    [TestCase("0x", true)]
-    [TestCase("0x80", true)]
-    [TestCase("0xc1", true)]
-    [TestCase("0xf8", true)]
-    [TestCase("0xf800", true)]
-    [TestCase("0xf838", true)]
-    [TestCase("0xff", true)]
-    [TestCase("0xc0c0", true)]
-    [TestCase("0xf6da940000000000000000000000000000000000000000c0c0c0c0c0da940000000000000000000000000000000000000000c0c0c0c0c0", false)]
-    public async Task NewPayloadV5_rejects_malformed_block_access_list(string encodedBlockAccessList, bool expectsInvalidParams)
+    [TestCase("0x", "Block access list must be a complete RLP list")]
+    [TestCase("0x80", "Block access list must be a complete RLP list")]
+    [TestCase("0xc1", "Block access list must be a complete RLP list")]
+    [TestCase("0xf8", "Block access list must be a complete RLP list")]
+    [TestCase("0xf800", "Block access list must be a complete RLP list")]
+    [TestCase("0xf838", "Block access list must be a complete RLP list")]
+    [TestCase("0xff", "Block access list must be a complete RLP list")]
+    [TestCase("0xc0c0", "Block access list must be a complete RLP list")]
+    [TestCase("0xf6da940000000000000000000000000000000000000000c0c0c0c0c0da940000000000000000000000000000000000000000c0c0c0c0c0", "Error decoding block access list:")]
+    public async Task NewPayloadV5_rejects_malformed_block_access_list(string encodedBlockAccessList, string expectedValidationError)
     {
         using MergeTestBlockchain chain = await CreateBlockchain(Amsterdam.Instance);
         Block block = Build.A.Block
@@ -379,23 +379,12 @@ public partial class EngineModuleTests
             Keccak.Zero,
             []);
 
-        if (expectsInvalidParams)
-        {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(response.Result.ResultType, Is.EqualTo(ResultType.Failure));
-                Assert.That(response.ErrorCode, Is.EqualTo(ErrorCodes.InvalidParams));
-            }
-
-            return;
-        }
-
         using (Assert.EnterMultipleScope())
         {
             Assert.That(response.Result.ResultType, Is.EqualTo(ResultType.Success));
             Assert.That(response.Data.Status, Is.EqualTo(PayloadStatus.Invalid));
             Assert.That(response.Data.LatestValidHash, Is.Null);
-            Assert.That(response.Data.ValidationError, Does.StartWith("Error decoding block access list:"));
+            Assert.That(response.Data.ValidationError, Does.StartWith(expectedValidationError));
         }
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -379,9 +379,11 @@ public partial class EngineModuleTests
             Keccak.Zero,
             []);
 
+        Assert.That(response.Result.ResultType, Is.EqualTo(ResultType.Success));
+        Assert.That(response.Data, Is.Not.Null);
+
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(response.Result.ResultType, Is.EqualTo(ResultType.Success));
             Assert.That(response.Data.Status, Is.EqualTo(PayloadStatus.Invalid));
             Assert.That(response.Data.LatestValidHash, Is.Null);
             Assert.That(response.Data.ValidationError, Does.StartWith(expectedValidationError));

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -351,14 +351,14 @@ public partial class EngineModuleTests
         }
     }
 
-    [TestCase("0x", "Block access list must be a complete RLP list")]
-    [TestCase("0x80", "Block access list must be a complete RLP list")]
-    [TestCase("0xc1", "Block access list must be a complete RLP list")]
-    [TestCase("0xf8", "Block access list must be a complete RLP list")]
-    [TestCase("0xf800", "Block access list must be a complete RLP list")]
-    [TestCase("0xf838", "Block access list must be a complete RLP list")]
-    [TestCase("0xff", "Block access list must be a complete RLP list")]
-    [TestCase("0xc0c0", "Block access list must be a complete RLP list")]
+    [TestCase("0x", "Error decoding block access list: Must be a complete RLP list")]
+    [TestCase("0x80", "Error decoding block access list: Must be a complete RLP list")]
+    [TestCase("0xc1", "Error decoding block access list: Must be a complete RLP list")]
+    [TestCase("0xf8", "Error decoding block access list: Must be a complete RLP list")]
+    [TestCase("0xf800", "Error decoding block access list: Must be a complete RLP list")]
+    [TestCase("0xf838", "Error decoding block access list: Must be a complete RLP list")]
+    [TestCase("0xff", "Error decoding block access list: Must be a complete RLP list")]
+    [TestCase("0xc0c0", "Error decoding block access list: Must be a complete RLP list")]
     [TestCase("0xf6da940000000000000000000000000000000000000000c0c0c0c0c0da940000000000000000000000000000000000000000c0c0c0c0c0", "Error decoding block access list:")]
     public async Task NewPayloadV5_rejects_malformed_block_access_list(string encodedBlockAccessList, string expectedValidationError)
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
@@ -137,7 +137,7 @@ public class ExecutionPayloadParams<TVersionedExecutionPayload>(
                 if (!ExecutionPayloadV4.HasCompleteRlpListEnvelope(encodedBlockAccessList))
                 {
                     error = "Block access list must be a complete RLP list";
-                    return ValidationResult.Fail;
+                    return ValidationResult.Invalid;
                 }
 
                 bool decoded = executionPayload is ExecutionPayloadV4 executionPayloadV4

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/IExecutionPayloadParams.cs
@@ -136,7 +136,7 @@ public class ExecutionPayloadParams<TVersionedExecutionPayload>(
             {
                 if (!ExecutionPayloadV4.HasCompleteRlpListEnvelope(encodedBlockAccessList))
                 {
-                    error = "Block access list must be a complete RLP list";
+                    error = "Error decoding block access list: Must be a complete RLP list";
                     return ValidationResult.Invalid;
                 }
 


### PR DESCRIPTION
Clarify behavior around undecodable BALs:
https://github.com/ethereum/execution-apis/pull/869