### PR TITLE
test: cover per-EIP config gating of frame transactions

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -689,6 +689,31 @@ public class TxValidatorTests
     }
 
     [Test]
+    public void IsWellFormed_FrameTxWhenEip8141Disabled_ReturnsInvalidTxType()
+    {
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            Nonce = 0,
+            SenderAddress = TestItem.AddressA,
+            Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default)],
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 100,
+        };
+
+        TxValidator txValidator = new(TestBlockchainIds.ChainId);
+        ValidationResult result = txValidator.IsWellFormed(tx, Prague.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.AsBool, Is.False);
+            Assert.That(result.Error, Is.EqualTo(TxErrorMessages.InvalidTxType(Prague.Instance.Name)));
+        }
+    }
+
+    [Test]
     public void IsWellFormed_TransactionWithGasLimitExceedingEip7825Cap_ReturnsFalse()
     {
         Transaction tx = Build.A.Transaction

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -50,6 +50,8 @@ public class FrameTxValidationTests
         // assert frame.mode < 4 (EIP-7906 widened it from 3)
         yield return Case("FrameModeFour_InvalidMode",
             static tx => tx.Frames = [Frame(mode: 4)], FrameTxValidation.InvalidMode);
+        yield return Case("FrameModeFive_InvalidMode",
+            static tx => tx.Frames = [Frame(mode: 5)], FrameTxValidation.InvalidMode);
 
         // POST_TX frames form a trailing suffix; the approval scope they may carry is enforced at the
         // opcode, so an unexercised permission bit is not an envelope defect.

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -27,6 +27,19 @@ public class FrameTxValidationTests
         Assert.That(error, Is.EqualTo(expectedError));
     }
 
+    [TestCase(true, null)]
+    [TestCase(false, FrameTxValidation.PostTxNotEnabled)]
+    public void IsWellFormed_PostTxFrameGatedByItsFork_ReturnsExpectedError(bool postTxEnabled, string? expectedError)
+    {
+        Transaction tx = CreateValidFrameTx(static tx =>
+            tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModePostTx)]);
+
+        bool wellFormed = FrameTxValidation.IsWellFormed(tx, postTxEnabled, out string? error);
+
+        Assert.That(wellFormed, Is.EqualTo(expectedError is null));
+        Assert.That(error, Is.EqualTo(expectedError));
+    }
+
     private static IEnumerable<TestCaseData> ConstraintCases()
     {
         yield return Case("MinimalSelfVerifyFrame_Valid",
@@ -50,8 +63,6 @@ public class FrameTxValidationTests
         // assert frame.mode < 4 (EIP-7906 widened it from 3)
         yield return Case("FrameModeFour_InvalidMode",
             static tx => tx.Frames = [Frame(mode: 4)], FrameTxValidation.InvalidMode);
-        yield return Case("FrameModeFive_InvalidMode",
-            static tx => tx.Frames = [Frame(mode: 5)], FrameTxValidation.InvalidMode);
 
         // POST_TX frames form a trailing suffix; the approval scope they may carry is enforced at the
         // opcode, so an unexercised permission bit is not an envelope defect.

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
@@ -4,11 +4,9 @@
 using System;
 using Nethermind.Blockchain;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Serialization.Rlp;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
@@ -4,9 +4,11 @@
 using System;
 using Nethermind.Blockchain;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
@@ -289,6 +291,57 @@ public class FrameTxBlockGasTests
                 Is.EqualTo(tracer.GasConsumedResult.SpentGas - expectedStateGas),
                 "the two dimensions must together account for the gas the transaction spent");
         }
+    }
+
+    [Test]
+    public void Execute_WritingFrameTxAcrossTheFrameLimitsBoundary_KeepsTheConsensusHashAndMetersStateOnlyAfterActivation()
+    {
+        Address laterWriter = TestItem.AddressF;
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(Writer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        Deploy(laterWriter, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        TestSpecProvider provider = (TestSpecProvider)_specProvider;
+        OverridableReleaseSpec specAfterFork = (OverridableReleaseSpec)provider.GenesisSpec;
+        OverridableReleaseSpec specBeforeFork = new(Eip8141Prototype.Instance) { IsEip7906Enabled = true, IsEip8037Enabled = false };
+
+        Transaction sample = FrameTx(nonce: 7, laterWriter);
+        Hash256 hashAfterFork = ConsensusHash(sample);
+        provider.GenesisSpec = specBeforeFork;
+        Hash256 hashBeforeFork = ConsensusHash(sample);
+        provider.GenesisSpec = specAfterFork;
+
+        Transaction afterFork = FrameTx(nonce: 0, laterWriter);
+        TestAllTracerWithOutput after = new();
+        Assert.That(Process(afterFork, after).TransactionExecuted, Is.True);
+
+        provider.GenesisSpec = specBeforeFork;
+        Transaction beforeFork = FrameTx(nonce: 1, Writer);
+        TestAllTracerWithOutput before = new();
+        Assert.That(Process(beforeFork, before).TransactionExecuted, Is.True);
+
+        const ulong stateCharge = (ulong)GasCostOf.SSetState;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(hashAfterFork, Is.EqualTo(hashBeforeFork),
+                "the frame envelope is two-dimensional in both eras, so re-encoding keeps the consensus hash");
+            Assert.That(_state.Get(new StorageCell(Writer, (UInt256)0)).ToArray(), Is.Not.All.EqualTo((byte)0),
+                "the fresh slot is written before the fork");
+            Assert.That(_state.Get(new StorageCell(laterWriter, (UInt256)0)).ToArray(), Is.Not.All.EqualTo((byte)0),
+                "the fresh slot is written after the fork");
+            Assert.That(before.GasConsumedResult.BlockStateGas, Is.Zero,
+                "before frameLimitsTime the state dimension is inert, so a fresh slot owes no state gas");
+            Assert.That(after.GasConsumedResult.BlockStateGas, Is.EqualTo(stateCharge),
+                "after frameLimitsTime the same fresh-slot write is billed in the state dimension");
+        }
+    }
+
+    private static Hash256 ConsensusHash(Transaction tx)
+    {
+        byte[] bytes = new byte[TxDecoder.Instance.GetLength(tx, RlpBehaviors.SkipTypedWrapping)];
+        RlpWriter writer = new(bytes);
+        TxDecoder.Instance.Encode(ref writer, tx, RlpBehaviors.SkipTypedWrapping);
+        return Keccak.Compute(bytes);
     }
 
     private static byte[] ApproveCode(byte scope) =>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
@@ -294,7 +294,7 @@ public class FrameTxBlockGasTests
     }
 
     [Test]
-    public void Execute_WritingFrameTxAcrossTheFrameLimitsBoundary_KeepsTheConsensusHashAndMetersStateOnlyAfterActivation()
+    public void Execute_WritingFrameTxAcrossTheFrameLimitsBoundary_MetersStateOnlyAfterActivation()
     {
         Address laterWriter = TestItem.AddressF;
         Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
@@ -302,14 +302,7 @@ public class FrameTxBlockGasTests
         Deploy(laterWriter, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
 
         TestSpecProvider provider = (TestSpecProvider)_specProvider;
-        OverridableReleaseSpec specAfterFork = (OverridableReleaseSpec)provider.GenesisSpec;
         OverridableReleaseSpec specBeforeFork = new(Eip8141Prototype.Instance) { IsEip7906Enabled = true, IsEip8037Enabled = false };
-
-        Transaction sample = FrameTx(nonce: 7, laterWriter);
-        Hash256 hashAfterFork = ConsensusHash(sample);
-        provider.GenesisSpec = specBeforeFork;
-        Hash256 hashBeforeFork = ConsensusHash(sample);
-        provider.GenesisSpec = specAfterFork;
 
         Transaction afterFork = FrameTx(nonce: 0, laterWriter);
         TestAllTracerWithOutput after = new();
@@ -323,8 +316,6 @@ public class FrameTxBlockGasTests
         const ulong stateCharge = (ulong)GasCostOf.SSetState;
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(hashAfterFork, Is.EqualTo(hashBeforeFork),
-                "the frame envelope is two-dimensional in both eras, so re-encoding keeps the consensus hash");
             Assert.That(_state.Get(new StorageCell(Writer, (UInt256)0)).ToArray(), Is.Not.All.EqualTo((byte)0),
                 "the fresh slot is written before the fork");
             Assert.That(_state.Get(new StorageCell(laterWriter, (UInt256)0)).ToArray(), Is.Not.All.EqualTo((byte)0),
@@ -334,14 +325,6 @@ public class FrameTxBlockGasTests
             Assert.That(after.GasConsumedResult.BlockStateGas, Is.EqualTo(stateCharge),
                 "after frameLimitsTime the same fresh-slot write is billed in the state dimension");
         }
-    }
-
-    private static Hash256 ConsensusHash(Transaction tx)
-    {
-        byte[] bytes = new byte[TxDecoder.Instance.GetLength(tx, RlpBehaviors.SkipTypedWrapping)];
-        RlpWriter writer = new(bytes);
-        TxDecoder.Instance.Encode(ref writer, tx, RlpBehaviors.SkipTypedWrapping);
-        return Keccak.Compute(bytes);
     }
 
     private static byte[] ApproveCode(byte scope) =>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -2594,6 +2594,28 @@ public class FrameTxProcessorTests
         Assert.That(result.ErrorDescription, Does.Contain(FrameTxValidation.RecentRootReferencesNotEnabled));
     }
 
+    [Test]
+    public void Execute_AssertionForkWithoutKeyedNoncesOrRecentRoots_RunsPostTxButRefusesTheOtherEnvelopes()
+    {
+        ((TestSpecProvider)_specProvider).GenesisSpec =
+            new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip8250Enabled = false, IsEip8272Enabled = false, IsEip7906Enabled = true };
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        Transaction postTx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModePostTx, target: Recipient));
+        Transaction keyed = FrameTx(nonce: 1, SelfVerifyFrame());
+        keyed.NonceKeys = [(UInt256)7];
+        Transaction rooted = FrameTx(nonce: 1, SelfVerifyFrame());
+        rooted.RecentRootReferences = [];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Process(postTx).TransactionExecuted, Is.True, "the assertion fork must run a POST_TX frame");
+            Assert.That(Process(keyed).TransactionExecuted, Is.False, "keyed nonces must stay refused before their fork");
+            Assert.That(Process(rooted, slotNumber: 1_001).TransactionExecuted, Is.False, "recent-root references must stay refused before their fork");
+        }
+    }
+
     /// <remarks>A set built from RPC input reaches the processor uncapped, so rejecting it before
     /// <c>Measure</c> keeps that method's bounded <c>stackalloc</c> from an out-of-range slice.</remarks>
     [Test]
@@ -3501,5 +3523,73 @@ public class FrameTxProcessorTests
 
         Assert.That(Process(tx, slotNumber: HeadSlot).TransactionExecuted, Is.True);
         return (ulong)_stateProvider.Get(new StorageCell(Observer, 0)).ToUnsignedBigInteger();
+    }
+
+    [TestCase(Instruction.APPROVE, (byte)0xAA, TestName = "RegistryByte_APPROVE_0xAA")]
+    [TestCase(Instruction.TXPARAM, (byte)0xB0, TestName = "RegistryByte_TXPARAM_0xB0")]
+    [TestCase(Instruction.FRAMEDATALOAD, (byte)0xB1, TestName = "RegistryByte_FRAMEDATALOAD_0xB1")]
+    [TestCase(Instruction.FRAMEDATACOPY, (byte)0xB2, TestName = "RegistryByte_FRAMEDATACOPY_0xB2")]
+    [TestCase(Instruction.FRAMEPARAM, (byte)0xB3, TestName = "RegistryByte_FRAMEPARAM_0xB3")]
+    [TestCase(Instruction.SIGPARAM, (byte)0xB4, TestName = "RegistryByte_SIGPARAM_0xB4")]
+    [TestCase(Instruction.SIGDATACOPY, (byte)0xB5, TestName = "RegistryByte_SIGDATACOPY_0xB5")]
+    [TestCase(Instruction.RECENTROOTREFLOAD, (byte)0xB6, TestName = "RegistryByte_RECENTROOTREFLOAD_0xB6")]
+    public void FrameOpcodeByte_MatchesTheSpecRegistry(Instruction opcode, byte registryByte)
+        => Assert.That((byte)opcode, Is.EqualTo(registryByte));
+
+    [TestCase((byte)0xBA, TestName = "UnallocatedFrameOpcode_0xBA_Halts")]
+    [TestCase((byte)0xBB, TestName = "UnallocatedFrameOpcode_0xBB_Halts")]
+    [TestCase((byte)0xBD, TestName = "UnallocatedFrameOpcode_0xBD_Halts")]
+    [TestCase((byte)0xBF, TestName = "UnallocatedFrameOpcode_0xBF_Halts")]
+    public void Execute_UnallocatedFrameRangeOpcode_ExceptionallyHalts(byte opcode)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode
+            .Op(opcode)
+            .PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+
+        Assert.That(Process(tx, slotNumber: HeadSlot).TransactionExecuted, Is.True);
+        AssertStorage(Observer, 0, UInt256.Zero);
+    }
+
+    [Test]
+    public void Execute_KeyedNonceForkWithoutReferencesOrAssertions_RunsKeyedAndRefusesTheOtherEnvelopes()
+    {
+        _spec.IsEip8272Enabled = false;
+        _spec.IsEip7906Enabled = false;
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        Transaction keyed = FrameTx(nonce: 0, SelfVerifyFrame());
+        keyed.NonceKeys = [1, 7];
+        Assert.That(Process(keyed).TransactionExecuted, Is.True);
+
+        Transaction referencing = FrameTx(nonce: 0, SelfVerifyFrame());
+        referencing.RecentRootReferences = [];
+        Assert.That(Process(referencing, slotNumber: HeadSlot).TransactionExecuted, Is.False);
+
+        Transaction postTx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModePostTx, target: Recipient));
+        Assert.That(Process(postTx).TransactionExecuted, Is.False);
+    }
+
+    [Test]
+    public void Execute_ReferenceForkWithoutKeyedNoncesOrAssertions_RunsReferenceAndRefusesTheOtherEnvelopes()
+    {
+        _spec.IsEip8250Enabled = false;
+        _spec.IsEip7906Enabled = false;
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        Transaction referencing = FrameTx(nonce: 0, SelfVerifyFrame());
+        referencing.RecentRootReferences = [CommitReference(ReferencedSlot)];
+        Assert.That(Process(referencing, slotNumber: HeadSlot).TransactionExecuted, Is.True);
+
+        Transaction keyed = FrameTx(nonce: 1, SelfVerifyFrame());
+        keyed.NonceKeys = [7];
+        Assert.That(Process(keyed).TransactionExecuted, Is.False);
+
+        Transaction postTx = FrameTx(nonce: 1, SelfVerifyFrame(), Frame(TxFrame.ModePostTx, target: Recipient));
+        Assert.That(Process(postTx).TransactionExecuted, Is.False);
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -2597,8 +2597,8 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_AssertionForkWithoutKeyedNoncesOrRecentRoots_RunsPostTxButRefusesTheOtherEnvelopes()
     {
-        ((TestSpecProvider)_specProvider).GenesisSpec =
-            new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip8250Enabled = false, IsEip8272Enabled = false, IsEip7906Enabled = true };
+        _spec.IsEip8250Enabled = false;
+        _spec.IsEip8272Enabled = false;
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
 
@@ -2608,11 +2608,17 @@ public class FrameTxProcessorTests
         Transaction rooted = FrameTx(nonce: 1, SelfVerifyFrame());
         rooted.RecentRootReferences = [];
 
+        TransactionResult postResult = Process(postTx);
+        TransactionResult keyedResult = Process(keyed);
+        TransactionResult rootedResult = Process(rooted, slotNumber: 1_001);
+
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(Process(postTx).TransactionExecuted, Is.True, "the assertion fork must run a POST_TX frame");
-            Assert.That(Process(keyed).TransactionExecuted, Is.False, "keyed nonces must stay refused before their fork");
-            Assert.That(Process(rooted, slotNumber: 1_001).TransactionExecuted, Is.False, "recent-root references must stay refused before their fork");
+            Assert.That(postResult.TransactionExecuted, Is.True, "the assertion fork must run a POST_TX frame");
+            Assert.That(keyedResult.TransactionExecuted, Is.False, "keyed nonces must stay refused before their fork");
+            Assert.That(keyedResult.ErrorDescription, Does.Contain(FrameTxValidation.KeyedNoncesNotEnabled));
+            Assert.That(rootedResult.TransactionExecuted, Is.False, "recent-root references must stay refused before their fork");
+            Assert.That(rootedResult.ErrorDescription, Does.Contain(FrameTxValidation.RecentRootReferencesNotEnabled));
         }
     }
 
@@ -3533,12 +3539,17 @@ public class FrameTxProcessorTests
     [TestCase(Instruction.SIGPARAM, (byte)0xB4, TestName = "RegistryByte_SIGPARAM_0xB4")]
     [TestCase(Instruction.SIGDATACOPY, (byte)0xB5, TestName = "RegistryByte_SIGDATACOPY_0xB5")]
     [TestCase(Instruction.RECENTROOTREFLOAD, (byte)0xB6, TestName = "RegistryByte_RECENTROOTREFLOAD_0xB6")]
+    [TestCase(Instruction.TXTRACE, (byte)0xB7, TestName = "RegistryByte_TXTRACE_0xB7")]
+    [TestCase(Instruction.TXDIFF, (byte)0xB8, TestName = "RegistryByte_TXDIFF_0xB8")]
+    [TestCase(Instruction.EVENTDATACOPY, (byte)0xB9, TestName = "RegistryByte_EVENTDATACOPY_0xB9")]
     public void FrameOpcodeByte_MatchesTheSpecRegistry(Instruction opcode, byte registryByte)
         => Assert.That((byte)opcode, Is.EqualTo(registryByte));
 
     [TestCase((byte)0xBA, TestName = "UnallocatedFrameOpcode_0xBA_Halts")]
     [TestCase((byte)0xBB, TestName = "UnallocatedFrameOpcode_0xBB_Halts")]
+    [TestCase((byte)0xBC, TestName = "UnallocatedFrameOpcode_0xBC_Halts")]
     [TestCase((byte)0xBD, TestName = "UnallocatedFrameOpcode_0xBD_Halts")]
+    [TestCase((byte)0xBE, TestName = "UnallocatedFrameOpcode_0xBE_Halts")]
     [TestCase((byte)0xBF, TestName = "UnallocatedFrameOpcode_0xBF_Halts")]
     public void Execute_UnallocatedFrameRangeOpcode_ExceptionallyHalts(byte opcode)
     {
@@ -3567,10 +3578,14 @@ public class FrameTxProcessorTests
 
         Transaction referencing = FrameTx(nonce: 0, SelfVerifyFrame());
         referencing.RecentRootReferences = [];
-        Assert.That(Process(referencing, slotNumber: HeadSlot).TransactionExecuted, Is.False);
+        TransactionResult referencingResult = Process(referencing, slotNumber: HeadSlot);
+        Assert.That(referencingResult.TransactionExecuted, Is.False);
+        Assert.That(referencingResult.ErrorDescription, Does.Contain(FrameTxValidation.RecentRootReferencesNotEnabled));
 
         Transaction postTx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModePostTx, target: Recipient));
-        Assert.That(Process(postTx).TransactionExecuted, Is.False);
+        TransactionResult postTxResult = Process(postTx);
+        Assert.That(postTxResult.TransactionExecuted, Is.False);
+        Assert.That(postTxResult.ErrorDescription, Does.Contain(FrameTxValidation.PostTxNotEnabled));
     }
 
     [Test]
@@ -3587,9 +3602,13 @@ public class FrameTxProcessorTests
 
         Transaction keyed = FrameTx(nonce: 1, SelfVerifyFrame());
         keyed.NonceKeys = [7];
-        Assert.That(Process(keyed).TransactionExecuted, Is.False);
+        TransactionResult keyedResult = Process(keyed);
+        Assert.That(keyedResult.TransactionExecuted, Is.False);
+        Assert.That(keyedResult.ErrorDescription, Does.Contain(FrameTxValidation.KeyedNoncesNotEnabled));
 
         Transaction postTx = FrameTx(nonce: 1, SelfVerifyFrame(), Frame(TxFrame.ModePostTx, target: Recipient));
-        Assert.That(Process(postTx).TransactionExecuted, Is.False);
+        TransactionResult postTxResult = Process(postTx);
+        Assert.That(postTxResult.TransactionExecuted, Is.False);
+        Assert.That(postTxResult.ErrorDescription, Does.Contain(FrameTxValidation.PostTxNotEnabled));
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Capabilities.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Capabilities.cs
@@ -37,7 +37,10 @@ public partial class EngineModuleTests
         EngineRpcCapabilitiesProvider enabledProvider = new(new TestSingleReleaseSpecProvider(enabledSpec));
         EngineRpcCapabilitiesProvider disabledProvider = new(new TestSingleReleaseSpecProvider(disabledSpec));
 
-        Assert.That(enabledProvider.GetJsonRpcCapabilities()[method].IsEnabled(), Is.True);
-        Assert.That(disabledProvider.GetJsonRpcCapabilities()[method].IsEnabled(), Is.False);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(enabledProvider.GetJsonRpcCapabilities()[method].IsEnabled(), Is.True);
+            Assert.That(disabledProvider.GetJsonRpcCapabilities()[method].IsEnabled(), Is.False);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Capabilities.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Capabilities.cs
@@ -25,4 +25,19 @@ public partial class EngineModuleTests
 
         Assert.That(engineRpcCapabilitiesProvider.GetJsonRpcCapabilities()[nameof(IEngineRpcModule.engine_getBlobsV4)].IsEnabled(), Is.EqualTo(expected));
     }
+
+    [TestCase(nameof(IEngineRpcModule.engine_newPayloadV6))]
+    [TestCase(nameof(IEngineRpcModule.engine_getInclusionListV1))]
+    [TestCase(nameof(IEngineRpcModule.engine_forkchoiceUpdatedV5))]
+    [TestCase(nameof(IEngineRpcModule.engine_newPayloadWithWitnessV6))]
+    public void Engine_inclusionList_capabilities_follow_eip7805(string method)
+    {
+        IReleaseSpec enabledSpec = new ReleaseSpec { IsEip7805Enabled = true };
+        IReleaseSpec disabledSpec = new ReleaseSpec { IsEip7805Enabled = false };
+        EngineRpcCapabilitiesProvider enabledProvider = new(new TestSingleReleaseSpecProvider(enabledSpec));
+        EngineRpcCapabilitiesProvider disabledProvider = new(new TestSingleReleaseSpecProvider(disabledSpec));
+
+        Assert.That(enabledProvider.GetJsonRpcCapabilities()[method].IsEnabled(), Is.True);
+        Assert.That(disabledProvider.GetJsonRpcCapabilities()[method].IsEnabled(), Is.False);
+    }
 }

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -861,6 +861,48 @@ public class ChainSpecBasedSpecProviderTests
     }
 
     [Test]
+    public void Frame_family_eips_activate_only_at_their_own_transition_timestamp()
+    {
+        const ulong eip8141Timestamp = 10;
+        const ulong eip8250Timestamp = 20;
+        const ulong eip8272Timestamp = 30;
+        const ulong eip7906Timestamp = 40;
+        const ulong eip7805Timestamp = 50;
+        const ulong eip8037Timestamp = 60;
+        ChainSpec chainSpec = new()
+        {
+            Parameters = new ChainParameters
+            {
+                Eip8141TransitionTimestamp = eip8141Timestamp,
+                Eip8250TransitionTimestamp = eip8250Timestamp,
+                Eip8272TransitionTimestamp = eip8272Timestamp,
+                Eip7906TransitionTimestamp = eip7906Timestamp,
+                Eip7805TransitionTimestamp = eip7805Timestamp,
+                Eip8037TransitionTimestamp = eip8037Timestamp,
+            },
+            EngineChainSpecParametersProvider = TestChainSpecParametersProvider.NethDev
+        };
+
+        ChainSpecBasedSpecProvider provider = new(chainSpec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip8141Timestamp - 1)).IsEip8141Enabled, Is.False);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip8141Timestamp)).IsEip8141Enabled, Is.True);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip8250Timestamp - 1)).IsEip8250Enabled, Is.False);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip8250Timestamp)).IsEip8250Enabled, Is.True);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip8272Timestamp - 1)).IsEip8272Enabled, Is.False);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip8272Timestamp)).IsEip8272Enabled, Is.True);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip7906Timestamp - 1)).IsEip7906Enabled, Is.False);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip7906Timestamp)).IsEip7906Enabled, Is.True);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip7805Timestamp - 1)).IsEip7805Enabled, Is.False);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip7805Timestamp)).IsEip7805Enabled, Is.True);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip8037Timestamp - 1)).IsEip8037Enabled, Is.False);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(eip8037Timestamp)).IsEip8037Enabled, Is.True);
+        }
+    }
+
+    [Test]
     public void Eip2200_is_set_correctly_directly()
     {
         ChainSpec chainSpec = new()


### PR DESCRIPTION
Adds regression coverage that each frame-family EIP (8141, 8250, 8272, 7906, 7805) is independently gated by its chain-config transition timestamp, so a single build can join a devnet running any combination.

## Changes
- **TxValidator**: reject a type `0x06` transaction when EIP-8141 is disabled.
- **FrameTxValidation**: reject frame mode 5 while its owning EIP is inactive.
- **FrameTxProcessor**: opcode bytes match the family registry; an unallocated `0xB0-0xBF` byte exceptionally halts; single-config orthogonality checks that the keyed-nonce, recent-root and post-tx envelopes each run only under their own fork.
- **FrameTxBlockGas**: a frame transaction starts owing state gas only after activation.
- **ChainSpecBasedSpecProvider**: each frame-family EIP flips on exactly at its own transition timestamp.
- **Engine capabilities**: the FOCIL engine methods advertise only when EIP-7805 is enabled.
- **Optimism**: guard a nullable `Logs` dereference in the deposit builder so `Nethermind.Merge.Plugin.Test` builds.

Each control was verified by temporarily reverting its guard and confirming the test fails.

## Types of changes
- [x] Test
- [x] Bugfix (Optimism build)

## Testing
Affected suites pass: Evm.Test (16), Blockchain.Test, Core.Test, Specs.Test, Merge.Plugin.Test (12).
