### PR TITLE
chore: make Nethermind.Stateless.Executor lint clean

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -185,5 +185,5 @@ dotnet_diagnostic.IDE0130.severity = none
 # IDE0005: These Merge.Plugin source files are also linked into Nethermind.Stateless.Executor
 # (which has ImplicitUsings enabled), where their explicit usings are flagged as redundant. The
 # usings are required in Merge.Plugin (ImplicitUsings disabled), so suppress the false positive.
-[src/Nethermind/Nethermind.Merge.Plugin/{Data/ExecutionPayload,Data/IExecutionPayloadParams,SszRest/SszBlobCell,SszRest/SszBlobCellVectorTypeConverter,SszRest/SszKzgCommitment,SszRest/SszKzgCommitmentVectorTypeConverter}.cs]
+[src/Nethermind/Nethermind.Merge.Plugin/Data/{ExecutionPayload,ExecutionPayloadV4,IExecutionPayloadParams}.cs]
 dotnet_diagnostic.IDE0005.severity = none

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;

--- a/src/Nethermind/Nethermind.Stateless.Executor/IO/InputDecoder.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/IO/InputDecoder.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Buffers.Binary;
-using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;


### PR DESCRIPTION
## Changes

`Nethermind.Stateless.Executor` enables `ImplicitUsings` and link-includes five `Nethermind.Merge.Plugin` files, so their explicit `System` usings get reported as IDE0005 in that project (but are required in Merge.Plugin, which has `ImplicitUsings` disabled). Auditing the full link-include set against a lint build turned up three issues:

- **The suppression glob was missing a file.** Of the five link-included files, three trip IDE0005 — `Data/ExecutionPayload.cs`, `Data/ExecutionPayloadV4.cs` and `Data/IExecutionPayloadParams.cs`. `ExecutionPayloadV4.cs` was not in the glob, so the project did not lint clean. (`ExecutionPayloadV3.cs` and `Handlers/IForkValidator.cs` carry no implicit-using-shadowed directive and do not warn.)
- **The glob listed four dead entries.** `SszRest/SszBlobCell`, `SszRest/SszBlobCellVectorTypeConverter`, `SszRest/SszKzgCommitment` and `SszRest/SszKzgCommitmentVectorTypeConverter` are no longer link-included by any project — `Nethermind.Stateless.Executor` is the only project in the repo that does file-level link-includes from Merge.Plugin, and it links none of them. Those suppressions only blinded Merge.Plugin's own lint to real IDE0005, so they are removed.
- **One warning was a genuine unused using**, not a false positive: `using Nethermind.Core;` in `Nethermind.Stateless.Executor/IO/InputDecoder.cs` — the project's own source, not a link-include. Deleted rather than suppressed.

The glob is also narrowed to `Data/{...}.cs`, which keeps it shorter now that all three entries live in the same folder.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Verified with CI's own flag set from `code-lint.yml` (`-t:Rebuild` is essential — an incremental build silently replays no analyzer warnings):

```
dotnet build src/Nethermind/Stateless.slnx -t:Rebuild \
  -p:EnforceCodeStyleInBuild=true -p:TreatWarningsAsErrors=false -p:GenerateDocumentationFile=true \
  -p:NoWarn=CS0419%3BCS1570%3BCS1572%3BCS1573%3BCS1574%3BCS1584%3BCS1587%3BCS1591%3BCS1658%3BCS1711%3BCS1712%3BCS1723%3BCS1734%3BCS1735%3BNU1701%3BNUnit1032
```

- Zero `warning IDE` / `warning CA` across all 26 projects in `Stateless.slnx`.
- `Nethermind.Merge.Plugin` also lints clean with the four `SszRest` suppressions removed, so dropping them does not expose a pre-existing warning or regress `code-lint.yml`.
- Positive control: temporarily adding `using System.Text;` to `Data/ExecutionPayloadV3.cs` does produce IDE0005, confirming the rule is genuinely live and that the narrowed glob is not over-matching.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

**Should CI lint this project at all?** This was invisible to CI: `code-lint.yml` lints `src/Nethermind/Nethermind.slnx`, which does not contain `Nethermind.Stateless.Executor`. The project only appears in `src/Nethermind/Stateless.slnx` — a fourth solution that is built by `stateless-tests.yml` and `build-tools.yml` but never linted, and which is not mentioned in `AGENTS.md` (which documents only three solutions).

Since `Stateless.slnx` now lints clean end to end, adding a second `dotnet build` line for it to `code-lint.yml` would be a zero-fix-cost change. Happy to fold that in here if reviewers agree — left out for now to keep this PR to the fix itself.

Two caveats worth noting on the suppression approach generally:

- It is path-scoped, so it also blinds the `Nethermind.slnx` lint to genuinely unused usings in those three shared Merge.Plugin files, and it silently reintroduces the warning if `using System;` is ever added to another link-included file.
- A cleaner alternative is dropping `<ImplicitUsings>enable</ImplicitUsings>` from `Nethermind.Stateless.Executor.csproj` — it is the odd one out in the repo, and the linked files all carry explicit usings anyway — which removes the need for any suppression. Not done here as the larger change; flagging it as the option if reviewers prefer it.
