### PR TITLE
test(txpool): reuse the shared frame builders in the paymaster fixture

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Builders/FrameTxTestFrames.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/FrameTxTestFrames.cs
@@ -35,7 +35,8 @@ public static class FrameTxTestFrames
 
     public static TxFrame Pay(ulong gasLimit = 1_000) => Pay(TestItem.AddressC, gasLimit);
 
-    public static TxFrame Pay(Address target, ulong gasLimit = 1_000) =>
+    /// <remarks>A null <paramref name="target"/> is the omitted-target encoding, not a missing argument.</remarks>
+    public static TxFrame Pay(Address? target, ulong gasLimit = 1_000) =>
         new(TxFrame.ModeVerify, TxFrame.ApprovePayment, target, gasLimit, UInt256.Zero, default);
 
     public static TxFrame Deploy(ulong gasLimit = 1_000) =>

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPaymasterFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPaymasterFilterTests.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
@@ -20,6 +19,7 @@ using Nethermind.TxPool.Collections;
 using Nethermind.TxPool.Filters;
 using NSubstitute;
 using NUnit.Framework;
+using static Nethermind.Core.Test.Builders.FrameTxTestFrames;
 
 namespace Nethermind.TxPool.Test;
 
@@ -51,31 +51,31 @@ public class FrameTxPaymasterFilterTests
     private static IEnumerable<TestCaseData> CapCases()
     {
         yield return Case("SponsoredByDeployedPaymaster_Rejected",
-            () => FrameTx([OnlyVerifyFrame(), PayFrame(Paymaster)]), paymasterHasCode: true, rejected: true);
+            () => FrameTx([OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)]), paymasterHasCode: true, rejected: true);
 
         // The recognized prefix skips a leading expiry and deploy frame, so the cap still keys on the pay target.
         yield return Case("DeployPrefixSponsoredByDeployedPaymaster_Rejected",
-            () => FrameTx([ExpiryFrame(9999), DeployFrame(), OnlyVerifyFrame(), PayFrame(Paymaster)]), paymasterHasCode: true, rejected: true);
+            () => FrameTx([ExpiryAt(9999), DeployFrame(), OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)]), paymasterHasCode: true, rejected: true);
 
         // A default-code sponsor is not a paymaster: bounded by the per-payer exposure rule alone.
         yield return Case("SponsoredByDefaultCodeAccount_Accepted",
-            () => FrameTx([OnlyVerifyFrame(), PayFrame(Paymaster)]), paymasterHasCode: false, rejected: false);
+            () => FrameTx([OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)]), paymasterHasCode: false, rejected: false);
 
         yield return Case("SelfRelay_Accepted",
-            () => FrameTx([SelfVerifyFrame()]), paymasterHasCode: true, rejected: false);
+            () => FrameTx([SelfVerify(PrefixFrameGas)]), paymasterHasCode: true, rejected: false);
 
         // A null pay target resolves to the sender, so no paymaster is used.
         yield return Case("PayFrameWithoutTarget_Accepted",
-            () => FrameTx([OnlyVerifyFrame(), PayFrame(null)]), paymasterHasCode: true, rejected: false);
+            () => FrameTx([OnlyVerify(PrefixFrameGas), Pay(null, PrefixFrameGas)]), paymasterHasCode: true, rejected: false);
 
         // The leading frame already approves payment for the sender, so the later pay frame sponsors nothing.
         yield return Case("SelfPaidBeforePayFrame_Accepted",
-            () => FrameTx([SelfVerifyFrame(), PayFrame(Paymaster)]), paymasterHasCode: true, rejected: false);
+            () => FrameTx([SelfVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)]), paymasterHasCode: true, rejected: false);
 
         // The simulator walks the whole leading VERIFY run, so an unapproving frame before the pay frame
         // must not hide the sponsor from the cap.
         yield return Case("PayFrameBehindSpacerVerifyFrame_Rejected",
-            () => FrameTx([OnlyVerifyFrame(), SpacerVerifyFrame(), PayFrame(Paymaster)]), paymasterHasCode: true, rejected: true);
+            () => FrameTx([OnlyVerify(PrefixFrameGas), SpacerVerifyFrame(), Pay(Paymaster, PrefixFrameGas)]), paymasterHasCode: true, rejected: true);
 
         yield return Case("NonFrameTx_Accepted",
             () => Build.A.Transaction.WithSenderAddress(Sender).TestObject, paymasterHasCode: true, rejected: false);
@@ -93,7 +93,7 @@ public class FrameTxPaymasterFilterTests
         PendingPaymasterCache cache = new();
         cache.Reserve(Sender);
 
-        AcceptTxResult result = Accept(state, cache, FrameTx([OnlyVerifyFrame(), PayFrame(targetSpelledOut ? Sender : null)], nonce: 1));
+        AcceptTxResult result = Accept(state, cache, FrameTx([OnlyVerify(PrefixFrameGas), Pay(targetSpelledOut ? Sender : null, PrefixFrameGas)], nonce: 1));
 
         Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
     }
@@ -121,7 +121,7 @@ public class FrameTxPaymasterFilterTests
         TestReadOnlyStateProvider state = new();
         state.InsertCode([0x60, 0x00], Paymaster);
         PendingPaymasterCache cache = new();
-        Transaction tx = FrameTx([OnlyVerifyFrame(), PayFrame(Paymaster)]);
+        Transaction tx = FrameTx([OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)]);
 
         // Admission counts the slot itself, so the second submission sees the first one holding it.
         AcceptTxResult first = Accept(state, cache, tx);
@@ -143,7 +143,7 @@ public class FrameTxPaymasterFilterTests
         cache.Reserve(Paymaster);
         cache.Decrement(Paymaster);
 
-        AcceptTxResult result = Accept(state, cache, FrameTx([OnlyVerifyFrame(), PayFrame(Paymaster)]));
+        AcceptTxResult result = Accept(state, cache, FrameTx([OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)]));
 
         Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
     }
@@ -155,14 +155,14 @@ public class FrameTxPaymasterFilterTests
         state.InsertCode([0x60, 0x00], Paymaster);
         state.InsertCode([0x60, 0x00], OtherPaymaster);
 
-        Transaction pending = FrameTx([OnlyVerifyFrame(), PayFrame(pendingPaymaster)], pendingNonce);
+        Transaction pending = FrameTx([OnlyVerify(PrefixFrameGas), Pay(pendingPaymaster, PrefixFrameGas)], pendingNonce);
         PendingPaymasterCache cache = new();
         cache.Reserve(pendingPaymaster);
         // The incoming tx's own paymaster must be at the cap for the discount to be what decides.
         if (pendingPaymaster != Paymaster) cache.Reserve(Paymaster);
 
         // A fee bump is the same sender and nonce at a higher price.
-        Transaction incoming = FrameTx([OnlyVerifyFrame(), PayFrame(Paymaster)], incomingNonce, gasPrice: 2);
+        Transaction incoming = FrameTx([OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)], incomingNonce, gasPrice: 2);
         AcceptTxResult result = Accept(state, cache, incoming, Pool(blobs: false, pending));
 
         Assert.That(result, Is.EqualTo(rejected ? AcceptTxResult.NonCanonicalPaymasterLimitReached : AcceptTxResult.Accepted));
@@ -175,11 +175,11 @@ public class FrameTxPaymasterFilterTests
         TestReadOnlyStateProvider state = new();
         state.InsertCode([0x60, 0x00], Paymaster);
 
-        Transaction pending = FrameTx([OnlyVerifyFrame(), PayFrame(Paymaster)], carriesBlobs: true);
+        Transaction pending = FrameTx([OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)], carriesBlobs: true);
         PendingPaymasterCache cache = new();
         cache.Reserve(Paymaster);
 
-        Transaction incoming = FrameTx([OnlyVerifyFrame(), PayFrame(Paymaster)], gasPrice: 2, carriesBlobs: true);
+        Transaction incoming = FrameTx([OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)], gasPrice: 2, carriesBlobs: true);
         AcceptTxResult result = Accept(state, cache, incoming, Pool(blobs: true, pending));
 
         Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
@@ -194,7 +194,7 @@ public class FrameTxPaymasterFilterTests
         state.CreateAccount(Sender, Unit.Ether);
         state.InsertCode([0x60, 0x00], Paymaster);
 
-        Transaction record = new LightTransaction(FrameTx([OnlyVerifyFrame(), PayFrame(Paymaster)], carriesBlobs: true));
+        Transaction record = new LightTransaction(FrameTx([OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)], carriesBlobs: true));
         Assert.That(record.Frames, Is.Null, "the record must be frameless, or this pins nothing");
 
         PendingPaymasterCache cache = new();
@@ -202,9 +202,9 @@ public class FrameTxPaymasterFilterTests
 
         // The bump displaces the record, so the discount has to resolve the record's paymaster; a later
         // nonce displaces nothing and must still be capped.
-        Transaction bump = FrameTx([OnlyVerifyFrame(), PayFrame(Paymaster)], gasPrice: 2, carriesBlobs: true);
+        Transaction bump = FrameTx([OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)], gasPrice: 2, carriesBlobs: true);
         AcceptTxResult replacement = Accept(state, cache, bump, Pool(blobs: true, record));
-        AcceptTxResult second = Accept(state, cache, FrameTx([OnlyVerifyFrame(), PayFrame(Paymaster)], nonce: 1, carriesBlobs: true), Pool(blobs: true, record));
+        AcceptTxResult second = Accept(state, cache, FrameTx([OnlyVerify(PrefixFrameGas), Pay(Paymaster, PrefixFrameGas)], nonce: 1, carriesBlobs: true), Pool(blobs: true, record));
 
         using (Assert.EnterMultipleScope())
         {
@@ -299,25 +299,10 @@ public class FrameTxPaymasterFilterTests
         return tx;
     }
 
-    private static TxFrame SelfVerifyFrame() =>
-        new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default);
-
-    private static TxFrame OnlyVerifyFrame() =>
-        new(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 100_000, UInt256.Zero, default);
-
-    private static TxFrame PayFrame(Address? target) =>
-        new(TxFrame.ModeVerify, TxFrame.ApprovePayment, target, gasLimit: 100_000, UInt256.Zero, default);
-
+    /// <remarks>A non-approving VERIFY frame, so the paymaster walk has to step over it to reach the PAY frame.</remarks>
     private static TxFrame SpacerVerifyFrame() =>
-        new(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, target: TestItem.AddressD, gasLimit: 100_000, UInt256.Zero, default);
+        new(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, target: TestItem.AddressD, gasLimit: PrefixFrameGas, UInt256.Zero, default);
 
     private static TxFrame DeployFrame() =>
-        new(TxFrame.ModeDefault, flags: 0, target: null, gasLimit: 50_000, UInt256.Zero, default);
-
-    private static TxFrame ExpiryFrame(ulong deadline)
-    {
-        byte[] data = new byte[Eip8141Constants.ExpiryDataLength];
-        BinaryPrimitives.WriteUInt64BigEndian(data, deadline);
-        return new TxFrame(TxFrame.ModeVerify, flags: 0, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 30_000, UInt256.Zero, data);
-    }
+        new(TxFrame.ModeDefault, TxFrame.ApproveScopeNone, target: null, gasLimit: 50_000, UInt256.Zero, default);
 }


### PR DESCRIPTION
## Changes

The paymaster cap fixture predates #12930, so it carried its own copies of the prefix frame builders that PR moved into `FrameTxTestFrames`. This puts it back on the shared set.

- Replace the four exactly-equivalent local builders with the shared ones: `SelfVerifyFrame`/`OnlyVerifyFrame`/`PayFrame` → `SelfVerify(PrefixFrameGas)`/`OnlyVerify(PrefixFrameGas)`/`Pay(…, PrefixFrameGas)`, and `ExpiryFrame(9999)` → `ExpiryAt(9999)`. `PrefixFrameGas` is already the `100_000` the local helpers used, and `ExpiryAt` already defaults to the same `30_000`, so every layout is byte-for-byte what it was.
- Widen the shared `Pay` builder's target to `Address?`. The fixture covers the omitted-target encoding (`Pay(null)`), which the frame grammar allows, and the builder forwards straight into `TxFrame`'s nullable `target`. Widening is source-compatible, and `null` is not convertible to `ulong`, so the `Pay(ulong)` overload stays unambiguous.
- Keep `SpacerVerifyFrame` and `DeployFrame` local, spelling their `flags: 0` as `TxFrame.ApproveScopeNone` (the constant is `0x0`, so the layouts are unchanged) and giving the spacer the same `PrefixFrameGas` as its siblings. Neither has a shared equivalent — the spacer shape (VERIFY at `AddressD` approving nothing) appears nowhere else in the repo, and the shared `Deploy` targets `AddressD` where this one has a null target, so substituting would have changed the layout under test. Both are single-consumer, so promoting them would grow the shared surface for one caller.

`FrameTx` stays local as well: it takes `nonce`/`gasPrice`/`carriesBlobs` and is not the shared overload.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

No behaviour change — the substitutions preserve every frame's mode, flags, target, and gas limit, checked constant by constant (`PrefixFrameGas` is `100_000`, `ApproveScopeNone` is `0x0`).

Rebuilt onto the current `eip8141-frame-txs-devnet7`. The branch had been stacked on `eip8141-paymaster-pending-cap`, so against this PR's base it showed that whole stack (18 files) rather than its own change; that branch has since merged and been deleted, so the fix was to re-apply the one commit on top of the base. The diff is now the intended two files.

Re-verified on that base: release build of `Nethermind.slnx` clean at 0 warnings / 0 errors; `Nethermind.TxPool.Test` 944 passed / 0 failed / 4 skipped in **both** release and debug (the exposure-ledger symmetry assert is `#if DEBUG`); `Nethermind.Core.Test` 6085 passed / 0 failed / 135 skipped, covering the other consumers of the widened `Pay`; lint gate clean; `dotnet format whitespace --verify-no-changes` clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

