### PR TITLE
test(eip8141): close three gaps in the frame exception fragments

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -631,10 +631,6 @@ public abstract class BlockchainTestBase
         ("TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM", "exceeds the transaction gas cap of"),
         // Reached only when gasLimit * price (+ value) overflows, never on a plain balance shortfall.
         ("TransactionException.GASLIMIT_PRICE_PRODUCT_OVERFLOW", "required balance exceeds 256 bits"),
-        // The decoder names neither the field nor the type, so these widen both labels suite-wide to any
-        // untyped collection-limit rejection, not merely to the other fee field. No narrowing available.
-        ("TransactionException.GASPRICE_OVERFLOW", "Collection count of"),
-        ("TransactionException.PRIORITY_OVERFLOW", "Collection count of"),
         .. Eip8141Mappings(),
     ];
 
@@ -649,6 +645,11 @@ public abstract class BlockchainTestBase
             yield return ("TransactionException.TYPE_6_INVALID_FRAME_EXECUTION", fragment);
         foreach (string fragment in FrameExceptionFragments.Decode)
             yield return ("TransactionException.TYPE_6_INVALID_FRAME_FORMAT", fragment);
+        foreach (string fragment in FrameExceptionFragments.FeeOverflow)
+        {
+            yield return ("TransactionException.GASPRICE_OVERFLOW", fragment);
+            yield return ("TransactionException.PRIORITY_OVERFLOW", fragment);
+        }
     }
 
     private const RegexOptions ValidationErrorRegexOptions = RegexOptions.CultureInvariant | RegexOptions.Compiled;

--- a/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
+++ b/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
@@ -120,10 +120,13 @@ public static class FrameExceptionFragments
     public static readonly string[] Decode =
     [
         "Unexpected length of integer value",
-        // Two distinct rejections: "Unexpected RLP prefix" is the address-decode wording, and a
-        // field that should be a sequence and is not reports its own, trimmed of the range here.
+        // Two producers: RlpReader words a bad address prefix, RlpHelpers a field that should be a
+        // sequence and is not. The latter is trimmed of the byte range it goes on to name.
         "Unexpected RLP prefix",
         "Expected a sequence prefix",
-        .. FeeOverflow,
+        // Kept in step with FeeOverflow by DecodeCarriesEveryFeeOverflowWording, rather than spread
+        // from it: a static initialiser reading a field declared below it silently reads null.
+        "Collection count",
+        "An RLP limit exceeded",
     ];
 }

--- a/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
+++ b/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
@@ -91,25 +91,39 @@ public static class FrameExceptionFragments
     /// </summary>
     public static readonly string[] Execution =
     [
-        "VERIFY frame reverted",
+        // Covers both the VERIFY and the validation-prefix wording of a reverting frame.
+        "frame reverted",
         "SENDER frame before execution approval",
         "never set a payer",
+    ];
+
+    /// <summary>
+    /// A fee field wider than its type, which the decoder rejects through its length guard.
+    /// </summary>
+    /// <remarks>
+    /// The guard names neither the field nor the type, so these widen both fee labels suite-wide to
+    /// any untyped limit rejection, not merely to the other fee field. Both wordings are one
+    /// rejection: <c>Rlp.ThrowCountOverLimit</c> composes the detailed text only when <c>Rlp</c>'s
+    /// static logger has trace enabled and otherwise throws the bare message, so listing only the
+    /// detailed one leaves the mapping dead in the default configuration.
+    /// </remarks>
+    public static readonly string[] FeeOverflow =
+    [
+        "Collection count",
+        "An RLP limit exceeded",
     ];
 
     /// <summary>
     /// Decode-time rejections of a frame field too wide or too long for its type, which the fixtures
     /// also name as format failures. Reported before any rule runs, so they name no rule.
     /// </summary>
-    /// <remarks>
-    /// The last two fragments are one rejection under two wordings: <c>Rlp.ThrowCountOverLimit</c> composes the
-    /// detailed text only when <c>Rlp</c>'s static logger has trace enabled and otherwise throws the bare message,
-    /// so both are listed rather than depending on which log manager the runner leaves installed.
-    /// </remarks>
     public static readonly string[] Decode =
     [
         "Unexpected length of integer value",
+        // Two distinct rejections: "Unexpected RLP prefix" is the address-decode wording, and a
+        // field that should be a sequence and is not reports its own, trimmed of the range here.
         "Unexpected RLP prefix",
-        "Collection count",
-        "An RLP limit exceeded",
+        "Expected a sequence prefix",
+        .. FeeOverflow,
     ];
 }

--- a/src/Nethermind/Ethereum.Transaction.Test/FrameExceptionFragmentsTests.cs
+++ b/src/Nethermind/Ethereum.Transaction.Test/FrameExceptionFragmentsTests.cs
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Ethereum.Test.Base;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Ethereum.Transaction.Test;
+
+/// <summary>
+/// Guards the client wordings behind each frame-transaction fixture label: that the decoder's real
+/// rejection messages are covered, and that the sets stay pairwise disjoint.
+/// </summary>
+public class FrameExceptionFragmentsTests
+{
+    private static bool Covers(IEnumerable<string> fragments, string message)
+    {
+        foreach (string fragment in fragments)
+        {
+            if (message.Contains(fragment, StringComparison.Ordinal)) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Encodes a frame transaction payload, defective only in the field the caller varies.</summary>
+    private static string DecodeFailureMessage(Rlp frames, Rlp maxPriorityFeePerGas)
+    {
+        Rlp payloadSequence = Rlp.Encode(
+            Rlp.Encode(1L),                      // chain_id
+            Rlp.Encode(0L),                      // nonce
+            Rlp.Encode(TestItem.AddressA.Bytes), // sender
+            frames,
+            Rlp.Encode(Array.Empty<Rlp>()),      // signatures
+            Rlp.Encode(maxPriorityFeePerGas, Rlp.Encode(0L), Rlp.Encode(0L)),
+            Rlp.Encode(Array.Empty<Rlp>()));     // blob_versioned_hashes
+
+        byte[] payload = new byte[1 + payloadSequence.Length];
+        payload[0] = (byte)TxType.FrameTx;
+        payloadSequence.Bytes.CopyTo(payload, 1);
+
+        // Catch, not Throws: the length guard raises the RlpLimitException subclass.
+        RlpException thrown = Assert.Catch<RlpException>(() =>
+        {
+            RlpReader reader = new(payload);
+            Rlp.GetDecoder<Nethermind.Core.Transaction>()!
+                .DecodeGuardNotNull(ref reader, RlpBehaviors.SkipTypedWrapping);
+        })!;
+
+        return thrown.Message;
+    }
+
+    [Test]
+    public void Decode_CoversAFrameListThatIsNotASequence()
+    {
+        // "Unexpected RLP prefix" is the address-decode wording; a field that should be a sequence
+        // and is not reports the accepted range instead.
+        string message = DecodeFailureMessage(
+            frames: Rlp.Encode(new byte[19]),               // a string where a list belongs
+            maxPriorityFeePerGas: Rlp.Encode(0L));
+
+        Assert.That(message, Does.Contain("Expected a sequence prefix"));
+        Assert.That(Covers(FrameExceptionFragments.Decode, message), Is.True, message);
+    }
+
+    [Test]
+    public void FeeOverflow_CoversAFeeFieldWiderThanItsType()
+    {
+        string message = DecodeFailureMessage(
+            frames: Rlp.Encode(Array.Empty<Rlp>()),
+            maxPriorityFeePerGas: Rlp.Encode(new byte[33])); // one byte over the 32-byte field
+
+        Assert.That(Covers(FrameExceptionFragments.FeeOverflow, message), Is.True, message);
+    }
+
+    // The detailed wording is composed only when Rlp's static logger has trace enabled, so a set
+    // holding it alone leaves the mapping dead in the default configuration.
+    [TestCase("An RLP limit exceeded")]
+    [TestCase("Collection count of 33 is over limit 32 or 40 bytes left")]
+    public void FeeOverflow_CoversBothWordingsOfTheLengthGuard(string message) =>
+        Assert.That(Covers(FrameExceptionFragments.FeeOverflow, message), Is.True);
+
+    // Both entry points, because the processor words a halt differently under the mempool admission
+    // simulator, whose wordings no fixture reaches, than on the block-processing path.
+    [TestCase("VERIFY frame reverted")]
+    [TestCase("validation prefix frame reverted")]
+    [TestCase("SENDER frame before execution approval")]
+    [TestCase("frame transaction never set a payer")]
+    [TestCase("frame transaction validation prefix never set a payer")]
+    public void Execution_CoversTheHaltWordingsOfBothEntryPoints(string message) =>
+        Assert.That(Covers(FrameExceptionFragments.Execution, message), Is.True);
+
+    private static IEnumerable<TestCaseData> DisjointnessCases()
+    {
+        (string Name, string[] Set)[] sets =
+        [
+            ("Format", FrameExceptionFragments.Format),
+            ("Signature", FrameExceptionFragments.Signature),
+            ("Execution", FrameExceptionFragments.Execution),
+        ];
+
+        foreach ((string ownerName, string[] owner) in sets)
+        {
+            foreach ((string otherName, string[] other) in sets)
+            {
+                if (!ReferenceEquals(owner, other))
+                {
+                    yield return new TestCaseData(owner, other).SetName($"{ownerName} messages are not matched by {otherName}");
+                }
+            }
+        }
+    }
+
+    [TestCaseSource(nameof(DisjointnessCases))]
+    public void Sets_StayPairwiseDisjoint(string[] owner, string[] other)
+    {
+        // A fixture naming one label has to fail when the client rejects for one of the other two,
+        // so no set may hold a fragment broad enough to catch another's messages.
+        using (Assert.EnterMultipleScope())
+        {
+            foreach (string message in owner)
+            {
+                Assert.That(Covers(other, message), Is.False, message);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Ethereum.Transaction.Test/FrameExceptionFragmentsTests.cs
+++ b/src/Nethermind/Ethereum.Transaction.Test/FrameExceptionFragmentsTests.cs
@@ -12,9 +12,14 @@ using NUnit.Framework;
 namespace Ethereum.Transaction.Test;
 
 /// <summary>
-/// Guards the client wordings behind each frame-transaction fixture label: that the decoder's real
-/// rejection messages are covered, and that the sets stay pairwise disjoint.
+/// Guards the client wordings behind each frame-transaction fixture label.
 /// </summary>
+/// <remarks>
+/// The two <c>DecodeFailureMessage</c> tests drive the real decoder, so they fail if its wording moves
+/// away from the table. The rest assert the table against literals and cannot: a processor reword
+/// leaves both the case and the fragment green while the mapping goes dead. Reaching the processor
+/// wordings the same way needs constants behind them, which this fixture cannot add on its own.
+/// </remarks>
 public class FrameExceptionFragmentsTests
 {
     private static bool Covers(IEnumerable<string> fragments, string message)
@@ -57,8 +62,6 @@ public class FrameExceptionFragmentsTests
     [Test]
     public void Decode_CoversAFrameListThatIsNotASequence()
     {
-        // "Unexpected RLP prefix" is the address-decode wording; a field that should be a sequence
-        // and is not reports the accepted range instead.
         string message = DecodeFailureMessage(
             frames: Rlp.Encode(new byte[19]),               // a string where a list belongs
             maxPriorityFeePerGas: Rlp.Encode(0L));
@@ -77,15 +80,14 @@ public class FrameExceptionFragmentsTests
         Assert.That(Covers(FrameExceptionFragments.FeeOverflow, message), Is.True, message);
     }
 
-    // The detailed wording is composed only when Rlp's static logger has trace enabled, so a set
-    // holding it alone leaves the mapping dead in the default configuration.
+    // Both wordings of one guard; see FrameExceptionFragments.FeeOverflow for which is which.
     [TestCase("An RLP limit exceeded")]
     [TestCase("Collection count of 33 is over limit 32 or 40 bytes left")]
     public void FeeOverflow_CoversBothWordingsOfTheLengthGuard(string message) =>
         Assert.That(Covers(FrameExceptionFragments.FeeOverflow, message), Is.True);
 
-    // Both entry points, because the processor words a halt differently under the mempool admission
-    // simulator, whose wordings no fixture reaches, than on the block-processing path.
+    // The validation-prefix wordings reach only the mempool admission simulator, so no fixture
+    // produces them; they are pinned so a reword of that path does not slip past the set.
     [TestCase("VERIFY frame reverted")]
     [TestCase("validation prefix frame reverted")]
     [TestCase("SENDER frame before execution approval")]
@@ -93,6 +95,17 @@ public class FrameExceptionFragmentsTests
     [TestCase("frame transaction validation prefix never set a payer")]
     public void Execution_CoversTheHaltWordingsOfBothEntryPoints(string message) =>
         Assert.That(Covers(FrameExceptionFragments.Execution, message), Is.True);
+
+    [Test]
+    public void DecodeCarriesEveryFeeOverflowWording()
+    {
+        // Decode inlines these rather than spreading FeeOverflow, which would make it read null if
+        // ever declared below it. This is the check that keeps the two in step instead.
+        foreach (string fragment in FrameExceptionFragments.FeeOverflow)
+        {
+            Assert.That(FrameExceptionFragments.Decode, Does.Contain(fragment));
+        }
+    }
 
     private static IEnumerable<TestCaseData> DisjointnessCases()
     {


### PR DESCRIPTION
## Changes

Two gaps and one consolidation in `FrameExceptionFragments`, the table mapping client rejection wordings to the `TransactionException` labels the fixtures name.

**1. The fee-overflow mapping never fired.** `GASPRICE_OVERFLOW` and `PRIORITY_OVERFLOW` matched only `"Collection count of"`. That wording is composed by `Rlp.ThrowCountOverLimit` **only when `Rlp`'s static logger has trace enabled**; with it off the guard throws the bare `"An RLP limit exceeded"`. The runner does not enable trace, so the mapping was dead in the configuration the lane actually runs — it read as covered while matching nothing. Both labels now route through a `FeeOverflow` set holding both wordings.

**2. A field that should be a sequence and is not was unmapped.** `Decode` carried `"Unexpected RLP prefix"`, which is the *address*-decode wording. A frame list encoded as a string reports `"Expected a sequence prefix to be in the range of <192, 255> and got <n>"` instead, which matched nothing and fell through to the generic decode catch-all.

**3. Consolidation, not a gap.** `Execution` carried `"VERIFY frame reverted"` and missed `"validation prefix frame reverted"`. Both are now covered by the single fragment `"frame reverted"`, which stays disjoint from the format and signature sets. To be precise about what this buys: the validation-prefix wording is emitted only inside `SimulateFrameValidationPrefix`, which is reached solely through `FrameTxPrefixSimulator` from the mempool admission filter, so **no fixture can produce it**. The fragment is consolidation and reword-robustness, not a fixture gap.

## Why it matters

These are the client-side counterpart of the same class of defect I have raised upstream. Gaps 1 and 2 correspond exactly to the two wordings that the last completed hive `frames` run reported against this client and that no mapping resolved:

```
Transaction 0 is not valid: Expected a sequence prefix to be in the range of <192, 255> and got 147
Transaction 0 is not valid: An RLP limit exceeded
```

A missing fragment does not make the lane red — the mapping is additive and the fixture simply fails to find its label — but a mapping that can never fire is worse than an absent one, because it reads as covered.

## Testing

New `FrameExceptionFragmentsTests` in `Ethereum.Transaction.Test`, the CI-running project that already consumes this table through `TransactionTestBase`:

* two tests drive the **real decoder** over a deliberately malformed frame transaction payload and assert the thrown message is covered — so the wordings are the decoder's actual output, not literals copied from a log;
* table cases cover both wordings of the length guard and every halt wording;
* a disjointness test asserts the format, signature and execution sets stay pairwise disjoint, since a fixture naming one label has to fail when the client rejects for another. This guards the new broader `"frame reverted"` fragment.

Against the pre-fix table exactly three fail:

```
failed Decode_CoversAFrameListThatIsNotASequence
failed Execution_CoversTheHaltWordingsOfBothEntryPoints("validation prefix frame reverted")
failed FeeOverflow_CoversBothWordingsOfTheLengthGuard("An RLP limit exceeded")
```

With the fix, 15/15 pass and the full `Ethereum.Transaction.Test` suite is 183/183. `EthereumTests.slnx` builds clean in release (0 errors, 0 warnings). The style gate (`EnforceCodeStyleInBuild` + `GenerateDocumentationFile`) adds no new findings — positive-controlled with an injected unused `using` firing `IDE0005`, then removed; the four `CS1574` findings in `BlockchainTestBase` are present identically on the base branch.

## Notes

No production code is touched — this is test-harness mapping only.

## Types of changes

- [x] Bug fix (a non-breaking change that fixes an issue)

## Documentation

- [x] Requires documentation update: **no**
