### PR TITLE
fix(optimism): guard the null log set when deriving user deposits

### DIFF
--- a/src/Nethermind/Nethermind.Optimism.Test/CL/DepositTransactionBuilderTest.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/CL/DepositTransactionBuilderTest.cs
@@ -46,6 +46,24 @@ public class DepositTransactionBuilderTest
     }
 
     [Test]
+    public void DeriveUserDeposits_NullLogs()
+    {
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.EIP1559,
+                Status = 1,
+                Logs = null,
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions.Length, Is.EqualTo(0));
+    }
+
+    [Test]
     public void DeriveUserDeposits_OtherLog()
     {
         ReceiptForRpc[] receipts =

--- a/src/Nethermind/Nethermind.Optimism/CL/Derivation/DepositTransactionBuilder.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Derivation/DepositTransactionBuilder.cs
@@ -78,7 +78,8 @@ public class DepositTransactionBuilder(ulong chainId, CLChainSpecEngineParameter
         foreach (ReceiptForRpc receipt in receipts)
         {
             if (receipt.Status != StatusCode.Success) continue;
-            foreach (LogEntryForRpc log in receipt.Logs)
+            // An L1 node omits "logs" or sends null for a receipt with no logs.
+            foreach (LogEntryForRpc log in receipt.Logs ?? [])
             {
                 if (log.Address != engineParameters.OptimismPortalProxy) continue;
                 if (log.Topics.Length == 0 || log.Topics[0] != DepositEvent.ABIHash) continue;


### PR DESCRIPTION
## Changes

Guards the null log set in `DepositTransactionBuilder.BuildUserDepositTransactions`.

`ReceiptForRpc.Logs` became `LogEntryForRpc[]?` in #12923 (a correct annotation — `TxReceiptConverter.Write` emits `"logs": null` for an empty log set, so the converter's own output NRE'd in `ToReceipt()`). The unguarded `foreach` in `DepositTransactionBuilder` then became `CS8602`.

This is not confined to the docs build as first thought — `Build solutions` → `Build (release, Nethermind)` fails with the identical error, so **nine workflows are red on `eip8141-frame-txs-devnet7` off this one defect**, and the test workflows are not independently broken; they simply cannot build:

```
Build solutions              <- root cause
Build tools
Nethermind/Ethereum tests
Nethermind extra test variants
Nethermind tests (Flat DB)
Integration tests (E2E)
Nix
Trivy scanner
Sync PR Gate (Hoodi)
```

The null is reachable rather than theoretical: these receipts are deserialized from an L1 node's `eth_getBlockReceipts` response. The sibling `SystemConfigDeriver` on the same derivation path already uses exactly this `?? []` guard, so this matches the established idiom rather than inventing one.

A full-solution build after the fix is clean (`0 Warning(s) / 0 Error(s)`), confirming nothing further was hidden behind the first error.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`DeriveUserDeposits_NullLogs` added. Revert-checked: with the guard removed the solution does not compile (reproducing the CI error at the exact file:line:col); isolating runtime from compile-time with `receipt.Logs!` gives exactly one failure, `DeriveUserDeposits_NullLogs` (`NullReferenceException`), 698 others passing.

- `Nethermind.Optimism.Test` 699/699
- `Nethermind.JsonRpc.Test` 1987 passed, 22 skipped
- `Nethermind.Blockchain.Test` 1753 passed, 9 skipped
- `tools/DocGen/DocGen.slnx` builds clean
- Lint gate clean and positive-controlled; `dotnet format whitespace --verify-no-changes` clean

## Documentation

Requires documentation update: no
