### PR TITLE
chore: remove unused System.Threading using in ExecutionPayload

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;


### PR DESCRIPTION
## Changes

Removes a single unused `using System.Threading;` directive from `src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs`.

The directive was introduced by the FOCIL merge (d4ef4fd56e, "Implement EIP-7805 (FOCIL) (#8003)"). It is genuinely unused: the file references no `System.Threading` type (no `CancellationToken`, `Interlocked`, `Lock`, etc.), and its use of `Task` is covered by the separate `using System.Threading.Tasks;` directive on the following line.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring
- [ ] Configuration change
- [ ] Build-related changes
- [x] Other: code-style cleanup (no behavioral change)

## Testing

Requires testing

- [ ] Yes
- [x] No

No behavioral change — removing an unused compile-time directive cannot alter runtime behavior.

Verification performed:

- **Positive control** — with the directive still present, the code-style gate fails as expected:
  ```
  ExecutionPayload.cs(6,1): error IDE0005: Using directive is unnecessary.
  Build FAILED.
  ```
- **After removal** — the same gate command reports `Build succeeded. 0 Error(s)`:
  ```
  dotnet build src/Nethermind/Nethermind.Merge.Plugin/Nethermind.Merge.Plugin.csproj -c release \
    -p:EnforceCodeStyleInBuild=true -p:GenerateDocumentationFile=true \
    -p:TreatWarningsAsErrors=false -p:WarningsAsErrors=IDE0005
  ```
- **Plain release build** of `Nethermind.Merge.Plugin` — `Build succeeded. 0 Warning(s), 0 Error(s)`.

## Documentation

Requires documentation update

- [ ] Yes
- [x] No

Requires explanation in Release Notes

- [ ] Yes
- [x] No