### PR TITLE
ci: send GCP machine types to the smoke-test dispatches

### DIFF
--- a/.github/workflows/rpc-comparison.yml
+++ b/.github/workflows/rpc-comparison.yml
@@ -139,7 +139,7 @@ jobs:
           convert_to_paprika="${{ inputs.convert_to_paprika }}"
           machine_type=""
           if [[ "$convert_to_paprika" == 'true' ]]; then
-            machine_type="n2d-custom-8-32768"
+            machine_type="n2d-standard-8"
           fi
           echo "custom_machine_type=$machine_type" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/rpc-comparison.yml
+++ b/.github/workflows/rpc-comparison.yml
@@ -139,7 +139,7 @@ jobs:
           convert_to_paprika="${{ inputs.convert_to_paprika }}"
           machine_type=""
           if [[ "$convert_to_paprika" == 'true' ]]; then
-            machine_type="g6-standard-8"
+            machine_type="n2d-custom-8-32768"
           fi
           echo "custom_machine_type=$machine_type" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/run-a-geth-node.yml
+++ b/.github/workflows/run-a-geth-node.yml
@@ -115,7 +115,7 @@ jobs:
           set -euo pipefail
           [ "$ALLOWED_IPS" == "null" ] && ALLOWED_IPS=""
           [ "$MACHINE_TYPE" == "null" ] && MACHINE_TYPE=""
-          [ -z "$MACHINE_TYPE" ] && MACHINE_TYPE="n2d-custom-16-65536"
+          [ -z "$MACHINE_TYPE" ] && MACHINE_TYPE="n2d-standard-16"
 
           case "$NETWORK" in
             mainnet) CHECKPOINT_URL="https://mainnet-checkpoint-sync.attestant.io" ;;

--- a/.github/workflows/run-a-geth-node.yml
+++ b/.github/workflows/run-a-geth-node.yml
@@ -115,7 +115,7 @@ jobs:
           set -euo pipefail
           [ "$ALLOWED_IPS" == "null" ] && ALLOWED_IPS=""
           [ "$MACHINE_TYPE" == "null" ] && MACHINE_TYPE=""
-          [ -z "$MACHINE_TYPE" ] && MACHINE_TYPE="g6-standard-16"
+          [ -z "$MACHINE_TYPE" ] && MACHINE_TYPE="n2d-custom-16-65536"
 
           case "$NETWORK" in
             mainnet) CHECKPOINT_URL="https://mainnet-checkpoint-sync.attestant.io" ;;
@@ -147,7 +147,6 @@ jobs:
             -f firewall_ips="$ALLOWED_IPS" \
             -f config_json="$config_json" \
             -f tests_active="0" \
-            -f monitor_enabled="false" \
             -f timeout="$TIMEOUT"
 
       - name: Wait for creation of node


### PR DESCRIPTION
Stacked on #13013 — review the layers below first.

Depends on NethermindEth/post-merge-smoke-tests#215 and should not merge before it.

## Changes

`post-merge-smoke-tests` is migrating its node provisioning from Linode to GCP. The `workflow_dispatch` input *names* of `run-smoketests.yml`, `run-custom-node.yml` and `manual-destroy-smoketests.yml` are unchanged by that PR — I diffed all three against `main` — but the machine type *values* they accept are now GCP strings. These two dispatches were still sending Linode plan slugs.

- **`run-a-geth-node.yml`** — fallback machine type `g6-standard-16` → `n2d-custom-16-65536`.
- **`rpc-comparison.yml`** — paprika-conversion override `g6-standard-8` → `n2d-custom-8-32768`.

`n2d` matches the family that migration standardises on, and both are sized to preserve what the Linode plans provided rather than dropping to the new baseline: `g6-standard-16` was 16 vCPU / 64 GB, and the `g6-standard-8` override exists specifically to give paprika conversion more memory than the default node gets.

Also drops `-f monitor_enabled="false"` from the `run-smoketests.yml` dispatch. That input does not exist in the receiving workflow on either `main` or the migration branch, and `gh workflow run` rejects undeclared inputs, so this dispatch could not have succeeded. Unrelated to the migration — it is broken on master today — but it sits in the block being changed.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Three-line change, verified statically. `actionlint` reports 31 findings across these two files both before and after the change — all pre-existing style and info noise, none introduced here. YAML parses. No Linode plan slug remains anywhere under `.github/`.

End-to-end testing requires the dependency PR to be merged, since the receiving workflow must accept GCP machine types.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Worth a second opinion on the two sizes. Preserving the Linode capacity means `n2d-custom-16-65536` rather than the `n2d-custom-16-32768` tier the migration defines, which costs more; if halving the memory is acceptable for a geth snap sync, that is a one-word change.
