### PR TITLE
fix(txpool): skip corrupt light blob tx records instead of aborting restore

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
@@ -10,6 +10,8 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Db;
 using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
 namespace Nethermind.TxPool.Test;
@@ -212,6 +214,58 @@ public class BlobTxStorageTests
         Assert.That(found, Is.EqualTo(0));
         Assert.That(results[0], Is.Null);
         Assert.That(results[1], Is.Null);
+    }
+
+    private static IEnumerable<TestCaseData> CorruptLightTxRecords()
+    {
+        byte[] valid = LightTxDecoder.Encode(CreateBlobTransaction());
+
+        yield return new TestCaseData(Array.Empty<byte>(), typeof(IndexOutOfRangeException)).SetName("empty_record");
+        yield return new TestCaseData(valid[..2], typeof(ArgumentOutOfRangeException)).SetName("truncated_record");
+        yield return new TestCaseData((byte[])[.. valid, 0x01], typeof(RlpException)).SetName("excess_trailing_field");
+    }
+
+    [TestCaseSource(nameof(CorruptLightTxRecords))]
+    public void GetAll_should_skip_corrupt_light_tx_record(byte[] corruptRecord, Type expectedException)
+    {
+        MemColumnsDb<BlobTxsColumns> columnsDb = new();
+        BlobTxStorage blobTxStorage = new(columnsDb);
+        Transaction tx = CreateBlobTransaction();
+        blobTxStorage.Add(tx);
+        columnsDb.GetColumnDb(BlobTxsColumns.LightBlobTxs).Set(TestItem.KeccakA.Bytes, corruptRecord);
+
+        List<LightTransaction> restored = [.. blobTxStorage.GetAll()];
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Pinned because the skip has to absorb all three roots: truncation surfaces as
+            // ArgumentOutOfRangeException/IndexOutOfRangeException, not as RlpException.
+            Assert.That(() => LightTxDecoder.Decode(corruptRecord), Throws.InstanceOf(expectedException));
+            Assert.That(restored, Has.Count.EqualTo(1));
+            Assert.That(restored[0].Hash, Is.EqualTo(tx.Hash));
+        }
+    }
+
+    [Test]
+    public void GetAll_should_warn_once_for_all_skipped_records()
+    {
+        TestLogger logger = new() { IsDebug = false, IsTrace = false };
+        MemColumnsDb<BlobTxsColumns> columnsDb = new();
+        BlobTxStorage blobTxStorage = new(columnsDb, new OneLoggerLogManager(new(logger)));
+        blobTxStorage.Add(CreateBlobTransaction());
+        IDb lightBlobTxsDb = columnsDb.GetColumnDb(BlobTxsColumns.LightBlobTxs);
+        lightBlobTxsDb.Set(TestItem.KeccakA.Bytes, []);
+        lightBlobTxsDb.Set(TestItem.KeccakB.Bytes, []);
+        lightBlobTxsDb.Set(TestItem.KeccakC.Bytes, []);
+
+        List<LightTransaction> restored = [.. blobTxStorage.GetAll()];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(restored, Has.Count.EqualTo(1));
+            Assert.That(logger.LogList, Has.Count.EqualTo(1));
+            Assert.That(logger.LogList[0], Does.Contain("3"));
+        }
     }
 
     private static Transaction CreateBlobTransaction() => Build.A.Transaction

--- a/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Int256;
@@ -18,6 +19,9 @@ namespace Nethermind.TxPool.Test;
 [TestFixture]
 public class LightTxDecoderTests
 {
+    private const int FieldsBeforeTrailingFields = 12;
+    private const int TrailingFieldCount = 4;
+
     [Test]
     public void should_roundtrip_sparse_blob_tx_cell_mask_and_consensus_size()
     {
@@ -41,17 +45,35 @@ public class LightTxDecoderTests
     [Test]
     public void should_roundtrip_v0_proof_version()
     {
-        Transaction tx = Build.A.Transaction
-            .WithShardBlobTxTypeAndFields(spec: Cancun.Instance)
-            .WithMaxFeePerGas(1.GWei)
-            .WithMaxPriorityFeePerGas(1.GWei)
-            .WithNonce(0UL)
-            .SignedAndResolved()
-            .TestObject;
-
-        LightTransaction decoded = LightTxDecoder.Decode(LightTxDecoder.Encode(tx));
+        LightTransaction decoded = LightTxDecoder.Decode(LightTxDecoder.Encode(BuildBlobTx(Cancun.Instance)));
 
         Assert.That(decoded.ProofVersion, Is.EqualTo(ProofVersion.V0));
+    }
+
+    [TestCase(ProofVersion.V0, (byte)0x80)]
+    [TestCase(ProofVersion.V1, (byte)0x01)]
+    public void should_pin_on_disk_trailing_field_layout(ProofVersion version, byte expectedProofVersionByte)
+    {
+        Transaction tx = BuildBlobTx(version is ProofVersion.V0 ? Cancun.Instance : Osaka.Instance);
+        Assert.That(tx.GetProofVersion(), Is.EqualTo(version));
+        byte[] encoded = LightTxDecoder.Encode(tx);
+
+        // A builder blob tx carries full blobs, so the persisted mask is BlobCellMask.Full.
+        byte[] expectedCellMask = new byte[BlobCellMask.FixedByteLength + 1];
+        expectedCellMask[0] = 0x80 + BlobCellMask.FixedByteLength;
+        expectedCellMask.AsSpan(1).Fill(0xff);
+
+        // Pinned from the write side because the decoder dispatches these four positionally off
+        // PeekNumberOfItemsRemaining: every roundtrip test stays green if the encoder switches an
+        // item to a raw byte, while already-persisted records then mis-decode.
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(CountTrailingFields(encoded), Is.EqualTo(TrailingFieldCount));
+            Assert.That(TrailingField(encoded, 0), Is.EqualTo(new[] { expectedProofVersionByte }));
+            Assert.That(TrailingField(encoded, 1), Is.EqualTo(expectedCellMask));
+            Assert.That(TrailingField(encoded, 2), Is.EqualTo(Rlp.Encode(tx.GetLength(shouldCountBlobs: false)).Bytes));
+            Assert.That(TrailingField(encoded, 3), Is.EqualTo(new byte[] { 0x01 }));
+        }
     }
 
     [Test]
@@ -132,13 +154,36 @@ public class LightTxDecoderTests
         }
     }
 
-    private static Transaction BuildBlobTx() => Build.A.Transaction
-        .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+    private static Transaction BuildBlobTx(IReleaseSpec spec = null) => Build.A.Transaction
+        .WithShardBlobTxTypeAndFields(spec: spec ?? Osaka.Instance)
         .WithMaxFeePerGas(1.GWei)
         .WithMaxPriorityFeePerGas(1.GWei)
         .WithNonce(0UL)
         .SignedAndResolved()
         .TestObject;
+
+    /// <returns>The raw RLP bytes of the trailing field at <paramref name="index"/>, prefix included.</returns>
+    private static byte[] TrailingField(byte[] encoded, int index)
+    {
+        RlpReader reader = new(encoded);
+        for (int i = 0; i < FieldsBeforeTrailingFields + index; i++)
+        {
+            reader.SkipItem();
+        }
+
+        return reader.PeekNextItem().ToArray();
+    }
+
+    private static int CountTrailingFields(byte[] encoded)
+    {
+        RlpReader reader = new(encoded);
+        for (int i = 0; i < FieldsBeforeTrailingFields; i++)
+        {
+            reader.SkipItem();
+        }
+
+        return reader.PeekNumberOfItemsRemaining();
+    }
 
     private static byte[] EncodeLegacy(
         Transaction tx,

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -13,11 +13,12 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Db;
 using Nethermind.Int256;
+using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.TxPool;
 
-public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage, IBlobTxMetadataStorage
+public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database, ILogManager? logManager = null) : IBlobTxStorage, IBlobTxMetadataStorage
 {
     private const int MaxPooledKeys = 128;
     private const int TransactionLockCount = 64;
@@ -34,6 +35,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     private readonly IDb _fullBlobTxsDb = database.GetColumnDb(BlobTxsColumns.FullBlobTxs);
     private readonly IDb _lightBlobTxsDb = database.GetColumnDb(BlobTxsColumns.LightBlobTxs);
     private readonly IDb _processedBlobTxsDb = database.GetColumnDb(BlobTxsColumns.ProcessedTxs);
+    private readonly ILogger _logger = (logManager ?? LimboLogs.Instance).GetClassLogger<BlobTxStorage>();
 
     public BlobTxStorage() : this(new MemColumnsDb<BlobTxsColumns>()) { }
 
@@ -100,14 +102,29 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         }
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// A record that fails to decode is skipped rather than aborting the enumeration, so a single
+    /// corrupt entry cannot prevent the rest of the persistent blob pool from being restored.
+    /// </remarks>
     public IEnumerable<LightTransaction> GetAll()
     {
+        int skippedCount = 0;
         foreach (byte[] txBytes in _lightBlobTxsDb.GetAllValues())
         {
             if (TryDecodeLightTx(txBytes, out LightTransaction? transaction))
             {
                 yield return transaction!;
             }
+            else if (txBytes is not null)
+            {
+                skippedCount++;
+            }
+        }
+
+        if (skippedCount > 0 && _logger.IsWarn)
+        {
+            _logger.Warn($"Skipped {skippedCount} unreadable blob transaction(s) while loading the persistent blob tx pool.");
         }
     }
 
@@ -234,12 +251,21 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         return false;
     }
 
-    private static bool TryDecodeLightTx(byte[]? txBytes, out LightTransaction? lightTx)
+    private bool TryDecodeLightTx(byte[]? txBytes, out LightTransaction? lightTx)
     {
         if (txBytes is not null)
         {
-            lightTx = LightTxDecoder.Decode(txBytes);
-            return true;
+            try
+            {
+                lightTx = LightTxDecoder.Decode(txBytes);
+                return true;
+            }
+            // Truncated records surface as ArgumentOutOfRangeException/IndexOutOfRangeException from the
+            // unchecked span reads in RlpReader, so RlpException alone does not cover a corrupt record.
+            catch (Exception e) when (e is RlpException or ArgumentOutOfRangeException or IndexOutOfRangeException)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Failed to decode a persisted blob transaction: {e}");
+            }
         }
 
         lightTx = default;


### PR DESCRIPTION
## Changes

- `BlobTxStorage.GetAll()` no longer aborts on a corrupt light blob tx record. Despite its name, `TryDecodeLightTx` only null-guarded the byte array and called `LightTxDecoder.Decode` unguarded, so a single bad record threw out of the iterator and abandoned restoration of the entire persistent blob pool at node startup. The record is now skipped and enumeration continues.
- The skip covers all three exception roots a corrupt light record produces, not just `RlpException`: `RlpReader.Read(int)` is an unchecked `Data.Slice(Position, length)` and `ReadByte()` an unchecked `Data[Position++]`, so **truncation** surfaces as `ArgumentOutOfRangeException` / `IndexOutOfRangeException`.
- One aggregated `Warn` with the skipped count per restore (not one line per record); the individual exception goes to `Debug`. `BlobTxStorage` gains an optional `ILogManager` (defaulted, so existing call sites are untouched; Autofac binds the registered one).
- Pins the on-disk layout of the four optional trailing fields in `LightTxDecoder` — proof version, cell mask, consensus encoding size, size format version.

## Why the layout pin

Carried over from #12782, which is being closed as obsolete (its production fix landed independently in #11094) but which held a guard master still lacked.

Every existing case in `LightTxDecoderTests` runs `Encode` on both sides, so they only assert `Decode(Encode(x)) == x` and never constrain the bytes actually in the `LightBlobTxs` column. Switching the encoder to write the proof version as a raw byte *and* changing the decoder to match keeps every round-trip green while every already-persisted record mis-decodes — exactly the bug that shipped once already (a V0 record read back as proof version 128 never equals `CurrentProofVersion`, so `SpecDrivenTxGossipPolicy.ShouldGossipTransaction` returned false and the transaction was permanently withheld from gossip).

The original pinned only the proof version. Master's decoder now dispatches all four trailing fields positionally off `PeekNumberOfItemsRemaining(maxSearch: 5)`, which makes every one of them load-bearing, so all four are pinned.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`BlobTxStorageTests`:
- `GetAll_should_skip_corrupt_light_tx_record` — parameterized over the three roots (empty record → `IndexOutOfRangeException`, truncated record → `ArgumentOutOfRangeException`, excess trailing field → `RlpException`). Each case also asserts that `LightTxDecoder.Decode` really throws that type, so the catch filter stays justified rather than aspirational.
- `GetAll_should_warn_once_for_all_skipped_records` — three corrupt records produce exactly one log line carrying the count.

Negative control: narrowing the catch to `RlpException` only fails the truncated and empty cases (and the warn-once test) while the trailing-field case still passes.

`LightTxDecoderTests.should_pin_on_disk_trailing_field_layout` pins the trailing-field count plus the raw RLP bytes of all four fields, for both V0 (`0x80`) and V1 (`0x01`) proof versions.

Negative control: moving the field offset from 12 to 11 or 13 fails every one of the assertions.

Full `Nethermind.TxPool.Test` green in both Debug and Release (722 tests). `EthereumRunnerTests` green on a warm run (276), confirming the added constructor parameter resolves for every shipped config.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

A corrupt record in the `LightBlobTxs` column no longer prevents the persistent blob transaction pool from being restored at startup; unreadable records are skipped with a warning.