### PR TITLE
refactor(test): drop dead intrinsic-gas cap regex mapping

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -660,7 +660,6 @@ public abstract class BlockchainTestBase
         ("TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED", ValidationErrorRegex(@"BlockBlobGasExceeded: A block cannot have more than \d+ blob gas, blobs count \d+, blobs gas used: \d+")),
         ("TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED", ValidationErrorRegex(@"BlobTxGasLimitExceeded: Transaction's totalDataGas=\d+ exceeded MaxBlobGas per transaction=\d+")),
         ("TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM", ValidationErrorRegex(@"TxGasLimitCapExceeded:")),
-        ("TransactionException.INTRINSIC_GAS_TOO_LOW", ValidationErrorRegex(@"TxGasLimitCapExceeded: Intrinsic gas")),
         ("BlockException.INCORRECT_EXCESS_BLOB_GAS", ValidationErrorRegex(@"HeaderExcessBlobGasMismatch: Excess blob gas in header does not match calculated|Overflow in excess blob gas")),
         ("BlockException.INVALID_BLOCK_HASH", ValidationErrorRegex(@"Invalid block hash 0x[0-9a-f]+ does not match calculated hash 0x[0-9a-f]+")),
         ("BlockException.INCORRECT_BLOCK_FORMAT", ValidationErrorRegex(@"Invalid block hash 0x[0-9a-f]+ does not match calculated hash 0x[0-9a-f]+")),


### PR DESCRIPTION
## Changes

- Remove the `("TransactionException.INTRINSIC_GAS_TOO_LOW", ValidationErrorRegex(@"TxGasLimitCapExceeded: Intrinsic gas"))` entry from `ValidationErrorRegexMappings` in `Ethereum.Test.Base/BlockchainTestBase.cs`.

The regex could never match. The sole producer of a `TxGasLimitCapExceeded:`-prefixed message is `TxErrorMessages.TxGasLimitCapExceeded`, which renders as `TxGasLimitCapExceeded: Gas limit {gasLimit} exceeded cap of {gasLimitCap}.` — the text after the prefix is always `Gas limit`, never `Intrinsic gas`.

The intrinsic-gas-vs-cap rejection is a different helper, `TxErrorMessages.TxIntrinsicGasExceedsCap` (raised from `TxValidator` and `TransactionProcessor`), which renders with the `IntrinsicGasTooLow` constant as its prefix:

```
intrinsic gas too low: Intrinsic gas (execution {n}, floor {m}) exceeded cap of {cap}.
```

That wording is already mapped to `TransactionException.INTRINSIC_GAS_TOO_LOW` (and to `INTRINSIC_GAS_BELOW_FLOOR_GAS_COST`) by the existing `"intrinsic gas too low"` substring entry in `ValidationErrorSubstringMappings`, so deleting the dead regex loses no coverage. `MapValidationErrorsToEestExceptions` unions the substring and regex hits, so there is no ordering effect either.

Presumably the regex predates the rename of that message.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Behaviour-preserving dead-code removal, verified by grepping every producer of both wordings. `Ethereum.Test.Base` is not part of `Nethermind.slnx`, so the `code-lint.yml` gate does not cover it; the project was built directly with the same flags (`EnforceCodeStyleInBuild=true`, `GenerateDocumentationFile=true`, matching `NoWarn`) — 0 warnings, 0 errors. The gate was positive-controlled by temporarily adding an unused `using`, which produced the expected `IDE0005`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Lines 662 and 671 both map the bare `@"TxGasLimitCapExceeded:"` regex, to `GAS_LIMIT_EXCEEDS_MAXIMUM` and `GAS_ALLOWANCE_EXCEEDED` respectively. That looks deliberate (two EEST ids accepted for one client message) rather than dead, so it is left untouched here.