### PR TITLE
test(eip8141): extract the shared frame tx payload skeleton

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -155,7 +155,7 @@ public class FrameTxDecoderTests
         // The sender is mandatory: a frame transaction names its payer outright rather than recovering
         // it from an envelope signature, so — unlike `to` or a frame target — an empty field has no
         // "absent" meaning and must not decode to a null sender.
-        byte[] payload = TypedPayload(FrameTxBody(sender: Rlp.Encode(Array.Empty<byte>())));
+        byte[] payload = TypedPayload(FrameTxBody(sender: Rlp.Encode(Array.Empty<byte>()))); // the empty string 0x80
 
         void Decode()
         {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -121,19 +121,7 @@ public class FrameTxDecoderTests
     public void Decode_NetworkWrapperWithoutSidecar_ThrowsRlpException()
     {
         // A wrapper holding only the body leaves the reader at the end of the buffer, where the peek reads out of bounds.
-        Rlp body = Rlp.Encode(
-            Rlp.Encode(TestBlockchainIds.ChainId),   // chain_id
-            Rlp.Encode(0L),                          // nonce
-            Rlp.Encode(TestItem.AddressA.Bytes),     // sender
-            Rlp.Encode(Array.Empty<Rlp>()),          // frames
-            Rlp.Encode(Array.Empty<Rlp>()),          // signatures
-            Rlp.Encode(Rlp.Encode(0L), Rlp.Encode(0L), Rlp.Encode(0L)), // fees
-            Rlp.Encode(Array.Empty<Rlp>()));         // blob_versioned_hashes
-        Rlp wrapper = Rlp.Encode(new[] { body });
-
-        byte[] payload = new byte[1 + wrapper.Length];
-        payload[0] = (byte)TxType.FrameTx;
-        wrapper.Bytes.CopyTo(payload, 1);
+        byte[] payload = TypedPayload(Rlp.Encode(new[] { FrameTxBody() }));
 
         void Decode()
         {
@@ -149,21 +137,8 @@ public class FrameTxDecoderTests
     {
         // The payload is exactly 7 fields with no envelope signature, so an appended [v, r, s] triple must be
         // rejected: decoding it with a spurious signature is a divergence that also changes the transaction hash.
-        Rlp sequence = Rlp.Encode(
-            Rlp.Encode(TestBlockchainIds.ChainId),   // chain_id
-            Rlp.Encode(0L),                          // nonce
-            Rlp.Encode(TestItem.AddressA.Bytes),     // sender
-            Rlp.Encode(Array.Empty<Rlp>()),          // frames
-            Rlp.Encode(Array.Empty<Rlp>()),          // signatures
-            Rlp.Encode(Rlp.Encode(0L), Rlp.Encode(0L), Rlp.Encode(0L)), // fees
-            Rlp.Encode(Array.Empty<Rlp>()),          // blob_versioned_hashes
-            Rlp.Encode(27L),                         // trailing v
-            Rlp.Encode(new byte[32]),                // trailing r
-            Rlp.Encode(new byte[32]));               // trailing s
-
-        byte[] payload = new byte[1 + sequence.Length];
-        payload[0] = (byte)TxType.FrameTx;
-        sequence.Bytes.CopyTo(payload, 1);
+        byte[] payload = TypedPayload(FrameTxBody(trailing:
+            [Rlp.Encode(27L), Rlp.Encode(new byte[32]), Rlp.Encode(new byte[32])]));
 
         void Decode()
         {
@@ -180,18 +155,7 @@ public class FrameTxDecoderTests
         // The sender is mandatory: a frame transaction names its payer outright rather than recovering
         // it from an envelope signature, so — unlike `to` or a frame target — an empty field has no
         // "absent" meaning and must not decode to a null sender.
-        Rlp sequence = Rlp.Encode(
-            Rlp.Encode(TestBlockchainIds.ChainId),   // chain_id
-            Rlp.Encode(0L),                          // nonce
-            Rlp.Encode(Array.Empty<byte>()),         // sender, encoded as the empty string 0x80
-            Rlp.Encode(Array.Empty<Rlp>()),          // frames
-            Rlp.Encode(Array.Empty<Rlp>()),          // signatures
-            Rlp.Encode(Rlp.Encode(0L), Rlp.Encode(0L), Rlp.Encode(0L)), // fees
-            Rlp.Encode(Array.Empty<Rlp>()));         // blob_versioned_hashes
-
-        byte[] payload = new byte[1 + sequence.Length];
-        payload[0] = (byte)TxType.FrameTx;
-        sequence.Bytes.CopyTo(payload, 1);
+        byte[] payload = TypedPayload(FrameTxBody(sender: Rlp.Encode(Array.Empty<byte>())));
 
         void Decode()
         {
@@ -304,22 +268,33 @@ public class FrameTxDecoderTests
 
     private Transaction DecodeReferenceEnvelope(Rlp references)
     {
-        Rlp sequence = Rlp.Encode(
-            Rlp.Encode(TestBlockchainIds.ChainId),
-            Rlp.Encode(0L),
-            Rlp.Encode(TestItem.AddressA.Bytes),
-            Rlp.Encode(Array.Empty<Rlp>()),
-            Rlp.Encode(Array.Empty<Rlp>()),
-            Rlp.Encode(Rlp.Encode(0L), Rlp.Encode(0L), Rlp.Encode(0L)),
-            Rlp.Encode(Array.Empty<Rlp>()),
-            references);
-
-        byte[] payload = new byte[1 + sequence.Length];
-        payload[0] = (byte)TxType.FrameTx;
-        sequence.Bytes.CopyTo(payload, 1);
-
-        RlpReader reader = new(payload);
+        RlpReader reader = new(TypedPayload(FrameTxBody(trailing: references)));
         return _txDecoder.DecodeGuardNotNull(ref reader, RlpBehaviors.SkipTypedWrapping);
+    }
+
+    /// <summary>
+    /// Encodes the well-formed type-6 payload body that the hand-built payload tests start from.
+    /// </summary>
+    /// <param name="sender">Replaces the sender field; defaults to <see cref="TestItem.AddressA"/>.</param>
+    /// <param name="trailing">Extra elements appended after <c>blob_versioned_hashes</c>.</param>
+    private static Rlp FrameTxBody(Rlp? sender = null, params Rlp[] trailing) =>
+        Rlp.Encode([
+            Rlp.Encode(TestBlockchainIds.ChainId),          // chain_id
+            Rlp.Encode(0L),                                 // nonce
+            sender ?? Rlp.Encode(TestItem.AddressA.Bytes),  // sender
+            Rlp.Encode(Array.Empty<Rlp>()),                 // frames
+            Rlp.Encode(Array.Empty<Rlp>()),                 // signatures
+            Rlp.Encode(Rlp.Encode(0L), Rlp.Encode(0L), Rlp.Encode(0L)), // fees
+            Rlp.Encode(Array.Empty<Rlp>()),                 // blob_versioned_hashes
+            .. trailing]);
+
+    /// <summary>Prefixes <paramref name="rlp"/> with the frame transaction type byte.</summary>
+    private static byte[] TypedPayload(Rlp rlp)
+    {
+        byte[] payload = new byte[1 + rlp.Length];
+        payload[0] = (byte)TxType.FrameTx;
+        rlp.Bytes.CopyTo(payload, 1);
+        return payload;
     }
 
     private static Rlp EncodeReference(byte[] sourceId, ulong slot, byte[] root) =>


### PR DESCRIPTION
## Changes

- Extract the hand-built EIP-8141 type-6 payload skeleton in `FrameTxDecoderTests` into a shared `FrameTxBody` helper, replacing four copies of the same nine/seven-field literal.
- `FrameTxBody(Rlp? sender = null, params Rlp[] trailing)` returns the **inner `Rlp`**, not a finished `byte[]`, so each caller stays free to wrap it and choose its own `RlpBehaviors`. This is what makes the extraction possible at all: `Decode_NetworkWrapperWithoutSidecar_ThrowsRlpException` encodes the body inside a second sequence and decodes with `InMempoolForm`, which a helper returning finished bytes could not express.
- The two axes of variation become parameters: `sender` (overridden by `Decode_PayloadWithEmptySenderField_Throws`) and `trailing` (the `[v, r, s]` triple in `Decode_PayloadWithTrailingSignature_Throws`, the reference list in `DecodeReferenceEnvelope`).
- Add `TypedPayload(Rlp)` for the repeated type-byte prefix-and-copy.

Motivation: when the fee fields were nested into a `fees` sub-sequence, the change had to be patched into each copy separately. There is now one definition of the payload shape.

Note this also folds in a fourth copy, `DecodeReferenceEnvelope`, which carried the same skeleton plus one trailing element.

No production code is touched and no test's assertions change — this is a pure test-side deduplication.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Refactoring of existing tests, so the existing tests are the test. Verified on the rebased branch:

- Release build of `src/Nethermind/Nethermind.slnx`: 0 Errors, 0 Warnings.
- `Nethermind.Core.Test` filtered to `FrameTxDecoderTests`: 37 total, 37 succeeded, 0 failed.
- Each rewritten call site also exercised individually, including `Decode_WellFormedRecentRootReferenceList_Decodes` — the control that proves the shared body still *decodes* rather than throwing for an unrelated reason, which is what would otherwise let the malformed-payload tests pass vacuously.
- `dotnet format whitespace src/Nethermind/ --folder --verify-no-changes`: clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
