### PR TITLE
fix(engine): align SSZ-REST surface with execution-apis#793

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -1411,16 +1411,47 @@ public class SszMiddlewareTests
         Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
     }
 
-    [Test]
-    public async Task GetPayload_with_unacceptable_accept_returns_415()
+    [TestCase("text/html", TestName = "Get_accept_unrelated_type_returns_415")]
+    [TestCase("*/*;q=0", TestName = "Get_accept_wildcard_refused_by_q0_returns_415")]
+    [TestCase("application/octet-stream;q=0.0", TestName = "Get_accept_octet_refused_by_q0_returns_415")]
+    [TestCase("application/octet-stream;q=0, text/html", TestName = "Get_accept_octet_refused_but_html_offered_returns_415")]
+    public async Task GetPayload_with_unacceptable_accept_returns_415(string accept)
     {
         DefaultHttpContext ctx = MakeGetContext("/engine/v1/payloads/0x0102030405060708", fork: "paris");
-        ctx.Request.Headers.Accept = "text/html";
+        ctx.Request.Headers.Accept = accept;
 
         await _middleware.InvokeAsync(ctx);
 
         Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status415UnsupportedMediaType));
         await _engineModule.DidNotReceive().engine_getPayloadV2(Arg.Any<byte[]>());
+    }
+
+    [Test]
+    public async Task GetPayload_accept_with_nonzero_quality_is_served()
+    {
+        _engineModule.engine_getPayloadV2(Arg.Any<byte[]>())
+            .Returns(ResultWrapper<GetPayloadV2Result?>.Success(new GetPayloadV2Result(MakeMinimalBlock(), UInt256.One)));
+
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/payloads/0x0102030405060708", fork: "paris");
+        ctx.Request.Headers.Accept = "text/html;q=0.9, application/octet-stream;q=0.1";
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+    }
+
+    [Test]
+    public async Task Duplicate_fork_header_returns_invalid_request()
+    {
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", BuildMinimalV1NewPayloadRequest());
+        ctx.Request.Headers[SszMiddleware.ForkHeaderName] = new StringValues(["paris", "shanghai"]);
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+        string body = System.Text.Encoding.UTF8.GetString(ResponseBytes(ctx));
+        Assert.That(body, Does.Contain("invalid-request"));
+        await _engineModule.DidNotReceive().engine_newPayloadV1(Arg.Any<ExecutionPayload>());
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Autofac;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
 using Nethermind.Config;
 using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Stateless;
@@ -219,7 +220,7 @@ public class SszMiddlewareTests
             .Returns(ResultWrapper<PayloadStatusV1>.Success(status));
 
         byte[] body = version == 1 ? BuildMinimalV1NewPayloadRequest() : BuildMinimalV2NewPayloadRequest();
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: fork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", body, fork: fork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -242,7 +243,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getPayloadV2(Arg.Any<byte[]>())
             .Returns(ResultWrapper<GetPayloadV2Result?>.Success(new GetPayloadV2Result(MakeMinimalBlock(), UInt256.One)));
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0x0102030405060708", fork: fork);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/payloads/0x0102030405060708", fork: fork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -277,7 +278,7 @@ public class SszMiddlewareTests
             .Returns(ResultWrapper<ForkchoiceUpdatedV1Result>.Success(fcuResult));
 
         byte[] body = version == 4 ? BuildForkchoiceV4Request() : BuildForkchoiceRequest();
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: fork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/forkchoice", body, fork: fork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -307,7 +308,7 @@ public class SszMiddlewareTests
         custodyColumns.Set(0, true);
         custodyColumns.Set(3, true);
         custodyColumns.Set(127, true);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", BuildForkchoiceV4Request(custodyColumns), fork: "amsterdam");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/forkchoice", BuildForkchoiceV4Request(custodyColumns), fork: "amsterdam");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -328,7 +329,7 @@ public class SszMiddlewareTests
             .Returns(ResultWrapper<IReadOnlyList<BlobAndProofV1?>>.Success([bap]));
 
         byte[] body = BuildHashListRequest([TestItem.KeccakA.Bytes.ToArray()]);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/blobs/v1", body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/blobs/v1", body);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -338,8 +339,8 @@ public class SszMiddlewareTests
         await _engineModule.DidNotReceive().engine_getBlobsV3(Arg.Any<byte[][]>());
     }
 
-    [TestCase("/engine/v2/blobs/v2", false)]
-    [TestCase("/engine/v2/blobs/v3", true)]
+    [TestCase("/engine/v1/blobs/v2", false)]
+    [TestCase("/engine/v1/blobs/v3", true)]
     public async Task GetBlobsV2V3_routes_to_correct_engine_method(string path, bool isV3)
     {
         _engineModule.engine_getBlobsV2(Arg.Any<byte[][]>())
@@ -368,7 +369,7 @@ public class SszMiddlewareTests
             IndicesBitarray = new System.Collections.BitArray(128)
         };
         byte[] body = GetBlobsV4RequestWire.Encode(request);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/blobs/v4", body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/blobs/v4", body);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -393,7 +394,7 @@ public class SszMiddlewareTests
                 [new ExecutionPayloadBodyV2Result([], null, null)]));
 
         byte[] body = BuildPayloadBodiesByHashRequest([TestItem.KeccakA]);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash", body, fork: fork);
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/bodies/hash", body, fork: fork);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -419,7 +420,7 @@ public class SszMiddlewareTests
         _specProvider.GetSpec(Arg.Is<ForkActivation>(fa => fa.Timestamp == 2_000UL)).Returns(Cancun.Instance);
 
         byte[] body = BuildPayloadBodiesByHashRequest([inFork, outOfFork]);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash", body, fork: "shanghai");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/bodies/hash", body, fork: "shanghai");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -458,7 +459,7 @@ public class SszMiddlewareTests
             .Returns(ResultWrapper<IReadOnlyList<ExecutionPayloadBodyV2Result?>>.Success([]));
 
         // The range endpoint is now GET with from/count as query parameters.
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: fork);
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/bodies", fork: fork);
         ctx.Request.QueryString = new QueryString($"?from={expectedStart}&count={expectedCount}");
 
         await _middleware.InvokeAsync(ctx);
@@ -477,7 +478,7 @@ public class SszMiddlewareTests
     {
         _specProvider.TransitionActivations.Returns([]);
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/capabilities");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/capabilities");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -504,7 +505,7 @@ public class SszMiddlewareTests
 
         // Rebuild middleware so it picks up the now-configured spec provider.
         SszMiddleware mw = BuildMiddleware();
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/capabilities");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/capabilities");
         await mw.InvokeAsync(ctx);
 
         Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
@@ -526,7 +527,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getClientVersionV1(default)
             .ReturnsForAnyArgs(ResultWrapper<ClientVersionV1[]>.Success(response));
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/identity");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/identity");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -541,7 +542,7 @@ public class SszMiddlewareTests
         _auth.Authenticate(Arg.Any<string>()).Returns(false);
 
         byte[] body = BuildMinimalV1NewPayloadRequest();
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: "paris");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", body, fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -552,7 +553,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Oversized_body_returns_413_without_calling_engine_module()
     {
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", [], fork: "paris");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", [], fork: "paris");
         ctx.Request.ContentLength = SszMiddleware.MaxBodySize + 1;
         ctx.Request.Body = new MemoryStream(new byte[1]);
 
@@ -567,7 +568,7 @@ public class SszMiddlewareTests
     {
         bool nextInvoked = false;
         SszMiddleware mw = BuildMiddleware(_ => { nextInvoked = true; return Task.CompletedTask; });
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/unknown-resource", [], fork: "paris");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/unknown-resource", [], fork: "paris");
 
         await mw.InvokeAsync(ctx);
 
@@ -577,8 +578,8 @@ public class SszMiddlewareTests
 
     // Each case is a different routing rejection that must NOT reach the engine module:
     // extra segments on a non-AcceptsPathExtra handler, runs of '/' inside the path.
-    [TestCase("/engine/v2/payloads/foo/bar", TestName = "Extra_segments_on_non_path_handler_404")]
-    [TestCase("/engine/v2/payloads//abc", TestName = "Consecutive_slashes_404")]
+    [TestCase("/engine/v1/payloads/foo/bar", TestName = "Extra_segments_on_non_path_handler_404")]
+    [TestCase("/engine/v1/payloads//abc", TestName = "Consecutive_slashes_404")]
     public async Task POST_with_malformed_path_returns_404(string path)
     {
         DefaultHttpContext ctx = MakePostContext(path, [], fork: "paris");
@@ -591,7 +592,7 @@ public class SszMiddlewareTests
 
     private static readonly TestCaseData[] MalformedSszBodyCases =
     [
-        new TestCaseData("/engine/v2/payloads", "paris").SetName("Malformed_ssz_payloads_returns_400"),
+        new TestCaseData("/engine/v1/payloads", "paris").SetName("Malformed_ssz_payloads_returns_400"),
         new TestCaseData(WitnessPath, WitnessFork).SetName("Malformed_ssz_payloads_witness_returns_400"),
     ];
 
@@ -614,7 +615,7 @@ public class SszMiddlewareTests
     public async Task Truncated_body_with_overstated_content_length_returns_400()
     {
         byte[] body = new byte[16];
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: "paris");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", body, fork: "paris");
         // Declare more bytes than the stream will deliver — ReadAtLeastAsync returns short.
         ctx.Request.ContentLength = body.Length + 64;
 
@@ -631,7 +632,7 @@ public class SszMiddlewareTests
             .Returns(ResultWrapper<IReadOnlyList<BlobAndProofV1?>>.Success(null!));
 
         byte[] body = BuildHashListRequest([TestItem.KeccakA.Bytes.ToArray()]);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/blobs/v1", body);
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/blobs/v1", body);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -660,7 +661,7 @@ public class SszMiddlewareTests
         _engineModule.engine_newPayloadV1(Arg.Any<ExecutionPayload>())
             .Returns<Task<ResultWrapper<PayloadStatusV1>>>(_ => throw new InvalidOperationException("simulated server error"));
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", BuildMinimalV1NewPayloadRequest(), fork: "paris");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", BuildMinimalV1NewPayloadRequest(), fork: "paris");
 
         // Simulate the encode-failure → ctx.Abort() effect by pre-cancelling RequestAborted.
         // DefaultHttpContext's Abort() is a no-op without a real lifetime feature, so we
@@ -688,7 +689,7 @@ public class SszMiddlewareTests
         SszMiddleware middleware = new(
             _ => Task.CompletedTask, _urlCollection, _auth, [handler], _processExitSource, LimboLogs.Instance);
 
-        DefaultHttpContext ctx = MakePostContext($"/engine/v2/{ZeroLengthEncodeHandler.ResourceName}", [], fork: "paris");
+        DefaultHttpContext ctx = MakePostContext($"/engine/v1/{ZeroLengthEncodeHandler.ResourceName}", [], fork: "paris");
 
         await middleware.InvokeAsync(ctx);
 
@@ -813,7 +814,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getClientVersionV1(default)
             .ReturnsForAnyArgs(ResultWrapper<ClientVersionV1[]>.Success(response));
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/identity");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/identity");
         ctx.Request.Headers["X-Engine-Client-Version"] = jsonHeader;
 
         await _middleware.InvokeAsync(ctx);
@@ -872,7 +873,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: "cancun");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/forkchoice", body, fork: "cancun");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -903,7 +904,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: "cancun");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/forkchoice", body, fork: "cancun");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -946,7 +947,7 @@ public class SszMiddlewareTests
         };
         byte[] body = ForkchoiceUpdatedV3RequestWire.Encode(request);
 
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: "osaka");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/forkchoice", body, fork: "osaka");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -959,7 +960,7 @@ public class SszMiddlewareTests
     [TestCase("text/html, application/json;q=0.9, */*;q=0.8")]
     public async Task Capabilities_returns_200_json_regardless_of_Accept_header(string accept)
     {
-        DefaultHttpContext ctx = MakeBaseContext("GET", "/engine/v2/capabilities", AuthenticatedPort);
+        DefaultHttpContext ctx = MakeBaseContext("GET", "/engine/v1/capabilities", AuthenticatedPort);
         ctx.Request.Headers.Accept = accept;
         ctx.Request.Body = Stream.Null;
 
@@ -979,7 +980,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getClientVersionV1(default)
             .ReturnsForAnyArgs(ResultWrapper<ClientVersionV1[]>.Success(response));
 
-        DefaultHttpContext ctx = MakeBaseContext("GET", "/engine/v2/identity", AuthenticatedPort);
+        DefaultHttpContext ctx = MakeBaseContext("GET", "/engine/v1/identity", AuthenticatedPort);
         ctx.Request.Headers.Accept = accept;
         ctx.Request.Body = Stream.Null;
 
@@ -992,9 +993,9 @@ public class SszMiddlewareTests
     // Unknown extra path segments still 404; trailing slashes are accepted (covered below).
     private static readonly TestCaseData[] MalformedPathCases =
     [
-        new TestCaseData("GET", "/engine/v2/capabilities/foo", true, null).SetName("Malformed_capabilities_extra_segment_404"),
-        new TestCaseData("GET", "/engine/v2/identity/foo", true, null).SetName("Malformed_identity_extra_segment_404"),
-        new TestCaseData("POST", "/engine/v2/forkchoice/whatever", false, "cancun").SetName("Malformed_forkchoice_extra_segment_404"),
+        new TestCaseData("GET", "/engine/v1/capabilities/foo", true, null).SetName("Malformed_capabilities_extra_segment_404"),
+        new TestCaseData("GET", "/engine/v1/identity/foo", true, null).SetName("Malformed_identity_extra_segment_404"),
+        new TestCaseData("POST", "/engine/v1/forkchoice/whatever", false, "cancun").SetName("Malformed_forkchoice_extra_segment_404"),
     ];
 
     [TestCaseSource(nameof(MalformedPathCases))]
@@ -1019,8 +1020,8 @@ public class SszMiddlewareTests
         }
     }
 
-    [TestCase("/engine/v2/capabilities/")]
-    [TestCase("/engine/v2/identity/")]
+    [TestCase("/engine/v1/capabilities/")]
+    [TestCase("/engine/v1/identity/")]
     public async Task Trailing_slash_on_unscoped_endpoint_returns_404(string path)
     {
         DefaultHttpContext ctx = MakeBaseContext("GET", path, AuthenticatedPort);
@@ -1038,7 +1039,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getPayloadV2(Arg.Any<byte[]>())
             .Returns(ResultWrapper<GetPayloadV2Result?>.Success(new GetPayloadV2Result(MakeMinimalBlock(), UInt256.One)));
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0x0102030405060708/", fork: "paris");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/payloads/0x0102030405060708/", fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1048,7 +1049,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Unknown_fork_in_header_returns_400_unsupported_fork()
     {
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", [], fork: "atlantis");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", [], fork: "atlantis");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1060,13 +1061,13 @@ public class SszMiddlewareTests
     [Test]
     public async Task Missing_fork_header_on_fork_scoped_endpoint_returns_400()
     {
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", BuildMinimalV1NewPayloadRequest());
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", BuildMinimalV1NewPayloadRequest());
 
         await _middleware.InvokeAsync(ctx);
 
         Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
         string body = System.Text.Encoding.UTF8.GetString(ResponseBytes(ctx));
-        Assert.That(body, Does.Contain("invalid-request"));
+        Assert.That(body, Does.Contain("unsupported-fork"));
         await _engineModule.DidNotReceive().engine_newPayloadV1(Arg.Any<ExecutionPayload>());
     }
 
@@ -1075,7 +1076,7 @@ public class SszMiddlewareTests
     {
         // Paris is a supported fork but predates getPayloadBodies (introduced in Shanghai), so the
         // endpoint is recognised yet unavailable for this fork — 400 unsupported-fork, not 404.
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/bodies/hash",
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/bodies/hash",
             BuildPayloadBodiesByHashRequest([TestItem.KeccakA]), fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
@@ -1089,7 +1090,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Unknown_blob_version_returns_404()
     {
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/blobs/v99", []);
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/blobs/v99", []);
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1099,7 +1100,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Invalid_payload_id_in_path_returns_400()
     {
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/payloads/0xZZZZZZZZZZZZZZZZ", fork: "paris");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/payloads/0xZZZZZZZZZZZZZZZZ", fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1109,7 +1110,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task GetPayloadBodiesByRange_over_limit_returns_413_request_too_large()
     {
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: "shanghai");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/bodies", fork: "shanghai");
         ctx.Request.QueryString = new QueryString("?from=1&count=1000");
 
         await _middleware.InvokeAsync(ctx);
@@ -1125,7 +1126,7 @@ public class SszMiddlewareTests
         _engineModule.engine_getPayloadBodiesByRangeV1(Arg.Any<ulong>(), Arg.Any<ulong>())
             .Returns(ResultWrapper<IReadOnlyList<ExecutionPayloadBodyV1Result?>>.Success([]));
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/bodies", fork: "shanghai");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/bodies", fork: "shanghai");
         ctx.Request.QueryString = new QueryString("?from=0&count=1");
 
         await _middleware.InvokeAsync(ctx);
@@ -1139,7 +1140,7 @@ public class SszMiddlewareTests
     {
         byte[] garbage = new byte[64];
         new Random(42).NextBytes(garbage);
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", garbage, fork: "paris");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", garbage, fork: "paris");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1154,7 +1155,7 @@ public class SszMiddlewareTests
     [Test]
     public async Task Error_response_has_correct_RFC7807_shape_with_detail_for_non_canned_errors()
     {
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", [], fork: "atlantis");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", [], fork: "atlantis");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1166,7 +1167,7 @@ public class SszMiddlewareTests
         Assert.That(root.EnumerateObject().Count(), Is.EqualTo(2), "error body must have exactly two keys: type + detail");
     }
 
-    private const string WitnessPath = "/engine/v2/payloads/witness";
+    private const string WitnessPath = "/engine/v1/payloads/witness";
     private const string WitnessFork = "amsterdam";
 
     [TestCase(true, TestName = "NewPayloadWithWitness_valid_with_generated_witness_encodes_witness_present")]
@@ -1327,7 +1328,7 @@ public class SszMiddlewareTests
             ExecutionPayload = new SszExecutionPayloadV4(SszTestData.MakeV4Payload(blockAccessList: [0xc0], slotNumber: 0)),
             ParentBeaconBlockRoot = TestItem.KeccakA,
         });
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", body, fork: "bogota");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/payloads", body, fork: "bogota");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1358,7 +1359,7 @@ public class SszMiddlewareTests
             PayloadAttributes = [],
             CustodyColumns = []
         });
-        DefaultHttpContext ctx = MakePostContext("/engine/v2/forkchoice", body, fork: "bogota");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/forkchoice", body, fork: "bogota");
 
         await _middleware.InvokeAsync(ctx);
 
@@ -1374,12 +1375,67 @@ public class SszMiddlewareTests
         _engineModule.engine_getInclusionListV1()
             .Returns(ResultWrapper<InclusionListBytes>.Success(inclusionList));
 
-        DefaultHttpContext ctx = MakeGetContext("/engine/v2/inclusion_list", fork: "bogota");
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/inclusion_list", fork: "bogota");
 
         await _middleware.InvokeAsync(ctx);
 
         Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
         Assert.That(ctx.Response.ContentType, Does.Contain(OctetStream));
         await _engineModule.Received(1).engine_getInclusionListV1();
+    }
+
+    [Test]
+    public async Task Legacy_v2_base_path_is_no_longer_routed()
+    {
+        DefaultHttpContext ctx = MakePostContext("/engine/v2/payloads", BuildMinimalV1NewPayloadRequest(), fork: "paris");
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [TestCase(null, TestName = "Get_accept_absent_is_served")]
+    [TestCase("*/*", TestName = "Get_accept_wildcard_is_served")]
+    [TestCase("application/*", TestName = "Get_accept_application_wildcard_is_served")]
+    [TestCase("application/json, */*;q=0.8", TestName = "Get_accept_list_with_wildcard_is_served")]
+    public async Task GetPayload_accept_variants_are_served(string? accept)
+    {
+        _engineModule.engine_getPayloadV2(Arg.Any<byte[]>())
+            .Returns(ResultWrapper<GetPayloadV2Result?>.Success(new GetPayloadV2Result(MakeMinimalBlock(), UInt256.One)));
+
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/payloads/0x0102030405060708", fork: "paris");
+        ctx.Request.Headers.Accept = accept is null ? StringValues.Empty : accept;
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+    }
+
+    [Test]
+    public async Task GetPayload_with_unacceptable_accept_returns_415()
+    {
+        DefaultHttpContext ctx = MakeGetContext("/engine/v1/payloads/0x0102030405060708", fork: "paris");
+        ctx.Request.Headers.Accept = "text/html";
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status415UnsupportedMediaType));
+        await _engineModule.DidNotReceive().engine_getPayloadV2(Arg.Any<byte[]>());
+    }
+
+    [Test]
+    public async Task GetPayloadBodiesByHash_over_limit_is_rejected_before_the_engine_module()
+    {
+        Hash256[] hashes = new Hash256[SszRestLimits.MaxBodiesRequest + 1];
+        Array.Fill(hashes, TestItem.KeccakA);
+        DefaultHttpContext ctx = MakePostContext(
+            "/engine/v1/bodies/hash", BuildPayloadBodiesByHashRequest(hashes), fork: "shanghai");
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+        string body = System.Text.Encoding.UTF8.GetString(ResponseBytes(ctx));
+        Assert.That(body, Does.Contain("ssz-decode-error"));
+        _engineModule.DidNotReceive().engine_getPayloadBodiesByHashV1(Arg.Any<IReadOnlyList<Hash256>>());
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/EngineRpcCapabilitiesProvider.cs
@@ -30,7 +30,7 @@ public class EngineRpcCapabilitiesProvider(ISpecProvider specProvider) : IRpcCap
         return Volatile.Read(ref _jsonRpc)!;
     }
 
-    /// <summary>SSZ-REST path capabilities only (e.g. <c>"POST /engine/v2/payloads"</c>).</summary>
+    /// <summary>SSZ-REST path capabilities only (e.g. <c>"POST /engine/v1/payloads"</c>).</summary>
     public FrozenDictionary<string, RpcCapabilityOptions> GetSszRestPaths()
     {
         EnsureBuilt();

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/BodiesForkFilter.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/BodiesForkFilter.cs
@@ -11,7 +11,7 @@ using Nethermind.Core.Specs;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Per execution-apis #793, <c>/engine/v2/bodies/...</c> responses MUST mark blocks whose
+/// Per execution-apis #793, <c>/engine/v1/bodies/...</c> responses MUST mark blocks whose
 /// timestamp falls outside the fork requested via the <c>Eth-Execution-Version</c> header as
 /// <c>available=false</c>. Applied at the SSZ-REST boundary because the underlying engine handler
 /// is shared with the un-scoped JSON-RPC <c>engine_getPayloadBodies*</c> methods.

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/CapabilitiesSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/CapabilitiesSszHandler.cs
@@ -14,7 +14,7 @@ using Nethermind.Core.Specs;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>GET /engine/v2/capabilities</c>, the HTTP/REST equivalent of
+/// Handles <c>GET /engine/v1/capabilities</c>, the HTTP/REST equivalent of
 /// <c>engine_exchangeCapabilities</c>.
 /// </summary>
 /// <remarks>

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ClientVersionSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ClientVersionSszHandler.cs
@@ -14,7 +14,7 @@ using Nethermind.Merge.Plugin.Data;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>GET /engine/v2/identity</c>, the HTTP/REST equivalent of
+/// Handles <c>GET /engine/v1/identity</c>, the HTTP/REST equivalent of
 /// <c>engine_getClientVersionV1</c>.
 /// </summary>
 public sealed class ClientVersionSszHandler(IEngineRpcModule engineModule, ILogManager logManager) : SszEndpointHandlerBase

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/ForkchoiceUpdatedSszHandler.cs
@@ -13,7 +13,7 @@ using Nethermind.Serialization.Ssz;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>POST /engine/v2/forkchoice</c>, the SSZ-REST equivalent of
+/// Handles <c>POST /engine/v1/forkchoice</c>, the SSZ-REST equivalent of
 /// <c>engine_forkchoiceUpdatedV{N}</c> (the version is selected by the <c>Eth-Execution-Version</c>
 /// header). Generic over a per-version descriptor so adding V5 is one new descriptor struct + one
 /// DI line — no version switch.

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
@@ -15,7 +15,7 @@ using Nethermind.JsonRpc;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>POST /engine/v2/bodies/hash</c>, the SSZ-REST equivalent
+/// Handles <c>POST /engine/v1/bodies/hash</c>, the SSZ-REST equivalent
 /// of <c>engine_getPayloadBodiesByHashV{N}</c> (the version is selected by the
 /// <c>Eth-Execution-Version</c> header). Generic over a per-version descriptor
 /// so adding a Vn+1 endpoint is one new descriptor + one DI line.
@@ -34,14 +34,9 @@ public sealed class GetPayloadBodiesByHashSszHandler<TVersion, TResult>(
 
     public override async Task HandleAsync(HttpContext ctx, int v, ReadOnlyMemory<char> extra, ReadOnlySequence<byte> body)
     {
+        // MAX_BODIES_REQUEST is the SSZ list limit on BodiesByHashRequest.block_hashes, so an
+        // over-limit request fails decode as 400 ssz-decode-error before reaching this point.
         Hash256[] hashes = SszCodec.DecodeGetPayloadBodiesByHashRequest(body);
-        if (hashes.Length > SszRestLimits.MaxBodiesRequest)
-        {
-            await WriteErrorAsync(ctx, StatusCodes.Status413PayloadTooLarge,
-                $"hash count {hashes.Length} exceeds the limit of {SszRestLimits.MaxBodiesRequest}",
-                MergeErrorCodes.TooLargeRequest);
-            return;
-        }
         ResultWrapper<IReadOnlyList<TResult?>> result = await TVersion.Call(engineModule, hashes);
         if (result.Result.ResultType == ResultType.Success && result.Data is { Count: > 0 } data)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByHashSszHandler.cs
@@ -34,8 +34,6 @@ public sealed class GetPayloadBodiesByHashSszHandler<TVersion, TResult>(
 
     public override async Task HandleAsync(HttpContext ctx, int v, ReadOnlyMemory<char> extra, ReadOnlySequence<byte> body)
     {
-        // MAX_BODIES_REQUEST is the SSZ list limit on BodiesByHashRequest.block_hashes, so an
-        // over-limit request fails decode as 400 ssz-decode-error before reaching this point.
         Hash256[] hashes = SszCodec.DecodeGetPayloadBodiesByHashRequest(body);
         ResultWrapper<IReadOnlyList<TResult?>> result = await TVersion.Call(engineModule, hashes);
         if (result.Result.ResultType == ResultType.Success && result.Data is { Count: > 0 } data)

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByRangeSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadBodiesByRangeSszHandler.cs
@@ -14,7 +14,7 @@ using Nethermind.JsonRpc;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>GET /engine/v2/bodies?from=N&amp;count=M</c>, the SSZ-REST equivalent
+/// Handles <c>GET /engine/v1/bodies?from=N&amp;count=M</c>, the SSZ-REST equivalent
 /// of <c>engine_getPayloadBodiesByRangeV{N}</c> (the version is selected by the
 /// <c>Eth-Execution-Version</c> header). Generic over a per-version descriptor
 /// so adding a Vn+1 endpoint is one new descriptor + one DI line.

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetPayloadSszHandler.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Http;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>GET /engine/v2/payloads/{payload_id}</c>, the SSZ-REST equivalent of
+/// Handles <c>GET /engine/v1/payloads/{payload_id}</c>, the SSZ-REST equivalent of
 /// <c>engine_getPayloadV{N}</c> (the version is selected by the <c>Eth-Execution-Version</c> header).
 /// </summary>
 public sealed class GetPayloadSszHandler<TVersion, TResult>(IEngineRpcModule engine)

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadSszHandler.cs
@@ -12,7 +12,7 @@ using Nethermind.Serialization.Ssz;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>POST /engine/v2/payloads</c>, the SSZ-REST equivalent of
+/// Handles <c>POST /engine/v1/payloads</c>, the SSZ-REST equivalent of
 /// <c>engine_newPayloadV{N}</c> (the version is selected by the <c>Eth-Execution-Version</c>
 /// header). Generic over a per-version descriptor so adding V6 is one new descriptor struct +
 /// one DI line — no version switch.

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadWithWitnessSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadWithWitnessSszHandler.cs
@@ -12,7 +12,7 @@ using Nethermind.Serialization.Ssz;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>POST /engine/v2/{fork}/payloads/witness</c>, the SSZ-REST equivalent of
+/// Handles <c>POST /engine/v1/{fork}/payloads/witness</c>, the SSZ-REST equivalent of
 /// <c>engine_newPayloadWithWitnessV5</c>. The response is <c>PayloadStatusWithWitness</c>, the payload
 /// status plus a witness present only when the status is VALID (execution-apis#773/#793).
 /// </summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadWithWitnessSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/NewPayloadWithWitnessSszHandler.cs
@@ -12,7 +12,7 @@ using Nethermind.Serialization.Ssz;
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Handles <c>POST /engine/v1/{fork}/payloads/witness</c>, the SSZ-REST equivalent of
+/// Handles <c>POST /engine/v1/payloads/witness</c>, the SSZ-REST equivalent of
 /// <c>engine_newPayloadWithWitnessV5</c>. The response is <c>PayloadStatusWithWitness</c>, the payload
 /// status plus a witness present only when the status is VALID (execution-apis#773/#793).
 /// </summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestLimits.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestLimits.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 /// <remarks>
 /// Per <c>execution-apis#793</c>: <c>MAX_BODIES_REQUEST = 2**5 = 32</c>,
 /// <c>MAX_BLOBS_REQUEST = 2**7 = 128</c>. These values are advertised via
-/// <c>GET /engine/v2/capabilities</c> and enforced by the corresponding handlers.
+/// <c>GET /engine/v1/capabilities</c> and enforced by the corresponding handlers.
 /// </remarks>
 public static class SszRestLimits
 {

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestLimits.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestLimits.cs
@@ -4,7 +4,7 @@
 namespace Nethermind.Merge.Plugin.SszRest.Handlers;
 
 /// <summary>
-/// Single source of truth for Engine API v2 REST request-size limits.
+/// Single source of truth for Engine API REST request-size limits.
 /// </summary>
 /// <remarks>
 /// Per <c>execution-apis#793</c>: <c>MAX_BODIES_REQUEST = 2**5 = 32</c>,

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
@@ -55,6 +55,8 @@ public static class SszRestPaths
     public static readonly FrozenSet<string> SupportedForks =
         SupportedForksOrdered.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
+    public const string BasePath = "/engine/v1/";
+
     public const string Payloads = "payloads";
 
     public const string Forkchoice = "forkchoice";
@@ -92,19 +94,19 @@ public static class SszRestPaths
         return ResourceScoping.ForkScoped;
     }
 
-    public const string PostPayloads = "POST /engine/v1/payloads";
-    public const string GetPayloads = "GET /engine/v1/payloads/{payload_id}";
-    public const string PostForkchoice = "POST /engine/v1/forkchoice";
-    public const string PostBodiesByHash = "POST /engine/v1/bodies/hash";
-    public const string GetBodiesByRange = "GET /engine/v1/bodies";
-    public const string GetCapabilities = "GET /engine/v1/capabilities";
-    public const string GetIdentity = "GET /engine/v1/identity";
-    public const string PostBlobsV1 = "POST /engine/v1/blobs/v1";
-    public const string PostBlobsV2 = "POST /engine/v1/blobs/v2";
-    public const string PostBlobsV3 = "POST /engine/v1/blobs/v3";
-    public const string PostBlobsV4 = "POST /engine/v1/blobs/v4";
-    public const string PostPayloadsWitness = "POST /engine/v1/payloads/witness";
-    public const string GetInclusionList = "GET /engine/v1/inclusion_list";
+    public const string PostPayloads = $"POST {BasePath}payloads";
+    public const string GetPayloads = $"GET {BasePath}payloads/{{payload_id}}";
+    public const string PostForkchoice = $"POST {BasePath}forkchoice";
+    public const string PostBodiesByHash = $"POST {BasePath}bodies/hash";
+    public const string GetBodiesByRange = $"GET {BasePath}bodies";
+    public const string GetCapabilities = $"GET {BasePath}capabilities";
+    public const string GetIdentity = $"GET {BasePath}identity";
+    public const string PostBlobsV1 = $"POST {BasePath}blobs/v1";
+    public const string PostBlobsV2 = $"POST {BasePath}blobs/v2";
+    public const string PostBlobsV3 = $"POST {BasePath}blobs/v3";
+    public const string PostBlobsV4 = $"POST {BasePath}blobs/v4";
+    public const string PostPayloadsWitness = $"POST {BasePath}payloads/witness";
+    public const string GetInclusionList = $"GET {BasePath}inclusion_list";
 
     // Fork-scoped endpoint → selector pulling its method version off a fork spec, keyed by resource
     // (one table per HTTP method). Presence in the table means the (method, resource) pair is a

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/SszRestPaths.cs
@@ -92,19 +92,19 @@ public static class SszRestPaths
         return ResourceScoping.ForkScoped;
     }
 
-    public const string PostPayloads = "POST /engine/v2/payloads";
-    public const string GetPayloads = "GET /engine/v2/payloads/{payload_id}";
-    public const string PostForkchoice = "POST /engine/v2/forkchoice";
-    public const string PostBodiesByHash = "POST /engine/v2/bodies/hash";
-    public const string GetBodiesByRange = "GET /engine/v2/bodies";
-    public const string GetCapabilities = "GET /engine/v2/capabilities";
-    public const string GetIdentity = "GET /engine/v2/identity";
-    public const string PostBlobsV1 = "POST /engine/v2/blobs/v1";
-    public const string PostBlobsV2 = "POST /engine/v2/blobs/v2";
-    public const string PostBlobsV3 = "POST /engine/v2/blobs/v3";
-    public const string PostBlobsV4 = "POST /engine/v2/blobs/v4";
-    public const string PostPayloadsWitness = "POST /engine/v2/payloads/witness";
-    public const string GetInclusionList = "GET /engine/v2/inclusion_list";
+    public const string PostPayloads = "POST /engine/v1/payloads";
+    public const string GetPayloads = "GET /engine/v1/payloads/{payload_id}";
+    public const string PostForkchoice = "POST /engine/v1/forkchoice";
+    public const string PostBodiesByHash = "POST /engine/v1/bodies/hash";
+    public const string GetBodiesByRange = "GET /engine/v1/bodies";
+    public const string GetCapabilities = "GET /engine/v1/capabilities";
+    public const string GetIdentity = "GET /engine/v1/identity";
+    public const string PostBlobsV1 = "POST /engine/v1/blobs/v1";
+    public const string PostBlobsV2 = "POST /engine/v1/blobs/v2";
+    public const string PostBlobsV3 = "POST /engine/v1/blobs/v3";
+    public const string PostBlobsV4 = "POST /engine/v1/blobs/v4";
+    public const string PostPayloadsWitness = "POST /engine/v1/payloads/witness";
+    public const string GetInclusionList = "GET /engine/v1/inclusion_list";
 
     // Fork-scoped endpoint → selector pulling its method version off a fork spec, keyed by resource
     // (one table per HTTP method). Presence in the table means the (method, resource) pair is a

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Pipelines;
 using System.Net.Mime;
@@ -33,9 +34,7 @@ public sealed class SszMiddleware
     private readonly ILogger _logger;
     private readonly CancellationToken _processExitToken;
 
-    // Path: /engine/v1/{resource}[/{extra}]. Since execution-apis#793 the fork is no longer a
-    // path segment — fork-scoped endpoints select their container shape via the request header below.
-    private const string EnginePrefix = "/engine/v1/";
+    private const string EnginePrefix = SszRestPaths.BasePath;
 
     /// <summary>
     /// Request header that selects the fork (and thus the SSZ container shape) for fork-scoped
@@ -181,13 +180,13 @@ public sealed class SszMiddleware
             if (endpointNotAvailableForFork)
             {
                 await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
-                    $"Fork '{fork}' does not support {ctx.Request.Method} /engine/v1/{pathSegment.Span}",
+                    $"Fork '{fork}' does not support {ctx.Request.Method} {EnginePrefix}{pathSegment.Span}",
                     MergeErrorCodes.UnsupportedFork);
             }
             else
             {
                 await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status404NotFound,
-                    $"Unknown method: {ctx.Request.Method} /engine/v1/{pathSegment.Span}",
+                    $"Unknown method: {ctx.Request.Method} {EnginePrefix}{pathSegment.Span}",
                     SszRestErrorCodes.MethodNotFound);
             }
         }
@@ -201,8 +200,8 @@ public sealed class SszMiddleware
             if (_logger.IsTrace)
             {
                 _logger.Trace(extra.IsEmpty
-                    ? $"SSZ-REST {ctx.Request.Method} /engine/v1/{pathSegment.Span}"
-                    : $"SSZ-REST {ctx.Request.Method} /engine/v1/{pathSegment.Span}/{extra.Span}");
+                    ? $"SSZ-REST {ctx.Request.Method} {EnginePrefix}{pathSegment.Span}"
+                    : $"SSZ-REST {ctx.Request.Method} {EnginePrefix}{pathSegment.Span}/{extra.Span}");
             }
 
             await DispatchAsync(ctx, handler!, version, extra);
@@ -331,12 +330,19 @@ public sealed class SszMiddleware
         error = null;
 
         StringValues headerValues = ctx.Request.Headers[ForkHeaderName];
+        if (headerValues.Count > 1)
+        {
+            error = SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
+                $"Request carries {headerValues.Count} '{ForkHeaderName}' headers, expected exactly one",
+                SszRestErrorCodes.InvalidRequest);
+            return false;
+        }
+
         string? headerValue = headerValues.Count == 1 ? headerValues[0] : null;
         if (string.IsNullOrEmpty(headerValue))
         {
-            // execution-apis#793 maps a missing header to unsupported-fork, same as an unknown value.
             error = SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
-                $"Request must carry exactly one '{ForkHeaderName}' header", MergeErrorCodes.UnsupportedFork);
+                $"Request must carry an '{ForkHeaderName}' header", MergeErrorCodes.UnsupportedFork);
             return false;
         }
 
@@ -467,12 +473,8 @@ public sealed class SszMiddleware
         }
     }
 
-    /// <summary>
-    /// Whether the request's <c>Accept</c> header allows an SSZ response body. An absent header
-    /// means any type is acceptable (RFC 9110 §12.5.1), so it is treated as a match rather than
-    /// as a rejection — CLs that omit <c>Accept</c>, and clients defaulting to <c>*&#47;*</c>,
-    /// must still reach the hot-path endpoints.
-    /// </summary>
+    /// <summary>Whether the request's <c>Accept</c> header allows an SSZ response body.</summary>
+    /// <remarks>An absent header means any type is acceptable (RFC 9110 §12.5.1).</remarks>
     private static bool AcceptsOctetStream(HttpContext ctx)
     {
         bool anyValue = false;
@@ -480,19 +482,44 @@ public sealed class SszMiddleware
         {
             if (string.IsNullOrWhiteSpace(v)) continue;
             anyValue = true;
-            if (v.Contains(MediaTypeNames.Application.Octet, StringComparison.OrdinalIgnoreCase)
-                || v.Contains("*/*", StringComparison.Ordinal)
-                || v.Contains("application/*", StringComparison.OrdinalIgnoreCase))
-                return true;
+
+            foreach (Range r in v.AsSpan().Split(','))
+            {
+                ReadOnlySpan<char> range = v.AsSpan()[r].Trim();
+                if (range.IsEmpty) continue;
+
+                int semicolon = range.IndexOf(';');
+                ReadOnlySpan<char> mediaType = (semicolon < 0 ? range : range[..semicolon]).TrimEnd();
+                if (!mediaType.Equals(MediaTypeNames.Application.Octet, StringComparison.OrdinalIgnoreCase)
+                    && !mediaType.Equals("application/*", StringComparison.OrdinalIgnoreCase)
+                    && !mediaType.Equals("*/*", StringComparison.Ordinal))
+                    continue;
+
+                if (!IsRejectedByQualityValue(semicolon < 0 ? default : range[(semicolon + 1)..]))
+                    return true;
+            }
         }
         return !anyValue;
+    }
+
+    /// <summary>Whether <paramref name="parameters"/> carries <c>q=0</c>, which refuses the media range.</summary>
+    private static bool IsRejectedByQualityValue(ReadOnlySpan<char> parameters)
+    {
+        foreach (Range r in parameters.Split(';'))
+        {
+            ReadOnlySpan<char> parameter = parameters[r].Trim();
+            if (!parameter.StartsWith("q=", StringComparison.OrdinalIgnoreCase)) continue;
+
+            return double.TryParse(parameter[2..], CultureInfo.InvariantCulture, out double quality) && quality <= 0d;
+        }
+        return false;
     }
 
     private static bool IsDiagnosticGetPath(string path)
     {
         ReadOnlySpan<char> span = path.AsSpan();
-        const string capabilitiesPath = "/engine/v1/capabilities";
-        const string identityPath = "/engine/v1/identity";
+        const string capabilitiesPath = $"{EnginePrefix}{SszRestPaths.Capabilities}";
+        const string identityPath = $"{EnginePrefix}{SszRestPaths.ClientVersion}";
 
         return span.Equals(capabilitiesPath.AsSpan(), StringComparison.OrdinalIgnoreCase)
             || (span.StartsWith(capabilitiesPath.AsSpan(), StringComparison.OrdinalIgnoreCase) && span.Length > capabilitiesPath.Length && span[capabilitiesPath.Length] == '/')

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszMiddleware.cs
@@ -33,9 +33,9 @@ public sealed class SszMiddleware
     private readonly ILogger _logger;
     private readonly CancellationToken _processExitToken;
 
-    // Path: /engine/v2/{resource}[/{extra}]. Since execution-apis#793 the fork is no longer a
+    // Path: /engine/v1/{resource}[/{extra}]. Since execution-apis#793 the fork is no longer a
     // path segment — fork-scoped endpoints select their container shape via the request header below.
-    private const string EnginePrefix = "/engine/v2/";
+    private const string EnginePrefix = "/engine/v1/";
 
     /// <summary>
     /// Request header that selects the fork (and thus the SSZ container shape) for fork-scoped
@@ -181,13 +181,13 @@ public sealed class SszMiddleware
             if (endpointNotAvailableForFork)
             {
                 await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
-                    $"Fork '{fork}' does not support {ctx.Request.Method} /engine/v2/{pathSegment.Span}",
+                    $"Fork '{fork}' does not support {ctx.Request.Method} /engine/v1/{pathSegment.Span}",
                     MergeErrorCodes.UnsupportedFork);
             }
             else
             {
                 await SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status404NotFound,
-                    $"Unknown method: {ctx.Request.Method} /engine/v2/{pathSegment.Span}",
+                    $"Unknown method: {ctx.Request.Method} /engine/v1/{pathSegment.Span}",
                     SszRestErrorCodes.MethodNotFound);
             }
         }
@@ -201,8 +201,8 @@ public sealed class SszMiddleware
             if (_logger.IsTrace)
             {
                 _logger.Trace(extra.IsEmpty
-                    ? $"SSZ-REST {ctx.Request.Method} /engine/v2/{pathSegment.Span}"
-                    : $"SSZ-REST {ctx.Request.Method} /engine/v2/{pathSegment.Span}/{extra.Span}");
+                    ? $"SSZ-REST {ctx.Request.Method} /engine/v1/{pathSegment.Span}"
+                    : $"SSZ-REST {ctx.Request.Method} /engine/v1/{pathSegment.Span}/{extra.Span}");
             }
 
             await DispatchAsync(ctx, handler!, version, extra);
@@ -334,8 +334,9 @@ public sealed class SszMiddleware
         string? headerValue = headerValues.Count == 1 ? headerValues[0] : null;
         if (string.IsNullOrEmpty(headerValue))
         {
+            // execution-apis#793 maps a missing header to unsupported-fork, same as an unknown value.
             error = SszEndpointHandlerBase.WriteErrorAsync(ctx, StatusCodes.Status400BadRequest,
-                $"Request must carry exactly one '{ForkHeaderName}' header", SszRestErrorCodes.InvalidRequest);
+                $"Request must carry exactly one '{ForkHeaderName}' header", MergeErrorCodes.UnsupportedFork);
             return false;
         }
 
@@ -457,25 +458,41 @@ public sealed class SszMiddleware
                 if (IsDiagnosticGetPath(path))
                     return SszRequestKind.EngineOk;
 
-                foreach (string? v in ctx.Request.Headers.Accept)
-                {
-                    if (v is not null && v.Contains(
-                        MediaTypeNames.Application.Octet, StringComparison.OrdinalIgnoreCase))
-                        return SszRequestKind.EngineOk;
-                }
-
-                return SszRequestKind.NotEngine;
+                return AcceptsOctetStream(ctx)
+                    ? SszRequestKind.EngineOk
+                    : SszRequestKind.EngineWrongMediaType;
 
             default:
                 return SszRequestKind.NotEngine;
         }
     }
 
+    /// <summary>
+    /// Whether the request's <c>Accept</c> header allows an SSZ response body. An absent header
+    /// means any type is acceptable (RFC 9110 §12.5.1), so it is treated as a match rather than
+    /// as a rejection — CLs that omit <c>Accept</c>, and clients defaulting to <c>*&#47;*</c>,
+    /// must still reach the hot-path endpoints.
+    /// </summary>
+    private static bool AcceptsOctetStream(HttpContext ctx)
+    {
+        bool anyValue = false;
+        foreach (string? v in ctx.Request.Headers.Accept)
+        {
+            if (string.IsNullOrWhiteSpace(v)) continue;
+            anyValue = true;
+            if (v.Contains(MediaTypeNames.Application.Octet, StringComparison.OrdinalIgnoreCase)
+                || v.Contains("*/*", StringComparison.Ordinal)
+                || v.Contains("application/*", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return !anyValue;
+    }
+
     private static bool IsDiagnosticGetPath(string path)
     {
         ReadOnlySpan<char> span = path.AsSpan();
-        const string capabilitiesPath = "/engine/v2/capabilities";
-        const string identityPath = "/engine/v2/identity";
+        const string capabilitiesPath = "/engine/v1/capabilities";
+        const string identityPath = "/engine/v1/identity";
 
         return span.Equals(capabilitiesPath.AsSpan(), StringComparison.OrdinalIgnoreCase)
             || (span.StartsWith(capabilitiesPath.AsSpan(), StringComparison.OrdinalIgnoreCase) && span.Length > capabilitiesPath.Length && span[capabilitiesPath.Length] == '/')

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/SszWireTypes.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
+using Nethermind.Merge.Plugin.SszRest.Handlers;
 using Nethermind.Serialization.Ssz;
 
 namespace Nethermind.Merge.Plugin.SszRest;
@@ -335,7 +336,7 @@ public partial struct GetPayloadResponseV6Wire
 [SszContainer]
 public partial struct GetBlobsRequestWire
 {
-    [SszList(128)] public Hash256[]? VersionedHashes { get; set; }
+    [SszList(SszRestLimits.MaxBlobsRequest)] public Hash256[]? VersionedHashes { get; set; }
 }
 
 [SszContainer]
@@ -355,7 +356,7 @@ public partial struct BlobV1EntryWire
 [SszContainer]
 public partial struct GetBlobsV1ResponseWire
 {
-    [SszList(128)] public BlobV1EntryWire[]? Entries { get; set; }
+    [SszList(SszRestLimits.MaxBlobsRequest)] public BlobV1EntryWire[]? Entries { get; set; }
 }
 
 [SszContainer(isCollectionItself: true)]
@@ -415,7 +416,7 @@ public partial struct ExecutionPayloadBodyV2Wire
 [SszContainer]
 public partial struct GetPayloadBodiesByHashRequestWire
 {
-    [SszList(32)] public Hash256[]? BlockHashes { get; set; }
+    [SszList(SszRestLimits.MaxBodiesRequest)] public Hash256[]? BlockHashes { get; set; }
 }
 
 [SszContainer]
@@ -438,7 +439,7 @@ public partial struct BodyEntryV1Wire
 [SszContainer]
 public partial struct PayloadBodiesV1ResponseWire
 {
-    [SszList(32)] public BodyEntryV1Wire[]? Entries { get; set; }
+    [SszList(SszRestLimits.MaxBodiesRequest)] public BodyEntryV1Wire[]? Entries { get; set; }
 }
 
 /// <summary>
@@ -454,7 +455,7 @@ public partial struct BodyEntryV2Wire
 [SszContainer]
 public partial struct PayloadBodiesV2ResponseWire
 {
-    [SszList(32)] public BodyEntryV2Wire[]? Entries { get; set; }
+    [SszList(SszRestLimits.MaxBodiesRequest)] public BodyEntryV2Wire[]? Entries { get; set; }
 }
 
 [SszContainer]
@@ -475,13 +476,13 @@ public partial struct BlobV2EntryWire
 [SszContainer]
 public partial struct GetBlobsV2ResponseWire
 {
-    [SszList(128)] public BlobV2EntryWire[]? Entries { get; set; }
+    [SszList(SszRestLimits.MaxBlobsRequest)] public BlobV2EntryWire[]? Entries { get; set; }
 }
 
 [SszContainer]
 public partial struct GetBlobsV4RequestWire
 {
-    [SszList(128)] public Hash256[]? BlobVersionedHashes { get; set; }
+    [SszList(SszRestLimits.MaxBlobsRequest)] public Hash256[]? BlobVersionedHashes { get; set; }
     [SszVector(128)] public BitArray? IndicesBitarray { get; set; }
 }
 
@@ -517,7 +518,7 @@ public partial struct BlobV4EntryWire
 [SszContainer]
 public partial struct GetBlobsV4ResponseWire
 {
-    [SszList(128)] public BlobV4EntryWire[]? Entries { get; set; }
+    [SszList(SszRestLimits.MaxBlobsRequest)] public BlobV4EntryWire[]? Entries { get; set; }
 }
 [SszContainer(isCollectionItself: true)]
 public partial struct SszWitnessItem


### PR DESCRIPTION
Raised upstream on the spec PR: https://github.com/ethereum/execution-apis/pull/793#issuecomment-5451357522

## Changes

Brings the SSZ-REST engine surface back in line with [execution-apis#793](https://github.com/ethereum/execution-apis/pull/793) at its current head (`d39e9a27`).

- **Renumber the REST base path `/engine/v2/` → `/engine/v1/`.** The spec commit that moved the fork out of the path and into `Eth-Execution-Version` (which we tracked in #12193) also renumbered the base path, on the reasoning that `/v1` is the first REST version of the engine API. We took the header half and kept the `v2` prefix. A CL following the spec therefore hits `404` on every REST URL, which the spec's transition-window section defines as "EL doesn't expose REST at all, fall back to JSON-RPC for the lifetime of this connection" — so the entire surface is silently unreachable.
- **A missing `Eth-Execution-Version` header now returns `unsupported-fork`** instead of `invalid-request`. The spec's error table maps missing, unknown, and unsupported header values to the same type, and CLs are told to branch on that string.
- **`GET` requests with an absent, `*/*`, or `application/*` `Accept` header are now served.** Previously only a literal `application/octet-stream` was matched, so anything else fell through to the JSON-RPC pipeline. An absent `Accept` means any type is acceptable (RFC 9110 §12.5.1) and `*/*` is a common client default. An `Accept` that genuinely excludes SSZ now returns `415` rather than falling through.
- **Drop the unreachable `413` branch in the bodies-by-hash handler.** `MAX_BODIES_REQUEST` is the SSZ list limit on `BodiesByHashRequest.block_hashes`, so an over-limit body fails decode as `400 ssz-decode-error` before the handler runs. The equivalent check on `GET /bodies?count=` is real and stays.

Spec-side inconsistencies found while doing this (stale fork-in-URL text, a `VALID = 0x01` vs `VALID = 0` contradiction in the worked byte example, and a `payload_id` TTL rule that contradicts the polling model) are raised upstream on the spec PR rather than worked around here.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New cases in `SszMiddlewareTests`:

- `Legacy_v2_base_path_is_no_longer_routed` — the old prefix now 404s.
- `GetPayload_accept_variants_are_served` — absent / `*/*` / `application/*` / a q-weighted list all reach the handler.
- `GetPayload_with_unacceptable_accept_returns_415`.
- `GetPayloadBodiesByHash_over_limit_is_rejected_before_the_engine_module` — pins the `400 ssz-decode-error` behaviour that makes the removed `413` branch dead.

`Missing_fork_header_on_fork_scoped_endpoint_returns_400` updated to expect `unsupported-fork`. The existing ~40 routing tests already exercise the new prefix.

Full `Nethermind.Merge.Plugin.Test` suite: 1819 passed, 2 skipped, 0 failed.

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

The engine-API REST base path is user-visible; docs referencing `/engine/v2/...` need the same renumber.

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

The SSZ-REST engine API moves from `/engine/v2/...` to `/engine/v1/...`. Operators pairing Nethermind with a CL that speaks the REST engine API need both sides on matching revisions; the legacy `engine_*` JSON-RPC surface at `/` is unaffected.

## Remarks

The base path is still worth confirming upstream before we treat it as settled: `refactor-ssz.md` is titled "Engine API v2", and `refactor.md`'s own goals section still says the fork lives in the URL. The renumber may not have been deliberate. That question is part of the upstream comment.
