### PR TITLE
Preserve RIPEMD touch across nested reverts

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -106,26 +106,62 @@ namespace Nethermind.Evm.Test
             Assert.That(TestState.AccountExists(target), Is.False);
         }
 
-        [Test]
-        public void Nested_revert_preserves_ripemd_empty_account_deletion()
+        [TestCase(Instruction.INVALID)]
+        [TestCase(Instruction.REVERT)]
+        public void Nested_halt_preserves_ripemd_empty_account_deletion(Instruction halt)
         {
             Address child = TestItem.AddressC;
-            TestState.CreateAccount(Ripemd160Precompile.Address, UInt256.Zero);
             TestState.CreateAccount(child, UInt256.Zero);
-            byte[] childCode = Prepare.EvmCode
-                .Call(Ripemd160Precompile.Address, 50_000)
-                .Op(Instruction.POP)
-                .Call(BN254PairingCheckPrecompile.Address, 0)
-                .Op(Instruction.POP)
-                .Op(Instruction.INVALID)
-                .Done;
+            byte[] childCode = BuildRipemdTouchThenHalt(halt);
             TestState.InsertCode(child, childCode, SpecProvider.GenesisSpec);
             byte[] code = Prepare.EvmCode
                 .Call(child, 150_000)
                 .Op(Instruction.POP)
                 .Op(Instruction.STOP)
                 .Done;
-            (Block block, Transaction transaction) = PrepareTx((MainnetSpecProvider.ByzantiumBlockNumber, 0), 300_000, code, value: 0);
+            AssertRipemdTouchPreserved(code, (MainnetSpecProvider.ByzantiumBlockNumber, 0), 300_000);
+        }
+
+        [TestCase(Instruction.INVALID)]
+        [TestCase(Instruction.REVERT)]
+        public void Top_level_halt_preserves_ripemd_empty_account_deletion(Instruction halt)
+        {
+            byte[] code = BuildRipemdTouchThenHalt(halt);
+            AssertRipemdTouchPreserved(code, (MainnetSpecProvider.ByzantiumBlockNumber, 0), 300_000);
+        }
+
+        [Test]
+        public void Failed_nested_code_deposit_preserves_ripemd_empty_account_deletion()
+        {
+            byte[] initCode = BuildRipemdTouchThenReturnInvalidCode();
+            byte[] code = Prepare.EvmCode
+                .Create(initCode, UInt256.Zero)
+                .Op(Instruction.POP)
+                .Op(Instruction.STOP)
+                .Done;
+            AssertRipemdTouchPreserved(code, (MainnetSpecProvider.LondonBlockNumber, 0), 500_000);
+        }
+
+        [Test]
+        public void Failed_top_level_code_deposit_preserves_ripemd_empty_account_deletion()
+        {
+            byte[] initCode = BuildRipemdTouchThenReturnInvalidCode();
+            AssertRipemdTouchPreserved(initCode, (MainnetSpecProvider.LondonBlockNumber, 0), 500_000, contractCreation: true);
+        }
+
+        private void AssertRipemdTouchPreserved(
+            byte[] code,
+            ForkActivation activation,
+            ulong gasLimit,
+            bool contractCreation = false)
+        {
+            TestState.CreateAccount(Ripemd160Precompile.Address, UInt256.Zero);
+            (Block block, Transaction transaction) = PrepareTx(activation, gasLimit, code, value: 0);
+            if (contractCreation)
+            {
+                transaction.To = null;
+                transaction.Data = code;
+            }
 
             TransactionResult result = _processor.Execute(
                 transaction,
@@ -138,6 +174,33 @@ namespace Nethermind.Evm.Test
                 Assert.That(TestState.AccountExists(Ripemd160Precompile.Address), Is.False);
             }
         }
+
+        private static byte[] BuildRipemdTouchThenHalt(Instruction halt)
+        {
+            Prepare code = Prepare.EvmCode
+                .Call(Ripemd160Precompile.Address, 50_000)
+                .Op(Instruction.POP)
+                .Call(BN254PairingCheckPrecompile.Address, 0)
+                .Op(Instruction.POP);
+
+            return halt switch
+            {
+                Instruction.INVALID => code.Op(Instruction.INVALID).Done,
+                Instruction.REVERT => code.Revert(0, 0).Done,
+                _ => throw new ArgumentOutOfRangeException(nameof(halt), halt, null),
+            };
+        }
+
+        private static byte[] BuildRipemdTouchThenReturnInvalidCode() => Prepare.EvmCode
+            .Call(Ripemd160Precompile.Address, 50_000)
+            .Op(Instruction.POP)
+            .PushData(0xef)
+            .PushData(0)
+            .Op(Instruction.MSTORE8)
+            .PushData(1)
+            .PushData(0)
+            .Op(Instruction.RETURN)
+            .Done;
 
         [TestCase(false)]
         [TestCase(true)]

--- a/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.GasPolicy;
+using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Evm.Tracing;
@@ -103,6 +104,39 @@ namespace Nethermind.Evm.Test
 
             Assert.That(result.TransactionExecuted, Is.True);
             Assert.That(TestState.AccountExists(target), Is.False);
+        }
+
+        [Test]
+        public void Nested_revert_preserves_ripemd_empty_account_deletion()
+        {
+            Address child = TestItem.AddressC;
+            TestState.CreateAccount(Ripemd160Precompile.Address, UInt256.Zero);
+            TestState.CreateAccount(child, UInt256.Zero);
+            byte[] childCode = Prepare.EvmCode
+                .Call(Ripemd160Precompile.Address, 50_000)
+                .Op(Instruction.POP)
+                .Call(BN254PairingCheckPrecompile.Address, 0)
+                .Op(Instruction.POP)
+                .Op(Instruction.INVALID)
+                .Done;
+            TestState.InsertCode(child, childCode, SpecProvider.GenesisSpec);
+            byte[] code = Prepare.EvmCode
+                .Call(child, 150_000)
+                .Op(Instruction.POP)
+                .Op(Instruction.STOP)
+                .Done;
+            (Block block, Transaction transaction) = PrepareTx((MainnetSpecProvider.ByzantiumBlockNumber, 0), 300_000, code, value: 0);
+
+            TransactionResult result = _processor.Execute(
+                transaction,
+                new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)),
+                NullTxTracer.Instance);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.TransactionExecuted, Is.True);
+                Assert.That(TestState.AccountExists(Ripemd160Precompile.Address), Is.False);
+            }
         }
 
         [TestCase(false)]

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1405,6 +1405,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 {
                     if (Logger.IsTrace) Logger.Trace("Restoring state from before transaction");
                     WorldState.Restore(snapshot);
+                    VirtualMachineStatics.RestoreRipemdTouch(WorldState, spec, substate.ShouldRestoreRipemdTouch);
                 }
                 else
                 {
@@ -1461,13 +1462,18 @@ namespace Nethermind.Evm.TransactionProcessing
             EvmExceptionType deployException = CodeDepositHandler.CodeIsInvalid(spec, substate.Output)
                 ? EvmExceptionType.InvalidCode
                 : EvmExceptionType.OutOfGas;
+            bool shouldRestoreRipemdTouch = substate.ShouldRestoreRipemdTouch;
             substate = new(substate.Output, substate.Refund, substate.DestroyList, substate.Logs,
-                shouldRevert: false, isTracerConnected: false, evmExceptionType: deployException, logger: Logger);
+                shouldRevert: false, isTracerConnected: false, evmExceptionType: deployException, logger: Logger)
+            {
+                ShouldRestoreRipemdTouch = shouldRestoreRipemdTouch,
+            };
             if (spec.ChargeForTopLevelCreate)
             {
                 TGasPolicy.SetOutOfGas(ref gasAvailable);
             }
             WorldState.Restore(snapshot);
+            VirtualMachineStatics.RestoreRipemdTouch(WorldState, spec, substate.ShouldRestoreRipemdTouch);
             TGasPolicy intrinsicGasStandard = gas.Standard;
             if (spec.IsEip8037Enabled)
             {

--- a/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
@@ -54,6 +54,7 @@ public readonly ref struct TransactionSubstate
     public long Refund { get; }
     public JournalCollection<LogEntry> Logs => _logs;
     public JournalSet<Address>? DestroyList => _destroyList;
+    internal bool ShouldRestoreRipemdTouch { get; init; }
 
     public TransactionSubstate(EvmExceptionType exceptionType, bool isTracerConnected, string? substateError = null)
     {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -62,6 +62,22 @@ public static class VirtualMachineStatics
 
     public static readonly PrecompileExecutionFailureException PrecompileExecutionFailureException = new();
     public static readonly OutOfGasException PrecompileOutOfGasException = new();
+    internal static readonly Address Ripemd160Address = Address.FromNumber(3);
+
+    /// <summary>
+    /// Restores the RIPEMD-160 empty-account touch after a world-state snapshot rollback.
+    /// </summary>
+    /// <remarks>
+    /// The historical <see href="https://eips.ethereum.org/EIPS/eip-161">EIP-161</see> exception keeps
+    /// this touch alive for the rest of the transaction, matching Geth's non-revertible dirty marker.
+    /// </remarks>
+    internal static void RestoreRipemdTouch(IWorldState worldState, IReleaseSpec spec, bool shouldRestore)
+    {
+        if (shouldRestore && worldState.AccountExists(Ripemd160Address))
+        {
+            worldState.AddToBalance(Ripemd160Address, UInt256.Zero, spec);
+        }
+    }
 
     [DoesNotReturn]
     internal static void ThrowOperationCanceledException() => throw new OperationCanceledException("Cancellation Requested");
@@ -81,7 +97,7 @@ public partial class VirtualMachine<TGasPolicy>(
     protected readonly VmStateStack<TGasPolicy> _stateStack = new(MaxCallDepth + 1);
 
     protected IWorldState _worldState;
-    private (Address Address, bool ShouldDelete) _parityTouchBugAccount = (Address.FromNumber(3), false);
+    private bool _shouldRestoreRipemdTouch;
 
     protected ITxTracer _txTracer = NullTxTracer.Instance;
 
@@ -152,8 +168,7 @@ public partial class VirtualMachine<TGasPolicy>(
         _isTracingActionsCached = txTracer.IsTracingActions;
         _worldState = worldState;
 
-        // Reset Parity touch bug state to prevent cross-transaction leakage.
-        _parityTouchBugAccount.ShouldDelete = false;
+        _shouldRestoreRipemdTouch = false;
 
         // Prepare the specification and opcode mapping based on the current block header.
         IReleaseSpec spec = BlockExecutionContext.Spec;
@@ -458,7 +473,10 @@ public partial class VirtualMachine<TGasPolicy>(
             callResult.ShouldRevert,
             isTracerConnected: _txTracer.IsTracing,
             callResult.ExceptionType,
-            _logger);
+            _logger)
+        {
+            ShouldRestoreRipemdTouch = _shouldRestoreRipemdTouch,
+        };
     }
 
     private void TryChargeAndDepositCode(
@@ -514,6 +532,7 @@ public partial class VirtualMachine<TGasPolicy>(
             {
                 _worldState.DeleteAccount(callCodeOwner);
             }
+            RestoreRipemdTouch(_worldState, spec, _shouldRestoreRipemdTouch);
 
             _previousCallResult = BytesZero;
             previousStateSucceeded = false;
@@ -549,6 +568,7 @@ public partial class VirtualMachine<TGasPolicy>(
     {
         // Restore the world state to the snapshot taken before the execution of the call.
         _worldState.Restore(previousState.Snapshot);
+        RestoreRipemdTouch(_worldState, BlockExecutionContext.Spec, _shouldRestoreRipemdTouch);
 
         // Cache the output bytes from the call result to avoid multiple property accesses.
         ReadOnlyMemory<byte> outputBytes = callResult.Output;
@@ -598,8 +618,7 @@ public partial class VirtualMachine<TGasPolicy>(
         // Revert the world state to the snapshot taken at the start of the current state's execution.
         _worldState.Restore(_currentState.Snapshot);
 
-        // Revert any modifications specific to the Parity touch bug, if applicable.
-        RevertParityTouchBugAccount();
+        RestoreRipemdTouch(_worldState, BlockExecutionContext.Spec, _shouldRestoreRipemdTouch);
 
         // Cache the transaction tracer for local use.
         ITxTracer txTracer = _txTracer;
@@ -629,7 +648,10 @@ public partial class VirtualMachine<TGasPolicy>(
             // For an OverflowException, force the error type to a generic Other error.
             EvmExceptionType finalErrorType = failure is OverflowException ? EvmExceptionType.Other : errorType;
             shouldExit = true;
-            return new TransactionSubstate(finalErrorType, txTracer.IsTracing, substateError);
+            return new TransactionSubstate(finalErrorType, txTracer.IsTracing, substateError)
+            {
+                ShouldRestoreRipemdTouch = _shouldRestoreRipemdTouch,
+            };
         }
 
         _previousCallResult = StatusCode.FailureBytes;
@@ -803,8 +825,7 @@ public partial class VirtualMachine<TGasPolicy>(
         // Restore the world state to its snapshot before the current call execution.
         _worldState.Restore(_currentState.Snapshot);
 
-        // Revert any modifications that might have been applied due to the Parity touch bug.
-        RevertParityTouchBugAccount();
+        RestoreRipemdTouch(_worldState, BlockExecutionContext.Spec, _shouldRestoreRipemdTouch);
 
         // If this is the top-level call, return a final transaction substate encapsulating the error.
         // The state-gas reset is performed by TransactionProcessor.Refund (see top-level halt
@@ -812,7 +833,10 @@ public partial class VirtualMachine<TGasPolicy>(
         if (_currentState.IsTopLevel)
         {
             shouldExit = true;
-            return new TransactionSubstate(callResult.ExceptionType, txTracer.IsTracing);
+            return new TransactionSubstate(callResult.ExceptionType, txTracer.IsTracing)
+            {
+                ShouldRestoreRipemdTouch = _shouldRestoreRipemdTouch,
+            };
         }
 
         _previousCallResult = StatusCode.FailureBytes;
@@ -922,7 +946,7 @@ public partial class VirtualMachine<TGasPolicy>(
     /// EIP-161 empty-account deletion, which the inline path does not replay.
     /// </remarks>
     protected internal virtual bool CanExecutePrecompileCallDirectly(IPrecompile precompile, Address codeSource) =>
-        !codeSource.Equals(_parityTouchBugAccount.Address);
+        !codeSource.Equals(Ripemd160Address);
 
     /// <summary>
     /// Runs a precompile outside of a call frame for the inline STATICCALL fast path, applying the same
@@ -1068,17 +1092,6 @@ public partial class VirtualMachine<TGasPolicy>(
         }
     }
 
-    private void RevertParityTouchBugAccount()
-    {
-        if (_parityTouchBugAccount.ShouldDelete)
-        {
-            if (_worldState.AccountExists(_parityTouchBugAccount.Address))
-            {
-                _worldState.AddToBalance(_parityTouchBugAccount.Address, UInt256.Zero, BlockExecutionContext.Spec);
-            }
-        }
-    }
-
     private CallResult RunPrecompile(VmState<TGasPolicy> state)
     {
         ReadOnlyMemory<byte> callData = state.Env.InputData;
@@ -1102,9 +1115,10 @@ public partial class VirtualMachine<TGasPolicy>(
         if (!wasCreated &&
             transferValue.IsZero &&
             spec.ClearEmptyAccountWhenTouched &&
-            state.Env.ExecutingAccount.Equals(_parityTouchBugAccount.Address))
+            state.Env.ExecutingAccount.Equals(Ripemd160Address) &&
+            _worldState.IsDeadAccount(Ripemd160Address))
         {
-            _parityTouchBugAccount.ShouldDelete = true;
+            _shouldRestoreRipemdTouch = true;
         }
 
         // The policy reads the precompile's own base/data cost (with the overflow guard inside).

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -1076,8 +1076,6 @@ public partial class VirtualMachine<TGasPolicy>(
             {
                 _worldState.AddToBalance(_parityTouchBugAccount.Address, UInt256.Zero, BlockExecutionContext.Spec);
             }
-
-            _parityTouchBugAccount.ShouldDelete = false;
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.zkevm.cs
@@ -67,7 +67,7 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
         {
             // Precompile hard failure (out of gas): mirror HandleFailure + PopAndRestoreParentState.
             _worldState.Restore(child.Snapshot);
-            RevertParityTouchBugAccount();
+            RestoreRipemdTouch(_worldState, BlockExecutionContext.Spec, _shouldRestoreRipemdTouch);
             RemoveAdvancedStateGasRefund(child, ref child.Gas);
             TGasPolicy.RestoreChildStateGasOnHalt(ref parent.Gas, in child.Gas);
             // EIP-8037: the failed call did not create its (dead) recipient; refund NEW_ACCOUNT.
@@ -115,6 +115,7 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
         if (reverted)
         {
             _worldState.Restore(child.Snapshot);
+            RestoreRipemdTouch(_worldState, BlockExecutionContext.Spec, _shouldRestoreRipemdTouch);
         }
         else
         {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.zkevm.cs
@@ -67,7 +67,7 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
         {
             // Precompile hard failure (out of gas): mirror HandleFailure + PopAndRestoreParentState.
             _worldState.Restore(child.Snapshot);
-            RestoreRipemdTouch(_worldState, BlockExecutionContext.Spec, _shouldRestoreRipemdTouch);
+            VirtualMachineStatics.RestoreRipemdTouch(_worldState, BlockExecutionContext.Spec, _shouldRestoreRipemdTouch);
             RemoveAdvancedStateGasRefund(child, ref child.Gas);
             TGasPolicy.RestoreChildStateGasOnHalt(ref parent.Gas, in child.Gas);
             // EIP-8037: the failed call did not create its (dead) recipient; refund NEW_ACCOUNT.
@@ -115,7 +115,7 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
         if (reverted)
         {
             _worldState.Restore(child.Snapshot);
-            RestoreRipemdTouch(_worldState, BlockExecutionContext.Spec, _shouldRestoreRipemdTouch);
+            VirtualMachineStatics.RestoreRipemdTouch(_worldState, BlockExecutionContext.Spec, _shouldRestoreRipemdTouch);
         }
         else
         {


### PR DESCRIPTION
## Changes

- Keep the historical RIPEMD-160 touch marker active for the full transaction so every failed parent frame replays the touch after restoring its snapshot.
- Add regression coverage for a precompile out-of-gas failure followed by a parent-frame revert.
- Restore the six affected Hive legacy cases across Byzantium, Constantinople, and ConstantinopleFix.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Verified the focused regression, all affected legacy fixtures, the full EVM test project, and all three Nethermind solutions with warnings treated as errors.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This restores the historical EIP-161 RIPEMD-160 empty-account behavior when a precompile failure is followed by another exceptional unwind: https://eips.ethereum.org/EIPS/eip-161

Hive reproduction: https://hive.ethpandaops.io/#/test/generic/1787356849-79462c2f4736277f8194c4edb72f34aa
