### PR TITLE
fix(xdc): stop advertising eth versions with no handler

### DIFF
--- a/src/Nethermind/Nethermind.Xdc.Test/XdcP2PCapabilityResolverTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcP2PCapabilityResolverTests.cs
@@ -7,6 +7,7 @@ using Nethermind.Core.Container;
 using Nethermind.Network;
 using Nethermind.Network.Contract.P2P;
 using Nethermind.Stats.Model;
+using Nethermind.Xdc.P2P;
 using NUnit.Framework;
 
 namespace Nethermind.Xdc.Test;
@@ -24,8 +25,6 @@ public class XdcP2PCapabilityResolverTests
 
         Assert.That(capabilities, Is.EquivalentTo(new[]
         {
-            new Capability(Protocol.Eth, 62),
-            new Capability(Protocol.Eth, 63),
             new Capability(Protocol.Eth, 100),
             new Capability(Protocol.Eth, 164),
             new Capability(Protocol.Eth, 165),
@@ -51,11 +50,23 @@ public class XdcP2PCapabilityResolverTests
         // eth/68 (the default's contribution) is gone; only XDC's versions remain.
         Assert.That(capabilities, Is.EquivalentTo(new[]
         {
-            new Capability(Protocol.Eth, 62),
-            new Capability(Protocol.Eth, 63),
             new Capability(Protocol.Eth, 100),
             new Capability(Protocol.Eth, 164),
             new Capability(Protocol.Eth, 165),
         }));
+    }
+
+    [Test]
+    public void Resolve_advertises_no_version_without_a_handler()
+    {
+        XdcP2PCapabilityResolver resolver = new();
+
+        HashSet<Capability> capabilities = [];
+        resolver.Resolve(capabilities);
+
+        // Capability agreement picks the highest common version, so an advertised version that XdcModule
+        // registers no handler factory for makes ProtocolsManager.InitProtocol throw on the peer's Hello.
+        Assert.That(capabilities, Has.All.Matches<Capability>(
+            capability => XdcProtocolVersions.IsXdcVersion((byte)capability.Version)));
     }
 }

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcP2PCapabilityResolverTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcP2PCapabilityResolverTests.cs
@@ -7,7 +7,6 @@ using Nethermind.Core.Container;
 using Nethermind.Network;
 using Nethermind.Network.Contract.P2P;
 using Nethermind.Stats.Model;
-using Nethermind.Xdc.P2P;
 using NUnit.Framework;
 
 namespace Nethermind.Xdc.Test;
@@ -54,19 +53,5 @@ public class XdcP2PCapabilityResolverTests
             new Capability(Protocol.Eth, 164),
             new Capability(Protocol.Eth, 165),
         }));
-    }
-
-    [Test]
-    public void Resolve_advertises_no_version_without_a_handler()
-    {
-        XdcP2PCapabilityResolver resolver = new();
-
-        HashSet<Capability> capabilities = [];
-        resolver.Resolve(capabilities);
-
-        // Capability agreement picks the highest common version, so an advertised version that XdcModule
-        // registers no handler factory for makes ProtocolsManager.InitProtocol throw on the peer's Hello.
-        Assert.That(capabilities, Has.All.Matches<Capability>(
-            capability => XdcProtocolVersions.IsXdcVersion((byte)capability.Version)));
     }
 }

--- a/src/Nethermind/Nethermind.Xdc/README.md
+++ b/src/Nethermind/Nethermind.Xdc/README.md
@@ -361,8 +361,8 @@ Votes and timeouts are ignored entirely while the node is syncing (unless it is 
 re-broadcast is deduplicated so a message is forwarded to a peer at most once.
 
 [`XdcP2PCapabilityResolver`](XdcP2PCapabilityResolver.cs) replaces the default resolver so the node advertises
-exactly `eth/100`, `eth/164` and `eth/165` — one per registered handler. A peer that offers nothing from that set
-is disconnected as having no capability in common.
+exactly `eth/100`, `eth/164` and `eth/165` — one per registered handler. A peer that shares no capability at all
+(an old `tomo` node offering nothing above `eth/63`, for example) is disconnected with `NoCapabilityMatched`.
 
 ### Discovery
 

--- a/src/Nethermind/Nethermind.Xdc/README.md
+++ b/src/Nethermind/Nethermind.Xdc/README.md
@@ -361,7 +361,8 @@ Votes and timeouts are ignored entirely while the node is syncing (unless it is 
 re-broadcast is deduplicated so a message is forwarded to a peer at most once.
 
 [`XdcP2PCapabilityResolver`](XdcP2PCapabilityResolver.cs) replaces the default resolver so the node advertises
-exactly `eth/62`, `eth/63` and `eth/100`.
+exactly `eth/100`, `eth/164` and `eth/165` — one per registered handler. A peer that offers nothing from that set
+is disconnected as having no capability in common.
 
 ### Discovery
 

--- a/src/Nethermind/Nethermind.Xdc/XdcP2PCapabilityResolver.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcP2PCapabilityResolver.cs
@@ -11,8 +11,8 @@ using Nethermind.Xdc.P2P;
 namespace Nethermind.Xdc;
 
 /// <summary>
-/// XDC advertises only the versions <c>XdcModule</c> registers a handler for. The default eth/68 resolver is
-/// dropped at registration (see <c>XdcModule</c>), so this resolver contributes the whole set.
+/// Contributes every <c>eth</c> version <c>XdcModule</c> registers a handler for. The default eth/68 resolver is
+/// dropped at registration (see <c>XdcModule</c>), so no other <c>eth</c> version is advertised.
 /// </summary>
 public class XdcP2PCapabilityResolver : IP2PCapabilityResolver
 {

--- a/src/Nethermind/Nethermind.Xdc/XdcP2PCapabilityResolver.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcP2PCapabilityResolver.cs
@@ -14,11 +14,6 @@ namespace Nethermind.Xdc;
 /// XDC advertises only the versions <c>XdcModule</c> registers a handler for. The default eth/68 resolver is
 /// dropped at registration (see <c>XdcModule</c>), so this resolver contributes the whole set.
 /// </summary>
-/// <remarks>
-/// Advertising a version without a handler makes <c>ProtocolsManager.InitProtocol</c> throw
-/// <see cref="NotSupportedException"/> on the peer's <c>Hello</c>, because capability agreement picks the highest
-/// common version. eth/62 and eth/63 were advertised that way and broke every peer that offered nothing newer.
-/// </remarks>
 public class XdcP2PCapabilityResolver : IP2PCapabilityResolver
 {
     // XDC's capability set is static, so the cache never needs invalidating.

--- a/src/Nethermind/Nethermind.Xdc/XdcP2PCapabilityResolver.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcP2PCapabilityResolver.cs
@@ -11,9 +11,14 @@ using Nethermind.Xdc.P2P;
 namespace Nethermind.Xdc;
 
 /// <summary>
-/// XDC advertises eth/62, eth/63 and the XDC versions. The default eth/68 resolver is dropped at registration
-/// (see <c>XdcModule</c>), so this resolver only contributes the XDC-specific versions.
+/// XDC advertises only the versions <c>XdcModule</c> registers a handler for. The default eth/68 resolver is
+/// dropped at registration (see <c>XdcModule</c>), so this resolver contributes the whole set.
 /// </summary>
+/// <remarks>
+/// Advertising a version without a handler makes <c>ProtocolsManager.InitProtocol</c> throw
+/// <see cref="NotSupportedException"/> on the peer's <c>Hello</c>, because capability agreement picks the highest
+/// common version. eth/62 and eth/63 were advertised that way and broke every peer that offered nothing newer.
+/// </remarks>
 public class XdcP2PCapabilityResolver : IP2PCapabilityResolver
 {
     // XDC's capability set is static, so the cache never needs invalidating.
@@ -21,8 +26,6 @@ public class XdcP2PCapabilityResolver : IP2PCapabilityResolver
 
     public void Resolve(ISet<Capability> capabilities)
     {
-        capabilities.Add(new Capability(Protocol.Eth, 62));
-        capabilities.Add(new Capability(Protocol.Eth, 63));
         capabilities.Add(new Capability(Protocol.Eth, XdcProtocolVersions.Legacy));
         capabilities.Add(new Capability(Protocol.Eth, XdcProtocolVersions.Xdc164));
         capabilities.Add(new Capability(Protocol.Eth, XdcProtocolVersions.Xdc165));


### PR DESCRIPTION
## Changes

- `XdcP2PCapabilityResolver` no longer advertises `eth/62` and `eth/63`. It now advertises exactly the versions `XdcModule` registers a handler factory for: `eth/100`, `eth/164`, `eth/165`.
- Regression test asserting every advertised capability satisfies `XdcProtocolVersions.IsXdcVersion`, plus the two existing expectations updated.
- `Nethermind.Xdc/README.md` wire-protocol section corrected — it documented the old set as deliberate.

### Why

Capability agreement picks the highest common version (`P2PProtocolHandler.TryGetNextAgreedCapability`). A peer that offered nothing above `eth/63` — old `tomo/v2.6.0-stable` nodes on XDC still do — agreed on 63, matched no factory, and `ProtocolsManager.InitProtocol` threw `NotSupportedException` out of `Session.ReceiveMessage` into the netty pipeline on every `Hello`. Observed live on XDC mainnet as a steady stream of exceptions and peer churn.

Advertising only implemented versions turns that into a clean `DisconnectNoCapabilityMatched`. Peers offering 100/164/165 are unaffected — the highest-version rule already preferred those — so the only behaviour change is for peers that top out at eth/62-63, which we could not talk to anyway.

Registering real `eth/62`/`eth/63` handlers was the alternative and was rejected: the vanilla `Eth62ProtocolHandler`/`Eth63ProtocolHandler` conflict with XDC in two ways. TomoX order and lending broadcasts on `0x08`/`0x09` (sent on every version, see `XdcConsensusMessageHandler`) land inside eth/63's 17-code id space with no case to handle them and disconnect the peer with `BreachOfProtocol` — the exact defect #12814 fixed for xdc/100 — and the consensus codes `0xe0`-`0xe2` fall outside that space, so such peers would be deaf to XDPoS votes in both directions.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.Xdc.Test` passes in full (666/666). The new test fails against the previous resolver, since `IsXdcVersion(62)` is false.

Not verified against a live XDC node in this branch; the diagnosis came from a mainnet run on `master` where the negotiated version was `eth/63` for `tomo/sintral_lab/v2.6.0-stable` and `tomo/v2.6.0-stable` peers.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The `NotSupportedException` takes the disconnect branch of `ZeroNettyP2PHandler.ExceptionCaught`, not the `base` branch that reaches DotNetty's tail. If tail warnings persist on XDC after this lands, there is a second exception behind them on a static or trusted peer — that path neither disconnects nor logs above Debug.

Surfacing that second exception is harder than it should be: DotNetty routes through `NethermindLoggerFactory`, whose adapter passes the exception to `InterfaceLogger` only on the `Error` branch, so the tail warning arrives carrying an exception that is then discarded. Left alone here; worth a separate PR.
